### PR TITLE
Moves a clippy attribute

### DIFF
--- a/memory-management/src/aligned_memory.rs
+++ b/memory-management/src/aligned_memory.rs
@@ -207,8 +207,8 @@ impl<const ALIGN: usize, T: AsRef<[u8]>> From<T> for AlignedMemory<ALIGN> {
 }
 
 #[cfg(test)]
+#[allow(clippy::arithmetic_side_effects)]
 mod tests {
-    #![allow(clippy::arithmetic_side_effects)]
     use {super::*, std::io::Write};
 
     fn do_test<const ALIGN: usize>() {


### PR DESCRIPTION
#### Problem

New clippy nighly has a new warning:

```
warning: item has both inner and outer attributes
   --> memory-management/src/aligned_memory.rs:209:1
    |
209 | / #[cfg(test)]
210 | | mod tests {
211 | |     #![allow(clippy::arithmetic_side_effects)]
    | |______________________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mixed_attributes_style
    = note: `#[warn(clippy::mixed_attributes_style)]` on by default
```


#### Summary of Changes

Move the attribute.