### PR TITLE
Runtime: Expose builtin program IDs to crate

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -531,7 +531,7 @@ impl PartialEq for Bank {
             epoch_stakes,
             is_delta,
             // TODO: Confirm if all these fields are intentionally ignored!
-            builtin_programs: _,
+            builtin_program_ids: _,
             runtime_config: _,
             rewards: _,
             cluster_type: _,
@@ -758,7 +758,7 @@ pub struct Bank {
     /// stream for the slot == self.slot
     is_delta: AtomicBool,
 
-    builtin_programs: HashSet<Pubkey>,
+    builtin_program_ids: HashSet<Pubkey>,
 
     /// Optional config parameters that can override runtime behavior
     pub(crate) runtime_config: Arc<RuntimeConfig>,
@@ -977,7 +977,7 @@ impl Bank {
             stakes_cache: StakesCache::default(),
             epoch_stakes: HashMap::<Epoch, EpochStakes>::default(),
             is_delta: AtomicBool::default(),
-            builtin_programs: HashSet::<Pubkey>::default(),
+            builtin_program_ids: HashSet::<Pubkey>::default(),
             runtime_config: Arc::<RuntimeConfig>::default(),
             rewards: RwLock::<Vec<(Pubkey, RewardInfo)>>::default(),
             cluster_type: Option::<ClusterType>::default(),
@@ -1233,8 +1233,8 @@ impl Bank {
 
         let (epoch_stakes, epoch_stakes_time_us) = measure_us!(parent.epoch_stakes.clone());
 
-        let (builtin_programs, builtin_programs_time_us) =
-            measure_us!(parent.builtin_programs.clone());
+        let (builtin_program_ids, builtin_program_ids_time_us) =
+            measure_us!(parent.builtin_program_ids.clone());
 
         let (rewards_pool_pubkeys, rewards_pool_pubkeys_time_us) =
             measure_us!(parent.rewards_pool_pubkeys.clone());
@@ -1290,7 +1290,7 @@ impl Bank {
             ancestors: Ancestors::default(),
             hash: RwLock::new(Hash::default()),
             is_delta: AtomicBool::new(false),
-            builtin_programs,
+            builtin_program_ids,
             tick_height: AtomicU64::new(parent.tick_height.load(Relaxed)),
             signature_count: AtomicU64::new(0),
             runtime_config: parent.runtime_config.clone(),
@@ -1451,7 +1451,7 @@ impl Bank {
                 blockhash_queue_time_us,
                 stakes_cache_time_us,
                 epoch_stakes_time_us,
-                builtin_programs_time_us,
+                builtin_program_ids_time_us,
                 rewards_pool_pubkeys_time_us,
                 executor_cache_time_us: 0,
                 transaction_debug_keys_time_us,
@@ -1846,7 +1846,7 @@ impl Bank {
             stakes_cache: StakesCache::new(stakes),
             epoch_stakes: fields.epoch_stakes,
             is_delta: AtomicBool::new(fields.is_delta),
-            builtin_programs: HashSet::<Pubkey>::default(),
+            builtin_program_ids: HashSet::<Pubkey>::default(),
             runtime_config,
             rewards: RwLock::new(vec![]),
             cluster_type: Some(genesis_config.cluster_type),
@@ -4653,7 +4653,7 @@ impl Bank {
                 recording_config,
                 timings,
                 account_overrides,
-                self.builtin_programs.iter(),
+                self.builtin_program_ids.iter(),
                 log_messages_bytes_limit,
                 limit_to_load_programs,
             );
@@ -7092,7 +7092,7 @@ impl Bank {
     pub fn add_builtin(&mut self, program_id: Pubkey, name: String, builtin: LoadedProgram) {
         debug!("Adding program {} under {:?}", name, program_id);
         self.add_builtin_account(name.as_str(), &program_id, false);
-        self.builtin_programs.insert(program_id);
+        self.builtin_program_ids.insert(program_id);
         self.program_cache
             .write()
             .unwrap()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6064,6 +6064,10 @@ impl Bank {
         }
     }
 
+    pub(crate) fn get_builtin_program_ids(&self) -> &HashSet<Pubkey> {
+        &self.builtin_program_ids
+    }
+
     // Hi! leaky abstraction here....
     // try to use get_account_with_fixed_root() if it's called ONLY from on-chain runtime account
     // processing. That alternative fn provides more safety.

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -31,7 +31,7 @@ pub(crate) struct NewBankTimings {
     pub(crate) blockhash_queue_time_us: u64,
     pub(crate) stakes_cache_time_us: u64,
     pub(crate) epoch_stakes_time_us: u64,
-    pub(crate) builtin_programs_time_us: u64,
+    pub(crate) builtin_program_ids_time_us: u64,
     pub(crate) rewards_pool_pubkeys_time_us: u64,
     pub(crate) executor_cache_time_us: u64,
     pub(crate) transaction_debug_keys_time_us: u64,
@@ -125,7 +125,11 @@ pub(crate) fn report_new_bank_metrics(
         ("blockhash_queue_us", timings.blockhash_queue_time_us, i64),
         ("stakes_cache_us", timings.stakes_cache_time_us, i64),
         ("epoch_stakes_time_us", timings.epoch_stakes_time_us, i64),
-        ("builtin_programs_us", timings.builtin_programs_time_us, i64),
+        (
+            "builtin_programs_us",
+            timings.builtin_program_ids_time_us,
+            i64
+        ),
         (
             "rewards_pool_pubkeys_us",
             timings.rewards_pool_pubkeys_time_us,

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -1,10 +1,7 @@
 //! Used to create minimal snapshots - separated here to keep accounts_db simpler
 
 use {
-    crate::{
-        bank::{builtins::BUILTINS, Bank},
-        static_ids,
-    },
+    crate::{bank::Bank, static_ids},
     dashmap::DashSet,
     log::info,
     rayon::{
@@ -116,9 +113,12 @@ impl<'a> SnapshotMinimizer<'a> {
 
     /// Used to get builtin accounts in `minimize`
     fn get_builtins(&self) {
-        BUILTINS.iter().for_each(|e| {
-            self.minimized_account_set.insert(e.program_id);
-        });
+        self.bank
+            .get_builtin_program_ids()
+            .iter()
+            .for_each(|program_id| {
+                self.minimized_account_set.insert(*program_id);
+            });
     }
 
     /// Used to get static runtime accounts in `minimize`


### PR DESCRIPTION
This is chunk 2/7 of the broken-up PR #79.

#### Problem
As we prepare to migrate builtin programs to Core BPF, it's important to decouple
components such as snapshot minimization from the static `BUILTINS` list.

By adding a crate-only method to `Bank` that will allow a caller to immutably
borrow the bank's list of builtin program IDs, other runtime components can
get the bank's current list of supported builtins.

#### Summary of Changes
Two commits:
1. Rename the bank's `builtin_programs` field to `builtin_program_ids` since the term "builtin" is heavily overloaded as it is, and this field is _only_ the IDs, not the `BuiltinPrototype` elements, as seen elsewhere in `bank.rs`.
2. Expose a crate-only method `get_builtin_program_ids(&self) -> &HashSet<Pubkey>` on the bank and use it in the snapshot minimizer.