### PR TITLE
[clap-v3-utils] Use `Arg::new` in place of `Arg::with_name`

### DIFF
--- a/clap-v3-utils/src/compute_budget.rs
+++ b/clap-v3-utils/src/compute_budget.rs
@@ -16,7 +16,7 @@ pub const COMPUTE_UNIT_LIMIT_ARG: ArgConstant<'static> = ArgConstant {
 };
 
 pub fn compute_unit_price_arg<'a>() -> Arg<'a> {
-    Arg::with_name(COMPUTE_UNIT_PRICE_ARG.name)
+    Arg::new(COMPUTE_UNIT_PRICE_ARG.name)
         .long(COMPUTE_UNIT_PRICE_ARG.long)
         .takes_value(true)
         .value_name("COMPUTE-UNIT-PRICE")
@@ -25,7 +25,7 @@ pub fn compute_unit_price_arg<'a>() -> Arg<'a> {
 }
 
 pub fn compute_unit_limit_arg<'a>() -> Arg<'a> {
-    Arg::with_name(COMPUTE_UNIT_LIMIT_ARG.name)
+    Arg::new(COMPUTE_UNIT_LIMIT_ARG.name)
         .long(COMPUTE_UNIT_LIMIT_ARG.long)
         .takes_value(true)
         .value_name("COMPUTE-UNIT-LIMIT")


### PR DESCRIPTION
#### Problem
Sorry I missed this in the review for https://github.com/anza-xyz/agave/pull/440. `Arg::with_name` actually seems like it is deprecated in clap-v3 in favor of `Arg::new`.

#### Summary of Changes
Replace `Arg::with_name` with `Arg::new`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
