### PR TITLE
[clap-v3-utils] Remove deprecated functions

### DIFF
--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 chrono = { workspace = true, features = ["default"] }
-clap = { version = "3.2.23", features = ["cargo"] }
+clap = { version = "3.2.23", features = ["cargo", "deprecated"] }
 rpassword = { workspace = true }
 solana-remote-wallet = { workspace = true }
 solana-sdk = { workspace = true }

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 chrono = { workspace = true, features = ["default"] }
-clap = { version = "3.2.23", features = ["cargo", "deprecated"] }
+clap = { version = "3.2.23", features = ["cargo"] }
 rpassword = { workspace = true }
 solana-remote-wallet = { workspace = true }
 solana-sdk = { workspace = true }

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -272,6 +272,11 @@ pub fn parse_derived_address_seed(arg: &str) -> Result<String, String> {
 }
 
 // Return the keypair for an argument with filename `name` or None if not present.
+#[deprecated(
+    since = "1.19.0",
+    note = "Please use `input_parsers::signer::try_keypair_of` instead"
+)]
+#[allow(deprecated)]
 pub fn keypair_of(matches: &ArgMatches, name: &str) -> Option<Keypair> {
     if let Some(value) = matches.value_of(name) {
         if value == ASK_KEYWORD {
@@ -285,6 +290,11 @@ pub fn keypair_of(matches: &ArgMatches, name: &str) -> Option<Keypair> {
     }
 }
 
+#[deprecated(
+    since = "1.19.0",
+    note = "Please use `input_parsers::signer::try_keypairs_of` instead"
+)]
+#[allow(deprecated)]
 pub fn keypairs_of(matches: &ArgMatches, name: &str) -> Option<Vec<Keypair>> {
     matches.values_of(name).map(|values| {
         values
@@ -302,10 +312,20 @@ pub fn keypairs_of(matches: &ArgMatches, name: &str) -> Option<Vec<Keypair>> {
 
 // Return a pubkey for an argument that can itself be parsed into a pubkey,
 // or is a filename that can be read as a keypair
+#[deprecated(
+    since = "1.19.0",
+    note = "Please use `input_parsers::signer::try_pubkey_of` instead"
+)]
+#[allow(deprecated)]
 pub fn pubkey_of(matches: &ArgMatches, name: &str) -> Option<Pubkey> {
     value_of(matches, name).or_else(|| keypair_of(matches, name).map(|keypair| keypair.pubkey()))
 }
 
+#[deprecated(
+    since = "1.19.0",
+    note = "Please use `input_parsers::signer::try_pubkeys_of` instead"
+)]
+#[allow(deprecated)]
 pub fn pubkeys_of(matches: &ArgMatches, name: &str) -> Option<Vec<Pubkey>> {
     matches.values_of(name).map(|values| {
         values

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -339,6 +339,7 @@ pub fn pubkeys_of(matches: &ArgMatches, name: &str) -> Option<Vec<Pubkey>> {
     })
 }
 
+#[allow(deprecated)]
 #[cfg(test)]
 mod tests {
     use {

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -83,6 +83,11 @@ pub fn lamports_of_sol(matches: &ArgMatches, name: &str) -> Option<u64> {
     value_of(matches, name).map(sol_to_lamports)
 }
 
+#[deprecated(
+    since = "1.19.0",
+    note = "Please use `ArgMatches::get_one::<ClusterType>(...)` instead"
+)]
+#[allow(deprecated)]
 pub fn cluster_type_of(matches: &ArgMatches, name: &str) -> Option<ClusterType> {
     value_of(matches, name)
 }
@@ -585,6 +590,33 @@ mod tests {
         let matches_error = command
             .clone()
             .try_get_matches_from(vec!["test", "--timestamp", "this_is_an_invalid_arg"])
+            .unwrap_err();
+        assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn test_cluster_type() {
+        let command = Command::new("test").arg(
+            Arg::new("cluster")
+                .long("cluster")
+                .takes_value(true)
+                .value_parser(clap::value_parser!(ClusterType)),
+        );
+
+        // success case
+        let matches = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--cluster", "testnet"])
+            .unwrap();
+        assert_eq!(
+            *matches.get_one::<ClusterType>("cluster").unwrap(),
+            ClusterType::Testnet
+        );
+
+        // validation fails
+        let matches_error = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--cluster", "this_is_an_invalid_arg"])
             .unwrap_err();
         assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
     }

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -298,7 +298,7 @@ pub fn pubkeys_of(matches: &ArgMatches, name: &str) -> Option<Vec<Pubkey>> {
 mod tests {
     use {
         super::*,
-        clap::{Arg, Command},
+        clap::{Arg, ArgAction, Command},
         solana_sdk::{hash::Hash, pubkey::Pubkey},
     };
 
@@ -308,7 +308,7 @@ mod tests {
                 Arg::new("multiple")
                     .long("multiple")
                     .takes_value(true)
-                    .multiple_occurrences(true)
+                    .action(ArgAction::Append)
                     .multiple_values(true),
             )
             .arg(Arg::new("single").takes_value(true).long("single"))

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -58,6 +58,11 @@ where
         .and_then(|value| value.parse::<T>().ok())
 }
 
+#[deprecated(
+    since = "1.19.0",
+    note = "Please use `ArgMatches::get_one::<UnixTimestamp>(...)` instead"
+)]
+#[allow(deprecated)]
 pub fn unix_timestamp_from_rfc3339_datetime(
     matches: &ArgMatches,
     name: &str,
@@ -555,5 +560,32 @@ mod tests {
                 assert_eq!(matches.get_one::<String>("derivation").unwrap(), arg);
             }
         }
+    }
+
+    #[test]
+    fn test_unix_timestamp_from_rfc3339_datetime() {
+        let command = Command::new("test").arg(
+            Arg::new("timestamp")
+                .long("timestamp")
+                .takes_value(true)
+                .value_parser(clap::value_parser!(UnixTimestamp)),
+        );
+
+        // success case
+        let matches = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--timestamp", "1234"])
+            .unwrap();
+        assert_eq!(
+            *matches.get_one::<UnixTimestamp>("timestamp").unwrap(),
+            1234,
+        );
+
+        // validation fails
+        let matches_error = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--timestamp", "this_is_an_invalid_arg"])
+            .unwrap_err();
+        assert_eq!(matches_error.kind, clap::error::ErrorKind::ValueValidation);
     }
 }

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -27,6 +27,11 @@ pub use signer::{
 };
 
 // Return parsed values from matches at `name`
