### PR TITLE
Flushes storages in parallel

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -25,6 +25,7 @@ use {
     },
     bincode::{config::Options, serialize_into},
     log::*,
+    rayon::prelude::*,
     solana_accounts_db::{
         accounts_db::{
             AccountShrinkThreshold, AccountStorageEntry, AccountsDbConfig, AtomicAccountsFileId,
@@ -99,6 +100,19 @@ pub fn add_bank_snapshot(
             bank_snapshot_path.display(),
         );
 
+        let (_, measure_flush) = measure!(bank
+            .rc
+            .accounts
+            .accounts_db
+            .thread_pool_clean
+            .install(|| {
+                snapshot_storages
+                    .par_iter()
+                    .map(|storage| storage.flush())
+                    .collect::<Result<(), _>>()
+            })
+            .map_err(AddBankSnapshotError::FlushStorages)?);
+
         // We are constructing the snapshot directory to contain the full snapshot state information to allow
         // constructing a bank from this directory.  It acts like an archive to include the full state.
         // The set of the account storages files is the necessary part of this snapshot state.  Hard-link them
@@ -157,6 +171,7 @@ pub fn add_bank_snapshot(
             ("slot", slot, i64),
             ("bank_size", bank_snapshot_consumed_size, i64),
             ("status_cache_size", status_cache_consumed_size, i64),
+            ("flush_storages_us", measure_flush.as_us(), i64),
             ("hard_link_storages_us", measure_hard_linking.as_us(), i64),
             ("bank_serialize_us", bank_serialize.as_us(), i64),
             (

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -413,6 +413,9 @@ pub enum AddBankSnapshotError {
     #[error("failed to create snapshot dir '{1}': {0}")]
     CreateSnapshotDir(#[source] IoError, PathBuf),
 
+    #[error("failed to flush storages: {0}")]
+    FlushStorages(#[source] AccountsFileError),
+
     #[error("failed to hard link storages: {0}")]
     HardLinkStorages(#[source] HardLinkStoragesToSnapshotError),
 
@@ -501,9 +504,6 @@ pub enum ArchiveSnapshotPackageError {
 pub enum HardLinkStoragesToSnapshotError {
     #[error("failed to create accounts hard links dir '{1}': {0}")]
     CreateAccountsHardLinksDir(#[source] IoError, PathBuf),
-
-    #[error("failed to flush storage: {0}")]
-    FlushStorage(#[source] AccountsFileError),
 
     #[error("failed to get the snapshot's accounts hard link dir: {0}")]
     GetSnapshotHardLinksDir(#[from] GetSnapshotAccountsHardLinkDirError),
@@ -1184,9 +1184,6 @@ pub fn hard_link_storages_to_snapshot(
 
     let mut account_paths: HashSet<PathBuf> = HashSet::new();
     for storage in snapshot_storages {
-        storage
-            .flush()
-            .map_err(HardLinkStoragesToSnapshotError::FlushStorage)?;
         let storage_path = storage.accounts.get_path();
         let snapshot_hardlink_dir = get_snapshot_accounts_hardlink_dir(
             &storage_path,


### PR DESCRIPTION
#### Problem

When taking a snapshot, flushing the storages' mmaps takes a long time. Approximately 4 to 8 seconds!


#### Summary of Changes

Flush storages in parallel. This reduces the time to flush the storages to around 500 milliseconds.

The code uses the `thread_pool_clean` to perform the parallelization. This pool is used by the accounts background services for doing `clean` and `shrink`. Since those operations run in serial to taking snapshots, we are not negatively impacting them.

The thread pool is also used when calculating accounts hashes in AccountsHashVerifier. Since ABS to AHV is basically a pipeline, flushing here in ABS needs to happen before the snapshot can be processed in AHV. There is a corner case where AHV is already processing a full snapshot and then ABS is busy on a newer snapshot. I have not noticed increased snapshot time while AHV is processing a full snapshot. I also have not seen impacts to replay time either (in case there are concerns for added thread contention).



<details><summary>OLD metrics</summary>
<p>

To gather the metrics for the current perf, I added some measure calls to see how long flushing took. You'll see those numbers under `hard_link_storages_to_snapshot flush_us`:

```
[2024-03-27T18:29:34.071578259Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=4595372i mkdir_us=14564i link_us=5273243i
[2024-03-27T18:29:40.451257280Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256806904i bank_size=951765153i status_cache_size=23120500i hard_link_storages_us=10825460i bank_serialize_us=6317476i status_cache_serialize_us=62118i write_version_file_us=54i write_state_complete_file_us=12i total_us=17205269i
[2024-03-27T18:30:21.694653999Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=4454317i mkdir_us=16177i link_us=5262895i
[2024-03-27T18:30:27.900599309Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256807016i bank_size=951765009i status_cache_size=22624748i hard_link_storages_us=10677152i bank_serialize_us=6135836i status_cache_serialize_us=70004i write_version_file_us=67i write_state_complete_file_us=7i total_us=16883192i
[2024-03-27T18:31:11.498515083Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=4409789i mkdir_us=17722i link_us=5335417i
[2024-03-27T18:31:17.628483430Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256807118i bank_size=951764753i status_cache_size=22307344i hard_link_storages_us=10714439i bank_serialize_us=6066827i status_cache_serialize_us=63166i write_version_file_us=56i write_state_complete_file_us=7i total_us=16844662i
[2024-03-27T18:32:02.310493715Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=5280980i mkdir_us=9841i link_us=5319653i
[2024-03-27T18:32:08.474048689Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256807235i bank_size=951764625i status_cache_size=21499660i hard_link_storages_us=11545201i bank_serialize_us=6109510i status_cache_serialize_us=53962i write_version_file_us=54i write_state_complete_file_us=9i total_us=17708872i
[2024-03-27T18:32:56.070320741Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=4523834i mkdir_us=20042i link_us=5343784i
[2024-03-27T18:33:02.183983765Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256807354i bank_size=951764337i status_cache_size=21033502i hard_link_storages_us=10838011i bank_serialize_us=6057097i status_cache_serialize_us=56452i write_version_file_us=75i write_state_complete_file_us=8i total_us=16951767i
[2024-03-27T18:33:42.794397271Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=5123345i mkdir_us=18397i link_us=5406043i
[2024-03-27T18:33:48.809400606Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256807458i bank_size=951764065i status_cache_size=20473224i hard_link_storages_us=11491879i bank_serialize_us=5959893i status_cache_serialize_us=55006i write_version_file_us=64i write_state_complete_file_us=7i total_us=17507002i
[2024-03-27T18:34:34.781294662Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=4134135i mkdir_us=11377i link_us=5045341i
[2024-03-27T18:34:40.986073665Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256807567i bank_size=951764049i status_cache_size=20627084i hard_link_storages_us=10120193i bank_serialize_us=6152791i status_cache_serialize_us=51894i write_version_file_us=55i write_state_complete_file_us=13i total_us=16325102i
[2024-03-27T18:35:27.428074240Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=3968968i mkdir_us=20021i link_us=5378450i
[2024-03-27T18:35:33.536625019Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256807677i bank_size=951763649i status_cache_size=20608100i hard_link_storages_us=10320800i bank_serialize_us=6048673i status_cache_serialize_us=59770i write_version_file_us=66i write_state_complete_file_us=7i total_us=16429444i
[2024-03-27T18:36:18.498712788Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=3845048i mkdir_us=16718i link_us=5238376i
[2024-03-27T18:36:24.548868926Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256807793i bank_size=951764705i status_cache_size=20363562i hard_link_storages_us=10042561i bank_serialize_us=5998771i status_cache_serialize_us=51291i write_version_file_us=54i write_state_complete_file_us=8i total_us=16092816i
[2024-03-27T18:37:10.945767917Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=4217446i mkdir_us=20156i link_us=5367369i
[2024-03-27T18:37:17.198458206Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256807913i bank_size=951765329i status_cache_size=20114494i hard_link_storages_us=10556324i bank_serialize_us=6198244i status_cache_serialize_us=54371i write_version_file_us=53i write_state_complete_file_us=11i total_us=16809114i
[2024-03-27T18:37:56.018382342Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=4957944i mkdir_us=15951i link_us=5289027i
[2024-03-27T18:38:01.609459731Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256808029i bank_size=951765201i status_cache_size=20114288i hard_link_storages_us=11203176i bank_serialize_us=6008325i status_cache_serialize_us=54821i write_version_file_us=46i write_state_complete_file_us=7i total_us=17266496i
[2024-03-27T18:38:40.228897000Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=4655588i mkdir_us=19660i link_us=5281694i
[2024-03-27T18:38:46.250329901Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256808133i bank_size=951764865i status_cache_size=20135660i hard_link_storages_us=10901903i bank_serialize_us=5967409i status_cache_serialize_us=53911i write_version_file_us=72i write_state_complete_file_us=11i total_us=16923452i
[2024-03-27T18:39:26.026964614Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=5029770i mkdir_us=19817i link_us=5405473i
[2024-03-27T18:39:32.190489016Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256808234i bank_size=951765153i status_cache_size=20902472i hard_link_storages_us=11406415i bank_serialize_us=6108612i status_cache_serialize_us=54817i write_version_file_us=55i write_state_complete_file_us=12i total_us=17570042i
[2024-03-27T18:40:14.187117547Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=4572371i mkdir_us=22854i link_us=5429865i
[2024-03-27T18:40:20.353148493Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256808341i bank_size=951765649i status_cache_size=21448340i hard_link_storages_us=10982907i bank_serialize_us=6101216i status_cache_serialize_us=64712i write_version_file_us=69i write_state_complete_file_us=8i total_us=17149039i
[2024-03-27T18:41:01.187659721Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=7103903i mkdir_us=25741i link_us=5666174i
[2024-03-27T18:41:07.232861756Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256808443i bank_size=951766385i status_cache_size=21600464i hard_link_storages_us=13760285i bank_serialize_us=5987611i status_cache_serialize_us=57509i write_version_file_us=57i write_state_complete_file_us=7i total_us=19805599i
[2024-03-27T18:41:46.847765260Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=8427305i mkdir_us=23864i link_us=5715125i
[2024-03-27T18:41:52.872684167Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256808544i bank_size=951766609i status_cache_size=21194788i hard_link_storages_us=15133239i bank_serialize_us=5971777i status_cache_serialize_us=53055i write_version_file_us=51i write_state_complete_file_us=9i total_us=21158276i
[2024-03-27T18:42:30.551559859Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=6240386i mkdir_us=20127i link_us=5301727i
[2024-03-27T18:42:36.891023954Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256808652i bank_size=951766881i status_cache_size=21397968i hard_link_storages_us=12517952i bank_serialize_us=6280885i status_cache_serialize_us=58490i write_version_file_us=56i write_state_complete_file_us=11i total_us=18857505i
[2024-03-27T18:43:17.275943947Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=7453074i mkdir_us=18057i link_us=5419516i
[2024-03-27T18:43:23.684635639Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256808754i bank_size=951766721i status_cache_size=21496314i hard_link_storages_us=13836319i bank_serialize_us=6350625i status_cache_serialize_us=57949i write_version_file_us=78i write_state_complete_file_us=9i total_us=20245108i
[2024-03-27T18:44:04.895968945Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=7835022i mkdir_us=39065i link_us=6303170i
[2024-03-27T18:44:13.111403236Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256808859i bank_size=951766929i status_cache_size=21631602i hard_link_storages_us=15201494i bank_serialize_us=8144005i status_cache_serialize_us=71320i write_version_file_us=58i write_state_complete_file_us=11i total_us=23417036i
[2024-03-27T18:44:49.502221085Z INFO  solana_metrics::metrics] datapoint: snapshot-hard_link_storages_to_snapshot flush_us=6835286i mkdir_us=46504i link_us=6183084i
[2024-03-27T18:44:55.741550555Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256808960i bank_size=951767185i status_cache_size=21404180i hard_link_storages_us=14066185i bank_serialize_us=6179415i status_cache_serialize_us=59495i write_version_file_us=61i write_state_complete_file_us=14i total_us=20305413i
```

</p>
</details> 

<details><summary>NEW metrics</summary>
<p>

Here's the metrics for this PR. Notice that flushing storages is now under `snapshot_bank flush_storages_us`. You can compare the `total_us` in OLD and NEW too!

```
[2024-03-27T21:10:28.901976319Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256829258i bank_size=951891585i status_cache_size=22412822i flush_storages_us=481997i hard_link_storages_us=5820798i bank_serialize_us=5934006i status_cache_serialize_us=62702i write_version_file_us=59i write_state_complete_file_us=8i total_us=12300015i
[2024-03-27T21:11:14.826109571Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256829358i bank_size=951891489i status_cache_size=22898496i flush_storages_us=369907i hard_link_storages_us=5880335i bank_serialize_us=6102434i status_cache_serialize_us=60540i write_version_file_us=52i write_state_complete_file_us=7i total_us=12413597i
[2024-03-27T21:11:57.254018504Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256829461i bank_size=951891713i status_cache_size=22652540i flush_storages_us=508310i hard_link_storages_us=5846968i bank_serialize_us=6088841i status_cache_serialize_us=61151i write_version_file_us=56i write_state_complete_file_us=8i total_us=12505487i
[2024-03-27T21:12:42.316471136Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256829561i bank_size=951891809i status_cache_size=22857330i flush_storages_us=359002i hard_link_storages_us=5949352i bank_serialize_us=5880635i status_cache_serialize_us=61971i write_version_file_us=59i write_state_complete_file_us=7i total_us=12251325i
[2024-03-27T21:13:23.539995315Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256829665i bank_size=951892113i status_cache_size=22070624i flush_storages_us=503662i hard_link_storages_us=6006205i bank_serialize_us=6117445i status_cache_serialize_us=62192i write_version_file_us=82i write_state_complete_file_us=12i total_us=12689736i
[2024-03-27T21:14:09.347421829Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256829768i bank_size=951892305i status_cache_size=22458964i flush_storages_us=423048i hard_link_storages_us=5879774i bank_serialize_us=5886778i status_cache_serialize_us=61136i write_version_file_us=62i write_state_complete_file_us=7i total_us=12250969i
[2024-03-27T21:14:54.458826076Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256829870i bank_size=951892129i status_cache_size=21962558i flush_storages_us=568085i hard_link_storages_us=5876490i bank_serialize_us=6070879i status_cache_serialize_us=61961i write_version_file_us=57i write_state_complete_file_us=8i total_us=12577763i
[2024-03-27T21:15:41.667415368Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256829978i bank_size=951892353i status_cache_size=22453932i flush_storages_us=274215i hard_link_storages_us=5835347i bank_serialize_us=6119035i status_cache_serialize_us=60069i write_version_file_us=58i write_state_complete_file_us=8i total_us=12288892i
[2024-03-27T21:16:25.950246349Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256830078i bank_size=951892257i status_cache_size=22120928i flush_storages_us=421769i hard_link_storages_us=5781314i bank_serialize_us=5953078i status_cache_serialize_us=59800i write_version_file_us=56i write_state_complete_file_us=7i total_us=12216175i
[2024-03-27T21:17:07.966081843Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256830179i bank_size=951892609i status_cache_size=22110424i flush_storages_us=462706i hard_link_storages_us=6085963i bank_serialize_us=6400394i status_cache_serialize_us=61116i write_version_file_us=59i write_state_complete_file_us=7i total_us=13010395i
[2024-03-27T21:17:52.307053824Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256830279i bank_size=951893073i status_cache_size=22243452i flush_storages_us=549134i hard_link_storages_us=5694710i bank_serialize_us=6096465i status_cache_serialize_us=59725i write_version_file_us=57i write_state_complete_file_us=7i total_us=12400253i
[2024-03-27T21:18:34.673192766Z INFO  solana_metrics::metrics] datapoint: snapshot_bank slot=256830383i bank_size=951893313i status_cache_size=22352526i flush_storages_us=612687i hard_link_storages_us=5814101i bank_serialize_us=6148490i status_cache_serialize_us=58876i write_version_file_us=54i write_state_complete_file_us=7i total_us=12634332i
```

</p>
</details> 
