### PR TITLE
[clap-v3-utils] Make `SignerSource::parse` public

### DIFF
--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -89,7 +89,7 @@ impl SignerSource {
         }
     }
 
-    pub(crate) fn parse<S: AsRef<str>>(source: S) -> Result<Self, SignerSourceError> {
+    pub fn parse<S: AsRef<str>>(source: S) -> Result<Self, SignerSourceError> {
         let source = source.as_ref();
         let source = {
             #[cfg(target_family = "windows")]


### PR DESCRIPTION
#### Problem
Currently, the `SignerSource::parse` function is set to be `pub(crate)`. This function is used internally by the `clap::builder::ValueParser` (created by `SignerSourceParserBuilder`) to parse arguments as `SignerSource` and can be invoked by `ArgMatches::get_one::<SignerSource>(...)`.

However, there are situations where we would like to create `SignerSource` directly. For example, consider the following logic from `solana-keypair`:
```
fn get_keypair_from_matches(
    matches: &ArgMatches,
    config: Config,
    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
) -> Result<Box<dyn Signer>, Box<dyn error::Error>> {
    let mut path = dirs_next::home_dir().expect("home directory");
    let path = if matches.is_present("keypair") {
        matches.value_of("keypair").unwrap() // should replace `value_of` with `matches.get_one::<SignerSource>("keypair")`
    } else if !config.keypair_path.is_empty() {
        &config.keypair_path // <-- HERE: replace: `SignerSource::parse(&config.keypair_path)`
    } else {
        path.extend([".config", "solana", "id.json"]);
        path.to_str().unwrap() // <-- HERE: replace `SignerSource::parse(path)`
    };
    signer_from_path(matches, path, "pubkey recovery", wallet_manager) // should replace `signer_from_path` to `signer_from_source`
}
```
If `keypair` is not provided with the argument, then we hard-code the paths. Here, it would be clean to call `SignerSource::parse(...)`.

#### Summary of Changes
Make `SignerSource::parse` a public function.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
