### PR TITLE
Combine builtin and BPF compute cost in cost model

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -285,8 +285,7 @@ pub struct BatchedTransactionCostDetails {
     pub batched_signature_cost: u64,
     pub batched_write_lock_cost: u64,
     pub batched_data_bytes_cost: u64,
-    pub batched_builtins_execute_cost: u64,
-    pub batched_bpf_execute_cost: u64,
+    pub batched_programs_execute_cost: u64,
 }
 
 #[derive(Debug, Default)]

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1549,16 +1549,17 @@ mod tests {
             assert_eq!(retryable_transaction_indexes, vec![1]);
 
             let expected_block_cost = if !apply_cost_tracker_during_replay_enabled {
-                let actual_bpf_execution_cost = match commit_transactions_result.first().unwrap() {
-                    CommitTransactionDetails::Committed { compute_units } => *compute_units,
-                    CommitTransactionDetails::NotCommitted => {
-                        unreachable!()
-                    }
-                };
+                let actual_programs_execution_cost =
+                    match commit_transactions_result.first().unwrap() {
+                        CommitTransactionDetails::Committed { compute_units } => *compute_units,
+                        CommitTransactionDetails::NotCommitted => {
+                            unreachable!()
+                        }
+                    };
 
                 let mut cost = CostModel::calculate_cost(&transactions[0], &bank.feature_set);
                 if let TransactionCost::Transaction(ref mut usage_cost) = cost {
-                    usage_cost.bpf_execution_cost = actual_bpf_execution_cost;
+                    usage_cost.programs_execution_cost = actual_programs_execution_cost;
                 }
 
                 block_cost + cost.sum()

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -512,7 +512,9 @@ impl QosServiceMetrics {
                 ),
                 (
                     "actual_programs_execute_cu",
-                    self.stats.actual_programs_execute_cu.swap(0, Ordering::Relaxed),
+                    self.stats
+                        .actual_programs_execute_cu
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -717,7 +719,7 @@ mod tests {
             let committed_status: Vec<CommitTransactionDetails> = qos_cost_results
                 .iter()
                 .map(|tx_cost| CommitTransactionDetails::Committed {
-                    compute_units: tx_cost.as_ref().unwrap().bpf_execution_cost()
+                    compute_units: tx_cost.as_ref().unwrap().programs_execution_cost()
                         + execute_units_adjustment,
                 })
                 .collect();
@@ -844,7 +846,7 @@ mod tests {
                         CommitTransactionDetails::NotCommitted
                     } else {
                         CommitTransactionDetails::Committed {
-                            compute_units: tx_cost.as_ref().unwrap().bpf_execution_cost()
+                            compute_units: tx_cost.as_ref().unwrap().programs_execution_cost()
                                 + execute_units_adjustment,
                         }
                     }
@@ -880,8 +882,7 @@ mod tests {
         let signature_cost = 1;
         let write_lock_cost = 2;
         let data_bytes_cost = 3;
-        let builtins_execution_cost = 4;
-        let bpf_execution_cost = 10;
+        let programs_execution_cost = 10;
         let num_txs = 4;
 
         let tx_cost_results: Vec<_> = (0..num_txs)
@@ -891,8 +892,7 @@ mod tests {
                         signature_cost,
                         write_lock_cost,
                         data_bytes_cost,
-                        builtins_execution_cost,
-                        bpf_execution_cost,
+                        programs_execution_cost,
                         ..UsageCostDetails::default()
                     }))
                 } else {
@@ -904,8 +904,7 @@ mod tests {
         let expected_signatures = signature_cost * (num_txs / 2);
         let expected_write_locks = write_lock_cost * (num_txs / 2);
         let expected_data_bytes = data_bytes_cost * (num_txs / 2);
-        let expected_builtins_execution_costs = builtins_execution_cost * (num_txs / 2);
-        let expected_bpf_execution_costs = bpf_execution_cost * (num_txs / 2);
+        let expected_programs_execution_costs = programs_execution_cost * (num_txs / 2);
         let batched_transaction_details =
             QosService::accumulate_batched_transaction_costs(tx_cost_results.iter());
         assert_eq!(
@@ -921,14 +920,10 @@ mod tests {
             batched_transaction_details.costs.batched_data_bytes_cost
         );
         assert_eq!(
-            expected_builtins_execution_costs,
+            expected_programs_execution_costs,
             batched_transaction_details
                 .costs
-                .batched_builtins_execute_cost
-        );
-        assert_eq!(
-            expected_bpf_execution_costs,
-            batched_transaction_details.costs.batched_bpf_execute_cost
+                .batched_programs_execute_cost
         );
     }
 }

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -236,14 +236,10 @@ impl QosService {
             batched_transaction_details.costs.batched_data_bytes_cost,
             Ordering::Relaxed,
         );
-        self.metrics.stats.estimated_builtins_execute_cu.fetch_add(
+        self.metrics.stats.estimated_programs_execute_cu.fetch_add(
             batched_transaction_details
                 .costs
-                .batched_builtins_execute_cost,
-            Ordering::Relaxed,
-        );
-        self.metrics.stats.estimated_bpf_execute_cu.fetch_add(
-            batched_transaction_details.costs.batched_bpf_execute_cost,
+                .batched_programs_execute_cost,
             Ordering::Relaxed,
         );
 
@@ -297,7 +293,7 @@ impl QosService {
     pub fn accumulate_actual_execute_cu(&self, units: u64) {
         self.metrics
             .stats
-            .actual_bpf_execute_cu
+            .actual_programs_execute_cu
             .fetch_add(units, Ordering::Relaxed);
     }
 
@@ -331,12 +327,8 @@ impl QosService {
                 saturating_add_assign!(
                     batched_transaction_details
                         .costs
-                        .batched_builtins_execute_cost,
-                    cost.builtins_execution_cost()
-                );
-                saturating_add_assign!(
-                    batched_transaction_details.costs.batched_bpf_execute_cost,
-                    cost.bpf_execution_cost()
+                        .batched_programs_execute_cost,
+                    cost.programs_execution_cost()
                 );
             }
             Err(transaction_error) => match transaction_error {
@@ -427,14 +419,11 @@ struct QosServiceMetricsStats {
     /// accumulated estimated instruction data Compute Units to be packed into block
     estimated_data_bytes_cu: AtomicU64,
 
-    /// accumulated estimated builtin programs Compute Units to be packed into block
-    estimated_builtins_execute_cu: AtomicU64,
-
-    /// accumulated estimated SBF program Compute Units to be packed into block
-    estimated_bpf_execute_cu: AtomicU64,
+    /// accumulated estimated program Compute Units to be packed into block
+    estimated_programs_execute_cu: AtomicU64,
 
     /// accumulated actual program Compute Units that have been packed into block
-    actual_bpf_execute_cu: AtomicU64,
+    actual_programs_execute_cu: AtomicU64,
 
     /// accumulated actual program execute micro-sec that have been packed into block
     actual_execute_time_us: AtomicU64,
@@ -515,22 +504,15 @@ impl QosServiceMetrics {
                     i64
                 ),
                 (
-                    "estimated_builtins_execute_cu",
+                    "estimated_programs_execute_cu",
                     self.stats
-                        .estimated_builtins_execute_cu
+                        .estimated_programs_execute_cu
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
-                    "estimated_bpf_execute_cu",
-                    self.stats
-                        .estimated_bpf_execute_cu
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "actual_bpf_execute_cu",
-                    self.stats.actual_bpf_execute_cu.swap(0, Ordering::Relaxed),
+                    "actual_programs_execute_cu",
+                    self.stats.actual_programs_execute_cu.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -100,15 +100,18 @@ impl CostModel {
         let mut has_user_space_instructions = false;
 
         for (program_id, instruction) in transaction.message().program_instructions_iter() {
-            programs_execution_costs =
+            let ix_execution_cost =
                 if let Some(builtin_cost) = BUILT_IN_INSTRUCTION_COSTS.get(program_id) {
-                    programs_execution_costs.saturating_add(*builtin_cost)
+                    *builtin_cost
                 } else {
                     has_user_space_instructions = true;
-                    programs_execution_costs
-                        .saturating_add(u64::from(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT))
-                }
+                    u64::from(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT)
+                };
+
+            programs_execution_costs = programs_execution_costs
+                .saturating_add(ix_execution_cost)
                 .min(u64::from(MAX_COMPUTE_UNIT_LIMIT));
+
             data_bytes_len_total =
                 data_bytes_len_total.saturating_add(instruction.data.len() as u64);
 

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -307,7 +307,7 @@ mod tests {
             system_transaction::transfer(mint_keypair, &keypair.pubkey(), 2, *start_hash),
         );
         let mut tx_cost = UsageCostDetails::new_with_capacity(1);
-        tx_cost.bpf_execution_cost = 5;
+        tx_cost.programs_execution_cost = 5;
         tx_cost.writable_accounts.push(mint_keypair.pubkey());
 
         (simple_transaction, TransactionCost::Transaction(tx_cost))
@@ -606,7 +606,7 @@ mod tests {
         {
             let tx_cost = TransactionCost::Transaction(UsageCostDetails {
                 writable_accounts: vec![acct1, acct2, acct3],
-                bpf_execution_cost: cost,
+                programs_execution_cost: cost,
                 ..UsageCostDetails::default()
             });
             assert!(testee.try_add(&tx_cost).is_ok());
@@ -624,7 +624,7 @@ mod tests {
         {
             let tx_cost = TransactionCost::Transaction(UsageCostDetails {
                 writable_accounts: vec![acct2],
-                bpf_execution_cost: cost,
+                programs_execution_cost: cost,
                 ..UsageCostDetails::default()
             });
             assert!(testee.try_add(&tx_cost).is_ok());
@@ -644,7 +644,7 @@ mod tests {
         {
             let tx_cost = TransactionCost::Transaction(UsageCostDetails {
                 writable_accounts: vec![acct1, acct2],
-                bpf_execution_cost: cost,
+                programs_execution_cost: cost,
                 ..UsageCostDetails::default()
             });
             assert!(testee.try_add(&tx_cost).is_err());
@@ -668,7 +668,7 @@ mod tests {
         let mut testee = CostTracker::new(account_max, block_max, block_max);
         let tx_cost = TransactionCost::Transaction(UsageCostDetails {
             writable_accounts: vec![acct1, acct2, acct3],
-            bpf_execution_cost: cost,
+            programs_execution_cost: cost,
             ..UsageCostDetails::default()
         });
         let mut expected_block_cost = tx_cost.sum();
@@ -755,7 +755,7 @@ mod tests {
 
         let tx_cost = TransactionCost::Transaction(UsageCostDetails {
             writable_accounts: vec![acct1, acct2, acct3],
-            bpf_execution_cost: cost,
+            programs_execution_cost: cost,
             ..UsageCostDetails::default()
         });
 
@@ -802,7 +802,7 @@ mod tests {
         let cost = 100u64;
         let tx_cost = TransactionCost::Transaction(UsageCostDetails {
             writable_accounts: vec![Pubkey::new_unique()],
-            bpf_execution_cost: cost,
+            programs_execution_cost: cost,
             ..UsageCostDetails::default()
         });
 

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -105,7 +105,7 @@ impl CostTracker {
         estimated_tx_cost: &TransactionCost,
         actual_execution_units: u64,
     ) {
-        let estimated_execution_units = estimated_tx_cost.bpf_execution_cost();
+        let estimated_execution_units = estimated_tx_cost.programs_execution_cost();
         match actual_execution_units.cmp(&estimated_execution_units) {
             Ordering::Equal => (),
             Ordering::Greater => {

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -91,9 +91,6 @@ pub struct UsageCostDetails {
     pub signature_cost: u64,
     pub write_lock_cost: u64,
     pub data_bytes_cost: u64,
-    // since https://github.com/solana-labs/solana/issues/30620 activated everywhere,
-    // all builtins consume compute units same as bpf. It is no longer necessary
-    // to separate builtin execution cost from bpf's
     pub programs_execution_cost: u64,
     pub loaded_accounts_data_size_cost: u64,
     pub account_data_size: u64,


### PR DESCRIPTION
#### Problem
feature gate https://github.com/solana-labs/solana/issues/30620 has been activated everywhere, SVM now consumes compute units uniformly for both builtins and BPF instructions. Cost Model should no longer estimate their cost separately.

Original PR: https://github.com/solana-labs/solana/pull/32080

#### Summary of Changes
- combine builtin and bpf cost into `programs_execution_cost`, update metrics reporting as well.
- update tests

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
