### PR TITLE
[TieredStorage] Enable file hash in TieredStorage

### DIFF
--- a/accounts-db/src/tiered_storage/error.rs
+++ b/accounts-db/src/tiered_storage/error.rs
@@ -1,4 +1,7 @@
-use {super::footer::SanitizeFooterError, std::path::PathBuf, thiserror::Error};
+use {
+    super::footer::SanitizeFooterError, solana_sdk::hash::Hash, std::path::PathBuf,
+    thiserror::Error,
+};
 
 #[derive(Error, Debug)]
 pub enum TieredStorageError {
@@ -31,4 +34,7 @@ pub enum TieredStorageError {
 
     #[error("OffsetAlignmentError: offset {0} must be multiple of {1}")]
     OffsetAlignmentError(usize, usize),
+
+    #[error("FileHashMismatch: {0} {1}")]
+    FileHashMismatch(Hash, Hash),
 }

--- a/accounts-db/src/tiered_storage/file.rs
+++ b/accounts-db/src/tiered_storage/file.rs
@@ -1,6 +1,7 @@
 use {
-    super::{error::TieredStorageError, TieredStorageResult},
+    super::{error::TieredStorageError, footer::FOOTER_TAIL_SIZE, TieredStorageResult},
     bytemuck::{AnyBitPattern, NoUninit, Pod, Zeroable},
+    solana_sdk::hash::Hash,
     std::{
         fs::{File, OpenOptions},
         io::{BufWriter, Read, Result as IoResult, Seek, SeekFrom, Write},
@@ -38,17 +39,37 @@ impl TieredReadableFile {
         );
 
         file.check_magic_number()?;
+        file.check_file_hash()?;
 
         Ok(file)
     }
 
-    pub fn new_writable(file_path: impl AsRef<Path>) -> IoResult<Self> {
-        Ok(Self(
-            OpenOptions::new()
-                .create_new(true)
-                .write(true)
-                .open(file_path)?,
-        ))
+    fn check_file_hash(&self) -> TieredStorageResult<()> {
+        self.seek(0)?;
+
+        let len = self.0.metadata()?.len() as usize;
+        let hashed_len = len - std::mem::size_of::<Hash>() - FOOTER_TAIL_SIZE;
+        let mut hasher = blake3::Hasher::new();
+
+        const BLOCK_SIZE: usize = 4096;
+        let mut buffer = [0u8; BLOCK_SIZE];
+        let mut offset = 0;
+        while offset < hashed_len {
+            let block_size = std::cmp::min(BLOCK_SIZE, hashed_len - offset);
+            self.read_bytes(&mut buffer[0..block_size])?;
+            hasher.update(&buffer[0..block_size]);
+
+            offset += block_size;
+        }
+        let hash = Hash::new_from_array(hasher.finalize().into());
+
+        let mut raw_hash_from_file = [0u8; 32];
+        self.read_bytes(&mut raw_hash_from_file)?;
+        let hash_from_file = Hash::new_from_array(raw_hash_from_file);
+
+        (hash == hash_from_file)
+            .then(|| Ok(()))
+            .unwrap_or_else(|| Err(TieredStorageError::FileHashMismatch(hash, hash_from_file)))
     }
 
     fn check_magic_number(&self) -> TieredStorageResult<()> {
@@ -105,16 +126,22 @@ impl TieredReadableFile {
 }
 
 #[derive(Debug)]
-pub struct TieredWritableFile(pub BufWriter<File>);
+pub struct TieredWritableFile {
+    file: BufWriter<File>,
+    hasher: blake3::Hasher,
+}
 
 impl TieredWritableFile {
     pub fn new(file_path: impl AsRef<Path>) -> IoResult<Self> {
-        Ok(Self(BufWriter::new(
-            OpenOptions::new()
-                .create_new(true)
-                .write(true)
-                .open(file_path)?,
-        )))
+        Ok(Self {
+            file: BufWriter::new(
+                OpenOptions::new()
+                    .create_new(true)
+                    .write(true)
+                    .open(file_path)?,
+            ),
+            hasher: blake3::Hasher::new(),
+        })
     }
 
     /// Writes `value` to the file.
@@ -142,17 +169,22 @@ impl TieredWritableFile {
     }
 
     pub fn seek(&mut self, offset: u64) -> IoResult<u64> {
-        self.0.seek(SeekFrom::Start(offset))
+        self.file.seek(SeekFrom::Start(offset))
     }
 
     pub fn seek_from_end(&mut self, offset: i64) -> IoResult<u64> {
-        self.0.seek(SeekFrom::End(offset))
+        self.file.seek(SeekFrom::End(offset))
     }
 
     pub fn write_bytes(&mut self, bytes: &[u8]) -> IoResult<usize> {
-        self.0.write_all(bytes)?;
+        self.file.write_all(bytes)?;
+        self.hasher.update(bytes);
 
         Ok(bytes.len())
+    }
+
+    pub fn hash(&self) -> Hash {
+        Hash::new_from_array(self.hasher.finalize().into())
     }
 }
 
@@ -161,14 +193,47 @@ mod tests {
     use {
         crate::tiered_storage::{
             error::TieredStorageError,
-            file::{TieredReadableFile, TieredWritableFile, FILE_MAGIC_NUMBER},
+            file::{
+                TieredReadableFile, TieredStorageMagicNumber, TieredWritableFile, FILE_MAGIC_NUMBER,
+            },
+            footer::TieredStorageFooter,
         },
         std::path::Path,
         tempfile::TempDir,
     };
 
+    // Only write the footer and update the hash without writing the magic number
+    fn write_footer_only(footer: &mut TieredStorageFooter, file: &mut TieredWritableFile) {
+        // SAFETY: The footer does not contain any uninitialized bytes.
+        unsafe {
+            file.write_type(&footer.account_meta_format).unwrap();
+            file.write_type(&footer.owners_block_format).unwrap();
+            file.write_type(&footer.index_block_format).unwrap();
+            file.write_type(&footer.account_block_format).unwrap();
+        }
+
+        file.write_pod(&footer.account_entry_count).unwrap();
+        file.write_pod(&footer.account_meta_entry_size).unwrap();
+        file.write_pod(&footer.account_block_size).unwrap();
+        file.write_pod(&footer.owner_count).unwrap();
+        file.write_pod(&footer.owner_entry_size).unwrap();
+        file.write_pod(&footer.index_block_offset).unwrap();
+        file.write_pod(&footer.owners_block_offset).unwrap();
+        file.write_pod(&footer.min_account_address).unwrap();
+        file.write_pod(&footer.max_account_address).unwrap();
+
+        // everything before the FooterTail will be hashed
+        footer.hash = file.hash();
+        file.write_pod(&footer.hash).unwrap();
+
+        file.write_pod(&footer.format_version).unwrap();
+        file.write_pod(&footer.footer_size).unwrap();
+    }
+
     fn generate_test_file_with_number(path: impl AsRef<Path>, number: u64) {
         let mut file = TieredWritableFile::new(path).unwrap();
+        let mut footer = TieredStorageFooter::default();
+        write_footer_only(&mut footer, &mut file);
         file.write_pod(&number).unwrap();
     }
 
@@ -189,5 +254,57 @@ mod tests {
             TieredReadableFile::new(&path),
             Err(TieredStorageError::MagicNumberMismatch(_, _))
         ));
+    }
+
+    #[test]
+    fn test_file_hash() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test_file_hash_mismatch");
+        let mut expected_footer = TieredStorageFooter {
+            account_entry_count: 300,
+            account_meta_entry_size: 24,
+            account_block_size: 4096,
+            owner_count: 250,
+            owner_entry_size: 32,
+            index_block_offset: 1069600,
+            owners_block_offset: 1081200,
+            ..TieredStorageFooter::default()
+        };
+
+        // Manually persist the footer without updating the hash
+        {
+            let mut file = TieredWritableFile::new(&path).unwrap();
+            // SAFETY: the footer does not contain any uninitialized bytes
+            unsafe {
+                file.write_type(&expected_footer).unwrap();
+            }
+            file.write_pod(&TieredStorageMagicNumber::default())
+                .unwrap();
+        }
+
+        // Reopen the same storage and expect FileHashMismatch
+        {
+            let result = TieredReadableFile::new(&path);
+            assert!(matches!(
+                result,
+                Err(TieredStorageError::FileHashMismatch(_, _))
+            ));
+        }
+
+        // Rewrite the same footer into a different file, but this time using
+        // the standard way to persist the footer that will also update the
+        // file hash.
+        let path = temp_dir.path().join("test_file_hash");
+        {
+            let mut file = TieredWritableFile::new(&path).unwrap();
+            expected_footer.write_footer_block(&mut file).unwrap()
+        }
+
+        // Reopen the same storage and expect the footer matches
+        {
+            let file = TieredReadableFile::new(&path).unwrap();
+            let footer = TieredStorageFooter::new_from_footer_block(&file).unwrap();
+            assert_eq!(expected_footer, footer);
+        }
     }
 }

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -216,7 +216,7 @@ mod tests {
             .path()
             .join("test_get_account_address_out_of_bounds");
 
-        let footer = TieredStorageFooter {
+        let mut footer = TieredStorageFooter {
             account_entry_count: 100,
             index_block_format: IndexBlockFormat::AddressesThenOffsets,
             ..TieredStorageFooter::default()
@@ -249,7 +249,7 @@ mod tests {
             .path()
             .join("test_get_account_address_exceeds_index_block_boundary");
 
-        let footer = TieredStorageFooter {
+        let mut footer = TieredStorageFooter {
             account_entry_count: 100,
             index_block_format: IndexBlockFormat::AddressesThenOffsets,
             index_block_offset: 1024,
@@ -287,7 +287,7 @@ mod tests {
             .path()
             .join("test_get_account_offset_out_of_bounds");
 
-        let footer = TieredStorageFooter {
+        let mut footer = TieredStorageFooter {
             account_entry_count: 100,
             index_block_format: IndexBlockFormat::AddressesThenOffsets,
             ..TieredStorageFooter::default()
@@ -324,7 +324,7 @@ mod tests {
             .path()
             .join("test_get_account_offset_exceeds_index_block_boundary");
 
-        let footer = TieredStorageFooter {
+        let mut footer = TieredStorageFooter {
             account_entry_count: 100,
             index_block_format: IndexBlockFormat::AddressesThenOffsets,
             index_block_offset: 1024,

--- a/accounts-db/src/tiered_storage/owners.rs
+++ b/accounts-db/src/tiered_storage/owners.rs
@@ -131,7 +131,7 @@ mod tests {
             .take(NUM_OWNERS as usize)
             .collect();
 
-        let footer = TieredStorageFooter {
+        let mut footer = TieredStorageFooter {
             // Set owners_block_offset to 0 as we didn't write any account
             // meta/data nor index block.
             owners_block_offset: 0,


### PR DESCRIPTION
#### Problem
File hash feature isn't implemented in tiered-storage.

#### Summary of Changes
This PR enables file hash in TieredStorage with the following changes.

#### Test Plan
Added new unit-tests for file hash match and mismatch cases.
Updated existing tests to also cover the file hash verification.

