### PR TITLE
runtime: parallelize Stakes::new using rayon

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1591,7 +1591,7 @@ impl Bank {
         // Note that we are disabling the read cache while we populate the stakes cache.
         // The stakes accounts will not be expected to be loaded again.
         // If we populate the read cache with these loads, then we'll just soon have to evict these.
-        let (stakes, stakes_time) = measure!(Stakes::new(fields.stakes, |pubkey| {
+        let (stakes, stakes_time) = measure!(Stakes::new(&fields.stakes, |pubkey| {
             let (account, _slot) = bank_rc
                 .accounts
                 .load_with_fixed_root_do_not_populate_read_cache(&ancestors, pubkey)?;
@@ -1601,7 +1601,7 @@ impl Bank {
             "Stakes cache is inconsistent with accounts-db. This can indicate \
             a corrupted snapshot or bugs in cached accounts or accounts-db.",
         ));
-        info!("Loading Stakes took: {}", stakes_time);
+        info!("Loading Stakes took: {stakes_time}");
         let stakes_accounts_load_duration = now.elapsed();
         let mut bank = Self {
             skipped_rewrites: Mutex::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1587,10 +1587,11 @@ impl Bank {
         // from Stakes<Delegation> by reading the full account state from
         // accounts-db. Note that it is crucial that these accounts are loaded
         // at the right slot and match precisely with serialized Delegations.
+
         // Note that we are disabling the read cache while we populate the stakes cache.
         // The stakes accounts will not be expected to be loaded again.
         // If we populate the read cache with these loads, then we'll just soon have to evict these.
-        let stakes = Stakes::new(fields.stakes, |pubkey| {
+        let (stakes, stakes_time) = measure!(Stakes::new(fields.stakes, |pubkey| {
             let (account, _slot) = bank_rc
                 .accounts
                 .load_with_fixed_root_do_not_populate_read_cache(&ancestors, pubkey)?;
@@ -1599,7 +1600,8 @@ impl Bank {
         .expect(
             "Stakes cache is inconsistent with accounts-db. This can indicate \
             a corrupted snapshot or bugs in cached accounts or accounts-db.",
-        );
+        ));
+        info!("Loading Stakes took: {}", stakes_time);
         let stakes_accounts_load_duration = now.elapsed();
         let mut bank = Self {
             skipped_rewrites: Mutex::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1587,7 +1587,7 @@ impl Bank {
         // from Stakes<Delegation> by reading the full account state from
         // accounts-db. Note that it is crucial that these accounts are loaded
         // at the right slot and match precisely with serialized Delegations.
-
+        //
         // Note that we are disabling the read cache while we populate the stakes cache.
         // The stakes accounts will not be expected to be loaded again.
         // If we populate the read cache with these loads, then we'll just soon have to evict these.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1590,7 +1590,7 @@ impl Bank {
         // Note that we are disabling the read cache while we populate the stakes cache.
         // The stakes accounts will not be expected to be loaded again.
         // If we populate the read cache with these loads, then we'll just soon have to evict these.
-        let stakes = Stakes::new(&fields.stakes, |pubkey| {
+        let stakes = Stakes::new(fields.stakes, |pubkey| {
             let (account, _slot) = bank_rc
                 .accounts
                 .load_with_fixed_root_do_not_populate_read_cache(&ancestors, pubkey)?;

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -229,10 +229,12 @@ impl Stakes<StakeAccount> {
     where
         F: Fn(&Pubkey) -> Option<AccountSharedData> + Sync,
     {
-        // im::HashMap doesn't support rayon so we manually build a temporary vector. Note this is
-        // what std HashMap::par_iter() does internally too.
-        let stake_delegations_vec = stakes.stake_delegations.iter().collect::<Vec<_>>();
-        let stake_delegations = stake_delegations_vec
+        let stake_delegations = stakes
+            .stake_delegations
+            .iter()
+            // im::HashMap doesn't support rayon so we manually build a temporary vector. Note this is
+            // what std HashMap::par_iter() does internally too.
+            .collect::<Vec<_>>()
             .into_par_iter()
             // We use fold/reduce to aggregate the results, which does a bit more work than calling
             // collect()/collect_vec_list() and then im::HashMap::from_iter(collected.into_iter()),


### PR DESCRIPTION
~~We used to do two loops over `stakes.stake_delegations` plus another loop over `voter_pubkeys`. Do the same logic but with just one loop.~~

I've now parallelized it using rayon. On my devbox it goes from ~50s to ~10s.