### PR TITLE
Cli stake-split: adjust transfer amount if recipient has lamports

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2254,7 +2254,7 @@ mod tests {
             memo: None,
             split_stake_account: 1,
             seed: None,
-            lamports: 30,
+            lamports: 200_000_000,
             fee_payer: 0,
             compute_unit_price: None,
             rent_exempt_reserve: None,

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2008,10 +2008,10 @@ pub fn process_split_stake(
                 0
             };
 
-        let minimum_balance =
+        let rent_exempt_reserve =
             rpc_client.get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
 
-        minimum_balance.saturating_sub(current_balance)
+        rent_exempt_reserve.saturating_sub(current_balance)
     } else {
         rent_exempt_reserve
             .cloned()

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2006,13 +2006,6 @@ pub fn process_split_stake(
         let minimum_balance =
             rpc_client.get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
 
-        if lamports < minimum_balance {
-            return Err(CliError::BadParameter(format!(
-                "need at least {minimum_balance} lamports for stake account to be rent exempt, \
-                 provided lamports: {lamports}"
-            ))
-            .into());
-        }
         minimum_balance
     } else {
         rent_exempt_reserve

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1981,22 +1981,22 @@ pub fn process_split_stake(
 
     let rent_exempt_reserve = if !sign_only {
         let check_stake_account = |account: Account| -> Result<(), CliError> {
-            if account.owner == stake::program::id() {
-                Err(CliError::BadParameter(format!(
+            match account.owner {
+                owner if owner == stake::program::id() => Err(CliError::BadParameter(format!(
                     "Stake account {split_stake_account_address} already exists"
-                )))
-            } else if account.owner == system_program::id() {
-                if !account.data.is_empty() {
-                    Err(CliError::BadParameter(format!(
-                        "Account {split_stake_account_address} has data and cannot be used to split stake"
-                    )))
-                } else {
-                    // if `stake_account`'s owner is the system_program and its data is
-                    // empty, `stake_account` is allowed to receive the stake split
-                    Ok(())
+                ))),
+                owner if owner == system_program::id() => {
+                    if !account.data.is_empty() {
+                        Err(CliError::BadParameter(format!(
+                            "Account {split_stake_account_address} has data and cannot be used to split stake"
+                        )))
+                    } else {
+                        // if `stake_account`'s owner is the system_program and its data is
+                        // empty, `stake_account` is allowed to receive the stake split
+                        Ok(())
+                    }
                 }
-            } else {
-                Err(CliError::BadParameter(format!(
+                _ => Err(CliError::BadParameter(format!(
                     "Account {split_stake_account_address} already exists and cannot be used to split stake"
                 )))
             }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2020,11 +2020,14 @@ pub fn process_split_stake(
 
     let recent_blockhash = blockhash_query.get_blockhash(rpc_client, config.commitment)?;
 
-    let mut ixs = vec![system_instruction::transfer(
-        &fee_payer.pubkey(),
-        &split_stake_account_address,
-        rent_exempt_reserve,
-    )];
+    let mut ixs = vec![];
+    if rent_exempt_reserve > 0 {
+        ixs.push(system_instruction::transfer(
+            &fee_payer.pubkey(),
+            &split_stake_account_address,
+            rent_exempt_reserve,
+        ));
+    }
     if let Some(seed) = split_stake_account_seed {
         ixs.append(
             &mut stake_instruction::split_with_seed(


### PR DESCRIPTION
#### Problem
The https://github.com/anza-xyz/agave/pull/162 cli change permits split recipients that carry a lamports balance. However, the message builder below always funds the account with the full rent-exempt reserve regardless of such an existing balance.

#### Summary of Changes
Some refactoring to make cases easier to follow (review by commit will be best)
Subtract (saturating) any existing lamports balance from the transfer amount
