### PR TITLE
[TieredStorage] Deprecate the use of account-hash in HotStorage

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -128,7 +128,8 @@ impl<'storage> StoredAccountMeta<'storage> {
     pub fn hash(&self) -> &'storage AccountHash {
         match self {
             Self::AppendVec(av) => av.hash(),
-            Self::Hot(hot) => hot.hash().unwrap_or(&DEFAULT_ACCOUNT_HASH),
+            // tiered-storage has deprecated the use of AccountHash
+            Self::Hot(_) => &DEFAULT_ACCOUNT_HASH,
         }
     }
 

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -362,15 +362,15 @@ mod tests {
 
         let mut expected_accounts_map = HashMap::new();
         for i in 0..num_accounts {
-            let (account, address, account_hash, _write_version) = storable_accounts.get(i);
-            expected_accounts_map.insert(address, (account, account_hash));
+            let (account, address, _account_hash, _write_version) = storable_accounts.get(i);
+            expected_accounts_map.insert(address, account);
         }
 
         let mut index_offset = IndexOffset(0);
         let mut verified_accounts = HashSet::new();
         while let Some((stored_meta, next)) = reader.get_account(index_offset).unwrap() {
-            if let Some((account, account_hash)) = expected_accounts_map.get(stored_meta.pubkey()) {
-                verify_test_account(&stored_meta, *account, stored_meta.pubkey(), account_hash);
+            if let Some(account) = expected_accounts_map.get(stored_meta.pubkey()) {
+                verify_test_account(&stored_meta, *account, stored_meta.pubkey());
                 verified_accounts.insert(stored_meta.pubkey());
             }
             index_offset = next;

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -2,7 +2,6 @@ use {
     crate::{
         account_storage::meta::StoredAccountMeta,
         accounts_file::MatchAccountOwnerError,
-        accounts_hash::AccountHash,
         tiered_storage::{
             footer::{AccountMetaFormat, TieredStorageFooter},
             hot::HotStorageReader,
@@ -38,11 +37,6 @@ impl<'accounts_file, M: TieredAccountMeta> TieredReadableAccount<'accounts_file,
     /// Returns the address of this account.
     pub fn address(&self) -> &'accounts_file Pubkey {
         self.address
-    }
-
-    /// Returns the hash of this account.
-    pub fn hash(&self) -> Option<&'accounts_file AccountHash> {
-        None
     }
 
     /// Returns the index to this account in its AccountsFile.

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -42,7 +42,7 @@ impl<'accounts_file, M: TieredAccountMeta> TieredReadableAccount<'accounts_file,
 
     /// Returns the hash of this account.
     pub fn hash(&self) -> Option<&'accounts_file AccountHash> {
-        self.meta.account_hash(self.account_block)
+        None
     }
 
     /// Returns the index to this account in its AccountsFile.

--- a/accounts-db/src/tiered_storage/test_utils.rs
+++ b/accounts-db/src/tiered_storage/test_utils.rs
@@ -48,20 +48,10 @@ pub(super) fn verify_test_account(
     stored_meta: &StoredAccountMeta<'_>,
     account: Option<&impl ReadableAccount>,
     address: &Pubkey,
-    account_hash: &AccountHash,
 ) {
-    let (lamports, owner, data, executable, account_hash) = account
-        .map(|acc| {
-            (
-                acc.lamports(),
-                acc.owner(),
-                acc.data(),
-                acc.executable(),
-                // only persist rent_epoch for those rent-paying accounts
-                Some(*account_hash),
-            )
-        })
-        .unwrap_or((0, &OWNER_NO_OWNER, &[], false, None));
+    let (lamports, owner, data, executable) = account
+        .map(|acc| (acc.lamports(), acc.owner(), acc.data(), acc.executable()))
+        .unwrap_or((0, &OWNER_NO_OWNER, &[], false));
 
     assert_eq!(stored_meta.lamports(), lamports);
     assert_eq!(stored_meta.data().len(), data.len());
@@ -69,8 +59,5 @@ pub(super) fn verify_test_account(
     assert_eq!(stored_meta.executable(), executable);
     assert_eq!(stored_meta.owner(), owner);
     assert_eq!(stored_meta.pubkey(), address);
-    assert_eq!(
-        *stored_meta.hash(),
-        account_hash.unwrap_or(AccountHash(Hash::default()))
-    );
+    assert_eq!(*stored_meta.hash(), AccountHash(Hash::default()));
 }


### PR DESCRIPTION
#### Problem
TieredStorage stores account hash as an optional field inside its HotStorage.
However, the field isn't used and we have already decided to deprecate
the account hash.

#### Summary of Changes
Remove account-hash from the tiered-storage.

#### Test Plan
Existing tiered-storage tests.
Running validators w/ tiered-storage in mainnet-beta w/o storing account-hash.

