### PR TITLE
Geyser notification to be sent on account deletion

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -104,6 +104,12 @@ pub enum AccountAddressFilter {
     Include, // only include addresses matching the filter
 }
 
+struct CollectedAccountsData<'a> {
+    pub accounts_to_store: Vec<(&'a Pubkey, &'a AccountSharedData)>,
+    pub transactions: Vec<Option<&'a SanitizedTransaction>>,
+    pub preexecution_account_datas: Option<Vec<Option<&'a AccountSharedData>>>,
+}
+
 impl Accounts {
     pub fn new(accounts_db: Arc<AccountsDb>) -> Self {
         Self {
@@ -644,18 +650,32 @@ impl Accounts {
         loaded: &mut [TransactionLoadResult],
         durable_nonce: &DurableNonce,
         lamports_per_signature: u64,
+        preexection_account_data: Option<HashMap<Pubkey, AccountSharedData>>,
     ) {
-        let (accounts_to_store, transactions) =
-            self.collect_accounts_to_store(txs, res, loaded, durable_nonce, lamports_per_signature);
-        self.accounts_db
-            .store_cached_inline_update_index((slot, &accounts_to_store[..]), Some(&transactions));
+        let CollectedAccountsData {
+            accounts_to_store,
+            transactions,
+            preexecution_account_datas,
+        } = self.collect_accounts_to_store(
+            txs,
+            res,
+            loaded,
+            durable_nonce,
+            lamports_per_signature,
+            preexection_account_data.as_ref(),
+        );
+        self.accounts_db.store_cached_inline_update_index(
+            (slot, &accounts_to_store[..]),
+            Some(&transactions),
+            preexecution_account_datas,
+        );
     }
 
     pub fn store_accounts_cached<'a, T: ReadableAccount + Sync + ZeroLamport + 'a>(
         &self,
         accounts: impl StorableAccounts<'a, T>,
     ) {
-        self.accounts_db.store_cached(accounts, None)
+        self.accounts_db.store_cached(accounts, None, None)
     }
 
     /// Add a slot to root.  Root slots cannot be purged
@@ -671,12 +691,23 @@ impl Accounts {
         load_results: &'a mut [TransactionLoadResult],
         durable_nonce: &DurableNonce,
         lamports_per_signature: u64,
-    ) -> (
-        Vec<(&'a Pubkey, &'a AccountSharedData)>,
-        Vec<Option<&'a SanitizedTransaction>>,
-    ) {
+        preexecution_account_map: Option<&'a HashMap<Pubkey, AccountSharedData>>,
+    ) -> CollectedAccountsData<'a> {
         let mut accounts = Vec::with_capacity(load_results.len());
         let mut transactions = Vec::with_capacity(load_results.len());
+        // to track the accounts as they change when transactions are executed
+        let collect_preexecution_account_data = preexecution_account_map.is_some();
+
+        let mut preexecution_account_datas = if collect_preexecution_account_data {
+            Vec::with_capacity(load_results.len())
+        } else {
+            // preexeution account data not required
+            vec![]
+        };
+        let mut preexecution_account_map: HashMap<Pubkey, &AccountSharedData> =
+            preexecution_account_map
+                .map(|map| map.iter().map(|(key, acc)| (*key, acc)).collect())
+                .unwrap_or_default();
         for (i, ((tx_load_result, nonce), tx)) in load_results.iter_mut().zip(txs).enumerate() {
             if tx_load_result.is_err() {
                 // Don't store any accounts if tx failed to load
@@ -727,11 +758,27 @@ impl Accounts {
                         // Add to the accounts to store
                         accounts.push((&*address, &*account));
                         transactions.push(Some(tx));
+                        // get and update old account state
+                        if collect_preexecution_account_data {
+                            let prev_acc = preexecution_account_map.insert(*address, &*account);
+                            preexecution_account_datas.push(prev_acc);
+                        }
                     }
                 }
             }
         }
-        (accounts, transactions)
+        let preexecution_account_datas =
+            collect_preexecution_account_data.then_some(preexecution_account_datas);
+        CollectedAccountsData {
+            accounts_to_store: accounts,
+            transactions,
+            preexecution_account_datas,
+        }
+    }
+
+    pub fn enable_preexecution_account_states_notification(&self) -> bool {
+        self.accounts_db
+            .enable_preexecution_account_states_notification()
     }
 }
 
