### PR TITLE
[TieredStorage] Add AccountsFile::TieredStorage

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -966,9 +966,7 @@ pub const fn get_ancient_append_vec_capacity() -> u64 {
 
 /// is this a max-size append vec designed to be used as an ancient append vec?
 pub fn is_ancient(storage: &AccountsFile) -> bool {
-    match storage {
-        AccountsFile::AppendVec(storage) => storage.capacity() >= get_ancient_append_vec_capacity(),
-    }
+    storage.capacity() >= get_ancient_append_vec_capacity()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
AccountsFile currently doesn't have an implementation for TieredStorage.
To enable AccountsDB tests for the TieredStorage, we need AccountsFile
to support TieredStorage.

#### Summary of Changes
This PR implements a AccountsFile::TieredStorage, a thin wrapper between
AccountsFile and TieredStorage.
