### PR TITLE
[clap-v3-utils] Add `try_get_word_count`

### DIFF
--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -35,19 +35,17 @@ pub fn word_count_arg<'a>() -> Arg<'a> {
         .help(WORD_COUNT_ARG.help)
 }
 
-pub fn get_word_count(matches: &ArgMatches) -> usize {
-    match matches
-        .get_one::<String>(WORD_COUNT_ARG.name)
-        .unwrap()
-        .as_str()
-    {
-        "12" => 12,
-        "15" => 15,
-        "18" => 18,
-        "21" => 21,
-        "24" => 24,
-        _ => unreachable!(),
-    }
+pub fn try_get_word_count(matches: &ArgMatches) -> Result<Option<usize>, Box<dyn error::Error>> {
+    Ok(matches
+        .try_get_one::<String>(WORD_COUNT_ARG.name)?
+        .map(|count| match count.as_str() {
+            "12" => 12,
+            "15" => 15,
+            "18" => 18,
+            "21" => 21,
+            "24" => 24,
+            _ => unreachable!(),
+        }))
 }
 
 pub fn language_arg<'a>() -> Arg<'a> {

--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -35,7 +35,7 @@ pub fn word_count_arg<'a>() -> Arg<'a> {
         .help(WORD_COUNT_ARG.help)
 }
 
-pub fn acquire_word_count(matches: &ArgMatches) -> usize {
+pub fn get_word_count(matches: &ArgMatches) -> usize {
     match matches
         .get_one::<String>(WORD_COUNT_ARG.name)
         .unwrap()

--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -35,6 +35,21 @@ pub fn word_count_arg<'a>() -> Arg<'a> {
         .help(WORD_COUNT_ARG.help)
 }
 
+pub fn acquire_word_count(matches: &ArgMatches) -> usize {
+    match matches
+        .get_one::<String>(WORD_COUNT_ARG.name)
+        .unwrap()
+        .as_str()
+    {
+        "12" => 12,
+        "15" => 15,
+        "18" => 18,
+        "21" => 21,
+        "24" => 24,
+        _ => unreachable!(),
+    }
+}
+
 pub fn language_arg<'a>() -> Arg<'a> {
     Arg::new(LANGUAGE_ARG.name)
         .long(LANGUAGE_ARG.long)

--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -25,10 +25,13 @@ pub const NO_PASSPHRASE_ARG: ArgConstant<'static> = ArgConstant {
     help: "Do not prompt for a BIP39 passphrase",
 };
 
+// The constant `POSSIBLE_WORD_COUNTS` and function `try_get_word_count` must always be updated in
+// sync
+const POSSIBLE_WORD_COUNTS: &[&str] = &["12", "15", "18", "21", "24"];
 pub fn word_count_arg<'a>() -> Arg<'a> {
     Arg::new(WORD_COUNT_ARG.name)
         .long(WORD_COUNT_ARG.long)
-        .value_parser(PossibleValuesParser::new(["12", "15", "18", "21", "24"]))
+        .value_parser(PossibleValuesParser::new(POSSIBLE_WORD_COUNTS))
         .default_value("12")
         .value_name("NUMBER")
         .takes_value(true)


### PR DESCRIPTION
#### Problem
With clap-v3, the `value_of`, `value_of_t`, and other `value_of_...` functions have been deprecated. These functions were convenient in that they performed a type conversion on the parsed string argument. The function that replaces these functions `get_one::<T>(...)` can also perform type conversion by specifying a generic type `T`; unfortunately, the need to specify `T` as a concrete type makes usage less flexible.

For example, consider the word count argument.
```
pub fn word_count_arg<'a>() -> Arg<'a> {
    Arg::new(WORD_COUNT_ARG.name)
        .long(WORD_COUNT_ARG.long)
        .value_parser(PossibleValuesParser::new(["12", "15", "18", "21", "24"]))
        .default_value("12")
        .value_name("NUMBER")
        .takes_value(true)
        .help(WORD_COUNT_ARG.help)
}
```
With the possible values specified as strings, calling `get_one::<usize>(WORD_COUNT_ARG.name)` will produce a downcast error since we have not specified how to convert each string to `usize`.

The canonical way to take care of this in clap-v3 is to create an `enum WordCount { ... }`, implement `Into<usize>` and call `let var: usize = get_one::<WordCount>(...).into()`.

Alternatively, we can let caller take care of the string conversion `get_one::<String>(...).map(|word_count| word_count.parse::<usize>())`.

Both methods seem to produce unnecessary and inelegant code.

#### Summary of Changes
Add a function `try_get_word_count` that can directly parse usize from arg matches.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
