### PR TITLE
Add in metrics for detecting Redundant Pulls

### DIFF
--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -639,6 +639,7 @@ pub(crate) fn submit_gossip_stats(
         ),
         ("RestartHeaviestFork-push", crds_stats.push.counts[13], i64),
         ("RestartHeaviestFork-pull", crds_stats.pull.counts[13], i64),
+        ("RedundantPull", crds_stats.redundant_pull, i64),
         (
             "all-push",
             crds_stats.push.counts.iter().sum::<usize>(),

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -316,6 +316,11 @@ pub(crate) fn submit_gossip_stats(
             i64
         ),
         (
+            "num_redundant_pull_responses",
+            crds_stats.num_redundant_pull_responses,
+            i64
+        ),
+        (
             "push_response_count",
             stats.push_response_count.clear(),
             i64
@@ -639,7 +644,6 @@ pub(crate) fn submit_gossip_stats(
         ),
         ("RestartHeaviestFork-push", crds_stats.push.counts[13], i64),
         ("RestartHeaviestFork-pull", crds_stats.pull.counts[13], i64),
-        ("RedundantPull", crds_stats.redundant_pull, i64),
         (
             "all-push",
             crds_stats.push.counts.iter().sum::<usize>(),

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -115,6 +115,7 @@ pub(crate) struct CrdsDataStats {
 pub(crate) struct CrdsStats {
     pub(crate) pull: CrdsDataStats,
     pub(crate) push: CrdsDataStats,
+    pub(crate) redundant_pull: i64,
 }
 
 /// This structure stores some local metadata associated with the CrdsValue
@@ -127,8 +128,8 @@ pub struct VersionedCrdsValue {
     pub(crate) local_timestamp: u64,
     /// value hash
     pub(crate) value_hash: Hash,
-    /// Number of times duplicates of this value are recevied from gossip push.
-    num_push_dups: u8,
+    /// Number of times this value is recevied from gossip push.
+    num_push_recv: u8,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -147,14 +148,19 @@ impl Cursor {
 }
 
 impl VersionedCrdsValue {
-    fn new(value: CrdsValue, cursor: Cursor, local_timestamp: u64) -> Self {
+    fn new(value: CrdsValue, cursor: Cursor, local_timestamp: u64, route: GossipRoute) -> Self {
         let value_hash = hash(&serialize(&value).unwrap());
+        let num_push_recv = match route {
+            // Set PushMessage count to 1
+            GossipRoute::PushMessage(_) => 1u8,
+            _ => 0u8,
+        };
         VersionedCrdsValue {
             ordinal: cursor.ordinal(),
             value,
             local_timestamp,
             value_hash,
-            num_push_dups: 0u8,
+            num_push_recv,
         }
     }
 }
@@ -222,7 +228,7 @@ impl Crds {
     ) -> Result<(), CrdsError> {
         let label = value.label();
         let pubkey = value.pubkey();
-        let value = VersionedCrdsValue::new(value, self.cursor, now);
+        let value = VersionedCrdsValue::new(value, self.cursor, now, route);
         match self.table.entry(label) {
             Entry::Vacant(entry) => {
                 self.stats.lock().unwrap().record_insert(&value, route);
@@ -303,8 +309,14 @@ impl Crds {
                     Err(CrdsError::InsertFailed)
                 } else if matches!(route, GossipRoute::PushMessage(_)) {
                     let entry = entry.get_mut();
-                    entry.num_push_dups = entry.num_push_dups.saturating_add(1);
-                    Err(CrdsError::DuplicatePush(entry.num_push_dups))
+                    // This is a duplicate entry. If num_push_recv == 0, we
+                    // know this data was first received via PullResponse
+                    // This is a redundant pull.
+                    if entry.num_push_recv == 0 {
+                        self.stats.lock().unwrap().record_redundant_pull();
+                    }
+                    entry.num_push_recv = entry.num_push_recv.saturating_add(1);
+                    Err(CrdsError::DuplicatePush(entry.num_push_recv))
                 } else {
                     Err(CrdsError::InsertFailed)
                 }
@@ -745,6 +757,10 @@ impl CrdsStats {
             GossipRoute::PushMessage(_) => self.push.record_fail(entry),
             GossipRoute::PullResponse => self.pull.record_fail(entry),
         }
+    }
+
+    fn record_redundant_pull(&mut self) {
+        self.redundant_pull += 1;
     }
 }
 
@@ -1450,8 +1466,9 @@ mod tests {
     #[allow(clippy::neg_cmp_op_on_partial_ord)]
     fn test_equal() {
         let val = CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(ContactInfo::default()));
-        let v1 = VersionedCrdsValue::new(val.clone(), Cursor::default(), 1);
-        let v2 = VersionedCrdsValue::new(val, Cursor::default(), 1);
+        let v1 =
+            VersionedCrdsValue::new(val.clone(), Cursor::default(), 1, GossipRoute::LocalMessage);
+        let v2 = VersionedCrdsValue::new(val, Cursor::default(), 1, GossipRoute::LocalMessage);
         assert_eq!(v1, v2);
         assert!(!(v1 != v2));
         assert!(!overrides(&v1.value, &v2));
@@ -1467,6 +1484,7 @@ mod tests {
             ))),
             Cursor::default(),
             1, // local_timestamp
+            GossipRoute::LocalMessage,
         );
         let v2 = VersionedCrdsValue::new(
             {
@@ -1476,6 +1494,7 @@ mod tests {
             },
             Cursor::default(),
             1, // local_timestamp
+            GossipRoute::LocalMessage,
         );
 
         assert_eq!(v1.value.label(), v2.value.label());
@@ -1501,6 +1520,7 @@ mod tests {
             ))),
             Cursor::default(),
             1, // local_timestamp
+            GossipRoute::LocalMessage,
         );
         let v2 = VersionedCrdsValue::new(
             CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(ContactInfo::new_localhost(
@@ -1509,6 +1529,7 @@ mod tests {
             ))),
             Cursor::default(),
             1, // local_timestamp
+            GossipRoute::LocalMessage,
         );
         assert_eq!(v1.value.label(), v2.value.label());
         assert!(overrides(&v1.value, &v2));
@@ -1527,6 +1548,7 @@ mod tests {
             ))),
             Cursor::default(),
             1, // local_timestamp
+            GossipRoute::LocalMessage,
         );
         let v2 = VersionedCrdsValue::new(
             CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(ContactInfo::new_localhost(
@@ -1535,6 +1557,7 @@ mod tests {
             ))),
             Cursor::default(),
             1, // local_timestamp
+            GossipRoute::LocalMessage,
         );
         assert_ne!(v1, v2);
         assert!(!(v1 == v2));

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -75,7 +75,7 @@ pub struct Crds {
     votes: BTreeMap<u64 /*insert order*/, usize /*index*/>,
     // Indices of EpochSlots keyed by insert order.
     epoch_slots: BTreeMap<u64 /*insert order*/, usize /*index*/>,
-    // Indices of DuplicateShred keyed by insert order.
+    // Indice of DuplicateShred keyed by insert order.
     duplicate_shreds: BTreeMap<u64 /*insert order*/, usize /*index*/>,
     // Indices of all crds values associated with a node.
     records: HashMap<Pubkey, IndexSet<usize>>,
@@ -93,7 +93,6 @@ pub enum CrdsError {
     DuplicatePush(/*num dups:*/ u8),
     InsertFailed,
     UnknownStakes,
-    RedundantPull,
 }
 
 #[derive(Clone, Copy)]
@@ -119,6 +118,34 @@ pub(crate) struct CrdsStats {
     pub(crate) redundant_pull: i64,
 }
 
+#[derive(PartialEq, Eq, Debug, Clone)]
+struct NumPushRecv {
+    pub count: u8,
+    pub received_first_via_pull_response: bool,
+}
+
+impl NumPushRecv {
+    fn new(route: GossipRoute) -> Self {
+        let (count, received_first_via_pull_response) = match route {
+            GossipRoute::PullRequest => (0, true),
+            GossipRoute::PushMessage(_) => (1, false),
+            _ => (0, false),
+        };
+        Self {
+            count,
+            received_first_via_pull_response,
+        }
+    }
+
+    // If first time message was received via PullResponse and count == 0,
+    // we know this data was first received via PullResponse.
+    // This is a redundant pull, meaning we received a PushMessage
+    // after we had already received the same message first via PullResponse
+    fn is_redundant_pull(&self) -> bool {
+        self.received_first_via_pull_response && self.count == 0
+    }
+}
+
 /// This structure stores some local metadata associated with the CrdsValue
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VersionedCrdsValue {
@@ -129,8 +156,9 @@ pub struct VersionedCrdsValue {
     pub(crate) local_timestamp: u64,
     /// value hash
     pub(crate) value_hash: Hash,
-    /// Number of times this value is recevied from gossip push.
-    num_push_recv: u8,
+    /// Tracks number of times this value is recevied from gossip push.
+    /// And if this value was first entered into crds via redundant pull
+    num_push_recv: NumPushRecv,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -151,12 +179,7 @@ impl Cursor {
 impl VersionedCrdsValue {
     fn new(value: CrdsValue, cursor: Cursor, local_timestamp: u64, route: GossipRoute) -> Self {
         let value_hash = hash(&serialize(&value).unwrap());
-        let num_push_recv = match route {
-            // If we received a PushMessage, set
-            // num_push_recv <- 1
-            GossipRoute::PushMessage(_) => 1u8,
-            _ => 0u8,
-        };
+        let num_push_recv = NumPushRecv::new(route);
         VersionedCrdsValue {
             ordinal: cursor.ordinal(),
             value,
@@ -311,20 +334,14 @@ impl Crds {
                     Err(CrdsError::InsertFailed)
                 } else if matches!(route, GossipRoute::PushMessage(_)) {
                     let entry = entry.get_mut();
-                    // If num_push_recv == 0, we know this data was first received
-                    // via PullResponse. This is a redundant pull, meaning we received
-                    // a PushMessage after we had already received the same message
-                    // first via PullResponse
-                    if entry.num_push_recv == 0 {
-                        entry.num_push_recv = entry.num_push_recv.saturating_add(1);
-                        self.stats.lock().unwrap().record_redundant_pull();
-                        return Err(CrdsError::RedundantPull);
+                    if entry.num_push_recv.is_redundant_pull() {
+                        self.stats.lock().unwrap().redundant_pull += 1;
                     }
-                    entry.num_push_recv = entry.num_push_recv.saturating_add(1);
-                    // num_push_recv tracks number of received push messages, but we return
+                    entry.num_push_recv.count = entry.num_push_recv.count.saturating_add(1);
+                    // num_push_recv.count tracks number of received push messages, but we return
                     // duplicate push message count. so we need to subtract 1
                     Err(CrdsError::DuplicatePush(
-                        entry.num_push_recv.saturating_sub(1),
+                        entry.num_push_recv.count.saturating_sub(1),
                     ))
                 } else {
                     Err(CrdsError::InsertFailed)
@@ -766,10 +783,6 @@ impl CrdsStats {
             GossipRoute::PushMessage(_) => self.push.record_fail(entry),
             GossipRoute::PullResponse => self.pull.record_fail(entry),
         }
-    }
-
-    fn record_redundant_pull(&mut self) {
-        self.redundant_pull += 1;
     }
 }
 

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -157,12 +157,6 @@ impl CrdsGossipPush {
                         received_cache.record(origin, from, /*num_dups:*/ usize::MAX);
                         self.num_old.fetch_add(1, Ordering::Relaxed);
                     }
-                    Err(CrdsError::RedundantPull) => {
-                        // rewarded for being after Pull but first Push??
-                        received_cache.record(origin, from, /*num_dups:*/ 0);
-                        // still track that it is old message
-                        self.num_old.fetch_add(1, Ordering::Relaxed);
-                    }
                 }
             }
         }

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -157,6 +157,12 @@ impl CrdsGossipPush {
                         received_cache.record(origin, from, /*num_dups:*/ usize::MAX);
                         self.num_old.fetch_add(1, Ordering::Relaxed);
                     }
+                    Err(CrdsError::RedundantPull) => {
+                        // rewarded for being after Pull but first Push??
+                        received_cache.record(origin, from, /*num_dups:*/ 0);
+                        // still track that it is old message
+                        self.num_old.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Problem
We had previously added in a metric for tracking gossip push messages through the network in [PR: #32725](https://github.com/solana-labs/solana/pull/32725). However, this metric does not account for redundant pull requests. 
*Redundant Pull:* A node receives a message via `PullResponse` and then receives the same message via `Push`. 
Redundant Pulls prevent us from accurately calculating how well messages are propagating via `Push`. 

#### Summary of Changes
Add in a metric to report when we receive a `Push` for a message we already (and first) received via `PullResponse`
- `num_push_dups` changed to `num_push_recv` and now tracks the number of times we have received a push message. 
- add a new metric to `cluster_info_crds_stats` called `num_redundant_pull_responses`. It counts the number of times a unique message is received via a Redundant Pull

#### Identifying redundant Pulls:
1) Receive a message via `PullRequest` that successfully updates `crds.table`, set the `num_push_recv` of this message to 0. Set `num_push_recv` to 1 if it is a `PushMessage`
2) Receive the same message again but via `Push`, it will fail to insert. Since the already existing entry has `num_push_recv  == 0`,  we know this is a Redundant Pull. 
3) Increment `CrdsStats.num_redundant_pull_responses`

#### Calculating fraction of messages received via Redundant Pull:
```
num_redundant_pull_responses / (num_redundant_pull_responses + all-push)
```

#### Monogon Simulation: % of redundant pulls in a 100 validator cluster
We see a mean Redundant Pull percentage of ~0.2%. But it does seem to increase with the number of validators
<img width="1657" alt="Screenshot 2024-03-11 at 8 09 13 PM" src="https://github.com/anza-xyz/agave/assets/11299967/a9f2626b-e510-4d18-9d30-7e9f7e8a65a2">