### PR TITLE
Move AccountsDb replication arguments to deprecated list

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1173,44 +1173,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("The maximum request body size accepted by rpc service"),
         )
         .arg(
-            Arg::with_name("enable_accountsdb_repl")
-                .long("enable-accountsdb-repl")
-                .takes_value(false)
-                .hidden(hidden_unless_forced())
-                .help("Enable AccountsDb Replication"),
-        )
-        .arg(
-            Arg::with_name("accountsdb_repl_bind_address")
-                .long("accountsdb-repl-bind-address")
-                .value_name("HOST")
-                .takes_value(true)
-                .validator(solana_net_utils::is_host)
-                .hidden(hidden_unless_forced())
-                .help(
-                    "IP address to bind the AccountsDb Replication port [default: use \
-                     --bind-address]",
-                ),
-        )
-        .arg(
-            Arg::with_name("accountsdb_repl_port")
-                .long("accountsdb-repl-port")
-                .value_name("PORT")
-                .takes_value(true)
-                .validator(port_validator)
-                .hidden(hidden_unless_forced())
-                .help("Enable AccountsDb Replication Service on this port"),
-        )
-        .arg(
-            Arg::with_name("accountsdb_repl_threads")
-                .long("accountsdb-repl-threads")
-                .value_name("NUMBER")
-                .validator(is_parsable::<usize>)
-                .takes_value(true)
-                .default_value(&default_args.accountsdb_repl_threads)
-                .hidden(hidden_unless_forced())
-                .help("Number of threads to use for servicing AccountsDb Replication requests"),
-        )
-        .arg(
             Arg::with_name("geyser_plugin_config")
                 .long("geyser-plugin-config")
                 .alias("accountsdb-plugin-config")
@@ -1989,6 +1951,27 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
                 Ok(())
             }
         }));
+    add_arg!(Arg::with_name("accountsdb_repl_bind_address")
+        .long("accountsdb-repl-bind-address")
+        .value_name("HOST")
+        .takes_value(true)
+        .validator(solana_net_utils::is_host)
+        .help(
+            "IP address to bind the AccountsDb Replication port [default: use \
+                     --bind-address]",
+        ));
+    add_arg!(Arg::with_name("accountsdb_repl_port")
+        .long("accountsdb-repl-port")
+        .value_name("PORT")
+        .takes_value(true)
+        .validator(port_validator)
+        .help("Enable AccountsDb Replication Service on this port"));
+    add_arg!(Arg::with_name("accountsdb_repl_threads")
+        .long("accountsdb-repl-threads")
+        .value_name("NUMBER")
+        .validator(is_parsable::<usize>)
+        .takes_value(true)
+        .help("Number of threads to use for servicing AccountsDb Replication requests"));
     add_arg!(Arg::with_name("disable_accounts_disk_index")
         .long("disable-accounts-disk-index")
         .help("Disable the disk-based accounts index if it is enabled by default.")
@@ -1999,6 +1982,10 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .takes_value(false),
         usage_warning: "The quic server cannot be disabled.",
     );
+    add_arg!(Arg::with_name("enable_accountsdb_repl")
+        .long("enable-accountsdb-repl")
+        .takes_value(false)
+        .help("Enable AccountsDb Replication"));
     add_arg!(
         Arg::with_name("enable_cpi_and_log_storage")
             .long("enable-cpi-and-log-storage")
@@ -2162,8 +2149,6 @@ pub struct DefaultArgs {
 
     pub contact_debug_interval: String,
 
-    pub accountsdb_repl_threads: String,
-
     pub snapshot_version: SnapshotVersion,
     pub snapshot_archive_format: String,
 
@@ -2239,7 +2224,6 @@ impl DefaultArgs {
             rpc_bigtable_max_message_size: solana_storage_bigtable::DEFAULT_MAX_MESSAGE_SIZE
                 .to_string(),
             rpc_pubsub_worker_threads: "4".to_string(),
-            accountsdb_repl_threads: num_cpus::get().to_string(),
             maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN
                 .to_string(),
             maximum_incremental_snapshot_archives_to_retain:


### PR DESCRIPTION
#### Problem
These arguments are not read by anything, and they appear to correspond to a proposed feature that is no longer in the codebase.

#### Summary of Changes
Move deprecated args to deprecated list to get them out of the way. Maybe we can dump a lot of these if we do `2.0` release in the near future

Done as cleanup related to https://github.com/anza-xyz/agave/issues/105