### PR TITLE
(v1.17) CI: Checkout v1.17 branch from SPL for downstream job

### DIFF
--- a/.github/scripts/downstream-project-spl-common.sh
+++ b/.github/scripts/downstream-project-spl-common.sh
@@ -8,7 +8,7 @@ source "$here"/../../ci/downstream-projects/common.sh
 
 set -x
 rm -rf spl
-git clone https://github.com/solana-labs/solana-program-library.git spl
+git clone https://github.com/solana-labs/solana-program-library.git spl -b v1.17
 
 # copy toolchain file to use solana's rust version
 cp "$SOLANA_DIR"/rust-toolchain.toml spl/


### PR DESCRIPTION
#### Problem

As pointed out in #106, the SPL downstream job is failing CI on 1.17 because SPL is using 1.18.

#### Summary of Changes

When performing the downstream job, checkout branch `v1.17` on the SPL repo, which is the last commit on 1.17.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
