### PR TITLE
add tx_priority_fee argument for program deploy subcommand

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -248,7 +248,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .long("compute-unit-price")
                                 .takes_value(true)
                                 .help(
-                                    "Add priotity fee to boost transactions resulting in faster execution speed \
+                                    "Set computeUnitPrice (tx priotity fee) to boost transactions resulting in faster execution speed \
                                     [Note: priority fee is added in LAMPORTS, so enter priority fee in terms of LAMPORTS]",
                                 ),
                         ).

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -13,6 +13,7 @@ use {
     solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
     solana_clap_utils::{
         self,
+        compute_unit_price::compute_unit_price_arg,
         fee_payer::{fee_payer_arg, FEE_PAYER_ARG},
         hidden_unless_forced,
         input_parsers::*,
@@ -240,15 +241,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                      holds a large balance of SOL",
                                 ),
                         )
-                        .arg(
-                            Arg::with_name("compute_unit_price")
-                                .long("compute-unit-price")
-                                .takes_value(true)
-                                .help(
-                                    "Set computeUnitPrice (tx priotity fee) to boost transactions resulting in faster execution speed \
-                                    [Note: priority fee is added in Micro Lamports, so enter priority fee in terms of Micro Lamports]",
-                                ),
-                        )
+                        .arg(compute_unit_price_arg()),
                 )
                 .subcommand(
                     SubCommand::with_name("upgrade")
@@ -320,7 +313,8 @@ impl ProgramSubCommands for App<'_, '_> {
                                     "Maximum length of the upgradeable program \
                                     [default: the length of the original deployed program]",
                                 ),
-                        ),
+                        )
+                        .arg(compute_unit_price_arg()),
                 )
                 .subcommand(
                     SubCommand::with_name("set-buffer-authority")

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2790,7 +2790,6 @@ fn set_compute_budget_ixs_if_needed(
     ixs_len: usize,
 ) {
     if let Some(compute_unit_price) = compute_unit_price {
-        println!("ixs_len: {}", ixs_len);
         ixs.push(ComputeBudgetInstruction::set_compute_unit_limit(
             ((ixs_len + 2) as u32) * 200_000u32,
         ));

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -250,14 +250,6 @@ impl ProgramSubCommands for App<'_, '_> {
                                     [Note: priority fee is added in LAMPORTS, so enter priority fee in terms of LAMPORTS]",
                                 ),
                         ).
-                        arg(
-                            Arg::with_name("max_retires")
-                                .long("max-retries")
-                                .takes_value(true)
-                                .help(
-                                    "Specifies the max retry count for failed transactions",
-                                ),
-                        ),
                 )
                 .subcommand(
                     SubCommand::with_name("upgrade")

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -21,6 +21,7 @@ use {
         feature_set::FeatureSet,
         pubkey::Pubkey,
         signature::{Keypair, NullSigner, Signer},
+        signer::EncodableKey,
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_test_validator::TestValidator,
@@ -30,6 +31,7 @@ use {
         io::Read,
         path::{Path, PathBuf},
         str::FromStr,
+        time::Instant,
     },
     test_case::test_case,
 };
@@ -88,7 +90,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -139,7 +141,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
     let account1 = rpc_client
@@ -199,7 +201,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     let err = process_command(&config).unwrap_err();
     assert_eq!(
@@ -224,7 +226,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
 }
@@ -287,7 +289,7 @@ fn test_cli_program_deploy_no_authority() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -316,7 +318,7 @@ fn test_cli_program_deploy_no_authority() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
 }
@@ -380,7 +382,7 @@ fn test_cli_program_deploy_with_authority() {
         max_len: Some(max_len),
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -434,7 +436,7 @@ fn test_cli_program_deploy_with_authority() {
         max_len: Some(max_len),
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -482,7 +484,7 @@ fn test_cli_program_deploy_with_authority() {
         max_len: Some(max_len),
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -562,7 +564,7 @@ fn test_cli_program_deploy_with_authority() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -646,7 +648,7 @@ fn test_cli_program_deploy_with_authority() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
 
@@ -665,7 +667,7 @@ fn test_cli_program_deploy_with_authority() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -771,7 +773,7 @@ fn test_cli_program_close_program() {
         max_len: Some(max_len),
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -883,7 +885,7 @@ fn test_cli_program_extend_program() {
         max_len: None, // Use None to check that it defaults to the max length
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -932,7 +934,7 @@ fn test_cli_program_extend_program() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
 
@@ -966,7 +968,7 @@ fn test_cli_program_extend_program() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
 }
@@ -1032,7 +1034,7 @@ fn test_cli_program_write_buffer() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -1070,7 +1072,7 @@ fn test_cli_program_write_buffer() {
         max_len: Some(max_len),
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1135,7 +1137,7 @@ fn test_cli_program_write_buffer() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1176,7 +1178,7 @@ fn test_cli_program_write_buffer() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1253,7 +1255,7 @@ fn test_cli_program_write_buffer() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -1297,7 +1299,7 @@ fn test_cli_program_write_buffer() {
         max_len: None, //Some(max_len),
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
     config.signers = vec![&keypair, &buffer_keypair];
@@ -1314,7 +1316,7 @@ fn test_cli_program_write_buffer() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let error = process_command(&config).unwrap_err();
@@ -1375,7 +1377,7 @@ fn test_cli_program_set_buffer_authority() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
@@ -1429,7 +1431,7 @@ fn test_cli_program_set_buffer_authority() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap_err();
@@ -1476,7 +1478,7 @@ fn test_cli_program_set_buffer_authority() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1534,7 +1536,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
@@ -1560,7 +1562,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
 
@@ -1579,7 +1581,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
 }
@@ -1664,7 +1666,7 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
         max_len: Some(max_program_data_len), // allows for larger program size with future upgrades
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1833,7 +1835,7 @@ fn test_cli_program_show() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
 
@@ -1896,7 +1898,7 @@ fn test_cli_program_show() {
         max_len: Some(max_len),
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let min_slot = rpc_client.get_slot().unwrap();
@@ -2026,7 +2028,7 @@ fn test_cli_program_dump() {
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
 
@@ -2071,7 +2073,7 @@ fn create_buffer_with_offline_authority<'a>(
         max_len: None,
         skip_fee_check: false,
         max_retries: None,
-        tx_priority_fee: None,
+        compute_unit_price: None,
     });
     process_command(config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_signer.pubkey()).unwrap();

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -89,7 +89,6 @@ fn test_cli_program_deploy_non_upgradeable() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -140,7 +139,6 @@ fn test_cli_program_deploy_non_upgradeable() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -200,7 +198,6 @@ fn test_cli_program_deploy_non_upgradeable() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     let err = process_command(&config).unwrap_err();
@@ -225,7 +222,6 @@ fn test_cli_program_deploy_non_upgradeable() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
@@ -288,7 +284,6 @@ fn test_cli_program_deploy_no_authority() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -317,7 +312,6 @@ fn test_cli_program_deploy_no_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
@@ -381,7 +375,6 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -435,7 +428,6 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     let response = process_command(&config);
@@ -483,7 +475,6 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -563,7 +554,6 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -647,7 +637,6 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
@@ -666,7 +655,6 @@ fn test_cli_program_deploy_with_authority() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     let response = process_command(&config);
@@ -772,7 +760,6 @@ fn test_cli_program_close_program() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -884,7 +871,6 @@ fn test_cli_program_extend_program() {
         is_final: false,
         max_len: None, // Use None to check that it defaults to the max length
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -933,7 +919,6 @@ fn test_cli_program_extend_program() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
@@ -967,7 +952,6 @@ fn test_cli_program_extend_program() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -1033,7 +1017,7 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
+
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1071,7 +1055,7 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: Some(max_len),
         skip_fee_check: false,
-        max_retries: None,
+
         compute_unit_price: None,
     });
     let response = process_command(&config);
@@ -1136,7 +1120,7 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
+
         compute_unit_price: None,
     });
     let response = process_command(&config);
@@ -1177,7 +1161,7 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
+
         compute_unit_price: None,
     });
     let response = process_command(&config);
@@ -1254,7 +1238,7 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
+
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1298,7 +1282,7 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: None, //Some(max_len),
         skip_fee_check: false,
-        max_retries: None,
+
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -1315,7 +1299,6 @@ fn test_cli_program_write_buffer() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1376,7 +1359,7 @@ fn test_cli_program_set_buffer_authority() {
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
+
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -1430,7 +1413,6 @@ fn test_cli_program_set_buffer_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1477,7 +1459,6 @@ fn test_cli_program_set_buffer_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1535,7 +1516,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
+
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -1561,7 +1542,6 @@ fn test_cli_program_mismatch_buffer_authority() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
@@ -1580,7 +1560,6 @@ fn test_cli_program_mismatch_buffer_authority() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -1665,7 +1644,6 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
         is_final: false,
         max_len: Some(max_program_data_len), // allows for larger program size with future upgrades
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1834,7 +1812,7 @@ fn test_cli_program_show() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
+
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -1897,7 +1875,6 @@ fn test_cli_program_show() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
-        max_retries: None,
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -2027,7 +2004,7 @@ fn test_cli_program_dump() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
+
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -2072,7 +2049,7 @@ fn create_buffer_with_offline_authority<'a>(
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
-        max_retries: None,
+
         compute_unit_price: None,
     });
     process_command(config).unwrap();

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -21,7 +21,6 @@ use {
         feature_set::FeatureSet,
         pubkey::Pubkey,
         signature::{Keypair, NullSigner, Signer},
-        signer::EncodableKey,
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_test_validator::TestValidator,
@@ -31,7 +30,6 @@ use {
         io::Read,
         path::{Path, PathBuf},
         str::FromStr,
-        time::Instant,
     },
     test_case::test_case,
 };

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -87,6 +87,8 @@ fn test_cli_program_deploy_non_upgradeable() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -136,6 +138,8 @@ fn test_cli_program_deploy_non_upgradeable() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap();
     let account1 = rpc_client
