### PR TITLE
Simd 129: alt_bn128 syscalls - simplified error code

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1576,6 +1576,7 @@ declare_builtin_function!(
         let result_point = match calculation(input) {
             Ok(result_point) => result_point,
             Err(_) => {
+                //TODO: add feature gate
                 return Ok(1);
             }
         };

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1573,11 +1573,18 @@ declare_builtin_function!(
             }
         };
 
+        let simplify_alt_bn128_syscall_error_codes = invoke_context
+            .feature_set
+            .is_active(&feature_set::simplify_alt_bn128_syscall_error_codes::id());
+
         let result_point = match calculation(input) {
             Ok(result_point) => result_point,
-            Err(_) => {
-                //TODO: add feature gate
-                return Ok(1);
+            Err(e) => {
+                return if simplify_alt_bn128_syscall_error_codes {
+                    Ok(1)
+                } else {
+                    Ok(e.into())
+                }
             }
         };
 

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1575,8 +1575,8 @@ declare_builtin_function!(
 
         let result_point = match calculation(input) {
             Ok(result_point) => result_point,
-            Err(e) => {
-                return Ok(e.into());
+            Err(_) => {
+                return Ok(1);
             }
         };
 
@@ -1722,8 +1722,8 @@ declare_builtin_function!(
             .collect::<Result<Vec<_>, Error>>()?;
         let hash = match poseidon::hashv(parameters, endianness, inputs.as_slice()) {
             Ok(hash) => hash,
-            Err(e) => {
-                return Ok(e.into());
+            Err(_) => {
+                return Ok(1);
             }
         };
         hash_result.copy_from_slice(&hash.to_bytes());
@@ -1811,8 +1811,8 @@ declare_builtin_function!(
             ALT_BN128_G1_COMPRESS => {
                 let result_point = match alt_bn128_g1_compress(input) {
                     Ok(result_point) => result_point,
-                    Err(e) => {
-                        return Ok(e.into());
+                    Err(_) => {
+                        return Ok(1);
                     }
                 };
                 call_result.copy_from_slice(&result_point);
@@ -1821,8 +1821,8 @@ declare_builtin_function!(
             ALT_BN128_G1_DECOMPRESS => {
                 let result_point = match alt_bn128_g1_decompress(input) {
                     Ok(result_point) => result_point,
-                    Err(e) => {
-                        return Ok(e.into());
+                    Err(_) => {
+                        return Ok(1);
                     }
                 };
                 call_result.copy_from_slice(&result_point);
@@ -1831,8 +1831,8 @@ declare_builtin_function!(
             ALT_BN128_G2_COMPRESS => {
                 let result_point = match alt_bn128_g2_compress(input) {
                     Ok(result_point) => result_point,
-                    Err(e) => {
-                        return Ok(e.into());
+                    Err(_) => {
+                        return Ok(1);
                     }
                 };
                 call_result.copy_from_slice(&result_point);
@@ -1841,8 +1841,8 @@ declare_builtin_function!(
             ALT_BN128_G2_DECOMPRESS => {
                 let result_point = match alt_bn128_g2_decompress(input) {
                     Ok(result_point) => result_point,
-                    Err(e) => {
-                        return Ok(e.into());
+                    Err(_) => {
+                        return Ok(1);
                     }
                 };
                 call_result.copy_from_slice(&result_point);

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1584,12 +1584,16 @@ declare_builtin_function!(
                     Ok(1)
                 } else {
                     Ok(e.into())
-                }
+                };
             }
         };
 
         if result_point.len() != output {
-            return Ok(AltBn128Error::SliceOutOfBounds.into());
+            return if simplify_alt_bn128_syscall_error_codes {
+                Ok(1)
+            } else {
+                Ok(AltBn128Error::SliceOutOfBounds.into())
+            };
         }
 
         call_result.copy_from_slice(&result_point);

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1589,7 +1589,7 @@ declare_builtin_function!(
         };
 
         // This can never happen and should be removed when the
-        // simplify_alt_bn128_syscall_error_codes fature gets activated
+        // simplify_alt_bn128_syscall_error_codes feature gets activated
         if result_point.len() != output && !simplify_alt_bn128_syscall_error_codes {
             return Ok(AltBn128Error::SliceOutOfBounds.into());
         }

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1732,10 +1732,19 @@ declare_builtin_function!(
                 )
             })
             .collect::<Result<Vec<_>, Error>>()?;
+
+        let simplify_alt_bn128_syscall_error_codes = invoke_context
+            .feature_set
+            .is_active(&feature_set::simplify_alt_bn128_syscall_error_codes::id());
+
         let hash = match poseidon::hashv(parameters, endianness, inputs.as_slice()) {
             Ok(hash) => hash,
-            Err(_) => {
-                return Ok(1);
+            Err(e) => {
+                return if simplify_alt_bn128_syscall_error_codes {
+                    Ok(1)
+                } else {
+                    Ok(e.into())
+                };
             }
         };
         hash_result.copy_from_slice(&hash.to_bytes());
@@ -1819,12 +1828,20 @@ declare_builtin_function!(
             invoke_context.get_check_aligned(),
         )?;
 
+        let simplify_alt_bn128_syscall_error_codes = invoke_context
+            .feature_set
+            .is_active(&feature_set::simplify_alt_bn128_syscall_error_codes::id());
+
         match op {
             ALT_BN128_G1_COMPRESS => {
                 let result_point = match alt_bn128_g1_compress(input) {
                     Ok(result_point) => result_point,
-                    Err(_) => {
-                        return Ok(1);
+                    Err(e) => {
+                        return if simplify_alt_bn128_syscall_error_codes {
+                            Ok(1)
+                        } else {
+                            Ok(e.into())
+                        };
                     }
                 };
                 call_result.copy_from_slice(&result_point);
@@ -1833,8 +1850,12 @@ declare_builtin_function!(
             ALT_BN128_G1_DECOMPRESS => {
                 let result_point = match alt_bn128_g1_decompress(input) {
                     Ok(result_point) => result_point,
-                    Err(_) => {
-                        return Ok(1);
+                    Err(e) => {
+                        return if simplify_alt_bn128_syscall_error_codes {
+                            Ok(1)
+                        } else {
+                            Ok(e.into())
+                        };
                     }
                 };
                 call_result.copy_from_slice(&result_point);
@@ -1843,8 +1864,12 @@ declare_builtin_function!(
             ALT_BN128_G2_COMPRESS => {
                 let result_point = match alt_bn128_g2_compress(input) {
                     Ok(result_point) => result_point,
-                    Err(_) => {
-                        return Ok(1);
+                    Err(e) => {
+                        return if simplify_alt_bn128_syscall_error_codes {
+                            Ok(1)
+                        } else {
+                            Ok(e.into())
+                        };
                     }
                 };
                 call_result.copy_from_slice(&result_point);
@@ -1853,8 +1878,12 @@ declare_builtin_function!(
             ALT_BN128_G2_DECOMPRESS => {
                 let result_point = match alt_bn128_g2_decompress(input) {
                     Ok(result_point) => result_point,
-                    Err(_) => {
-                        return Ok(1);
+                    Err(e) => {
+                        return if simplify_alt_bn128_syscall_error_codes {
+                            Ok(1)
+                        } else {
+                            Ok(e.into())
+                        };
                     }
                 };
                 call_result.copy_from_slice(&result_point);

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1588,12 +1588,10 @@ declare_builtin_function!(
             }
         };
 
-        if result_point.len() != output {
-            return if simplify_alt_bn128_syscall_error_codes {
-                Ok(1)
-            } else {
-                Ok(AltBn128Error::SliceOutOfBounds.into())
-            };
+        // This can never happen and should be removed when the
+        // simplify_alt_bn128_syscall_error_codes fature gets activated
+        if result_point.len() != output && !simplify_alt_bn128_syscall_error_codes {
+            return Ok(AltBn128Error::SliceOutOfBounds.into());
         }
 
         call_result.copy_from_slice(&result_point);

--- a/sdk/program/src/alt_bn128/compression.rs
+++ b/sdk/program/src/alt_bn128/compression.rs
@@ -20,6 +20,8 @@ mod alt_bn128_compression_size {
     pub const G2_COMPRESSED: usize = 64;
 }
 
+// AltBn128CompressionError must be removed once the
+// simplify_alt_bn128_syscall_error_codes fature gets activated
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum AltBn128CompressionError {
     #[error("Unexpected error")]

--- a/sdk/program/src/alt_bn128/compression.rs
+++ b/sdk/program/src/alt_bn128/compression.rs
@@ -21,7 +21,7 @@ mod alt_bn128_compression_size {
 }
 
 // AltBn128CompressionError must be removed once the
-// simplify_alt_bn128_syscall_error_codes fature gets activated
+// simplify_alt_bn128_syscall_error_codes feature gets activated
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum AltBn128CompressionError {
     #[error("Unexpected error")]

--- a/sdk/program/src/alt_bn128/compression.rs
+++ b/sdk/program/src/alt_bn128/compression.rs
@@ -209,7 +209,7 @@ mod target_arch {
 
         match result {
             0 => Ok(result_buffer),
-            error => Err(AltBn128CompressionError::from(error)),
+            _ => Err(AltBn128CompressionError::UnexpectedError),
         }
     }
 
@@ -226,7 +226,7 @@ mod target_arch {
 
         match result {
             0 => Ok(result_buffer),
-            error => Err(AltBn128CompressionError::from(error)),
+            _ => Err(AltBn128CompressionError::UnexpectedError),
         }
     }
 
@@ -245,7 +245,7 @@ mod target_arch {
 
         match result {
             0 => Ok(result_buffer),
-            error => Err(AltBn128CompressionError::from(error)),
+            _ => Err(AltBn128CompressionError::UnexpectedError),
         }
     }
 
@@ -264,7 +264,7 @@ mod target_arch {
 
         match result {
             0 => Ok(result_buffer),
-            error => Err(AltBn128CompressionError::from(error)),
+            _ => Err(AltBn128CompressionError::UnexpectedError),
         }
     }
 }

--- a/sdk/program/src/alt_bn128/compression.rs
+++ b/sdk/program/src/alt_bn128/compression.rs
@@ -36,6 +36,19 @@ pub enum AltBn128CompressionError {
     InvalidInputSize,
 }
 
+impl From<u64> for AltBn128CompressionError {
+    fn from(v: u64) -> AltBn128CompressionError {
+        match v {
+            1 => AltBn128CompressionError::G1DecompressionFailed,
+            2 => AltBn128CompressionError::G2DecompressionFailed,
+            3 => AltBn128CompressionError::G1CompressionFailed,
+            4 => AltBn128CompressionError::G2CompressionFailed,
+            5 => AltBn128CompressionError::InvalidInputSize,
+            _ => AltBn128CompressionError::UnexpectedError,
+        }
+    }
+}
+
 impl From<AltBn128CompressionError> for u64 {
     fn from(v: AltBn128CompressionError) -> u64 {
         // note: should never return 0, as it risks to be confused with syscall success

--- a/sdk/program/src/alt_bn128/compression.rs
+++ b/sdk/program/src/alt_bn128/compression.rs
@@ -87,7 +87,7 @@ mod target_arch {
         let decompressed_g1 = G1::deserialize_with_mode(
             convert_endianness::<32, 32>(&g1_bytes).as_slice(),
             Compress::Yes,
-            Validate::Yes,
+            Validate::No,
         )
         .map_err(|_| AltBn128CompressionError::G1DecompressionFailed)?;
         let mut decompressed_g1_bytes = [0u8; alt_bn128_compression_size::G1];
@@ -114,7 +114,7 @@ mod target_arch {
         let g1 = G1::deserialize_with_mode(
             convert_endianness::<32, 64>(&g1_bytes).as_slice(),
             Compress::No,
-            Validate::Yes,
+            Validate::No,
         )
         .map_err(|_| AltBn128CompressionError::G1CompressionFailed)?;
         let mut g1_bytes = [0u8; alt_bn128_compression_size::G1_COMPRESSED];
@@ -135,7 +135,7 @@ mod target_arch {
         let decompressed_g2 = G2::deserialize_with_mode(
             convert_endianness::<64, 64>(&g2_bytes).as_slice(),
             Compress::Yes,
-            Validate::Yes,
+            Validate::No,
         )
         .map_err(|_| AltBn128CompressionError::G2DecompressionFailed)?;
         let mut decompressed_g2_bytes = [0u8; alt_bn128_compression_size::G2];
@@ -162,7 +162,7 @@ mod target_arch {
         let g2 = G2::deserialize_with_mode(
             convert_endianness::<64, 128>(&g2_bytes).as_slice(),
             Compress::No,
-            Validate::Yes,
+            Validate::No,
         )
         .map_err(|_| AltBn128CompressionError::G2CompressionFailed)?;
         let mut g2_bytes = [0u8; alt_bn128_compression_size::G2_COMPRESSED];

--- a/sdk/program/src/alt_bn128/compression.rs
+++ b/sdk/program/src/alt_bn128/compression.rs
@@ -51,13 +51,14 @@ impl From<u64> for AltBn128CompressionError {
 
 impl From<AltBn128CompressionError> for u64 {
     fn from(v: AltBn128CompressionError) -> u64 {
+        // note: should never return 0, as it risks to be confused with syscall success
         match v {
             AltBn128CompressionError::G1DecompressionFailed => 1,
             AltBn128CompressionError::G2DecompressionFailed => 2,
             AltBn128CompressionError::G1CompressionFailed => 3,
             AltBn128CompressionError::G2CompressionFailed => 4,
             AltBn128CompressionError::InvalidInputSize => 5,
-            AltBn128CompressionError::UnexpectedError => 0,
+            AltBn128CompressionError::UnexpectedError => 6,
         }
     }
 }
@@ -86,7 +87,7 @@ mod target_arch {
         let decompressed_g1 = G1::deserialize_with_mode(
             convert_endianness::<32, 32>(&g1_bytes).as_slice(),
             Compress::Yes,
-            Validate::No,
+            Validate::Yes,
         )
         .map_err(|_| AltBn128CompressionError::G1DecompressionFailed)?;
         let mut decompressed_g1_bytes = [0u8; alt_bn128_compression_size::G1];
@@ -113,12 +114,12 @@ mod target_arch {
         let g1 = G1::deserialize_with_mode(
             convert_endianness::<32, 64>(&g1_bytes).as_slice(),
             Compress::No,
-            Validate::No,
+            Validate::Yes,
         )
         .map_err(|_| AltBn128CompressionError::G1CompressionFailed)?;
         let mut g1_bytes = [0u8; alt_bn128_compression_size::G1_COMPRESSED];
         G1::serialize_compressed(&g1, g1_bytes.as_mut_slice())
-            .map_err(|_| AltBn128CompressionError::G2CompressionFailed)?;
+            .map_err(|_| AltBn128CompressionError::G1CompressionFailed)?;
         Ok(convert_endianness::<32, 32>(&g1_bytes))
     }
 
@@ -131,9 +132,12 @@ mod target_arch {
         if g2_bytes == [0u8; alt_bn128_compression_size::G2_COMPRESSED] {
             return Ok([0u8; alt_bn128_compression_size::G2]);
         }
-        let decompressed_g2 =
-            G2::deserialize_compressed(convert_endianness::<64, 64>(&g2_bytes).as_slice())
-                .map_err(|_| AltBn128CompressionError::G2DecompressionFailed)?;
+        let decompressed_g2 = G2::deserialize_with_mode(
+            convert_endianness::<64, 64>(&g2_bytes).as_slice(),
+            Compress::Yes,
+            Validate::Yes,
+        )
+        .map_err(|_| AltBn128CompressionError::G2DecompressionFailed)?;
         let mut decompressed_g2_bytes = [0u8; alt_bn128_compression_size::G2];
         decompressed_g2
             .x
@@ -158,9 +162,9 @@ mod target_arch {
         let g2 = G2::deserialize_with_mode(
             convert_endianness::<64, 128>(&g2_bytes).as_slice(),
             Compress::No,
-            Validate::No,
+            Validate::Yes,
         )
-        .map_err(|_| AltBn128CompressionError::G2DecompressionFailed)?;
+        .map_err(|_| AltBn128CompressionError::G2CompressionFailed)?;
         let mut g2_bytes = [0u8; alt_bn128_compression_size::G2_COMPRESSED];
         G2::serialize_compressed(&g2, g2_bytes.as_mut_slice())
             .map_err(|_| AltBn128CompressionError::G2CompressionFailed)?;

--- a/sdk/program/src/alt_bn128/compression.rs
+++ b/sdk/program/src/alt_bn128/compression.rs
@@ -36,19 +36,6 @@ pub enum AltBn128CompressionError {
     InvalidInputSize,
 }
 
-impl From<u64> for AltBn128CompressionError {
-    fn from(v: u64) -> AltBn128CompressionError {
-        match v {
-            1 => AltBn128CompressionError::G1DecompressionFailed,
-            2 => AltBn128CompressionError::G2DecompressionFailed,
-            3 => AltBn128CompressionError::G1CompressionFailed,
-            4 => AltBn128CompressionError::G2CompressionFailed,
-            5 => AltBn128CompressionError::InvalidInputSize,
-            _ => AltBn128CompressionError::UnexpectedError,
-        }
-    }
-}
-
 impl From<AltBn128CompressionError> for u64 {
     fn from(v: AltBn128CompressionError) -> u64 {
         // note: should never return 0, as it risks to be confused with syscall success

--- a/sdk/program/src/alt_bn128/mod.rs
+++ b/sdk/program/src/alt_bn128/mod.rs
@@ -57,6 +57,19 @@ pub enum AltBn128Error {
     ProjectiveToG1Failed,
 }
 
+impl From<u64> for AltBn128Error {
+    fn from(v: u64) -> AltBn128Error {
+        match v {
+            1 => AltBn128Error::InvalidInputData,
+            2 => AltBn128Error::GroupError,
+            3 => AltBn128Error::SliceOutOfBounds,
+            4 => AltBn128Error::TryIntoVecError(Vec::new()),
+            5 => AltBn128Error::ProjectiveToG1Failed,
+            _ => AltBn128Error::UnexpectedError,
+        }
+    }
+}
+
 impl From<AltBn128Error> for u64 {
     fn from(v: AltBn128Error) -> u64 {
         // note: should never return 0, as it risks to be confused with syscall success

--- a/sdk/program/src/alt_bn128/mod.rs
+++ b/sdk/program/src/alt_bn128/mod.rs
@@ -320,7 +320,7 @@ mod target_arch {
 
         match result {
             0 => Ok(result_buffer.to_vec()),
-            error => Err(AltBn128Error::from(error)),
+            _ => Err(AltBn128Error::UnexpectedError),
         }
     }
 
@@ -340,7 +340,7 @@ mod target_arch {
 
         match result {
             0 => Ok(result_buffer.to_vec()),
-            error => Err(AltBn128Error::from(error)),
+            _ => Err(AltBn128Error::UnexpectedError),
         }
     }
 
@@ -364,7 +364,7 @@ mod target_arch {
 
         match result {
             0 => Ok(result_buffer.to_vec()),
-            error => Err(AltBn128Error::from(error)),
+            _ => Err(AltBn128Error::UnexpectedError),
         }
     }
 }

--- a/sdk/program/src/alt_bn128/mod.rs
+++ b/sdk/program/src/alt_bn128/mod.rs
@@ -72,13 +72,14 @@ impl From<u64> for AltBn128Error {
 
 impl From<AltBn128Error> for u64 {
     fn from(v: AltBn128Error) -> u64 {
+        // note: should never return 0, as it risks to be confused with syscall success
         match v {
             AltBn128Error::InvalidInputData => 1,
             AltBn128Error::GroupError => 2,
             AltBn128Error::SliceOutOfBounds => 3,
             AltBn128Error::TryIntoVecError(_) => 4,
             AltBn128Error::ProjectiveToG1Failed => 5,
-            AltBn128Error::UnexpectedError => 0,
+            AltBn128Error::UnexpectedError => 6,
         }
     }
 }

--- a/sdk/program/src/alt_bn128/mod.rs
+++ b/sdk/program/src/alt_bn128/mod.rs
@@ -57,19 +57,6 @@ pub enum AltBn128Error {
     ProjectiveToG1Failed,
 }
 
-impl From<u64> for AltBn128Error {
-    fn from(v: u64) -> AltBn128Error {
-        match v {
-            1 => AltBn128Error::InvalidInputData,
-            2 => AltBn128Error::GroupError,
-            3 => AltBn128Error::SliceOutOfBounds,
-            4 => AltBn128Error::TryIntoVecError(Vec::new()),
-            5 => AltBn128Error::ProjectiveToG1Failed,
-            _ => AltBn128Error::UnexpectedError,
-        }
-    }
-}
-
 impl From<AltBn128Error> for u64 {
     fn from(v: AltBn128Error) -> u64 {
         // note: should never return 0, as it risks to be confused with syscall success

--- a/sdk/program/src/alt_bn128/mod.rs
+++ b/sdk/program/src/alt_bn128/mod.rs
@@ -41,6 +41,8 @@ mod consts {
     pub const ALT_BN128_PAIRING: u64 = 3;
 }
 
+// AltBn128Error must be removed once the
+// simplify_alt_bn128_syscall_error_codes fature gets activated
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum AltBn128Error {
     #[error("The input data is invalid")]

--- a/sdk/program/src/alt_bn128/mod.rs
+++ b/sdk/program/src/alt_bn128/mod.rs
@@ -42,7 +42,7 @@ mod consts {
 }
 
 // AltBn128Error must be removed once the
-// simplify_alt_bn128_syscall_error_codes fature gets activated
+// simplify_alt_bn128_syscall_error_codes feature gets activated
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum AltBn128Error {
     #[error("The input data is invalid")]

--- a/sdk/program/src/poseidon.rs
+++ b/sdk/program/src/poseidon.rs
@@ -37,6 +37,25 @@ pub enum PoseidonSyscallError {
     Unexpected,
 }
 
+impl From<u64> for PoseidonSyscallError {
+    fn from(error: u64) -> Self {
+        match error {
+            1 => PoseidonSyscallError::InvalidParameters,
+            2 => PoseidonSyscallError::InvalidEndianness,
+            3 => PoseidonSyscallError::InvalidNumberOfInputs,
+            4 => PoseidonSyscallError::EmptyInput,
+            5 => PoseidonSyscallError::InvalidInputLength,
+            6 => PoseidonSyscallError::BytesToPrimeFieldElement,
+            7 => PoseidonSyscallError::InputLargerThanModulus,
+            8 => PoseidonSyscallError::VecToArray,
+            9 => PoseidonSyscallError::U64Tou8,
+            10 => PoseidonSyscallError::BytesToBigInt,
+            11 => PoseidonSyscallError::InvalidWidthCircom,
+            _ => PoseidonSyscallError::Unexpected,
+        }
+    }
+}
+
 impl From<PoseidonSyscallError> for u64 {
     fn from(error: PoseidonSyscallError) -> Self {
         match error {

--- a/sdk/program/src/poseidon.rs
+++ b/sdk/program/src/poseidon.rs
@@ -37,25 +37,6 @@ pub enum PoseidonSyscallError {
     Unexpected,
 }
 
-impl From<u64> for PoseidonSyscallError {
-    fn from(error: u64) -> Self {
-        match error {
-            1 => PoseidonSyscallError::InvalidParameters,
-            2 => PoseidonSyscallError::InvalidEndianness,
-            3 => PoseidonSyscallError::InvalidNumberOfInputs,
-            4 => PoseidonSyscallError::EmptyInput,
-            5 => PoseidonSyscallError::InvalidInputLength,
-            6 => PoseidonSyscallError::BytesToPrimeFieldElement,
-            7 => PoseidonSyscallError::InputLargerThanModulus,
-            8 => PoseidonSyscallError::VecToArray,
-            9 => PoseidonSyscallError::U64Tou8,
-            10 => PoseidonSyscallError::BytesToBigInt,
-            11 => PoseidonSyscallError::InvalidWidthCircom,
-            _ => PoseidonSyscallError::Unexpected,
-        }
-    }
-}
-
 impl From<PoseidonSyscallError> for u64 {
     fn from(error: PoseidonSyscallError) -> Self {
         match error {

--- a/sdk/program/src/poseidon.rs
+++ b/sdk/program/src/poseidon.rs
@@ -7,6 +7,8 @@ use thiserror::Error;
 /// Length of Poseidon hash result.
 pub const HASH_BYTES: usize = 32;
 
+// PoseidonSyscallError must be removed once the
+// simplify_alt_bn128_syscall_error_codes fature gets activated
 #[derive(Error, Debug)]
 pub enum PoseidonSyscallError {
     #[error("Invalid parameters.")]

--- a/sdk/program/src/poseidon.rs
+++ b/sdk/program/src/poseidon.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 pub const HASH_BYTES: usize = 32;
 
 // PoseidonSyscallError must be removed once the
-// simplify_alt_bn128_syscall_error_codes fature gets activated
+// simplify_alt_bn128_syscall_error_codes feature gets activated
 #[derive(Error, Debug)]
 pub enum PoseidonSyscallError {
     #[error("Invalid parameters.")]

--- a/sdk/program/src/poseidon.rs
+++ b/sdk/program/src/poseidon.rs
@@ -267,7 +267,7 @@ pub fn hashv(
 
         match result {
             0 => Ok(PoseidonHash::new(hash_result)),
-            e => Err(PoseidonSyscallError::from(e)),
+            _ => Err(PoseidonSyscallError::Unexpected),
         }
     }
 }


### PR DESCRIPTION
#### Problem

The alt_bn128 family of syscalls have a wide range of return errors (some of which also invalid/that can never happen). We'd like to simplify to limit the risk of consensus issue among different clients (e.g. Agave vs Firedancer).

#### Summary of Changes

- [x] Main change: return `Ok(1)` instead of `Ok(e.into())`, i.e. one single error code for the syscalls
- [x] UnexpectedError shouldn't be 0, as 0 would be confused with SUCCESS (included for completeness, even though the previous change makes this irrelevant)
- [x] Minor fixes on return errors caused by copy&paste (included for completeness, even though the previous change makes this irrelevant)
- [x] Feature gate the change in `SyscallAltBn128`

Feature Gate Issue: #320

SIMD-0129: https://github.com/solana-foundation/solana-improvement-documents/pull/129