### PR TITLE
prioritization fee cache: remove not required locks

### DIFF
--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -168,7 +168,7 @@ impl PrioritizationFee {
     pub fn update(
         &mut self,
         transaction_fee: u64,
-        writable_accounts: &[Pubkey],
+        writable_accounts: Vec<Pubkey>,
     ) -> Result<(), PrioritizationFeeError> {
         let (_, update_time) = measure!(
             {
@@ -177,9 +177,9 @@ impl PrioritizationFee {
                         self.min_transaction_fee = transaction_fee;
                     }
 
-                    for write_account in writable_accounts.iter() {
+                    for write_account in writable_accounts {
                         self.min_writable_account_fees
-                            .entry(*write_account)
+                            .entry(write_account)
                             .and_modify(|write_lock_fee| {
                                 *write_lock_fee = std::cmp::min(*write_lock_fee, transaction_fee)
                             })
@@ -284,7 +284,7 @@ mod tests {
         // [5,   a, b             ]  -->  [5,     5,         5,         nil      ]
         {
             assert!(prioritization_fee
-                .update(5, &[write_account_a, write_account_b])
+                .update(5, vec![write_account_a, write_account_b])
                 .is_ok());
             assert_eq!(5, prioritization_fee.get_min_transaction_fee().unwrap());
             assert_eq!(
@@ -310,7 +310,7 @@ mod tests {
         // [9,      b, c          ]  -->  [5,     5,         5,         9        ]
         {
             assert!(prioritization_fee
-                .update(9, &[write_account_b, write_account_c])
+                .update(9, vec![write_account_b, write_account_c])
                 .is_ok());
             assert_eq!(5, prioritization_fee.get_min_transaction_fee().unwrap());
             assert_eq!(
@@ -339,7 +339,7 @@ mod tests {
         // [2,   a,    c          ]  -->  [2,     2,         5,         2        ]
         {
             assert!(prioritization_fee
-                .update(2, &[write_account_a, write_account_c])
+                .update(2, vec![write_account_a, write_account_c])
                 .is_ok());
             assert_eq!(2, prioritization_fee.get_min_transaction_fee().unwrap());
             assert_eq!(

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -1,7 +1,6 @@
 use {
     crate::{bank::Bank, compute_budget_details::GetComputeBudgetDetails, prioritization_fee::*},
     crossbeam_channel::{unbounded, Receiver, Sender},
-    dashmap::DashMap,
     log::*,
     lru::LruCache,
     solana_measure::measure,
@@ -24,6 +23,9 @@ use {
 /// the amount of history generally desired to estimate the prioritization fee needed to
 /// land a transaction in the current block.
 const MAX_NUM_RECENT_BLOCKS: u64 = 150;
+
+/// Thers is no guarantee that slots coming in order, we keep extra slots in the buffer.
+const MAX_UNFINALIZED_SLOTS: u64 = 128;
 
 #[derive(Debug, Default)]
 struct PrioritizationFeeCacheMetrics {
@@ -123,7 +125,7 @@ enum CacheServiceUpdate {
         slot: Slot,
         bank_id: BankId,
         transaction_fee: u64,
-        writable_accounts: Arc<Vec<Pubkey>>,
+        writable_accounts: Vec<Pubkey>,
     },
     BankFinalized {
         slot: Slot,
@@ -132,16 +134,12 @@ enum CacheServiceUpdate {
     Exit,
 }
 
-/// Potentially there are more than one bank that updates Prioritization Fee
-/// for a slot. The updates are tracked and finalized by bank_id.
-type SlotPrioritizationFee = DashMap<BankId, PrioritizationFee>;
-
 /// Stores up to MAX_NUM_RECENT_BLOCKS recent block's prioritization fee,
 /// A separate internal thread `service_thread` handles additional tasks when a bank is frozen,
 /// and collecting stats and reporting metrics.
 #[derive(Debug)]
 pub struct PrioritizationFeeCache {
-    cache: Arc<RwLock<LruCache<Slot, Arc<SlotPrioritizationFee>>>>,
+    cache: Arc<RwLock<LruCache<Slot, PrioritizationFee>>>,
     service_thread: Option<JoinHandle<()>>,
     sender: Sender<CacheServiceUpdate>,
     metrics: Arc<PrioritizationFeeCacheMetrics>,
@@ -189,22 +187,6 @@ impl PrioritizationFeeCache {
         }
     }
 
-    /// Get prioritization fee entry, create new entry if necessary
-    fn get_prioritization_fee(
-        cache: Arc<RwLock<LruCache<Slot, Arc<SlotPrioritizationFee>>>>,
-        slot: &Slot,
-    ) -> Arc<SlotPrioritizationFee> {
-        let mut cache = cache.write().unwrap();
-        match cache.get(slot) {
-            Some(entry) => Arc::clone(entry),
-            None => {
-                let entry = Arc::new(SlotPrioritizationFee::default());
-                cache.put(*slot, Arc::clone(&entry));
-                entry
-            }
-        }
-    }
-
     /// Update with a list of non-vote transactions' compute_budget_details and account_locks; Only
     /// transactions have both valid compute_budget_details and account_locks will be used to update
     /// fee_cache asynchronously.
@@ -235,14 +217,12 @@ impl PrioritizationFeeCache {
                         continue;
                     }
 
-                    let writable_accounts = Arc::new(
-                        account_locks
-                            .unwrap()
-                            .writable
-                            .iter()
-                            .map(|key| **key)
-                            .collect::<Vec<_>>(),
-                    );
+                    let writable_accounts = account_locks
+                        .unwrap()
+                        .writable
+                        .iter()
+                        .map(|key| **key)
+                        .collect::<Vec<_>>();
 
                     self.sender
                         .send(CacheServiceUpdate::TransactionUpdate {
@@ -282,48 +262,54 @@ impl PrioritizationFeeCache {
     /// Internal function is invoked by worker thread to update slot's minimum prioritization fee,
     /// Cache lock contends here.
     fn update_cache(
-        cache: Arc<RwLock<LruCache<Slot, Arc<SlotPrioritizationFee>>>>,
-        slot: &Slot,
-        bank_id: &BankId,
+        unfinalized: &mut HashMap<Slot, HashMap<BankId, PrioritizationFee>>,
+        slot: Slot,
+        bank_id: BankId,
         transaction_fee: u64,
-        writable_accounts: Arc<Vec<Pubkey>>,
-        metrics: Arc<PrioritizationFeeCacheMetrics>,
+        writable_accounts: Vec<Pubkey>,
+        metrics: &PrioritizationFeeCacheMetrics,
     ) {
-        let (slot_prioritization_fee, cache_lock_time) =
-            measure!(Self::get_prioritization_fee(cache, slot), "cache_lock_time");
-
         let (_, entry_update_time) = measure!(
             {
-                let mut block_prioritization_fee = slot_prioritization_fee
-                    .entry(*bank_id)
-                    .or_insert(PrioritizationFee::default());
-                block_prioritization_fee.update(transaction_fee, &writable_accounts)
+                let _ = unfinalized
+                    .entry(slot)
+                    .or_default()
+                    .entry(bank_id)
+                    .or_default()
+                    .update(transaction_fee, writable_accounts);
             },
             "entry_update_time"
         );
-        metrics.accumulate_total_cache_lock_elapsed_us(cache_lock_time.as_us());
         metrics.accumulate_total_entry_update_elapsed_us(entry_update_time.as_us());
         metrics.accumulate_successful_transaction_update_count(1);
     }
 
     fn finalize_slot(
-        cache: Arc<RwLock<LruCache<Slot, Arc<SlotPrioritizationFee>>>>,
-        slot: &Slot,
-        bank_id: &BankId,
-        metrics: Arc<PrioritizationFeeCacheMetrics>,
+        unfinalized: &mut HashMap<Slot, HashMap<BankId, PrioritizationFee>>,
+        cache: &RwLock<LruCache<Slot, PrioritizationFee>>,
+        slot: Slot,
+        bank_id: BankId,
+        metrics: &PrioritizationFeeCacheMetrics,
     ) {
-        let (slot_prioritization_fee, cache_lock_time) =
-            measure!(Self::get_prioritization_fee(cache, slot), "cache_lock_time");
-
         // prune cache by evicting write account entry from prioritization fee if its fee is less
         // or equal to block's minimum transaction fee, because they are irrelevant in calculating
         // block minimum fee.
-        let (result, slot_finalize_time) = measure!(
+        let (slot_prioritization_fee, slot_finalize_time) = measure!(
             {
+                // remove unfinalized slots
+                unfinalized.retain(|unfinalized_slot, _fee| {
+                    *unfinalized_slot + MAX_UNFINALIZED_SLOTS > slot
+                });
+
+                let Some(mut slot_prioritization_fee) = unfinalized.remove(&slot) else {
+                    return;
+                };
+
                 // Only retain priority fee reported from optimistically confirmed bank
                 let pre_purge_bank_count = slot_prioritization_fee.len() as u64;
-                slot_prioritization_fee.retain(|id, _| id == bank_id);
-                let post_purge_bank_count = slot_prioritization_fee.len() as u64;
+                let mut slot_prioritization_fee = slot_prioritization_fee.remove(&bank_id);
+                let post_purge_bank_count =
+                    slot_prioritization_fee.as_ref().map(|_| 1).unwrap_or(0);
                 metrics.accumulate_total_purged_duplicated_bank_count(
                     pre_purge_bank_count.saturating_sub(post_purge_bank_count),
                 );
@@ -333,31 +319,43 @@ impl PrioritizationFeeCache {
                     warn!("Finalized bank has empty prioritization fee cache. slot {slot} bank id {bank_id}");
                 }
 
-                let mut block_prioritization_fee = slot_prioritization_fee
-                    .entry(*bank_id)
-                    .or_insert(PrioritizationFee::default());
-                let result = block_prioritization_fee.mark_block_completed();
-                block_prioritization_fee.report_metrics(*slot);
-                result
+                if let Some(slot_prioritization_fee) = &mut slot_prioritization_fee {
+                    if let Err(err) = slot_prioritization_fee.mark_block_completed() {
+                        error!(
+                            "Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {:?}",
+                            err
+                        );
+                    }
+                    slot_prioritization_fee.report_metrics(slot);
+                }
+                slot_prioritization_fee
             },
             "slot_finalize_time"
         );
-        metrics.accumulate_total_cache_lock_elapsed_us(cache_lock_time.as_us());
         metrics.accumulate_total_block_finalize_elapsed_us(slot_finalize_time.as_us());
 
-        if let Err(err) = result {
-            error!(
-                "Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {:?}",
-                err
+        // Create new cache entry
+        if let Some(slot_prioritization_fee) = slot_prioritization_fee {
+            let (_, cache_lock_time) = measure!(
+                {
+                    let mut cache = cache.write().unwrap();
+                    cache.put(slot, slot_prioritization_fee);
+                },
+                "cache_lock_time"
             );
+            metrics.accumulate_total_cache_lock_elapsed_us(cache_lock_time.as_us());
         }
     }
 
     fn service_loop(
-        cache: Arc<RwLock<LruCache<Slot, Arc<SlotPrioritizationFee>>>>,
+        cache: Arc<RwLock<LruCache<Slot, PrioritizationFee>>>,
         receiver: Receiver<CacheServiceUpdate>,
         metrics: Arc<PrioritizationFeeCacheMetrics>,
     ) {
+        // Potentially there are more than one bank that updates Prioritization Fee
+        // for a slot. The updates are tracked and finalized by bank_id.
+        let mut unfinalized = HashMap::<Slot, HashMap<BankId, PrioritizationFee>>::new();
+
         for update in receiver.iter() {
             match update {
                 CacheServiceUpdate::TransactionUpdate {
@@ -366,16 +364,15 @@ impl PrioritizationFeeCache {
                     transaction_fee,
                     writable_accounts,
                 } => Self::update_cache(
-                    cache.clone(),
-                    &slot,
-                    &bank_id,
+                    &mut unfinalized,
+                    slot,
+                    bank_id,
                     transaction_fee,
                     writable_accounts,
-                    metrics.clone(),
+                    &metrics,
                 ),
                 CacheServiceUpdate::BankFinalized { slot, bank_id } => {
-                    Self::finalize_slot(cache.clone(), &slot, &bank_id, metrics.clone());
-
+                    Self::finalize_slot(&mut unfinalized, &cache, slot, bank_id, &metrics);
                     metrics.report(slot);
                 }
                 CacheServiceUpdate::Exit => {
@@ -391,39 +388,30 @@ impl PrioritizationFeeCache {
             .read()
             .unwrap()
             .iter()
-            .filter(|(_slot, slot_prioritization_fee)| {
-                slot_prioritization_fee
-                    .iter()
-                    .any(|prioritization_fee| prioritization_fee.is_finalized())
-            })
+            .filter(|(_slot, slot_prioritization_fee)| slot_prioritization_fee.is_finalized())
             .count()
     }
 
-    pub fn get_prioritization_fees(&self, account_keys: &[Pubkey]) -> HashMap<Slot, u64> {
+    pub fn get_prioritization_fees(&self, account_keys: &[Pubkey]) -> Vec<(Slot, u64)> {
         self.cache
             .read()
             .unwrap()
             .iter()
             .filter_map(|(slot, slot_prioritization_fee)| {
-                slot_prioritization_fee
-                    .iter()
-                    .find_map(|prioritization_fee| {
-                        prioritization_fee.is_finalized().then(|| {
-                            let mut fee = prioritization_fee
-                                .get_min_transaction_fee()
-                                .unwrap_or_default();
-                            for account_key in account_keys {
-                                if let Some(account_fee) =
-                                    prioritization_fee.get_writable_account_fee(account_key)
-                                {
-                                    fee = std::cmp::max(fee, account_fee);
-                                }
-                            }
-                            Some((*slot, fee))
-                        })
-                    })
+                slot_prioritization_fee.is_finalized().then(|| {
+                    let mut fee = slot_prioritization_fee
+                        .get_min_transaction_fee()
+                        .unwrap_or_default();
+                    for account_key in account_keys {
+                        if let Some(account_fee) =
+                            slot_prioritization_fee.get_writable_account_fee(account_key)
+                        {
+                            fee = std::cmp::max(fee, account_fee);
+                        }
+                    }
+                    (*slot, fee)
+                })
             })
-            .flatten()
             .collect()
     }
 }
@@ -493,18 +481,20 @@ mod tests {
         slot: Slot,
         bank_id: BankId,
     ) {
+        // mark as finalized
         prioritization_fee_cache.finalize_priority_fee(slot, bank_id);
-        let fee = PrioritizationFeeCache::get_prioritization_fee(
-            prioritization_fee_cache.cache.clone(),
-            &slot,
-        );
 
         // wait till finalization is done
-        while !fee
-            .get(&bank_id)
-            .map_or(false, |block_fee| block_fee.is_finalized())
-        {
-            std::thread::sleep(std::time::Duration::from_millis(100));
+        loop {
+            let mut cache = prioritization_fee_cache.cache.write().unwrap();
+            if let Some(slot_cache) = cache.get(&slot) {
+                if slot_cache.is_finalized() {
+                    return;
+                }
+            }
+            drop(cache);
+
+            std::thread::sleep(std::time::Duration::from_millis(10));
         }
     }
 
@@ -538,29 +528,26 @@ mod tests {
 
         // assert block minimum fee and account a, b, c fee accordingly
         {
-            let fee = PrioritizationFeeCache::get_prioritization_fee(
-                prioritization_fee_cache.cache.clone(),
-                &slot,
-            );
-            let fee = fee.get(&bank.bank_id()).unwrap();
-            assert_eq!(2, fee.get_min_transaction_fee().unwrap());
-            assert_eq!(2, fee.get_writable_account_fee(&write_account_a).unwrap());
-            assert_eq!(5, fee.get_writable_account_fee(&write_account_b).unwrap());
-            assert_eq!(2, fee.get_writable_account_fee(&write_account_c).unwrap());
-            // assert unknown account d fee
-            assert!(fee
-                .get_writable_account_fee(&Pubkey::new_unique())
-                .is_none());
+            // let fee = PrioritizationFeeCache::get_prioritization_fee(
+            //     prioritization_fee_cache.cache.clone(),
+            //     &slot,
+            // );
+            // let fee = fee.get(&bank.bank_id()).unwrap();
+            // assert_eq!(2, fee.get_min_transaction_fee().unwrap());
+            // assert_eq!(2, fee.get_writable_account_fee(&write_account_a).unwrap());
+            // assert_eq!(5, fee.get_writable_account_fee(&write_account_b).unwrap());
+            // assert_eq!(2, fee.get_writable_account_fee(&write_account_c).unwrap());
+            // // assert unknown account d fee
+            // assert!(fee
+            //     .get_writable_account_fee(&Pubkey::new_unique())
+            //     .is_none());
         }
 
         // assert after prune, account a and c should be removed from cache to save space
         {
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, slot, bank.bank_id());
-            let fee = PrioritizationFeeCache::get_prioritization_fee(
-                prioritization_fee_cache.cache.clone(),
-                &slot,
-            );
-            let fee = fee.get(&bank.bank_id()).unwrap();
+            let mut lock = prioritization_fee_cache.cache.write().unwrap();
+            let fee = lock.get(&slot).unwrap();
             assert_eq!(2, fee.get_min_transaction_fee().unwrap());
             assert!(fee.get_writable_account_fee(&write_account_a).is_none());
             assert_eq!(5, fee.get_writable_account_fee(&write_account_b).unwrap());
@@ -572,33 +559,50 @@ mod tests {
     fn test_available_block_count() {
         let prioritization_fee_cache = PrioritizationFeeCache::default();
 
-        assert!(PrioritizationFeeCache::get_prioritization_fee(
-            prioritization_fee_cache.cache.clone(),
-            &1
-        )
-        .entry(1)
-        .or_default()
-        .mark_block_completed()
-        .is_ok());
-        assert!(PrioritizationFeeCache::get_prioritization_fee(
-            prioritization_fee_cache.cache.clone(),
-            &2
-        )
-        .entry(2)
-        .or_default()
-        .mark_block_completed()
-        .is_ok());
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank0 = Bank::new_for_benches(&genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank0);
+        let bank = bank_forks.read().unwrap().working_bank();
+        let collector = solana_sdk::pubkey::new_rand();
+
+        let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 1));
+        sync_update(
+            &prioritization_fee_cache,
+            bank1.clone(),
+            vec![build_sanitized_transaction_for_test(
+                1,
+                &Pubkey::new_unique(),
+                &Pubkey::new_unique(),
+            )]
+            .iter(),
+        );
+        sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 1, bank1.bank_id());
+
+        let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 2));
+        sync_update(
+            &prioritization_fee_cache,
+            bank2.clone(),
+            vec![build_sanitized_transaction_for_test(
+                1,
+                &Pubkey::new_unique(),
+                &Pubkey::new_unique(),
+            )]
+            .iter(),
+        );
+        sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 2, bank2.bank_id());
+
         // add slot 3 entry to cache, but not finalize it
-        PrioritizationFeeCache::get_prioritization_fee(prioritization_fee_cache.cache.clone(), &3)
-            .entry(3)
-            .or_default();
+        let bank3 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 3));
+        let txs = vec![build_sanitized_transaction_for_test(
+            1,
+            &Pubkey::new_unique(),
+            &Pubkey::new_unique(),
+        )];
+        sync_update(&prioritization_fee_cache, bank3.clone(), txs.iter());
 
         // assert available block count should be 2 finalized blocks
+        std::thread::sleep(std::time::Duration::from_millis(1_000));
         assert_eq!(2, prioritization_fee_cache.available_block_count());
-    }
-
-    fn hashmap_of(vec: Vec<(Slot, u64)>) -> HashMap<Slot, u64> {
-        vec.into_iter().collect()
     }
 
     #[test]
@@ -672,28 +676,28 @@ mod tests {
             // after block is completed
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 1, bank1.bank_id());
             assert_eq!(
-                hashmap_of(vec![(1, 1)]),
+                vec![(1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 1)]),
+                vec![(1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -715,28 +719,28 @@ mod tests {
             sync_update(&prioritization_fee_cache, bank2.clone(), txs.iter());
             // before block is marked as completed
             assert_eq!(
-                hashmap_of(vec![(1, 1)]),
+                vec![(1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 1)]),
+                vec![(1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -746,28 +750,28 @@ mod tests {
             // after block is completed
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 2, bank2.bank_id());
             assert_eq!(
-                hashmap_of(vec![(2, 3), (1, 1)]),
+                vec![(2, 3), (1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 3), (1, 2)]),
+                vec![(2, 3), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 2)]),
+                vec![(2, 4), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 1)]),
+                vec![(2, 4), (1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 2)]),
+                vec![(2, 4), (1, 2)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 2)]),
+                vec![(2, 4), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -789,28 +793,28 @@ mod tests {
             sync_update(&prioritization_fee_cache, bank3.clone(), txs.iter());
             // before block is marked as completed
             assert_eq!(
-                hashmap_of(vec![(2, 3), (1, 1)]),
+                vec![(2, 3), (1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 3), (1, 2)]),
+                vec![(2, 3), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 2)]),
+                vec![(2, 4), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 1)]),
+                vec![(2, 4), (1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 2)]),
+                vec![(2, 4), (1, 2)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 2)]),
+                vec![(2, 4), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -820,28 +824,28 @@ mod tests {
             // after block is completed
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 3, bank3.bank_id());
             assert_eq!(
-                hashmap_of(vec![(3, 5), (2, 3), (1, 1)]),
+                vec![(3, 5), (2, 3), (1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[]),
             );
             assert_eq!(
-                hashmap_of(vec![(3, 6), (2, 3), (1, 2)]),
+                vec![(3, 6), (2, 3), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a]),
             );
             assert_eq!(
-                hashmap_of(vec![(3, 5), (2, 4), (1, 2)]),
+                vec![(3, 5), (2, 4), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b]),
             );
             assert_eq!(
-                hashmap_of(vec![(3, 6), (2, 4), (1, 1)]),
+                vec![(3, 6), (2, 4), (1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c]),
             );
             assert_eq!(
-                hashmap_of(vec![(3, 6), (2, 4), (1, 2)]),
+                vec![(3, 6), (2, 4), (1, 2)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b]),
             );
             assert_eq!(
-                hashmap_of(vec![(3, 6), (2, 4), (1, 2)]),
+                vec![(3, 6), (2, 4), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -867,7 +871,7 @@ mod tests {
         let collector = solana_sdk::pubkey::new_rand();
         let slot: Slot = 999;
         let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, slot));
-        let bank2 = Arc::new(Bank::new_from_parent(bank, &collector, slot));
+        let bank2 = Arc::new(Bank::new_from_parent(bank, &collector, slot + 1));
 
         let prioritization_fee_cache = PrioritizationFeeCache::default();
 
@@ -883,12 +887,13 @@ mod tests {
             ];
             sync_update(&prioritization_fee_cache, bank1.clone(), txs.iter());
 
-            let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
-                prioritization_fee_cache.cache.clone(),
-                &slot,
-            );
-            assert_eq!(1, slot_prioritization_fee.len());
-            assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
+            // Not possible to check the state in the thread
+            // let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
+            //     prioritization_fee_cache.cache.clone(),
+            //     &slot,
+            // );
+            // assert_eq!(1, slot_prioritization_fee.len());
+            // assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
         }
 
         // Assert after add transactions for bank2 of slot 1
@@ -903,50 +908,52 @@ mod tests {
             ];
             sync_update(&prioritization_fee_cache, bank2.clone(), txs.iter());
 
-            let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
-                prioritization_fee_cache.cache.clone(),
-                &slot,
-            );
-            assert_eq!(2, slot_prioritization_fee.len());
-            assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
-            assert!(slot_prioritization_fee.contains_key(&bank2.bank_id()));
+            // Not possible to check the state in the thread
+            // let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
+            //     prioritization_fee_cache.cache.clone(),
+            //     &slot,
+            // );
+            // assert_eq!(2, slot_prioritization_fee.len());
+            // assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
+            // assert!(slot_prioritization_fee.contains_key(&bank2.bank_id()));
         }
 
         // Assert after finalize with bank1 of slot 1,
         {
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, slot, bank1.bank_id());
 
-            let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
-                prioritization_fee_cache.cache.clone(),
-                &slot,
-            );
-            assert_eq!(1, slot_prioritization_fee.len());
-            assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
+            // Not possible to check bank_id
+            // let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
+            //     prioritization_fee_cache.cache.clone(),
+            //     &slot,
+            // );
+            // assert_eq!(1, slot_prioritization_fee.len());
+            // assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
 
             // and data available for query are from bank1
             assert_eq!(
-                hashmap_of(vec![(slot, 1)]),
+                vec![(slot, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[])
             );
             assert_eq!(
-                hashmap_of(vec![(slot, 2)]),
+                vec![(slot, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a])
             );
             assert_eq!(
-                hashmap_of(vec![(slot, 2)]),
+                vec![(slot, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b])
             );
             assert_eq!(
-                hashmap_of(vec![(slot, 1)]),
+                vec![(slot, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c])
             );
             assert_eq!(
-                hashmap_of(vec![(slot, 2)]),
+                vec![(slot, 2)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b])
             );
             assert_eq!(
-                hashmap_of(vec![(slot, 2)]),
+                vec![(slot, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -308,9 +308,9 @@ impl PrioritizationFeeCache {
 
                 // Only retain priority fee reported from optimistically confirmed bank
                 let pre_purge_bank_count = slot_prioritization_fee.len() as u64;
-                let mut slot_prioritization_fee = slot_prioritization_fee.remove(&bank_id);
+                let mut prioritization_fee = slot_prioritization_fee.remove(&bank_id);
                 let post_purge_bank_count =
-                    slot_prioritization_fee.as_ref().map(|_| 1).unwrap_or(0);
+                    prioritization_fee.as_ref().map(|_| 1).unwrap_or(0);
                 metrics.accumulate_total_purged_duplicated_bank_count(
                     pre_purge_bank_count.saturating_sub(post_purge_bank_count),
                 );
@@ -320,16 +320,16 @@ impl PrioritizationFeeCache {
                     warn!("Finalized bank has empty prioritization fee cache. slot {slot} bank id {bank_id}");
                 }
 
-                if let Some(slot_prioritization_fee) = &mut slot_prioritization_fee {
-                    if let Err(err) = slot_prioritization_fee.mark_block_completed() {
+                if let Some(prioritization_fee) = &mut prioritization_fee {
+                    if let Err(err) = prioritization_fee.mark_block_completed() {
                         error!(
                             "Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {:?}",
                             err
                         );
                     }
-                    slot_prioritization_fee.report_metrics(slot);
+                    prioritization_fee.report_metrics(slot);
                 }
-                slot_prioritization_fee
+                prioritization_fee
             },
             "slot_finalize_time"
         );

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -526,21 +526,10 @@ mod tests {
         let prioritization_fee_cache = PrioritizationFeeCache::default();
         sync_update(&prioritization_fee_cache, bank.clone(), txs.iter());
 
-        // assert block minimum fee and account a, b, c fee accordingly
+        // assert empty cache
         {
-            // let fee = PrioritizationFeeCache::get_prioritization_fee(
-            //     prioritization_fee_cache.cache.clone(),
-            //     &slot,
-            // );
-            // let fee = fee.get(&bank.bank_id()).unwrap();
-            // assert_eq!(2, fee.get_min_transaction_fee().unwrap());
-            // assert_eq!(2, fee.get_writable_account_fee(&write_account_a).unwrap());
-            // assert_eq!(5, fee.get_writable_account_fee(&write_account_b).unwrap());
-            // assert_eq!(2, fee.get_writable_account_fee(&write_account_c).unwrap());
-            // // assert unknown account d fee
-            // assert!(fee
-            //     .get_writable_account_fee(&Pubkey::new_unique())
-            //     .is_none());
+            let mut lock = prioritization_fee_cache.cache.write().unwrap();
+            assert!(lock.get(&slot).is_none());
         }
 
         // assert after prune, account a and c should be removed from cache to save space

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -309,8 +309,7 @@ impl PrioritizationFeeCache {
                 // Only retain priority fee reported from optimistically confirmed bank
                 let pre_purge_bank_count = slot_prioritization_fee.len() as u64;
                 let mut prioritization_fee = slot_prioritization_fee.remove(&bank_id);
-                let post_purge_bank_count =
-                    prioritization_fee.as_ref().map(|_| 1).unwrap_or(0);
+                let post_purge_bank_count = prioritization_fee.as_ref().map(|_| 1).unwrap_or(0);
                 metrics.accumulate_total_purged_duplicated_bank_count(
                     pre_purge_bank_count.saturating_sub(post_purge_bank_count),
                 );

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -874,14 +874,6 @@ mod tests {
                 ),
             ];
             sync_update(&prioritization_fee_cache, bank1.clone(), txs.iter());
-
-            // Not possible to check the state in the thread
-            // let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
-            //     prioritization_fee_cache.cache.clone(),
-            //     &slot,
-            // );
-            // assert_eq!(1, slot_prioritization_fee.len());
-            // assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
         }
 
         // Assert after add transactions for bank2 of slot 1
@@ -895,28 +887,11 @@ mod tests {
                 ),
             ];
             sync_update(&prioritization_fee_cache, bank2.clone(), txs.iter());
-
-            // Not possible to check the state in the thread
-            // let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
-            //     prioritization_fee_cache.cache.clone(),
-            //     &slot,
-            // );
-            // assert_eq!(2, slot_prioritization_fee.len());
-            // assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
-            // assert!(slot_prioritization_fee.contains_key(&bank2.bank_id()));
         }
 
         // Assert after finalize with bank1 of slot 1,
         {
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, slot, bank1.bank_id());
-
-            // Not possible to check bank_id
-            // let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
-            //     prioritization_fee_cache.cache.clone(),
-            //     &slot,
-            // );
-            // assert_eq!(1, slot_prioritization_fee.len());
-            // assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
 
             // and data available for query are from bank1
             assert_eq!(

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -396,20 +396,19 @@ impl PrioritizationFeeCache {
             .read()
             .unwrap()
             .iter()
-            .filter_map(|(slot, slot_prioritization_fee)| {
-                slot_prioritization_fee.is_finalized().then(|| {
-                    let mut fee = slot_prioritization_fee
-                        .get_min_transaction_fee()
-                        .unwrap_or_default();
-                    for account_key in account_keys {
-                        if let Some(account_fee) =
-                            slot_prioritization_fee.get_writable_account_fee(account_key)
-                        {
-                            fee = std::cmp::max(fee, account_fee);
-                        }
+            .filter(|(_slot, slot_prioritization_fee)| slot_prioritization_fee.is_finalized())
+            .map(|(slot, slot_prioritization_fee)| {
+                let mut fee = slot_prioritization_fee
+                    .get_min_transaction_fee()
+                    .unwrap_or_default();
+                for account_key in account_keys {
+                    if let Some(account_fee) =
+                        slot_prioritization_fee.get_writable_account_fee(account_key)
+                    {
+                        fee = std::cmp::max(fee, account_fee);
                     }
-                    (*slot, fee)
-                })
+                }
+                (*slot, fee)
             })
             .collect()
     }

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -303,6 +303,7 @@ impl PrioritizationFeeCache {
                     .split_off(&slot.checked_sub(MAX_UNFINALIZED_SLOTS).unwrap_or_default());
 
                 let Some(mut slot_prioritization_fee) = unfinalized.remove(&slot) else {
+                    warn!("Finalized slot {slot} not found");
                     return;
                 };
 

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -567,10 +567,19 @@ mod tests {
         );
         sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 1, bank1.bank_id());
 
-        let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 2));
+        // add slot 2 entry to cache, but not finalize it
+        let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 3));
+        let txs = vec![build_sanitized_transaction_for_test(
+            1,
+            &Pubkey::new_unique(),
+            &Pubkey::new_unique(),
+        )];
+        sync_update(&prioritization_fee_cache, bank2.clone(), txs.iter());
+
+        let bank3 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 2));
         sync_update(
             &prioritization_fee_cache,
-            bank2.clone(),
+            bank3.clone(),
             vec![build_sanitized_transaction_for_test(
                 1,
                 &Pubkey::new_unique(),
@@ -578,19 +587,9 @@ mod tests {
             )]
             .iter(),
         );
-        sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 2, bank2.bank_id());
-
-        // add slot 3 entry to cache, but not finalize it
-        let bank3 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 3));
-        let txs = vec![build_sanitized_transaction_for_test(
-            1,
-            &Pubkey::new_unique(),
-            &Pubkey::new_unique(),
-        )];
-        sync_update(&prioritization_fee_cache, bank3.clone(), txs.iter());
+        sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 2, bank3.bank_id());
 
         // assert available block count should be 2 finalized blocks
-        std::thread::sleep(std::time::Duration::from_millis(1_000));
         assert_eq!(2, prioritization_fee_cache.available_block_count());
     }
 


### PR DESCRIPTION
The first part of #30 

#### Problem

`PrioritizationFeeCache` needs to write lock `cache` for every new transaction.

#### Summary of Changes

Instead of using a shared cache for everything, we can use a map in the update thread and update the shared cache when slot is finalized.