### PR TITLE
Adds a new bench for accounts delta hash

### DIFF
--- a/accounts-db/benches/bench_hashing.rs
+++ b/accounts-db/benches/bench_hashing.rs
@@ -1,7 +1,11 @@
 use {
-    criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput},
-    solana_accounts_db::accounts_db::AccountsDb,
-    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+    criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput},
+    rand::seq::SliceRandom,
+    solana_accounts_db::{
+        accounts_db::AccountsDb,
+        accounts_hash::{AccountHash, AccountsHasher},
+    },
+    solana_sdk::{account::AccountSharedData, hash::Hash, pubkey::Pubkey},
 };
 
 const KB: usize = 1024;
@@ -39,5 +43,43 @@ fn bench_hash_account(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_hash_account,);
+fn bench_accounts_delta_hash(c: &mut Criterion) {
+    const ACCOUNTS_COUNTS: [usize; 4] = [
+        1,      // the smallest count; will bench overhead
+        100,    // number of accounts written per slot on mnb (with *no* rent rewrites)
+        1_000,  // number of accounts written slot on mnb (with rent rewrites)
+        10_000, // reasonable largest number of accounts written per slot
+    ];
+
+    fn create_account_hashes(accounts_count: usize) -> Vec<(Pubkey, AccountHash)> {
+        let mut account_hashes: Vec<_> = std::iter::repeat_with(|| {
+            let address = Pubkey::new_unique();
+            let hash = AccountHash(Hash::new_unique());
+            (address, hash)
+        })
+        .take(accounts_count)
+        .collect();
+
+        // since the accounts delta hash needs to sort the accounts first, ensure we're not
+        // creating a pre-sorted vec.
+        let mut rng = rand::thread_rng();
+        account_hashes.shuffle(&mut rng);
+        account_hashes
+    }
+
+    let mut group = c.benchmark_group("accounts_delta_hash");
+    for accounts_count in ACCOUNTS_COUNTS {
+        group.throughput(Throughput::Elements(accounts_count as u64));
+        let account_hashes = create_account_hashes(accounts_count);
+        group.bench_function(BenchmarkId::new("accounts_count", accounts_count), |b| {
+            b.iter_batched(
+                || account_hashes.clone(),
+                AccountsHasher::accumulate_account_hashes,
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(benches, bench_hash_account, bench_accounts_delta_hash);
 criterion_main!(benches);


### PR DESCRIPTION
#### Problem

There isn't a bench for running just the computation of the accounts delta hash. We'll also want this to compare with the lattice hash implementation in the future.


#### Summary of Changes

Adds a new bench for computing the accounts delta hash.


##### Benchmark Report

Here's some screenshots showing how the reports look. I ran the benchmark in a loop while CI was running, so a good number of iterations (46, to be precise).

<details><summary>Overview</summary>
<p>

![overview](https://github.com/anza-xyz/agave/assets/840349/75fe25bb-922c-4d69-af81-4f454b8bef91)

</p>
</details> 

<details><summary>Single Datapoint</summary>
<p>

![single point](https://github.com/anza-xyz/agave/assets/840349/8e0e4642-df99-4d5b-8c64-da08d21b3155)

</p>
</details> 

<details><summary>History</summary>
<p>

![history](https://github.com/anza-xyz/agave/assets/840349/5511e6b8-4ebf-4bc6-9104-d242799de356)

</p>
</details> 