### PR TITLE
stake history get entry syscall

### DIFF
--- a/account-decoder/src/parse_sysvar.rs
+++ b/account-decoder/src/parse_sysvar.rs
@@ -79,7 +79,7 @@ pub fn parse_sysvar(data: &[u8], pubkey: &Pubkey) -> Result<SysvarAccountType, P
                     .iter()
                     .map(|entry| UiStakeHistoryEntry {
                         epoch: entry.0,
-                        stake_history: entry.1.clone(),
+                        stake_history: entry.1,
                     })
                     .collect();
                 SysvarAccountType::StakeHistory(stake_history)
@@ -340,7 +340,7 @@ mod test {
             activating: 2,
             deactivating: 3,
         };
-        stake_history.add(1, stake_history_entry.clone());
+        stake_history.add(1, stake_history_entry);
         let stake_history_sysvar = create_account_for_test(&stake_history);
         assert_eq!(
             parse_sysvar(&stake_history_sysvar.data, &sysvar::stake_history::id()).unwrap(),

--- a/account-decoder/src/parse_sysvar.rs
+++ b/account-decoder/src/parse_sysvar.rs
@@ -79,7 +79,7 @@ pub fn parse_sysvar(data: &[u8], pubkey: &Pubkey) -> Result<SysvarAccountType, P
                     .iter()
                     .map(|entry| UiStakeHistoryEntry {
                         epoch: entry.0,
-                        stake_history: entry.1,
+                        stake_history: entry.1.clone(),
                     })
                     .collect();
                 SysvarAccountType::StakeHistory(stake_history)
@@ -340,7 +340,7 @@ mod test {
             activating: 2,
             deactivating: 3,
         };
-        stake_history.add(1, stake_history_entry);
+        stake_history.add(1, stake_history_entry.clone());
         let stake_history_sysvar = create_account_for_test(&stake_history);
         assert_eq!(
             parse_sysvar(&stake_history_sysvar.data, &sysvar::stake_history::id()).unwrap(),

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -7,7 +7,7 @@ pub use self::{
     sysvar::{
         SyscallGetClockSysvar, SyscallGetEpochRewardsSysvar, SyscallGetEpochScheduleSysvar,
         SyscallGetFeesSysvar, SyscallGetLastRestartSlotSysvar, SyscallGetRentSysvar,
-        SyscallStakeHistoryGetEntry,
+        SyscallGetStakeHistoryEntry,
     },
 };
 #[allow(deprecated)]
@@ -39,9 +39,9 @@ use {
             disable_deploy_of_alloc_free_syscall, disable_fees_sysvar,
             enable_alt_bn128_compression_syscall, enable_alt_bn128_syscall,
             enable_big_mod_exp_syscall, enable_partitioned_epoch_reward, enable_poseidon_syscall,
-            error_on_syscall_bpf_function_hash_collisions, last_restart_slot_sysvar,
-            reject_callx_r10, remaining_compute_units_syscall_enabled,
-            stake_history_get_entry_syscall_enabled, switch_to_new_elf_parser,
+            error_on_syscall_bpf_function_hash_collisions, get_stake_history_entry_syscall_enabled,
+            last_restart_slot_sysvar, reject_callx_r10, remaining_compute_units_syscall_enabled,
+            switch_to_new_elf_parser,
         },
         hash::{Hash, Hasher},
         instruction::{AccountMeta, InstructionError, ProcessedSiblingInstruction},
@@ -262,8 +262,8 @@ pub fn create_program_runtime_environment_v1<'a>(
     let enable_poseidon_syscall = feature_set.is_active(&enable_poseidon_syscall::id());
     let remaining_compute_units_syscall_enabled =
         feature_set.is_active(&remaining_compute_units_syscall_enabled::id());
-    let stake_history_get_entry_syscall_enabled =
-        feature_set.is_active(&stake_history_get_entry_syscall_enabled::id());
+    let get_stake_history_entry_syscall_enabled =
+        feature_set.is_active(&get_stake_history_entry_syscall_enabled::id());
     // !!! ATTENTION !!!
     // When adding new features for RBPF here,
     // also add them to `Bank::apply_builtin_program_feature_transitions()`.
@@ -453,9 +453,9 @@ pub fn create_program_runtime_environment_v1<'a>(
     // StakeHistoryEntry getter
     register_feature_gated_function!(
         result,
-        stake_history_get_entry_syscall_enabled,
-        *b"sol_stake_history_get_entry",
-        SyscallStakeHistoryGetEntry::vm,
+        get_stake_history_entry_syscall_enabled,
+        *b"sol_get_stake_history_entry",
+        SyscallGetStakeHistoryEntry::vm,
     )?;
 
     // Log data

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -7,6 +7,7 @@ pub use self::{
     sysvar::{
         SyscallGetClockSysvar, SyscallGetEpochRewardsSysvar, SyscallGetEpochScheduleSysvar,
         SyscallGetFeesSysvar, SyscallGetLastRestartSlotSysvar, SyscallGetRentSysvar,
+        SyscallStakeHistoryGetEntry,
     },
 };
 #[allow(deprecated)]
@@ -39,7 +40,8 @@ use {
             enable_alt_bn128_compression_syscall, enable_alt_bn128_syscall,
             enable_big_mod_exp_syscall, enable_partitioned_epoch_reward, enable_poseidon_syscall,
             error_on_syscall_bpf_function_hash_collisions, last_restart_slot_sysvar,
-            reject_callx_r10, remaining_compute_units_syscall_enabled, switch_to_new_elf_parser,
+            reject_callx_r10, remaining_compute_units_syscall_enabled,
+            stake_history_get_entry_syscall_enabled, switch_to_new_elf_parser,
         },
         hash::{Hash, Hasher},
         instruction::{AccountMeta, InstructionError, ProcessedSiblingInstruction},
@@ -260,6 +262,8 @@ pub fn create_program_runtime_environment_v1<'a>(
     let enable_poseidon_syscall = feature_set.is_active(&enable_poseidon_syscall::id());
     let remaining_compute_units_syscall_enabled =
         feature_set.is_active(&remaining_compute_units_syscall_enabled::id());
+    let stake_history_get_entry_syscall_enabled =
+        feature_set.is_active(&stake_history_get_entry_syscall_enabled::id());
     // !!! ATTENTION !!!
     // When adding new features for RBPF here,
     // also add them to `Bank::apply_builtin_program_feature_transitions()`.
@@ -444,6 +448,14 @@ pub fn create_program_runtime_environment_v1<'a>(
         enable_alt_bn128_compression_syscall,
         *b"sol_alt_bn128_compression",
         SyscallAltBn128Compression::vm,
+    )?;
+
+    // StakeHistoryEntry getter
+    register_feature_gated_function!(
+        result,
+        stake_history_get_entry_syscall_enabled,
+        *b"sol_stake_history_get_entry",
+        SyscallStakeHistoryGetEntry::vm,
     )?;
 
     // Log data

--- a/programs/bpf_loader/src/syscalls/sysvar.rs
+++ b/programs/bpf_loader/src/syscalls/sysvar.rs
@@ -1,4 +1,7 @@
-use super::*;
+use {
+    super::*,
+    solana_sdk::stake_history::{StakeHistoryEntry, StakeHistoryGetEntry},
+};
 
 fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
     sysvar: Result<Arc<T>, InstructionError>,
@@ -154,5 +157,38 @@ declare_builtin_function!(
             memory_mapping,
             invoke_context,
         )
+    }
+);
+
+declare_builtin_function!(
+    /// Get a StakeHistoryEntry at a given epoch
+    SyscallStakeHistoryGetEntry,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        var_addr: u64,
+        epoch: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        consume_compute_meter(
+            invoke_context,
+            invoke_context
+                .get_compute_budget()
+                .sysvar_base_cost
+                .saturating_add(size_of::<Option<StakeHistoryEntry>>() as u64),
+        )?;
+
+        let stake_history = invoke_context.get_sysvar_cache().get_stake_history()?;
+        let var = translate_type_mut::<Option<StakeHistoryEntry>>(
+            memory_mapping,
+            var_addr,
+            invoke_context.get_check_aligned(),
+        )?;
+
+        *var = stake_history.get_entry(epoch);
+
+        Ok(SUCCESS)
     }
 );

