### PR TITLE
[keygen] Remove deprecated functions from `keygen` cli (minus `grind` command)

### DIFF
--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 bs58 = { workspace = true }
-clap = { version = "3.1.5", features = ["cargo"] }
+clap = { version = "3.1.5", features = ["cargo", "deprecated"] }
 dirs-next = { workspace = true }
 num_cpus = { workspace = true }
 solana-clap-v3-utils = { workspace = true }

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 bs58 = { workspace = true }
-clap = { version = "3.1.5", features = ["cargo", "deprecated"] }
+clap = { version = "3.1.5", features = ["cargo"] }
 dirs-next = { workspace = true }
 num_cpus = { workspace = true }
 solana-clap-v3-utils = { workspace = true }

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::arithmetic_side_effects)]
+#![allow(deprecated)]
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, value_parser, Arg, ArgMatches, Command},

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -444,7 +444,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 }
 
 fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
-    let config = if let Some(config_file) = matches.value_of("config_file") {
+    let config = if let Some(config_file) = matches.try_get_one::<String>("config_file")? {
         Config::load(config_file).unwrap_or_default()
     } else {
         Config::default()

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -7,7 +7,6 @@ use {
             signer::{SignerSource, SignerSourceParserBuilder},
             STDOUT_OUTFILE_TOKEN,
         },
-        input_validators::is_prompt_signer_source,
         keygen::{
             check_for_overwrite,
             derivation_path::{acquire_derivation_path, derivation_path_arg},
@@ -18,7 +17,7 @@ use {
             no_outfile_arg, KeyGenerationCommonArgs, NO_OUTFILE_ARG,
         },
         keypair::{
-            keypair_from_path, keypair_from_seed_phrase, signer_from_source,
+            keypair_from_seed_phrase, keypair_from_source, signer_from_source,
             SKIP_SEED_PHRASE_VALIDATION_ARG,
         },
         DisplayError,
@@ -410,7 +409,7 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .index(1)
                         .value_name("KEYPAIR")
                         .takes_value(true)
-                        .validator(is_prompt_signer_source)
+                        .value_parser(SignerSourceParserBuilder::default().allow_prompt().allow_legacy().build())
                         .help("`prompt:` URI scheme or `ASK` keyword"),
                 )
                 .arg(
@@ -522,8 +521,8 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
         }
         ("recover", matches) => {
             let mut path = dirs_next::home_dir().expect("home directory");
-            let outfile = if matches.is_present("outfile") {
-                matches.value_of("outfile").unwrap()
+            let outfile = if matches.try_contains_id("outfile")? {
+                matches.get_one::<String>("outfile").unwrap()
             } else {
                 path.extend([".config", "solana", "id.json"]);
                 path.to_str().unwrap()
@@ -534,12 +533,14 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             }
 
             let keypair_name = "recover";
-            let keypair = if let Some(path) = matches.value_of("prompt_signer") {
-                keypair_from_path(matches, path, keypair_name, true)?
-            } else {
-                let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
-                keypair_from_seed_phrase(keypair_name, skip_validation, true, None, true)?
-            };
+            let keypair =
+                if let Some(source) = matches.try_get_one::<SignerSource>("prompt_signer")? {
+                    keypair_from_source(matches, source, keypair_name, true)?
+                } else {
+                    let skip_validation =
+                        matches.try_contains_id(SKIP_SEED_PHRASE_VALIDATION_ARG.name)?;
+                    keypair_from_seed_phrase(keypair_name, skip_validation, true, None, true)?
+                };
             output_keypair(&keypair, outfile, "recovered")?;
         }
         ("grind", matches) => {

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::arithmetic_side_effects)]
-#![allow(deprecated)]
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, value_parser, Arg, ArgMatches, Command},

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -13,7 +13,7 @@ use {
             derivation_path::{acquire_derivation_path, derivation_path_arg},
             mnemonic::{
                 acquire_language, acquire_passphrase_and_message, no_passphrase_and_message,
-                WORD_COUNT_ARG,
+                try_get_language, try_get_word_count, WORD_COUNT_ARG,
             },
             no_outfile_arg, KeyGenerationCommonArgs, NO_OUTFILE_ARG,
         },
@@ -470,9 +470,9 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
         }
         ("new", matches) => {
             let mut path = dirs_next::home_dir().expect("home directory");
-            let outfile = if matches.is_present("outfile") {
-                matches.value_of("outfile")
-            } else if matches.is_present(NO_OUTFILE_ARG.name) {
+            let outfile = if matches.try_contains_id("outfile")? {
+                matches.get_one::<String>("outfile").map(|s| s.as_str())
+            } else if matches.try_contains_id(NO_OUTFILE_ARG.name)? {
                 None
             } else {
                 path.extend([".config", "solana", "id.json"]);
@@ -485,11 +485,11 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                 None => (),
             }
 
-            let word_count: usize = matches.value_of_t(WORD_COUNT_ARG.name).unwrap();
+            let word_count = try_get_word_count(matches)?.unwrap();
             let mnemonic_type = MnemonicType::for_word_count(word_count)?;
-            let language = acquire_language(matches);
+            let language = try_get_language(matches)?.unwrap();
 
-            let silent = matches.is_present("silent");
+            let silent = matches.try_contains_id("silent")?;
             if !silent {
                 println!("Generating a new keypair");
             }


### PR DESCRIPTION
#### Problem
The keygen cli uses clap-v3 and solana-clap-v3-utils, but still uses deprecated functions from clap-v2.

#### Summary of Changes
Replaced deprecated clap-v2 functions with clap-v3 functions. I organized the changes so that each commit is associated with different commands.

This PR removes all the deprecated functions for all commands except for the `grind` command. The `grind` command seems like it will need a bit more structural changes, so I will make the changes in a follow-up PR.

The first and last commits here adds and removes the `deprecated` feature from clap-v3. If this feature is set, then clap-v3 warns on the use of deprecated functions. I removed this feature since the `grind` command is not yet updated.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
