### PR TITLE
loaded-programs: Use `Measure::end_as_us()`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -441,7 +441,7 @@ impl<'a> InvokeContext<'a> {
         timings: &mut ExecuteTimings,
     ) -> Result<(), InstructionError> {
         let instruction_context = self.transaction_context.get_current_instruction_context()?;
-        let mut process_executable_chain_time = Measure::start("process_executable_chain_time");
+        let process_executable_chain_time = Measure::start("process_executable_chain_time");
 
         let builtin_id = {
             let borrowed_root_account = instruction_context
@@ -523,13 +523,12 @@ impl<'a> InvokeContext<'a> {
             return Err(InstructionError::BuiltinProgramsMustConsumeComputeUnits);
         }
 
-        process_executable_chain_time.stop();
         saturating_add_assign!(
             timings
                 .execute_accessories
                 .process_instructions
                 .process_executable_chain_us,
-            process_executable_chain_time.as_us()
+            process_executable_chain_time.end_as_us()
         );
         result
     }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -335,27 +335,24 @@ impl LoadedProgram {
         metrics: &mut LoadProgramMetrics,
         reloading: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let mut load_elf_time = Measure::start("load_elf_time");
+        let load_elf_time = Measure::start("load_elf_time");
         // The following unused_mut exception is needed for architectures that do not
         // support JIT compilation.
         #[allow(unused_mut)]
         let mut executable = Executable::load(elf_bytes, program_runtime_environment.clone())?;
-        load_elf_time.stop();
-        metrics.load_elf_us = load_elf_time.as_us();
+        metrics.load_elf_us = load_elf_time.end_as_us();
 
         if !reloading {
-            let mut verify_code_time = Measure::start("verify_code_time");
+            let verify_code_time = Measure::start("verify_code_time");
             executable.verify::<RequisiteVerifier>()?;
-            verify_code_time.stop();
-            metrics.verify_code_us = verify_code_time.as_us();
+            metrics.verify_code_us = verify_code_time.end_as_us();
         }
 
         #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
         {
-            let mut jit_compile_time = Measure::start("jit_compile_time");
+            let jit_compile_time = Measure::start("jit_compile_time");
             executable.jit_compile()?;
-            jit_compile_time.stop();
-            metrics.jit_compile_us = jit_compile_time.as_us();
+            metrics.jit_compile_us = jit_compile_time.end_as_us();
         }
 
         let program = if bpf_loader_deprecated::check_id(loader_key) {

--- a/program-runtime/src/message_processor.rs
+++ b/program-runtime/src/message_processor.rs
@@ -133,7 +133,7 @@ impl MessageProcessor {
                         invoke_context.transaction_context.pop()
                     })
             } else {
-                let mut time = Measure::start("execute_instruction");
+                let time = Measure::start("execute_instruction");
                 let mut compute_units_consumed = 0;
                 let result = invoke_context.process_instruction(
                     &instruction.data,
@@ -142,12 +142,12 @@ impl MessageProcessor {
                     &mut compute_units_consumed,
                     timings,
                 );
-                time.stop();
+                let time = time.end_as_us();
                 *accumulated_consumed_units =
                     accumulated_consumed_units.saturating_add(compute_units_consumed);
                 timings.details.accumulate_program(
                     program_id,
-                    time.as_us(),
+                    time,
                     compute_units_consumed,
                     result.is_err(),
                 );
@@ -157,7 +157,7 @@ impl MessageProcessor {
                 };
                 saturating_add_assign!(
                     timings.execute_accessories.process_instructions.total_us,
-                    time.as_us()
+                    time
                 );
                 result
             };


### PR DESCRIPTION
It is a bit nicer API, compared to the `stop()/as_us()` pair.  Does not require the value to be `mut`.

---

Moved over from https://github.com/solana-labs/solana/pull/35285.
Already approved there, I just forgot to press the "Merge" button in time %)