### PR TITLE
ff cleanup: vote_state_add_vote_latency

### DIFF
--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -31,14 +31,14 @@ use {
     solana_rpc_client_api::config::RpcGetVoteAccountsConfig,
     solana_rpc_client_nonce_utils::blockhash_query::BlockhashQuery,
     solana_sdk::{
-        account::Account, commitment_config::CommitmentConfig, feature, message::Message,
+        account::Account, commitment_config::CommitmentConfig, message::Message,
         native_token::lamports_to_sol, pubkey::Pubkey, system_instruction::SystemError,
         transaction::Transaction,
     },
     solana_vote_program::{
         vote_error::VoteError,
         vote_instruction::{self, withdraw, CreateVoteAccountConfig},
-        vote_state::{VoteAuthorize, VoteInit, VoteState, VoteStateVersions},
+        vote_state::{VoteAuthorize, VoteInit, VoteState},
     },
     std::rc::Rc,
 };
@@ -821,12 +821,7 @@ pub fn process_create_vote_account(
     let fee_payer = config.signers[fee_payer];
     let nonce_authority = config.signers[nonce_authority];
 
-    let is_feature_active = (!sign_only)
-        .then(solana_sdk::feature_set::vote_state_add_vote_latency::id)
-        .and_then(|feature_address| rpc_client.get_account(&feature_address).ok())
-        .and_then(|account| feature::from_account(&account))
-        .map_or(false, |feature| feature.activated_at.is_some());
-    let space = VoteStateVersions::vote_state_size_of(is_feature_active) as u64;
+    let space = VoteState::size_of() as u64;
 
     let build_message = |lamports| {
         let vote_init = VoteInit {

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -55,7 +55,7 @@ pub(crate) mod tests {
                 },
                 amount,
                 vote_instruction::CreateVoteAccountConfig {
-                    space: VoteStateVersions::vote_state_size_of(true) as u64,
+                    space: VoteState::size_of() as u64,
                     ..vote_instruction::CreateVoteAccountConfig::default()
                 },
             ),

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -33,7 +33,6 @@ use {
         clock::{Slot, DEFAULT_DEV_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT},
         commitment_config::CommitmentConfig,
         epoch_schedule::EpochSchedule,
-        feature_set,
         genesis_config::{ClusterType, GenesisConfig},
         message::Message,
         poh_config::PohConfig,
@@ -699,17 +698,6 @@ impl LocalCluster {
             == 0
         {
             // 1) Create vote account
-            // Unlike the bootstrap validator we have to check if the new vote state is being used
-            // as the cluster is already running, and using the wrong account size will cause the
-            // InitializeAccount tx to fail
-            let use_current_vote_state = client
-                .poll_get_balance_with_commitment(
-                    &feature_set::vote_state_add_vote_latency::id(),
-                    CommitmentConfig::processed(),
-                )
-                .unwrap_or(0)
-                > 0;
-
             let instructions = vote_instruction::create_account_with_config(
                 &from_account.pubkey(),
                 &vote_account_pubkey,
@@ -721,8 +709,7 @@ impl LocalCluster {
                 },
                 amount,
                 vote_instruction::CreateVoteAccountConfig {
-                    space: vote_state::VoteStateVersions::vote_state_size_of(use_current_vote_state)
-                        as u64,
+                    space: vote_state::VoteState::size_of() as u64,
                     ..vote_instruction::CreateVoteAccountConfig::default()
                 },
             );

--- a/program-test/tests/setup.rs
+++ b/program-test/tests/setup.rs
@@ -68,7 +68,7 @@ pub async fn setup_vote(context: &mut ProgramTestContext) -> Pubkey {
         },
         vote_lamports,
         vote_instruction::CreateVoteAccountConfig {
-            space: vote_state::VoteStateVersions::vote_state_size_of(true) as u64,
+            space: vote_state::VoteState::size_of() as u64,
             ..vote_instruction::CreateVoteAccountConfig::default()
         },
     ));

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -1758,7 +1758,10 @@ mod tests {
                 commission: 0,
             },
             101,
-            CreateVoteAccountConfig::default(),
+            CreateVoteAccountConfig {
+                space: vote_state::VoteState1_14_11::size_of() as u64,
+                with_seed: None,
+            },
         );
         // grab the `space` value from SystemInstruction::CreateAccount by directly indexing, for
         // expediency
@@ -1773,15 +1776,15 @@ mod tests {
             (sysvar::rent::id(), create_default_rent_account()),
         ];
 
-        // should succeed when vote_state_add_vote_latency is disabled
+        // should fail
         process_instruction_disabled_features(
             &instructions[1].data,
             transaction_accounts.clone(),
             instructions[1].accounts.clone(),
-            Ok(()),
+            Err(InstructionError::InvalidAccountData),
         );
 
-        // should fail, if vote_state_add_vote_latency is enabled
+        // should fail
         process_instruction(
             &instructions[1].data,
             transaction_accounts,
@@ -1822,15 +1825,15 @@ mod tests {
             (sysvar::rent::id(), create_default_rent_account()),
         ];
 
-        // should fail, if vote_state_add_vote_latency is disabled
+        // succeeds
         process_instruction_disabled_features(
             &instructions[1].data,
             transaction_accounts.clone(),
             instructions[1].accounts.clone(),
-            Err(InstructionError::InvalidAccountData),
+            Ok(()),
         );
 
-        // succeeds, since vote_state_add_vote_latency is enabled
+        // succeeds
         process_instruction(
             &instructions[1].data,
             transaction_accounts,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4205,7 +4205,7 @@ fn test_bank_vote_accounts() {
         },
         10,
         vote_instruction::CreateVoteAccountConfig {
-            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            space: VoteState::size_of() as u64,
             ..vote_instruction::CreateVoteAccountConfig::default()
         },
     );
@@ -4273,7 +4273,7 @@ fn test_bank_cloned_stake_delegations() {
         },
         vote_balance,
         vote_instruction::CreateVoteAccountConfig {
-            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            space: VoteState::size_of() as u64,
             ..vote_instruction::CreateVoteAccountConfig::default()
         },
     );
@@ -4585,7 +4585,7 @@ fn test_add_builtin() {
         },
         1,
         vote_instruction::CreateVoteAccountConfig {
-            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            space: VoteState::size_of() as u64,
             ..vote_instruction::CreateVoteAccountConfig::default()
         },
     );
@@ -4632,7 +4632,7 @@ fn test_add_duplicate_static_program() {
         },
         1,
         vote_instruction::CreateVoteAccountConfig {
-            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            space: VoteState::size_of() as u64,
             ..vote_instruction::CreateVoteAccountConfig::default()
         },
     );