@@ -1488,11 +1535,13 @@ mod tests {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let pubkey = solana_sdk::pubkey::new_rand();
+        let preexec_account = AccountSharedData::new(0, 0, &Pubkey::default());
         let account0 = AccountSharedData::new(1, 0, &Pubkey::default());
         let account1 = AccountSharedData::new(2, 0, &Pubkey::default());
         let account2 = AccountSharedData::new(3, 0, &Pubkey::default());
 
         let instructions = vec![CompiledInstruction::new(2, &(), vec![0, 1])];
+        let mut pre_execution_account_map = HashMap::<Pubkey, AccountSharedData>::new();
         let message = Message::new_with_compiled_instructions(
             1,
             0,
@@ -1501,6 +1550,9 @@ mod tests {
             Hash::default(),
             instructions,
         );
+
+        pre_execution_account_map.insert(message.account_keys[0], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[1], preexec_account.clone());
         let transaction_accounts0 = vec![
             (message.account_keys[0], account0),
             (message.account_keys[1], account2.clone()),
@@ -1516,6 +1568,9 @@ mod tests {
             Hash::default(),
             instructions,
         );
+
+        pre_execution_account_map.insert(message.account_keys[0], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[1], preexec_account.clone());
         let transaction_accounts1 = vec![
             (message.account_keys[0], account1),
             (message.account_keys[1], account2),
@@ -1555,24 +1610,34 @@ mod tests {
         }
         let txs = vec![tx0.clone(), tx1.clone()];
         let execution_results = vec![new_execution_result(Ok(()), None); 2];
-        let (collected_accounts, transactions) = accounts.collect_accounts_to_store(
+        let CollectedAccountsData {
+            accounts_to_store,
+            transactions,
+            preexecution_account_datas,
+        } = accounts.collect_accounts_to_store(
             &txs,
             &execution_results,
             loaded.as_mut_slice(),
             &DurableNonce::default(),
             0,
+            Some(&pre_execution_account_map),
         );
-        assert_eq!(collected_accounts.len(), 2);
-        assert!(collected_accounts
+        assert_eq!(accounts_to_store.len(), 2);
+        assert!(accounts_to_store
             .iter()
             .any(|(pubkey, _account)| *pubkey == &keypair0.pubkey()));
-        assert!(collected_accounts
+        assert!(accounts_to_store
             .iter()
             .any(|(pubkey, _account)| *pubkey == &keypair1.pubkey()));
 
         assert_eq!(transactions.len(), 2);
         assert!(transactions.iter().any(|txn| txn.unwrap().eq(&tx0)));
         assert!(transactions.iter().any(|txn| txn.unwrap().eq(&tx1)));
+        assert!(preexecution_account_datas.is_some());
+        let preexecution_account_datas = preexecution_account_datas.unwrap();
+        assert_eq!(preexecution_account_datas.len(), 2);
+        assert_eq!(preexecution_account_datas[0], Some(&preexec_account));
+        assert_eq!(preexecution_account_datas[1], Some(&preexec_account));
 
         // Ensure readonly_lock reflects lock
         assert_eq!(
@@ -1874,6 +1939,7 @@ mod tests {
         )));
         let nonce_account_post =
             AccountSharedData::new_data(43, &nonce_state, &system_program::id()).unwrap();
+        let preexec_account = AccountSharedData::new(1000, 0, &Pubkey::default());
         let from_account_post = AccountSharedData::new(4199, 0, &Pubkey::default());
         let to_account = AccountSharedData::new(2, 0, &Pubkey::default());
         let nonce_authority_account = AccountSharedData::new(3, 0, &Pubkey::default());
@@ -1892,6 +1958,14 @@ mod tests {
             (message.account_keys[3], to_account),
             (message.account_keys[4], recent_blockhashes_sysvar_account),
         ];
+
+        let mut pre_execution_account_map = HashMap::<Pubkey, AccountSharedData>::new();
+        pre_execution_account_map.insert(message.account_keys[0], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[1], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[2], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[3], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[4], preexec_account.clone());
+
         let tx = new_sanitized_tx(&[&nonce_authority, &from], message, blockhash);
 
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
@@ -1933,16 +2007,21 @@ mod tests {
             )),
             nonce.as_ref(),
         )];
-        let (collected_accounts, _) = accounts.collect_accounts_to_store(
+        let CollectedAccountsData {
+            accounts_to_store,
+            preexecution_account_datas,
+            ..
+        } = accounts.collect_accounts_to_store(
             &txs,
             &execution_results,
             loaded.as_mut_slice(),
             &durable_nonce,
             0,
+            Some(&pre_execution_account_map),
         );
-        assert_eq!(collected_accounts.len(), 2);
+        assert_eq!(accounts_to_store.len(), 2);
         assert_eq!(
-            collected_accounts
+            accounts_to_store
                 .iter()
                 .find(|(pubkey, _account)| *pubkey == &from_address)
                 .map(|(_pubkey, account)| *account)
@@ -1950,7 +2029,7 @@ mod tests {
                 .unwrap(),
             from_account_pre,
         );
-        let collected_nonce_account = collected_accounts
+        let collected_nonce_account = accounts_to_store
             .iter()
             .find(|(pubkey, _account)| *pubkey == &nonce_address)
             .map(|(_pubkey, account)| *account)
@@ -1960,6 +2039,11 @@ mod tests {
             collected_nonce_account.lamports(),
             nonce_account_pre.lamports(),
         );
+        assert!(preexecution_account_datas.is_some());
+        let preexecution_account_datas = preexecution_account_datas.unwrap();
+        assert_eq!(preexecution_account_datas.len(), 2);
+        assert_eq!(preexecution_account_datas[0], Some(&preexec_account));
+        assert_eq!(preexecution_account_datas[1], Some(&preexec_account));
         assert_matches!(
             nonce_account::verify_nonce_account(&collected_nonce_account, durable_nonce.as_hash()),
             Some(_)
@@ -1985,6 +2069,7 @@ mod tests {
         let to_account = AccountSharedData::new(2, 0, &Pubkey::default());
         let nonce_authority_account = AccountSharedData::new(3, 0, &Pubkey::default());
         let recent_blockhashes_sysvar_account = AccountSharedData::new(4, 0, &Pubkey::default());
+        let preexec_account = AccountSharedData::new(100, 0, &Pubkey::default());
 
         let instructions = vec![
             system_instruction::advance_nonce_account(&nonce_address, &nonce_authority.pubkey()),
@@ -1999,6 +2084,13 @@ mod tests {
             (message.account_keys[3], to_account),
             (message.account_keys[4], recent_blockhashes_sysvar_account),
         ];
+        let mut pre_execution_account_map = HashMap::<Pubkey, AccountSharedData>::new();
+        pre_execution_account_map.insert(message.account_keys[0], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[1], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[2], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[3], preexec_account.clone());
+        pre_execution_account_map.insert(message.account_keys[4], preexec_account.clone());
+
         let tx = new_sanitized_tx(&[&nonce_authority, &from], message, blockhash);
 
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
@@ -2039,15 +2131,20 @@ mod tests {
             )),
             nonce.as_ref(),
         )];
-        let (collected_accounts, _) = accounts.collect_accounts_to_store(
+        let CollectedAccountsData {
+            accounts_to_store,
+            preexecution_account_datas,
+            ..
+        } = accounts.collect_accounts_to_store(
             &txs,
             &execution_results,
             loaded.as_mut_slice(),
             &durable_nonce,
             0,
+            Some(&pre_execution_account_map),
         );
-        assert_eq!(collected_accounts.len(), 1);
-        let collected_nonce_account = collected_accounts
+        assert_eq!(accounts_to_store.len(), 1);
+        let collected_nonce_account = accounts_to_store
             .iter()
             .find(|(pubkey, _account)| *pubkey == &nonce_address)
             .map(|(_pubkey, account)| *account)
@@ -2057,6 +2154,10 @@ mod tests {
             collected_nonce_account.lamports(),
             nonce_account_pre.lamports()
         );
+        assert!(preexecution_account_datas.is_some());
+        let preexecution_account_datas = preexecution_account_datas.unwrap();
+        assert_eq!(preexecution_account_datas.len(), 1);
+        assert_eq!(preexecution_account_datas[0], Some(&preexec_account));
         assert_matches!(
             nonce_account::verify_nonce_account(&collected_nonce_account, durable_nonce.as_hash()),
             Some(_)

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6623,6 +6623,7 @@ impl AccountsDb {
         accounts_and_meta_to_store: &impl StorableAccounts<'b, T>,
         txn_iter: Box<dyn std::iter::Iterator<Item = &Option<&SanitizedTransaction>> + 'a>,
         mut write_version_producer: P,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) -> Vec<AccountInfo>
     where
         P: Iterator<Item = u64>,
@@ -6634,19 +6635,24 @@ impl AccountsDb {
                     .account_default_if_zero_lamport(i)
                     .map(|account| account.to_account_shared_data())
                     .unwrap_or_default();
+                let pubkey = accounts_and_meta_to_store.pubkey(i);
+                let preexecution_account_data = preexecution_account_datas
+                    .as_ref()
+                    .map(|accounts| accounts[i])
+                    .unwrap_or_default();
+
                 let account_info = AccountInfo::new(StorageLocation::Cached, account.lamports());
 
                 self.notify_account_at_accounts_update(
                     slot,
                     &account,
                     txn,
-                    accounts_and_meta_to_store.pubkey(i),
+                    pubkey,
                     &mut write_version_producer,
+                    preexecution_account_data,
                 );
 
-                let cached_account =
-                    self.accounts_cache
-                        .store(slot, accounts_and_meta_to_store.pubkey(i), account);
+                let cached_account = self.accounts_cache.store(slot, pubkey, account);
                 // hash this account in the bg
                 match &self.sender_bg_hasher {
                     Some(ref sender) => {
@@ -6672,6 +6678,7 @@ impl AccountsDb {
         mut write_version_producer: P,
         store_to: &StoreTo,
         transactions: Option<&[Option<&'a SanitizedTransaction>]>,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) -> Vec<AccountInfo> {
         let mut calc_stored_meta_time = Measure::start("calc_stored_meta");
         let slot = accounts.target_slot();
@@ -6695,7 +6702,13 @@ impl AccountsDb {
                         None => Box::new(std::iter::repeat(&None).take(accounts.len())),
                     };
 
-                self.write_accounts_to_cache(slot, accounts, txn_iter, write_version_producer)
+                self.write_accounts_to_cache(
+                    slot,
+                    accounts,
+                    txn_iter,
+                    write_version_producer,
+                    preexecution_account_datas,
+                )
             }
             StoreTo::Storage(storage) => {
                 if accounts.has_hash_and_write_version() {
@@ -8378,6 +8391,7 @@ impl AccountsDb {
         &self,
         accounts: impl StorableAccounts<'a, T>,
         transactions: Option<&'a [Option<&'a SanitizedTransaction>]>,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) {
         self.store(
             accounts,
@@ -8385,6 +8399,7 @@ impl AccountsDb {
             transactions,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            preexecution_account_datas,
         );
     }
 
@@ -8395,6 +8410,7 @@ impl AccountsDb {
         &self,
         accounts: impl StorableAccounts<'a, T>,
         transactions: Option<&'a [Option<&'a SanitizedTransaction>]>,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) {
         self.store(
             accounts,
@@ -8402,6 +8418,7 @@ impl AccountsDb {
             transactions,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::Inline,
+            preexecution_account_datas,
         );
     }
 
@@ -8415,6 +8432,7 @@ impl AccountsDb {
             None,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            None,
         );
     }
 
@@ -8425,6 +8443,7 @@ impl AccountsDb {
         transactions: Option<&'a [Option<&'a SanitizedTransaction>]>,
         reclaim: StoreReclaims,
         update_index_thread_selection: UpdateIndexThreadSelection,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) {
         // If all transactions in a batch are errored,
         // it's possible to get a store with no accounts.
@@ -8462,6 +8481,7 @@ impl AccountsDb {
             transactions,
             reclaim,
             update_index_thread_selection,
+            preexecution_account_datas,
         );
         self.report_store_timings();
     }
@@ -8616,6 +8636,7 @@ impl AccountsDb {
         transactions: Option<&'a [Option<&'a SanitizedTransaction>]>,
         reclaim: StoreReclaims,
         update_index_thread_selection: UpdateIndexThreadSelection,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) {
         // This path comes from a store to a non-frozen slot.
         // If a store is dead here, then a newer update for
@@ -8634,6 +8655,7 @@ impl AccountsDb {
             transactions,
             reclaim,
             update_index_thread_selection,
+            preexecution_account_datas,
         );
     }
 
@@ -8658,9 +8680,11 @@ impl AccountsDb {
             None,
             reclaim,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            None,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn store_accounts_custom<'a, T: ReadableAccount + Sync + ZeroLamport + 'a>(
         &self,
         accounts: impl StorableAccounts<'a, T>,
@@ -8671,6 +8695,7 @@ impl AccountsDb {
         transactions: Option<&[Option<&SanitizedTransaction>]>,
         reclaim: StoreReclaims,
         update_index_thread_selection: UpdateIndexThreadSelection,
+        preexecution_account_datas: Option<Vec<Option<&AccountSharedData>>>,
     ) -> StoreAccountsTiming {
         let write_version_producer: Box<dyn Iterator<Item = u64>> = write_version_producer
             .unwrap_or_else(|| {
@@ -8692,6 +8717,7 @@ impl AccountsDb {
             write_version_producer,
             store_to,
             transactions,
+            preexecution_account_datas,
         );
         store_accounts_time.stop();
         self.stats
@@ -9447,6 +9473,13 @@ impl AccountsDb {
             );
         }
     }
+
+    pub fn enable_preexecution_account_states_notification(&self) -> bool {
+        self.accounts_update_notifier
+            .as_ref()
+            .map(|notifier| notifier.enable_preexecution_account_states_notification())
+            .unwrap_or_default()
+    }
 }
 
 /// Specify the source of the accounts data when calculating the accounts hash
@@ -9546,6 +9579,7 @@ impl AccountsDb {
             None,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            None,
         );
     }
 
@@ -11392,7 +11426,7 @@ pub mod tests {
         let ancestors = vec![(unrooted_slot, 1)].into_iter().collect();
         assert!(!db.accounts_index.contains(&key));
         if is_cached {
-            db.store_cached((unrooted_slot, &[(&key, &account0)][..]), None);
+            db.store_cached((unrooted_slot, &[(&key, &account0)][..]), None, None);
         } else {
             db.store_for_tests(unrooted_slot, &[(&key, &account0)]);
         }
@@ -12524,6 +12558,7 @@ pub mod tests {
             None,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            None,
         );
         db.add_root(some_slot);
         let check_hash = true;
@@ -12757,6 +12792,7 @@ pub mod tests {
             None,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            None,
         );
         db.add_root(some_slot);
 
@@ -13510,13 +13546,13 @@ pub mod tests {
 
         let account = AccountSharedData::new(1, 16 * 4096, &Pubkey::default());
         let pubkey1 = solana_sdk::pubkey::new_rand();
-        accounts.store_cached((0, &[(&pubkey1, &account)][..]), None);
+        accounts.store_cached((0, &[(&pubkey1, &account)][..]), None, None);
 
         let pubkey2 = solana_sdk::pubkey::new_rand();
-        accounts.store_cached((0, &[(&pubkey2, &account)][..]), None);
+        accounts.store_cached((0, &[(&pubkey2, &account)][..]), None, None);
 
         let zero_account = AccountSharedData::new(0, 1, &Pubkey::default());
-        accounts.store_cached((1, &[(&pubkey1, &zero_account)][..]), None);
+        accounts.store_cached((1, &[(&pubkey1, &zero_account)][..]), None, None);
 
         // Add root 0 and flush separately
         accounts.calculate_accounts_delta_hash(0);
@@ -13560,7 +13596,7 @@ pub mod tests {
         for i in 0..num_accounts {
             let account = AccountSharedData::new((i + 1) as u64, size, &Pubkey::default());
             let pubkey = solana_sdk::pubkey::new_rand();
-            accounts.store_cached((0 as Slot, &[(&pubkey, &account)][..]), None);
+            accounts.store_cached((0 as Slot, &[(&pubkey, &account)][..]), None, None);
             keys.push(pubkey);
         }
         // get delta hash to feed these accounts to clean
@@ -13574,7 +13610,7 @@ pub mod tests {
         for (i, key) in keys[1..].iter().enumerate() {
             let account =
                 AccountSharedData::new((1 + i + num_accounts) as u64, size, &Pubkey::default());
-            accounts.store_cached((1 as Slot, &[(key, &account)][..]), None);
+            accounts.store_cached((1 as Slot, &[(key, &account)][..]), None, None);
         }
         accounts.calculate_accounts_delta_hash(1);
         accounts.add_root(1);
@@ -13700,7 +13736,7 @@ pub mod tests {
         let key = Pubkey::default();
         let account0 = AccountSharedData::new(1, 0, &key);
         let slot = 0;
-        db.store_cached((slot, &[(&key, &account0)][..]), None);
+        db.store_cached((slot, &[(&key, &account0)][..]), None, None);
 
         // Load with no ancestors and no root will return nothing
         assert!(db
@@ -13732,7 +13768,7 @@ pub mod tests {
         let key = Pubkey::default();
         let account0 = AccountSharedData::new(1, 0, &key);
         let slot = 0;
-        db.store_cached((slot, &[(&key, &account0)][..]), None);
+        db.store_cached((slot, &[(&key, &account0)][..]), None, None);
         db.mark_slot_frozen(slot);
 
         // No root was added yet, requires an ancestor to find
@@ -13764,9 +13800,13 @@ pub mod tests {
         let unrooted_key = solana_sdk::pubkey::new_rand();
         let key5 = solana_sdk::pubkey::new_rand();
         let key6 = solana_sdk::pubkey::new_rand();
-        db.store_cached((unrooted_slot, &[(&unrooted_key, &account0)][..]), None);
-        db.store_cached((root5, &[(&key5, &account0)][..]), None);
-        db.store_cached((root6, &[(&key6, &account0)][..]), None);
+        db.store_cached(
+            (unrooted_slot, &[(&unrooted_key, &account0)][..]),
+            None,
+            None,
+        );
+        db.store_cached((root5, &[(&key5, &account0)][..]), None, None);
+        db.store_cached((root6, &[(&key6, &account0)][..]), None, None);
         for slot in &[unrooted_slot, root5, root6] {
             db.mark_slot_frozen(*slot);
         }
@@ -13825,7 +13865,7 @@ pub mod tests {
         let num_slots = 2 * max_cache_slots();
         for i in 0..num_roots + num_unrooted {
             let key = Pubkey::new_unique();
-            db.store_cached((i as Slot, &[(&key, &account0)][..]), None);
+            db.store_cached((i as Slot, &[(&key, &account0)][..]), None, None);
             keys.push(key);
             db.mark_slot_frozen(i as Slot);
             if i < num_roots {
@@ -13878,8 +13918,12 @@ pub mod tests {
         let zero_lamport_account =
             AccountSharedData::new(0, 0, AccountSharedData::default().owner());
         let slot1_account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
-        db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]), None);
-        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None);
+        db.store_cached(
+            (0, &[(&account_key, &zero_lamport_account)][..]),
+            None,
+            None,
+        );
+        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None, None);
 
         db.add_root(0);
         db.add_root(1);
@@ -13901,7 +13945,11 @@ pub mod tests {
             .unwrap();
         assert_eq!(account.lamports(), 1);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
-        db.store_cached((2, &[(&account_key, &zero_lamport_account)][..]), None);
+        db.store_cached(
+            (2, &[(&account_key, &zero_lamport_account)][..]),
+            None,
+            None,
+        );
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
         let account = db
             .load_with_fixed_root(&Ancestors::default(), &account_key)
@@ -13929,10 +13977,10 @@ pub mod tests {
         let account4_key = Pubkey::new_unique();
         let account4 = AccountSharedData::new(0, 1, &owners[1]);
 
-        db.store_cached((0, &[(&account1_key, &account1)][..]), None);
-        db.store_cached((1, &[(&account2_key, &account2)][..]), None);
-        db.store_cached((2, &[(&account3_key, &account3)][..]), None);
-        db.store_cached((3, &[(&account4_key, &account4)][..]), None);
+        db.store_cached((0, &[(&account1_key, &account1)][..]), None, None);
+        db.store_cached((1, &[(&account2_key, &account2)][..]), None, None);
+        db.store_cached((2, &[(&account3_key, &account3)][..]), None, None);
+        db.store_cached((3, &[(&account4_key, &account4)][..]), None, None);
 
         db.add_root(0);
         db.add_root(1);
@@ -14010,8 +14058,12 @@ pub mod tests {
         let zero_lamport_account =
             AccountSharedData::new(0, 0, AccountSharedData::default().owner());
         let slot1_account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
-        db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]), None);
-        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None);
+        db.store_cached(
+            (0, &[(&account_key, &zero_lamport_account)][..]),
+            None,
+            None,
+        );
+        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None, None);
 
         db.add_root(0);
         db.add_root(1);
@@ -14063,10 +14115,11 @@ pub mod tests {
         db.store_cached(
             (0, &[(&zero_lamport_account_key, &slot0_account)][..]),
             None,
+            None,
         );
         // Second key keeps other lamport account entry for slot 0 alive,
         // preventing clean of the zero_lamport_account in slot 1.
-        db.store_cached((0, &[(&other_account_key, &slot0_account)][..]), None);
+        db.store_cached((0, &[(&other_account_key, &slot0_account)][..]), None, None);
         db.add_root(0);
         db.flush_accounts_cache(true, None);
         assert!(db.storage.get_slot_storage_entry(0).is_some());
@@ -14074,6 +14127,7 @@ pub mod tests {
         // Store into slot 1, a dummy slot that will be dead and purged before flush
         db.store_cached(
             (1, &[(&zero_lamport_account_key, &zero_lamport_account)][..]),
+            None,
             None,
         );
 
@@ -14085,6 +14139,7 @@ pub mod tests {
         // `zero_lamport_account_key` from slot 2
         db.store_cached(
             (2, &[(&zero_lamport_account_key, &zero_lamport_account)][..]),
+            None,
             None,
         );
         db.add_root(1);
@@ -14202,11 +14257,15 @@ pub mod tests {
                                 /        \
                               1            2 (root)
         */
-        db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]), None);
-        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None);
+        db.store_cached(
+            (0, &[(&account_key, &zero_lamport_account)][..]),
+            None,
+            None,
+        );
+        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None, None);
         // Fodder for the scan so that the lock on `account_key` is not held
-        db.store_cached((1, &[(&account_key2, &slot1_account)][..]), None);
-        db.store_cached((2, &[(&account_key, &slot2_account)][..]), None);
+        db.store_cached((1, &[(&account_key2, &slot1_account)][..]), None, None);
+        db.store_cached((2, &[(&account_key, &slot2_account)][..]), None, None);
         db.calculate_accounts_delta_hash(0);
 
         let max_scan_root = 0;
@@ -14303,7 +14362,7 @@ pub mod tests {
 
         for data_size in 0..num_keys {
             let account = AccountSharedData::new(1, data_size, &Pubkey::default());
-            accounts_db.store_cached((slot, &[(&Pubkey::new_unique(), &account)][..]), None);
+            accounts_db.store_cached((slot, &[(&Pubkey::new_unique(), &account)][..]), None, None);
         }
 
         accounts_db.add_root(slot);
@@ -14358,6 +14417,7 @@ pub mod tests {
                     )][..],
                 ),
                 None,
+                None,
             );
         }
 
@@ -14371,6 +14431,7 @@ pub mod tests {
                         *slot,
                         &[(key, &AccountSharedData::new(1, space, &Pubkey::default()))][..],
                     ),
+                    None,
                     None,
                 );
             }
@@ -14418,6 +14479,7 @@ pub mod tests {
                     alive_slot,
                     &[(key, &AccountSharedData::new(1, 0, &Pubkey::default()))][..],
                 ),
+                None,
                 None,
             );
             accounts_db.add_root(alive_slot);
@@ -14758,7 +14820,7 @@ pub mod tests {
         }
 
         // Make account_key1 in slot 0 outdated by updating in rooted slot 1
-        db.store_cached((1, &[(&account_key1, &account1)][..]), None);
+        db.store_cached((1, &[(&account_key1, &account1)][..]), None, None);
         db.add_root(1);
         // Flushes all roots
         db.flush_accounts_cache(true, None);
@@ -14776,7 +14838,7 @@ pub mod tests {
         db.shrink_candidate_slots(&epoch_schedule);
 
         // Make slot 0 dead by updating the remaining key
-        db.store_cached((2, &[(&account_key2, &account1)][..]), None);
+        db.store_cached((2, &[(&account_key2, &account1)][..]), None, None);
         db.add_root(2);
 
         // Flushes all roots
@@ -15008,6 +15070,7 @@ pub mod tests {
                 )][..],
             ),
             None,
+            None,
         );
         db.add_root(0);
         db.flush_accounts_cache(true, None);
@@ -15026,7 +15089,7 @@ pub mod tests {
                             return;
                         }
                         account.set_lamports(slot + 1);
-                        db.store_cached((slot, &[(pubkey.as_ref(), &account)][..]), None);
+                        db.store_cached((slot, &[(pubkey.as_ref(), &account)][..]), None, None);
                         db.add_root(slot);
                         sleep(Duration::from_millis(RACY_SLEEP_MS));
                         db.flush_accounts_cache(true, None);
@@ -15172,7 +15235,7 @@ pub mod tests {
         let num_trials = 10;
         for _ in 0..num_trials {
             let pubkey = Pubkey::new_unique();
-            db.store_cached((slot, &[(&pubkey, &account)][..]), None);
+            db.store_cached((slot, &[(&pubkey, &account)][..]), None, None);
             // Wait for both threads to finish
             flush_trial_start_sender.send(()).unwrap();
             remove_trial_start_sender.send(()).unwrap();
@@ -15256,7 +15319,7 @@ pub mod tests {
             let slot_to_pubkey_map: HashMap<Slot, Pubkey> = (0..num_cached_slots)
                 .map(|slot| {
                     let pubkey = Pubkey::new_unique();
-                    db.store_cached((slot, &[(&pubkey, &account)][..]), None);
+                    db.store_cached((slot, &[(&pubkey, &account)][..]), None, None);
                     (slot, pubkey)
                 })
                 .collect();
@@ -15710,19 +15773,19 @@ pub mod tests {
 
         let slot1: Slot = 1;
         let account = AccountSharedData::new(111, space, &owner);
-        accounts_db.store_cached((slot1, &[(&pubkey, &account)][..]), None);
+        accounts_db.store_cached((slot1, &[(&pubkey, &account)][..]), None, None);
         accounts_db.calculate_accounts_delta_hash(slot1);
         accounts_db.add_root_and_flush_write_cache(slot1);
 
         let slot2: Slot = 2;
         let account = AccountSharedData::new(222, space, &owner);
-        accounts_db.store_cached((slot2, &[(&pubkey, &account)][..]), None);
+        accounts_db.store_cached((slot2, &[(&pubkey, &account)][..]), None, None);
         accounts_db.calculate_accounts_delta_hash(slot2);
         accounts_db.add_root_and_flush_write_cache(slot2);
 
         let slot3: Slot = 3;
         let account = AccountSharedData::new(0, space, &owner);
-        accounts_db.store_cached((slot3, &[(&pubkey, &account)][..]), None);
+        accounts_db.store_cached((slot3, &[(&pubkey, &account)][..]), None, None);
         accounts_db.calculate_accounts_delta_hash(slot3);
         accounts_db.add_root_and_flush_write_cache(slot3);
 
@@ -18010,7 +18073,7 @@ pub mod tests {
                 (&accounts[2].0, &accounts[2].1),
                 (&accounts[3].0, &accounts[3].1),
             ];
-            accounts_db.store_cached((slot, accounts.as_slice()), None);
+            accounts_db.store_cached((slot, accounts.as_slice()), None, None);
             accounts_db.add_root_and_flush_write_cache(slot);
         }
 
@@ -18027,7 +18090,7 @@ pub mod tests {
                 (&accounts[1].0, &accounts[1].1),
                 (&accounts[4].0, &accounts[4].1),
             ];
-            accounts_db.store_cached((slot, accounts.as_slice()), None);
+            accounts_db.store_cached((slot, accounts.as_slice()), None, None);
             accounts_db.add_root_and_flush_write_cache(slot);
         }
 
@@ -18073,7 +18136,7 @@ pub mod tests {
                 (&accounts[5].0, &accounts[5].1),
                 (&accounts[6].0, &accounts[6].1),
             ];
-            accounts_db.store_cached((slot, accounts.as_slice()), None);
+            accounts_db.store_cached((slot, accounts.as_slice()), None, None);
             accounts_db.add_root_and_flush_write_cache(slot);
         }
 
@@ -18094,7 +18157,7 @@ pub mod tests {
                 (&accounts[5].0, &accounts[5].1),
                 (&accounts[7].0, &accounts[7].1),
             ];
-            accounts_db.store_cached((slot, accounts.as_slice()), None);
+            accounts_db.store_cached((slot, accounts.as_slice()), None, None);
             accounts_db.add_root_and_flush_write_cache(slot);
         }
 

--- a/accounts-db/src/accounts_update_notifier_interface.rs
+++ b/accounts-db/src/accounts_update_notifier_interface.rs
@@ -15,6 +15,7 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
         txn: &Option<&SanitizedTransaction>,
         pubkey: &Pubkey,
         write_version: u64,
+        preexecution_account_data: Option<&AccountSharedData>,
     );
 
     /// Notified when the AccountsDb is initialized at start when restored
@@ -23,6 +24,8 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
 
     /// Notified when all accounts have been notified when restoring from a snapshot.
     fn notify_end_of_restore_from_snapshot(&self);
+
+    fn enable_preexecution_account_states_notification(&self) -> bool;
 }
 
 pub type AccountsUpdateNotifier = Arc<dyn AccountsUpdateNotifierInterface + Sync + Send>;

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -11,7 +11,7 @@ use {
         prioritization_fee_cache::PrioritizationFeeCache,
         transaction_batch::TransactionBatch,
     },
-    solana_sdk::{hash::Hash, pubkey::Pubkey, saturating_add_assign},
+    solana_sdk::{account::AccountSharedData, hash::Hash, pubkey::Pubkey, saturating_add_assign},
     solana_svm::{
         account_loader::TransactionLoadResult,
         transaction_results::{TransactionExecutionResult, TransactionResults},
@@ -76,6 +76,7 @@ impl Committer {
         executed_transactions_count: usize,
         executed_non_vote_transactions_count: usize,
         executed_with_successful_result_count: usize,
+        preexecution_account_states: Option<HashMap<Pubkey, AccountSharedData>>,
     ) -> (u64, Vec<CommitTransactionDetails>) {
         let executed_transactions = execution_results
             .iter()
@@ -98,6 +99,7 @@ impl Committer {
                 signature_count,
             },
             &mut execute_and_commit_timings.execute_timings,
+            preexecution_account_states,
         ));
         execute_and_commit_timings.commit_us = commit_time_us;
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -612,6 +612,7 @@ impl Consumer {
             executed_with_successful_result_count,
             signature_count,
             error_counters,
+            preexecution_account_states,
             ..
         } = load_and_execute_transactions_output;
 
@@ -691,6 +692,7 @@ impl Consumer {
                 executed_transactions_count,
                 executed_non_vote_transactions_count,
                 executed_with_successful_result_count,
+                preexecution_account_states,
             )
         } else {
             (

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -132,6 +132,7 @@ pub struct ReplicaPreviousAccountInfo<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Information about an account being updated
 /// (extended with reference to transaction doing this update)
+/// (extended with the prior state of the account)
 pub struct ReplicaAccountInfoV4<'a> {
     /// The Pubkey for the account
     pub pubkey: &'a [u8],

--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -2,7 +2,8 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaAccountInfoV3, ReplicaAccountInfoVersions,
+        ReplicaAccountInfoV3, ReplicaAccountInfoV4, ReplicaAccountInfoVersions,
+        ReplicaPreviousAccountInfo,
     },
     log::*,
     solana_accounts_db::{
@@ -32,31 +33,31 @@ impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
         txn: &Option<&SanitizedTransaction>,
         pubkey: &Pubkey,
         write_version: u64,
+        previous_account_state: Option<&AccountSharedData>,
     ) {
-        if let Some(account_info) =
-            self.accountinfo_from_shared_account_data(account, txn, pubkey, write_version)
-        {
-            self.notify_plugins_of_account_update(account_info, slot, false);
-        }
+        self.notify_plugins_of_account_update(
+            account,
+            txn,
+            pubkey,
+            write_version,
+            previous_account_state,
+            slot,
+            false,
+        );
     }
 
     fn notify_account_restore_from_snapshot(&self, slot: Slot, account: &StoredAccountMeta) {
         let mut measure_all = Measure::start("geyser-plugin-notify-account-restore-all");
-        let mut measure_copy = Measure::start("geyser-plugin-copy-stored-account-info");
 
-        let account = self.accountinfo_from_stored_account_meta(account);
-        measure_copy.stop();
-
-        inc_new_counter_debug!(
-            "geyser-plugin-copy-stored-account-info-us",
-            measure_copy.as_us() as usize,
-            100000,
-            100000
+        self.notify_plugins_of_account_update(
+            account,
+            &None,
+            account.pubkey(),
+            account.write_version(),
+            None,
+            slot,
+            true,
         );
-
-        if let Some(account_info) = account {
-            self.notify_plugins_of_account_update(account_info, slot, true);
-        }
         measure_all.stop();
 
         inc_new_counter_debug!(
@@ -97,6 +98,11 @@ impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
             );
         }
     }
+
+    fn enable_preexecution_account_states_notification(&self) -> bool {
+        let manager = self.plugin_manager.read().unwrap();
+        manager.enable_preexecution_account_states_notification()
+    }
 }
 
 impl AccountsUpdateNotifierImpl {
@@ -104,14 +110,15 @@ impl AccountsUpdateNotifierImpl {
         AccountsUpdateNotifierImpl { plugin_manager }
     }
 
-    fn accountinfo_from_shared_account_data<'a>(
+    fn accountinfo_from_shared_account_data_with_previous_state<'a, T: ReadableAccount>(
         &self,
-        account: &'a AccountSharedData,
+        account: &'a T,
         txn: &'a Option<&'a SanitizedTransaction>,
         pubkey: &'a Pubkey,
         write_version: u64,
-    ) -> Option<ReplicaAccountInfoV3<'a>> {
-        Some(ReplicaAccountInfoV3 {
+        previous_account_state: Option<&'a AccountSharedData>,
+    ) -> ReplicaAccountInfoV4<'a> {
+        ReplicaAccountInfoV4 {
             pubkey: pubkey.as_ref(),
             lamports: account.lamports(),
             owner: account.owner().as_ref(),
@@ -120,28 +127,44 @@ impl AccountsUpdateNotifierImpl {
             data: account.data(),
             write_version,
             txn: *txn,
-        })
+            previous_account_state: previous_account_state.map(|account| {
+                ReplicaPreviousAccountInfo {
+                    data: account.data(),
+                    executable: account.executable(),
+                    lamports: account.lamports(),
+                    owner: account.owner().as_ref(),
+                    rent_epoch: account.rent_epoch(),
+                }
+            }),
+        }
     }
 
-    fn accountinfo_from_stored_account_meta<'a>(
+    fn accountinfo_from_shared_account_data<'a, T: ReadableAccount>(
         &self,
-        stored_account_meta: &'a StoredAccountMeta,
-    ) -> Option<ReplicaAccountInfoV3<'a>> {
-        Some(ReplicaAccountInfoV3 {
-            pubkey: stored_account_meta.pubkey().as_ref(),
-            lamports: stored_account_meta.lamports(),
-            owner: stored_account_meta.owner().as_ref(),
-            executable: stored_account_meta.executable(),
-            rent_epoch: stored_account_meta.rent_epoch(),
-            data: stored_account_meta.data(),
-            write_version: stored_account_meta.write_version(),
-            txn: None,
-        })
+        account: &'a T,
+        txn: &'a Option<&'a SanitizedTransaction>,
+        pubkey: &'a Pubkey,
+        write_version: u64,
+    ) -> ReplicaAccountInfoV3<'a> {
+        ReplicaAccountInfoV3 {
+            pubkey: pubkey.as_ref(),
+            lamports: account.lamports(),
+            owner: account.owner().as_ref(),
+            executable: account.executable(),
+            rent_epoch: account.rent_epoch(),
+            data: account.data(),
+            write_version,
+            txn: *txn,
+        }
     }
 
