### PR TITLE
Fixes help text formatting

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2053,8 +2053,8 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .long("no-accounts-db-index-hashing")
             .help(
                 "This is obsolete. See --accounts-db-index-hashing. \
-                   Disables the use of the index in hash calculation in \
-                   AccountsHashVerifier/Accounts Background Service.",
+                 Disables the use of the index in hash calculation in \
+                 AccountsHashVerifier/Accounts Background Service.",
             ),
         usage_warning: "The accounts hash is only calculated without using the index.",
     );

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2042,8 +2042,8 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         .help("Enable incremental snapshots")
         .long_help(
             "Enable incremental snapshots by setting this flag.  When enabled, \
-             --snapshot-interval-slots will set the incremental snapshot interval. To set the
-                 full snapshot interval, use --full-snapshot-interval-slots.",
+             --snapshot-interval-slots will set the incremental snapshot interval. To set the \
+             full snapshot interval, use --full-snapshot-interval-slots.",
         ));
     add_arg!(Arg::with_name("minimal_rpc_api")
         .long("minimal-rpc-api")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1532,25 +1532,24 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .required(false)
                 .conflicts_with("wait_for_supermajority")
                 .help(
-                    "When specified, the validator will enter Wen Restart mode which
-                    pauses normal activity. Validators in this mode will gossip their last
-                    vote to reach consensus on a safe restart slot and repair all blocks
-                    on the selected fork. The safe slot will be a descendant of the latest
-                    optimistically confirmed slot to ensure we do not roll back any
-                    optimistically confirmed slots.
-
-                    The progress in this mode will be saved in the file location provided.
-                    If consensus is reached, the validator will automatically exit and then
-                    execute wait_for_supermajority logic so the cluster will resume execution.
-                    The progress file will be kept around for future debugging.
-
-                    After the cluster resumes normal operation, the validator arguments can
-                    be adjusted to remove --wen_restart and update expected_shred_version to
-                    the new shred_version agreed on in the consensus.
-
-                    If wen_restart fails, refer to the progress file (in proto3 format) for
-                    further debugging.
-                ",
+                    "When specified, the validator will enter Wen Restart mode which \
+                    pauses normal activity. Validators in this mode will gossip their last \
+                    vote to reach consensus on a safe restart slot and repair all blocks \
+                    on the selected fork. The safe slot will be a descendant of the latest \
+                    optimistically confirmed slot to ensure we do not roll back any \
+                    optimistically confirmed slots. \
+                    \n\n\
+                    The progress in this mode will be saved in the file location provided. \
+                    If consensus is reached, the validator will automatically exit and then \
+                    execute wait_for_supermajority logic so the cluster will resume execution. \
+                    The progress file will be kept around for future debugging. \
+                    \n\n\
+                    After the cluster resumes normal operation, the validator arguments can \
+                    be adjusted to remove --wen_restart and update expected_shred_version to \
+                    the new shred_version agreed on in the consensus. \
+                    \n\n\
+                    If wen_restart fails, refer to the progress file (in proto3 format) for \
+                    further debugging.",
                 ),
         )
         .args(&thread_args(&default_args.thread_args))

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -762,9 +762,9 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .hidden(hidden_unless_forced())
                 .long("no-wait-for-vote-to-start-leader")
                 .help(
-                    "If the validator starts up with no ledger, it will wait to start block
-                      production until it sees a vote land in a rooted slot. This prevents
-                      double signing. Turn off to risk double signing a block.",
+                    "If the validator starts up with no ledger, it will wait to start block \
+                     production until it sees a vote land in a rooted slot. This prevents \
+                     double signing. Turn off to risk double signing a block.",
                 ),
         )
         .arg(

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -233,7 +233,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(false)
                 .help(
                     "Enable historical transaction info over JSON RPC, including the \
-                     'getConfirmedBlock' API.  This will cause an increase in disk usage and IOPS",
+                     'getConfirmedBlock' API. This will cause an increase in disk usage and IOPS",
                 ),
         )
         .arg(
@@ -675,7 +675,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .possible_values(&["none", "lz4", "snappy", "zlib"])
                 .default_value(&default_args.rocksdb_ledger_compression)
                 .help(
-                    "The compression algorithm that is used to compress transaction status data.  \
+                    "The compression algorithm that is used to compress transaction status data. \
                      Turning on compression can save ~10% of the ledger size.",
                 ),
         )
@@ -841,7 +841,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .multiple(true)
                 .takes_value(true)
                 .help(
-                    "A list of validators to gossip with.  If specified, gossip will not \
+                    "A list of validators to gossip with. If specified, gossip will not \
                      push/pull from from validators outside this set. [default: all validators]",
                 ),
         )
@@ -2363,7 +2363,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .validator(is_pubkey)
                 .takes_value(true)
                 .help(
-                    "Address of the mint account that will receive tokens created at genesis.  If \
+                    "Address of the mint account that will receive tokens created at genesis. If \
                      the ledger already exists then this parameter is silently ignored \
                      [default: client keypair]",
                 ),


### PR DESCRIPTION
#### Problem

While viewing `validator --help`, I noticed a few help strings that needed formatting.


#### Summary of Changes

I've made each change its own commit. In each commit message—for a specific arg—there is how the help text is currently displayed.

- fix help for --incremental-snapshots
- fix help for --no-wait-for-vote-to-start-leader
- fix help for --wen-restart
- removes double spaces (for consistency, since we do not use double spaces elsewhere in help text)
- fix alignment