### PR TITLE
Reduce the default number of IP echo server threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6537,6 +6537,7 @@ dependencies = [
  "solana-logger",
  "solana-sdk",
  "solana-version",
+ "static_assertions",
  "tokio",
  "url 2.5.0",
 ]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -269,6 +269,7 @@ pub struct ValidatorConfig {
     pub use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup,
     pub wen_restart_proto_path: Option<PathBuf>,
     pub unified_scheduler_handler_threads: Option<usize>,
+    pub ip_echo_server_threads: NonZeroUsize,
     pub replay_forks_threads: NonZeroUsize,
     pub replay_transactions_threads: NonZeroUsize,
 }
@@ -338,6 +339,7 @@ impl Default for ValidatorConfig {
             use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup::default(),
             wen_restart_proto_path: None,
             unified_scheduler_handler_threads: None,
+            ip_echo_server_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             replay_transactions_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
         }
@@ -1079,6 +1081,7 @@ impl Validator {
             None => None,
             Some(tcp_listener) => Some(solana_net_utils::ip_echo_server(
                 tcp_listener,
+                config.ip_echo_server_threads,
                 Some(node.info.shred_version()),
             )),
         };

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -22,7 +22,6 @@ use {
     std::{
         collections::HashSet,
         net::{SocketAddr, TcpListener, UdpSocket},
-        num::NonZeroUsize,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc, RwLock,
@@ -162,10 +161,12 @@ pub fn discover(
         info!("Gossip Address: {:?}", my_gossip_addr);
     }
 
-    let num_threads =
-        NonZeroUsize::new(DEFAULT_IP_ECHO_SERVER_THREADS).expect("non-zero num threads");
     let _ip_echo_server = ip_echo.map(|tcp_listener| {
-        solana_net_utils::ip_echo_server(tcp_listener, num_threads, Some(my_shred_version))
+        solana_net_utils::ip_echo_server(
+            tcp_listener,
+            DEFAULT_IP_ECHO_SERVER_THREADS,
+            Some(my_shred_version),
+        )
     });
     let (met_criteria, elapsed, all_peers, tvu_peers) = spy(
         spy_ref.clone(),

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -162,8 +162,8 @@ pub fn discover(
         info!("Gossip Address: {:?}", my_gossip_addr);
     }
 
-    let num_threads = NonZeroUsize::new(DEFAULT_IP_ECHO_SERVER_THREADS)
-        .unwrap_or(NonZeroUsize::new(2).expect("non-zero num threads"));
+    let num_threads =
+        NonZeroUsize::new(DEFAULT_IP_ECHO_SERVER_THREADS).expect("non-zero num threads");
     let _ip_echo_server = ip_echo.map(|tcp_listener| {
         solana_net_utils::ip_echo_server(tcp_listener, num_threads, Some(my_shred_version))
     });

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -68,6 +68,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         use_snapshot_archives_at_startup: config.use_snapshot_archives_at_startup,
         wen_restart_proto_path: config.wen_restart_proto_path.clone(),
         unified_scheduler_handler_threads: config.unified_scheduler_handler_threads,
+        ip_echo_server_threads: config.ip_echo_server_threads,
         replay_forks_threads: config.replay_forks_threads,
         replay_transactions_threads: config.replay_transactions_threads,
     }

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -22,6 +22,7 @@ socket2 = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true }
 solana-version = { workspace = true }
+static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
 

--- a/net-utils/src/bin/ip_address_server.rs
+++ b/net-utils/src/bin/ip_address_server.rs
@@ -22,10 +22,11 @@ fn main() {
         .unwrap_or_else(|_| panic!("Unable to parse {port}"));
     let bind_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, port));
     let tcp_listener = TcpListener::bind(bind_addr).expect("unable to start tcp listener");
-    let num_threads =
-        std::num::NonZeroUsize::new(DEFAULT_IP_ECHO_SERVER_THREADS).expect("non-zero num threads");
-    let _runtime =
-        solana_net_utils::ip_echo_server(tcp_listener, num_threads, /*shred_version=*/ None);
+    let _runtime = solana_net_utils::ip_echo_server(
+        tcp_listener,
+        DEFAULT_IP_ECHO_SERVER_THREADS,
+        /*shred_version=*/ None,
+    );
     loop {
         std::thread::park();
     }

--- a/net-utils/src/bin/ip_address_server.rs
+++ b/net-utils/src/bin/ip_address_server.rs
@@ -1,5 +1,6 @@
 use {
     clap::{Arg, Command},
+    solana_net_utils::DEFAULT_IP_ECHO_SERVER_THREADS,
     std::net::{Ipv4Addr, SocketAddr, TcpListener},
 };
 
