### PR TITLE
deprecate `get_client` and `get_multi_client`

### DIFF
--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -39,6 +39,7 @@
 //! ```
 //!
 #![allow(clippy::arithmetic_side_effects)]
+#![allow(deprecated)]
 use {
     crossbeam_channel::{select, tick, unbounded, Receiver, Sender},
     itertools::Itertools,

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -194,6 +194,7 @@ pub fn discover(
 }
 
 /// Creates a ThinClient by selecting a valid node at random
+#[deprecated(since = "1.18.0", note = "Interface will change")]
 pub fn get_client(
     nodes: &[ContactInfo],
     socket_addr_space: &SocketAddrSpace,
@@ -209,6 +210,7 @@ pub fn get_client(
     ThinClient::new(rpc, tpu, connection_cache)
 }
 
+#[deprecated(since = "1.18.0", note = "Will be removed in favor of get_client")]
 pub fn get_multi_client(
     nodes: &[ContactInfo],
     socket_addr_space: &SocketAddrSpace,


### PR DESCRIPTION
3rd PR on the way to remove ThinClient completely.
See 
- 1st PR: https://github.com/solana-labs/solana/pull/35335
- 2nd PR: https://github.com/solana-labs/solana/pull/35365

This PR is made in response to: https://github.com/anza-xyz/agave/pull/117#discussion_r1516548416

This PR must be merged before PR: https://github.com/anza-xyz/agave/pull/117 

#### Problem
`ThinClient` is deprecated. Need to deprecate `get_client` and `get_multi_client` in `gossip/` before removing `ThinClient` from `dos/`

#### Summary of Changes
Deprecate `get_client` (changed interface note) and `get_multi_client` (will be removed)
