### PR TITLE
Archives storages directly

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -17,7 +17,7 @@ use {
         clock::Slot,
         pubkey::Pubkey,
     },
-    std::{borrow::Borrow, mem, path::PathBuf},
+    std::{borrow::Borrow, io::Read, mem, path::PathBuf},
     thiserror::Error,
 };
 
@@ -238,6 +238,17 @@ impl AccountsFile {
                     infos
                 })
                 .ok(),
+        }
+    }
+
+    /// Returns a Read implementation suitable for use when archiving accounts files
+    pub fn data_for_archive(&self) -> impl Read + '_ {
+        match self {
+            Self::AppendVec(av) => av.data_for_archive(),
+            Self::TieredStorage(ts) => ts
+                .reader()
+                .expect("must be a reader when archiving")
+                .data_for_archive(),
         }
     }
 }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -733,6 +733,11 @@ impl AppendVec {
             Some(rv)
         }
     }
+
+    /// Returns a slice suitable for use when archiving append vecs
+    pub fn data_for_archive(&self) -> &[u8] {
+        self.map.as_ref()
+    }
 }
 
 #[cfg(test)]

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -553,6 +553,11 @@ impl HotStorageReader {
         }
         Ok(accounts)
     }
+
+    /// Returns a slice suitable for use when archiving hot storages
+    pub fn data_for_archive(&self) -> &[u8] {
+        self.mmap.as_ref()
+    }
 }
 
 fn write_optional_fields(

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -108,4 +108,11 @@ impl TieredStorageReader {
             Self::Hot(hot) => hot.accounts(index_offset),
         }
     }
+
+    /// Returns a slice suitable for use when archiving tiered storages
+    pub fn data_for_archive(&self) -> &[u8] {
+        match self {
+            Self::Hot(hot) => hot.data_for_archive(),
+        }
+    }
 }


### PR DESCRIPTION
#### Problem

When archiving a snapshot, we need to add all the storages to the archive. Currently, we flush each file and then have the archiver load the file from disk.

Since the storages are all resident/in-sync with the validator process, we know they are all up to date. Also, we already flushed all the storages to disk in AccountsBackgroundService when calling `add_bank_snapshot()`, so flushing again is unnecessary and negatively impacts the rest of the system[^1].

[^1]: Quantifying the negative impacts is something that I believe @alessandrod has done/shared.


#### Summary of Changes

Instead of flushing to disk first, get the storages data directly from the mmaps and add it to the archive.


#### Additional Testing

Running `ledger-tool create-snapshot` on mnb showed that this PR does not impact how long it takes to archive a snapshot.

master:
```
solana_runtime::snapshot_utils] Successfully created /home/sol/ledger/snapshot-257173898-5hquoxg3NyjYVnX86x79VeS5KHBAwW5viLBiVbjsYZXe.tar.zst. slot: 257173898, elapsed ms: 1181220, size: 67725864176
```

this pr:
```
solana_runtime::snapshot_utils] Successfully created /home/sol/ledger/snapshot-257173898-5hquoxg3NyjYVnX86x79VeS5KHBAwW5viLBiVbjsYZXe.tar.zst. slot: 257173898, elapsed ms: 1181327, size: 67722885806
```

I also tested loading from this new snapshot created with this PR to ensure it actually works properly. Happy to report that was successful too.