### PR TITLE
RPC sendTransaction: be more liberal in determining and setting last_valid_block_height for skip_preflight case

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3645,8 +3645,11 @@ pub mod rpc_full {
             let (wire_transaction, unsanitized_tx) =
                 decode_and_deserialize::<VersionedTransaction>(data, binary_encoding)?;
 
-            let preflight_commitment =
-                preflight_commitment.map(|commitment| CommitmentConfig { commitment });
+            let preflight_commitment = if skip_preflight {
+                Some(CommitmentConfig::processed())
+            } else {
+                preflight_commitment.map(|commitment| CommitmentConfig { commitment })
+            };
             let preflight_bank = &*meta.get_bank_with_config(RpcContextConfig {
                 commitment: preflight_commitment,
                 min_context_slot,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3665,7 +3665,7 @@ pub mod rpc_full {
             let durable_nonce_info = transaction
                 .get_durable_nonce()
                 .map(|&pubkey| (pubkey, *transaction.message().recent_blockhash()));
-            if durable_nonce_info.is_some() {
+            if durable_nonce_info.is_some() || (skip_preflight && last_valid_block_height == 0) {
                 // While it uses a defined constant, this last_valid_block_height value is chosen arbitrarily.
                 // It provides a fallback timeout for durable-nonce transaction retries in case of
                 // malicious packing of the retry queue. Durable-nonce transactions are otherwise


### PR DESCRIPTION
#### Problem
Transactions submitted to RPC `sendTransaction` with `skipPreflight: true` frequently aren't retried by the SendTransactionService (STS). This happens when the transaction's recent blockhash is newer than the RPC node's finalized bank, because unless `preflightCommitment` is speficied, the RPC handler uses the default finalized bank to find a `last_valid_block_height` to provide to the STS. If the blockhash cannot be found (as when too new), `last_valid_block_height` is set to `0`, and the STS only broadcasts the transaction once.

#### Summary of Changes
- If `skip_preflight` is set, use the `processed` commitment Bank to search for the recent blockhash.
- If the `last_valid_block_height` still cannot be determined, use the durable-nonce logic to retry the transaction for an arbitrary, fixed number of blocks (`skip_preflight` being an indication that a client wants their transactions to be sprayed around regardless of likelihood of success).

Fixes #479
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
