### PR TITLE
[TieredStorage] enum-based AccountsFileProvider

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -297,14 +297,14 @@ pub(crate) mod tests {
             slot,
             id,
             store_file_size,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         ));
         let entry2 = Arc::new(AccountStorageEntry::new(
             common_store_path,
             slot,
             id,
             store_file_size2,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         ));
         storage
             .map
@@ -355,7 +355,7 @@ pub(crate) mod tests {
                 slot,
                 id,
                 store_file_size,
-                &AccountsFileProvider::AppendVec,
+                AccountsFileProvider::AppendVec,
             ))
         }
         fn get_test_storage(&self) -> Arc<AccountStorageEntry> {

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -276,7 +276,7 @@ impl Default for AccountStorageStatus {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use {super::*, std::path::Path};
+    use {super::*, crate::accounts_file::AccountsFileProvider, std::path::Path};
 
     #[test]
     fn test_shrink_in_progress() {
@@ -297,12 +297,14 @@ pub(crate) mod tests {
             slot,
             id,
             store_file_size,
+            &AccountsFileProvider::AppendVec,
         ));
         let entry2 = Arc::new(AccountStorageEntry::new(
             common_store_path,
             slot,
             id,
             store_file_size2,
+            &AccountsFileProvider::AppendVec,
         ));
         storage
             .map
@@ -353,6 +355,7 @@ pub(crate) mod tests {
                 slot,
                 id,
                 store_file_size,
+                &AccountsFileProvider::AppendVec,
             ))
         }
         fn get_test_storage(&self) -> Arc<AccountStorageEntry> {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -32,7 +32,8 @@ use {
         },
         accounts_cache::{AccountsCache, CachedAccount, SlotCache},
         accounts_file::{
-            AccountsFile, AccountsFileError, MatchAccountOwnerError, ALIGN_BOUNDARY_OFFSET,
+            AccountsFile, AccountsFileError, AccountsFileProvider, MatchAccountOwnerError,
+            ALIGN_BOUNDARY_OFFSET,
         },
         accounts_hash::{
             AccountHash, AccountsDeltaHash, AccountsHash, AccountsHashKind, AccountsHasher,
@@ -55,9 +56,7 @@ use {
         ancient_append_vecs::{
             get_ancient_append_vec_capacity, is_ancient, AccountsToStore, StorageSelector,
         },
-        append_vec::{
-            aligned_stored_size, AppendVec, APPEND_VEC_MMAPPED_FILES_OPEN, STORE_META_OVERHEAD,
-        },
+        append_vec::{aligned_stored_size, APPEND_VEC_MMAPPED_FILES_OPEN, STORE_META_OVERHEAD},
         cache_hash_data::{
             CacheHashData, CacheHashDataFileReference, DeletionPolicy as CacheHashDeletionPolicy,
         },
@@ -1033,10 +1032,16 @@ pub struct AccountStorageEntry {
 }
 
 impl AccountStorageEntry {
-    pub fn new(path: &Path, slot: Slot, id: AccountsFileId, file_size: u64) -> Self {
+    pub fn new(
+        path: &Path,
+        slot: Slot,
+        id: AccountsFileId,
+        file_size: u64,
+        provider: &AccountsFileProvider,
+    ) -> Self {
         let tail = AccountsFile::file_name(slot, id);
         let path = Path::new(path).join(tail);
-        let accounts = AccountsFile::AppendVec(AppendVec::new(path, true, file_size as usize));
+        let accounts = provider.new_writable(path, file_size);
 
         Self {
             id,
@@ -2516,7 +2521,13 @@ impl AccountsDb {
     }
 
     fn new_storage_entry(&self, slot: Slot, path: &Path, size: u64) -> AccountStorageEntry {
-        AccountStorageEntry::new(path, slot, self.next_id(), size)
+        AccountStorageEntry::new(
+            path,
+            slot,
+            self.next_id(),
+            size,
+            &AccountsFileProvider::AppendVec,
+        )
     }
 
     pub fn expected_cluster_type(&self) -> ClusterType {
@@ -9475,7 +9486,7 @@ pub mod tests {
             accounts_hash::MERKLE_FANOUT,
             accounts_index::{tests::*, AccountSecondaryIndexesIncludeExclude},
             ancient_append_vecs,
-            append_vec::{test_utils::TempFile, AppendVecStoredAccountMeta},
+            append_vec::{test_utils::TempFile, AppendVec, AppendVecStoredAccountMeta},
             cache_hash_data::CacheHashDataFile,
             inline_spl_token,
         },
@@ -10487,7 +10498,13 @@ pub mod tests {
         let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
         let slot_expected: Slot = 0;
         let size: usize = 123;
-        let data = AccountStorageEntry::new(&paths[0], slot_expected, 0, size as u64);
+        let data = AccountStorageEntry::new(
+            &paths[0],
+            slot_expected,
+            0,
+            size as u64,
+            &AccountsFileProvider::AppendVec,
+        );
 
         let arc = Arc::new(data);
         let storages = vec![arc];
@@ -10538,7 +10555,13 @@ pub mod tests {
         let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
         let slot_expected: Slot = 0;
         let size: usize = 123;
-        let mut data = AccountStorageEntry::new(&paths[0], slot_expected, 0, size as u64);
+        let mut data = AccountStorageEntry::new(
+            &paths[0],
+            slot_expected,
+            0,
+            size as u64,
+            &AccountsFileProvider::AppendVec,
+        );
         let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, true, 1024 * 1024));
         data.accounts = av;
 
@@ -10654,7 +10677,13 @@ pub mod tests {
         let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
         let slot_expected: Slot = 0;
         let size: usize = 123;
-        let mut data = AccountStorageEntry::new(&paths[0], slot_expected, 0, size as u64);
+        let mut data = AccountStorageEntry::new(
+            &paths[0],
+            slot_expected,
+            0,
+            size as u64,
+            &AccountsFileProvider::AppendVec,
+        );
         let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, true, 1024 * 1024));
         data.accounts = av;
 
@@ -10733,7 +10762,13 @@ pub mod tests {
         let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
         let file_size = account_data_size.unwrap_or(123) * 100 / fill_percentage;
         let size_aligned: usize = aligned_stored_size(file_size as usize);
-        let mut data = AccountStorageEntry::new(&paths[0], slot, id, size_aligned as u64);
+        let mut data = AccountStorageEntry::new(
+            &paths[0],
+            slot,
+            id,
+            size_aligned as u64,
+            &AccountsFileProvider::AppendVec,
+        );
         let av = AccountsFile::AppendVec(AppendVec::new(
             &tf.path,
             true,
@@ -12842,6 +12877,7 @@ pub mod tests {
             slot_id_1,
             store1_id,
             store_file_size,
+            &AccountsFileProvider::AppendVec,
         ));
         store1.alive_bytes.store(0, Ordering::Release);
 
@@ -12855,6 +12891,7 @@ pub mod tests {
             slot_id_2,
             store2_id,
             store_file_size,
+            &AccountsFileProvider::AppendVec,
         ));
 
         // The store2's alive_ratio is 0.5: as its page aligned alive size is 1 page.
@@ -12871,6 +12908,7 @@ pub mod tests {
             slot_id_3,
             store3_id,
             store_file_size,
+            &AccountsFileProvider::AppendVec,
         ));
 
         db.storage.insert(slot_id_1, Arc::clone(&store1));
@@ -12915,6 +12953,7 @@ pub mod tests {
             slot_id_1,
             store1_id,
             store_file_size,
+            &AccountsFileProvider::AppendVec,
         ));
         store1.alive_bytes.store(0, Ordering::Release);
         db.storage.insert(slot_id_1, Arc::clone(&store1));
@@ -12927,6 +12966,7 @@ pub mod tests {
             slot_id_2,
             store2_id,
             store_file_size,
+            &AccountsFileProvider::AppendVec,
         ));
         db.storage.insert(slot_id_2, Arc::clone(&store2));
 
@@ -12944,6 +12984,7 @@ pub mod tests {
             slot_id_3,
             store3_id,
             store_file_size,
+            &AccountsFileProvider::AppendVec,
         ));
 
         // The store3's alive ratio is 1.0 as its page-aligned alive size is 2 pages
@@ -12981,6 +13022,7 @@ pub mod tests {
             slot1,
             store1_id,
             store_file_size,
+            &AccountsFileProvider::AppendVec,
         ));
 
         // store1 has 1 page-aligned alive bytes, its alive ratio is 1/4: 0.25
@@ -12999,6 +13041,7 @@ pub mod tests {
             slot2,
             store2_id,
             store_file_size,
+            &AccountsFileProvider::AppendVec,
         ));
 
         // store2 has 2 page-aligned bytes, its alive ratio is 2/4: 0.5
@@ -15006,11 +15049,18 @@ pub mod tests {
     #[test]
     fn test_shrink_productive() {
         solana_logger::setup();
-        let s1 = AccountStorageEntry::new(Path::new("."), 0, 0, 1024);
+        let s1 =
+            AccountStorageEntry::new(Path::new("."), 0, 0, 1024, &AccountsFileProvider::AppendVec);
         let store = Arc::new(s1);
         assert!(!AccountsDb::is_shrinking_productive(0, &store));
 
-        let s1 = AccountStorageEntry::new(Path::new("."), 0, 0, PAGE_SIZE * 4);
+        let s1 = AccountStorageEntry::new(
+            Path::new("."),
+            0,
+            0,
+            PAGE_SIZE * 4,
+            &AccountsFileProvider::AppendVec,
+        );
         let store = Arc::new(s1);
         store.add_account((3 * PAGE_SIZE as usize) - 1);
         store.add_account(10);
@@ -15033,6 +15083,7 @@ pub mod tests {
             0,
             1,
             store_file_size,
+            &AccountsFileProvider::AppendVec,
         ));
         match accounts.shrink_ratio {
             AccountShrinkThreshold::TotalSpace { shrink_ratio } => {
@@ -17369,6 +17420,7 @@ pub mod tests {
             0,
             1,
             store_file_size,
+            &AccountsFileProvider::AppendVec,
         ));
         let db = AccountsDb::new_single_for_tests();
         let slot0 = 0;

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1037,7 +1037,7 @@ impl AccountStorageEntry {
         slot: Slot,
         id: AccountsFileId,
         file_size: u64,
-        provider: &AccountsFileProvider,
+        provider: AccountsFileProvider,
     ) -> Self {
         let tail = AccountsFile::file_name(slot, id);
         let path = Path::new(path).join(tail);
@@ -2526,7 +2526,7 @@ impl AccountsDb {
             slot,
             self.next_id(),
             size,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         )
     }
 
@@ -10503,7 +10503,7 @@ pub mod tests {
             slot_expected,
             0,
             size as u64,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         );
 
         let arc = Arc::new(data);
@@ -10560,7 +10560,7 @@ pub mod tests {
             slot_expected,
             0,
             size as u64,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         );
         let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, true, 1024 * 1024));
         data.accounts = av;
@@ -10682,7 +10682,7 @@ pub mod tests {
             slot_expected,
             0,
             size as u64,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         );
         let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, true, 1024 * 1024));
         data.accounts = av;
