### PR TITLE
output txn signature for debug purpose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5970,6 +5970,7 @@ dependencies = [
  "solana-stake-program",
  "solana-streamer",
  "solana-tpu-client",
+ "solana-transaction-metrics-tracker",
  "solana-transaction-status",
  "solana-turbine",
  "solana-version",
@@ -7213,9 +7214,11 @@ dependencies = [
  "rcgen",
  "rustls",
  "solana-logger",
+ "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-sdk",
+ "solana-transaction-metrics-tracker",
  "thiserror",
  "tokio",
  "x509-parser",
@@ -7359,6 +7362,20 @@ dependencies = [
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
+]
+
+[[package]]
+name = "solana-transaction-metrics-tracker"
+version = "1.17.26"
+dependencies = [
+ "Inflector",
+ "base64 0.21.4",
+ "bincode",
+ "lazy_static",
+ "log",
+ "rand 0.8.5",
+ "solana-perf",
+ "solana-sdk",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -364,6 +364,7 @@ solana-system-program = { path = "programs/system", version = "=1.17.26" }
 solana-test-validator = { path = "test-validator", version = "=1.17.26" }
 solana-thin-client = { path = "thin-client", version = "=1.17.26" }
 solana-tpu-client = { path = "tpu-client", version = "=1.17.26", default-features = false }
+solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=1.17.26" }
 solana-transaction-status = { path = "transaction-status", version = "=1.17.26" }
 solana-turbine = { path = "turbine", version = "=1.17.26" }
 solana-udp-client = { path = "udp-client", version = "=1.17.26" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -66,6 +66,7 @@ solana-sdk = { workspace = true }
 solana-send-transaction-service = { workspace = true }
 solana-streamer = { workspace = true }
 solana-tpu-client = { workspace = true }
+solana-transaction-metrics-tracker = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-turbine = { workspace = true }
 solana-version = { workspace = true }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -201,6 +201,32 @@ impl Consumer {
             .slot_metrics_tracker
             .increment_retryable_packets_count(retryable_transaction_indexes.len() as u64);
 
+        // Now we track the performance for the interested transactions which is not in the retryable_transaction_indexes
+        // We assume the retryable_transaction_indexes is already sorted.
+        let mut retryable_idx = 0;
+        for (index, packet) in packets_to_process.iter().enumerate() {
+            if packet.original_packet().meta().is_perf_track_packet() {
+                if let Some(start_time) = packet.start_time() {
+                    if retryable_idx >= retryable_transaction_indexes.len()
+                        || retryable_transaction_indexes[retryable_idx] != index
+                    {
+                        let duration = Instant::now().duration_since(*start_time);
+
+                        debug!(
+                            "Banking stage processing took {duration:?} for transaction {:?}",
+                            packet.transaction().get_signatures().first()
+                        );
+                        payload
+                            .slot_metrics_tracker
+                            .increment_process_sampled_packets_us(duration.as_micros() as u64);
+                    } else {
+                        // This packet is retried, advance the retry index to the next, as the next packet's index will
+                        // certainly be > than this.
+                        retryable_idx += 1;
+                    }
+                }
+            }
+        }
         Some(retryable_transaction_indexes)
     }
 

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -15,7 +15,7 @@ use {
             VersionedTransaction,
         },
     },
-    std::{cmp::Ordering, mem::size_of, sync::Arc},
+    std::{cmp::Ordering, mem::size_of, sync::Arc, time::Instant},
     thiserror::Error,
 };
 
@@ -43,10 +43,16 @@ pub struct ImmutableDeserializedPacket {
     message_hash: Hash,
     is_simple_vote: bool,
     priority_details: TransactionPriorityDetails,
+    banking_stage_start_time: Option<Instant>,
 }
 
 impl ImmutableDeserializedPacket {
     pub fn new(packet: Packet) -> Result<Self, DeserializedPacketError> {
+        let banking_stage_start_time = packet
+            .meta()
+            .is_perf_track_packet()
+            .then_some(Instant::now());
+
         let versioned_transaction: VersionedTransaction = packet.deserialize_slice(..)?;
         let sanitized_transaction = SanitizedVersionedTransaction::try_from(versioned_transaction)?;
         let message_bytes = packet_message(&packet)?;
@@ -69,6 +75,7 @@ impl ImmutableDeserializedPacket {
             message_hash,
             is_simple_vote,
             priority_details,
+            banking_stage_start_time,
         })
     }
 
@@ -94,6 +101,10 @@ impl ImmutableDeserializedPacket {
 
     pub fn compute_unit_limit(&self) -> u64 {
         self.priority_details.compute_unit_limit
+    }
+
+    pub fn start_time(&self) -> &Option<Instant> {
+        &self.banking_stage_start_time
     }
 
     // This function deserializes packets into transactions, computes the blake3 hash of transaction

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -839,6 +839,17 @@ impl LeaderSlotMetricsTracker {
             );
         }
     }
+
+    pub(crate) fn increment_process_sampled_packets_us(&mut self, us: u64) {
+        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
+            leader_slot_metrics
+                .timing_metrics
+                .process_packets_timings
+                .process_sampled_packets_us_hist
+                .increment(us)
+                .unwrap();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/core/src/banking_stage/leader_slot_timing_metrics.rs
+++ b/core/src/banking_stage/leader_slot_timing_metrics.rs
@@ -244,6 +244,9 @@ pub(crate) struct ProcessPacketsTimings {
     // Time spent running the cost model in processing transactions before executing
     // transactions
     pub cost_model_us: u64,
+
+    // banking stage processing time histogram for sampled packets
+    pub process_sampled_packets_us_hist: histogram::Histogram,
 }
 
 impl ProcessPacketsTimings {
@@ -264,6 +267,28 @@ impl ProcessPacketsTimings {
                 i64
             ),
             ("cost_model_us", self.cost_model_us, i64),
+            (
+                "process_sampled_packets_us_90pct",
+                self.process_sampled_packets_us_hist
+                    .percentile(90.0)
+                    .unwrap_or(0),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_min",
+                self.process_sampled_packets_us_hist.minimum().unwrap_or(0),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_max",
+                self.process_sampled_packets_us_hist.maximum().unwrap_or(0),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_mean",
+                self.process_sampled_packets_us_hist.mean().unwrap_or(0),
+                i64
+            ),
         );
     }
 }

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -876,6 +876,7 @@ impl ThreadLocalUnprocessedPackets {
                 .iter()
                 .map(|p| (*p).clone())
                 .collect_vec();
+
             let retryable_packets = if let Some(retryable_transaction_indexes) =
                 processing_function(&packets_to_process, payload)
             {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4901,6 +4901,7 @@ dependencies = [
  "solana-send-transaction-service",
  "solana-streamer",
  "solana-tpu-client",
+ "solana-transaction-metrics-tracker",
  "solana-transaction-status",
  "solana-turbine",
  "solana-version",
@@ -6241,9 +6242,11 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "rustls",
+ "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-sdk",
+ "solana-transaction-metrics-tracker",
  "thiserror",
  "tokio",
  "x509-parser",
@@ -6324,6 +6327,20 @@ dependencies = [
  "solana-sdk",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "solana-transaction-metrics-tracker"
+version = "1.17.26"
+dependencies = [
+ "Inflector",
+ "base64 0.21.4",
+ "bincode",
+ "lazy_static",
+ "log",
+ "rand 0.8.5",
+ "solana-perf",
+ "solana-sdk",
 ]
 
 [[package]]

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -33,6 +33,8 @@ bitflags! {
         /// the packet is built.
         /// This field can be removed when the above feature gate is adopted by mainnet-beta.
         const ROUND_COMPUTE_UNIT_PRICE = 0b0010_0000;
+        /// For tracking performance
+        const PERF_TRACK_PACKET  = 0b0100_0000;
     }
 }
 
@@ -229,6 +231,12 @@ impl Meta {
     }
 
     #[inline]
+    pub fn set_track_performance(&mut self, is_performance_track: bool) {
+        self.flags
+            .set(PacketFlags::PERF_TRACK_PACKET, is_performance_track);
+    }
+
+    #[inline]
     pub fn set_simple_vote(&mut self, is_simple_vote: bool) {
         self.flags.set(PacketFlags::SIMPLE_VOTE_TX, is_simple_vote);
     }
@@ -259,6 +267,11 @@ impl Meta {
     #[inline]
     pub fn is_tracer_packet(&self) -> bool {
         self.flags.contains(PacketFlags::TRACER_PACKET)
+    }
+
+    #[inline]
+    pub fn is_perf_track_packet(&self) -> bool {
+        self.flags.contains(PacketFlags::PERF_TRACK_PACKET)
     }
 
     #[inline]

--- a/sdk/src/transaction/versioned/sanitized.rs
+++ b/sdk/src/transaction/versioned/sanitized.rs
@@ -32,6 +32,10 @@ impl SanitizedVersionedTransaction {
     pub fn get_message(&self) -> &SanitizedVersionedMessage {
         &self.message
     }
+
+    pub fn get_signatures(&self) -> &Vec<Signature> {
+        &self.signatures
+    }
 }
 
 #[cfg(test)]

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -28,9 +28,11 @@ quinn-proto = { workspace = true }
 rand = { workspace = true }
 rcgen = { workspace = true }
 rustls = { workspace = true, features = ["dangerous_configuration"] }
+solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-perf = { workspace = true }
 solana-sdk = { workspace = true }
+solana-transaction-metrics-tracker = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 x509-parser = { workspace = true }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -14,6 +14,7 @@ use {
     quinn::{Connecting, Connection, Endpoint, EndpointConfig, TokioRuntime, VarInt},
     quinn_proto::VarIntBoundsExceeded,
     rand::{thread_rng, Rng},
+    solana_measure::measure::Measure,
     solana_perf::packet::{PacketBatch, PACKETS_PER_BATCH},
     solana_sdk::{
         packet::{Meta, PACKET_DATA_SIZE},
@@ -24,9 +25,10 @@ use {
             QUIC_MIN_STAKED_CONCURRENT_STREAMS, QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO,
             QUIC_TOTAL_STAKED_CONCURRENT_STREAMS, QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO,
         },
-        signature::Keypair,
+        signature::{Keypair, Signature},
         timing,
     },
+    solana_transaction_metrics_tracker::signature_if_should_track_packet,
     std::{
         iter::repeat_with,
         net::{IpAddr, SocketAddr, UdpSocket},
@@ -83,6 +85,7 @@ struct PacketChunk {
 struct PacketAccumulator {
     pub meta: Meta,
     pub chunks: Vec<PacketChunk>,
+    pub start_time: Instant,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -613,6 +616,7 @@ async fn packet_batch_sender(
     trace!("enter packet_batch_sender");
     let mut batch_start_time = Instant::now();
     loop {
+        let mut packet_perf_measure: Vec<([u8; 64], std::time::Instant)> = Vec::default();
         let mut packet_batch = PacketBatch::with_capacity(PACKETS_PER_BATCH);
         let mut total_bytes: usize = 0;
 
@@ -632,6 +636,8 @@ async fn packet_batch_sender(
                 || (!packet_batch.is_empty() && elapsed >= coalesce)
             {
                 let len = packet_batch.len();
+                track_streamer_fetch_packet_performance(&mut packet_perf_measure, &stats);
+
                 if let Err(e) = packet_sender.send(packet_batch) {
                     stats
                         .total_packet_batch_send_err
@@ -677,6 +683,14 @@ async fn packet_batch_sender(
 
                 total_bytes += packet_batch[i].meta().size;
 
+                if let Some(signature) = signature_if_should_track_packet(&packet_batch[i])
+                    .ok()
+                    .flatten()
+                {
+                    packet_perf_measure.push((*signature, packet_accumulator.start_time));
+                    // we set the PERF_TRACK_PACKET on
+                    packet_batch[i].meta_mut().set_track_performance(true);
+                }
                 stats
                     .total_chunks_processed_by_batcher
                     .fetch_add(num_chunks, Ordering::Relaxed);
@@ -712,6 +726,32 @@ fn reset_throttling_params_if_needed(last_instant: &mut tokio::time::Instant) ->
     } else {
         false
     }
+}
+
+fn track_streamer_fetch_packet_performance(
+    packet_perf_measure: &mut [([u8; 64], Instant)],
+    stats: &Arc<StreamStats>,
+) {
+    if packet_perf_measure.is_empty() {
+        return;
+    }
+    let mut measure = Measure::start("track_perf");
+    let mut process_sampled_packets_us_hist = stats.process_sampled_packets_us_hist.lock().unwrap();
+
+    for (signature, start_time) in packet_perf_measure.iter() {
+        let duration = Instant::now().duration_since(*start_time);
+        debug!(
+            "QUIC streamer fetch stage took {duration:?} for transaction {:?}",
+            Signature::from(*signature)
+        );
+        process_sampled_packets_us_hist
+            .increment(duration.as_micros() as u64)
+            .unwrap();
+    }
+    measure.stop();
+    stats
+        .perf_track_overhead_us
+        .fetch_add(measure.as_us(), Ordering::Relaxed);
 }
 
 async fn handle_connection(
@@ -861,6 +901,7 @@ async fn handle_chunk(
                     *packet_accum = Some(PacketAccumulator {
                         meta,
                         chunks: Vec::new(),
+                        start_time: Instant::now(),
                     });
                 }
 
@@ -1450,6 +1491,7 @@ pub mod test {
                     offset,
                     end_of_chunk: size,
                 }],
+                start_time: Instant::now(),
             };
             ptk_sender.send(packet_accum).await.unwrap();
         }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -16,8 +16,8 @@ use {
     std::{
         net::{IpAddr, UdpSocket},
         sync::{
-            atomic::{AtomicBool, AtomicUsize, Ordering},
-            Arc, RwLock,
+            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+            Arc, Mutex, RwLock,
         },
         thread,
         time::{Duration, SystemTime},
@@ -157,10 +157,14 @@ pub struct StreamStats {
     pub(crate) connection_removed: AtomicUsize,
     pub(crate) connection_remove_failed: AtomicUsize,
     pub(crate) throttled_streams: AtomicUsize,
+    pub(crate) process_sampled_packets_us_hist: Mutex<histogram::Histogram>,
+    pub(crate) perf_track_overhead_us: AtomicU64,
 }
 
 impl StreamStats {
     pub fn report(&self, name: &'static str) {
+        let mut process_sampled_packets_us_hist =
+            self.process_sampled_packets_us_hist.lock().unwrap();
         datapoint_info!(
             name,
             (
@@ -392,7 +396,35 @@ impl StreamStats {
                 self.throttled_streams.swap(0, Ordering::Relaxed),
                 i64
             ),
+            (
+                "process_sampled_packets_us_90pct",
+                process_sampled_packets_us_hist
+                    .percentile(90.0)
+                    .unwrap_or(0),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_min",
+                process_sampled_packets_us_hist.minimum().unwrap_or(0),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_max",
+                process_sampled_packets_us_hist.maximum().unwrap_or(0),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_mean",
+                process_sampled_packets_us_hist.mean().unwrap_or(0),
+                i64
+            ),
+            (
+                "perf_track_overhead_us",
+                self.perf_track_overhead_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
         );
+        process_sampled_packets_us_hist.clear();
     }
 }
 

--- a/transaction-metrics-tracker/Cargo.toml
+++ b/transaction-metrics-tracker/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "solana-transaction-metrics-tracker"
+description = "Solana transaction metrics tracker"
+documentation = "https://docs.rs/solana-transaction-metrics-tracker"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = false
+
+[dependencies]
+Inflector = { workspace = true }
+base64 = { workspace = true }
+bincode = { workspace = true }
+# Update this borsh dependency to the workspace version once
+lazy_static = { workspace = true }
+log = { workspace = true }
+rand = { workspace = true }
+solana-perf = { workspace = true }
+solana-sdk = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-metrics-tracker/src/lib.rs
+++ b/transaction-metrics-tracker/src/lib.rs
@@ -1,0 +1,157 @@
+use {
+    lazy_static::lazy_static,
+    log::*,
+    rand::Rng,
+    solana_perf::sigverify::PacketError,
+    solana_sdk::{packet::Packet, short_vec::decode_shortu16_len, signature::SIGNATURE_BYTES},
+};
+
+// The mask is 12 bits long (1<<12 = 4096), it means the probability of matching
+// the transaction is 1/4096 assuming the portion being matched is random.
+lazy_static! {
+    static ref TXN_MASK: u16 = rand::thread_rng().gen_range(0..4096);
+}
+
+/// Check if a transaction given its signature matches the randomly selected mask.
+/// The signaure should be from the reference of Signature
+pub fn should_track_transaction(signature: &[u8; SIGNATURE_BYTES]) -> bool {
+    // We do not use the highest signature byte as it is not really random
+    let match_portion: u16 = u16::from_le_bytes([signature[61], signature[62]]) >> 4;
+    trace!("Matching txn: {match_portion:016b} {:016b}", *TXN_MASK);
+    *TXN_MASK == match_portion
+}
+
+/// Check if a transaction packet's signature matches the mask.
+/// This does a rudimentry verification to make sure the packet at least
+/// contains the signature data and it returns the reference to the signature.
+pub fn signature_if_should_track_packet(
+    packet: &Packet,
+) -> Result<Option<&[u8; SIGNATURE_BYTES]>, PacketError> {
+    let signature = get_signature_from_packet(packet)?;
+    Ok(should_track_transaction(signature).then_some(signature))
+}
+
+/// Get the signature of the transaction packet
+/// This does a rudimentry verification to make sure the packet at least
+/// contains the signature data and it returns the reference to the signature.
+pub fn get_signature_from_packet(packet: &Packet) -> Result<&[u8; SIGNATURE_BYTES], PacketError> {
+    let (sig_len_untrusted, sig_start) = packet
+        .data(..)
+        .and_then(|bytes| decode_shortu16_len(bytes).ok())
+        .ok_or(PacketError::InvalidShortVec)?;
+
+    if sig_len_untrusted < 1 {
+        return Err(PacketError::InvalidSignatureLen);
+    }
+
+    let signature = packet
+        .data(sig_start..sig_start.saturating_add(SIGNATURE_BYTES))
+        .ok_or(PacketError::InvalidSignatureLen)?;
+    let signature = signature
+        .try_into()
+        .map_err(|_| PacketError::InvalidSignatureLen)?;
+    Ok(signature)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_sdk::{
+            hash::Hash,
+            signature::{Keypair, Signature},
+            system_transaction,
+        },
+    };
+
+    #[test]
+    fn test_get_signature_from_packet() {
+        // Default invalid txn packet
+        let packet = Packet::default();
+        let sig = get_signature_from_packet(&packet);
+        assert_eq!(sig, Err(PacketError::InvalidShortVec));
+
+        // Use a valid transaction, it should succeed
+        let tx = system_transaction::transfer(
+            &Keypair::new(),
+            &solana_sdk::pubkey::new_rand(),
+            1,
+            Hash::new_unique(),
+        );
+        let mut packet = Packet::from_data(None, tx).unwrap();
+
+        let sig = get_signature_from_packet(&packet);
+        assert!(sig.is_ok());
+
+        // Invalid signature length
+        packet.buffer_mut()[0] = 0x0;
+        let sig = get_signature_from_packet(&packet);
+        assert_eq!(sig, Err(PacketError::InvalidSignatureLen));
+    }
+
+    #[test]
+    fn test_should_track_transaction() {
+        let mut sig = [0x0; SIGNATURE_BYTES];
+        let track = should_track_transaction(&sig);
+        assert!(!track);
+
+        // Intentionally matching the randomly generated mask
+        // The lower four bits are ignored as only 12 highest bits from
+        // signature's 61 and 62 u8 are used for matching.
+        // We generate a random one
+        let mut rng = rand::thread_rng();
+        let random_number: u8 = rng.gen_range(0..=15);
+        sig[61] = ((*TXN_MASK & 0xf_u16) << 4) as u8 | random_number;
+        sig[62] = (*TXN_MASK >> 4) as u8;
+
+        let track = should_track_transaction(&sig);
+        assert!(track);
+    }
+
+    #[test]
+    fn test_signature_if_should_track_packet() {
+        // Default invalid txn packet
+        let packet = Packet::default();
+        let sig = signature_if_should_track_packet(&packet);
+        assert_eq!(sig, Err(PacketError::InvalidShortVec));
+
+        // Use a valid transaction which is not matched
+        let tx = system_transaction::transfer(
+            &Keypair::new(),
+            &solana_sdk::pubkey::new_rand(),
+            1,
+            Hash::new_unique(),
+        );
+        let packet = Packet::from_data(None, tx).unwrap();
+        let sig = signature_if_should_track_packet(&packet);
+        assert_eq!(Ok(None), sig);
+
+        // Now simulate a txn matching the signature mask
+        let mut tx = system_transaction::transfer(
+            &Keypair::new(),
+            &solana_sdk::pubkey::new_rand(),
+            1,
+            Hash::new_unique(),
+        );
+        let mut sig = [0x0; SIGNATURE_BYTES];
+        sig[61] = ((*TXN_MASK & 0xf_u16) << 4) as u8;
+        sig[62] = (*TXN_MASK >> 4) as u8;
+
+        let sig = Signature::from(sig);
+        tx.signatures[0] = sig;
+        let mut packet = Packet::from_data(None, tx).unwrap();
+        let sig2 = signature_if_should_track_packet(&packet);
+
+        match sig2 {
+            Ok(sig) => {
+                assert!(sig.is_some());
+            }
+            Err(_) => panic!("Expected to get a matching signature!"),
+        }
+
+        // Invalid signature length
+        packet.buffer_mut()[0] = 0x0;
+        let sig = signature_if_should_track_packet(&packet);
+        assert_eq!(sig, Err(PacketError::InvalidSignatureLen));
+    }
+}


### PR DESCRIPTION
trying txn mask matching

output txn to figure out why txn is not exactly matched

Use 62 and 61 portion

track fetch performance using random txn mask

track sigverify performance using random txn mask

track banking stage performance using random txn mask

adding missing cargo lock file

add debug messages

Revert "add debug messages"

This reverts commit 96aead5cbc4acb5b2fc9d8a37fcd506c73ddf552.

fixed some clippy issues

check-crate issue

Fix a clippy issue

Fix a clippy issue

debug why txns in banking stage shows fewer performance tracking points

debug why txns in banking stage shows fewer performance tracking points

debug why txns in banking stage shows fewer performance tracking points

debug why txns in banking stage shows fewer performance tracking points

get higher PPS for testing purpose

more debug messages on why txn is skipped

display if tracer packet in log

add debug before calling processing_function

debug at the initial of banking stage

track if a txn is forwarded

dependency order

missing cargo file

clean up debug messages

Do not use TRACER_PACKET, use its own bit

rename some functions

addressed some comments from Trent

Update core/src/banking_stage/immutable_deserialized_packet.rs

Co-authored-by: Trent Nelson <trent.a.b.nelson@gmail.com>

addressed some comments from Trent

Do not use binary_search, do simple compare in one loop

Use datapoint as opposed to counters

Add a unit test

removed a print

Added more unit tests

Making stats names consistent across layers

Added more unit tests

Added more unit tests

Do not use binary_search, do simple compare in one loop

measure perf track overhead

missing cargo.lock

Do not use Hashmap for perf track. Using vec. Measure the overhead of perf track

Clippy issue

clear histogram for streamer stage

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
