### PR TITLE
blockstore: Remove unnecessary function and threadpool

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -31,10 +31,7 @@ use {
     itertools::Itertools,
     log::*,
     rand::Rng,
-    rayon::{
-        iter::{IntoParallelIterator, ParallelIterator},
-        ThreadPool,
-    },
+    rayon::iter::{IntoParallelIterator, ParallelIterator},
     rocksdb::{DBRawIterator, LiveFile},
     solana_accounts_db::hardened_unpack::{
         unpack_genesis_archive, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
@@ -93,16 +90,6 @@ pub use {
     blockstore_purge::PurgeType,
     rocksdb::properties as RocksProperties,
 };
-
-// get_max_thread_count to match number of threads in the old code.
-// see: https://github.com/solana-labs/solana/pull/24853
-lazy_static! {
-    static ref PAR_THREAD_POOL_ALL_CPUS: ThreadPool = rayon::ThreadPoolBuilder::new()
-        .num_threads(num_cpus::get())
-        .thread_name(|i| format!("solBstoreAll{i:02}"))
-        .build()
-        .unwrap();
-}
 
 pub const MAX_REPLAY_WAKE_UP_SIGNALS: usize = 1;
 pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -455,7 +455,8 @@ impl Blockstore {
         for slot in from_slot..=to_slot {
             let primary_indexes = slot_indexes(slot);
 
-            let slot_entries = self.get_any_valid_slot_entries(slot, 0);
+            let (slot_entries, _, _) =
+                self.get_slot_entries_with_shred_info(slot, 0, true /* allow_dead_slots */)?;
             let transactions = slot_entries
                 .into_iter()
                 .flat_map(|entry| entry.transactions);


### PR DESCRIPTION
#### Problem
This is somewhat of a follow on to https://github.com/solana-labs/solana/pull/34768. Namely, that PR removed a threadpool that was used to fetch entries. There is a similar thread pool that is used to fetch entries for the use-case of purging special columns. Regardless of the use-case, the sentiment that we shouldn't be using a threadpool to fetch the entries remains

#### Summary of Changes
- Update `Blockstore::purge_special_columns_exact()` to use the public facing function
    - Use of `allow_dead_slots == true` retains previous functionality
- Remove the now unused function
- Removed the now unused threadpool

Note that the thread-pool was inside a `lazy_static!`, and would have only been accessed when `Blockstore::clear_unconfirmed_slot()` was called. That function gets called from `ReplayStage` when something is wrong (like the node forking off). So, any healthy node should not created this pool. Regardless, it is still good to cleanup

Work is part of https://github.com/anza-xyz/agave/issues/35