### PR TITLE
add scan_index for improving index generation

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8642,8 +8642,6 @@ impl AccountsDb {
         if accounts.next().is_none() {
             return SlotIndexGenerationInfo::default();
         }
-        let accounts = storage.accounts.account_iter();
-
         let secondary = !self.account_indexes.is_empty();
 
         let mut rent_paying_accounts_by_partition = Vec::default();
@@ -8652,19 +8650,45 @@ impl AccountsDb {
         let mut amount_to_top_off_rent = 0;
         let mut stored_size_alive = 0;
 
-        let items = accounts.map(|stored_account| {
-            stored_size_alive += stored_account.stored_size();
-            let pubkey = stored_account.pubkey();
-            if secondary {
-                self.accounts_index.update_secondary_indexes(
-                    pubkey,
-                    &stored_account,
-                    &self.account_indexes,
-                );
-            }
-            if !stored_account.is_zero_lamport() {
-                accounts_data_len += stored_account.data().len() as u64;
-            }
+        let (dirty_pubkeys, insert_time_us, mut generate_index_results) = if !secondary {
+            let mut items_local = Vec::default();
+            storage.accounts.scan_index(|info| {
+                stored_size_alive += info.size;
+                if info.index_info.lamports > 0 {
+                    accounts_data_len += info.data_len;
+                }
+                items_local.push(info.index_info);
+            });
+            let items = items_local.into_iter().map(|info| {
+                (
+                    info.pubkey,
+                    AccountInfo::new(
+                        StorageLocation::AppendVec(store_id, info.offset), // will never be cached
+                        info.lamports,
+                    ),
+                )
+            });
+            self.accounts_index
+                .insert_new_if_missing_into_primary_index(
+                    slot,
+                    storage.approx_stored_count(),
+                    items,
+                )
+        } else {
+            let accounts = storage.accounts.account_iter();
+            let items = accounts.map(|stored_account| {
+                stored_size_alive += stored_account.stored_size();
+                let pubkey = stored_account.pubkey();
+                if secondary {
+                    self.accounts_index.update_secondary_indexes(
+                        pubkey,
+                        &stored_account,
+                        &self.account_indexes,
+                    );
+                }
+                if !stored_account.is_zero_lamport() {
+                    accounts_data_len += stored_account.data().len() as u64;
+                }
 
             if let Some(amount_to_top_off_rent_this_account) = Self::stats_for_rent_payers(
                 pubkey,
@@ -8680,18 +8704,21 @@ impl AccountsDb {
                 rent_paying_accounts_by_partition.push(*pubkey);
             }
 
-            (
-                *pubkey,
-                AccountInfo::new(
-                    StorageLocation::AppendVec(store_id, stored_account.offset()), // will never be cached
-                    stored_account.lamports(),
-                ),
-            )
-        });
-
-        let (dirty_pubkeys, insert_time_us, mut generate_index_results) = self
-            .accounts_index
-            .insert_new_if_missing_into_primary_index(slot, storage.approx_stored_count(), items);
+                (
+                    *pubkey,
+                    AccountInfo::new(
+                        StorageLocation::AppendVec(store_id, stored_account.offset()), // will never be cached
+                        stored_account.lamports(),
+                    ),
+                )
+            });
+            self.accounts_index
+                .insert_new_if_missing_into_primary_index(
+                    slot,
+                    storage.approx_stored_count(),
+                    items,
+                )
+        };
 
         if let Some(duplicates_this_slot) = std::mem::take(&mut generate_index_results.duplicates) {
             // there were duplicate pubkeys in this same slot

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8653,7 +8653,7 @@ impl AccountsDb {
         let (dirty_pubkeys, insert_time_us, mut generate_index_results) = if !secondary {
             let mut items_local = Vec::default();
             storage.accounts.scan_index(|info| {
-                stored_size_alive += info.size;
+                stored_size_alive += info.stored_size_aligned;
                 if info.index_info.lamports > 0 {
                     accounts_data_len += info.data_len;
                 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8679,13 +8679,11 @@ impl AccountsDb {
             let items = accounts.map(|stored_account| {
                 stored_size_alive += stored_account.stored_size();
                 let pubkey = stored_account.pubkey();
-                if secondary {
-                    self.accounts_index.update_secondary_indexes(
-                        pubkey,
-                        &stored_account,
-                        &self.account_indexes,
-                    );
-                }
+                self.accounts_index.update_secondary_indexes(
+                    pubkey,
+                    &stored_account,
+                    &self.account_indexes,
+                );
                 if !stored_account.is_zero_lamport() {
                     accounts_data_len += stored_account.data().len() as u64;
                 }

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -6,7 +6,7 @@ use {
         },
         accounts_db::AccountsFileId,
         accounts_hash::AccountHash,
-        append_vec::{AppendVec, AppendVecError},
+        append_vec::{AppendVec, AppendVecError, IndexInfo},
         storable_accounts::StorableAccounts,
         tiered_storage::{
             error::TieredStorageError, hot::HOT_FORMAT, index::IndexOffset, TieredStorage,
@@ -178,6 +178,14 @@ impl AccountsFile {
     /// Return iterator for account metadata
     pub fn account_iter(&self) -> AccountsFileIter {
         AccountsFileIter::new(self)
+    }
+
+    /// iterate over all entries to put in index
+    pub(crate) fn scan_index(&self, callback: impl FnMut(IndexInfo)) {
+        match self {
+            Self::AppendVec(av) => av.scan_index(callback),
+            Self::TieredStorage(_ts) => unimplemented!(),
+        }
     }
 
     /// iterate over all pubkeys

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -634,7 +634,8 @@ impl AppendVec {
         }
     }
 
-    /// iterate over all pubkeys
+    /// Iterate over all accounts and call `callback` with `IndexInfo` for each.
+    /// This fn can help generate an index of the data in this storage.
     pub(crate) fn scan_index(&self, mut callback: impl FnMut(IndexInfo)) {
         let mut offset = 0;
         loop {
@@ -648,7 +649,7 @@ impl AppendVec {
             };
             let next = Self::next_account_offset(offset, stored_meta);
             if next.offset_to_end_of_data > self.len() {
-                // data doesn't fit, so don't include this pubkey
+                // data doesn't fit, so don't include this account
                 break;
             }
             callback(IndexInfo {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -202,8 +202,6 @@ pub(crate) struct IndexInfo {
     /// size of entry, aligned to next u64
     /// This matches the return of `get_account`
     pub stored_size_aligned: usize,
-    /// len of data vec
-    pub data_len: u64,
     /// info on the entry
     pub index_info: IndexInfoInner,
 }
@@ -214,6 +212,9 @@ pub(crate) struct IndexInfoInner {
     pub offset: usize,
     pub pubkey: Pubkey,
     pub lamports: u64,
+    pub rent_epoch: Epoch,
+    pub executable: bool,
+    pub data_len: u64,
 }
 
 /// offsets to help navigate the persisted format of `AppendVec`
@@ -655,9 +656,11 @@ impl AppendVec {
                         pubkey: stored_meta.pubkey,
                         lamports: account_meta.lamports,
                         offset,
+                        data_len: stored_meta.data_len,
+                        executable: account_meta.executable,
+                        rent_epoch: account_meta.rent_epoch,
                     }
                 },
-                data_len: stored_meta.data_len,
                 stored_size_aligned: next.stored_size_aligned,
             });
             offset = next.next_account_offset;


### PR DESCRIPTION
#### Problem
total account state is exceeding available ram on validators. We are also introducing a new storage format.

#### Summary of Changes
Add `scan_index` to storage apis to allow efficiently returning what is necessary to index storages.
This will result in improved performance if we stop mmapping but also just with the hot storage format.

There is a lot of noise in index generation. This change is not worse and may be better just on time today.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
