### PR TITLE
Cli: improve vote-account vote-authority display

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1654,8 +1654,10 @@ impl fmt::Display for CliAuthorizedVoters {
             write!(f, "None")?;
         }
         if self.authorized_voters.len() > 1 {
-            let (epoch, upcoming_authorized_voter) =
-                self.authorized_voters.last_key_value().unwrap();
+            let (epoch, upcoming_authorized_voter) = self
+                .authorized_voters
+                .last_key_value()
+                .expect("CliAuthorizedVoters::authorized_voters.len() > 1");
             writeln!(f)?;
             write!(
                 f,

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1648,7 +1648,12 @@ impl VerboseDisplay for CliAuthorizedVoters {}
 
 impl fmt::Display for CliAuthorizedVoters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.authorized_voters)
+        let (_epoch, current_authorized_voter) = self
+            .authorized_voters
+            .first_key_value()
+            .expect("CliAuthorizedVoters::authorized_voters should have at least one entry");
+        write!(f, "{current_authorized_voter}")?;
+        Ok(())
     }
 }
 

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1653,6 +1653,15 @@ impl fmt::Display for CliAuthorizedVoters {
             .first_key_value()
             .expect("CliAuthorizedVoters::authorized_voters should have at least one entry");
         write!(f, "{current_authorized_voter}")?;
+        if self.authorized_voters.len() > 1 {
+            let (epoch, upcoming_authorized_voter) =
+                self.authorized_voters.last_key_value().unwrap();
+            writeln!(f)?;
+            write!(
+                f,
+                "  New Vote Authority as of Epoch {epoch}: {upcoming_authorized_voter}"
+            )?;
+        }
         Ok(())
     }
 }

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1648,11 +1648,11 @@ impl VerboseDisplay for CliAuthorizedVoters {}
 
 impl fmt::Display for CliAuthorizedVoters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let (_epoch, current_authorized_voter) = self
-            .authorized_voters
-            .first_key_value()
-            .expect("CliAuthorizedVoters::authorized_voters should have at least one entry");
-        write!(f, "{current_authorized_voter}")?;
+        if let Some((_epoch, current_authorized_voter)) = self.authorized_voters.first_key_value() {
+            write!(f, "{current_authorized_voter}")?;
+        } else {
+            write!(f, "None")?;
+        }
         if self.authorized_voters.len() > 1 {
             let (epoch, upcoming_authorized_voter) =
                 self.authorized_voters.last_key_value().unwrap();
@@ -3393,12 +3393,12 @@ mod tests {
             ..CliVoteAccount::default()
         };
         let s = format!("{c}");
-        assert_eq!(s, "Account Balance: 0.00001 SOL\nValidator Identity: 11111111111111111111111111111111\nVote Authority: {}\nWithdraw Authority: \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z from slot 0\nEpoch Rewards:\n  Epoch   Reward Slot  Time                        Amount              New Balance         Percent Change             APR  Commission\n  1       100          1970-01-01 00:00:00 UTC  ◎0.000000010        ◎0.000000100               11.000%          10.00%          1%\n  2       200          1970-01-12 13:46:40 UTC  ◎0.000000012        ◎0.000000100               11.000%          13.00%          1%\n");
+        assert_eq!(s, "Account Balance: 0.00001 SOL\nValidator Identity: 11111111111111111111111111111111\nVote Authority: None\nWithdraw Authority: \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z from slot 0\nEpoch Rewards:\n  Epoch   Reward Slot  Time                        Amount              New Balance         Percent Change             APR  Commission\n  1       100          1970-01-01 00:00:00 UTC  ◎0.000000010        ◎0.000000100               11.000%          10.00%          1%\n  2       200          1970-01-12 13:46:40 UTC  ◎0.000000012        ◎0.000000100               11.000%          13.00%          1%\n");
         println!("{s}");
 
         c.use_csv = true;
         let s = format!("{c}");
-        assert_eq!(s, "Account Balance: 0.00001 SOL\nValidator Identity: 11111111111111111111111111111111\nVote Authority: {}\nWithdraw Authority: \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z from slot 0\nEpoch Rewards:\nEpoch,Reward Slot,Time,Amount,New Balance,Percent Change,APR,Commission\n1,100,1970-01-01 00:00:00 UTC,0.00000001,0.0000001,11%,10.00%,1%\n2,200,1970-01-12 13:46:40 UTC,0.000000012,0.0000001,11%,13.00%,1%\n");
+        assert_eq!(s, "Account Balance: 0.00001 SOL\nValidator Identity: 11111111111111111111111111111111\nVote Authority: None\nWithdraw Authority: \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z from slot 0\nEpoch Rewards:\nEpoch,Reward Slot,Time,Amount,New Balance,Percent Change,APR,Commission\n1,100,1970-01-01 00:00:00 UTC,0.00000001,0.0000001,11%,10.00%,1%\n2,200,1970-01-12 13:46:40 UTC,0.000000012,0.0000001,11%,13.00%,1%\n");
         println!("{s}");
     }
 }


### PR DESCRIPTION
#### Problem
In `solana vote-account` output, the Vote Authority line is not clear. It returns a map of one or more numbers to address strings, eg:
```
Vote Authority: {2: "A1T3QdPZGRT99twji2M4vrkFRDXjp8aEbFc6GCJuviSp"}
```

The number is in fact an epoch, the epoch the respective authority is active. This is usually the current epoch, but in the case of a vote-authority update, it is the epoch in which the new vote authority will go into effect.

Cleaning up small, old Labs issues: https://github.com/solana-labs/solana/issues/11273

#### Summary of Changes
Simplify normal display:
```
Vote Authority: A1T3QdPZGRT99twji2M4vrkFRDXjp8aEbFc6GCJuviSp
```

If a new vote authority has been authorized, display its information, eg:
```
Vote Authority: A1T3QdPZGRT99twji2M4vrkFRDXjp8aEbFc6GCJuviSp
  New Vote Authority as of Epoch 4: EvgdtuXcKoBAMW6eL6KMiqDre1do5o2v4tinFv91H2Fo
```

Fixes https://github.com/solana-labs/solana/issues/11273