### PR TITLE
[clap-v3-utils] Add `try_get_language` and deprecate `acquire_language`

### DIFF
--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -51,19 +51,21 @@ pub fn try_get_word_count(matches: &ArgMatches) -> Result<Option<usize>, Box<dyn
         }))
 }
 
+// The constant `POSSIBLE_LANGUAGES` and function `try_get_language` must always be updated in sync
+const POSSIBLE_LANGUAGES: &[&str] = &[
+    "english",
+    "chinese-simplified",
+    "chinese-traditional",
+    "japanese",
+    "spanish",
+    "korean",
+    "french",
+    "italian",
+];
 pub fn language_arg<'a>() -> Arg<'a> {
     Arg::new(LANGUAGE_ARG.name)
         .long(LANGUAGE_ARG.long)
-        .value_parser(PossibleValuesParser::new([
-            "english",
-            "chinese-simplified",
-            "chinese-traditional",
-            "japanese",
-            "spanish",
-            "korean",
-            "french",
-            "italian",
-        ]))
+        .value_parser(PossibleValuesParser::new(POSSIBLE_LANGUAGES))
         .default_value("english")
         .value_name("LANGUAGE")
         .takes_value(true)

--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -95,6 +95,22 @@ pub fn acquire_language(matches: &ArgMatches) -> Language {
     }
 }
 
+pub fn try_get_language(matches: &ArgMatches) -> Result<Option<Language>, Box<dyn error::Error>> {
+    Ok(matches
+        .try_get_one::<String>(LANGUAGE_ARG.name)?
+        .map(|language| match language.as_str() {
+            "english" => Language::English,
+            "chinese-simplified" => Language::ChineseSimplified,
+            "chinese-traditional" => Language::ChineseTraditional,
+            "japanese" => Language::Japanese,
+            "spanish" => Language::Spanish,
+            "korean" => Language::Korean,
+            "french" => Language::French,
+            "italian" => Language::Italian,
+            _ => unreachable!(),
+        }))
+}
+
 pub fn no_passphrase_and_message() -> (String, String) {
     (NO_PASSPHRASE.to_string(), "".to_string())
 }

--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -77,6 +77,7 @@ pub fn no_passphrase_arg<'a>() -> Arg<'a> {
         .help(NO_PASSPHRASE_ARG.help)
 }
 
+#[deprecated(since = "2.0.0", note = "Please use `try_get_language` instead")]
 pub fn acquire_language(matches: &ArgMatches) -> Language {
     match matches
         .get_one::<String>(LANGUAGE_ARG.name)


### PR DESCRIPTION
#### Problem
Currently, the `acquire_language` function, which is used to parse the language argument could panic if the language argument is not specified in the `App`.

#### Summary of Changes
Add the function `try_get_language`, which handles potential errors properly.

This is a follow-up to https://github.com/anza-xyz/agave/pull/411#discussion_r1538568030.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
