### PR TITLE
Add option to record transactions to ledger-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7080,6 +7080,7 @@ dependencies = [
  "solana-stake-program",
  "solana-svm",
  "solana-system-program",
+ "solana-transaction-status",
  "solana-version",
  "solana-vote",
  "solana-vote-program",

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -100,6 +100,7 @@ pub fn load_and_process_ledger_or_exit(
     process_options: ProcessOptions,
     snapshot_archive_path: Option<PathBuf>,
     incremental_snapshot_archive_path: Option<PathBuf>,
+    transaction_status_sender: Option<TransactionStatusSender>,
 ) -> (Arc<RwLock<BankForks>>, Option<StartingSnapshotHashes>) {
     load_and_process_ledger(
         arg_matches,
@@ -108,6 +109,7 @@ pub fn load_and_process_ledger_or_exit(
         process_options,
         snapshot_archive_path,
         incremental_snapshot_archive_path,
+        transaction_status_sender,
     )
     .unwrap_or_else(|err| {
         eprintln!("Exiting. Failed to load and process ledger: {err}");
@@ -122,6 +124,7 @@ pub fn load_and_process_ledger(
     process_options: ProcessOptions,
     snapshot_archive_path: Option<PathBuf>,
     incremental_snapshot_archive_path: Option<PathBuf>,
+    transaction_status_sender: Option<TransactionStatusSender>,
 ) -> Result<(Arc<RwLock<BankForks>>, Option<StartingSnapshotHashes>), LoadAndProcessLedgerError> {
     let bank_snapshots_dir = if blockstore.is_primary_access() {
         blockstore.ledger_path().join("snapshot")
@@ -387,7 +390,7 @@ pub fn load_and_process_ledger(
             Some(transaction_status_service),
         )
     } else {
-        (None, None)
+        (transaction_status_sender, None)
     };
 
     let result = blockstore_processor::process_blockstore_from_root(

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -93,6 +93,7 @@ fn load_blockstore(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -> Arc<Bank
         process_options,
         snapshot_archive_path,
         incremental_snapshot_archive_path,
+        None,
     );
     let bank = bank_forks.read().unwrap().working_bank();
     bank

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5691,6 +5691,7 @@ dependencies = [
  "solana-stake-program",
  "solana-svm",
  "solana-system-program",
+ "solana-transaction-status",
  "solana-version",
  "solana-vote",
  "solana-vote-program",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -67,6 +67,7 @@ solana-sdk = { workspace = true }
 solana-stake-program = { workspace = true }
 solana-svm = { workspace = true }
 solana-system-program = { workspace = true }
+solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
 solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }

--- a/runtime/src/bank/bank_hash_details.rs
+++ b/runtime/src/bank/bank_hash_details.rs
@@ -18,6 +18,8 @@ use {
         hash::Hash,
         pubkey::Pubkey,
     },
+    solana_svm::transaction_results::TransactionExecutionDetails,
+    solana_transaction_status::UiInstruction,
     std::str::FromStr,
 };
 
@@ -28,11 +30,11 @@ pub struct BankHashDetails {
     /// The encoding format for account data buffers
     pub account_data_encoding: String,
     /// Bank hash details for a collection of banks
-    pub bank_hash_details: Vec<BankHashSlotDetails>,
+    pub bank_hash_details: Vec<SlotDetails>,
 }
 
 impl BankHashDetails {
-    pub fn new(bank_hash_details: Vec<BankHashSlotDetails>) -> Self {
+    pub fn new(bank_hash_details: Vec<SlotDetails>) -> Self {
         Self {
             version: solana_version::version!().to_string(),
             account_data_encoding: "base64".to_string(),
@@ -65,9 +67,18 @@ impl BankHashDetails {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+pub struct TransactionDetails {
+    pub index: usize,
+    pub accounts: Vec<String>,
+    pub instructions: Vec<UiInstruction>,
+    pub is_simple_vote_tx: bool,
+    pub execution_results: Option<TransactionExecutionDetails>,
+}
+
 /// The components that go into a bank hash calculation for a single bank/slot.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
-pub struct BankHashSlotDetails {
+pub struct SlotDetails {
     pub slot: Slot,
     pub bank_hash: String,
     #[serde(skip_serializing_if = "String::is_empty")]
@@ -82,20 +93,23 @@ pub struct BankHashSlotDetails {
     #[serde(skip_serializing_if = "String::is_empty")]
     #[serde(default)]
     pub last_blockhash: String,
-    #[serde(skip_serializing_if = "bankhashaccounts_is_empty")]
+    #[serde(skip_serializing_if = "accounts_is_empty")]
     #[serde(default)]
-    pub accounts: BankHashAccounts,
+    pub accounts: AccountsDetails,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub transactions: Vec<TransactionDetails>,
 }
 
 fn u64_is_zero(val: &u64) -> bool {
     *val == 0
 }
 
-fn bankhashaccounts_is_empty(accounts: &BankHashAccounts) -> bool {
+fn accounts_is_empty(accounts: &AccountsDetails) -> bool {
     accounts.accounts.is_empty()
 }
 
-impl BankHashSlotDetails {
+impl SlotDetails {
     pub fn new(
         slot: Slot,
         bank_hash: Hash,
@@ -103,7 +117,7 @@ impl BankHashSlotDetails {
         accounts_delta_hash: Hash,
         signature_count: u64,
         last_blockhash: Hash,
-        accounts: BankHashAccounts,
+        accounts: AccountsDetails,
     ) -> Self {
         Self {
             slot,
@@ -113,11 +127,12 @@ impl BankHashSlotDetails {
             signature_count,
             last_blockhash: last_blockhash.to_string(),
             accounts,
+            transactions: Vec::new(),
         }
     }
 }
 
-impl TryFrom<&Bank> for BankHashSlotDetails {
+impl TryFrom<&Bank> for SlotDetails {
     type Error = String;
 
     fn try_from(bank: &Bank) -> Result<Self, Self::Error> {
@@ -152,7 +167,7 @@ impl TryFrom<&Bank> for BankHashSlotDetails {
             accounts_delta_hash,
             bank.signature_count(),
             bank.last_blockhash(),
-            BankHashAccounts { accounts },
+            AccountsDetails { accounts },
         ))
     }
 }
@@ -160,7 +175,7 @@ impl TryFrom<&Bank> for BankHashSlotDetails {
 /// Wrapper around a Vec<_> to facilitate custom Serialize/Deserialize trait
 /// implementations.
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
-pub struct BankHashAccounts {
+pub struct AccountsDetails {
     pub accounts: Vec<PubkeyHashAccount>,
 }
 
@@ -221,7 +236,7 @@ impl TryFrom<SerdeAccount> for PubkeyHashAccount {
     }
 }
 
-impl Serialize for BankHashAccounts {
+impl Serialize for AccountsDetails {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -235,7 +250,7 @@ impl Serialize for BankHashAccounts {
     }
 }
 
-impl<'de> Deserialize<'de> for BankHashAccounts {
+impl<'de> Deserialize<'de> for AccountsDetails {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -246,7 +261,7 @@ impl<'de> Deserialize<'de> for BankHashAccounts {
             .map(PubkeyHashAccount::try_from)
             .collect();
         let pubkey_hash_accounts = pubkey_hash_accounts.map_err(de::Error::custom)?;
-        Ok(BankHashAccounts {
+        Ok(AccountsDetails {
             accounts: pubkey_hash_accounts,
         })
     }
@@ -254,7 +269,7 @@ impl<'de> Deserialize<'de> for BankHashAccounts {
 
 /// Output the components that comprise the overall bank hash for the supplied `Bank`
 pub fn write_bank_hash_details_file(bank: &Bank) -> std::result::Result<(), String> {
-    let slot_details = BankHashSlotDetails::try_from(bank)?;
+    let slot_details = SlotDetails::try_from(bank)?;
     let details = BankHashDetails::new(vec![slot_details]);
 
     let parent_dir = bank
@@ -306,7 +321,7 @@ pub mod tests {
                 });
                 let account_pubkey = Pubkey::new_unique();
                 let account_hash = AccountHash(hash("account".as_bytes()));
-                let accounts = BankHashAccounts {
+                let accounts = AccountsDetails {
                     accounts: vec![PubkeyHashAccount {
                         pubkey: account_pubkey,
                         hash: account_hash,
@@ -319,7 +334,7 @@ pub mod tests {
                 let accounts_delta_hash = hash("accounts_delta".as_bytes());
                 let last_blockhash = hash("last_blockhash".as_bytes());
 
-                BankHashSlotDetails::new(
+                SlotDetails::new(
                     slot as Slot,
                     bank_hash,
                     parent_bank_hash,

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -31,7 +31,7 @@ pub struct FeeStructure {
     pub compute_fee_bins: Vec<FeeBin>,
 }
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
 pub struct FeeDetails {
     transaction_fee: u64,
     prioritization_fee: u64,

--- a/svm/src/transaction_results.rs
+++ b/svm/src/transaction_results.rs
@@ -5,6 +5,7 @@
 )]
 pub use solana_sdk::inner_instruction::{InnerInstruction, InnerInstructionsList};
 use {
+    serde::{Deserialize, Serialize},
     solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
     solana_sdk::{
         fee::FeeDetails,
@@ -76,7 +77,7 @@ impl TransactionExecutionResult {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TransactionExecutionDetails {
     pub status: transaction::Result<()>,
     pub log_messages: Option<Vec<String>>,

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -142,7 +142,7 @@ pub enum UiInstruction {
 }
 
 impl UiInstruction {
-    fn parse(
+    pub fn parse(
         instruction: &CompiledInstruction,
         account_keys: &AccountKeys,
         stack_height: Option<u32>,


### PR DESCRIPTION
#### Problem

When diagnosing a consensus failure, ledger-tool has the `--record-slots` and `--verify-slots` option to find the diverging slot. This PR add a `--record-slots-config=tx` option, which writes all transactions to the recording. This can be be used to find the exact transaction where the failure was.

Short workflow:

- `ledger-tool verify --records-slots --record-slots-config=tx`
- (make change to the runtime)
- `ledger-tool verify --record-slots slots-before.json --record-slots-config=tx`
- `diff -u slots.json slots-before.json`

Longer Workflow if the files get too large:

- `ledger-tool verify --records-slots`
- (make change to the runtime)
- `ledger-tool verify --verify-slots` => slot 102 diverges
- `ledger-tool verify --record-slots-config=tx --record-slots=after.json --halt-at-slot 102`
- (revert runtime change)
- `ledger-tool verify --record-slots-config=tx --record-slots=before.json --halt-at-slot 102`
- `diff -u after.json before.json`

Now the diff will show exactly where things went wrong.


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
