### PR TITLE
Give SigVerify and ShredFetch threads unique names

### DIFF
--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -160,7 +160,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
     let (packet_s, packet_r) = unbounded();
     let (verified_s, verified_r) = BankingTracer::channel_for_test();
     let verifier = TransactionSigVerifier::new(verified_s);
-    let stage = SigVerifyStage::new(packet_r, verifier, "bench");
+    let stage = SigVerifyStage::new(packet_r, verifier, "solSigVerBench", "bench");
 
     bencher.iter(move || {
         let now = Instant::now();

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -148,6 +148,7 @@ impl ShredFetchStage {
     #[allow(clippy::too_many_arguments)]
     fn packet_modifier(
         receiver_thread_name: &'static str,
+        modifier_thread_name: &'static str,
         sockets: Vec<Arc<UdpSocket>>,
         exit: Arc<AtomicBool>,
         sender: Sender<PacketBatch>,
@@ -178,7 +179,7 @@ impl ShredFetchStage {
             })
             .collect();
         let modifier_hdl = Builder::new()
-            .name("solTvuFetchPMod".to_string())
+            .name(modifier_thread_name.to_string())
             .spawn(move || {
                 let repair_context = repair_context
                     .as_ref()
@@ -215,6 +216,7 @@ impl ShredFetchStage {
 
         let (mut tvu_threads, tvu_filter) = Self::packet_modifier(
             "solRcvrShred",
+            "solTvuPktMod",
             sockets,
             exit.clone(),
             sender.clone(),
@@ -229,6 +231,7 @@ impl ShredFetchStage {
 
         let (repair_receiver, repair_handler) = Self::packet_modifier(
             "solRcvrShredRep",
+            "solTvuRepPktMod",
             vec![repair_socket.clone()],
             exit.clone(),
             sender.clone(),

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -190,14 +190,19 @@ impl Tpu {
 
         let sigverify_stage = {
             let verifier = TransactionSigVerifier::new(non_vote_sender);
-            SigVerifyStage::new(packet_receiver, verifier, "tpu-verifier")
+            SigVerifyStage::new(packet_receiver, verifier, "solSigVerTpu", "tpu-verifier")
         };
 
         let (tpu_vote_sender, tpu_vote_receiver) = banking_tracer.create_channel_tpu_vote();
 
         let vote_sigverify_stage = {
             let verifier = TransactionSigVerifier::new_reject_non_vote(tpu_vote_sender);
-            SigVerifyStage::new(vote_packet_receiver, verifier, "tpu-vote-verifier")
+            SigVerifyStage::new(
+                vote_packet_receiver,
+                verifier,
+                "solSigVerTpuVot",
+                "tpu-vote-verifier",
+            )
         };
 
         let (gossip_vote_sender, gossip_vote_receiver) =


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/issues/34 for context

#### Summary of Changes
- `solTvuFetchPmod` ==> `solTvuPktMod` + `solTvuRepPktMod`
- `solSigVerifier` ==> `solSigVerTpu` + `solSigVerTpuVot`
