### PR TITLE
Add functions to collect executed transactions fee in details;

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -263,7 +263,7 @@ pub(crate) struct CollectorFeeDetails {
 }
 
 impl CollectorFeeDetails {
-    pub(crate) fn add(&mut self, fee_details: &FeeDetails) {
+    pub(crate) fn accumulate(&mut self, fee_details: &FeeDetails) {
         self.transaction_fee = self
             .transaction_fee
             .saturating_add(fee_details.transaction_fee());
@@ -568,7 +568,7 @@ impl PartialEq for Bank {
             epoch_reward_status: _,
             transaction_processor: _,
             check_program_modification_slot: _,
-            collector_fee_details,
+            collector_fee_details: _,
             // Ignore new fields explicitly if they do not impact PartialEq.
             // Adding ".." will remove compile-time checks that if a new field
             // is added to the struct, this PartialEq is accordingly updated.
@@ -602,8 +602,6 @@ impl PartialEq for Bank {
             && *stakes_cache.stakes() == *other.stakes_cache.stakes()
             && epoch_stakes == &other.epoch_stakes
             && is_delta.load(Relaxed) == other.is_delta.load(Relaxed)
-            && *collector_fee_details.read().unwrap()
-                == *other.collector_fee_details.read().unwrap()
     }
 }
 
@@ -4986,7 +4984,7 @@ impl Bank {
         self.collector_fee_details
             .write()
             .unwrap()
-            .add(&accumulated_fee_details);
+            .accumulate(&accumulated_fee_details);
         results
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -256,8 +256,7 @@ impl AddAssign for SquashTiming {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default, PartialEq)]
 pub(crate) struct CollectorFeeDetails {
     pub transaction_fee: u64,
     pub priority_fee: u64,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -256,7 +256,7 @@ impl AddAssign for SquashTiming {
     }
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(AbiExample, Debug, Default, PartialEq)]
 pub(crate) struct CollectorFeeDetails {
     pub transaction_fee: u64,
     pub priority_fee: u64,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13792,3 +13792,73 @@ fn test_failed_simulation_compute_units() {
     let simulation = bank.simulate_transaction(&sanitized, false);
     assert_eq!(expected_consumed_units, simulation.units_consumed);
 }
+
+#[test]
+fn test_filter_program_errors_and_collect_fee_details() {
+    // TX  | EXECUTION RESULT                        | COLLECT            | ADDITIONAL          | COLLECT
+    //                                               | (TX_FEE, PRIO_FEE) | WITHDRAW FROM PAYER | RESULT
+    // --------------------------------------------------------------------------------------------------
+    // tx1 | executed and no error                   | (5_000, 1_000)     | 0                   | Ok
+    // tx2 | executed has error                      | (5_000, 1_000)     | 6_000               | Ok
+    // tx3 | not executed                            | (0    , 0)         | 0                   | Original Err
+    // tx4 | executed error, payer insufficient fund | (0    , 0)         | 0                   | InsufficientFundsForFee
+    //
+    let initial_payer_balance = 7_000;
+    let additional_payer_withdraw = 6_000;
+    let expected_collected_fee_details = CollectorFeeDetails {
+        transaction_fee: 10_000,
+        priority_fee: 2_000,
+    };
+
+    let GenesisConfigInfo {
+        mut genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config_with_leader(initial_payer_balance, &Pubkey::new_unique(), 3);
+    genesis_config.fee_rate_governor = FeeRateGovernor::new(5000, 0);
+    let bank = Bank::new_for_tests(&genesis_config);
+
+    let tx = SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
+        &[
+            system_instruction::transfer(&mint_keypair.pubkey(), &Pubkey::new_unique(), 2),
+            ComputeBudgetInstruction::set_compute_unit_limit(1_000),
+            ComputeBudgetInstruction::set_compute_unit_price(1_000_000),
+        ],
+        Some(&mint_keypair.pubkey()),
+        &[&mint_keypair],
+        genesis_config.hash(),
+    ));
+    let txs = vec![tx.clone(), tx.clone(), tx.clone(), tx];
+
+    let results = vec![
+        new_execution_result(Ok(()), None),
+        new_execution_result(
+            Err(TransactionError::InstructionError(
+                1,
+                SystemError::ResultWithNegativeLamports.into(),
+            )),
+            None,
+        ),
+        TransactionExecutionResult::NotExecuted(TransactionError::AccountNotFound),
+        new_execution_result(Err(TransactionError::AccountNotFound), None),
+    ];
+
+    let expected_collect_results = vec![
+        Ok(()),
+        Ok(()),
+        Err(TransactionError::AccountNotFound),
+        Err(TransactionError::InsufficientFundsForFee),
+    ];
+
+    let results = bank.filter_program_errors_and_collect_fee_details(&txs, &results);
+
+    assert_eq!(
+        expected_collected_fee_details,
+        *bank.collector_fee_details.read().unwrap()
+    );
+    assert_eq!(
+        initial_payer_balance - additional_payer_withdraw,
+        bank.get_balance(&mint_keypair.pubkey())
+    );
+    assert_eq!(expected_collect_results, results);
+}

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13795,20 +13795,29 @@ fn test_failed_simulation_compute_units() {
 
 #[test]
 fn test_filter_program_errors_and_collect_fee_details() {
-    // TX  | EXECUTION RESULT                        | COLLECT            | ADDITIONAL          | COLLECT
-    //                                               | (TX_FEE, PRIO_FEE) | WITHDRAW FROM PAYER | RESULT
-    // --------------------------------------------------------------------------------------------------
-    // tx1 | executed and no error                   | (5_000, 1_000)     | 0                   | Ok
-    // tx2 | executed has error                      | (5_000, 1_000)     | 6_000               | Ok
-    // tx3 | not executed                            | (0    , 0)         | 0                   | Original Err
-    // tx4 | executed error, payer insufficient fund | (0    , 0)         | 0                   | InsufficientFundsForFee
+    // TX  | EXECUTION RESULT            | is nonce | COLLECT            | ADDITIONAL          | COLLECT
+    //     |                             |          | (TX_FEE, PRIO_FEE) | WITHDRAW FROM PAYER | RESULT
+    // ------------------------------------------------------------------------------------------------------
+    // tx1 | not executed                | n/a      | (0    , 0)         | 0                   | Original Err
+    // tx2 | executed and no error       | n/a      | (5_000, 1_000)     | 0                   | Ok
+    // tx3 | executed has error          | true     | (5_000, 1_000)     | 0                   | Ok
+    // tx4 | executed has error          | false    | (5_000, 1_000)     | 6_000               | Ok
+    // tx5 | executed error,
+    //         payer insufficient fund   | false    | (0    , 0)         | 0                   | InsufficientFundsForFee
     //
     let initial_payer_balance = 7_000;
     let additional_payer_withdraw = 6_000;
     let expected_collected_fee_details = CollectorFeeDetails {
-        transaction_fee: 10_000,
-        priority_fee: 2_000,
+        transaction_fee: 15_000,
+        priority_fee: 3_000,
     };
+    let expected_collect_results = vec![
+        Err(TransactionError::AccountNotFound),
+        Ok(()),
+        Ok(()),
+        Ok(()),
+        Err(TransactionError::InsufficientFundsForFee),
+    ];
 
     let GenesisConfigInfo {
         mut genesis_config,
@@ -13828,10 +13837,18 @@ fn test_filter_program_errors_and_collect_fee_details() {
         &[&mint_keypair],
         genesis_config.hash(),
     ));
-    let txs = vec![tx.clone(), tx.clone(), tx.clone(), tx];
+    let txs = vec![tx.clone(), tx.clone(), tx.clone(), tx.clone(), tx];
 
     let results = vec![
+        TransactionExecutionResult::NotExecuted(TransactionError::AccountNotFound),
         new_execution_result(Ok(()), None),
+        new_execution_result(
+            Err(TransactionError::InstructionError(
+                1,
+                SystemError::ResultWithNegativeLamports.into(),
+            )),
+            Some(&NonceFull::default()),
+        ),
         new_execution_result(
             Err(TransactionError::InstructionError(
                 1,
@@ -13839,15 +13856,7 @@ fn test_filter_program_errors_and_collect_fee_details() {
             )),
             None,
         ),
-        TransactionExecutionResult::NotExecuted(TransactionError::AccountNotFound),
         new_execution_result(Err(TransactionError::AccountNotFound), None),
-    ];
-
-    let expected_collect_results = vec![
-        Ok(()),
-        Ok(()),
-        Err(TransactionError::AccountNotFound),
-        Err(TransactionError::InsufficientFundsForFee),
     ];
 
     let results = bank.filter_program_errors_and_collect_fee_details(&txs, &results);
@@ -13861,4 +13870,54 @@ fn test_filter_program_errors_and_collect_fee_details() {
         bank.get_balance(&mint_keypair.pubkey())
     );
     assert_eq!(expected_collect_results, results);
+}
+
+#[test]
+fn test_check_execution_status_and_charge_fee() {
+    let fee = 5000;
+    let initial_balance = fee - 1000;
+    let tx_error =
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature);
+    let GenesisConfigInfo {
+        mut genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config_with_leader(initial_balance, &Pubkey::new_unique(), 3);
+    genesis_config.fee_rate_governor = FeeRateGovernor::new(5000, 0);
+    let bank = Bank::new_for_tests(&genesis_config);
+    let message = new_sanitized_message(Message::new(
+        &[system_instruction::transfer(
+            &mint_keypair.pubkey(),
+            &Pubkey::new_unique(),
+            1,
+        )],
+        Some(&mint_keypair.pubkey()),
+    ));
+
+    [Ok(()), Err(tx_error)]
+        .iter()
+        .flat_map(|result| [true, false].iter().map(move |is_nonce| (result, is_nonce)))
+        .for_each(|(result, is_nonce)| {
+            if result.is_err() && !is_nonce {
+                assert_eq!(
+                    Err(TransactionError::InsufficientFundsForFee),
+                    bank.check_execution_status_and_charge_fee(&message, result, *is_nonce, fee)
+                );
+                assert_eq!(initial_balance, bank.get_balance(&mint_keypair.pubkey()));
+
+                let small_fee = 1;
+                assert!(bank
+                    .check_execution_status_and_charge_fee(&message, result, *is_nonce, small_fee)
+                    .is_ok());
+                assert_eq!(
+                    initial_balance - small_fee,
+                    bank.get_balance(&mint_keypair.pubkey())
+                );
+            } else {
+                assert!(bank
+                    .check_execution_status_and_charge_fee(&message, result, *is_nonce, fee)
+                    .is_ok());
+                assert_eq!(initial_balance, bank.get_balance(&mint_keypair.pubkey()));
+            }
+        });
 }

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -47,6 +47,23 @@ impl FeeDetails {
             (total_fee as f64).round() as u64
         }
     }
+
+    pub fn accumulate(&mut self, fee_details: &FeeDetails) {
+        self.transaction_fee = self
+            .transaction_fee
+            .saturating_add(fee_details.transaction_fee);
+        self.prioritization_fee = self
+            .prioritization_fee
+            .saturating_add(fee_details.prioritization_fee)
+    }
+
+    pub fn transaction_fee(&self) -> u64 {
+        self.transaction_fee
+    }
+
+    pub fn prioritization_fee(&self) -> u64 {
+        self.prioritization_fee
+    }
 }
 
 pub const ACCOUNT_DATA_COST_PAGE_SIZE: u64 = 32_u64.saturating_mul(1024);


### PR DESCRIPTION
#### Problem
Working bank should be able to collect executed transactions's fee in detail, separating transaction_fee (half burnt) and prio fee (100% rewarded).

#### Summary of Changes
- Add CollectorFeeDetails to bank, which is NOT (de)serialized
- Add dead_code filter_program_errors_and_collect_fee_details() implements collecting fee_details. This function is not called yet, next PR will invoke it behind a feature gate.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
