### PR TITLE
Support --block-production-method in banking-bench

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -9,6 +9,7 @@ use {
     solana_core::{
         banking_stage::BankingStage,
         banking_trace::{BankingPacketBatch, BankingTracer, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
+        validator::BlockProductionMethod,
     },
     solana_gossip::cluster_info::{ClusterInfo, Node},
     solana_ledger::{
@@ -280,6 +281,14 @@ fn main() {
                 .help("Number of batches to send in each iteration"),
         )
         .arg(
+            Arg::with_name("block_production_method")
+                .long("block-production-method")
+                .value_name("METHOD")
+                .takes_value(true)
+                .possible_values(BlockProductionMethod::cli_names())
+                .help(BlockProductionMethod::cli_message()),
+        )
+        .arg(
             Arg::new("num_banking_threads")
                 .long("num-banking-threads")
                 .takes_value(true)
@@ -306,6 +315,9 @@ fn main() {
         )
         .get_matches();
 
+    let block_production_method = matches
+        .value_of_t::<BlockProductionMethod>("block_production_method")
+        .unwrap_or_default();
     let num_banking_threads = matches
         .value_of_t::<u32>("num_banking_threads")
         .unwrap_or_else(|_| BankingStage::num_threads());
@@ -448,7 +460,8 @@ fn main() {
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
         ),
     };
-    let banking_stage = BankingStage::new_thread_local_multi_iterator(
+    let banking_stage = BankingStage::new_num_threads(
+        block_production_method,
         &cluster_info,
         &poh_recorder,
         non_vote_receiver,


### PR DESCRIPTION
#### Problem
- `banking-bench` has no way to switch between scheduler modes

#### Summary of Changes
- support `--block-production-method` in `banking-bench`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
