### PR TITLE
stop once we need 10 storages

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -191,7 +191,12 @@ impl AncientSlotInfos {
             // combined ancient storages is less than the threshold, then
             // we've gone too far, so get rid of this entry and all after it.
             // Every storage after this one is larger.
-            if storages_remaining + ancient_storages_required < low_threshold {
+            // if we ever get to more than 10 required ancient storages, that is enough to stop for now.
+            // It will take a while to create that many. This should be a limit that only affects
+            // extreme testing environments.
+            if storages_remaining + ancient_storages_required < low_threshold
+                || ancient_storages_required > 10
+            {
                 self.all_infos.truncate(i);
                 break;
             }
@@ -2163,8 +2168,9 @@ pub mod tests {
                         let tuning = PackedAncientStorageTuning {
                             percent_of_alive_shrunk_data: 100,
                             max_ancient_slots: 0,
-                            // irrelevant
-                            ideal_storage_size: NonZeroU64::new(1).unwrap(),
+                            // irrelevant for what this test is trying to test, but necessary to avoid minimums
+                            ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity())
+                                .unwrap(),
                             can_randomly_shrink,
                         };
                         infos = db.collect_sort_filter_ancient_slots(vec![slot1], &tuning);
@@ -2321,7 +2327,10 @@ pub mod tests {
                                 percent_of_alive_shrunk_data: 100,
                                 max_ancient_slots: 0,
                                 // irrelevant
-                                ideal_storage_size: NonZeroU64::new(1).unwrap(),
+                                ideal_storage_size: NonZeroU64::new(
+                                    get_ancient_append_vec_capacity(),
+                                )
+                                .unwrap(),
                                 can_randomly_shrink,
                             };
                             db.collect_sort_filter_ancient_slots(slot_vec.clone(), &tuning)
@@ -2631,8 +2640,9 @@ pub mod tests {
                         let tuning = PackedAncientStorageTuning {
                             percent_of_alive_shrunk_data: 100,
                             max_ancient_slots: 0,
-                            // irrelevant
-                            ideal_storage_size: NonZeroU64::new(1).unwrap(),
+                            // irrelevant for what this test is trying to test, but necessary to avoid minimums
+                            ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity())
+                                .unwrap(),
                             can_randomly_shrink,
                         };
                         // note this can sort infos.all_infos
@@ -2640,7 +2650,7 @@ pub mod tests {
                     }
                 };
 
-                assert_eq!(infos.all_infos.len(), 2);
+                assert_eq!(infos.all_infos.len(), 2, "{method:?}");
                 storages.iter().for_each(|storage| {
                     assert!(infos
                         .all_infos
@@ -2836,8 +2846,11 @@ pub mod tests {
                                 percent_of_alive_shrunk_data,
                                 // 0 so that we combine everything with regard to the overall # of slots limit
                                 max_ancient_slots: 0,
-                                // this is irrelevant since the limit is artificially 0
-                                ideal_storage_size: NonZeroU64::new(1).unwrap(),
+                                // irrelevant for what this test is trying to test, but necessary to avoid minimums
+                                ideal_storage_size: NonZeroU64::new(
+                                    get_ancient_append_vec_capacity(),
+                                )
+                                .unwrap(),
                                 can_randomly_shrink: false,
                             };
                             infos.filter_ancient_slots(&tuning);


### PR DESCRIPTION
#### Problem
Account state continues to grow.
We'd like to turn off rent exempt rewrites.
At that point, we accumulate old append vecs.
We append or pack those into 'ancient' append vecs.
The packing algorithm can go off the rails in certain testing scenarios.
Note that the ancient algorithm is currently 'append'. This code does not affect 'append' at all.
The packing algorithm is the future. Packing is enabled with `--accounts-db-create-ancient-storage-packed`

#### Summary of Changes
Apply some limits to what the packing algorithm will attempt.
In this case, once we have identified enough content to pack into 10 storages, we stop trying to identify more to pack.
This limit of 10 is a stop gap to prevent machines from running oom by trying to combine too many append vecs in one pass (by not flushing the write cache most likely or by loading pubkeys into memory for billions of accounts).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
