### PR TITLE
enables chained Merkle shreds for ClusterType::Development

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4998,7 +4998,7 @@ pub mod tests {
             blockstore_options::{BlockstoreRocksFifoOptions, ShredStorageType},
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
             leader_schedule::{FixedSchedule, LeaderSchedule},
-            shred::{max_ticks_per_n_shreds, ShredFlags},
+            shred::{max_ticks_per_n_shreds, ShredFlags, LEGACY_SHRED_DATA_CAPACITY},
         },
         assert_matches::assert_matches,
         bincode::serialize,
@@ -10629,7 +10629,7 @@ pub mod tests {
         let larger_last_shred_index = 8;
 
         let setup_test_shreds = |slot: Slot| -> Vec<Shred> {
-            let num_entries = max_ticks_per_n_shreds(num_shreds, None);
+            let num_entries = max_ticks_per_n_shreds(num_shreds, Some(LEGACY_SHRED_DATA_CAPACITY));
             let (mut shreds, _) =
                 make_slot_entries(slot, 0, num_entries, /*merkle_variant:*/ false);
             shreds[smaller_last_shred_index].set_last_in_slot();

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -1151,7 +1151,7 @@ pub fn max_entries_per_n_shred(
 ) -> u64 {
     // Default 32:32 erasure batches yields 64 shreds; log2(64) = 6.
     let merkle_variant = Some((
-        /*proof_size:*/ 6, /*chained:*/ false, /*resigned:*/ false,
+        /*proof_size:*/ 6, /*chained:*/ true, /*resigned:*/ true,
     ));
     let data_buffer_size = ShredData::capacity(merkle_variant).unwrap();
     let shred_data_size = shred_data_size.unwrap_or(data_buffer_size) as u64;

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -177,16 +177,11 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         )
         .expect("Expected to create a new shredder");
 
-        // Chained Merkle shreds are always discarded in epoch 0, due to
-        // feature_set::enable_chained_merkle_shreds. Below can be removed once
-        // the feature gated code is removed.
-        let should_chain_merkle_shreds = bank.epoch() > 0;
-
         let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
             keypair,
             &receive_results.entries,
             last_tick_height == bank.max_tick_height() && last_entries.is_none(),
-            should_chain_merkle_shreds.then_some(self.chained_merkle_root),
+            Some(self.chained_merkle_root),
             self.next_shred_index,
             self.next_code_index,
             true, // merkle_variant
@@ -206,7 +201,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     keypair,
                     &[original_last_entry],
                     true,
-                    should_chain_merkle_shreds.then_some(self.chained_merkle_root),
+                    Some(self.chained_merkle_root),
                     self.next_shred_index,
                     self.next_code_index,
                     true, // merkle_variant
@@ -220,7 +215,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     keypair,
                     &duplicate_extra_last_entries,
                     true,
-                    should_chain_merkle_shreds.then_some(self.chained_merkle_root),
+                    Some(self.chained_merkle_root),
                     self.next_shred_index,
                     self.next_code_index,
                     true, // merkle_variant

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -527,8 +527,8 @@ impl BroadcastRun for StandardBroadcastRun {
     }
 }
 
-fn should_chain_merkle_shreds(_slot: Slot, _cluster_type: ClusterType) -> bool {
-    false
+fn should_chain_merkle_shreds(_slot: Slot, cluster_type: ClusterType) -> bool {
+    cluster_type == ClusterType::Development
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
Testing and developing with chained Merkle shreds

#### Summary of Changes
Enabled chained Merkle shreds for `ClusterType::Development`.


Original pull request: https://github.com/solana-labs/solana/pull/35227