### PR TITLE
allow FlushStats to accumulate

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1721,6 +1721,14 @@ struct FlushStats {
     total_size: u64,
 }
 
+impl FlushStats {
+    fn accumulate(&mut self, other: &Self) {
+        saturating_add_assign!(self.num_flushed, other.num_flushed);
+        saturating_add_assign!(self.num_purged, other.num_purged);
+        saturating_add_assign!(self.total_size, other.total_size);
+    }
+}
+
 #[derive(Debug, Default)]
 struct LatestAccountsIndexRootsStats {
     roots_len: AtomicUsize,
@@ -6078,9 +6086,7 @@ impl AccountsDb {
                 if old_slot > max_flushed_root {
                     if self.should_aggressively_flush_cache() {
                         if let Some(stats) = self.flush_slot_cache(old_slot) {
-                            flush_stats.num_flushed += stats.num_flushed;
-                            flush_stats.num_purged += stats.num_purged;
-                            flush_stats.total_size += stats.total_size;
+                            flush_stats.accumulate(&stats);
                         }
                     }
                 } else {


### PR DESCRIPTION
#### Problem
Stats on the cost to store accounts and update the index for flushing are poor.
Better stats on flush will help us evaluate performance issues with writing to storage, updating the index, etc.

#### Summary of Changes
Add the ability to accumulate `FlushStats`. This will be useful when we return `FlushStats` from more places and flush many slots one after the other.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
