### PR TITLE
[TieredStorage] Refactor file_size() code path

### DIFF
--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -155,8 +155,13 @@ impl TieredStorage {
     }
 
     /// Returns the size of the underlying accounts file.
-    pub fn file_size(&self) -> TieredStorageResult<u64> {
-        Ok(self.reader().map_or(0, |reader| reader.len()))
+    pub fn len(&self) -> usize {
+        self.reader().map_or(0, |reader| reader.len())
+    }
+
+    /// Returns whether the underlying storage is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 
@@ -220,7 +225,7 @@ mod tests {
 
         assert!(tiered_storage.is_read_only());
         assert_eq!(
-            tiered_storage.file_size().unwrap() as usize,
+            tiered_storage.len(),
             std::mem::size_of::<TieredStorageFooter>()
                 + std::mem::size_of::<TieredStorageMagicNumber>()
         );
@@ -238,7 +243,7 @@ mod tests {
 
             assert!(!tiered_storage.is_read_only());
             assert_eq!(tiered_storage.path(), tiered_storage_path);
-            assert_eq!(tiered_storage.file_size().unwrap(), 0);
+            assert_eq!(tiered_storage.len(), 0);
 
             write_zero_accounts(&tiered_storage, Ok(vec![]));
         }
@@ -252,7 +257,7 @@ mod tests {
         assert_eq!(footer.index_block_format, HOT_FORMAT.index_block_format);
         assert_eq!(footer.account_block_format, HOT_FORMAT.account_block_format);
         assert_eq!(
-            tiered_storage_readonly.file_size().unwrap() as usize,
+            tiered_storage_readonly.len(),
             std::mem::size_of::<TieredStorageFooter>()
                 + std::mem::size_of::<TieredStorageMagicNumber>()
         );

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -360,8 +360,8 @@ impl HotStorageReader {
     }
 
     /// Returns the size of the underlying storage.
-    pub fn len(&self) -> u64 {
-        self.mmap.len() as u64
+    pub fn len(&self) -> usize {
+        self.mmap.len()
     }
 
     /// Returns whether the nderlying storage is empty.
@@ -1432,10 +1432,10 @@ pub mod tests {
         }
         let footer = hot_storage.footer();
 
-        let expected_size: u64 = footer.owners_block_offset
-            + std::mem::size_of::<Pubkey>() as u64 * footer.owner_count as u64
-            + std::mem::size_of::<TieredStorageFooter>() as u64
-            + std::mem::size_of::<TieredStorageMagicNumber>() as u64;
+        let expected_size = footer.owners_block_offset as usize
+            + std::mem::size_of::<Pubkey>() * footer.owner_count as usize
+            + std::mem::size_of::<TieredStorageFooter>()
+            + std::mem::size_of::<TieredStorageMagicNumber>();
 
         assert!(!hot_storage.is_empty());
         assert_eq!(expected_size, hot_storage.len());

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -31,7 +31,7 @@ impl TieredStorageReader {
     }
 
     /// Returns the size of the underlying storage.
-    pub fn len(&self) -> u64 {
+    pub fn len(&self) -> usize {
         match self {
             Self::Hot(hot) => hot.len(),
         }


### PR DESCRIPTION
#### Problem
TieredStorage::file_size() essentially supports AccountsFile::len(),
but its API is inconsistent with AccountsFile's.

#### Summary of Changes
Refactor TieredStorage::file_size() to ::len() and share the same API
as AccountsFile's.

#### Test Plan
Build
Existing unit-tests.
