### PR TITLE
Uses Into<PathBuf> for path in AccountsFile::new_from_file()

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -12,11 +12,7 @@ use {
         },
     },
     solana_sdk::{account::ReadableAccount, clock::Slot, pubkey::Pubkey},
-    std::{
-        borrow::Borrow,
-        mem,
-        path::{Path, PathBuf},
-    },
+    std::{borrow::Borrow, mem, path::PathBuf},
     thiserror::Error,
 };
 
@@ -66,8 +62,8 @@ impl AccountsFile {
     ///
     /// The second element of the returned tuple is the number of accounts in the
     /// accounts file.
-    pub fn new_from_file(path: impl AsRef<Path>, current_len: usize) -> Result<(Self, usize)> {
-        let (av, num_accounts) = AppendVec::new_from_file(path.as_ref(), current_len)?;
+    pub fn new_from_file(path: impl Into<PathBuf>, current_len: usize) -> Result<(Self, usize)> {
+        let (av, num_accounts) = AppendVec::new_from_file(path, current_len)?;
         Ok((Self::AppendVec(av), num_accounts))
     }
 


### PR DESCRIPTION
#### Problem

While reviewing https://github.com/anza-xyz/agave/pull/334, I made a wrong suggestion and noticed that the path parameter in `AppendVec::new()` et al should be `Into<PathBuf>` instead of a raw Path or `AsRef<Path>`.

This also extends to `AccountsFile::new_from_file()`.

#### Summary of Changes

Update AccountsFile::new_from_file() to take the path parameter as `Into<PathBuf>`.