### PR TITLE
Allow configuration of replay thread pools from CLI

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -51,7 +51,6 @@ use {
     solana_measure::measure::Measure,
     solana_poh::poh_recorder::{PohLeaderStatus, PohRecorder, GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS},
     solana_program_runtime::timings::ExecuteTimings,
-    solana_rayon_threadlimit::get_max_thread_count,
     solana_rpc::{
         optimistically_confirmed_bank_tracker::{BankNotification, BankNotificationSenderConfig},
         rpc_subscriptions::RpcSubscriptions,
@@ -80,6 +79,7 @@ use {
     solana_vote_program::vote_state::VoteTransaction,
     std::{
         collections::{HashMap, HashSet},
+        num::NonZeroUsize,
         result,
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
@@ -99,7 +99,6 @@ const MAX_VOTE_SIGNATURES: usize = 200;
 const MAX_VOTE_REFRESH_INTERVAL_MILLIS: usize = 5000;
 // Expect this number to be small enough to minimize thread pool overhead while large enough
 // to be able to replay all active forks at the same time in most cases.
-const MAX_CONCURRENT_FORKS_TO_REPLAY: usize = 4;
 const MAX_REPAIR_RETRY_LOOP_ATTEMPTS: usize = 10;
 
 #[derive(PartialEq, Eq, Debug)]
@@ -291,7 +290,8 @@ pub struct ReplayStageConfig {
     // Stops voting until this slot has been reached. Should be used to avoid
     // duplicate voting which can lead to slashing.
     pub wait_to_vote_slot: Option<Slot>,
-    pub replay_slots_concurrently: bool,
+    pub replay_forks_threads: NonZeroUsize,
+    pub replay_transactions_threads: NonZeroUsize,
 }
 
 /// Timing information for the ReplayStage main processing loop
@@ -574,7 +574,8 @@ impl ReplayStage {
             ancestor_hashes_replay_update_sender,
             tower_storage,
             wait_to_vote_slot,
-            replay_slots_concurrently,
+            replay_forks_threads,
+            replay_transactions_threads,
         } = config;
 
         trace!("replay stage");
@@ -654,9 +655,11 @@ impl ReplayStage {
                 )
             };
             // Thread pool to (maybe) replay multiple threads in parallel
-            let replay_mode = if replay_slots_concurrently {
+            let replay_mode = if replay_forks_threads.get() == 1 {
+                ForkReplayMode::Serial
+            } else {
                 let pool = rayon::ThreadPoolBuilder::new()
-                    .num_threads(MAX_CONCURRENT_FORKS_TO_REPLAY)
+                    .num_threads(replay_forks_threads.get())
                     .thread_name(|i| format!("solReplayFork{i:02}"))
                     .build()
                     .expect("new rayon threadpool");
@@ -666,7 +669,7 @@ impl ReplayStage {
             };
             // Thread pool to replay multiple transactions within one block in parallel
             let replay_tx_thread_pool = rayon::ThreadPoolBuilder::new()
-                .num_threads(get_max_thread_count())
+                .num_threads(replay_transactions_threads.get())
                 .thread_name(|i| format!("solReplayTx{i:02}"))
                 .build()
                 .expect("new rayon threadpool");

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -663,8 +663,6 @@ impl ReplayStage {
                     .build()
                     .expect("new rayon threadpool");
                 ForkReplayMode::Parallel(pool)
-            } else {
-                ForkReplayMode::Serial
             };
             // Thread pool to replay multiple transactions within one block in parallel
             let replay_tx_thread_pool = rayon::ThreadPoolBuilder::new()

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -95,10 +95,6 @@ pub const SUPERMINORITY_THRESHOLD: f64 = 1f64 / 3f64;
 pub const MAX_UNCONFIRMED_SLOTS: usize = 5;
 pub const DUPLICATE_LIVENESS_THRESHOLD: f64 = 0.1;
 pub const DUPLICATE_THRESHOLD: f64 = 1.0 - SWITCH_FORK_THRESHOLD - DUPLICATE_LIVENESS_THRESHOLD;
-// The maximum number of threads to allocate for replaying forks concurrently
-// This value was chosen to be small enough to limit the overhead of having a large thread pool
-// while also being large enough to allow replay of all active forks in most scenarios.
-pub const MAX_CONCURRENT_FORKS_TO_REPLAY: usize = 4;
 
 const MAX_VOTE_SIGNATURES: usize = 200;
 const MAX_VOTE_REFRESH_INTERVAL_MILLIS: usize = 5000;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -95,6 +95,11 @@ pub const SUPERMINORITY_THRESHOLD: f64 = 1f64 / 3f64;
 pub const MAX_UNCONFIRMED_SLOTS: usize = 5;
 pub const DUPLICATE_LIVENESS_THRESHOLD: f64 = 0.1;
 pub const DUPLICATE_THRESHOLD: f64 = 1.0 - SWITCH_FORK_THRESHOLD - DUPLICATE_LIVENESS_THRESHOLD;
+// The maximum number of threads to allocate for replaying forks concurrently
+// This value was chosen to be small enough to limit the overhead of having a large thread pool
+// while also being large enough to allow replay of all active forks in most scenarios.
+pub const MAX_CONCURRENT_FORKS_TO_REPLAY: usize = 4;
+
 const MAX_VOTE_SIGNATURES: usize = 200;
 const MAX_VOTE_REFRESH_INTERVAL_MILLIS: usize = 5000;
 const MAX_REPAIR_RETRY_LOOP_ATTEMPTS: usize = 10;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -97,8 +97,6 @@ pub const DUPLICATE_LIVENESS_THRESHOLD: f64 = 0.1;
 pub const DUPLICATE_THRESHOLD: f64 = 1.0 - SWITCH_FORK_THRESHOLD - DUPLICATE_LIVENESS_THRESHOLD;
 const MAX_VOTE_SIGNATURES: usize = 200;
 const MAX_VOTE_REFRESH_INTERVAL_MILLIS: usize = 5000;
-// Expect this number to be small enough to minimize thread pool overhead while large enough
-// to be able to replay all active forks at the same time in most cases.
 const MAX_REPAIR_RETRY_LOOP_ATTEMPTS: usize = 10;
 
 #[derive(PartialEq, Eq, Debug)]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -349,7 +349,7 @@ impl ValidatorConfig {
             enforce_ulimit_nofile: false,
             rpc_config: JsonRpcConfig::default_for_test(),
             block_production_method: BlockProductionMethod::ThreadLocalMultiIterator,
-            replay_forks_threads: NonZeroUsize::new(8).expect("8 is non-zero"),
+            replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             replay_transactions_threads: NonZeroUsize::new(8).expect("8 is non-zero"),
             ..Self::default()
         }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -74,6 +74,7 @@ use {
         poh_service::{self, PohService},
     },
     solana_program_runtime::runtime_config::RuntimeConfig,
+    solana_rayon_threadlimit::get_max_thread_count,
     solana_rpc::{
         max_slots::MaxSlots,
         optimistically_confirmed_bank_tracker::{
@@ -350,7 +351,8 @@ impl ValidatorConfig {
             rpc_config: JsonRpcConfig::default_for_test(),
             block_production_method: BlockProductionMethod::ThreadLocalMultiIterator,
             replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
-            replay_transactions_threads: NonZeroUsize::new(8).expect("8 is non-zero"),
+            replay_transactions_threads: NonZeroUsize::new(get_max_thread_count())
+                .expect("thread count is non-zero"),
             ..Self::default()
         }
     }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -123,6 +123,7 @@ use {
     std::{
         collections::{HashMap, HashSet},
         net::SocketAddr,
+        num::NonZeroUsize,
         path::{Path, PathBuf},
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
@@ -260,7 +261,6 @@ pub struct ValidatorConfig {
     pub wait_to_vote_slot: Option<Slot>,
     pub ledger_column_options: LedgerColumnOptions,
     pub runtime_config: RuntimeConfig,
-    pub replay_slots_concurrently: bool,
     pub banking_trace_dir_byte_limit: banking_trace::DirByteLimit,
     pub block_verification_method: BlockVerificationMethod,
     pub block_production_method: BlockProductionMethod,
@@ -268,6 +268,8 @@ pub struct ValidatorConfig {
     pub use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup,
     pub wen_restart_proto_path: Option<PathBuf>,
     pub unified_scheduler_handler_threads: Option<usize>,
+    pub replay_forks_threads: NonZeroUsize,
+    pub replay_transactions_threads: NonZeroUsize,
 }
 
 impl Default for ValidatorConfig {
@@ -328,7 +330,6 @@ impl Default for ValidatorConfig {
             wait_to_vote_slot: None,
             ledger_column_options: LedgerColumnOptions::default(),
             runtime_config: RuntimeConfig::default(),
-            replay_slots_concurrently: false,
             banking_trace_dir_byte_limit: 0,
             block_verification_method: BlockVerificationMethod::default(),
             block_production_method: BlockProductionMethod::default(),
@@ -336,6 +337,8 @@ impl Default for ValidatorConfig {
             use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup::default(),
             wen_restart_proto_path: None,
             unified_scheduler_handler_threads: None,
+            replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
+            replay_transactions_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
         }
     }
 }
@@ -346,6 +349,8 @@ impl ValidatorConfig {
             enforce_ulimit_nofile: false,
             rpc_config: JsonRpcConfig::default_for_test(),
             block_production_method: BlockProductionMethod::ThreadLocalMultiIterator,
+            replay_forks_threads: NonZeroUsize::new(8).expect("8 is non-zero"),
+            replay_transactions_threads: NonZeroUsize::new(8).expect("8 is non-zero"),
             ..Self::default()
         }
     }
@@ -1305,7 +1310,8 @@ impl Validator {
                 repair_validators: config.repair_validators.clone(),
                 repair_whitelist: config.repair_whitelist.clone(),
                 wait_for_vote_to_start_leader,
-                replay_slots_concurrently: config.replay_slots_concurrently,
+                replay_forks_threads: config.replay_forks_threads,
+                replay_transactions_threads: config.replay_transactions_threads,
             },
             &max_slots,
             block_metadata_notifier,

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -61,7 +61,6 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         wait_to_vote_slot: config.wait_to_vote_slot,
         ledger_column_options: config.ledger_column_options.clone(),
         runtime_config: config.runtime_config.clone(),
-        replay_slots_concurrently: config.replay_slots_concurrently,
         banking_trace_dir_byte_limit: config.banking_trace_dir_byte_limit,
         block_verification_method: config.block_verification_method.clone(),
         block_production_method: config.block_production_method.clone(),
@@ -69,6 +68,8 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         use_snapshot_archives_at_startup: config.use_snapshot_archives_at_startup,
         wen_restart_proto_path: config.wen_restart_proto_path.clone(),
         unified_scheduler_handler_threads: config.unified_scheduler_handler_threads,
+        replay_forks_threads: config.replay_forks_threads,
+        replay_transactions_threads: config.replay_transactions_threads,
     }
 }
 

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -52,7 +52,7 @@ use {
     std::{path::PathBuf, str::FromStr},
 };
 
-mod thread_args;
+pub mod thread_args;
 use thread_args::{thread_args, DefaultThreadArgs};
 
 const EXCLUDE_KEY: &str = "account-index-exclude-key";

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -52,6 +52,9 @@ use {
     std::{path::PathBuf, str::FromStr},
 };
 
+mod thread_args;
+use thread_args::{thread_args, DefaultThreadArgs};
+
 const EXCLUDE_KEY: &str = "account-index-exclude-key";
 const INCLUDE_KEY: &str = "account-index-include-key";
 // The default minimal snapshot download speed (bytes/second)
@@ -1539,6 +1542,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 ",
                 ),
         )
+        .args(&thread_args(&default_args.thread_args))
         .args(&get_deprecated_arguments())
         .after_help("The default subcommand is run")
         .subcommand(
@@ -2179,6 +2183,8 @@ pub struct DefaultArgs {
     pub banking_trace_dir_byte_limit: String,
 
     pub wen_restart_path: String,
+
+    pub thread_args: DefaultThreadArgs,
 }
 
 impl DefaultArgs {
@@ -2261,6 +2267,7 @@ impl DefaultArgs {
             wait_for_restart_window_max_delinquent_stake: "5".to_string(),
             banking_trace_dir_byte_limit: BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT.to_string(),
             wen_restart_path: "wen_restart_progress.proto".to_string(),
+            thread_args: DefaultThreadArgs::default(),
         }
     }
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1454,11 +1454,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Maximum number of bytes written to the program log before truncation"),
         )
         .arg(
-            Arg::with_name("replay_slots_concurrently")
-                .long("replay-slots-concurrently")
-                .help("Allow concurrent replay of slots on different forks"),
-        )
-        .arg(
             Arg::with_name("banking_trace_dir_byte_limit")
                 // expose friendly alternative name to cli than internal
                 // implementation-oriented one
@@ -2061,6 +2056,13 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         .long("no-rocksdb-compaction")
         .takes_value(false)
         .help("Disable manual compaction of the ledger database"));
+    add_arg!(
+        Arg::with_name("replay_slots_concurrently")
+            .long("replay-slots-concurrently")
+            .help("Allow concurrent replay of slots on different forks")
+            .conflicts_with("replay_forks_threads"),
+        replaced_by: "replay_forks_threads",
+        usage_warning: "Equivalent behavior to this flag would be --replay-forks-threads 4");
     add_arg!(Arg::with_name("rocksdb_compaction_interval")
         .long("rocksdb-compaction-interval-slots")
         .value_name("ROCKSDB_COMPACTION_INTERVAL_SLOTS")

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -3,7 +3,6 @@
 use {
     clap::{value_t_or_exit, Arg, ArgMatches},
     solana_clap_utils::{hidden_unless_forced, input_validators::is_within_range},
-    solana_core::replay_stage::MAX_CONCURRENT_FORKS_TO_REPLAY,
     solana_rayon_threadlimit::get_max_thread_count,
     std::num::NonZeroUsize,
 };
@@ -37,7 +36,7 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
             .takes_value(true)
             .value_name("NUMBER")
             .default_value(&defaults.replay_forks_threads)
-            .validator(|num| is_within_range(num, 1..=MAX_CONCURRENT_FORKS_TO_REPLAY))
+            .validator(|num| is_within_range(num, 1..=replay_forks_threads::MAX))
             .hidden(hidden_unless_forced())
             .help(replay_forks_threads::HELP),
         Arg::with_name(replay_transactions_threads::NAME)
@@ -70,6 +69,9 @@ mod replay_forks_threads {
     pub const NAME: &str = "replay_forks_threads";
     pub const LONG_ARG: &str = "replay-forks-threads";
     pub const HELP: &str = "Number of threads to use for replay of blocks on different forks";
+    // Choose a value that is small enough to limit the overhead of having a large thread pool
+    // while also being large enough to allow replay of all active forks in most scenarios
+    pub const MAX: usize = 4;
 }
 
 mod replay_transactions_threads {

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -32,22 +32,22 @@ pub struct NumThreadConfig {
 pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
     // Do not let any threadpool size scale over the number of threads
     vec![
-        Arg::with_name("replay_forks_threads")
-            .long("replay-forks-threads")
+        Arg::with_name(replay_forks_threads::NAME)
+            .long(replay_forks_threads::LONG_ARG)
             .takes_value(true)
             .value_name("NUMBER")
             .default_value(&defaults.replay_forks_threads)
             .validator(|num| is_within_range(num, 1..=MAX_CONCURRENT_FORKS_TO_REPLAY))
             .hidden(hidden_unless_forced())
-            .help("Number of threads to use for replay of blocks on different forks"),
-        Arg::with_name("replay_transactions_threads")
-            .long("replay-transactions-threads")
+            .help(replay_forks_threads::HELP),
+        Arg::with_name(replay_transactions_threads::NAME)
+            .long(replay_transactions_threads::LONG_ARG)
             .takes_value(true)
             .value_name("NUMBER")
             .default_value(&defaults.replay_transactions_threads)
             .validator(|num| is_within_range(num, 1..=get_max_thread_count()))
             .hidden(hidden_unless_forced())
-            .help("Number of threads to use for transaction replay"),
+            .help(replay_transactions_threads::HELP),
     ]
 }
 
@@ -56,12 +56,24 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
         replay_forks_threads: if matches.is_present("replay_slots_concurrently") {
             NonZeroUsize::new(4).expect("4 is non-zero")
         } else {
-            value_t_or_exit!(matches, "replay_forks_threads", NonZeroUsize)
+            value_t_or_exit!(matches, replay_forks_threads::NAME, NonZeroUsize)
         },
         replay_transactions_threads: value_t_or_exit!(
             matches,
-            "replay_transactions_threads",
+            replay_transactions_threads::NAME,
             NonZeroUsize
         ),
     }
+}
+
+mod replay_forks_threads {
+    pub const NAME: &str = "replay_forks_threads";
+    pub const LONG_ARG: &str = "replay-forks-threads";
+    pub const HELP: &str = "Number of threads to use for replay of blocks on different forks";
+}
+
+mod replay_transactions_threads {
+    pub const NAME: &str = "replay_transactions_threads";
+    pub const LONG_ARG: &str = "replay-transactions-threads";
+    pub const HELP: &str = "Number of threads to use for transaction replay";
 }

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -2,6 +2,7 @@
 
 use {
     clap::Arg, solana_clap_utils::input_validators::is_within_range,
+    solana_core::replay_stage::MAX_CONCURRENT_FORKS_TO_REPLAY,
     solana_rayon_threadlimit::get_max_thread_count,
 };
 
@@ -29,7 +30,7 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
             .takes_value(true)
             .value_name("NUMBER")
             .default_value(&defaults.replay_forks_threads)
-            .validator(|num| is_within_range(num, 1..=get_max_thread_count()))
+            .validator(|num| is_within_range(num, 1..=MAX_CONCURRENT_FORKS_TO_REPLAY))
             .help("Number of threads to use for replay of blocks on different forks"),
         Arg::with_name("replay_transactions_threads")
             .long("replay-transactions-threads")

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -1,7 +1,8 @@
 //! Arguments for controlling the number of threads allocated for various tasks
 
 use {
-    clap::Arg, solana_clap_utils::input_validators::is_within_range,
+    clap::Arg,
+    solana_clap_utils::{hidden_unless_forced, input_validators::is_within_range},
     solana_core::replay_stage::MAX_CONCURRENT_FORKS_TO_REPLAY,
     solana_rayon_threadlimit::get_max_thread_count,
 };
@@ -31,6 +32,7 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
             .value_name("NUMBER")
             .default_value(&defaults.replay_forks_threads)
             .validator(|num| is_within_range(num, 1..=MAX_CONCURRENT_FORKS_TO_REPLAY))
+            .hidden(hidden_unless_forced())
             .help("Number of threads to use for replay of blocks on different forks"),
         Arg::with_name("replay_transactions_threads")
             .long("replay-transactions-threads")
@@ -38,6 +40,7 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
             .value_name("NUMBER")
             .default_value(&defaults.replay_transactions_threads)
             .validator(|num| is_within_range(num, 1..=get_max_thread_count()))
+            .hidden(hidden_unless_forced())
             .help("Number of threads to use for transaction replay"),
     ]
 }

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -71,16 +71,16 @@ trait ThreadArg {
 
     /// The default number of threads
     fn default() -> usize;
-    /// The minimum allowed value of threads (inclusive)
+    /// The minimum allowed number of threads (inclusive)
     fn min() -> usize {
         1
     }
-    /// The maximum allowed value of threads (inclusive)
+    /// The maximum allowed number of threads (inclusive)
     fn max() -> usize {
-        // By default, no thread pool should scale over the machine's number of threads
+        // By default, no thread pool should scale over the number of the machine's threads
         get_max_thread_count()
     }
-    /// The range of allowable values
+    /// The range of allowed number of threads (inclusive on both ends)
     fn range() -> RangeInclusive<usize> {
         RangeInclusive::new(Self::min(), Self::max())
     }

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -1,0 +1,42 @@
+//! Arguments for controlling the number of threads allocated for various tasks
+
+use {
+    clap::Arg, solana_clap_utils::input_validators::is_within_range,
+    solana_rayon_threadlimit::get_max_thread_count,
+};
+
+pub struct DefaultThreadArgs {
+    pub replay_forks_threads: String,
+    pub replay_transactions_threads: String,
+}
+
+impl Default for DefaultThreadArgs {
+    fn default() -> Self {
+        let num_total_threads = get_max_thread_count();
+
+        Self {
+            replay_forks_threads: 1.to_string(),
+            replay_transactions_threads: num_total_threads.to_string(),
+        }
+    }
+}
+
+pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
+    // Do not let any threadpool size scale over the number of threads
+    vec![
+        Arg::with_name("replay_forks_threads")
+            .long("replay-forks-threads")
+            .takes_value(true)
+            .value_name("NUMBER")
+            .default_value(&defaults.replay_forks_threads)
+            .validator(|num| is_within_range(num, 1..=get_max_thread_count()))
+            .help("Number of threads to use for replay of blocks on different forks"),
+        Arg::with_name("replay_transactions_threads")
+            .long("replay-transactions-threads")
+            .takes_value(true)
+            .value_name("NUMBER")
+            .default_value(&defaults.replay_transactions_threads)
+            .validator(|num| is_within_range(num, 1..=get_max_thread_count()))
+            .help("Number of threads to use for transaction replay"),
+    ]
+}

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -4,7 +4,7 @@ use {
     clap::{value_t_or_exit, Arg, ArgMatches},
     solana_clap_utils::{hidden_unless_forced, input_validators::is_within_range},
     solana_rayon_threadlimit::get_max_thread_count,
-    std::num::NonZeroUsize,
+    std::{num::NonZeroUsize, ops::RangeInclusive},
 };
 
 pub struct DefaultThreadArgs {
@@ -17,7 +17,7 @@ impl Default for DefaultThreadArgs {
         let num_total_threads = get_max_thread_count();
 
         Self {
-            replay_forks_threads: 1.to_string(),
+            replay_forks_threads: ReplayForksThreadsArg::default().to_string(),
             replay_transactions_threads: num_total_threads.to_string(),
         }
     }
@@ -29,16 +29,8 @@ pub struct NumThreadConfig {
 }
 
 pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
-    // Do not let any threadpool size scale over the number of threads
     vec![
-        Arg::with_name(replay_forks_threads::NAME)
-            .long(replay_forks_threads::LONG_ARG)
-            .takes_value(true)
-            .value_name("NUMBER")
-            .default_value(&defaults.replay_forks_threads)
-            .validator(|num| is_within_range(num, 1..=replay_forks_threads::MAX))
-            .hidden(hidden_unless_forced())
-            .help(replay_forks_threads::HELP),
+        new_thread_arg::<ReplayForksThreadsArg>(&defaults.replay_forks_threads),
         Arg::with_name(replay_transactions_threads::NAME)
             .long(replay_transactions_threads::LONG_ARG)
             .takes_value(true)
@@ -50,12 +42,23 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
     ]
 }
 
+fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
+    Arg::with_name(T::NAME)
+        .long(T::LONG_NAME)
+        .takes_value(true)
+        .value_name("NUMBER")
+        .default_value(default)
+        .validator(|num| is_within_range(num, T::range()))
+        .hidden(hidden_unless_forced())
+        .help(T::HELP)
+}
+
 pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
     NumThreadConfig {
         replay_forks_threads: if matches.is_present("replay_slots_concurrently") {
             NonZeroUsize::new(4).expect("4 is non-zero")
         } else {
-            value_t_or_exit!(matches, replay_forks_threads::NAME, NonZeroUsize)
+            value_t_or_exit!(matches, ReplayForksThreadsArg::NAME, NonZeroUsize)
         },
         replay_transactions_threads: value_t_or_exit!(
             matches,
@@ -65,13 +68,47 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
     }
 }
 
