### PR TITLE
Upgrades Rust to 1.77.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.77.0"


### PR DESCRIPTION
https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html
https://releases.rs/docs/1.77.0/