### PR TITLE
Bump curve25519-dalek from 3.2.1 to 4.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5",
+ "block-padding",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
@@ -914,7 +914,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
  "generic-array 0.14.7",
 ]
 
@@ -935,12 +934,6 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
@@ -1708,9 +1701,38 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "platforms",
+ "rand_core 0.6.4",
+ "rustc_version 0.4.0",
  "serde",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1967,7 +1989,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.1",
  "ed25519",
  "rand 0.7.3",
  "serde",
@@ -2141,6 +2163,12 @@ name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -4013,6 +4041,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "platforms"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
+
+[[package]]
 name = "plotters"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5143,18 +5177,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -6581,7 +6603,7 @@ dependencies = [
  "bincode",
  "bv",
  "caps",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "dlopen2",
  "fnv",
  "lazy_static",
@@ -6674,7 +6696,7 @@ dependencies = [
  "cc",
  "console_error_panic_hook",
  "console_log",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "getrandom 0.2.10",
  "itertools",
  "js-sys",
@@ -6694,7 +6716,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-logger",
@@ -7113,7 +7135,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "chrono",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "derivation-path",
  "digest 0.10.7",
  "ed25519-dalek",
@@ -7142,7 +7164,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "siphasher",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
@@ -7734,17 +7756,17 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bytemuck",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "itertools",
  "lazy_static",
  "merlin",
  "num-derive",
  "num-traits",
- "rand 0.7.3",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "serde_json",
- "sha3 0.9.1",
+ "sha3",
  "solana-program",
  "solana-sdk",
  "subtle",
@@ -7759,7 +7781,7 @@ version = "2.0.0"
 dependencies = [
  "bytemuck",
  "criterion",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "num-derive",
  "num-traits",
  "solana-program-runtime",
@@ -7772,7 +7794,7 @@ name = "solana-zk-token-proof-program-tests"
 version = "2.0.0"
 dependencies = [
  "bytemuck",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "solana-compute-budget",
  "solana-program-test",
  "solana-sdk",
@@ -7788,18 +7810,18 @@ dependencies = [
  "bincode",
  "bytemuck",
  "byteorder",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "getrandom 0.1.16",
  "itertools",
  "lazy_static",
  "merlin",
  "num-derive",
  "num-traits",
- "rand 0.7.3",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "serde_json",
- "sha3 0.9.1",
+ "sha3",
  "solana-program",
  "solana-sdk",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ criterion-stats = "0.3.0"
 crossbeam-channel = "0.5.13"
 csv = "1.3.0"
 ctrlc = "3.4.4"
-curve25519-dalek = "3.2.1"
+curve25519-dalek = { version = "4.1.2", features = ["digest", "rand_core"] }
 dashmap = "5.5.3"
 derivation-path = { version = "0.2.0", default-features = false }
 derivative = "2.2.0"

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -1280,7 +1280,7 @@ mod tests {
             for _ in 0..1_000_000 {
                 thread_rng().fill(&mut input);
                 let ans = get_checked_scalar(&input);
-                let ref_ans = Scalar::from_canonical_bytes(input);
+                let ref_ans = Option::<Scalar>::from(Scalar::from_canonical_bytes(input));
                 if let Some(ref_ans) = ref_ans {
                     passed += 1;
                     assert_eq!(ans.unwrap(), ref_ans.to_bytes());
@@ -1315,7 +1315,8 @@ mod tests {
             for _ in 0..1_000_000 {
                 thread_rng().fill(&mut input);
                 let ans = check_packed_ge_small_order(&input);
-                let ref_ge = CompressedEdwardsY::from_slice(&input);
+                let ref_ge = CompressedEdwardsY::from_slice(&input)
+                    .expect("Input slice should have a length of 32");
                 if let Some(ref_element) = ref_ge.decompress() {
                     if ref_element.is_small_order() {
                         assert!(!ans);

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -700,7 +700,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5",
+ "block-padding",
  "byte-tools",
  "byteorder 1.5.0",
  "generic-array 0.12.4",
@@ -712,7 +712,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
  "generic-array 0.14.7",
 ]
 
@@ -733,12 +732,6 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
@@ -1258,9 +1251,38 @@ dependencies = [
  "byteorder 1.5.0",
  "digest 0.9.0",
  "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "platforms",
+ "rand_core 0.6.4",
+ "rustc_version",
  "serde",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1500,7 +1522,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.1",
  "ed25519",
  "rand 0.7.3",
  "serde",
@@ -1683,6 +1705,12 @@ name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -3489,6 +3517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "platforms"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4432,18 +4466,6 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
@@ -5292,7 +5314,7 @@ dependencies = [
  "bincode",
  "bv",
  "caps",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "dlopen2",
  "fnv",
  "lazy_static",
@@ -5354,7 +5376,7 @@ dependencies = [
  "cc",
  "console_error_panic_hook",
  "console_log",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "getrandom 0.2.10",
  "itertools",
  "js-sys",
@@ -5373,7 +5395,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "solana-sdk-macro",
  "thiserror",
  "wasm-bindgen",
@@ -6159,7 +6181,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "siphasher",
  "solana-program",
  "solana-sdk-macro",
@@ -6589,18 +6611,18 @@ dependencies = [
  "bincode",
  "bytemuck",
  "byteorder 1.5.0",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "getrandom 0.1.14",
  "itertools",
  "lazy_static",
  "merlin",
  "num-derive",
  "num-traits",
- "rand 0.7.3",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "serde_json",
- "sha3 0.9.1",
+ "sha3",
  "solana-program",
  "solana-sdk",
  "subtle",

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -170,6 +170,7 @@ pub fn bytes_are_curve_point<T: AsRef<[u8]>>(_bytes: T) -> bool {
     #[cfg(not(target_os = "solana"))]
     {
         curve25519_dalek::edwards::CompressedEdwardsY::from_slice(_bytes.as_ref())
+            .expect("Input slice should have a length of 32")
             .decompress()
             .is_some()
     }
@@ -948,6 +949,7 @@ mod tests {
                 let is_on_curve = curve25519_dalek::edwards::CompressedEdwardsY::from_slice(
                     &program_address.to_bytes(),
                 )
+                .expect("Input slice should have a length of 32")
                 .decompress()
                 .is_some();
                 assert!(!is_on_curve);

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -27,11 +27,11 @@ bincode = { workspace = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
-rand = { version = "0.7" }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-sha3 = "0.9"
+sha3 = { workspace = true }
 solana-sdk = { workspace = true }
 subtle = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -308,7 +308,7 @@ impl ElGamalPubkey {
     #[allow(non_snake_case)]
     pub fn new(secret: &ElGamalSecretKey) -> Self {
         let s = &secret.0;
-        assert!(s != &Scalar::zero());
+        assert!(s != &Scalar::ZERO);
 
         ElGamalPubkey(s.invert() * &(*H))
     }
@@ -375,6 +375,7 @@ impl TryFrom<&[u8]> for ElGamalPubkey {
 
         Ok(ElGamalPubkey(
             CompressedRistretto::from_slice(bytes)
+                .expect("Input slice should have a length of 32")
                 .decompress()
                 .ok_or(ElGamalError::PubkeyDeserialization)?,
         ))
@@ -530,7 +531,7 @@ impl TryFrom<&[u8]> for ElGamalSecretKey {
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         match bytes.try_into() {
             Ok(bytes) => Ok(ElGamalSecretKey::from(
-                Scalar::from_canonical_bytes(bytes)
+                Option::<Scalar>::from(Scalar::from_canonical_bytes(bytes))
                     .ok_or(ElGamalError::SecretKeyDeserialization)?,
             )),
             _ => Err(ElGamalError::SecretKeyDeserialization),
@@ -720,7 +721,9 @@ impl DecryptHandle {
         }
 
         Some(DecryptHandle(
-            CompressedRistretto::from_slice(bytes).decompress()?,
+            CompressedRistretto::from_slice(bytes)
+                .expect("Input slice should have a length of 32")
+                .decompress()?,
         ))
     }
 }

--- a/zk-sdk/src/encryption/pedersen.rs
+++ b/zk-sdk/src/encryption/pedersen.rs
@@ -90,7 +90,7 @@ impl PedersenOpening {
 
     pub fn from_bytes(bytes: &[u8]) -> Option<PedersenOpening> {
         match bytes.try_into() {
-            Ok(bytes) => Scalar::from_canonical_bytes(bytes).map(PedersenOpening),
+            Ok(bytes) => Option::from(Scalar::from_canonical_bytes(bytes)).map(PedersenOpening),
             _ => None,
         }
     }
@@ -185,7 +185,9 @@ impl PedersenCommitment {
         }
 
         Some(PedersenCommitment(
-            CompressedRistretto::from_slice(bytes).decompress()?,
+            CompressedRistretto::from_slice(bytes)
+                .expect("Input slice should have a length of 32")
+                .decompress()?,
         ))
     }
 }

--- a/zk-sdk/src/range_proof/generators.rs
+++ b/zk-sdk/src/range_proof/generators.rs
@@ -4,14 +4,14 @@ use {
         digest::{ExtendableOutput, Update, XofReader},
         ristretto::RistrettoPoint,
     },
-    sha3::{Sha3XofReader, Shake256},
+    sha3::{Shake256, Shake256Reader},
 };
 
 const MAX_GENERATOR_LENGTH: usize = u32::MAX as usize;
 
 /// Generators for Pedersen vector commitments that are used for inner-product proofs.
 struct GeneratorsChain {
-    reader: Sha3XofReader,
+    reader: Shake256Reader,
 }
 
 impl GeneratorsChain {

--- a/zk-sdk/src/range_proof/inner_product.rs
+++ b/zk-sdk/src/range_proof/inner_product.rs
@@ -411,10 +411,12 @@ impl InnerProductProof {
         }
 
         let pos = 2 * lg_n * 32;
-        let a = Scalar::from_canonical_bytes(util::read32(&slice[pos..]))
+        let a = Option::from(Scalar::from_canonical_bytes(util::read32(&slice[pos..])))
             .ok_or(RangeProofVerificationError::Deserialization)?;
-        let b = Scalar::from_canonical_bytes(util::read32(&slice[pos + 32..]))
-            .ok_or(RangeProofVerificationError::Deserialization)?;
+        let b = Option::from(Scalar::from_canonical_bytes(util::read32(
+            &slice[pos + 32..],
+        )))
+        .ok_or(RangeProofVerificationError::Deserialization)?;
 
         Ok(InnerProductProof { L_vec, R_vec, a, b })
     }
@@ -441,7 +443,7 @@ mod tests {
         let b: Vec<_> = (0..n).map(|_| Scalar::random(&mut OsRng)).collect();
         let c = util::inner_product(&a, &b).unwrap();
 
-        let G_factors: Vec<Scalar> = iter::repeat(Scalar::one()).take(n).collect();
+        let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(n).collect();
 
         let y_inv = Scalar::random(&mut OsRng);
         let H_factors: Vec<Scalar> = util::exp_iter(y_inv).take(n).collect();
@@ -478,7 +480,7 @@ mod tests {
         assert!(proof
             .verify(
                 n,
-                iter::repeat(Scalar::one()).take(n),
+                iter::repeat(Scalar::ONE).take(n),
                 util::exp_iter(y_inv).take(n),
                 &P,
                 &Q,
@@ -493,7 +495,7 @@ mod tests {
         assert!(proof
             .verify(
                 n,
-                iter::repeat(Scalar::one()).take(n),
+                iter::repeat(Scalar::ONE).take(n),
                 util::exp_iter(y_inv).take(n),
                 &P,
                 &Q,

--- a/zk-sdk/src/range_proof/mod.rs
+++ b/zk-sdk/src/range_proof/mod.rs
@@ -180,16 +180,16 @@ impl RangeProof {
 
         let mut i = 0;
         let mut exp_z = z * z;
-        let mut exp_y = Scalar::one();
+        let mut exp_y = Scalar::ONE;
 
         for (amount_i, n_i) in amounts.iter().zip(bit_lengths.iter()) {
-            let mut exp_2 = Scalar::one();
+            let mut exp_2 = Scalar::ONE;
 
             for j in 0..(*n_i) {
                 // `j` is guaranteed to be at most `u64::BITS` (a 6-bit number) and therefore,
                 // casting is lossless and right shift can be safely unwrapped
                 let a_L_j = Scalar::from(amount_i.checked_shr(j as u32).unwrap() & 1);
-                let a_R_j = a_L_j - Scalar::one();
+                let a_R_j = a_L_j - Scalar::ONE;
 
                 l_poly.0[i] = a_L_j - z;
                 l_poly.1[i] = s_L[i];
@@ -224,7 +224,7 @@ impl RangeProof {
         // z^2 * V_1 + z^3 * V_2 + ... + z^{m+1} * V_m + delta(y, z)*G + x*T_1 + x^2*T_2
         let x = transcript.challenge_scalar(b"x");
 
-        let mut agg_opening = Scalar::zero();
+        let mut agg_opening = Scalar::ZERO;
         let mut exp_z = z;
         for opening in openings {
             exp_z *= z;
@@ -255,7 +255,7 @@ impl RangeProof {
         let w = transcript.challenge_scalar(b"w");
         let Q = w * &(*G);
 
-        let G_factors: Vec<Scalar> = iter::repeat(Scalar::one()).take(nm).collect();
+        let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(nm).collect();
         let H_factors: Vec<Scalar> = util::exp_iter(y.invert()).take(nm).collect();
 
         // generate challenge `c` for consistency with the verifier's transcript
@@ -358,7 +358,7 @@ impl RangeProof {
         let value_commitment_scalars = util::exp_iter(z).take(m).map(|z_exp| c * zz * z_exp);
 
         let mega_check = RistrettoPoint::optional_multiscalar_mul(
-            iter::once(Scalar::one())
+            iter::once(Scalar::ONE)
                 .chain(iter::once(x))
                 .chain(iter::once(c * x))
                 .chain(iter::once(c * x * x))
@@ -420,11 +420,12 @@ impl RangeProof {
         let T_1 = CompressedRistretto(util::read32(&slice[2 * 32..]));
         let T_2 = CompressedRistretto(util::read32(&slice[3 * 32..]));
 
-        let t_x = Scalar::from_canonical_bytes(util::read32(&slice[4 * 32..]))
+        let t_x = Option::from(Scalar::from_canonical_bytes(util::read32(&slice[4 * 32..])))
             .ok_or(RangeProofVerificationError::Deserialization)?;
-        let t_x_blinding = Scalar::from_canonical_bytes(util::read32(&slice[5 * 32..]))
-            .ok_or(RangeProofVerificationError::Deserialization)?;
-        let e_blinding = Scalar::from_canonical_bytes(util::read32(&slice[6 * 32..]))
+        let t_x_blinding =
+            Option::from(Scalar::from_canonical_bytes(util::read32(&slice[5 * 32..])))
+                .ok_or(RangeProofVerificationError::Deserialization)?;
+        let e_blinding = Option::from(Scalar::from_canonical_bytes(util::read32(&slice[6 * 32..])))
             .ok_or(RangeProofVerificationError::Deserialization)?;
 
         let ipp_proof = InnerProductProof::from_bytes(&slice[7 * 32..])?;

--- a/zk-sdk/src/range_proof/util.rs
+++ b/zk-sdk/src/range_proof/util.rs
@@ -9,7 +9,7 @@ pub struct VecPoly1(pub Vec<Scalar>, pub Vec<Scalar>);
 
 impl VecPoly1 {
     pub fn zero(n: usize) -> Self {
-        VecPoly1(vec![Scalar::zero(); n], vec![Scalar::zero(); n])
+        VecPoly1(vec![Scalar::ZERO; n], vec![Scalar::ZERO; n])
     }
 
     pub fn inner_product(&self, rhs: &VecPoly1) -> Option<Poly2> {
@@ -30,7 +30,7 @@ impl VecPoly1 {
 
     pub fn eval(&self, x: Scalar) -> Vec<Scalar> {
         let n = self.0.len();
-        let mut out = vec![Scalar::zero(); n];
+        let mut out = vec![Scalar::ZERO; n];
         #[allow(clippy::needless_range_loop)]
         for i in 0..n {
             out[i] = self.0[i] + self.1[i] * x;
@@ -72,7 +72,7 @@ impl Iterator for ScalarExp {
 
 /// Return an iterator of the powers of `x`.
 pub fn exp_iter(x: Scalar) -> ScalarExp {
-    let next_exp_x = Scalar::one();
+    let next_exp_x = Scalar::ONE;
     ScalarExp { x, next_exp_x }
 }
 
@@ -81,7 +81,7 @@ pub fn add_vec(a: &[Scalar], b: &[Scalar]) -> Vec<Scalar> {
         // throw some error
         //println!("lengths of vectors don't match for vector addition");
     }
-    let mut out = vec![Scalar::zero(); b.len()];
+    let mut out = vec![Scalar::ZERO; b.len()];
     for i in 0..a.len() {
         out[i] = a[i] + b[i];
     }
@@ -101,7 +101,7 @@ pub fn read32(data: &[u8]) -> [u8; 32] {
 /// \\]
 /// Errors if the lengths of \\(\mathbf{a}\\) and \\(\mathbf{b}\\) are not equal.
 pub fn inner_product(a: &[Scalar], b: &[Scalar]) -> Option<Scalar> {
-    let mut out = Scalar::zero();
+    let mut out = Scalar::ZERO;
     if a.len() != b.len() {
         return None;
     }
@@ -123,7 +123,7 @@ pub fn sum_of_powers(x: &Scalar, n: usize) -> Scalar {
         return Scalar::from(n as u64);
     }
     let mut m = n;
-    let mut result = Scalar::one() + x;
+    let mut result = Scalar::ONE + x;
     let mut factor = *x;
     while m > 2 {
         factor = factor * factor;

--- a/zk-sdk/src/sigma_proofs/ciphertext_ciphertext_equality.rs
+++ b/zk-sdk/src/sigma_proofs/ciphertext_ciphertext_equality.rs
@@ -189,7 +189,7 @@ impl CiphertextCiphertextEqualityProof {
             vec![
                 &self.z_s,            // z_s
                 &(-&c),               // -c
-                &(-&Scalar::one()),   // -identity
+                &(-&Scalar::ONE),     // -identity
                 &(&w * &self.z_x),    // w * z_x
                 &(&w * &self.z_s),    // w * z_s
                 &(&w_negated * &c),   // -w * c

--- a/zk-sdk/src/sigma_proofs/ciphertext_commitment_equality.rs
+++ b/zk-sdk/src/sigma_proofs/ciphertext_commitment_equality.rs
@@ -176,7 +176,7 @@ impl CiphertextCommitmentEqualityProof {
             vec![
                 &self.z_s,           // z_s
                 &(-&c),              // -c
-                &(-&Scalar::one()),  // -identity
+                &(-&Scalar::ONE),    // -identity
                 &(&w * &self.z_x),   // w * z_x
                 &(&w * &self.z_s),   // w * z_s
                 &(&w_negated * &c),  // -w * c

--- a/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_2.rs
@@ -176,7 +176,7 @@ impl GroupedCiphertext2HandlesValidityProof {
                 &self.z_r,           // z_r
                 &self.z_x,           // z_x
                 &(-&c),              // -c
-                &-(&Scalar::one()),  // -identity
+                &-(&Scalar::ONE),    // -identity
                 &(&w * &self.z_r),   // w * z_r
                 &(&w_negated * &c),  // -w * c
                 &w_negated,          // -w

--- a/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_3.rs
@@ -197,7 +197,7 @@ impl GroupedCiphertext3HandlesValidityProof {
                 &self.z_r,            // z_r
                 &self.z_x,            // z_x
                 &(-&c),               // -c
-                &-(&Scalar::one()),   // -identity
+                &-(&Scalar::ONE),     // -identity
                 &(&w * &self.z_r),    // w * z_r
                 &(&w_negated * &c),   // -w * c
                 &w_negated,           // -w

--- a/zk-sdk/src/sigma_proofs/mod.rs
+++ b/zk-sdk/src/sigma_proofs/mod.rs
@@ -68,7 +68,9 @@ fn ristretto_point_from_optional_slice(
 ) -> Result<CompressedRistretto, SigmaProofVerificationError> {
     optional_slice
         .and_then(|slice| (slice.len() == RISTRETTO_POINT_LEN).then_some(slice))
-        .map(CompressedRistretto::from_slice)
+        .map(|slice| {
+            CompressedRistretto::from_slice(slice).expect("Input slice should have a length of 32")
+        })
         .ok_or(SigmaProofVerificationError::Deserialization)
 }
 
@@ -83,6 +85,6 @@ fn canonical_scalar_from_optional_slice(
     optional_slice
         .and_then(|slice| (slice.len() == SCALAR_LEN).then_some(slice)) // if chunk is the wrong length, convert to None
         .and_then(|slice| slice.try_into().ok()) // convert to array
-        .and_then(Scalar::from_canonical_bytes)
+        .and_then(|slice| Option::from(Scalar::from_canonical_bytes(slice)))
         .ok_or(SigmaProofVerificationError::Deserialization)
 }

--- a/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
+++ b/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
@@ -393,7 +393,7 @@ impl PercentageWithCapProof {
                 c_max_proof,
                 -c_max_proof * m,
                 -z_max,
-                Scalar::one(),
+                Scalar::ONE,
                 w * z_x,
                 w * z_delta_real,
                 -w * c_equality,

--- a/zk-sdk/src/sigma_proofs/pubkey_validity.rs
+++ b/zk-sdk/src/sigma_proofs/pubkey_validity.rs
@@ -65,7 +65,7 @@ impl PubkeyValidityProof {
         // extract the relevant scalar and Ristretto points from the input
         let s = elgamal_keypair.secret().get_scalar();
 
-        assert!(s != &Scalar::zero());
+        assert!(s != &Scalar::ZERO);
         let s_inv = s.invert();
 
         // generate a random masking factor that also serves as a nonce
@@ -109,7 +109,7 @@ impl PubkeyValidityProof {
             .ok_or(SigmaProofVerificationError::Deserialization)?;
 
         let check = RistrettoPoint::vartime_multiscalar_mul(
-            vec![&self.z, &(-&c), &(-&Scalar::one())],
+            vec![&self.z, &(-&c), &(-&Scalar::ONE)],
             vec![&(*H), P, &Y],
         );
 

--- a/zk-sdk/src/sigma_proofs/zero_ciphertext.rs
+++ b/zk-sdk/src/sigma_proofs/zero_ciphertext.rs
@@ -136,7 +136,7 @@ impl ZeroCiphertextProof {
             vec![
                 &self.z,            // z
                 &(-&c),             // -c
-                &(-&Scalar::one()), // -identity
+                &(-&Scalar::ONE),   // -identity
                 &(&w * &self.z),    // w * z
                 &(&w_negated * &c), // -w * c
                 &w_negated,         // -w

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -29,11 +29,11 @@ getrandom = { version = "0.1", features = ["dummy"] }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 merlin = { workspace = true }
-rand = { version = "0.7" }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-sha3 = "0.9"
+sha3 = { workspace = true }
 solana-sdk = { workspace = true }
 subtle = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }

--- a/zk-token-sdk/src/curve25519/edwards.rs
+++ b/zk-token-sdk/src/curve25519/edwards.rs
@@ -64,6 +64,7 @@ mod target_arch {
 
         fn try_from(pod: &PodEdwardsPoint) -> Result<Self, Self::Error> {
             CompressedEdwardsY::from_slice(&pod.0)
+                .expect("Input slice should have a length of 32")
                 .decompress()
                 .ok_or(Curve25519Error::PodConversion)
         }
@@ -74,6 +75,7 @@ mod target_arch {
 
         fn validate_point(&self) -> bool {
             CompressedEdwardsY::from_slice(&self.0)
+                .expect("Input slice should have a length of 32")
                 .decompress()
                 .is_some()
         }

--- a/zk-token-sdk/src/curve25519/ristretto.rs
+++ b/zk-token-sdk/src/curve25519/ristretto.rs
@@ -64,6 +64,7 @@ mod target_arch {
 
         fn try_from(pod: &PodRistrettoPoint) -> Result<Self, Self::Error> {
             CompressedRistretto::from_slice(&pod.0)
+                .expect("Input slice should have a length of 32")
                 .decompress()
                 .ok_or(Curve25519Error::PodConversion)
         }
@@ -74,6 +75,7 @@ mod target_arch {
 
         fn validate_point(&self) -> bool {
             CompressedRistretto::from_slice(&self.0)
+                .expect("Input slice should have a length of 32")
                 .decompress()
                 .is_some()
         }

--- a/zk-token-sdk/src/curve25519/scalar.rs
+++ b/zk-token-sdk/src/curve25519/scalar.rs
@@ -18,7 +18,7 @@ mod target_arch {
         type Error = Curve25519Error;
 
         fn try_from(pod: &PodScalar) -> Result<Self, Self::Error> {
-            Scalar::from_canonical_bytes(pod.0).ok_or(Curve25519Error::PodConversion)
+            Option::from(Scalar::from_canonical_bytes(pod.0)).ok_or(Curve25519Error::PodConversion)
         }
     }
 }

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -358,7 +358,7 @@ impl ElGamalPubkey {
     #[allow(non_snake_case)]
     pub fn new(secret: &ElGamalSecretKey) -> Self {
         let s = &secret.0;
-        assert!(s != &Scalar::zero());
+        assert_ne!(s, &Scalar::ZERO);
 
         ElGamalPubkey(s.invert() * &(*H))
     }
@@ -379,7 +379,9 @@ impl ElGamalPubkey {
         }
 
         Some(ElGamalPubkey(
-            CompressedRistretto::from_slice(bytes).decompress()?,
+            CompressedRistretto::from_slice(bytes)
+                .expect("Input slice should have a length of 32")
+                .decompress()?,
         ))
     }
 
@@ -442,6 +444,7 @@ impl TryFrom<&[u8]> for ElGamalPubkey {
 
         Ok(ElGamalPubkey(
             CompressedRistretto::from_slice(bytes)
+                .expect("Input slice should have a length of 32")
                 .decompress()
                 .ok_or(ElGamalError::PubkeyDeserialization)?,
         ))
@@ -552,7 +555,9 @@ impl ElGamalSecretKey {
     #[deprecated(note = "please use `try_from()` instead")]
     pub fn from_bytes(bytes: &[u8]) -> Option<ElGamalSecretKey> {
         match bytes.try_into() {
-            Ok(bytes) => Scalar::from_canonical_bytes(bytes).map(ElGamalSecretKey),
+            Ok(bytes) => Scalar::from_canonical_bytes(bytes)
+                .map(ElGamalSecretKey)
+                .into(),
             _ => None,
         }
     }
@@ -610,7 +615,7 @@ impl TryFrom<&[u8]> for ElGamalSecretKey {
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         match bytes.try_into() {
             Ok(bytes) => Ok(ElGamalSecretKey::from(
-                Scalar::from_canonical_bytes(bytes)
+                Option::<Scalar>::from(Scalar::from_canonical_bytes(bytes))
                     .ok_or(ElGamalError::SecretKeyDeserialization)?,
             )),
             _ => Err(ElGamalError::SecretKeyDeserialization),
@@ -800,7 +805,9 @@ impl DecryptHandle {
         }
 
         Some(DecryptHandle(
-            CompressedRistretto::from_slice(bytes).decompress()?,
+            CompressedRistretto::from_slice(bytes)
+                .expect("Input slice should have a length of 32")
+                .decompress()?,
         ))
     }
 }

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -99,7 +99,9 @@ impl PedersenOpening {
 
     pub fn from_bytes(bytes: &[u8]) -> Option<PedersenOpening> {
         match bytes.try_into() {
-            Ok(bytes) => Scalar::from_canonical_bytes(bytes).map(PedersenOpening),
+            Ok(bytes) => Scalar::from_canonical_bytes(bytes)
+                .map(PedersenOpening)
+                .into(),
             _ => None,
         }
     }
@@ -194,7 +196,9 @@ impl PedersenCommitment {
         }
 
         Some(PedersenCommitment(
-            CompressedRistretto::from_slice(bytes).decompress()?,
+            CompressedRistretto::from_slice(bytes)
+                .expect("Input slice should have a length of 32")
+                .decompress()?,
         ))
     }
 }

--- a/zk-token-sdk/src/instruction/transfer/mod.rs
+++ b/zk-token-sdk/src/instruction/transfer/mod.rs
@@ -36,7 +36,6 @@ pub enum Role {
 /// Takes in a 64-bit number `amount` and a bit length `bit_length`. It returns:
 ///  - the `bit_length` low bits of `amount` interpreted as u64
 ///  - the (64 - `bit_length`) high bits of `amount` interpreted as u64
-#[deprecated(since = "1.18.0", note = "please use `try_split_u64` instead")]
 #[cfg(not(target_os = "solana"))]
 pub fn split_u64(amount: u64, bit_length: usize) -> (u64, u64) {
     if bit_length == 64 {
@@ -71,7 +70,6 @@ pub fn try_split_u64(amount: u64, bit_length: usize) -> Result<(u64, u64), Instr
     }
 }
 
-#[deprecated(since = "1.18.0", note = "please use `try_combine_lo_hi_u64` instead")]
 #[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_u64(amount_lo: u64, amount_hi: u64, bit_length: usize) -> u64 {
     if bit_length == 64 {
@@ -118,10 +116,6 @@ fn try_combine_lo_hi_ciphertexts(
     Ok(ciphertext_lo + &(ciphertext_hi * &Scalar::from(two_power)))
 }
 
-#[deprecated(
-    since = "1.18.0",
-    note = "please use `try_combine_lo_hi_commitments` instead"
-)]
 #[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_commitments(
     comm_lo: &PedersenCommitment,
@@ -146,10 +140,6 @@ pub fn try_combine_lo_hi_commitments(
     Ok(comm_lo + comm_hi * &Scalar::from(two_power))
 }
 
-#[deprecated(
-    since = "1.18.0",
-    note = "please use `try_combine_lo_hi_openings` instead"
-)]
 #[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_openings(
     opening_lo: &PedersenOpening,

--- a/zk-token-sdk/src/instruction/zero_balance.rs
+++ b/zk-token-sdk/src/instruction/zero_balance.rs
@@ -1,7 +1,7 @@
 //! The zero-balance proof instruction.
 //!
 //! A zero-balance proof is defined with respect to a twisted ElGamal ciphertext. The proof
-//! certifies that a given ciphertext encrypts the message 0 in the field (`Scalar::zero()`). To
+//! certifies that a given ciphertext encrypts the message 0 in the field (`Scalar::ZERO`). To
 //! generate the proof, a prover must provide the decryption key for the ciphertext.
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/range_proof/generators.rs
+++ b/zk-token-sdk/src/range_proof/generators.rs
@@ -4,7 +4,7 @@ use {
         digest::{ExtendableOutput, Update, XofReader},
         ristretto::RistrettoPoint,
     },
-    sha3::{Sha3XofReader, Shake256},
+    sha3::{Shake256, Shake256Reader},
 };
 
 #[cfg(not(target_os = "solana"))]
@@ -12,7 +12,7 @@ const MAX_GENERATOR_LENGTH: usize = u32::MAX as usize;
 
 /// Generators for Pedersen vector commitments that are used for inner-product proofs.
 struct GeneratorsChain {
-    reader: Sha3XofReader,
+    reader: Shake256Reader,
 }
 
 impl GeneratorsChain {

--- a/zk-token-sdk/src/range_proof/inner_product.rs
+++ b/zk-token-sdk/src/range_proof/inner_product.rs
@@ -411,10 +411,12 @@ impl InnerProductProof {
         }
 
         let pos = 2 * lg_n * 32;
-        let a = Scalar::from_canonical_bytes(util::read32(&slice[pos..]))
+        let a = Option::from(Scalar::from_canonical_bytes(util::read32(&slice[pos..])))
             .ok_or(RangeProofVerificationError::Deserialization)?;
-        let b = Scalar::from_canonical_bytes(util::read32(&slice[pos + 32..]))
-            .ok_or(RangeProofVerificationError::Deserialization)?;
+        let b = Option::from(Scalar::from_canonical_bytes(util::read32(
+            &slice[pos + 32..],
+        )))
+        .ok_or(RangeProofVerificationError::Deserialization)?;
 
         Ok(InnerProductProof { L_vec, R_vec, a, b })
     }
@@ -442,7 +444,7 @@ mod tests {
         let b: Vec<_> = (0..n).map(|_| Scalar::random(&mut OsRng)).collect();
         let c = util::inner_product(&a, &b).unwrap();
 
-        let G_factors: Vec<Scalar> = iter::repeat(Scalar::one()).take(n).collect();
+        let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(n).collect();
 
         let y_inv = Scalar::random(&mut OsRng);
         let H_factors: Vec<Scalar> = util::exp_iter(y_inv).take(n).collect();
@@ -479,7 +481,7 @@ mod tests {
         assert!(proof
             .verify(
                 n,
-                iter::repeat(Scalar::one()).take(n),
+                iter::repeat(Scalar::ONE).take(n),
                 util::exp_iter(y_inv).take(n),
                 &P,
                 &Q,
@@ -494,7 +496,7 @@ mod tests {
         assert!(proof
             .verify(
                 n,
-                iter::repeat(Scalar::one()).take(n),
+                iter::repeat(Scalar::ONE).take(n),
                 util::exp_iter(y_inv).take(n),
                 &P,
                 &Q,

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -149,16 +149,16 @@ impl RangeProof {
 
         let mut i = 0;
         let mut exp_z = z * z;
-        let mut exp_y = Scalar::one();
+        let mut exp_y = Scalar::ONE;
 
         for (amount_i, n_i) in amounts.iter().zip(bit_lengths.iter()) {
-            let mut exp_2 = Scalar::one();
+            let mut exp_2 = Scalar::ONE;
 
             for j in 0..(*n_i) {
                 // `j` is guaranteed to be at most `u64::BITS` (a 6-bit number) and therefore,
                 // casting is lossless and right shift can be safely unwrapped
                 let a_L_j = Scalar::from(amount_i.checked_shr(j as u32).unwrap() & 1);
-                let a_R_j = a_L_j - Scalar::one();
+                let a_R_j = a_L_j - Scalar::ONE;
 
                 l_poly.0[i] = a_L_j - z;
                 l_poly.1[i] = s_L[i];
@@ -193,7 +193,7 @@ impl RangeProof {
         // z^2 * V_1 + z^3 * V_2 + ... + z^{m+1} * V_m + delta(y, z)*G + x*T_1 + x^2*T_2
         let x = transcript.challenge_scalar(b"x");
 
-        let mut agg_opening = Scalar::zero();
+        let mut agg_opening = Scalar::ZERO;
         let mut exp_z = z;
         for opening in openings {
             exp_z *= z;
@@ -224,7 +224,7 @@ impl RangeProof {
         let w = transcript.challenge_scalar(b"w");
         let Q = w * &(*G);
 
-        let G_factors: Vec<Scalar> = iter::repeat(Scalar::one()).take(nm).collect();
+        let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(nm).collect();
         let H_factors: Vec<Scalar> = util::exp_iter(y.invert()).take(nm).collect();
 
         // generate challenge `c` for consistency with the verifier's transcript
@@ -325,7 +325,7 @@ impl RangeProof {
         let value_commitment_scalars = util::exp_iter(z).take(m).map(|z_exp| c * zz * z_exp);
 
         let mega_check = RistrettoPoint::optional_multiscalar_mul(
-            iter::once(Scalar::one())
+            iter::once(Scalar::ONE)
                 .chain(iter::once(x))
                 .chain(iter::once(c * x))
                 .chain(iter::once(c * x * x))
@@ -387,11 +387,12 @@ impl RangeProof {
         let T_1 = CompressedRistretto(util::read32(&slice[2 * 32..]));
         let T_2 = CompressedRistretto(util::read32(&slice[3 * 32..]));
 
-        let t_x = Scalar::from_canonical_bytes(util::read32(&slice[4 * 32..]))
+        let t_x = Option::from(Scalar::from_canonical_bytes(util::read32(&slice[4 * 32..])))
             .ok_or(RangeProofVerificationError::Deserialization)?;
-        let t_x_blinding = Scalar::from_canonical_bytes(util::read32(&slice[5 * 32..]))
-            .ok_or(RangeProofVerificationError::Deserialization)?;
-        let e_blinding = Scalar::from_canonical_bytes(util::read32(&slice[6 * 32..]))
+        let t_x_blinding =
+            Option::from(Scalar::from_canonical_bytes(util::read32(&slice[5 * 32..])))
+                .ok_or(RangeProofVerificationError::Deserialization)?;
+        let e_blinding = Option::from(Scalar::from_canonical_bytes(util::read32(&slice[6 * 32..])))
             .ok_or(RangeProofVerificationError::Deserialization)?;
 
         let ipp_proof = InnerProductProof::from_bytes(&slice[7 * 32..])?;

--- a/zk-token-sdk/src/range_proof/util.rs
+++ b/zk-token-sdk/src/range_proof/util.rs
@@ -8,7 +8,7 @@ pub struct VecPoly1(pub Vec<Scalar>, pub Vec<Scalar>);
 
 impl VecPoly1 {
     pub fn zero(n: usize) -> Self {
-        VecPoly1(vec![Scalar::zero(); n], vec![Scalar::zero(); n])
+        VecPoly1(vec![Scalar::ZERO; n], vec![Scalar::ZERO; n])
     }
 
     pub fn inner_product(&self, rhs: &VecPoly1) -> Option<Poly2> {
@@ -29,7 +29,7 @@ impl VecPoly1 {
 
     pub fn eval(&self, x: Scalar) -> Vec<Scalar> {
         let n = self.0.len();
-        let mut out = vec![Scalar::zero(); n];
+        let mut out = vec![Scalar::ZERO; n];
         #[allow(clippy::needless_range_loop)]
         for i in 0..n {
             out[i] = self.0[i] + self.1[i] * x;
@@ -71,7 +71,7 @@ impl Iterator for ScalarExp {
 
 /// Return an iterator of the powers of `x`.
 pub fn exp_iter(x: Scalar) -> ScalarExp {
-    let next_exp_x = Scalar::one();
+    let next_exp_x = Scalar::ONE;
     ScalarExp { x, next_exp_x }
 }
 
@@ -80,7 +80,7 @@ pub fn add_vec(a: &[Scalar], b: &[Scalar]) -> Vec<Scalar> {
         // throw some error
         //println!("lengths of vectors don't match for vector addition");
     }
-    let mut out = vec![Scalar::zero(); b.len()];
+    let mut out = vec![Scalar::ZERO; b.len()];
     for i in 0..a.len() {
         out[i] = a[i] + b[i];
     }
@@ -100,7 +100,7 @@ pub fn read32(data: &[u8]) -> [u8; 32] {
 /// \\]
 /// Errors if the lengths of \\(\mathbf{a}\\) and \\(\mathbf{b}\\) are not equal.
 pub fn inner_product(a: &[Scalar], b: &[Scalar]) -> Option<Scalar> {
-    let mut out = Scalar::zero();
+    let mut out = Scalar::ZERO;
     if a.len() != b.len() {
         return None;
     }
@@ -122,7 +122,7 @@ pub fn sum_of_powers(x: &Scalar, n: usize) -> Scalar {
         return Scalar::from(n as u64);
     }
     let mut m = n;
-    let mut result = Scalar::one() + x;
+    let mut result = Scalar::ONE + x;
     let mut factor = *x;
     while m > 2 {
         factor = factor * factor;

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_ciphertext_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_ciphertext_equality_proof.rs
@@ -189,7 +189,7 @@ impl CiphertextCiphertextEqualityProof {
             vec![
                 &self.z_s,            // z_s
                 &(-&c),               // -c
-                &(-&Scalar::one()),   // -identity
+                &(-&Scalar::ONE),     // -identity
                 &(&w * &self.z_x),    // w * z_x
                 &(&w * &self.z_s),    // w * z_s
                 &(&w_negated * &c),   // -w * c

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
@@ -177,7 +177,7 @@ impl CiphertextCommitmentEqualityProof {
             vec![
                 &self.z_s,           // z_s
                 &(-&c),              // -c
-                &(-&Scalar::one()),  // -identity
+                &(-&Scalar::ONE),    // -identity
                 &(&w * &self.z_x),   // w * z_x
                 &(&w * &self.z_s),   // w * z_s
                 &(&w_negated * &c),  // -w * c

--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -358,7 +358,7 @@ impl FeeSigmaProof {
                 c_max_proof,
                 -c_max_proof * m,
                 -z_max,
-                Scalar::one(),
+                Scalar::ONE,
                 w * z_x,
                 w * z_delta_real,
                 -w * c_equality,

--- a/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof/handles_2.rs
+++ b/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof/handles_2.rs
@@ -172,7 +172,7 @@ impl GroupedCiphertext2HandlesValidityProof {
                 &self.z_r,           // z_r
                 &self.z_x,           // z_x
                 &(-&c),              // -c
-                &-(&Scalar::one()),  // -identity
+                &-(&Scalar::ONE),    // -identity
                 &(&w * &self.z_r),   // w * z_r
                 &(&w_negated * &c),  // -w * c
                 &w_negated,          // -w

--- a/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof/handles_3.rs
+++ b/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof/handles_3.rs
@@ -201,7 +201,7 @@ impl GroupedCiphertext3HandlesValidityProof {
                 &self.z_r,            // z_r
                 &self.z_x,            // z_x
                 &(-&c),               // -c
-                &-(&Scalar::one()),   // -identity
+                &-(&Scalar::ONE),     // -identity
                 &(&w * &self.z_r),    // w * z_r
                 &(&w_negated * &c),   // -w * c
                 &w_negated,           // -w

--- a/zk-token-sdk/src/sigma_proofs/mod.rs
+++ b/zk-token-sdk/src/sigma_proofs/mod.rs
@@ -38,7 +38,9 @@ fn ristretto_point_from_optional_slice(
 ) -> Result<CompressedRistretto, SigmaProofVerificationError> {
     optional_slice
         .and_then(|slice| (slice.len() == RISTRETTO_POINT_LEN).then_some(slice))
-        .map(CompressedRistretto::from_slice)
+        .map(|slice| {
+            CompressedRistretto::from_slice(slice).expect("Input slice should have a length of 32")
+        })
         .ok_or(SigmaProofVerificationError::Deserialization)
 }
 
@@ -53,6 +55,6 @@ fn canonical_scalar_from_optional_slice(
     optional_slice
         .and_then(|slice| (slice.len() == SCALAR_LEN).then_some(slice)) // if chunk is the wrong length, convert to None
         .and_then(|slice| slice.try_into().ok()) // convert to array
-        .and_then(Scalar::from_canonical_bytes)
+        .and_then(|bytes| Scalar::from_canonical_bytes(bytes).into())
         .ok_or(SigmaProofVerificationError::Deserialization)
 }

--- a/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
@@ -65,7 +65,7 @@ impl PubkeyValidityProof {
         // extract the relevant scalar and Ristretto points from the input
         let s = elgamal_keypair.secret().get_scalar();
 
-        assert!(s != &Scalar::zero());
+        assert!(s != &Scalar::ZERO);
         let s_inv = s.invert();
 
         // generate a random masking factor that also serves as a nonce
@@ -109,7 +109,7 @@ impl PubkeyValidityProof {
             .ok_or(SigmaProofVerificationError::Deserialization)?;
 
         let check = RistrettoPoint::vartime_multiscalar_mul(
-            vec![&self.z, &(-&c), &(-&Scalar::one())],
+            vec![&self.z, &(-&c), &(-&Scalar::ONE)],
             vec![&(*H), P, &Y],
         );
 

--- a/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
@@ -136,7 +136,7 @@ impl ZeroBalanceProof {
             vec![
                 &self.z,            // z
                 &(-&c),             // -c
-                &(-&Scalar::one()), // -identity
+                &(-&Scalar::ONE),   // -identity
                 &(&w * &self.z),    // w * z
                 &(&w_negated * &c), // -w * c
                 &w_negated,         // -w

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -64,7 +64,8 @@ mod target_arch {
         type Error = ElGamalError;
 
         fn try_from(pod: PodScalar) -> Result<Self, Self::Error> {
-            Scalar::from_canonical_bytes(pod.0).ok_or(ElGamalError::CiphertextDeserialization)
+            Option::from(Scalar::from_canonical_bytes(pod.0))
+                .ok_or(ElGamalError::CiphertextDeserialization)
         }
     }
 


### PR DESCRIPTION
- Bumped `curve25519-dalek` from 3.2.1 to 4.1.2
- Fixed `sha3` version mismatch
- Fixed bump `rand` to 0.8.5 in #36

#### Problem
Dependabot tried to bump `rand` to 0.8.5 in #36, but failed to do so.

#### Summary of Changes
I updated the necessary dependencies together for `rand` update to succeed:
- `curve25519-dalek`
- `sha3`
- `rand`

Fixes #36
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
