### PR TITLE
runtime: Move `From<AddressLookupError>` from sdk

### DIFF
--- a/sdk/program/src/address_lookup_table/error.rs
+++ b/sdk/program/src/address_lookup_table/error.rs
@@ -1,5 +1,3 @@
-#[cfg(not(target_os = "solana"))]
-use solana_program::message::AddressLoaderError;
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Eq, Clone)]
@@ -19,16 +17,4 @@ pub enum AddressLookupError {
     /// Address lookup contains an invalid index
     #[error("Address lookup contains an invalid index")]
     InvalidLookupIndex,
-}
-
-#[cfg(not(target_os = "solana"))]
-impl From<AddressLookupError> for AddressLoaderError {
-    fn from(err: AddressLookupError) -> Self {
-        match err {
-            AddressLookupError::LookupTableAccountNotFound => Self::LookupTableAccountNotFound,
-            AddressLookupError::InvalidAccountOwner => Self::InvalidAccountOwner,
-            AddressLookupError::InvalidAccountData => Self::InvalidAccountData,
-            AddressLookupError::InvalidLookupIndex => Self::InvalidLookupIndex,
-        }
-    }
 }


### PR DESCRIPTION
#### Problem

As part of the migration of the address-lookup-table program to BPF, we've had to also port over the conversion from `AddressLookupError` to `AddressLoaderError`, but it's only needed in one place in the runtime.

See https://github.com/solana-program/address-lookup-table/pull/7#discussion_r1515226708 some more info

#### Summary of Changes

Move the error conversion function to where it's used in the runtime. The main motivation for moving it up rather than keeping it in the SDK is to avoid a circular dependency between `solana-program` and the new address-lookup-table BPF crate.

Let me know if this works with your conception of address loaders. It does seem like structs implementing `AddressLoader` might want the error converter since they'll be using lookup tables, but I'm not sure of a better place to put it.

Alternatively, we could create a `solana-message` crate which has all of the `sdk/program/src/message` code, and re-export it in `solana-sdk`. That crate could safely depend on `solana-program ` and the new address-lookup-table crate.

cc @buffalojoec 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->