### PR TITLE
[zk-token-sdk] Remove `std::thread` from wasm target

### DIFF
--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -168,11 +168,11 @@ impl DiscreteLog {
                 })
                 .collect::<Vec<_>>();
 
-        handles
-            .into_iter()
-            .map_while(|h| h.join().ok())
-            .find(|x| x.is_some())
-            .flatten()
+            handles
+                .into_iter()
+                .map_while(|h| h.join().ok())
+                .find(|x| x.is_some())
+                .flatten()
         }
         #[cfg(target_arch = "wasm32")]
         {

--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -16,6 +16,8 @@
 
 #![cfg(not(target_os = "solana"))]
 
+#[cfg(not(target_arch = "wasm32"))]
+use std::thread;
 use {
     crate::RISTRETTO_POINT_LEN,
     curve25519_dalek::{
@@ -26,7 +28,7 @@ use {
     },
     itertools::Itertools,
     serde::{Deserialize, Serialize},
-    std::{collections::HashMap, thread},
+    std::collections::HashMap,
     thiserror::Error,
 };
 

--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -36,6 +36,7 @@ const TWO16: u64 = 65536; // 2^16
 const TWO17: u64 = 131072; // 2^17
 
 /// Maximum number of threads permitted for discrete log computation
+#[cfg(not(target_arch = "wasm32"))]
 const MAX_THREAD: usize = 65536;
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
@@ -114,6 +115,7 @@ impl DiscreteLog {
     }
 
     /// Adjusts number of threads in a discrete log instance.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn num_threads(&mut self, num_threads: usize) -> Result<(), DiscreteLogError> {
         // number of threads must be a positive power-of-two integer
         if num_threads == 0 || (num_threads & (num_threads - 1)) != 0 || num_threads > MAX_THREAD {

--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -294,6 +294,7 @@ mod tests {
         println!("single thread discrete log computation secs: {computation_secs:?} sec");
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_decode_correctness_threaded() {
         // general case

--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -168,14 +168,11 @@ impl DiscreteLog {
                 })
                 .collect::<Vec<_>>();
 
-            let mut solution = None;
-            for handle in handles {
-                let discrete_log = handle.join().unwrap();
-                if discrete_log.is_some() {
-                    solution = discrete_log;
-                }
-            }
-            solution
+        handles
+            .into_iter()
+            .map_while(|h| h.join().ok())
+            .find(|x| x.is_some())
+            .flatten()
         }
         #[cfg(target_arch = "wasm32")]
         {

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -791,6 +791,7 @@ mod tests {
         assert_eq!(57_u64, secret.decrypt_u32(&ciphertext).unwrap());
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_encrypt_decrypt_correctness_multithreaded() {
         let ElGamalKeypair { public, secret } = ElGamalKeypair::new_rand();


### PR DESCRIPTION
#### Problem
ElGamal decryption algorithm is an expensive though parallelizable operation. Currently, the ElGamal decryption uses `std::thread` to give the caller an option to invoke discrete log using multiple threads. However, `std::thread` is a blocker when compiling zk-token-sdk to certain targets. In particular, `std::thread` is not supported for wasm.

#### Summary of Changes
Use conditional compilation to remove dependency on `std::therad` when target is wasm.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
