### PR TITLE
no need to call handle_reclaims if reclaims was not populated

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8517,23 +8517,29 @@ impl AccountsDb {
         //
         // From 1) and 2) we guarantee passing `no_purge_stats` == None, which is
         // equivalent to asserting there will be no dead slots, is safe.
-        let mut handle_reclaims_time = Measure::start("handle_reclaims");
-        self.handle_reclaims(
-            (!reclaims.is_empty()).then(|| reclaims.iter()),
-            expected_single_dead_slot,
-            None,
-            reset_accounts,
-            &HashSet::default(),
-        );
-        handle_reclaims_time.stop();
-        self.stats
-            .store_handle_reclaims
-            .fetch_add(handle_reclaims_time.as_us(), Ordering::Relaxed);
+        let mut handle_reclaims_elapsed = 0;
+        if reclaim == UpsertReclaim::PopulateReclaims {
+            let mut handle_reclaims_time = Measure::start("handle_reclaims");
+            self.handle_reclaims(
+                (!reclaims.is_empty()).then(|| reclaims.iter()),
+                expected_single_dead_slot,
+                None,
+                reset_accounts,
+                &HashSet::default(),
+            );
+            handle_reclaims_time.stop();
+            handle_reclaims_elapsed = handle_reclaims_time.as_us();
+            self.stats
+                .store_handle_reclaims
+                .fetch_add(handle_reclaims_elapsed, Ordering::Relaxed);
+        } else {
+            assert!(reclaims.is_empty());
+        }
 
         StoreAccountsTiming {
             store_accounts_elapsed: store_accounts_time.as_us(),
             update_index_elapsed: update_index_time.as_us(),
-            handle_reclaims_elapsed: handle_reclaims_time.as_us(),
+            handle_reclaims_elapsed,
         }
     }
 


### PR DESCRIPTION
#### Problem
`handle_reclaims` ends up being an expensive and complicated algorithm.

#### Summary of Changes
The goal is to simplify `handle_reclaims` and the fns it calls as well as improve the performance.
Step 1 is to not call `handle_reclaims` unless there are actually reclaims. This means we can optimize the signature to `handle_reclaims`. Currently `handle_reclaims` takes `purge_stats_and_reclaim_result: Option<(&PurgeStats, &mut ReclaimResult)>`. The most efficient way to handle looking up sizes is if we group the reclaim data by slot. This is the only callsite that passes None for that map. We can get rid of `Option` and always pass the map. This lets us efficiently lookup the sizes of accounts we are reclaiming. We should never have reclaims in tx processing since we have the write cache. So, this whole thing is old code.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
