### PR TITLE
Removes redundant imports

### DIFF
--- a/frozen-abi/src/abi_digester.rs
+++ b/frozen-abi/src/abi_digester.rs
@@ -4,10 +4,7 @@ use {
         hash::{Hash, Hasher},
     },
     log::*,
-    serde::{
-        ser::{Error as SerdeError, *},
-        Serialize, Serializer,
-    },
+    serde::ser::{Error as SerdeError, *},
     std::{any::type_name, io::Write},
     thiserror::Error,
 };

--- a/programs/bpf_loader/gen-syscall-list/build.rs
+++ b/programs/bpf_loader/gen-syscall-list/build.rs
@@ -2,7 +2,7 @@ use {
     regex::Regex,
     std::{
         fs::File,
-        io::{prelude::*, BufWriter, Read},
+        io::{prelude::*, BufWriter},
         path::PathBuf,
         str,
     },

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -8,7 +8,6 @@ use {
     proc_macro::TokenStream,
     proc_macro2::{Delimiter, Span, TokenTree},
     quote::{quote, ToTokens},
-    std::convert::TryFrom,
     syn::{
         bracketed,
         parse::{Parse, ParseStream, Result},


### PR DESCRIPTION
#### Problem

clippy nightly throws new lints for redundant imports. For example:

```
warning: the item `Read` is imported redundantly
 --> programs/bpf_loader/gen-syscall-list/build.rs:5:37
  |
5 |         io::{prelude::*, BufWriter, Read},
  |              ----------             ^^^^
  |              |
  |              the item `Read` is already imported here
  |
  = note: `#[warn(unused_imports)]` on by default
```

#### Summary of Changes

Remove 'em.