@@ -194,6 +198,8 @@ fn test_cli_program_deploy_non_upgradeable() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     let err = process_command(&config).unwrap_err();
     assert_eq!(
@@ -217,6 +223,8 @@ fn test_cli_program_deploy_non_upgradeable() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap_err();
 }
@@ -278,6 +286,8 @@ fn test_cli_program_deploy_no_authority() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -305,6 +315,8 @@ fn test_cli_program_deploy_no_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap_err();
 }
@@ -367,6 +379,8 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -419,6 +433,8 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -465,6 +481,8 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -543,6 +561,8 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -625,6 +645,8 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap_err();
 
@@ -642,6 +664,8 @@ fn test_cli_program_deploy_with_authority() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -746,6 +770,8 @@ fn test_cli_program_close_program() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -856,6 +882,8 @@ fn test_cli_program_extend_program() {
         is_final: false,
         max_len: None, // Use None to check that it defaults to the max length
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -903,6 +931,8 @@ fn test_cli_program_extend_program() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap_err();
 
@@ -935,6 +965,8 @@ fn test_cli_program_extend_program() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap();
 }
@@ -999,6 +1031,8 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -1035,6 +1069,8 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: Some(max_len),
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1098,6 +1134,8 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1137,6 +1175,8 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1212,6 +1252,8 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -1254,6 +1296,8 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: None, //Some(max_len),
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap();
     config.signers = vec![&keypair, &buffer_keypair];
