### PR TITLE
config: deprecate date instructions

### DIFF
--- a/programs/config/src/lib.rs
+++ b/programs/config/src/lib.rs
@@ -1,6 +1,10 @@
 #![allow(clippy::arithmetic_side_effects)]
 pub mod config_instruction;
 pub mod config_processor;
+#[deprecated(
+    since = "2.0.0",
+    note = "The config program API no longer supports date instructions."
+)]
 pub mod date_instruction;
 
 pub use solana_sdk::config::program::id;


### PR DESCRIPTION
#### Problem
As we prepare to migrate the Config program to core BPF and roll out
a new major version, we see it as an opportunity to streamline the crate
by eliminating any unnecessary bloat. Consequently, we have opted to
discontinue support for date instructions.

#### Summary of Changes
Deprecate the date instructions in the config program crate.
