### PR TITLE
[keygen] Remove deprecated functions from the `grind` command

### DIFF
--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 bs58 = { workspace = true }
-clap = { version = "3.1.5", features = ["cargo"] }
+clap = { version = "3.1.5", features = ["cargo", "deprecated"] }
 dirs-next = { workspace = true }
 num_cpus = { workspace = true }
 solana-clap-v3-utils = { workspace = true }

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 bs58 = { workspace = true }
-clap = { version = "3.1.5", features = ["cargo", "deprecated"] }
+clap = { version = "3.1.5", features = ["cargo"] }
 dirs-next = { workspace = true }
 num_cpus = { workspace = true }
 solana-clap-v3-utils = { workspace = true }

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -546,9 +546,9 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             output_keypair(&keypair, outfile, "recovered")?;
         }
         ("grind", matches) => {
-            let ignore_case = matches.is_present("ignore_case");
+            let ignore_case = matches.try_contains_id("ignore_case")?;
 
-            let starts_with_args = if matches.is_present("starts_with") {
+            let starts_with_args = if matches.try_contains_id("starts_with")? {
                 matches
                     .values_of_t_or_exit::<String>("starts_with")
                     .into_iter()
@@ -557,7 +557,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             } else {
                 HashSet::new()
             };
-            let ends_with_args = if matches.is_present("ends_with") {
+            let ends_with_args = if matches.try_contains_id("ends_with")? {
                 matches
                     .values_of_t_or_exit::<String>("ends_with")
                     .into_iter()
@@ -566,7 +566,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             } else {
                 HashSet::new()
             };
-            let starts_and_ends_with_args = if matches.is_present("starts_and_ends_with") {
+            let starts_and_ends_with_args = if matches.try_contains_id("starts_and_ends_with")? {
                 matches
                     .values_of_t_or_exit::<String>("starts_and_ends_with")
                     .into_iter()
@@ -595,7 +595,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                 num_threads,
             );
 
-            let use_mnemonic = matches.is_present("use_mnemonic");
+            let use_mnemonic = matches.try_contains_id("use_mnemonic")?;
 
             let derivation_path = acquire_derivation_path(matches)?;
 
@@ -608,7 +608,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             } else {
                 no_passphrase_and_message()
             };
-            let no_outfile = matches.is_present(NO_OUTFILE_ARG.name);
+            let no_outfile = matches.try_contains_id(NO_OUTFILE_ARG.name)?;
 
             // The vast majority of base58 encoded public keys have length 44, but
             // these only encapsulate prefixes 1-9 and A-H.  If the user is searching

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -79,7 +79,7 @@ fn grind_parser(grind_type: GrindType) -> ValueParser {
         let (required_div_count, prefix_suffix) = match grind_type {
             GrindType::Starts => (1, "PREFIX"),
             GrindType::Ends => (1, "SUFFIX"),
-            GrindType::StartsEnds => (2, "PREFIX and SUFFIX"),
+            GrindType::StartsAndEnds => (2, "PREFIX and SUFFIX"),
         };
         if v.matches(':').count() != required_div_count || (v.starts_with(':') || v.ends_with(':'))
         {
@@ -324,7 +324,7 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .takes_value(true)
                         .action(ArgAction::Append)
                         .multiple_values(true)
-                        .value_parser(grind_parser(GrindType::StartsEnds))
+                        .value_parser(grind_parser(GrindType::StartsAndEnds))
                         .help("Saves specified number of keypairs whos public key starts and ends with the indicated perfix and suffix\nExample: --starts-and-ends-with sol:ana:4\nPREFIX and SUFFIX type is Base58\nCOUNT type is u64"),
                 )
                 .arg(

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -11,8 +11,8 @@ use {
             check_for_overwrite,
             derivation_path::{acquire_derivation_path, derivation_path_arg},
             mnemonic::{
-                acquire_language, acquire_passphrase_and_message, no_passphrase_and_message,
-                try_get_language, try_get_word_count, WORD_COUNT_ARG,
+                acquire_passphrase_and_message, no_passphrase_and_message, try_get_language,
+                try_get_word_count,
             },
             no_outfile_arg, KeyGenerationCommonArgs, NO_OUTFILE_ARG,
         },
@@ -599,9 +599,9 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
 
             let derivation_path = acquire_derivation_path(matches)?;
 
-            let word_count: usize = matches.value_of_t(WORD_COUNT_ARG.name).unwrap();
+            let word_count = try_get_word_count(matches)?.unwrap();
             let mnemonic_type = MnemonicType::for_word_count(word_count)?;
-            let language = acquire_language(matches);
+            let language = try_get_language(matches)?.unwrap();
 
             let (passphrase, passphrase_message) = if use_mnemonic {
                 acquire_passphrase_and_message(matches).unwrap()

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -85,6 +85,7 @@ fn grind_parser(grind_type: GrindType) -> ValueParser {
         {
             return Err(format!("Expected : between {} and COUNT", prefix_suffix));
         }
+        // `args` is guaranteed to have length at least 1 by the previous if statement
         let mut args: Vec<&str> = v.split(':').collect();
         let count = args.pop().unwrap().parse::<u64>();
         for arg in args.iter() {

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -535,27 +535,45 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
 
             let starts_with_args = if matches.try_contains_id("starts_with")? {
                 matches
-                    .values_of_t_or_exit::<String>("starts_with")
-                    .into_iter()
-                    .map(|s| if ignore_case { s.to_lowercase() } else { s })
+                    .get_many::<String>("starts_with")
+                    .unwrap()
+                    .map(|s| {
+                        if ignore_case {
+                            s.to_lowercase()
+                        } else {
+                            s.to_owned()
+                        }
+                    })
                     .collect()
             } else {
                 HashSet::new()
             };
             let ends_with_args = if matches.try_contains_id("ends_with")? {
                 matches
-                    .values_of_t_or_exit::<String>("ends_with")
-                    .into_iter()
-                    .map(|s| if ignore_case { s.to_lowercase() } else { s })
+                    .get_many::<String>("ends_with")
+                    .unwrap()
+                    .map(|s| {
+                        if ignore_case {
+                            s.to_lowercase()
+                        } else {
+                            s.to_owned()
+                        }
+                    })
                     .collect()
             } else {
                 HashSet::new()
             };
             let starts_and_ends_with_args = if matches.try_contains_id("starts_and_ends_with")? {
                 matches
-                    .values_of_t_or_exit::<String>("starts_and_ends_with")
-                    .into_iter()
-                    .map(|s| if ignore_case { s.to_lowercase() } else { s })
+                    .get_many::<String>("starts_and_ends_with")
+                    .unwrap()
+                    .map(|s| {
+                        if ignore_case {
+                            s.to_lowercase()
+                        } else {
+                            s.to_owned()
+                        }
+                    })
                     .collect()
             } else {
                 HashSet::new()

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
-    clap::{crate_description, crate_name, value_parser, Arg, ArgMatches, Command},
+    clap::{crate_description, crate_name, value_parser, Arg, ArgAction, ArgMatches, Command},
     solana_clap_v3_utils::{
         input_parsers::{
             signer::{SignerSource, SignerSourceParserBuilder},
@@ -315,7 +315,7 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .value_name("PREFIX:COUNT")
                         .number_of_values(1)
                         .takes_value(true)
-                        .multiple_occurrences(true)
+                        .action(ArgAction::Append)
                         .multiple_values(true)
                         .validator(grind_validator_starts_with)
                         .help("Saves specified number of keypairs whos public key starts with the indicated prefix\nExample: --starts-with sol:4\nPREFIX type is Base58\nCOUNT type is u64"),
@@ -326,7 +326,7 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .value_name("SUFFIX:COUNT")
                         .number_of_values(1)
                         .takes_value(true)
-                        .multiple_occurrences(true)
+                        .action(ArgAction::Append)
                         .multiple_values(true)
                         .validator(grind_validator_ends_with)
                         .help("Saves specified number of keypairs whos public key ends with the indicated suffix\nExample: --ends-with ana:4\nSUFFIX type is Base58\nCOUNT type is u64"),
@@ -337,7 +337,7 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .value_name("PREFIX:SUFFIX:COUNT")
                         .number_of_values(1)
                         .takes_value(true)
-                        .multiple_occurrences(true)
+                        .action(ArgAction::Append)
                         .multiple_values(true)
                         .validator(grind_validator_starts_and_ends_with)
                         .help("Saves specified number of keypairs whos public key starts and ends with the indicated perfix and suffix\nExample: --starts-and-ends-with sol:ana:4\nPREFIX and SUFFIX type is Base58\nCOUNT type is u64"),

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -71,7 +71,7 @@ struct GrindMatch {
 enum GrindType {
     Starts,
     Ends,
-    StartsEnds,
+    StartsAndEnds,
 }
 
 fn grind_parser(grind_type: GrindType) -> ValueParser {

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::arithmetic_side_effects)]
-#![allow(deprecated)]
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, value_parser, Arg, ArgMatches, Command},


### PR DESCRIPTION
#### Problem
The `solana-keygen` cli still has some deprecated functions from clap-v2 for the `grind` command logic.

#### Summary of Changes
Removed deprecated functions from the `grind` command.

I think most commits should be pretty straightforward except for [f4aee92](https://github.com/anza-xyz/agave/pull/490/commits/f4aee927e59562930b41215abd17a6a3174492a5), which replaces grind validator functions with a united grind parser. It would be nice to implement a parser that returns a `GrindMatch` type directly so that we can run `matches.get_one::<GrindMatch>(...)`, but the parsing logic depends on the `ignore_case` argument, which makes this hard to do. I ended up just defining `String` parser that executes the existing validation logic for grind arguments.

This is a follow-up to https://github.com/anza-xyz/agave/pull/438.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
