### PR TITLE
Back-port Bump platform tools version (from `solana-labs/solana` #35330)

### DIFF
--- a/programs/sbf/rust/sanity/src/lib.rs
+++ b/programs/sbf/rust/sanity/src/lib.rs
@@ -16,6 +16,21 @@ struct SStruct {
     z: u64,
 }
 
+#[allow(dead_code)]
+#[repr(C)]
+enum TestEnum {
+    VariantOne,
+    VariantTwo,
+}
+
+#[allow(dead_code)]
+#[allow(clippy::enum_clike_unportable_variant)]
+#[repr(C)]
+enum Test64BitEnum {
+    VariantOne,
+    VariantTwo = 0xFFFFFFFFF,
+}
+
 #[inline(never)]
 fn return_sstruct() -> SStruct {
     SStruct { x: 1, y: 2, z: 3 }
@@ -70,6 +85,14 @@ pub fn process_instruction(
         let num = num.powf(0.333f64);
         // check that the result is in a correct interval close to 1.998614185980905
         assert!(1.9986f64 < num && num < 2.0f64);
+    }
+
+    {
+        // #[repr(C) enums must not change size between compiler version
+        // 32-bit for #[repr(C)] enum
+        assert_eq!(std::mem::size_of::<TestEnum>(), 4);
+        // 64-bit for enum with a declared value
+        assert_eq!(std::mem::size_of::<Test64BitEnum>(), 8);
     }
 
     check_type_assumptions();

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1356,7 +1356,7 @@ fn assert_instruction_count() {
     #[cfg(feature = "sbf_c")]
     {
         programs.extend_from_slice(&[
-            ("alloc", 11502),
+            ("alloc", 14575),
             ("sbf_to_sbf", 313),
             ("multiple_static", 208),
             ("noop", 5),

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -109,16 +109,16 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install Rust-BPF
-version=v1.39
+version=v1.41
 if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
   (
     set -e
     rm -rf bpf-tools*
     rm -rf xargo
     job="download \
-           https://github.com/solana-labs/bpf-tools/releases/download \
+           https://github.com/anza-xyz/platform-tools/releases/download \
            $version \
-           solana-bpf-tools-${machine}-${arch}.tar.bz2 \
+           platform-tools-${machine}-${arch}.tar.bz2 \
            bpf-tools"
     get $version bpf-tools "$job"
   )

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -913,7 +913,7 @@ fn main() {
 
     // The following line is scanned by CI configuration script to
     // separate cargo caches according to the version of platform-tools.
-    let platform_tools_version = String::from("v1.39");
+    let platform_tools_version = String::from("v1.41");
     let rust_base_version = get_base_rust_version(platform_tools_version.as_str());
     let version = format!(
         "{}\nplatform-tools {}\n{}",

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-rust-version = "1.72.0" # solana platform-tools rust version
+rust-version = "1.75.0" # solana platform-tools rust version
 
 [dependencies]
 bincode = { workspace = true }

--- a/sdk/sbf/c/sbf.mk
+++ b/sdk/sbf/c/sbf.mk
@@ -15,7 +15,7 @@ OUT_DIR ?= ./out
 OS := $(shell uname)
 
 LLVM_DIR = $(LOCAL_PATH)../dependencies/platform-tools/llvm
-LLVM_SYSTEM_INC_DIRS := $(LLVM_DIR)/lib/clang/15.0.4/include
+LLVM_SYSTEM_INC_DIRS := $(LLVM_DIR)/lib/clang/17/include
 COMPILER_RT_DIR = $(LOCAL_PATH)../dependencies/platform-tools/rust/lib/rustlib/sbf-solana-solana/lib
 STD_INC_DIRS := $(LLVM_DIR)/include
 STD_LIB_DIRS := $(LLVM_DIR)/lib

--- a/sdk/sbf/scripts/install.sh
+++ b/sdk/sbf/scripts/install.sh
@@ -109,13 +109,13 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install platform tools
-version=v1.39
+version=v1.41
 if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
   (
     set -e
     rm -rf platform-tools*
     job="download \
-           https://github.com/solana-labs/platform-tools/releases/download \
+           https://github.com/anza-xyz/platform-tools/releases/download \
            $version \
            platform-tools-${machine}-${arch}.tar.bz2 \
            platform-tools"


### PR DESCRIPTION
#### Problem

Platform tools v1.39 shipped with Solana v1.18 contains a bug in the discriminator size and in the stack allocation.

The new version contains a fix for the incorrect enum size introduced in Rust 1.72: https://github.com/anza-xyz/rust/pull/90. This could cause programs to stop working, if developers build them with new tools.

In addition, v1.39 introduced changes in the SROA (Scalar Replacement of Aggregates) pass, which caused multiple functions to utilize more stack space than before: #252. v1.41 fixes this as well.

#### Summary of Changes

This is a back port of https://github.com/solana-labs/solana/pull/35330 to v1.18.

