### PR TITLE
windows: Use vcpkg for openssl dep

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -43,17 +43,8 @@ jobs:
         id: build
         shell: bash
         run: |
-          choco install openssl --version=3.1.1
-          if [[ -d "C:\Program Files\OpenSSL" ]]; then
-            echo "OPENSSL_DIR: C:\Program Files\OpenSSL"
-            export OPENSSL_DIR="C:\Program Files\OpenSSL"
-          elif [[ -d "C:\Program Files\OpenSSL-Win64" ]]; then
-            echo "OPENSSL_DIR: C:\Program Files\OpenSSL-Win64"
-            export OPENSSL_DIR="C:\Program Files\OpenSSL-Win64"
-          else
-            echo "can't determine OPENSSL_DIR"
-            exit 1
-          fi
+          vcpkg install openssl:x64-windows-static-md
+          vcpkg integrate install
           choco install protoc
           export PROTOC="C:\ProgramData\chocolatey\lib\protoc\tools\bin\protoc.exe"
           source /tmp/env.sh


### PR DESCRIPTION
#### Problem

The windows build of `solana-test-validator.exe` does not currently work on a fresh windows machine. Users get two errors:

```
The code execution cannot proceed because libssl-3-x64.dll was not found. Reinstalling the program may fix the problem.
```

And also for `libcrypto-3-x64.dll`. This is happening because these libraries are linked dynamically into the executable, but machines don't have them unless they are installed with `choco`, just like during the CI build.

#### Summary of Changes

Rather than picking up the dynamic libs with `choco`, use `vcpkg` to fetch the static versions of the libraries, and link them directly into the executable.

I triggered the run on my own branch, and you'll see when running `ldd solana-test-validator` (at the end of the run) that libcrypto-3 and libssl-3 are not linked dynamically anymore: https://github.com/joncinque/solana/actions/runs/8147872620/job/22269501499

```
	ntdll.dll => /c/Windows/SYSTEM32/ntdll.dll (0x7ffc32010000)
	KERNEL32.DLL => /c/Windows/System32/KERNEL32.DLL (0x7ffc315c0000)
	KERNELBASE.dll => /c/Windows/System32/KERNELBASE.dll (0x7ffc2f6a0000)
	apphelp.dll => /c/Windows/SYSTEM32/apphelp.dll (0x7ffc2d6a0000)
	USER32.dll => /c/Windows/System32/USER32.dll (0x7ffc30790000)
	POWRPROF.dll => /c/Windows/SYSTEM32/POWRPROF.dll (0x7ffc2f470000)
	win32u.dll => /c/Windows/System32/win32u.dll (0x7ffc2fa10000)
	ucrtbase.dll => /c/Windows/System32/ucrtbase.dll (0x7ffc2f590000)
	GDI32.dll => /c/Windows/System32/GDI32.dll (0x7ffc31680000)
	gdi32full.dll => /c/Windows/System32/gdi32full.dll (0x7ffc2fb50000)
	RPCRT4.dll => /c/Windows/System32/RPCRT4.dll (0x7ffc31ad0000)
	msvcp_win.dll => /c/Windows/System32/msvcp_win.dll (0x7ffc2fa40000)
	CRYPT32.dll => /c/Windows/System32/CRYPT32.dll (0x7ffc2fc70000)
	SHLWAPI.dll => /c/Windows/System32/SHLWAPI.dll (0x7ffc30730000)
	msvcrt.dll => /c/Windows/System32/msvcrt.dll (0x7ffc31360000)
	ws2_32.dll => /c/Windows/System32/ws2_32.dll (0x7ffc30ac0000)
	shell32.dll => /c/Windows/System32/shell32.dll (0x7ffc30c00000)
	ole32.dll => /c/Windows/System32/ole32.dll (0x7ffc31d60000)
	combase.dll => /c/Windows/System32/combase.dll (0x7ffc2ff40000)
	advapi32.dll => /c/Windows/System32/advapi32.dll (0x7ffc30b40000)
	secur32.dll => /c/Windows/SYSTEM32/secur32.dll (0x7ffc22a90000)
	sechost.dll => /c/Windows/System32/sechost.dll (0x7ffc31740000)
	bcrypt.dll => /c/Windows/System32/bcrypt.dll (0x7ffc2fe50000)
	VCRUNTIME140.dll => /c/Windows/SYSTEM32/VCRUNTIME140.dll (0x7ffc22ca0000)
	MSVCP140.dll => /c/Windows/SYSTEM32/MSVCP140.dll (0x7ffc22cc0000)
	VCRUNTIME140_1.dll => /c/Windows/SYSTEM32/VCRUNTIME140_1.dll (0x7ffc22c90000)
	SSPICLI.DLL => /c/Windows/SYSTEM32/SSPICLI.DLL (0x7ffc2ef50000)
	CRYPTBASE.DLL => /c/Windows/SYSTEM32/CRYPTBASE.DLL (0x7ffc2ed10000)
```

Fixes [#34793](https://github.com/solana-labs/solana/issues/34793) Fixes [#32372](https://github.com/solana-labs/solana/issues/32372)
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->