### PR TITLE
[TieredStorage] TieredStorageFile -> TieredReadonlyFile and TieredWritableFIle

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -7,7 +7,7 @@ use {
         accounts_hash::AccountHash,
         tiered_storage::{
             byte_block,
-            file::TieredStorageFile,
+            file::TieredWritableFile,
             footer::{AccountBlockFormat, AccountMetaFormat, TieredStorageFooter},
             index::{AccountIndexWriterEntry, AccountOffset, IndexBlockFormat, IndexOffset},
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
@@ -542,7 +542,7 @@ impl HotStorageReader {
 }
 
 fn write_optional_fields(
-    file: &TieredStorageFile,
+    file: &TieredWritableFile,
     opt_fields: &AccountMetaOptionalFields,
 ) -> TieredStorageResult<usize> {
     let mut size = 0;
@@ -558,14 +558,14 @@ fn write_optional_fields(
 /// The writer that creates a hot accounts file.
 #[derive(Debug)]
 pub struct HotStorageWriter {
-    storage: TieredStorageFile,
+    storage: TieredWritableFile,
 }
 
 impl HotStorageWriter {
     /// Create a new HotStorageWriter with the specified path.
     pub fn new(file_path: impl AsRef<Path>) -> TieredStorageResult<Self> {
         Ok(Self {
-            storage: TieredStorageFile::new_writable(file_path)?,
+            storage: TieredWritableFile::new(file_path)?,
         })
     }
 
@@ -706,7 +706,7 @@ pub mod tests {
         super::*,
         crate::tiered_storage::{
             byte_block::ByteBlockWriter,
-            file::TieredStorageFile,
+            file::TieredWritableFile,
             footer::{AccountBlockFormat, AccountMetaFormat, TieredStorageFooter, FOOTER_SIZE},
             hot::{HotAccountMeta, HotStorageReader},
             index::{AccountIndexWriterEntry, IndexBlockFormat, IndexOffset},
@@ -892,7 +892,7 @@ pub mod tests {
         };
 
         {
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
             expected_footer.write_footer_block(&file).unwrap();
         }
 
@@ -928,7 +928,7 @@ pub mod tests {
             ..TieredStorageFooter::default()
         };
         {
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
             let mut current_offset = 0;
 
             account_offsets = hot_account_metas
@@ -971,7 +971,7 @@ pub mod tests {
         };
 
         {
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
             footer.write_footer_block(&file).unwrap();
         }
 
@@ -1016,7 +1016,7 @@ pub mod tests {
             ..TieredStorageFooter::default()
         };
         {
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
 
             let cursor = footer
                 .index_block_format
@@ -1059,7 +1059,7 @@ pub mod tests {
         };
 
         {
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
 
             let mut owners_table = OwnersTable::default();
             addresses.iter().for_each(|owner_address| {
@@ -1118,7 +1118,7 @@ pub mod tests {
         let account_offsets: Vec<_>;
 
         {
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
             let mut current_offset = 0;
 
             account_offsets = hot_account_metas
@@ -1237,7 +1237,7 @@ pub mod tests {
         };
 
         {
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
             let mut current_offset = 0;
 
             // write accounts blocks

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -1,6 +1,6 @@
 use {
     crate::tiered_storage::{
-        file::TieredStorageFile, footer::TieredStorageFooter, mmap_utils::get_pod,
+        file::TieredWritableFile, footer::TieredStorageFooter, mmap_utils::get_pod,
         TieredStorageResult,
     },
     bytemuck::{Pod, Zeroable},
@@ -59,7 +59,7 @@ impl IndexBlockFormat {
     /// the total number of bytes written.
     pub fn write_index_block(
         &self,
-        file: &TieredStorageFile,
+        file: &TieredWritableFile,
         index_entries: &[AccountIndexWriterEntry<impl AccountOffset>],
     ) -> TieredStorageResult<usize> {
         match self {
@@ -147,7 +147,7 @@ mod tests {
     use {
         super::*,
         crate::tiered_storage::{
-            file::TieredStorageFile,
+            file::TieredWritableFile,
             hot::{HotAccountOffset, HOT_ACCOUNT_ALIGNMENT},
         },
         memmap2::MmapOptions,
@@ -181,7 +181,7 @@ mod tests {
             .collect();
 
         {
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
             let indexer = IndexBlockFormat::AddressesThenOffsets;
             let cursor = indexer.write_index_block(&file, &index_entries).unwrap();
             footer.owners_block_offset = cursor as u64;
@@ -223,7 +223,7 @@ mod tests {
         {
             // we only write a footer here as the test should hit an assert
             // failure before it actually reads the file.
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
             footer.write_footer_block(&file).unwrap();
         }
 
@@ -259,7 +259,7 @@ mod tests {
         {
             // we only write a footer here as the test should hit an assert
             // failure before it actually reads the file.
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
             footer.write_footer_block(&file).unwrap();
         }
 
@@ -294,7 +294,7 @@ mod tests {
         {
             // we only write a footer here as the test should hit an assert
             // failure before we actually read the file.
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
             footer.write_footer_block(&file).unwrap();
         }
 
@@ -334,7 +334,7 @@ mod tests {
         {
             // we only write a footer here as the test should hit an assert
             // failure before we actually read the file.
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
             footer.write_footer_block(&file).unwrap();
         }
 

--- a/accounts-db/src/tiered_storage/owners.rs
+++ b/accounts-db/src/tiered_storage/owners.rs
@@ -1,6 +1,6 @@
 use {
     crate::tiered_storage::{
-        file::TieredStorageFile, footer::TieredStorageFooter, mmap_utils::get_pod,
+        file::TieredWritableFile, footer::TieredStorageFooter, mmap_utils::get_pod,
         TieredStorageResult,
     },
     indexmap::set::IndexSet,
@@ -47,7 +47,7 @@ impl OwnersBlockFormat {
     /// Persists the provided owners' addresses into the specified file.
     pub fn write_owners_block(
         &self,
-        file: &TieredStorageFile,
+        file: &TieredWritableFile,
         owners_table: &OwnersTable,
     ) -> TieredStorageResult<usize> {
         match self {
@@ -116,7 +116,7 @@ impl<'a> OwnersTable<'a> {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::tiered_storage::file::TieredStorageFile, memmap2::MmapOptions,
+        super::*, crate::tiered_storage::file::TieredWritableFile, memmap2::MmapOptions,
         std::fs::OpenOptions, tempfile::TempDir,
     };
 
@@ -139,7 +139,7 @@ mod tests {
         };
 
         {
-            let file = TieredStorageFile::new_writable(&path).unwrap();
+            let file = TieredWritableFile::new(&path).unwrap();
 
             let mut owners_table = OwnersTable::default();
             addresses.iter().for_each(|owner_address| {


### PR DESCRIPTION
#### Problem
TieredStorageFile struct currently offers new_readonly() and new_writable()
to allow both read and write work-load to share the same struct.  However,
as we need the writer to use BufWriter to improve performance as well as
enable Hasher on writes.  There is a need to refactor TieredStorageFile to
split its usage for read-only and writable.

#### Summary of Changes
Refactor TieredStorageFile to TieredReadonlyFIle and TieredWritableFile.

#### Test Plan
Existing tiered-storage tests.