### PR TITLE
Fix - `FailedVerification` and `Closed` tombstones

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -522,7 +522,11 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     let mut loaded_programs =
         bank.new_program_cache_for_tx_batch_for_slot(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
     for key in cached_account_keys {
-        loaded_programs.replenish(key, bank.load_program(&key, false, bank.epoch()).unwrap());
+        loaded_programs.replenish(
+            key,
+            bank.load_program(&key, false, bank.epoch())
+                .expect("Couldn't find program account"),
+        );
         debug!("Loaded program {}", key);
     }
     invoke_context.programs_loaded_for_tx_batch = &loaded_programs;

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -522,7 +522,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     let mut loaded_programs =
         bank.new_program_cache_for_tx_batch_for_slot(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
     for key in cached_account_keys {
-        loaded_programs.replenish(key, bank.load_program(&key, false, bank.epoch()));
+        loaded_programs.replenish(key, bank.load_program(&key, false, bank.epoch()).unwrap());
         debug!("Loaded program {}", key);
     }
     invoke_context.programs_loaded_for_tx_batch = &loaded_programs;

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -65,7 +65,9 @@ pub trait ForkGraph {
 pub enum LoadedProgramType {
     /// Tombstone for programs which currently do not pass the verifier but could if the feature set changed.
     FailedVerification(ProgramRuntimeEnvironment),
-    /// Tombstone for accounts which are not programs but might still be owned by a loader.
+    /// Tombstone for programs that were either explicitly closed or never deployed.
+    ///
+    /// It's also used for accounts belonging to program loaders, that don't actually contain program code (e.g. buffer accounts for LoaderV3 programs).
     #[default]
     Closed,
     /// Tombstone for programs which have recently been modified but the new version is not visible yet.
@@ -774,6 +776,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             Ok(index) => {
                 let existing = slot_versions.get_mut(index).unwrap();
                 match (&existing.program, &entry.program) {
+                    // Add test for Closed => Loaded transition in same slot
                     (LoadedProgramType::Builtin(_), LoadedProgramType::Builtin(_))
                     | (LoadedProgramType::Closed, LoadedProgramType::LegacyV0(_))
                     | (LoadedProgramType::Closed, LoadedProgramType::LegacyV1(_))

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -63,11 +63,9 @@ pub trait ForkGraph {
 /// Actual payload of [LoadedProgram].
 #[derive(Default)]
 pub enum LoadedProgramType {
-    /// Tombstone for programs which did not pass the verifier.
-    ///
-    /// These can potentially come back alive if the environment changes.
+    /// Tombstone for programs which currently do not pass the verifier but could if the feature set changed.
     FailedVerification(ProgramRuntimeEnvironment),
-    /// Tombstone for programs which were explicitly undeployed / closed.
+    /// Tombstone for accounts which are not programs but might still be owned by a loader.
     #[default]
     Closed,
     /// Tombstone for programs which have recently been modified but the new version is not visible yet.
@@ -777,11 +775,15 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                 let existing = slot_versions.get_mut(index).unwrap();
                 match (&existing.program, &entry.program) {
                     (LoadedProgramType::Builtin(_), LoadedProgramType::Builtin(_))
+                    | (LoadedProgramType::Closed, LoadedProgramType::LegacyV0(_))
+                    | (LoadedProgramType::Closed, LoadedProgramType::LegacyV1(_))
+                    | (LoadedProgramType::Closed, LoadedProgramType::Typed(_))
                     | (LoadedProgramType::Unloaded(_), LoadedProgramType::LegacyV0(_))
                     | (LoadedProgramType::Unloaded(_), LoadedProgramType::LegacyV1(_))
                     | (LoadedProgramType::Unloaded(_), LoadedProgramType::Typed(_)) => {}
                     #[cfg(test)]
-                    (LoadedProgramType::Unloaded(_), LoadedProgramType::TestLoaded(_)) => {}
+                    (LoadedProgramType::Closed, LoadedProgramType::TestLoaded(_))
+                    | (LoadedProgramType::Unloaded(_), LoadedProgramType::TestLoaded(_)) => {}
                     _ => {
                         // Something is wrong, I can feel it ...
                         error!("ProgramCache::assign_program() failed key={:?} existing={:?} entry={:?}", key, slot_versions, entry);
@@ -1680,7 +1682,6 @@ mod tests {
     #[test_matrix(
         (
             LoadedProgramType::FailedVerification(Arc::new(BuiltinProgram::new_mock())),
-            LoadedProgramType::Closed,
             LoadedProgramType::TestLoaded(Arc::new(BuiltinProgram::new_mock())),
         ),
         (
@@ -1692,7 +1693,10 @@ mod tests {
         )
     )]
     #[test_matrix(
-        (LoadedProgramType::Unloaded(Arc::new(BuiltinProgram::new_mock())),),
+        (
+            LoadedProgramType::Closed,
+            LoadedProgramType::Unloaded(Arc::new(BuiltinProgram::new_mock())),
+        ),
         (
             LoadedProgramType::FailedVerification(Arc::new(BuiltinProgram::new_mock())),
             LoadedProgramType::Closed,
@@ -1739,6 +1743,10 @@ mod tests {
         );
     }
 
+    #[test_case(
+        LoadedProgramType::Closed,
+        LoadedProgramType::TestLoaded(Arc::new(BuiltinProgram::new_mock()))
+    )]
     #[test_case(
         LoadedProgramType::Unloaded(Arc::new(BuiltinProgram::new_mock())),
         LoadedProgramType::TestLoaded(Arc::new(BuiltinProgram::new_mock()))

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7137,7 +7137,7 @@ fn test_bank_load_program() {
     programdata_account.set_rent_epoch(1);
     bank.store_account_and_update_capitalization(&key1, &program_account);
     bank.store_account_and_update_capitalization(&programdata_key, &programdata_account);
-    let program = bank.load_program(&key1, false, bank.epoch());
+    let program = bank.load_program(&key1, false, bank.epoch()).unwrap();
     assert_matches!(program.program, LoadedProgramType::LegacyV1(_));
     assert_eq!(
         program.account_size,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -401,7 +401,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         };
 
         let mut loaded_program =
-            match self.load_program_accounts(callbacks, pubkey, environments) {
+            match self.load_program_accounts(callbacks, pubkey) {
                 None | Some(ProgramAccountLoadResult::InvalidAccountData) => Ok(LoadedProgram::new_tombstone(
                     self.slot,
                     LoadedProgramType::Closed,
@@ -836,7 +836,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         &self,
         callbacks: &CB,
         pubkey: &Pubkey,
-        _environments: &solana_program_runtime::loaded_programs::ProgramRuntimeEnvironments,
     ) -> Option<ProgramAccountLoadResult> {
         let program_account = callbacks.get_account_shared_data(pubkey)?;
 
@@ -1078,10 +1077,9 @@ mod tests {
     fn test_load_program_accounts_account_not_found() {
         let mut mock_bank = MockBankCallback::default();
         let key = Pubkey::new_unique();
-        let environment = ProgramRuntimeEnvironments::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
-        let result = batch_processor.load_program_accounts(&mock_bank, &key, &environment);
+        let result = batch_processor.load_program_accounts(&mock_bank, &key);
         assert!(result.is_none());
 
         let mut account_data = AccountSharedData::default();
@@ -1094,7 +1092,7 @@ mod tests {
             .account_shared_data
             .insert(key, account_data.clone());
 
-        let result = batch_processor.load_program_accounts(&mock_bank, &key, &environment);
+        let result = batch_processor.load_program_accounts(&mock_bank, &key);
         assert!(matches!(
             result,
             Some(ProgramAccountLoadResult::InvalidAccountData)
@@ -1103,7 +1101,7 @@ mod tests {
         account_data.set_data(Vec::new());
         mock_bank.account_shared_data.insert(key, account_data);
 
-        let result = batch_processor.load_program_accounts(&mock_bank, &key, &environment);
+        let result = batch_processor.load_program_accounts(&mock_bank, &key);
 
         assert!(matches!(
             result,
@@ -1117,13 +1115,12 @@ mod tests {
         let mut mock_bank = MockBankCallback::default();
         let mut account_data = AccountSharedData::default();
         account_data.set_owner(loader_v4::id());
-        let environment = ProgramRuntimeEnvironments::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         mock_bank
             .account_shared_data
             .insert(key, account_data.clone());
 
-        let result = batch_processor.load_program_accounts(&mock_bank, &key, &environment);
+        let result = batch_processor.load_program_accounts(&mock_bank, &key);
         assert!(matches!(
             result,
             Some(ProgramAccountLoadResult::InvalidAccountData)
@@ -1133,7 +1130,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .insert(key, account_data.clone());
-        let result = batch_processor.load_program_accounts(&mock_bank, &key, &environment);
+        let result = batch_processor.load_program_accounts(&mock_bank, &key);
         assert!(matches!(
             result,
             Some(ProgramAccountLoadResult::InvalidAccountData)
@@ -1154,7 +1151,7 @@ mod tests {
             .account_shared_data
             .insert(key, account_data.clone());
 
-        let result = batch_processor.load_program_accounts(&mock_bank, &key, &environment);
+        let result = batch_processor.load_program_accounts(&mock_bank, &key);
 
         match result {
             Some(ProgramAccountLoadResult::ProgramOfLoaderV4(data, slot)) => {
@@ -1172,13 +1169,12 @@ mod tests {
         let mut mock_bank = MockBankCallback::default();
         let mut account_data = AccountSharedData::default();
         account_data.set_owner(bpf_loader::id());
-        let environment = ProgramRuntimeEnvironments::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         mock_bank
             .account_shared_data
             .insert(key, account_data.clone());
 
-        let result = batch_processor.load_program_accounts(&mock_bank, &key, &environment);
+        let result = batch_processor.load_program_accounts(&mock_bank, &key);
         match result {
             Some(ProgramAccountLoadResult::ProgramOfLoaderV1orV2(data)) => {
                 assert_eq!(data, account_data);
@@ -1192,7 +1188,6 @@ mod tests {
         let key1 = Pubkey::new_unique();
         let key2 = Pubkey::new_unique();
         let mut mock_bank = MockBankCallback::default();
-        let environment = ProgramRuntimeEnvironments::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
         let mut account_data = AccountSharedData::default();
@@ -1216,7 +1211,7 @@ mod tests {
             .account_shared_data
             .insert(key2, account_data2.clone());
 
-        let result = batch_processor.load_program_accounts(&mock_bank, &key1, &environment);
+        let result = batch_processor.load_program_accounts(&mock_bank, &key1);
 
         match result {
             Some(ProgramAccountLoadResult::ProgramOfLoaderV3(data1, data2, slot)) => {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -384,8 +384,11 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         result
     }
 
-    /// Load program with a specific pubkey from program cache, and
-    /// update the program's access slot as a side-effect.
+    /// Loads the program with the given pubkey.
+    ///
+    /// If the account doesn't exist it returns `None`. If the account does exist, it must be a program
+    /// account (belong to one of the program loaders). Returns `Some(InvalidAccountData)` if the program
+    /// account is `Closed`, contains invalid data or any of the programdata accounts are invalid.
     pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
         &self,
         callbacks: &CB,
@@ -837,10 +840,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         pubkey: &Pubkey,
     ) -> Option<ProgramAccountLoadResult> {
         let program_account = callbacks.get_account_shared_data(pubkey)?;
-
-        debug_assert!(solana_bpf_loader_program::check_loader_id(
-            program_account.owner()
-        ));
 
         if loader_v4::check_id(program_account.owner()) {
             return Some(


### PR DESCRIPTION
#### Problems
1. `TransactionBatchProcessor::load_program_with_pubkey()` returns `LoadedProgramType::FailedVerification` even for accounts which never got to the verifier (because they are empty or buffers for example) which should be marked as `LoadedProgramType::Closed` instead. `LoadedProgramType::FailedVerification` should only be used if there is a chance a program gets valid again in the recompilation phase when the feature set and environment changes.

2. In the tests we currently check that loading non existent accounts results in `LoadedProgramType::Closed` entries. This however can not happen in integration because we only attempt to load accounts which have a loader as a owner, thus these account must exist. The situation is similar to when we tested `LoadedProgramType::FailedVerification` existing in the global cache (which can't happen either) and it led to confusion and wasted efforts.

#### Summary of Changes
- Allow the transition from `LoadedProgramType::Closed` to loaded programs in the same slot.
- Replace `ProgramAccountLoadResult::AccountNotFound` by `None`
- Have `TransactionBatchProcessor::load_program_accounts()` only return `ProgramAccountLoadResult::InvalidAccountData` in other error cases
- Have `TransactionBatchProcessor::load_program_with_pubkey()` return `LoadedProgramType::Closed` when `TransactionBatchProcessor::load_program_accounts()` returned `ProgramAccountLoadResult::InvalidAccountData`
- Panic in `replenish_program_cache()` when attempting to load a nonexistent account, and add a test for that
- Allowed `ProgramCache::assign_program()` transition from `LoadedProgramType::Closed` to loaded programs in the same slot (reverted in #673).

`test_bpf_loader_upgradeable_deploy_with_max_len()`:
- Replace `mock_process_instruction()` by a proper message send
- Tests the invocation of an empty account before a program is deployed there
- Tests the invocation of a buffer account before it is used to deploy a program