-mod replay_forks_threads {
-    pub const NAME: &str = "replay_forks_threads";
-    pub const LONG_ARG: &str = "replay-forks-threads";
-    pub const HELP: &str = "Number of threads to use for replay of blocks on different forks";
-    // Choose a value that is small enough to limit the overhead of having a large thread pool
-    // while also being large enough to allow replay of all active forks in most scenarios
-    pub const MAX: usize = 4;
+/// Configuration for CLAP arguments that control the number of threads for various functions
+trait ThreadArg {
+    /// The argument's name
+    const NAME: &'static str;
+    /// The argument's long name
+    const LONG_NAME: &'static str;
+    /// The argument's help message
+    const HELP: &'static str;
+
+    /// The default number of threads
+    fn default() -> usize;
+    /// The minimum allowed value of threads (inclusive)
+    fn min() -> usize {
+        1
+    }
+    /// The maximum allowed value of threads (inclusive)
+    fn max() -> usize {
+        // By default, no thread pool should scale over the machine's number of threads
+        get_max_thread_count()
+    }
+    /// The range of allowable values
+    fn range() -> RangeInclusive<usize> {
+        RangeInclusive::new(Self::min(), Self::max())
+    }
+}
+
+struct ReplayForksThreadsArg;
+impl ThreadArg for ReplayForksThreadsArg {
+    const NAME: &'static str = "replay_forks_threads";
+    const LONG_NAME: &'static str = "replay-forks-threads";
+    const HELP: &'static str = "Number of threads to use for replay of blocks on different forks";
+
+    fn default() -> usize {
+        // Default to single threaded fork execution
+        1
+    }
+    fn max() -> usize {
+        // Choose a value that is small enough to limit the overhead of having a large thread pool
+        // while also being large enough to allow replay of all active forks in most scenarios
+        4
+    }
 }
 
 mod replay_transactions_threads {

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -7,6 +7,7 @@ use {
     std::{num::NonZeroUsize, ops::RangeInclusive},
 };
 
+// Need this struct to provide &str whose lifetime matches that of the CLAP Arg's
 pub struct DefaultThreadArgs {
     pub replay_forks_threads: String,
     pub replay_transactions_threads: String,
@@ -19,11 +20,6 @@ impl Default for DefaultThreadArgs {
             replay_transactions_threads: ReplayTransactionsThreadsArg::default().to_string(),
         }
     }
-}
-
-pub struct NumThreadConfig {
-    pub replay_forks_threads: NonZeroUsize,
-    pub replay_transactions_threads: NonZeroUsize,
 }
 
 pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
@@ -42,6 +38,11 @@ fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
         .validator(|num| is_within_range(num, T::range()))
         .hidden(hidden_unless_forced())
         .help(T::HELP)
+}
+
+pub struct NumThreadConfig {
+    pub replay_forks_threads: NonZeroUsize,
+    pub replay_transactions_threads: NonZeroUsize,
 }
 
 pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -6,7 +6,7 @@ use {
         admin_rpc_service,
         admin_rpc_service::{load_staked_nodes_overrides, StakedNodesOverrides},
         bootstrap,
-        cli::{app, warn_for_deprecated_arguments, DefaultArgs},
+        cli::{self, app, warn_for_deprecated_arguments, DefaultArgs},
         dashboard::Dashboard,
         ledger_lockfile, lock_ledger, new_spinner_progress_bar, println_name_value,
         redirect_stderr_to_file,
@@ -1310,6 +1310,11 @@ pub fn main() {
     }
     let full_api = matches.is_present("full_rpc_api");
 
+    let cli::thread_args::NumThreadConfig {
+        replay_forks_threads,
+        replay_transactions_threads,
+    } = cli::thread_args::parse_num_threads_args(&matches);
+
     let mut validator_config = ValidatorConfig {
         require_tower: matches.is_present("require_tower"),
         tower_storage,
@@ -1451,16 +1456,8 @@ pub fn main() {
             use_snapshot_archives_at_startup::cli::NAME,
             UseSnapshotArchivesAtStartup
         ),
-        replay_forks_threads: if matches.is_present("replay_slots_concurrently") {
-            NonZeroUsize::new(4).expect("4 is non-zero")
-        } else {
-            value_t_or_exit!(matches, "replay_forks_threads", NonZeroUsize)
-        },
-        replay_transactions_threads: value_t_or_exit!(
-            matches,
-            "replay_transactions_threads",
-            NonZeroUsize
-        ),
+        replay_forks_threads,
+        replay_transactions_threads,
         ..ValidatorConfig::default()
     };
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1446,11 +1446,20 @@ pub fn main() {
             ..RuntimeConfig::default()
         },
         staked_nodes_overrides: staked_nodes_overrides.clone(),
-        replay_slots_concurrently: matches.is_present("replay_slots_concurrently"),
         use_snapshot_archives_at_startup: value_t_or_exit!(
             matches,
             use_snapshot_archives_at_startup::cli::NAME,
             UseSnapshotArchivesAtStartup
+        ),
+        replay_forks_threads: if matches.is_present("replay_slots_concurrently") {
+            NonZeroUsize::new(4).expect("4 is non-zero")
+        } else {
+            value_t_or_exit!(matches, "replay_forks_threads", NonZeroUsize)
+        },
+        replay_transactions_threads: value_t_or_exit!(
+            matches,
+            "replay_transactions_threads",
+            NonZeroUsize
         ),
         ..ValidatorConfig::default()
     };


### PR DESCRIPTION
#### Problem
We want to be able to control threadpool sizes on the CLI - see https://github.com/anza-xyz/agave/issues/105 for more context

#### Summary of Changes
- Introduce two new arguments to the CLI
    - One to control the number of threads for replaying multiple forks in parallel (this is a replacement for `--replay-slots-concurrently` which was a boolean with hard-coded number of threads if `true`)
    - One to control the size of the thread-pool used to execute transactions
- Deprecate the pre-existing `--replay-slots-concurrently` argument

I did a sanity check real quick to make sure nothing broke on CLI. Namely,
- Specify neither of the two new args and ensure default line up with existing behavior
- Specify custom values for each and observe those taking effect
- Specify `--replay-slots-concurrently` and `--replay-forks-threads` and observed error for conflict as expected

Lastly, there is another somewhat related pool that we may wish to control, the one used to replay local ledger before `ReplayStage` is created. While that is related, I think we can push to another PR, especially since we'll want an accompanying argument added to ledger-tool as well.
