### PR TITLE
relax stake split destination check

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1986,12 +1986,13 @@ pub fn process_split_stake(
                     "Stake account {split_stake_account_address} already exists"
                 ))
                 .into());
-            } else if stake_account.owner == system_program::id() && !stake_account.data.is_empty()
-            {
-                return Err(CliError::BadParameter(format!(
+            } else if stake_account.owner == system_program::id() {
+                if !stake_account.data.is_empty() {
+                    return Err(CliError::BadParameter(format!(
                         "Account {split_stake_account_address} has data and cannot be used to split stake"
                     ))
                     .into());
+                }
             } else {
                 return Err(CliError::BadParameter(format!(
                     "Account {split_stake_account_address} already exists and is not a stake account"

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1993,6 +1993,7 @@ pub fn process_split_stake(
                     ))
                     .into());
                 }
+            // if stake_accout owner is system_program and account data is empty it is allowed to receive stake split
             } else {
                 return Err(CliError::BadParameter(format!(
                     "Account {split_stake_account_address} already exists and cannot be used to split stake"

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1993,7 +1993,8 @@ pub fn process_split_stake(
                     ))
                     .into());
                 }
-            // if stake_account owner is system_program and account data is empty it is allowed to receive stake split
+            // if `stake_account`'s owner is the system_program and its data is
+            // empty, `stake_account` is allowed to receive the stake split
             } else {
                 return Err(CliError::BadParameter(format!(
                     "Account {split_stake_account_address} already exists and cannot be used to split stake"

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1993,7 +1993,7 @@ pub fn process_split_stake(
                     ))
                     .into());
                 }
-            // if stake_accout owner is system_program and account data is empty it is allowed to receive stake split
+            // if stake_account owner is system_program and account data is empty it is allowed to receive stake split
             } else {
                 return Err(CliError::BadParameter(format!(
                     "Account {split_stake_account_address} already exists and cannot be used to split stake"

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1995,7 +1995,7 @@ pub fn process_split_stake(
                 }
             } else {
                 return Err(CliError::BadParameter(format!(
-                    "Account {split_stake_account_address} already exists and is not a stake account"
+                    "Account {split_stake_account_address} already exists and cannot be used to split stake"
                 ))
                 .into());
             }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1986,22 +1986,18 @@ pub fn process_split_stake(
                     "Stake account {split_stake_account_address} already exists"
                 ))
                 .into());
-            }
-            if stake_account.owner == system_program::id() {
-                if stake_account.data.len() > 0 {
-                    return Err(CliError::BadParameter(format!(
+            } else if stake_account.owner == system_program::id() && !stake_account.data.is_empty()
+            {
+                return Err(CliError::BadParameter(format!(
                         "Account {split_stake_account_address} has data and cannot be used to split stake"
                     ))
                     .into());
-                }
-
-                if stake_account.lamports == 0 {
-                    return Err(CliError::BadParameter(format!(
-                        "Account {split_stake_account_address} has zero lamports and cannot be used to split stake"
-                    ))
-                    .into());
-                }
-            };
+            } else {
+                return Err(CliError::BadParameter(format!(
+                    "Account {split_stake_account_address} already exists and is not a stake account"
+                ))
+                .into());
+            }
         }
         let minimum_balance =
             rpc_client.get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1999,6 +1999,7 @@ pub fn process_split_stake(
                 .into());
             }
         }
+
         let minimum_balance =
             rpc_client.get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
 


### PR DESCRIPTION
Issue #147 

####Improvements
1. Removed strict checks for staked_split_account and allowed account owned by system program with no data and some lamports to be allocated as a new stake account to receive stake split


#### Summary of Changes
1 solana/cli/src/stake.rs  
function - process_split_stake
removed some strict checks resulting in  allowing system account (without data and some lamports) to be allocated as new stake account to receive split
