### PR TITLE
WIP: GHA to sync new commits from anza-xyz/agave -> solana-labs/solana

### DIFF
--- a/.github/scripts/cherry-pick-from-branch.sh
+++ b/.github/scripts/cherry-pick-from-branch.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script is intended to be called by the Github Action update_upstream_from_fork.yaml
+# It is triggered on a push event and will cherry-pick the commits from the push
+# onto "DEST_REMOTE/$DEST_BRANCH
+# Assumptions:
+# In a repo
+# $DEST_REPO/$DEST_BRANCH is defined, readable, and writeable
+# $BEFORE_SHA..$LAST_SHA must define a sequence of commits
+
+# TODO git grep agave -- * after cherry-pick. Fail if we find new agave references?
+
+DEST_REMOTE=$1      # eg "upstream" (must already be defined and writeable in the repo)
+DEST_BRANCH=$2      # eg "master" - must exist in the repo
+BEFORE_SHA=$3       # the last commit before the ones to cherry-pick. $BEFORE_SHA is NOT cherry-picked.
+LAST_SHA=$4         # The last commit to cherry-pick.
+
+echo "DEST_REMOTE: $DEST_REMOTE"
+echo "DEST_BRANCH: $DEST_BRANCH"
+echo "BEFORE_SHA: $BEFORE_SHA"
+echo "LAST_SHA: $LAST_SHA"
+
+SKIP_COMMIT_STRING="\[anza migration\]"
+
+# TODO commenting these causes a silent failure. Make it fail loudly
+git config --global user.email "noreply@anza.xyz"
+git config --global user.name "GHA: Update Upstream From Fork"
+git fetch --all
+echo "-------------------------"
+echo "git log --oneline remotes/$DEST_REMOTE/$DEST_BRANCH:"
+git log --oneline "remotes/$DEST_REMOTE/$DEST_BRANCH" -10
+echo "-----------------------"
+echo "git log --oneline $BEFORE_SHA~..$LAST_SHA"
+git log --oneline "$BEFORE_SHA~..$LAST_SHA" -10
+echo "-------------------------"
+git checkout -b temp_branch "remotes/$DEST_REMOTE/$DEST_BRANCH"
+
+for sha1 in $(git log --reverse --format=format:%H $BEFORE_SHA..$LAST_SHA); do
+    echo "-------------------------------------"
+    echo "SHA1: $sha1"
+    commit_message=$(git log --format=%B $sha1~..$sha1)
+    echo "Commit message: $commit_message"
+    if ! [[ $commit_message =~ $SKIP_COMMIT_STRING ]] ; then
+        echo "Commit message '$commit_message' does not contain $SKIP_COMMIT_STRING. Cherry-picking..."
+        git cherry-pick "$sha1"
+    else
+        echo "Commit message  '$commit_message' contains $SKIP_COMMIT_STRING. Skipping..."
+    fi
+done
+git status
+git log -10
+git push "$DEST_REMOTE" "$DEST_BRANCH"      # TODO This seems to be pushing the local copy of DEST_BRANCH rather than the temp_branch

--- a/.github/workflows/update_upstream_from_fork.yml
+++ b/.github/workflows/update_upstream_from_fork.yml
@@ -1,0 +1,60 @@
+# TODO Minimize the PAT permissions. Leave a comment about which are required.
+
+name: Update Upstream From Fork
+
+on:
+  push:
+    branches:
+      - master
+      - v1.18
+      - v1.17
+
+env:
+  GH_TOKEN: ${{ secrets.SYNC_TEST_ADMIN2 }}
+  GH_REPO: ${{ github.repository }}
+  BRANCH_REF: ${{ github.ref_name }}
+  REF: ${{ github.event.REF}}
+  BEFORE_SHA: ${{ github.event.before }}
+  LAST_SHA: ${{ github.event.after}}
+  UPSTREAM: https://github.com/solana-labs/sync_test.git
+  GITHUB_OBJ: ${{ toJSON(github) }}
+
+jobs:
+  update-upstream-from-fork:
+    # TODO need to update this repo name to anza-xyz/agave
+    if: github.repository == 'willhickey/sync_test'
+    name: "Update Upstream From Fork"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo git status
+        run: |
+          echo "---------------"
+          echo "gh auth status"
+          gh auth status
+          echo "---------------"
+          echo "git config -l: "
+          git config -l
+          echo "---------------"
+        shell: bash
+      - uses: actions/checkout@v4
+        with:
+          # By default checkout only gets 1 commit. We want to cherry-pick
+          # all the commits from the push, so fetch the entire history
+          fetch-depth: 0
+          # By default checkout uses secrets.GITHUB_TOKEN. That token won't
+          # have any permissions in the upstream repo, so we need to override it
+          # with a Personal Access Token that can access both repos
+          token: ${{ env.GH_TOKEN }}
+      - name: Add remote for upstream
+        run: git remote add upstream $UPSTREAM
+        shell: bash
+      - name: show remotes and branches
+        run: |
+          git fetch --all
+          git remote --verbose
+          git branch --all
+        shell: bash
+      - name: Cherry pick from origin to upstream
+        run: |
+          .github/scripts/cherry-pick-from-branch.sh upstream "$BRANCH_REF" "$BEFORE_SHA" "$LAST_SHA"
+        shell: bash


### PR DESCRIPTION
#### Problem
We need to sync all commits pushed to [master, v1.18, v1.17] in anza-xyz/agave back to the corresponding branches in solana-labs/solana.

#### Summary of Changes
On push cherry-pick the pushed commit(s) back to the corresponding branch in the upstream repo.