### PR TITLE
Increases account hash's stack buffer to hold 200 bytes of data

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -42,7 +42,7 @@ regex = { workspace = true }
 seqlock = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
-smallvec = { workspace = true }
+smallvec = { workspace = true, features = ["const_generics"] }
 solana-bucket-map = { workspace = true }
 solana-config-program = { workspace = true }
 solana-frozen-abi = { workspace = true }


### PR DESCRIPTION
#### Problem

When hashing an account, we create a buffer on the stack to reduce the number of unique hash calls to make. The buffer is currently 128 bytes. The metadata fields occupy 81 bytes, which leaves 47 bytes for the account's data.

On mnb today there is approximately 431 million accounts. Of that, approximately 388 million are token accounts. That's 90% of accounts. We should ensure the stack buffer can hold the account data for a token account.

Token accounts have a size of 165 bytes[^1]. This size will be growing though. ATA and Token22 extensions will be larger too. Jon estimates 170-182 bytes is "safe"[^2].

Also, there are ~1 million stake accounts. They are 200 bytes.

We could size the stack buffer to hold 200 bytes, which will cover the vast majority of accounts. Currently, the vast majority of calls to hash an account have to perform a heap allocation.

[^1]: https://github.com/solana-labs/solana-program-library/blob/e651623033fca7997ccd21e55d0f2388473122f9/token/program/src/state.rs#L134 

[^2]: https://discord.com/channels/428295358100013066/977244255212937306/1212827836281524224

#### Summary of Changes

Increases account hash's stack buffer to hold 200 bytes of data. This improves perf for hashing both stake accounts and spl token accounts by ~5%.

<details><summary>Benchmark Results</summary>
<p>

I ran the account hashing benchmark on this pr and on master multiple times to get stable results. Here's a representative result.

First with this PR (stack buffer is 200 bytes)
```
hash_account/data_size/0                                                                            
                        time:   [202.56 ns 202.64 ns 202.72 ns]
                        thrpt:  [381.05 MiB/s 381.20 MiB/s 381.35 MiB/s]
hash_account/data_size/165                                                                            
                        time:   [344.77 ns 345.00 ns 345.26 ns]
                        thrpt:  [679.49 MiB/s 680.01 MiB/s 680.46 MiB/s]
hash_account/data_size/200                                                                            
                        time:   [411.29 ns 411.79 ns 412.32 ns]
                        thrpt:  [649.93 MiB/s 650.78 MiB/s 651.57 MiB/s]
hash_account/data_size/1024                                                                             
                        time:   [1.4292 µs 1.4295 µs 1.4302 µs]
                        thrpt:  [736.85 MiB/s 737.17 MiB/s 737.37 MiB/s]
hash_account/data_size/1048576                                                                            
                        time:   [269.75 µs 269.78 µs 269.80 µs]
                        thrpt:  [3.6198 GiB/s 3.6202 GiB/s 3.6205 GiB/s]
hash_account/data_size/10485760                                                                             
                        time:   [2.6642 ms 2.6648 ms 2.6654 ms]
                        thrpt:  [3.6638 GiB/s 3.6647 GiB/s 3.6655 GiB/s]
```

Second with master (stack buffer is 47 bytes)
```
hash_account/data_size/0                                                                            
                        time:   [205.01 ns 205.17 ns 205.37 ns]
                        thrpt:  [376.14 MiB/s 376.50 MiB/s 376.80 MiB/s]
                 change:
                        time:   [+0.9893% +1.1179% +1.2289%] (p = 0.00 < 0.05)
                        thrpt:  [-1.2140% -1.1055% -0.9796%]
                        Change within noise threshold.
hash_account/data_size/165                                                                            
                        time:   [362.42 ns 362.56 ns 362.72 ns]
                        thrpt:  [646.80 MiB/s 647.07 MiB/s 647.32 MiB/s]
                 change:
                        time:   [+5.0576% +5.1817% +5.3143%] (p = 0.00 < 0.05)
                        thrpt:  [-5.0461% -4.9265% -4.8141%]
                        Performance has regressed.
hash_account/data_size/200                                                                            
                        time:   [435.20 ns 435.33 ns 435.46 ns]
                        thrpt:  [615.40 MiB/s 615.58 MiB/s 615.77 MiB/s]
                 change:
                        time:   [+5.3151% +5.4726% +5.6149%] (p = 0.00 < 0.05)
                        thrpt:  [-5.3164% -5.1887% -5.0469%]
                        Performance has regressed.
hash_account/data_size/1024                                                                             
                        time:   [1.4255 µs 1.4261 µs 1.4270 µs]
                        thrpt:  [738.48 MiB/s 738.96 MiB/s 739.28 MiB/s]
                 change:
                        time:   [-0.2172% -0.1373% -0.0381%] (p = 0.00 < 0.05)
                        thrpt:  [+0.0381% +0.1374% +0.2176%]
                        Change within noise threshold.
hash_account/data_size/1048576                                                                            
                        time:   [270.51 µs 270.59 µs 270.75 µs]
                        thrpt:  [3.6071 GiB/s 3.6092 GiB/s 3.6104 GiB/s]
                 change:
                        time:   [+0.2766% +0.3051% +0.3489%] (p = 0.00 < 0.05)
                        thrpt:  [-0.3477% -0.3041% -0.2758%]
                        Change within noise threshold.
hash_account/data_size/10485760                                                                             
                        time:   [2.6608 ms 2.6614 ms 2.6622 ms]
                        thrpt:  [3.6682 GiB/s 3.6694 GiB/s 3.6703 GiB/s]
                 change:
                        time:   [-0.1625% -0.1292% -0.0874%] (p = 0.00 < 0.05)
                        thrpt:  [+0.0875% +0.1294% +0.1628%]
                        Change within noise threshold.
```

My takeaways:
* Both the 165 and 200 byte benchmarks are better with this PR; about 5%. This makes sense to me, and that's what this PR is targeting.
* The sizes *above* 200 bytes (1k, 1m, 10m) perform the same. This makes sense to me because both master and this PR will need to make a heap allocation for the larger data size.
* The 0 byte benchmark is the same/within the noise (I did run this many times, and often the change was less than 0.1%). This also makes sense, as neither master nor this PR will need to make a heap allocation.

</p>
</details> 