### PR TITLE
update changelog and remove deprecated label on `gossip_service::get_client()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Release channels have their own copy of this changelog:
   * New program deployments default to the exact size of a program, instead of
     double the size. Program accounts must be extended with `solana program extend`
     before an upgrade if they need to accommodate larger programs.
+  * Interface for `gossip_service::get_client()` has changed. `gossip_service::get_multi_client()` has been removed.
 * Upgrade Notes
   * `solana-program` and `solana-sdk` default to support for Borsh v1, with
 limited backward compatibility for v0.10 and v0.9. Please upgrade to Borsh v1.

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -197,8 +197,7 @@ pub fn discover(
     ))
 }
 
-/// Creates a ThinClient by selecting a valid node at random
-#[deprecated(since = "1.18.6", note = "Interface will change")]
+/// Creates a TpuClient by selecting a valid node at random
 pub fn get_client(
     nodes: &[ContactInfo],
     connection_cache: Arc<ConnectionCache>,


### PR DESCRIPTION
7th PR on the way to remove `ThinClient` completely.
See 
- 1st PR: https://github.com/solana-labs/solana/pull/35335
- 2nd PR: https://github.com/solana-labs/solana/pull/35365
- 3rd PR: https://github.com/anza-xyz/agave/pull/177
- 4th PR: https://github.com/anza-xyz/agave/pull/184
- 5th PR: https://github.com/anza-xyz/agave/pull/117
- 6th PR: https://github.com/anza-xyz/agave/pull/132

#### Problem
added breaking changes in PR: https://github.com/anza-xyz/agave/pull/117, so need to update changelog

#### Summary of Changes
1) Update changelog
2) Remove `gossip_service::get_client()` `deprecated` tag
