### PR TITLE
frozen-abi: Remove proc_macro_hygiene featurization

### DIFF
--- a/frozen-abi/build.rs
+++ b/frozen-abi/build.rs
@@ -17,11 +17,6 @@ fn main() {
         }
         Channel::Dev => {
             println!("cargo:rustc-cfg=RUSTC_WITH_SPECIALIZATION");
-            // See https://github.com/solana-labs/solana/issues/11055
-            // We may be running the custom `rust-bpf-builder` toolchain,
-            // which currently needs `#![feature(proc_macro_hygiene)]` to
-            // be applied.
-            println!("cargo:rustc-cfg=RUSTC_NEEDS_PROC_MACRO_HYGIENE");
         }
     }
 }

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -1,6 +1,5 @@
 #![allow(incomplete_features)]
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
-#![cfg_attr(RUSTC_NEEDS_PROC_MACRO_HYGIENE, feature(proc_macro_hygiene))]
 
 // Allows macro expansion of `use ::solana_frozen_abi::*` to work within this crate
 extern crate self as solana_frozen_abi;

--- a/perf/build.rs
+++ b/perf/build.rs
@@ -27,11 +27,6 @@ fn main() {
         }
         Channel::Dev => {
             println!("cargo:rustc-cfg=RUSTC_WITH_SPECIALIZATION");
-            // See https://github.com/solana-labs/solana/issues/11055
-            // We may be running the custom `rust-bpf-builder` toolchain,
-            // which currently needs `#![feature(proc_macro_hygiene)]` to
-            // be applied.
-            println!("cargo:rustc-cfg=RUSTC_NEEDS_PROC_MACRO_HYGIENE");
         }
     }
 }

--- a/programs/address-lookup-table/src/lib.rs
+++ b/programs/address-lookup-table/src/lib.rs
@@ -1,6 +1,5 @@
 #![allow(incomplete_features)]
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
-#![cfg_attr(RUSTC_NEEDS_PROC_MACRO_HYGIENE, feature(proc_macro_hygiene))]
 
 #[cfg(not(target_os = "solana"))]
 pub mod processor;

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -465,7 +465,6 @@
 
 #![allow(incomplete_features)]
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
-#![cfg_attr(RUSTC_NEEDS_PROC_MACRO_HYGIENE, feature(proc_macro_hygiene))]
 
 // Allows macro expansion of `use ::solana_program::*` to work within this crate
 extern crate self as solana_program;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -31,7 +31,6 @@
 
 #![allow(incomplete_features)]
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
-#![cfg_attr(RUSTC_NEEDS_PROC_MACRO_HYGIENE, feature(proc_macro_hygiene))]
 
 // Allows macro expansion of `use ::solana_sdk::*` to work within this crate
 extern crate self as solana_sdk;


### PR DESCRIPTION
#### Problem

There's still usage of an additional `proc_macro_hygiene` feature in frozen-abi and a few of its dependencies, but the issue referenced in the comment, https://github.com/solana-labs/solana/issues/11055, has been long resolved.

#### Summary of Changes

I'm not sure if this is OK, but I wanted to get the discussion started with a simple PR to remove this usage everywhere. If I'm missing something, I'll be happy to close the PR!

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
