### PR TITLE
frozen-abi-macro: use `log` from `solana_frozen_abi`

### DIFF
--- a/frozen-abi/macro/src/lib.rs
+++ b/frozen-abi/macro/src/lib.rs
@@ -146,7 +146,7 @@ fn derive_abi_sample_enum_type(input: ItemEnum) -> TokenStream {
         #( #attrs )*
         impl #impl_generics ::solana_frozen_abi::abi_example::AbiExample for #type_name #ty_generics #where_clause {
             fn example() -> Self {
-                ::log::info!(
+                ::solana_frozen_abi::log::info!(
                     "AbiExample for enum: {}",
                     std::any::type_name::<#type_name #ty_generics>()
                 );
@@ -198,7 +198,7 @@ fn derive_abi_sample_struct_type(input: ItemStruct) -> TokenStream {
         #( #attrs )*
         impl #impl_generics ::solana_frozen_abi::abi_example::AbiExample for #type_name #ty_generics #where_clause {
             fn example() -> Self {
-                ::log::info!(
+                ::solana_frozen_abi::log::info!(
                     "AbiExample for struct: {}",
                     std::any::type_name::<#type_name #ty_generics>()
                 );
@@ -300,7 +300,7 @@ fn quote_for_test(
                 let mut hash = digester.finalize();
                 // pretty-print error
                 if result.is_err() {
-                    ::log::error!("digest error: {:#?}", result);
+                    ::solana_frozen_abi::log::error!("digest error: {:#?}", result);
                 }
                 result.unwrap();
                 let actual_digest = format!("{}", hash);
@@ -308,7 +308,7 @@ fn quote_for_test(
                     if #expected_digest != actual_digest {
                         #p!("sed -i -e 's/{}/{}/g' $(git grep --files-with-matches frozen_abi)", #expected_digest, hash);
                     }
-                    ::log::warn!("Not testing the abi digest under SOLANA_ABI_BULK_UPDATE!");
+                    ::solana_frozen_abi::log::warn!("Not testing the abi digest under SOLANA_ABI_BULK_UPDATE!");
                 } else {
                     if let Ok(dir) = ::std::env::var("SOLANA_ABI_DUMP_DIR") {
                         assert_eq!(#expected_digest, actual_digest, "Possibly ABI changed? Examine the diff in SOLANA_ABI_DUMP_DIR!: \n$ diff -u {}/*{}* {}/*{}*", dir, #expected_digest, dir, actual_digest);

--- a/frozen-abi/macro/src/lib.rs
+++ b/frozen-abi/macro/src/lib.rs
@@ -146,7 +146,7 @@ fn derive_abi_sample_enum_type(input: ItemEnum) -> TokenStream {
         #( #attrs )*
         impl #impl_generics ::solana_frozen_abi::abi_example::AbiExample for #type_name #ty_generics #where_clause {
             fn example() -> Self {
-                ::solana_frozen_abi::log::info!(
+                ::solana_frozen_abi::__private::log::info!(
                     "AbiExample for enum: {}",
                     std::any::type_name::<#type_name #ty_generics>()
                 );
@@ -198,7 +198,7 @@ fn derive_abi_sample_struct_type(input: ItemStruct) -> TokenStream {
         #( #attrs )*
         impl #impl_generics ::solana_frozen_abi::abi_example::AbiExample for #type_name #ty_generics #where_clause {
             fn example() -> Self {
-                ::solana_frozen_abi::log::info!(
+                ::solana_frozen_abi::__private::log::info!(
                     "AbiExample for struct: {}",
                     std::any::type_name::<#type_name #ty_generics>()
                 );
@@ -300,7 +300,7 @@ fn quote_for_test(
                 let mut hash = digester.finalize();
                 // pretty-print error
                 if result.is_err() {
-                    ::solana_frozen_abi::log::error!("digest error: {:#?}", result);
+                    ::solana_frozen_abi::__private::log::error!("digest error: {:#?}", result);
                 }
                 result.unwrap();
                 let actual_digest = format!("{}", hash);
@@ -308,7 +308,7 @@ fn quote_for_test(
                     if #expected_digest != actual_digest {
                         #p!("sed -i -e 's/{}/{}/g' $(git grep --files-with-matches frozen_abi)", #expected_digest, hash);
                     }
-                    ::solana_frozen_abi::log::warn!("Not testing the abi digest under SOLANA_ABI_BULK_UPDATE!");
+                    ::solana_frozen_abi::__private::log::warn!("Not testing the abi digest under SOLANA_ABI_BULK_UPDATE!");
                 } else {
                     if let Ok(dir) = ::std::env::var("SOLANA_ABI_DUMP_DIR") {
                         assert_eq!(#expected_digest, actual_digest, "Possibly ABI changed? Examine the diff in SOLANA_ABI_DUMP_DIR!: \n$ diff -u {}/*{}* {}/*{}*", dir, #expected_digest, dir, actual_digest);

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -20,4 +20,9 @@ extern crate solana_frozen_abi_macro;
 #[macro_use]
 extern crate serde_derive;
 
-pub use log;
+// Not public API. Referenced by macro-generated code.
+#[doc(hidden)]
+pub mod __private {
+    #[doc(hidden)]
+    pub use log;
+}

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -19,3 +19,5 @@ extern crate solana_frozen_abi_macro;
 #[cfg(test)]
 #[macro_use]
 extern crate serde_derive;
+
+pub use log;


### PR DESCRIPTION
#### Problem
When annotating a struct with the `#[derive(AbiExample)]` macro and compiling a crate with `cargo build-sbf`, the compiler will complain that `log` was not found in the dependency list.

```
#[derive(Debug, PartialEq, Eq, Clone, AbiExample)]
|                                      ^^^^^^^^^^ could not find `log` in the list of imported crate
```

#### Summary of Changes
Modify the macro to point to the `log` dependency used by `solana_frozen_abi`.

Fixes #152 
