### PR TITLE
Update sysvar API in integration test

### DIFF
--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -443,15 +443,7 @@ fn svm_integration() {
     );
 
     // The sysvars must be put in the cache
-    batch_processor
-        .sysvar_cache
-        .write()
-        .unwrap()
-        .fill_missing_entries(|pubkey, callback| {
-            if let Some(account) = mock_bank.get_account_shared_data(pubkey) {
-                callback(account.data());
-            }
-        });
+    batch_processor.fill_missing_sysvar_cache_entries(&mock_bank);
 
     let mut error_counter = TransactionErrorMetrics::default();
     let recording_config = ExecutionRecordingConfig {


### PR DESCRIPTION
#### Problem

#402 moves the sysvar function to the SVM folder, but the integration tests was not updated to reflect the new API.

#### Summary of Changes

I updated the test.

