### PR TITLE
Add ProgramCacheUs to execute timings

### DIFF
--- a/program-runtime/src/timings.rs
+++ b/program-runtime/src/timings.rs
@@ -51,6 +51,7 @@ pub enum ExecuteTimingType {
     CollectLogsUs,
     TotalBatchesLen,
     UpdateTransactionStatuses,
+    ProgramCacheUs,
 }
 
 pub struct Metrics([u64; ExecuteTimingType::CARDINALITY]);
@@ -92,6 +93,13 @@ eager_macro_rules! { $eager_1
                 *$self
                     .metrics
                     .index(ExecuteTimingType::CheckUs),
+                i64
+            ),
+            (
+                "program_cache_us",
+                *$self
+                    .metrics
+                    .index(ExecuteTimingType::ProgramCacheUs),
                 i64
             ),
             (

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -210,6 +210,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         log_messages_bytes_limit: Option<usize>,
         limit_to_load_programs: bool,
     ) -> LoadAndExecuteSanitizedTransactionsOutput {
+        let mut program_cache_time = Measure::start("program_cache");
         let mut program_accounts_map = Self::filter_executable_program_accounts(
             callbacks,
             sanitized_txs,
@@ -233,6 +234,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 execution_results: vec![],
             };
         }
+        program_cache_time.stop();
 
         let mut load_time = Measure::start("accounts_load");
         let mut loaded_transactions = load_accounts(
@@ -327,6 +329,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             sanitized_txs.len(),
         );
 
+        timings.saturating_add_in_place(
+            ExecuteTimingType::ProgramCacheUs,
+            program_cache_time.as_us(),
+        );
         timings.saturating_add_in_place(ExecuteTimingType::LoadUs, load_time.as_us());
         timings.saturating_add_in_place(ExecuteTimingType::ExecuteUs, execution_time.as_us());
 


### PR DESCRIPTION
#### Problem
- Related to #471 (does not complete the issue, as ExecuteTimings are not reported in BankingStage yet)
- We do not directly measure total time spent in program cache related activities
- Program cache is a shared resource we should be measuring time/contention on

#### Summary of Changes
- Record ProgramCacheUs into `ExecuteTimings`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
