### PR TITLE
Move code to check_program_modification_slot out of SVM

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -744,6 +744,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         }
     }
 
+    /// Find the slot in which the program was most recently modified.
+    /// Returns slot 0 for programs deployed with v1/v2 loaders, since programs deployed
+    /// with those loaders do not retain deployment slot information.
+    /// Returns an error if the program's account state can not be found or parsed.
     pub fn program_modification_slot<CB: TransactionProcessingCallback>(
         &self,
         callbacks: &CB,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -103,6 +103,10 @@ pub trait TransactionProcessingCallback {
     ) -> transaction::Result<()> {
         Ok(())
     }
+
+    fn get_program_match_criteria(&self, _program: &Pubkey) -> LoadedProgramMatchCriteria {
+        LoadedProgramMatchCriteria::NoCriteria
+    }
 }
 
 #[derive(Debug)]
@@ -128,8 +132,6 @@ pub struct TransactionBatchProcessor<FG: ForkGraph> {
     /// Transaction fee structure
     fee_structure: FeeStructure,
 
-    pub check_program_modification_slot: bool,
-
     /// Optional config parameters that can override runtime behavior
     runtime_config: Arc<RuntimeConfig>,
 
@@ -145,10 +147,6 @@ impl<FG: ForkGraph> Debug for TransactionBatchProcessor<FG> {
             .field("epoch", &self.epoch)
             .field("epoch_schedule", &self.epoch_schedule)
             .field("fee_structure", &self.fee_structure)
-            .field(
-                "check_program_modification_slot",
-                &self.check_program_modification_slot,
-            )
             .field("runtime_config", &self.runtime_config)
             .field("sysvar_cache", &self.sysvar_cache)
             .field("loaded_programs_cache", &self.loaded_programs_cache)
@@ -163,7 +161,6 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
             epoch: Epoch::default(),
             epoch_schedule: EpochSchedule::default(),
             fee_structure: FeeStructure::default(),
-            check_program_modification_slot: false,
             runtime_config: Arc::<RuntimeConfig>::default(),
             sysvar_cache: RwLock::<SysvarCache>::default(),
             loaded_programs_cache: Arc::new(RwLock::new(LoadedPrograms::new(
@@ -188,7 +185,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             epoch,
             epoch_schedule,
             fee_structure,
-            check_program_modification_slot: false,
             runtime_config,
             sysvar_cache: RwLock::<SysvarCache>::default(),
             loaded_programs_cache,
@@ -491,30 +487,15 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         limit_to_load_programs: bool,
     ) -> LoadedProgramsForTxBatch {
         let mut missing_programs: Vec<(Pubkey, (LoadedProgramMatchCriteria, u64))> =
-            if self.check_program_modification_slot {
-                program_accounts_map
-                    .iter()
-                    .map(|(pubkey, (_, count))| {
-                        (
-                            *pubkey,
-                            (
-                                self.program_modification_slot(callback, pubkey)
-                                    .map_or(LoadedProgramMatchCriteria::Tombstone, |slot| {
-                                        LoadedProgramMatchCriteria::DeployedOnOrAfterSlot(slot)
-                                    }),
-                                *count,
-                            ),
-                        )
-                    })
-                    .collect()
-            } else {
-                program_accounts_map
-                    .iter()
-                    .map(|(pubkey, (_, count))| {
-                        (*pubkey, (LoadedProgramMatchCriteria::NoCriteria, *count))
-                    })
-                    .collect()
-            };
+            program_accounts_map
+                .iter()
+                .map(|(pubkey, (_, count))| {
+                    (
+                        *pubkey,
+                        (callback.get_program_match_criteria(pubkey), *count),
+                    )
+                })
+                .collect();
 
         let mut loaded_programs_for_txs = None;
         let mut program_to_store = None;
@@ -763,7 +744,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         }
     }
 
-    fn program_modification_slot<CB: TransactionProcessingCallback>(
+    pub fn program_modification_slot<CB: TransactionProcessingCallback>(
         &self,
         callbacks: &CB,
         pubkey: &Pubkey,
@@ -1815,10 +1796,7 @@ mod tests {
     fn test_replenish_program_cache() {
         // Case 1
         let mut mock_bank = MockBankCallback::default();
-        let mut batch_processor = TransactionBatchProcessor::<TestForkGraph> {
-            check_program_modification_slot: true,
-            ..TransactionBatchProcessor::default()
-        };
+        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         batch_processor
             .loaded_programs_cache
             .write()
@@ -1848,8 +1826,6 @@ mod tests {
         ));
 
         // Case 2
-        batch_processor.check_program_modification_slot = false;
-
         let result = batch_processor.replenish_program_cache(&mock_bank, &account_maps, true);
 
         let program1 = result.find(&key1).unwrap();


### PR DESCRIPTION
#### Problem
The code to `check_program_modification_slot` doesn't belong in SVM. It's an implementation detail that should be handled by the user of SVM.

#### Summary of Changes
Move the code out of SVM and call it using a trait method.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
