### PR TITLE
Write default hash to account storage

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -10215,14 +10215,16 @@ pub mod tests {
     );
 
     #[test]
-    #[should_panic(expected = "MismatchedAccountsHash")]
     fn test_accountsdb_scan_snapshot_stores_check_hash() {
         solana_logger::setup();
         let accounts_db = AccountsDb::new_single_for_tests();
         let (storages, _raw_expected) = sample_storages_and_accounts(&accounts_db);
         let max_slot = storages.iter().map(|storage| storage.slot()).max().unwrap();
 
-        let hash =
+        // bogus_hash is ignored during appendvec store. When we verify hashes
+        // later during scan, the test will recompute the "correct" hash and
+        // should not mismatch.
+        let bogus_hash =
             AccountHash(Hash::from_str("7JcmM6TFZMkcDkZe6RKVkGaWwN5dXciGC4fa3RxvqQc9").unwrap());
 
         // replace the sample storages, storing bogus hash values so that we trigger the hash mismatch
@@ -10242,7 +10244,7 @@ pub mod tests {
                     .collect::<Vec<_>>();
                 let slice = &accounts[..];
                 let account_data = (slot, slice);
-                let hashes = (0..account_data.len()).map(|_| &hash).collect();
+                let hashes = (0..account_data.len()).map(|_| &bogus_hash).collect();
                 let storable_accounts =
                     StorableAccountsWithHashes::new_with_hashes(&account_data, hashes);
                 copied_storage

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -17,10 +17,10 @@ use {
     },
     log::*,
     memmap2::MmapMut,
-    solana_sdk::hash::Hash,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         clock::Slot,
+        hash::Hash,
         pubkey::Pubkey,
         stake_history::Epoch,
     },

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -772,7 +772,6 @@ impl AppendVec {
                 let account_meta_ptr = &account_meta as *const AccountMeta;
                 let data_len = stored_meta.data_len as usize;
                 let data_ptr = account.data().as_ptr();
-                let hash_ptr = bytemuck::bytes_of(hash).as_ptr();
                 let hash_ptr = bytemuck::bytes_of(&default_hash).as_ptr();
                 let ptrs = [
                     (meta_ptr as *const u8, mem::size_of::<StoredMeta>()),


### PR DESCRIPTION
#### Problem

Storing default hash in account storage helps storage compression and saves snapshot storage. 


#### Summary of Changes

Write default hash to account storage. 

Note: This PR depends on https://github.com/anza-xyz/agave/pull/519 to be released. Once #519 is released. We can then merge this PR.  For details, see the discussion here https://github.com/anza-xyz/agave/pull/476#issuecomment-2029853055


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
