### PR TITLE
Refactor transaction account unlocking

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4376,13 +4376,11 @@ impl Bank {
         account_overrides
     }
 
-    pub fn unlock_accounts(&self, batch: &mut TransactionBatch) {
-        if batch.needs_unlock() {
-            batch.set_needs_unlock(false);
-            self.rc
-                .accounts
-                .unlock_accounts(batch.sanitized_transactions().iter(), batch.lock_results())
-        }
+    pub fn unlock_accounts<'a>(
+        &self,
+        txs_and_results: impl Iterator<Item = (&'a SanitizedTransaction, &'a Result<()>)>,
+    ) {
+        self.rc.accounts.unlock_accounts(txs_and_results)
     }
 
     pub fn remove_unrooted_slots(&self, slots: &[(Slot, BankId)]) {

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -51,7 +51,14 @@ impl<'a, 'b> TransactionBatch<'a, 'b> {
 // Unlock all locked accounts in destructor.
 impl<'a, 'b> Drop for TransactionBatch<'a, 'b> {
     fn drop(&mut self) {
-        self.bank.unlock_accounts(self)
+        if self.needs_unlock() {
+            self.set_needs_unlock(false);
+            self.bank.unlock_accounts(
+                self.sanitized_transactions()
+                    .iter()
+                    .zip(self.lock_results()),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
#### Problem
Current transaction account unlocking APIs aren't ideal for implementing partial transaction batch unlocking. Partial unlocking is needed for https://github.com/solana-labs/solana/issues/34825 by implementing a process of
1. lock txs
2. check qos
3. unlock txs that fail qos

#### Summary of Changes
- Changed `Accounts::unlock_accounts` and `Bank::unlock_accounts` to operate over a zipped iterator of transactions and lock results so that it's easier to implement a partial unlock of a transaction batch.
- Added debug assertions to ensure that no tests are relying on double unlocking transactions
- Added an `is_empty` check inside `Accounts::unlock_accounts` to avoid taking the accounts lock if it's not needed

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
