### PR TITLE
V1.17.27 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "log",
  "solana-sdk",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "agave-install"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "atty",
  "bincode",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "agave-ledger-tool"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_cmd",
  "bs58",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "agave-validator"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "agave-geyser-plugin-interface",
  "chrono",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "agave-watchtower"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "clap 2.33.3",
  "humantime",
@@ -887,7 +887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "gen-headers"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "log",
  "regex",
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "gen-syscall-list"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "regex",
 ]
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "protobuf-src",
  "tonic-build",
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "rbpf-cli"
-version = "1.17.26"
+version = "1.17.27"
 
 [[package]]
 name = "rcgen"
@@ -5276,7 +5276,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "Inflector",
  "assert_matches",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-bench"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-cluster-bench"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "arrayref",
  "assert_matches",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program-tests"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banking-bench"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "clap 3.2.23",
  "crossbeam-channel",
@@ -5463,7 +5463,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "borsh 0.10.3",
  "futures 0.3.28",
@@ -5480,7 +5480,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-streamer"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "clap 3.2.23",
  "crossbeam-channel",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-tps"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "clap 2.33.3",
  "crossbeam-channel",
@@ -5559,7 +5559,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bv",
  "fnv",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5597,7 +5597,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program-tests"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bv",
  "bytemuck",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-build-bpf"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "log",
  "solana-logger",
@@ -5635,7 +5635,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-build-sbf"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_cmd",
  "bzip2",
@@ -5656,11 +5656,11 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-test-bpf"
-version = "1.17.26"
+version = "1.17.27"
 
 [[package]]
 name = "solana-cargo-test-sbf"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "cargo_metadata",
  "clap 3.2.23",
@@ -5671,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -5688,7 +5688,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5759,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -5774,7 +5774,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "Inflector",
  "base64 0.21.4",
@@ -5800,7 +5800,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client-test"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "futures-util",
  "rand 0.8.5",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -5870,7 +5870,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "chrono",
@@ -5883,7 +5883,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "base64 0.21.4",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "lazy_static",
  "log",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "solana-dos"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "clap 3.2.23",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "console",
  "indicatif",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-program-tests"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "ed25519-dalek",
@@ -6068,7 +6068,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "byteorder",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "ahash 0.8.5",
  "bitflags 2.3.3",
@@ -6142,7 +6142,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "base64 0.21.4",
  "bincode",
@@ -6177,7 +6177,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "log",
  "solana-accounts-db",
@@ -6188,7 +6188,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -6213,7 +6213,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6264,7 +6264,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keygen"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bs58",
  "clap 3.2.23",
