### PR TITLE
clap-utils: Add more compute unit helpers

### DIFF
--- a/clap-utils/src/compute_budget.rs
+++ b/clap-utils/src/compute_budget.rs
@@ -1,0 +1,15 @@
+use {crate::ArgConstant, clap::Arg};
+
+pub const COMPUTE_UNIT_PRICE_ARG: ArgConstant<'static> = ArgConstant {
+    name: "compute_unit_price",
+    long: "--with-compute-unit-price",
+    help: "Set compute unit price for transaction, in increments of 0.000001 lamports per compute unit.",
+};
+
+pub fn compute_unit_price_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name(COMPUTE_UNIT_PRICE_ARG.name)
+        .long(COMPUTE_UNIT_PRICE_ARG.long)
+        .takes_value(true)
+        .value_name("COMPUTE-UNIT-PRICE")
+        .help(COMPUTE_UNIT_PRICE_ARG.help)
+}

--- a/clap-utils/src/compute_budget.rs
+++ b/clap-utils/src/compute_budget.rs
@@ -9,6 +9,12 @@ pub const COMPUTE_UNIT_PRICE_ARG: ArgConstant<'static> = ArgConstant {
     help: "Set compute unit price for transaction, in increments of 0.000001 lamports per compute unit.",
 };
 
+pub const COMPUTE_UNIT_LIMIT_ARG: ArgConstant<'static> = ArgConstant {
+    name: "compute_unit_limit",
+    long: "--with-compute-unit-limit",
+    help: "Set compute unit limit for transaction.",
+};
+
 pub fn compute_unit_price_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(COMPUTE_UNIT_PRICE_ARG.name)
         .long(COMPUTE_UNIT_PRICE_ARG.long)
@@ -16,4 +22,13 @@ pub fn compute_unit_price_arg<'a, 'b>() -> Arg<'a, 'b> {
         .value_name("COMPUTE-UNIT-PRICE")
         .validator(is_parsable::<u64>)
         .help(COMPUTE_UNIT_PRICE_ARG.help)
+}
+
+pub fn compute_unit_limit_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name(COMPUTE_UNIT_LIMIT_ARG.name)
+        .long(COMPUTE_UNIT_LIMIT_ARG.long)
+        .takes_value(true)
+        .value_name("COMPUTE-UNIT-LIMIT")
+        .validator(is_parsable::<u32>)
+        .help(COMPUTE_UNIT_LIMIT_ARG.help)
 }

--- a/clap-utils/src/compute_budget.rs
+++ b/clap-utils/src/compute_budget.rs
@@ -1,4 +1,7 @@
-use {crate::ArgConstant, clap::Arg};
+use {
+    crate::{input_validators::is_parsable, ArgConstant},
+    clap::Arg,
+};
 
 pub const COMPUTE_UNIT_PRICE_ARG: ArgConstant<'static> = ArgConstant {
     name: "compute_unit_price",
@@ -11,5 +14,6 @@ pub fn compute_unit_price_arg<'a, 'b>() -> Arg<'a, 'b> {
         .long(COMPUTE_UNIT_PRICE_ARG.long)
         .takes_value(true)
         .value_name("COMPUTE-UNIT-PRICE")
+        .validator(is_parsable::<u64>)
         .help(COMPUTE_UNIT_PRICE_ARG.help)
 }

--- a/clap-utils/src/compute_unit_price.rs
+++ b/clap-utils/src/compute_unit_price.rs
@@ -1,1 +1,2 @@
+#[deprecated(since = "2.0.0", note = "Please use `compute_budget` instead")]
 pub use crate::compute_budget::{compute_unit_price_arg, COMPUTE_UNIT_PRICE_ARG};

--- a/clap-utils/src/compute_unit_price.rs
+++ b/clap-utils/src/compute_unit_price.rs
@@ -1,15 +1,1 @@
-use {crate::ArgConstant, clap::Arg};
-
-pub const COMPUTE_UNIT_PRICE_ARG: ArgConstant<'static> = ArgConstant {
-    name: "compute_unit_price",
-    long: "--with-compute-unit-price",
-    help: "Set compute unit price for transaction, in increments of 0.000001 lamports per compute unit.",
-};
-
-pub fn compute_unit_price_arg<'a, 'b>() -> Arg<'a, 'b> {
-    Arg::with_name(COMPUTE_UNIT_PRICE_ARG.name)
-        .long(COMPUTE_UNIT_PRICE_ARG.long)
-        .takes_value(true)
-        .value_name("COMPUTE-UNIT-PRICE")
-        .help(COMPUTE_UNIT_PRICE_ARG.help)
-}
+pub use crate::compute_budget::{compute_unit_price_arg, COMPUTE_UNIT_PRICE_ARG};

--- a/clap-utils/src/lib.rs
+++ b/clap-utils/src/lib.rs
@@ -27,6 +27,7 @@ pub fn hidden_unless_forced() -> bool {
     std::env::var("SOLANA_NO_HIDDEN_CLI_ARGS").is_err()
 }
 
+pub mod compute_budget;
 pub mod compute_unit_price;
 pub mod fee_payer;
 pub mod input_parsers;

--- a/clap-v3-utils/src/compute_budget.rs
+++ b/clap-v3-utils/src/compute_budget.rs
@@ -1,0 +1,34 @@
+use {
+    crate::ArgConstant,
+    clap::{value_parser, Arg},
+};
+
+pub const COMPUTE_UNIT_PRICE_ARG: ArgConstant<'static> = ArgConstant {
+    name: "compute_unit_price",
+    long: "--with-compute-unit-price",
+    help: "Set compute unit price for transaction, in increments of 0.000001 lamports per compute unit.",
+};
+
+pub const COMPUTE_UNIT_LIMIT_ARG: ArgConstant<'static> = ArgConstant {
+    name: "compute_unit_limit",
+    long: "--with-compute-unit-limit",
+    help: "Set compute unit limit for transaction.",
+};
+
+pub fn compute_unit_price_arg<'a>() -> Arg<'a> {
+    Arg::with_name(COMPUTE_UNIT_PRICE_ARG.name)
+        .long(COMPUTE_UNIT_PRICE_ARG.long)
+        .takes_value(true)
+        .value_name("COMPUTE-UNIT-PRICE")
+        .value_parser(value_parser!(u64))
+        .help(COMPUTE_UNIT_PRICE_ARG.help)
+}
+
+pub fn compute_unit_limit_arg<'a>() -> Arg<'a> {
+    Arg::with_name(COMPUTE_UNIT_LIMIT_ARG.name)
+        .long(COMPUTE_UNIT_LIMIT_ARG.long)
+        .takes_value(true)
+        .value_name("COMPUTE-UNIT-LIMIT")
+        .value_parser(value_parser!(u32))
+        .help(COMPUTE_UNIT_LIMIT_ARG.help)
+}

--- a/clap-v3-utils/src/lib.rs
+++ b/clap-v3-utils/src/lib.rs
@@ -23,6 +23,7 @@ impl std::fmt::Debug for DisplayError {
     }
 }
 
+pub mod compute_budget;
 pub mod fee_payer;
 pub mod input_parsers;
 pub mod input_validators;


### PR DESCRIPTION
#### Problem

While working on adding compute budget instructions to CLIs, I've noticed some bits missing in the clap-utils:

* There's no arg for setting the compute unit limit
* There's no support for clap v3

#### Summary of Changes

Pretty simple: add a compute unit limit arg to clap-utils, and both args to clap-v3-utils.

While working on this, it made sense to move the current `compute_unit_price` helper into a more general `compute_budget` module. Let me know how this looks!

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
