### PR TITLE
introduce scan_pubkeys for clean storage iteration

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -16668,6 +16668,7 @@ pub mod tests {
                     .map(|account| (*account.pubkey(), account.to_account_shared_data()))
                     .collect::<Vec<_>>();
                 // make sure scan_pubkeys results match
+                // Note that we assume traversals are both in the same order, but this doesn't have to be true.
                 let mut compare = Vec::default();
                 storage.accounts.scan_pubkeys(|k| {
                     compare.push(*k);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2902,7 +2902,7 @@ impl AccountsDb {
                             dirty_ancient_stores.fetch_add(1, Ordering::Relaxed);
                         }
                         oldest_dirty_slot = oldest_dirty_slot.min(*slot);
-                        store.accounts.pubkey_iter(|k| {
+                        store.accounts.scan_pubkeys(|k| {
                             pubkeys.insert(*k);
                         });
                     });
@@ -16667,9 +16667,9 @@ pub mod tests {
                     .account_iter()
                     .map(|account| (*account.pubkey(), account.to_account_shared_data()))
                     .collect::<Vec<_>>();
-                // make sure pubkey_iter results match
+                // make sure scan_pubkeys results match
                 let mut compare = Vec::default();
-                storage.accounts.pubkey_iter(|k| {
+                storage.accounts.scan_pubkeys(|k| {
                     compare.push(*k);
                 });
                 assert_eq!(compare, vec.iter().map(|(k, _)| *k).collect::<Vec<_>>());

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -156,6 +156,14 @@ impl AccountsFile {
         AccountsFileIter::new(self)
     }
 
+    /// iterate over all pubkeys
+    pub(crate) fn pubkey_iter(&self, callback: impl FnMut(&Pubkey)) {
+        match self {
+            Self::AppendVec(av) => av.pubkey_iter(callback),
+            Self::TieredStorage(_) => unimplemented!(""),
+        }
+    }
+
     /// Return a vector of account metadata for each account, starting from `offset`.
     pub fn accounts(&self, offset: usize) -> Vec<StoredAccountMeta> {
         match self {

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -157,9 +157,9 @@ impl AccountsFile {
     }
 
     /// iterate over all pubkeys
-    pub(crate) fn pubkey_iter(&self, callback: impl FnMut(&Pubkey)) {
+    pub(crate) fn scan_pubkeys(&self, callback: impl FnMut(&Pubkey)) {
         match self {
-            Self::AppendVec(av) => av.pubkey_iter(callback),
+            Self::AppendVec(av) => av.scan_pubkeys(callback),
             Self::TieredStorage(_) => unimplemented!(""),
         }
     }

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -160,7 +160,7 @@ impl AccountsFile {
     pub(crate) fn scan_pubkeys(&self, callback: impl FnMut(&Pubkey)) {
         match self {
             Self::AppendVec(av) => av.scan_pubkeys(callback),
-            Self::TieredStorage(_) => unimplemented!(""),
+            Self::TieredStorage(_) => unimplemented!(),
         }
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -584,7 +584,7 @@ impl AppendVec {
     /// `data` is completely ignored, for example.
     /// Also, no references have to be maintained/returned from an iterator function.
     /// This fn can operate on a batch of data at once.
-    pub(crate) fn pubkey_iter(&self, mut callback: impl FnMut(&Pubkey)) {
+    pub(crate) fn scan_pubkeys(&self, mut callback: impl FnMut(&Pubkey)) {
         let mut offset = 0;
         loop {
             let Some((stored_meta, _)) = self.get_type::<StoredMeta>(offset) else {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -20,7 +20,6 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::Slot,
-        hash::Hash,
         pubkey::Pubkey,
         stake_history::Epoch,
     },
@@ -567,10 +566,10 @@ impl AppendVec {
     /// the next account is then aligned on a 64 bit boundary.
     /// With these helpers, we can skip over reading some of the data depending on what the caller wants.
     fn next_account_offset(start_offset: usize, stored_meta: &StoredMeta) -> AccountOffsets {
-        let next_after_stored_meta = start_offset + std::mem::size_of::<StoredMeta>();
-        let start_of_data = next_after_stored_meta
+        let start_of_data = start_offset
+            + std::mem::size_of::<StoredMeta>()
             + std::mem::size_of::<AccountMeta>()
-            + std::mem::size_of::<Hash>();
+            + std::mem::size_of::<AccountHash>();
         let aligned_data_len = u64_align!(stored_meta.data_len as usize);
         let next_account_offset = start_of_data + aligned_data_len;
         let offset_to_end_of_data = start_of_data + stored_meta.data_len as usize;


### PR DESCRIPTION
#### Problem
account state mmapped in is exceeding free ram. There are different types of storage iteration. For clean, we need an iterator which just returns pubkeys.

#### Summary of Changes
Add `pubkey_iter()` to give the storage implementation flexibility in how it satisfies a desire to enumerate all pubkeys. For other storage formats such as hot storage, this can be implemented much more efficiently than the general iterator `account_iter()`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
