### PR TITLE
Runtime: Core BPF Migration: Struct for loading and checking source BPF program accounts

### DIFF
--- a/runtime/src/bank/builtins/core_bpf_migration/error.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/error.rs
@@ -15,4 +15,21 @@ pub enum CoreBpfMigrationError {
     /// Program has a data account
     #[error("Data account exists for program {0:?}")]
     ProgramHasDataAccount(Pubkey),
+    /// Program has no data account
+    #[error("Data account does not exist for program {0:?}")]
+    ProgramHasNoDataAccount(Pubkey),
+    /// Invalid program account
+    #[error("Invalid program account: {0:?}")]
+    InvalidProgramAccount(Pubkey),
+    /// Invalid program data account
+    #[error("Invalid program data account: {0:?}")]
+    InvalidProgramDataAccount(Pubkey),
+    /// Failed to serialize new program account
+    #[error("Failed to serialize new program account")]
+    FailedToSerialize,
+    // Since `core_bpf_migration` does not return `ProgramError` or
+    // `InstructionError`, we have to duplicate `ArithmeticOverflow` here.
+    /// Arithmetic overflow
+    #[error("Arithmetic overflow")]
+    ArithmeticOverflow,
 }

--- a/runtime/src/bank/builtins/core_bpf_migration/error.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/error.rs
@@ -1,8 +1,11 @@
 use {solana_sdk::pubkey::Pubkey, thiserror::Error};
 
 /// Errors returned by a Core BPF migration.
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error)]
 pub enum CoreBpfMigrationError {
+    /// Bincode serialization error
+    #[error("Bincode serialization error: {0:?}")]
+    BincodeError(#[from] bincode::Error),
     /// Account not found
     #[error("Account not found: {0:?}")]
     AccountNotFound(Pubkey),

--- a/runtime/src/bank/builtins/core_bpf_migration/error.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/error.rs
@@ -24,11 +24,6 @@ pub enum CoreBpfMigrationError {
     /// Invalid program data account
     #[error("Invalid program data account: {0:?}")]
     InvalidProgramDataAccount(Pubkey),
-    /// Failed to serialize new program account
-    #[error("Failed to serialize new program account")]
-    FailedToSerialize,
-    // Since `core_bpf_migration` does not return `ProgramError` or
-    // `InstructionError`, we have to duplicate `ArithmeticOverflow` here.
     /// Arithmetic overflow
     #[error("Arithmetic overflow")]
     ArithmeticOverflow,

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)] // Removed in later commit
 pub(crate) mod error;
+mod source_bpf_upgradeable;
 mod target_builtin;
 
 pub(crate) enum CoreBpfMigrationTargetType {

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)] // Removed in later commit
 pub(crate) mod error;