@@ -6281,7 +6281,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6349,7 +6349,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "log",
@@ -6361,7 +6361,7 @@ dependencies = [
 
 [[package]]
 name = "solana-local-cluster"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "crossbeam-channel",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-analyzer"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "byte-unit",
  "clap 3.2.23",
@@ -6412,7 +6412,7 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -6421,7 +6421,7 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "log",
  "solana-sdk",
@@ -6429,11 +6429,11 @@ dependencies = [
 
 [[package]]
 name = "solana-memory-management"
-version = "1.17.26"
+version = "1.17.27"
 
 [[package]]
 name = "solana-merkle-root-bench"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -6446,7 +6446,7 @@ dependencies = [
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "fast-math",
  "hex",
@@ -6455,7 +6455,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "crossbeam-channel",
  "env_logger",
@@ -6471,7 +6471,7 @@ dependencies = [
 
 [[package]]
 name = "solana-net-shaper"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "clap 3.2.23",
  "rand 0.8.5",
@@ -6482,7 +6482,7 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "clap 3.2.23",
@@ -6502,7 +6502,7 @@ dependencies = [
 
 [[package]]
 name = "solana-notifier"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "log",
  "reqwest",
@@ -6512,7 +6512,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "ahash 0.8.5",
  "assert_matches",
@@ -6543,7 +6543,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6564,7 +6564,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh-bench"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "clap 3.2.23",
  "log",
@@ -6579,7 +6579,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -6636,7 +6636,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "base64 0.21.4",
@@ -6665,7 +6665,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -6694,7 +6694,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -6718,7 +6718,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -6746,7 +6746,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -6754,7 +6754,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "console",
@@ -6773,7 +6773,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "base64 0.21.4",
  "bincode",
@@ -6832,7 +6832,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -6861,7 +6861,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "base64 0.21.4",
  "bs58",
@@ -6881,7 +6881,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "anyhow",
  "clap 2.33.3",
@@ -6898,7 +6898,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-test"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "bs58",
@@ -6925,7 +6925,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "arrayref",
  "assert_matches",
@@ -7008,7 +7008,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -7066,7 +7066,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -7083,7 +7083,7 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -7098,7 +7098,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-accounts"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "clap 2.33.3",
  "solana-clap-utils",
@@ -7114,7 +7114,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -7131,7 +7131,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "backoff",
  "bincode",
@@ -7163,7 +7163,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "bs58",
@@ -7179,7 +7179,7 @@ dependencies = [
 
 [[package]]
 name = "solana-store-tool"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -7191,7 +7191,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "async-channel",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -7237,7 +7237,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "base64 0.21.4",
  "bincode",
@@ -7267,7 +7267,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "log",
@@ -7281,7 +7281,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tokens"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -7314,7 +7314,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7336,7 +7336,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-dos"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -7363,7 +7363,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "Inflector",
  "base64 0.21.4",
@@ -7386,7 +7386,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -7423,7 +7423,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -7436,7 +7436,7 @@ dependencies = [
 
 [[package]]
 name = "solana-upload-perf"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "serde_json",
  "solana-metrics",
@@ -7444,7 +7444,7 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "log",
  "rustc_version 0.4.0",
@@ -7458,7 +7458,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -7477,7 +7477,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -7500,7 +7500,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-keygen"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bs58",
  "clap 3.2.23",
@@ -7519,7 +7519,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bytemuck",
  "criterion",
@@ -7533,7 +7533,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program-tests"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bytemuck",
  "curve25519-dalek",
@@ -7545,7 +7545,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "1.17.26"
+version = "1.17.27"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana"
 homepage = "https://solanalabs.com/"
@@ -299,80 +299,80 @@ smpl_jwt = "0.7.1"
 socket2 = "0.5.4"
 soketto = "0.7"
 solana_rbpf = "=0.8.0"
-solana-account-decoder = { path = "account-decoder", version = "=1.17.26" }
-solana-accounts-db = { path = "accounts-db", version = "=1.17.26" }
-solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=1.17.26" }
-solana-banks-client = { path = "banks-client", version = "=1.17.26" }
-solana-banks-interface = { path = "banks-interface", version = "=1.17.26" }
-solana-banks-server = { path = "banks-server", version = "=1.17.26" }
-solana-bench-tps = { path = "bench-tps", version = "=1.17.26" }
-solana-bloom = { path = "bloom", version = "=1.17.26" }
-solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=1.17.26" }
-solana-bucket-map = { path = "bucket_map", version = "=1.17.26" }
-solana-connection-cache = { path = "connection-cache", version = "=1.17.26", default-features = false }
-solana-clap-utils = { path = "clap-utils", version = "=1.17.26" }
-solana-clap-v3-utils = { path = "clap-v3-utils", version = "=1.17.26" }
-solana-cli = { path = "cli", version = "=1.17.26" }
-solana-cli-config = { path = "cli-config", version = "=1.17.26" }
-solana-cli-output = { path = "cli-output", version = "=1.17.26" }
-solana-client = { path = "client", version = "=1.17.26" }
-solana-compute-budget-program = { path = "programs/compute-budget", version = "=1.17.26" }
-solana-config-program = { path = "programs/config", version = "=1.17.26" }
-solana-core = { path = "core", version = "=1.17.26" }
-solana-cost-model = { path = "cost-model", version = "=1.17.26" }
-solana-download-utils = { path = "download-utils", version = "=1.17.26" }
-solana-entry = { path = "entry", version = "=1.17.26" }
-solana-faucet = { path = "faucet", version = "=1.17.26" }
-solana-frozen-abi = { path = "frozen-abi", version = "=1.17.26" }
-solana-frozen-abi-macro = { path = "frozen-abi/macro", version = "=1.17.26" }
-solana-genesis = { path = "genesis", version = "=1.17.26" }
-solana-genesis-utils = { path = "genesis-utils", version = "=1.17.26" }
-agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=1.17.26" }
-solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=1.17.26" }
-solana-gossip = { path = "gossip", version = "=1.17.26" }
-solana-loader-v4-program = { path = "programs/loader-v4", version = "=1.17.26" }
-solana-ledger = { path = "ledger", version = "=1.17.26" }
-solana-local-cluster = { path = "local-cluster", version = "=1.17.26" }
-solana-logger = { path = "logger", version = "=1.17.26" }
-solana-measure = { path = "measure", version = "=1.17.26" }
-solana-merkle-tree = { path = "merkle-tree", version = "=1.17.26" }
-solana-metrics = { path = "metrics", version = "=1.17.26" }
-solana-net-utils = { path = "net-utils", version = "=1.17.26" }
-solana-notifier = { path = "notifier", version = "=1.17.26" }
-solana-perf = { path = "perf", version = "=1.17.26" }
-solana-poh = { path = "poh", version = "=1.17.26" }
-solana-program = { path = "sdk/program", version = "=1.17.26" }
-solana-program-runtime = { path = "program-runtime", version = "=1.17.26" }
-solana-program-test = { path = "program-test", version = "=1.17.26" }
-solana-pubsub-client = { path = "pubsub-client", version = "=1.17.26" }
-solana-quic-client = { path = "quic-client", version = "=1.17.26" }
-solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=1.17.26" }
-solana-remote-wallet = { path = "remote-wallet", version = "=1.17.26", default-features = false }
-solana-rpc = { path = "rpc", version = "=1.17.26" }
-solana-rpc-client = { path = "rpc-client", version = "=1.17.26", default-features = false }
-solana-rpc-client-api = { path = "rpc-client-api", version = "=1.17.26" }
-solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=1.17.26" }
-solana-runtime = { path = "runtime", version = "=1.17.26" }
-solana-sdk = { path = "sdk", version = "=1.17.26" }
-solana-sdk-macro = { path = "sdk/macro", version = "=1.17.26" }
-solana-send-transaction-service = { path = "send-transaction-service", version = "=1.17.26" }
-solana-stake-program = { path = "programs/stake", version = "=1.17.26" }
-solana-storage-bigtable = { path = "storage-bigtable", version = "=1.17.26" }
-solana-storage-proto = { path = "storage-proto", version = "=1.17.26" }
-solana-streamer = { path = "streamer", version = "=1.17.26" }
-solana-system-program = { path = "programs/system", version = "=1.17.26" }
-solana-test-validator = { path = "test-validator", version = "=1.17.26" }
-solana-thin-client = { path = "thin-client", version = "=1.17.26" }
-solana-tpu-client = { path = "tpu-client", version = "=1.17.26", default-features = false }
-solana-transaction-status = { path = "transaction-status", version = "=1.17.26" }
-solana-turbine = { path = "turbine", version = "=1.17.26" }
-solana-udp-client = { path = "udp-client", version = "=1.17.26" }
-solana-version = { path = "version", version = "=1.17.26" }
-solana-vote = { path = "vote", version = "=1.17.26" }
-solana-vote-program = { path = "programs/vote", version = "=1.17.26" }
-solana-zk-keygen = { path = "zk-keygen", version = "=1.17.26" }
-solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=1.17.26" }
-solana-zk-token-sdk = { path = "zk-token-sdk", version = "=1.17.26" }
+solana-account-decoder = { path = "account-decoder", version = "=1.17.27" }
+solana-accounts-db = { path = "accounts-db", version = "=1.17.27" }
+solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=1.17.27" }
+solana-banks-client = { path = "banks-client", version = "=1.17.27" }
+solana-banks-interface = { path = "banks-interface", version = "=1.17.27" }
+solana-banks-server = { path = "banks-server", version = "=1.17.27" }
+solana-bench-tps = { path = "bench-tps", version = "=1.17.27" }
+solana-bloom = { path = "bloom", version = "=1.17.27" }
+solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=1.17.27" }
+solana-bucket-map = { path = "bucket_map", version = "=1.17.27" }
+solana-connection-cache = { path = "connection-cache", version = "=1.17.27", default-features = false }
+solana-clap-utils = { path = "clap-utils", version = "=1.17.27" }
+solana-clap-v3-utils = { path = "clap-v3-utils", version = "=1.17.27" }
+solana-cli = { path = "cli", version = "=1.17.27" }
+solana-cli-config = { path = "cli-config", version = "=1.17.27" }
+solana-cli-output = { path = "cli-output", version = "=1.17.27" }
+solana-client = { path = "client", version = "=1.17.27" }
+solana-compute-budget-program = { path = "programs/compute-budget", version = "=1.17.27" }
+solana-config-program = { path = "programs/config", version = "=1.17.27" }
+solana-core = { path = "core", version = "=1.17.27" }
+solana-cost-model = { path = "cost-model", version = "=1.17.27" }
+solana-download-utils = { path = "download-utils", version = "=1.17.27" }
+solana-entry = { path = "entry", version = "=1.17.27" }
+solana-faucet = { path = "faucet", version = "=1.17.27" }
+solana-frozen-abi = { path = "frozen-abi", version = "=1.17.27" }
+solana-frozen-abi-macro = { path = "frozen-abi/macro", version = "=1.17.27" }
+solana-genesis = { path = "genesis", version = "=1.17.27" }
+solana-genesis-utils = { path = "genesis-utils", version = "=1.17.27" }
+agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=1.17.27" }
+solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=1.17.27" }
+solana-gossip = { path = "gossip", version = "=1.17.27" }
+solana-loader-v4-program = { path = "programs/loader-v4", version = "=1.17.27" }
+solana-ledger = { path = "ledger", version = "=1.17.27" }
+solana-local-cluster = { path = "local-cluster", version = "=1.17.27" }
+solana-logger = { path = "logger", version = "=1.17.27" }
+solana-measure = { path = "measure", version = "=1.17.27" }
+solana-merkle-tree = { path = "merkle-tree", version = "=1.17.27" }
+solana-metrics = { path = "metrics", version = "=1.17.27" }
+solana-net-utils = { path = "net-utils", version = "=1.17.27" }
+solana-notifier = { path = "notifier", version = "=1.17.27" }
+solana-perf = { path = "perf", version = "=1.17.27" }
+solana-poh = { path = "poh", version = "=1.17.27" }
+solana-program = { path = "sdk/program", version = "=1.17.27" }
+solana-program-runtime = { path = "program-runtime", version = "=1.17.27" }
+solana-program-test = { path = "program-test", version = "=1.17.27" }
+solana-pubsub-client = { path = "pubsub-client", version = "=1.17.27" }
+solana-quic-client = { path = "quic-client", version = "=1.17.27" }
+solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=1.17.27" }
+solana-remote-wallet = { path = "remote-wallet", version = "=1.17.27", default-features = false }
+solana-rpc = { path = "rpc", version = "=1.17.27" }
+solana-rpc-client = { path = "rpc-client", version = "=1.17.27", default-features = false }
+solana-rpc-client-api = { path = "rpc-client-api", version = "=1.17.27" }
+solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=1.17.27" }
+solana-runtime = { path = "runtime", version = "=1.17.27" }
+solana-sdk = { path = "sdk", version = "=1.17.27" }
+solana-sdk-macro = { path = "sdk/macro", version = "=1.17.27" }
+solana-send-transaction-service = { path = "send-transaction-service", version = "=1.17.27" }
+solana-stake-program = { path = "programs/stake", version = "=1.17.27" }
+solana-storage-bigtable = { path = "storage-bigtable", version = "=1.17.27" }
+solana-storage-proto = { path = "storage-proto", version = "=1.17.27" }
+solana-streamer = { path = "streamer", version = "=1.17.27" }
+solana-system-program = { path = "programs/system", version = "=1.17.27" }
+solana-test-validator = { path = "test-validator", version = "=1.17.27" }
+solana-thin-client = { path = "thin-client", version = "=1.17.27" }
+solana-tpu-client = { path = "tpu-client", version = "=1.17.27", default-features = false }
+solana-transaction-status = { path = "transaction-status", version = "=1.17.27" }
+solana-turbine = { path = "turbine", version = "=1.17.27" }
+solana-udp-client = { path = "udp-client", version = "=1.17.27" }
+solana-version = { path = "version", version = "=1.17.27" }
+solana-vote = { path = "vote", version = "=1.17.27" }
+solana-vote-program = { path = "programs/vote", version = "=1.17.27" }
+solana-zk-keygen = { path = "zk-keygen", version = "=1.17.27" }
+solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=1.17.27" }
+solana-zk-token-sdk = { path = "zk-token-sdk", version = "=1.17.27" }
 spl-associated-token-account = "=2.3.0"
 spl-instruction-padding = "0.1"
 spl-memo = "=4.0.0"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -741,7 +741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "log",
  "solana-sdk",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "agave-validator"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "agave-geyser-plugin-interface",
  "chrono",
@@ -741,7 +741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -4520,7 +4520,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "Inflector",
  "base64 0.21.4",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "arrayref",
  "bincode",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4619,7 +4619,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "borsh 0.10.3",
  "futures 0.3.28",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bv",
  "fnv",
@@ -4678,7 +4678,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-rust-big-mod-exp"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "array-bytes",
  "serde",
@@ -4705,7 +4705,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bv",
  "bytemuck",
@@ -4721,7 +4721,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -4736,7 +4736,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "Inflector",
  "base64 0.21.4",
@@ -4775,7 +4775,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "chrono",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "base64 0.21.4",
  "bincode",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "lazy_static",
  "log",
@@ -4940,7 +4940,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "console",
  "indicatif",
@@ -4952,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4994,7 +4994,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "ahash 0.8.5",
  "blake3",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5032,7 +5032,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "log",
  "solana-accounts-db",
@@ -5043,7 +5043,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "log",
  "solana-measure",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "log",
  "solana-sdk",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "fast-math",
  "solana-program",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "clap 3.1.6",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "ahash 0.8.5",
  "bincode",
@@ -5276,7 +5276,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "base64 0.21.4",
  "bincode",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -5446,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "console",
  "dialoguer",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "base64 0.21.4",
  "bincode",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "async-trait",
  "base64 0.21.4",
@@ -5550,7 +5550,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "base64 0.21.4",
  "bs58",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "clap 2.33.3",
  "solana-clap-utils",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "arrayref",
  "base64 0.21.4",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-programs"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-128bit-dep",
@@ -5693,21 +5693,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit-dep"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-alloc"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "array-bytes",
  "solana-program",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128-compression"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "array-bytes",
  "solana-program",
@@ -5723,21 +5723,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-depth"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-caller-access"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-curve25519"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
  "solana-zk-token-sdk",
@@ -5745,14 +5745,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-custom-heap"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-dep-crate"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "byteorder 1.4.3",
  "solana-program",
@@ -5760,21 +5760,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-deprecated-loader"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-dup-accounts"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-error-handling"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "num-derive 0.3.0",
  "num-traits",
@@ -5784,42 +5784,42 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-external-spend"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-finalize"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-get-minimum-delegation"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-inner_instruction_alignment_check"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-instruction-introspection"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "rustversion",
  "solana-program",
@@ -5829,49 +5829,49 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-error"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-ok"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-return"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoked"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-iter"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-log-data"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-many-args"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-many-args-dep",
@@ -5879,14 +5879,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-many-args-dep"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-mem"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
  "solana-program-runtime",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-membuiltins"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-mem",
@@ -5904,21 +5904,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-noop"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-panic"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-param-passing"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-param-passing-dep",
@@ -5926,14 +5926,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-param-passing-dep"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-poseidon"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "array-bytes",
  "solana-program",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-rand"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "getrandom 0.2.10",
  "rand 0.8.5",
@@ -5950,14 +5950,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-realloc",
@@ -5965,7 +5965,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-remaining-compute-units"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
  "solana-program-runtime",
@@ -5975,21 +5975,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-ro-account_modify"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-ro-modify"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sanity"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
  "solana-program-runtime",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-secp256k1-recover"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "libsecp256k1 0.7.0",
  "solana-program",
@@ -6007,7 +6007,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sha"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "blake3",
  "solana-program",
@@ -6015,21 +6015,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sibling-instructions"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sibling_inner-instructions"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-simulation"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "agave-validator",
  "solana-logger",
@@ -6040,21 +6040,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-spoof1"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-spoof1-system"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sysvar"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
  "solana-program-runtime",
@@ -6064,21 +6064,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-upgradeable"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-upgraded"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sdk"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "assert_matches",
  "base64 0.21.4",
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -6147,7 +6147,7 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -6161,7 +6161,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "log",
@@ -6174,7 +6174,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "backoff",
  "bincode",
@@ -6206,7 +6206,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "bs58",
@@ -6221,7 +6221,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "async-channel",
  "bytes",
@@ -6251,7 +6251,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "log",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "base64 0.21.4",
  "bincode",
@@ -6293,7 +6293,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "log",
@@ -6306,7 +6306,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6328,7 +6328,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "Inflector",
  "base64 0.21.4",
@@ -6351,7 +6351,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "bytes",
@@ -6386,7 +6386,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -6399,7 +6399,7 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "log",
  "rustc_version",
@@ -6413,7 +6413,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "crossbeam-channel",
  "itertools",
@@ -6430,7 +6430,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bincode",
  "log",
@@ -6450,7 +6450,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "bytemuck",
  "num-derive 0.3.0",
@@ -6462,7 +6462,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.17.26"
+version = "1.17.27"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.4",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.17.26"
+version = "1.17.27"
 description = "Solana SBF test program written in Rust"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -26,29 +26,29 @@ rustversion = "1.0.14"
 serde = "1.0.112"
 serde_json = "1.0.56"
 solana_rbpf = "=0.8.0"
-solana-account-decoder = { path = "../../account-decoder", version = "=1.17.26" }
-solana-accounts-db = { path = "../../accounts-db", version = "=1.17.26" }
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.17.26" }
-solana-cli-output = { path = "../../cli-output", version = "=1.17.26" }
-solana-ledger = { path = "../../ledger", version = "=1.17.26" }
-solana-logger = { path = "../../logger", version = "=1.17.26" }
-solana-measure = { path = "../../measure", version = "=1.17.26" }
-solana-program = { path = "../../sdk/program", version = "=1.17.26" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.17.26" }
-solana-program-test = { path = "../../program-test", version = "=1.17.26" }
-solana-runtime = { path = "../../runtime", version = "=1.17.26" }
-solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=1.17.26" }
-solana-sbf-rust-invoke = { path = "rust/invoke", version = "=1.17.26" }
-solana-sbf-rust-invoked = { path = "rust/invoked", version = "=1.17.26", default-features = false }
-solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=1.17.26" }
-solana-sbf-rust-mem = { path = "rust/mem", version = "=1.17.26" }
-solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=1.17.26" }
-solana-sbf-rust-realloc = { path = "rust/realloc", version = "=1.17.26", default-features = false }
-solana-sbf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.17.26" }
-solana-sdk = { path = "../../sdk", version = "=1.17.26" }
-solana-transaction-status = { path = "../../transaction-status", version = "=1.17.26" }
-agave-validator = { path = "../../validator", version = "=1.17.26" }
-solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.17.26" }
+solana-account-decoder = { path = "../../account-decoder", version = "=1.17.27" }
+solana-accounts-db = { path = "../../accounts-db", version = "=1.17.27" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.17.27" }
+solana-cli-output = { path = "../../cli-output", version = "=1.17.27" }
+solana-ledger = { path = "../../ledger", version = "=1.17.27" }
+solana-logger = { path = "../../logger", version = "=1.17.27" }
+solana-measure = { path = "../../measure", version = "=1.17.27" }
+solana-program = { path = "../../sdk/program", version = "=1.17.27" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.17.27" }
+solana-program-test = { path = "../../program-test", version = "=1.17.27" }
+solana-runtime = { path = "../../runtime", version = "=1.17.27" }
+solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=1.17.27" }
+solana-sbf-rust-invoke = { path = "rust/invoke", version = "=1.17.27" }
+solana-sbf-rust-invoked = { path = "rust/invoked", version = "=1.17.27", default-features = false }
+solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=1.17.27" }
+solana-sbf-rust-mem = { path = "rust/mem", version = "=1.17.27" }
+solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=1.17.27" }
+solana-sbf-rust-realloc = { path = "rust/realloc", version = "=1.17.27", default-features = false }
+solana-sbf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.17.27" }
+solana-sdk = { path = "../../sdk", version = "=1.17.27" }
+solana-transaction-status = { path = "../../transaction-status", version = "=1.17.27" }
+agave-validator = { path = "../../validator", version = "=1.17.27" }
+solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.17.27" }
 static_assertions = "1.1.0"
 thiserror = "1.0"
 

--- a/sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+++ b/sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "1.17.26"
+version = "1.17.27"
 description = "Solana SBF test program written in Rust"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-program = { path = "../../../../program", version = "=1.17.26" }
+solana-program = { path = "../../../../program", version = "=1.17.27" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noop"
-version = "1.17.26"
+version = "1.17.27"
 description = "Solana SBF test program written in Rust"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-program = { path = "../../../../program", version = "=1.17.26" }
+solana-program = { path = "../../../../program", version = "=1.17.27" }
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
#### Summary of Changes
Ran `./scripts/increment-cargo-version.sh` patch and manually undo hashbrown version bum

I see we already cut v1.17.26 with the current tip of v1.17 (https://github.com/anza-xyz/agave/commit/2332aee4a27713be651a8d14b475d4d48c65a4c6) so this should probably land before any additional v1.17 BP's do