### PR TITLE
Prep Anchor downstream CI job for v2 bump

### DIFF
--- a/scripts/build-downstream-anchor-projects.sh
+++ b/scripts/build-downstream-anchor-projects.sh
@@ -69,7 +69,10 @@ anchor() {
   patch_spl_crates . Cargo.toml "$spl_dir"
 
   $cargo test
-  (cd spl && $cargo_build_sbf --features dex metadata stake)
+  # serum_dex and mpl-token-metadata are using caret versions of solana and SPL dependencies
+  # rather pull and patch those as well, ignore for now
+  # (cd spl && $cargo_build_sbf --features dex metadata stake)
+  (cd spl && $cargo_build_sbf --features stake)
   (cd client && $cargo test --all-features)
 
   anchor_dir=$PWD

--- a/scripts/build-downstream-anchor-projects.sh
+++ b/scripts/build-downstream-anchor-projects.sh
@@ -8,6 +8,7 @@ cd "$(dirname "$0")"/..
 source ci/_
 source scripts/patch-crates.sh
 source scripts/read-cargo-variable.sh
+source scripts/patch-spl-crates-for-anchor.sh
 
 anchor_version=$1
 solana_ver=$(readCargoVariable version Cargo.toml)
@@ -43,6 +44,14 @@ EOF
 # NOTE This isn't run in a subshell to get $anchor_dir and $anchor_ver
 anchor() {
   set -x
+
+  rm -rf spl
+  git clone https://github.com/solana-labs/solana-program-library.git spl
+  cd spl || exit 1
+  spl_dir=$PWD
+  get_spl_versions "$spl_dir"
+  cd ..
+
   rm -rf anchor
   git clone https://github.com/coral-xyz/anchor.git
   cd anchor || exit 1
@@ -57,6 +66,7 @@ anchor() {
 
   update_solana_dependencies . "$solana_ver"
   patch_crates_io_solana Cargo.toml "$solana_dir"
+  patch_spl_crates . Cargo.toml "$spl_dir"
 
   $cargo test
   (cd spl && $cargo_build_sbf --features dex metadata stake)

--- a/scripts/patch-spl-crates-for-anchor.sh
+++ b/scripts/patch-spl-crates-for-anchor.sh
@@ -1,0 +1,51 @@
+spl_memo_version=
+spl_token_version=
+spl_token_2022_version=
+spl_tlv_account_resolution_verison=
+spl_transfer_hook_interface_version=
+
+get_spl_versions() {
+    declare spl_dir="$1"
+    spl_memo_version=$(readCargoVariable version "$spl_dir/memo/program/Cargo.toml")
+    spl_token_version=$(readCargoVariable version "$spl_dir/token/program/Cargo.toml")
+    spl_token_2022_version=$(readCargoVariable version "$spl_dir/token/program-2022/Cargo.toml")
+    spl_tlv_account_resolution_verison=$(readCargoVariable version "$spl_dir/libraries/tlv-account-resolution/Cargo.toml")
+    spl_transfer_hook_interface_version=$(readCargoVariable version "$spl_dir/token/transfer-hook/interface/Cargo.toml")
+}
+
+patch_spl_crates() {
+    declare project_root="$1"
+    declare Cargo_toml="$2"
+    declare spl_dir="$3"
+    update_spl_dependencies "$project_root"
+    patch_crates_io "$Cargo_toml" "$spl_dir"
+}
+
+update_spl_dependencies() {
+    declare project_root="$1"
+    declare tomls=()
+    while IFS='' read -r line; do tomls+=("$line"); done < <(find "$project_root" -name Cargo.toml)
+
+    sed -i -e "s#\(spl-memo = \"\)[^\"]*\(\"\)#\1$spl_memo_version\2#g" "${tomls[@]}" || return $?
+    sed -i -e "s#\(spl-memo = { version = \"\)[^\"]*\(\"\)#\1$spl_memo_version\2#g" "${tomls[@]}" || return $?
+    sed -i -e "s#\(spl-token = \"\)[^\"]*\(\"\)#\1$spl_token_version\2#g" "${tomls[@]}" || return $?
+    sed -i -e "s#\(spl-token = { version = \"\)[^\"]*\(\"\)#\1$spl_token_version\2#g" "${tomls[@]}" || return $?
+    sed -i -e "s#\(spl-token-2022 = \"\).*\(\"\)#\1$spl_token_2022_version\2#g" "${tomls[@]}" || return $?
+    sed -i -e "s#\(spl-token-2022 = { version = \"\)[^\"]*\(\"\)#\1$spl_token_2022_version\2#g" "${tomls[@]}" || return $?
+    sed -i -e "s#\(spl-tlv-account-resolution = \"\)[^\"]*\(\"\)#\1=$spl_tlv_account_resolution_verison\2#g" "${tomls[@]}" || return $?
+    sed -i -e "s#\(spl-tlv-account-resolution = { version = \"\)[^\"]*\(\"\)#\1=$spl_tlv_account_resolution_verison\2#g" "${tomls[@]}" || return $?
+    sed -i -e "s#\(spl-transfer-hook-interface = \"\)[^\"]*\(\"\)#\1=$spl_transfer_hook_interface_version\2#g" "${tomls[@]}" || return $?
+    sed -i -e "s#\(spl-transfer-hook-interface = { version = \"\)[^\"]*\(\"\)#\1=$spl_transfer_hook_interface_version\2#g" "${tomls[@]}" || return $?
+}
+
+patch_crates_io() {
+    declare Cargo_toml="$1"
+    declare spl_dir="$2"
+    cat >> "$Cargo_toml" <<EOF
+    spl-memo = { path = "$spl_dir/memo/program" }
+    spl-token = { path = "$spl_dir/token/program" }
+    spl-token-2022 = { path = "$spl_dir/token/program-2022" }
+    spl-tlv-account-resolution = { path = "$spl_dir/libraries/tlv-account-resolution" }
+    spl-transfer-hook-interface = { path = "$spl_dir/token/transfer-hook/interface" }
+EOF
+}

--- a/scripts/patch-spl-crates-for-anchor.sh
+++ b/scripts/patch-spl-crates-for-anchor.sh
@@ -36,6 +36,10 @@ update_spl_dependencies() {
     sed -i -e "s#\(spl-tlv-account-resolution = { version = \"\)[^\"]*\(\"\)#\1=$spl_tlv_account_resolution_verison\2#g" "${tomls[@]}" || return $?
     sed -i -e "s#\(spl-transfer-hook-interface = \"\)[^\"]*\(\"\)#\1=$spl_transfer_hook_interface_version\2#g" "${tomls[@]}" || return $?
     sed -i -e "s#\(spl-transfer-hook-interface = { version = \"\)[^\"]*\(\"\)#\1=$spl_transfer_hook_interface_version\2#g" "${tomls[@]}" || return $?
+
+    # patch ahash. This is super brittle; putting here for convenience, since we are already iterating through the tomls
+    ahash_minor_version="0.8"
+    sed -i -e "s#\(ahash = \"\)[^\"]*\(\"\)#\1$ahash_minor_version\2#g" "${tomls[@]}" || return $?
 }
 
 patch_crates_io() {

--- a/scripts/patch-spl-crates-for-anchor.sh
+++ b/scripts/patch-spl-crates-for-anchor.sh
@@ -8,7 +8,7 @@ get_spl_versions() {
     declare spl_dir="$1"
     spl_memo_version=$(readCargoVariable version "$spl_dir/memo/program/Cargo.toml")
     spl_token_version=$(readCargoVariable version "$spl_dir/token/program/Cargo.toml")
-    spl_token_2022_version=$(readCargoVariable version "$spl_dir/token/program-2022/Cargo.toml")
+    spl_token_2022_version=$(readCargoVariable version "$spl_dir/token/program-2022/Cargo.toml"| head -c1) # only use the major version for convenience
     spl_tlv_account_resolution_verison=$(readCargoVariable version "$spl_dir/libraries/tlv-account-resolution/Cargo.toml")
     spl_transfer_hook_interface_version=$(readCargoVariable version "$spl_dir/token/transfer-hook/interface/Cargo.toml")
 }


### PR DESCRIPTION
#### Problem
Anchor downstream job fails when we [bump the repo version to v2](https://github.com/anza-xyz/agave/pull/121): https://github.com/anza-xyz/agave/actions/runs/8179607730/job/22365981772?pr=121
This is because anchor pulls in old versions of SPL programs that don't support v2 solana crates.

#### Summary of Changes
Add a script to clone SPL and patch Anchor to these versions of the crates
v2 CI run with this patch: https://github.com/anza-xyz/agave/actions/runs/8179883451/job/22366823402?pr=121
