### PR TITLE
replace Vec::new() with Vec::with_capacity(2)

### DIFF
--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -317,7 +317,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
         .instructions()
         .iter()
         .map(|instruction| {
-            let mut account_indices = Vec::new();
+            let mut account_indices = Vec::with_capacity(2);
             let mut program_index = instruction.program_id_index as usize;
             // This command may never return error, because the transaction is sanitized
             let (program_id, program_account) = accounts


### PR DESCRIPTION
#### Problem

The Vec created on line 320 has at most two elements so we can use Vec::with_capacity(2). It would be nice to avoid allocating in the inner loop at all but that's more than a one-line change


#### Summary of Changes

use Vec::with_capacity(2)