@@ -10767,7 +10767,7 @@ pub mod tests {
             slot,
             id,
             size_aligned as u64,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         );
         let av = AccountsFile::AppendVec(AppendVec::new(
             &tf.path,
@@ -12877,7 +12877,7 @@ pub mod tests {
             slot_id_1,
             store1_id,
             store_file_size,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         ));
         store1.alive_bytes.store(0, Ordering::Release);
 
@@ -12891,7 +12891,7 @@ pub mod tests {
             slot_id_2,
             store2_id,
             store_file_size,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         ));
 
         // The store2's alive_ratio is 0.5: as its page aligned alive size is 1 page.
@@ -12908,7 +12908,7 @@ pub mod tests {
             slot_id_3,
             store3_id,
             store_file_size,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         ));
 
         db.storage.insert(slot_id_1, Arc::clone(&store1));
@@ -12953,7 +12953,7 @@ pub mod tests {
             slot_id_1,
             store1_id,
             store_file_size,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         ));
         store1.alive_bytes.store(0, Ordering::Release);
         db.storage.insert(slot_id_1, Arc::clone(&store1));
@@ -12966,7 +12966,7 @@ pub mod tests {
             slot_id_2,
             store2_id,
             store_file_size,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         ));
         db.storage.insert(slot_id_2, Arc::clone(&store2));
 
