### PR TITLE
feat: include replaced blockhash in RPC simulation response

### DIFF
--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -424,6 +424,7 @@ pub struct RpcSimulateTransactionResult {
     pub units_consumed: Option<u64>,
     pub return_data: Option<UiTransactionReturnData>,
     pub inner_instructions: Option<Vec<UiInnerInstructions>>,
+    pub blockhash: Option<RpcBlockhash>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -424,7 +424,7 @@ pub struct RpcSimulateTransactionResult {
     pub units_consumed: Option<u64>,
     pub return_data: Option<UiTransactionReturnData>,
     pub inner_instructions: Option<Vec<UiInnerInstructions>>,
-    pub blockhash: Option<RpcBlockhash>,
+    pub replacement_blockhash: Option<RpcBlockhash>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -351,6 +351,7 @@ impl RpcSender for MockSender {
                     units_consumed: None,
                     return_data: None,
                     inner_instructions: None,
+                    blockhash: None
                 },
             })?,
             "getMinimumBalanceForRentExemption" => json![20],

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -351,7 +351,7 @@ impl RpcSender for MockSender {
                     units_consumed: None,
                     return_data: None,
                     inner_instructions: None,
-                    blockhash: None
+                    replacement_blockhash: None
                 },
             })?,
             "getMinimumBalanceForRentExemption" => json![20],

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -6942,7 +6942,7 @@ pub mod tests {
         assert_eq!(
             res,
             Some(
-                r#"{"jsonrpc":"2.0","error":{"code":-32002,"message":"Transaction simulation failed: Blockhash not found","data":{"accounts":null,"err":"BlockhashNotFound","innerInstructions":null,"logs":[],"returnData":null,"unitsConsumed":0}},"id":1}"#.to_string(),
+                r#"{"jsonrpc":"2.0","error":{"code":-32002,"message":"Transaction simulation failed: Blockhash not found","data":{"accounts":null,"err":"BlockhashNotFound","innerInstructions":null,"logs":[],"replacementBlockhash":null,"returnData":null,"unitsConsumed":0}},"id":1}"#.to_string(),
             )
         );
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3723,7 +3723,7 @@ pub mod rpc_full {
                             units_consumed: Some(units_consumed),
                             return_data: return_data.map(|return_data| return_data.into()),
                             inner_instructions: None,
-                            blockhash: None,
+                            replacement_blockhash: None,
                         },
                     }
                     .into());
@@ -3867,7 +3867,7 @@ pub mod rpc_full {
                     units_consumed: Some(units_consumed),
                     return_data: return_data.map(|return_data| return_data.into()),
                     inner_instructions,
-                    blockhash,
+                    replacement_blockhash: blockhash,
                 },
             ))
         }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -6020,6 +6020,7 @@ pub mod tests {
                         "Program 11111111111111111111111111111111 invoke [1]",
                         "Program 11111111111111111111111111111111 success"
                     ],
+                    "replacementBlockhash": null,
                     "returnData":null,
                     "unitsConsumed":150,
                 }
@@ -6105,6 +6106,7 @@ pub mod tests {
                         "Program 11111111111111111111111111111111 invoke [1]",
                         "Program 11111111111111111111111111111111 success"
                     ],
+                    "replacementBlockhash": null,
                     "returnData":null,
                     "unitsConsumed":150,
                 }
@@ -6134,7 +6136,8 @@ pub mod tests {
                         "Program 11111111111111111111111111111111 invoke [1]",
                         "Program 11111111111111111111111111111111 success"
                     ],
-                    "returnData":null,
+                    "replacementBlockhash": null,
+                    "returnData": null,
                     "unitsConsumed":150,
                 }
             },
@@ -6184,7 +6187,8 @@ pub mod tests {
                     "accounts":null,
                     "innerInstructions":null,
                     "logs":[],
-                    "returnData":null,
+                    "replacementBlockhash": null,
+                    "returnData": null,
                     "unitsConsumed":0,
                 }
             },
@@ -6202,6 +6206,11 @@ pub mod tests {
             r#"{{"jsonrpc":"2.0","id":1,"method":"simulateTransaction","params":["{tx_invalid_recent_blockhash}", {{"replaceRecentBlockhash": true}}]}}"#,
         );
         let res = io.handle_request_sync(&req, meta.clone());
+        let latest_blockhash = bank.confirmed_last_blockhash();
+        let expiry_slot = bank
+            .get_blockhash_last_valid_block_height(&latest_blockhash)
+            .expect("blockhash exists");
+
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
@@ -6214,6 +6223,10 @@ pub mod tests {
                         "Program 11111111111111111111111111111111 invoke [1]",
                         "Program 11111111111111111111111111111111 success"
                     ],
+                    "replacementBlockhash": {
+                        "blockhash": latest_blockhash.to_string(),
+                        "lastValidBlockHeight": expiry_slot
+                    },
                     "returnData":null,
                     "unitsConsumed":150,
                 }
@@ -6358,6 +6371,7 @@ pub mod tests {
                         "Program 11111111111111111111111111111111 invoke [1]",
                         "Program 11111111111111111111111111111111 success"
                     ],
+                    "replacementBlockhash": null,
                     "returnData": null,
                     "unitsConsumed": 150,
                 }
@@ -6438,6 +6452,7 @@ pub mod tests {
                         "Program 11111111111111111111111111111111 success",
                         "Program AddressLookupTab1e1111111111111111111111111 success"
                     ],
+                    "replacementBlockhash": null,
                     "returnData":null,
                     "unitsConsumed":1200,
                 }
@@ -6481,6 +6496,7 @@ pub mod tests {
                         "Program 11111111111111111111111111111111 success",
                         "Program AddressLookupTab1e1111111111111111111111111 success"
                     ],
+                    "replacementBlockhash": null,
                     "returnData":null,
                     "unitsConsumed":1200,
                 }
@@ -6567,6 +6583,7 @@ pub mod tests {
                         "Program 11111111111111111111111111111111 success",
                         "Program AddressLookupTab1e1111111111111111111111111 success"
                     ],
+                    "replacementBlockhash": null,
                     "returnData":null,
                     "unitsConsumed":1200,
                 }


### PR DESCRIPTION
#### Problem
Oftentimes, after simulating a transaction, clients must then fetch a new latest blockhash to apply before sending the transaction. This extra fetch could be avoided if the simulate transaction endpoint returned the latest blockhash that was used when the config param `replace_recent_blockhash` is set to true.

#### Summary of Changes
Add a new field (`replacement_blockhash`) to the simulate transaction rpc endpoint that returns the replacement blockhash that was applied during simulation

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
