### PR TITLE
accounts-db: use io_uring when available to remove large directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-io-uring"
+version = "3.0.0"
+dependencies = [
+ "io-uring",
+ "libc",
+ "log",
+ "slab",
+ "smallvec",
+]
+
+[[package]]
 name = "agave-ledger-tool"
 version = "3.0.0"
 dependencies = [
@@ -3793,6 +3804,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ebb93303c65a11753dd0e45cd6bfa5c65ee1f0b9f8e2178b6998ddc8b284f04"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if 1.0.0",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6722,6 +6722,7 @@ dependencies = [
 name = "solana-accounts-db"
 version = "3.0.0"
 dependencies = [
+ "agave-io-uring",
  "agave-reserved-account-keys",
  "ahash 0.8.11",
  "assert_matches",
@@ -6735,6 +6736,7 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "indexmap 2.9.0",
+ "io-uring",
  "itertools 0.12.1",
  "libsecp256k1",
  "log",
@@ -6752,6 +6754,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
+ "slab",
  "smallvec",
  "solana-account",
  "solana-accounts-db",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "geyser-plugin-manager",
     "gossip",
     "install",
+    "io-uring",
     "keygen",
     "lattice-hash",
     "ledger",
@@ -180,6 +181,7 @@ agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", vers
 agave-cargo-registry = { path = "cargo-registry", version = "=3.0.0" }
 agave-feature-set = { path = "feature-set", version = "=3.0.0" }
 agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=3.0.0" }
+agave-io-uring = { path = "io-uring", version = "=3.0.0" }
 agave-precompiles = { path = "precompiles", version = "=3.0.0" }
 agave-reserved-account-keys = { path = "reserved-account-keys", version = "=3.0.0" }
 agave-thread-manager = { path = "thread-manager", version = "=3.0.0" }
@@ -278,6 +280,7 @@ hyper-proxy = "0.9.1"
 im = "15.1.0"
 indexmap = "2.9.0"
 indicatif = "0.17.11"
+io-uring = "0.7.4"
 itertools = "0.12.1"
 jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
     "unprefixed_malloc_on_supported_platforms",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -59,6 +59,7 @@ rayon = { workspace = true }
 seqlock = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
+slab = { workspace = true }
 smallvec = { workspace = true, features = ["const_generics"] }
 solana-account = { workspace = true, features = ["serde"] }
 solana-address-lookup-table-interface = { workspace = true, features = [
@@ -105,6 +106,10 @@ static_assertions = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+agave-io-uring = { workspace = true }
+io-uring = { workspace = true }
 
 [dev-dependencies]
 agave-reserved-account-keys = { workspace = true }

--- a/accounts-db/src/io_uring/dir_remover.rs
+++ b/accounts-db/src/io_uring/dir_remover.rs
@@ -1,0 +1,256 @@
+use {
+    agave_io_uring::{Completion, Ring, RingOp},
+    io_uring::{opcode, squeue, types, IoUring},
+    slab::Slab,
+    std::{
+        collections::VecDeque,
+        ffi::{CString, OsString},
+        fs, io,
+        os::{
+            fd::{AsRawFd, IntoRawFd, OwnedFd, RawFd},
+            unix::ffi::OsStringExt as _,
+        },
+        path::PathBuf,
+    },
+};
+
+/// A fast directory remover using io_uring.
+pub struct RingDirRemover {
+    ring: Ring<State, Op>,
+}
+
+impl RingDirRemover {
+    /// Creates a new remover.
+    pub fn new() -> io::Result<RingDirRemover> {
+        let ring = IoUring::builder().setup_sqpoll(1000).build(1024)?;
+        // 12 is a good round number. Empirically removing unpacked snapshots, it appears to be high
+        // enough to be fast but not too high to cause too much inode contention.
+        ring.submitter().register_iowq_max_workers(&mut [12, 0])?;
+        Ok(Self::with_ring(ring))
+    }
+
+    /// Creates a new remover, using the provided io_uring instance.
+    fn with_ring(ring: IoUring) -> RingDirRemover {
+        RingDirRemover {
+            ring: Ring::new(ring, State { dirs: Slab::new() }),
+        }
+    }
+
+    /// Removes a directory and all its contents.
+    pub fn remove_dir_all(&mut self, path: impl Into<PathBuf>) -> io::Result<()> {
+        self.remove(path, true)
+    }
+
+    /// Removes the contents of a directory, but not the directory itself.
+    pub fn remove_dir_contents(&mut self, path: impl Into<PathBuf>) -> io::Result<()> {
+        self.remove(path, false)
+    }
+
+    fn remove(&mut self, path: impl Into<PathBuf>, remove_root: bool) -> io::Result<()> {
+        let path = path.into();
+
+        let root_path = path.clone();
+        let mut stack = VecDeque::new();
+
+        // iterate over all directories recursively and unlink all entries
+        stack.push_back(path);
+        while let Some(dir_path) = stack.pop_front() {
+            let file = std::fs::File::open(&dir_path)?;
+            let fd = OwnedFd::from(file);
+            let dir_fd = fd.as_raw_fd();
+            let dir_key = self.ring.context_mut().dirs.insert(Directory::new(fd));
+
+            for entry in fs::read_dir(&dir_path)? {
+                let entry = entry?;
+                let dir = &mut self.ring.context_mut().dirs[dir_key];
+
+                let is_dir = entry.file_type()?.is_dir();
+                if is_dir {
+                    stack.push_back(entry.path());
+                } else {
+                    dir.unlink_started += 1;
+                    let op = UnlinkOp::new(dir_key, dir_fd, entry.file_name());
+
+                    self.ring.push(Op::Unlink(op))?;
+                }
+            }
+
+            // mark the directory as having finished scanning
+            let dir = &mut self.ring.context_mut().dirs[dir_key];
+            dir.set_finished_scanning();
+
+            // If the directory was empty or all unlink ops completed before we called
+            // dir.set_finished_scanning(), we must close the dir fd now. Otherwise it gets
+            // closed by the last UnlinkOp::complete() call.
+            if dir.scanned_and_unlinked() {
+                if let Some(fd) = dir.fd.take() {
+                    self.ring
+                        .push(Op::Close(CloseOp::new(dir_key, fd.into_raw_fd())))?;
+                }
+            }
+        }
+
+        // wait for all ring operations to complete
+        self.ring.drain()?;
+
+        if remove_root {
+            fs::remove_dir_all(root_path)?;
+        } else {
+            for dir in fs::read_dir(root_path)? {
+                let dir = dir?;
+                if dir.file_type()?.is_dir() {
+                    fs::remove_dir_all(dir.path())?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub struct State {
+    dirs: Slab<Directory>,
+}
+
+pub struct Directory {
+    // File descriptor of the directory.
+    fd: Option<OwnedFd>,
+    // Keep track of how many ops are in flight
+    unlink_started: usize,
+    unlink_completed: usize,
+    // Whether we have finished scanning the directory
+    finished_scanning: bool,
+}
+
+impl Directory {
+    pub fn new(fd: OwnedFd) -> Directory {
+        Directory {
+            fd: Some(fd),
+            unlink_started: 0,
+            unlink_completed: 0,
+            finished_scanning: false,
+        }
+    }
+
+    fn set_finished_scanning(&mut self) {
+        self.finished_scanning = true;
+    }
+
+    // Returns true once we have finished scanning the directory and all unlink
+    // ops have completed.
+    //
+    // This is used to determine whether we can close the directory fd.
+    fn scanned_and_unlinked(&self) -> bool {
+        self.finished_scanning && self.unlink_started == self.unlink_completed
+    }
+}
+
+// Op used to unlink a file within a directory.
+struct UnlinkOp {
+    // directory key within state.dirs
+    dir_key: usize,
+    // file descriptor of the parent dir and path of the file to unlink
+    dir_fd: RawFd,
+    path: CString,
+}
+
+impl std::fmt::Debug for UnlinkOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UnlinkOp")
+            .field("dir_key", &self.dir_key)
+            .field("dir_fd", &self.dir_fd)
+            // Safety: the path is guaranteed to be null terminated
+            .field("path", &self.path.as_c_str())
+            .finish()
+    }
+}
+
+impl UnlinkOp {
+    fn new(dir_key: usize, dir_fd: RawFd, file_name: OsString) -> UnlinkOp {
+        UnlinkOp {
+            dir_key,
+            dir_fd,
+            path: CString::new(file_name.into_vec()).unwrap(),
+        }
+    }
+
+    fn entry(&mut self) -> squeue::Entry {
+        opcode::UnlinkAt::new(types::Fd(self.dir_fd), self.path.as_ptr() as _).build()
+    }
+
+    fn complete(
+        &mut self,
+        comp: &mut Completion<State, Op>,
+        res: io::Result<i32>,
+    ) -> io::Result<()> {
+        let _ = res?;
+
+        let dir = &mut comp.context_mut().dirs[self.dir_key];
+        dir.unlink_completed += 1;
+        if dir.scanned_and_unlinked() {
+            // This was the last file to be removed, we can now close the parent
+            // directory fd.
+            //
+            // Safety: the entry doesn't hold any pointers
+            if let Some(fd) = dir.fd.take() {
+                comp.push(Op::Close(CloseOp::new(self.dir_key, fd.into_raw_fd())));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// Op used to close the directory file descriptor once we have finished scanning and unlinking all
+// entries.
+#[derive(Debug)]
+struct CloseOp {
+    dir_key: usize,
+    fd: RawFd,
+}
+
+impl CloseOp {
+    fn new(dir_key: usize, fd: RawFd) -> Self {
+        Self { dir_key, fd }
+    }
+
+    fn entry(&mut self) -> squeue::Entry {
+        opcode::Close::new(types::Fd(self.fd)).build()
+    }
+
+    fn complete(
+        &mut self,
+        comp: &mut Completion<State, Op>,
+        res: io::Result<i32>,
+    ) -> io::Result<()> {
+        let _ = res?;
+        let _ = comp.context_mut().dirs.remove(self.dir_key);
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+enum Op {
+    Unlink(UnlinkOp),
+    Close(CloseOp),
+}
+
+impl RingOp<State> for Op {
+    fn entry(&mut self) -> squeue::Entry {
+        match self {
+            Op::Unlink(op) => op.entry(),
+            Op::Close(op) => op.entry(),
+        }
+    }
+
+    fn complete(
+        &mut self,
+        comp: &mut Completion<State, Self>,
+        res: io::Result<i32>,
+    ) -> io::Result<()> {
+        match self {
+            Op::Unlink(op) => op.complete(comp, res),
+            Op::Close(op) => op.complete(comp, res),
+        }
+    }
+}

--- a/accounts-db/src/io_uring/mod.rs
+++ b/accounts-db/src/io_uring/mod.rs
@@ -1,0 +1,3 @@
+#![cfg(target_os = "linux")]
+
+pub mod dir_remover;

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -28,6 +28,7 @@ pub mod contains;
 pub mod epoch_accounts_hash;
 mod file_io;
 pub mod hardened_unpack;
+mod io_uring;
 pub mod is_loadable;
 mod is_zero_lamport;
 pub mod partitioned_rewards;

--- a/io-uring/Cargo.toml
+++ b/io-uring/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "agave-io-uring"
+description = "Agave io_uring wrapper"
+documentation = "https://docs.rs/agave-io-uring"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+libc = { workspace = true }
+log = { workspace = true }
+slab = { workspace = true }
+smallvec = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+io-uring = { workspace = true }

--- a/io-uring/src/lib.rs
+++ b/io-uring/src/lib.rs
@@ -1,0 +1,38 @@
+#![cfg(target_os = "linux")]
+mod ring;
+mod slab;
+pub use ring::*;
+use {
+    io_uring::IoUring,
+    std::{io, sync::Once},
+};
+
+pub fn io_uring_supported() -> bool {
+    static mut IO_URING_SUPPORTED: bool = false;
+    static IO_URING_SUPPORTED_ONCE: Once = Once::new();
+    IO_URING_SUPPORTED_ONCE.call_once(|| {
+        fn check() -> io::Result<()> {
+            let ring = IoUring::new(1)?;
+            if !ring.params().is_feature_nodrop() {
+                return Err(io::Error::other("no IORING_FEAT_NODROP"));
+            }
+            if !ring.params().is_feature_sqpoll_nonfixed() {
+                return Err(io::Error::other("no IORING_FEAT_SQPOLL_NONFIXED"));
+            }
+            Ok(())
+        }
+        unsafe {
+            IO_URING_SUPPORTED = match check() {
+                Ok(_) => {
+                    log::info!("io_uring supported");
+                    true
+                }
+                Err(e) => {
+                    log::info!("io_uring NOT supported: {}", e);
+                    false
+                }
+            };
+        }
+    });
+    unsafe { IO_URING_SUPPORTED }
+}

--- a/io-uring/src/ring.rs
+++ b/io-uring/src/ring.rs
@@ -1,0 +1,240 @@
+use {
+    crate::slab::FixedSlab,
+    io_uring::{
+        cqueue, squeue,
+        types::{SubmitArgs, Timespec},
+        IoUring,
+    },
+    smallvec::{smallvec, SmallVec},
+    std::{io, time::Duration},
+};
+
+/// An io_uring instance.
+pub struct Ring<T, E: RingOp<T>> {
+    ring: IoUring,
+    entries: FixedSlab<E>,
+    context: T,
+}
+
+impl<T, E: RingOp<T>> Ring<T, E> {
+    /// Creates a new ring with the provided io_uring instance and context.
+    ///
+    /// The context `T` is a user defined value that will be passed to entries `E` once they
+    /// complete. This value can be used to update state or perform additional actions as operations
+    /// complete asynchronously.
+    pub fn new(ring: IoUring, ctx: T) -> Self {
+        Self {
+            entries: FixedSlab::with_capacity(ring.params().cq_entries() as usize),
+            ring,
+            context: ctx,
+        }
+    }
+
+    /// Returns a reference to the context value.
+    pub fn context(&self) -> &T {
+        &self.context
+    }
+
+    /// Returns a mutable reference to the context value.
+    pub fn context_mut(&mut self) -> &mut T {
+        &mut self.context
+    }
+
+    /// Registers in-memory fixed buffers for I/O with the kernel.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that the iov_base and iov_len values are valid and will be valid until
+    /// buffers are unregistered or the ring destroyed, otherwise undefined behaviour may occur.
+    ///
+    /// See
+    /// [Submitter::register_buffers](https://docs.rs/io-uring/0.6.3/io_uring/struct.Submitter.html#method.register_buffers).
+    pub unsafe fn register_buffers(&self, iovecs: &[libc::iovec]) -> io::Result<()> {
+        self.ring.submitter().register_buffers(iovecs)
+    }
+
+    /// Pushes an operation to the submission queue.
+    ///
+    /// Once completed, [RingOp::complete] will be called with the result.
+    ///
+    /// Note that the operation is not submitted to the kernel until [Ring::submit] is called. If
+    /// the submission queue is full, submit will be called internally to make room for the new
+    /// operation.
+    ///
+    /// See also [Ring::submit].
+    pub fn push(&mut self, op: E) -> io::Result<()> {
+        loop {
+            self.process_completions()?;
+
+            if !self.entries.is_full() {
+                break;
+            }
+            // if the entries slab is full, we need to submit and poll
+            // completions to make room
+            self.submit_and_wait(1, None)?;
+        }
+        let key = self.entries.insert(op);
+        let entry = self.entries.get_mut(key).unwrap().entry();
+        let entry = entry.user_data(key as u64);
+        // Safety: the entry is stored in self.entries and guaranteed to be valid for the lifetime
+        // of the operation. E implementations must still ensure that the entry
+        // remains valid until the last E::complete call.
+        while unsafe { self.ring.submission().push(&entry) }.is_err() {
+            self.submit()?;
+            self.process_completions()?;
+        }
+
+        Ok(())
+    }
+
+    /// Submits all pending operations to the kernel.
+    ///
+    /// If the ring can't accept any more submissions because the completion
+    /// queue is full, this will process completions and retry until the
+    /// submissions are accepted.
+    ///
+    /// See also [Ring::process_completions].
+    pub fn submit(&mut self) -> io::Result<()> {
+        self.submit_and_wait(0, None).map(|_| ())
+    }
+
+    /// Submits all pending operations to the kernel and waits for completions.
+    ///
+    /// If no `timeout` is passed this will block until `want` completions are available. If a
+    /// timeout is passed, this will block until `want` completions are available or the timeout is
+    /// reached.
+    ///
+    /// Returns the number of completions received.
+    pub fn submit_and_wait(&mut self, want: usize, timeout: Option<Duration>) -> io::Result<usize> {
+        let mut args = SubmitArgs::new();
+        let ts;
+        if let Some(timeout) = timeout {
+            ts = Timespec::from(timeout);
+            args = args.timespec(&ts);
+        }
+
+        loop {
+            match self.ring.submitter().submit_with_args(want, &args) {
+                Ok(n) => return Ok(n),
+                Err(e) if e.raw_os_error() == Some(libc::ETIME) => return Ok(0),
+                Err(e) if e.raw_os_error() == Some(libc::EBUSY) => {
+                    // the completion queue is full, process completions and retry
+                    self.process_completions()?;
+                    continue;
+                }
+                Err(e) if e.raw_os_error() == Some(libc::EINTR) => return Ok(0),
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// Processes completions from the kernel.
+    ///
+    /// This will process all completions currently available in the completion
+    /// queue and invoke [RingOp::complete] for each completed operation.
+    pub fn process_completions(&mut self) -> io::Result<()> {
+        let mut completion = self.ring.completion();
+        let mut new_entries = smallvec![];
+        loop {
+            let Some(cqe) = completion.next() else {
+                break;
+            };
+            let completed_key = cqe.user_data() as usize;
+            let entry = self.entries.get_mut(completed_key).unwrap();
+            let result = entry.result(cqe.result());
+            let mut comp_ctx = Completion {
+                context: &mut self.context,
+                new_entries,
+            };
+            let res = entry.complete(&mut comp_ctx, result);
+            if !cqueue::more(cqe.flags()) {
+                self.entries.remove(completed_key);
+            }
+            res?;
+            new_entries = std::mem::take(&mut comp_ctx.new_entries);
+            if !new_entries.is_empty() {
+                completion.sync();
+                drop(completion);
+                for new_entry in new_entries.drain(..) {
+                    self.push(new_entry)?;
+                }
+                completion = self.ring.completion();
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Drains the ring.
+    ///
+    /// This will submit all pending operations to the kernel and process all
+    /// completions until the ring is empty.
+    pub fn drain(&mut self) -> io::Result<()> {
+        loop {
+            self.process_completions()?;
+
+            if self.entries.is_empty() {
+                break;
+            }
+
+            match self.ring.submitter().submit_with_args(
+                1,
+                &SubmitArgs::new().timespec(&Timespec::from(Duration::from_millis(10))),
+            ) {
+                Ok(_) => {}
+                Err(e) if e.raw_os_error() == Some(libc::ETIME) => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Trait for operations that can be submitted to a [Ring].
+pub trait RingOp<T> {
+    fn entry(&mut self) -> squeue::Entry;
+    fn complete(&mut self, ctx: &mut Completion<T, Self>, res: io::Result<i32>) -> io::Result<()>
+    where
+        Self: Sized;
+    fn result(&self, res: i32) -> io::Result<i32> {
+        if res < 0 {
+            Err(io::Error::from_raw_os_error(res.wrapping_neg()))
+        } else {
+            Ok(res)
+        }
+    }
+}
+
+/// Context object passed to [RingOp::complete].
+pub struct Completion<'a, T, E: RingOp<T>> {
+    // Give new_entries a stack size of 2 to avoid heap allocations in the common case where only
+    // one or two ops are queued from a completion handler.
+    //
+    // It's common to want to queue some extra work after a completion, for instance if you've
+    // completed a read and want to close the file descriptor, or if you're doing chained operations
+    // and want to push the next one. It's less common to want to queue many operations.
+    new_entries: SmallVec<[E; 2]>,
+    context: &'a mut T,
+}
+
+impl<T, E: RingOp<T>> Completion<'_, T, E> {
+    /// Returns a reference to the context value stored in a [Ring].
+    pub fn context(&self) -> &T {
+        self.context
+    }
+
+    /// Returns a mutable reference to the context value stored in a [Ring].
+    pub fn context_mut(&mut self) -> &mut T {
+        self.context
+    }
+
+    /// Pushes an operation to the submission queue.
+    ///
+    /// This can be used to push new operations from within [RingOp::complete].
+    ///
+    /// See also [Ring::push].
+    pub fn push(&mut self, op: E) {
+        self.new_entries.push(op);
+    }
+}

--- a/io-uring/src/slab.rs
+++ b/io-uring/src/slab.rs
@@ -1,0 +1,44 @@
+use slab::Slab;
+
+pub(crate) struct FixedSlab<T> {
+    inner: Slab<T>,
+}
+
+impl<T> FixedSlab<T> {
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            inner: Slab::with_capacity(cap),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.len() == self.capacity()
+    }
+
+    pub fn insert(&mut self, value: T) -> usize {
+        if self.is_full() {
+            panic!("FixedSlab is full, cannot insert new value");
+        }
+        self.inner.insert(value)
+    }
+
+    pub fn remove(&mut self, key: usize) -> T {
+        self.inner.remove(key)
+    }
+
+    pub fn get_mut(&mut self, key: usize) -> Option<&mut T> {
+        self.inner.get_mut(key)
+    }
+}

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -96,6 +96,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-io-uring"
+version = "3.0.0"
+dependencies = [
+ "io-uring",
+ "libc",
+ "log",
+ "slab",
+ "smallvec",
+]
+
+[[package]]
 name = "agave-precompiles"
 version = "3.0.0"
 dependencies = [
@@ -2892,6 +2903,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ebb93303c65a11753dd0e45cd6bfa5c65ee1f0b9f8e2178b6998ddc8b284f04"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5404,6 +5426,7 @@ dependencies = [
 name = "solana-accounts-db"
 version = "3.0.0"
 dependencies = [
+ "agave-io-uring",
  "ahash 0.8.11",
  "bincode",
  "blake3",
@@ -5414,6 +5437,7 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "indexmap 2.9.0",
+ "io-uring",
  "itertools 0.12.1",
  "log",
  "lz4",
@@ -5426,6 +5450,7 @@ dependencies = [
  "seqlock",
  "serde",
  "serde_derive",
+ "slab",
  "smallvec",
  "solana-account",
  "solana-address-lookup-table-interface",

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -37,7 +37,7 @@ use {
         },
         accounts_hash::MerkleOrLatticeAccountsHash,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
-        utils::delete_contents_of_path,
+        utils::remove_dir_contents,
     },
     solana_builtins::prototype::BuiltinPrototype,
     solana_clock::{Epoch, Slot},
@@ -384,7 +384,7 @@ pub fn bank_from_snapshot_dir(
     // Clear the contents of the account paths run directories.  When constructing the bank, the appendvec
     // files will be extracted from the snapshot hardlink directories into these run/ directories.
     for path in account_paths {
-        delete_contents_of_path(path);
+        remove_dir_contents(path);
     }
 
     let next_append_vec_id = Arc::new(AtomicAccountsFileId::new(0));

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -96,6 +96,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-io-uring"
+version = "3.0.0"
+dependencies = [
+ "io-uring",
+ "libc",
+ "log",
+ "slab",
+ "smallvec",
+]
+
+[[package]]
 name = "agave-precompiles"
 version = "3.0.0"
 dependencies = [
@@ -2766,6 +2777,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ebb93303c65a11753dd0e45cd6bfa5c65ee1f0b9f8e2178b6998ddc8b284f04"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5251,6 +5273,7 @@ dependencies = [
 name = "solana-accounts-db"
 version = "3.0.0"
 dependencies = [
+ "agave-io-uring",
  "ahash 0.8.11",
  "bincode",
  "blake3",
@@ -5261,6 +5284,7 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "indexmap 2.9.0",
+ "io-uring",
  "itertools 0.12.1",
  "log",
  "lz4",
@@ -5273,6 +5297,7 @@ dependencies = [
  "seqlock",
  "serde",
  "serde_derive",
+ "slab",
  "smallvec",
  "solana-account",
  "solana-address-lookup-table-interface",


### PR DESCRIPTION
Hello! 

This PR introduces two things: the smallest possible io_uring abstraction in `ring.rs` and `RingDirRemover`, a fast directory remover that uses io_uring.

I started working on `ring.rs` as part of something I'm going to send separately (faster snapshot unpack), and while testing that I noticed that account paths cleanup is also incredibly slow, so here we are.

This  makes `delete_contents_of_path` (renamed `remove_dir_contents` for consistency with `remove_dir_all`) and `move_and_async_delete_path` use io_uring when available.

With this change, ledger-tool verify startup goes from:

```
INFO  agave_ledger_tool::ledger_utils] Cleaning account paths took 51.5s
```

to

```
INFO  agave_ledger_tool::ledger_utils] Cleaning account paths took 4.7s
```

The speed of light something something ⭕️