### PR TITLE
Refactors storage flushing when taking a snapshot

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -99,6 +99,12 @@ pub fn add_bank_snapshot(
             bank_snapshot_path.display(),
         );
 
+        let (_, measure_flush) = measure!(for storage in snapshot_storages {
+            storage
+                .flush()
+                .map_err(|err| AddBankSnapshotError::FlushStorage(err, storage.get_path()))?;
+        });
+
         // We are constructing the snapshot directory to contain the full snapshot state information to allow
         // constructing a bank from this directory.  It acts like an archive to include the full state.
         // The set of the account storages files is the necessary part of this snapshot state.  Hard-link them
@@ -157,6 +163,7 @@ pub fn add_bank_snapshot(
             ("slot", slot, i64),
             ("bank_size", bank_snapshot_consumed_size, i64),
             ("status_cache_size", status_cache_consumed_size, i64),
+            ("flush_storages_us", measure_flush.as_us(), i64),
             ("hard_link_storages_us", measure_hard_linking.as_us(), i64),
             ("bank_serialize_us", bank_serialize.as_us(), i64),
             (

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -418,6 +418,9 @@ pub enum AddBankSnapshotError {
     #[error("failed to create snapshot dir '{1}': {0}")]
     CreateSnapshotDir(#[source] IoError, PathBuf),
 
+    #[error("failed to flush storage '{1}': {0}")]
+    FlushStorage(#[source] AccountsFileError, PathBuf),
+
     #[error("failed to hard link storages: {0}")]
     HardLinkStorages(#[source] HardLinkStoragesToSnapshotError),
 
@@ -506,9 +509,6 @@ pub enum ArchiveSnapshotPackageError {
 pub enum HardLinkStoragesToSnapshotError {
     #[error("failed to create accounts hard links dir '{1}': {0}")]
     CreateAccountsHardLinksDir(#[source] IoError, PathBuf),
-
-    #[error("failed to flush storage: {0}")]
-    FlushStorage(#[source] AccountsFileError),
 
     #[error("failed to get the snapshot's accounts hard link dir: {0}")]
     GetSnapshotHardLinksDir(#[from] GetSnapshotAccountsHardLinkDirError),
@@ -1259,9 +1259,6 @@ pub fn hard_link_storages_to_snapshot(
 
     let mut account_paths: HashSet<PathBuf> = HashSet::new();
     for storage in snapshot_storages {
-        storage
-            .flush()
-            .map_err(HardLinkStoragesToSnapshotError::FlushStorage)?;
         let storage_path = storage.accounts.get_path();
         let snapshot_hardlink_dir = get_snapshot_accounts_hardlink_dir(
             &storage_path,


### PR DESCRIPTION
#### Problem

When taking a snapshot, we flush the account storages[^1]. Right now that's done while hard linking. But those are two separate tasks. 

Doing the flush and the hard link in a single loop does save on looping, but I don't think that's much of an issue. Flushing all the storages takes about 6 seconds, and hard linking all the storages also takes about 6 seconds (on mnb). Looping over all the storages is blazing fast in comparison.

Also, I'm working on an io_uring impl for hard linking. For that, I'll need to split out the flushing separate from the hard linking anyway. So I'm proactively moving the flush code to keep all the PRs small.

(*And*, if we do decide to parallelize the flush call, a la https://github.com/anza-xyz/agave/pull/460, *that* PR can easily build on *this* PR.)

[^1]: I know we *shouldn't* be flushing the mmaps here, but we do. Changing that is on the backlog, but out of scope for this PR.


#### Summary of Changes

Move flushing out of the hard linking function. And add a metric for how long flushing takes.