### PR TITLE
fix polarity for concurrent replay

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -654,15 +654,15 @@ impl ReplayStage {
                 )
             };
             // Thread pool to (maybe) replay multiple threads in parallel
-            let replay_mode = if !replay_slots_concurrently {
-                ForkReplayMode::Serial
-            } else {
+            let replay_mode = if replay_slots_concurrently {
                 let pool = rayon::ThreadPoolBuilder::new()
                     .num_threads(MAX_CONCURRENT_FORKS_TO_REPLAY)
                     .thread_name(|i| format!("solReplayFork{i:02}"))
                     .build()
                     .expect("new rayon threadpool");
                 ForkReplayMode::Parallel(pool)
+            } else {
+                ForkReplayMode::Serial
             };
             // Thread pool to replay multiple transactions within one block in parallel
             let replay_tx_thread_pool = rayon::ThreadPoolBuilder::new()

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -654,7 +654,7 @@ impl ReplayStage {
                 )
             };
             // Thread pool to (maybe) replay multiple threads in parallel
-            let replay_mode = if replay_slots_concurrently {
+            let replay_mode = if !replay_slots_concurrently {
                 ForkReplayMode::Serial
             } else {
                 let pool = rayon::ThreadPoolBuilder::new()


### PR DESCRIPTION
#### Problem
Polarity is wrong for deciding whether to replay serially or concurrently.

I blame the reviewer of #137 

#### Summary of Changes
Switch polarity