@@ -21,7 +22,10 @@ fn main() {
         .unwrap_or_else(|_| panic!("Unable to parse {port}"));
     let bind_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, port));
     let tcp_listener = TcpListener::bind(bind_addr).expect("unable to start tcp listener");
-    let _runtime = solana_net_utils::ip_echo_server(tcp_listener, /*shred_version=*/ None);
+    let num_threads =
+        std::num::NonZeroUsize::new(DEFAULT_IP_ECHO_SERVER_THREADS).expect("non-zero num threads");
+    let _runtime =
+        solana_net_utils::ip_echo_server(tcp_listener, num_threads, /*shred_version=*/ None);
     loop {
         std::thread::park();
     }

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -19,14 +19,14 @@ use {
 
 pub type IpEchoServer = Runtime;
 
-// Enforce a minimum of two thread
+// Enforce a minimum of two threads:
 // - One thread to monitor the TcpListener and spawn async tasks
 // - One thread to service the spawned tasks
 pub const MINIMUM_IP_ECHO_SERVER_THREADS: usize = 2;
 // IP echo requests require little computation and come in fairly infrequently,
 // so keep the number of server workers small to avoid overhead
 pub const DEFAULT_IP_ECHO_SERVER_THREADS: usize = MINIMUM_IP_ECHO_SERVER_THREADS;
-// There must be at least one worker so the value must be non-zero
+// tokio::runtime::Builder::worker_threads() panics if passed 0
 static_assertions::const_assert!(MINIMUM_IP_ECHO_SERVER_THREADS > 0);
 pub const MAX_PORT_COUNT_PER_MESSAGE: usize = 4;
 

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -18,11 +18,16 @@ use {
 };
 
 pub type IpEchoServer = Runtime;
-// IP echo requests require little computation and come in fairly infrequently
+
+// Enforce a minimum of two thread
+// - One thread to monitor the TcpListener and spawn async tasks
+// - One thread to service the spawned tasks
+pub const MINIMUM_IP_ECHO_SERVER_THREADS: usize = 2;
+// IP echo requests require little computation and come in fairly infrequently,
 // so keep the number of server workers small to avoid overhead
-pub const DEFAULT_IP_ECHO_SERVER_THREADS: usize = 2;
+pub const DEFAULT_IP_ECHO_SERVER_THREADS: usize = MINIMUM_IP_ECHO_SERVER_THREADS;
 // There must be at least one worker so the value must be non-zero
-static_assertions::const_assert!(DEFAULT_IP_ECHO_SERVER_THREADS > 0);
+static_assertions::const_assert!(MINIMUM_IP_ECHO_SERVER_THREADS > 0);
 pub const MAX_PORT_COUNT_PER_MESSAGE: usize = 4;
 
 const IO_TIMEOUT: Duration = Duration::from_secs(5);

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -22,12 +22,11 @@ pub type IpEchoServer = Runtime;
 // Enforce a minimum of two threads:
 // - One thread to monitor the TcpListener and spawn async tasks
 // - One thread to service the spawned tasks
-pub const MINIMUM_IP_ECHO_SERVER_THREADS: usize = 2;
+// The unsafe is safe because we're using a fixed, known non-zero value
+pub const MINIMUM_IP_ECHO_SERVER_THREADS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(2) };
 // IP echo requests require little computation and come in fairly infrequently,
 // so keep the number of server workers small to avoid overhead
