### PR TITLE
[TieredStorage] Use mmap.len() in TieredStorage::file_size() for HotStorage

### DIFF
--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -27,7 +27,7 @@ use {
     solana_sdk::account::ReadableAccount,
     std::{
         borrow::Borrow,
-        fs::{self, OpenOptions},
+        fs,
         path::{Path, PathBuf},
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -156,12 +156,7 @@ impl TieredStorage {
 
     /// Returns the size of the underlying accounts file.
     pub fn file_size(&self) -> TieredStorageResult<u64> {
-        let file = OpenOptions::new().read(true).open(&self.path);
-
-        Ok(file
-            .and_then(|file| file.metadata())
-            .map(|metadata| metadata.len())
-            .unwrap_or(0))
+        Ok(self.reader().map_or(0, |reader| reader.len()))
     }
 }
 

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -30,6 +30,20 @@ impl TieredStorageReader {
         }
     }
 
+    /// Returns the size of the underlying storage.
+    pub fn len(&self) -> u64 {
+        match self {
+            Self::Hot(hot) => hot.len(),
+        }
+    }
+
+    /// Returns whether the nderlying storage is empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Hot(hot) => hot.is_empty(),
+        }
+    }
+
     /// Returns the footer of the associated HotAccountsFile.
     pub fn footer(&self) -> &TieredStorageFooter {
         match self {


### PR DESCRIPTION
#### Problem
The current implementation of TieredStorage::file_size() requires
a sys-call to provide the file size.

#### Summary of Changes
Add len() API to TieredStorageReader, and have HotStorageReader()
implement the API using Mmap::len().

#### Test Plan
Update existing unit-test to also verify HotStorageReader::len().