### PR TITLE
assert simple vote tx const cost

### DIFF
--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -19,7 +19,17 @@ pub enum TransactionCost {
 impl TransactionCost {
     pub fn sum(&self) -> u64 {
         match self {
-            Self::SimpleVote { .. } => SIMPLE_VOTE_USAGE_COST,
+            Self::SimpleVote { .. } => {
+                const _: () = assert!(
+                    SIMPLE_VOTE_USAGE_COST
+                        == solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS
+                            + block_cost_limits::SIGNATURE_COST
+                            + 2 * block_cost_limits::WRITE_LOCK_UNITS
+                            + 8
+                );
+
+                SIMPLE_VOTE_USAGE_COST
+            }
             Self::Transaction(usage_cost) => usage_cost.sum(),
         }
     }

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -18,6 +18,7 @@ pub enum TransactionCost {
 
 impl TransactionCost {
     pub fn sum(&self) -> u64 {
+        #![allow(clippy::assertions_on_constants)]
         match self {
             Self::SimpleVote { .. } => {
                 const _: () = assert!(


### PR DESCRIPTION
#### Problem
Simple Vote Transaction has static cost, which is sum of vote instruction cost, signature cost, 2 write lock cost, and 8CU for data size. Should have some way to make sure the const value are correct.

#### Summary of Changes
- add assert on the const values 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
