### PR TITLE
Make ReplayStage create the parallel fork replay threadpool

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3217,7 +3217,7 @@ impl ReplayStage {
                         prioritization_fee_cache,
                     )
                 }
-                _ => active_bank_slots
+                ForkReplayMode::Serial | ForkReplayMode::Parallel(_) => active_bank_slots
                     .iter()
                     .map(|bank_slot| {
                         Self::replay_active_bank(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -124,7 +124,7 @@ pub enum HeaviestForkFailures {
 
 enum ForkReplayMode {
     Serial,
-    Parallel(ThreadPool)
+    Parallel(ThreadPool),
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -3196,26 +3196,25 @@ impl ReplayStage {
         if num_active_banks > 0 {
             let replay_result_vec = match replay_mode {
                 // Skip the overhead of the threadpool if there is only one bank to play
-                ForkReplayMode::Parallel(thread_pool) if num_active_banks > 1  => {
-                Self::replay_active_banks_concurrently(
-                    blockstore,
-                    bank_forks,
-                    thread_pool,
-                    my_pubkey,
-                    vote_account,
-                    progress,
-                    transaction_status_sender,
-                    entry_notification_sender,
-                    verify_recyclers,
-                    replay_vote_sender,
-                    replay_timing,
-                    log_messages_bytes_limit,
-                    &active_bank_slots,
-                    prioritization_fee_cache,
-                )
-                },
-                _ => {
-                active_bank_slots
+                ForkReplayMode::Parallel(thread_pool) if num_active_banks > 1 => {
+                    Self::replay_active_banks_concurrently(
+                        blockstore,
+                        bank_forks,
+                        thread_pool,
+                        my_pubkey,
+                        vote_account,
+                        progress,
+                        transaction_status_sender,
+                        entry_notification_sender,
+                        verify_recyclers,
+                        replay_vote_sender,
+                        replay_timing,
+                        log_messages_bytes_limit,
+                        &active_bank_slots,
+                        prioritization_fee_cache,
+                    )
+                }
+                _ => active_bank_slots
                     .iter()
                     .map(|bank_slot| {
                         Self::replay_active_bank(
@@ -3234,8 +3233,7 @@ impl ReplayStage {
                             prioritization_fee_cache,
                         )
                     })
-                    .collect()
-                }
+                    .collect(),
             };
 
             Self::process_replay_results(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3193,7 +3193,10 @@ impl ReplayStage {
             num_active_banks,
             active_bank_slots
         );
-        if num_active_banks > 0 {
+        if active_bank_slots.is_empty() {
+            return false;
+        }
+
             let replay_result_vec = match replay_mode {
                 // Skip the overhead of the threadpool if there is only one bank to play
                 ForkReplayMode::Parallel(thread_pool) if num_active_banks > 1 => {
@@ -3259,9 +3262,6 @@ impl ReplayStage {
                 &replay_result_vec,
                 purge_repair_slot_counter,
             )
-        } else {
-            false
-        }
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
#### Problem
As part of work for https://github.com/anza-xyz/agave/issues/105, it will be desirable to make the thread pool size configurable on the CLI. The pool is currently within a `lazy_static`; configuring the size for that from the CLI is a little "messy". We'd need to add another function that sets a global (before the thread pool is created), and then have thread pool creation read that value. This is of course susceptible to a potential race condition and/or some annoying code to ensure that the pool comes back the size we actually wanted it to be.

#### Summary of Changes
Instead of using the lazy_static, just have `ReplayStage` create the thread pool (if parallel replay is enabled).

There will be some whitespace difference - I'd suggest either viewing with "hide whitespace", or view commit-by-commit (I ran `cargo fmt` in separate commits)