### PR TITLE
Share the threadpool for tx execution and entry verifification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6613,6 +6613,7 @@ dependencies = [
  "solana-logger",
  "solana-measure",
  "solana-perf",
+ "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-version",
 ]

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -786,7 +786,7 @@ mod tests {
         crate::banking_trace::{BankingPacketBatch, BankingTracer},
         crossbeam_channel::{unbounded, Receiver},
         itertools::Itertools,
-        solana_entry::entry::{Entry, EntrySlice},
+        solana_entry::entry::{entry_thread_pool_for_tests, Entry, EntrySlice},
         solana_gossip::cluster_info::Node,
         solana_ledger::{
             blockstore::Blockstore,
@@ -941,7 +941,7 @@ mod tests {
                 .collect();
             trace!("done");
             assert_eq!(entries.len(), genesis_config.ticks_per_slot as usize);
-            assert!(entries.verify(&start_hash));
+            assert!(entries.verify(&start_hash, &entry_thread_pool_for_tests()));
             assert_eq!(entries[entries.len() - 1].hash, bank.last_blockhash());
             banking_stage.join().unwrap();
         }
@@ -1060,7 +1060,7 @@ mod tests {
                     .map(|(_bank, (entry, _tick_height))| entry)
                     .collect();
 
-                assert!(entries.verify(&blockhash));
+                assert!(entries.verify(&blockhash, &entry_thread_pool_for_tests()));
                 if !entries.is_empty() {
                     blockhash = entries.last().unwrap().hash;
                     for entry in entries {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -786,7 +786,7 @@ mod tests {
         crate::banking_trace::{BankingPacketBatch, BankingTracer},
         crossbeam_channel::{unbounded, Receiver},
         itertools::Itertools,
-        solana_entry::entry::{entry_thread_pool_for_tests, Entry, EntrySlice},
+        solana_entry::entry::{self, Entry, EntrySlice},
         solana_gossip::cluster_info::Node,
         solana_ledger::{
             blockstore::Blockstore,
@@ -941,7 +941,7 @@ mod tests {
                 .collect();
             trace!("done");
             assert_eq!(entries.len(), genesis_config.ticks_per_slot as usize);
-            assert!(entries.verify(&start_hash, &entry_thread_pool_for_tests()));
+            assert!(entries.verify(&start_hash, &entry::thread_pool_for_tests()));
             assert_eq!(entries[entries.len() - 1].hash, bank.last_blockhash());
             banking_stage.join().unwrap();
         }
@@ -1060,7 +1060,7 @@ mod tests {
                     .map(|(_bank, (entry, _tick_height))| entry)
                     .collect();
 
-                assert!(entries.verify(&blockhash, &entry_thread_pool_for_tests()));
+                assert!(entries.verify(&blockhash, &entry::thread_pool_for_tests()));
                 if !entries.is_empty() {
                     blockhash = entries.last().unwrap().hash;
                     for entry in entries {

--- a/entry/benches/entry_sigverify.rs
+++ b/entry/benches/entry_sigverify.rs
@@ -16,6 +16,7 @@ use {
 
 #[bench]
 fn bench_gpusigverify(bencher: &mut Bencher) {
+    let thread_pool = entry::thread_pool_for_benches();
     let entries = (0..131072)
         .map(|_| {
             let transaction = test_tx();
@@ -53,6 +54,7 @@ fn bench_gpusigverify(bencher: &mut Bencher) {
         let res = entry::start_verify_transactions(
             entries.clone(),
             false,
+            &thread_pool,
             recycler.clone(),
             Arc::new(verify_transaction),
         );
@@ -65,6 +67,7 @@ fn bench_gpusigverify(bencher: &mut Bencher) {
 
 #[bench]
 fn bench_cpusigverify(bencher: &mut Bencher) {
+    let thread_pool = entry::thread_pool_for_benches();
     let entries = (0..131072)
         .map(|_| {
             let transaction = test_tx();
@@ -89,6 +92,7 @@ fn bench_cpusigverify(bencher: &mut Bencher) {
     };
 
     bencher.iter(|| {
-        let _ans = entry::verify_transactions(entries.clone(), Arc::new(verify_transaction));
+        let _ans =
+            entry::verify_transactions(entries.clone(), &thread_pool, Arc::new(verify_transaction));
     })
 }

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -955,6 +955,10 @@ pub fn next_versioned_entry(
 }
 
 pub fn thread_pool_for_tests() -> ThreadPool {
+    // Allocate fewer threads for unit tests
+    // Unit tests typically aren't creating massive blocks to verify, and
+    // multiple tests could be running in parallel so any further parallelism
+    // will do more harm than good
     rayon::ThreadPoolBuilder::new()
         .num_threads(4)
         .thread_name(|i| format!("solEntryTest{i:02}"))

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -954,7 +954,7 @@ pub fn next_versioned_entry(
     }
 }
 
-pub fn entry_thread_pool_for_tests() -> ThreadPool {
+pub fn thread_pool_for_tests() -> ThreadPool {
     rayon::ThreadPoolBuilder::new()
         .num_threads(4)
         .thread_name(|i| format!("solEntryTest{i:02}"))
@@ -1061,7 +1061,7 @@ mod tests {
 
     #[test]
     fn test_entry_gpu_verify() {
-        let thread_pool = entry_thread_pool_for_tests();
+        let thread_pool = thread_pool_for_tests();
 
         let verify_transaction = {
             move |versioned_tx: VersionedTransaction,
@@ -1139,7 +1139,7 @@ mod tests {
 
     #[test]
     fn test_transaction_signing() {
-        let thread_pool = entry_thread_pool_for_tests();
+        let thread_pool = thread_pool_for_tests();
 
         use solana_sdk::signature::Signature;
         let zero = Hash::default();
@@ -1203,7 +1203,7 @@ mod tests {
     #[test]
     fn test_verify_slice1() {
         solana_logger::setup();
-        let thread_pool = entry_thread_pool_for_tests();
+        let thread_pool = thread_pool_for_tests();
 
         let zero = Hash::default();
         let one = hash(zero.as_ref());
@@ -1225,7 +1225,7 @@ mod tests {
     #[test]
     fn test_verify_slice_with_hashes1() {
         solana_logger::setup();
-        let thread_pool = entry_thread_pool_for_tests();
+        let thread_pool = thread_pool_for_tests();
 
         let zero = Hash::default();
         let one = hash(zero.as_ref());
@@ -1252,7 +1252,7 @@ mod tests {
     #[test]
     fn test_verify_slice_with_hashes_and_transactions() {
         solana_logger::setup();
-        let thread_pool = entry_thread_pool_for_tests();
+        let thread_pool = thread_pool_for_tests();
 
         let zero = Hash::default();
         let one = hash(zero.as_ref());
@@ -1421,7 +1421,7 @@ mod tests {
 
             info!("done.. {}", time);
             let mut time = Measure::start("poh");
-            let res = entries.verify(&Hash::default(), &entry_thread_pool_for_tests());
+            let res = entries.verify(&Hash::default(), &thread_pool_for_tests());
             assert_eq!(res, !modified);
             time.stop();
             info!("{} {}", time, res);

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -20,6 +20,7 @@ use {
         recycler::Recycler,
         sigverify,
     },
+    solana_rayon_threadlimit::get_max_thread_count,
     solana_sdk::{
         hash::Hash,
         packet::Meta,
@@ -957,6 +958,14 @@ pub fn entry_thread_pool_for_tests() -> ThreadPool {
     rayon::ThreadPoolBuilder::new()
         .num_threads(4)
         .thread_name(|i| format!("solEntryTest{i:02}"))
+        .build()
+        .expect("new rayon threadpool")
+}
+
+pub fn thread_pool_for_benches() -> ThreadPool {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(get_max_thread_count())
+        .thread_name(|i| format!("solEntryBnch{i:02}"))
         .build()
         .expect("new rayon threadpool")
 }

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -180,7 +180,7 @@ pub fn send_many_transactions(
 
 pub fn verify_ledger_ticks(ledger_path: &Path, ticks_per_slot: usize) {
     let ledger = Blockstore::open(ledger_path).unwrap();
-    let thread_pool = entry::entry_thread_pool_for_tests();
+    let thread_pool = entry::thread_pool_for_tests();
 
     let zeroth_slot = ledger.get_slot_entries(0, 0).unwrap();
     let last_id = zeroth_slot.last().unwrap().hash;

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -5,7 +5,7 @@
 use log::*;
 use {
     rand::{thread_rng, Rng},
-    rayon::prelude::*,
+    rayon::{prelude::*, ThreadPool},
     solana_client::{
         connection_cache::{ConnectionCache, Protocol},
         thin_client::ThinClient,
@@ -14,7 +14,7 @@ use {
         tower_storage::{FileTowerStorage, SavedTower, SavedTowerVersions, TowerStorage},
         VOTE_THRESHOLD_DEPTH,
     },
-    solana_entry::entry::{Entry, EntrySlice},
+    solana_entry::entry::{self, Entry, EntrySlice},
     solana_gossip::{
         cluster_info::{self, ClusterInfo},
         contact_info::{ContactInfo, LegacyContactInfo},
@@ -180,6 +180,8 @@ pub fn send_many_transactions(
 
 pub fn verify_ledger_ticks(ledger_path: &Path, ticks_per_slot: usize) {
     let ledger = Blockstore::open(ledger_path).unwrap();
+    let thread_pool = entry::entry_thread_pool_for_tests();
+
     let zeroth_slot = ledger.get_slot_entries(0, 0).unwrap();
     let last_id = zeroth_slot.last().unwrap().hash;
     let next_slots = ledger.get_slots_since(&[0]).unwrap().remove(&0).unwrap();
@@ -201,7 +203,7 @@ pub fn verify_ledger_ticks(ledger_path: &Path, ticks_per_slot: usize) {
             None
         };
 
-        let last_id = verify_slot_ticks(&ledger, slot, &last_id, should_verify_ticks);
+        let last_id = verify_slot_ticks(&ledger, &thread_pool, slot, &last_id, should_verify_ticks);
         pending_slots.extend(
             next_slots
                 .into_iter()
@@ -630,21 +632,23 @@ pub fn start_gossip_voter(
 
 fn get_and_verify_slot_entries(
     blockstore: &Blockstore,
+    thread_pool: &ThreadPool,
     slot: Slot,
     last_entry: &Hash,
 ) -> Vec<Entry> {
     let entries = blockstore.get_slot_entries(slot, 0).unwrap();
-    assert!(entries.verify(last_entry));
+    assert!(entries.verify(last_entry, thread_pool));
     entries
 }
 
 fn verify_slot_ticks(
     blockstore: &Blockstore,
+    thread_pool: &ThreadPool,
     slot: Slot,
     last_entry: &Hash,
     expected_num_ticks: Option<usize>,
 ) -> Hash {
-    let entries = get_and_verify_slot_entries(blockstore, slot, last_entry);
+    let entries = get_and_verify_slot_entries(blockstore, thread_pool, slot, last_entry);
     let num_ticks: usize = entries.iter().map(|entry| entry.is_tick() as usize).sum();
     if let Some(expected_num_ticks) = expected_num_ticks {
         assert_eq!(num_ticks, expected_num_ticks);

--- a/poh-bench/Cargo.toml
+++ b/poh-bench/Cargo.toml
@@ -17,6 +17,7 @@ solana-entry = { workspace = true }
 solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-perf = { workspace = true }
+solana-rayon-threadlimit = { workspace = true }
 solana-sdk = { workspace = true }
 solana-version = { workspace = true }
 

--- a/poh/benches/poh_verify.rs
+++ b/poh/benches/poh_verify.rs
@@ -2,7 +2,7 @@
 extern crate test;
 
 use {
-    solana_entry::entry::{next_entry_mut, Entry, EntrySlice},
+    solana_entry::entry::{self, next_entry_mut, Entry, EntrySlice},
     solana_sdk::{
         hash::{hash, Hash},
         signature::{Keypair, Signer},
@@ -17,6 +17,8 @@ const NUM_ENTRIES: usize = 800;
 #[bench]
 fn bench_poh_verify_ticks(bencher: &mut Bencher) {
     solana_logger::setup();
+    let thread_pool = entry::thread_pool_for_benches();
+
     let zero = Hash::default();
     let start_hash = hash(zero.as_ref());
     let mut cur_hash = start_hash;
@@ -27,12 +29,14 @@ fn bench_poh_verify_ticks(bencher: &mut Bencher) {
     }
 
     bencher.iter(|| {
-        assert!(ticks.verify(&start_hash));
+        assert!(ticks.verify(&start_hash, &thread_pool));
     })
 }
 
 #[bench]
 fn bench_poh_verify_transaction_entries(bencher: &mut Bencher) {
+    let thread_pool = entry::thread_pool_for_benches();
+
     let zero = Hash::default();
     let start_hash = hash(zero.as_ref());
     let mut cur_hash = start_hash;
@@ -47,6 +51,6 @@ fn bench_poh_verify_transaction_entries(bencher: &mut Bencher) {
     }
 
     bencher.iter(|| {
-        assert!(ticks.verify(&start_hash));
+        assert!(ticks.verify(&start_hash, &thread_pool));
     })
 }


### PR DESCRIPTION
#### Problem
Previously, entry verification had a dedicated threadpool used to verify PoH hashes as well as some basic transaction verification via `Bank::verify_transaction()`. It should also be noted that the entry verification code provides logic to offload to a GPU if one is present.

Regardless of whether a GPU is present or not, some of the verification must be done on a CPU. Moreso, the CPU verification of entries and transaction execution are serial operations; entry verification finishes first before moving onto transaction execution.

#### Summary of Changes
So, tx execution and entry verification are not competing for CPU cycles at the same time and can use the same pool.

One exception to the above statement is that if someone is using the feature to replay forks in parallel, then hypothetically, different forks may end up competing for the same resources at the same time. However, that is already true given that we had pools that were shared between replay of multiple forks. So, this change doesn't really change much for that case, but will reduce overhead in the single fork case which is the vast majority of the time.

This PR part of work for https://github.com/anza-xyz/agave/issues/35

#### Performance / Testing
In order to test, I got two identical nodes running against mnb (same DC / hardware / software). I then updated one node to pull in the extra commit to use same thread pool while other node stayed constant. This allows us to control for variations in timing data that naturally ebbs and flows with network activity. The nodes were running the same commit until about ~07:00 on March 21. At that point, one node was updated but both were restarted for the sake of keeping experiment as controlled as possible.

A couple relevant metrics that I'll highlight:
- `replay-slot-stats.entry_poh_verification_time`: time spent doing PoH verification
- `replay-slot-stats.entry_transaction_verification_time`: time spent verifying tx's
- `replay-slot-stats.confirmation_time_us`: time spent within `blockstore_processor::confirm()` slot, which is inclusive of above two numbers as well as everything else (fetching shreds, tx execution, etc)

Lastly, the cyan/light blue trace is the node with this branch whereas the purple trace is the control node.

**Figure 1: Mean PoH Verification Time**
<img width="1715" alt="image" src="https://github.com/anza-xyz/agave/assets/5400107/9167fb5f-3222-408e-9a6c-d220a89d1282">

**Figure 2: Mean Tx Verification Time**
<img width="1713" alt="image" src="https://github.com/anza-xyz/agave/assets/5400107/3ba9ef10-c903-4a21-b1e3-0c575a5273f6">

**Figure 3: Mean Confirmation Time**
<img width="1711" alt="image" src="https://github.com/anza-xyz/agave/assets/5400107/ceac2a81-036a-45a5-8e3a-b472c011d434">

Looking at these, the traces are very similar both before and after the update. This is pretty expected; we're still using the same number of threads for each operation. However, we're decreasing general system overhead by having fewer threads. But, if we turn up the averaging (via `group by`) to a larger value, we can that there does appear to be a very small performance improvement as well.

**Figure 4: Mean PoH Verification Time (6 hour buckets for `group by`)**
<img width="1714" alt="image" src="https://github.com/anza-xyz/agave/assets/5400107/88a6489f-5e38-43eb-b9cb-32734b1556b8">

**Figure 5: Mean Tx Verification Time (6 hour buckets for `group by`)**
<img width="1708" alt="image" src="https://github.com/anza-xyz/agave/assets/5400107/bb39e06f-cd39-4ab7-8d88-7b3fc8689dec">

**Figure 6: Mean Confirmation Time (6 hour buckets for `group by`)**
<img width="1717" alt="image" src="https://github.com/anza-xyz/agave/assets/5400107/f64128d6-3d81-4055-a4f6-85ccdb4789d1">

Figure 4 and 5 show that the gap increases between the traces. However, it should be called out that the difference is pretty small, maybe less than half a millisecond per each. The same trend is there for Figure 6; however, confirmation time is a larger chunk of time overall so these marginal differences are barely visible on the graph.