### PR TITLE
clippy: Automated fixes for Rust 1.77.0

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -12102,7 +12102,7 @@ pub mod tests {
         db.print_accounts_stats("pre");
 
         let slots: HashSet<Slot> = vec![1].into_iter().collect();
-        let purge_keys = vec![(key1, slots)];
+        let purge_keys = [(key1, slots)];
         let _ = db.purge_keys_exact(purge_keys.iter());
 
         let account2 = AccountSharedData::new(3, 0, &key);

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1609,7 +1609,7 @@ mod tests {
 
     #[test]
     fn test_accountsdb_de_dup_accounts_zero_chunks() {
-        let vec = vec![vec![CalculateHashIntermediate {
+        let vec = [vec![CalculateHashIntermediate {
             lamports: 1,
             hash: AccountHash(Hash::default()),
             pubkey: Pubkey::default(),

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -120,7 +120,7 @@ impl ScanConfig {
     /// use existing 'abort' if available, otherwise allocate one
     pub fn recreate_with_abort(&self) -> Self {
         ScanConfig {
-            abort: Some(self.abort.as_ref().map(Arc::clone).unwrap_or_default()),
+            abort: Some(self.abort.clone().unwrap_or_default()),
             collect_all_unsorted: self.collect_all_unsorted,
         }
     }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -174,8 +174,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             bucket: storage
                 .disk
                 .as_ref()
-                .map(|disk| disk.get_bucket_from_index(bin))
-                .map(Arc::clone),
+                .map(|disk| disk.get_bucket_from_index(bin)).cloned(),
             cache_ranges_held: CacheRangesHeld::default(),
             stop_evictions_changes: AtomicU64::default(),
             stop_evictions: AtomicU64::default(),
@@ -346,7 +345,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     ) -> RT {
         // SAFETY: Since we're passing the entry Arc clone to `callback`, we must
         // also add the entry to the in-mem cache.
-        self.get_internal(pubkey, |entry| (true, callback(entry.map(Arc::clone))))
+        self.get_internal(pubkey, |entry| (true, callback(entry.cloned())))
     }
 
     /// lookup 'pubkey' in index (in_mem or disk).

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -174,7 +174,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             bucket: storage
                 .disk
                 .as_ref()
-                .map(|disk| disk.get_bucket_from_index(bin)).cloned(),
+                .map(|disk| disk.get_bucket_from_index(bin))
+                .cloned(),
             cache_ranges_held: CacheRangesHeld::default(),
             stop_evictions_changes: AtomicU64::default(),
             stop_evictions: AtomicU64::default(),

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -872,7 +872,7 @@ impl RepairService {
             ServeRepair::repair_proto_to_bytes(&request_proto, &identity_keypair).unwrap();
 
         // Prepare packet batch to send
-        let reqs = vec![(packet_buf, address)];
+        let reqs = [(packet_buf, address)];
 
         // Send packet batch
         match batch_send(repair_socket, &reqs[..]) {

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -1104,7 +1104,7 @@ mod tests {
         let tx1 = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, zero);
 
         // Verify entry with 2 transactions
-        let mut e0 = vec![Entry::new(&zero, 0, vec![tx0, tx1])];
+        let mut e0 = [Entry::new(&zero, 0, vec![tx0, tx1])];
         assert!(e0.verify(&zero));
 
         // Clear signature of the first transaction, see that it does not verify
@@ -1124,7 +1124,7 @@ mod tests {
         assert!(!e0.verify(&zero));
 
         // Pass an entry with no transactions
-        let e0 = vec![Entry::new(&zero, 0, vec![])];
+        let e0 = [Entry::new(&zero, 0, vec![])];
         assert!(e0.verify(&zero));
     }
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -87,7 +87,7 @@ pub enum ProgramTestError {
 }
 
 thread_local! {
-    static INVOKE_CONTEXT: RefCell<Option<usize>> = RefCell::new(None);
+    static INVOKE_CONTEXT: RefCell<Option<usize>> = const { RefCell::new(None) };
 }
 fn set_invoke_context(new: &mut InvokeContext) {
     INVOKE_CONTEXT

--- a/rpc-client-nonce-utils/src/nonblocking/mod.rs
+++ b/rpc-client-nonce-utils/src/nonblocking/mod.rs
@@ -228,7 +228,7 @@ pub fn data_from_account<T: ReadableAccount + StateMut<Versions>>(
     account: &T,
 ) -> Result<Data, Error> {
     account_identity_ok(account)?;
-    state_from_account(account).and_then(|ref s| data_from_state(s).map(|d| d.clone()))
+    state_from_account(account).and_then(|ref s| data_from_state(s).cloned())
 }
 
 /// Get the nonce data from its [`State`] value.

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -266,7 +266,7 @@ struct RpcNotifier {
 }
 
 thread_local! {
-    static RPC_NOTIFIER_BUF: RefCell<Vec<u8>> = RefCell::new(Vec::new());
+    static RPC_NOTIFIER_BUF: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
 }
 
 #[derive(Debug, Serialize)]

--- a/sdk/program/src/message/account_keys.rs
+++ b/sdk/program/src/message/account_keys.rs
@@ -171,11 +171,9 @@ mod tests {
         };
         let account_keys = AccountKeys::new(&static_keys, Some(&dynamic_keys));
 
-        let expected_segments = vec![
-            vec![keys[0], keys[1], keys[2]],
+        let expected_segments = [vec![keys[0], keys[1], keys[2]],
             vec![keys[3], keys[4]],
-            vec![keys[5]],
-        ];
+            vec![keys[5]]];
 
         assert!(account_keys.key_segment_iter().eq(expected_segments.iter()));
     }

--- a/sdk/program/src/message/account_keys.rs
+++ b/sdk/program/src/message/account_keys.rs
@@ -171,9 +171,11 @@ mod tests {
         };
         let account_keys = AccountKeys::new(&static_keys, Some(&dynamic_keys));
 
-        let expected_segments = [vec![keys[0], keys[1], keys[2]],
+        let expected_segments = [
+            vec![keys[0], keys[1], keys[2]],
             vec![keys[3], keys[4]],
-            vec![keys[5]]];
+            vec![keys[5]],
+        ];
 
         assert!(account_keys.key_segment_iter().eq(expected_segments.iter()));
     }


### PR DESCRIPTION
#### Problem

While upgrading Rust to v1.77.0 in https://github.com/anza-xyz/agave/pull/386, we ran into new clippy lints.


#### Summary of Changes

These are all the ones that clippy was able to fix itself by using `clippy --fix`