### PR TITLE
Improve transaction inclusion when block is nearly full

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1711,8 +1711,13 @@ mod tests {
 
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+            // Hold onto poh lock so that workers cannot finish recording
+            // transactions and cannot unlock accounts immediately. This allows
+            // us to test having parallel workers that have account lock
+            // conflicts.
             let poh_lock = poh_recorder.write().unwrap();
+
+            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
             let worker1 = {
                 let bank = bank.clone();
                 let committer = Committer::new(


### PR DESCRIPTION
#### Problem
When a leader prepares a transaction batch for execution, it needs to check if the accounts for each transaction can be locked and it needs to check if the transaction will fit within the cost tracker limits. Currently the banking stage consumer first selects transactions that can fit within remaining block space and THEN locks the accounts. If any account locking fails, the consumer is needlessly holding onto reserved block space until the consumer finishes processing that batch of transactions.

#### Summary of Changes
- Updated `process_and_record_transactions_with_pre_results` to first lock as many transactions as possible in a batch, then reserve block space, and then finally unlock any transactions that didn't fit in the block.

Fixes https://github.com/solana-labs/solana/issues/34825
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
