### PR TITLE
implement get_builtin_program_ids() trait for TransactionProcessingCallback

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7689,7 +7689,7 @@ impl TransactionProcessingCallback for Bank {
     }
 
     fn get_builtin_program_ids(&self) -> Vec<Pubkey> {
-        self.builtin_programs
+        self.builtin_program_ids.iter().copied().collect()
     }
 
     fn get_program_match_criteria(&self, program: &Pubkey) -> LoadedProgramMatchCriteria {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4683,7 +4683,6 @@ impl Bank {
                 recording_config,
                 timings,
                 account_overrides,
-                self.builtin_program_ids.iter(),
                 log_messages_bytes_limit,
                 limit_to_load_programs,
             );
@@ -7687,6 +7686,10 @@ impl TransactionProcessingCallback for Bank {
         } else {
             Ok(())
         }
+    }
+
+    fn get_builtin_program_ids(&self) -> Vec<Pubkey> {
+        self.builtin_programs
     }
 
     fn get_program_match_criteria(&self, program: &Pubkey) -> LoadedProgramMatchCriteria {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -48,7 +48,7 @@ use {
     },
     std::{
         cell::RefCell,
-        collections::{hash_map::Entry, HashMap, HashSet},
+        collections::{hash_map::Entry, HashMap},
         fmt::{Debug, Formatter},
         rc::Rc,
         sync::{atomic::Ordering, Arc, RwLock},


### PR DESCRIPTION
Fixes Issue #303 
#### Improvement 
1. In order to use the SVM, we must register the builtins as it is now done in the add_builtin function in bank.rs ([link](https://github.com/anza-xyz/agave/blob/64412096829241e5c70d537403584dbc9e04ee93/runtime/src/bank.rs#L7089-L7098)), and then pass them to load_and_execute_sanitized_transactions as a vector of public keys.
instead of this we can implement get_builtin_programs() trait to TransactionProcessingCallback and get builtin_programs inside  load_and_execute_sanitized_transactions fn 

#### Summary of Changes
1. Implement trait get_builtin_programs() for TransactionProcessingCallback 
2. remove vec of builtin_program passed as an array of pubkeys to load_and_execute_sanitized_transactions
