### PR TITLE
[TieredStorage] Add capacity() API and limit file size to 16GB

### DIFF
--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -38,6 +38,8 @@ use {
 
 pub type TieredStorageResult<T> = Result<T, TieredStorageError>;
 
+const MAX_TIERED_STORAGE_FILE_SIZE: u64 = 16 * 1024 * 1024 * 1024; // 16 GiB;
+
 /// The struct that defines the formats of all building blocks of a
 /// TieredStorage.
 #[derive(Clone, Debug, PartialEq)]
@@ -162,6 +164,11 @@ impl TieredStorage {
     /// Returns whether the underlying storage is empty.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    pub fn capacity(&self) -> u64 {
+        self.reader()
+            .map_or(MAX_TIERED_STORAGE_FILE_SIZE, |reader| reader.capacity())
     }
 }
 

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -16,7 +16,7 @@ use {
             mmap_utils::{get_pod, get_slice},
             owners::{OwnerOffset, OwnersBlockFormat, OwnersTable, OWNER_NO_OWNER},
             StorableAccounts, StorableAccountsWithHashesAndWriteVersions, TieredStorageError,
-            TieredStorageFormat, TieredStorageResult, MAX_TIERED_STORAGE_FILE_SIZE,
+            TieredStorageFormat, TieredStorageResult,
         },
     },
     bytemuck::{Pod, Zeroable},
@@ -370,9 +370,6 @@ impl HotStorageReader {
     }
 
     pub fn capacity(&self) -> u64 {
-        if self.is_empty() {
-            return MAX_TIERED_STORAGE_FILE_SIZE;
-        }
         self.len() as u64
     }
 

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -16,7 +16,7 @@ use {
             mmap_utils::{get_pod, get_slice},
             owners::{OwnerOffset, OwnersBlockFormat, OwnersTable, OWNER_NO_OWNER},
             StorableAccounts, StorableAccountsWithHashesAndWriteVersions, TieredStorageError,
-            TieredStorageFormat, TieredStorageResult,
+            TieredStorageFormat, TieredStorageResult, MAX_TIERED_STORAGE_FILE_SIZE,
         },
     },
     bytemuck::{Pod, Zeroable},
@@ -367,6 +367,13 @@ impl HotStorageReader {
     /// Returns whether the nderlying storage is empty.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    pub fn capacity(&self) -> u64 {
+        if self.is_empty() {
+            return MAX_TIERED_STORAGE_FILE_SIZE;
+        }
+        self.len() as u64
     }
 
     /// Returns the footer of the underlying tiered-storage accounts file.

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -44,6 +44,12 @@ impl TieredStorageReader {
         }
     }
 
+    pub fn capacity(&self) -> u64 {
+        match self {
+            Self::Hot(hot) => hot.capacity(),
+        }
+    }
+
     /// Returns the footer of the associated HotAccountsFile.
     pub fn footer(&self) -> &TieredStorageFooter {
         match self {


### PR DESCRIPTION
#### Problem
The TieredStorage has not yet implemented the AccountsFile::capacity()
API.

#### Summary of Changes
Implement capacity() API for TieredStorage and limit file size to 16GB,
same as the append-vec file.
