### PR TITLE
Move `add_builtin` to SVM

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -806,7 +806,7 @@ impl ProgramTest {
         debug!("Payer address: {}", mint_keypair.pubkey());
         debug!("Genesis config: {}", genesis_config);
 
-        let mut bank = Bank::new_with_paths(
+        let bank = Bank::new_with_paths(
             &genesis_config,
             Arc::new(RuntimeConfig {
                 compute_budget: self.compute_max_units.map(|max_units| ComputeBudget {
@@ -837,7 +837,8 @@ impl ProgramTest {
         let mut builtin_programs = Vec::new();
         std::mem::swap(&mut self.builtin_programs, &mut builtin_programs);
         for (program_id, name, builtin) in builtin_programs.into_iter() {
-            bank.add_builtin(program_id, name, builtin);
+            bank.get_transaction_processor()
+                .add_builtin(&bank, program_id, name, builtin);
         }
 
         for (address, account) in self.accounts.iter() {

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4278,7 +4278,7 @@ fn test_cpi_change_account_data_memory_allocation() {
         ..
     } = create_genesis_config(100_123_456_789);
 
-    let mut bank = Bank::new_for_tests(&genesis_config);
+    let bank = Bank::new_for_tests(&genesis_config);
 
     declare_process_instruction!(MockBuiltin, 42, |invoke_context| {
         let transaction_context = &invoke_context.transaction_context;
@@ -4314,7 +4314,8 @@ fn test_cpi_change_account_data_memory_allocation() {
     });
 
     let builtin_program_id = Pubkey::new_unique();
-    bank.add_builtin(
+    bank.get_transaction_processor().add_builtin(
+        &bank,
         builtin_program_id,
         "test_cpi_change_account_data_memory_allocation_builtin",
         LoadedProgram::new_builtin(0, 42, MockBuiltin::vm),

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -20,6 +20,7 @@ use {
         signature::{Keypair, Signer},
         transaction::Transaction,
     },
+    solana_svm::transaction_processor::TransactionProcessingCallback,
     std::{sync::Arc, thread::sleep, time::Duration},
     test::Bencher,
 };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6896,7 +6896,7 @@ impl TransactionProcessingCallback for Bank {
 
     // NOTE: must hold idempotent for the same set of arguments
     /// Add a builtin program account
-    fn add_builtin_account(&self, name: &str, program_id: &Pubkey, must_replace: bool) {
+    fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {
         let existing_genuine_program =
             self.get_account_with_fixed_root(program_id)
                 .and_then(|account| {
@@ -6912,25 +6912,10 @@ impl TransactionProcessingCallback for Bank {
                     }
                 });
 
-        if must_replace {
-            // updating builtin program
-            match &existing_genuine_program {
-                None => panic!(
-                    "There is no account to replace with builtin program ({name}, {program_id})."
-                ),
-                Some(account) => {
-                    if *name == String::from_utf8_lossy(account.data()) {
-                        // The existing account is well formed
-                        return;
-                    }
-                }
-            }
-        } else {
-            // introducing builtin program
-            if existing_genuine_program.is_some() {
-                // The existing account is sufficient
-                return;
-            }
+        // introducing builtin program
+        if existing_genuine_program.is_some() {
+            // The existing account is sufficient
+            return;
         }
 
         assert!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -555,7 +555,6 @@ impl PartialEq for Bank {
             epoch_stakes,
             is_delta,
             // TODO: Confirm if all these fields are intentionally ignored!
-            builtin_program_ids: _,
             runtime_config: _,
             rewards: _,
             cluster_type: _,
@@ -761,8 +760,6 @@ pub struct Bank {
     /// stream for the slot == self.slot
     is_delta: AtomicBool,
 
-    builtin_program_ids: HashSet<Pubkey>,
-
     /// Optional config parameters that can override runtime behavior
     pub(crate) runtime_config: Arc<RuntimeConfig>,
 
@@ -923,7 +920,6 @@ impl Bank {
             stakes_cache: StakesCache::default(),
             epoch_stakes: HashMap::<Epoch, EpochStakes>::default(),
             is_delta: AtomicBool::default(),
-            builtin_program_ids: HashSet::<Pubkey>::default(),
             runtime_config: Arc::<RuntimeConfig>::default(),
             rewards: RwLock::<Vec<(Pubkey, RewardInfo)>>::default(),
             cluster_type: Option::<ClusterType>::default(),
@@ -958,6 +954,7 @@ impl Bank {
                 Slot::default(),
                 Epoch::default(),
             ))),
+            HashSet::default(),
         );
 
         let accounts_data_size_initial = bank.get_total_accounts_stats().unwrap().data_len as u64;
@@ -1110,8 +1107,12 @@ impl Bank {
 
         let (epoch_stakes, epoch_stakes_time_us) = measure_us!(parent.epoch_stakes.clone());
 
-        let (builtin_program_ids, builtin_program_ids_time_us) =
-            measure_us!(parent.builtin_program_ids.clone());
+        let (builtin_program_ids, builtin_program_ids_time_us) = measure_us!(parent
+            .transaction_processor
+            .builtin_program_ids
+            .read()
+            .unwrap()
+            .clone());
 
         let (rewards_pool_pubkeys, rewards_pool_pubkeys_time_us) =
             measure_us!(parent.rewards_pool_pubkeys.clone());
@@ -1167,7 +1168,6 @@ impl Bank {
             ancestors: Ancestors::default(),
             hash: RwLock::new(Hash::default()),
             is_delta: AtomicBool::new(false),
-            builtin_program_ids,
             tick_height: AtomicU64::new(parent.tick_height.load(Relaxed)),
             signature_count: AtomicU64::new(0),
             runtime_config: parent.runtime_config.clone(),
@@ -1208,6 +1208,7 @@ impl Bank {
             new.fee_structure.clone(),
             new.runtime_config.clone(),
             parent.transaction_processor.program_cache.clone(),
+            builtin_program_ids,
         );
 
         let (_, ancestors_time_us) = measure_us!({
@@ -1629,7 +1630,6 @@ impl Bank {
             stakes_cache: StakesCache::new(stakes),
             epoch_stakes: fields.epoch_stakes,
             is_delta: AtomicBool::new(fields.is_delta),
-            builtin_program_ids: HashSet::<Pubkey>::default(),
             runtime_config,
             rewards: RwLock::new(vec![]),
             cluster_type: Some(genesis_config.cluster_type),
@@ -1662,6 +1662,7 @@ impl Bank {
             bank.fee_structure.clone(),
             bank.runtime_config.clone(),
             Arc::new(RwLock::new(ProgramCache::new(fields.slot, fields.epoch))),
+            HashSet::default(),
         );
 
         bank.finish_init(
@@ -3153,44 +3154,6 @@ impl Bank {
         self.calculate_and_update_accounts_data_size_delta_off_chain(old_data_size, 0);
     }
 
-    // NOTE: must hold idempotent for the same set of arguments
-    /// Add a builtin program account
-    pub fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {
-        let existing_genuine_program =
-            self.get_account_with_fixed_root(program_id)
-                .and_then(|account| {
-                    // it's very unlikely to be squatted at program_id as non-system account because of burden to
-                    // find victim's pubkey/hash. So, when account.owner is indeed native_loader's, it's
-                    // safe to assume it's a genuine program.
-                    if native_loader::check_id(account.owner()) {
-                        Some(account)
-                    } else {
-                        // malicious account is pre-occupying at program_id
-                        self.burn_and_purge_account(program_id, account);
-                        None
-                    }
-                });
-
-        // introducing builtin program
-        if existing_genuine_program.is_some() {
-            // The existing account is sufficient
-            return;
-        }
-
-        assert!(
-            !self.freeze_started(),
-            "Can't change frozen bank by adding not-existing new builtin program ({name}, {program_id}). \
-            Maybe, inconsistent program activation is detected on snapshot restore?"
-        );
-
-        // Add a bogus executable builtin account, which will be loaded and ignored.
-        let account = native_loader::create_loadable_account_with_fields(
-            name,
-            self.inherit_specially_retained_account_fields(&existing_genuine_program),
-        );
-        self.store_account_and_update_capitalization(program_id, &account);
-    }
-
     /// Add a precompiled program account
     pub fn add_precompiled_account(&self, program_id: &Pubkey) {
         self.add_precompiled_account_with_owner(program_id, native_loader::id())
@@ -3919,7 +3882,6 @@ impl Bank {
                 recording_config,
                 timings,
                 account_overrides,
-                self.builtin_program_ids.iter(),
                 log_messages_bytes_limit,
                 limit_to_load_programs,
             );
@@ -5338,7 +5300,8 @@ impl Bank {
                 .chain(additional_builtins.unwrap_or(&[]).iter())
             {
                 if builtin.enable_feature_id.is_none() {
-                    self.add_builtin(
+                    self.transaction_processor.add_builtin(
+                        self,
                         builtin.program_id,
                         builtin.name,
                         LoadedProgram::new_builtin(0, builtin.name.len(), builtin.entrypoint),
@@ -5402,10 +5365,6 @@ impl Bank {
                 .unwrap()
                 .register(new_hard_fork_slot);
         }
-    }
-
-    pub(crate) fn get_builtin_program_ids(&self) -> &HashSet<Pubkey> {
-        &self.builtin_program_ids
     }
 
     // Hi! leaky abstraction here....
@@ -6425,24 +6384,12 @@ impl Bank {
         program_id: Pubkey,
         builtin_function: BuiltinFunctionWithContext,
     ) {
-        self.add_builtin(
+        self.transaction_processor.add_builtin(
+            self,
             program_id,
             "mockup",
             LoadedProgram::new_builtin(self.slot, 0, builtin_function),
         );
-    }
-
-    /// Add a built-in program
-    pub fn add_builtin(&mut self, program_id: Pubkey, name: &str, builtin: LoadedProgram) {
-        debug!("Adding program {} under {:?}", name, program_id);
-        self.add_builtin_account(name, &program_id);
-        self.builtin_program_ids.insert(program_id);
-        self.transaction_processor
-            .program_cache
-            .write()
-            .unwrap()
-            .assign_program(program_id, Arc::new(builtin));
-        debug!("Added program {} under {:?}", name, program_id);
     }
 
     /// Remove a built-in instruction processor
@@ -6450,7 +6397,8 @@ impl Bank {
         debug!("Removing program {}", program_id);
         // Don't remove the account since the bank expects the account state to
         // be idempotent
-        self.add_builtin(
+        self.transaction_processor.add_builtin(
+            self,
             program_id,
             name,
             LoadedProgram::new_tombstone(self.slot, LoadedProgramType::Closed),
@@ -6696,7 +6644,8 @@ impl Bank {
                         self.feature_set.is_active(&feature_id)
                     };
                 if should_apply_action_for_feature_transition {
-                    self.add_builtin(
+                    self.transaction_processor.add_builtin(
+                        self,
                         builtin.program_id,
                         builtin.name,
                         LoadedProgram::new_builtin(
@@ -6878,6 +6827,10 @@ impl Bank {
         self.transaction_processor
             .load_program_with_pubkey(self, pubkey, reload, effective_epoch)
     }
+
+    pub fn get_transaction_processor(&self) -> &TransactionBatchProcessor<BankForks> {
+        &self.transaction_processor
+    }
 }
 
 impl TransactionProcessingCallback for Bank {
@@ -6939,6 +6892,59 @@ impl TransactionProcessingCallback for Bank {
         } else {
             LoadedProgramMatchCriteria::NoCriteria
         }
+    }
+
+    // NOTE: must hold idempotent for the same set of arguments
+    /// Add a builtin program account
+    fn add_builtin_account(&self, name: &str, program_id: &Pubkey, must_replace: bool) {
+        let existing_genuine_program =
+            self.get_account_with_fixed_root(program_id)
+                .and_then(|account| {
+                    // it's very unlikely to be squatted at program_id as non-system account because of burden to
+                    // find victim's pubkey/hash. So, when account.owner is indeed native_loader's, it's
+                    // safe to assume it's a genuine program.
+                    if native_loader::check_id(account.owner()) {
+                        Some(account)
+                    } else {
+                        // malicious account is pre-occupying at program_id
+                        self.burn_and_purge_account(program_id, account);
+                        None
+                    }
+                });
+
+        if must_replace {
+            // updating builtin program
+            match &existing_genuine_program {
+                None => panic!(
+                    "There is no account to replace with builtin program ({name}, {program_id})."
+                ),
+                Some(account) => {
+                    if *name == String::from_utf8_lossy(account.data()) {
+                        // The existing account is well formed
+                        return;
+                    }
+                }
+            }
+        } else {
+            // introducing builtin program
+            if existing_genuine_program.is_some() {
+                // The existing account is sufficient
+                return;
+            }
+        }
+
+        assert!(
+            !self.freeze_started(),
+            "Can't change frozen bank by adding not-existing new builtin program ({name}, {program_id}). \
+            Maybe, inconsistent program activation is detected on snapshot restore?"
+        );
+
+        // Add a bogus executable builtin account, which will be loaded and ignored.
+        let account = native_loader::create_loadable_account_with_fields(
+            name,
+            self.inherit_specially_retained_account_fields(&existing_genuine_program),
+        );
+        self.store_account_and_update_capitalization(program_id, &account);
     }
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4700,12 +4700,14 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
             continue;
         }
 
-        bank.add_builtin(
+        bank.transaction_processor.add_builtin(
+            &bank,
             vote_id,
             "mock_program1",
             LoadedProgram::new_builtin(0, 0, MockBuiltin::vm),
         );
-        bank.add_builtin(
+        bank.transaction_processor.add_builtin(
+            &bank,
             stake_id,
             "mock_program2",
             LoadedProgram::new_builtin(0, 0, MockBuiltin::vm),
@@ -6286,7 +6288,7 @@ fn test_ref_account_key_after_program_id() {
 fn test_fuzz_instructions() {
     solana_logger::setup();
     use rand::{thread_rng, Rng};
-    let mut bank = create_simple_test_bank(1_000_000_000);
+    let bank = create_simple_test_bank(1_000_000_000);
 
     let max_programs = 5;
     let program_keys: Vec<_> = (0..max_programs)
@@ -6294,7 +6296,8 @@ fn test_fuzz_instructions() {
         .map(|i| {
             let key = solana_sdk::pubkey::new_rand();
             let name = format!("program{i:?}");
-            bank.add_builtin(
+            bank.transaction_processor.add_builtin(
+                &bank,
                 key,
                 name.as_str(),
                 LoadedProgram::new_builtin(0, 0, MockBuiltin::vm),

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -112,7 +112,10 @@ impl<'a> SnapshotMinimizer<'a> {
     /// Used to get builtin accounts in `minimize`
     fn get_builtins(&self) {
         self.bank
-            .get_builtin_program_ids()
+            .get_transaction_processor()
+            .builtin_program_ids
+            .read()
+            .unwrap()
             .iter()
             .for_each(|program_id| {
                 self.minimized_account_set.insert(*program_id);

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -529,7 +529,7 @@ mod tests {
             self.feature_set.clone()
         }
 
-        fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey, _must_replace: bool) {
+        fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {
             todo!()
         }
     }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -528,6 +528,10 @@ mod tests {
         fn get_feature_set(&self) -> Arc<FeatureSet> {
             self.feature_set.clone()
         }
+
+        fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey, _must_replace: bool) {
+            todo!()
+        }
     }
 
     fn load_accounts_with_fee_and_rent(

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -528,10 +528,6 @@ mod tests {
         fn get_feature_set(&self) -> Arc<FeatureSet> {
             self.feature_set.clone()
         }
-
-        fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {
-            todo!()
-        }
     }
 
     fn load_accounts_with_fee_and_rent(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -109,7 +109,7 @@ pub trait TransactionProcessingCallback {
         LoadedProgramMatchCriteria::NoCriteria
     }
 
-    fn add_builtin_account(&self, name: &str, program_id: &Pubkey, must_replace: bool);
+    fn add_builtin_account(&self, name: &str, program_id: &Pubkey);
 }
 
 #[derive(Debug)]
@@ -971,7 +971,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         builtin: LoadedProgram,
     ) {
         debug!("Adding program {} under {:?}", name, program_id);
-        callbacks.add_builtin_account(name, &program_id, false);
+        callbacks.add_builtin_account(name, &program_id);
         self.builtin_program_ids.write().unwrap().insert(program_id);
         self.program_cache
             .write()
@@ -1051,7 +1051,7 @@ mod tests {
             self.feature_set.clone()
         }
 
-        fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey, _must_replace: bool) {
+        fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {
             unimplemented!()
         }
     }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -49,7 +49,7 @@ use {
     },
     std::{
         cell::RefCell,
-        collections::{hash_map::Entry, HashMap},
+        collections::{hash_map::Entry, HashMap, HashSet},
         fmt::{Debug, Formatter},
         rc::Rc,
         sync::{atomic::Ordering, Arc, RwLock},
@@ -108,6 +108,8 @@ pub trait TransactionProcessingCallback {
     fn get_program_match_criteria(&self, _program: &Pubkey) -> LoadedProgramMatchCriteria {
         LoadedProgramMatchCriteria::NoCriteria
     }
+
+    fn add_builtin_account(&self, name: &str, program_id: &Pubkey, must_replace: bool);
 }
 
 #[derive(Debug)]
@@ -142,6 +144,9 @@ pub struct TransactionBatchProcessor<FG: ForkGraph> {
 
     /// Programs required for transaction batch processing
     pub program_cache: Arc<RwLock<ProgramCache<FG>>>,
+
+    /// Builtin program ids
+    pub builtin_program_ids: RwLock<HashSet<Pubkey>>,
 }
 
 impl<FG: ForkGraph> Debug for TransactionBatchProcessor<FG> {
@@ -171,6 +176,7 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
                 Slot::default(),
                 Epoch::default(),
             ))),
+            builtin_program_ids: RwLock::new(HashSet::new()),
         }
     }
 }
@@ -183,6 +189,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         fee_structure: FeeStructure,
         runtime_config: Arc<RuntimeConfig>,
         program_cache: Arc<RwLock<ProgramCache<FG>>>,
+        builtin_program_ids: HashSet<Pubkey>,
     ) -> Self {
         Self {
             slot,
@@ -192,12 +199,13 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             runtime_config,
             sysvar_cache: RwLock::<SysvarCache>::default(),
             program_cache,
+            builtin_program_ids: RwLock::new(builtin_program_ids),
         }
     }
 
     /// Main entrypoint to the SVM.
     #[allow(clippy::too_many_arguments)]
-    pub fn load_and_execute_sanitized_transactions<'a, CB: TransactionProcessingCallback>(
+    pub fn load_and_execute_sanitized_transactions<CB: TransactionProcessingCallback>(
         &self,
         callbacks: &CB,
         sanitized_txs: &[SanitizedTransaction],
@@ -206,7 +214,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         recording_config: ExecutionRecordingConfig,
         timings: &mut ExecuteTimings,
         account_overrides: Option<&AccountOverrides>,
-        builtin_programs: impl Iterator<Item = &'a Pubkey>,
         log_messages_bytes_limit: Option<usize>,
         limit_to_load_programs: bool,
     ) -> LoadAndExecuteSanitizedTransactionsOutput {
@@ -218,7 +225,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             PROGRAM_OWNERS,
         );
         let native_loader = native_loader::id();
-        for builtin_program in builtin_programs {
+        for builtin_program in self.builtin_program_ids.read().unwrap().iter() {
             program_accounts_map.insert(*builtin_program, (&native_loader, 0));
         }
 
@@ -954,6 +961,24 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     pub fn get_sysvar_cache_for_tests(&self) -> SysvarCache {
         self.sysvar_cache.read().unwrap().clone()
     }
+
+    /// Add a built-in program
+    pub fn add_builtin<CB: TransactionProcessingCallback>(
+        &self,
+        callbacks: &CB,
+        program_id: Pubkey,
+        name: &str,
+        builtin: LoadedProgram,
+    ) {
+        debug!("Adding program {} under {:?}", name, program_id);
+        callbacks.add_builtin_account(name, &program_id, false);
+        self.builtin_program_ids.write().unwrap().insert(program_id);
+        self.program_cache
+            .write()
+            .unwrap()
+            .assign_program(program_id, Arc::new(builtin));
+        debug!("Added program {} under {:?}", name, program_id);
+    }
 }
 
 #[cfg(test)]
@@ -1024,6 +1049,10 @@ mod tests {
 
         fn get_feature_set(&self) -> Arc<FeatureSet> {
             self.feature_set.clone()
+        }
+
+        fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey, _must_replace: bool) {
+            todo!()
         }
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1052,7 +1052,7 @@ mod tests {
         }
 
         fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey, _must_replace: bool) {
-            todo!()
+            unimplemented!()
         }
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -109,7 +109,7 @@ pub trait TransactionProcessingCallback {
         LoadedProgramMatchCriteria::NoCriteria
     }
 
-    fn add_builtin_account(&self, name: &str, program_id: &Pubkey);
+    fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {}
 }
 
 #[derive(Debug)]
@@ -1049,10 +1049,6 @@ mod tests {
 
         fn get_feature_set(&self) -> Arc<FeatureSet> {
             self.feature_set.clone()
-        }
-
-        fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {
-            unimplemented!()
         }
     }
 

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -48,7 +48,7 @@ impl TransactionProcessingCallback for MockBankCallback {
         self.feature_set.clone()
     }
 
-    fn add_builtin_account(&self, name: &str, program_id: &Pubkey, _must_replace: bool) {
+    fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {
         let account_data = native_loader::create_loadable_account_with_fields(name, (5000, 0));
 
         self.account_shared_data

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -3,23 +3,24 @@ use {
         account::{AccountSharedData, ReadableAccount},
         feature_set::FeatureSet,
         hash::Hash,
+        native_loader,
         pubkey::Pubkey,
         rent_collector::RentCollector,
     },
     solana_svm::transaction_processor::TransactionProcessingCallback,
-    std::{collections::HashMap, sync::Arc},
+    std::{cell::RefCell, collections::HashMap, sync::Arc},
 };
 
 #[derive(Default)]
 pub struct MockBankCallback {
     rent_collector: RentCollector,
     feature_set: Arc<FeatureSet>,
-    pub account_shared_data: HashMap<Pubkey, AccountSharedData>,
+    pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
 }
 
 impl TransactionProcessingCallback for MockBankCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {
-        if let Some(data) = self.account_shared_data.get(account) {
+        if let Some(data) = self.account_shared_data.borrow().get(account) {
             if data.lamports() == 0 {
                 None
             } else {
@@ -31,7 +32,7 @@ impl TransactionProcessingCallback for MockBankCallback {
     }
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
-        self.account_shared_data.get(pubkey).cloned()
+        self.account_shared_data.borrow().get(pubkey).cloned()
     }
 
     fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64) {
@@ -45,5 +46,13 @@ impl TransactionProcessingCallback for MockBankCallback {
 
     fn get_feature_set(&self) -> Arc<FeatureSet> {
         self.feature_set.clone()
+    }
+
+    fn add_builtin_account(&self, name: &str, program_id: &Pubkey, _must_replace: bool) {
+        let account_data = native_loader::create_loadable_account_with_fields(name, (5000, 0));
+
+        self.account_shared_data
+            .borrow_mut()
+            .insert(*program_id, account_data);
     }
 }


### PR DESCRIPTION
#### Problem

Presently, external SVM users must register builtins in two different places separately: the program cache and a vector passed to `load_and_process_sanitized_transactions`. These steps are burdensome and can lead to potential mistakes. In addition, the execution of programs should be self contained in the SVM, so the registration of builtins is semantically related to the SVM scope.

#### Summary of Changes

1. Moved `add_builtin` from `bank.rs` to the SVM folder.
2. `add_builtin_account` is now part of the trait `TransactionProcessingCallback`.
3. Moved `builtin_program_ids` from `struct Bank` to `struct TransactionBatchProcessor`.

Fixes #303
