### PR TITLE
[TieredStorage] Optimize the storage size of HotAccountMeta from 16 bytes to 8 bytes

### DIFF
--- a/accounts-db/src/tiered_storage/error.rs
+++ b/accounts-db/src/tiered_storage/error.rs
@@ -31,4 +31,7 @@ pub enum TieredStorageError {
 
     #[error("OffsetAlignmentError: offset {0} must be multiple of {1}")]
     OffsetAlignmentError(usize, usize),
+
+    #[error("UnsupportedAccountMetaFormat: format is deprecated or unsupported.")]
+    UnsupportedAccountMetaFormat(),
 }

--- a/accounts-db/src/tiered_storage/error.rs
+++ b/accounts-db/src/tiered_storage/error.rs
@@ -32,6 +32,6 @@ pub enum TieredStorageError {
     #[error("OffsetAlignmentError: offset {0} must be multiple of {1}")]
     OffsetAlignmentError(usize, usize),
 
-    #[error("UnsupportedAccountMetaFormat: format is deprecated or unsupported.")]
-    UnsupportedAccountMetaFormat(),
+    #[error("UnsupportedAccountMetaFormat: format is unsupported.")]
+    UnsupportedAccountMetaFormat,
 }

--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -57,9 +57,7 @@ impl Default for TieredStorageMagicNumber {
 pub enum AccountMetaFormat {
     #[default]
     Hot = 0,
-    HotPacked,
-    // Temporarily comment out to avoid unimplemented!() block
-    // Cold = 1,
+    HotPacked = 1,
 }
 
 #[repr(u16)]

--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -57,6 +57,7 @@ impl Default for TieredStorageMagicNumber {
 pub enum AccountMetaFormat {
     #[default]
     Hot = 0,
+    HotPacked,
     // Temporarily comment out to avoid unimplemented!() block
     // Cold = 1,
 }
@@ -336,7 +337,7 @@ mod tests {
     fn test_footer() {
         let path = get_append_vec_path("test_file_footer");
         let expected_footer = TieredStorageFooter {
-            account_meta_format: AccountMetaFormat::Hot,
+            account_meta_format: AccountMetaFormat::HotPacked,
             owners_block_format: OwnersBlockFormat::AddressesOnly,
             index_block_format: IndexBlockFormat::AddressesThenOffsets,
             account_block_format: AccountBlockFormat::AlignedRaw,

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -141,8 +141,6 @@ impl HotAccountOffset {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Pod, Zeroable)]
 #[repr(C)]
 pub struct HotAccountMeta {
-    /// The balance of this account.
-    lamports: u64,
     /// Stores important fields in a packed struct.
     packed_fields: HotMetaPackedFields,
     /// Stores boolean flags and existence of each optional field.
@@ -150,13 +148,12 @@ pub struct HotAccountMeta {
 }
 
 // Ensure there are no implicit padding bytes
-const _: () = assert!(std::mem::size_of::<HotAccountMeta>() == 8 + 4 + 4);
+const _: () = assert!(std::mem::size_of::<HotAccountMeta>() == 4 + 4);
 
 impl TieredAccountMeta for HotAccountMeta {
     /// Construct a HotAccountMeta instance.
     fn new() -> Self {
         HotAccountMeta {
-            lamports: 0,
             packed_fields: HotMetaPackedFields::default(),
             flags: AccountMetaFlags::new(),
         }
@@ -762,10 +759,9 @@ pub mod tests {
 
     #[test]
     fn test_hot_account_meta_layout() {
-        assert_eq!(offset_of!(HotAccountMeta, lamports), 0x00);
-        assert_eq!(offset_of!(HotAccountMeta, packed_fields), 0x08);
-        assert_eq!(offset_of!(HotAccountMeta, flags), 0x0C);
-        assert_eq!(std::mem::size_of::<HotAccountMeta>(), 16);
+        assert_eq!(offset_of!(HotAccountMeta, packed_fields), 0x00);
+        assert_eq!(offset_of!(HotAccountMeta, flags), 0x04);
+        assert_eq!(std::mem::size_of::<HotAccountMeta>(), 8);
     }
 
     #[test]

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -29,7 +29,7 @@ use {
 
 pub const HOT_FORMAT: TieredStorageFormat = TieredStorageFormat {
     meta_entry_size: std::mem::size_of::<HotAccountMeta>(),
-    account_meta_format: AccountMetaFormat::Hot,
+    account_meta_format: AccountMetaFormat::HotPacked,
     owners_block_format: OwnersBlockFormat::AddressesOnly,
     index_block_format: IndexBlockFormat::AddressesThenOffsets,
     account_block_format: AccountBlockFormat::AlignedRaw,
@@ -398,17 +398,22 @@ impl HotStorageReader {
         &self,
         account_offset: HotAccountOffset,
     ) -> TieredStorageResult<&HotAccountMeta> {
-        let offset = account_offset.offset();
+        match self.footer.account_meta_format {
+            AccountMetaFormat::HotPacked => {
+                let offset = account_offset.offset();
 
-        assert!(
-            offset.saturating_add(std::mem::size_of::<HotAccountMeta>())
-                <= self.footer.index_block_offset as usize,
-            "reading HotAccountOffset ({}) would exceed accounts blocks offset boundary ({}).",
-            offset,
-            self.footer.index_block_offset,
-        );
-        let (meta, _) = get_pod::<HotAccountMeta>(&self.mmap, offset)?;
-        Ok(meta)
+                assert!(
+                    offset.saturating_add(std::mem::size_of::<HotAccountMeta>())
+                        <= self.footer.index_block_offset as usize,
+                    "reading HotAccountOffset ({}) would exceed accounts blocks offset boundary ({}).",
+                    offset,
+                    self.footer.index_block_offset,
+                );
+                let (meta, _) = get_pod::<HotAccountMeta>(&self.mmap, offset)?;
+                Ok(meta)
+            }
+            _ => Err(TieredStorageError::UnsupportedAccountMetaFormat()),
+        }
     }
 
     /// Returns the offset to the account given the specified index.
@@ -927,7 +932,7 @@ pub mod tests {
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("test_hot_storage_footer");
         let expected_footer = TieredStorageFooter {
-            account_meta_format: AccountMetaFormat::Hot,
+            account_meta_format: AccountMetaFormat::HotPacked,
             owners_block_format: OwnersBlockFormat::AddressesOnly,
             index_block_format: IndexBlockFormat::AddressesThenOffsets,
             account_block_format: AccountBlockFormat::AlignedRaw,
@@ -975,7 +980,7 @@ pub mod tests {
 
         let account_offsets: Vec<_>;
         let mut footer = TieredStorageFooter {
-            account_meta_format: AccountMetaFormat::Hot,
+            account_meta_format: AccountMetaFormat::HotPacked,
             account_entry_count: NUM_ACCOUNTS,
             ..TieredStorageFooter::default()
         };
@@ -1017,7 +1022,7 @@ pub mod tests {
             .join("test_get_acount_meta_from_offset_out_of_bounds");
 
         let footer = TieredStorageFooter {
-            account_meta_format: AccountMetaFormat::Hot,
+            account_meta_format: AccountMetaFormat::HotPacked,
             index_block_offset: 160,
             ..TieredStorageFooter::default()
         };
@@ -1060,7 +1065,7 @@ pub mod tests {
             .collect();
 
         let mut footer = TieredStorageFooter {
-            account_meta_format: AccountMetaFormat::Hot,
+            account_meta_format: AccountMetaFormat::HotPacked,
             account_entry_count: NUM_ACCOUNTS,
             // Set index_block_offset to 0 as we didn't write any account
             // meta/data in this test
@@ -1104,7 +1109,7 @@ pub mod tests {
             .collect();
 
         let footer = TieredStorageFooter {
-            account_meta_format: AccountMetaFormat::Hot,
+            account_meta_format: AccountMetaFormat::HotPacked,
             // meta/data nor index block in this test
             owners_block_offset: 0,
             ..TieredStorageFooter::default()
@@ -1165,7 +1170,7 @@ pub mod tests {
         .take(NUM_ACCOUNTS as usize)
         .collect();
         let mut footer = TieredStorageFooter {
-            account_meta_format: AccountMetaFormat::Hot,
+            account_meta_format: AccountMetaFormat::HotPacked,
             account_entry_count: NUM_ACCOUNTS,
             owner_count: NUM_OWNERS,
             ..TieredStorageFooter::default()
@@ -1284,7 +1289,7 @@ pub mod tests {
             .collect();
 
         let mut footer = TieredStorageFooter {
-            account_meta_format: AccountMetaFormat::Hot,
+            account_meta_format: AccountMetaFormat::HotPacked,
             account_entry_count: NUM_ACCOUNTS as u32,
             owner_count: NUM_OWNERS as u32,
             ..TieredStorageFooter::default()

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -162,12 +162,6 @@ impl TieredAccountMeta for HotAccountMeta {
         }
     }
 
-    /// A builder function that initializes lamports.
-    fn with_lamports(mut self, lamports: u64) -> Self {
-        self.lamports = lamports;
-        self
-    }
-
     /// A builder function that initializes the number of padding bytes
     /// for the account data associated with the current meta.
     fn with_account_data_padding(mut self, padding: u8) -> Self {
@@ -201,9 +195,30 @@ impl TieredAccountMeta for HotAccountMeta {
         self
     }
 
-    /// Returns the balance of the lamports associated with the account.
-    fn lamports(&self) -> u64 {
-        self.lamports
+    /// Whether the account has zero lamports.
+    fn has_zero_lamports(&self) -> bool {
+        self.flags.has_zero_lamports()
+    }
+
+    /// Returns the balance of the lamports associated with the account
+    /// from the TieredAccountMeta, or None if the lamports is stored
+    /// inside the optional field.
+    fn lamports_from_meta(&self) -> Option<u64> {
+        self.flags.lamports()
+    }
+
+    /// Returns the balance of the lamports associated with the account
+    /// from the optional fields, or None if the lamports is stored
+    /// inside the TieredAccountMeta.
+    fn lamports_from_optional_fields(&self, account_block: &[u8]) -> Option<u64> {
+        self.flags
+            .has_optional_lamports_field()
+            .then(|| {
+                let offset = self.optional_fields_offset(account_block)
+                    + AccountMetaOptionalFields::lamports_offset(self.flags());
+                byte_block::read_pod::<u64>(account_block, offset).copied()
+            })
+            .flatten()
     }
 
     /// Returns the number of padding bytes for the associated account data
@@ -299,7 +314,15 @@ impl<'accounts_file, M: TieredAccountMeta> HotAccount<'accounts_file, M> {
 impl<'accounts_file, M: TieredAccountMeta> ReadableAccount for HotAccount<'accounts_file, M> {
     /// Returns the balance of the lamports of this account.
     fn lamports(&self) -> u64 {
-        self.meta.lamports()
+        if let Some(lamports) = self.meta.lamports_from_meta() {
+            return lamports;
+        }
+
+        // If the meta does not have the lamports, then it must inside the optional
+        // fields.
+        self.meta
+            .lamports_from_optional_fields(self.account_block)
+            .unwrap()
     }
 
     /// Returns the address of the owner of this account.
@@ -431,7 +454,7 @@ impl HotStorageReader {
             .get_account_meta_from_offset(account_offset)
             .map_err(|_| MatchAccountOwnerError::UnableToLoad)?;
 
-        if account_meta.lamports() == 0 {
+        if account_meta.has_zero_lamports() {
             Err(MatchAccountOwnerError::NoMatch)
         } else {
             let account_owner = self
@@ -549,6 +572,9 @@ fn write_optional_fields(
     if let Some(rent_epoch) = opt_fields.rent_epoch {
         size += file.write_pod(&rent_epoch)?;
     }
+    if let Some(lamports) = opt_fields.lamports {
+        size += file.write_pod(&lamports)?;
+    }
 
     debug_assert_eq!(size, opt_fields.size());
 
@@ -579,14 +605,16 @@ impl HotStorageWriter {
         executable: bool,
         rent_epoch: Option<Epoch>,
     ) -> TieredStorageResult<usize> {
-        let optional_fields = AccountMetaOptionalFields { rent_epoch };
+        let optional_fields = AccountMetaOptionalFields {
+            rent_epoch,
+            lamports: AccountMetaFlags::get_optional_lamports_field(lamports),
+        };
 
-        let mut flags = AccountMetaFlags::new_from(&optional_fields);
+        let mut flags = AccountMetaFlags::new_from(&optional_fields, lamports);
         flags.set_executable(executable);
 
         let padding_len = padding_bytes(account_data.len());
         let meta = HotAccountMeta::new()
-            .with_lamports(lamports)
             .with_owner_offset(owner_offset)
             .with_account_data_size(account_data.len() as u64)
             .with_account_data_padding(padding_len)
@@ -710,7 +738,10 @@ pub mod tests {
             footer::{AccountBlockFormat, AccountMetaFormat, TieredStorageFooter, FOOTER_SIZE},
             hot::{HotAccountMeta, HotStorageReader},
             index::{AccountIndexWriterEntry, IndexBlockFormat, IndexOffset},
-            meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
+            meta::{
+                AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta,
+                LAMPORTS_INFO_MAX_BALANCE,
+            },
             owners::{OwnersBlockFormat, OwnersTable},
             test_utils::{create_test_account, verify_test_account},
         },
@@ -796,28 +827,42 @@ pub mod tests {
         HotAccountMeta::new().with_owner_offset(OwnerOffset(MAX_HOT_OWNER_OFFSET.0 + 1));
     }
 
-    #[test]
-    fn test_hot_account_meta() {
-        const TEST_LAMPORTS: u64 = 2314232137;
+    /// A helper function to test hot account lamports.
+    fn hot_account_lamports_test(lamports: u64, expected_lamports: Option<u64>) {
         const TEST_PADDING: u8 = 5;
         const TEST_OWNER_OFFSET: OwnerOffset = OwnerOffset(0x1fef_1234);
         const TEST_RENT_EPOCH: Epoch = 7;
 
         let optional_fields = AccountMetaOptionalFields {
             rent_epoch: Some(TEST_RENT_EPOCH),
+            lamports: AccountMetaFlags::get_optional_lamports_field(lamports),
         };
 
-        let flags = AccountMetaFlags::new_from(&optional_fields);
+        let flags = AccountMetaFlags::new_from(&optional_fields, lamports);
         let meta = HotAccountMeta::new()
-            .with_lamports(TEST_LAMPORTS)
             .with_account_data_padding(TEST_PADDING)
             .with_owner_offset(TEST_OWNER_OFFSET)
             .with_flags(&flags);
 
-        assert_eq!(meta.lamports(), TEST_LAMPORTS);
+        assert_eq!(meta.lamports_from_meta(), expected_lamports);
         assert_eq!(meta.account_data_padding(), TEST_PADDING);
         assert_eq!(meta.owner_offset(), TEST_OWNER_OFFSET);
         assert_eq!(*meta.flags(), flags);
+    }
+
+    #[test]
+    fn test_hot_account_zero_lamports() {
+        hot_account_lamports_test(0, Some(0));
+    }
+
+    #[test]
+    fn test_hot_account_lamports_in_meta() {
+        hot_account_lamports_test(LAMPORTS_INFO_MAX_BALANCE, Some(LAMPORTS_INFO_MAX_BALANCE));
+    }
+
+    #[test]
+    fn test_hot_account_lamports_not_fit() {
+        hot_account_lamports_test(LAMPORTS_INFO_MAX_BALANCE + 1, None);
     }
 
     #[test]
@@ -828,14 +873,18 @@ pub mod tests {
         const TEST_LAMPORT: u64 = 2314232137;
         const OWNER_OFFSET: u32 = 0x1fef_1234;
         const TEST_RENT_EPOCH: Epoch = 7;
+        const TEST_BIG_LAMPORTS: u64 = u64::MAX;
 
         let optional_fields = AccountMetaOptionalFields {
             rent_epoch: Some(TEST_RENT_EPOCH),
+            lamports: AccountMetaFlags::get_optional_lamports_field(TEST_BIG_LAMPORTS),
         };
+        // Since the lamports is too big to fit into meta, it is expected
+        // to be in the optional fields.
+        assert_eq!(optional_fields.lamports, Some(TEST_BIG_LAMPORTS));
 
-        let flags = AccountMetaFlags::new_from(&optional_fields);
+        let flags = AccountMetaFlags::new_from(&optional_fields, TEST_BIG_LAMPORTS);
         let expected_meta = HotAccountMeta::new()
-            .with_lamports(TEST_LAMPORT)
             .with_account_data_padding(padding.len().try_into().unwrap())
             .with_owner_offset(OwnerOffset(OWNER_OFFSET))
             .with_flags(&flags);
@@ -854,6 +903,7 @@ pub mod tests {
         assert_eq!(expected_meta, *meta);
         assert!(meta.flags().has_rent_epoch());
         assert_eq!(meta.account_data_padding() as usize, padding.len());
+        assert!(meta.flags().has_optional_lamports_field());
 
         let account_block = &buffer[std::mem::size_of::<HotAccountMeta>()..];
         assert_eq!(
@@ -865,6 +915,10 @@ pub mod tests {
         assert_eq!(account_data.len(), meta.account_data_size(account_block));
         assert_eq!(account_data, meta.account_data(account_block));
         assert_eq!(meta.rent_epoch(account_block), optional_fields.rent_epoch);
+        assert_eq!(
+            meta.lamports_from_optional_fields(account_block),
+            optional_fields.lamports
+        );
     }
 
     #[test]
@@ -915,9 +969,7 @@ pub mod tests {
 
         let hot_account_metas: Vec<_> = (0..NUM_ACCOUNTS)
             .map(|_| {
-                HotAccountMeta::new()
-                    .with_lamports(rng.gen_range(0..u64::MAX))
-                    .with_owner_offset(OwnerOffset(rng.gen_range(0..NUM_ACCOUNTS)))
+                HotAccountMeta::new().with_owner_offset(OwnerOffset(rng.gen_range(0..NUM_ACCOUNTS)))
             })
             .collect();
 
@@ -1103,8 +1155,11 @@ pub mod tests {
         let hot_account_metas: Vec<_> = std::iter::repeat_with({
             || {
                 HotAccountMeta::new()
-                    .with_lamports(rng.gen_range(1..u64::MAX))
                     .with_owner_offset(OwnerOffset(rng.gen_range(0..NUM_OWNERS)))
+                    .with_flags(&AccountMetaFlags::new_from(
+                        &AccountMetaOptionalFields::default(),
+                        rng.gen_range(0..LAMPORTS_INFO_MAX_BALANCE),
+                    ))
             }
         })
         .take(NUM_ACCOUNTS as usize)
@@ -1218,7 +1273,6 @@ pub mod tests {
         let account_metas: Vec<_> = (0..NUM_ACCOUNTS)
             .map(|i| {
                 HotAccountMeta::new()
-                    .with_lamports(rng.gen_range(0..u64::MAX))
                     .with_owner_offset(OwnerOffset(rng.gen_range(0..NUM_OWNERS) as u32))
                     .with_account_data_padding(padding_bytes(account_datas[i].len()))
             })
@@ -1288,7 +1342,6 @@ pub mod tests {
                 .get_account(IndexOffset(i as u32))
                 .unwrap()
                 .unwrap();
-            assert_eq!(stored_meta.lamports(), account_metas[i].lamports());
             assert_eq!(stored_meta.data().len(), account_datas[i].len());
             assert_eq!(stored_meta.data(), account_datas[i]);
             assert_eq!(

--- a/accounts-db/src/tiered_storage/meta.rs
+++ b/accounts-db/src/tiered_storage/meta.rs
@@ -16,9 +16,32 @@ pub struct AccountMetaFlags {
     pub has_rent_epoch: bool,
     /// whether the account is executable
     pub executable: bool,
-    /// the reserved bits.
-    reserved: B30,
+    /// this fewer-than-u64 lamports info stores lamports that can fit
+    /// within its limitation, or a bit indicating the lamport is stored
+    /// separately as an optional field.
+    ///
+    /// Note that the number of bits using in this field must match
+    /// the const LAMPORTS_INFO_BITS.
+    pub lamports_info: B30,
 }
+
+/// The number of bits used in lamports_info field.
+/// Note that this value must match the bits in AccountMetaFlags::lamports_info.
+pub const LAMPORTS_INFO_BITS: u64 = 30;
+/// The max lamports balance that the lamports_info field can handle.
+/// Any lamports beyond this value will be stored separately in optional fields.
+pub const LAMPORTS_INFO_MAX_BALANCE: u64 =
+    ((1u64 << LAMPORTS_INFO_BITS) - 1) - LAMPORTS_INFO_RESERVED_VALUES;
+
+/// The number of special values inside lamports_info.
+/// This const MUST be updated when adding new reserved values.
+pub const LAMPORTS_INFO_RESERVED_VALUES: u64 = 2;
+
+/// A reserved lamports_info value indicating zero-lamports balance.
+pub const LAMPORTS_INFO_IS_ZERO_BALANCE: u32 = 0;
+/// A reserved lamports_info value indicating the lamports balance is stored
+/// in optional fields.
+pub const LAMPORTS_INFO_HAS_OPTIONAL_FIELD: u32 = 1;
 
 // Ensure there are no implicit padding bytes
 const _: () = assert!(std::mem::size_of::<AccountMetaFlags>() == 4);
@@ -28,9 +51,6 @@ const _: () = assert!(std::mem::size_of::<AccountMetaFlags>() == 4);
 pub trait TieredAccountMeta: Sized {
     /// Constructs a TieredAcountMeta instance.
     fn new() -> Self;
-
-    /// A builder function that initializes lamports.
-    fn with_lamports(self, lamports: u64) -> Self;
 
     /// A builder function that initializes the number of padding bytes
     /// for the account data associated with the current meta.
@@ -47,8 +67,18 @@ pub trait TieredAccountMeta: Sized {
     /// meta.
     fn with_flags(self, flags: &AccountMetaFlags) -> Self;
 
-    /// Returns the balance of the lamports associated with the account.
-    fn lamports(&self) -> u64;
+    /// Whether the account has zero lamports.
+    fn has_zero_lamports(&self) -> bool;
+
+    /// Returns the balance of the lamports associated with the account
+    /// from the TieredAccountMeta, or None if the lamports is stored
+    /// inside the optional field.
+    fn lamports_from_meta(&self) -> Option<u64>;
+
+    /// Returns the balance of the lamports associated with the account
+    /// from the optional fields, or None if the lamports is stored
+    /// inside the TieredAccountMeta.
+    fn lamports_from_optional_fields(&self, _account_block: &[u8]) -> Option<u64>;
 
     /// Returns the number of padding bytes for the associated account data
     fn account_data_padding(&self) -> u8;
@@ -82,11 +112,41 @@ pub trait TieredAccountMeta: Sized {
 }
 
 impl AccountMetaFlags {
-    pub fn new_from(optional_fields: &AccountMetaOptionalFields) -> Self {
+    pub fn new_from(optional_fields: &AccountMetaOptionalFields, lamports: u64) -> Self {
         let mut flags = AccountMetaFlags::default();
         flags.set_has_rent_epoch(optional_fields.rent_epoch.is_some());
+        if optional_fields.lamports.is_some() {
+            flags.set_lamports_info(LAMPORTS_INFO_HAS_OPTIONAL_FIELD);
+        } else if lamports != 0 {
+            debug_assert!(lamports <= LAMPORTS_INFO_MAX_BALANCE);
+            flags.set_lamports_info((lamports + LAMPORTS_INFO_RESERVED_VALUES) as u32);
+        }
         flags.set_executable(false);
         flags
+    }
+
+    pub fn lamports(&self) -> Option<u64> {
+        match self.lamports_info() {
+            LAMPORTS_INFO_IS_ZERO_BALANCE => Some(0),
+            LAMPORTS_INFO_HAS_OPTIONAL_FIELD => None,
+            packed_lamports => Some(packed_lamports as u64 - LAMPORTS_INFO_RESERVED_VALUES),
+        }
+    }
+
+    pub fn has_zero_lamports(&self) -> bool {
+        self.lamports_info() == LAMPORTS_INFO_IS_ZERO_BALANCE
+    }
+
+    pub fn has_optional_lamports_field(&self) -> bool {
+        self.lamports_info() == LAMPORTS_INFO_HAS_OPTIONAL_FIELD
+    }
+
+    pub fn get_optional_lamports_field(lamports: u64) -> Option<u64> {
+        if lamports > LAMPORTS_INFO_MAX_BALANCE {
+            Some(lamports)
+        } else {
+            None
+        }
     }
 }
 
@@ -94,16 +154,22 @@ impl AccountMetaFlags {
 ///
 /// Note that the storage representation of the optional fields might be
 /// different from its in-memory representation.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct AccountMetaOptionalFields {
     /// the epoch at which its associated account will next owe rent
     pub rent_epoch: Option<Epoch>,
+    /// The balance of this account.
+    ///
+    /// It is Some only when lamports balance of the current account
+    /// cannot be stored inside the AccountMeta.
+    pub lamports: Option<u64>,
 }
 
 impl AccountMetaOptionalFields {
     /// The size of the optional fields in bytes (excluding the boolean flags).
     pub fn size(&self) -> usize {
         self.rent_epoch.map_or(0, |_| std::mem::size_of::<Epoch>())
+            + self.lamports.map_or(0, |_| std::mem::size_of::<u64>())
     }
 
     /// Given the specified AccountMetaFlags, returns the size of its
@@ -114,6 +180,10 @@ impl AccountMetaOptionalFields {
             fields_size += std::mem::size_of::<Epoch>();
         }
 
+        if flags.lamports_info() == LAMPORTS_INFO_HAS_OPTIONAL_FIELD {
+            fields_size += std::mem::size_of::<u64>();
+        }
+
         fields_size
     }
 
@@ -122,18 +192,35 @@ impl AccountMetaOptionalFields {
     pub fn rent_epoch_offset(_flags: &AccountMetaFlags) -> usize {
         0
     }
+
+    /// Given the specified AccountMetaFlags, returns the relative offset
+    /// of its lamports field to the offset of its optional fields entry.
+    pub fn lamports_offset(flags: &AccountMetaFlags) -> usize {
+        let mut offset = Self::rent_epoch_offset(flags);
+        if flags.has_rent_epoch() {
+            offset += std::mem::size_of::<Epoch>();
+        }
+
+        offset
+    }
 }
 
 #[cfg(test)]
 pub mod tests {
     use super::*;
 
+    impl AccountMetaFlags {
+        pub fn new_from_test(optional_fields: &AccountMetaOptionalFields) -> Self {
+            AccountMetaFlags::new_from(optional_fields, 0)
+        }
+    }
+
     #[test]
     fn test_account_meta_flags_new() {
         let flags = AccountMetaFlags::new();
 
         assert!(!flags.has_rent_epoch());
-        assert_eq!(flags.reserved(), 0u32);
+        assert_eq!(flags.lamports_info(), 0u32);
 
         assert_eq!(
             std::mem::size_of::<AccountMetaFlags>(),
@@ -160,65 +247,85 @@ pub mod tests {
         assert!(flags.executable());
         verify_flags_serialization(&flags);
 
-        // make sure the reserved bits are untouched.
-        assert_eq!(flags.reserved(), 0u32);
+        // make sure the lamports_info bits are untouched.
+        assert_eq!(flags.lamports_info(), 0u32);
     }
 
     fn update_and_verify_flags(opt_fields: &AccountMetaOptionalFields) {
-        let flags: AccountMetaFlags = AccountMetaFlags::new_from(opt_fields);
+        let flags: AccountMetaFlags = AccountMetaFlags::new_from_test(opt_fields);
         assert_eq!(flags.has_rent_epoch(), opt_fields.rent_epoch.is_some());
-        assert_eq!(flags.reserved(), 0u32);
+        assert_eq!(
+            flags.lamports_info(),
+            opt_fields
+                .lamports
+                .map_or(0, |_| LAMPORTS_INFO_HAS_OPTIONAL_FIELD)
+        );
     }
 
     #[test]
     fn test_optional_fields_update_flags() {
         let test_epoch = 5432312;
+        let test_lamports = 2314312321321;
 
         for rent_epoch in [None, Some(test_epoch)] {
-            update_and_verify_flags(&AccountMetaOptionalFields { rent_epoch });
+            for lamports in [None, Some(test_lamports)] {
+                update_and_verify_flags(&AccountMetaOptionalFields {
+                    rent_epoch,
+                    lamports,
+                });
+            }
         }
     }
 
     #[test]
     fn test_optional_fields_size() {
         let test_epoch = 5432312;
+        let test_lamports = 2314312321321;
 
         for rent_epoch in [None, Some(test_epoch)] {
-            let opt_fields = AccountMetaOptionalFields { rent_epoch };
-            assert_eq!(
-                opt_fields.size(),
-                rent_epoch.map_or(0, |_| std::mem::size_of::<Epoch>()),
-            );
-            assert_eq!(
-                opt_fields.size(),
-                AccountMetaOptionalFields::size_from_flags(&AccountMetaFlags::new_from(
-                    &opt_fields
-                ))
-            );
+            for lamports in [None, Some(test_lamports)] {
+                let opt_fields = AccountMetaOptionalFields {
+                    rent_epoch,
+                    lamports,
+                };
+                assert_eq!(
+                    opt_fields.size(),
+                    rent_epoch.map_or(0, |_| std::mem::size_of::<Epoch>())
+                        + lamports.map_or(0, |_| std::mem::size_of::<u64>()),
+                );
+                assert_eq!(
+                    opt_fields.size(),
+                    AccountMetaOptionalFields::size_from_flags(&AccountMetaFlags::new_from_test(
+                        &opt_fields,
+                    ))
+                );
+            }
         }
     }
 
     #[test]
     fn test_optional_fields_offset() {
         let test_epoch = 5432312;
+        let test_lamports = 2314312321321;
 
         for rent_epoch in [None, Some(test_epoch)] {
-            let rent_epoch_offset = 0;
-            let derived_size = if rent_epoch.is_some() {
-                std::mem::size_of::<Epoch>()
-            } else {
-                0
-            };
-            let opt_fields = AccountMetaOptionalFields { rent_epoch };
-            let flags = AccountMetaFlags::new_from(&opt_fields);
-            assert_eq!(
-                AccountMetaOptionalFields::rent_epoch_offset(&flags),
-                rent_epoch_offset
-            );
-            assert_eq!(
-                AccountMetaOptionalFields::size_from_flags(&flags),
-                derived_size
-            );
+            for lamports in [None, Some(test_lamports)] {
+                let opt_fields = AccountMetaOptionalFields {
+                    rent_epoch,
+                    lamports,
+                };
+                let flags = AccountMetaFlags::new_from_test(&opt_fields);
+                assert_eq!(AccountMetaOptionalFields::rent_epoch_offset(&flags), 0,);
+                assert_eq!(
+                    AccountMetaOptionalFields::lamports_offset(&flags),
+                    rent_epoch.map_or(0, |_| std::mem::size_of::<Epoch>()),
+                );
+                assert_eq!(
+                    AccountMetaOptionalFields::size_from_flags(&flags),
+                    rent_epoch.map_or(0, |_| std::mem::size_of::<Epoch>())
+                        + lamports.map_or(0, |_| std::mem::size_of::<u64>()),
+                );
+            }
         }
     }
 }

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -3,6 +3,7 @@ use {
         account_storage::meta::StoredAccountMeta,
         accounts_file::MatchAccountOwnerError,
         tiered_storage::{
+            error::TieredStorageError,
             footer::{AccountMetaFormat, TieredStorageFooter},
             hot::HotStorageReader,
             index::IndexOffset,
@@ -24,7 +25,8 @@ impl TieredStorageReader {
     pub fn new_from_path(path: impl AsRef<Path>) -> TieredStorageResult<Self> {
         let footer = TieredStorageFooter::new_from_path(&path)?;
         match footer.account_meta_format {
-            AccountMetaFormat::Hot => Ok(Self::Hot(HotStorageReader::new_from_path(path)?)),
+            AccountMetaFormat::HotPacked => Ok(Self::Hot(HotStorageReader::new_from_path(path)?)),
+            _ => Err(TieredStorageError::UnsupportedAccountMetaFormat()),
         }
     }
 
@@ -85,5 +87,34 @@ impl TieredStorageReader {
         match self {
             Self::Hot(hot) => hot.accounts(index_offset),
         }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use {
+        super::*,
+        crate::tiered_storage::{file::TieredStorageFile, footer::AccountMetaFormat},
+        tempfile::TempDir,
+    };
+
+    #[test]
+    #[should_panic(expected = "UnsupportedAccountMetaFormat")]
+    fn test_unsupported_meta_format() {
+        // Generate a new temp path that is guaranteed to NOT already have a file.
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test_unsupported_meta_format");
+
+        let footer = TieredStorageFooter {
+            account_meta_format: AccountMetaFormat::Hot, // deprecated
+            ..TieredStorageFooter::default()
+        };
+
+        {
+            let file = TieredStorageFile::new_writable(&path).unwrap();
+            footer.write_footer_block(&file).unwrap();
+        }
+
+        TieredStorageReader::new_from_path(&path).unwrap();
     }
 }

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -26,7 +26,7 @@ impl TieredStorageReader {
         let footer = TieredStorageFooter::new_from_path(&path)?;
         match footer.account_meta_format {
             AccountMetaFormat::HotPacked => Ok(Self::Hot(HotStorageReader::new_from_path(path)?)),
-            _ => Err(TieredStorageError::UnsupportedAccountMetaFormat()),
+            _ => Err(TieredStorageError::UnsupportedAccountMetaFormat),
         }
     }
 

--- a/accounts-db/src/tiered_storage/test_utils.rs
+++ b/accounts-db/src/tiered_storage/test_utils.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         account_storage::meta::{StoredAccountMeta, StoredMeta},
         accounts_hash::AccountHash,
-        tiered_storage::owners::OWNER_NO_OWNER,
+        tiered_storage::{meta::LAMPORTS_INFO_MAX_BALANCE, owners::OWNER_NO_OWNER},
     },
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount},
@@ -24,7 +24,13 @@ pub(super) fn create_test_account(seed: u64) -> (StoredMeta, AccountSharedData) 
     let data_byte = seed as u8;
     let owner_byte = u8::MAX - data_byte;
     let account = Account {
-        lamports: seed,
+        // make sure the created test accounts cover both lamports inside meta
+        // and lamports inside optional fields.
+        lamports: if seed % 2 == 0 {
+            seed
+        } else {
+            seed + LAMPORTS_INFO_MAX_BALANCE
+        },
         data: std::iter::repeat(data_byte).take(seed as usize).collect(),
         // this will allow some test account sharing the same owner.
         owner: [owner_byte; 32].into(),


### PR DESCRIPTION
#### Problem
Lamports-balance requires a u64 to fully represent its value range.
However, most lamports-balance can fit in fewer bits (> 95% can fit in 25 bits).
This finding allows us to utilize the reserved bits inside AccountMetaFlags
to store lamports-balance, or as an optional field when it cannot be represented
using the remaining bits inside AccountMetaFlags.

#### Summary of Changes
This PR moves the lamports field from HotAccountMeta to AccountsMetaFlags.
For more than 95% of the accounts, this PR can save 8 bytes per account.

#### Test Plan
Added new tests to cover zero lamports, lamports inside meta, and lamports inside optional fields.
Update existing tests to cover all cases.
