### PR TITLE
[TieredStorage] Disable accounts-file type check before enabling tiered-storage

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -69,23 +69,6 @@ impl AccountsFile {
     pub fn new_from_file(path: impl AsRef<Path>, current_len: usize) -> Result<(Self, usize)> {
         let (av, num_accounts) = AppendVec::new_from_file(path, current_len)?;
         Ok((Self::AppendVec(av), num_accounts))
-        // Disable the file-type check before fully enable the tiered-storage
-        /*
-        match TieredStorage::new_readonly(path.as_ref()) {
-            Ok(tiered_storage) => {
-                // unwrap() note: TieredStorage::new_readonly() is guaranteed to have a valid
-                // reader instance when opening with new_readonly.
-                let num_accounts = tiered_storage.reader().unwrap().num_accounts();
-                Ok((Self::TieredStorage(tiered_storage), num_accounts))
-            }
-            Err(TieredStorageError::MagicNumberMismatch(_, _)) => {
-                // In case of MagicNumberMismatch, we can assume that this is not
-                // a tiered-storage file.
-                let (av, num_accounts) = AppendVec::new_from_file(path, current_len)?;
-                Ok((Self::AppendVec(av), num_accounts))
-            }
-            Err(e) => Err(AccountsFileError::TieredStorageError(e)),
-        }*/
     }
 
     pub fn flush(&self) -> Result<()> {

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -67,6 +67,10 @@ impl AccountsFile {
     /// The second element of the returned tuple is the number of accounts in the
     /// accounts file.
     pub fn new_from_file(path: impl AsRef<Path>, current_len: usize) -> Result<(Self, usize)> {
+        let (av, num_accounts) = AppendVec::new_from_file(path, current_len)?;
+        Ok((Self::AppendVec(av), num_accounts))
+        // Disable the file-type check before fully enable the tiered-storage
+        /*
         match TieredStorage::new_readonly(path.as_ref()) {
             Ok(tiered_storage) => {
                 // unwrap() note: TieredStorage::new_readonly() is guaranteed to have a valid
@@ -81,7 +85,7 @@ impl AccountsFile {
                 Ok((Self::AppendVec(av), num_accounts))
             }
             Err(e) => Err(AccountsFileError::TieredStorageError(e)),
-        }
+        }*/
     }
 
     pub fn flush(&self) -> Result<()> {


### PR DESCRIPTION
#### Problem
As #72 introduced AccountsFile::TieredStorage, it also performs
file-type check when opening an accounts-file to determine whether
it is a tiered-storage or an append-vec.  But before tiered-storage is
enabled, this opening check is unnecessary.

#### Summary of Changes
Remove the accounts-file type check code and simply assume everything
is append-vec on AccountsFile::new_from_file().
