### PR TITLE
Add `--with-compute-unit-price` to cli program deploy commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5780,6 +5780,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubsub-client",
  "solana-remote-wallet",
+ "solana-rpc",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-rpc-client-nonce-utils",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -56,6 +56,7 @@ tiny-bip39 = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+solana-rpc = { workspace = true }
 solana-streamer = { workspace = true }
 solana-test-validator = { workspace = true }
 tempfile = { workspace = true }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2650,18 +2650,18 @@ fn simulate_and_update_compute_unit_limit(
         .instructions
         .iter()
         .enumerate()
-        .filter_map(|(ix_index, instruction)| {
+        .find_map(|(ix_index, instruction)| {
             let ix_program_id = transaction.message.program_id(ix_index)?;
             if ix_program_id != &compute_budget::id() {
                 return None;
             }
 
-            match try_from_slice_unchecked(&instruction.data).ok()? {
-                ComputeBudgetInstruction::SetComputeUnitLimit(_) => Some(ix_index),
-                _ => None,
-            }
+            matches!(
+                try_from_slice_unchecked(&instruction.data),
+                Ok(ComputeBudgetInstruction::SetComputeUnitLimit(_))
+            )
+            .then_some(ix_index)
         })
-        .next()
     else {
         return Ok(UpdateComputeUnitLimitResult::NoInstructionFound);
     };

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2226,11 +2226,11 @@ fn do_process_program_write_and_deploy(
     let blockhash = rpc_client.get_latest_blockhash()?;
 
     // Initialize buffer account or complete if already partially initialized
-    let (ixs, balance_needed) = if let Some(account) = rpc_client
+    let (ixs, balance_needed, buffer_program_data) = if let Some(mut account) = rpc_client
         .get_account_with_commitment(buffer_pubkey, config.commitment)?
         .value
     {
-        complete_partial_program_init(
+        let (ixs, balance_needed) = complete_partial_program_init(
             loader_id,
             &fee_payer_signer.pubkey(),
             buffer_pubkey,
@@ -2242,7 +2242,11 @@ fn do_process_program_write_and_deploy(
             },
             min_rent_exempt_program_data_balance,
             allow_excessive_balance,
-        )?
+        )?;
+        let buffer_program_data = account
+            .data
+            .split_off(UpgradeableLoaderState::size_of_buffer_metadata());
+        (ixs, balance_needed, buffer_program_data)
     } else if loader_id == &bpf_loader_upgradeable::id() {
         (
             bpf_loader_upgradeable::create_buffer(
@@ -2253,6 +2257,7 @@ fn do_process_program_write_and_deploy(
                 program_len,
             )?,
             min_rent_exempt_program_data_balance,
+            vec![0; program_len],
         )
     } else {
         (
@@ -2264,6 +2269,7 @@ fn do_process_program_write_and_deploy(
                 loader_id,
             )],
             min_rent_exempt_program_data_balance,
+            vec![0; program_len],
         )
     };
 
@@ -2303,7 +2309,10 @@ fn do_process_program_write_and_deploy(
     let mut write_messages = vec![];
     let chunk_size = calculate_max_chunk_size(&create_msg);
     for (chunk, i) in program_data.chunks(chunk_size).zip(0..) {
-        write_messages.push(create_msg((i * chunk_size) as u32, chunk.to_vec()));
+        let offset = i * chunk_size;
+        if chunk != &buffer_program_data[offset..offset + chunk.len()] {
+            write_messages.push(create_msg(offset as u32, chunk.to_vec()));
+        }
     }
 
     // Create and add final message
@@ -2395,11 +2404,11 @@ fn do_process_program_upgrade(
         buffer_signer
     {
         // Check Buffer account to see if partial initialization has occurred
-        let (ixs, balance_needed) = if let Some(account) = rpc_client
+        let (ixs, balance_needed, buffer_program_data) = if let Some(mut account) = rpc_client
             .get_account_with_commitment(&buffer_signer.pubkey(), config.commitment)?
             .value
         {
-            complete_partial_program_init(
+            let (ixs, balance_needed) = complete_partial_program_init(
                 &bpf_loader_upgradeable::id(),
                 &fee_payer_signer.pubkey(),
                 &buffer_signer.pubkey(),
@@ -2407,7 +2416,11 @@ fn do_process_program_upgrade(
                 UpgradeableLoaderState::size_of_buffer(program_len),
                 min_rent_exempt_program_data_balance,
                 true,
-            )?
+            )?;
+            let buffer_program_data = account
+                .data
+                .split_off(UpgradeableLoaderState::size_of_buffer_metadata());
+            (ixs, balance_needed, buffer_program_data)
         } else {
             (
                 bpf_loader_upgradeable::create_buffer(
@@ -2418,7 +2431,18 @@ fn do_process_program_upgrade(
                     program_len,
                 )?,
                 min_rent_exempt_program_data_balance,
+                vec![0; program_len],
             )
+        };
+
+        let initial_message = if !ixs.is_empty() {
+            Some(Message::new_with_blockhash(
+                &ixs,
+                Some(&fee_payer_signer.pubkey()),
+                &blockhash,
+            ))
+        } else {
+            None
         };
         let mut initial_instructions: Vec<Instruction> = Vec::new();
 
@@ -2455,7 +2479,10 @@ fn do_process_program_upgrade(
         let mut write_messages = vec![];
         let chunk_size = calculate_max_chunk_size(&create_msg);
         for (chunk, i) in program_data.chunks(chunk_size).zip(0..) {
-            write_messages.push(create_msg((i * chunk_size) as u32, chunk.to_vec()));
+            let offset = i * chunk_size;
+            if chunk != &buffer_program_data[offset..offset + chunk.len()] {
+                write_messages.push(create_msg(offset as u32, chunk.to_vec()));
+            }
         }
 
         (initial_message, write_messages, balance_needed)

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -13,6 +13,7 @@ use {
     solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
     solana_clap_utils::{
         self,
+        compute_unit_price::compute_unit_price_arg,
         fee_payer::{fee_payer_arg, FEE_PAYER_ARG},
         hidden_unless_forced,
         input_parsers::*,
@@ -48,6 +49,7 @@ use {
         account_utils::StateMut,
         bpf_loader, bpf_loader_deprecated,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
+        compute_budget::ComputeBudgetInstruction,
         feature_set::FeatureSet,
         instruction::{Instruction, InstructionError},
         loader_instruction,
@@ -90,6 +92,7 @@ pub enum ProgramCliCommand {
         max_len: Option<usize>,
         allow_excessive_balance: bool,
         skip_fee_check: bool,
+        compute_unit_price: Option<u64>,
     },
     Upgrade {
         fee_payer_signer_index: SignerIndex,
@@ -108,6 +111,7 @@ pub enum ProgramCliCommand {
         buffer_authority_signer_index: SignerIndex,
         max_len: Option<usize>,
         skip_fee_check: bool,
+        compute_unit_price: Option<u64>,
     },
     SetBufferAuthority {
         buffer_pubkey: Pubkey,
@@ -236,7 +240,8 @@ impl ProgramSubCommands for App<'_, '_> {
                                     "Use the designated program id even if the account already \
                                      holds a large balance of SOL",
                                 ),
-                        ),
+                        )
+                        .arg(compute_unit_price_arg()),
                 )
                 .subcommand(
                     SubCommand::with_name("upgrade")
@@ -308,7 +313,8 @@ impl ProgramSubCommands for App<'_, '_> {
                                     "Maximum length of the upgradeable program \
                                     [default: the length of the original deployed program]",
                                 ),
-                        ),
+                        )
+                        .arg(compute_unit_price_arg()),
                 )
                 .subcommand(
                     SubCommand::with_name("set-buffer-authority")
@@ -601,6 +607,8 @@ pub fn parse_program_subcommand(
             let signer_info =
                 default_signer.generate_unique_signers(bulk_signers, matches, wallet_manager)?;
 
+            let compute_unit_price = value_of(matches, "compute_unit_price");
+
             CliCommandInfo {
                 command: CliCommand::Program(ProgramCliCommand::Deploy {
                     program_location,
@@ -616,6 +624,7 @@ pub fn parse_program_subcommand(
                     max_len,
                     allow_excessive_balance: matches.is_present("allow_excessive_balance"),
                     skip_fee_check,
+                    compute_unit_price,
                 }),
                 signers: signer_info.signers,
             }
@@ -687,6 +696,8 @@ pub fn parse_program_subcommand(
             let signer_info =
                 default_signer.generate_unique_signers(bulk_signers, matches, wallet_manager)?;
 
+            let compute_unit_price = value_of(matches, "compute_unit_price");
+
             CliCommandInfo {
                 command: CliCommand::Program(ProgramCliCommand::WriteBuffer {
                     program_location: matches.value_of("program_location").unwrap().to_string(),
@@ -698,6 +709,7 @@ pub fn parse_program_subcommand(
                         .unwrap(),
                     max_len,
                     skip_fee_check,
+                    compute_unit_price,
                 }),
                 signers: signer_info.signers,
             }
@@ -899,6 +911,7 @@ pub fn process_program_subcommand(
             max_len,
             allow_excessive_balance,
             skip_fee_check,
+            compute_unit_price,
         } => process_program_deploy(
             rpc_client,
             config,
@@ -913,6 +926,7 @@ pub fn process_program_subcommand(
             *max_len,
             *allow_excessive_balance,
             *skip_fee_check,
+            *compute_unit_price,
         ),
         ProgramCliCommand::Upgrade {
             fee_payer_signer_index,
@@ -941,6 +955,7 @@ pub fn process_program_subcommand(
             buffer_authority_signer_index,
             max_len,
             skip_fee_check,
+            compute_unit_price,
         } => process_write_buffer(
             rpc_client,
             config,
@@ -951,6 +966,7 @@ pub fn process_program_subcommand(
             *buffer_authority_signer_index,
             *max_len,
             *skip_fee_check,
+            *compute_unit_price,
         ),
         ProgramCliCommand::SetBufferAuthority {
             buffer_pubkey,
@@ -1082,6 +1098,7 @@ fn process_program_deploy(
     max_len: Option<usize>,
     allow_excessive_balance: bool,
     skip_fee_check: bool,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let fee_payer_signer = config.signers[fee_payer_signer_index];
     let upgrade_authority_signer = config.signers[upgrade_authority_signer_index];
@@ -1221,6 +1238,7 @@ fn process_program_deploy(
             upgrade_authority_signer,
             allow_excessive_balance,
             skip_fee_check,
+            compute_unit_price,
         )
     } else {
         do_process_program_upgrade(
@@ -1235,6 +1253,7 @@ fn process_program_deploy(
             &buffer_pubkey,
             buffer_signer,
             skip_fee_check,
+            compute_unit_price,
         )
     };
     if result.is_ok() && is_final {
@@ -1382,6 +1401,7 @@ fn process_write_buffer(
     buffer_authority_signer_index: SignerIndex,
     max_len: Option<usize>,
     skip_fee_check: bool,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let fee_payer_signer = config.signers[fee_payer_signer_index];
     let buffer_authority = config.signers[buffer_authority_signer_index];
@@ -1447,6 +1467,7 @@ fn process_write_buffer(
         buffer_authority,
         true,
         skip_fee_check,
+        compute_unit_price,
     );
     if result.is_err() && buffer_signer_index.is_none() && buffer_signer.is_some() {
         report_ephemeral_mnemonic(words, mnemonic);
@@ -2200,16 +2221,16 @@ fn do_process_program_write_and_deploy(
     buffer_authority_signer: &dyn Signer,
     allow_excessive_balance: bool,
     skip_fee_check: bool,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let blockhash = rpc_client.get_latest_blockhash()?;
 
     // Initialize buffer account or complete if already partially initialized
-    let (initial_instructions, balance_needed, buffer_program_data) = if let Some(mut account) =
-        rpc_client
-            .get_account_with_commitment(buffer_pubkey, config.commitment)?
-            .value
+    let (ixs, balance_needed) = if let Some(account) = rpc_client
+        .get_account_with_commitment(buffer_pubkey, config.commitment)?
+        .value
     {
-        let (ixs, balance_needed) = complete_partial_program_init(
+        complete_partial_program_init(
             loader_id,
             &fee_payer_signer.pubkey(),
             buffer_pubkey,
@@ -2221,11 +2242,7 @@ fn do_process_program_write_and_deploy(
             },
             min_rent_exempt_program_data_balance,
             allow_excessive_balance,
-        )?;
-        let buffer_program_data = account
-            .data
-            .split_off(UpgradeableLoaderState::size_of_buffer_metadata());
-        (ixs, balance_needed, buffer_program_data)
+        )?
     } else if loader_id == &bpf_loader_upgradeable::id() {
         (
             bpf_loader_upgradeable::create_buffer(
@@ -2236,7 +2253,6 @@ fn do_process_program_write_and_deploy(
                 program_len,
             )?,
             min_rent_exempt_program_data_balance,
-            vec![0; program_len],
         )
     } else {
         (
@@ -2248,9 +2264,13 @@ fn do_process_program_write_and_deploy(
                 loader_id,
             )],
             min_rent_exempt_program_data_balance,
-            vec![0; program_len],
         )
     };
+
+    let mut initial_instructions: Vec<Instruction> = Vec::new();
+
+    set_compute_budget_ixs_if_needed(&mut initial_instructions, &compute_unit_price);
+    initial_instructions.extend(ixs);
     let initial_message = if !initial_instructions.is_empty() {
         Some(Message::new_with_blockhash(
             &initial_instructions,
@@ -2263,7 +2283,8 @@ fn do_process_program_write_and_deploy(
 
     // Create and add write messages
     let create_msg = |offset: u32, bytes: Vec<u8>| {
-        let instruction = if loader_id == &bpf_loader_upgradeable::id() {
+        let mut write_ixs: Vec<Instruction> = Vec::new();
+        let ix_to_add = if loader_id == &bpf_loader_upgradeable::id() {
             bpf_loader_upgradeable::write(
                 buffer_pubkey,
                 &buffer_authority_signer.pubkey(),
@@ -2273,41 +2294,42 @@ fn do_process_program_write_and_deploy(
         } else {
             loader_instruction::write(buffer_pubkey, loader_id, offset, bytes)
         };
-        Message::new_with_blockhash(&[instruction], Some(&fee_payer_signer.pubkey()), &blockhash)
+
+        set_compute_budget_ixs_if_needed(&mut write_ixs, &compute_unit_price);
+        write_ixs.push(ix_to_add);
+        Message::new_with_blockhash(&write_ixs, Some(&fee_payer_signer.pubkey()), &blockhash)
     };
 
     let mut write_messages = vec![];
     let chunk_size = calculate_max_chunk_size(&create_msg);
     for (chunk, i) in program_data.chunks(chunk_size).zip(0..) {
-        let offset = i * chunk_size;
-        if chunk != &buffer_program_data[offset..offset + chunk.len()] {
-            write_messages.push(create_msg(offset as u32, chunk.to_vec()));
-        }
+        write_messages.push(create_msg((i * chunk_size) as u32, chunk.to_vec()));
     }
 
     // Create and add final message
     let final_message = if let Some(program_signers) = program_signers {
+        let mut final_ixs: Vec<Instruction> = Vec::new();
+
         let message = if loader_id == &bpf_loader_upgradeable::id() {
-            Message::new_with_blockhash(
-                &bpf_loader_upgradeable::deploy_with_max_program_len(
-                    &fee_payer_signer.pubkey(),
-                    &program_signers[0].pubkey(),
-                    buffer_pubkey,
-                    &program_signers[1].pubkey(),
-                    rpc_client.get_minimum_balance_for_rent_exemption(
-                        UpgradeableLoaderState::size_of_program(),
-                    )?,
-                    program_data_max_len,
+            let ixs_to_add = bpf_loader_upgradeable::deploy_with_max_program_len(
+                &fee_payer_signer.pubkey(),
+                &program_signers[0].pubkey(),
+                buffer_pubkey,
+                &program_signers[1].pubkey(),
+                rpc_client.get_minimum_balance_for_rent_exemption(
+                    UpgradeableLoaderState::size_of_program(),
                 )?,
-                Some(&fee_payer_signer.pubkey()),
-                &blockhash,
-            )
+                program_data_max_len,
+            )?;
+
+            set_compute_budget_ixs_if_needed(&mut final_ixs, &compute_unit_price);
+            final_ixs.extend(ixs_to_add);
+            Message::new_with_blockhash(&final_ixs, Some(&fee_payer_signer.pubkey()), &blockhash)
         } else {
-            Message::new_with_blockhash(
-                &[loader_instruction::finalize(buffer_pubkey, loader_id)],
-                Some(&fee_payer_signer.pubkey()),
-                &blockhash,
-            )
+            set_compute_budget_ixs_if_needed(&mut final_ixs, &compute_unit_price);
+
+            final_ixs.push(loader_instruction::finalize(buffer_pubkey, loader_id));
+            Message::new_with_blockhash(&final_ixs, Some(&fee_payer_signer.pubkey()), &blockhash)
         };
         Some(message)
     } else {
@@ -2365,96 +2387,95 @@ fn do_process_program_upgrade(
     buffer_pubkey: &Pubkey,
     buffer_signer: Option<&dyn Signer>,
     skip_fee_check: bool,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let blockhash = rpc_client.get_latest_blockhash()?;
 
-    let (initial_message, write_messages, balance_needed) =
-        if let Some(buffer_signer) = buffer_signer {
-            // Check Buffer account to see if partial initialization has occurred
-            let (initial_instructions, balance_needed, buffer_program_data) =
-                if let Some(mut account) = rpc_client
-                    .get_account_with_commitment(&buffer_signer.pubkey(), config.commitment)?
-                    .value
-                {
-                    let (ixs, balance_needed) = complete_partial_program_init(
-                        &bpf_loader_upgradeable::id(),
-                        &fee_payer_signer.pubkey(),
-                        &buffer_signer.pubkey(),
-                        &account,
-                        UpgradeableLoaderState::size_of_buffer(program_len),
-                        min_rent_exempt_program_data_balance,
-                        true,
-                    )?;
-                    let buffer_program_data = account
-                        .data
-                        .split_off(UpgradeableLoaderState::size_of_buffer_metadata());
-                    (ixs, balance_needed, buffer_program_data)
-                } else {
-                    (
-                        bpf_loader_upgradeable::create_buffer(
-                            &fee_payer_signer.pubkey(),
-                            buffer_pubkey,
-                            &upgrade_authority.pubkey(),
-                            min_rent_exempt_program_data_balance,
-                            program_len,
-                        )?,
-                        min_rent_exempt_program_data_balance,
-                        vec![0; program_len],
-                    )
-                };
-
-            let initial_message = if !initial_instructions.is_empty() {
-                Some(Message::new_with_blockhash(
-                    &initial_instructions,
-                    Some(&fee_payer_signer.pubkey()),
-                    &blockhash,
-                ))
-            } else {
-                None
-            };
-
-            let buffer_signer_pubkey = buffer_signer.pubkey();
-            let upgrade_authority_pubkey = upgrade_authority.pubkey();
-            let create_msg = |offset: u32, bytes: Vec<u8>| {
-                let instruction = bpf_loader_upgradeable::write(
-                    &buffer_signer_pubkey,
-                    &upgrade_authority_pubkey,
-                    offset,
-                    bytes,
-                );
-                Message::new_with_blockhash(
-                    &[instruction],
-                    Some(&fee_payer_signer.pubkey()),
-                    &blockhash,
-                )
-            };
-
-            // Create and add write messages
-            let mut write_messages = vec![];
-            let chunk_size = calculate_max_chunk_size(&create_msg);
-            for (chunk, i) in program_data.chunks(chunk_size).zip(0..) {
-                let offset = i * chunk_size;
-                if chunk != &buffer_program_data[offset..offset + chunk.len()] {
-                    write_messages.push(create_msg(offset as u32, chunk.to_vec()));
-                }
-            }
-
-            (initial_message, write_messages, balance_needed)
+    let (initial_message, write_messages, balance_needed) = if let Some(buffer_signer) =
+        buffer_signer
+    {
+        // Check Buffer account to see if partial initialization has occurred
+        let (ixs, balance_needed) = if let Some(account) = rpc_client
+            .get_account_with_commitment(&buffer_signer.pubkey(), config.commitment)?
+            .value
+        {
+            complete_partial_program_init(
+                &bpf_loader_upgradeable::id(),
+                &fee_payer_signer.pubkey(),
+                &buffer_signer.pubkey(),
+                &account,
+                UpgradeableLoaderState::size_of_buffer(program_len),
+                min_rent_exempt_program_data_balance,
+                true,
+            )?
         } else {
-            (None, vec![], 0)
+            (
+                bpf_loader_upgradeable::create_buffer(
+                    &fee_payer_signer.pubkey(),
+                    buffer_pubkey,
+                    &upgrade_authority.pubkey(),
+                    min_rent_exempt_program_data_balance,
+                    program_len,
+                )?,
+                min_rent_exempt_program_data_balance,
+            )
+        };
+        let mut initial_instructions: Vec<Instruction> = Vec::new();
+
+        set_compute_budget_ixs_if_needed(&mut initial_instructions, &compute_unit_price);
+        initial_instructions.extend(ixs);
+        let initial_message = if !initial_instructions.is_empty() {
+            Some(Message::new_with_blockhash(
+                &initial_instructions,
+                Some(&fee_payer_signer.pubkey()),
+                &blockhash,
+            ))
+        } else {
+            None
         };
 
+        let buffer_signer_pubkey = buffer_signer.pubkey();
+        let upgrade_authority_pubkey = upgrade_authority.pubkey();
+        let create_msg = |offset: u32, bytes: Vec<u8>| {
+            let mut write_ixs: Vec<Instruction> = Vec::new();
+            let ix_to_add = bpf_loader_upgradeable::write(
+                &buffer_signer_pubkey,
+                &upgrade_authority_pubkey,
+                offset,
+                bytes,
+            );
+
+            set_compute_budget_ixs_if_needed(&mut write_ixs, &compute_unit_price);
+            write_ixs.push(ix_to_add);
+
+            Message::new_with_blockhash(&write_ixs, Some(&fee_payer_signer.pubkey()), &blockhash)
+        };
+
+        // Create and add write messages
+        let mut write_messages = vec![];
+        let chunk_size = calculate_max_chunk_size(&create_msg);
+        for (chunk, i) in program_data.chunks(chunk_size).zip(0..) {
+            write_messages.push(create_msg((i * chunk_size) as u32, chunk.to_vec()));
+        }
+
+        (initial_message, write_messages, balance_needed)
+    } else {
+        (None, vec![], 0)
+    };
+
     // Create and add final message
-    let final_message = Message::new_with_blockhash(
-        &[bpf_loader_upgradeable::upgrade(
-            program_id,
-            buffer_pubkey,
-            &upgrade_authority.pubkey(),
-            &fee_payer_signer.pubkey(),
-        )],
-        Some(&fee_payer_signer.pubkey()),
-        &blockhash,
-    );
+    let mut final_ixs: Vec<Instruction> = Vec::new();
+
+    set_compute_budget_ixs_if_needed(&mut final_ixs, &compute_unit_price);
+
+    final_ixs.push(bpf_loader_upgradeable::upgrade(
+        program_id,
+        buffer_pubkey,
+        &upgrade_authority.pubkey(),
+        &fee_payer_signer.pubkey(),
+    ));
+    let final_message =
+        Message::new_with_blockhash(&final_ixs, Some(&fee_payer_signer.pubkey()), &blockhash);
     let final_message = Some(final_message);
 
     if !skip_fee_check {
@@ -2650,6 +2671,7 @@ fn send_deploy_messages(
                 .send_and_confirm_messages_with_spinner(
                     write_messages,
                     &[fee_payer_signer, write_signer],
+
                 ),
                 ConnectionCache::Quic(cache) => {
                     let tpu_client_fut = solana_client::nonblocking::tpu_client::TpuClient::new_with_connection_cache(
@@ -2740,6 +2762,30 @@ fn report_ephemeral_mnemonic(words: usize, mnemonic: bip39::Mnemonic) {
     eprintln!("[BUFFER_ACCOUNT_ADDRESS] argument to `solana program close`.\n{divider}");
 }
 
+fn set_compute_budget_ixs_if_needed(ixs: &mut Vec<Instruction>, compute_unit_price: &Option<u64>) {
+    let mut compute_units_required_for_ixs: u32 = 0;
+    for ix in ixs.iter() {
+        if ix.program_id == bpf_loader_upgradeable::id() {
+            compute_units_required_for_ixs += 2370u32;
+        } else if ix.program_id == system_program::id() {
+            compute_units_required_for_ixs += 150u32;
+        } else {
+            compute_units_required_for_ixs += 2000u32;
+        }
+    }
+
+    let compute_units_for_compute_budget_ixs = 300u32;
+
+    if let Some(compute_unit_price) = compute_unit_price {
+        ixs.push(ComputeBudgetInstruction::set_compute_unit_limit(
+            compute_units_required_for_ixs + compute_units_for_compute_budget_ixs,
+        ));
+        ixs.push(ComputeBudgetInstruction::set_compute_unit_price(
+            *compute_unit_price,
+        ));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
@@ -2798,6 +2844,7 @@ mod tests {
                     max_len: None,
                     allow_excessive_balance: false,
                     skip_fee_check: false,
+                    compute_unit_price: None
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
@@ -2826,6 +2873,7 @@ mod tests {
                     max_len: Some(42),
                     allow_excessive_balance: false,
                     skip_fee_check: false,
+                    compute_unit_price: None
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
@@ -2856,6 +2904,7 @@ mod tests {
                     max_len: None,
                     allow_excessive_balance: false,
                     skip_fee_check: false,
+                    compute_unit_price: None
                 }),
                 signers: vec![
                     Box::new(read_keypair_file(&keypair_file).unwrap()),
@@ -2888,6 +2937,7 @@ mod tests {
                     max_len: None,
                     allow_excessive_balance: false,
                     skip_fee_check: false,
+                    compute_unit_price: None
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
@@ -2919,6 +2969,7 @@ mod tests {
                     max_len: None,
                     allow_excessive_balance: false,
                     skip_fee_check: false,
+                    compute_unit_price: None
                 }),
                 signers: vec![
                     Box::new(read_keypair_file(&keypair_file).unwrap()),
@@ -2953,6 +3004,7 @@ mod tests {
                     max_len: None,
                     allow_excessive_balance: false,
                     skip_fee_check: false,
+                    compute_unit_price: None
                 }),
                 signers: vec![
                     Box::new(read_keypair_file(&keypair_file).unwrap()),
@@ -2983,6 +3035,7 @@ mod tests {
                     max_len: None,
                     skip_fee_check: false,
                     allow_excessive_balance: false,
+                    compute_unit_price: None
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
@@ -3017,6 +3070,7 @@ mod tests {
                     buffer_authority_signer_index: 0,
                     max_len: None,
                     skip_fee_check: false,
+                    compute_unit_price: None
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
@@ -3042,6 +3096,7 @@ mod tests {
                     buffer_authority_signer_index: 0,
                     max_len: Some(42),
                     skip_fee_check: false,
+                    compute_unit_price: None
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
@@ -3070,6 +3125,7 @@ mod tests {
                     buffer_authority_signer_index: 0,
                     max_len: None,
                     skip_fee_check: false,
+                    compute_unit_price: None
                 }),
                 signers: vec![
                     Box::new(read_keypair_file(&keypair_file).unwrap()),
@@ -3101,6 +3157,7 @@ mod tests {
                     buffer_authority_signer_index: 1,
                     max_len: None,
                     skip_fee_check: false,
+                    compute_unit_price: None
                 }),
                 signers: vec![
                     Box::new(read_keypair_file(&keypair_file).unwrap()),
@@ -3137,6 +3194,7 @@ mod tests {
                     buffer_authority_signer_index: 2,
                     max_len: None,
                     skip_fee_check: false,
+                    compute_unit_price: None
                 }),
                 signers: vec![
                     Box::new(read_keypair_file(&keypair_file).unwrap()),
@@ -3695,6 +3753,7 @@ mod tests {
                 max_len: None,
                 allow_excessive_balance: false,
                 skip_fee_check: false,
+                compute_unit_price: None,
             }),
             signers: vec![&default_keypair],
             output_format: OutputFormat::JsonCompact,

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2435,15 +2435,6 @@ fn do_process_program_upgrade(
             )
         };
 
-        let initial_message = if !ixs.is_empty() {
-            Some(Message::new_with_blockhash(
-                &ixs,
-                Some(&fee_payer_signer.pubkey()),
-                &blockhash,
-            ))
-        } else {
-            None
-        };
         let mut initial_instructions: Vec<Instruction> = Vec::new();
 
         set_compute_budget_ixs_if_needed(&mut initial_instructions, &compute_unit_price);

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -19,6 +19,7 @@ use {
         commitment_config::CommitmentConfig,
         pubkey::Pubkey,
         signature::{Keypair, NullSigner, Signer},
+        signer::EncodableKey,
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_test_validator::TestValidator,
@@ -28,6 +29,7 @@ use {
         io::Read,
         path::{Path, PathBuf},
         str::FromStr,
+        time::Instant,
     },
     test_case::test_case,
 };
@@ -85,6 +87,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -131,6 +134,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
     let account1 = rpc_client
@@ -186,6 +190,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     let err = process_command(&config).unwrap_err();
     assert_eq!(
@@ -209,6 +214,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
 }
@@ -270,6 +276,7 @@ fn test_cli_program_deploy_no_authority() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -297,6 +304,7 @@ fn test_cli_program_deploy_no_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
 }
@@ -359,6 +367,7 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -408,6 +417,7 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -451,6 +461,7 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -526,6 +537,7 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -605,6 +617,7 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
 
@@ -622,6 +635,7 @@ fn test_cli_program_deploy_with_authority() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -726,6 +740,7 @@ fn test_cli_program_close_program() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -836,6 +851,7 @@ fn test_cli_program_extend_program() {
         is_final: false,
         max_len: None, // Use None to check that it defaults to the max length
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -883,6 +899,7 @@ fn test_cli_program_extend_program() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
 
@@ -915,6 +932,7 @@ fn test_cli_program_extend_program() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
 }
@@ -979,6 +997,8 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
+
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -1015,6 +1035,8 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: Some(max_len),
         skip_fee_check: false,
+
+        compute_unit_price: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1078,6 +1100,8 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
+
+        compute_unit_price: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1117,6 +1141,8 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
+
+        compute_unit_price: None,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1192,6 +1218,8 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
+
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -1234,6 +1262,8 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: None, //Some(max_len),
         skip_fee_check: false,
+
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
     config.signers = vec![&keypair, &buffer_keypair];
@@ -1249,6 +1279,7 @@ fn test_cli_program_write_buffer() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let error = process_command(&config).unwrap_err();
@@ -1308,6 +1339,8 @@ fn test_cli_program_set_buffer_authority() {
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
+
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
@@ -1360,6 +1393,7 @@ fn test_cli_program_set_buffer_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap_err();
@@ -1405,6 +1439,7 @@ fn test_cli_program_set_buffer_authority() {
         is_final: false,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1461,6 +1496,8 @@ fn test_cli_program_mismatch_buffer_authority() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
+
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
@@ -1485,6 +1522,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap_err();
 
@@ -1502,6 +1540,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         is_final: true,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
 }
@@ -1585,6 +1624,7 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
         is_final: false,
         max_len: Some(max_program_data_len), // allows for larger program size with future upgrades
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1752,6 +1792,8 @@ fn test_cli_program_show() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
+
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
 
@@ -1813,6 +1855,7 @@ fn test_cli_program_show() {
         is_final: false,
         max_len: Some(max_len),
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
     let min_slot = rpc_client.get_slot().unwrap();
@@ -1941,6 +1984,8 @@ fn test_cli_program_dump() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
+
+        compute_unit_price: None,
     });
     process_command(&config).unwrap();
 
@@ -1984,6 +2029,7 @@ fn create_buffer_with_offline_authority<'a>(
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
+        compute_unit_price: None,
     });
     process_command(config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_signer.pubkey()).unwrap();
@@ -2008,4 +2054,70 @@ fn create_buffer_with_offline_authority<'a>(
     } else {
         panic!("not a buffer account");
     }
+}
+
+fn program_deploy_with_args(compute_unit_price: Option<u64>) {
+    solana_logger::setup();
+
+    let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    noop_path.push("tests");
+    noop_path.push("fixtures");
+    noop_path.push("noop");
+    noop_path.set_extension("so");
+
+    let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
+    let mut program_data = Vec::new();
+    file.read_to_end(&mut program_data).unwrap();
+
+    let mut config = CliConfig::recent_for_tests();
+    let keypair = Keypair::read_from_file(&config.keypair_path).unwrap();
+
+    let upgrade_authority = Keypair::new();
+
+    config.json_rpc_url = "https://api.devnet.solana.com".to_string();
+
+    config.signers = vec![&keypair];
+
+    // Deploy a program
+    config.signers = vec![&keypair, &upgrade_authority];
+    config.command = CliCommand::Program(ProgramCliCommand::Deploy {
+        program_location: Some(noop_path.to_str().unwrap().to_string()),
+        fee_payer_signer_index: 0,
+        program_signer_index: None,
+        program_pubkey: None,
+        buffer_signer_index: None,
+        buffer_pubkey: None,
+        allow_excessive_balance: false,
+        upgrade_authority_signer_index: 1,
+        is_final: true,
+        max_len: None,
+        skip_fee_check: false,
+        compute_unit_price,
+    });
+    config.output_format = OutputFormat::JsonCompact;
+    let start = Instant::now();
+    let response = process_command(&config);
+    let duration = start.elapsed();
+    println!("Time elapsed: {:?}", duration);
+    let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
+    let program_pubkey_str = json
+        .as_object()
+        .unwrap()
+        .get("programId")
+        .unwrap()
+        .as_str()
+        .unwrap();
+    println!(
+        "Program deployed successfully with id: {}",
+        program_pubkey_str
+    );
+}
+
+#[test]
+fn test_cli_program_deploy_with_compute_unit_price() {
+    //test without compute_unit_price
+    program_deploy_with_args(None);
+
+    //test with 1000 micro lamports as compute_unit_price
+    program_deploy_with_args(Some(1000));
 }

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1006,7 +1006,6 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
-
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1044,7 +1043,6 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: Some(max_len),
         skip_fee_check: false,
-
         compute_unit_price: None,
     });
     let response = process_command(&config);
@@ -1109,7 +1107,6 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
-
         compute_unit_price: None,
     });
     let response = process_command(&config);
@@ -1150,7 +1147,6 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
-
         compute_unit_price: None,
     });
     let response = process_command(&config);
@@ -1227,7 +1223,6 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
-
         compute_unit_price: None,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1271,7 +1266,6 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: 0,
         max_len: None, //Some(max_len),
         skip_fee_check: false,
-
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -1348,7 +1342,6 @@ fn test_cli_program_set_buffer_authority() {
         buffer_authority_signer_index: 0,
         max_len: None,
         skip_fee_check: false,
-
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -1505,7 +1498,6 @@ fn test_cli_program_mismatch_buffer_authority() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
-
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -1801,7 +1793,6 @@ fn test_cli_program_show() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
-
         compute_unit_price: None,
     });
     process_command(&config).unwrap();
@@ -1993,7 +1984,6 @@ fn test_cli_program_dump() {
         buffer_authority_signer_index: 2,
         max_len: None,
         skip_fee_check: false,
-
         compute_unit_price: None,
     });
     process_command(&config).unwrap();

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::items_after_test_module)]
 
 use {
+    assert_matches::assert_matches,
     serde_json::Value,
     solana_cli::{
         cli::{process_command, CliCommand, CliConfig},
@@ -2191,25 +2192,24 @@ fn cli_program_deploy_with_args(compute_unit_price: Option<u64>) {
                 );
             }
 
-            match try_from_slice_unchecked(&tx.message.instructions[0].data) {
-                Ok(ComputeBudgetInstruction::SetComputeUnitPrice(price))
-                    if price == compute_unit_price => {}
-                ix => assert!(false, "unexpected ix {ix:?}"),
-            }
+            assert_matches!(
+                try_from_slice_unchecked(&tx.message.instructions[0].data),
+                Ok(ComputeBudgetInstruction::SetComputeUnitPrice(price)) if price == compute_unit_price
+            );
         }
 
-        match try_from_slice_unchecked(&initial_tx.message.instructions[1].data) {
-            Ok(ComputeBudgetInstruction::SetComputeUnitLimit(2820)) => {}
-            ix => assert!(false, "unexpected ix {ix:?}"),
-        }
-        match try_from_slice_unchecked(&write_tx.message.instructions[1].data) {
-            Ok(ComputeBudgetInstruction::SetComputeUnitLimit(2670)) => {}
-            ix => assert!(false, "unexpected ix {ix:?}"),
-        }
-        match try_from_slice_unchecked(&final_tx.message.instructions[1].data) {
-            Ok(ComputeBudgetInstruction::SetComputeUnitLimit(2970)) => {}
-            ix => assert!(false, "unexpected ix {ix:?}"),
-        }
+        assert_matches!(
+            try_from_slice_unchecked(&initial_tx.message.instructions[1].data),
+            Ok(ComputeBudgetInstruction::SetComputeUnitLimit(2820))
+        );
+        assert_matches!(
+            try_from_slice_unchecked(&write_tx.message.instructions[1].data),
+            Ok(ComputeBudgetInstruction::SetComputeUnitLimit(2670))
+        );
+        assert_matches!(
+            try_from_slice_unchecked(&final_tx.message.instructions[1].data),
+            Ok(ComputeBudgetInstruction::SetComputeUnitLimit(2970))
+        );
     } else {
         assert_eq!(
             initial_tx.message.instructions[0].program_id(&initial_tx.message.account_keys),

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -247,7 +247,7 @@ fn run_transactions_dos(
             upgrade_authority_signer_index: 0,
             is_final: true,
             max_len: None,
-            compute_unit_price,
+            compute_unit_price: None,
             skip_fee_check: true, // skip_fee_check
         });
 

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -247,6 +247,7 @@ fn run_transactions_dos(
             upgrade_authority_signer_index: 0,
             is_final: true,
             max_len: None,
+            compute_unit_price,
             skip_fee_check: true, // skip_fee_check
         });
 


### PR DESCRIPTION
#### Problem
It's not possible to set a compute unit price or limit on deploy transactions. This causes deploys to be very slow when transaction priority fees increase on the cluster.

#### Summary of Changes
- Add compute unit price and limit instructions to deploy instructions when the `--with-compute-unit-price` flag is passed for `solana program deploy` and `solana program write-buffer`
- Compute unit limit is set by first simulating each type of deploy transaction and then using the number of compute units consumed

Fixes https://github.com/anza-xyz/agave/issues/21
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