-    fn notify_plugins_of_account_update(
+    fn notify_plugins_of_account_update<T: ReadableAccount>(
         &self,
-        account: ReplicaAccountInfoV3,
+        account: &T,
+        txn: &Option<&SanitizedTransaction>,
+        pubkey: &Pubkey,
+        write_version: u64,
+        previous_account_state: Option<&AccountSharedData>,
         slot: Slot,
         is_startup: bool,
     ) {
@@ -153,15 +176,33 @@ impl AccountsUpdateNotifierImpl {
         }
         for plugin in plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-update-account");
-            match plugin.update_account(
-                ReplicaAccountInfoVersions::V0_0_3(&account),
-                slot,
-                is_startup,
-            ) {
+            let res = if plugin.enable_pre_trasaction_execution_accounts_data() {
+                let account = self.accountinfo_from_shared_account_data_with_previous_state(
+                    account,
+                    txn,
+                    pubkey,
+                    write_version,
+                    previous_account_state,
+                );
+                plugin.update_account(
+                    ReplicaAccountInfoVersions::V0_0_4(&account),
+                    slot,
+                    is_startup,
+                )
+            } else {
+                let account =
+                    self.accountinfo_from_shared_account_data(account, txn, pubkey, write_version);
+                plugin.update_account(
+                    ReplicaAccountInfoVersions::V0_0_3(&account),
+                    slot,
+                    is_startup,
+                )
+            };
+            match res {
                 Err(err) => {
                     error!(
                         "Failed to update account {} at slot {}, error: {} to plugin {}",
-                        bs58::encode(account.pubkey).into_string(),
+                        bs58::encode(pubkey).into_string(),
                         slot,
                         err,
                         plugin.name()
@@ -170,7 +211,7 @@ impl AccountsUpdateNotifierImpl {
                 Ok(_) => {
                     trace!(
                         "Successfully updated account {} at slot {} to plugin {}",
-                        bs58::encode(account.pubkey).into_string(),
+                        bs58::encode(pubkey).into_string(),
                         slot,
                         plugin.name()
                     );

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -99,7 +99,6 @@ impl GeyserPluginManager {
         }
         false
     }
-
     /// Admin RPC request handler
     pub(crate) fn list_plugins(&self) -> JsonRpcResult<Vec<String>> {
         Ok(self.plugins.iter().map(|p| p.name().to_owned()).collect())
@@ -265,6 +264,12 @@ impl GeyserPluginManager {
         drop(current_plugin);
         drop(current_lib);
         info!("Unloaded plugin {name} at idx {idx}");
+    }
+
+    pub fn enable_preexecution_account_states_notification(&self) -> bool {
+        self.plugins
+            .iter()
+            .any(|plugin| plugin.enable_pre_trasaction_execution_accounts_data())
     }
 }
 

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -59,7 +59,7 @@ fn test_shrink_and_clean() {
             for (pubkey, account) in alive_accounts.iter_mut() {
                 account.checked_sub_lamports(1).unwrap();
 
-                accounts.store_cached((current_slot, &[(&*pubkey, &*account)][..]), None);
+                accounts.store_cached((current_slot, &[(&*pubkey, &*account)][..]), None, None);
             }
             accounts.add_root(current_slot);
             accounts.flush_accounts_cache(true, Some(current_slot));
@@ -125,7 +125,7 @@ fn test_bad_bank_hash() {
             .iter()
             .map(|idx| (&accounts_keys[*idx].0, &accounts_keys[*idx].1))
             .collect();
-        db.store_cached((some_slot, &account_refs[..]), None);
+        db.store_cached((some_slot, &account_refs[..]), None, None);
         for pass in 0..2 {
             for (key, account) in &account_refs {
                 assert_eq!(


### PR DESCRIPTION
Geyser sends account delete notifications with the a wrong owner.

In GRPC, we subscribe to account notifications with the owner. The owner can be some program id. Currently, we do not get any notification on grpc if the account has been deleted because the notification sent on geyser channel is account with the owner defaulted to 0. So GRPC cannot notify that the account was deleted because the owner has been changed.
Summary of Changes

Geyser can optionally return the account state before the transaction changed the account. This is called preexecution account state in this context.

A new geyser account message type was added, ReplicaAccountInfoV4, which will be returned instead of the previous ReplicaAccountInfoV3 in case any plugin requires pre-execution accounts data. ReplicaAccountInfoV4 will only be returned only if this feature is enable else it will return previous ReplicaAccountInfoV3.

This feature can be enabled if enable_pre_trasaction_execution_accounts_data() returns true.

The bank will save of the accounts states before the transaction batch is executed only if any of the plugins requires the data and pass them to the geyser plugin to send the notification.

This will also enable us to compare account changes other than owner etc. The geyser plugin can use Binary delta compression techniques using this feature.