-pub const DEFAULT_IP_ECHO_SERVER_THREADS: usize = MINIMUM_IP_ECHO_SERVER_THREADS;
-// tokio::runtime::Builder::worker_threads() panics if passed 0
-static_assertions::const_assert!(MINIMUM_IP_ECHO_SERVER_THREADS > 0);
+pub const DEFAULT_IP_ECHO_SERVER_THREADS: NonZeroUsize = MINIMUM_IP_ECHO_SERVER_THREADS;
 pub const MAX_PORT_COUNT_PER_MESSAGE: usize = 4;
 
 const IO_TIMEOUT: Duration = Duration::from_secs(5);

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -18,6 +18,7 @@ use {
 mod ip_echo_server;
 pub use ip_echo_server::{
     ip_echo_server, IpEchoServer, DEFAULT_IP_ECHO_SERVER_THREADS, MAX_PORT_COUNT_PER_MESSAGE,
+    MINIMUM_IP_ECHO_SERVER_THREADS,
 };
 use ip_echo_server::{IpEchoServerMessage, IpEchoServerResponse};
 

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -16,7 +16,9 @@ use {
 };
 
 mod ip_echo_server;
-pub use ip_echo_server::{ip_echo_server, IpEchoServer, MAX_PORT_COUNT_PER_MESSAGE};
+pub use ip_echo_server::{
+    ip_echo_server, IpEchoServer, DEFAULT_IP_ECHO_SERVER_THREADS, MAX_PORT_COUNT_PER_MESSAGE,
+};
 use ip_echo_server::{IpEchoServerMessage, IpEchoServerResponse};
 
 /// A data type representing a public Udp socket
@@ -580,7 +582,10 @@ pub fn find_available_port_in_range(ip_addr: IpAddr, range: PortRange) -> io::Re
 
 #[cfg(test)]
 mod tests {
-    use {super::*, std::net::Ipv4Addr};
+    use {
+        super::*,
+        std::{net::Ipv4Addr, num::NonZeroUsize},
+    };
 
     #[test]
     fn test_response_length() {
@@ -744,7 +749,11 @@ mod tests {
         let (_server_port, (server_udp_socket, server_tcp_listener)) =
             bind_common_in_range(ip_addr, (3200, 3250)).unwrap();
 
-        let _runtime = ip_echo_server(server_tcp_listener, /*shred_version=*/ Some(42));
+        let _runtime = ip_echo_server(
+            server_tcp_listener,
+            NonZeroUsize::new(DEFAULT_IP_ECHO_SERVER_THREADS).expect("non-zero num workers"),
+            /*shred_version=*/ Some(42),
+        );
 
         let server_ip_echo_addr = server_udp_socket.local_addr().unwrap();
         assert_eq!(
@@ -764,7 +773,11 @@ mod tests {
         let (client_port, (client_udp_socket, client_tcp_listener)) =
             bind_common_in_range(ip_addr, (3200, 3250)).unwrap();
 
-        let _runtime = ip_echo_server(server_tcp_listener, /*shred_version=*/ Some(65535));
+        let _runtime = ip_echo_server(
+            server_tcp_listener,
+            NonZeroUsize::new(DEFAULT_IP_ECHO_SERVER_THREADS).expect("non-zero num workers"),
+            /*shred_version=*/ Some(65535),
+        );
 
         let ip_echo_server_addr = server_udp_socket.local_addr().unwrap();
         assert_eq!(

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -583,10 +583,7 @@ pub fn find_available_port_in_range(ip_addr: IpAddr, range: PortRange) -> io::Re
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        std::{net::Ipv4Addr, num::NonZeroUsize},
-    };
+    use {super::*, std::net::Ipv4Addr};
 
     #[test]
     fn test_response_length() {
@@ -752,7 +749,7 @@ mod tests {
 
         let _runtime = ip_echo_server(
             server_tcp_listener,
-            NonZeroUsize::new(DEFAULT_IP_ECHO_SERVER_THREADS).expect("non-zero num workers"),
+            DEFAULT_IP_ECHO_SERVER_THREADS,
             /*shred_version=*/ Some(42),
         );
 
@@ -776,7 +773,7 @@ mod tests {
 
         let _runtime = ip_echo_server(
             server_tcp_listener,
-            NonZeroUsize::new(DEFAULT_IP_ECHO_SERVER_THREADS).expect("non-zero num workers"),
+            DEFAULT_IP_ECHO_SERVER_THREADS,
             /*shred_version=*/ Some(65535),
         );
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5329,6 +5329,7 @@ dependencies = [
  "solana-logger",
  "solana-sdk",
  "solana-version",
+ "static_assertions",
  "tokio",
  "url 2.5.0",
 ]

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -102,10 +102,10 @@ impl ThreadArg for IpEchoServerThreadsArg {
     const HELP: &'static str = "Number of threads to use for the IP echo server";
 
     fn default() -> usize {
-        solana_net_utils::DEFAULT_IP_ECHO_SERVER_THREADS
+        solana_net_utils::DEFAULT_IP_ECHO_SERVER_THREADS.get()
     }
     fn min() -> usize {
-        solana_net_utils::MINIMUM_IP_ECHO_SERVER_THREADS
+        solana_net_utils::MINIMUM_IP_ECHO_SERVER_THREADS.get()
     }
 }
 

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -102,7 +102,7 @@ impl ThreadArg for IpEchoServerThreadsArg {
     const HELP: &'static str = "Number of threads to use for the IP echo server";
 
     fn default() -> usize {
-        get_max_thread_count()
+        solana_net_utils::DEFAULT_IP_ECHO_SERVER_THREADS
     }
 }
 

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -9,6 +9,7 @@ use {
 
 // Need this struct to provide &str whose lifetime matches that of the CLAP Arg's
 pub struct DefaultThreadArgs {
+    pub ip_echo_server_threads: String,
     pub replay_forks_threads: String,
     pub replay_transactions_threads: String,
 }
@@ -16,6 +17,7 @@ pub struct DefaultThreadArgs {
 impl Default for DefaultThreadArgs {
     fn default() -> Self {
         Self {
+            ip_echo_server_threads: IpEchoServerThreadsArg::default().to_string(),
             replay_forks_threads: ReplayForksThreadsArg::default().to_string(),
             replay_transactions_threads: ReplayTransactionsThreadsArg::default().to_string(),
         }
@@ -24,6 +26,7 @@ impl Default for DefaultThreadArgs {
 
 pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
     vec![
+        new_thread_arg::<IpEchoServerThreadsArg>(&defaults.ip_echo_server_threads),
         new_thread_arg::<ReplayForksThreadsArg>(&defaults.replay_forks_threads),
         new_thread_arg::<ReplayTransactionsThreadsArg>(&defaults.replay_transactions_threads),
     ]
@@ -41,12 +44,18 @@ fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
 }
 
 pub struct NumThreadConfig {
+    pub ip_echo_server_threads: NonZeroUsize,
     pub replay_forks_threads: NonZeroUsize,
     pub replay_transactions_threads: NonZeroUsize,
 }
 
 pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
     NumThreadConfig {
+        ip_echo_server_threads: value_t_or_exit!(
+            matches,
+            IpEchoServerThreadsArg::NAME,
+            NonZeroUsize
+        ),
         replay_forks_threads: if matches.is_present("replay_slots_concurrently") {
             NonZeroUsize::new(4).expect("4 is non-zero")
         } else {
@@ -83,6 +92,17 @@ trait ThreadArg {
     /// The range of allowed number of threads (inclusive on both ends)
     fn range() -> RangeInclusive<usize> {
         RangeInclusive::new(Self::min(), Self::max())
+    }
+}
+
+struct IpEchoServerThreadsArg;
+impl ThreadArg for IpEchoServerThreadsArg {
+    const NAME: &'static str = "ip_echo_server_threads";
+    const LONG_NAME: &'static str = "ip-echo-server-threads";
+    const HELP: &'static str = "Number of threads to use for the IP echo server";
+
+    fn default() -> usize {
+        get_max_thread_count()
     }
 }
 

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -104,6 +104,9 @@ impl ThreadArg for IpEchoServerThreadsArg {
     fn default() -> usize {
         solana_net_utils::DEFAULT_IP_ECHO_SERVER_THREADS
     }
+    fn min() -> usize {
+        solana_net_utils::MINIMUM_IP_ECHO_SERVER_THREADS
+    }
 }
 
 struct ReplayForksThreadsArg;

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1332,6 +1332,7 @@ pub fn main() {
     let full_api = matches.is_present("full_rpc_api");
 
     let cli::thread_args::NumThreadConfig {
+        ip_echo_server_threads,
         replay_forks_threads,
         replay_transactions_threads,
     } = cli::thread_args::parse_num_threads_args(&matches);
@@ -1474,6 +1475,7 @@ pub fn main() {
             use_snapshot_archives_at_startup::cli::NAME,
             UseSnapshotArchivesAtStartup
         ),
+        ip_echo_server_threads,
         replay_forks_threads,
         replay_transactions_threads,
         ..ValidatorConfig::default()


### PR DESCRIPTION
#### Problem
The IP echo server currently spins up as many worker threads as there are threads on the machine. This server is important for the services that entrypoint nodes provide. However, for just about every other node, this thread pool is very over-provisioned and a waste of resources. Moreso, with everything a validator has to do, we don't really want all the system's threads to be able to be tied up serving these requests.

See https://github.com/anza-xyz/agave/issues/105 and https://github.com/anza-xyz/agave/issues/35 for more general context

#### Summary of Changes
- Plumb the number of IP echo server threads through from the CLI
- Adjust the default to only create 2 worker threads by default

#### Normal Nodes
I've examined logs for unstaked nodes running against mainnet; logs would show that my node receives about ~200 of these requests a day. I got data from a highly staked validator who saw similar numbers.

#### Entrypoint Nodes
Examining the MNB nodes that are `entrypointX.mainnet-beta.solana.com:8001`, I'm seeing no more than 240k requests per day (more like 225k but 240k to keep rounder numbers). This can be determined from logs by counting the number of `connection from` logs.
```
240,000 * 1 / (24 * 60 * 60) = 2.77 requests per second
```
Between these low request rate and the relatively little work that is performed by the worker threads in `process_connection()`, this seemed appropriate.

So, for the general case, I think two threads (one listening on TCP port / one to process requests) is sufficient. For our entrypoint nodes, we can add the extra flag to bump up the thread pool size.