### PR TITLE
Apply AccountsFileProvider to more functions

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -276,7 +276,7 @@ impl Default for AccountStorageStatus {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use {super::*, std::path::Path};
+    use {super::*, crate::accounts_file::AppendVecProvider, std::path::Path};
 
     #[test]
     fn test_shrink_in_progress() {
@@ -292,13 +292,13 @@ pub(crate) mod tests {
         let store_file_size = 4000;
         let store_file_size2 = store_file_size * 2;
         // 2 append vecs with same id, but different sizes
-        let entry = Arc::new(AccountStorageEntry::new(
+        let entry = Arc::new(AccountStorageEntry::new::<AppendVecProvider>(
             common_store_path,
             slot,
             id,
             store_file_size,
         ));
-        let entry2 = Arc::new(AccountStorageEntry::new(
+        let entry2 = Arc::new(AccountStorageEntry::new::<AppendVecProvider>(
             common_store_path,
             slot,
             id,
@@ -348,7 +348,7 @@ pub(crate) mod tests {
             // add a map store
             let common_store_path = Path::new("");
             let store_file_size = 4000;
-            Arc::new(AccountStorageEntry::new(
+            Arc::new(AccountStorageEntry::new::<AppendVecProvider>(
                 common_store_path,
                 slot,
                 id,

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -223,6 +223,29 @@ impl<'a> Iterator for AccountsFileIter<'a> {
     }
 }
 
+/// A trait that creates AccountsFile instance with the specified format.
+pub trait AccountsFileProvider {
+    fn new_writable(path: impl Into<PathBuf>, file_size: u64) -> AccountsFile;
+}
+
+/// A struct that creates AccountsFile instance under AppendVec format.
+#[derive(Debug)]
+pub struct AppendVecProvider;
+impl AccountsFileProvider for AppendVecProvider {
+    fn new_writable(path: impl Into<PathBuf>, file_size: u64) -> AccountsFile {
+        AccountsFile::AppendVec(AppendVec::new(path, true, file_size as usize))
+    }
+}
+
+/// A struct that creates AccountsFile instance under HotStorage format.
+#[derive(Debug)]
+pub struct HotStorageProvider;
+impl AccountsFileProvider for HotStorageProvider {
+    fn new_writable(path: impl Into<PathBuf>, _file_size: u64) -> AccountsFile {
+        AccountsFile::TieredStorage(TieredStorage::new_writable(path))
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use crate::accounts_file::AccountsFile;

--- a/accounts-db/src/sorted_storages.rs
+++ b/accounts-db/src/sorted_storages.rs
@@ -196,7 +196,7 @@ mod tests {
         super::*,
         crate::{
             accounts_db::{AccountStorageEntry, AccountsFileId},
-            accounts_file::AccountsFile,
+            accounts_file::{AccountsFile, AppendVecProvider},
             append_vec::AppendVec,
         },
         std::sync::Arc,
@@ -445,7 +445,8 @@ mod tests {
         let (_temp_dirs, paths) = crate::accounts_db::get_temp_accounts_paths(1).unwrap();
         let size: usize = 123;
         let slot = 0;
-        let mut data = AccountStorageEntry::new(&paths[0], slot, id, size as u64);
+        let mut data =
+            AccountStorageEntry::new::<AppendVecProvider>(&paths[0], slot, id, size as u64);
         let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, true, 1024 * 1024));
         data.accounts = av;
 


### PR DESCRIPTION
#### Problem
#334 introduces AccountsFileProvider trait to start allowing functions
to switch between different AccountsFile implementations, but most
functions are still using hard-coded AppendVecProvider instead of
taking a generic.

#### Summary of Changes
Apply generic AccountsFileProvider to more functions, but still leave
the top-level caller to use AppendVecProvider.

#### Dependencies
#334

