### PR TITLE
[SIMD-0137]: Return `SyscallError::InvalidAttribute` on invalid curve or op id on curve25519 syscalls

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -916,7 +916,7 @@ declare_builtin_function!(
                     Ok(1)
                 }
             }
-            _ => Ok(1),
+            _ => Err(SyscallError::InvalidAttribute.into()),
         }
     }
 );
@@ -1024,7 +1024,7 @@ declare_builtin_function!(
                         Ok(1)
                     }
                 }
-                _ => Ok(1),
+                _ => Err(SyscallError::InvalidAttribute.into()),
             },
 
             CURVE25519_RISTRETTO => match group_op {
@@ -1114,10 +1114,10 @@ declare_builtin_function!(
                         Ok(1)
                     }
                 }
-                _ => Ok(1),
+                _ => Err(SyscallError::InvalidAttribute.into()),
             },
 
-            _ => Ok(1),
+            _ => Err(SyscallError::InvalidAttribute.into()),
         }
     }
 );
@@ -1223,7 +1223,7 @@ declare_builtin_function!(
                 }
             }
 
-            _ => Ok(1),
+            _ => Err(SyscallError::InvalidAttribute.into()),
         }
     }
 );

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -34,7 +34,7 @@ use {
         feature_set::bpf_account_data_direct_mapping,
         feature_set::FeatureSet,
         feature_set::{
-            self, blake3_syscall_enabled, curve25519_syscall_enabled,
+            self, abort_on_invalid_curve, blake3_syscall_enabled, curve25519_syscall_enabled,
             disable_deploy_of_alloc_free_syscall, disable_fees_sysvar,
             enable_alt_bn128_compression_syscall, enable_alt_bn128_syscall,
             enable_big_mod_exp_syscall, enable_partitioned_epoch_reward, enable_poseidon_syscall,
@@ -916,7 +916,16 @@ declare_builtin_function!(
                     Ok(1)
                 }
             }
-            _ => Err(SyscallError::InvalidAttribute.into()),
+            _ => {
+                if invoke_context
+                    .feature_set
+                    .is_active(&abort_on_invalid_curve::id())
+                {
+                    Err(SyscallError::InvalidAttribute.into())
+                } else {
+                    Ok(1)
+                }
+            }
         }
     }
 );
@@ -1024,7 +1033,16 @@ declare_builtin_function!(
                         Ok(1)
                     }
                 }
-                _ => Err(SyscallError::InvalidAttribute.into()),
+                _ => {
+                    if invoke_context
+                        .feature_set
+                        .is_active(&abort_on_invalid_curve::id())
+                    {
+                        Err(SyscallError::InvalidAttribute.into())
+                    } else {
+                        Ok(1)
+                    }
+                }
             },
 
             CURVE25519_RISTRETTO => match group_op {
@@ -1114,10 +1132,28 @@ declare_builtin_function!(
                         Ok(1)
                     }
                 }
-                _ => Err(SyscallError::InvalidAttribute.into()),
+                _ => {
+                    if invoke_context
+                        .feature_set
+                        .is_active(&abort_on_invalid_curve::id())
+                    {
+                        Err(SyscallError::InvalidAttribute.into())
+                    } else {
+                        Ok(1)
+                    }
+                }
             },
 
-            _ => Err(SyscallError::InvalidAttribute.into()),
+            _ => {
+                if invoke_context
+                    .feature_set
+                    .is_active(&abort_on_invalid_curve::id())
+                {
+                    Err(SyscallError::InvalidAttribute.into())
+                } else {
+                    Ok(1)
+                }
+            }
         }
     }
 );
@@ -1223,7 +1259,16 @@ declare_builtin_function!(
                 }
             }
 
-            _ => Err(SyscallError::InvalidAttribute.into()),
+            _ => {
+                if invoke_context
+                    .feature_set
+                    .is_active(&abort_on_invalid_curve::id())
+                {
+                    Err(SyscallError::InvalidAttribute.into())
+                } else {
+                    Ok(1)
+                }
+            }
         }
     }
 );

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -995,7 +995,7 @@ lazy_static! {
         (enable_tower_sync_ix::id(), "Enable tower sync vote instruction"),
         (chained_merkle_conflict_duplicate_proofs::id(), "generate duplicate proofs for chained merkle root conflicts"),
         (reward_full_priority_fee::id(), "Reward full priority fee to validators #34731"),
-        (abort_on_invalid_curve::id(), "Abort when elliptic curve syscalls invoked on invalid curve id")
+        (abort_on_invalid_curve::id(), "Abort when elliptic curve syscalls invoked on invalid curve id SIMD-0137")
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -797,6 +797,10 @@ pub mod reward_full_priority_fee {
     solana_sdk::declare_id!("3opE3EzAKnUftUDURkzMgwpNgimBAypW1mNDYH4x4Zg7");
 }
 
+pub mod abort_on_invalid_curve {
+    solana_sdk::declare_id!("FuS3FPfJDKSNot99ECLXtp3rueq36hMNStJkPJwWodLh");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -991,6 +995,7 @@ lazy_static! {
         (enable_tower_sync_ix::id(), "Enable tower sync vote instruction"),
         (chained_merkle_conflict_duplicate_proofs::id(), "generate duplicate proofs for chained merkle root conflicts"),
         (reward_full_priority_fee::id(), "Reward full priority fee to validators #34731"),
+        (abort_on_invalid_curve::id(), "Abort when elliptic curve syscalls invoked on invalid curve id")
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Currently, ther is inconsistency in the way unsupported curve id's are handles in curve25519 and alt_bn128 syscall functions. (https://github.com/solana-foundation/solana-improvement-documents/pull/137)

#### Summary of Changes
Update the curve25519 syscalls to immediately abort since invoking the syscalls on an unsupported curve id should be an unrecoverable error.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
