### PR TITLE
deps: Update base64 to 0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Release channels have their own copy of this changelog:
 ## [2.0.0] - Unreleased
 * Changes
   * `central-scheduler` as default option for `--block-production-method` (#34891)
+  * `solana-rpc-client-api`: `RpcFilterError` depends on `base64` version 0.22, so users may need to upgrade to `base64` version 0.22
 
 ## [1.18.0]
 * Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5315,7 +5321,7 @@ version = "2.0.0"
 dependencies = [
  "Inflector",
  "assert_matches",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bs58",
  "bv",
@@ -5818,7 +5824,7 @@ name = "solana-cli-output"
 version = "2.0.0"
 dependencies = [
  "Inflector",
- "base64 0.21.7",
+ "base64 0.22.0",
  "chrono",
  "clap 2.33.3",
  "console",
@@ -5950,7 +5956,7 @@ name = "solana-core"
 version = "2.0.0"
 dependencies = [
  "assert_matches",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bs58",
  "bytes",
@@ -6191,7 +6197,7 @@ dependencies = [
 name = "solana-genesis"
 version = "2.0.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "clap 2.33.3",
  "itertools",
@@ -6635,7 +6641,7 @@ dependencies = [
  "ark-serialize",
  "array-bytes",
  "assert_matches",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bitflags 2.4.2",
  "blake3",
@@ -6687,7 +6693,7 @@ name = "solana-program-runtime"
 version = "2.0.0"
 dependencies = [
  "assert_matches",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "eager",
  "enum-iterator",
@@ -6718,7 +6724,7 @@ version = "2.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "chrono-humanize",
  "crossbeam-channel",
@@ -6824,7 +6830,7 @@ dependencies = [
 name = "solana-rpc"
 version = "2.0.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bs58",
  "crossbeam-channel",
@@ -6886,7 +6892,7 @@ version = "2.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bs58",
  "crossbeam-channel",
@@ -6913,7 +6919,7 @@ dependencies = [
 name = "solana-rpc-client-api"
 version = "2.0.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "bs58",
  "jsonrpc-core",
  "reqwest",
@@ -6980,7 +6986,7 @@ dependencies = [
  "aquamarine",
  "arrayref",
  "assert_matches",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "blake3",
  "bv",
@@ -7076,7 +7082,7 @@ version = "2.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bitflags 2.4.2",
  "borsh 1.2.1",
@@ -7323,7 +7329,7 @@ dependencies = [
 name = "solana-test-validator"
 version = "2.0.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "crossbeam-channel",
  "log",
@@ -7450,7 +7456,7 @@ name = "solana-transaction-status"
 version = "2.0.0"
 dependencies = [
  "Inflector",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "borsh 0.10.3",
  "bs58",
@@ -7683,7 +7689,7 @@ name = "solana-zk-token-sdk"
 version = "2.0.0"
 dependencies = [
  "aes-gcm-siv",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bytemuck",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ async-mutex = "1.4.0"
 async-trait = "0.1.77"
 atty = "0.2.11"
 backoff = "0.4.0"
-base64 = "0.21.7"
+base64 = "0.22.0"
 bincode = "1.3.3"
 bitflags = { version = "2.4.2", features = ["serde"] }
 blake3 = "1.5.0"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -616,6 +616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4602,7 +4608,7 @@ name = "solana-account-decoder"
 version = "2.0.0"
 dependencies = [
  "Inflector",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bs58",
  "bv",
@@ -4835,7 +4841,7 @@ name = "solana-cli-output"
 version = "2.0.0"
 dependencies = [
  "Inflector",
- "base64 0.21.7",
+ "base64 0.22.0",
  "chrono",
  "clap 2.33.3",
  "console",
@@ -4929,7 +4935,7 @@ dependencies = [
 name = "solana-core"
 version = "2.0.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bs58",
  "bytes",
@@ -5384,7 +5390,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-serialize",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bitflags 2.4.2",
  "blake3",
@@ -5433,7 +5439,7 @@ dependencies = [
 name = "solana-program-runtime"
 version = "2.0.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "eager",
  "enum-iterator",
@@ -5461,7 +5467,7 @@ version = "2.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "chrono-humanize",
  "crossbeam-channel",
@@ -5560,7 +5566,7 @@ dependencies = [
 name = "solana-rpc"
 version = "2.0.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bs58",
  "crossbeam-channel",
@@ -5617,7 +5623,7 @@ name = "solana-rpc-client"
 version = "2.0.0"
 dependencies = [
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bs58",
  "indicatif",
@@ -5640,7 +5646,7 @@ dependencies = [
 name = "solana-rpc-client-api"
 version = "2.0.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "bs58",
  "jsonrpc-core",
  "reqwest",
@@ -5673,7 +5679,7 @@ version = "2.0.0"
 dependencies = [
  "aquamarine",
  "arrayref",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "blake3",
  "bv",
@@ -6170,7 +6176,7 @@ name = "solana-sdk"
 version = "2.0.0"
 dependencies = [
  "assert_matches",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bitflags 2.4.2",
  "borsh 1.2.1",
@@ -6372,7 +6378,7 @@ dependencies = [
 name = "solana-test-validator"
 version = "2.0.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "crossbeam-channel",
  "log",
@@ -6438,7 +6444,7 @@ name = "solana-transaction-status"
 version = "2.0.0"
 dependencies = [
  "Inflector",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "borsh 0.10.3",
  "bs58",
@@ -6614,7 +6620,7 @@ name = "solana-zk-token-sdk"
 version = "2.0.0"
 dependencies = [
  "aes-gcm-siv",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bytemuck",
  "byteorder 1.5.0",


### PR DESCRIPTION
#### Problem

As we discovered in https://github.com/anza-xyz/agave/pull/130#discussion_r1523296269, the newer version of the `base64` crate fixes an issue with decoding into a fixed-size array.

#### Summary of Changes

Bump the version of base64 to 0.22.

I believe this is a breaking change in rpc-client-api, since `RpcFilterError` uses `base64::DecodeError` at https://github.com/anza-xyz/agave/blob/7f27644e6556a9f3b765df0ee52dd05098364cda/rpc-client-api/src/filter.rs#L110, but maybe that's ok since we're at 2.0 right now.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