+#[deprecated(
+    since = "1.19.0",
+    note = "Please use the functions `ArgMatches::get_many` or `ArgMatches::try_get_many` instead"
+)]
+#[allow(deprecated)]
 pub fn values_of<T>(matches: &ArgMatches, name: &str) -> Option<Vec<T>>
 where
     T: std::str::FromStr,
@@ -38,6 +43,11 @@ where
 }
 
 // Return a parsed value from matches at `name`
+#[deprecated(
+    since = "1.19.0",
+    note = "Please use the functions `ArgMatches::get_one` or `ArgMatches::try_get_one` instead"
+)]
+#[allow(deprecated)]
 pub fn value_of<T>(matches: &ArgMatches, name: &str) -> Option<T>
 where
     T: std::str::FromStr,
@@ -63,6 +73,7 @@ pub fn unix_timestamp_from_rfc3339_datetime(
     since = "1.17.0",
     note = "please use `Amount::parse_decimal` and `Amount::sol_to_lamport` instead"
 )]
+#[allow(deprecated)]
 pub fn lamports_of_sol(matches: &ArgMatches, name: &str) -> Option<u64> {
     value_of(matches, name).map(sol_to_lamports)
 }

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -22,8 +22,7 @@ pub mod signer;
     note = "Please use the functions in `solana_clap_v3_utils::input_parsers::signer` directly instead"
 )]
 pub use signer::{
-    pubkey_of_signer, pubkeys_of_multiple_signers, pubkeys_sigs_of, resolve_signer, signer_of,
-    STDOUT_OUTFILE_TOKEN,
+    pubkey_of_signer, pubkeys_of_multiple_signers, resolve_signer, signer_of, STDOUT_OUTFILE_TOKEN,
 };
 
 // Return parsed values from matches at `name`

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -29,7 +29,7 @@ pub use signer::{
 
 // Return parsed values from matches at `name`
 #[deprecated(
-    since = "1.19.0",
+    since = "2.0.0",
     note = "Please use the functions `ArgMatches::get_many` or `ArgMatches::try_get_many` instead"
 )]
 #[allow(deprecated)]
