### PR TITLE
Removes trailing whitespace in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ reader is or is working on behalf of a Specially Designated National
 (SDN) or a person subject to similar blocking or denied party
 prohibitions.
 
-The reader should be aware that U.S. export control and sanctions laws prohibit 
-U.S. persons (and other persons that are subject to such laws) from transacting 
-with persons in certain countries and territories or that are on the SDN list. 
-Accordingly, there is a risk to individuals that other persons using any of the 
-code contained in this repo, or a derivation thereof, may be sanctioned persons 
-and that transactions with such persons would be a violation of U.S. export 
+The reader should be aware that U.S. export control and sanctions laws prohibit
+U.S. persons (and other persons that are subject to such laws) from transacting
+with persons in certain countries and territories or that are on the SDN list.
+Accordingly, there is a risk to individuals that other persons using any of the
+code contained in this repo, or a derivation thereof, may be sanctioned persons
+and that transactions with such persons would be a violation of U.S. export
 controls and sanctions law.


### PR DESCRIPTION
#### Problem

`README.md` has trailing whitespace, which breaks CI.

See https://buildkite.com/anza/agave/builds/102#018e0a09-e7d5-4876-9675-adaaae5921f4 for an example.


#### Summary of Changes

Remove trailing whitespace.