-mod source_bpf_upgradeable;
+mod source_upgradeable_bpf;
 mod target_builtin;
 
 pub(crate) enum CoreBpfMigrationTargetType {

--- a/runtime/src/bank/builtins/core_bpf_migration/source_bpf_upgradeable.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/source_bpf_upgradeable.rs
@@ -116,3 +116,250 @@ impl SourceProgramBpfUpgradeable {
         Ok(config)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::bank::tests::create_simple_test_bank,
+        solana_sdk::{account::Account, bpf_loader_upgradeable::ID as BPF_LOADER_UPGRADEABLE_ID},
+    };
+
+    fn store_account<T: serde::Serialize>(
+        bank: &Bank,
+        address: &Pubkey,
+        data: &T,
+        additional_data: Option<&[u8]>,
+        executable: bool,
+        owner: &Pubkey,
+    ) {
+        let mut data = bincode::serialize(data).unwrap();
+        if let Some(additional_data) = additional_data {
+            data.extend_from_slice(additional_data);
+        }
+        let data_len = data.len();
+        let lamports = bank.get_minimum_balance_for_rent_exemption(data_len);
+        let account = AccountSharedData::from(Account {
+            data,
+            executable,
+            lamports,
+            owner: *owner,
+            ..Account::default()
+        });
+        bank.store_account_and_update_capitalization(address, &account);
+    }
+
+    #[test]
+    fn test_source_program_bpf_upgradeable() {
+        let bank = create_simple_test_bank(0);
+
+        let program_id = Pubkey::new_unique();
+        let program_data_address = get_program_data_address(&program_id);
+
+        // Fail if the program account does not exist
+        assert_eq!(
+            SourceProgramBpfUpgradeable::new_checked(&bank, &program_id).unwrap_err(),
+            CoreBpfMigrationError::AccountNotFound(program_id)
+        );
+
+        // Store the proper program account
+        let proper_program_account_state = UpgradeableLoaderState::Program {
+            programdata_address: program_data_address,
+        };
+        store_account(
+            &bank,
+            &program_id,
+            &proper_program_account_state,
+            None,
+            true,
+            &BPF_LOADER_UPGRADEABLE_ID,
+        );
+
+        // Fail if the program data account does not exist
+        assert_eq!(
+            SourceProgramBpfUpgradeable::new_checked(&bank, &program_id).unwrap_err(),
+            CoreBpfMigrationError::ProgramHasNoDataAccount(program_id)
+        );
+
+        // Store the proper program data account
+        let proper_program_data_account_state = UpgradeableLoaderState::ProgramData {
+            slot: 0,
+            upgrade_authority_address: Some(Pubkey::new_unique()),
+        };
+        store_account(
+            &bank,
+            &program_data_address,
+            &proper_program_data_account_state,
+            Some(&[4u8; 200]),
+            false,
+            &BPF_LOADER_UPGRADEABLE_ID,
+        );
+
+        // Success
+        let bpf_upgradeable_program_config =
+            SourceProgramBpfUpgradeable::new_checked(&bank, &program_id).unwrap();
+
+        let check_program_account_data = bincode::serialize(&proper_program_account_state).unwrap();
+        let check_program_account_data_len = check_program_account_data.len();
+        let check_program_lamports =
+            bank.get_minimum_balance_for_rent_exemption(check_program_account_data_len);
+        let check_program_account = AccountSharedData::from(Account {
+            data: check_program_account_data,
+            executable: true,
+            lamports: check_program_lamports,
+            owner: BPF_LOADER_UPGRADEABLE_ID,
+            ..Account::default()
+        });
+
+        let mut check_program_data_account_data =
+            bincode::serialize(&proper_program_data_account_state).unwrap();
+        check_program_data_account_data.extend_from_slice(&[4u8; 200]);
+        let check_program_data_account_data_len = check_program_data_account_data.len();
+        let check_program_data_lamports =
+            bank.get_minimum_balance_for_rent_exemption(check_program_data_account_data_len);
+        let check_program_data_account = AccountSharedData::from(Account {
+            data: check_program_data_account_data,
+            executable: false,
+            lamports: check_program_data_lamports,
+            owner: BPF_LOADER_UPGRADEABLE_ID,
+            ..Account::default()
+        });
+
+        assert_eq!(bpf_upgradeable_program_config.program_address, program_id);
+        assert_eq!(
+            bpf_upgradeable_program_config.program_account,
+            check_program_account
+        );
+        assert_eq!(
+            bpf_upgradeable_program_config.program_data_address,
+            program_data_address
+        );
+        assert_eq!(
+            bpf_upgradeable_program_config.program_data_account,
+            check_program_data_account
+        );
+        assert_eq!(
+            bpf_upgradeable_program_config.total_data_size,
+            check_program_account_data_len + check_program_data_account_data_len
+        );
+    }
+
+    #[test]
+    fn test_source_program_bpf_upgradeable_bad_program_account() {
+        let bank = create_simple_test_bank(0);
+
+        let program_id = Pubkey::new_unique();
+        let program_data_address = get_program_data_address(&program_id);
+
+        // Store the proper program data account
+        store_account(
+            &bank,
+            &program_data_address,
+            &UpgradeableLoaderState::ProgramData {
+                slot: 0,
+                upgrade_authority_address: Some(Pubkey::new_unique()),
+            },
+            Some(&[4u8; 200]),
+            false,
+            &BPF_LOADER_UPGRADEABLE_ID,
+        );
+
+        // Fail if the program account is not owned by the upgradeable loader
+        store_account(
+            &bank,
+            &program_id,
+            &UpgradeableLoaderState::Program {
+                programdata_address: program_data_address,
+            },
+            None,
+            true,
+            &Pubkey::new_unique(), // Not the upgradeable loader
+        );
+        assert_eq!(
+            SourceProgramBpfUpgradeable::new_checked(&bank, &program_id).unwrap_err(),
+            CoreBpfMigrationError::IncorrectOwner(program_id)
+        );
+
+        // Fail if the program account's state is not `UpgradeableLoaderState::Program`
+        store_account(
+            &bank,
+            &program_id,
+            &vec![0u8; 200],
+            None,
+            true,
+            &BPF_LOADER_UPGRADEABLE_ID,
+        );
+        assert_eq!(
+            SourceProgramBpfUpgradeable::new_checked(&bank, &program_id).unwrap_err(),
+            CoreBpfMigrationError::InvalidProgramAccount(program_id)
+        );
+
+        // Fail if the program account's state is `UpgradeableLoaderState::Program`,
+        // but it points to the wrong data account
+        store_account(
+            &bank,
+            &program_id,
+            &UpgradeableLoaderState::Program {
+                programdata_address: Pubkey::new_unique(), // Not the correct data account
+            },
+            None,
+            true,
+            &BPF_LOADER_UPGRADEABLE_ID,
+        );
+        assert_eq!(
+            SourceProgramBpfUpgradeable::new_checked(&bank, &program_id).unwrap_err(),
+            CoreBpfMigrationError::InvalidProgramAccount(program_id)
+        );
+    }
+
+    #[test]
+    fn test_source_program_bpf_upgradeable_bad_program_data_account() {
+        let bank = create_simple_test_bank(0);
+
+        let program_id = Pubkey::new_unique();
+        let program_data_address = get_program_data_address(&program_id);
+
+        // Store the proper program account
+        store_account(
+            &bank,
+            &program_id,
+            &UpgradeableLoaderState::Program {
+                programdata_address: program_data_address,
+            },
+            None,
+            true,
+            &BPF_LOADER_UPGRADEABLE_ID,
+        );
+
+        // Fail if the program data account is not owned by the upgradeable loader
+        store_account(
+            &bank,
+            &program_data_address,
+            &UpgradeableLoaderState::ProgramData {
+                slot: 0,
+                upgrade_authority_address: Some(Pubkey::new_unique()),
+            },
+            Some(&[4u8; 200]),
+            false,
+            &Pubkey::new_unique(), // Not the upgradeable loader
+        );
+        assert_eq!(
+            SourceProgramBpfUpgradeable::new_checked(&bank, &program_id).unwrap_err(),
+            CoreBpfMigrationError::IncorrectOwner(program_data_address)
+        );
+
+        // Fail if the program data account does not have the correct state
+        store_account(
+            &bank,
+            &program_data_address,
+            &vec![4u8; 200], // Not the correct state
+            None,
+            false,
+            &BPF_LOADER_UPGRADEABLE_ID,
+        );
+        assert_eq!(
+            SourceProgramBpfUpgradeable::new_checked(&bank, &program_id).unwrap_err(),
+            CoreBpfMigrationError::InvalidProgramDataAccount(program_data_address)
+        );
+    }
+}

