### PR TITLE
Extract solana-config-program-api and use it in solana-account-decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5323,7 +5323,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-config-program",
+ "solana-config-program-api",
  "solana-sdk",
  "spl-pod",
  "spl-token",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5917,8 +5917,19 @@ dependencies = [
  "chrono",
  "serde",
  "serde_derive",
+ "solana-config-program-api",
  "solana-logger",
  "solana-program-runtime",
+ "solana-sdk",
+]
+
+[[package]]
+name = "solana-config-program-api"
+version = "0.0.1"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
  "solana-sdk",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,6 +325,7 @@ solana-cli-output = { path = "cli-output", version = "=2.0.0" }
 solana-client = { path = "client", version = "=2.0.0" }
 solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.0.0" }
 solana-config-program = { path = "programs/config", version = "=2.0.0" }
+solana-config-program-api = { path = "programs/config-api", version = "=0.0.1" }
 solana-connection-cache = { path = "connection-cache", version = "=2.0.0", default-features = false }
 solana-core = { path = "core", version = "=2.0.0" }
 solana-cost-model = { path = "cost-model", version = "=2.0.0" }

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-solana-config-program = { workspace = true }
+solana-config-program-api = { workspace = true }
 solana-sdk = { workspace = true }
 spl-token = { workspace = true, features = ["no-entrypoint"] }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }

