### PR TITLE
prioritization fee cache: remove lru crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6994,7 +6994,6 @@ dependencies = [
  "libc",
  "libsecp256k1",
  "log",
- "lru",
  "lz4",
  "memmap2",
  "memoffset 0.9.0",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5681,7 +5681,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "lru",
  "lz4",
  "memmap2",
  "mockall",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -30,7 +30,6 @@ itertools = { workspace = true }
 lazy_static = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
-lru = { workspace = true }
 lz4 = { workspace = true }
 memmap2 = { workspace = true }
 mockall = { workspace = true }

--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -165,11 +165,7 @@ impl Default for PrioritizationFee {
 
 impl PrioritizationFee {
     /// Update self for minimum transaction fee in the block and minimum fee for each writable account.
-    pub fn update(
-        &mut self,
-        transaction_fee: u64,
-        writable_accounts: Vec<Pubkey>,
-    ) -> Result<(), PrioritizationFeeError> {
+    pub fn update(&mut self, transaction_fee: u64, writable_accounts: Vec<Pubkey>) {
         let (_, update_time) = measure!(
             {
                 if !self.is_finalized {
@@ -199,7 +195,6 @@ impl PrioritizationFee {
 
         self.metrics
             .accumulate_total_update_elapsed_us(update_time.as_us());
-        Ok(())
     }
 
     /// Accounts that have minimum fees lesser or equal to the minimum fee in the block are redundant, they are
@@ -283,9 +278,7 @@ mod tests {
         // -----------------------------------------------------------------------
         // [5,   a, b             ]  -->  [5,     5,         5,         nil      ]
         {
-            assert!(prioritization_fee
-                .update(5, vec![write_account_a, write_account_b])
-                .is_ok());
+            prioritization_fee.update(5, vec![write_account_a, write_account_b]);
             assert_eq!(5, prioritization_fee.get_min_transaction_fee().unwrap());
             assert_eq!(
                 5,
@@ -309,9 +302,7 @@ mod tests {
         // -----------------------------------------------------------------------
         // [9,      b, c          ]  -->  [5,     5,         5,         9        ]
         {
-            assert!(prioritization_fee
-                .update(9, vec![write_account_b, write_account_c])
-                .is_ok());
+            prioritization_fee.update(9, vec![write_account_b, write_account_c]);
             assert_eq!(5, prioritization_fee.get_min_transaction_fee().unwrap());
             assert_eq!(
                 5,
@@ -338,9 +329,7 @@ mod tests {
         // -----------------------------------------------------------------------
         // [2,   a,    c          ]  -->  [2,     2,         5,         2        ]
         {
-            assert!(prioritization_fee
-                .update(2, vec![write_account_a, write_account_c])
-                .is_ok());
+            prioritization_fee.update(2, vec![write_account_a, write_account_c]);
             assert_eq!(2, prioritization_fee.get_min_transaction_fee().unwrap());
             assert_eq!(
                 2,


### PR DESCRIPTION
Moved from https://github.com/solana-labs/solana/pull/35228

#### Problem

`lru::LruCache` requires `write` lock for any action.

#### Summary of Changes

Use `BTreeMap` instead of `LruCache`, write lock would be required only on finalizing slot + `BTreeMap` allows easily to remove the oldest slot.