### PR TITLE
Simd 118: rekey partitioned epoch rewards feature

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -370,7 +370,7 @@ pub mod update_rewards_from_cached_accounts {
     solana_sdk::declare_id!("28s7i3htzhahXQKqmS2ExzbEoUypg9krwvtK2M9UWXh9");
 }
 pub mod enable_partitioned_epoch_reward {
-    solana_sdk::declare_id!("41tVp5qR1XwWRt5WifvtSQyuxtqQWJgEK8w91AtBqSwP");
+    solana_sdk::declare_id!("9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK");
 }
 
 pub mod spl_token_v3_4_0 {


### PR DESCRIPTION
#### Problem
[SIMD-0118](https://github.com/solana-foundation/solana-improvement-documents/pull/118) was merged, superseding the existing design and implementation. The existing feature should not be activated.

#### Summary of Changes
Rekey the feature to set the minimum version for activation to v2.0.0

New feature issue here: https://github.com/anza-xyz/agave/issues/426