--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -18,7 +18,7 @@ use {
 lazy_static! {
     static ref ADDRESS_LOOKUP_PROGRAM_ID: Pubkey = address_lookup_table::program::id();
     static ref BPF_UPGRADEABLE_LOADER_PROGRAM_ID: Pubkey = solana_sdk::bpf_loader_upgradeable::id();
-    static ref CONFIG_PROGRAM_ID: Pubkey = solana_config_program::id();
+    static ref CONFIG_PROGRAM_ID: Pubkey = solana_sdk::config::program::id();
     static ref STAKE_PROGRAM_ID: Pubkey = stake::program::id();
     static ref SYSTEM_PROGRAM_ID: Pubkey = system_program::id();
     static ref SYSVAR_PROGRAM_ID: Pubkey = sysvar::id();

--- a/account-decoder/src/parse_config.rs
+++ b/account-decoder/src/parse_config.rs
@@ -5,7 +5,7 @@ use {
     },
     bincode::deserialize,
     serde_json::Value,
-    solana_config_program::{get_config_data, ConfigKeys},
+    solana_config_program_api::{get_config_data, ConfigKeys},
     solana_sdk::{
         pubkey::Pubkey,
         stake::config::{
@@ -99,7 +99,7 @@ pub struct UiConfig<T> {
 mod test {
     use {
         super::*, crate::validator_info::ValidatorInfo, serde_json::json,
-        solana_config_program::create_config_account, solana_sdk::account::ReadableAccount,
+        solana_config_program_api::create_config_account, solana_sdk::account::ReadableAccount,
     };
 
     #[test]

--- a/account-decoder/src/validator_info.rs
+++ b/account-decoder/src/validator_info.rs
@@ -1,4 +1,4 @@
-use solana_config_program::ConfigState;
+use solana_config_program_api::ConfigState;
 
 pub const MAX_SHORT_FIELD_LENGTH: usize = 80;
 pub const MAX_LONG_FIELD_LENGTH: usize = 300;

--- a/programs/config-api/Cargo.toml
+++ b/programs/config-api/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-config-program-api"
+description = "Solana Config program API"
+documentation = "https://docs.rs/solana-config-program-api"
+version = "0.0.1"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+bincode = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }
+solana-sdk = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/config-api/src/lib.rs
+++ b/programs/config-api/src/lib.rs
@@ -1,0 +1,60 @@
+#[allow(deprecated)]
+use solana_sdk::stake::config::Config as StakeConfig;
+use {
+    bincode::{deserialize, serialize, serialized_size},
+    serde_derive::{Deserialize, Serialize},
+    solana_sdk::{
+        account::{Account, AccountSharedData},
+        pubkey::Pubkey,
+        short_vec,
+    },
+};
+
+pub trait ConfigState: serde::Serialize + Default {
+    /// Maximum space that the serialized representation will require
+    fn max_space() -> u64;
+}
+
+#[allow(deprecated)]
+impl ConfigState for StakeConfig {
+    fn max_space() -> u64 {
+        serialized_size(&StakeConfig::default()).unwrap()
+    }
+}
+
+/// A collection of keys to be stored in Config account data.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct ConfigKeys {
+    // Each key tuple comprises a unique `Pubkey` identifier,
+    // and `bool` whether that key is a signer of the data
+    #[serde(with = "short_vec")]
+    pub keys: Vec<(Pubkey, bool)>,
+}
+
+impl ConfigKeys {
+    pub fn serialized_size(keys: Vec<(Pubkey, bool)>) -> u64 {
+        serialized_size(&ConfigKeys { keys }).unwrap()
+    }
+}
+
+pub fn get_config_data(bytes: &[u8]) -> Result<&[u8], bincode::Error> {
+    deserialize::<ConfigKeys>(bytes)
+        .and_then(|keys| serialized_size(&keys))
+        .map(|offset| &bytes[offset as usize..])
+}
+
+// utility for pre-made Accounts
+pub fn create_config_account<T: ConfigState>(
+    keys: Vec<(Pubkey, bool)>,
+    config_data: &T,
+    lamports: u64,
+) -> AccountSharedData {
+    let mut data = serialize(&ConfigKeys { keys }).unwrap();
+    data.extend_from_slice(&serialize(config_data).unwrap());
+    AccountSharedData::from(Account {
+        lamports,
+        data,
+        owner: solana_sdk::config::program::id(),
+        ..Account::default()
+    })
+}

--- a/programs/config/Cargo.toml
+++ b/programs/config/Cargo.toml
@@ -14,6 +14,7 @@ bincode = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
 serde = { workspace = true }
 serde_derive = { workspace = true }
+solana-config-program-api = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 

--- a/programs/config/src/lib.rs
+++ b/programs/config/src/lib.rs
@@ -3,65 +3,7 @@ pub mod config_instruction;
 pub mod config_processor;
 pub mod date_instruction;
 
-pub use solana_sdk::config::program::id;
-#[allow(deprecated)]
-use solana_sdk::stake::config::Config as StakeConfig;
-use {
-    bincode::{deserialize, serialize, serialized_size},
-    serde_derive::{Deserialize, Serialize},
-    solana_sdk::{
-        account::{Account, AccountSharedData},
-        pubkey::Pubkey,
-        short_vec,
-    },
+pub use {
+    solana_config_program_api::{create_config_account, get_config_data, ConfigKeys, ConfigState},
+    solana_sdk::config::program::id,
 };
-
-pub trait ConfigState: serde::Serialize + Default {
-    /// Maximum space that the serialized representation will require
-    fn max_space() -> u64;
-}
-
-// TODO move ConfigState into `solana_program` to implement trait locally
-#[allow(deprecated)]
-impl ConfigState for StakeConfig {
-    fn max_space() -> u64 {
-        serialized_size(&StakeConfig::default()).unwrap()
-    }
-}
-
-/// A collection of keys to be stored in Config account data.
-#[derive(Debug, Default, Deserialize, Serialize)]
-pub struct ConfigKeys {
-    // Each key tuple comprises a unique `Pubkey` identifier,
-    // and `bool` whether that key is a signer of the data
-    #[serde(with = "short_vec")]
-    pub keys: Vec<(Pubkey, bool)>,
-}
-
-impl ConfigKeys {
-    pub fn serialized_size(keys: Vec<(Pubkey, bool)>) -> u64 {
-        serialized_size(&ConfigKeys { keys }).unwrap()
-    }
-}
-
-pub fn get_config_data(bytes: &[u8]) -> Result<&[u8], bincode::Error> {
-    deserialize::<ConfigKeys>(bytes)
-        .and_then(|keys| serialized_size(&keys))
-        .map(|offset| &bytes[offset as usize..])
-}
-
-// utility for pre-made Accounts
-pub fn create_config_account<T: ConfigState>(
-    keys: Vec<(Pubkey, bool)>,
-    config_data: &T,
-    lamports: u64,
-) -> AccountSharedData {
-    let mut data = serialize(&ConfigKeys { keys }).unwrap();
-    data.extend_from_slice(&serialize(config_data).unwrap());
-    AccountSharedData::from(Account {
-        lamports,
-        data,
-        owner: id(),
-        ..Account::default()
-    })
-}

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4616,7 +4616,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-config-program",
+ "solana-config-program-api",
  "solana-sdk",
  "spl-token",
  "spl-token-2022",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4908,7 +4908,18 @@ dependencies = [
  "chrono",
  "serde",
  "serde_derive",
+ "solana-config-program-api",
  "solana-program-runtime",
+ "solana-sdk",
+]
+
+[[package]]
+name = "solana-config-program-api"
+version = "0.0.1"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
  "solana-sdk",
 ]
 


### PR DESCRIPTION
#### Problem

`solana-account-decoder` depends on `solana-config-program`, which depends on `solana-program-runtime` which is an awful thing to depend on if you don't need it (I can elaborate if you like, but one reason is that it brings in `reqwest` as a dependency). The good news is that `solana-program-runtime` is not part of `solana-config-program`'s API, so if we extract a separate `solana-config-program-api` crate, we can use that instead and be free of `solana-program-runtime` in `solana-account-decoder`.


#### Summary of Changes

- Rips the API code (basically the stuff in lib.rs) out of `solana-config-program` and moves it into a new crate `solana-config-program-api`
- Re-exports the contents of `solana-config-program-api` in `solana-config-program` for backwards compatibility.
- Replaces `solana-config-program` with `solana-config-program-api` in `solana-account-decoder`

Per [CONTRIBUTING.md](https://github.com/anza-xyz/agave/blob/a2579d484efd78099ba67db5911b2ba12c77b711/CONTRIBUTING.md) I have set the version of the new crate to 0.0.1

There are more crates in the repo that could also swap out for the lighter dependency but I decided to keep the PR small
