### PR TITLE
[zk-token-sdk] Allow discrete log to be executed in the current thread

### DIFF
--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -28,7 +28,7 @@ use {
     },
     itertools::Itertools,
     serde::{Deserialize, Serialize},
-    std::collections::HashMap,
+    std::{collections::HashMap, num::NonZeroUsize},
     thiserror::Error,
 };
 
@@ -57,7 +57,7 @@ pub struct DiscreteLog {
     /// Target point for discrete log
     pub target: RistrettoPoint,
     /// Number of threads used for discrete log computation
-    num_threads: usize,
+    num_threads: Option<NonZeroUsize>,
     /// Range bound for discrete log search derived from the max value to search for and
     /// `num_threads`
     range_bound: usize,
@@ -107,7 +107,7 @@ impl DiscreteLog {
         Self {
             generator,
             target,
-            num_threads: 1,
+            num_threads: None,
             range_bound: TWO16 as usize,
             step_point: G,
             compression_batch_size: 32,
@@ -116,15 +116,15 @@ impl DiscreteLog {
 
     /// Adjusts number of threads in a discrete log instance.
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn num_threads(&mut self, num_threads: usize) -> Result<(), DiscreteLogError> {
+    pub fn num_threads(&mut self, num_threads: NonZeroUsize) -> Result<(), DiscreteLogError> {
         // number of threads must be a positive power-of-two integer
-        if num_threads == 0 || (num_threads & (num_threads - 1)) != 0 || num_threads > MAX_THREAD {
+        if !num_threads.is_power_of_two() || num_threads.get() > MAX_THREAD {
             return Err(DiscreteLogError::DiscreteLogThreads);
         }
 
-        self.num_threads = num_threads;
-        self.range_bound = (TWO16 as usize).checked_div(num_threads).unwrap();
-        self.step_point = Scalar::from(num_threads as u64) * G;
+        self.num_threads = Some(num_threads);
+        self.range_bound = (TWO16 as usize).checked_div(num_threads.get()).unwrap();
+        self.step_point = Scalar::from(num_threads.get() as u64) * G;
 
         Ok(())
     }
@@ -145,41 +145,41 @@ impl DiscreteLog {
     /// Solves the discrete log problem under the assumption that the solution
     /// is a positive 32-bit number.
     pub fn decode_u32(self) -> Option<u64> {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let mut starting_point = self.target;
-            let handles = (0..self.num_threads)
-                .map(|i| {
-                    let ristretto_iterator = RistrettoIterator::new(
-                        (starting_point, i as u64),
-                        (-(&self.step_point), self.num_threads as u64),
-                    );
+        if let Some(num_threads) = self.num_threads {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let mut starting_point = self.target;
+                let handles = (0..num_threads.get())
+                    .map(|i| {
+                        let ristretto_iterator = RistrettoIterator::new(
+                            (starting_point, i as u64),
+                            (-(&self.step_point), num_threads.get() as u64),
+                        );
 
-                    let handle = thread::spawn(move || {
-                        Self::decode_range(
-                            ristretto_iterator,
-                            self.range_bound,
-                            self.compression_batch_size,
-                        )
-                    });
+                        let handle = thread::spawn(move || {
+                            Self::decode_range(
+                                ristretto_iterator,
+                                self.range_bound,
+                                self.compression_batch_size,
+                            )
+                        });
 
-                    starting_point -= G;
-                    handle
-                })
-                .collect::<Vec<_>>();
+                        starting_point -= G;
+                        handle
+                    })
+                    .collect::<Vec<_>>();
 
-            handles
-                .into_iter()
-                .map_while(|h| h.join().ok())
-                .find(|x| x.is_some())
-                .flatten()
-        }
-        #[cfg(target_arch = "wasm32")]
-        {
-            let ristretto_iterator = RistrettoIterator::new(
-                (self.target, 0_u64),
-                (-(&self.step_point), self.num_threads as u64),
-            );
+                handles
+                    .into_iter()
+                    .map_while(|h| h.join().ok())
+                    .find(|x| x.is_some())
+                    .flatten()
+            }
+            #[cfg(target_arch = "wasm32")]
+            unreachable!() // `self.num_threads` always `None` on wasm target
+        } else {
+            let ristretto_iterator =
+                RistrettoIterator::new((self.target, 0_u64), (-(&self.step_point), 1u64));
 
             Self::decode_range(
                 ristretto_iterator,
@@ -298,7 +298,7 @@ mod tests {
         let amount: u64 = 55;
 
         let mut instance = DiscreteLog::new(G, Scalar::from(amount) * G);
-        instance.num_threads(4).unwrap();
+        instance.num_threads(4.try_into().unwrap()).unwrap();
 
         // Very informal measurements for now
         let start_computation = Instant::now();

--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -126,7 +126,7 @@ impl DiscreteLog {
         self.range_bound = (TWO16 as usize)
             .checked_div(num_threads.get())
             .and_then(|range_bound| range_bound.try_into().ok())
-            .unwrap(); // `num_threads` cannot exceed `TWO16`, so `range_bound` always positive
+            .unwrap(); // `num_threads` cannot exceed `TWO16`, so `range_bound` always non-zero
         self.step_point = Scalar::from(num_threads.get() as u64) * G;
 
         Ok(())

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -799,7 +799,7 @@ mod tests {
         let ciphertext = ElGamal::encrypt(&public, amount);
 
         let mut instance = ElGamal::decrypt(&secret, &ciphertext);
-        instance.num_threads(4).unwrap();
+        instance.num_threads(4.try_into().unwrap()).unwrap();
         assert_eq!(57_u64, instance.decode_u32().unwrap());
     }
 


### PR DESCRIPTION
#### Problem
Currently, the discrete log computation that is used for ElGamal decryption always creates a new execution thread by default even though the number of thread is configured to be 1. It would be nice to give the caller the option to compute discrete log using either the current thread or new thread(s).

Also, in the discrete log implementation, `usize` is used to represent numbers that could better be represented with `std::num::NonZeroUsize`.

#### Summary of Changes
- Replaced the discrete log `num_threads` field to be `Option<NonZeroUsize>`. If this field is `None`, then discrete log computation will be executed in the current threads. If `Some(N)`, then `N` new threads will be created to compute discrete log.
- Used `NonZeroUsize` for the `range_bound` and `compression_batch_size` field, which should also be positive numbers.

This is a follow-up to https://github.com/anza-xyz/agave/pull/379#discussion_r1538446903.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
