### PR TITLE
Bugfix: Report scheduler slot timing metrics under correct name

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -290,7 +290,7 @@ impl SlotSchedulerTimingMetrics {
             // Only report if there was an assigned slot.
             if self.slot.is_some() {
                 self.metrics
-                    .report("banking_stage_scheduler_slot_counts", self.slot);
+                    .report("banking_stage_scheduler_slot_timing", self.slot);
             }
             self.metrics.reset();
             self.slot = slot;


### PR DESCRIPTION
#### Problem
- These timing metrics are reported under wrong name

#### Summary of Changes
- Report them under the correct name "banking_stage_scheduler_slot_timing"

Fixes #273
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
