### PR TITLE
Fix pubkey formatter 

### DIFF
--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -291,7 +291,7 @@ impl RemoteWalletInfo {
     }
 
     pub fn get_pretty_path(&self) -> String {
-        format!("usb://{}/{:?}", self.manufacturer, self.pubkey,)
+        format!("usb://{}/{}", self.manufacturer, self.pubkey,)
     }
 
     pub(crate) fn matches(&self, other: &Self) -> bool {

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -665,13 +665,15 @@ impl AsMut<[u8]> for Pubkey {
 
 impl fmt::Debug for Pubkey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", bs58::encode(self.0).into_string())
+        let _ = bs58::encode(self.0).into_string().fmt(f);
+        write!(f, "")
     }
 }
 
 impl fmt::Display for Pubkey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", bs58::encode(self.0).into_string())
+        let _ = bs58::encode(self.0).into_string().fmt(f);
+        write!(f, "")
     }
 }
 
@@ -991,5 +993,18 @@ mod tests {
             Err(PubkeyError::IllegalOwner)
         );
         assert!(pubkey_from_seed_by_marker(&PDA_MARKER[1..]).is_ok());
+    }
+
+    /// 1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM (before)
+    /// 1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKMxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (this pr)
+    #[test]
+    fn test_pubkey_fmt() {
+        let key = Pubkey::new_unique();
+        let s = format!("{:x<80}", key);
+        assert_eq!(s.len(), 80);
+        assert_eq!(
+            s,
+            "1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKMxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        );
     }
 }

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -665,15 +665,13 @@ impl AsMut<[u8]> for Pubkey {
 
 impl fmt::Debug for Pubkey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let _ = bs58::encode(self.0).into_string().fmt(f);
-        write!(f, "")
+        bs58::encode(self.0).into_string().fmt(f)
     }
 }
 
 impl fmt::Display for Pubkey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let _ = bs58::encode(self.0).into_string().fmt(f);
-        write!(f, "")
+        bs58::encode(self.0).into_string().fmt(f)
     }
 }
 


### PR DESCRIPTION
#### Problem

Per https://github.com/anza-xyz/agave/pull/241

pubkey display didn't honor user supplied format string. Inside `fmt`, it always use "{}". This commit fix it by using the fmt from the argument to format the string.

We probably should do this for all other user customized type formatter.


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
