### PR TITLE
add in method for building a `TpuClient` for `LocalCluster` tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6427,6 +6427,7 @@ dependencies = [
  "solana-ledger",
  "solana-logger",
  "solana-pubsub-client",
+ "solana-quic-client",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-runtime",

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -7,14 +7,11 @@ use {
         cli::{Config, InstructionPaddingConfig},
         send_batch::generate_durable_nonce_accounts,
     },
-    solana_client::{
-        connection_cache::ConnectionCache,
-        tpu_client::{TpuClient, TpuClientConfig},
-    },
+    solana_client::tpu_client::{TpuClient, TpuClientConfig},
     solana_core::validator::ValidatorConfig,
     solana_faucet::faucet::run_local_faucet,
     solana_local_cluster::{
-        local_cluster::{ClusterConfig, LocalCluster},
+        local_cluster::{build_tpu_quic_client, ClusterConfig, LocalCluster},
         validator_configs::make_identical_validator_configs,
     },
     solana_rpc::rpc::JsonRpcConfig,
@@ -78,24 +75,9 @@ fn test_bench_tps_local_cluster(config: Config) {
 
     cluster.transfer(&cluster.funding_keypair, &faucet_pubkey, 100_000_000);
 
-    let ConnectionCache::Quic(cache) = &*cluster.connection_cache else {
-        panic!("Expected a Quic ConnectionCache.");
-    };
-
-    let rpc_pubsub_url = format!("ws://{}/", cluster.entry_point_info.rpc_pubsub().unwrap());
-    let rpc_url = format!("http://{}", cluster.entry_point_info.rpc().unwrap());
-
-    let client = Arc::new(
-        TpuClient::new_with_connection_cache(
-            Arc::new(RpcClient::new(rpc_url)),
-            rpc_pubsub_url.as_str(),
-            TpuClientConfig::default(),
-            cache.clone(),
-        )
-        .unwrap_or_else(|err| {
-            panic!("Could not create TpuClient {err:?}");
-        }),
-    );
+    let client = Arc::new(build_tpu_quic_client(&cluster).unwrap_or_else(|err| {
+        panic!("Could not create TpuClient with Quic Cache {err:?}");
+    }));
 
     let lamports_per_account = 100;
 

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -11,7 +11,8 @@ use {
     solana_core::validator::ValidatorConfig,
     solana_faucet::faucet::run_local_faucet,
     solana_local_cluster::{
-        local_cluster::{build_tpu_quic_client, ClusterConfig, LocalCluster},
+        cluster::Cluster,
+        local_cluster::{ClusterConfig, LocalCluster},
         validator_configs::make_identical_validator_configs,
     },
     solana_rpc::rpc::JsonRpcConfig,
@@ -75,7 +76,7 @@ fn test_bench_tps_local_cluster(config: Config) {
 
     cluster.transfer(&cluster.funding_keypair, &faucet_pubkey, 100_000_000);
 
-    let client = Arc::new(build_tpu_quic_client(&cluster).unwrap_or_else(|err| {
+    let client = Arc::new(cluster.build_tpu_quic_client().unwrap_or_else(|err| {
         panic!("Could not create TpuClient with Quic Cache {err:?}");
     }));
 

--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -21,6 +21,8 @@ pub use {
     solana_tpu_client::tpu_client::{TpuClientConfig, DEFAULT_FANOUT_SLOTS, MAX_FANOUT_SLOTS},
 };
 
+pub type QuicTpuClient = TpuClient<QuicPool, QuicConnectionManager, QuicConfig>;
+
 pub enum TpuClientWrapper {
     Quic(TpuClient<QuicPool, QuicConnectionManager, QuicConfig>),
     Udp(TpuClient<UdpPool, UdpConnectionManager, UdpConfig>),

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -818,16 +818,15 @@ fn main() {
 pub mod test {
     use {
         super::*,
-        solana_client::tpu_client::TpuClient,
+        solana_client::tpu_client::QuicTpuClient,
         solana_core::validator::ValidatorConfig,
         solana_faucet::faucet::run_local_faucet,
         solana_gossip::contact_info::LegacyContactInfo,
         solana_local_cluster::{
             cluster::Cluster,
-            local_cluster::{build_tpu_quic_client, ClusterConfig, LocalCluster},
+            local_cluster::{ClusterConfig, LocalCluster},
             validator_configs::make_identical_validator_configs,
         },
-        solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
         solana_rpc::rpc::JsonRpcConfig,
         solana_sdk::timing::timestamp,
     };
@@ -837,9 +836,7 @@ pub mod test {
     // thin wrapper for the run_dos function
     // to avoid specifying everywhere generic parameters
     fn run_dos_no_client(nodes: &[ContactInfo], iterations: usize, params: DosClientParameters) {
-        run_dos::<TpuClient<QuicPool, QuicConnectionManager, QuicConfig>>(
-            nodes, iterations, None, params,
-        );
+        run_dos::<QuicTpuClient>(nodes, iterations, None, params);
     }
 
     #[test]
@@ -979,7 +976,7 @@ pub mod test {
             .unwrap();
         let nodes_slice = [node];
 
-        let client = Arc::new(build_tpu_quic_client(&cluster).unwrap_or_else(|err| {
+        let client = Arc::new(cluster.build_tpu_quic_client().unwrap_or_else(|err| {
             panic!("Could not create TpuClient with Quic Cache {err:?}");
         }));
 
@@ -1113,7 +1110,7 @@ pub mod test {
             .unwrap();
         let nodes_slice = [node];
 
-        let client = Arc::new(build_tpu_quic_client(&cluster).unwrap_or_else(|err| {
+        let client = Arc::new(cluster.build_tpu_quic_client().unwrap_or_else(|err| {
             panic!("Could not create TpuClient with Quic Cache {err:?}");
         }));
 

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -24,6 +24,7 @@ solana-gossip = { workspace = true }
 solana-ledger = { workspace = true }
 solana-logger = { workspace = true }
 solana-pubsub-client = { workspace = true }
+solana-quic-client = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }

--- a/local-cluster/src/cluster.rs
+++ b/local-cluster/src/cluster.rs
@@ -1,11 +1,11 @@
 use {
-    solana_client::thin_client::ThinClient,
+    solana_client::{thin_client::ThinClient, tpu_client::QuicTpuClient},
     solana_core::validator::{Validator, ValidatorConfig},
     solana_gossip::{cluster_info::Node, contact_info::ContactInfo},
     solana_ledger::shred::Shred,
-    solana_sdk::{pubkey::Pubkey, signature::Keypair},
+    solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Keypair},
     solana_streamer::socket::SocketAddrSpace,
-    std::{path::PathBuf, sync::Arc},
+    std::{io::Result, path::PathBuf, sync::Arc},
 };
 
 pub struct ValidatorInfo {
@@ -38,6 +38,11 @@ impl ClusterValidatorInfo {
 pub trait Cluster {
     fn get_node_pubkeys(&self) -> Vec<Pubkey>;
     fn get_validator_client(&self, pubkey: &Pubkey) -> Option<ThinClient>;
+    fn build_tpu_quic_client(&self) -> Result<QuicTpuClient>;
+    fn build_tpu_quic_client_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> Result<QuicTpuClient>;
     fn get_contact_info(&self, pubkey: &Pubkey) -> Option<&ContactInfo>;
     fn exit_node(&mut self, pubkey: &Pubkey) -> ClusterValidatorInfo;
     fn restart_node(

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -7,7 +7,12 @@ use {
     itertools::izip,
     log::*,
     solana_accounts_db::utils::create_accounts_run_and_snapshot_dirs,
-    solana_client::{connection_cache::ConnectionCache, thin_client::ThinClient},
+    solana_client::{
+        connection_cache::ConnectionCache,
+        rpc_client::RpcClient,
+        thin_client::ThinClient,
+        tpu_client::{TpuClient, TpuClientConfig},
+    },
     solana_core::{
         consensus::tower_storage::FileTowerStorage,
         validator::{Validator, ValidatorConfig, ValidatorStartProgress},
@@ -18,6 +23,7 @@ use {
         gossip_service::discover_cluster,
     },
     solana_ledger::{create_new_tmp_ledger, shred::Shred},
+    solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
     solana_runtime::{
         genesis_utils::{
             create_genesis_config_with_vote_accounts_and_cluster_type, GenesisConfigInfo,
@@ -62,6 +68,52 @@ use {
         sync::{Arc, RwLock},
     },
 };
+
+pub fn build_tpu_quic_client(
+    cluster: &LocalCluster,
+) -> Result<TpuClient<QuicPool, QuicConnectionManager, QuicConfig>> {
+    build_tpu_client(cluster, |rpc_url| Arc::new(RpcClient::new(rpc_url)))
+}
+
+pub fn build_tpu_quic_client_with_commitment(
+    cluster: &LocalCluster,
+    commitment_config: CommitmentConfig,
+) -> Result<TpuClient<QuicPool, QuicConnectionManager, QuicConfig>> {
+    build_tpu_client(cluster, |rpc_url| {
+        Arc::new(RpcClient::new_with_commitment(rpc_url, commitment_config))
+    })
+}
+
+fn build_tpu_client<F>(
+    cluster: &LocalCluster,
+    rpc_client_builder: F,
+) -> Result<TpuClient<QuicPool, QuicConnectionManager, QuicConfig>>
+where
+    F: FnOnce(String) -> Arc<RpcClient>,
+{
+    let rpc_pubsub_url = format!("ws://{}/", cluster.entry_point_info.rpc_pubsub().unwrap());
+    let rpc_url = format!("http://{}", cluster.entry_point_info.rpc().unwrap());
+
+    let cache = match &*cluster.connection_cache {
+        ConnectionCache::Quic(cache) => cache,
+        ConnectionCache::Udp(_) => {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "Expected a Quic ConnectionCache. Got UDP",
+            ))
+        }
+    };
+
+    let tpu_client = TpuClient::new_with_connection_cache(
+        rpc_client_builder(rpc_url),
+        rpc_pubsub_url.as_str(),
+        TpuClientConfig::default(),
+        cache.clone(),
+    )
+    .map_err(|err| Error::new(ErrorKind::Other, format!("TpuSenderError: {}", err)))?;
+
+    Ok(tpu_client)
+}
 
 const DUMMY_SNAPSHOT_CONFIG_PATH_MARKER: &str = "dummy";
 


### PR DESCRIPTION
A PR to setup the removal of `ThinClient` from `LocalCluster`

#### Problem
Building a `TpuClient` with a quic cache for tests can be cumbersome. Requires a decent amount of duplicate code. 

#### Summary of Changes
1) Add methods `build_tpu_quic_client` and `build_tpu_quic_client_with_commitment` 
2) Update `dos/` and `bench-tps/` tests to use the new methods

Note: `build_tpu_quic_client_with_commitment` is not currently used but will be in future changes 

This is the 8th PR on the way to remove `ThinClient` completely. 
See 
- 1st PR: https://github.com/solana-labs/solana/pull/35335
- 2nd PR: https://github.com/solana-labs/solana/pull/35365
- 3rd PR: https://github.com/anza-xyz/agave/pull/177
- 4th PR: https://github.com/anza-xyz/agave/pull/184
- 5th PR: https://github.com/anza-xyz/agave/pull/117
- 6th PR: https://github.com/anza-xyz/agave/pull/132
- 7th PR: https://github.com/anza-xyz/agave/pull/227