### PR TITLE
Bump blake3 from v1.5.0 to v1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
 dependencies = [
  "arrayref",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ backoff = "0.4.0"
 base64 = "0.22.0"
 bincode = "1.3.3"
 bitflags = { version = "2.4.2", features = ["serde"] }
-blake3 = "1.5.0"
+blake3 = "1.5.1"
 block-buffer = "0.10.4"
 borsh = { version = "1.2.1", features = ["derive", "unstable__schema"] }
 bs58 = "0.4.0"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
 dependencies = [
  "arrayref",
  "arrayvec",


### PR DESCRIPTION
#### Problem

Recently `blake3` made `miri`-compatible upstream by me: https://github.com/BLAKE3-team/BLAKE3/pull/387 and released https://github.com/BLAKE3-team/BLAKE3/releases/tag/1.5.1:

> The Rust crate is now compatible with Miri.

However our dependabot doesn't spoil me for the chore for some reason. ;)

#### Summary of Changes

Update the crate manually.

Fyi, this unblocks `cargo miri test -p solana-unified-scheduler-logic`. ref: https://github.com/anza-xyz/agave/pull/129

cc: @apfitzge @alessandrod