### PR TITLE
Recompute hash on load if default hash is stored for the account

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7572,7 +7572,10 @@ impl AccountsDb {
                     Some((*loaded_account.pubkey(), loaded_account.loaded_hash()))
                 },
                 |accum: &DashMap<Pubkey, AccountHash>, loaded_account: LoadedAccount| {
-                    let loaded_hash = loaded_account.loaded_hash();
+                    let mut loaded_hash = loaded_account.loaded_hash();
+                    if loaded_hash == AccountHash(Hash::default()) {
+                        loaded_hash = Self::hash_account(&loaded_account, loaded_account.pubkey())
+                    }
                     accum.insert(*loaded_account.pubkey(), loaded_hash);
                 },
             );
@@ -7604,9 +7607,13 @@ impl AccountsDb {
             |accum: &DashMap<Pubkey, (AccountHash, AccountSharedData)>,
              loaded_account: LoadedAccount| {
                 // Storage may have duplicates so only keep the latest version for each key
+                let mut loaded_hash = loaded_account.loaded_hash();
+                if loaded_hash == AccountHash(Hash::default()) {
+                    loaded_hash = Self::hash_account(&loaded_account, loaded_account.pubkey())
+                }
                 accum.insert(
                     *loaded_account.pubkey(),
-                    (loaded_account.loaded_hash(), loaded_account.take_account()),
+                    (loaded_hash, loaded_account.take_account()),
                 );
             },
         );


### PR DESCRIPTION
#### Problem

We are going to store default hash to account's storage in https://github.com/anza-xyz/agave/pull/469/.

Before #469 is merged, we need to have all nodes support recompute hash on
load. This PR adds that support.


#### Summary of Changes

Recompute account's hash on load if the hash stored in account storage is
default hash.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
