### PR TITLE
congestion_multiplier as u64

### DIFF
--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -105,9 +105,9 @@ impl FeeStructure {
     ) -> u64 {
         // Fee based on compute units and signatures
         let congestion_multiplier = if lamports_per_signature == 0 {
-            0.0 // test only
+            0 // test only
         } else {
-            1.0 // multiplier that has no effect
+            1 // multiplier that has no effect
         };
 
         self.calculate_fee_details(
@@ -116,7 +116,7 @@ impl FeeStructure {
             include_loaded_account_data_size_in_fee,
         )
         .total_fee(remove_rounding_in_fee_calculation)
-        .saturating_mul(congestion_multiplier as u64)
+        .saturating_mul(congestion_multiplier)
     }
 
     /// Calculate fee details for `SanitizedMessage`


### PR DESCRIPTION
#### Problem
- `congestion_multiplier` is either 0.0 or 1.0 and does not affect rounding
- no point for it to be an f64 any longer

#### Summary of Changes
- make `congestion_multiplier` a u64
- remove `as u64` cast

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
