### PR TITLE
Moves accounts-db stats into a submodule

### DIFF
--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -1,0 +1,668 @@
+use {
+    crate::{
+        accounts_index::{in_mem_accounts_index::StartupStats, AccountsIndexRootsStats},
+        append_vec::APPEND_VEC_MMAPPED_FILES_OPEN,
+    },
+    solana_sdk::{saturating_add_assign, timing::AtomicInterval},
+    std::sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+};
+
+#[derive(Debug, Default)]
+pub struct AccountsStats {
+    pub delta_hash_scan_time_total_us: AtomicU64,
+    pub delta_hash_accumulate_time_total_us: AtomicU64,
+    pub delta_hash_num: AtomicU64,
+    pub skipped_rewrites_num: AtomicUsize,
+
+    pub last_store_report: AtomicInterval,
+    pub store_hash_accounts: AtomicU64,
+    pub calc_stored_meta: AtomicU64,
+    pub store_accounts: AtomicU64,
+    pub store_update_index: AtomicU64,
+    pub store_handle_reclaims: AtomicU64,
+    pub store_append_accounts: AtomicU64,
+    pub stakes_cache_check_and_store_us: AtomicU64,
+    pub store_num_accounts: AtomicU64,
+    pub store_total_data: AtomicU64,
+    pub recycle_store_count: AtomicU64,
+    pub create_store_count: AtomicU64,
+    pub store_get_slot_store: AtomicU64,
+    pub store_find_existing: AtomicU64,
+    pub dropped_stores: AtomicU64,
+    pub store_uncleaned_update: AtomicU64,
+    pub handle_dead_keys_us: AtomicU64,
+    pub purge_exact_us: AtomicU64,
+    pub purge_exact_count: AtomicU64,
+}
+
+#[derive(Debug, Default)]
+pub struct PurgeStats {
+    last_report: AtomicInterval,
+    pub safety_checks_elapsed: AtomicU64,
+    pub remove_cache_elapsed: AtomicU64,
+    pub remove_storage_entries_elapsed: AtomicU64,
+    pub drop_storage_entries_elapsed: AtomicU64,
+    pub num_cached_slots_removed: AtomicUsize,
+    pub num_stored_slots_removed: AtomicUsize,
+    pub total_removed_storage_entries: AtomicUsize,
+    pub total_removed_cached_bytes: AtomicU64,
+    pub total_removed_stored_bytes: AtomicU64,
+    pub recycle_stores_write_elapsed: AtomicU64,
+    pub scan_storages_elapsed: AtomicU64,
+    pub purge_accounts_index_elapsed: AtomicU64,
+    pub handle_reclaims_elapsed: AtomicU64,
+}
+
+impl PurgeStats {
+    pub fn report(&self, metric_name: &'static str, report_interval_ms: Option<u64>) {
+        let should_report = report_interval_ms
+            .map(|report_interval_ms| self.last_report.should_update(report_interval_ms))
+            .unwrap_or(true);
+
+        if should_report {
+            datapoint_info!(
+                metric_name,
+                (
+                    "safety_checks_elapsed",
+                    self.safety_checks_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "remove_cache_elapsed",
+                    self.remove_cache_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "remove_storage_entries_elapsed",
+                    self.remove_storage_entries_elapsed
+                        .swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "drop_storage_entries_elapsed",
+                    self.drop_storage_entries_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "num_cached_slots_removed",
+                    self.num_cached_slots_removed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "num_stored_slots_removed",
+                    self.num_stored_slots_removed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "total_removed_storage_entries",
+                    self.total_removed_storage_entries
+                        .swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "total_removed_cached_bytes",
+                    self.total_removed_cached_bytes.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "total_removed_stored_bytes",
+                    self.total_removed_stored_bytes.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "recycle_stores_write_elapsed",
+                    self.recycle_stores_write_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "scan_storages_elapsed",
+                    self.scan_storages_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "purge_accounts_index_elapsed",
+                    self.purge_accounts_index_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "handle_reclaims_elapsed",
+                    self.handle_reclaims_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+            );
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FlushStats {
+    pub num_flushed: usize,
+    pub num_purged: usize,
+    pub total_size: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct LatestAccountsIndexRootsStats {
+    roots_len: AtomicUsize,
+    uncleaned_roots_len: AtomicUsize,
+    roots_range: AtomicU64,
+    rooted_cleaned_count: AtomicUsize,
+    unrooted_cleaned_count: AtomicUsize,
+    clean_unref_from_storage_us: AtomicU64,
+    clean_dead_slot_us: AtomicU64,
+}
+
+impl LatestAccountsIndexRootsStats {
+    pub fn update(&self, accounts_index_roots_stats: &AccountsIndexRootsStats) {
+        if let Some(value) = accounts_index_roots_stats.roots_len {
+            self.roots_len.store(value, Ordering::Relaxed);
+        }
+        if let Some(value) = accounts_index_roots_stats.uncleaned_roots_len {
+            self.uncleaned_roots_len.store(value, Ordering::Relaxed);
+        }
+        if let Some(value) = accounts_index_roots_stats.roots_range {
+            self.roots_range.store(value, Ordering::Relaxed);
+        }
+        self.rooted_cleaned_count.fetch_add(
+            accounts_index_roots_stats.rooted_cleaned_count,
+            Ordering::Relaxed,
+        );
+        self.unrooted_cleaned_count.fetch_add(
+            accounts_index_roots_stats.unrooted_cleaned_count,
+            Ordering::Relaxed,
+        );
+        self.clean_unref_from_storage_us.fetch_add(
+            accounts_index_roots_stats.clean_unref_from_storage_us,
+            Ordering::Relaxed,
+        );
+        self.clean_dead_slot_us.fetch_add(
+            accounts_index_roots_stats.clean_dead_slot_us,
+            Ordering::Relaxed,
+        );
+    }
+
+    fn report(&self) {
+        datapoint_info!(
+            "accounts_index_roots_len",
+            (
+                "roots_len",
+                self.roots_len.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "uncleaned_roots_len",
+                self.uncleaned_roots_len.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "roots_range_width",
+                self.roots_range.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "unrooted_cleaned_count",
+                self.unrooted_cleaned_count.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "rooted_cleaned_count",
+                self.rooted_cleaned_count.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "clean_unref_from_storage_us",
+                self.clean_unref_from_storage_us.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "clean_dead_slot_us",
+                self.clean_dead_slot_us.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "append_vecs_open",
+                APPEND_VEC_MMAPPED_FILES_OPEN.load(Ordering::Relaxed) as i64,
+                i64
+            )
+        );
+
+        // Don't need to reset since this tracks the latest updates, not a cumulative total
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct CleanAccountsStats {
+    pub purge_stats: PurgeStats,
+    pub latest_accounts_index_roots_stats: LatestAccountsIndexRootsStats,
+
+    // stats held here and reported by clean_accounts
+    pub clean_old_root_us: AtomicU64,
+    pub clean_old_root_reclaim_us: AtomicU64,
+    pub reset_uncleaned_roots_us: AtomicU64,
+    pub remove_dead_accounts_remove_us: AtomicU64,
+    pub remove_dead_accounts_shrink_us: AtomicU64,
+    pub clean_stored_dead_slots_us: AtomicU64,
+}
+
+impl CleanAccountsStats {
+    pub fn report(&self) {
+        self.purge_stats.report("clean_purge_slots_stats", None);
+        self.latest_accounts_index_roots_stats.report();
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ShrinkAncientStats {
+    pub shrink_stats: ShrinkStats,
+    pub ancient_append_vecs_shrunk: AtomicU64,
+    pub total_us: AtomicU64,
+    pub random_shrink: AtomicU64,
+    pub slots_considered: AtomicU64,
+    pub ancient_scanned: AtomicU64,
+    pub bytes_ancient_created: AtomicU64,
+}
+
+#[derive(Debug, Default)]
+pub struct ShrinkStatsSub {
+    pub store_accounts_timing: StoreAccountsTiming,
+    pub rewrite_elapsed_us: u64,
+    pub create_and_insert_store_elapsed_us: u64,
+    pub unpackable_slots_count: usize,
+    pub newest_alive_packed_count: usize,
+}
+
+impl ShrinkStatsSub {
+    pub fn accumulate(&mut self, other: &Self) {
+        self.store_accounts_timing
+            .accumulate(&other.store_accounts_timing);
+        saturating_add_assign!(self.rewrite_elapsed_us, other.rewrite_elapsed_us);
+        saturating_add_assign!(
+            self.create_and_insert_store_elapsed_us,
+            other.create_and_insert_store_elapsed_us
+        );
+        saturating_add_assign!(self.unpackable_slots_count, other.unpackable_slots_count);
+        saturating_add_assign!(
+            self.newest_alive_packed_count,
+            other.newest_alive_packed_count
+        );
+    }
+}
+#[derive(Debug, Default)]
+pub struct ShrinkStats {
+    last_report: AtomicInterval,
+    pub num_slots_shrunk: AtomicUsize,
+    pub storage_read_elapsed: AtomicU64,
+    pub index_read_elapsed: AtomicU64,
+    pub create_and_insert_store_elapsed: AtomicU64,
+    pub store_accounts_elapsed: AtomicU64,
+    pub update_index_elapsed: AtomicU64,
+    pub handle_reclaims_elapsed: AtomicU64,
+    pub remove_old_stores_shrink_us: AtomicU64,
+    pub rewrite_elapsed: AtomicU64,
+    pub unpackable_slots_count: AtomicU64,
+    pub newest_alive_packed_count: AtomicU64,
+    pub drop_storage_entries_elapsed: AtomicU64,
+    pub recycle_stores_write_elapsed: AtomicU64,
+    pub accounts_removed: AtomicUsize,
+    pub bytes_removed: AtomicU64,
+    pub bytes_written: AtomicU64,
+    pub skipped_shrink: AtomicU64,
+    pub dead_accounts: AtomicU64,
+    pub alive_accounts: AtomicU64,
+    pub accounts_loaded: AtomicU64,
+}
+
+impl ShrinkStats {
+    pub fn report(&self) {
+        if self.last_report.should_update(1000) {
+            datapoint_info!(
+                "shrink_stats",
+                (
+                    "num_slots_shrunk",
+                    self.num_slots_shrunk.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "storage_read_elapsed",
+                    self.storage_read_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "index_read_elapsed",
+                    self.index_read_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "create_and_insert_store_elapsed",
+                    self.create_and_insert_store_elapsed
+                        .swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "store_accounts_elapsed",
+                    self.store_accounts_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "update_index_elapsed",
+                    self.update_index_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "handle_reclaims_elapsed",
+                    self.handle_reclaims_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "remove_old_stores_shrink_us",
+                    self.remove_old_stores_shrink_us.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "rewrite_elapsed",
+                    self.rewrite_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "drop_storage_entries_elapsed",
+                    self.drop_storage_entries_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "recycle_stores_write_time",
+                    self.recycle_stores_write_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "accounts_removed",
+                    self.accounts_removed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "bytes_removed",
+                    self.bytes_removed.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "bytes_written",
+                    self.bytes_written.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "skipped_shrink",
+                    self.skipped_shrink.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "alive_accounts",
+                    self.alive_accounts.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "dead_accounts",
+                    self.dead_accounts.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "accounts_loaded",
+                    self.accounts_loaded.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+            );
+        }
+    }
+}
+
+impl ShrinkAncientStats {
+    pub(crate) fn report(&self) {
+        datapoint_info!(
+            "shrink_ancient_stats",
+            (
+                "num_slots_shrunk",
+                self.shrink_stats
+                    .num_slots_shrunk
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "storage_read_elapsed",
+                self.shrink_stats
+                    .storage_read_elapsed
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "index_read_elapsed",
+                self.shrink_stats
+                    .index_read_elapsed
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "create_and_insert_store_elapsed",
+                self.shrink_stats
+                    .create_and_insert_store_elapsed
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "store_accounts_elapsed",
+                self.shrink_stats
+                    .store_accounts_elapsed
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "update_index_elapsed",
+                self.shrink_stats
+                    .update_index_elapsed
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "handle_reclaims_elapsed",
+                self.shrink_stats
+                    .handle_reclaims_elapsed
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "remove_old_stores_shrink_us",
+                self.shrink_stats
+                    .remove_old_stores_shrink_us
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "rewrite_elapsed",
+                self.shrink_stats.rewrite_elapsed.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "unpackable_slots_count",
+                self.shrink_stats
+                    .unpackable_slots_count
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "newest_alive_packed_count",
+                self.shrink_stats
+                    .newest_alive_packed_count
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "drop_storage_entries_elapsed",
+                self.shrink_stats
+                    .drop_storage_entries_elapsed
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "recycle_stores_write_time",
+                self.shrink_stats
+                    .recycle_stores_write_elapsed
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "accounts_removed",
+                self.shrink_stats
+                    .accounts_removed
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "bytes_removed",
+                self.shrink_stats.bytes_removed.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "bytes_written",
+                self.shrink_stats.bytes_written.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "alive_accounts",
+                self.shrink_stats.alive_accounts.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "dead_accounts",
+                self.shrink_stats.dead_accounts.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "accounts_loaded",
+                self.shrink_stats.accounts_loaded.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "ancient_append_vecs_shrunk",
+                self.ancient_append_vecs_shrunk.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "random",
+                self.random_shrink.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "slots_considered",
+                self.slots_considered.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "ancient_scanned",
+                self.ancient_scanned.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "total_us",
+                self.total_us.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "bytes_ancient_created",
+                self.bytes_ancient_created.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+        );
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct GenerateIndexTimings {
+    pub total_time_us: u64,
+    pub index_time: u64,
+    pub scan_time: u64,
+    pub insertion_time_us: u64,
+    pub min_bin_size: usize,
+    pub max_bin_size: usize,
+    pub total_items: usize,
+    pub storage_size_storages_us: u64,
+    pub index_flush_us: u64,
+    pub rent_paying: AtomicUsize,
+    pub amount_to_top_off_rent: AtomicU64,
+    pub total_including_duplicates: u64,
+    pub accounts_data_len_dedup_time_us: u64,
+    pub total_duplicate_slot_keys: u64,
+    pub populate_duplicate_keys_us: u64,
+    pub total_slots: u64,
+    pub slots_to_clean: u64,
+}
+
+impl GenerateIndexTimings {
+    pub fn report(&self, startup_stats: &StartupStats) {
+        datapoint_info!(
+            "generate_index",
+            ("overall_us", self.total_time_us, i64),
+            // we cannot accurately measure index insertion time because of many threads and lock contention
+            ("total_us", self.index_time, i64),
+            ("scan_stores_us", self.scan_time, i64),
+            ("insertion_time_us", self.insertion_time_us, i64),
+            ("min_bin_size", self.min_bin_size as i64, i64),
+            ("max_bin_size", self.max_bin_size as i64, i64),
+            (
+                "storage_size_storages_us",
+                self.storage_size_storages_us as i64,
+                i64
+            ),
+            ("index_flush_us", self.index_flush_us as i64, i64),
+            (
+                "total_rent_paying",
+                self.rent_paying.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "amount_to_top_off_rent",
+                self.amount_to_top_off_rent.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "total_items_including_duplicates",
+                self.total_including_duplicates as i64,
+                i64
+            ),
+            ("total_items", self.total_items as i64, i64),
+            (
+                "accounts_data_len_dedup_time_us",
+                self.accounts_data_len_dedup_time_us as i64,
+                i64
+            ),
+            (
+                "total_duplicate_slot_keys",
+                self.total_duplicate_slot_keys as i64,
+                i64
+            ),
+            (
+                "populate_duplicate_keys_us",
+                self.populate_duplicate_keys_us as i64,
+                i64
+            ),
+            ("total_slots", self.total_slots, i64),
+            ("slots_to_clean", self.slots_to_clean, i64),
+            (
+                "copy_data_us",
+                startup_stats.copy_data_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
+        );
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct StoreAccountsTiming {
+    pub store_accounts_elapsed: u64,
+    pub update_index_elapsed: u64,
+    pub handle_reclaims_elapsed: u64,
+}
+
+impl StoreAccountsTiming {
+    pub fn accumulate(&mut self, other: &Self) {
+        self.store_accounts_elapsed += other.store_accounts_elapsed;
+        self.update_index_elapsed += other.update_index_elapsed;
+        self.handle_reclaims_elapsed += other.handle_reclaims_elapsed;
+    }
+}

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -9,9 +9,7 @@ use {
         prelude::ParallelSlice,
     },
     solana_accounts_db::{
-        accounts_db::{
-            AccountStorageEntry, AccountsDb, GetUniqueAccountsResult, PurgeStats, StoreReclaims,
-        },
+        accounts_db::{AccountStorageEntry, AccountsDb, GetUniqueAccountsResult, StoreReclaims},
         accounts_partition,
     },
     solana_measure::measure,
@@ -395,9 +393,8 @@ impl<'a> SnapshotMinimizer<'a> {
 
     /// Purge dead slots from storage and cache
     fn purge_dead_slots(&self, dead_slots: Vec<Slot>) {
-        let stats = PurgeStats::default();
         self.accounts_db()
-            .purge_slots_from_cache_and_store(dead_slots.iter(), &stats, false);
+            .purge_slots_from_cache_and_store_without_stats(dead_slots.iter(), false);
     }
 
     /// Convenience function for getting accounts_db


### PR DESCRIPTION
#### Problem

`accounts_db.rs` is getting quite large. It's over 18,000 lines currently. Personally this impacts my editor, as it parses the file, and the slowdown is noticeable 😅. I also find it harder to navigate files this large in general. I'd like to move some self contained pieces into their own submodules. This would reduce file size, and make handling visibility (pub, crate, super, priv) easier too.

There are many stats-related structs in `accounts_db.rs`. They don't need to be accessed outside of this file, so they are self contained. 

#### Summary of Changes

Move the stats into their own file.