### PR TITLE
Adds StartingSnapshotStorages to AccountsHashVerifier

### DIFF
--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -37,6 +37,7 @@ pub mod secondary_index;
 pub mod shared_buffer_reader;
 pub mod sorted_storages;
 pub mod stake_rewards;
+pub mod starting_snapshot_storages;
 pub mod storable_accounts;
 pub mod tiered_storage;
 pub mod utils;

--- a/accounts-db/src/starting_snapshot_storages.rs
+++ b/accounts-db/src/starting_snapshot_storages.rs
@@ -1,0 +1,19 @@
+use {crate::accounts_db::AccountStorageEntry, std::sync::Arc};
+
+/// Snapshot storages that the node loaded from
+///
+/// This is used to support fastboot.  Since fastboot reuses existing storages, we must carefully
+/// handle the storages used to load at startup.  If we do not handle these storages properly,
+/// restarting from the same local state (i.e. bank snapshot) may fail.
+#[derive(Debug)]
+pub enum StartingSnapshotStorages {
+    /// Starting from genesis has no storages yet
+    Genesis,
+    /// Starting from a snapshot archive always extracts the storages from the archive, so no
+    /// special handling is necessary to preserve them.
+    Archive,
+    /// Starting from local state must preserve the loaded storages.  These storages must *not* be
+    /// recycled or removed prior to taking the next snapshot, otherwise restarting from the same
+    /// bank snapshot may fail.
+    Fastboot(Vec<Arc<AccountStorageEntry>>),
+}

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -9,6 +9,7 @@ use {
         accounts_hash::CalcAccountsHashConfig,
         accounts_index::AccountSecondaryIndexes,
         epoch_accounts_hash::EpochAccountsHash,
+        starting_snapshot_storages::StartingSnapshotStorages,
     },
     solana_core::{
         accounts_hash_verifier::AccountsHashVerifier,
@@ -196,6 +197,7 @@ impl BackgroundServices {
             accounts_package_sender.clone(),
             accounts_package_receiver,
             Some(snapshot_package_sender),
+            StartingSnapshotStorages::Genesis,
             exit.clone(),
             snapshot_config.clone(),
         );

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -11,6 +11,7 @@ use {
         accounts_hash::AccountsHash,
         accounts_index::AccountSecondaryIndexes,
         epoch_accounts_hash::EpochAccountsHash,
+        starting_snapshot_storages::StartingSnapshotStorages,
     },
     solana_core::{
         accounts_hash_verifier::AccountsHashVerifier,
@@ -1043,6 +1044,7 @@ fn test_snapshots_with_background_services(
         accounts_package_sender,
         accounts_package_receiver,
         Some(snapshot_package_sender),
+        StartingSnapshotStorages::Genesis,
         exit.clone(),
         snapshot_test_config.snapshot_config.clone(),
     );

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -268,19 +268,24 @@ pub fn load_and_process_ledger(
     };
 
     let exit = Arc::new(AtomicBool::new(false));
-    let (bank_forks, leader_schedule_cache, starting_snapshot_hashes, ..) =
-        bank_forks_utils::load_bank_forks(
-            genesis_config,
-            blockstore.as_ref(),
-            account_paths,
-            snapshot_config.as_ref(),
-            &process_options,
-            None,
-            None, // Maybe support this later, though
-            accounts_update_notifier,
-            exit.clone(),
-        )
-        .map_err(LoadAndProcessLedgerError::LoadBankForks)?;
+    let (
+        bank_forks,
+        leader_schedule_cache,
+        starting_snapshot_hashes,
+        starting_snapshot_storages,
+        ..,
+    ) = bank_forks_utils::load_bank_forks(
+        genesis_config,
+        blockstore.as_ref(),
+        account_paths,
+        snapshot_config.as_ref(),
+        &process_options,
+        None,
+        None, // Maybe support this later, though
+        accounts_update_notifier,
+        exit.clone(),
+    )
+    .map_err(LoadAndProcessLedgerError::LoadBankForks)?;
     let block_verification_method = value_t!(
         arg_matches,
         "block_verification_method",
@@ -325,6 +330,7 @@ pub fn load_and_process_ledger(
         accounts_package_sender.clone(),
         accounts_package_receiver,
         None,
+        starting_snapshot_storages,
         exit.clone(),
         SnapshotConfig::new_load_only(),
     );


### PR DESCRIPTION
#### Problem

When starting up from fastboot, if `shrink` runs *before* taking the next bank snapshot, then snapshot storages can change. And then if the node restarts before taking the next bank snapshot, it may fail because the snapshot storages are now wrong.

Please see https://github.com/solana-labs/solana/issues/35376 for more information.


#### Summary of Changes

At startup, get the storages that were loaded from, for fastboot. Pass them into AccountsHashVerifier, because AHV is in charge of holding fastboot storages to prevent early cleanup.

I tested this with a node on mnb.
1. I started a node and let it run for a while, so it took a bunch of snapshots
2. I *removed* the code to purge all bank snapshots at startup with fastboot
3. I restarted the node, and it started with fastboot correctly
4. I inserted code to crash the node before the bank snapshot POST was reserialized (this ensures `shrink` runs)
5. the node crashed, as expected
6. I restarted the node, and it used the same snapshot for fastboot as in step (3)

And it worked! Previously, this would crash.

Fixes https://github.com/solana-labs/solana/issues/35376
