### PR TITLE
Checks if bank snapshot is loadable before fastbooting

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -312,14 +312,14 @@ impl AccountsHashVerifier {
                 bank_incremental_snapshot_persistence.as_ref(),
             );
 
-            // now write the fastboot file after reserializing so this bank snapshot is loadable
+            // now write the full snapshot slot file after reserializing so this bank snapshot is loadable
             let full_snapshot_archive_slot = match accounts_package.package_kind {
                 AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(base_slot)) => {
                     base_slot
                 }
                 _ => accounts_package.slot,
             };
-            snapshot_utils::write_fastboot_file(
+            snapshot_utils::write_full_snapshot_slot_file(
                 &snapshot_info.bank_snapshot_dir,
                 full_snapshot_archive_slot,
             )

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -313,18 +313,21 @@ impl AccountsHashVerifier {
             );
 
             // now write the fastboot file after reserializing so this bank snapshot is loadable
-            let fastboot_slot = match accounts_package.package_kind {
+            let full_snapshot_archive_slot = match accounts_package.package_kind {
                 AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(base_slot)) => {
                     base_slot
                 }
                 _ => accounts_package.slot,
             };
-            snapshot_utils::write_fastboot_file(&snapshot_info.bank_snapshot_dir, fastboot_slot)
-                .map_err(|err| {
-                    IoError::other(format!(
-                        "failed to calculate accounts hash for {accounts_package:?}: {err}"
-                    ))
-                })?;
+            snapshot_utils::write_fastboot_file(
+                &snapshot_info.bank_snapshot_dir,
+                full_snapshot_archive_slot,
+            )
+            .map_err(|err| {
+                IoError::other(format!(
+                    "failed to calculate accounts hash for {accounts_package:?}: {err}"
+                ))
+            })?;
         }
 
         if accounts_package.package_kind

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -24,6 +24,7 @@ use {
         hash::Hash,
     },
     std::{
+        io::{Error as IoError, Result as IoResult},
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc,
@@ -71,12 +72,17 @@ impl AccountsHashVerifier {
                     info!("handling accounts package: {accounts_package:?}");
                     let enqueued_time = accounts_package.enqueued.elapsed();
 
-                    let (_, handling_time_us) = measure_us!(Self::process_accounts_package(
+                    let (result, handling_time_us) = measure_us!(Self::process_accounts_package(
                         accounts_package,
                         snapshot_package_sender.as_ref(),
                         &snapshot_config,
                         &exit,
                     ));
+                    if let Err(err) = result {
+                        error!("Stopping AccountsHashVerifier! Fatal error while processing accounts package: {err}");
+                        exit.store(true, Ordering::Relaxed);
+                        break;
+                    }
 
                     datapoint_info!(
                         "accounts_hash_verifier",
@@ -208,9 +214,9 @@ impl AccountsHashVerifier {
         snapshot_package_sender: Option<&Sender<SnapshotPackage>>,
         snapshot_config: &SnapshotConfig,
         exit: &AtomicBool,
-    ) {
+    ) -> IoResult<()> {
         let accounts_hash =
-            Self::calculate_and_verify_accounts_hash(&accounts_package, snapshot_config);
+            Self::calculate_and_verify_accounts_hash(&accounts_package, snapshot_config)?;
 
         Self::save_epoch_accounts_hash(&accounts_package, accounts_hash);
 
@@ -221,13 +227,15 @@ impl AccountsHashVerifier {
             accounts_hash,
             exit,
         );
+
+        Ok(())
     }
 
     /// returns calculated accounts hash
     fn calculate_and_verify_accounts_hash(
         accounts_package: &AccountsPackage,
         snapshot_config: &SnapshotConfig,
-    ) -> AccountsHashKind {
+    ) -> IoResult<AccountsHashKind> {
         let accounts_hash_calculation_kind = match accounts_package.package_kind {
             AccountsPackageKind::AccountsHashVerifier => CalcAccountsHashKind::Full,
             AccountsPackageKind::EpochAccountsHash => CalcAccountsHashKind::Full,
@@ -312,7 +320,11 @@ impl AccountsHashVerifier {
                 _ => accounts_package.slot,
             };
             snapshot_utils::write_fastboot_file(&snapshot_info.bank_snapshot_dir, fastboot_slot)
-                .unwrap();
+                .map_err(|err| {
+                    IoError::other(format!(
+                        "failed to calculate accounts hash for {accounts_package:?}: {err}"
+                    ))
+                })?;
         }
 
         if accounts_package.package_kind
@@ -350,7 +362,7 @@ impl AccountsHashVerifier {
             );
         }
 
-        accounts_hash_kind
+        Ok(accounts_hash_kind)
     }
 
     fn _calculate_full_accounts_hash(

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -303,6 +303,16 @@ impl AccountsHashVerifier {
                 &accounts_hash_for_reserialize,
                 bank_incremental_snapshot_persistence.as_ref(),
             );
+
+            // now write the fastboot file after reserializing so this bank snapshot is loadable
+            let fastboot_slot = match accounts_package.package_kind {
+                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(base_slot)) => {
+                    base_slot
+                }
+                _ => accounts_package.slot,
+            };
+            snapshot_utils::write_fastboot_file(&snapshot_info.bank_snapshot_dir, fastboot_slot)
+                .unwrap();
         }
 
         if accounts_package.package_kind

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1266,8 +1266,8 @@ mod tests {
                 get_highest_loadable_bank_snapshot, purge_all_bank_snapshots, purge_bank_snapshot,
                 purge_bank_snapshots_older_than_slot, purge_incomplete_bank_snapshots,
                 purge_old_bank_snapshots, purge_old_bank_snapshots_at_startup,
-                snapshot_storage_rebuilder::get_slot_and_append_vec_id, write_fastboot_file,
-                ArchiveFormat, SNAPSHOT_FASTBOOT_FILENAME,
+                snapshot_storage_rebuilder::get_slot_and_append_vec_id,
+                write_full_snapshot_slot_file, ArchiveFormat, SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME,
             },
             status_cache::Status,
         },
@@ -2697,7 +2697,7 @@ mod tests {
                     None,
                 )
             );
-            write_fastboot_file(&bank_snapshot_info.snapshot_dir, slot).unwrap();
+            write_full_snapshot_slot_file(&bank_snapshot_info.snapshot_dir, slot).unwrap();
             package_and_archive_full_snapshot(
                 &bank,
                 &bank_snapshot_info,
@@ -2759,8 +2759,13 @@ mod tests {
         let bank_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
         assert_eq!(bank_snapshot.slot, highest_bank_snapshot_post.slot - 1);
 
-        // 6. delete the fastboot file, get_highest_loadable() should return NONE
-        fs::remove_file(bank_snapshot.snapshot_dir.join(SNAPSHOT_FASTBOOT_FILENAME)).unwrap();
+        // 6. delete the full snapshot slot file, get_highest_loadable() should return NONE
+        fs::remove_file(
+            bank_snapshot
+                .snapshot_dir
+                .join(SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME),
+        )
+        .unwrap();
         assert!(get_highest_loadable_bank_snapshot(&snapshot_config).is_none());
 
         // 7. however, a load-only snapshot config should return Some() again

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1258,13 +1258,16 @@ mod tests {
         crate::{
             bank_forks::BankForks,
             genesis_utils,
+            snapshot_config::SnapshotConfig,
             snapshot_utils::{
                 clean_orphaned_account_snapshot_dirs, create_tmp_accounts_dir_for_tests,
                 get_bank_snapshots, get_bank_snapshots_post, get_bank_snapshots_pre,
-                get_highest_bank_snapshot, purge_all_bank_snapshots, purge_bank_snapshot,
+                get_highest_bank_snapshot, get_highest_bank_snapshot_pre,
+                get_highest_loadable_bank_snapshot, purge_all_bank_snapshots, purge_bank_snapshot,
                 purge_bank_snapshots_older_than_slot, purge_incomplete_bank_snapshots,
                 purge_old_bank_snapshots, purge_old_bank_snapshots_at_startup,
-                snapshot_storage_rebuilder::get_slot_and_append_vec_id, ArchiveFormat,
+                snapshot_storage_rebuilder::get_slot_and_append_vec_id, write_fastboot_file,
+                ArchiveFormat, SNAPSHOT_FASTBOOT_FILENAME,
             },
             status_cache::Status,
         },
@@ -2637,5 +2640,132 @@ mod tests {
             result,
             Err(VerifySlotDeltasError::SlotNotFoundInDeltas(333)),
         );
+    }
+
+    #[test]
+    fn test_get_highest_loadable_bank_snapshot() {
+        let bank_snapshots_dir = TempDir::new().unwrap();
+        let full_snapshot_archives_dir = TempDir::new().unwrap();
+        let incremental_snapshot_archives_dir = TempDir::new().unwrap();
+
+        let snapshot_config = SnapshotConfig {
+            bank_snapshots_dir: bank_snapshots_dir.as_ref().to_path_buf(),
+            full_snapshot_archives_dir: full_snapshot_archives_dir.as_ref().to_path_buf(),
+            incremental_snapshot_archives_dir: incremental_snapshot_archives_dir
+                .as_ref()
+                .to_path_buf(),
+            ..Default::default()
+        };
+        let load_only_snapshot_config = SnapshotConfig {
+            bank_snapshots_dir: snapshot_config.bank_snapshots_dir.clone(),
+            full_snapshot_archives_dir: snapshot_config.full_snapshot_archives_dir.clone(),
+            incremental_snapshot_archives_dir: snapshot_config
+                .incremental_snapshot_archives_dir
+                .clone(),
+            ..SnapshotConfig::new_load_only()
+        };
+
+        let genesis_config = GenesisConfig::default();
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
+
+        // take some snapshots, and archive them
+        for _ in 0..snapshot_config
+            .maximum_full_snapshot_archives_to_retain
+            .get()
+        {
+            let slot = bank.slot() + 1;
+            bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
+            bank.fill_bank_with_ticks_for_tests();
+            bank.squash();
+            bank.force_flush_accounts_cache();
+            bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
+            let snapshot_storages = bank.get_snapshot_storages(None);
+            let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
+            let bank_snapshot_info = add_bank_snapshot(
+                &bank_snapshots_dir,
+                &bank,
+                &snapshot_storages,
+                snapshot_config.snapshot_version,
+                slot_deltas,
+            )
+            .unwrap();
+            assert!(
+                crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
+                    &bank_snapshot_info.snapshot_dir,
+                    bank.slot(),
+                    &bank.get_accounts_hash().unwrap(),
+                    None,
+                )
+            );
+            write_fastboot_file(&bank_snapshot_info.snapshot_dir, slot).unwrap();
+            package_and_archive_full_snapshot(
+                &bank,
+                &bank_snapshot_info,
+                &full_snapshot_archives_dir,
+                &incremental_snapshot_archives_dir,
+                snapshot_storages,
+                snapshot_config.archive_format,
+                snapshot_config.snapshot_version,
+                snapshot_config.maximum_full_snapshot_archives_to_retain,
+                snapshot_config.maximum_incremental_snapshot_archives_to_retain,
+            )
+            .unwrap();
+        }
+
+        // take another snapshot, but leave it as PRE
+        let slot = bank.slot() + 1;
+        bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
+        bank.fill_bank_with_ticks_for_tests();
+        bank.squash();
+        bank.force_flush_accounts_cache();
+        let snapshot_storages = bank.get_snapshot_storages(None);
+        let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
+        add_bank_snapshot(
+            &bank_snapshots_dir,
+            &bank,
+            &snapshot_storages,
+            SnapshotVersion::default(),
+            slot_deltas,
+        )
+        .unwrap();
+
+        let highest_full_snapshot_archive =
+            get_highest_full_snapshot_archive_info(&full_snapshot_archives_dir).unwrap();
+        let highest_bank_snapshot_post =
+            get_highest_bank_snapshot_post(&bank_snapshots_dir).unwrap();
+        let highest_bank_snapshot_pre = get_highest_bank_snapshot_pre(&bank_snapshots_dir).unwrap();
+
+        // we want a bank snapshot PRE with the highest slot to ensure get_highest_loadable()
+        // correctly skips bank snapshots PRE
+        assert!(highest_bank_snapshot_pre.slot > highest_bank_snapshot_post.slot);
+
+        // 1. call get_highest_loadable() but bad snapshot dir, so returns None
+        assert!(get_highest_loadable_bank_snapshot(&SnapshotConfig::default()).is_none());
+
+        // 2. get_highest_loadable(), should return highest_bank_snapshot_post_slot
+        let bank_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
+        assert_eq!(bank_snapshot, highest_bank_snapshot_post);
+
+        // 3. delete highest full snapshot archive, get_highest_loadable() should return NONE
+        fs::remove_file(highest_full_snapshot_archive.path()).unwrap();
+        assert!(get_highest_loadable_bank_snapshot(&snapshot_config).is_none());
+
+        // 4. get_highest_loadable(), but with a load-only snapshot config, should return Some()
+        let bank_snapshot = get_highest_loadable_bank_snapshot(&load_only_snapshot_config).unwrap();
+        assert_eq!(bank_snapshot, highest_bank_snapshot_post);
+
+        // 5. delete highest bank snapshot, get_highest_loadable() should return Some() again, with slot-1
+        fs::remove_dir_all(&highest_bank_snapshot_post.snapshot_dir).unwrap();
+        let bank_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
+        assert_eq!(bank_snapshot.slot, highest_bank_snapshot_post.slot - 1);
+
+        // 6. delete the fastboot file, get_highest_loadable() should return NONE
+        fs::remove_file(bank_snapshot.snapshot_dir.join(SNAPSHOT_FASTBOOT_FILENAME)).unwrap();
+        assert!(get_highest_loadable_bank_snapshot(&snapshot_config).is_none());
+
+        // 7. however, a load-only snapshot config should return Some() again
+        let bank_snapshot2 =
+            get_highest_loadable_bank_snapshot(&load_only_snapshot_config).unwrap();
+        assert_eq!(bank_snapshot2, bank_snapshot);
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -630,7 +630,12 @@ fn is_bank_snapshot_complete(bank_snapshot_dir: impl AsRef<Path>) -> bool {
 /// Writes the fastboot file into the bank snapshot dir
 pub fn write_fastboot_file(bank_snapshot_dir: impl AsRef<Path>, slot: Slot) -> IoResult<()> {
     let fastboot_path = bank_snapshot_dir.as_ref().join(SNAPSHOT_FASTBOOT_FILENAME);
-    fs::write(fastboot_path, slot.to_le_bytes())
+    fs::write(&fastboot_path, slot.to_le_bytes()).map_err(|err| {
+        IoError::other(format!(
+            "failed to write fastboot file '{}': {err}",
+            fastboot_path.display(),
+        ))
+    })
 }
 
 // Reads the fastboot file from the bank snapshot dir


### PR DESCRIPTION
#### Problem

Please refer to https://github.com/solana-labs/solana/issues/35367


#### Summary of Changes

Before loading a bank snapshot for fastboot, ensure it can be used! This means that if we do fastboot the bank snapshot, it has the correct other stuff on disk (aka the right full snapshot archive) so that *subsequent* snapshots will succeed, and we won't hit the error described in the problem.

Fixes https://github.com/solana-labs/solana/issues/35367