### PR TITLE
Scheduler: Add leader bank detection metrics

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -56,14 +56,14 @@ pub(crate) struct SchedulerController {
     container: TransactionStateContainer,
     /// State for scheduling and communicating with worker threads.
     scheduler: PrioGraphScheduler,
+    /// Metrics tracking time for leader bank detection.
+    leader_detection_metrics: SchedulerLeaderDetectionMetrics,
     /// Metrics tracking counts on transactions in different states
     /// over an interval and during a leader slot.
     count_metrics: SchedulerCountMetrics,
     /// Metrics tracking time spent in difference code sections
     /// over an interval and during a leader slot.
     timing_metrics: SchedulerTimingMetrics,
-    /// Metrics tracking time for leader bank detection.
-    leader_detection_metrics: SchedulerLeaderDetectionMetrics,
     /// Metric report handles for the worker threads.
     worker_metrics: Vec<Arc<ConsumeWorkerMetrics>>,
 }
@@ -83,9 +83,9 @@ impl SchedulerController {
             transaction_id_generator: TransactionIdGenerator::default(),
             container: TransactionStateContainer::with_capacity(TOTAL_BUFFERED_PACKETS),
             scheduler,
+            leader_detection_metrics: SchedulerLeaderDetectionMetrics::default(),
             count_metrics: SchedulerCountMetrics::default(),
             timing_metrics: SchedulerTimingMetrics::default(),
-            leader_detection_metrics: SchedulerLeaderDetectionMetrics::default(),
             worker_metrics,
         }
     }

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -394,11 +394,6 @@ impl SchedulerLeaderDetectionMetrics {
                 bank_detected_to_slot_end_detected_us,
                 i64
             ),
-            (
-                "bank_creation_to_slot_end_detected_us",
-                bank_detected_to_slot_end_detected_us + bank_detected_delay_us,
-                i64
-            ),
         );
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -1,6 +1,8 @@
 use {
     itertools::MinMaxResult,
+    solana_poh::poh_recorder::BankStart,
     solana_sdk::{clock::Slot, timing::AtomicInterval},
+    std::time::Instant,
 };
 
 #[derive(Default)]
@@ -330,5 +332,73 @@ impl SchedulerTimingMetricsInner {
         self.clear_time_us = 0;
         self.clean_time_us = 0;
         self.receive_completed_time_us = 0;
+    }
+}
+
+#[derive(Default)]
+pub struct SchedulerLeaderDetectionMetrics {
+    inner: Option<SchedulerLeaderDetectionMetricsInner>,
+}
+
+pub struct SchedulerLeaderDetectionMetricsInner {
+    slot: Slot,
+    bank_detected_time: Instant,
+    bank_detected_delay_us: u64,
+}
+
+impl SchedulerLeaderDetectionMetrics {
+    pub fn update_and_maybe_report(&mut self, bank_start: Option<&BankStart>) {
+        match (&self.inner, bank_start) {
+            (None, Some(bank_start)) => self.initialize_inner(bank_start),
+            (Some(_inner), None) => self.report_and_reset(),
+            (Some(inner), Some(bank_start)) if inner.slot != bank_start.working_bank.slot() => {
+                self.report_and_reset();
+                self.initialize_inner(bank_start);
+            }
+            _ => {}
+        }
+    }
+
+    fn initialize_inner(&mut self, bank_start: &BankStart) {
+        let bank_detected_time = Instant::now();
+        let bank_detected_delay_us = bank_detected_time
+            .duration_since(*bank_start.bank_creation_time)
+            .as_micros()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        self.inner = Some(SchedulerLeaderDetectionMetricsInner {
+            slot: bank_start.working_bank.slot(),
+            bank_detected_time,
+            bank_detected_delay_us,
+        });
+    }
+
+    fn report_and_reset(&mut self) {
+        let SchedulerLeaderDetectionMetricsInner {
+            slot,
+            bank_detected_time,
+            bank_detected_delay_us,
+        } = self.inner.take().expect("inner must be present");
+
+        let bank_detected_to_slot_end_detected_us = bank_detected_time
+            .elapsed()
+            .as_micros()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        datapoint_info!(
+            "banking_stage_scheduler_leader_detection",
+            ("slot", slot, i64),
+            ("bank_detected_delay_us", bank_detected_delay_us, i64),
+            (
+                "bank_detected_to_slot_end_detected_us",
+                bank_detected_to_slot_end_detected_us,
+                i64
+            ),
+            (
+                "bank_creation_to_slot_end_detected_us",
+                bank_detected_to_slot_end_detected_us + bank_detected_delay_us,
+                i64
+            ),
+        );
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -340,7 +340,7 @@ pub struct SchedulerLeaderDetectionMetrics {
     inner: Option<SchedulerLeaderDetectionMetricsInner>,
 }
 
-pub struct SchedulerLeaderDetectionMetricsInner {
+struct SchedulerLeaderDetectionMetricsInner {
     slot: Slot,
     bank_detected_time: Instant,
     bank_detected_delay_us: u64,


### PR DESCRIPTION
#### Problem
- It's useful to know how delayed the scheduler was in detecting the leader bank

#### Summary of Changes
- Add scheduler metrics, reported at slot-level, for time to detect leader bank from creation, time until end of slot detected

Fixes #393 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
