### PR TITLE
[anza migration] fix: use the correct log filter for non-unix

### DIFF
--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -77,7 +77,7 @@ pub fn redirect_stderr_to_file(logfile: Option<String>) -> Option<JoinHandle<()>
             #[cfg(not(unix))]
             {
                 println!("logrotate is not supported on this platform");
-                solana_logger::setup_file_with_default(&logfile, filter);
+                solana_logger::setup_file_with_default(&logfile, solana_logger::DEFAULT_FILTER);
                 None
             }
         }


### PR DESCRIPTION
#### Problem

I removed the `filter` variable in #223, but I didn't notice that the non-Unix code was also using it 😞 

#### Summary of Changes

use the new public const in the solana_logger

https://github.com/anza-xyz/agave/blob/51dc7e6fb7589344497ce030950663c800685408/logger/src/lib.rs#L13