### PR TITLE
[solana-install-init] Optimize error message for Windows user permission installation

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -1,4 +1,3 @@
-use std::io::RawOsError;
 use {
     crate::{
         config::{Config, ExplicitRelease},
@@ -1174,16 +1173,9 @@ pub fn init_or_update(config_file: &str, is_init: bool, check_only: bool) -> Res
     )
     .map_err(|err| match err.raw_os_error() {
         #[cfg(windows)]
-        Some(os_err) => if os_err == winapi::shared::winerror::ERROR_PRIVILEGE_NOT_HELD {
+        Some(os_err) if os_err == winapi::shared::winerror::ERROR_PRIVILEGE_NOT_HELD => {
             "You need to run this command with administrator privileges.".to_string()
-        } else {
-            format!(
-                "Unable to symlink {:?} to {:?}: {}",
-                release_dir,
-                config.active_release_dir(),
-                err
-            )
-        },
+        }
         _ => format!(
             "Unable to symlink {:?} to {:?}: {}",
             release_dir,

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -778,6 +778,51 @@ pub fn deploy(
 }
 
 #[cfg(windows)]
+fn check_administrator_privileges() -> Result<(), String> {
+    use std::io::Error;
+    use std::ptr;
+    use winapi::um::processthreadsapi::{GetCurrentProcess, OpenProcessToken};
+    use winapi::um::securitybaseapi::GetTokenInformation;
+    use winapi::um::winnt::{TokenElevation, HANDLE, TOKEN_ELEVATION, TOKEN_QUERY};
+
+    unsafe {
+        let mut handle: HANDLE = ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut handle) == 0 {
+            return Err(format!("{}", Error::last_os_error()));
+        }
+
+        let mut elevation = TOKEN_ELEVATION::default();
+        let size = std::mem::size_of::<TOKEN_ELEVATION>() as u32;
+        let mut ret_size = size;
+        let result = GetTokenInformation(
+            handle,
+            TokenElevation,
+            &mut elevation as *mut _ as *mut _,
+            size,
+            &mut ret_size,
+        );
+        if result == 0 {
+            return Err(format!("{}", Error::last_os_error()));
+        }
+
+        if elevation.TokenIsElevated != 0 {
+            Ok(())
+        } else {
+            Err(
+                "You need to run this command with administrator privileges."
+                    .parse()
+                    .unwrap(),
+            )
+        }
+    }
+}
+
+#[cfg(unix)]
+fn check_administrator_privileges() -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(windows)]
 fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> std::io::Result<()> {
     std::os::windows::fs::symlink_dir(src, dst)
 }
@@ -966,6 +1011,8 @@ pub fn update(config_file: &str, check_only: bool) -> Result<bool, String> {
 
 pub fn init_or_update(config_file: &str, is_init: bool, check_only: bool) -> Result<bool, String> {
     let mut config = Config::load(config_file)?;
+
+    check_administrator_privileges()?;
 
     let (updated_version, download_url_and_sha256, release_dir) = if let Some(explicit_release) =
         &config.explicit_release
@@ -1171,13 +1218,14 @@ pub fn init_or_update(config_file: &str, is_init: bool, check_only: bool) -> Res
         release_dir.join("solana-release"),
         config.active_release_dir(),
     )
-    .map_err(|err| {
-        format!(
+    .map_err(|err| match err.raw_os_error() {
+        Some(1314) => "You need to run this command with administrator privileges.".to_string(),
+        _ => format!(
             "Unable to symlink {:?} to {:?}: {}",
             release_dir,
             config.active_release_dir(),
             err
-        )
+        ),
     })?;
 
     config.save(config_file)?;


### PR DESCRIPTION
#### Problem

When users attempt to execute this command without administrator privileges, it results in error code 1314. 

Most users find it challenging to promptly recognize that this issue stems from permission limitations.

![image](https://github.com/solana-labs/solana/assets/6522980/2e42259a-00ae-4424-a11f-3147e1347d65)

#### Summary of Changes

Therefore, I propose two possible solutions:

1. Implement a permission checking function utilizing winapi.
```
unsafe {
        let mut handle: HANDLE = ptr::null_mut();
        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut handle) == 0 {
            return Err(format!("{}", Error::last_os_error()));
        }

        let mut elevation = TOKEN_ELEVATION::default();
        let size = std::mem::size_of::<TOKEN_ELEVATION>() as u32;
        let mut ret_size = size;
        let result = GetTokenInformation(
            handle,
            TokenElevation,
            &mut elevation as *mut _ as *mut _,
            size,
            &mut ret_size,
        );
        if result == 0 {
            return Err(format!("{}", Error::last_os_error()));
        }

        if elevation.TokenIsElevated != 0 {
            Ok(())
        } else {
            Err(
                "You need to run this command with administrator privileges."
                    .parse()
                    .unwrap(),
            )
        }
    }
```
2. Check for error code 1314 in the error message.

```
symlink_dir(
        release_dir.join("solana-release"),
        config.active_release_dir(),
    )
    .map_err(|err| match err.raw_os_error() {
        Some(1314) => "You need to run this command with administrator privileges.".to_string(),
        _ => format!(
            "Unable to symlink {:?} to {:?}: {}",
            release_dir,
            config.active_release_dir(),
            err
        ),
    })?;
```
Your valuable feedback on these proposed solutions would be greatly appreciated.