### PR TITLE
[anza migration]: fix download link for net scripts

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -563,7 +563,7 @@ prepareDeploy() {
     if [[ -n $releaseChannel ]]; then
       echo "Downloading release from channel: $releaseChannel"
       rm -f "$SOLANA_ROOT"/solana-release.tar.bz2
-      declare updateDownloadUrl=https://release.agave.xyz/"$releaseChannel"/solana-release-x86_64-unknown-linux-gnu.tar.bz2
+      declare updateDownloadUrl=https://release.anza.xyz/"$releaseChannel"/solana-release-x86_64-unknown-linux-gnu.tar.bz2
       (
         set -x
         curl -L -I "$updateDownloadUrl"

--- a/scripts/agave-install-deploy.sh
+++ b/scripts/agave-install-deploy.sh
@@ -57,7 +57,7 @@ esac
 
 case $TAG in
 edge|beta)
-  DOWNLOAD_URL=https://release.agave.xyz/"$TAG"/solana-release-$TARGET.tar.bz2
+  DOWNLOAD_URL=https://release.anza.xyz/"$TAG"/solana-release-$TARGET.tar.bz2
   ;;
 *)
   DOWNLOAD_URL=https://github.com/anza-xyz/agave/releases/download/"$TAG"/solana-release-$TARGET.tar.bz2


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/pull/204 introduced a wrong download link 😞 

#### Summary of Changes

correct it