### PR TITLE
runtime: use str::split instead of regex to parse appendvec filenames

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2366,7 +2366,8 @@ mod tests {
             fs::read_dir(path).unwrap().for_each(|entry| {
                 let path = entry.unwrap().path();
                 let filename = path.file_name().unwrap();
-                let (_slot, append_vec_id) = get_slot_and_append_vec_id(filename.to_str().unwrap());
+                let (_slot, append_vec_id) =
+                    get_slot_and_append_vec_id(filename.to_str().unwrap()).unwrap();
                 max_id = std::cmp::max(max_id, append_vec_id);
             });
         }


### PR DESCRIPTION
We used to use a regex, which was unnecessary.