### PR TITLE
v1.17: Remove unnecessary unwrap from `simulate_transaction_unchecked()` (backport of #35375)

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4384,9 +4384,7 @@ impl Bank {
         let post_simulation_accounts = loaded_transactions
             .into_iter()
             .next()
-            .unwrap()
-            .0
-            .ok()
+            .and_then(|(loaded_transactions_res, _)| loaded_transactions_res.ok())
             .map(|loaded_transaction| {
                 loaded_transaction
                     .accounts
@@ -4406,7 +4404,12 @@ impl Bank {
 
         debug!("simulate_transaction: {:?}", timings);
 
-        let execution_result = execution_results.pop().unwrap();
+        let execution_result =
+            execution_results
+                .pop()
+                .unwrap_or(TransactionExecutionResult::NotExecuted(
+                    TransactionError::InvalidProgramForExecution,
+                ));
         let flattened_result = execution_result.flattened_result();
         let (logs, return_data) = match execution_result {
             TransactionExecutionResult::Executed { details, .. } => {


### PR DESCRIPTION
Remove unnecessary unwrap from `simulate_transaction_unchecked()` (#35375)

Remove unnecessary unwrap from simulate_transaction_unchecked()

(cherry picked from commit cb260f10d1b05743391b9b442bf175c19d894931)

Recreating https://github.com/solana-labs/solana/pull/35396 in anza repo.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