@@ -1269,6 +1313,8 @@ fn test_cli_program_write_buffer() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let error = process_command(&config).unwrap_err();
@@ -1328,6 +1374,8 @@ fn test_cli_program_set_buffer_authority() {
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
@@ -1380,6 +1428,8 @@ fn test_cli_program_set_buffer_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap_err();
@@ -1425,6 +1475,8 @@ fn test_cli_program_set_buffer_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1481,6 +1533,8 @@ fn test_cli_program_mismatch_buffer_authority() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
@@ -1505,6 +1559,8 @@ fn test_cli_program_mismatch_buffer_authority() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap_err();
 
@@ -1522,6 +1578,8 @@ fn test_cli_program_mismatch_buffer_authority() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap();
 }
@@ -1605,6 +1663,8 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
         is_final: false,
         max_len: Some(max_program_data_len), // allows for larger program size with future upgrades
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1772,6 +1832,8 @@ fn test_cli_program_show() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap();
 
@@ -1833,6 +1895,8 @@ fn test_cli_program_show() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let min_slot = rpc_client.get_slot().unwrap();
@@ -1961,6 +2025,8 @@ fn test_cli_program_dump() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(&config).unwrap();
 
@@ -2004,6 +2070,8 @@ fn create_buffer_with_offline_authority<'a>(
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
+        max_retries: None,
+        tx_priority_fee: None,
     });
     process_command(config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_signer.pubkey()).unwrap();

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -248,6 +248,8 @@ fn run_transactions_dos(
             is_final: true,
             max_len: None,
             skip_fee_check: true, // skip_fee_check
+            max_retries: None,
+            compute_unit_price: None,
         });
 
         process_command(&config).expect("deploy didn't pass");

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -248,7 +248,6 @@ fn run_transactions_dos(
             is_final: true,
             max_len: None,
             skip_fee_check: true, // skip_fee_check
-            max_retries: None,
             compute_unit_price: None,
         });
 


### PR DESCRIPTION
Issue - #21 

Add Transaction priority fee argument in terms of LAMPORTS to solana program deploy subcommand

#### Problem
1. solana program deploy command could take a lot of time to finish due to program code size .Transaction execution speeds can be increased or txs can be prioritised by setting compute_unit_price (priority fee) for every tx this price is set and txs are executes faster than normal therefore making program deployment faster. 
usage - solana program deploy --tx-priority-fee 1000000 

#### Summary of Changes

solana/cli/program - added tx_priority_fee logic 


