### PR TITLE
bench-tps: allow option to not set account data size on every transaction

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -69,6 +69,7 @@ pub struct Config {
     pub use_quic: bool,
     pub tpu_connection_pool_size: usize,
     pub compute_unit_price: Option<ComputeUnitPrice>,
+    pub skip_tx_account_data_size: bool,
     pub use_durable_nonce: bool,
     pub instruction_padding_config: Option<InstructionPaddingConfig>,
     pub num_conflict_groups: Option<usize>,
@@ -101,6 +102,7 @@ impl Default for Config {
             use_quic: DEFAULT_TPU_USE_QUIC,
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
             compute_unit_price: None,
+            skip_tx_account_data_size: false,
             use_durable_nonce: false,
             instruction_padding_config: None,
             num_conflict_groups: None,
@@ -359,6 +361,13 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .help("Sets random compute-unit-price in range [0..100] to transfer transactions"),
         )
         .arg(
+            Arg::with_name("skip_tx_account_data_size")
+                .long("skip-tx-account-data-size")
+                .takes_value(false)
+                .conflicts_with("instruction_padding_data_size")
+                .help("Skips setting the account data size for each transaction"),
+        )
+        .arg(
             Arg::with_name("use_durable_nonce")
                 .long("use-durable-nonce")
                 .help("Use durable transaction nonce instead of recent blockhash"),
@@ -535,6 +544,10 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
 
     if matches.is_present("use_randomized_compute_unit_price") {
         args.compute_unit_price = Some(ComputeUnitPrice::Random);
+    }
+
+    if matches.is_present("skip_tx_account_data_size") {
+        args.skip_tx_account_data_size = true;
     }
 
     if matches.is_present("use_durable_nonce") {

--- a/bench-tps/src/keypairs.rs
+++ b/bench-tps/src/keypairs.rs
@@ -16,6 +16,7 @@ pub fn get_keypairs<T>(
     num_lamports_per_account: u64,
     client_ids_and_stake_file: &str,
     read_from_client_file: bool,
+    skip_tx_account_data_size: bool,
     enable_padding: bool,
 ) -> Vec<Keypair>
 where
@@ -57,6 +58,7 @@ where
             &keypairs,
             keypairs.len().saturating_sub(keypair_count) as u64,
             last_balance,
+            skip_tx_account_data_size,
             enable_padding,
         )
         .unwrap_or_else(|e| {
@@ -70,6 +72,7 @@ where
             id,
             keypair_count,
             num_lamports_per_account,
+            skip_tx_account_data_size,
             enable_padding,
         )
         .unwrap_or_else(|e| {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -194,6 +194,7 @@ fn main() {
         external_client_type,
         use_quic,
         tpu_connection_pool_size,
+        skip_tx_account_data_size,
         compute_unit_price,
         use_durable_nonce,
         instruction_padding_config,
@@ -267,6 +268,7 @@ fn main() {
         *num_lamports_per_account,
         client_ids_and_stake_file,
         *read_from_client_file,
+        *skip_tx_account_data_size,
         instruction_padding_config.is_some(),
     );
 

--- a/bench-tps/src/send_batch.rs
+++ b/bench-tps/src/send_batch.rs
@@ -66,7 +66,7 @@ pub fn fund_keys<T: 'static + BenchTpsClient + Send + Sync + ?Sized>(
     total: u64,
     max_fee: u64,
     lamports_per_account: u64,
-    data_size_limit: u32,
+    data_size_limit: Option<u32>,
 ) {
     let mut funded: Vec<&Keypair> = vec![source];
     let mut funded_funds = total;
@@ -354,7 +354,7 @@ trait FundingTransactions<'a>: SendBatchTransactions<'a, FundingSigners<'a>> {
         client: &Arc<T>,
         to_fund: &FundingChunk<'a>,
         to_lamports: u64,
-        data_size_limit: u32,
+        data_size_limit: Option<u32>,
     );
 }
 
@@ -364,13 +364,15 @@ impl<'a> FundingTransactions<'a> for FundingContainer<'a> {
         client: &Arc<T>,
         to_fund: &FundingChunk<'a>,
         to_lamports: u64,
-        data_size_limit: u32,
+        data_size_limit: Option<u32>,
     ) {
         self.make(to_fund, |(k, t)| -> (FundingSigners<'a>, Transaction) {
             let mut instructions = system_instruction::transfer_many(&k.pubkey(), t);
-            instructions.push(
-                ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(data_size_limit),
-            );
+            if let Some(data_size_limit) = data_size_limit {
+                instructions.push(
+                    ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(data_size_limit),
+                );
+            }
             let message = Message::new(&instructions, Some(&k.pubkey()));
             (*k, Transaction::new_unsigned(message))
         });

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -106,6 +106,7 @@ fn test_bench_tps_local_cluster(config: Config) {
         keypair_count,
         lamports_per_account,
         false,
+        false,
     )
     .unwrap();
 
@@ -151,6 +152,7 @@ fn test_bench_tps_test_validator(config: Config) {
         &config.id,
         keypair_count,
         lamports_per_account,
+        false,
         false,
     )
     .unwrap();

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -560,6 +560,7 @@ fn create_payers<T: 'static + BenchTpsClient + Send + Sync>(
             size,
             1_000_000,
             false,
+            false,
         )
         .unwrap_or_else(|e| {
             eprintln!("Error could not fund keys: {e:?}");


### PR DESCRIPTION
#### Problem

Bench TPS needs [this feature](https://github.com/solana-labs/solana/issues/30366) activated on the cluster since all transactions are hardcoded to include the instruction to set the account data size. However, this will not work on a test cluster where this feature is not activated. Moreover, Firedancer currently does not support that instruction.

#### Summary of Changes

This adds a flag `--skip-tx-account-data-size` which when specified, will not add that instruction. This makes Bench TPS work with FIredancer (and Solana clusters without any features activated).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
