### PR TITLE
Add get_blocks and get_slot methods to bench-tps-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5591,6 +5591,7 @@ dependencies = [
  "solana-test-validator",
  "solana-thin-client",
  "solana-tpu-client",
+ "solana-transaction-status",
  "solana-version",
  "spl-instruction-padding",
  "tempfile",

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -37,6 +37,7 @@ solana-sdk = { workspace = true }
 solana-streamer = { workspace = true }
 solana-thin-client = { workspace = true }
 solana-tpu-client = { workspace = true }
+solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
 spl-instruction-padding = { workspace = true }
 thiserror = { workspace = true }

--- a/bench-tps/src/bench_tps_client.rs
+++ b/bench-tps/src/bench_tps_client.rs
@@ -95,9 +95,14 @@ pub trait BenchTpsClient {
 
     fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>>;
 
-    fn get_slot(&self) -> Result<Slot>;
+    fn get_slot_with_commitment(&self, commitment_config: CommitmentConfig) -> Result<Slot>;
 
-    fn get_blocks(&self, start_slot: Slot, end_slot: Option<Slot>) -> Result<Vec<Slot>>;
+    fn get_blocks_with_commitment(
+        &self,
+        start_slot: Slot,
+        end_slot: Option<Slot>,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Vec<Slot>>;
 
     fn get_block_with_config(
         &self,

--- a/bench-tps/src/bench_tps_client.rs
+++ b/bench-tps/src/bench_tps_client.rs
@@ -1,11 +1,12 @@
 use {
-    solana_rpc_client_api::client_error::Error as ClientError,
+    solana_rpc_client_api::{client_error::Error as ClientError, config::RpcBlockConfig},
     solana_sdk::{
         account::Account, commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash,
-        message::Message, pubkey::Pubkey, signature::Signature, transaction::Transaction,
-        transport::TransportError,
+        message::Message, pubkey::Pubkey, signature::Signature, slot_history::Slot,
+        transaction::Transaction, transport::TransportError,
     },
     solana_tpu_client::tpu_client::TpuSenderError,
+    solana_transaction_status::UiConfirmedBlock,
     thiserror::Error,
 };
 
@@ -93,6 +94,16 @@ pub trait BenchTpsClient {
     ) -> Result<Account>;
 
     fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>>;
+
+    fn get_slot(&self) -> Result<Slot>;
+
+    fn get_blocks(&self, start_slot: Slot, end_slot: Option<Slot>) -> Result<Vec<Slot>>;
+
+    fn get_block_with_config(
+        &self,
+        slot: Slot,
+        rpc_block_config: RpcBlockConfig,
+    ) -> Result<UiConfirmedBlock>;
 }
 
 mod bank_client;

--- a/bench-tps/src/bench_tps_client/bank_client.rs
+++ b/bench-tps/src/bench_tps_client/bank_client.rs
@@ -115,11 +115,16 @@ impl BenchTpsClient for BankClient {
         unimplemented!("BankClient doesn't support get_multiple_accounts");
     }
 
-    fn get_slot(&self) -> Result<Slot> {
-        SyncClient::get_slot(self).map_err(|err| err.into())
+    fn get_slot_with_commitment(&self, commitment_config: CommitmentConfig) -> Result<Slot> {
+        SyncClient::get_slot_with_commitment(self, commitment_config).map_err(|err| err.into())
     }
 
-    fn get_blocks(&self, _start_slot: Slot, _end_slot: Option<Slot>) -> Result<Vec<Slot>> {
+    fn get_blocks_with_commitment(
+        &self,
+        _start_slot: Slot,
+        _end_slot: Option<Slot>,
+        _commitment_config: CommitmentConfig,
+    ) -> Result<Vec<Slot>> {
         unimplemented!("BankClient doesn't support get_blocks");
     }
 

--- a/bench-tps/src/bench_tps_client/bank_client.rs
+++ b/bench-tps/src/bench_tps_client/bank_client.rs
@@ -1,5 +1,6 @@
 use {
     crate::bench_tps_client::{BenchTpsClient, BenchTpsError, Result},
+    solana_rpc_client_api::config::RpcBlockConfig,
     solana_runtime::bank_client::BankClient,
     solana_sdk::{
         account::Account,
@@ -10,8 +11,10 @@ use {
         message::Message,
         pubkey::Pubkey,
         signature::Signature,
+        slot_history::Slot,
         transaction::Transaction,
     },
+    solana_transaction_status::UiConfirmedBlock,
 };
 
 impl BenchTpsClient for BankClient {
@@ -110,5 +113,21 @@ impl BenchTpsClient for BankClient {
 
     fn get_multiple_accounts(&self, _pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>> {
         unimplemented!("BankClient doesn't support get_multiple_accounts");
+    }
+
+    fn get_slot(&self) -> Result<Slot> {
+        SyncClient::get_slot(self).map_err(|err| err.into())
+    }
+
+    fn get_blocks(&self, _start_slot: Slot, _end_slot: Option<Slot>) -> Result<Vec<Slot>> {
+        unimplemented!("BankClient doesn't support get_blocks");
+    }
+
+    fn get_block_with_config(
+        &self,
+        _slot: Slot,
+        _rpc_block_config: RpcBlockConfig,
+    ) -> Result<UiConfirmedBlock> {
+        unimplemented!("BankClient doesn't support get_block_with_config");
     }
 }

--- a/bench-tps/src/bench_tps_client/rpc_client.rs
+++ b/bench-tps/src/bench_tps_client/rpc_client.rs
@@ -1,10 +1,13 @@
 use {
     crate::bench_tps_client::{BenchTpsClient, BenchTpsError, Result},
     solana_rpc_client::rpc_client::RpcClient,
+    solana_rpc_client_api::config::RpcBlockConfig,
     solana_sdk::{
         account::Account, commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash,
-        message::Message, pubkey::Pubkey, signature::Signature, transaction::Transaction,
+        message::Message, pubkey::Pubkey, signature::Signature, slot_history::Slot,
+        transaction::Transaction,
     },
+    solana_transaction_status::UiConfirmedBlock,
 };
 
 impl BenchTpsClient for RpcClient {
@@ -103,5 +106,21 @@ impl BenchTpsClient for RpcClient {
 
     fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>> {
         RpcClient::get_multiple_accounts(self, pubkeys).map_err(|err| err.into())
+    }
+
+    fn get_slot(&self) -> Result<Slot> {
+        RpcClient::get_slot(self).map_err(|err| err.into())
+    }
+
+    fn get_blocks(&self, start_slot: Slot, end_slot: Option<Slot>) -> Result<Vec<Slot>> {
+        RpcClient::get_blocks(self, start_slot, end_slot).map_err(|err| err.into())
+    }
+
+    fn get_block_with_config(
+        &self,
+        slot: Slot,
+        rpc_block_config: RpcBlockConfig,
+    ) -> Result<UiConfirmedBlock> {
+        RpcClient::get_block_with_config(self, slot, rpc_block_config).map_err(|err| err.into())
     }
 }

--- a/bench-tps/src/bench_tps_client/rpc_client.rs
+++ b/bench-tps/src/bench_tps_client/rpc_client.rs
@@ -108,12 +108,18 @@ impl BenchTpsClient for RpcClient {
         RpcClient::get_multiple_accounts(self, pubkeys).map_err(|err| err.into())
     }
 
-    fn get_slot(&self) -> Result<Slot> {
-        RpcClient::get_slot(self).map_err(|err| err.into())
+    fn get_slot_with_commitment(&self, commitment_config: CommitmentConfig) -> Result<Slot> {
+        RpcClient::get_slot_with_commitment(self, commitment_config).map_err(|err| err.into())
     }
 
-    fn get_blocks(&self, start_slot: Slot, end_slot: Option<Slot>) -> Result<Vec<Slot>> {
-        RpcClient::get_blocks(self, start_slot, end_slot).map_err(|err| err.into())
+    fn get_blocks_with_commitment(
+        &self,
+        start_slot: Slot,
+        end_slot: Option<Slot>,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Vec<Slot>> {
+        RpcClient::get_blocks_with_commitment(self, start_slot, end_slot, commitment_config)
+            .map_err(|err| err.into())
     }
 
     fn get_block_with_config(

--- a/bench-tps/src/bench_tps_client/thin_client.rs
+++ b/bench-tps/src/bench_tps_client/thin_client.rs
@@ -1,6 +1,7 @@
 use {
     crate::bench_tps_client::{BenchTpsClient, BenchTpsError, Result},
     solana_client::thin_client::ThinClient,
+    solana_rpc_client_api::config::RpcBlockConfig,
     solana_sdk::{
         account::Account,
         client::{AsyncClient, Client, SyncClient},
@@ -10,8 +11,10 @@ use {
         message::Message,
         pubkey::Pubkey,
         signature::Signature,
+        slot_history::Slot,
         transaction::Transaction,
     },
+    solana_transaction_status::UiConfirmedBlock,
 };
 
 impl BenchTpsClient for ThinClient {
@@ -108,6 +111,26 @@ impl BenchTpsClient for ThinClient {
     fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>> {
         self.rpc_client()
             .get_multiple_accounts(pubkeys)
+            .map_err(|err| err.into())
+    }
+
+    fn get_slot(&self) -> Result<Slot> {
+        self.rpc_client().get_slot().map_err(|err| err.into())
+    }
+
+    fn get_blocks(&self, start_slot: Slot, end_slot: Option<Slot>) -> Result<Vec<Slot>> {
+        self.rpc_client()
+            .get_blocks(start_slot, end_slot)
+            .map_err(|err| err.into())
+    }
+
+    fn get_block_with_config(
+        &self,
+        slot: Slot,
+        rpc_block_config: RpcBlockConfig,
+    ) -> Result<UiConfirmedBlock> {
+        self.rpc_client()
+            .get_block_with_config(slot, rpc_block_config)
             .map_err(|err| err.into())
     }
 }

--- a/bench-tps/src/bench_tps_client/thin_client.rs
+++ b/bench-tps/src/bench_tps_client/thin_client.rs
@@ -114,13 +114,20 @@ impl BenchTpsClient for ThinClient {
             .map_err(|err| err.into())
     }
 
-    fn get_slot(&self) -> Result<Slot> {
-        self.rpc_client().get_slot().map_err(|err| err.into())
+    fn get_slot_with_commitment(&self, commitment_config: CommitmentConfig) -> Result<Slot> {
+        self.rpc_client()
+            .get_slot_with_commitment(commitment_config)
+            .map_err(|err| err.into())
     }
 
-    fn get_blocks(&self, start_slot: Slot, end_slot: Option<Slot>) -> Result<Vec<Slot>> {
+    fn get_blocks_with_commitment(
+        &self,
+        start_slot: Slot,
+        end_slot: Option<Slot>,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Vec<Slot>> {
         self.rpc_client()
-            .get_blocks(start_slot, end_slot)
+            .get_blocks_with_commitment(start_slot, end_slot, commitment_config)
             .map_err(|err| err.into())
     }
 

--- a/bench-tps/src/bench_tps_client/tpu_client.rs
+++ b/bench-tps/src/bench_tps_client/tpu_client.rs
@@ -4,10 +4,13 @@ use {
     solana_connection_cache::connection_cache::{
         ConnectionManager, ConnectionPool, NewConnectionConfig,
     },
+    solana_rpc_client_api::config::RpcBlockConfig,
     solana_sdk::{
         account::Account, commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash,
-        message::Message, pubkey::Pubkey, signature::Signature, transaction::Transaction,
+        message::Message, pubkey::Pubkey, signature::Signature, slot_history::Slot,
+        transaction::Transaction,
     },
+    solana_transaction_status::UiConfirmedBlock,
 };
 
 impl<P, M, C> BenchTpsClient for TpuClient<P, M, C>
@@ -128,6 +131,26 @@ where
     fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>> {
         self.rpc_client()
             .get_multiple_accounts(pubkeys)
+            .map_err(|err| err.into())
+    }
+
+    fn get_slot(&self) -> Result<Slot> {
+        self.rpc_client().get_slot().map_err(|err| err.into())
+    }
+
+    fn get_blocks(&self, start_slot: Slot, end_slot: Option<Slot>) -> Result<Vec<Slot>> {
+        self.rpc_client()
+            .get_blocks(start_slot, end_slot)
+            .map_err(|err| err.into())
+    }
+
+    fn get_block_with_config(
+        &self,
+        slot: Slot,
+        rpc_block_config: RpcBlockConfig,
+    ) -> Result<UiConfirmedBlock> {
+        self.rpc_client()
+            .get_block_with_config(slot, rpc_block_config)
             .map_err(|err| err.into())
     }
 }

--- a/bench-tps/src/bench_tps_client/tpu_client.rs
+++ b/bench-tps/src/bench_tps_client/tpu_client.rs
@@ -134,13 +134,20 @@ where
             .map_err(|err| err.into())
     }
 
-    fn get_slot(&self) -> Result<Slot> {
-        self.rpc_client().get_slot().map_err(|err| err.into())
+    fn get_slot_with_commitment(&self, commitment_config: CommitmentConfig) -> Result<Slot> {
+        self.rpc_client()
+            .get_slot_with_commitment(commitment_config)
+            .map_err(|err| err.into())
     }
 
-    fn get_blocks(&self, start_slot: Slot, end_slot: Option<Slot>) -> Result<Vec<Slot>> {
+    fn get_blocks_with_commitment(
+        &self,
+        start_slot: Slot,
+        end_slot: Option<Slot>,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Vec<Slot>> {
         self.rpc_client()
-            .get_blocks(start_slot, end_slot)
+            .get_blocks_with_commitment(start_slot, end_slot, commitment_config)
             .map_err(|err| err.into())
     }
 


### PR DESCRIPTION
#### Problem

For the analysis of the confirmed transactions implemented in https://github.com/anza-xyz/agave/pull/92 `BenchTpsClient` needs some additional methods.

#### Summary of Changes

Add `get_block`, `get_blocks` and `get_slot` methods.

