### PR TITLE
Removes atomic-ness from AccountStorageEntry `id` and `slot` fields

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1005,9 +1005,9 @@ struct CleanKeyTimings {
 /// Persistent storage structure holding the accounts
 #[derive(Debug)]
 pub struct AccountStorageEntry {
-    pub(crate) id: AtomicAppendVecId,
+    pub(crate) id: AppendVecId,
 
-    pub(crate) slot: AtomicU64,
+    pub(crate) slot: Slot,
 
     /// storage holding the accounts
     pub accounts: AccountsFile,
@@ -1037,8 +1037,8 @@ impl AccountStorageEntry {
         let accounts = AccountsFile::AppendVec(AppendVec::new(&path, true, file_size as usize));
 
         Self {
-            id: AtomicAppendVecId::new(id),
-            slot: AtomicU64::new(slot),
+            id,
+            slot,
             accounts,
             count_and_status: SeqLock::new((0, AccountStorageStatus::Available)),
             approx_store_count: AtomicUsize::new(0),
@@ -1053,8 +1053,8 @@ impl AccountStorageEntry {
         num_accounts: usize,
     ) -> Self {
         Self {
-            id: AtomicAppendVecId::new(id),
-            slot: AtomicU64::new(slot),
+            id,
+            slot,
             accounts,
             count_and_status: SeqLock::new((0, AccountStorageStatus::Available)),
             approx_store_count: AtomicUsize::new(num_accounts),
@@ -1112,11 +1112,11 @@ impl AccountStorageEntry {
     }
 
     pub fn slot(&self) -> Slot {
-        self.slot.load(Ordering::Acquire)
+        self.slot
     }
 
     pub fn append_vec_id(&self) -> AppendVecId {
-        self.id.load(Ordering::Acquire)
+        self.id
     }
 
     pub fn flush(&self) -> Result<(), AccountsFileError> {


### PR DESCRIPTION
#### Problem

As of #118, the `id` and `slot` fields in `AccountStorageEntry` no longer need to be atomic.


#### Summary of Changes

Removes atomic-ness from AccountStorageEntry `id` and `slot` fields