### PR TITLE
support Pubkey::to_bytes as constexpr

### DIFF
--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -631,7 +631,7 @@ impl Pubkey {
         }
     }
 
-    pub fn to_bytes(self) -> [u8; 32] {
+    pub const fn to_bytes(self) -> [u8; 32] {
         self.0
     }
 


### PR DESCRIPTION
#### Problem

Cannot do compile-time tricks with static const pubkeys

#### Summary of Changes

Adds support for constexprs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