@@ -45,7 +45,7 @@ where
 
 // Return a parsed value from matches at `name`
 #[deprecated(
-    since = "1.19.0",
+    since = "2.0.0",
     note = "Please use the functions `ArgMatches::get_one` or `ArgMatches::try_get_one` instead"
 )]
 #[allow(deprecated)]
@@ -60,7 +60,7 @@ where
 }
 
 #[deprecated(
-    since = "1.19.0",
+    since = "2.0.0",
     note = "Please use `ArgMatches::get_one::<UnixTimestamp>(...)` instead"
 )]
 #[allow(deprecated)]
@@ -85,7 +85,7 @@ pub fn lamports_of_sol(matches: &ArgMatches, name: &str) -> Option<u64> {
 }
 
 #[deprecated(
-    since = "1.19.0",
+    since = "2.0.0",
     note = "Please use `ArgMatches::get_one::<ClusterType>(...)` instead"
 )]
 #[allow(deprecated)]
@@ -94,7 +94,7 @@ pub fn cluster_type_of(matches: &ArgMatches, name: &str) -> Option<ClusterType> 
 }
 
 #[deprecated(
-    since = "1.19.0",
+    since = "2.0.0",
     note = "Please use `ArgMatches::get_one::<CommitmentConfig>(...)` instead"
 )]
 #[allow(deprecated)]
@@ -274,7 +274,7 @@ pub fn parse_derived_address_seed(arg: &str) -> Result<String, String> {
 
 // Return the keypair for an argument with filename `name` or None if not present.
 #[deprecated(
-    since = "1.19.0",
+    since = "2.0.0",
     note = "Please use `input_parsers::signer::try_keypair_of` instead"
 )]
 #[allow(deprecated)]
@@ -292,7 +292,7 @@ pub fn keypair_of(matches: &ArgMatches, name: &str) -> Option<Keypair> {
 }
 
 #[deprecated(
-    since = "1.19.0",
+    since = "2.0.0",
     note = "Please use `input_parsers::signer::try_keypairs_of` instead"
 )]
 #[allow(deprecated)]
@@ -314,7 +314,7 @@ pub fn keypairs_of(matches: &ArgMatches, name: &str) -> Option<Vec<Keypair>> {
 // Return a pubkey for an argument that can itself be parsed into a pubkey,
 // or is a filename that can be read as a keypair
 #[deprecated(
-    since = "1.19.0",
+    since = "2.0.0",
     note = "Please use `input_parsers::signer::try_pubkey_of` instead"
 )]
 #[allow(deprecated)]
@@ -323,7 +323,7 @@ pub fn pubkey_of(matches: &ArgMatches, name: &str) -> Option<Pubkey> {
 }
 
 #[deprecated(
-    since = "1.19.0",
+    since = "2.0.0",
     note = "Please use `input_parsers::signer::try_pubkeys_of` instead"
 )]
 #[allow(deprecated)]

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -21,8 +21,10 @@ pub mod signer;
     since = "1.17.0",
     note = "Please use the functions in `solana_clap_v3_utils::input_parsers::signer` directly instead"
 )]
