### PR TITLE
blockstore_purge: fix inspect -> inspect_err

### DIFF
--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -213,7 +213,7 @@ impl Blockstore {
         delete_range_timer.stop();
 
         let mut write_timer = Measure::start("write_batch");
-        self.db.write(write_batch).inspect(|e| {
+        self.db.write(write_batch).inspect_err(|e| {
             error!(
                 "Error: {:?} while submitting write batch for purge from_slot {} to_slot {}",
                 e, from_slot, to_slot


### PR DESCRIPTION
original change https://github.com/solana-labs/solana/pull/35124/files#diff-317f52baf65751e39be1d7e1cbe5cefd2738f2828dd79293032de1d971d425b3 used `inspect` instead of `inspect_err` which causes this `ERROR` log to be printed on successfull writes. 