@@ -9119,7 +9119,7 @@ fn test_vote_epoch_panic() {
         },
         1_000_000_000,
         vote_instruction::CreateVoteAccountConfig {
-            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            space: VoteState::size_of() as u64,
             ..vote_instruction::CreateVoteAccountConfig::default()
         },
     ));

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -338,7 +338,7 @@ fn test_stake_account_lifetime() {
             },
             vote_balance,
             vote_instruction::CreateVoteAccountConfig {
-                space: VoteStateVersions::vote_state_size_of(true) as u64,
+                space: VoteState::size_of() as u64,
                 ..vote_instruction::CreateVoteAccountConfig::default()
             },
         ),
@@ -613,7 +613,7 @@ fn test_create_stake_account_from_seed() {
             },
             10,
             vote_instruction::CreateVoteAccountConfig {
-                space: VoteStateVersions::vote_state_size_of(true) as u64,
+                space: VoteState::size_of() as u64,
                 ..vote_instruction::CreateVoteAccountConfig::default()
             },
         ),

--- a/sdk/program/src/vote/instruction.rs
+++ b/sdk/program/src/vote/instruction.rs
@@ -1,7 +1,7 @@
 //! Vote program instructions
 
 use {
-    super::state::TowerSync,
+    super::state::{TowerSync, VoteState},
     crate::{
         clock::{Slot, UnixTimestamp},
         hash::Hash,
@@ -13,7 +13,7 @@ use {
             state::{
                 serde_compact_vote_state_update, serde_tower_sync, Vote, VoteAuthorize,
                 VoteAuthorizeCheckedWithSeedArgs, VoteAuthorizeWithSeedArgs, VoteInit,
-                VoteStateUpdate, VoteStateVersions,
+                VoteStateUpdate,
             },
         },
     },
@@ -251,7 +251,7 @@ pub struct CreateVoteAccountConfig<'a> {
 impl<'a> Default for CreateVoteAccountConfig<'a> {
     fn default() -> Self {
         Self {
-            space: VoteStateVersions::vote_state_size_of(false) as u64,
+            space: VoteState::size_of() as u64,
             with_seed: None,
         }
     }

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -1512,7 +1512,7 @@ mod tests {
     #[test]
     fn test_is_correct_size_and_initialized() {
         // Check all zeroes
-        let mut vote_account_data = vec![0; VoteStateVersions::vote_state_size_of(true)];
+        let mut vote_account_data = vec![0; VoteState::size_of()];
         assert!(!VoteStateVersions::is_correct_size_and_initialized(
             &vote_account_data
         ));
@@ -1531,7 +1531,7 @@ mod tests {
         ));
 
         // Check non-zero large account
-        let mut large_vote_data = vec![1; 2 * VoteStateVersions::vote_state_size_of(true)];
+        let mut large_vote_data = vec![1; 2 * VoteState::size_of()];
         let default_account_state = VoteStateVersions::new_current(VoteState::default());
         VoteState::serialize(&default_account_state, &mut large_vote_data).unwrap();
         assert!(!VoteStateVersions::is_correct_size_and_initialized(
@@ -1557,7 +1557,7 @@ mod tests {
         // Check old VoteState that hasn't been upgraded to newest version yet
         let old_vote_state = VoteState1_14_11::from(vote_state);
         let account_state = VoteStateVersions::V1_14_11(Box::new(old_vote_state));
-        let mut vote_account_data = vec![0; VoteStateVersions::vote_state_size_of(false)];
+        let mut vote_account_data = vec![0; VoteState::size_of()];
         VoteState::serialize(&account_state, &mut vote_account_data).unwrap();
         assert!(VoteStateVersions::is_correct_size_and_initialized(
             &vote_account_data

--- a/sdk/program/src/vote/state/vote_state_versions.rs
+++ b/sdk/program/src/vote/state/vote_state_versions.rs
@@ -79,14 +79,6 @@ impl VoteStateVersions {
         }
     }
 
-    pub fn vote_state_size_of(is_current: bool) -> usize {
-        if is_current {
-            VoteState::size_of()
-        } else {
-            VoteState1_14_11::size_of()
-        }
-    }
-
     pub fn is_correct_size_and_initialized(data: &[u8]) -> bool {
         VoteState::is_correct_size_and_initialized(data)
             || VoteState1_14_11::is_correct_size_and_initialized(data)

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -292,7 +292,7 @@ mod test {
             sysvar,
             vote::{
                 instruction as vote_instruction,
-                state::{Vote, VoteAuthorize, VoteInit, VoteStateUpdate, VoteStateVersions},
+                state::{Vote, VoteAuthorize, VoteInit, VoteState, VoteStateUpdate},
             },
         },
     };
@@ -319,7 +319,7 @@ mod test {
             &vote_init,
             lamports,
             vote_instruction::CreateVoteAccountConfig {
-                space: VoteStateVersions::vote_state_size_of(true) as u64,
+                space: VoteState::size_of() as u64,
                 ..vote_instruction::CreateVoteAccountConfig::default()
             },
         );


### PR DESCRIPTION
As of 3/28/24 there are no longer any non delinquent vote states using the old format, making it safe to remove this feature flag.

The feature flag has been activated on all clusters 

We cannot remove the migration logic at this moment as it could be a consensus breaking change. This will be done in a future pr with feature flag.

Fixes https://github.com/solana-labs/solana/issues/31264