### PR TITLE
Name previously unnamed thread pool threads

### DIFF
--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -177,7 +177,7 @@ pub fn ip_echo_server(
         .thread_name("solIpEchoSrvrRt")
         .enable_all()
         .build()
-        .unwrap();
+        .expect("new tokio runtime");
     runtime.spawn(run_echo_server(tcp_listener, shred_version));
     runtime
 }

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -173,7 +173,11 @@ pub fn ip_echo_server(
 ) -> IpEchoServer {
     tcp_listener.set_nonblocking(true).unwrap();
 
-    let runtime = Runtime::new().expect("Failed to create Runtime");
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .thread_name("solIpEchoSrvrRt")
+        .enable_all()
+        .build()
+        .unwrap();
     runtime.spawn(run_echo_server(tcp_listener, shred_version));
     runtime
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1486,7 +1486,7 @@ impl Bank {
             ThreadPoolBuilder::new()
                 .thread_name(|i| format!("solBnkNewEpch{i:02}"))
                 .build()
-                .unwrap(),
+                .expect("new rayon threadpool"),
             "thread_pool_creation",
         );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1483,7 +1483,10 @@ impl Bank {
         let epoch = self.epoch();
         let slot = self.slot();
         let (thread_pool, thread_pool_time) = measure!(
-            ThreadPoolBuilder::new().build().unwrap(),
+            ThreadPoolBuilder::new()
+                .thread_name(|i| format!("solBnkNewEpch{i:02}"))
+                .build()
+                .unwrap(),
             "thread_pool_creation",
         );
 

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -418,6 +418,7 @@ impl SnapshotStorageRebuilder {
     /// Builds thread pool to rebuild with
     fn build_thread_pool(&self) -> ThreadPool {
         ThreadPoolBuilder::default()
+            .thread_name(|i| format!("solRbuildSnap{i:02}"))
             .num_threads(self.num_threads)
             .build()
             .unwrap()

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -421,7 +421,7 @@ impl SnapshotStorageRebuilder {
             .thread_name(|i| format!("solRbuildSnap{i:02}"))
             .num_threads(self.num_threads)
             .build()
-            .unwrap()
+            .expect("new rayon threadpool")
     }
 }
 

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -816,7 +816,11 @@ pub async fn connect(ledger_path: &Path) -> std::result::Result<gen_client::Clie
 }
 
 pub fn runtime() -> Runtime {
-    Runtime::new().expect("new tokio runtime")
+    tokio::runtime::Builder::new_multi_thread()
+        .thread_name("solAdminRpcRt")
+        .enable_all()
+        .build()
+        .expect("new tokio runtime")
 }
 
 #[derive(Default, Deserialize, Clone)]


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/issues/34 for context

#### Summary of Changes
- Name the threads in thread pools that were previously unnamed

A few notes on the tokio pools:
- Both pools look to be heavily over-provisioned; however, that is not the goal of this PR and will be addressed in further work
- It seemed better to import tokio directly over using the re-export from `jsonrpc_server_utils`
- `Runtime::new()` calls `Builder::new_multi_thread().enable_all()` under the hood, so there is no change in behavior here; builder allows us to name the threads
https://github.com/tokio-rs/tokio/blob/1f924f95f12c362f5116c560acfa005149f110a1/tokio/src/runtime/runtime.rs#L181-L183
