### PR TITLE
Make CostTracker aware of inflight transactions

### DIFF
--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -62,6 +62,7 @@ impl CostUpdateService {
                                     "inflight transaction count is {in_flight_transaction_count} \
                                     for slot {slot} after {loop_count} iteration(s)"
                                 );
+                                cost_tracker.report_stats(slot);
                                 break;
                             }
                         }

--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -55,8 +55,10 @@ impl CostUpdateService {
                             .in_flight_transaction_count();
                         if in_flight_transaction_count == 0 {
                             let slot = bank.slot();
-                            trace!("inflight transaction count for slot {slot} settled to zero \
-                                after {loop_count} iterations");
+                            trace!(
+                                "inflight transaction count for slot {slot} settled to zero \
+                                after {loop_count} iterations"
+                            );
                             break;
                         }
 

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -61,6 +61,8 @@ pub struct CostTracker {
     transaction_signature_count: u64,
     secp256k1_instruction_signature_count: u64,
     ed25519_instruction_signature_count: u64,
+
+    in_flight_transaction_count: usize,
 }
 
 impl Default for CostTracker {
@@ -83,6 +85,7 @@ impl Default for CostTracker {
             transaction_signature_count: 0,
             secp256k1_instruction_signature_count: 0,
             ed25519_instruction_signature_count: 0,
+            in_flight_transaction_count: 0,
         }
     }
 }
@@ -98,6 +101,23 @@ impl CostTracker {
         self.account_cost_limit = account_cost_limit;
         self.block_cost_limit = block_cost_limit;
         self.vote_cost_limit = vote_cost_limit;
+    }
+
+    pub fn in_flight_transaction_count(&self) -> usize {
+        self.in_flight_transaction_count
+    }
+
+    pub fn add_transactions_in_flight(&mut self, in_flight_transaction_count: usize) {
+        saturating_add_assign!(
+            self.in_flight_transaction_count,
+            in_flight_transaction_count
+        );
+    }
+
+    pub fn sub_transactions_in_flight(&mut self, in_flight_transaction_count: usize) {
+        self.in_flight_transaction_count = self
+            .in_flight_transaction_count
+            .saturating_sub(in_flight_transaction_count);
     }
 
     pub fn try_add(&mut self, tx_cost: &TransactionCost) -> Result<u64, CostTrackerError> {

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -61,7 +61,9 @@ pub struct CostTracker {
     transaction_signature_count: u64,
     secp256k1_instruction_signature_count: u64,
     ed25519_instruction_signature_count: u64,
-
+    /// The number of transactions that have had their estimated cost added to
+    /// the tracker, but are still waiting for an update with actual usage or
+    /// removal if the transaction does not end up getting committed.
     in_flight_transaction_count: usize,
 }
 
@@ -192,6 +194,11 @@ impl CostTracker {
             (
                 "ed25519_instruction_signature_count",
                 self.ed25519_instruction_signature_count,
+                i64
+            ),
+            (
+                "inflight_transaction_count",
+                self.in_flight_transaction_count,
                 i64
             ),
         );


### PR DESCRIPTION
#### Problem
When a leader is packing a `Bank`, transactions are added to the cost-tracker and then later updated or removed, depending on whether the transactions were committed or not. However, it is also possible for a `Bank` to get frozen while these transactions are "in-flight".

After the bank is frozen, the bank is sent over to `CostUpdateService` almost immediately. The result is that we've observed a `Bank` having its' cost details reported to metrics BEFORE the updates / removals were made to the `CostTracker` for these in-flight transactions. This causes a leader to submit metrics with an over-reported cost in comparison to what we calculate from replaying the block.

Taking over work done by @apfitzge  in https://github.com/anza-xyz/agave/pull/398 

#### Summary of Changes
- Add in-flight transaction count to CostTracker
- Increment / decrement the in-flight transaction count in BankingStage
- Make CostUpdateService wait (with a timeout) for in-flight transaction count to settle to zero

Fixes #366 