### PR TITLE
[zk-token-sdk] Make inner bytes of cryptographic pod types opaque

### DIFF
--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -14,7 +14,7 @@ const AE_CIPHERTEXT_LEN: usize = 36;
 /// The `AeCiphertext` type as a `Pod`.
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct AeCiphertext(pub [u8; AE_CIPHERTEXT_LEN]);
+pub struct AeCiphertext(pub(crate) [u8; AE_CIPHERTEXT_LEN]);
 
 // `AeCiphertext` is a wrapper type for a byte array, which is both `Pod` and `Zeroable`. However,
 // the marker traits `bytemuck::Pod` and `bytemuck::Zeroable` can only be derived for power-of-two

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -26,7 +26,7 @@ const ELGAMAL_CIPHERTEXT_LEN: usize = PEDERSEN_COMMITMENT_LEN + DECRYPT_HANDLE_L
 /// The `ElGamalCiphertext` type as a `Pod`.
 #[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct ElGamalCiphertext(pub [u8; ELGAMAL_CIPHERTEXT_LEN]);
+pub struct ElGamalCiphertext(pub(crate) [u8; ELGAMAL_CIPHERTEXT_LEN]);
 
 impl fmt::Debug for ElGamalCiphertext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -65,7 +65,7 @@ impl TryFrom<ElGamalCiphertext> for decoded::ElGamalCiphertext {
 /// The `ElGamalPubkey` type as a `Pod`.
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct ElGamalPubkey(pub [u8; ELGAMAL_PUBKEY_LEN]);
+pub struct ElGamalPubkey(pub(crate) [u8; ELGAMAL_PUBKEY_LEN]);
 
 impl fmt::Debug for ElGamalPubkey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -98,7 +98,7 @@ impl TryFrom<ElGamalPubkey> for decoded::ElGamalPubkey {
 /// The `DecryptHandle` type as a `Pod`.
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct DecryptHandle(pub [u8; DECRYPT_HANDLE_LEN]);
+pub struct DecryptHandle(pub(crate) [u8; DECRYPT_HANDLE_LEN]);
 
 impl fmt::Debug for DecryptHandle {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
@@ -20,7 +20,7 @@ const GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES: usize =
 /// The `GroupedElGamalCiphertext` type with two decryption handles as a `Pod`
 #[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct GroupedElGamalCiphertext2Handles(pub [u8; GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES]);
+pub struct GroupedElGamalCiphertext2Handles(pub(crate) [u8; GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES]);
 
 impl fmt::Debug for GroupedElGamalCiphertext2Handles {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -52,7 +52,7 @@ impl TryFrom<GroupedElGamalCiphertext2Handles> for GroupedElGamalCiphertext<2> {
 /// The `GroupedElGamalCiphertext` type with three decryption handles as a `Pod`
 #[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct GroupedElGamalCiphertext3Handles(pub [u8; GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES]);
+pub struct GroupedElGamalCiphertext3Handles(pub(crate) [u8; GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES]);
 
 impl fmt::Debug for GroupedElGamalCiphertext3Handles {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -7,7 +7,7 @@ use crate::{encryption::elgamal::ElGamalError, instruction::transfer as decoded}
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
-pub struct TransferAmountCiphertext(pub GroupedElGamalCiphertext3Handles);
+pub struct TransferAmountCiphertext(pub(crate) GroupedElGamalCiphertext3Handles);
 
 #[cfg(not(target_os = "solana"))]
 impl From<decoded::TransferAmountCiphertext> for TransferAmountCiphertext {
@@ -27,7 +27,7 @@ impl TryFrom<TransferAmountCiphertext> for decoded::TransferAmountCiphertext {
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
-pub struct FeeEncryption(pub GroupedElGamalCiphertext2Handles);
+pub struct FeeEncryption(pub(crate) GroupedElGamalCiphertext2Handles);
 
 #[cfg(not(target_os = "solana"))]
 impl From<decoded::FeeEncryption> for FeeEncryption {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -72,4 +72,4 @@ impl TryFrom<PodProofType> for ProofType {
 
 #[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct CompressedRistretto(pub [u8; 32]);
+pub struct CompressedRistretto(pub(crate) [u8; 32]);

--- a/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
@@ -19,7 +19,7 @@ pub(crate) const PEDERSEN_COMMITMENT_LEN: usize = RISTRETTO_POINT_LEN;
 /// The `PedersenCommitment` type as a `Pod`.
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct PedersenCommitment(pub [u8; PEDERSEN_COMMITMENT_LEN]);
+pub struct PedersenCommitment(pub(crate) [u8; PEDERSEN_COMMITMENT_LEN]);
 
 impl fmt::Debug for PedersenCommitment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/range_proof.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/range_proof.rs
@@ -37,7 +37,7 @@ const RANGE_PROOF_U256_LEN: usize =
 /// The `RangeProof` type as a `Pod` restricted to proofs on 64-bit numbers.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct RangeProofU64(pub [u8; RANGE_PROOF_U64_LEN]);
+pub struct RangeProofU64(pub(crate) [u8; RANGE_PROOF_U64_LEN]);
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<decoded::RangeProof> for RangeProofU64 {
@@ -68,7 +68,7 @@ impl TryFrom<RangeProofU64> for decoded::RangeProof {
 /// The `RangeProof` type as a `Pod` restricted to proofs on 128-bit numbers.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct RangeProofU128(pub [u8; RANGE_PROOF_U128_LEN]);
+pub struct RangeProofU128(pub(crate) [u8; RANGE_PROOF_U128_LEN]);
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<decoded::RangeProof> for RangeProofU128 {
@@ -99,7 +99,7 @@ impl TryFrom<RangeProofU128> for decoded::RangeProof {
 /// The `RangeProof` type as a `Pod` restricted to proofs on 256-bit numbers.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct RangeProofU256(pub [u8; RANGE_PROOF_U256_LEN]);
+pub struct RangeProofU256(pub(crate) [u8; RANGE_PROOF_U256_LEN]);
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<decoded::RangeProof> for RangeProofU256 {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/sigma_proofs.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/sigma_proofs.rs
@@ -36,7 +36,9 @@ const PUBKEY_VALIDITY_PROOF_LEN: usize = 64;
 /// The `CiphertextCommitmentEqualityProof` type as a `Pod`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct CiphertextCommitmentEqualityProof(pub [u8; CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_LEN]);
+pub struct CiphertextCommitmentEqualityProof(
+    pub(crate) [u8; CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_LEN],
+);
 
 #[cfg(not(target_os = "solana"))]
 impl From<DecodedCiphertextCommitmentEqualityProof> for CiphertextCommitmentEqualityProof {
@@ -57,7 +59,9 @@ impl TryFrom<CiphertextCommitmentEqualityProof> for DecodedCiphertextCommitmentE
 /// The `CiphertextCiphertextEqualityProof` type as a `Pod`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct CiphertextCiphertextEqualityProof(pub [u8; CIPHERTEXT_CIPHERTEXT_EQUALITY_PROOF_LEN]);
+pub struct CiphertextCiphertextEqualityProof(
+    pub(crate) [u8; CIPHERTEXT_CIPHERTEXT_EQUALITY_PROOF_LEN],
+);
 
 #[cfg(not(target_os = "solana"))]
 impl From<DecodedCiphertextCiphertextEqualityProof> for CiphertextCiphertextEqualityProof {
@@ -79,7 +83,7 @@ impl TryFrom<CiphertextCiphertextEqualityProof> for DecodedCiphertextCiphertextE
 #[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct GroupedCiphertext2HandlesValidityProof(
-    pub [u8; GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN],
+    pub(crate) [u8; GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN],
 );
 
 #[cfg(not(target_os = "solana"))]
@@ -106,7 +110,7 @@ impl TryFrom<GroupedCiphertext2HandlesValidityProof>
 #[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct BatchedGroupedCiphertext2HandlesValidityProof(
-    pub [u8; BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN],
+    pub(crate) [u8; BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN],
 );
 
 #[cfg(not(target_os = "solana"))]
@@ -134,7 +138,7 @@ impl TryFrom<BatchedGroupedCiphertext2HandlesValidityProof>
 /// The `ZeroBalanceProof` type as a `Pod`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct ZeroBalanceProof(pub [u8; ZERO_BALANCE_PROOF_LEN]);
+pub struct ZeroBalanceProof(pub(crate) [u8; ZERO_BALANCE_PROOF_LEN]);
 
 #[cfg(not(target_os = "solana"))]
 impl From<DecodedZeroBalanceProof> for ZeroBalanceProof {
@@ -155,7 +159,7 @@ impl TryFrom<ZeroBalanceProof> for DecodedZeroBalanceProof {
 /// The `FeeSigmaProof` type as a `Pod`.
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(transparent)]
-pub struct FeeSigmaProof(pub [u8; FEE_SIGMA_PROOF_LEN]);
+pub struct FeeSigmaProof(pub(crate) [u8; FEE_SIGMA_PROOF_LEN]);
 
 #[cfg(not(target_os = "solana"))]
 impl From<DecodedFeeSigmaProof> for FeeSigmaProof {
@@ -176,7 +180,7 @@ impl TryFrom<FeeSigmaProof> for DecodedFeeSigmaProof {
 /// The `PubkeyValidityProof` type as a `Pod`.
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(transparent)]
-pub struct PubkeyValidityProof(pub [u8; PUBKEY_VALIDITY_PROOF_LEN]);
+pub struct PubkeyValidityProof(pub(crate) [u8; PUBKEY_VALIDITY_PROOF_LEN]);
 
 #[cfg(not(target_os = "solana"))]
 impl From<DecodedPubkeyValidityProof> for PubkeyValidityProof {


### PR DESCRIPTION
#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
