### PR TITLE
disable read cache while populating stakes cache on load

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -174,6 +174,14 @@ impl Accounts {
         self.load_slow(ancestors, pubkey, LoadHint::FixedMaxRoot)
     }
 
+    pub fn load_with_fixed_root_do_not_populate_read_cache(
+        &self,
+        ancestors: &Ancestors,
+        pubkey: &Pubkey,
+    ) -> Option<(AccountSharedData, Slot)> {
+        self.load_slow(ancestors, pubkey, LoadHint::FixedMaxRootDoNotPopulateReadCache)
+    }
+
     pub fn load_without_fixed_root(
         &self,
         ancestors: &Ancestors,

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -174,6 +174,8 @@ impl Accounts {
         self.load_slow(ancestors, pubkey, LoadHint::FixedMaxRoot)
     }
 
+    /// same as `load_with_fixed_root` except:
+    /// if the account is not already in the read cache, it is NOT put in the read cache on successful load
     pub fn load_with_fixed_root_do_not_populate_read_cache(
         &self,
         ancestors: &Ancestors,

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -181,7 +181,11 @@ impl Accounts {
         ancestors: &Ancestors,
         pubkey: &Pubkey,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.load_slow(ancestors, pubkey, LoadHint::FixedMaxRootDoNotPopulateReadCache)
+        self.load_slow(
+            ancestors,
+            pubkey,
+            LoadHint::FixedMaxRootDoNotPopulateReadCache,
+        )
     }
 
     pub fn load_without_fixed_root(

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1268,6 +1268,31 @@ struct RemoveUnrootedSlotsSynchronization {
 
 type AccountInfoAccountsIndex = AccountsIndex<AccountInfo, AccountInfo>;
 
+/// When an instance of this exists, the read cache is not updated for account loads.
+/// When all instances are dropped, the read cache is populated for account loads.
+/// By default, all loads will populate the read cache.
+/// This cannot be incorrect, it is only a performance penalty at worst.
+pub struct DisableReadCacheUpdates<'a> {
+    accounts_db: &'a AccountsDb,
+}
+
+impl<'a> DisableReadCacheUpdates<'a> {
+    pub fn new(accounts_db: &'a AccountsDb) -> Self {
+        accounts_db
+            .disable_read_cache_updates_count
+            .fetch_add(1, Ordering::Relaxed);
+        Self { accounts_db }
+    }
+}
+
+impl<'a> Drop for DisableReadCacheUpdates<'a> {
+    fn drop(&mut self) {
+        self.accounts_db
+            .disable_read_cache_updates_count
+            .fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 // This structure handles the load/store of the accounts
 #[derive(Debug)]
 pub struct AccountsDb {
@@ -1275,7 +1300,7 @@ pub struct AccountsDb {
     pub accounts_index: AccountInfoAccountsIndex,
 
     /// if != 0, read cache is not updated on loads
-    disable_read_cache_updates: AtomicU64,
+    disable_read_cache_updates_count: AtomicU64,
 
     /// Some(offset) iff we want to squash old append vecs together into 'ancient append vecs'
     /// Some(offset) means for slots up to (max_slot - (slots_per_epoch - 'offset')), put them in ancient append vecs
@@ -2330,7 +2355,7 @@ impl AccountsDb {
             active_stats: ActiveStats::default(),
             skip_initial_hash_calc: false,
             ancient_append_vec_offset: None,
-            disable_read_cache_updates: AtomicU64::default(),
+            disable_read_cache_updates_count: AtomicU64::default(),
             accounts_index,
             storage: AccountStorage::default(),
             accounts_cache: AccountsCache::default(),
@@ -5352,7 +5377,12 @@ impl AccountsDb {
             return None;
         }
 
-        if !is_cached && self.disable_read_cache_updates.load(Ordering::Relaxed) == 0 {
+        if !is_cached
+            && self
+                .disable_read_cache_updates_count
+                .load(Ordering::Relaxed)
+                == 0
+        {
             /*
             We show this store into the read-only cache for account 'A' and future loads of 'A' from the read-only cache are
             safe/reflect 'A''s latest state on this fork.
@@ -8349,20 +8379,6 @@ impl AccountsDb {
                     i64
                 ),
             );
-        }
-    }
-
-    /// pass true to cause loads to NOT populate the read cache.
-    /// Balance true calls with false calls.
-    /// By default, all loads will populate the read cache.
-    /// This cannot be incorrect, it is only a performance penalty at worst.
-    pub fn disable_read_cache_updates(&self, disable: bool) {
-        if disable {
-            self.disable_read_cache_updates
-                .fetch_add(1, Ordering::Relaxed);
-        } else {
-            self.disable_read_cache_updates
-                .fetch_sub(1, Ordering::Relaxed);
         }
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -787,6 +787,8 @@ pub enum LoadHint {
     // account loading, while maintaining the determinism of account loading and resultant
     // transaction execution thereof.
     FixedMaxRoot,
+    /// same as `FixedMaxRoot`, except do not populate the read cache on load
+    FixedMaxRootDoNotPopulateReadCache,
     // Caller can't hint the above safety assumption. Generally RPC and miscellaneous
     // other call-site falls into this category. The likelihood of slower path is slightly
     // increased as well.
@@ -5148,7 +5150,7 @@ impl AccountsDb {
                     // so retry. This works because in accounts cache flush, an account is written to
                     // storage *before* it is removed from the cache
                     match load_hint {
-                        LoadHint::FixedMaxRoot => {
+                        LoadHint::FixedMaxRootDoNotPopulateReadCache | LoadHint::FixedMaxRoot => {
                             // it's impossible for this to fail for transaction loads from
                             // replaying/banking more than once.
                             // This is because:
@@ -5168,7 +5170,7 @@ impl AccountsDb {
                 }
                 LoadedAccountAccessor::Stored(None) => {
                     match load_hint {
-                        LoadHint::FixedMaxRoot => {
+                        LoadHint::FixedMaxRootDoNotPopulateReadCache | LoadHint::FixedMaxRoot => {
                             // When running replay on the validator, or banking stage on the leader,
                             // it should be very rare that the storage entry doesn't exist if the
                             // entry in the accounts index is the latest version of this account.
@@ -5377,12 +5379,7 @@ impl AccountsDb {
             return None;
         }
 
-        if !is_cached
-            && self
-                .disable_read_cache_updates_count
-                .load(Ordering::Relaxed)
-                == 0
-        {
+        if !is_cached && load_hint != LoadHint::FixedMaxRootDoNotPopulateReadCache {
             /*
             We show this store into the read-only cache for account 'A' and future loads of 'A' from the read-only cache are
             safe/reflect 'A''s latest state on this fork.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1823,6 +1823,13 @@ impl Bank {
         // from Stakes<Delegation> by reading the full account state from
         // accounts-db. Note that it is crucial that these accounts are loaded
         // at the right slot and match precisely with serialized Delegations.
+        // Note that we are disabling the read cache while we populate the stakes cache.
+        // The stakes accounts will not be expected to be loaded again.
+        // If we populate the read cache with these loads, then we'll just soon have to evict these.
+        bank_rc
+            .accounts
+            .accounts_db
+            .disable_read_cache_updates(true);
         let stakes = Stakes::new(&fields.stakes, |pubkey| {
             let (account, _slot) = bank_rc.accounts.load_with_fixed_root(&ancestors, pubkey)?;
             Some(account)
@@ -1831,6 +1838,10 @@ impl Bank {
             "Stakes cache is inconsistent with accounts-db. This can indicate \
             a corrupted snapshot or bugs in cached accounts or accounts-db.",
         );
+        bank_rc
+            .accounts
+            .accounts_db
+            .disable_read_cache_updates(false);
         let stakes_accounts_load_duration = now.elapsed();
         let mut bank = Self {
             skipped_rewrites: Mutex::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1827,17 +1827,16 @@ impl Bank {
         // Note that we are disabling the read cache while we populate the stakes cache.
         // The stakes accounts will not be expected to be loaded again.
         // If we populate the read cache with these loads, then we'll just soon have to evict these.
-        let stakes = {
-            let _guard = DisableReadCacheUpdates::new(&bank_rc.accounts.accounts_db);
-            Stakes::new(&fields.stakes, |pubkey| {
-                let (account, _slot) = bank_rc.accounts.load_with_fixed_root(&ancestors, pubkey)?;
+        let stakes = Stakes::new(&fields.stakes, |pubkey| {
+            let (account, _slot) = bank_rc
+                .accounts
+                .load_with_fixed_root_do_not_populate_read_cache(&ancestors, pubkey)?;
                 Some(account)
             })
             .expect(
                 "Stakes cache is inconsistent with accounts-db. This can indicate \
             a corrupted snapshot or bugs in cached accounts or accounts-db.",
-            )
-        };
+        );
         let stakes_accounts_load_duration = now.elapsed();
         let mut bank = Self {
             skipped_rewrites: Mutex::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -72,7 +72,8 @@ use {
         accounts::{AccountAddressFilter, Accounts, PubkeyAccountSlot},
         accounts_db::{
             AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig,
-            CalcAccountsHashDataSource, VerifyAccountsHashAndLamportsConfig,
+            CalcAccountsHashDataSource, DisableReadCacheUpdates,
+            VerifyAccountsHashAndLamportsConfig,
         },
         accounts_hash::{
             AccountHash, AccountsHash, CalcAccountsHashConfig, HashStats, IncrementalAccountsHash,
@@ -1826,22 +1827,17 @@ impl Bank {
         // Note that we are disabling the read cache while we populate the stakes cache.
         // The stakes accounts will not be expected to be loaded again.
         // If we populate the read cache with these loads, then we'll just soon have to evict these.
-        bank_rc
-            .accounts
-            .accounts_db
-            .disable_read_cache_updates(true);
-        let stakes = Stakes::new(&fields.stakes, |pubkey| {
-            let (account, _slot) = bank_rc.accounts.load_with_fixed_root(&ancestors, pubkey)?;
-            Some(account)
-        })
-        .expect(
-            "Stakes cache is inconsistent with accounts-db. This can indicate \
+        let stakes = {
+            let _guard = DisableReadCacheUpdates::new(&bank_rc.accounts.accounts_db);
+            Stakes::new(&fields.stakes, |pubkey| {
+                let (account, _slot) = bank_rc.accounts.load_with_fixed_root(&ancestors, pubkey)?;
+                Some(account)
+            })
+            .expect(
+                "Stakes cache is inconsistent with accounts-db. This can indicate \
             a corrupted snapshot or bugs in cached accounts or accounts-db.",
-        );
-        bank_rc
-            .accounts
-            .accounts_db
-            .disable_read_cache_updates(false);
+            )
+        };
         let stakes_accounts_load_duration = now.elapsed();
         let mut bank = Self {
             skipped_rewrites: Mutex::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -72,8 +72,7 @@ use {
         accounts::{AccountAddressFilter, Accounts, PubkeyAccountSlot},
         accounts_db::{
             AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig,
-            CalcAccountsHashDataSource, DisableReadCacheUpdates,
-            VerifyAccountsHashAndLamportsConfig,
+            CalcAccountsHashDataSource, VerifyAccountsHashAndLamportsConfig,
         },
         accounts_hash::{
             AccountHash, AccountsHash, CalcAccountsHashConfig, HashStats, IncrementalAccountsHash,
@@ -1831,10 +1830,10 @@ impl Bank {
             let (account, _slot) = bank_rc
                 .accounts
                 .load_with_fixed_root_do_not_populate_read_cache(&ancestors, pubkey)?;
-                Some(account)
-            })
-            .expect(
-                "Stakes cache is inconsistent with accounts-db. This can indicate \
+            Some(account)
+        })
+        .expect(
+            "Stakes cache is inconsistent with accounts-db. This can indicate \
             a corrupted snapshot or bugs in cached accounts or accounts-db.",
         );
         let stakes_accounts_load_duration = now.elapsed();


### PR DESCRIPTION
#### Problem
stakes cache reads tons of accounts. These fill up the read cache. We then spend time evicting all these accounts, which hurts performance of startup and tx processing.

#### Summary of Changes
skip populating the read cache while loading stake accounts.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
