### PR TITLE
[TieredStorage] Refactor TieredStorage::new_readonly() code path

### DIFF
--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -170,7 +170,8 @@ mod tests {
     use {
         super::*,
         crate::account_storage::meta::StoredMetaWriteVersion,
-        footer::{TieredStorageFooter, TieredStorageMagicNumber},
+        file::TieredStorageMagicNumber,
+        footer::TieredStorageFooter,
         hot::HOT_FORMAT,
         index::IndexOffset,
         solana_sdk::{

--- a/accounts-db/src/tiered_storage/file.rs
+++ b/accounts-db/src/tiered_storage/file.rs
@@ -1,5 +1,6 @@
 use {
-    bytemuck::{AnyBitPattern, NoUninit},
+    super::{error::TieredStorageError, TieredStorageResult},
+    bytemuck::{AnyBitPattern, NoUninit, Pod, Zeroable},
     std::{
         fs::{File, OpenOptions},
         io::{BufWriter, Read, Result as IoResult, Seek, SeekFrom, Write},
@@ -8,23 +9,37 @@ use {
     },
 };
 
+/// The ending 8 bytes of a valid tiered account storage file.
+pub const FILE_MAGIC_NUMBER: u64 = 0xA72A2AB5; // ANZALABS
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct TieredStorageMagicNumber(pub u64);
+
+// Ensure there are no implicit padding bytes
+const _: () = assert!(std::mem::size_of::<TieredStorageMagicNumber>() == 8);
+
+impl Default for TieredStorageMagicNumber {
+    fn default() -> Self {
+        Self(FILE_MAGIC_NUMBER)
+    }
+}
+
 #[derive(Debug)]
 pub struct TieredReadableFile(pub File);
 
 impl TieredReadableFile {
-    pub fn new(file_path: impl AsRef<Path>) -> Self {
-        Self(
+    pub fn new(file_path: impl AsRef<Path>) -> TieredStorageResult<Self> {
+        let file = Self(
             OpenOptions::new()
                 .read(true)
                 .create(false)
-                .open(&file_path)
-                .unwrap_or_else(|err| {
-                    panic!(
-                        "[TieredStorageError] Unable to open {} as read-only: {err}",
-                        file_path.as_ref().display(),
-                    );
-                }),
-        )
+                .open(&file_path)?,
+        );
+
+        file.check_magic_number()?;
+
+        Ok(file)
     }
 
     pub fn new_writable(file_path: impl AsRef<Path>) -> IoResult<Self> {
@@ -34,6 +49,19 @@ impl TieredReadableFile {
                 .write(true)
                 .open(file_path)?,
         ))
+    }
+
+    fn check_magic_number(&self) -> TieredStorageResult<()> {
+        self.seek_from_end(-(std::mem::size_of::<TieredStorageMagicNumber>() as i64))?;
+        let mut magic_number = TieredStorageMagicNumber::zeroed();
+        self.read_pod(&mut magic_number)?;
+        if magic_number != TieredStorageMagicNumber::default() {
+            return Err(TieredStorageError::MagicNumberMismatch(
+                TieredStorageMagicNumber::default().0,
+                magic_number.0,
+            ));
+        }
+        Ok(())
     }
 
     /// Reads a value of type `T` from the file.
@@ -125,5 +153,42 @@ impl TieredWritableFile {
         self.0.write_all(bytes)?;
 
         Ok(bytes.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        crate::tiered_storage::{
+            error::TieredStorageError,
+            file::{TieredReadableFile, TieredWritableFile, FILE_MAGIC_NUMBER},
+        },
+        std::path::Path,
+        tempfile::TempDir,
+    };
+
+    fn generate_test_file_with_number(path: impl AsRef<Path>, number: u64) {
+        // Generate a new temp path that is guaranteed to NOT already have a file.
+        let mut file = TieredWritableFile::new(path).unwrap();
+        file.write_pod(&number).unwrap();
+    }
+
+    #[test]
+    fn test_new() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test_new");
+        generate_test_file_with_number(&path, FILE_MAGIC_NUMBER);
+        TieredReadableFile::new(&path).unwrap();
+    }
+
+    #[test]
+    fn test_magic_number_mismatch() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test_magic_number_mismatch");
+        generate_test_file_with_number(&path, !FILE_MAGIC_NUMBER);
+        assert!(matches!(
+            TieredReadableFile::new(&path),
+            Err(TieredStorageError::MagicNumberMismatch(_, _))
+        ));
     }
 }

--- a/accounts-db/src/tiered_storage/file.rs
+++ b/accounts-db/src/tiered_storage/file.rs
@@ -10,7 +10,7 @@ use {
 };
 
 /// The ending 8 bytes of a valid tiered account storage file.
-pub const FILE_MAGIC_NUMBER: u64 = 0xA72A2AB5; // ANZALABS
+pub const FILE_MAGIC_NUMBER: u64 = u64::from_le_bytes(*b"AnzaTech");
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
@@ -168,7 +168,6 @@ mod tests {
     };
 
     fn generate_test_file_with_number(path: impl AsRef<Path>, number: u64) {
-        // Generate a new temp path that is guaranteed to NOT already have a file.
         let mut file = TieredWritableFile::new(path).unwrap();
         file.write_pod(&number).unwrap();
     }
@@ -178,7 +177,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("test_new");
         generate_test_file_with_number(&path, FILE_MAGIC_NUMBER);
-        TieredReadableFile::new(&path).unwrap();
+        assert!(TieredReadableFile::new(&path).is_ok());
     }
 
     #[test]

--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -1,13 +1,13 @@
 use {
     crate::tiered_storage::{
         error::TieredStorageError,
-        file::{TieredReadableFile, TieredWritableFile},
+        file::{TieredReadableFile, TieredStorageMagicNumber, TieredWritableFile},
         index::IndexBlockFormat,
         mmap_utils::{get_pod, get_type},
         owners::OwnersBlockFormat,
         TieredStorageResult,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck::Zeroable,
     memmap2::Mmap,
     num_enum::TryFromPrimitiveError,
     solana_sdk::{hash::Hash, pubkey::Pubkey},
@@ -25,22 +25,6 @@ static_assertions::const_assert_eq!(mem::size_of::<TieredStorageFooter>(), 160);
 /// The size of the ending part of the footer.  This size should remain unchanged
 /// even when the footer's format changes.
 pub const FOOTER_TAIL_SIZE: usize = 24;
-
-/// The ending 8 bytes of a valid tiered account storage file.
-pub const FOOTER_MAGIC_NUMBER: u64 = 0x502A2AB5; // SOLALABS -> SOLANA LABS
-
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Pod, Zeroable)]
-#[repr(C)]
-pub struct TieredStorageMagicNumber(pub u64);
-
-// Ensure there are no implicit padding bytes
-const _: () = assert!(std::mem::size_of::<TieredStorageMagicNumber>() == 8);
-
-impl Default for TieredStorageMagicNumber {
-    fn default() -> Self {
-        Self(FOOTER_MAGIC_NUMBER)
-    }
-}
 
 #[repr(u16)]
 #[derive(
@@ -133,7 +117,7 @@ pub struct TieredStorageFooter {
     /// The size of the footer including the magic number.
     pub footer_size: u64,
     // This field is persisted in the storage but not in this struct.
-    // The number should match FOOTER_MAGIC_NUMBER.
+    // The number should match FILE_MAGIC_NUMBER.
     // pub magic_number: u64,
 }
 
@@ -186,7 +170,7 @@ impl Default for TieredStorageFooter {
 
 impl TieredStorageFooter {
     pub fn new_from_path(path: impl AsRef<Path>) -> TieredStorageResult<Self> {
-        let file = TieredReadableFile::new(path);
+        let file = TieredReadableFile::new(path)?;
         Self::new_from_footer_block(&file)
     }
 

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -3,6 +3,7 @@ use {
         account_storage::meta::StoredAccountMeta,
         accounts_file::MatchAccountOwnerError,
         tiered_storage::{
+            file::TieredReadableFile,
             footer::{AccountMetaFormat, TieredStorageFooter},
             hot::HotStorageReader,
             index::IndexOffset,
@@ -22,9 +23,10 @@ pub enum TieredStorageReader {
 impl TieredStorageReader {
     /// Creates a reader for the specified tiered storage accounts file.
     pub fn new_from_path(path: impl AsRef<Path>) -> TieredStorageResult<Self> {
-        let footer = TieredStorageFooter::new_from_path(&path)?;
+        let file = TieredReadableFile::new(&path)?;
+        let footer = TieredStorageFooter::new_from_footer_block(&file)?;
         match footer.account_meta_format {
-            AccountMetaFormat::Hot => Ok(Self::Hot(HotStorageReader::new_from_path(path)?)),
+            AccountMetaFormat::Hot => Ok(Self::Hot(HotStorageReader::new(file)?)),
         }
     }
 


### PR DESCRIPTION
#### Problem
The TieredStorage::new_readonly() function currently has the following
problems:

* It opens the file without checking the magic number before checking and loading the footer.
* It opens the file twice: first to load the footer, then open again by the reader.

#### Summary of Changes
This PR refactors TieredStorage::new_readonly() so that it first performs all
checks inside the constructor of TieredReadableFile.  The TieredReadableFile
instance is then passed to the proper reader (currently HotStorageReader)
when all checks are passed.

#### Test Plan
* Added a new test to check MagicNumberMismatch.
* Existing tiered-storage tests
