### PR TITLE
Uses Into<PathBuf> for path in AppendVec::new()

### DIFF
--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -58,7 +58,7 @@ fn bench_write_accounts_file(c: &mut Criterion) {
                 || {
                     let path = temp_dir.path().join(format!("append_vec_{accounts_count}"));
                     let file_size = accounts.len() * (space + append_vec::STORE_META_OVERHEAD);
-                    AppendVec::new(&path, true, file_size)
+                    AppendVec::new(path, true, file_size)
                 },
                 |append_vec| {
                     let res = append_vec.append_accounts(&storable_accounts, 0).unwrap();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1034,7 +1034,7 @@ impl AccountStorageEntry {
     pub fn new(path: &Path, slot: Slot, id: AccountsFileId, file_size: u64) -> Self {
         let tail = AccountsFile::file_name(slot, id);
         let path = Path::new(path).join(tail);
-        let accounts = AccountsFile::AppendVec(AppendVec::new(&path, true, file_size as usize));
+        let accounts = AccountsFile::AppendVec(AppendVec::new(path, true, file_size as usize));
 
         Self {
             id,

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -67,7 +67,7 @@ impl AccountsFile {
     /// The second element of the returned tuple is the number of accounts in the
     /// accounts file.
     pub fn new_from_file(path: impl AsRef<Path>, current_len: usize) -> Result<(Self, usize)> {
-        let (av, num_accounts) = AppendVec::new_from_file(path, current_len)?;
+        let (av, num_accounts) = AppendVec::new_from_file(path.as_ref(), current_len)?;
         Ok((Self::AppendVec(av), num_accounts))
     }
 


### PR DESCRIPTION
#### Problem

While reviewing https://github.com/anza-xyz/agave/pull/334, I made a wrong suggestion and noticed that the path parameter in `AppendVec::new()` et al should be `Into<PathBuf>` instead of a raw Path or `AsRef<Path>`.

#### Summary of Changes

Update AppendVec::new() et al to take the path parameter as `Into<PathBuf>`, and update callers.