### PR TITLE
Clean up require_rent_exempt_split_destination feature

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -468,12 +468,6 @@ mod tests {
         feature_set
     }
 
-    fn feature_set_without_require_rent_exempt_split_destination() -> Arc<FeatureSet> {
-        let mut feature_set = FeatureSet::all_enabled();
-        feature_set.deactivate(&feature_set::require_rent_exempt_split_destination::id());
-        Arc::new(feature_set)
-    }
-
     fn create_default_account() -> AccountSharedData {
         AccountSharedData::new(0, 0, &Pubkey::new_unique())
     }
@@ -6013,7 +6007,6 @@ mod tests {
         }
     }
 
-    #[test_case(feature_set_without_require_rent_exempt_split_destination(), Ok(()); "without_require_rent_exempt_split_destination")]
     #[test_case(feature_set_all_enabled(), Err(InstructionError::InsufficientFunds); "all_enabled")]
     fn test_split_require_rent_exempt_destination(
         feature_set: Arc<FeatureSet>,

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -985,8 +985,7 @@ fn validate_split_amount(
     let rent = invoke_context.get_sysvar_cache().get_rent()?;
     let destination_rent_exempt_reserve = rent.minimum_balance(destination_data_len);
 
-    // As of feature `require_rent_exempt_split_destination`, if the source is active stake, one of
-    // these criteria must be met:
+    // If the source is active stake, one of these criteria must be met:
     // 1. the destination account must be prefunded with at least the rent-exempt reserve, or
     // 2. the split must consume 100% of the source
     if source_is_active

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -417,15 +417,10 @@ pub fn split(
         StakeStateV2::Stake(meta, mut stake, stake_flags) => {
             meta.authorized.check(signers, StakeAuthorize::Staker)?;
             let minimum_delegation = crate::get_minimum_delegation(&invoke_context.feature_set);
-            let is_active = if invoke_context
-                .feature_set
-                .is_active(&feature_set::require_rent_exempt_split_destination::id())
-            {
+            let is_active = {
                 let clock = invoke_context.get_sysvar_cache().get_clock()?;
                 let status = get_stake_status(invoke_context, &stake, &clock)?;
                 status.effective > 0
-            } else {
-                false
             };
             let validated_split_info = validate_split_amount(
                 invoke_context,
@@ -994,10 +989,7 @@ fn validate_split_amount(
     // these criteria must be met:
     // 1. the destination account must be prefunded with at least the rent-exempt reserve, or
     // 2. the split must consume 100% of the source
-    if invoke_context
-        .feature_set
-        .is_active(&feature_set::require_rent_exempt_split_destination::id())
-        && source_is_active
+    if source_is_active
         && source_remaining_balance != 0
         && destination_lamports < destination_rent_exempt_reserve
     {


### PR DESCRIPTION
#### Problem
This feature has been activated on all clusters:
`D2aip4BBr8NPWtU9vLrwrBvbuaQ8w1zV38zFLxx4pfBV`: require_rent_exempt_split_destination::id(), "Require stake split destination account to be rent exempt"

#### Summary of Changes
Clean up feature-gate logic

Closes https://github.com/solana-labs/solana/issues/33300
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
