### PR TITLE
Remove unused account_deps

### DIFF
--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -196,7 +196,6 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
     let mut tx_rent: TransactionRent = 0;
     let account_keys = message.account_keys();
     let mut accounts_found = Vec::with_capacity(account_keys.len());
-    let mut account_deps = Vec::with_capacity(account_keys.len());
     let mut rent_debits = RentDebits::default();
     let rent_collector = callbacks.get_rent_collector();
 
@@ -315,13 +314,6 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
         error_counters.account_not_found += 1;
         return Err(TransactionError::AccountNotFound);
     }
-
-    // Appends the account_deps at the end of the accounts,
-    // this way they can be accessed in a uniform way.
-    // At places where only the accounts are needed,
-    // the account_deps are truncated using e.g:
-    // accounts.iter().take(message.account_keys.len())
-    accounts.append(&mut account_deps);
 
     let builtins_start_index = accounts.len();
     let program_indices = message


### PR DESCRIPTION
#### Problem
- `account_deps` never has any elements and is appended to `accounts`

#### Summary of Changes
- remove `account_deps`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
