### PR TITLE
Runtime: Core BPF Migration: Path to migrate a builtin to Core BPF

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -168,6 +168,29 @@ macro_rules! deploy_program {
     }};
 }
 
+/// Directly deploy a program using a provided invoke context.
+/// This function should only be invoked from the runtime, since it does not
+/// provide any account loads or checks.
+pub fn direct_deploy_program(
+    invoke_context: &mut InvokeContext,
+    program_id: &Pubkey,
+    loader_key: &Pubkey,
+    account_size: usize,
+    elf: &[u8],
+    slot: Slot,
+) -> Result<(), InstructionError> {
+    deploy_program!(
+        invoke_context,
+        *program_id,
+        loader_key,
+        account_size,
+        slot,
+        {},
+        elf,
+    );
+    Ok(())
+}
+
 fn write_program_data(
     program_data_offset: usize,
     bytes: &[u8],

--- a/runtime/src/bank/builtins/core_bpf_migration/error.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/error.rs
@@ -1,8 +1,14 @@
-use {solana_sdk::pubkey::Pubkey, thiserror::Error};
+use {
+    solana_sdk::{instruction::InstructionError, pubkey::Pubkey},
+    thiserror::Error,
+};
 
 /// Errors returned by a Core BPF migration.
 #[derive(Debug, Error)]
 pub enum CoreBpfMigrationError {
+    /// Solana instruction error
+    #[error("Solana instruction error: {0:?}")]
+    InstructionError(#[from] InstructionError),
     /// Bincode serialization error
     #[error("Bincode serialization error: {0:?}")]
     BincodeError(#[from] bincode::Error),

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -137,3 +137,257 @@ impl CoreBpfMigrationConfig {
         Ok(())
     }
 }
+
+// All of the account state checks are handled by the `new_checked` functions
+// on both `TargetBuiltin` and `SourceUpgradeableBpf`.
+// Each of these checks are tested in the `core_bpf_migration` test suites
+// within the `source_upgradeable_bpf` and `target_builtin` sub-modules.
+// Here we're just testing the actual migration at the runtime level, ensuring
+// the accounts are properly replaced and the bank's state is updated.
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::bank::tests::create_simple_test_bank,
+        solana_program_runtime::loaded_programs::LoadedProgram,
+        solana_sdk::{
+            account_utils::StateMut,
+            bpf_loader_upgradeable::{self, get_program_data_address},
+            clock::Slot,
+            native_loader,
+        },
+    };
+
+    const PROGRAM_DATA_OFFSET: usize = UpgradeableLoaderState::size_of_programdata_metadata();
+
+    struct TestContext {
+        builtin_id: Pubkey,
+        source_program_id: Pubkey,
+        slot: Slot,
+        upgrade_authority_address: Option<Pubkey>,
+        elf: Vec<u8>,
+    }
+    impl TestContext {
+        // Initialize some test values and set up the source BPF upgradeable
+        // program in the bank.
+        fn new(bank: &Bank) -> Self {
+            let builtin_id = Pubkey::new_unique();
+            let source_program_id = Pubkey::new_unique();
+            let slot = 99;
+            let upgrade_authority_address = Some(Pubkey::new_unique());
+            let elf = vec![4; 2000];
+
+            let source_program_data_address = get_program_data_address(&source_program_id);
+
+            let source_program_account = AccountSharedData::new_data(
+                100_000_000,
+                &UpgradeableLoaderState::Program {
+                    programdata_address: source_program_data_address,
+                },
+                &bpf_loader_upgradeable::id(),
+            )
+            .unwrap();
+
+            let source_program_data_account = {
+                let mut data = bincode::serialize(&UpgradeableLoaderState::ProgramData {
+                    slot,
+                    upgrade_authority_address,
+                })
+                .unwrap();
+                data.extend_from_slice(&elf);
+
+                let mut account =
+                    AccountSharedData::new(100_000_000, data.len(), &bpf_loader_upgradeable::id());
+                account.set_data(data);
+                account
+            };
+
+            bank.store_account_and_update_capitalization(
+                &source_program_id,
+                &source_program_account,
+            );
+            bank.store_account_and_update_capitalization(
+                &source_program_data_address,
+                &source_program_data_account,
+            );
+
+            Self {
+                builtin_id,
+                source_program_id,
+                slot,
+                upgrade_authority_address,
+                elf,
+            }
+        }
+
+        // Evaluate the account state of the builtin and source post-migration.
+        // Ensure the builtin program account is now a BPF upgradeable program,
+        // the source program account and data account have been cleared, and
+        // the bank's builtin IDs and cache have been updated.
+        fn run_program_checks_post_migration(&self, bank: &Bank) {
+            // Verify both the source program account and source program data
+            // account have been cleared.
+            assert!(bank.get_account(&self.source_program_id).is_none());
+            assert!(bank
+                .get_account(&get_program_data_address(&self.source_program_id))
+                .is_none());
+
+            let program_account = bank.get_account(&self.builtin_id).unwrap();
+            let program_data_address = get_program_data_address(&self.builtin_id);
+
+            // Program account is owned by the upgradeable loader.
+            assert_eq!(program_account.owner(), &bpf_loader_upgradeable::id());
+
+            // Program account has the correct state, with a pointer to its program
+            // data address.
+            let program_account_state: UpgradeableLoaderState = program_account.state().unwrap();
+            assert_eq!(
+                program_account_state,
+                UpgradeableLoaderState::Program {
+                    programdata_address: program_data_address
+                }
+            );
+
+            let program_data_account = bank.get_account(&program_data_address).unwrap();
+
+            // Program data account is owned by the upgradeable loader.
+            assert_eq!(program_data_account.owner(), &bpf_loader_upgradeable::id());
+
+            // Program data account has the correct state.
+            // It should exactly match the original, including upgrade authority
+            // and slot.
+            let program_data_account_state_metadata: UpgradeableLoaderState =
+                bincode::deserialize(&program_data_account.data()[..PROGRAM_DATA_OFFSET]).unwrap();
+            assert_eq!(
+                program_data_account_state_metadata,
+                UpgradeableLoaderState::ProgramData {
+                    slot: self.slot,
+                    upgrade_authority_address: self.upgrade_authority_address
+                },
+            );
+            assert_eq!(
+                &program_data_account.data()[PROGRAM_DATA_OFFSET..],
+                &self.elf,
+            );
+
+            // The bank's builtins should no longer contain the builtin
+            // program ID.
+            assert!(!bank.builtin_program_ids.contains(&self.builtin_id));
+
+            // The cache should have unloaded both programs.
+            let program_cache = bank.transaction_processor.program_cache.read().unwrap();
+            assert!(!program_cache
+                .get_flattened_entries(true, true)
+                .iter()
+                .any(|(id, _)| id == &self.builtin_id || id == &self.source_program_id));
+        }
+    }
+
+    #[test]
+    fn test_migrate_builtin() {
+        let mut bank = create_simple_test_bank(0);
+
+        let test_context = TestContext::new(&bank);
+
+        let TestContext {
+            builtin_id,
+            source_program_id,
+            ..
+        } = test_context;
+
+        // This will be checked by `TargetBuiltinProgram::new_checked`, but set
+        // up the mock builtin and ensure it exists as configured.
+        let builtin_account = {
+            let builtin_name = String::from("test_builtin");
+            let account =
+                AccountSharedData::new_data(100_000_000, &builtin_name, &native_loader::id())
+                    .unwrap();
+            bank.store_account_and_update_capitalization(&builtin_id, &account);
+            bank.add_builtin(builtin_id, builtin_name, LoadedProgram::default());
+            account
+        };
+        assert_eq!(&bank.get_account(&builtin_id).unwrap(), &builtin_account);
+
+        let core_bpf_migration_config = CoreBpfMigrationConfig {
+            source_program_id,
+            feature_id: Pubkey::new_unique(),
+            migration_target: CoreBpfMigrationTargetType::Builtin,
+            datapoint_name: "test_migrate_builtin",
+        };
+
+        // Gather bank information to check later.
+        let bank_pre_migration_capitalization = bank.capitalization();
+        let bank_pre_migration_accounts_data_size_delta_off_chain =
+            bank.accounts_data_size_delta_off_chain.load(Relaxed);
+
+        // Perform the migration.
+        core_bpf_migration_config
+            .migrate_builtin_to_core_bpf(&mut bank, &builtin_id)
+            .unwrap();
+
+        // Run the post-migration program checks.
+        test_context.run_program_checks_post_migration(&bank);
+
+        // The bank's capitalization should reflect the burned lamports
+        // from the replaced builtin program account.
+        assert_eq!(
+            bank.capitalization(),
+            bank_pre_migration_capitalization - builtin_account.lamports()
+        );
+
+        // The bank's accounts data size delta off-chain should reflect the
+        // change in data size from the replaced builtin program account.
+        assert_eq!(
+            bank.accounts_data_size_delta_off_chain.load(Relaxed),
+            bank_pre_migration_accounts_data_size_delta_off_chain
+                - builtin_account.data().len() as i64,
+        );
+    }
+
+    #[test]
+    fn test_migrate_stateless_builtin() {
+        let mut bank = create_simple_test_bank(0);
+
+        let test_context = TestContext::new(&bank);
+
+        let TestContext {
+            builtin_id,
+            source_program_id,
+            ..
+        } = test_context;
+
+        // This will be checked by `TargetBuiltinProgram::new_checked`, but
+        // assert the stateless builtin account doesn't exist.
+        assert!(bank.get_account(&builtin_id).is_none());
+
+        let core_bpf_migration_config = CoreBpfMigrationConfig {
+            source_program_id,
+            feature_id: Pubkey::new_unique(),
+            migration_target: CoreBpfMigrationTargetType::Stateless,
+            datapoint_name: "test_migrate_stateless_builtin",
+        };
+
+        // Gather bank information to check later.
+        let bank_pre_migration_capitalization = bank.capitalization();
+        let bank_pre_migration_accounts_data_size_delta_off_chain =
+            bank.accounts_data_size_delta_off_chain.load(Relaxed);
+
+        // Perform the migration.
+        core_bpf_migration_config
+            .migrate_builtin_to_core_bpf(&mut bank, &builtin_id)
+            .unwrap();
+
+        // Run the post-migration program checks.
+        test_context.run_program_checks_post_migration(&bank);
+
+        // The bank's capitalization should be exactly the same.
+        assert_eq!(bank.capitalization(), bank_pre_migration_capitalization);
+
+        // The bank's accounts data size delta off-chain should be exactly the
+        // same.
+        assert_eq!(
+            bank.accounts_data_size_delta_off_chain.load(Relaxed),
+            bank_pre_migration_accounts_data_size_delta_off_chain,
+        );
+    }
+}

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -3,7 +3,137 @@ pub(crate) mod error;
 mod source_upgradeable_bpf;
 mod target_builtin;
 
+use {
+    crate::bank::Bank,
+    error::CoreBpfMigrationError,
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount},
+        bpf_loader_upgradeable::UpgradeableLoaderState,
+        pubkey::Pubkey,
+    },
+    source_upgradeable_bpf::SourceUpgradeableBpf,
+    std::sync::atomic::Ordering::Relaxed,
+    target_builtin::TargetBuiltin,
+};
+
+/// Sets up a Core BPF migration for a built-in program.
+#[derive(Debug)]
 pub(crate) enum CoreBpfMigrationTargetType {
+    /// Builtin programs should have a program account.
     Builtin,
+    /// Stateless builtins should not have a program account.
     Stateless,
+}
+
+/// Configurations for migrating a built-in program to Core BPF.
+#[derive(Debug)]
+pub(crate) struct CoreBpfMigrationConfig {
+    /// The source program ID to replace the builtin with.
+    pub source_program_id: Pubkey,
+    /// The feature gate to trigger the migration to Core BPF.
+    /// Note: This feature gate should never be the same as any builtin's
+    /// `enable_feature_id`. It should always be a feature gate that will be
+    /// activated after the builtin is already enabled.
+    pub feature_id: Pubkey,
+    /// The type of migration to perform.
+    pub migration_target: CoreBpfMigrationTargetType,
+    pub datapoint_name: &'static str,
+}
+
+fn checked_add(a: usize, b: usize) -> Result<usize, CoreBpfMigrationError> {
+    a.checked_add(b)
+        .ok_or(CoreBpfMigrationError::ArithmeticOverflow)
+}
+
+/// Create a new `Account` with a pointer to the target's new data account.
+///
+/// Note the pointer is created manually, as well as the owner and
+/// executable values. The rest is inherited from the source program
+/// account, including the lamports.
+fn create_new_target_program_account(
+    target: &TargetBuiltin,
+    source: &SourceUpgradeableBpf,
+) -> Result<AccountSharedData, CoreBpfMigrationError> {
+    let state = UpgradeableLoaderState::Program {
+        programdata_address: target.program_data_address,
+    };
+    let data = bincode::serialize(&state)?;
+    // The source program account has the same state, so it should already have
+    // a sufficient lamports balance to cover rent for this state.
+    // Out of an abundance of caution, first ensure the source program
+    // account's data is the same length as the serialized state.
+    if source.program_account.data().len() != data.len() {
+        return Err(CoreBpfMigrationError::InvalidProgramAccount(
+            source.program_address,
+        ));
+    }
+    // Then copy the source account's contents and overwrite the data with the
+    // newly created target program account data.
+    let mut account = source.program_account.clone();
+    account.set_data_from_slice(&data);
+    Ok(account)
+}
+
+impl CoreBpfMigrationConfig {
+    pub(crate) fn migrate_builtin_to_core_bpf(
+        &self,
+        bank: &mut Bank,
+        program_id: &Pubkey,
+    ) -> Result<(), CoreBpfMigrationError> {
+        datapoint_info!(self.datapoint_name, ("slot", bank.slot, i64));
+
+        let target = TargetBuiltin::new_checked(bank, program_id, &self.migration_target)?;
+        let source = SourceUpgradeableBpf::new_checked(bank, &self.source_program_id)?;
+
+        // Attempt serialization first before touching the bank.
+        let new_target_program_account = create_new_target_program_account(&target, &source)?;
+
+        // Update the account data size delta.
+        // The old data size is the total size of all accounts involved.
+        // The new data size is the total size of the source program accounts,
+        // since the target program account is replaced.
+        //
+        // [B] Builtin      =>      [S]  Source         =       [S]  New Target
+        //                  =>      [SD] SourceData     =       [SD] SourceData
+        //
+        //       Old Data Size: [B + S + SD]            New Data Size: [S + SD]
+        //
+        let target_program_len = target.program_account.data().len();
+        let source_program_len = source.program_account.data().len();
+        let source_program_data_len = source.program_data_account.data().len();
+        let old_data_size = checked_add(
+            target_program_len,
+            checked_add(source_program_len, source_program_data_len)?,
+        )?;
+        let new_data_size = checked_add(source_program_len, source_program_data_len)?;
+        bank.calculate_and_update_accounts_data_size_delta_off_chain(old_data_size, new_data_size);
+
+        // Burn lamports from the target program account, since it will be
+        // replaced.
+        bank.capitalization
+            .fetch_sub(target.program_account.lamports(), Relaxed);
+
+        // Replace the native program account with the created to point to the new data
+        // account and clear the source program account.
+        bank.store_account(&target.program_address, &new_target_program_account);
+        bank.store_account(&source.program_address, &AccountSharedData::default());
+
+        // Copy the upgradeable BPF program's data account into the native
+        // program's data address, which is checked to be empty, then clear the
+        // upgradeable BPF program's data account.
+        bank.store_account(&target.program_data_address, &source.program_data_account);
+        bank.store_account(&source.program_data_address, &AccountSharedData::default());
+
+        // Remove the built-in program from the bank's list of built-ins.
+        bank.builtin_program_ids.remove(&target.program_address);
+
+        // Unload the programs from the bank's cache.
+        bank.transaction_processor
+            .program_cache
+            .write()
+            .unwrap()
+            .remove_programs([source.program_address, target.program_address].into_iter());
+
+        Ok(())
+    }
 }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -58,7 +58,7 @@ fn checked_add(a: usize, b: usize) -> Result<usize, CoreBpfMigrationError> {
 /// Note that the account's data is initialized manually, but the rest of the
 /// account's fields are inherited from the source program account, including
 /// the lamports.
-fn create_new_target_program_account(
+fn new_target_program_account(
     target: &TargetBuiltin,
     source: &SourceUpgradeableBpf,
 ) -> Result<AccountSharedData, CoreBpfMigrationError> {
@@ -94,7 +94,7 @@ impl CoreBpfMigrationConfig {
         let source = SourceUpgradeableBpf::new_checked(bank, &self.source_program_id)?;
 
         // Attempt serialization first before touching the bank.
-        let new_target_program_account = create_new_target_program_account(&target, &source)?;
+        let new_target_program_account = new_target_program_account(&target, &source)?;
 
         // Update the account data size delta.
         // The old data size is the total size of all accounts involved.

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -96,7 +96,8 @@ impl CoreBpfMigrationConfig {
         // Attempt serialization first before touching the bank.
         let new_target_program_account = new_target_program_account(&target, &source)?;
 
-        // Update the account data size delta.
+        // Gather old and new account data sizes, for updating the bank's
+        // accounts data size delta off-chain.
         // The old data size is the total size of all accounts involved.
         // The new data size is the total size of the source program accounts,
         // since the target program account is replaced with a new program
@@ -111,7 +112,6 @@ impl CoreBpfMigrationConfig {
             checked_add(source_program_len, source_program_data_len)?,
         )?;
         let new_data_size = checked_add(source_program_len, source_program_data_len)?;
-        bank.calculate_and_update_accounts_data_size_delta_off_chain(old_data_size, new_data_size);
 
         // Burn lamports from the target program account, since it will be
         // replaced.
@@ -139,6 +139,9 @@ impl CoreBpfMigrationConfig {
             .write()
             .unwrap()
             .remove_programs([source.program_address, target.program_address].into_iter());
+
+        // Update the account data size delta.
+        bank.calculate_and_update_accounts_data_size_delta_off_chain(old_data_size, new_data_size);
 
         Ok(())
     }


### PR DESCRIPTION
This is chunk 5/7 of the broken-up PR #79.

#### Problem

Now that the checked account loaders are in place for evaluating the program 
accounts involved in a builtin's migration to Core BPF, the runtime needs a 
function to actually perform said migration.

#### Summary of Changes

Add a struct `CoreBpgMigrationConfig` for housing the configurations for a Core 
BPF migration, which includes the Feature ID whose activation on which the 
migration will occur.

Assign this struct a method for performing a migration of the given builtin to 
its BPF counterpart and add test coverage for this method.

Note this module remains off the hot path after this change.