### PR TITLE
ci: add release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  trigger-buildkite-pipeline:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger a Buildkite Build
+        uses: "buildkite/trigger-pipeline-action@v2.0.0"
+        with:
+          buildkite_api_access_token: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}
+          pipeline: "anza/agave-secondary"
+          branch: "${{ github.ref_name }}"
+          commit: "HEAD"
+          message: ":github: Triggered from a GitHub Action"
+
+  draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: '${{ github.ref_name }}',
+              name: 'Release ${{ github.ref_name }}',
+              body: '🚧',
+              draft: true,
+              prerelease: false
+            })
+
+  version-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Parse Info
+        id: parse_info
+        run: |
+          # get the next version
+          version=${{ github.ref_name }}
+          major=$(echo $version | cut -d'.' -f1)
+          minor=$(echo $version | cut -d'.' -f2)
+          patch=$(echo $version | cut -d'.' -f3)
+          next_version=$major.$minor.$((patch+1))
+          : "${next_version:?}"
+
+          # get the traget branch
+          target_branch=$major.$minor
+          : "${target_branch:?}"
+
+          echo "next_version=$next_version" | tee -a $GITHUB_OUTPUT
+          echo "target_branch=$target_branch" | tee -a $GITHUB_OUTPUT
+
+      - name: Create branch and make changes
+        run: |
+          next_version=${{ steps.parse_info.outputs.next_version }}
+
+          git checkout -b version-bump-$next_version
+          ./scripts/increment-cargo-version.sh patch
+
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git commit -am "Bump version to $next_version"
+          git push origin version-bump-$next_version
+
+      - name: Create PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Bump version to ${{ steps.parse_info.outputs.next_version }}',
+              head: 'version-bump-${{ steps.parse_info.outputs.next_version }}',
+              base: '${{ steps.parse_info.outputs.target_branch }}'
+            })


### PR DESCRIPTION
### Problem

we should have an automatic release pipeline. this PR is the first step. it will be triggered by a pushing tag. when it becomes stable, I will push another PR for pushing tag weekly!

### Summary of Changes

add 3 different jobs in this release pipeline

#### trigger-buildkite-pipeline 

this one will trigger secondary pipeline on buildkite instead of webhook. It will ensure all secondary pipelines are executed successfully.

<details>
  <summary>image</summary>
  
![Screenshot 2024-03-28 at 21 51 40](https://github.com/anza-xyz/agave/assets/8209234/f1d11206-59bf-4a4c-93d4-bf29aeb5333f)
</details>


#### draft-release

create a draft release for binaries. 

<details>
  <summary>image</summary>
  
![Screenshot 2024-03-28 at 21 51 21](https://github.com/anza-xyz/agave/assets/8209234/424933d7-34de-4ef6-a851-b2763f8fbbbf)
</details>

#### version-bump

create a version bump PR automatically.

<details>
  <summary>image</summary>
  
![Screenshot 2024-03-28 at 21 50 40](https://github.com/anza-xyz/agave/assets/8209234/26807a22-45ac-4881-ab01-d4c59ecffa70)
</details>

---

### Before Merge

- [x] add `TRIGGER_BK_BUILD_TOKEN` to Github Actions
- [x] remove tag triggering on Buildkite