### PR TITLE
ci: trigger macos clippy after linux check passed

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -1,23 +1,17 @@
 name: Cargo
 
 on:
-  push:
-    branches:
-      - master
-      - v[0-9]+.[0-9]+
-  pull_request:
-    branches:
-      - master
-      - v[0-9]+.[0-9]+
-    paths:
-      - "**.rs"
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-      - ".github/scripts/cargo-clippy-before-script.sh"
-      - ".github/workflows/cargo.yml"
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "commit hash"
+        required: true
+      ref:
+        description: "branch"
+        required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.event.inputs.sha }}
   cancel-in-progress: true
 
 env:
@@ -26,7 +20,26 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
+  setup-status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          retries: 3
+          script: |
+            github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: "macos-clippy",
+              description: "triggered by buildkite",
+              sha: "${{ github.event.inputs.sha }}",
+              state: "pending",
+              target_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            })
+
   clippy-stable:
+    needs: setup-status
     strategy:
       matrix:
         os:
@@ -49,6 +62,7 @@ jobs:
           scripts/cargo-clippy-stable.sh
 
   clippy-nightly:
+    needs: setup-status
     strategy:
       matrix:
         os:
@@ -69,3 +83,27 @@ jobs:
           source ci/rust-version.sh nightly
           rustup component add clippy --toolchain "$rust_nightly"
           scripts/cargo-clippy-nightly.sh
+
+  update-status:
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - clippy-stable
+      - clippy-nightly
+    env:
+      STATE: ${{ (contains(needs.clippy-stable.result, 'success') && contains(needs.clippy-nightly.result, 'success')) && 'success' || 'failure' }}
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          retries: 3
+          script: |
+            github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: "macos-clippy",
+              description: "triggered by buildkite",
+              sha: "${{ github.event.inputs.sha }}",
+              state: process.env.STATE,
+              target_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            })

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -60,13 +60,7 @@ pull_request_rules:
           - status-success=build & deploy docs
         - or:
           - -files~=(\.rs|Cargo\.toml|Cargo\.lock|\.github/scripts/cargo-clippy-before-script\.sh|\.github/workflows/cargo\.yml)$
-          - and:
-            - or:
-              - check-success=clippy-stable (macos-latest)
-              - check-success=clippy-stable (macos-latest-large)
-            - or:
-              - check-success=clippy-nightly (macos-latest)
-              - check-success=clippy-nightly (macos-latest-large)
+          - check-success=macos-clippy
         - or:
           - -files~=(\.rs|Cargo\.toml|Cargo\.lock|cargo-build-bpf|cargo-test-bpf|cargo-build-sbf|cargo-test-sbf|ci/downstream-projects/run-spl\.sh|\.github/workflows/downstream-project-spl\.yml)$
           - and:

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -161,6 +161,28 @@ all_test_steps() {
     annotate --style info --context test-docs \
       "Docs skipped as no .rs files were modified"
   fi
+
+  # trigger macos clippy
+  if affects \
+    .rs$ \
+    Cargo.lock$ \
+    Cargo.toml$ \
+    .github/scripts/cargo-clippy-before-script.sh \
+    .github/workflows/cargo.yml \
+  ; then
+    cat >> "$output_file" <<"EOF"
+  - command: "./ci/trigger-macos-clippy-test.sh"
+    name: "trigger macos clippy"
+    timeout_in_minutes: 5
+    soft_fail: true
+    agents:
+      queue: "solana"
+EOF
+  else
+    annotate --style info \
+      "macos clippy skipped as no relevant files were modified"
+  fi
+
   wait_step
 
   # SBF test suite

--- a/ci/trigger-macos-clippy-test.sh
+++ b/ci/trigger-macos-clippy-test.sh
@@ -6,7 +6,7 @@ set -e
 : "${CI_BRANCH:?}"
 : "${CI_COMMIT:?}"
 
-curl -L -X POST --fail-with-body \
+curl -L -X POST --fail \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer $GH_TOKEN" \
   -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/ci/trigger-macos-clippy-test.sh
+++ b/ci/trigger-macos-clippy-test.sh
@@ -6,7 +6,7 @@ set -e
 : "${CI_BRANCH:?}"
 : "${CI_COMMIT:?}"
 
-curl -L -X POST \
+curl -L -X POST --fail-with-body \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer $GH_TOKEN" \
   -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/ci/trigger-macos-clippy-test.sh
+++ b/ci/trigger-macos-clippy-test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+: "${GH_TOKEN:?}"
+: "${CI_BRANCH:?}"
+: "${CI_COMMIT:?}"
+
+curl -L -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GH_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/anza-xyz/agave/actions/workflows/cargo.yml/dispatches \
+  -d '{"ref":"master","inputs":{"ref":'"$CI_BRANCH"',"sha":'"$CI_COMMIT"'}}'


### PR DESCRIPTION
#### Problem

We use large runners for `macos clippy`. would like to have another process for saving money. 💸 

#### Summary of Changes

call `macos clippy` after linux check.

(--fail-with-body is added in 7.76.0 😞 so I use --fail instead)