### PR TITLE
[anza migration]: add 'agave=info' to default log level

### DIFF
--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -13,7 +13,7 @@ use {
 };
 
 fn main() {
-    solana_logger::setup_with_default("solana=info");
+    solana_logger::setup_with_default_filter();
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -168,7 +168,7 @@ fn create_client(
 }
 
 fn main() {
-    solana_logger::setup_with_default("solana=info");
+    solana_logger::setup_with_default_filter();
     solana_metrics::set_panic_hook("bench-tps", /*version:*/ None);
 
     let matches = cli::build_args(solana_version::version!()).get_matches();

--- a/cargo-registry/src/main.rs
+++ b/cargo-registry/src/main.rs
@@ -263,7 +263,7 @@ impl CargoRegistryService {
 
 #[tokio::main]
 async fn main() {
-    solana_logger::setup_with_default("solana=info");
+    solana_logger::setup_with_default_filter();
     let client = Arc::new(Client::new().expect("Failed to get RPC Client instance"));
 
     let bind_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), client.port);

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -759,7 +759,7 @@ fn run_dos<T: 'static + BenchTpsClient + Send + Sync>(
 }
 
 fn main() {
-    solana_logger::setup_with_default("solana=info");
+    solana_logger::setup_with_default_filter();
     let cmd_params = build_cli_parameters();
 
     let (nodes, client) = if !cmd_params.skip_gossip {

--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -19,7 +19,7 @@ use {
 async fn main() {
     let default_keypair = solana_cli_config::Config::default().keypair_path;
 
-    solana_logger::setup_with_default("solana=info");
+    solana_logger::setup_with_default_filter();
     solana_metrics::set_panic_hook("faucet", /*version:*/ None);
     let matches = App::new(crate_name!())
         .about(crate_description!())

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -326,7 +326,7 @@ fn process_rpc_url(
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
-    solana_logger::setup_with_default("solana=info");
+    solana_logger::setup_with_default_filter();
 
     let matches = parse_matches();
     let socket_addr_space = SocketAddrSpace::new(matches.is_present("allow_private_addr"));

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -555,7 +555,7 @@ fn main() {
     const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = std::usize::MAX;
     const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = std::usize::MAX;
 
-    solana_logger::setup_with_default("solana=info");
+    solana_logger::setup_with_default_filter();
 
     let no_snapshot_arg = Arg::with_name("no_snapshot")
         .long("no-snapshot")

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -10,6 +10,8 @@ lazy_static! {
         Arc::new(RwLock::new(env_logger::Logger::from_default_env()));
 }
 
+pub const DEFAULT_FILTER: &str = "solana=info,agave=info";
+
 struct LoggerShim {}
 
 impl log::Log for LoggerShim {
@@ -47,6 +49,11 @@ pub fn setup_with_default(filter: &str) {
         .format_timestamp_nanos()
         .build();
     replace_logger(logger);
+}
+
+// Configures logging with the `DEFAULT_FILTER` if RUST_LOG is not set
+pub fn setup_with_default_filter() {
+    setup_with_default(DEFAULT_FILTER);
 }
 
 // Configures logging with the default filter "error" if RUST_LOG is not set

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -37,7 +37,7 @@ $ok || {
   exit 1
 }
 
-export RUST_LOG=${RUST_LOG:-solana=info,solana_runtime::message_processor=debug} # if RUST_LOG is unset, default to info
+export RUST_LOG=${RUST_LOG:-solana=info,agave=info,solana_runtime::message_processor=debug} # if RUST_LOG is unset, default to info
 export RUST_BACKTRACE=1
 dataDir=$PWD/config/"$(basename "$0" .sh)"
 ledgerDir=$PWD/config/ledger

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -426,7 +426,7 @@ fn run_transactions_dos(
 }
 
 fn main() {
-    solana_logger::setup_with_default("solana=info");
+    solana_logger::setup_with_default_filter();
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -41,10 +41,9 @@ pub fn redirect_stderr_to_file(logfile: Option<String>) -> Option<JoinHandle<()>
         env::set_var("RUST_BACKTRACE", "1")
     }
 
-    let filter = "solana=info";
     match logfile {
         None => {
-            solana_logger::setup_with_default(filter);
+            solana_logger::setup_with_default_filter();
             None
         }
         Some(logfile) => {
@@ -58,7 +57,7 @@ pub fn redirect_stderr_to_file(logfile: Option<String>) -> Option<JoinHandle<()>
                             exit(1);
                         });
 
-                solana_logger::setup_with_default(filter);
+                solana_logger::setup_with_default_filter();
                 redirect_stderr(&logfile);
                 Some(
                     std::thread::Builder::new()

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -246,7 +246,7 @@ fn get_cluster_info(
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
-    solana_logger::setup_with_default("solana=info");
+    solana_logger::setup_with_default_filter();
     solana_metrics::set_panic_hook("watchtower", /*version:*/ None);
 
     let config = get_config();


### PR DESCRIPTION
#### Problem

`agave-validator`'s log doesn't print to file due to I don't set a proper default log level for it.

#### Summary of Changes

use `solana=info,agave=info` as our default log level filter.

---

cc @willhickey
