### PR TITLE
Fix: deploy program on last slot of epoch during environment change

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -514,9 +514,8 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
 
     // Adding `DELAY_VISIBILITY_SLOT_OFFSET` to slots to accommodate for delay visibility of the program
-    let slot = bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET;
     let mut loaded_programs =
-        LoadedProgramsForTxBatch::new(slot, bank.get_runtime_environments_for_slot(slot));
+        bank.new_program_cache_for_tx_batch_for_slot(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
     for key in cached_account_keys {
         loaded_programs.replenish(key, bank.load_program(&key, false, bank.epoch()));
         debug!("Loaded program {}", key);

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -21,11 +21,12 @@ use {
     },
     solana_runtime::bank::Bank,
     solana_sdk::{
-        account::AccountSharedData,
+        account::{create_account_shared_data_for_test, AccountSharedData},
         account_utils::StateMut,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         pubkey::Pubkey,
         slot_history::Slot,
+        sysvar,
         transaction_context::{IndexOfAccount, InstructionAccount},
     },
     std::{
@@ -509,6 +510,10 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     transaction_accounts.push((
         program_id, // ID of the loaded program. It can modify accounts with the same owner key
         AccountSharedData::new(0, 0, &loader_id),
+    ));
+    transaction_accounts.push((
+        sysvar::epoch_schedule::id(),
+        create_account_shared_data_for_test(bank.epoch_schedule()),
     ));
     let interpreted = matches.value_of("mode").unwrap() != "jit";
     with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -216,10 +216,10 @@ impl<'a> InvokeContext<'a> {
 
     pub fn get_environments_for_slot(
         &self,
-        slot: Slot,
+        effective_slot: Slot,
     ) -> Result<&ProgramRuntimeEnvironments, InstructionError> {
         let epoch_schedule = self.sysvar_cache.get_epoch_schedule()?;
-        let epoch = epoch_schedule.get_epoch(slot);
+        let epoch = epoch_schedule.get_epoch(effective_slot);
         Ok(self
             .programs_loaded_for_tx_batch
             .get_environments_for_epoch(epoch))

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -214,7 +214,7 @@ impl<'a> InvokeContext<'a> {
             .or_else(|| self.programs_loaded_for_tx_batch.find(pubkey))
     }
 
-    pub fn get_runtime_environments_for_slot(
+    pub fn get_environments_for_slot(
         &self,
         slot: Slot,
     ) -> Result<&ProgramRuntimeEnvironments, InstructionError> {

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -651,7 +651,7 @@ impl LoadedProgramsForTxBatch {
     pub fn new_from_cache<FG: ForkGraph>(
         slot: Slot,
         epoch: Epoch,
-        cache: &LoadedPrograms<FG>,
+        cache: &ProgramCache<FG>,
     ) -> Self {
         Self {
             entries: HashMap::new(),

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -648,6 +648,21 @@ impl LoadedProgramsForTxBatch {
         }
     }
 
+    pub fn new_from_cache<FG: ForkGraph>(
+        slot: Slot,
+        epoch: Epoch,
+        cache: &LoadedPrograms<FG>,
+    ) -> Self {
+        Self {
+            entries: HashMap::new(),
+            slot,
+            environments: cache.get_environments_for_epoch(epoch).clone(),
+            upcoming_environments: cache.get_upcoming_environments_for_epoch(epoch),
+            latest_root_epoch: cache.latest_root_epoch,
+            hit_max_limit: false,
+        }
+    }
+
     /// Returns the current environments depending on the given epoch
     pub fn get_environments_for_epoch(&self, epoch: Epoch) -> &ProgramRuntimeEnvironments {
         if epoch != self.latest_root_epoch {

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -618,11 +618,13 @@ pub struct LoadedProgramsForTxBatch {
     entries: HashMap<Pubkey, Arc<LoadedProgram>>,
     slot: Slot,
     pub environments: ProgramRuntimeEnvironments,
-    /// Anticipated replacement for `environments` at the next epoch
+    /// Anticipated replacement for `environments` at the next epoch.
     ///
     /// This is `None` during most of an epoch, and only `Some` around the boundaries (at the end and beginning of an epoch).
     /// More precisely, it starts with the recompilation phase a few hundred slots before the epoch boundary,
     /// and it ends with the first rerooting after the epoch boundary.
+    /// Needed when a program is deployed at the last slot of an epoch, becomes effective in the next epoch.
+    /// So needs to be compiled with the environment for the next epoch.
     pub upcoming_environments: Option<ProgramRuntimeEnvironments>,
     /// The epoch of the last rerooting
     pub latest_root_epoch: Epoch,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -618,17 +618,42 @@ pub struct LoadedProgramsForTxBatch {
     entries: HashMap<Pubkey, Arc<LoadedProgram>>,
     slot: Slot,
     pub environments: ProgramRuntimeEnvironments,
+    /// Anticipated replacement for `environments` at the next epoch
+    ///
+    /// This is `None` during most of an epoch, and only `Some` around the boundaries (at the end and beginning of an epoch).
+    /// More precisely, it starts with the recompilation phase a few hundred slots before the epoch boundary,
+    /// and it ends with the first rerooting after the epoch boundary.
+    pub upcoming_environments: Option<ProgramRuntimeEnvironments>,
+    /// The epoch of the last rerooting
+    pub latest_root_epoch: Epoch,
     pub hit_max_limit: bool,
 }
 
 impl LoadedProgramsForTxBatch {
-    pub fn new(slot: Slot, environments: ProgramRuntimeEnvironments) -> Self {
+    pub fn new(
+        slot: Slot,
+        environments: ProgramRuntimeEnvironments,
+        upcoming_environments: Option<ProgramRuntimeEnvironments>,
+        latest_root_epoch: Epoch,
+    ) -> Self {
         Self {
             entries: HashMap::new(),
             slot,
             environments,
+            upcoming_environments,
+            latest_root_epoch,
             hit_max_limit: false,
         }
+    }
+
+    /// Returns the current environments depending on the given epoch
+    pub fn get_environments_for_epoch(&self, epoch: Epoch) -> &ProgramRuntimeEnvironments {
+        if epoch != self.latest_root_epoch {
+            if let Some(upcoming_environments) = self.upcoming_environments.as_ref() {
+                return upcoming_environments;
+            }
+        }
+        &self.environments
     }
 
     /// Refill the cache with a single entry. It's typically called during transaction loading, and
@@ -708,6 +733,17 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             }
         }
         &self.environments
+    }
+
+    /// Returns the upcoming environments depending on the given epoch
+    pub fn get_upcoming_environments_for_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> Option<ProgramRuntimeEnvironments> {
+        if epoch == self.latest_root_epoch {
+            return self.upcoming_environments.clone();
+        }
+        None
     }
 
     /// Insert a single entry. It's typically called during transaction loading,
@@ -2057,7 +2093,7 @@ mod tests {
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 3)),
             (program4, (LoadedProgramMatchCriteria::NoCriteria, 4)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(22, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(22, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 20, 22));
@@ -2073,7 +2109,7 @@ mod tests {
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program4, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(15, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(15, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 15));
@@ -2096,7 +2132,7 @@ mod tests {
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program4, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(18, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(18, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 18));
@@ -2114,7 +2150,7 @@ mod tests {
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program4, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(23, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(23, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 23));
@@ -2132,7 +2168,7 @@ mod tests {
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program4, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(11, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(11, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 11));
@@ -2170,7 +2206,7 @@ mod tests {
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program4, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(21, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(21, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         // Since the fork was pruned, we should not find the entry deployed at slot 20.
@@ -2187,7 +2223,7 @@ mod tests {
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program4, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(27, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(27, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 27));
@@ -2219,7 +2255,7 @@ mod tests {
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program4, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(23, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(23, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 23));
@@ -2274,7 +2310,7 @@ mod tests {
             (program2, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(12, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(12, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 12));
@@ -2294,7 +2330,7 @@ mod tests {
             ),
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(12, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(12, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program2, 11, 12));
@@ -2360,7 +2396,7 @@ mod tests {
             (program2, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(19, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(19, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 19));
@@ -2374,7 +2410,7 @@ mod tests {
             (program2, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(27, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(27, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 27));
@@ -2388,7 +2424,7 @@ mod tests {
             (program2, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program3, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(22, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(22, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 20, 22));
@@ -2469,7 +2505,7 @@ mod tests {
         cache.prune(10, 0);
 
         let mut missing = vec![(program1, (LoadedProgramMatchCriteria::NoCriteria, 1))];
-        let mut extracted = LoadedProgramsForTxBatch::new(20, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(20, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         // The cache should have the program deployed at slot 0
@@ -2513,7 +2549,7 @@ mod tests {
             (program1, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program2, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(20, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(20, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 20));
@@ -2523,7 +2559,7 @@ mod tests {
             (program1, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program2, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(6, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(6, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 5, 6));
@@ -2537,7 +2573,7 @@ mod tests {
             (program1, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program2, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(20, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(20, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 20));
@@ -2547,7 +2583,7 @@ mod tests {
             (program1, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program2, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(6, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(6, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 6));
@@ -2561,7 +2597,7 @@ mod tests {
             (program1, (LoadedProgramMatchCriteria::NoCriteria, 1)),
             (program2, (LoadedProgramMatchCriteria::NoCriteria, 1)),
         ];
-        let mut extracted = LoadedProgramsForTxBatch::new(20, cache.environments.clone());
+        let mut extracted = LoadedProgramsForTxBatch::new(20, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
 
         assert!(match_slot(&extracted, &program1, 0, 20));

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1541,6 +1541,7 @@ mod tests {
             },
             account_utils::StateMut,
             clock::Clock,
+            epoch_schedule::EpochSchedule,
             instruction::{AccountMeta, InstructionError},
             pubkey::Pubkey,
             rent::Rent,
@@ -3728,7 +3729,10 @@ mod tests {
 
     #[test]
     fn test_program_usage_count_on_upgrade() {
-        let transaction_accounts = vec![];
+        let transaction_accounts = vec![(
+            sysvar::epoch_schedule::id(),
+            create_account_for_test(&EpochSchedule::default()),
+        )];
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
         let program_id = Pubkey::new_unique();
         let env = Arc::new(BuiltinProgram::new_mock());
@@ -3768,7 +3772,10 @@ mod tests {
 
     #[test]
     fn test_program_usage_count_on_non_upgrade() {
-        let transaction_accounts = vec![];
+        let transaction_accounts = vec![(
+            sysvar::epoch_schedule::id(),
+            create_account_for_test(&EpochSchedule::default()),
+        )];
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
         let program_id = Pubkey::new_unique();
         let env = Arc::new(BuiltinProgram::new_mock());

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -239,12 +239,11 @@ macro_rules! register_feature_gated_function {
     };
 }
 
-pub fn morph_program_runtime_environment_v1(
+pub fn morph_into_deployment_environment_v1(
     from: Arc<BuiltinProgram<InvokeContext>>,
-    reject_deployment_of_broken_elfs: bool,
 ) -> Result<BuiltinProgram<InvokeContext>, Error> {
     let mut config = *from.get_config();
-    config.reject_broken_elfs = reject_deployment_of_broken_elfs;
+    config.reject_broken_elfs = true;
 
     let mut result = FunctionRegistry::<BuiltinFunction<InvokeContext>>::default();
 

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -239,6 +239,22 @@ macro_rules! register_feature_gated_function {
     };
 }
 
+pub fn morph_program_runtime_environment_v1(
+    from: Arc<BuiltinProgram<InvokeContext>>,
+    reject_deployment_of_broken_elfs: bool,
+) -> Result<BuiltinProgram<InvokeContext>, Error> {
+    let mut config = *from.get_config();
+    config.reject_broken_elfs = reject_deployment_of_broken_elfs;
+
+    let mut result = FunctionRegistry::<BuiltinFunction<InvokeContext>>::default();
+
+    for (key, (name, value)) in from.get_function_registry().iter() {
+        result.register_function(key, name, value)?;
+    }
+
+    Ok(BuiltinProgram::new_loader(config, result))
+}
+
 pub fn create_program_runtime_environment_v1<'a>(
     feature_set: &FeatureSet,
     compute_budget: &ComputeBudget,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -249,7 +249,10 @@ pub fn morph_program_runtime_environment_v1(
     let mut result = FunctionRegistry::<BuiltinFunction<InvokeContext>>::default();
 
     for (key, (name, value)) in from.get_function_registry().iter() {
-        result.register_function(key, name, value)?;
+        // Deployment of programs with sol_alloc_free is disabled. So do not register the syscall.
+        if name != *b"sol_alloc_free_" {
+            result.register_function(key, name, value)?;
+        }
     }
 
     Ok(BuiltinProgram::new_loader(config, result))

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -406,8 +406,9 @@ pub fn process_instruction_deploy(
     let effective_slot = deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET);
 
     let environments = invoke_context
-        .get_runtime_environments_for_slot(effective_slot)
+        .get_environments_for_slot(effective_slot)
         .map_err(|err| {
+            // This will never fail since the epoch schedule is already configured.
             ic_logger_msg!(log_collector, "Failed to get runtime environment {}", err);
             InstructionError::InvalidArgument
         })?;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7886,13 +7886,10 @@ impl Bank {
     }
 
     pub fn new_program_cache_for_tx_batch_for_slot(&self, slot: Slot) -> LoadedProgramsForTxBatch {
-        let program_cache_r = self.program_cache.read().unwrap();
-        let epoch = self.epoch_schedule.get_epoch(slot);
-        LoadedProgramsForTxBatch::new(
+        LoadedProgramsForTxBatch::new_from_cache(
             slot,
-            program_cache_r.get_environments_for_epoch(epoch).clone(),
-            program_cache_r.get_upcoming_environments_for_epoch(epoch),
-            program_cache_r.latest_root_epoch,
+            self.epoch_schedule.get_epoch(slot),
+            &self.program_cache.read().unwrap(),
         )
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -101,8 +101,8 @@ use {
         compute_budget_processor::process_compute_budget_instructions,
         invoke_context::BuiltinFunctionWithContext,
         loaded_programs::{
-            LoadedProgram, LoadedProgramMatchCriteria, LoadedProgramType, ProgramCache,
-            ProgramRuntimeEnvironments,
+            LoadedProgram, LoadedProgramMatchCriteria, LoadedProgramType, LoadedProgramsForTxBatch,
+            ProgramCache, ProgramRuntimeEnvironments,
         },
         runtime_config::RuntimeConfig,
         timings::{ExecuteTimingType, ExecuteTimings},
@@ -1527,6 +1527,19 @@ impl Bank {
             .unwrap()
             .get_environments_for_epoch(epoch)
             .clone()
+    }
+
+    pub fn new_program_cache_for_tx_batch_for_slot(&self, slot: Slot) -> LoadedProgramsForTxBatch {
+        let loaded_program_cache_r = self.program_cache.read().unwrap();
+        let epoch = self.epoch_schedule.get_epoch(slot);
+        LoadedProgramsForTxBatch::new(
+            slot,
+            loaded_program_cache_r
+                .get_environments_for_epoch(epoch)
+                .clone(),
+            loaded_program_cache_r.get_upcoming_environments_for_epoch(epoch),
+            loaded_program_cache_r.latest_root_epoch,
+        )
     }
 
     /// Epoch in which the new cooldown warmup rate for stake was activated

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -510,11 +510,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 // Initialize our local cache.
                 let is_first_round = loaded_programs_for_txs.is_none();
                 if is_first_round {
-                    loaded_programs_for_txs = Some(LoadedProgramsForTxBatch::new(
+                    loaded_programs_for_txs = Some(LoadedProgramsForTxBatch::new_from_cache(
                         self.slot,
-                        program_cache.get_environments_for_epoch(self.epoch).clone(),
-                        program_cache.get_upcoming_environments_for_epoch(self.epoch),
-                        program_cache.latest_root_epoch,
+                        self.epoch,
+                        &program_cache,
                     ));
                 }
                 // Submit our last completed loading task.
@@ -525,11 +524,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         // This branch is taken when there is an error in assigning a program to a
                         // cache slot. It is not possible to mock this error for SVM unit
                         // tests purposes.
-                        let mut ret = LoadedProgramsForTxBatch::new(
+                        let mut ret = LoadedProgramsForTxBatch::new_from_cache(
                             self.slot,
-                            program_cache.get_environments_for_epoch(self.epoch).clone(),
-                            program_cache.get_upcoming_environments_for_epoch(self.epoch),
-                            program_cache.latest_root_epoch,
+                            self.epoch,
+                            &program_cache,
                         );
                         ret.hit_max_limit = true;
                         return ret;

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -513,6 +513,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     loaded_programs_for_txs = Some(LoadedProgramsForTxBatch::new(
                         self.slot,
                         program_cache.get_environments_for_epoch(self.epoch).clone(),
+                        program_cache.get_upcoming_environments_for_epoch(self.epoch),
+                        program_cache.latest_root_epoch,
                     ));
                 }
                 // Submit our last completed loading task.
@@ -526,6 +528,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         let mut ret = LoadedProgramsForTxBatch::new(
                             self.slot,
                             program_cache.get_environments_for_epoch(self.epoch).clone(),
+                            program_cache.get_upcoming_environments_for_epoch(self.epoch),
+                            program_cache.latest_root_epoch,
                         );
                         ret.hit_max_limit = true;
                         return ret;
@@ -630,6 +634,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let mut programs_modified_by_tx = LoadedProgramsForTxBatch::new(
             self.slot,
             programs_loaded_for_tx_batch.environments.clone(),
+            programs_loaded_for_tx_batch.upcoming_environments.clone(),
+            programs_loaded_for_tx_batch.latest_root_epoch,
         );
         let mut process_message_time = Measure::start("process_message_time");
         let process_result = MessageProcessor::process_message(


### PR DESCRIPTION
#### Problem
On runtime environment change, the program deployed in the last slot of the prior epoch will use incorrect environment. This will also prevent the loading of the program in future epochs with the correct runtime environment.

#### Summary of Changes
The problem happens because the effective slot for the deployed program is in the next epoch, where the new environment becomes effective. 
This change updates the program deployment procedure, to use the environment of the epoch where the program actually becomes effective.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
