### PR TITLE
qos service should also accumulate executed but errored units

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -772,7 +772,9 @@ impl Consumer {
             (0, 0),
             |(units, times), program_timings| {
                 (
-                    units.saturating_add(program_timings.accumulated_units),
+                    units
+                        .saturating_add(program_timings.accumulated_units)
+                        .saturating_add(program_timings.total_errored_units),
                     times.saturating_add(program_timings.accumulated_us),
                 )
             },


### PR DESCRIPTION
#### Problem

qos_service accumulates executed units to report metrics. But it didn't include executed but errored units. 

#### Summary of Changes
- include executed and errored units in qos_service accumulation.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
