### PR TITLE
Net script fix for expected shred version

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -88,6 +88,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --expected-bank-hash ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 == --expected-shred-version ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 == --accounts ]]; then
       args+=("$1" "$2")
       shift 2

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -264,7 +264,8 @@ EOF
 
       if [[ -n "$maybeWaitForSupermajority" ]]; then
         bankHash=$(agave-ledger-tool -l config/bootstrap-validator bank-hash --halt-at-slot 0)
-        extraNodeArgs="$extraNodeArgs --expected-bank-hash $bankHash"
+        shredVersion="$(cat "$SOLANA_CONFIG_DIR"/shred-version)"
+        extraNodeArgs="$extraNodeArgs --expected-bank-hash $bankHash --expected-shred-version $shredVersion"
         echo "$bankHash" > config/bank-hash
       fi
     fi


### PR DESCRIPTION
#### Problem

net script to start GCE cluster is failing with the following error:

solana@testnet-dev-lijun2-bootstrap-validator:~/solana$ agave-validator --gossip-host 10.138.0.136 --gossip-port 8001 --init-complete-file init-complete-node.log --wait-for-supermajority 1 --expected-bank-hash NeBvD6Vb26TYxgyUvsKDofAzmViZHi7xrFpstmyNLqp --require-tower --ledger /home/solana/solana/net/../config/bootstrap-validator --rpc-port 8899 --snapshot-interval-slots 200 --no-incremental-snapshots --identity /home/solana/solana/net/../config/bootstrap-validator/identity.json --vote-account /home/solana/solana/net/../config/bootstrap-validator/vote-account.json --rpc-faucet-address 127.0.0.1:9900 --no-poh-speed-test --no-os-network-limits-test --no-wait-for-vote-to-start-leader --full-rpc-api --allow-private-addr --log -
error: The following required arguments were not provided:
    --expected-shred-version <VERSION>

#### Summary of Changes
pass  --expected-shred-version  when starting the bootstrap node and make net.sh support it.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
