### PR TITLE
Removes Incremental Accounts Hash featurization

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -241,13 +241,7 @@ impl AccountsHashVerifier {
             AccountsPackageKind::EpochAccountsHash => CalcAccountsHashKind::Full,
             AccountsPackageKind::Snapshot(snapshot_kind) => match snapshot_kind {
                 SnapshotKind::FullSnapshot => CalcAccountsHashKind::Full,
-                SnapshotKind::IncrementalSnapshot(_) => {
-                    if accounts_package.is_incremental_accounts_hash_feature_enabled {
-                        CalcAccountsHashKind::Incremental
-                    } else {
-                        CalcAccountsHashKind::Full
-                    }
-                }
+                SnapshotKind::IncrementalSnapshot(_) => CalcAccountsHashKind::Incremental,
             },
         };
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -41,7 +41,6 @@ use {
     solana_measure::{measure, measure::Measure},
     solana_sdk::{
         clock::{Epoch, Slot},
-        feature_set,
         genesis_config::GenesisConfig,
         hash::Hash,
         pubkey::Pubkey,
@@ -366,11 +365,7 @@ pub fn bank_from_snapshot_archives(
         snapshot_archive_info.hash,
     )?;
 
-    let base = (incremental_snapshot_archive_info.is_some()
-        && bank
-            .feature_set
-            .is_active(&feature_set::incremental_snapshot_only_incremental_hash_calculation::id()))
-    .then(|| {
+    let base = incremental_snapshot_archive_info.is_some().then(|| {
         let base_slot = full_snapshot_archive_info.slot();
         let base_capitalization = bank
             .rc
@@ -1097,14 +1092,7 @@ pub fn bank_to_incremental_snapshot_archive(
     bank.squash(); // Bank may not be a root
     bank.force_flush_accounts_cache();
     bank.clean_accounts(Some(full_snapshot_slot));
-    if bank
-        .feature_set
-        .is_active(&feature_set::incremental_snapshot_only_incremental_hash_calculation::id())
-    {
-        bank.update_incremental_accounts_hash(full_snapshot_slot);
-    } else {
-        bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
-    }
+    bank.update_incremental_accounts_hash(full_snapshot_slot);
     bank.rehash(); // Bank accounts may have been manually modified by the caller
 
     let temp_dir = tempfile::tempdir_in(bank_snapshots_dir)?;
@@ -1211,50 +1199,33 @@ pub fn package_and_archive_incremental_snapshot(
         None,
     );
 
-    let (accounts_hash_kind, accounts_hash_for_reserialize, bank_incremental_snapshot_persistence) =
-        if bank
-            .feature_set
-            .is_active(&feature_set::incremental_snapshot_only_incremental_hash_calculation::id())
-        {
-            let (base_accounts_hash, base_capitalization) = bank
-                .rc
-                .accounts
-                .accounts_db
-                .get_accounts_hash(incremental_snapshot_base_slot)
-                .expect("base accounts hash is required for incremental snapshot");
-            let (incremental_accounts_hash, incremental_capitalization) = bank
-                .rc
-                .accounts
-                .accounts_db
-                .get_incremental_accounts_hash(bank.slot())
-                .expect("incremental accounts hash is required for incremental snapshot");
-            let bank_incremental_snapshot_persistence = BankIncrementalSnapshotPersistence {
-                full_slot: incremental_snapshot_base_slot,
-                full_hash: base_accounts_hash.into(),
-                full_capitalization: base_capitalization,
-                incremental_hash: incremental_accounts_hash.into(),
-                incremental_capitalization,
-            };
-            (
-                incremental_accounts_hash.into(),
-                AccountsHash(Hash::default()), // value does not matter; not used for incremental snapshots
-                Some(bank_incremental_snapshot_persistence),
-            )
-        } else {
-            let accounts_hash = bank
-                .get_accounts_hash()
-                .expect("accounts hash is required for snapshot");
-            (accounts_hash.into(), accounts_hash, None)
-        };
-
+    let (base_accounts_hash, base_capitalization) = bank
+        .rc
+        .accounts
+        .accounts_db
+        .get_accounts_hash(incremental_snapshot_base_slot)
+        .expect("base accounts hash is required for incremental snapshot");
+    let (incremental_accounts_hash, incremental_capitalization) = bank
+        .rc
+        .accounts
+        .accounts_db
+        .get_incremental_accounts_hash(bank.slot())
+        .expect("incremental accounts hash is required for incremental snapshot");
+    let bank_incremental_snapshot_persistence = Some(BankIncrementalSnapshotPersistence {
+        full_slot: incremental_snapshot_base_slot,
+        full_hash: base_accounts_hash.into(),
+        full_capitalization: base_capitalization,
+        incremental_hash: incremental_accounts_hash.into(),
+        incremental_capitalization,
+    });
     crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
         accounts_package.bank_snapshot_dir(),
         accounts_package.slot,
-        &accounts_hash_for_reserialize,
+        &AccountsHash(Hash::default()), // value does not matter; not used for incremental snapshots
         bank_incremental_snapshot_persistence.as_ref(),
     );
 
-    let snapshot_package = SnapshotPackage::new(accounts_package, accounts_hash_kind);
+    let snapshot_package = SnapshotPackage::new(accounts_package, incremental_accounts_hash.into());
     archive_snapshot_package(
         &snapshot_package,
         full_snapshot_archives_dir,

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -13,8 +13,7 @@ use {
         epoch_accounts_hash::EpochAccountsHash,
     },
     solana_sdk::{
-        clock::Slot, feature_set, rent_collector::RentCollector,
-        sysvar::epoch_schedule::EpochSchedule,
+        clock::Slot, rent_collector::RentCollector, sysvar::epoch_schedule::EpochSchedule,
     },
     std::{
         path::{Path, PathBuf},
@@ -37,7 +36,6 @@ pub struct AccountsPackage {
     pub accounts: Arc<Accounts>,
     pub epoch_schedule: EpochSchedule,
     pub rent_collector: RentCollector,
-    pub is_incremental_accounts_hash_feature_enabled: bool,
 
     /// Supplemental information needed for snapshots
     pub snapshot_info: Option<SupplementalSnapshotInfo>,
@@ -139,9 +137,6 @@ impl AccountsPackage {
         accounts_hash_for_testing: Option<AccountsHash>,
         snapshot_info: Option<SupplementalSnapshotInfo>,
     ) -> Self {
-        let is_incremental_accounts_hash_feature_enabled = bank
-            .feature_set
-            .is_active(&feature_set::incremental_snapshot_only_incremental_hash_calculation::id());
         Self {
             package_kind,
             slot: bank.slot(),
@@ -152,7 +147,6 @@ impl AccountsPackage {
             accounts: bank.accounts(),
             epoch_schedule: bank.epoch_schedule().clone(),
             rent_collector: bank.rent_collector().clone(),
-            is_incremental_accounts_hash_feature_enabled,
             snapshot_info,
             enqueued: Instant::now(),
         }
@@ -173,7 +167,6 @@ impl AccountsPackage {
             accounts: Arc::new(accounts),
             epoch_schedule: EpochSchedule::default(),
             rent_collector: RentCollector::default(),
-            is_incremental_accounts_hash_feature_enabled: bool::default(),
             snapshot_info: Some(SupplementalSnapshotInfo {
                 bank_snapshot_dir: PathBuf::default(),
                 archive_format: ArchiveFormat::Tar,


### PR DESCRIPTION
#### Problem

The [Incremental Accounts Hash](https://github.com/solana-labs/solana/issues/30819) feature has been enabled on all clusters. Its featurization code can now be removed.


#### Summary of Changes

Remove the featurization code.

Fixes #30819

Originally from https://github.com/solana-labs/solana/pull/34957