### PR TITLE
Removes AccountsFile::is_recyclable()

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -103,12 +103,6 @@ impl AccountsFile {
         }
     }
 
-    pub fn is_recyclable(&self) -> bool {
-        match self {
-            Self::AppendVec(_) => true,
-        }
-    }
-
     pub fn file_name(slot: Slot, id: impl std::fmt::Display) -> String {
         format!("{slot}.{id}")
     }


### PR DESCRIPTION
#### Problem

#118 removed the storages recycler. It no longer makes sense to ask if storages can be recycled.


#### Summary of Changes

Remove `AccountsFile::is_recyclable()`.