### PR TITLE
Use `&str` instead of `String` in `add_builtin`

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -463,7 +463,7 @@ pub fn read_file<P: AsRef<Path>>(path: P) -> Vec<u8> {
 
 pub struct ProgramTest {
     accounts: Vec<(Pubkey, AccountSharedData)>,
-    builtin_programs: Vec<(Pubkey, String, LoadedProgram)>,
+    builtin_programs: Vec<(Pubkey, &'static str, LoadedProgram)>,
     compute_max_units: Option<u64>,
     prefer_bpf: bool,
     deactivate_feature_set: HashSet<Pubkey>,
@@ -513,7 +513,7 @@ impl ProgramTest {
     /// [`default`]: #method.default
     /// [`add_program`]: #method.add_program
     pub fn new(
-        program_name: &str,
+        program_name: &'static str,
         program_id: Pubkey,
         builtin_function: Option<BuiltinFunctionWithContext>,
     ) -> Self {
@@ -613,7 +613,7 @@ impl ProgramTest {
     /// SBF shared object depending on the `BPF_OUT_DIR` environment variable.
     pub fn add_program(
         &mut self,
-        program_name: &str,
+        program_name: &'static str,
         program_id: Pubkey,
         builtin_function: Option<BuiltinFunctionWithContext>,
     ) {
@@ -720,14 +720,14 @@ impl ProgramTest {
     /// Note that builtin programs are responsible for their own `stable_log` output.
     pub fn add_builtin_program(
         &mut self,
-        program_name: &str,
+        program_name: &'static str,
         program_id: Pubkey,
         builtin_function: BuiltinFunctionWithContext,
     ) {
         info!("\"{}\" builtin program", program_name);
         self.builtin_programs.push((
             program_id,
-            program_name.to_string(),
+            program_name,
             LoadedProgram::new_builtin(0, program_name.len(), builtin_function),
         ));
     }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4316,7 +4316,7 @@ fn test_cpi_change_account_data_memory_allocation() {
     let builtin_program_id = Pubkey::new_unique();
     bank.add_builtin(
         builtin_program_id,
-        "test_cpi_change_account_data_memory_allocation_builtin".to_string(),
+        "test_cpi_change_account_data_memory_allocation_builtin",
         LoadedProgram::new_builtin(0, 42, MockBuiltin::vm),
     );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5865,7 +5865,7 @@ impl Bank {
                 if builtin.enable_feature_id.is_none() {
                     self.add_builtin(
                         builtin.program_id,
-                        builtin.name.to_string(),
+                        builtin.name,
                         LoadedProgram::new_builtin(0, builtin.name.len(), builtin.entrypoint),
                     );
                 }
@@ -6952,15 +6952,15 @@ impl Bank {
     ) {
         self.add_builtin(
             program_id,
-            "mockup".to_string(),
+            "mockup",
             LoadedProgram::new_builtin(self.slot, 0, builtin_function),
         );
     }
 
     /// Add a built-in program
-    pub fn add_builtin(&mut self, program_id: Pubkey, name: String, builtin: LoadedProgram) {
+    pub fn add_builtin(&mut self, program_id: Pubkey, name: &str, builtin: LoadedProgram) {
         debug!("Adding program {} under {:?}", name, program_id);
-        self.add_builtin_account(name.as_str(), &program_id, false);
+        self.add_builtin_account(name, &program_id, false);
         self.builtin_program_ids.insert(program_id);
         self.transaction_processor
             .program_cache
@@ -6971,7 +6971,7 @@ impl Bank {
     }
 
     /// Remove a built-in instruction processor
-    pub fn remove_builtin(&mut self, program_id: Pubkey, name: String) {
+    pub fn remove_builtin(&mut self, program_id: Pubkey, name: &str) {
         debug!("Removing program {}", program_id);
         // Don't remove the account since the bank expects the account state to
         // be idempotent
@@ -7223,7 +7223,7 @@ impl Bank {
                 if should_apply_action_for_feature_transition {
                     self.add_builtin(
                         builtin.program_id,
-                        builtin.name.to_string(),
+                        builtin.name,
                         LoadedProgram::new_builtin(
                             self.feature_set.activated_slot(&feature_id).unwrap_or(0),
                             builtin.name.len(),

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -468,7 +468,7 @@ mod tests {
             let account =
                 AccountSharedData::new_data(1, &builtin_name, &native_loader::id()).unwrap();
             bank.store_account_and_update_capitalization(&builtin_id, &account);
-            bank.add_builtin(builtin_id, builtin_name, LoadedProgram::default());
+            bank.add_builtin(builtin_id, builtin_name.as_str(), LoadedProgram::default());
             account
         };
         assert_eq!(&bank.get_account(&builtin_id).unwrap(), &builtin_account);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4709,12 +4709,12 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
 
         bank.add_builtin(
             vote_id,
-            "mock_program1".to_string(),
+            "mock_program1",
             LoadedProgram::new_builtin(0, 0, MockBuiltin::vm),
         );
         bank.add_builtin(
             stake_id,
-            "mock_program2".to_string(),
+            "mock_program2",
             LoadedProgram::new_builtin(0, 0, MockBuiltin::vm),
         );
         {
@@ -6303,7 +6303,7 @@ fn test_fuzz_instructions() {
             let name = format!("program{i:?}");
             bank.add_builtin(
                 key,
-                name.clone(),
+                name.as_str(),
                 LoadedProgram::new_builtin(0, 0, MockBuiltin::vm),
             );
             (key, name.as_bytes().to_vec())


### PR DESCRIPTION
#### Problem

`add_builtin` receives a `String`, but only needs a `&str`. In addition, all its callers transform a `&str` into a `String`, allocating unnecessary memory. I wanted to change this before moving `add_builtin` to SVM.

#### Summary of Changes

I changed the argument type and made the necessary adaptations.