@@ -12984,7 +12984,7 @@ pub mod tests {
             slot_id_3,
             store3_id,
             store_file_size,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         ));
 
         // The store3's alive ratio is 1.0 as its page-aligned alive size is 2 pages
@@ -13022,7 +13022,7 @@ pub mod tests {
             slot1,
             store1_id,
             store_file_size,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         ));
 
         // store1 has 1 page-aligned alive bytes, its alive ratio is 1/4: 0.25
@@ -13041,7 +13041,7 @@ pub mod tests {
             slot2,
             store2_id,
             store_file_size,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         ));
 
         // store2 has 2 page-aligned bytes, its alive ratio is 2/4: 0.5
@@ -15050,7 +15050,7 @@ pub mod tests {
     fn test_shrink_productive() {
         solana_logger::setup();
         let s1 =
-            AccountStorageEntry::new(Path::new("."), 0, 0, 1024, &AccountsFileProvider::AppendVec);
+            AccountStorageEntry::new(Path::new("."), 0, 0, 1024, AccountsFileProvider::AppendVec);
         let store = Arc::new(s1);
         assert!(!AccountsDb::is_shrinking_productive(0, &store));
 
@@ -15059,7 +15059,7 @@ pub mod tests {
             0,
             0,
             PAGE_SIZE * 4,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         );
         let store = Arc::new(s1);
         store.add_account((3 * PAGE_SIZE as usize) - 1);
@@ -15083,7 +15083,7 @@ pub mod tests {
             0,
             1,
             store_file_size,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         ));
         match accounts.shrink_ratio {
             AccountShrinkThreshold::TotalSpace { shrink_ratio } => {
@@ -17420,7 +17420,7 @@ pub mod tests {
             0,
             1,
             store_file_size,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         ));
         let db = AccountsDb::new_single_for_tests();
         let slot0 = 0;

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -223,6 +223,23 @@ impl<'a> Iterator for AccountsFileIter<'a> {
     }
 }
 
+/// An enum that creates AccountsFile instance with the specified format.
+pub enum AccountsFileProvider {
+    AppendVec,
+    HotStorage,
+}
+
+impl AccountsFileProvider {
+    pub fn new_writable(&self, path: impl Into<PathBuf>, file_size: u64) -> AccountsFile {
+        match self {
+            Self::AppendVec => {
+                AccountsFile::AppendVec(AppendVec::new(path, true, file_size as usize))
+            }
+            Self::HotStorage => AccountsFile::TieredStorage(TieredStorage::new_writable(path)),
+        }
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use crate::accounts_file::AccountsFile;

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -224,6 +224,7 @@ impl<'a> Iterator for AccountsFileIter<'a> {
 }
 
 /// An enum that creates AccountsFile instance with the specified format.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum AccountsFileProvider {
     AppendVec,
     HotStorage,

--- a/accounts-db/src/sorted_storages.rs
+++ b/accounts-db/src/sorted_storages.rs
@@ -196,7 +196,7 @@ mod tests {
         super::*,
         crate::{
             accounts_db::{AccountStorageEntry, AccountsFileId},
-            accounts_file::AccountsFile,
+            accounts_file::{AccountsFile, AccountsFileProvider},
             append_vec::AppendVec,
         },
         std::sync::Arc,
@@ -445,7 +445,13 @@ mod tests {
         let (_temp_dirs, paths) = crate::accounts_db::get_temp_accounts_paths(1).unwrap();
         let size: usize = 123;
         let slot = 0;
-        let mut data = AccountStorageEntry::new(&paths[0], slot, id, size as u64);
+        let mut data = AccountStorageEntry::new(
+            &paths[0],
+            slot,
+            id,
+            size as u64,
+            &AccountsFileProvider::AppendVec,
+        );
         let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, true, 1024 * 1024));
         data.accounts = av;
 

--- a/accounts-db/src/sorted_storages.rs
+++ b/accounts-db/src/sorted_storages.rs
@@ -450,7 +450,7 @@ mod tests {
             slot,
             id,
             size as u64,
-            &AccountsFileProvider::AppendVec,
+            AccountsFileProvider::AppendVec,
         );
         let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, true, 1024 * 1024));
         data.accounts = av;


### PR DESCRIPTION
#### Problem
Currently, all existing code paths for creating a new writable AccountsFile
are hard-coded to create an AppendVec.  As we introduce a new AccountsFile
format, we will need a more programmatic way to create writable AccountsFiles
using a different format.

#### Summary of Changes
This PR introduces AccountsFileProvider enum, which allows both AppendVec
and TieredStorage to provide their implementations to create a new AccountsFile.
This will later allow tests and the production code-path to switch between different
formats programmatically.

For existing places where AppendVec is created, this PR simply replaces them by
passing an AccountsFileProvider::AppendVec instance.  Will create follow-up PRs
that change them to share the same instance from AccountsDb.