### PR TITLE
Update crate check to new crates.io error string

### DIFF
--- a/ci/check-crates.sh
+++ b/ci/check-crates.sh
@@ -54,7 +54,7 @@ for file in "${files[@]}"; do
   errors=$(echo "$response" | jq .errors)
   if [[ $errors != "null" ]]; then
     details=$(echo "$response" | jq .errors | jq -r ".[0].detail")
-    if [[ $details = *"Not Found"* ]]; then
+    if [[ $details = *"does not exist"* ]]; then
       ((error_count++))
       echo "❌ new crate $crate_name not found on crates.io. you can either
 


### PR DESCRIPTION
#### Problem
`ci/check-crates.sh` no longer prints helpful action info when it fails: https://github.com/anza-xyz/agave/actions/runs/8475326027/job/23223238562?pr=456

#### Summary of Changes
Update match to new crates.io error string. This still seems super brittle; not sure if there are more robust error codes we should be using instead.
