### PR TITLE
ff cleanup: reduce_stake_warmup_cooldown

### DIFF
--- a/sdk/program/src/stake/instruction.rs
+++ b/sdk/program/src/stake/instruction.rs
@@ -108,7 +108,7 @@ pub enum StakeInstruction {
     ///   1. `[]` Vote account to which this stake will be delegated
     ///   2. `[]` Clock sysvar
     ///   3. `[]` Stake history sysvar that carries stake warmup/cooldown history
-    ///   4. `[]` Address of config account that carries stake config
+    ///   4. `[]` Unused account, formerly the stake config
     ///   5. `[SIGNER]` Stake authority
     ///
     /// The entire balance of the staking account is staked.  DelegateStake
@@ -289,7 +289,7 @@ pub enum StakeInstruction {
     ///      plus rent exempt minimum
     ///   1. `[WRITE]` Uninitialized stake account that will hold the redelegated stake
     ///   2. `[]` Vote account to which this stake will be re-delegated
-    ///   3. `[]` Address of config account that carries stake config
+    ///   3. `[]` Unused account, formerly the stake config
     ///   4. `[SIGNER]` Stake authority
     ///
     Redelegate,
@@ -677,6 +677,7 @@ pub fn delegate_stake(
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(sysvar::stake_history::id(), false),
         #[allow(deprecated)]
+        // For backwards compatibility we pass the stake config, although this account is unused
         AccountMeta::new_readonly(config::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
@@ -782,6 +783,7 @@ fn _redelegate(
         AccountMeta::new(*uninitialized_stake_pubkey, false),
         AccountMeta::new_readonly(*vote_pubkey, false),
         #[allow(deprecated)]
+        // For backwards compatibility we pass the stake config, although this account is unused
         AccountMeta::new_readonly(config::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];


### PR DESCRIPTION
This feature has been activated on all clusters.

There are a couple more uses that we cannot yet remove, in order for historical stake information to function properly:
https://github.com/anza-xyz/agave/blob/182d27f718e1d6df347bdbe60edaba6026f1c6b5/cli/src/stake.rs#L2573-L2576
https://github.com/anza-xyz/agave/blob/182d27f718e1d6df347bdbe60edaba6026f1c6b5/cli/src/cluster_query.rs#L1830-L1831
https://github.com/anza-xyz/agave/blob/182d27f718e1d6df347bdbe60edaba6026f1c6b5/sdk/src/feature_set.rs#L1079-L1082

Fixes https://github.com/solana-labs/solana/issues/32724