### PR TITLE
Runtime: Bank: Prioritize additional builtins for init and feature activations

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1488,7 +1488,11 @@ impl Bank {
         );
 
         let (_, apply_feature_activations_time) = measure!(
-            self.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false),
+            self.apply_feature_activations(
+                ApplyFeatureActivationsCaller::NewFromParent,
+                false,
+                None
+            ),
             "apply_feature_activation",
         );
 
@@ -1716,7 +1720,7 @@ impl Bank {
 
         let parent_timestamp = parent.clock().unix_timestamp;
         let mut new = Bank::new_from_parent(parent, collector_id, slot);
-        new.apply_feature_activations(ApplyFeatureActivationsCaller::WarpFromParent, false);
+        new.apply_feature_activations(ApplyFeatureActivationsCaller::WarpFromParent, false, None);
         new.update_epoch_stakes(new.epoch_schedule().get_epoch(slot));
         new.tick_height.store(new.max_tick_height(), Relaxed);
 
@@ -5963,12 +5967,20 @@ impl Bank {
         self.apply_feature_activations(
             ApplyFeatureActivationsCaller::FinishInit,
             debug_do_not_add_builtins,
+            additional_builtins,
         );
 
         if !debug_do_not_add_builtins {
+            let additional_builtins = additional_builtins.unwrap_or(&[]);
             for builtin in BUILTINS
                 .iter()
-                .chain(additional_builtins.unwrap_or(&[]).iter())
+                .filter(|builtin| {
+                    // Give priority to additional builtins.
+                    !additional_builtins
+                        .iter()
+                        .any(|b| b.program_id == builtin.program_id)
+                })
+                .chain(additional_builtins.iter())
             {
                 if builtin.feature_id.is_none() {
                     self.add_builtin(
@@ -7189,6 +7201,7 @@ impl Bank {
         &mut self,
         caller: ApplyFeatureActivationsCaller,
         debug_do_not_add_builtins: bool,
+        additional_builtins: Option<&[BuiltinPrototype]>,
     ) {
         use ApplyFeatureActivationsCaller as Caller;
         let allow_new_activations = match caller {
@@ -7230,6 +7243,7 @@ impl Bank {
             self.apply_builtin_program_feature_transitions(
                 allow_new_activations,
                 &new_feature_activations,
+                additional_builtins,
             );
         }
 
@@ -7314,8 +7328,19 @@ impl Bank {
         &mut self,
         only_apply_transitions_for_new_features: bool,
         new_feature_activations: &HashSet<Pubkey>,
+        additional_builtins: Option<&[BuiltinPrototype]>,
     ) {
-        for builtin in BUILTINS.iter() {
+        let additional_builtins = additional_builtins.unwrap_or(&[]);
+        for builtin in BUILTINS
+            .iter()
+            .filter(|builtin| {
+                // Give priority to additional builtins.
+                !additional_builtins
+                    .iter()
+                    .any(|b| b.program_id == builtin.program_id)
+            })
+            .chain(additional_builtins.iter())
+        {
             if let Some(feature_id) = builtin.feature_id {
                 let should_apply_action_for_feature_transition =
                     if only_apply_transitions_for_new_features {

--- a/runtime/src/bank/builtin_programs.rs
+++ b/runtime/src/bank/builtin_programs.rs
@@ -39,6 +39,7 @@ mod tests {
         bank.apply_builtin_program_feature_transitions(
             only_apply_transitions_for_new_features,
             &HashSet::new(),
+            None,
         );
     }
 

--- a/runtime/src/bank/builtin_programs.rs
+++ b/runtime/src/bank/builtin_programs.rs
@@ -1,9 +1,12 @@
 #[cfg(test)]
 mod tests {
     use {
-        crate::bank::*,
+        crate::{bank::*, builtins::BUILTINS},
         solana_sdk::{
-            ed25519_program, feature_set::FeatureSet, genesis_config::create_genesis_config,
+            ed25519_program,
+            feature::{self, Feature},
+            feature_set::FeatureSet,
+            genesis_config::create_genesis_config,
         },
     };
 
@@ -61,5 +64,196 @@ mod tests {
 
         // Simulate starting up from snapshot finishing the initialization for a frozen bank
         bank.finish_init(&genesis_config, None, false);
+    }
+
+    #[test]
+    fn test_override_builtins() {
+        let check_bank_builtins = |builtins: &[BuiltinPrototype], expected_len| {
+            let bank = Bank::new_with_paths(
+                &GenesisConfig::default(),
+                Arc::<RuntimeConfig>::default(),
+                Vec::new(),
+                None,
+                Some(builtins),
+                AccountSecondaryIndexes::default(),
+                AccountShrinkThreshold::default(),
+                false,
+                Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
+                None,
+                Some(Pubkey::new_unique()),
+                Arc::default(),
+            );
+
+            // Assert the bank's builtins contain all additional builtins.
+            assert_eq!(bank.builtin_programs.len(), expected_len);
+            BUILTINS
+                .iter()
+                .filter(|b| b.feature_id.is_none())
+                .chain(builtins)
+                .for_each(|b| {
+                    assert!(bank.builtin_programs.get(&b.program_id).is_some());
+                });
+        };
+
+        let builtins_len = BUILTINS.iter().filter(|b| b.feature_id.is_none()).count();
+
+        check_bank_builtins(&[], builtins_len);
+        check_bank_builtins(
+            &[BuiltinPrototype {
+                feature_id: None,
+                program_id: solana_system_program::id(),
+                name: "system_program",
+                entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+            }],
+            // System program should be overriden.
+            builtins_len,
+        );
+        check_bank_builtins(
+            &[
+                BuiltinPrototype {
+                    feature_id: None,
+                    program_id: solana_system_program::id(),
+                    name: "system_program",
+                    entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+                },
+                BuiltinPrototype {
+                    feature_id: None,
+                    program_id: Pubkey::new_unique(),
+                    name: "random_program",
+                    entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+                },
+            ],
+            // System program should be overriden, and random program should be added.
+            builtins_len + 1,
+        );
+        check_bank_builtins(
+            &[
+                BuiltinPrototype {
+                    feature_id: None,
+                    program_id: solana_system_program::id(),
+                    name: "system_program",
+                    entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+                },
+                BuiltinPrototype {
+                    feature_id: None,
+                    program_id: solana_stake_program::id(),
+                    name: "stake_program",
+                    entrypoint: solana_stake_program::stake_instruction::Entrypoint::vm,
+                },
+                BuiltinPrototype {
+                    feature_id: None,
+                    program_id: Pubkey::new_unique(),
+                    name: "random_program1",
+                    entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+                },
+                BuiltinPrototype {
+                    feature_id: None,
+                    program_id: Pubkey::new_unique(),
+                    name: "stake_program2",
+                    entrypoint: solana_stake_program::stake_instruction::Entrypoint::vm,
+                },
+            ],
+            // System & stake should be overriden, and random programs should be added.
+            builtins_len + 2,
+        );
+    }
+
+    #[test]
+    fn test_override_builtins_on_feature_activation() {
+        let check_bank_builtin_feature_activation = |builtins: &[BuiltinPrototype]| {
+            let mut bank = Bank::new_with_paths(
+                &GenesisConfig::default(),
+                Arc::<RuntimeConfig>::default(),
+                Vec::new(),
+                None,
+                Some(builtins),
+                AccountSecondaryIndexes::default(),
+                AccountShrinkThreshold::default(),
+                false,
+                Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
+                None,
+                Some(Pubkey::new_unique()),
+                Arc::default(),
+            );
+
+            let mut feature_set = FeatureSet::default();
+            builtins
+                .iter()
+                .filter_map(|builtin| builtin.feature_id)
+                .for_each(|feature_id| {
+                    feature_set.inactive.insert(feature_id);
+                    bank.store_account(
+                        &feature_id,
+                        &feature::create_account(&Feature::default(), 42),
+                    );
+                });
+            bank.feature_set = Arc::new(feature_set.clone());
+
+            // Assert the bank's builtins _do not_ contain the additional
+            // builtins, since they have not been enabled.
+            builtins.iter().for_each(|b| {
+                assert!(bank.builtin_programs.get(&b.program_id).is_none());
+            });
+
+            bank.apply_feature_activations(
+                ApplyFeatureActivationsCaller::NewFromParent,
+                false,
+                Some(builtins),
+            );
+
+            // Assert the bank's builtins contain the additional builtins,
+            // since they have now been enabled.
+            builtins.iter().for_each(|builtin| {
+                assert!(bank.builtin_programs.get(&builtin.program_id).is_some());
+            });
+        };
+
+        check_bank_builtin_feature_activation(&[]);
+        check_bank_builtin_feature_activation(&[BuiltinPrototype {
+            feature_id: Some(Pubkey::new_unique()),
+            program_id: solana_system_program::id(),
+            name: "system_program",
+            entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+        }]);
+        check_bank_builtin_feature_activation(&[
+            BuiltinPrototype {
+                feature_id: Some(Pubkey::new_unique()),
+                program_id: solana_system_program::id(),
+                name: "system_program",
+                entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+            },
+            BuiltinPrototype {
+                feature_id: Some(Pubkey::new_unique()),
+                program_id: Pubkey::new_unique(),
+                name: "random_program",
+                entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+            },
+        ]);
+        check_bank_builtin_feature_activation(&[
+            BuiltinPrototype {
+                feature_id: Some(Pubkey::new_unique()),
+                program_id: solana_system_program::id(),
+                name: "system_program",
+                entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+            },
+            BuiltinPrototype {
+                feature_id: Some(Pubkey::new_unique()),
+                program_id: solana_stake_program::id(),
+                name: "stake_program",
+                entrypoint: solana_stake_program::stake_instruction::Entrypoint::vm,
+            },
+            BuiltinPrototype {
+                feature_id: Some(Pubkey::new_unique()),
+                program_id: Pubkey::new_unique(),
+                name: "random_program1",
+                entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+            },
+            BuiltinPrototype {
+                feature_id: Some(Pubkey::new_unique()),
+                program_id: Pubkey::new_unique(),
+                name: "stake_program2",
+                entrypoint: solana_stake_program::stake_instruction::Entrypoint::vm,
+            },
+        ]);
     }
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7944,7 +7944,7 @@ fn test_compute_active_feature_set() {
     assert!(new_activations.contains(&test_feature));
 
     // Actually activate the pending activation
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, true);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, true, None);
     let feature = feature::from_account(&bank.get_account(&test_feature).expect("get_account"))
         .expect("from_account");
     assert_eq!(feature.activated_at, Some(1));
@@ -11699,7 +11699,7 @@ fn test_feature_activation_idempotent() {
     assert_eq!(bank.hashes_per_tick, Some(HASHES_PER_TICK_START));
 
     // Don't activate feature
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(HASHES_PER_TICK_START));
 
     // Activate feature
@@ -11709,11 +11709,11 @@ fn test_feature_activation_idempotent() {
         &feature_set::update_hashes_per_tick::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(DEFAULT_HASHES_PER_TICK));
 
     // Activate feature "again"
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(DEFAULT_HASHES_PER_TICK));
 }
 
@@ -11727,7 +11727,7 @@ fn test_feature_hashes_per_tick() {
     assert_eq!(bank.hashes_per_tick, Some(HASHES_PER_TICK_START));
 
     // Don't activate feature
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(HASHES_PER_TICK_START));
 
     // Activate feature
@@ -11737,7 +11737,7 @@ fn test_feature_hashes_per_tick() {
         &feature_set::update_hashes_per_tick::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(DEFAULT_HASHES_PER_TICK));
 
     // Activate feature
@@ -11747,7 +11747,7 @@ fn test_feature_hashes_per_tick() {
         &feature_set::update_hashes_per_tick2::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(UPDATED_HASHES_PER_TICK2));
 
     // Activate feature
@@ -11757,7 +11757,7 @@ fn test_feature_hashes_per_tick() {
         &feature_set::update_hashes_per_tick3::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(UPDATED_HASHES_PER_TICK3));
 
     // Activate feature
@@ -11767,7 +11767,7 @@ fn test_feature_hashes_per_tick() {
         &feature_set::update_hashes_per_tick4::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(UPDATED_HASHES_PER_TICK4));
 
     // Activate feature
@@ -11777,7 +11777,7 @@ fn test_feature_hashes_per_tick() {
         &feature_set::update_hashes_per_tick5::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(UPDATED_HASHES_PER_TICK5));
 
     // Activate feature
@@ -11787,7 +11787,7 @@ fn test_feature_hashes_per_tick() {
         &feature_set::update_hashes_per_tick6::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(UPDATED_HASHES_PER_TICK6));
 }
 


### PR DESCRIPTION
#### Problem
The act of enabling a builtin program via feature activation involves adding the 
new builtin to the static `BUILTINS` list in the `builtins` module with the 
feature ID that will enable it. 

Since this action keys on the elements in the `BUILTINS` list, it's impossible 
to test this feature activation functionality dynamically.

As we prepare to migrate builtin programs to Core BPF, the ability to test 
builtin program feature transitions is paramount.

If `apply_builtin_program_feature_transitions` accepted an additional slice of 
`BuiltinPrototype`, we could better test builtin feature transition behavior.

#### Summary
1. Add the same exact `additional_builtins: Option<&[BuiltinPrototype]>` 
parameter accepted by `Bank::new_with_paths` to:

- `apply_feature_activations`
- `apply_builtin_program_feature_transitions`

2. Give priority to any additional builtins with a matching program ID to a 
   builtin in the static `BUILTINS` list through a filter in:

- `finish_init`
- `apply_builtin_program_feature_transitions`

3. Write test coverage for builtin feature activations using this change.