### PR TITLE
remove dead code

### DIFF
--- a/accounts-db/src/accounts_partition.rs
+++ b/accounts-db/src/accounts_partition.rs
@@ -98,36 +98,6 @@ pub fn get_partition_from_slot_indexes(
     (start_partition_index, end_partition_index, partition_count)
 }
 
-/// used only by filler accounts in debug path
-/// previous means slot - 1, not parent
-// These functions/fields are only usable from a dev context (i.e. tests and benches)
-#[cfg(feature = "dev-context-only-utils")]
-pub fn variable_cycle_partition_from_previous_slot(
-    epoch_schedule: &EpochSchedule,
-    slot: Slot,
-) -> Partition {
-    // similar code to Bank::variable_cycle_partitions
-    let (current_epoch, current_slot_index) = epoch_schedule.get_epoch_and_slot_index(slot);
-    let (parent_epoch, mut parent_slot_index) =
-        epoch_schedule.get_epoch_and_slot_index(slot.saturating_sub(1));
-    let cycle_params = rent_single_epoch_collection_cycle_params(
-        current_epoch,
-        epoch_schedule.get_slots_in_epoch(current_epoch),
-    );
-
-    if parent_epoch < current_epoch {
-        parent_slot_index = 0;
-    }
-
-    let generated_for_gapped_epochs = false;
-    get_partition_from_slot_indexes(
-        cycle_params,
-        parent_slot_index,
-        current_slot_index,
-        generated_for_gapped_epochs,
-    )
-}
-
 /// return all end partition indexes for the given partition
 /// partition could be (0, 1, N). In this case we only return [1]
 ///  the single 'end_index' that covers this partition.


### PR DESCRIPTION
#### Problem
I ran across some dead code that only runs in tests.
This code has not been used since 1.13, I think. In 1.13, it was used from:
`maybe_add_filler_accounts`

#### Summary of Changes
Remove the dead code.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
