### PR TITLE
v1.18: ignore mio audit report 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3394,9 +3394,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -30,6 +30,9 @@ cargo_audit_ignores=(
   --ignore RUSTSEC-2023-0001
 
   --ignore RUSTSEC-2022-0093
+
+  # mio
+  --ignore RUSTSEC-2024-0019
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2914,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",


### PR DESCRIPTION
#### Problem

discussion is in https://github.com/anza-xyz/agave/pull/60

#### Summary of Changes

1. revert the bumping backport that I approved carelessly 😢 
2. ignore the mio audit
