### PR TITLE
Implementing sending banking stage transaction errors over geyser

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1,7 +1,6 @@
 //! The `banking_stage` processes Transaction messages. It is intended to be used
 //! to construct a software pipeline. The stage uses all available CPU cores and
 //! can do its processing in parallel with signature verification on the GPU.
-
 use {
     self::{
         committer::Committer,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -445,7 +445,13 @@ impl Consumer {
                 // Re-sanitized transaction should be equal to the original transaction,
                 // but whether it will pass sanitization needs to be checked.
                 let resanitized_tx =
-                    bank.fully_verify_transaction(tx.to_versioned_transaction())?;
+                    match bank.fully_verify_transaction(tx.to_versioned_transaction()) {
+                        Ok(resanitized_tx) => resanitized_tx,
+                        Err(e) => {
+                            bank.notify_transaction_error(tx, Some(e.clone()));
+                            return Err(e);
+                        }
+                    };
                 if resanitized_tx != *tx {
                     // Sanitization before/after epoch give different transaction data - do not execute.
                     return Err(TransactionError::ResanitizationNeeded);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -74,7 +74,7 @@ use {
         saturating_add_assign,
         signature::{Keypair, Signature, Signer},
         timing::timestamp,
-        transaction::Transaction,
+        transaction::{BankingTransactionResultNotifier, Transaction},
     },
     solana_vote::vote_sender_types::ReplayVoteSender,
     solana_vote_program::vote_state::VoteTransaction,
@@ -295,6 +295,7 @@ pub struct ReplayStageConfig {
     // duplicate voting which can lead to slashing.
     pub wait_to_vote_slot: Option<Slot>,
     pub replay_slots_concurrently: bool,
+    pub banking_transaction_result_notifier: Option<BankingTransactionResultNotifier>,
 }
 
 /// Timing information for the ReplayStage main processing loop
@@ -578,6 +579,7 @@ impl ReplayStage {
             tower_storage,
             wait_to_vote_slot,
             replay_slots_concurrently,
+            banking_transaction_result_notifier: banking_transaction_result_notifier_lock,
         } = config;
 
         trace!("replay stage");
@@ -1131,6 +1133,7 @@ impl ReplayStage {
                         &banking_tracer,
                         has_new_vote_been_rooted,
                         transaction_status_sender.is_some(),
+                        banking_transaction_result_notifier_lock.clone(),
                     );
 
                     let poh_bank = poh_recorder.read().unwrap().bank();
@@ -1994,6 +1997,7 @@ impl ReplayStage {
         banking_tracer: &Arc<BankingTracer>,
         has_new_vote_been_rooted: bool,
         track_transaction_indexes: bool,
+        banking_transaction_result_notifier_lock: Option<BankingTransactionResultNotifier>,
     ) {
         // all the individual calls to poh_recorder.read() are designed to
         // increase granularity, decrease contention
@@ -2104,7 +2108,7 @@ impl ReplayStage {
                 false
             };
 
-            let tpu_bank = Self::new_bank_from_parent_with_notify(
+            let mut tpu_bank = Self::new_bank_from_parent_with_notify(
                 parent.clone(),
                 poh_slot,
                 root_slot,
@@ -2112,6 +2116,11 @@ impl ReplayStage {
                 rpc_subscriptions,
                 NewBankOptions { vote_only_bank },
             );
+            if banking_transaction_result_notifier_lock.is_some() {
+                tpu_bank.set_banking_transaction_results_notifier(
+                    banking_transaction_result_notifier_lock,
+                );
+            }
             // make sure parent is frozen for finalized hashes via the above
             // new()-ing of its child bank
             banking_tracer.hash_event(parent.slot(), &parent.last_blockhash(), &parent.hash());

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -47,7 +47,10 @@ use {
         accounts_background_service::AbsRequestSender, bank_forks::BankForks,
         commitment::BlockCommitmentCache, prioritization_fee_cache::PrioritizationFeeCache,
     },
-    solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Keypair},
+    solana_sdk::{
+        clock::Slot, pubkey::Pubkey, signature::Keypair,
+        transaction::BankingTransactionResultNotifier,
+    },
     solana_turbine::retransmit_stage::RetransmitStage,
     solana_vote::vote_sender_types::ReplayVoteSender,
     std::{
@@ -144,6 +147,7 @@ impl Tvu {
         outstanding_repair_requests: Arc<RwLock<OutstandingShredRepairs>>,
         cluster_slots: Arc<ClusterSlots>,
         wen_restart_repair_slots: Option<Arc<RwLock<Vec<Slot>>>>,
+        banking_transaction_result_notifier: Option<BankingTransactionResultNotifier>,
     ) -> Result<Self, String> {
         let TvuSockets {
             repair: repair_socket,
@@ -266,6 +270,7 @@ impl Tvu {
             tower_storage: tower_storage.clone(),
             wait_to_vote_slot,
             replay_slots_concurrently: tvu_config.replay_slots_concurrently,
+            banking_transaction_result_notifier,
         };
 
         let (voting_sender, voting_receiver) = unbounded();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -658,6 +658,13 @@ impl Validator {
             .as_ref()
             .and_then(|geyser_plugin_service| geyser_plugin_service.get_block_metadata_notifier());
 
+        let banking_transaction_results_notifier =
+            geyser_plugin_service
+                .as_ref()
+                .and_then(|geyser_plugin_service| {
+                    geyser_plugin_service.get_banking_transaction_result_notifier()
+                });
+
         info!(
             "Geyser plugin: accounts_update_notifier: {}, \
             transaction_notifier: {}, \
@@ -1321,6 +1328,7 @@ impl Validator {
             outstanding_repair_requests.clone(),
             cluster_slots.clone(),
             wen_restart_repair_slots.clone(),
+            banking_transaction_results_notifier,
         )?;
 
         if in_wen_restart {

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -6,7 +6,7 @@ use {
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
         signature::Signature,
-        transaction::SanitizedTransaction,
+        transaction::{SanitizedTransaction, TransactionError},
     },
     solana_transaction_status::{Reward, TransactionStatusMeta},
     std::{any::Any, error, io},
@@ -418,6 +418,17 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         Ok(())
     }
 
+    /// Called when we get banking stage errors.
+    #[allow(unused_variables)]
+    fn notify_banking_stage_transaction_results(
+        &self,
+        transaction: &SanitizedTransaction,
+        error: Option<TransactionError>,
+        slot: Slot,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     /// Check if the plugin is interested in account data
     /// Default is true -- if the plugin is not interested in
     /// account data, please return false.
@@ -436,6 +447,13 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// Default is false -- if the plugin is interested in
     /// entry data, return true.
     fn entry_notifications_enabled(&self) -> bool {
+        false
+    }
+
+    /// Check if the plugin is interesed in transaction errors duing banking
+    /// stage Default is false -- if the plugin is interested in naking
+    /// stage errors
+    fn banking_transaction_results_notifications_enabled(&self) -> bool {
         false
     }
 }

--- a/geyser-plugin-manager/src/banking_transaction_result_notifier.rs
+++ b/geyser-plugin-manager/src/banking_transaction_result_notifier.rs
@@ -1,0 +1,67 @@
+use {
+    crate::geyser_plugin_manager::GeyserPluginManager,
+    log::{error, log_enabled, trace},
+    solana_measure::measure::Measure,
+    solana_metrics::{create_counter, inc_counter, inc_new_counter, inc_new_counter_debug},
+    solana_sdk::{
+        slot_history::Slot,
+        transaction::{SanitizedTransaction, TransactionError, TransactionResultNotifier},
+    },
+    std::sync::{Arc, RwLock},
+};
+
+#[derive(Debug)]
+pub(crate) struct BankingTransactionResultImpl {
+    plugin_manager: Arc<RwLock<GeyserPluginManager>>,
+}
+
+impl TransactionResultNotifier for BankingTransactionResultImpl {
+    fn notify_banking_transaction_result(
+        &self,
+        transaction: &SanitizedTransaction,
+        result: Option<TransactionError>,
+        slot: Slot,
+    ) {
+        let mut measure = Measure::start("geyser-plugin-notify_plugins_of_entry_info");
+
+        let plugin_manager = self.plugin_manager.read().unwrap();
+        if plugin_manager.plugins.is_empty() {
+            return;
+        }
+
+        for plugin in plugin_manager.plugins.iter() {
+            if !plugin.banking_transaction_results_notifications_enabled() {
+                continue;
+            }
+            match plugin.notify_banking_stage_transaction_results(transaction, result.clone(), slot)
+            {
+                Err(err) => {
+                    error!(
+                        "Failed to notify banking transaction result, error: ({}) to plugin {}",
+                        err,
+                        plugin.name()
+                    )
+                }
+                Ok(_) => {
+                    trace!(
+                        "Successfully notified banking transaction result to plugin {}",
+                        plugin.name()
+                    );
+                }
+            }
+        }
+        measure.stop();
+        inc_new_counter_debug!(
+            "geyser-plugin-notify_plugins_of_banking_transaction_info-us",
+            measure.as_us() as usize,
+            10000,
+            10000
+        );
+    }
+}
+
+impl BankingTransactionResultImpl {
+    pub fn new(plugin_manager: Arc<RwLock<GeyserPluginManager>>) -> Self {
+        Self { plugin_manager }
+    }
+}

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -100,6 +100,15 @@ impl GeyserPluginManager {
         false
     }
 
+    pub fn banking_transaction_result_notification_enabled(&self) -> bool {
+        for plugin in &self.plugins {
+            if plugin.banking_transaction_results_notifications_enabled() {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Admin RPC request handler
     pub(crate) fn list_plugins(&self) -> JsonRpcResult<Vec<String>> {
         Ok(self.plugins.iter().map(|p| p.name().to_owned()).collect())

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         accounts_update_notifier::AccountsUpdateNotifierImpl,
+        banking_transaction_result_notifier::BankingTransactionResultImpl,
         block_metadata_notifier::BlockMetadataNotifierImpl,
         block_metadata_notifier_interface::BlockMetadataNotifierArc,
         entry_notifier::EntryNotifierImpl,
@@ -17,6 +18,7 @@ use {
         optimistically_confirmed_bank_tracker::SlotNotification,
         transaction_notifier_interface::TransactionNotifierArc,
     },
+    solana_sdk::transaction::BankingTransactionResultNotifier,
     std::{
         path::{Path, PathBuf},
         sync::{
@@ -37,6 +39,7 @@ pub struct GeyserPluginService {
     transaction_notifier: Option<TransactionNotifierArc>,
     entry_notifier: Option<EntryNotifierArc>,
     block_metadata_notifier: Option<BlockMetadataNotifierArc>,
+    banking_transaction_result_notifier: Option<BankingTransactionResultNotifier>,
 }
 
 impl GeyserPluginService {
@@ -81,6 +84,8 @@ impl GeyserPluginService {
             plugin_manager.account_data_notifications_enabled();
         let transaction_notifications_enabled = plugin_manager.transaction_notifications_enabled();
         let entry_notifications_enabled = plugin_manager.entry_notifications_enabled();
+        let banking_stage_transaction_result_notification =
+            plugin_manager.banking_transaction_result_notification_enabled();
         let plugin_manager = Arc::new(RwLock::new(plugin_manager));
 
         let accounts_update_notifier: Option<AccountsUpdateNotifier> =
@@ -106,6 +111,17 @@ impl GeyserPluginService {
         } else {
             None
         };
+
+        let transaction_result_notifier: Option<BankingTransactionResultNotifier> =
+            if banking_stage_transaction_result_notification {
+                let banking_transaction_result_notifier =
+                    BankingTransactionResultImpl::new(plugin_manager.clone());
+                Some(BankingTransactionResultNotifier {
+                    lock: Arc::new(RwLock::new(banking_transaction_result_notifier)),
+                })
+            } else {
+                None
+            };
 
         let (slot_status_observer, block_metadata_notifier): (
             Option<SlotStatusObserver>,
@@ -143,6 +159,7 @@ impl GeyserPluginService {
             transaction_notifier,
             entry_notifier,
             block_metadata_notifier,
+            banking_transaction_result_notifier: transaction_result_notifier,
         })
     }
 
@@ -166,6 +183,12 @@ impl GeyserPluginService {
 
     pub fn get_entry_notifier(&self) -> Option<EntryNotifierArc> {
         self.entry_notifier.clone()
+    }
+
+    pub fn get_banking_transaction_result_notifier(
+        &self,
+    ) -> Option<BankingTransactionResultNotifier> {
+        self.banking_transaction_result_notifier.clone()
     }
 
     pub fn get_block_metadata_notifier(&self) -> Option<BlockMetadataNotifierArc> {

--- a/geyser-plugin-manager/src/lib.rs
+++ b/geyser-plugin-manager/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod accounts_update_notifier;
+pub mod banking_transaction_result_notifier;
 pub mod block_metadata_notifier;
 pub mod block_metadata_notifier_interface;
 pub mod entry_notifier;
@@ -7,5 +8,4 @@ pub mod geyser_plugin_service;
 pub mod slot_status_notifier;
 pub mod slot_status_observer;
 pub mod transaction_notifier;
-
 pub use geyser_plugin_manager::GeyserPluginManagerRequest;


### PR DESCRIPTION
Currently we do not have any way to get out transaction results for transactions that were tried to be scheduled over banking stage. As scheduler is a topic still under development we will love to have some stats on those why transactions were not scheduled, how many times they were tried etc.

Here is the issue : https://github.com/solana-labs/solana/issues/33182
Summary of Changes

Implement a geyser interface which calls signature and result of banking stage.

Fixes #
