### PR TITLE
Rename AppendVecId to AccountsFileId

### DIFF
--- a/accounts-db/src/account_info.rs
+++ b/accounts-db/src/account_info.rs
@@ -4,7 +4,7 @@
 //! Note that AccountInfo is saved to disk buckets during runtime, but disk buckets are recreated at startup.
 use {
     crate::{
-        accounts_db::AppendVecId,
+        accounts_db::AccountsFileId,
         accounts_file::ALIGN_BOUNDARY_OFFSET,
         accounts_index::{IsCached, ZeroLamport},
     },
@@ -21,7 +21,7 @@ pub type StoredSize = u32;
 /// specify where account data is located
 #[derive(Debug, PartialEq, Eq)]
 pub enum StorageLocation {
-    AppendVec(AppendVecId, Offset),
+    AppendVec(AccountsFileId, Offset),
     Cached,
 }
 
@@ -85,7 +85,7 @@ pub struct PackedOffsetAndFlags {
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct AccountInfo {
     /// index identifying the append storage
-    store_id: AppendVecId,
+    store_id: AccountsFileId,
 
     account_offset_and_flags: AccountOffsetAndFlags,
 }
@@ -121,7 +121,7 @@ impl IsCached for StorageLocation {
 }
 
 /// We have to have SOME value for store_id when we are cached
-const CACHE_VIRTUAL_STORAGE_ID: AppendVecId = AppendVecId::MAX;
+const CACHE_VIRTUAL_STORAGE_ID: AccountsFileId = AccountsFileId::MAX;
 
 impl AccountInfo {
     pub fn new(storage_location: StorageLocation, lamports: u64) -> Self {
@@ -160,7 +160,7 @@ impl AccountInfo {
         (offset / ALIGN_BOUNDARY_OFFSET) as OffsetReduced
     }
 
-    pub fn store_id(&self) -> AppendVecId {
+    pub fn store_id(&self) -> AccountsFileId {
         // if the account is in a cached store, the store_id is meaningless
         assert!(!self.is_cached());
         self.store_id

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -1,7 +1,7 @@
 //! Manage the map of slot -> append vec
 
 use {
-    crate::accounts_db::{AccountStorageEntry, AppendVecId},
+    crate::accounts_db::{AccountStorageEntry, AccountsFileId},
     dashmap::DashMap,
     solana_sdk::clock::Slot,
     std::sync::Arc,
@@ -15,7 +15,7 @@ pub struct AccountStorageReference {
     pub storage: Arc<AccountStorageEntry>,
     /// id can be read from 'storage', but it is an atomic read.
     /// id will never change while a storage is held, so we store it separately here for faster runtime lookup in 'get_account_storage_entry'
-    pub id: AppendVecId,
+    pub id: AccountsFileId,
 }
 
 pub type AccountStorageMap = DashMap<Slot, AccountStorageReference>;
@@ -50,7 +50,7 @@ impl AccountStorage {
     pub(crate) fn get_account_storage_entry(
         &self,
         slot: Slot,
-        store_id: AppendVecId,
+        store_id: AccountsFileId,
     ) -> Option<Arc<AccountStorageEntry>> {
         let lookup_in_map = || {
             self.map
@@ -343,7 +343,7 @@ pub(crate) mod tests {
     }
 
     impl AccountStorage {
-        fn get_test_storage_with_id(&self, id: AppendVecId) -> Arc<AccountStorageEntry> {
+        fn get_test_storage_with_id(&self, id: AccountsFileId) -> Arc<AccountStorageEntry> {
             let slot = 0;
             // add a map store
             let common_store_path = Path::new("");

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -3,7 +3,7 @@ use {
         account_storage::meta::{
             StorableAccountsWithHashesAndWriteVersions, StoredAccountInfo, StoredAccountMeta,
         },
-        accounts_db::AppendVecId,
+        accounts_db::AccountsFileId,
         accounts_hash::AccountHash,
         append_vec::{AppendVec, AppendVecError},
         storable_accounts::StorableAccounts,
@@ -104,7 +104,7 @@ impl AccountsFile {
         }
     }
 
-    pub fn file_name(slot: Slot, id: AppendVecId) -> String {
+    pub fn file_name(slot: Slot, id: AccountsFileId) -> String {
         format!("{slot}.{id}")
     }
 

--- a/accounts-db/src/sorted_storages.rs
+++ b/accounts-db/src/sorted_storages.rs
@@ -195,7 +195,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            accounts_db::{AccountStorageEntry, AppendVecId},
+            accounts_db::{AccountStorageEntry, AccountsFileId},
             accounts_file::AccountsFile,
             append_vec::AppendVec,
         },
@@ -297,7 +297,7 @@ mod tests {
             assert!(
                 (slot != 2 && slot != 4)
                     ^ storage
-                        .map(|storage| storage.append_vec_id() == (slot as AppendVecId))
+                        .map(|storage| storage.append_vec_id() == (slot as AccountsFileId))
                         .unwrap_or(false),
                 "slot: {slot}, storage: {storage:?}"
             );
@@ -440,7 +440,7 @@ mod tests {
         );
     }
 
-    fn create_sample_store(id: AppendVecId) -> Arc<AccountStorageEntry> {
+    fn create_sample_store(id: AccountsFileId) -> Arc<AccountStorageEntry> {
         let tf = crate::append_vec::test_utils::get_append_vec_path("create_sample_store");
         let (_temp_dirs, paths) = crate::accounts_db::get_temp_accounts_paths(1).unwrap();
         let size: usize = 123;

--- a/docs/src/implemented-proposals/persistent-account-storage.md
+++ b/docs/src/implemented-proposals/persistent-account-storage.md
@@ -19,11 +19,11 @@ The underlying memory for an AppendVec is a memory-mapped file. Memory-mapped fi
 The account index is designed to support a single index for all the currently forked Accounts.
 
 ```text
-type AppendVecId = usize;
+type AccountsFileId = usize;
 
 type Fork = u64;
 
-struct AccountMap(Hashmap<Fork, (AppendVecId, u64)>);
+struct AccountMap(Hashmap<Fork, (AccountsFileId, u64)>);
 
 type AccountIndex = HashMap<Pubkey, AccountMap>;
 ```
@@ -39,7 +39,7 @@ The index is a map of account Pubkeys to a map of Forks and the location of the 
 pub fn load_slow(&self, id: Fork, pubkey: &Pubkey) -> Option<&Account>
 ```
 
-The read is satisfied by pointing to a memory-mapped location in the `AppendVecId` at the stored offset. A reference can be returned without a copy.
+The read is satisfied by pointing to a memory-mapped location in the `AccountsFileId` at the stored offset. A reference can be returned without a copy.
 
 ### Root Forks
 

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -14,7 +14,7 @@ mod tests {
             snapshot_bank_utils,
             snapshot_utils::{
                 self, create_tmp_accounts_dir_for_tests, get_storages_to_serialize, ArchiveFormat,
-                StorageAndNextAppendVecId, BANK_SNAPSHOT_PRE_FILENAME_EXTENSION,
+                StorageAndNextAccountsFileId, BANK_SNAPSHOT_PRE_FILENAME_EXTENSION,
             },
             status_cache::StatusCache,
         },
@@ -23,7 +23,7 @@ mod tests {
             account_storage::{AccountStorageMap, AccountStorageReference},
             accounts_db::{
                 get_temp_accounts_paths, AccountShrinkThreshold, AccountStorageEntry, AccountsDb,
-                AtomicAppendVecId,
+                AtomicAccountsFileId,
             },
             accounts_file::{AccountsFile, AccountsFileError},
             accounts_hash::{AccountsDeltaHash, AccountsHash},
@@ -53,7 +53,7 @@ mod tests {
     fn copy_append_vecs<P: AsRef<Path>>(
         accounts_db: &AccountsDb,
         output_dir: P,
-    ) -> Result<StorageAndNextAppendVecId, AccountsFileError> {
+    ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_snapshot_storages(RangeFull).0;
         let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
         let mut next_append_vec_id = 0;
@@ -84,9 +84,9 @@ mod tests {
             );
         }
 
-        Ok(StorageAndNextAppendVecId {
+        Ok(StorageAndNextAccountsFileId {
             storage,
-            next_append_vec_id: AtomicAppendVecId::new(next_append_vec_id + 1),
+            next_append_vec_id: AtomicAccountsFileId::new(next_append_vec_id + 1),
         })
     }
 

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -3,23 +3,23 @@ use {
     solana_accounts_db::accounts_db::AccountStorageEntry,
 };
 
-/// The serialized AppendVecId type is fixed as usize
-pub(crate) type SerializedAppendVecId = usize;
+/// The serialized AccountsFileId type is fixed as usize
+pub(crate) type SerializedAccountsFileId = usize;
 
 // Serializable version of AccountStorageEntry for snapshot format
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SerializableAccountStorageEntry {
-    id: SerializedAppendVecId,
+    id: SerializedAccountsFileId,
     accounts_current_len: usize,
 }
 
 pub(super) trait SerializableStorage {
-    fn id(&self) -> SerializedAppendVecId;
+    fn id(&self) -> SerializedAccountsFileId;
     fn current_len(&self) -> usize;
 }
 
 impl SerializableStorage for SerializableAccountStorageEntry {
-    fn id(&self) -> SerializedAppendVecId {
+    fn id(&self) -> SerializedAccountsFileId {
         self.id
     }
     fn current_len(&self) -> usize {
@@ -30,7 +30,7 @@ impl SerializableStorage for SerializableAccountStorageEntry {
 impl From<&AccountStorageEntry> for SerializableAccountStorageEntry {
     fn from(rhs: &AccountStorageEntry) -> Self {
         Self {
-            id: rhs.append_vec_id() as SerializedAppendVecId,
+            id: rhs.append_vec_id() as SerializedAccountsFileId,
             accounts_current_len: rhs.accounts.len(),
         }
     }

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -18,7 +18,7 @@ use {
             rebuild_storages_from_snapshot_dir, serialize_snapshot_data_file,
             verify_and_unarchive_snapshots, verify_unpacked_snapshots_dir_and_version,
             AddBankSnapshotError, ArchiveFormat, BankSnapshotInfo, BankSnapshotKind, SnapshotError,
-            SnapshotRootPaths, SnapshotVersion, StorageAndNextAppendVecId,
+            SnapshotRootPaths, SnapshotVersion, StorageAndNextAccountsFileId,
             UnpackedSnapshotsDirAndVersion, VerifySlotDeltasError,
         },
         status_cache,
@@ -27,7 +27,7 @@ use {
     log::*,
     solana_accounts_db::{
         accounts_db::{
-            AccountShrinkThreshold, AccountStorageEntry, AccountsDbConfig, AtomicAppendVecId,
+            AccountShrinkThreshold, AccountStorageEntry, AccountsDbConfig, AtomicAccountsFileId,
             CalcAccountsHashDataSource,
         },
         accounts_hash::AccountsHash,
@@ -308,7 +308,7 @@ pub fn bank_from_snapshot_archives(
         storage.extend(incremental_snapshot_storages);
     }
 
-    let storage_and_next_append_vec_id = StorageAndNextAppendVecId {
+    let storage_and_next_append_vec_id = StorageAndNextAccountsFileId {
         storage,
         next_append_vec_id,
     };
@@ -501,7 +501,7 @@ pub fn bank_from_snapshot_dir(
         delete_contents_of_path(path);
     }
 
-    let next_append_vec_id = Arc::new(AtomicAppendVecId::new(0));
+    let next_append_vec_id = Arc::new(AtomicAccountsFileId::new(0));
 
     let (storage, measure_rebuild_storages) = measure!(
         rebuild_storages_from_snapshot_dir(
@@ -515,7 +515,7 @@ pub fn bank_from_snapshot_dir(
 
     let next_append_vec_id =
         Arc::try_unwrap(next_append_vec_id).expect("this is the only strong reference");
-    let storage_and_next_append_vec_id = StorageAndNextAppendVecId {
+    let storage_and_next_append_vec_id = StorageAndNextAccountsFileId {
         storage,
         next_append_vec_id,
     };
@@ -685,7 +685,7 @@ fn rebuild_bank_from_unarchived_snapshots(
         &UnpackedSnapshotsDirAndVersion,
     >,
     account_paths: &[PathBuf],
-    storage_and_next_append_vec_id: StorageAndNextAppendVecId,
+    storage_and_next_append_vec_id: StorageAndNextAccountsFileId,
     genesis_config: &GenesisConfig,
     runtime_config: &RuntimeConfig,
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
@@ -781,7 +781,7 @@ fn rebuild_bank_from_unarchived_snapshots(
 fn rebuild_bank_from_snapshot(
     bank_snapshot: &BankSnapshotInfo,
     account_paths: &[PathBuf],
-    storage_and_next_append_vec_id: StorageAndNextAppendVecId,
+    storage_and_next_append_vec_id: StorageAndNextAccountsFileId,
     genesis_config: &GenesisConfig,
     runtime_config: &RuntimeConfig,
     debug_keys: Option<Arc<HashSet<Pubkey>>>,

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -4,7 +4,7 @@ use {
     super::{snapshot_version_from_file, SnapshotError, SnapshotFrom, SnapshotVersion},
     crate::serde_snapshot::{
         self, reconstruct_single_storage, remap_and_reconstruct_single_storage,
-        snapshot_storage_lengths_from_fields, SerdeStyle, SerializedAppendVecId,
+        snapshot_storage_lengths_from_fields, SerdeStyle, SerializedAccountsFileId,
     },
     crossbeam_channel::{select, unbounded, Receiver, Sender},
     dashmap::DashMap,
@@ -16,7 +16,7 @@ use {
     regex::Regex,
     solana_accounts_db::{
         account_storage::{AccountStorageMap, AccountStorageReference},
-        accounts_db::{AccountStorageEntry, AccountsDb, AppendVecId, AtomicAppendVecId},
+        accounts_db::{AccountStorageEntry, AccountsDb, AccountsFileId, AtomicAccountsFileId},
         append_vec::AppendVec,
     },
     solana_sdk::clock::Slot,
@@ -55,16 +55,16 @@ pub(crate) struct SnapshotStorageRebuilder {
     /// Number of threads to rebuild with
     num_threads: usize,
     /// Snapshot storage lengths - from the snapshot file
-    snapshot_storage_lengths: HashMap<Slot, HashMap<SerializedAppendVecId, usize>>,
+    snapshot_storage_lengths: HashMap<Slot, HashMap<SerializedAccountsFileId, usize>>,
     /// Container for storing snapshot file paths
     storage_paths: DashMap<Slot, Mutex<Vec<PathBuf>>>,
     /// Container for storing rebuilt snapshot storages
     storage: AccountStorageMap,
     /// Tracks next append_vec_id
-    next_append_vec_id: Arc<AtomicAppendVecId>,
+    next_append_vec_id: Arc<AtomicAccountsFileId>,
     /// Tracker for number of processed slots
     processed_slot_count: AtomicUsize,
-    /// Tracks the number of collisions in AppendVecId
+    /// Tracks the number of collisions in AccountsFileId
     num_collisions: AtomicUsize,
     /// Rebuild from the snapshot files or archives
     snapshot_from: SnapshotFrom,
@@ -75,7 +75,7 @@ impl SnapshotStorageRebuilder {
     pub(crate) fn rebuild_storage(
         file_receiver: Receiver<PathBuf>,
         num_threads: usize,
-        next_append_vec_id: Arc<AtomicAppendVecId>,
+        next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_from: SnapshotFrom,
     ) -> Result<RebuiltSnapshotStorage, SnapshotError> {
         let (snapshot_version_path, snapshot_file_path, append_vec_files) =
@@ -109,7 +109,7 @@ impl SnapshotStorageRebuilder {
     fn new(
         file_receiver: Receiver<PathBuf>,
         num_threads: usize,
-        next_append_vec_id: Arc<AtomicAppendVecId>,
+        next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_storage_lengths: HashMap<Slot, HashMap<usize, usize>>,
         snapshot_from: SnapshotFrom,
     ) -> Self {
@@ -199,7 +199,7 @@ impl SnapshotStorageRebuilder {
     fn spawn_rebuilder_threads(
         file_receiver: Receiver<PathBuf>,
         num_threads: usize,
-        next_append_vec_id: Arc<AtomicAppendVecId>,
+        next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_storage_lengths: HashMap<Slot, HashMap<usize, usize>>,
         append_vec_files: Vec<PathBuf>,
         snapshot_from: SnapshotFrom,
@@ -274,7 +274,7 @@ impl SnapshotStorageRebuilder {
                 // dir.  When loading from a snapshot archive, the max of the appendvec IDs is
                 // updated in remap_append_vec_file(), which is not in the from_dir route.
                 self.next_append_vec_id
-                    .fetch_max((append_vec_id + 1) as AppendVecId, Ordering::Relaxed);
+                    .fetch_max((append_vec_id + 1) as AccountsFileId, Ordering::Relaxed);
             }
             let slot_storage_count = self.insert_storage_file(&slot, path);
             if slot_storage_count == self.snapshot_storage_lengths.get(&slot).unwrap().len() {
@@ -324,13 +324,14 @@ impl SnapshotStorageRebuilder {
                         &slot,
                         path.as_path(),
                         current_len,
-                        old_append_vec_id as AppendVecId,
+                        old_append_vec_id as AccountsFileId,
                     )?,
                 };
 
                 Ok((storage_entry.append_vec_id(), storage_entry))
             })
-            .collect::<Result<HashMap<AppendVecId, Arc<AccountStorageEntry>>, SnapshotError>>()?;
+            .collect::<Result<HashMap<AccountsFileId, Arc<AccountStorageEntry>>, SnapshotError>>(
+            )?;
 
         let storage = if slot_stores.len() > 1 {
             let remapped_append_vec_folder = lock.first().unwrap().parent().unwrap();
@@ -365,10 +366,10 @@ impl SnapshotStorageRebuilder {
     /// increment `next_append_vec_id` until there is no file in `parent_folder` with this id and slot
     /// return the id
     fn get_unique_append_vec_id(
-        next_append_vec_id: &Arc<AtomicAppendVecId>,
+        next_append_vec_id: &Arc<AtomicAccountsFileId>,
         parent_folder: &Path,
         slot: Slot,
-    ) -> AppendVecId {
+    ) -> AccountsFileId {
         loop {
             let remapped_append_vec_id = next_append_vec_id.fetch_add(1, Ordering::AcqRel);
             let remapped_file_name = AppendVec::file_name(slot, remapped_append_vec_id);


### PR DESCRIPTION
#### Problem
The current AppendVecId actually refers to an accounts file id.

#### Summary of Changes
Rename AppendVecId to AccountsFileId.

#### Test Plan
Build