### PR TITLE
install: Fix check for windows build

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -1173,7 +1173,7 @@ pub fn init_or_update(config_file: &str, is_init: bool, check_only: bool) -> Res
     )
     .map_err(|err| match err.raw_os_error() {
         #[cfg(windows)]
-        Some(os_err) if os_err == winapi::shared::winerror::ERROR_PRIVILEGE_NOT_HELD => {
+        Some(os_err) if os_err == winapi::shared::winerror::ERROR_PRIVILEGE_NOT_HELD as i32 => {
             "You need to run this command with administrator privileges.".to_string()
         }
         _ => format!(


### PR DESCRIPTION
#### Problem

#234 broke the windows build because `raw_os_error()` returns an `i32` https://doc.rust-lang.org/std/io/type.RawOsError.html but the `winapi` types are defined as `u32`s at https://docs.rs/winapi/latest/winapi/shared/winerror/constant.ERROR_PRIVILEGE_NOT_HELD.html, so the comparison fails

#### Summary of Changes

Cast the winapi error to an `i32`

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
