### PR TITLE
program sdk: move `AddressLookupTableAccount` to `message::v0`

### DIFF
--- a/sdk/program/src/address_lookup_table/mod.rs
+++ b/sdk/program/src/address_lookup_table/mod.rs
@@ -9,12 +9,3 @@ pub mod state;
 pub mod program {
     crate::declare_id!("AddressLookupTab1e1111111111111111111111111");
 }
-
-/// The definition of address lookup table accounts.
-///
-/// As used by the `crate::message::v0` message format.
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct AddressLookupTableAccount {
-    pub key: crate::pubkey::Pubkey,
-    pub addresses: Vec<crate::pubkey::Pubkey>,
-}

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -535,14 +535,6 @@ pub mod sysvar;
 pub mod vote;
 pub mod wasm;
 
-#[deprecated(
-    since = "1.17.0",
-    note = "Please use `solana_sdk::address_lookup_table::AddressLookupTableAccount` instead"
-)]
-pub mod address_lookup_table_account {
-    pub use crate::address_lookup_table::AddressLookupTableAccount;
-}
-
 #[cfg(target_os = "solana")]
 pub use solana_sdk_macro::wasm_bindgen_stub as wasm_bindgen;
 /// Re-export of [wasm-bindgen].

--- a/sdk/program/src/message/compiled_keys.rs
+++ b/sdk/program/src/message/compiled_keys.rs
@@ -1,8 +1,5 @@
 #[cfg(not(target_os = "solana"))]
-use crate::{
-    address_lookup_table_account::AddressLookupTableAccount,
-    message::v0::{LoadedAddresses, MessageAddressTableLookup},
-};
+use crate::message::v0::{AddressLookupTableAccount, LoadedAddresses, MessageAddressTableLookup};
 use {
     crate::{instruction::Instruction, message::MessageHeader, pubkey::Pubkey},
     std::collections::BTreeMap,

--- a/sdk/program/src/message/versions/v0/mod.rs
+++ b/sdk/program/src/message/versions/v0/mod.rs
@@ -10,7 +10,6 @@
 //! [future message format]: https://docs.solanalabs.com/proposals/versioned-transactions
 
 use crate::{
-    address_lookup_table_account::AddressLookupTableAccount,
     bpf_loader_upgradeable,
     hash::Hash,
     instruction::{CompiledInstruction, Instruction},
@@ -26,6 +25,13 @@ use crate::{
 pub use loaded::*;
 
 mod loaded;
+
+/// The definition of address lookup table accounts.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct AddressLookupTableAccount {
+    pub key: crate::pubkey::Pubkey,
+    pub addresses: Vec<crate::pubkey::Pubkey>,
+}
 
 /// Address table lookups describe an on-chain address lookup table to use
 /// for loading more readonly and writable accounts in a single tx.
@@ -196,9 +202,8 @@ impl Message {
     /// use solana_rpc_client::rpc_client::RpcClient;
     /// use solana_program::address_lookup_table::{self, state::{AddressLookupTable, LookupTableMeta}};
     /// use solana_sdk::{
-    ///      address_lookup_table_account::AddressLookupTableAccount,
     ///      instruction::{AccountMeta, Instruction},
-    ///      message::{VersionedMessage, v0},
+    ///      message::{VersionedMessage, v0::{self, AddressLookupTableAccount}},
     ///      pubkey::Pubkey,
     ///      signature::{Keypair, Signer},
     ///      transaction::VersionedTransaction,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -39,8 +39,6 @@ extern crate self as solana_sdk;
 pub use signer::signers;
 // These solana_program imports could be *-imported, but that causes a bunch of
 // confusing duplication in the docs due to a rustdoc bug. #26211
-#[allow(deprecated)]
-pub use solana_program::address_lookup_table_account;
 #[cfg(not(target_os = "solana"))]
 pub use solana_program::program_stubs;
 pub use solana_program::{


### PR DESCRIPTION
#### Problem
Similar to #141, the struct for `AddressLookupTableAccount` exported from the Address Lookup Table program crate is also only used in one place: V0 Message.



#### Summary of Changes
Move the struct directly into `sdk::program::message::v0` as a public struct.

The struct's visibility makes it available for use in `sdk::program::message` as well as downstream for developers who may need the type when working with messages.

Again similar to #141, this allows the program SDK to remain decoupled from the new  core BPF Address Lookup Table program crate, [in development here](https://github.com/solana-program/address-lookup-table/pull/7).
