### PR TITLE
Adds bench for writing accounts to append vecs and hot storage

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -92,5 +92,9 @@ rustc_version = { workspace = true }
 dev-context-only-utils = []
 
 [[bench]]
+name = "bench_accounts_file"
+harness = false
+
+[[bench]]
 name = "bench_hashing"
 harness = false

--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -1,0 +1,93 @@
+#![allow(clippy::arithmetic_side_effects)]
+use {
+    criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput},
+    solana_accounts_db::{
+        account_storage::meta::StorableAccountsWithHashesAndWriteVersions,
+        accounts_hash::AccountHash,
+        append_vec::{self, AppendVec},
+        tiered_storage::hot::HotStorageWriter,
+    },
+    solana_sdk::{
+        account::Account, clock::Slot, hash::Hash, pubkey::Pubkey,
+        rent_collector::RENT_EXEMPT_RENT_EPOCH,
+    },
+};
+
+const ACCOUNTS_COUNTS: [usize; 4] = [
+    1,      // the smallest count; will bench overhead
+    100,    // number of accounts written per slot on mnb (with *no* rent rewrites)
+    1_000,  // number of accounts written slot on mnb (with rent rewrites)
+    10_000, // reasonable largest number of accounts written per slot
+];
+
+fn bench_write_accounts_file(c: &mut Criterion) {
+    let mut group = c.benchmark_group("write_accounts_file");
+
+    // most accounts on mnb are 165-200 bytes, so use that here too
+    let space = 200;
+    let lamports = 2_282_880; // the rent-exempt amount for 200 bytes of data
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    for accounts_count in ACCOUNTS_COUNTS {
+        group.throughput(Throughput::Elements(accounts_count as u64));
+
+        let accounts: Vec<_> = std::iter::repeat_with(|| {
+            (
+                Pubkey::new_unique(),
+                Account::new_rent_epoch(
+                    lamports,
+                    space,
+                    &Pubkey::new_unique(),
+                    RENT_EXEMPT_RENT_EPOCH,
+                ),
+            )
+        })
+        .take(accounts_count)
+        .collect();
+        let accounts_refs: Vec<_> = accounts.iter().collect();
+        let accounts_data = (Slot::MAX, accounts_refs.as_slice());
+        let storable_accounts =
+            StorableAccountsWithHashesAndWriteVersions::new_with_hashes_and_write_versions(
+                &accounts_data,
+                vec![AccountHash(Hash::default()); accounts_count],
+                vec![0; accounts_count],
+            );
+
+        group.bench_function(BenchmarkId::new("append_vec", accounts_count), |b| {
+            b.iter_batched_ref(
+                || {
+                    let path = temp_dir.path().join(format!("append_vec_{accounts_count}"));
+                    let file_size = accounts.len() * (space + append_vec::STORE_META_OVERHEAD);
+                    AppendVec::new(&path, true, file_size)
+                },
+                |append_vec| {
+                    let res = append_vec.append_accounts(&storable_accounts, 0).unwrap();
+                    let accounts_written_count = res.len();
+                    assert_eq!(accounts_written_count, accounts_count);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("hot_storage", accounts_count), |b| {
+            b.iter_batched_ref(
+                || {
+                    let path = temp_dir
+                        .path()
+                        .join(format!("hot_storage_{accounts_count}"));
+                    _ = std::fs::remove_file(&path);
+                    HotStorageWriter::new(path).unwrap()
+                },
+                |hot_storage| {
+                    let res = hot_storage.write_accounts(&storable_accounts, 0).unwrap();
+                    let accounts_written_count = res.len();
+                    assert_eq!(accounts_written_count, accounts_count);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(benches, bench_write_accounts_file);
+criterion_main!(benches);


### PR DESCRIPTION
#### Problem

There's not a bench in place to compare the perf between append vecs and tiered storage.


#### Summary of Changes

Add a bench for writing accounts. Subsequent PRs can add benches for reading accounts.

Here's what a run looks like:

```
write_accounts_file/append_vec/1
                        time:   [966.62 ns 983.87 ns 999.72 ns]
                        thrpt:  [1.0003 Melem/s 1.0164 Melem/s 1.0345 Melem/s]
write_accounts_file/hot_storage/1
                        time:   [277.20 ns 303.86 ns 342.69 ns]
                        thrpt:  [2.9181 Melem/s 3.2910 Melem/s 3.6075 Melem/s]
write_accounts_file/append_vec/100
                        time:   [16.793 µs 16.946 µs 17.084 µs]
                        thrpt:  [5.8533 Melem/s 5.9010 Melem/s 5.9550 Melem/s]
write_accounts_file/hot_storage/100
                        time:   [21.794 µs 21.994 µs 22.174 µs]
                        thrpt:  [4.5098 Melem/s 4.5468 Melem/s 4.5885 Melem/s]
write_accounts_file/append_vec/1000
                        time:   [160.72 µs 161.89 µs 162.82 µs]
                        thrpt:  [6.1419 Melem/s 6.1771 Melem/s 6.2220 Melem/s]
write_accounts_file/hot_storage/1000
                        time:   [222.95 µs 223.76 µs 224.42 µs]
                        thrpt:  [4.4559 Melem/s 4.4691 Melem/s 4.4854 Melem/s]
write_accounts_file/append_vec/10000
                        time:   [1.6278 ms 1.6291 ms 1.6305 ms]
                        thrpt:  [6.1331 Melem/s 6.1384 Melem/s 6.1432 Melem/s]
write_accounts_file/hot_storage/10000
                        time:   [2.2862 ms 2.2894 ms 2.2933 ms]
                        thrpt:  [4.3605 Melem/s 4.3679 Melem/s 4.3741 Melem/s]
```