### PR TITLE
Uses AppendVecId in AccountsFIle::file_name()

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -3,6 +3,7 @@ use {
         account_storage::meta::{
             StorableAccountsWithHashesAndWriteVersions, StoredAccountInfo, StoredAccountMeta,
         },
+        accounts_db::AppendVecId,
         accounts_hash::AccountHash,
         append_vec::{AppendVec, AppendVecError},
         storable_accounts::StorableAccounts,
@@ -103,7 +104,7 @@ impl AccountsFile {
         }
     }
 
-    pub fn file_name(slot: Slot, id: impl std::fmt::Display) -> String {
+    pub fn file_name(slot: Slot, id: AppendVecId) -> String {
         format!("{slot}.{id}")
     }
 


### PR DESCRIPTION
#### Problem

Creating an `AccountsFile` file name takes in the ID as anything display-able. This is... strange... Since we know this should be an append vec id, we should use that type directly.


#### Summary of Changes

Use `AppendVecId` in `file_name()`.