### PR TITLE
add high tps client: multi stake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5553,6 +5553,7 @@ dependencies = [
 name = "solana-bench-tps"
 version = "2.0.0"
 dependencies = [
+ "bincode",
  "chrono",
  "clap 2.33.3",
  "crossbeam-channel",
@@ -5592,6 +5593,7 @@ dependencies = [
  "spl-instruction-padding",
  "tempfile",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bincode = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -44,6 +45,7 @@ solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
 spl-instruction-padding = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/bench-tps/src/bench_tps_client.rs
+++ b/bench-tps/src/bench_tps_client.rs
@@ -112,5 +112,6 @@ pub trait BenchTpsClient {
 }
 
 mod bank_client;
+pub mod high_tps_client;
 mod rpc_client;
 mod tpu_client;

--- a/bench-tps/src/bench_tps_client/high_tps_client.rs
+++ b/bench-tps/src/bench_tps_client/high_tps_client.rs
@@ -1,0 +1,233 @@
+//! Client optimized for bench-tps: high mean TPS and moderate std
+//! This is achieved by:
+//! * optimizing the size of send batch
+//! * sending batches using connection cache in nonblocking fashion
+//! * use leader cache from TpuClient to minimize rpc calls
+//! * using several staked connection caches (not implemented yet)
+//!
+use {
+    crate::bench_tps_client::{BenchTpsClient, BenchTpsError, Result},
+    solana_client::{
+        connection_cache::Protocol, nonblocking::tpu_client::LeaderTpuService,
+        tpu_connection::TpuConnection,
+    },
+    solana_connection_cache::connection_cache::ConnectionCache as BackendConnectionCache,
+    solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
+    solana_rpc_client::rpc_client::RpcClient,
+    solana_rpc_client_api::config::RpcBlockConfig,
+    solana_sdk::{
+        account::Account, commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash,
+        message::Message, pubkey::Pubkey, signature::Signature, slot_history::Slot,
+        transaction::Transaction,
+    },
+    solana_transaction_status::UiConfirmedBlock,
+    std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct HighTpsClientConfig {
+    pub send_batch_size: usize,
+    pub fanout_slots: u64,
+}
+
+type ConnectionCache = BackendConnectionCache<QuicPool, QuicConnectionManager, QuicConfig>;
+pub struct HighTpsClient {
+    leader_tpu_service: LeaderTpuService,
+    exit: Arc<AtomicBool>,
+    rpc_client: Arc<RpcClient>,
+    connection_cache: Arc<ConnectionCache>,
+    config: HighTpsClientConfig,
+}
+
+impl Drop for HighTpsClient {
+    fn drop(&mut self) {
+        self.exit.store(true, Ordering::Relaxed);
+    }
+}
+
+impl HighTpsClient {
+    pub fn new(
+        rpc_client: Arc<RpcClient>,
+        websocket_url: &str,
+        config: HighTpsClientConfig,
+        connection_cache: Arc<ConnectionCache>,
+    ) -> Result<Self> {
+        let exit = Arc::new(AtomicBool::new(false));
+        let create_leader_tpu_service = LeaderTpuService::new(
+            rpc_client.get_inner_client().clone(),
+            websocket_url,
+            Protocol::QUIC,
+            exit.clone(),
+        );
+        let leader_tpu_service = tokio::task::block_in_place(|| {
+            rpc_client.runtime().block_on(create_leader_tpu_service)
+        })?;
+        Ok(Self {
+            leader_tpu_service,
+            exit,
+            rpc_client,
+            connection_cache,
+            config,
+        })
+    }
+}
+
+impl BenchTpsClient for HighTpsClient {
+    fn send_transaction(&self, transaction: Transaction) -> Result<Signature> {
+        self.rpc_client
+            .send_transaction(&transaction)
+            .map_err(|err| err.into())
+    }
+
+    fn send_batch(&self, transactions: Vec<Transaction>) -> Result<()> {
+        let wire_transactions = transactions
+            .into_iter() //.into_par_iter() any effect of this?
+            .map(|tx| bincode::serialize(&tx).expect("transaction should be valid."))
+            .collect::<Vec<_>>();
+        for c in wire_transactions.chunks(self.config.send_batch_size) {
+            let tpu_addresses = self
+                .leader_tpu_service
+                .leader_tpu_sockets(self.config.fanout_slots);
+            for tpu_address in &tpu_addresses {
+                let conn = self.connection_cache.get_connection(tpu_address);
+                let _ = conn.send_data_batch_async(c.to_vec());
+            }
+        }
+        Ok(())
+    }
+    fn get_latest_blockhash(&self) -> Result<Hash> {
+        self.rpc_client
+            .get_latest_blockhash()
+            .map_err(|err| err.into())
+    }
+
+    fn get_latest_blockhash_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> Result<(Hash, u64)> {
+        self.rpc_client
+            .get_latest_blockhash_with_commitment(commitment_config)
+            .map_err(|err| err.into())
+    }
+
+    fn get_transaction_count(&self) -> Result<u64> {
+        self.rpc_client
+            .get_transaction_count()
+            .map_err(|err| err.into())
+    }
+
+    fn get_transaction_count_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> Result<u64> {
+        self.rpc_client
+            .get_transaction_count_with_commitment(commitment_config)
+            .map_err(|err| err.into())
+    }
+
+    fn get_epoch_info(&self) -> Result<EpochInfo> {
+        self.rpc_client.get_epoch_info().map_err(|err| err.into())
+    }
+
+    fn get_balance(&self, pubkey: &Pubkey) -> Result<u64> {
+        self.rpc_client
+            .get_balance(pubkey)
+            .map_err(|err| err.into())
+    }
+
+    fn get_balance_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> Result<u64> {
+        self.rpc_client
+            .get_balance_with_commitment(pubkey, commitment_config)
+            .map(|res| res.value)
+            .map_err(|err| err.into())
+    }
+
+    fn get_fee_for_message(&self, message: &Message) -> Result<u64> {
+        self.rpc_client
+            .get_fee_for_message(message)
+            .map_err(|err| err.into())
+    }
+
+    fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> Result<u64> {
+        self.rpc_client
+            .get_minimum_balance_for_rent_exemption(data_len)
+            .map_err(|err| err.into())
+    }
+
+    fn addr(&self) -> String {
+        self.rpc_client.url()
+    }
+
+    fn request_airdrop_with_blockhash(
+        &self,
+        pubkey: &Pubkey,
+        lamports: u64,
+        recent_blockhash: &Hash,
+    ) -> Result<Signature> {
+        self.rpc_client
+            .request_airdrop_with_blockhash(pubkey, lamports, recent_blockhash)
+            .map_err(|err| err.into())
+    }
+
+    fn get_account(&self, pubkey: &Pubkey) -> Result<Account> {
+        self.rpc_client
+            .get_account(pubkey)
+            .map_err(|err| err.into())
+    }
+
+    fn get_account_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Account> {
+        self.rpc_client
+            .get_account_with_commitment(pubkey, commitment_config)
+            .map(|res| res.value)
+            .map_err(|err| err.into())
+            .and_then(|account| {
+                account.ok_or_else(|| {
+                    BenchTpsError::Custom(format!("AccountNotFound: pubkey={pubkey}"))
+                })
+            })
+    }
+
+    fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>> {
+        self.rpc_client
+            .get_multiple_accounts(pubkeys)
+            .map_err(|err| err.into())
+    }
+
+    fn get_slot_with_commitment(&self, commitment_config: CommitmentConfig) -> Result<Slot> {
+        self.rpc_client
+            .get_slot_with_commitment(commitment_config)
+            .map_err(|err| err.into())
+    }
+
+    fn get_blocks_with_commitment(
+        &self,
+        start_slot: Slot,
+        end_slot: Option<Slot>,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Vec<Slot>> {
+        self.rpc_client
+            .get_blocks_with_commitment(start_slot, end_slot, commitment_config)
+            .map_err(|err| err.into())
+    }
+
+    fn get_block_with_config(
+        &self,
+        slot: Slot,
+        rpc_block_config: RpcBlockConfig,
+    ) -> Result<UiConfirmedBlock> {
+        self.rpc_client
+            .get_block_with_config(slot, rpc_block_config)
+            .map_err(|err| err.into())
+    }
+}

--- a/bench-tps/src/bench_tps_client/high_tps_client.rs
+++ b/bench-tps/src/bench_tps_client/high_tps_client.rs
@@ -7,11 +7,12 @@
 //!
 use {
     crate::bench_tps_client::{BenchTpsClient, BenchTpsError, Result},
+    rand::prelude::*,
     solana_client::{
         connection_cache::Protocol, nonblocking::tpu_client::LeaderTpuService,
         tpu_connection::TpuConnection,
     },
-    solana_connection_cache::connection_cache::ConnectionCache as BackendConnectionCache,
+    solana_connection_cache::connection_cache::{self, ConnectionCache as BackendConnectionCache},
     solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::config::RpcBlockConfig,
@@ -38,7 +39,7 @@ pub struct HighTpsClient {
     leader_tpu_service: LeaderTpuService,
     exit: Arc<AtomicBool>,
     rpc_client: Arc<RpcClient>,
-    connection_cache: Arc<ConnectionCache>,
+    connection_caches: Vec<Arc<ConnectionCache>>,
     config: HighTpsClientConfig,
 }
 
@@ -53,7 +54,7 @@ impl HighTpsClient {
         rpc_client: Arc<RpcClient>,
         websocket_url: &str,
         config: HighTpsClientConfig,
-        connection_cache: Arc<ConnectionCache>,
+        connection_caches: Vec<Arc<ConnectionCache>>,
     ) -> Result<Self> {
         let exit = Arc::new(AtomicBool::new(false));
         let create_leader_tpu_service = LeaderTpuService::new(
@@ -69,7 +70,7 @@ impl HighTpsClient {
             leader_tpu_service,
             exit,
             rpc_client,
-            connection_cache,
+            connection_caches,
             config,
         })
     }
@@ -87,12 +88,14 @@ impl BenchTpsClient for HighTpsClient {
             .into_iter() //.into_par_iter() any effect of this?
             .map(|tx| bincode::serialize(&tx).expect("transaction should be valid."))
             .collect::<Vec<_>>();
+        let mut rng = rand::thread_rng();
+        let cc_index: usize = rng.gen_range(0..self.connection_caches.len());
         for c in wire_transactions.chunks(self.config.send_batch_size) {
             let tpu_addresses = self
                 .leader_tpu_service
                 .leader_tpu_sockets(self.config.fanout_slots);
             for tpu_address in &tpu_addresses {
-                let conn = self.connection_cache.get_connection(tpu_address);
+                let conn = self.connection_caches[cc_index].get_connection(tpu_address);
                 let _ = conn.send_data_batch_async(c.to_vec());
             }
         }

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -27,6 +27,8 @@ pub enum ExternalClientType {
     // Submits transactions directly to leaders using a TpuClient, broadcasting to upcoming leaders
     // via TpuClient default configuration
     TpuClient,
+
+    HighTpsClient,
 }
 
 impl Default for ExternalClientType {
@@ -339,6 +341,13 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .help("Submit transactions with a TpuClient")
         )
         .arg(
+            Arg::with_name("high_tps_client")
+                .long("use-high-tps-client")
+                .conflicts_with("rpc_client")
+                .takes_value(false)
+                .help("Submit transactions with a HighTpsClient")
+        )
+        .arg(
             Arg::with_name("tpu_disable_quic")
                 .long("tpu-disable-quic")
                 .takes_value(false)
@@ -477,6 +486,10 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
 
     if matches.is_present("rpc_client") {
         args.external_client_type = ExternalClientType::RpcClient;
+    }
+
+    if matches.is_present("high_tps_client") {
+        args.external_client_type = ExternalClientType::HighTpsClient;
     }
 
     if matches.is_present("tpu_disable_quic") {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -12,6 +12,7 @@ use {
         send_batch::{generate_durable_nonce_accounts, generate_keypairs},
     },
     solana_client::connection_cache::ConnectionCache,
+    solana_connection_cache::connection_cache,
     solana_genesis::Base64Account,
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{
@@ -78,20 +79,20 @@ fn create_connection_cache(
     tpu_connection_pool_size: usize,
     use_quic: bool,
     bind_address: IpAddr,
-    client_node_id: Option<&Keypair>,
+    client_node_ids: Option<&Vec<Keypair>>,
     commitment_config: CommitmentConfig,
-) -> ConnectionCache {
+) -> Vec<ConnectionCache> {
     if !use_quic {
-        return ConnectionCache::with_udp(
+        return vec![ConnectionCache::with_udp(
             "bench-tps-connection_cache_udp",
             tpu_connection_pool_size,
-        );
+        )];
     }
-    if client_node_id.is_none() {
-        return ConnectionCache::new_quic(
+    if client_node_ids.is_none() {
+        return vec![ConnectionCache::new_quic(
             "bench-tps-connection_cache_quic",
             tpu_connection_pool_size,
-        );
+        )];
     }
 
     let rpc_client = Arc::new(RpcClient::new_with_commitment(
@@ -99,25 +100,32 @@ fn create_connection_cache(
         commitment_config,
     ));
 
-    let client_node_id = client_node_id.unwrap();
-    let (stake, total_stake) =
-        find_node_activated_stake(rpc_client, client_node_id.pubkey()).unwrap_or_default();
-    info!("Stake for specified client_node_id: {stake}, total stake: {total_stake}");
-    let stakes = HashMap::from([
-        (client_node_id.pubkey(), stake),
-        (Pubkey::new_unique(), total_stake - stake),
-    ]);
-    let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(
-        Arc::new(stakes),
-        HashMap::<Pubkey, u64>::default(), // overrides
-    )));
-    ConnectionCache::new_with_client_options(
-        "bench-tps-connection_cache_quic",
-        tpu_connection_pool_size,
-        None,
-        Some((client_node_id, bind_address)),
-        Some((&staked_nodes, &client_node_id.pubkey())),
-    )
+    //TODO(klykov): can we use one HashMap for all the connections?
+    let client_node_ids = client_node_ids.unwrap();
+    let mut connection_caches = Vec::with_capacity(client_node_ids.len());
+    for client_node_id in client_node_ids {
+        let (stake, total_stake) =
+            find_node_activated_stake(rpc_client.clone(), client_node_id.pubkey())
+                .unwrap_or_default();
+        info!("Stake for specified client_node_id: {stake}, total stake: {total_stake}");
+        let stakes = HashMap::from([
+            (client_node_id.pubkey(), stake),
+            (Pubkey::new_unique(), total_stake - stake),
+        ]);
+        let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(
+            Arc::new(stakes),
+            HashMap::<Pubkey, u64>::default(), // overrides
+        )));
+        let cc = ConnectionCache::new_with_client_options(
+            "bench-tps-connection_cache_quic",
+            tpu_connection_pool_size,
+            None,
+            Some((client_node_id, bind_address)),
+            Some((&staked_nodes, &client_node_id.pubkey())),
+        );
+        connection_caches.push(cc);
+    }
+    connection_caches
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -125,7 +133,7 @@ fn create_client(
     external_client_type: &ExternalClientType,
     json_rpc_url: &str,
     websocket_url: &str,
-    connection_cache: ConnectionCache,
+    connection_caches: Vec<ConnectionCache>,
     commitment_config: CommitmentConfig,
 ) -> Arc<dyn BenchTpsClient + Send + Sync> {
     match external_client_type {
@@ -138,13 +146,13 @@ fn create_client(
                 json_rpc_url.to_string(),
                 commitment_config,
             ));
-            match connection_cache {
+            match &connection_caches[0] {
                 ConnectionCache::Udp(cache) => Arc::new(
                     TpuClient::new_with_connection_cache(
                         rpc_client,
                         websocket_url,
                         TpuClientConfig::default(),
-                        cache,
+                        cache.clone(),
                     )
                     .unwrap_or_else(|err| {
                         eprintln!("Could not create TpuClient {err:?}");
@@ -156,7 +164,7 @@ fn create_client(
                         rpc_client,
                         websocket_url,
                         TpuClientConfig::default(),
-                        cache,
+                        cache.clone(),
                     )
                     .unwrap_or_else(|err| {
                         eprintln!("Could not create TpuClient {err:?}");
@@ -170,26 +178,30 @@ fn create_client(
                 json_rpc_url.to_string(),
                 commitment_config,
             ));
-            match connection_cache {
-                ConnectionCache::Udp(_) => {
-                    unimplemented!("UDP protocol is not supported.");
-                }
-                ConnectionCache::Quic(cache) => Arc::new(
-                    HighTpsClient::new(
-                        rpc_client,
-                        websocket_url,
-                        HighTpsClientConfig {
-                            fanout_slots: 1,
-                            send_batch_size: 64,
-                        },
-                        cache,
-                    )
-                    .unwrap_or_else(|err| {
-                        eprintln!("Could not create HighTpsClient {err:?}");
-                        exit(1);
-                    }),
-                ),
-            }
+            let caches = connection_caches
+                .iter()
+                .map(|cache| match cache {
+                    ConnectionCache::Udp(_) => {
+                        unimplemented!("UDP protocol is not supported.");
+                    }
+                    ConnectionCache::Quic(cache) => cache.clone(),
+                })
+                .collect();
+            Arc::new(
+                HighTpsClient::new(
+                    rpc_client,
+                    websocket_url,
+                    HighTpsClientConfig {
+                        fanout_slots: 1,
+                        send_batch_size: 64,
+                    },
+                    caches,
+                )
+                .unwrap_or_else(|err| {
+                    eprintln!("Could not create HighTpsClient {err:?}");
+                    exit(1);
+                }),
+            )
         }
     }
 }
@@ -226,7 +238,7 @@ fn main() {
         use_durable_nonce,
         instruction_padding_config,
         bind_address,
-        client_node_id,
+        client_node_ids,
         commitment_config,
         ..
     } = &cli_config;
@@ -264,19 +276,19 @@ fn main() {
         return;
     }
 
-    let connection_cache = create_connection_cache(
+    let connection_caches = create_connection_cache(
         json_rpc_url,
         *tpu_connection_pool_size,
         *use_quic,
         *bind_address,
-        client_node_id.as_ref(),
+        client_node_ids.as_ref(),
         *commitment_config,
     );
     let client = create_client(
         external_client_type,
         json_rpc_url,
         websocket_url,
-        connection_cache,
+        connection_caches,
         *commitment_config,
     );
     if let Some(instruction_padding_config) = instruction_padding_config {

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -752,7 +752,7 @@ impl LeaderTpuService {
         self.recent_slots.estimated_current_slot()
     }
 
-    fn leader_tpu_sockets(&self, fanout_slots: u64) -> Vec<SocketAddr> {
+    pub fn leader_tpu_sockets(&self, fanout_slots: u64) -> Vec<SocketAddr> {
         let current_slot = self.recent_slots.estimated_current_slot();
         self.leader_tpu_cache
             .read()


### PR DESCRIPTION
#### Problem

This PR is on top of https://github.com/anza-xyz/agave/pull/544
It allows to send txs using different stakes. For that had created a new connection cache for each of the stakes.
This code is poc.

Initial testing shows (private cluster with 10 nodes in 2 different dc):
* 30% confirmed TPS improvement (now 13104+-6.7k, was ~10k) with two staked accounts (20% of total stake on private cluster)
* 50% confirmed TPS improvement (14717+-6.9k) with 4 staked accounts (40%)

#### Summary of Changes
