### PR TITLE
Adds a bench for hash_account()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5390,6 +5390,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "bzip2",
+ "criterion",
  "crossbeam-channel",
  "dashmap",
  "ed25519-dalek",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -70,6 +70,7 @@ name = "solana_accounts_db"
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+criterion = { workspace = true }
 ed25519-dalek = { workspace = true }
 libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }
@@ -89,3 +90,7 @@ rustc_version = { workspace = true }
 
 [features]
 dev-context-only-utils = []
+
+[[bench]]
+name = "bench_hashing"
+harness = false

--- a/accounts-db/benches/bench_hashing.rs
+++ b/accounts-db/benches/bench_hashing.rs
@@ -1,0 +1,43 @@
+use {
+    criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput},
+    solana_accounts_db::accounts_db::AccountsDb,
+    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+};
+
+const KB: usize = 1024;
+const MB: usize = KB * KB;
+
+const DATA_SIZES: [usize; 6] = [
+    0,       // the smallest account
+    165,     // the size of an spl token account
+    200,     // the size of a stake account
+    KB,      // a medium sized account
+    MB,      // a large sized account
+    10 * MB, // the largest account
+];
+
+/// The number of bytes of *non account data* that are also hashed as
+/// part of computing an account's hash.
+///
+/// Ensure this constant stays in sync with the value of `META_SIZE` in
+/// AccountsDb::hash_account_data().
+const META_SIZE: usize = 81;
+
+fn bench_hash_account(c: &mut Criterion) {
+    let lamports = 123_456_789;
+    let owner = Pubkey::default();
+    let address = Pubkey::default();
+
+    let mut group = c.benchmark_group("hash_account");
+    for data_size in DATA_SIZES {
+        let num_bytes = META_SIZE.checked_add(data_size).unwrap();
+        group.throughput(Throughput::Bytes(num_bytes as u64));
+        let account = AccountSharedData::new(lamports, data_size, &owner);
+        group.bench_function(BenchmarkId::new("data_size", data_size), |b| {
+            b.iter(|| AccountsDb::hash_account(&account, &address));
+        });
+    }
+}
+
+criterion_group!(benches, bench_hash_account,);
+criterion_main!(benches);


### PR DESCRIPTION
#### Problem

While tweaking the implementation for `AccountsDb::hash_account_data()`, I didn't have a way to benchmark my changes to see if there were any improvements.


#### Summary of Changes

Add a bench for `hash_account()`.


<details><summary>Details</summary>
<p>

After running the benchmark, criterion displays useful information. Here's an example of the text results:

```
hash_account/data_size/0                                                                            
                        time:   [205.23 ns 205.41 ns 205.63 ns]
                        thrpt:  [375.66 MiB/s 376.07 MiB/s 376.39 MiB/s]
                 change:
                        time:   [+0.1869% +0.2886% +0.3974%] (p = 0.00 < 0.05)
                        thrpt:  [-0.3958% -0.2877% -0.1866%]
                        Change within noise threshold.
hash_account/data_size/165                                                                            
                        time:   [362.53 ns 362.56 ns 362.59 ns]
                        thrpt:  [647.02 MiB/s 647.07 MiB/s 647.12 MiB/s]
                 change:
                        time:   [-0.1588% -0.0725% -0.0067%] (p = 0.06 > 0.05)
                        thrpt:  [+0.0067% +0.0726% +0.1591%]
                        No change in performance detected.
hash_account/data_size/200                                                                            
                        time:   [434.96 ns 435.01 ns 435.07 ns]
                        thrpt:  [615.95 MiB/s 616.04 MiB/s 616.11 MiB/s]
                 change:
                        time:   [-0.0787% +0.0154% +0.0886%] (p = 0.74 > 0.05)
                        thrpt:  [-0.0885% -0.0154% +0.0787%]
                        No change in performance detected.
hash_account/data_size/1024                                                                             
                        time:   [1.4254 µs 1.4261 µs 1.4272 µs]
                        thrpt:  [738.39 MiB/s 738.94 MiB/s 739.29 MiB/s]
                 change:
                        time:   [-0.1822% -0.0684% +0.0270%] (p = 0.22 > 0.05)
                        thrpt:  [-0.0270% +0.0685% +0.1825%]
                        No change in performance detected.
hash_account/data_size/1048576                                                                            
                        time:   [270.04 µs 270.09 µs 270.13 µs]
                        thrpt:  [3.6154 GiB/s 3.6160 GiB/s 3.6166 GiB/s]
                 change:
                        time:   [-0.2249% -0.1810% -0.1467%] (p = 0.00 < 0.05)
                        thrpt:  [+0.1469% +0.1813% +0.2254%]
                        Change within noise threshold.
hash_account/data_size/10485760                                                                             
                        time:   [2.6661 ms 2.6673 ms 2.6685 ms]
                        thrpt:  [3.6596 GiB/s 3.6613 GiB/s 3.6629 GiB/s]
                 change:
                        time:   [+0.1661% +0.2227% +0.2755%] (p = 0.00 < 0.05)
                        thrpt:  [-0.2747% -0.2223% -0.1659%]
                        Change within noise threshold.
```

And here's two of the many webpages that gets produced.

![200](https://github.com/anza-xyz/agave/assets/840349/e8c1018b-8053-4dd3-87f2-8fd59e9debb3)

![history](https://github.com/anza-xyz/agave/assets/840349/ccb17e80-1b62-4b50-8e2e-167fe346cf66)
</p>
</details> 