### PR TITLE
Refactor get_account_*_from_slot function

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7569,7 +7569,7 @@ impl AccountsDb {
     ) -> (Vec<R>, u64, Measure)
     where
         R: Send,
-        B: Send + Default + Sync,
+        B: Send + Sync,
     {
         type ScanResult<R, B> = ScanStorageResult<R, DashMap<Pubkey, B>>;
         let mut scan = Measure::start("scan");

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1226,7 +1226,7 @@ pub enum ZeroLamportAccounts {
 
 /// Hash of an account
 #[repr(transparent)]
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Pod, Zeroable, AbiExample)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Pod, Zeroable, AbiExample)]
 pub struct AccountHash(pub Hash);
 
 // Ensure the newtype wrapper never changes size from the underlying Hash

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1226,7 +1226,7 @@ pub enum ZeroLamportAccounts {
 
 /// Hash of an account
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Pod, Zeroable, AbiExample)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Pod, Zeroable, AbiExample)]
 pub struct AccountHash(pub Hash);
 
 // Ensure the newtype wrapper never changes size from the underlying Hash


### PR DESCRIPTION
#### Problem

The family of `get_***_for_slot` functions share the common pattern for accounts-db scanning. Their code can be shared.


#### Summary of Changes

- Add a generic function to collect relevant accounts data from a slot
- Update `get_***_for_slot` function to use the generic function.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
