### PR TITLE
Use agave prefix in scripts for pre-installed binaries

### DIFF
--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -30,7 +30,11 @@ if [[ -n $USE_INSTALL || ! -f "$SOLANA_ROOT"/Cargo.toml ]]; then
     if [[ -z $program ]]; then
       printf "solana"
     else
-      printf "solana-%s" "$program"
+      if [[ $program == "validator" || $program == "ledger-tool" || $program == "watchtower" || $program == "install" ]]; then
+        printf "agave-%s" "$program"
+      else
+        printf "solana-%s" "$program"
+      fi
     fi
   }
 else


### PR DESCRIPTION
#### Problem
Solana prefix is still being used for pre-installed binaries and this breaks net.sh deploys

#### Summary of Changes
Use agave prefix where necessary

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
