### PR TITLE
fix typo

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3114,7 +3114,7 @@ fn test_optimistic_confirmation_violation_without_tower() {
 //             |
 //             -> S4 (C) -> S5
 //
-// Step 5:
+// Step 4:
 // Without the persisted tower:
 //    `A` would choose to vote on the fork with `S4 -> S5`.
 //


### PR DESCRIPTION
#### Problem
Incorrect step # in comments of `test_optimistic_confirmation_violation_without_tower`,  it should be called step 4 now

https://github.com/anza-xyz/agave/blob/master/local-cluster/tests/local_cluster.rs#L3388-L3429

#### Summary of Changes
fix typo


<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
