### PR TITLE
[zk-token-sdk] Implement `FromStr` for `ElGamalPubkey`, `ElGamalCiphertext`, and `AeCiphertext`

### DIFF
--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -15,6 +15,7 @@ bytemuck = { workspace = true, features = ["derive"] }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 solana-program = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 tiny-bip39 = { workspace = true }
@@ -34,7 +35,6 @@ serde_json = { workspace = true }
 sha3 = "0.9"
 solana-sdk = { workspace = true }
 subtle = { workspace = true }
-thiserror = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [lib]

--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -53,7 +53,7 @@ impl FromStr for AeCiphertext {
             return Err(ParseError::WrongSize);
         }
         let ciphertext_vec = BASE64_STANDARD.decode(s).map_err(|_| ParseError::Invalid)?;
-        if ciphertext_vec.len() != std::mem::size_of::<AeCiphertext>() {
+        if ciphertext_vec.len() != AE_CIPHERTEXT_LEN {
             Err(ParseError::WrongSize)
         } else {
             <[u8; AE_CIPHERTEXT_LEN]>::try_from(ciphertext_vec)

--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -5,8 +5,7 @@ use crate::encryption::auth_encryption::{self as decoded, AuthenticatedEncryptio
 use {
     crate::zk_token_elgamal::pod::{impl_from_str, ParseError, Pod, Zeroable},
     base64::{prelude::BASE64_STANDARD, Engine},
-    std::fmt,
-    std::str::FromStr,
+    std::{fmt, str::FromStr},
 };
 
 /// Byte length of an authenticated encryption ciphertext

--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -1,17 +1,24 @@
 //! Plain Old Data types for the AES128-GCM-SIV authenticated encryption scheme.
 
-#[cfg(not(target_os = "solana"))]
-use crate::encryption::auth_encryption::{self as decoded, AuthenticatedEncryptionError};
 use {
-    crate::zk_token_elgamal::pod::{ParseError, Pod, Zeroable},
+    crate::zk_token_elgamal::pod::{Pod, Zeroable},
     base64::{prelude::BASE64_STANDARD, Engine},
-    std::{fmt, str::FromStr},
+    std::fmt,
+};
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{
+        encryption::auth_encryption::{self as decoded, AuthenticatedEncryptionError},
+        zk_token_elgamal::pod::ParseError,
+    },
+    std::str::FromStr,
 };
 
 /// Byte length of an authenticated encryption ciphertext
 const AE_CIPHERTEXT_LEN: usize = 36;
 
 /// Maximum length of a base64 encoded authenticated encryption ciphertext
+#[cfg(not(target_os = "solana"))]
 const AE_CIPHERTEXT_MAX_BASE64_LEN: usize = 48;
 
 /// The `AeCiphertext` type as a `Pod`.
@@ -37,6 +44,7 @@ impl fmt::Display for AeCiphertext {
     }
 }
 
+#[cfg(not(target_os = "solana"))]
 impl FromStr for AeCiphertext {
     type Err = ParseError;
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -5,7 +5,7 @@ use crate::encryption::auth_encryption::{self as decoded, AuthenticatedEncryptio
 use {
     crate::zk_token_elgamal::pod::{impl_from_str, ParseError, Pod, Zeroable},
     base64::{prelude::BASE64_STANDARD, Engine},
-    std::{fmt, str::FromStr},
+    std::fmt,
 };
 
 /// Byte length of an authenticated encryption ciphertext
@@ -67,7 +67,7 @@ impl TryFrom<AeCiphertext> for decoded::AeCiphertext {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::encryption::auth_encryption::AeKey};
+    use {super::*, crate::encryption::auth_encryption::AeKey, std::str::FromStr};
 
     #[test]
     fn ae_ciphertext_fromstr() {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -3,7 +3,7 @@
 #[cfg(not(target_os = "solana"))]
 use crate::encryption::auth_encryption::{self as decoded, AuthenticatedEncryptionError};
 use {
-    crate::zk_token_elgamal::pod::{impl_from_str, ParseError, Pod, Zeroable},
+    crate::zk_token_elgamal::pod::{impl_from_str, Pod, Zeroable},
     base64::{prelude::BASE64_STANDARD, Engine},
     std::fmt,
 };

--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -3,7 +3,7 @@
 #[cfg(not(target_os = "solana"))]
 use crate::encryption::auth_encryption::{self as decoded, AuthenticatedEncryptionError};
 use {
-    crate::zk_token_elgamal::pod::{ParseError, Pod, Zeroable},
+    crate::zk_token_elgamal::pod::{impl_from_str, ParseError, Pod, Zeroable},
     base64::{prelude::BASE64_STANDARD, Engine},
     std::fmt,
     std::str::FromStr,
@@ -38,23 +38,11 @@ impl fmt::Display for AeCiphertext {
     }
 }
 
-impl FromStr for AeCiphertext {
-    type Err = ParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() > AE_CIPHERTEXT_MAX_BASE64_LEN {
-            return Err(ParseError::WrongSize);
-        }
-        let ciphertext_vec = BASE64_STANDARD.decode(s).map_err(|_| ParseError::Invalid)?;
-        if ciphertext_vec.len() != AE_CIPHERTEXT_LEN {
-            Err(ParseError::WrongSize)
-        } else {
-            <[u8; AE_CIPHERTEXT_LEN]>::try_from(ciphertext_vec)
-                .map_err(|_| ParseError::Invalid)
-                .map(AeCiphertext)
-        }
-    }
-}
+impl_from_str!(
+    TYPE = AeCiphertext,
+    BYTES_LEN = AE_CIPHERTEXT_LEN,
+    BASE64_LEN = AE_CIPHERTEXT_MAX_BASE64_LEN
+);
 
 impl Default for AeCiphertext {
     fn default() -> Self {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -1,16 +1,11 @@
 //! Plain Old Data types for the AES128-GCM-SIV authenticated encryption scheme.
 
+#[cfg(not(target_os = "solana"))]
+use crate::encryption::auth_encryption::{self as decoded, AuthenticatedEncryptionError};
 use {
-    crate::zk_token_elgamal::pod::{Pod, Zeroable},
+    crate::zk_token_elgamal::pod::{ParseError, Pod, Zeroable},
     base64::{prelude::BASE64_STANDARD, Engine},
     std::fmt,
-};
-#[cfg(not(target_os = "solana"))]
-use {
-    crate::{
-        encryption::auth_encryption::{self as decoded, AuthenticatedEncryptionError},
-        zk_token_elgamal::pod::ParseError,
-    },
     std::str::FromStr,
 };
 
@@ -18,7 +13,6 @@ use {
 const AE_CIPHERTEXT_LEN: usize = 36;
 
 /// Maximum length of a base64 encoded authenticated encryption ciphertext
-#[cfg(not(target_os = "solana"))]
 const AE_CIPHERTEXT_MAX_BASE64_LEN: usize = 48;
 
 /// The `AeCiphertext` type as a `Pod`.
@@ -44,7 +38,6 @@ impl fmt::Display for AeCiphertext {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
 impl FromStr for AeCiphertext {
     type Err = ParseError;
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -13,7 +13,7 @@ use {
         RISTRETTO_POINT_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
-    std::{fmt, str::FromStr},
+    std::fmt,
 };
 
 /// Byte length of an ElGamal public key
@@ -152,7 +152,7 @@ impl TryFrom<DecryptHandle> for decoded::DecryptHandle {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::encryption::elgamal::ElGamalKeypair};
+    use {super::*, crate::encryption::elgamal::ElGamalKeypair, std::str::FromStr};
 
     #[test]
     fn elgamal_pubkey_fromstr() {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -2,22 +2,27 @@
 
 #[cfg(not(target_os = "solana"))]
 use {
-    crate::encryption::elgamal::{self as decoded, ElGamalError},
+    crate::{
+        encryption::elgamal::{self as decoded, ElGamalError},
+        zk_token_elgamal::pod::ParseError,
+    },
     curve25519_dalek::ristretto::CompressedRistretto,
+    std::str::FromStr,
 };
 use {
     crate::{
-        zk_token_elgamal::pod::{pedersen::PEDERSEN_COMMITMENT_LEN, ParseError, Pod, Zeroable},
+        zk_token_elgamal::pod::{pedersen::PEDERSEN_COMMITMENT_LEN, Pod, Zeroable},
         RISTRETTO_POINT_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
-    std::{fmt, str::FromStr},
+    std::fmt,
 };
 
 /// Byte length of an ElGamal public key
 const ELGAMAL_PUBKEY_LEN: usize = RISTRETTO_POINT_LEN;
 
 /// Maximum length of a base64 encoded ElGamal public key
+#[cfg(not(target_os = "solana"))]
 const ELGAMAL_PUBKEY_MAX_BASE64_LEN: usize = 44;
 
 /// Byte length of a decrypt handle
@@ -27,6 +32,7 @@ pub(crate) const DECRYPT_HANDLE_LEN: usize = RISTRETTO_POINT_LEN;
 const ELGAMAL_CIPHERTEXT_LEN: usize = PEDERSEN_COMMITMENT_LEN + DECRYPT_HANDLE_LEN;
 
 /// Maximum length of a base64 encoded ElGamal ciphertext
+#[cfg(not(target_os = "solana"))]
 const ELGAMAL_CIPHERTEXT_MAX_BASE64_LEN: usize = 88;
 
 /// The `ElGamalCiphertext` type as a `Pod`.
@@ -52,6 +58,7 @@ impl Default for ElGamalCiphertext {
     }
 }
 
+#[cfg(not(target_os = "solana"))]
 impl FromStr for ElGamalCiphertext {
     type Err = ParseError;
 
@@ -103,6 +110,7 @@ impl fmt::Display for ElGamalPubkey {
     }
 }
 
+#[cfg(not(target_os = "solana"))]
 impl FromStr for ElGamalPubkey {
     type Err = ParseError;
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -2,27 +2,23 @@
 
 #[cfg(not(target_os = "solana"))]
 use {
-    crate::{
-        encryption::elgamal::{self as decoded, ElGamalError},
-        zk_token_elgamal::pod::ParseError,
-    },
+    crate::encryption::elgamal::{self as decoded, ElGamalError},
     curve25519_dalek::ristretto::CompressedRistretto,
-    std::str::FromStr,
 };
 use {
     crate::{
-        zk_token_elgamal::pod::{pedersen::PEDERSEN_COMMITMENT_LEN, Pod, Zeroable},
+        zk_token_elgamal::pod::{pedersen::PEDERSEN_COMMITMENT_LEN, ParseError, Pod, Zeroable},
         RISTRETTO_POINT_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
     std::fmt,
+    std::str::FromStr,
 };
 
 /// Byte length of an ElGamal public key
 const ELGAMAL_PUBKEY_LEN: usize = RISTRETTO_POINT_LEN;
 
 /// Maximum length of a base64 encoded ElGamal public key
-#[cfg(not(target_os = "solana"))]
 const ELGAMAL_PUBKEY_MAX_BASE64_LEN: usize = 44;
 
 /// Byte length of a decrypt handle
@@ -32,7 +28,6 @@ pub(crate) const DECRYPT_HANDLE_LEN: usize = RISTRETTO_POINT_LEN;
 const ELGAMAL_CIPHERTEXT_LEN: usize = PEDERSEN_COMMITMENT_LEN + DECRYPT_HANDLE_LEN;
 
 /// Maximum length of a base64 encoded ElGamal ciphertext
-#[cfg(not(target_os = "solana"))]
 const ELGAMAL_CIPHERTEXT_MAX_BASE64_LEN: usize = 88;
 
 /// The `ElGamalCiphertext` type as a `Pod`.
@@ -58,7 +53,6 @@ impl Default for ElGamalCiphertext {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
 impl FromStr for ElGamalCiphertext {
     type Err = ParseError;
 
@@ -110,7 +104,6 @@ impl fmt::Display for ElGamalPubkey {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
 impl FromStr for ElGamalPubkey {
     type Err = ParseError;
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -67,7 +67,7 @@ impl FromStr for ElGamalCiphertext {
             return Err(ParseError::WrongSize);
         }
         let ciphertext_vec = BASE64_STANDARD.decode(s).map_err(|_| ParseError::Invalid)?;
-        if ciphertext_vec.len() != std::mem::size_of::<ElGamalCiphertext>() {
+        if ciphertext_vec.len() != ELGAMAL_CIPHERTEXT_LEN {
             Err(ParseError::WrongSize)
         } else {
             <[u8; ELGAMAL_CIPHERTEXT_LEN]>::try_from(ciphertext_vec)
@@ -119,7 +119,7 @@ impl FromStr for ElGamalPubkey {
             return Err(ParseError::WrongSize);
         }
         let pubkey_vec = BASE64_STANDARD.decode(s).map_err(|_| ParseError::Invalid)?;
-        if pubkey_vec.len() != std::mem::size_of::<ElGamalPubkey>() {
+        if pubkey_vec.len() != ELGAMAL_PUBKEY_LEN {
             Err(ParseError::WrongSize)
         } else {
             <[u8; ELGAMAL_PUBKEY_LEN]>::try_from(pubkey_vec)

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -7,21 +7,27 @@ use {
 };
 use {
     crate::{
-        zk_token_elgamal::pod::{pedersen::PEDERSEN_COMMITMENT_LEN, Pod, Zeroable},
+        zk_token_elgamal::pod::{pedersen::PEDERSEN_COMMITMENT_LEN, ParseError, Pod, Zeroable},
         RISTRETTO_POINT_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
-    std::fmt,
+    std::{fmt, str::FromStr},
 };
 
 /// Byte length of an ElGamal public key
 const ELGAMAL_PUBKEY_LEN: usize = RISTRETTO_POINT_LEN;
+
+/// Maximum length of a base64 encoded ElGamal public key
+const ELGAMAL_PUBKEY_MAX_BASE64_LEN: usize = 44;
 
 /// Byte length of a decrypt handle
 pub(crate) const DECRYPT_HANDLE_LEN: usize = RISTRETTO_POINT_LEN;
 
 /// Byte length of an ElGamal ciphertext
 const ELGAMAL_CIPHERTEXT_LEN: usize = PEDERSEN_COMMITMENT_LEN + DECRYPT_HANDLE_LEN;
+
+/// Maximum length of a base64 encoded ElGamal ciphertext
+const ELGAMAL_CIPHERTEXT_MAX_BASE64_LEN: usize = 88;
 
 /// The `ElGamalCiphertext` type as a `Pod`.
 #[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
@@ -43,6 +49,24 @@ impl fmt::Display for ElGamalCiphertext {
 impl Default for ElGamalCiphertext {
     fn default() -> Self {
         Self::zeroed()
+    }
+}
+
+impl FromStr for ElGamalCiphertext {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() > ELGAMAL_CIPHERTEXT_MAX_BASE64_LEN {
+            return Err(ParseError::WrongSize);
+        }
+        let ciphertext_vec = BASE64_STANDARD.decode(s).map_err(|_| ParseError::Invalid)?;
+        if ciphertext_vec.len() != std::mem::size_of::<ElGamalCiphertext>() {
+            Err(ParseError::WrongSize)
+        } else {
+            <[u8; ELGAMAL_CIPHERTEXT_LEN]>::try_from(ciphertext_vec)
+                .map_err(|_| ParseError::Invalid)
+                .map(ElGamalCiphertext)
+        }
     }
 }
 
@@ -76,6 +100,24 @@ impl fmt::Debug for ElGamalPubkey {
 impl fmt::Display for ElGamalPubkey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", BASE64_STANDARD.encode(self.0))
+    }
+}
+
+impl FromStr for ElGamalPubkey {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() > ELGAMAL_PUBKEY_MAX_BASE64_LEN {
+            return Err(ParseError::WrongSize);
+        }
+        let pubkey_vec = BASE64_STANDARD.decode(s).map_err(|_| ParseError::Invalid)?;
+        if pubkey_vec.len() != std::mem::size_of::<ElGamalPubkey>() {
+            Err(ParseError::WrongSize)
+        } else {
+            <[u8; ELGAMAL_PUBKEY_LEN]>::try_from(pubkey_vec)
+                .map_err(|_| ParseError::Invalid)
+                .map(ElGamalPubkey)
+        }
     }
 }
 
@@ -127,5 +169,34 @@ impl TryFrom<DecryptHandle> for decoded::DecryptHandle {
 
     fn try_from(pod_handle: DecryptHandle) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_handle.0).ok_or(ElGamalError::CiphertextDeserialization)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::encryption::elgamal::ElGamalKeypair};
+
+    #[test]
+    fn elgamal_pubkey_fromstr() {
+        let elgamal_keypair = ElGamalKeypair::new_rand();
+        let expected_elgamal_pubkey: ElGamalPubkey = (*elgamal_keypair.pubkey()).into();
+
+        let elgamal_pubkey_base64_str = format!("{}", expected_elgamal_pubkey);
+        let computed_elgamal_pubkey = ElGamalPubkey::from_str(&elgamal_pubkey_base64_str).unwrap();
+
+        assert_eq!(expected_elgamal_pubkey, computed_elgamal_pubkey);
+    }
+
+    #[test]
+    fn elgamal_ciphertext_fromstr() {
+        let elgamal_keypair = ElGamalKeypair::new_rand();
+        let expected_elgamal_ciphertext: ElGamalCiphertext =
+            elgamal_keypair.pubkey().encrypt(0_u64).into();
+
+        let elgamal_ciphertext_base64_str = format!("{}", expected_elgamal_ciphertext);
+        let computed_elgamal_ciphertext =
+            ElGamalCiphertext::from_str(&elgamal_ciphertext_base64_str).unwrap();
+
+        assert_eq!(expected_elgamal_ciphertext, computed_elgamal_ciphertext);
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -7,9 +7,7 @@ use {
 };
 use {
     crate::{
-        zk_token_elgamal::pod::{
-            impl_from_str, pedersen::PEDERSEN_COMMITMENT_LEN, ParseError, Pod, Zeroable,
-        },
+        zk_token_elgamal::pod::{impl_from_str, pedersen::PEDERSEN_COMMITMENT_LEN, Pod, Zeroable},
         RISTRETTO_POINT_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -13,8 +13,7 @@ use {
         RISTRETTO_POINT_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
-    std::fmt,
-    std::str::FromStr,
+    std::{fmt, str::FromStr},
 };
 
 /// Byte length of an ElGamal public key

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -7,7 +7,9 @@ use {
 };
 use {
     crate::{
-        zk_token_elgamal::pod::{pedersen::PEDERSEN_COMMITMENT_LEN, ParseError, Pod, Zeroable},
+        zk_token_elgamal::pod::{
+            impl_from_str, pedersen::PEDERSEN_COMMITMENT_LEN, ParseError, Pod, Zeroable,
+        },
         RISTRETTO_POINT_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
@@ -53,23 +55,11 @@ impl Default for ElGamalCiphertext {
     }
 }
 
-impl FromStr for ElGamalCiphertext {
-    type Err = ParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() > ELGAMAL_CIPHERTEXT_MAX_BASE64_LEN {
-            return Err(ParseError::WrongSize);
-        }
-        let ciphertext_vec = BASE64_STANDARD.decode(s).map_err(|_| ParseError::Invalid)?;
-        if ciphertext_vec.len() != ELGAMAL_CIPHERTEXT_LEN {
-            Err(ParseError::WrongSize)
-        } else {
-            <[u8; ELGAMAL_CIPHERTEXT_LEN]>::try_from(ciphertext_vec)
-                .map_err(|_| ParseError::Invalid)
-                .map(ElGamalCiphertext)
-        }
-    }
-}
+impl_from_str!(
+    TYPE = ElGamalCiphertext,
+    BYTES_LEN = ELGAMAL_CIPHERTEXT_LEN,
+    BASE64_LEN = ELGAMAL_CIPHERTEXT_MAX_BASE64_LEN
+);
 
 #[cfg(not(target_os = "solana"))]
 impl From<decoded::ElGamalCiphertext> for ElGamalCiphertext {
@@ -104,23 +94,11 @@ impl fmt::Display for ElGamalPubkey {
     }
 }
 
-impl FromStr for ElGamalPubkey {
-    type Err = ParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() > ELGAMAL_PUBKEY_MAX_BASE64_LEN {
-            return Err(ParseError::WrongSize);
-        }
-        let pubkey_vec = BASE64_STANDARD.decode(s).map_err(|_| ParseError::Invalid)?;
-        if pubkey_vec.len() != ELGAMAL_PUBKEY_LEN {
-            Err(ParseError::WrongSize)
-        } else {
-            <[u8; ELGAMAL_PUBKEY_LEN]>::try_from(pubkey_vec)
-                .map_err(|_| ParseError::Invalid)
-                .map(ElGamalPubkey)
-        }
-    }
-}
+impl_from_str!(
+    TYPE = ElGamalPubkey,
+    BYTES_LEN = ELGAMAL_PUBKEY_LEN,
+    BASE64_LEN = ELGAMAL_PUBKEY_MAX_BASE64_LEN
+);
 
 #[cfg(not(target_os = "solana"))]
 impl From<decoded::ElGamalPubkey> for ElGamalPubkey {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -13,7 +13,6 @@ use {
     num_traits::{FromPrimitive, ToPrimitive},
     solana_program::instruction::InstructionError,
 };
-
 pub use {
     auth_encryption::AeCiphertext,
     bytemuck::{Pod, Zeroable},

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -90,14 +90,14 @@ macro_rules! impl_from_str {
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 if s.len() > $base64_len {
-                    return Err(ParseError::WrongSize);
+                    return Err(Self::Err::WrongSize);
                 }
                 let mut bytes = [0u8; $bytes_len];
                 let decoded_len = BASE64_STANDARD
                     .decode_slice(s, &mut bytes)
-                    .map_err(|_| ParseError::Invalid)?;
+                    .map_err(|_| Self::Err::Invalid)?;
                 if decoded_len != $bytes_len {
-                    Err(ParseError::WrongSize)
+                    Err(Self::Err::WrongSize)
                 } else {
                     Ok($type(bytes))
                 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -6,12 +6,14 @@ mod pedersen;
 mod range_proof;
 mod sigma_proofs;
 
+#[cfg(not(target_os = "solana"))]
+use thiserror::Error;
 use {
     crate::zk_token_proof_instruction::ProofType,
     num_traits::{FromPrimitive, ToPrimitive},
     solana_program::instruction::InstructionError,
-    thiserror::Error,
 };
+
 pub use {
     auth_encryption::AeCiphertext,
     bytemuck::{Pod, Zeroable},
@@ -27,6 +29,7 @@ pub use {
     },
 };
 
+#[cfg(not(target_os = "solana"))]
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum ParseError {
     #[error("String is the wrong size")]

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -6,12 +6,11 @@ mod pedersen;
 mod range_proof;
 mod sigma_proofs;
 
-#[cfg(not(target_os = "solana"))]
-use thiserror::Error;
 use {
     crate::zk_token_proof_instruction::ProofType,
     num_traits::{FromPrimitive, ToPrimitive},
     solana_program::instruction::InstructionError,
+    thiserror::Error,
 };
 pub use {
     auth_encryption::AeCiphertext,
@@ -28,7 +27,6 @@ pub use {
     },
 };
 
-#[cfg(not(target_os = "solana"))]
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum ParseError {
     #[error("String is the wrong size")]

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -92,13 +92,14 @@ macro_rules! impl_from_str {
                 if s.len() > $base64_len {
                     return Err(ParseError::WrongSize);
                 }
-                let bytes_vec = BASE64_STANDARD.decode(s).map_err(|_| ParseError::Invalid)?;
-                if bytes_vec.len() != $bytes_len {
+                let mut bytes = [0u8; $bytes_len];
+                let decoded_len = BASE64_STANDARD
+                    .decode_slice(s, &mut bytes)
+                    .map_err(|_| ParseError::Invalid)?;
+                if decoded_len != $bytes_len {
                     Err(ParseError::WrongSize)
                 } else {
-                    <[u8; $bytes_len]>::try_from(bytes_vec)
-                        .map_err(|_| ParseError::Invalid)
-                        .map($type)
+                    Ok($type(bytes))
                 }
             }
         }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -83,7 +83,6 @@ impl TryFrom<PodProofType> for ProofType {
 #[repr(transparent)]
 pub struct CompressedRistretto(pub [u8; 32]);
 
-#[macro_export]
 macro_rules! impl_from_str {
     (TYPE = $type:ident, BYTES_LEN = $bytes_len:expr, BASE64_LEN = $base64_len:expr) => {
         impl FromStr for $type {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -85,8 +85,8 @@ pub struct CompressedRistretto(pub [u8; 32]);
 
 macro_rules! impl_from_str {
     (TYPE = $type:ident, BYTES_LEN = $bytes_len:expr, BASE64_LEN = $base64_len:expr) => {
-        impl FromStr for $type {
-            type Err = ParseError;
+        impl std::str::FromStr for $type {
+            type Err = crate::zk_token_elgamal::pod::ParseError;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 if s.len() > $base64_len {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -10,6 +10,7 @@ use {
     crate::zk_token_proof_instruction::ProofType,
     num_traits::{FromPrimitive, ToPrimitive},
     solana_program::instruction::InstructionError,
+    thiserror::Error,
 };
 pub use {
     auth_encryption::AeCiphertext,
@@ -25,6 +26,14 @@ pub use {
         PubkeyValidityProof, ZeroBalanceProof,
     },
 };
+
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    #[error("String is the wrong size")]
+    WrongSize,
+    #[error("Invalid Base64 string")]
+    Invalid,
+}
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
 #[repr(transparent)]


### PR DESCRIPTION
#### Problem
Currently, `ElGamalPubkey`, `ElGamalCiphertext` and `AeCiphertext` types implement the `Display` trait, but not `FromStr`. It would be nice to implement `FromStr` for these types since clap-v3 can automatically validate and parse string encodings of any type that implements `FromStr`. Also, `FromStr` makes life much easier when exposing these types in wasm binaries.

#### Summary of Changes
Implement `FromStr` for types `ElGamalPubkey`, `ElGamalCiphertext`, and `AeCiphertext`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
