### PR TITLE
cost-tracker-stats: add transaction cost distribution stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6029,6 +6029,7 @@ dependencies = [
 name = "solana-cost-model"
 version = "2.0.0"
 dependencies = [
+ "histogram",
  "lazy_static",
  "log",
  "rustc_version 0.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6038,7 +6038,6 @@ dependencies = [
  "solana-compute-budget-program",
  "solana-config-program",
  "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-loader-v4-program",
  "solana-logger",
  "solana-metrics",

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -519,21 +519,21 @@ impl Consumer {
         // once feature `apply_cost_tracker_during_replay` is activated, leader shall no longer
         // adjust block with executed cost (a behavior more inline with bankless leader), it
         // should use requested, or default `compute_unit_limit` as transaction's execution cost.
-        if !bank
+        if bank
             .feature_set
             .is_active(&feature_set::apply_cost_tracker_during_replay::id())
         {
-            QosService::update_costs(
+            QosService::record_unadjusted_costs(
                 transaction_qos_cost_results.iter(),
                 commit_transactions_result.as_ref().ok(),
                 bank,
             );
         } else {
-            QosService::record_unadjusted_costs(
+            QosService::update_costs(
                 transaction_qos_cost_results.iter(),
                 commit_transactions_result.as_ref().ok(),
                 bank,
-            )
+            );
         }
 
         retryable_transaction_indexes

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -528,6 +528,12 @@ impl Consumer {
                 commit_transactions_result.as_ref().ok(),
                 bank,
             );
+        } else {
+            QosService::record_unadjusted_costs(
+                transaction_qos_cost_results.iter(),
+                commit_transactions_result.as_ref().ok(),
+                bank,
+            )
         }
 
         retryable_transaction_indexes

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+histogram = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 solana-address-lookup-table-program = { workspace = true }

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -18,7 +18,6 @@ solana-bpf-loader-program = { workspace = true }
 solana-compute-budget-program = { workspace = true }
 solana-config-program = { workspace = true }
 solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
 solana-loader-v4-program = { workspace = true }
 solana-metrics = { workspace = true }
 solana-program-runtime = { workspace = true }

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -161,6 +161,11 @@ impl CostTracker {
         let _ = self.transaction_cost_histogram.increment(transaction_cost);
     }
 
+    pub fn record_unadjusted_cost(&mut self, tx_cost: &TransactionCost) {
+        let transaction_cost = tx_cost.sum();
+        let _ = self.transaction_cost_histogram.increment(transaction_cost);
+    }
+
     pub fn remove(&mut self, tx_cost: &TransactionCost) {
         self.remove_transaction_cost(tx_cost);
     }

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -49,7 +49,7 @@ impl From<CostTrackerError> for TransactionError {
     }
 }
 
-#[derive(AbiExample, Debug)]
+#[derive(Debug)]
 pub struct CostTracker {
     account_cost_limit: u64,
     block_cost_limit: u64,
@@ -92,6 +92,13 @@ impl Default for CostTracker {
             in_flight_transaction_count: 0,
             transaction_cost_histogram: Histogram::new(),
         }
+    }
+}
+
+#[cfg(RUSTC_WITH_SPECIALIZATION)]
+impl solana_frozen_abi::abi_example::AbiExample for CostTracker {
+    fn example() -> Self {
+        Self::default()
     }
 }
 

--- a/cost-model/src/lib.rs
+++ b/cost-model/src/lib.rs
@@ -5,4 +5,3 @@ pub mod block_cost_limits;
 pub mod cost_model;
 pub mod cost_tracker;
 pub mod transaction_cost;
-

--- a/cost-model/src/lib.rs
+++ b/cost-model/src/lib.rs
@@ -6,5 +6,3 @@ pub mod cost_model;
 pub mod cost_tracker;
 pub mod transaction_cost;
 
-#[macro_use]
-extern crate solana_frozen_abi_macro;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4994,6 +4994,7 @@ dependencies = [
 name = "solana-cost-model"
 version = "2.0.0"
 dependencies = [
+ "histogram",
  "lazy_static",
  "log",
  "rustc_version",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5003,7 +5003,6 @@ dependencies = [
  "solana-compute-budget-program",
  "solana-config-program",
  "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-loader-v4-program",
  "solana-metrics",
  "solana-program-runtime",


### PR DESCRIPTION
#### Problem
#463 

#### Summary of Changes
- Collect histogram on actual (committed) transaction costs
- Report (min, mean, max, p90) of transaction costs

Fixes #463 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
