### PR TITLE
add metric for duplicate push messages

### DIFF
--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -435,6 +435,11 @@ pub(crate) fn submit_gossip_stats(
         ),
         ("push_message_count", stats.push_message_count.clear(), i64),
         (
+            "num_duplicate_push_messages",
+            crds_stats.num_duplicate_push,
+            i64
+        ),
+        (
             "push_fanout_num_entries",
             stats.push_fanout_num_entries.clear(),
             i64

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -439,7 +439,6 @@ pub(crate) fn submit_gossip_stats(
             crds_stats.num_duplicate_push,
             i64
         ),
-        ("num_total_push", crds_stats.num_total_push, i64),
         (
             "push_fanout_num_entries",
             stats.push_fanout_num_entries.clear(),

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -436,7 +436,7 @@ pub(crate) fn submit_gossip_stats(
         ("push_message_count", stats.push_message_count.clear(), i64),
         (
             "num_duplicate_push_messages",
-            crds_stats.num_duplicate_push,
+            crds_stats.num_duplicate_push_messages,
             i64
         ),
         (

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -439,6 +439,7 @@ pub(crate) fn submit_gossip_stats(
             crds_stats.num_duplicate_push,
             i64
         ),
+        ("num_total_push", crds_stats.num_total_push, i64),
         (
             "push_fanout_num_entries",
             stats.push_fanout_num_entries.clear(),

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -119,6 +119,7 @@ pub(crate) struct CrdsStats {
     /// and that message was later received via a PushMessage
     pub(crate) num_redundant_pull_responses: u64,
     pub(crate) num_duplicate_push: u64,
+    pub(crate) num_total_push: u64,
 }
 
 /// This structure stores some local metadata associated with the CrdsValue
@@ -236,6 +237,9 @@ impl Crds {
         let label = value.label();
         let pubkey = value.pubkey();
         let value = VersionedCrdsValue::new(value, self.cursor, now, route);
+        if let GossipRoute::PushMessage(_) = route {
+            self.stats.lock().unwrap().num_total_push += 1
+        }
         match self.table.entry(label) {
             Entry::Vacant(entry) => {
                 self.stats.lock().unwrap().record_insert(&value, route);

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -118,7 +118,7 @@ pub(crate) struct CrdsStats {
     /// number of times a message was first received via a PullResponse
     /// and that message was later received via a PushMessage
     pub(crate) num_redundant_pull_responses: u64,
-    pub(crate) num_duplicate_push: u64,
+    pub(crate) num_duplicate_push_messages: u64,
 }
 
 /// This structure stores some local metadata associated with the CrdsValue
@@ -320,7 +320,7 @@ impl Crds {
                     if entry.num_push_recv == Some(0) {
                         stats.num_redundant_pull_responses += 1;
                     } else {
-                        stats.num_duplicate_push += 1;
+                        stats.num_duplicate_push_messages += 1;
                     }
                     let num_push_dups = entry.num_push_recv.unwrap_or_default();
                     entry.num_push_recv = Some(num_push_dups.saturating_add(1));

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -307,7 +307,8 @@ impl Crds {
                 Ok(())
             }
             Entry::Occupied(mut entry) => {
-                self.stats.lock().unwrap().record_fail(&value, route);
+                let mut stats = self.stats.lock().unwrap();
+                stats.record_fail(&value, route);
                 trace!(
                     "INSERT FAILED data: {} new.wallclock: {}",
                     value.value.label(),
@@ -321,11 +322,11 @@ impl Crds {
                 } else if matches!(route, GossipRoute::PushMessage(_)) {
                     let entry = entry.get_mut();
                     if entry.num_push_recv == Some(0) {
-                        self.stats.lock().unwrap().num_redundant_pull_responses += 1;
+                        stats.num_redundant_pull_responses += 1;
                     }
                     let num_push_dups = entry.num_push_recv.unwrap_or_default();
                     entry.num_push_recv = Some(num_push_dups.saturating_add(1));
-                    self.stats.lock().unwrap().num_duplicate_push += 1;
+                    stats.num_duplicate_push += 1;
                     Err(CrdsError::DuplicatePush(num_push_dups))
                 } else {
                     Err(CrdsError::InsertFailed)

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -118,6 +118,7 @@ pub(crate) struct CrdsStats {
     /// number of times a message was first received via a PullResponse
     /// and that message was later received via a PushMessage
     pub(crate) num_redundant_pull_responses: u64,
+    pub(crate) num_duplicate_push: u64,
 }
 
 /// This structure stores some local metadata associated with the CrdsValue
@@ -320,6 +321,7 @@ impl Crds {
                     }
                     let num_push_dups = entry.num_push_recv.unwrap_or_default();
                     entry.num_push_recv = Some(num_push_dups.saturating_add(1));
+                    self.stats.lock().unwrap().num_duplicate_push += 1;
                     Err(CrdsError::DuplicatePush(num_push_dups))
                 } else {
                     Err(CrdsError::InsertFailed)

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -119,7 +119,6 @@ pub(crate) struct CrdsStats {
     /// and that message was later received via a PushMessage
     pub(crate) num_redundant_pull_responses: u64,
     pub(crate) num_duplicate_push: u64,
-    pub(crate) num_total_push: u64,
 }
 
 /// This structure stores some local metadata associated with the CrdsValue
@@ -237,12 +236,10 @@ impl Crds {
         let label = value.label();
         let pubkey = value.pubkey();
         let value = VersionedCrdsValue::new(value, self.cursor, now, route);
-        if let GossipRoute::PushMessage(_) = route {
-            self.stats.lock().unwrap().num_total_push += 1
-        }
+        let mut stats = self.stats.lock().unwrap();
         match self.table.entry(label) {
             Entry::Vacant(entry) => {
-                self.stats.lock().unwrap().record_insert(&value, route);
+                stats.record_insert(&value, route);
                 let entry_index = entry.index();
                 self.shards.insert(entry_index, &value);
                 match &value.value.data {
@@ -268,7 +265,7 @@ impl Crds {
                 Ok(())
             }
             Entry::Occupied(mut entry) if overrides(&value.value, entry.get()) => {
-                self.stats.lock().unwrap().record_insert(&value, route);
+                stats.record_insert(&value, route);
                 let entry_index = entry.index();
                 self.shards.remove(entry_index, entry.get());
                 self.shards.insert(entry_index, &value);
@@ -307,7 +304,6 @@ impl Crds {
                 Ok(())
             }
             Entry::Occupied(mut entry) => {
-                let mut stats = self.stats.lock().unwrap();
                 stats.record_fail(&value, route);
                 trace!(
                     "INSERT FAILED data: {} new.wallclock: {}",
@@ -323,10 +319,11 @@ impl Crds {
                     let entry = entry.get_mut();
                     if entry.num_push_recv == Some(0) {
                         stats.num_redundant_pull_responses += 1;
+                    } else {
+                        stats.num_duplicate_push += 1;
                     }
                     let num_push_dups = entry.num_push_recv.unwrap_or_default();
                     entry.num_push_recv = Some(num_push_dups.saturating_add(1));
-                    stats.num_duplicate_push += 1;
                     Err(CrdsError::DuplicatePush(num_push_dups))
                 } else {
                     Err(CrdsError::InsertFailed)


### PR DESCRIPTION
#### Problem
We don't have any insight into what percentage of gossiped crds values are duplicates (or redundant)

#### Summary of Changes
Add a metric: 
* `num_duplicate_push` that reports the number of duplicate `CrdsValue`s received via push.
* `num_total_push` that reports the total number of `CrdsValue`s received via push

200 node test cluster on Monogon shows about 53% of Push messages are duplicates 

![fraction_duplicate_push](https://github.com/anza-xyz/agave/assets/11299967/aff3bf12-7ff3-48c5-bfeb-84700a2927d0)

