### PR TITLE
CostTracker - wait for in-flight transactions before reporting

### DIFF
--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -39,6 +39,7 @@ impl CostUpdateService {
         for cost_update in cost_update_receiver.iter() {
             match cost_update {
                 CostUpdate::FrozenBank { bank } => {
+                    let _lock = bank.cost_tracker_report_write_lock(); // wait for in-flight transactions to finish
                     bank.read_cost_tracker().unwrap().report_stats(bank.slot());
                 }
             }


### PR DESCRIPTION
#### Problem
- #366
- cost-tracker-stats can be reported during the period when a batch of transactions has reserved requested CUs, but not yet updated tracker with actual costs

#### Summary of Changes
- Execution threads hold a read-lock during execution (reserve through update)
- Reporting thread grabs write-lock before reporting

Fixes #366
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
