### PR TITLE
Scheduler: remove allow(dead_code) markers

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -36,7 +36,6 @@ pub(crate) struct ConsumeWorker {
     metrics: Arc<ConsumeWorkerMetrics>,
 }
 
-#[allow(dead_code)]
 impl ConsumeWorker {
     pub fn new(
         id: u32,

--- a/core/src/banking_stage/read_write_account_set.rs
+++ b/core/src/banking_stage/read_write_account_set.rs
@@ -14,7 +14,6 @@ pub struct ReadWriteAccountSet {
 
 impl ReadWriteAccountSet {
     /// Returns true if all account locks were available and false otherwise.
-    #[allow(dead_code)]
     pub fn check_locks(&self, message: &SanitizedMessage) -> bool {
         message
             .account_keys()

--- a/core/src/banking_stage/transaction_scheduler/in_flight_tracker.rs
+++ b/core/src/banking_stage/transaction_scheduler/in_flight_tracker.rs
@@ -34,6 +34,7 @@ impl InFlightTracker {
     }
 
     /// Returns the number of cus that are in flight for each thread.
+    #[allow(dead_code)]
     pub fn cus_in_flight_per_thread(&self) -> &[u64] {
         &self.cus_in_flight_per_thread
     }

--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -1,5 +1,4 @@
 mod batch_id_generator;
-#[allow(dead_code)]
 mod in_flight_tracker;
 pub(crate) mod prio_graph_scheduler;
 pub(crate) mod scheduler_controller;
@@ -8,7 +7,5 @@ mod scheduler_metrics;
 mod thread_aware_account_locks;
 mod transaction_id_generator;
 mod transaction_priority_id;
-#[allow(dead_code)]
 mod transaction_state;
-#[allow(dead_code)]
 mod transaction_state_container;

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -81,16 +81,6 @@ impl TransactionStateContainer {
             .map(|state| state.transaction_ttl())
     }
 
-    /// Take `SanitizedTransactionTTL` by id.
-    /// This transitions the transaction to `Pending` state.
-    /// Panics if the transaction does not exist.
-    pub(crate) fn take_transaction(&mut self, id: &TransactionId) -> SanitizedTransactionTTL {
-        self.id_to_transaction_state
-            .get_mut(id)
-            .expect("transaction must exist")
-            .transition_to_pending()
-    }
-
     /// Insert a new transaction into the container's queues and maps.
     /// Returns `true` if a packet was dropped due to capacity limits.
     pub(crate) fn insert_new_transaction(


### PR DESCRIPTION
#### Problem
- Some old `#[allow(dead_code)]` 

#### Summary of Changes
- Remove them

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
