### PR TITLE
Adjust the default transaction replay thread pool size 

### DIFF
--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -110,6 +110,8 @@ impl ThreadArg for ReplayTransactionsThreadsArg {
     const HELP: &'static str = "Number of threads to use for transaction replay";
 
     fn default() -> usize {
-        get_max_thread_count()
+        // Limit to 16 threads, larger values have empirically been found to
+        // not offer any benefit on machines with more cores
+        get_max_thread_count().min(16)
     }
 }


### PR DESCRIPTION
#### Problem
The thread pool that is used to perform entry(transaction verification) and transaction execution is currently set to have the same size as the number of virtual cores on a machine. For example, a 24 core / 48 thread machine will put 48 threads into this pool.

This thread-pool is over-provisioned, and the extra thread actually cause more harm than good. When work is sent to the pool, all thread are woken up, even if there is only work for one or two threads. This "thundering herd" effect causes lots of general system disruption, and can easily be mitigated by bounding the thread pool size to more accurately fit the workload we throw at it.

Part of work for https://github.com/anza-xyz/agave/issues/35

#### Summary of Changes
- Limit the default thread pool size to a maximum of X threads
