### PR TITLE
ci: fix Windows gh release pipeline

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: windows-artifact
-          path: .windows-release/
+          path: ./windows-release/
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
#### Problem

the Windows artifacts doesn't upload to the gh release page

#### Summary of Changes

use the correct download path
