### PR TITLE
Reorganize partitioned epoch rewards runtime code, 1 of 5

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -220,6 +220,7 @@ pub mod builtins;
 pub mod epoch_accounts_hash_utils;
 mod fee_distribution;
 mod metrics;
+mod partitioned_epoch_rewards;
 mod serde_snapshot;
 mod sysvar_cache;
 #[cfg(test)]

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -1,0 +1,1 @@
+use super::Bank;

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -1,1 +1,91 @@
-use super::Bank;
+use {
+    super::Bank,
+    crate::{stake_account::StakeAccount, stake_history::StakeHistory},
+    solana_accounts_db::stake_rewards::StakeReward,
+    solana_sdk::{
+        account::AccountSharedData, pubkey::Pubkey, reward_info::RewardInfo,
+        stake::state::Delegation,
+    },
+    solana_vote::vote_account::VoteAccounts,
+    std::sync::Arc,
+};
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub(super) enum RewardInterval {
+    /// the slot within the epoch is INSIDE the reward distribution interval
+    InsideInterval,
+    /// the slot within the epoch is OUTSIDE the reward distribution interval
+    OutsideInterval,
+}
+
+#[derive(AbiExample, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct StartBlockHeightAndRewards {
+    /// the block height of the slot at which rewards distribution began
+    pub(crate) start_block_height: u64,
+    /// calculated epoch rewards pending distribution, outer Vec is by partition (one partition per block)
+    pub(crate) stake_rewards_by_partition: Arc<Vec<StakeRewards>>,
+}
+
+/// Represent whether bank is in the reward phase or not.
+#[derive(AbiExample, AbiEnumVisitor, Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub(crate) enum EpochRewardStatus {
+    /// this bank is in the reward phase.
+    /// Contents are the start point for epoch reward calculation,
+    /// i.e. parent_slot and parent_block height for the starting
+    /// block of the current epoch.
+    Active(StartBlockHeightAndRewards),
+    /// this bank is outside of the rewarding phase.
+    #[default]
+    Inactive,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct VoteRewardsAccounts {
+    /// reward info for each vote account pubkey.
+    /// This type is used by `update_reward_history()`
+    pub(super) rewards: Vec<(Pubkey, RewardInfo)>,
+    /// corresponds to pubkey in `rewards`
+    /// Some if account is to be stored.
+    /// None if to be skipped.
+    pub(super) accounts_to_store: Vec<Option<AccountSharedData>>,
+}
+
+/// hold reward calc info to avoid recalculation across functions
+pub(super) struct EpochRewardCalculateParamInfo<'a> {
+    pub(super) stake_history: StakeHistory,
+    pub(super) stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+    pub(super) cached_vote_accounts: &'a VoteAccounts,
+}
+
+/// Hold all results from calculating the rewards for partitioned distribution.
+/// This struct exists so we can have a function which does all the calculation with no
+/// side effects.
+pub(super) struct PartitionedRewardsCalculation {
+    pub(super) vote_account_rewards: VoteRewardsAccounts,
+    pub(super) stake_rewards_by_partition: StakeRewardCalculationPartitioned,
+    pub(super) old_vote_balance_and_staked: u64,
+    pub(super) validator_rewards: u64,
+    pub(super) validator_rate: f64,
+    pub(super) foundation_rate: f64,
+    pub(super) prev_epoch_duration_in_years: f64,
+    pub(super) capitalization: u64,
+}
+
+/// result of calculating the stake rewards at beginning of new epoch
+pub(super) struct StakeRewardCalculationPartitioned {
+    /// each individual stake account to reward, grouped by partition
+    pub(super) stake_rewards_by_partition: Vec<StakeRewards>,
+    /// total lamports across all `stake_rewards`
+    pub(super) total_stake_rewards_lamports: u64,
+}
+
+pub(super) struct CalculateRewardsAndDistributeVoteRewardsResult {
+    /// total rewards for the epoch (including both vote rewards and stake rewards)
+    pub(super) total_rewards: u64,
+    /// distributed vote rewards
+    pub(super) distributed_rewards: u64,
+    /// stake rewards that still need to be distributed, grouped by partition
+    pub(super) stake_rewards_by_partition: Vec<StakeRewards>,
+}
+
+pub(crate) type StakeRewards = Vec<StakeReward>;

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -179,3 +179,191 @@ impl Bank {
             && self.partitioned_rewards_stake_account_stores_per_block() == u64::MAX
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::bank::tests::create_genesis_config,
+        solana_accounts_db::{
+            accounts_db::{
+                AccountShrinkThreshold, AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_TESTING,
+            },
+            accounts_index::AccountSecondaryIndexes,
+            partitioned_rewards::TestPartitionedEpochRewards,
+        },
+        solana_program_runtime::runtime_config::RuntimeConfig,
+        solana_sdk::{epoch_schedule::EpochSchedule, native_token::LAMPORTS_PER_SOL},
+    };
+
+    impl Bank {
+        /// Return the total number of blocks in reward interval (including both calculation and crediting).
+        pub(in crate::bank) fn get_reward_total_num_blocks(&self, rewards: &StakeRewards) -> u64 {
+            self.get_reward_calculation_num_blocks()
+                + self.get_reward_distribution_num_blocks(rewards)
+        }
+    }
+
+    #[test]
+    fn test_force_reward_interval_end() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let mut bank = Bank::new_for_tests(&genesis_config);
+
+        let expected_num = 100;
+
+        let stake_rewards = (0..expected_num)
+            .map(|_| StakeReward::new_random())
+            .collect::<Vec<_>>();
+
+        bank.set_epoch_reward_status_active(vec![stake_rewards]);
+        assert!(bank.get_reward_interval() == RewardInterval::InsideInterval);
+
+        bank.force_reward_interval_end_for_tests();
+        assert!(bank.get_reward_interval() == RewardInterval::OutsideInterval);
+    }
+
+    #[test]
+    fn test_is_partitioned_reward_feature_enable() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        assert!(!bank.is_partitioned_rewards_feature_enabled());
+        bank.activate_feature(&feature_set::enable_partitioned_epoch_reward::id());
+        assert!(bank.is_partitioned_rewards_feature_enabled());
+    }
+
+    #[test]
+    fn test_deactivate_epoch_reward_status() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let mut bank = Bank::new_for_tests(&genesis_config);
+
+        let expected_num = 100;
+
+        let stake_rewards = (0..expected_num)
+            .map(|_| StakeReward::new_random())
+            .collect::<Vec<_>>();
+
+        bank.set_epoch_reward_status_active(vec![stake_rewards]);
+
+        assert!(bank.get_reward_interval() == RewardInterval::InsideInterval);
+        bank.deactivate_epoch_reward_status();
+        assert!(bank.get_reward_interval() == RewardInterval::OutsideInterval);
+    }
+
+    /// Test get_reward_distribution_num_blocks, get_reward_calculation_num_blocks, get_reward_total_num_blocks during small epoch
+    /// The num_credit_blocks should be cap to 10% of the total number of blocks in the epoch.
+    #[test]
+    fn test_get_reward_distribution_num_blocks_cap() {
+        let (mut genesis_config, _mint_keypair) =
+            create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        genesis_config.epoch_schedule = EpochSchedule::custom(32, 32, false);
+
+        // Config stake reward distribution to be 10 per block
+        let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING.clone();
+        accounts_db_config.test_partitioned_epoch_rewards =
+            TestPartitionedEpochRewards::PartitionedEpochRewardsConfigRewardBlocks {
+                reward_calculation_num_blocks: 1,
+                stake_account_stores_per_block: 10,
+            };
+
+        let bank = Bank::new_with_paths(
+            &genesis_config,
+            Arc::new(RuntimeConfig::default()),
+            Vec::new(),
+            None,
+            None,
+            AccountSecondaryIndexes::default(),
+            AccountShrinkThreshold::default(),
+            false,
+            Some(accounts_db_config),
+            None,
+            Some(Pubkey::new_unique()),
+            Arc::default(),
+        );
+
+        let stake_account_stores_per_block =
+            bank.partitioned_rewards_stake_account_stores_per_block();
+        assert_eq!(stake_account_stores_per_block, 10);
+
+        let check_num_reward_distribution_blocks =
+            |num_stakes: u64,
+             expected_num_reward_distribution_blocks: u64,
+             expected_num_reward_computation_blocks: u64| {
+                // Given the short epoch, i.e. 32 slots, we should cap the number of reward distribution blocks to 32/10 = 3.
+                let stake_rewards = (0..num_stakes)
+                    .map(|_| StakeReward::new_random())
+                    .collect::<Vec<_>>();
+
+                assert_eq!(
+                    bank.get_reward_distribution_num_blocks(&stake_rewards),
+                    expected_num_reward_distribution_blocks
+                );
+                assert_eq!(
+                    bank.get_reward_calculation_num_blocks(),
+                    expected_num_reward_computation_blocks
+                );
+                assert_eq!(
+                    bank.get_reward_total_num_blocks(&stake_rewards),
+                    bank.get_reward_distribution_num_blocks(&stake_rewards)
+                        + bank.get_reward_calculation_num_blocks(),
+                );
+            };
+
+        for test_record in [
+            // num_stakes, expected_num_reward_distribution_blocks, expected_num_reward_computation_blocks
+            (0, 1, 1),
+            (1, 1, 1),
+            (stake_account_stores_per_block, 1, 1),
+            (2 * stake_account_stores_per_block - 1, 2, 1),
+            (2 * stake_account_stores_per_block, 2, 1),
+            (3 * stake_account_stores_per_block - 1, 3, 1),
+            (3 * stake_account_stores_per_block, 3, 1),
+            (4 * stake_account_stores_per_block, 3, 1), // cap at 3
+            (5 * stake_account_stores_per_block, 3, 1), //cap at 3
+        ] {
+            check_num_reward_distribution_blocks(test_record.0, test_record.1, test_record.2);
+        }
+    }
+
+    /// Test get_reward_distribution_num_blocks, get_reward_calculation_num_blocks, get_reward_total_num_blocks during normal epoch gives the expected result
+    #[test]
+    fn test_get_reward_distribution_num_blocks_normal() {
+        solana_logger::setup();
+        let (mut genesis_config, _mint_keypair) =
+            create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        genesis_config.epoch_schedule = EpochSchedule::custom(432000, 432000, false);
+
+        let bank = Bank::new_for_tests(&genesis_config);
+
+        // Given 8k rewards, it will take 2 blocks to credit all the rewards
+        let expected_num = 8192;
+        let stake_rewards = (0..expected_num)
+            .map(|_| StakeReward::new_random())
+            .collect::<Vec<_>>();
+
+        assert_eq!(bank.get_reward_distribution_num_blocks(&stake_rewards), 2);
+        assert_eq!(bank.get_reward_calculation_num_blocks(), 1);
+        assert_eq!(
+            bank.get_reward_total_num_blocks(&stake_rewards),
+            bank.get_reward_distribution_num_blocks(&stake_rewards)
+                + bank.get_reward_calculation_num_blocks(),
+        );
+    }
+
+    /// Test get_reward_distribution_num_blocks, get_reward_calculation_num_blocks, get_reward_total_num_blocks during warm up epoch gives the expected result.
+    /// The num_credit_blocks should be 1 during warm up epoch.
+    #[test]
+    fn test_get_reward_distribution_num_blocks_warmup() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+
+        let bank = Bank::new_for_tests(&genesis_config);
+        let rewards = vec![];
+        assert_eq!(bank.get_reward_distribution_num_blocks(&rewards), 1);
+        assert_eq!(bank.get_reward_calculation_num_blocks(), 1);
+        assert_eq!(
+            bank.get_reward_total_num_blocks(&rewards),
+            bank.get_reward_distribution_num_blocks(&rewards)
+                + bank.get_reward_calculation_num_blocks(),
+        );
+    }
+}

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -3,8 +3,8 @@ mod tests {
     use {
         crate::{
             bank::{
-                epoch_accounts_hash_utils, test_utils as bank_test_utils, Bank, EpochRewardStatus,
-                StartBlockHeightAndRewards,
+                epoch_accounts_hash_utils, partitioned_epoch_rewards::StartBlockHeightAndRewards,
+                test_utils as bank_test_utils, Bank, EpochRewardStatus,
             },
             genesis_utils::activate_all_features,
             serde_snapshot::{

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -605,7 +605,7 @@ mod tests {
 
         // This some what long test harness is required to freeze the ABI of
         // Bank's serialization due to versioned nature
-        #[frozen_abi(digest = "7BH2s2Y1yKy396c3ixC4TTyvvpkyenAvWDSiZvY5yb7P")]
+        #[frozen_abi(digest = "8BVfyLYrPt1ranknjF4sLePjZaZjpKXXrHt4wKf47g3W")]
         #[derive(Serialize, AbiExample)]
         pub struct BankAbiTestWrapperNewer {
             #[serde(serialize_with = "wrapper_newer")]

--- a/runtime/src/epoch_rewards_hasher.rs
+++ b/runtime/src/epoch_rewards_hasher.rs
@@ -1,5 +1,5 @@
 use {
-    crate::bank::StakeRewards,
+    crate::bank::partitioned_epoch_rewards::StakeRewards,
     solana_sdk::{epoch_rewards_hasher::EpochRewardsHasher, hash::Hash},
 };
 

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -5,7 +5,7 @@ use {
         *,
     },
     crate::{
-        bank::EpochRewardStatus,
+        bank::partitioned_epoch_rewards::EpochRewardStatus,
         stakes::{serde_stakes_enum_compat, StakesEnum},
     },
     solana_accounts_db::{accounts_hash::AccountsHash, ancestors::AncestorsForSerialization},


### PR DESCRIPTION
#### Problem
Code for partitioned epoch rewards is peppered throughout bank.rs. It is very hard to trace the flows, and figure out which structs and methods are needed for calculation vs distribution, or for sysvar handling.

#### Summary of Changes
This is the first of 5 reorg/refactoring PRs.
There are no functional changes in this PR, although some `pub` declarations may look different due to module nesting.
This is best reviewed by commit.

Eventually, partitioned_epoch_rewards module will look like this:
```
partitioned_epoch_rewards >
    calculation.rs
    compare.rs
    distribution.rs
    mod.rs
    sysvar.rs
````
The complete change is visible in [a draft PR](https://github.com/anza-xyz/agave/pull/510)