+#[allow(deprecated)]
 pub use signer::{
-    pubkey_of_signer, pubkeys_of_multiple_signers, resolve_signer, signer_of, STDOUT_OUTFILE_TOKEN,
+    pubkey_of_signer, pubkeys_of_multiple_signers, pubkeys_sigs_of, resolve_signer, signer_of,
+    STDOUT_OUTFILE_TOKEN,
 };
 
 // Return parsed values from matches at `name`

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -381,7 +381,7 @@ mod tests {
     use {
         super::*,
         assert_matches::assert_matches,
-        clap::{Arg, Command},
+        clap::{Arg, ArgAction, Command},
         solana_remote_wallet::locator::Manufacturer,
         solana_sdk::signature::write_keypair_file,
         std::fs,
@@ -512,7 +512,7 @@ mod tests {
                 Arg::new("multiple")
                     .long("multiple")
                     .takes_value(true)
-                    .multiple_occurrences(true)
+                    .action(ArgAction::Append)
                     .multiple_values(true),
             )
             .arg(Arg::new("single").takes_value(true).long("single"))

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -1,7 +1,7 @@
 use {
-    crate::{
-        input_parsers::{keypair_of, keypairs_of, pubkey_of, pubkeys_of},
-        keypair::{pubkey_from_path, resolve_signer_from_path, signer_from_path, ASK_KEYWORD},
+    crate::keypair::{
+        keypair_from_seed_phrase, pubkey_from_path, resolve_signer_from_path, signer_from_path,
+        ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
     clap::{builder::ValueParser, ArgMatches},
     solana_remote_wallet::{
@@ -11,7 +11,7 @@ use {
     solana_sdk::{
         derivation_path::{DerivationPath, DerivationPathError},
         pubkey::Pubkey,
-        signature::{Keypair, Signature, Signer},
+        signature::{read_keypair_file, Keypair, Signature, Signer},
     },
     std::{error, rc::Rc, str::FromStr},
     thiserror::Error,
@@ -236,16 +236,36 @@ pub fn try_keypair_of(
     matches: &ArgMatches,
     name: &str,
 ) -> Result<Option<Keypair>, Box<dyn error::Error>> {
-    matches.try_contains_id(name)?;
-    Ok(keypair_of(matches, name))
+    if let Some(value) = matches.try_get_one::<String>(name)? {
+        if value == ASK_KEYWORD {
+            let skip_validation = matches.try_contains_id(SKIP_SEED_PHRASE_VALIDATION_ARG.name)?;
+            keypair_from_seed_phrase(name, skip_validation, true, None, true).map(Some)
+        } else {
+            read_keypair_file(value).map(Some)
+        }
+    } else {
+        Ok(None)
+    }
 }
 
 pub fn try_keypairs_of(
     matches: &ArgMatches,
     name: &str,
 ) -> Result<Option<Vec<Keypair>>, Box<dyn error::Error>> {
-    matches.try_contains_id(name)?;
-    Ok(keypairs_of(matches, name))
+    Ok(matches.try_get_many::<String>(name)?.map(|values| {
+        values
+            .filter_map(|value| {
+                if value == ASK_KEYWORD {
+                    let skip_validation = matches
+                        .try_contains_id(SKIP_SEED_PHRASE_VALIDATION_ARG.name)
+                        .unwrap();
+                    keypair_from_seed_phrase(name, skip_validation, true, None, true).ok()
+                } else {
+                    read_keypair_file(value).ok()
+                }
+            })
+            .collect()
+    }))
 }
 
 // Return a `Result` wrapped pubkey for an argument that can itself be parsed into a pubkey,
@@ -254,16 +274,28 @@ pub fn try_pubkey_of(
     matches: &ArgMatches,
     name: &str,
 ) -> Result<Option<Pubkey>, Box<dyn error::Error>> {
-    matches.try_contains_id(name)?;
-    Ok(pubkey_of(matches, name))
+    if let Some(pubkey) = matches.try_get_one::<Pubkey>(name)? {
+        Ok(Some(*pubkey))
+    } else {
+        Ok(try_keypair_of(matches, name)?.map(|keypair| keypair.pubkey()))
+    }
 }
 
 pub fn try_pubkeys_of(
     matches: &ArgMatches,
     name: &str,
 ) -> Result<Option<Vec<Pubkey>>, Box<dyn error::Error>> {
-    matches.try_contains_id(name)?;
-    Ok(pubkeys_of(matches, name))
+    Ok(matches.try_get_many::<String>(name)?.map(|values| {
+        values
+            .map(|value| {
+                value.parse::<Pubkey>().unwrap_or_else(|_| {
+                    read_keypair_file(value)
+                        .expect("read_keypair_file failed")
+                        .pubkey()
+                })
+            })
+            .collect()
+    }))
 }
 
 // Return pubkey/signature pairs for a string of the form pubkey=signature
@@ -380,6 +412,7 @@ impl FromStr for PubkeySignature {
 mod tests {
     use {
         super::*,
+        crate::input_parsers::{keypair_of, pubkey_of, pubkeys_of},
         assert_matches::assert_matches,
         clap::{Arg, ArgAction, Command},
         solana_remote_wallet::locator::Manufacturer,

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -418,6 +418,7 @@ impl FromStr for PubkeySignature {
     }
 }
 
+#[allow(deprecated)]
 #[cfg(test)]
 mod tests {
     use {

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -296,7 +296,7 @@ pub fn try_pubkeys_of(
 }
 
 // Return pubkey/signature pairs for a string of the form pubkey=signature
-#[deprecated(since = "1.19.0", note = "Please use `try_pubkeys_sigs_of` instead")]
+#[deprecated(since = "2.0.0", note = "Please use `try_pubkeys_sigs_of` instead")]
 #[allow(deprecated)]
 pub fn pubkeys_sigs_of(matches: &ArgMatches, name: &str) -> Option<Vec<(Pubkey, Signature)>> {
     matches.values_of(name).map(|values| {

--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -1,7 +1,7 @@
 use {
     crate::{keypair::prompt_passphrase, ArgConstant},
     bip39::Language,
-    clap::{Arg, ArgMatches},
+    clap::{builder::PossibleValuesParser, Arg, ArgMatches},
     std::error,
 };
 
@@ -28,7 +28,7 @@ pub const NO_PASSPHRASE_ARG: ArgConstant<'static> = ArgConstant {
 pub fn word_count_arg<'a>() -> Arg<'a> {
     Arg::new(WORD_COUNT_ARG.name)
         .long(WORD_COUNT_ARG.long)
-        .possible_values(["12", "15", "18", "21", "24"])
+        .value_parser(PossibleValuesParser::new(["12", "15", "18", "21", "24"]))
         .default_value("12")
         .value_name("NUMBER")
         .takes_value(true)
@@ -38,7 +38,7 @@ pub fn word_count_arg<'a>() -> Arg<'a> {
 pub fn language_arg<'a>() -> Arg<'a> {
     Arg::new(LANGUAGE_ARG.name)
         .long(LANGUAGE_ARG.long)
-        .possible_values([
+        .value_parser(PossibleValuesParser::new([
             "english",
             "chinese-simplified",
             "chinese-traditional",
@@ -47,7 +47,7 @@ pub fn language_arg<'a>() -> Arg<'a> {
             "korean",
             "french",
             "italian",
-        ])
+        ]))
         .default_value("english")
         .value_name("LANGUAGE")
         .takes_value(true)

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -1257,6 +1257,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn signer_from_path_with_file() -> Result<(), Box<dyn std::error::Error>> {
         let dir = TempDir::new()?;
         let dir = dir.path();

--- a/clap-v3-utils/src/offline.rs
+++ b/clap-v3-utils/src/offline.rs
@@ -1,6 +1,6 @@
 use {
     crate::{input_parsers::signer::PubkeySignature, ArgConstant},
-    clap::{value_parser, Arg, Command},
+    clap::{value_parser, Arg, ArgAction, Command},
     solana_sdk::hash::Hash,
 };
 
@@ -52,7 +52,7 @@ fn signer_arg<'a>() -> Arg<'a> {
         .value_name("PUBKEY=SIGNATURE")
         .value_parser(value_parser!(PubkeySignature))
         .requires(BLOCKHASH_ARG.name)
-        .multiple_occurrences(true)
+        .action(ArgAction::Append)
         .multiple_values(false)
         .help(SIGNER_ARG.help)
 }


### PR DESCRIPTION
#### Problem
Solana cla-v3-utils still uses deprecated functions from clap-v2.

#### Summary of Changes
- Replaced a number of deprecated functions like possible_values, value_of, and multiple_occurrences with the updated functions from clap-v3.
- Deprecated some existing parser functions that can be replaced by existing clap-v3 functions
- Deprecated some panicking functions like keypair_of, keypairs_of, etc. in favor of their try_ variants

Clap-v3 has a feature deprecated that, when included, gives warnings on deprecated functions. With this PR, all the deprecated functions should either be removed or explicitly allowed (on deprecated functions). However, if I include the deprecated feature, it seems to turn this feature on in the rest of the repo on CI checks, so I left it out for now.

This is a port of https://github.com/solana-labs/solana/pull/34989.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