--- a/programs/bpf_loader/src/syscalls/sysvar.rs
+++ b/programs/bpf_loader/src/syscalls/sysvar.rs
@@ -162,7 +162,7 @@ declare_builtin_function!(
 
 declare_builtin_function!(
     /// Get a StakeHistoryEntry at a given epoch
-    SyscallStakeHistoryGetEntry,
+    SyscallGetStakeHistoryEntry,
     fn rust(
         invoke_context: &mut InvokeContext,
         var_addr: u64,

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -24,7 +24,7 @@ use {
             stake_flags::StakeFlags,
             tools::{acceptable_reference_epoch_credits, eligible_for_deactivate_delinquent},
         },
-        stake_history::{StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry},
+        stake_history::{StakeHistory, StakeHistoryEntry},
         transaction_context::{
             BorrowedAccount, IndexOfAccount, InstructionContext, TransactionContext,
         },

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -24,7 +24,7 @@ use {
             stake_flags::StakeFlags,
             tools::{acceptable_reference_epoch_credits, eligible_for_deactivate_delinquent},
         },
-        stake_history::{StakeHistory, StakeHistoryEntry},
+        stake_history::{StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry},
         transaction_context::{
             BorrowedAccount, IndexOfAccount, InstructionContext, TransactionContext,
         },

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -24,7 +24,7 @@ use {
             stake_flags::StakeFlags,
             tools::{acceptable_reference_epoch_credits, eligible_for_deactivate_delinquent},
         },
-        stake_history::{StakeHistory, StakeHistoryEntry},
+        stake_history::{StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry},
         transaction_context::{
             BorrowedAccount, IndexOfAccount, InstructionContext, TransactionContext,
         },
@@ -1979,7 +1979,7 @@ mod tests {
         }
 
         for epoch in 0..=stake.deactivation_epoch + 1 {
-            let history = stake_history.get(epoch).unwrap();
+            let history = stake_history.get_entry(epoch).unwrap();
             let other_activations: u64 = other_activations[..=epoch as usize].iter().sum();
             let expected_stake = history.effective - base_stake - other_activations;
             let (expected_activating, expected_deactivating) = if epoch < stake.deactivation_epoch {

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -24,7 +24,7 @@ use {
             stake_flags::StakeFlags,
             tools::{acceptable_reference_epoch_credits, eligible_for_deactivate_delinquent},
         },
-        stake_history::{StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry},
+        stake_history::{StakeHistory, StakeHistoryEntry},
         transaction_context::{
             BorrowedAccount, IndexOfAccount, InstructionContext, TransactionContext,
         },
@@ -1405,6 +1405,7 @@ mod tests {
             epoch_schedule::EpochSchedule,
             pubkey::Pubkey,
             stake::state::warmup_cooldown_rate,
+            stake_history::StakeHistoryGetEntry,
             sysvar::{epoch_schedule, SysvarId},
         },
         test_case::test_case,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -51,7 +51,7 @@ use {
         serde_snapshot::BankIncrementalSnapshotPersistence,
         snapshot_hash::SnapshotHash,
         stake_account::StakeAccount,
-        stake_history::StakeHistory,
+        stake_history::{StakeHistory, StakeHistoryGetEntry},
         stake_weighted_timestamp::{
             calculate_stake_weighted_timestamp, MaxAllowableDrift,
             MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2,
@@ -2453,7 +2453,7 @@ impl Bank {
             .fetch_add(validator_rewards_paid, Relaxed);
 
         let active_stake = if let Some(stake_history_entry) =
-            self.stakes_cache.stakes().history().get(prev_epoch)
+            self.stakes_cache.stakes().history().get_entry(prev_epoch)
         {
             stake_history_entry.effective
         } else {
@@ -2566,7 +2566,7 @@ impl Bank {
             .fetch_add(validator_rewards_paid, Relaxed);
 
         let active_stake = if let Some(stake_history_entry) =
-            self.stakes_cache.stakes().history().get(prev_epoch)
+            self.stakes_cache.stakes().history().get_entry(prev_epoch)
         {
             stake_history_entry.effective
         } else {

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -99,7 +99,7 @@ mod tests {
         let mut stake_history_inner = StakeHistoryInner::default();
         (2134..).take(11).for_each(|epoch| {
             let entry = rand_stake_history_entry();
-            stake_history_outer.add(epoch, entry.clone());
+            stake_history_outer.add(epoch, entry);
             stake_history_inner.add(epoch, entry);
         });
 

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -1,8 +1,14 @@
 //! This module implements clone-on-write semantics for the SDK's `StakeHistory` to reduce
 //! unnecessary cloning of the underlying vector.
-use std::{
-    ops::{Deref, DerefMut},
-    sync::Arc,
+use {
+    solana_sdk::{
+        clock::Epoch,
+        stake_history::{StakeHistoryEntry, StakeHistoryGetEntry},
+    },
+    std::{
+        ops::{Deref, DerefMut},
+        sync::Arc,
+    },
 };
 
 /// The SDK's stake history with clone-on-write semantics
@@ -19,6 +25,12 @@ impl Deref for StakeHistory {
 impl DerefMut for StakeHistory {
     fn deref_mut(&mut self) -> &mut Self::Target {
         Arc::make_mut(&mut self.0)
+    }
+}
+
+impl StakeHistoryGetEntry for StakeHistory {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        self.0.get_entry(epoch)
     }
 }
 

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -29,7 +29,7 @@ impl DerefMut for StakeHistory {
 }
 
 impl StakeHistoryGetEntry for StakeHistory {
-    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+    fn get_entry(&self, epoch: Epoch) -> Option<&StakeHistoryEntry> {
         self.0.get_entry(epoch)
     }
 }

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -27,7 +27,7 @@ impl DerefMut for StakeHistory {
 }
 
 impl StakeHistoryGetEntry for StakeHistory {
-    fn get_entry(&self, epoch: Epoch) -> Option<&StakeHistoryEntry> {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
         self.0.get_entry(epoch)
     }
 }

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -1,10 +1,8 @@
 //! This module implements clone-on-write semantics for the SDK's `StakeHistory` to reduce
 //! unnecessary cloning of the underlying vector.
+pub use solana_sdk::stake_history::StakeHistoryGetEntry;
 use {
-    solana_sdk::{
-        clock::Epoch,
-        stake_history::{StakeHistoryEntry, StakeHistoryGetEntry},
-    },
+    solana_sdk::{clock::Epoch, stake_history::StakeHistoryEntry},
     std::{
         ops::{Deref, DerefMut},
         sync::Arc,

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -99,7 +99,7 @@ mod tests {
         let mut stake_history_inner = StakeHistoryInner::default();
         (2134..).take(11).for_each(|epoch| {
             let entry = rand_stake_history_entry();
-            stake_history_outer.add(epoch, entry);
+            stake_history_outer.add(epoch, entry.clone());
             stake_history_inner.add(epoch, entry);
         });
 

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -61,6 +61,9 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_get_last_restart_slot(&self, _var_addr: *mut u8) -> u64 {
         UNSUPPORTED_SYSVAR
     }
+    fn sol_stake_history_get_entry(&self, _var_addr: *mut u8, _epoch: u64) -> u64 {
+        UNSUPPORTED_SYSVAR
+    }
     /// # Safety
     unsafe fn sol_memcpy(&self, dst: *mut u8, src: *const u8, n: usize) {
         // cannot be overlapping
@@ -169,6 +172,13 @@ pub(crate) fn sol_get_last_restart_slot(var_addr: *mut u8) -> u64 {
         .read()
         .unwrap()
         .sol_get_last_restart_slot(var_addr)
+}
+
+pub(crate) fn sol_stake_history_get_entry(var_addr: *mut u8, epoch: u64) -> u64 {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_stake_history_get_entry(var_addr, epoch)
 }
 
 pub(crate) fn sol_memcpy(dst: *mut u8, src: *const u8, n: usize) {

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -61,7 +61,7 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_get_last_restart_slot(&self, _var_addr: *mut u8) -> u64 {
         UNSUPPORTED_SYSVAR
     }
-    fn sol_stake_history_get_entry(&self, _var_addr: *mut u8, _epoch: u64) -> u64 {
+    fn sol_get_stake_history_entry(&self, _var_addr: *mut u8, _epoch: u64) -> u64 {
         UNSUPPORTED_SYSVAR
     }
     /// # Safety
@@ -174,11 +174,11 @@ pub(crate) fn sol_get_last_restart_slot(var_addr: *mut u8) -> u64 {
         .sol_get_last_restart_slot(var_addr)
 }
 
-pub(crate) fn sol_stake_history_get_entry(var_addr: *mut u8, epoch: u64) -> u64 {
+pub(crate) fn sol_get_stake_history_entry(var_addr: *mut u8, epoch: u64) -> u64 {
     SYSCALL_STUBS
         .read()
         .unwrap()
-        .sol_stake_history_get_entry(var_addr, epoch)
+        .sol_get_stake_history_entry(var_addr, epoch)
 }
 
 pub(crate) fn sol_memcpy(dst: *mut u8, src: *const u8, n: usize) {

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -12,7 +12,7 @@ use {
             instruction::{LockupArgs, StakeError},
             stake_flags::StakeFlags,
         },
-        stake_history::{StakeHistory, StakeHistoryEntry},
+        stake_history::{StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry},
     },
     borsh::{io, BorshDeserialize, BorshSchema, BorshSerialize},
     std::collections::HashSet,
@@ -638,10 +638,10 @@ impl Delegation {
         self.activation_epoch == std::u64::MAX
     }
 
-    pub fn stake(
+    pub fn stake<T: StakeHistoryGetEntry>(
         &self,
         epoch: Epoch,
-        history: &StakeHistory,
+        history: &T,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> u64 {
         self.stake_activating_and_deactivating(epoch, history, new_rate_activation_epoch)
@@ -649,10 +649,10 @@ impl Delegation {
     }
 
     #[allow(clippy::comparison_chain)]
-    pub fn stake_activating_and_deactivating(
+    pub fn stake_activating_and_deactivating<T: StakeHistoryGetEntry>(
         &self,
         target_epoch: Epoch,
-        history: &StakeHistory,
+        history: &T,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> StakeActivationStatus {
         // first, calculate an effective and activating stake
@@ -674,7 +674,7 @@ impl Delegation {
             // can only deactivate what's activated
             StakeActivationStatus::with_deactivating(effective_stake)
         } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) = history
-            .get(self.deactivation_epoch)
+            .get_entry(self.deactivation_epoch)
             .map(|cluster_stake_at_deactivation_epoch| {
                 (
                     history,
@@ -719,7 +719,7 @@ impl Delegation {
                 if current_epoch >= target_epoch {
                     break;
                 }
-                if let Some(current_cluster_stake) = history.get(current_epoch) {
+                if let Some(current_cluster_stake) = history.get_entry(current_epoch) {
                     prev_epoch = current_epoch;
                     prev_cluster_stake = current_cluster_stake;
                 } else {
@@ -736,10 +736,10 @@ impl Delegation {
     }
 
     // returned tuple is (effective, activating) stake
-    fn stake_and_activating(
+    fn stake_and_activating<T: StakeHistoryGetEntry>(
         &self,
         target_epoch: Epoch,
-        history: &StakeHistory,
+        history: &T,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> (u64, u64) {
         let delegated_stake = self.stake;
@@ -758,7 +758,7 @@ impl Delegation {
             // not yet enabled
             (0, 0)
         } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) = history
-            .get(self.activation_epoch)
+            .get_entry(self.activation_epoch)
             .map(|cluster_stake_at_activation_epoch| {
                 (
                     history,
@@ -804,7 +804,7 @@ impl Delegation {
                 if current_epoch >= target_epoch || current_epoch >= self.deactivation_epoch {
                     break;
                 }
-                if let Some(current_cluster_stake) = history.get(current_epoch) {
+                if let Some(current_cluster_stake) = history.get_entry(current_epoch) {
                     prev_epoch = current_epoch;
                     prev_cluster_stake = current_cluster_stake;
                 } else {

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -12,7 +12,7 @@ use {
             instruction::{LockupArgs, StakeError},
             stake_flags::StakeFlags,
         },
-        stake_history::{StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry},
+        stake_history::{StakeHistoryEntry, StakeHistoryGetEntry},
     },
     borsh::{io, BorshDeserialize, BorshSchema, BorshSerialize},
     std::collections::HashSet,

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -917,10 +917,10 @@ pub struct Stake {
 }
 
 impl Stake {
-    pub fn stake(
+    pub fn stake<T: StakeHistoryGetEntry>(
         &self,
         epoch: Epoch,
-        history: &StakeHistory,
+        history: &T,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> u64 {
         self.delegation

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -66,6 +66,8 @@ impl std::ops::Add for StakeHistoryEntry {
 pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);
 
 impl StakeHistory {
+    // deprecated due to naming clash with `Sysvar::get()`
+    #[deprecated(note = "Please use `get_entry` instead")]
     pub fn get(&self, epoch: Epoch) -> Option<&StakeHistoryEntry> {
         self.binary_search_by(|probe| epoch.cmp(&probe.0))
             .ok()

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -132,7 +132,6 @@ mod tests {
     #[test]
     fn test_stake_history() {
         let mut stake_history = StakeHistory::default();
-
         for i in 0..MAX_ENTRIES as u64 + 1 {
             stake_history.add(
                 i,
@@ -142,15 +141,18 @@ mod tests {
                 },
             );
         }
+
         assert_eq!(stake_history.len(), MAX_ENTRIES);
         assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
+
         assert_eq!(stake_history.get_entry(0), None);
-        assert_eq!(
-            stake_history.get_entry(1),
-            Some(StakeHistoryEntry {
-                activating: 1,
+        for i in 1..MAX_ENTRIES as u64 + 1 {
+            let expected = Some(StakeHistoryEntry {
+                activating: i,
                 ..StakeHistoryEntry::default()
-            })
-        );
+            });
+
+            assert_eq!(stake_history.get_entry(i), expected);
+        }
     }
 }

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -119,7 +119,22 @@ impl StakeHistoryGetEntry for StakeHistory {
 
 impl StakeHistoryGetEntry for StakeHistorySyscall {
     fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
-        unimplemented!()
+        let mut var = None;
+        let var_addr = &mut var as *mut _ as *mut u8;
+
+        #[cfg(target_os = "solana")]
+        msg!("HANA running on solana");
+        #[cfg(target_os = "solana")]
+        let result = unsafe { crate::syscalls::sol_stake_history_get_entry(var_addr, epoch) };
+
+        #[cfg(not(target_os = "solana"))]
+        let result = unimplemented!(); // XXX crate::program_stubs::sol_stake_history_get_entry(var_addr, epoch);
+
+        // HANA i dislike how this swallows errors but im not sure we really want to return Result<Option<_>, _>
+        match result {
+            crate::entrypoint::SUCCESS => var,
+            e => None,
+        }
     }
 }
 

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -119,21 +119,20 @@ impl StakeHistoryGetEntry for StakeHistory {
 
 impl StakeHistoryGetEntry for StakeHistorySyscall {
     fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        // HANA im gonna be honest i dont understand why we cast to a u8 pointer
         let mut var = None;
         let var_addr = &mut var as *mut _ as *mut u8;
 
         #[cfg(target_os = "solana")]
-        msg!("HANA running on solana");
-        #[cfg(target_os = "solana")]
         let result = unsafe { crate::syscalls::sol_stake_history_get_entry(var_addr, epoch) };
 
         #[cfg(not(target_os = "solana"))]
-        let result = unimplemented!(); // XXX crate::program_stubs::sol_stake_history_get_entry(var_addr, epoch);
+        let result = crate::program_stubs::sol_stake_history_get_entry(var_addr, epoch);
 
         // HANA i dislike how this swallows errors but im not sure we really want to return Result<Option<_>, _>
         match result {
             crate::entrypoint::SUCCESS => var,
-            e => None,
+            _ => None,
         }
     }
 }

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -105,10 +105,10 @@ impl StakeHistoryGetEntry for StakeHistorySyscall {
         let var_addr = &mut var as *mut _ as *mut u8;
 
         #[cfg(target_os = "solana")]
-        let result = unsafe { crate::syscalls::sol_stake_history_get_entry(var_addr, epoch) };
+        let result = unsafe { crate::syscalls::sol_get_stake_history_entry(var_addr, epoch) };
 
         #[cfg(not(target_os = "solana"))]
-        let result = crate::program_stubs::sol_stake_history_get_entry(var_addr, epoch);
+        let result = crate::program_stubs::sol_get_stake_history_entry(var_addr, epoch);
 
         // HANA i dislike how this swallows errors but im not sure we really want to return Result<Option<_>, _>
         match result {

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -11,7 +11,7 @@ use std::{ops::Deref, sync::Arc};
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, Copy, AbiExample)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, AbiExample)]
 pub struct StakeHistoryEntry {
     pub effective: u64,    // effective stake at this epoch
     pub activating: u64,   // sum of portion of stakes not fully warmed up
@@ -94,7 +94,7 @@ impl StakeHistoryGetEntry for StakeHistory {
     fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
         self.binary_search_by(|probe| epoch.cmp(&probe.0))
             .ok()
-            .map(|index| self[index].1)
+            .map(|index| self[index].1.clone())
     }
 }
 
@@ -144,10 +144,10 @@ mod tests {
         }
         assert_eq!(stake_history.len(), MAX_ENTRIES);
         assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
-        assert_eq!(stake_history.get(0), None);
+        assert_eq!(stake_history.get_entry(0), None);
         assert_eq!(
-            stake_history.get(1),
-            Some(&StakeHistoryEntry {
+            stake_history.get_entry(1),
+            Some(StakeHistoryEntry {
                 activating: 1,
                 ..StakeHistoryEntry::default()
             })

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -129,10 +129,10 @@ impl StakeHistoryGetEntry for Arc<StakeHistory> {
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Zeroable, Pod)]
 struct StakeHistoryEpochEntry {
-    pub epoch: Epoch,
-    pub effective: u64,
-    pub activating: u64,
-    pub deactivating: u64,
+    epoch: Epoch,
+    effective: u64,
+    activating: u64,
+    deactivating: u64,
 }
 
 impl StakeHistoryGetEntry for StakeHistoryData<'_> {

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -223,7 +223,7 @@ mod tests {
         );
         stake_history.to_account_info(&mut account_info).unwrap();
 
-        let stake_history_data = StakeHistoryData::from_account_info(&account_info);
+        let stake_history_data = StakeHistoryData::from_account_info(&account_info).unwrap();
 
         assert_eq!(stake_history_data.get_entry(0), None);
         assert_eq!(

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -7,7 +7,10 @@
 //! [`sysvar::stake_history`]: crate::sysvar::stake_history
 
 pub use crate::clock::Epoch;
-use std::ops::Deref;
+use {
+    crate::{account_info::AccountInfo, serialize_utils::cursor::read_u64},
+    std::{cell::RefCell, io::Cursor, ops::Deref, rc::Rc, sync::Arc},
+};
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 
@@ -81,9 +84,80 @@ impl Deref for StakeHistory {
     }
 }
 
+// HANA my stuff below
+
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
+pub struct StakeHistoryData<'a>(Rc<RefCell<&'a mut [u8]>>);
+
+impl<'a> StakeHistoryData<'a> {
+    pub fn from_account_info(account_info: &AccountInfo<'a>) -> StakeHistoryData<'a> {
+        // TODO check address
+        StakeHistoryData(account_info.data.clone())
+    }
+}
+
+// HANA i would like to change this to Option<&StakeHistoryEntry> but the types are complicated
+// i dont think its possible to take a reference to the data inside the RefCell
+// i also dont think theres any way to heap allocation in my new impl and get a normal reference
+// and i dont think theres a way to use something like AsRef to let me box my new one and not the old one
+// and anyway callers of the old one wouldnt have a type specialized to normal reference
+// so really i would need like... hmm i can put `ReturnType: AsRef<StakeHistoryEntry>`
+// and have each impl define its own return, Option<&StakeHistoryEntry> or Option<Box<StakeHistoryEntry>>
+pub trait StakeHistoryGetEntry {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry>;
+}
+
+impl StakeHistoryGetEntry for StakeHistory {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        self.binary_search_by(|probe| epoch.cmp(&probe.0))
+            .ok()
+            .map(|index| self[index].1.clone())
+    }
+}
+
+// HANA this is only required as long as we use the sysvar cache
+impl StakeHistoryGetEntry for Arc<StakeHistory> {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        self.deref().get_entry(epoch)
+    }
+}
+
+impl StakeHistoryGetEntry for StakeHistoryData<'_> {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        // TODO binary search
+        let data = self.0.borrow();
+        let mut cursor = Cursor::new(&*data);
+        let entry_count = read_u64(&mut cursor).unwrap();
+
+        for _ in 0..entry_count {
+            // TODO skip reading next three and just adjust the cursor
+            let entry_epoch = read_u64(&mut cursor).unwrap();
+            let effective = read_u64(&mut cursor).unwrap();
+            let activating = read_u64(&mut cursor).unwrap();
+            let deactivating = read_u64(&mut cursor).unwrap();
+
+            if epoch == entry_epoch {
+                return Some(StakeHistoryEntry {
+                    effective,
+                    activating,
+                    deactivating,
+                });
+            }
+        }
+
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {
+        super::*,
+        crate::{
+            pubkey::Pubkey,
+            sysvar::{Sysvar, SysvarId},
+        },
+    };
 
     #[test]
     fn test_stake_history() {
@@ -100,10 +174,55 @@ mod tests {
         }
         assert_eq!(stake_history.len(), MAX_ENTRIES);
         assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
-        assert_eq!(stake_history.get(0), None);
+        assert_eq!(stake_history.get_entry(0), None);
         assert_eq!(
-            stake_history.get(1),
-            Some(&StakeHistoryEntry {
+            stake_history.get_entry(1),
+            Some(StakeHistoryEntry {
+                activating: 1,
+                ..StakeHistoryEntry::default()
+            })
+        );
+    }
+
+    #[test]
+    fn test_stake_history_data() {
+        let mut stake_history = StakeHistory::default();
+
+        for i in 0..MAX_ENTRIES as u64 + 1 {
+            stake_history.add(
+                i,
+                StakeHistoryEntry {
+                    activating: i,
+                    ..StakeHistoryEntry::default()
+                },
+            );
+        }
+
+        assert_eq!(stake_history.len(), MAX_ENTRIES);
+        assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
+
+        let id = StakeHistory::id();
+        let mut lamports = 0;
+        let mut data = vec![0; StakeHistory::size_of()];
+        let owner = Pubkey::default();
+        let mut account_info = AccountInfo::new(
+            &id,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &owner,
+            false,
+            0,
+        );
+        stake_history.to_account_info(&mut account_info).unwrap();
+
+        let stake_history_data = StakeHistoryData::from_account_info(&account_info);
+
+        assert_eq!(stake_history_data.get_entry(0), None);
+        assert_eq!(
+            stake_history_data.get_entry(1),
+            Some(StakeHistoryEntry {
                 activating: 1,
                 ..StakeHistoryEntry::default()
             })

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -72,6 +72,7 @@ define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
 define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_remaining_compute_units() -> u64);
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
+define_syscall!(fn sol_stake_history_get_entry(addr: *mut u8, epoch: u64) -> u64);
 
 #[cfg(target_feature = "static-syscalls")]
 pub const fn sys_hash(name: &str) -> usize {

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -72,7 +72,7 @@ define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
 define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_remaining_compute_units() -> u64);
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
-define_syscall!(fn sol_stake_history_get_entry(addr: *mut u8, epoch: u64) -> u64);
+define_syscall!(fn sol_get_stake_history_entry(addr: *mut u8, epoch: u64) -> u64);
 
 #[cfg(target_feature = "static-syscalls")]
 pub const fn sys_hash(name: &str) -> usize {

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -95,10 +95,10 @@ mod tests {
         }
         assert_eq!(stake_history.len(), MAX_ENTRIES);
         assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
-        assert_eq!(stake_history.get(0), None);
+        assert_eq!(stake_history.get_entry(0), None);
         assert_eq!(
-            stake_history.get(1),
-            Some(&StakeHistoryEntry {
+            stake_history.get_entry(1),
+            Some(StakeHistoryEntry {
                 activating: 1,
                 ..StakeHistoryEntry::default()
             })

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -93,15 +93,18 @@ mod tests {
                 },
             );
         }
+
         assert_eq!(stake_history.len(), MAX_ENTRIES);
         assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
+
         assert_eq!(stake_history.get_entry(0), None);
-        assert_eq!(
-            stake_history.get_entry(1),
-            Some(StakeHistoryEntry {
-                activating: 1,
+        for i in 1..MAX_ENTRIES as u64 + 1 {
+            let expected = Some(StakeHistoryEntry {
+                activating: i,
                 ..StakeHistoryEntry::default()
-            })
-        );
+            });
+
+            assert_eq!(stake_history.get_entry(i), expected.as_ref());
+        }
     }
 }

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -104,7 +104,7 @@ mod tests {
                 ..StakeHistoryEntry::default()
             });
 
-            assert_eq!(stake_history.get_entry(i), expected.as_ref());
+            assert_eq!(stake_history.get_entry(i), expected);
         }
     }
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -780,7 +780,7 @@ pub mod remove_rounding_in_fee_calculation {
     solana_sdk::declare_id!("BtVN7YjDzNE6Dk7kTT7YTDgMNUZTNgiSJgsdzAeTg2jF");
 }
 
-pub mod stake_history_get_entry_syscall_enabled {
+pub mod get_stake_history_entry_syscall_enabled {
     solana_sdk::declare_id!("CLCoTADvV64PSrnR6QXty6Fwrt9Xc6EdxSJE4wLRePjq");
 }
 
@@ -974,7 +974,7 @@ lazy_static! {
         (enable_gossip_duplicate_proof_ingestion::id(), "enable gossip duplicate proof ingestion #32963"),
         (enable_chained_merkle_shreds::id(), "Enable chained Merkle shreds #34916"),
         (remove_rounding_in_fee_calculation::id(), "Removing unwanted rounding in fee calculation #34982"),
-        (stake_history_get_entry_syscall_enabled::id(), "Enable syscall for fetching StakeHistoryEntry by epoch #XXXXX"), // HANA
+        (get_stake_history_entry_syscall_enabled::id(), "Enable syscall for fetching StakeHistoryEntry by epoch #XXXXX"), // HANA
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -780,6 +780,10 @@ pub mod remove_rounding_in_fee_calculation {
     solana_sdk::declare_id!("BtVN7YjDzNE6Dk7kTT7YTDgMNUZTNgiSJgsdzAeTg2jF");
 }
 
+pub mod stake_history_get_entry_syscall_enabled {
+    solana_sdk::declare_id!("CLCoTADvV64PSrnR6QXty6Fwrt9Xc6EdxSJE4wLRePjq");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -970,6 +974,7 @@ lazy_static! {
         (enable_gossip_duplicate_proof_ingestion::id(), "enable gossip duplicate proof ingestion #32963"),
         (enable_chained_merkle_shreds::id(), "Enable chained Merkle shreds #34916"),
         (remove_rounding_in_fee_calculation::id(), "Removing unwanted rounding in fee calculation #34982"),
+        (stake_history_get_entry_syscall_enabled::id(), "Enable syscall for fetching StakeHistoryEntry by epoch #XXXXX"), // HANA
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
we are porting the stake program to bpf, and several instructions require (read-only) access to `StakeHistory` to be able to determine whether stake is active. this presents two problems:
* `StakeHistory` is 16kb, and we would prefer not to deserialize the entire struct to access, in nearly 100% of cases, one single 32 byte `StakeHistoryEntry`. previously this was not an issue because the native program could just use the already parsed struct from `SysvarCache`
* more importantly, `StakeInstruction::Split` has a dependency on `StakeHistory` introduced by `feature_set::require_rent_exempt_split_destination`, but does not pass in the account, so we need an out of band way to retrieve it to avoid breaking backwards compat

#### Summary of Changes
this introduces a new syscall, `SyscallStakeHistoryGetEntry`, which performs the equivalent of `StakeHistory::get()` using the `StakeHistory` from `SysvarCache`

we also introduce a new trait, `StakeHistoryGetEntry`, which provides `get_entry()`, a replacement for `get()`. we implement this for all existing versions of `StakeHistory` and a new dummy struct `StakeHistorySyscall` which wraps the syscall. key functions on `Delegation` are modified to accept `<T: StakeHistoryGetEntry>`

we also deprecate `get()` for cleanliness sake

(TODO this requires a simd and a feature gate issue, also remember to put the issue number in the code)