### PR TITLE
Do not purge all bank snapshots after fastboot

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -297,15 +297,6 @@ fn bank_forks_from_snapshot(
             source: err,
             path: fastboot_snapshot.snapshot_path(),
         })?;
-
-        // If the node crashes before taking the next bank snapshot, the next startup will attempt
-        // to load from the same bank snapshot again.  And if `shrink` has run, the account storage
-        // files that are hard linked in bank snapshot will be *different* than what the bank
-        // snapshot expects.  This would cause the node to crash again.  To prevent that, purge all
-        // the bank snapshots here.  In the above scenario, this will cause the node to load from a
-        // snapshot archive next time, which is safe.
-        snapshot_utils::purge_all_bank_snapshots(&snapshot_config.bank_snapshots_dir);
-
         bank
     } else {
         // Given that we are going to boot from an archive, the append vecs held in the snapshot dirs for fast-boot should


### PR DESCRIPTION
#### Problem

Please see https://github.com/solana-labs/solana/issues/35431


#### Summary of Changes

Do *not* purge all bank snapshots after fastbooting.

Fixes https://github.com/solana-labs/solana/issues/35431


#### Additional Testing

I ran leger-tool built from this PR on a mnb bank snapshot and confirmed I was able to repeatably use fastboot. Yay!

What's also really cool, is now that the storages recycler has been removed, we can fastboot from *older* bank snapshots as well; not just the latest.