--- a/runtime/src/bank/builtins/core_bpf_migration/source_bpf_upgradeable.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/source_bpf_upgradeable.rs
@@ -1,0 +1,118 @@
+use {
+    super::error::CoreBpfMigrationError,
+    crate::bank::Bank,
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount},
+        bpf_loader_upgradeable::{
+            get_program_data_address, UpgradeableLoaderState, ID as BPF_LOADER_UPGRADEABLE_ID,
+        },
+        pubkey::Pubkey,
+    },
+};
+
+/// Used to validate a source BPF Upgradeable program's account and data
+/// account before migrating a built-in program to Core BPF.
+#[derive(Debug)]
+pub(crate) struct SourceProgramBpfUpgradeable {
+    pub program_address: Pubkey,
+    pub program_account: AccountSharedData,
+    pub program_data_address: Pubkey,
+    pub program_data_account: AccountSharedData,
+    pub total_data_size: usize,
+}
+
+impl SourceProgramBpfUpgradeable {
+    fn check_program_account(&self) -> Result<(), CoreBpfMigrationError> {
+        // The program account should be owned by the upgradeable loader.
+        if self.program_account.owner() != &BPF_LOADER_UPGRADEABLE_ID {
+            return Err(CoreBpfMigrationError::IncorrectOwner(self.program_address));
+        }
+
+        // The program account should have a pointer to its data account.
+        if let UpgradeableLoaderState::Program {
+            programdata_address,
+        } = &self
+            .program_account
+            .deserialize_data()
+            .map_err::<CoreBpfMigrationError, _>(|_| {
+                CoreBpfMigrationError::InvalidProgramAccount(self.program_address)
+            })?
+        {
+            if programdata_address != &self.program_data_address {
+                return Err(CoreBpfMigrationError::InvalidProgramAccount(
+                    self.program_address,
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_program_data_account(&self) -> Result<(), CoreBpfMigrationError> {
+        // The program data account should be owned by the upgradeable loader.
+        if self.program_data_account.owner() != &BPF_LOADER_UPGRADEABLE_ID {
+            return Err(CoreBpfMigrationError::IncorrectOwner(
+                self.program_data_address,
+            ));
+        }
+
+        // The program data account should have the correct state.
+        let programdata_data_offset = UpgradeableLoaderState::size_of_programdata_metadata();
+        if self.program_data_account.data().len() < programdata_data_offset {
+            return Err(CoreBpfMigrationError::InvalidProgramDataAccount(
+                self.program_data_address,
+            ));
+        }
+        // Length checked in previous block.
+        match bincode::deserialize::<UpgradeableLoaderState>(
+            &self.program_data_account.data()[..programdata_data_offset],
+        ) {
+            Ok(UpgradeableLoaderState::ProgramData { .. }) => Ok(()),
+            _ => Err(CoreBpfMigrationError::InvalidProgramDataAccount(
+                self.program_data_address,
+            )),
+        }
+    }
+
+    /// Create a new migration configuration for a BPF Upgradeable source
+    /// program.
+    pub(crate) fn new_checked(
+        bank: &Bank,
+        program_id: &Pubkey,
+    ) -> Result<Self, CoreBpfMigrationError> {
+        let program_address = *program_id;
+        // The program account should exist.
+        let program_account = bank
+            .get_account_with_fixed_root(&program_address)
+            .ok_or(CoreBpfMigrationError::AccountNotFound(program_address))?;
+
+        // The program data account should exist.
+        let program_data_address = get_program_data_address(&program_address);
+        let program_data_account = bank
+            .get_account_with_fixed_root(&program_data_address)
+            .ok_or(CoreBpfMigrationError::ProgramHasNoDataAccount(
+                program_address,
+            ))?;
+
+        // The total data size is the size of the program account's data plus
+        // the size of the program data account's data.
+        let total_data_size = program_account
+            .data()
+            .len()
+            .checked_add(program_data_account.data().len())
+            .ok_or(CoreBpfMigrationError::ArithmeticOverflow)?;
+
+        let config = Self {
+            program_address,
+            program_account,
+            program_data_address,
+            program_data_account,
+            total_data_size,
+        };
+
+        config.check_program_account()?;
+        config.check_program_data_account()?;
+
+        Ok(config)
+    }
+}

--- a/runtime/src/bank/builtins/core_bpf_migration/source_upgradeable_bpf.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/source_upgradeable_bpf.rs
@@ -18,7 +18,6 @@ pub(crate) struct SourceUpgradeableBpf {
     pub program_account: AccountSharedData,
     pub program_data_address: Pubkey,
     pub program_data_account: AccountSharedData,
-    pub total_data_size: usize,
 }
 
 impl SourceUpgradeableBpf {
@@ -91,20 +90,11 @@ impl SourceUpgradeableBpf {
                 *program_address,
             ))?;
 
-        // The total data size is the size of the program account's data plus
-        // the size of the program data account's data.
-        let total_data_size = program_account
-            .data()
-            .len()
-            .checked_add(program_data_account.data().len())
-            .ok_or(CoreBpfMigrationError::ArithmeticOverflow)?;
-
         let source_upgradeable_bpf = Self {
             program_address: *program_address,
             program_account,
             program_data_address,
             program_data_account,
-            total_data_size,
         };
 
         source_upgradeable_bpf.check_program_account()?;
@@ -234,10 +224,6 @@ mod tests {
         assert_eq!(
             source_upgradeable_bpf.program_data_account,
             check_program_data_account
-        );
-        assert_eq!(
-            source_upgradeable_bpf.total_data_size,
-            check_program_account_data_len + check_program_data_account_data_len
         );
     }
 

--- a/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
@@ -15,7 +15,6 @@ pub(crate) struct TargetBuiltin {
     pub program_address: Pubkey,
     pub program_account: AccountSharedData,
     pub program_data_address: Pubkey,
-    pub total_data_size: usize,
 }
 
 impl TargetBuiltin {
@@ -62,14 +61,10 @@ impl TargetBuiltin {
             ));
         }
 
-        // The total data size is the size of the program account's data.
-        let total_data_size = program_account.data().len();
-
         Ok(Self {
             program_address: *program_address,
             program_account,
             program_data_address,
-            total_data_size,
         })
     }
 }
@@ -150,7 +145,6 @@ mod tests {
         assert_eq!(target_builtin.program_address, program_address);
         assert_eq!(target_builtin.program_account, program_account);
         assert_eq!(target_builtin.program_data_address, program_data_address);
-        assert_eq!(target_builtin.total_data_size, program_account.data().len());
 
         // Fail if the program account is not owned by the native loader
         store_account(
@@ -214,7 +208,6 @@ mod tests {
         assert_eq!(target_builtin.program_address, program_address);
         assert_eq!(target_builtin.program_account, program_account);
         assert_eq!(target_builtin.program_data_address, program_data_address);
-        assert_eq!(target_builtin.total_data_size, program_account.data().len());
 
         // Fail if the program data account exists
         store_account(

--- a/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
@@ -79,6 +79,7 @@ mod tests {
     use {
         super::*,
         crate::bank::{tests::create_simple_test_bank, ApplyFeatureActivationsCaller},
+        assert_matches::assert_matches,
         solana_sdk::{
             account::Account,
             bpf_loader_upgradeable::{UpgradeableLoaderState, ID as BPF_LOADER_UPGRADEABLE_ID},
@@ -159,9 +160,9 @@ mod tests {
             true,
             &Pubkey::new_unique(), // Not the native loader
         );
-        assert_eq!(
+        assert_matches!(
             TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap_err(),
-            CoreBpfMigrationError::IncorrectOwner(program_address)
+            CoreBpfMigrationError::IncorrectOwner(..)
         );
 
         // Fail if the program data account exists
@@ -182,9 +183,9 @@ mod tests {
             false,
             &BPF_LOADER_UPGRADEABLE_ID,
         );
-        assert_eq!(
+        assert_matches!(
             TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap_err(),
-            CoreBpfMigrationError::ProgramHasDataAccount(program_address)
+            CoreBpfMigrationError::ProgramHasDataAccount(..)
         );
 
         // Fail if the program account does not exist
@@ -192,9 +193,9 @@ mod tests {
             &program_address,
             &AccountSharedData::default(),
         );
-        assert_eq!(
+        assert_matches!(
             TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap_err(),
-            CoreBpfMigrationError::AccountNotFound(program_address)
+            CoreBpfMigrationError::AccountNotFound(..)
         );
     }
 
@@ -226,9 +227,9 @@ mod tests {
             false,
             &BPF_LOADER_UPGRADEABLE_ID,
         );
-        assert_eq!(
+        assert_matches!(
             TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap_err(),
-            CoreBpfMigrationError::ProgramHasDataAccount(program_address)
+            CoreBpfMigrationError::ProgramHasDataAccount(..)
         );
 
         // Fail if the program account exists
@@ -239,9 +240,9 @@ mod tests {
             true,
             &NATIVE_LOADER_ID,
         );
-        assert_eq!(
+        assert_matches!(
             TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap_err(),
-            CoreBpfMigrationError::AccountExists(program_address)
+            CoreBpfMigrationError::AccountExists(..)
         );
     }
 }

--- a/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
@@ -11,14 +11,14 @@ use {
 
 /// The account details of a built-in program to be migrated to Core BPF.
 #[derive(Debug)]
-pub(crate) struct TargetProgramBuiltin {
+pub(crate) struct TargetBuiltin {
     pub program_address: Pubkey,
     pub program_account: AccountSharedData,
     pub program_data_address: Pubkey,
     pub total_data_size: usize,
 }
 
-impl TargetProgramBuiltin {
+impl TargetBuiltin {
     /// Collects the details of a built-in program and verifies it is properly
     /// configured
     pub(crate) fn new_checked(
@@ -145,7 +145,7 @@ mod tests {
 
         // Success
         let target_builtin =
-            TargetProgramBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap();
+            TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap();
         assert_eq!(target_builtin.program_address, program_address);
         assert_eq!(target_builtin.program_account, program_account);
         assert_eq!(target_builtin.program_data_address, program_data_address);
@@ -160,8 +160,7 @@ mod tests {
             &Pubkey::new_unique(), // Not the native loader
         );
         assert_eq!(
-            TargetProgramBuiltin::new_checked(&bank, &program_address, &migration_target)
-                .unwrap_err(),
+            TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap_err(),
             CoreBpfMigrationError::IncorrectOwner(program_address)
         );
 
@@ -184,8 +183,7 @@ mod tests {
             &BPF_LOADER_UPGRADEABLE_ID,
         );
         assert_eq!(
-            TargetProgramBuiltin::new_checked(&bank, &program_address, &migration_target)
-                .unwrap_err(),
+            TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap_err(),
             CoreBpfMigrationError::ProgramHasDataAccount(program_address)
         );
 
@@ -195,8 +193,7 @@ mod tests {
             &AccountSharedData::default(),
         );
         assert_eq!(
-            TargetProgramBuiltin::new_checked(&bank, &program_address, &migration_target)
-                .unwrap_err(),
+            TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap_err(),
             CoreBpfMigrationError::AccountNotFound(program_address)
         );
     }
@@ -212,7 +209,7 @@ mod tests {
 
         // Success
         let target_builtin =
-            TargetProgramBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap();
+            TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap();
         assert_eq!(target_builtin.program_address, program_address);
         assert_eq!(target_builtin.program_account, program_account);
         assert_eq!(target_builtin.program_data_address, program_data_address);
@@ -230,8 +227,7 @@ mod tests {
             &BPF_LOADER_UPGRADEABLE_ID,
         );
         assert_eq!(
-            TargetProgramBuiltin::new_checked(&bank, &program_address, &migration_target)
-                .unwrap_err(),
+            TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap_err(),
             CoreBpfMigrationError::ProgramHasDataAccount(program_address)
         );
 
@@ -244,8 +240,7 @@ mod tests {
             &NATIVE_LOADER_ID,
         );
         assert_eq!(
-            TargetProgramBuiltin::new_checked(&bank, &program_address, &migration_target)
-                .unwrap_err(),
+            TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap_err(),
             CoreBpfMigrationError::AccountExists(program_address)
         );
     }


### PR DESCRIPTION
This is chunk 4/7 of the broken-up PR #79.

#### Problem
When the runtime desires to migrate a builtin program to Core BPF, it will do
so by replacing the builtin program's program account with that of a BPF
upgradeable program's program account, which will contain a pointer to its
corresponding program-data account.

Currently, there exists no reliable method in the bank or runtime more broadly
for loading a BPF upgradeable program's accounts and performing various
checks to ensure both program and program-data account are configured as
expected.

Being able to run these checks before fetching the program's accounts is
extremely important for ensuring a smooth migration to Core BPF.

#### Summary of Changes
Within the `builtins` submodule, add a module specifically for `core_bpf_migration`,
and inside of it create a new structure for loading a source BPF upgradeable program's
program and program-data account and running checks.