### PR TITLE
Remove public visibility of program cache from bank

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -398,10 +398,7 @@ fn simulate_process_entries(
     let bank_fork = BankForks::new_rw_arc(bank);
     let bank = bank_fork.read().unwrap().get_with_scheduler(slot).unwrap();
     bank.clone_without_scheduler()
-        .loaded_programs_cache
-        .write()
-        .unwrap()
-        .set_fork_graph(bank_fork.clone());
+        .set_fork_graph_in_program_cache(bank_fork.clone());
 
     for i in 0..(num_accounts / 2) {
         bank.transfer(initial_lamports, mint_keypair, &keypairs[i * 2].pubkey())

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1686,11 +1686,7 @@ impl ReplayStage {
             root_bank.clear_slot_signatures(slot);
 
             // Remove cached entries of the programs that were deployed in this slot.
-            root_bank
-                .loaded_programs_cache
-                .write()
-                .unwrap()
-                .prune_by_deployment_slot(slot);
+            root_bank.prune_program_cache_by_deployment_slot(slot);
 
             if let Some(bank_hash) = blockstore.get_bank_hash(slot) {
                 // If a descendant was successfully replayed and chained from a duplicate it must

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -514,14 +514,9 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
 
     // Adding `DELAY_VISIBILITY_SLOT_OFFSET` to slots to accommodate for delay visibility of the program
-    let mut loaded_programs = LoadedProgramsForTxBatch::new(
-        bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET,
-        bank.loaded_programs_cache
-            .read()
-            .unwrap()
-            .environments
-            .clone(),
-    );
+    let slot = bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET;
+    let mut loaded_programs =
+        LoadedProgramsForTxBatch::new(slot, bank.get_runtime_environments_for_slot(slot));
     for key in cached_account_keys {
         loaded_programs.replenish(key, bank.load_program(&key, false, bank.epoch()));
         debug!("Loaded program {}", key);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1674,11 +1674,7 @@ fn load_frozen_forks(
                 root = new_root_bank.slot();
 
                 leader_schedule_cache.set_root(new_root_bank);
-                new_root_bank
-                    .loaded_programs_cache
-                    .write()
-                    .unwrap()
-                    .prune(root, new_root_bank.epoch());
+                new_root_bank.prune_program_cache(root, new_root_bank.epoch());
                 let _ = bank_forks.write().unwrap().set_root(
                     root,
                     accounts_background_request_sender,

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -126,12 +126,7 @@ impl BankForks {
             scheduler_pool: None,
         }));
 
-        root_bank
-            .loaded_programs_cache
-            .write()
-            .unwrap()
-            .set_fork_graph(bank_forks.clone());
-
+        root_bank.set_fork_graph_in_program_cache(bank_forks.clone());
         bank_forks
     }
 
@@ -451,11 +446,7 @@ impl BankForks {
 
     pub fn prune_program_cache(&self, root: Slot) {
         if let Some(root_bank) = self.banks.get(&root) {
-            root_bank
-                .loaded_programs_cache
-                .write()
-                .unwrap()
-                .prune(root, root_bank.epoch());
+            root_bank.prune_program_cache(root, root_bank.epoch());
         }
     }
 

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -941,10 +941,7 @@ mod tests {
         let slot = bank.slot();
         let bank_fork = BankForks::new_rw_arc(bank);
         let bank = bank_fork.read().unwrap().get(slot).unwrap();
-        bank.loaded_programs_cache
-            .write()
-            .unwrap()
-            .set_fork_graph(bank_fork);
+        bank.set_fork_graph_in_program_cache(bank_fork);
         bank
     }
 


### PR DESCRIPTION
#### Problem
Public visibility of `Bank::loaded_programs_cache` is making it difficult to encapsulate cache within SVM API boundary.

#### Summary of Changes
Remove public visibility and provide necessary accessors from `bank`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
