### PR TITLE
[anza migration] Sets client id to Agave

### DIFF
--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -17,6 +17,7 @@ enum ClientId {
     SolanaLabs,
     JitoLabs,
     Firedancer,
+    Agave,
     // If new variants are added, update From<u16> and TryFrom<ClientId>.
     Unknown(u16),
 }
@@ -63,7 +64,7 @@ impl Default for Version {
             commit: compute_commit(option_env!("CI_COMMIT")).unwrap_or_default(),
             feature_set,
             // Other client implementations need to modify this line.
-            client: u16::try_from(ClientId::SolanaLabs).unwrap(),
+            client: u16::try_from(ClientId::Agave).unwrap(),
         }
     }
 }
@@ -97,6 +98,7 @@ impl From<u16> for ClientId {
             0u16 => Self::SolanaLabs,
             1u16 => Self::JitoLabs,
             2u16 => Self::Firedancer,
+            3u16 => Self::Agave,
             _ => Self::Unknown(client),
         }
     }
@@ -110,7 +112,8 @@ impl TryFrom<ClientId> for u16 {
             ClientId::SolanaLabs => Ok(0u16),
             ClientId::JitoLabs => Ok(1u16),
             ClientId::Firedancer => Ok(2u16),
-            ClientId::Unknown(client @ 0u16..=2u16) => Err(format!("Invalid client: {client}")),
+            ClientId::Agave => Ok(3u16),
+            ClientId::Unknown(client @ 0u16..=3u16) => Err(format!("Invalid client: {client}")),
             ClientId::Unknown(client) => Ok(client),
         }
     }
@@ -147,19 +150,21 @@ mod test {
         assert_eq!(ClientId::from(0u16), ClientId::SolanaLabs);
         assert_eq!(ClientId::from(1u16), ClientId::JitoLabs);
         assert_eq!(ClientId::from(2u16), ClientId::Firedancer);
-        for client in 3u16..=u16::MAX {
+        assert_eq!(ClientId::from(3u16), ClientId::Agave);
+        for client in 4u16..=u16::MAX {
             assert_eq!(ClientId::from(client), ClientId::Unknown(client));
         }
         assert_eq!(u16::try_from(ClientId::SolanaLabs), Ok(0u16));
         assert_eq!(u16::try_from(ClientId::JitoLabs), Ok(1u16));
         assert_eq!(u16::try_from(ClientId::Firedancer), Ok(2u16));
-        for client in 0..=2u16 {
+        assert_eq!(u16::try_from(ClientId::Agave), Ok(3u16));
+        for client in 0..=3u16 {
             assert_eq!(
                 u16::try_from(ClientId::Unknown(client)),
                 Err(format!("Invalid client: {client}"))
             );
         }
-        for client in 3u16..=u16::MAX {
+        for client in 4u16..=u16::MAX {
             assert_eq!(u16::try_from(ClientId::Unknown(client)), Ok(client));
         }
     }


### PR DESCRIPTION
#### Problem

The Agave fork still sets the client ID as "SolanaLabs", even though everything else (crates, binaries, etc) has migrated.


#### Summary of Changes

Set the client id to Agave.