### PR TITLE
v1.17: ensure that SPL downstream tests always succeed

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -136,23 +136,6 @@ jobs:
           - [single-pool/program]
 
     steps:
-      - uses: actions/checkout@v3
-
       - shell: bash
         run: |
-          .github/scripts/purge-ubuntu-runner.sh
-
-      - uses: mozilla-actions/sccache-action@v0.0.3
-        with:
-          version: "v0.5.4"
-
-      - shell: bash
-        run: |
-          source .github/scripts/downstream-project-spl-common.sh
-
-          programStr="${{ tojson(matrix.programs) }}"
-          IFS=', ' read -ra programs <<<"${programStr//[\[\]$'\n'$'\r' ]/}"
-
-          for program in "${programs[@]}"; do
-            $CARGO_TEST_SBF --manifest-path "$program"/Cargo.toml
-          done
+          echo "SPL repository has updated its minimum version to 1.18.x. Ignore this build."


### PR DESCRIPTION
#### Problem

SPL repo upgraded their dependencies version to v1.18.2 (https://github.com/solana-labs/solana-program-library/pull/6278). it caused two problems

1. its patch script won't work with lower version of solana dependencies.

the patch script that is in the SPL will only update the current version to the target version so we will get this diff: 

![Screenshot 2024-03-03 at 12 48 31](https://github.com/anza-xyz/agave/assets/8209234/ed8e21ee-66cf-4078-9d49-2978ea4f56de)

but the lock file in the SPL has already bumped to 1.18.2. it will make the build failed.

2. borsh version mismatch

due to 1, I tried to update the patch script to https://github.com/yihau/solana-program-library/commit/d7c17af478ff33738fc157745763fb5f4a0c25b0

it will get the diff look like:
![Screenshot 2024-03-06 at 17 02 50](https://github.com/anza-xyz/agave/assets/8209234/7407f696-b5ed-4d97-8686-dd9ed60cd1b4)

but we still couldn't get it pass due to the borsh version mismatch.


#### Summary of Changes

I think it should be better to disable SPL downstream test for v1.17 instead of reverting the PR in SPL.

