### PR TITLE
determine if account is in write cache earlier

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5343,14 +5343,14 @@ impl AccountsDb {
             max_root,
             load_hint,
         )?;
+        let in_write_cache = matches!(account_accessor, LoadedAccountAccessor::Cached(_));
         let loaded_account = account_accessor.check_and_get_loaded_account();
-        let is_cached = loaded_account.is_cached();
         let account = loaded_account.take_account();
         if matches!(load_zero_lamports, LoadZeroLamports::None) && account.is_zero_lamport() {
             return None;
         }
 
-        if !is_cached && load_hint != LoadHint::FixedMaxRootDoNotPopulateReadCache {
+        if !in_write_cache && load_hint != LoadHint::FixedMaxRootDoNotPopulateReadCache {
             /*
             We show this store into the read-only cache for account 'A' and future loads of 'A' from the read-only cache are
             safe/reflect 'A''s latest state on this fork.


### PR DESCRIPTION
#### Problem
Accounts db is slow when mmaps exceed free ram.

#### Summary of Changes
Refactoring how we load and scan account data. In this case, we can determine an account is in the write cache by looking at the index entry. This allows us to refactor how we load the `AccountSharedData` without the intermediate step. This allows improvements to the underlying account load code.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
