### PR TITLE
Add in metrics for detecting Redundant Pulls

### DIFF
--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -639,6 +639,7 @@ pub(crate) fn submit_gossip_stats(
         ),
         ("RestartHeaviestFork-push", crds_stats.push.counts[13], i64),
         ("RestartHeaviestFork-pull", crds_stats.pull.counts[13], i64),
+        ("RedundantPull", crds_stats.redundant_pull, i64),
         (
             "all-push",
             crds_stats.push.counts.iter().sum::<usize>(),

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -93,6 +93,7 @@ pub enum CrdsError {
     DuplicatePush(/*num dups:*/ u8),
     InsertFailed,
     UnknownStakes,
+    RedundantPull,
 }
 
 #[derive(Clone, Copy)]
@@ -151,7 +152,8 @@ impl VersionedCrdsValue {
     fn new(value: CrdsValue, cursor: Cursor, local_timestamp: u64, route: GossipRoute) -> Self {
         let value_hash = hash(&serialize(&value).unwrap());
         let num_push_recv = match route {
-            // Set PushMessage count to 1
+            // If we received a PushMessage, set
+            // num_push_recv <- 1
             GossipRoute::PushMessage(_) => 1u8,
             _ => 0u8,
         };
@@ -309,14 +311,20 @@ impl Crds {
                     Err(CrdsError::InsertFailed)
                 } else if matches!(route, GossipRoute::PushMessage(_)) {
                     let entry = entry.get_mut();
+                    entry.num_push_recv = entry.num_push_recv.saturating_add(1);
                     // This is a duplicate entry. If num_push_recv == 0, we
                     // know this data was first received via PullResponse
-                    // This is a redundant pull.
+                    // This is a redundant pull, meaning we received a PushMessage
+                    // after we had already received the same message first via PullResponse
                     if entry.num_push_recv == 0 {
                         self.stats.lock().unwrap().record_redundant_pull();
+                        return Err(CrdsError::RedundantPull);
                     }
-                    entry.num_push_recv = entry.num_push_recv.saturating_add(1);
-                    Err(CrdsError::DuplicatePush(entry.num_push_recv))
+                    // num_push_recv tracks number of received push messages, but we return
+                    // duplicate push message count. so we need to subtract 1 for just the duplicates
+                    Err(CrdsError::DuplicatePush(
+                        entry.num_push_recv.saturating_sub(1),
+                    ))
                 } else {
                     Err(CrdsError::InsertFailed)
                 }

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -157,6 +157,12 @@ impl CrdsGossipPush {
                         received_cache.record(origin, from, /*num_dups:*/ usize::MAX);
                         self.num_old.fetch_add(1, Ordering::Relaxed);
                     }
+                    Err(CrdsError::RedundantPull) => {
+                        // rewarded for being after Pull but first Push??
+                        received_cache.record(origin, from, /*num_dups:*/ 0);
+                        // still track that it is old message
+                        self.num_old.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Problem
We had previously added in a metric for tracking gossip push messages through the network in [PR: #32725](https://github.com/solana-labs/solana/pull/32725). However, this metric does not account for redundant pull requests. 
*Redundant Pull:* A node receives a message via `PullResponse` and then receives the same message via `Push`. 
Redundant Pulls prevent us from accurately calculating how well messages are propagating via `Push`. 

#### Summary of Changes
Add in a metric to report when we receive a `Push` for a message we already (and first) received via `PullResponse`
Modify `VersionedCrdsValue`. 
- `num_push_dups` changed to `num_push_recv` and now tracks the number of times we have received a push message. 
- add a new metric to `cluster_info_crds_stats` called `RedundantPull`. It counts the number of times a unique message is received via a Redundant Pull
- Add new `CrdsError::RedundantPull`. Peer sending the first Push message in a redundant pull counts as if it was the first peer to send us the message overall.

#### Identifying redundant Pulls:
1) Receive a message via `PullRequest` that successfully updates `crds.table`, set the `num_push_recv` of this message to 0. Set `num_push_recv` to 1 if it is a `PushMessage`
2) Receive the same message again but via `Push`, it will fail to insert. Since the already existing entry has `num_push_recv  == 0`,  we know this is a Redundant Pull. 
3) Increment `CrdsStats.redundant_pull`
4) Return `CrdsError::RedundantPull`

#### Calculating fraction of messages received via Redundant Pull:
```
num_redundant_pull / (num_redundant_pull + all-push)
```