### PR TITLE
Make --wait-for-supermajority require --expected-shred-version

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -745,6 +745,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
             Arg::with_name("wait_for_supermajority")
                 .long("wait-for-supermajority")
                 .requires("expected_bank_hash")
+                .requires("expected_shred_version")
                 .value_name("SLOT")
                 .validator(is_slot)
                 .help(


### PR DESCRIPTION
#### Problem
In cluster restart scenarios, an important step is scanning the Blockstore for blocks (shreds) that occur after the chosen restart slot with an incorrect shred version. Supposing the cluster is chosen to be restarted at slot `R`, the check ensures that any slots `> R` are purged from the Blockstore before the node enters the wait-for-supermajority loop. If a node skips this step, the node can encounter problems when that block is created again (post cluster restart)

This check only occurs if `--wait-for-supermajority` AND `--expected-shred-version` are set; however, `--expected-...` is currently optional when using `--wait-...`

#### Summary of Changes
Our restart instructions typically mention that one should specify `--expected-...` as well, but we should just enforce it at the CLI level to prevent mistakes / wasted time debuggging.

Forcing this will also enable us to run this sanity check:
https://github.com/anza-xyz/agave/blob/88f6a7a45997fd5f56e5f9a0b4432f52f9f2a8b2/core/src/validator.rs#L730-L738