### PR TITLE
Rename LoadedPrograms to ProgramCache for readability

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -145,7 +145,7 @@ pub struct LoadedProgram {
     pub latest_access_slot: AtomicU64,
 }
 
-/// Global cache statistics for [LoadedPrograms].
+/// Global cache statistics for [ProgramCache].
 #[derive(Debug, Default)]
 pub struct Stats {
     /// a program was already in the cache
@@ -568,7 +568,7 @@ struct SecondLevel {
 /// - allows for cooperative loading of TX batches which hit the same missing programs simultaneously.
 /// - enforces that all programs used in a batch are eagerly loaded ahead of execution.
 /// - is not persisted to disk or a snapshot, so it needs to cold start and warm up first.
-pub struct LoadedPrograms<FG: ForkGraph> {
+pub struct ProgramCache<FG: ForkGraph> {
     /// A two level index:
     ///
     /// The first level is for the address at which programs are deployed and the second level for the slot (and thus also fork).
@@ -595,9 +595,9 @@ pub struct LoadedPrograms<FG: ForkGraph> {
     pub loading_task_waiter: Arc<LoadingTaskWaiter>,
 }
 
-impl<FG: ForkGraph> Debug for LoadedPrograms<FG> {
+impl<FG: ForkGraph> Debug for ProgramCache<FG> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("LoadedPrograms")
+        f.debug_struct("ProgramCache")
             .field("root slot", &self.latest_root_slot)
             .field("root epoch", &self.latest_root_epoch)
             .field("stats", &self.stats)
@@ -606,11 +606,11 @@ impl<FG: ForkGraph> Debug for LoadedPrograms<FG> {
     }
 }
 
-/// Local view into [LoadedPrograms] which was extracted for a specific TX batch.
+/// Local view into [ProgramCache] which was extracted for a specific TX batch.
 ///
-/// This isolation enables the global [LoadedPrograms] to continue to evolve (e.g. evictions),
+/// This isolation enables the global [ProgramCache] to continue to evolve (e.g. evictions),
 /// while the TX batch is guaranteed it will continue to find all the programs it requires.
-/// For program management instructions this also buffers them before they are merged back into the global [LoadedPrograms].
+/// For program management instructions this also buffers them before they are merged back into the global [ProgramCache].
 #[derive(Clone, Debug, Default)]
 pub struct LoadedProgramsForTxBatch {
     /// Pubkey is the address of a program.
@@ -681,7 +681,7 @@ pub enum LoadedProgramMatchCriteria {
     NoCriteria,
 }
 
-impl<FG: ForkGraph> LoadedPrograms<FG> {
+impl<FG: ForkGraph> ProgramCache<FG> {
     pub fn new(root_slot: Slot, root_epoch: Epoch) -> Self {
         Self {
             entries: HashMap::new(),
@@ -734,7 +734,7 @@ impl<FG: ForkGraph> LoadedPrograms<FG> {
                     (LoadedProgramType::Unloaded(_), LoadedProgramType::TestLoaded(_)) => {}
                     _ => {
                         // Something is wrong, I can feel it ...
-                        error!("LoadedPrograms::assign_program() failed key={:?} existing={:?} entry={:?}", key, slot_versions, entry);
+                        error!("ProgramCache::assign_program() failed key={:?} existing={:?} entry={:?}", key, slot_versions, entry);
                         debug_assert!(false, "Unexpected replacement of an entry");
                         self.stats.replacements.fetch_add(1, Ordering::Relaxed);
                         return true;
@@ -1146,9 +1146,9 @@ impl solana_frozen_abi::abi_example::AbiExample for LoadedProgram {
 }
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
-impl<FG: ForkGraph> solana_frozen_abi::abi_example::AbiExample for LoadedPrograms<FG> {
+impl<FG: ForkGraph> solana_frozen_abi::abi_example::AbiExample for ProgramCache<FG> {
     fn example() -> Self {
-        // LoadedPrograms isn't serializable by definition.
+        // ProgramCache isn't serializable by definition.
         Self::new(Slot::default(), Epoch::default())
     }
 }
@@ -1158,7 +1158,7 @@ mod tests {
     use {
         crate::loaded_programs::{
             BlockRelation, ForkGraph, LoadedProgram, LoadedProgramMatchCriteria, LoadedProgramType,
-            LoadedPrograms, LoadedProgramsForTxBatch, ProgramRuntimeEnvironment,
+            LoadedProgramsForTxBatch, ProgramCache, ProgramRuntimeEnvironment,
             ProgramRuntimeEnvironments, DELAY_VISIBILITY_SLOT_OFFSET,
         },
         assert_matches::assert_matches,
@@ -1178,8 +1178,8 @@ mod tests {
     static MOCK_ENVIRONMENT: std::sync::OnceLock<ProgramRuntimeEnvironment> =
         std::sync::OnceLock::<ProgramRuntimeEnvironment>::new();
 
-    fn new_mock_cache<FG: ForkGraph>() -> LoadedPrograms<FG> {
-        let mut cache = LoadedPrograms::new(0, 0);
+    fn new_mock_cache<FG: ForkGraph>() -> ProgramCache<FG> {
+        let mut cache = ProgramCache::new(0, 0);
 
         cache.environments.program_runtime_v1 = MOCK_ENVIRONMENT
             .get_or_init(|| Arc::new(BuiltinProgram::new_mock()))
@@ -1220,7 +1220,7 @@ mod tests {
     }
 
     fn set_tombstone<FG: ForkGraph>(
-        cache: &mut LoadedPrograms<FG>,
+        cache: &mut ProgramCache<FG>,
         key: Pubkey,
         slot: Slot,
         reason: LoadedProgramType,
@@ -1231,7 +1231,7 @@ mod tests {
     }
 
     fn insert_unloaded_program<FG: ForkGraph>(
-        cache: &mut LoadedPrograms<FG>,
+        cache: &mut ProgramCache<FG>,
         key: Pubkey,
         slot: Slot,
     ) -> Arc<LoadedProgram> {
@@ -1254,7 +1254,7 @@ mod tests {
         unloaded
     }
 
-    fn num_matching_entries<P, FG>(cache: &LoadedPrograms<FG>, predicate: P) -> usize
+    fn num_matching_entries<P, FG>(cache: &ProgramCache<FG>, predicate: P) -> usize
     where
         P: Fn(&LoadedProgramType) -> bool,
         FG: ForkGraph,
@@ -1302,7 +1302,7 @@ mod tests {
     }
 
     fn program_deploy_test_helper(
-        cache: &mut LoadedPrograms<TestForkGraph>,
+        cache: &mut ProgramCache<TestForkGraph>,
         program: Pubkey,
         deployment_slots: Vec<Slot>,
         usage_counters: Vec<u64>,
@@ -2574,28 +2574,28 @@ mod tests {
         let tombstone = Arc::new(LoadedProgram::new_tombstone(0, LoadedProgramType::Closed));
 
         assert!(
-            LoadedPrograms::<TestForkGraph>::matches_loaded_program_criteria(
+            ProgramCache::<TestForkGraph>::matches_loaded_program_criteria(
                 &tombstone,
                 &LoadedProgramMatchCriteria::NoCriteria
             )
         );
 
         assert!(
-            LoadedPrograms::<TestForkGraph>::matches_loaded_program_criteria(
+            ProgramCache::<TestForkGraph>::matches_loaded_program_criteria(
                 &tombstone,
                 &LoadedProgramMatchCriteria::Tombstone
             )
         );
 
         assert!(
-            LoadedPrograms::<TestForkGraph>::matches_loaded_program_criteria(
+            ProgramCache::<TestForkGraph>::matches_loaded_program_criteria(
                 &tombstone,
                 &LoadedProgramMatchCriteria::DeployedOnOrAfterSlot(0)
             )
         );
 
         assert!(
-            !LoadedPrograms::<TestForkGraph>::matches_loaded_program_criteria(
+            !ProgramCache::<TestForkGraph>::matches_loaded_program_criteria(
                 &tombstone,
                 &LoadedProgramMatchCriteria::DeployedOnOrAfterSlot(1)
             )
@@ -2604,28 +2604,28 @@ mod tests {
         let program = new_test_loaded_program(0, 1);
 
         assert!(
-            LoadedPrograms::<TestForkGraph>::matches_loaded_program_criteria(
+            ProgramCache::<TestForkGraph>::matches_loaded_program_criteria(
                 &program,
                 &LoadedProgramMatchCriteria::NoCriteria
             )
         );
 
         assert!(
-            !LoadedPrograms::<TestForkGraph>::matches_loaded_program_criteria(
+            !ProgramCache::<TestForkGraph>::matches_loaded_program_criteria(
                 &program,
                 &LoadedProgramMatchCriteria::Tombstone
             )
         );
 
         assert!(
-            LoadedPrograms::<TestForkGraph>::matches_loaded_program_criteria(
+            ProgramCache::<TestForkGraph>::matches_loaded_program_criteria(
                 &program,
                 &LoadedProgramMatchCriteria::DeployedOnOrAfterSlot(0)
             )
         );
 
         assert!(
-            !LoadedPrograms::<TestForkGraph>::matches_loaded_program_criteria(
+            !ProgramCache::<TestForkGraph>::matches_loaded_program_criteria(
                 &program,
                 &LoadedProgramMatchCriteria::DeployedOnOrAfterSlot(1)
             )
@@ -2638,28 +2638,28 @@ mod tests {
         ));
 
         assert!(
-            LoadedPrograms::<TestForkGraph>::matches_loaded_program_criteria(
+            ProgramCache::<TestForkGraph>::matches_loaded_program_criteria(
                 &program,
                 &LoadedProgramMatchCriteria::NoCriteria
             )
         );
 
         assert!(
-            !LoadedPrograms::<TestForkGraph>::matches_loaded_program_criteria(
+            !ProgramCache::<TestForkGraph>::matches_loaded_program_criteria(
                 &program,
                 &LoadedProgramMatchCriteria::Tombstone
             )
         );
 
         assert!(
-            LoadedPrograms::<TestForkGraph>::matches_loaded_program_criteria(
+            ProgramCache::<TestForkGraph>::matches_loaded_program_criteria(
                 &program,
                 &LoadedProgramMatchCriteria::DeployedOnOrAfterSlot(0)
             )
         );
 
         assert!(
-            !LoadedPrograms::<TestForkGraph>::matches_loaded_program_criteria(
+            !ProgramCache::<TestForkGraph>::matches_loaded_program_criteria(
                 &program,
                 &LoadedProgramMatchCriteria::DeployedOnOrAfterSlot(1)
             )

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11910,14 +11910,14 @@ fn test_feature_activation_loaded_programs_recompilation_phase() {
     goto_end_of_slot(bank.clone());
     let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 16);
     let current_env = bank
-        .loaded_programs_cache
+        .program_cache
         .read()
         .unwrap()
         .get_environments_for_epoch(0)
         .program_runtime_v1
         .clone();
     let upcoming_env = bank
-        .loaded_programs_cache
+        .program_cache
         .read()
         .unwrap()
         .get_environments_for_epoch(1)
@@ -11926,9 +11926,8 @@ fn test_feature_activation_loaded_programs_recompilation_phase() {
 
     // Advance the bank to recompile the program.
     {
-        let loaded_programs_cache = bank.loaded_programs_cache.read().unwrap();
-        let slot_versions =
-            loaded_programs_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
+        let program_cache = bank.program_cache.read().unwrap();
+        let slot_versions = program_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
         assert_eq!(slot_versions.len(), 1);
         assert!(Arc::ptr_eq(
             slot_versions[0].program.get_environment().unwrap(),
@@ -11938,9 +11937,8 @@ fn test_feature_activation_loaded_programs_recompilation_phase() {
     goto_end_of_slot(bank.clone());
     let bank = new_from_parent_with_fork_next_slot(bank, bank_forks.as_ref());
     {
-        let loaded_programs_cache = bank.loaded_programs_cache.read().unwrap();
-        let slot_versions =
-            loaded_programs_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
+        let program_cache = bank.program_cache.read().unwrap();
+        let slot_versions = program_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
         assert_eq!(slot_versions.len(), 2);
         assert!(Arc::ptr_eq(
             slot_versions[0].program.get_environment().unwrap(),


### PR DESCRIPTION
#### Problem

LoadedPrograms name is heavily overloaded in the source base and inaccurate.

#### Summary of Changes

Replace LoadedPrograms by ProgramCache adhering to English grammar rule for adjective noun normally being in singular form.