### PR TITLE
Rework SysvarCache implementation

### DIFF
--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -21,6 +21,7 @@ num-derive = { workspace = true }
 num-traits = { workspace = true }
 percentage = { workspace = true }
 rand = { workspace = true }
+serde = { workspace = true }
 solana-frozen-abi = { workspace = true }
 solana-frozen-abi-macro = { workspace = true }
 solana-measure = { workspace = true }
@@ -31,7 +32,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-serde = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 test-case = { workspace = true }

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -3403,13 +3403,6 @@ mod tests {
         src_rewards.distributed_rewards = 10;
         src_rewards.active = true;
 
-        let mut sysvar_cache = SysvarCache::default();
-        sysvar_cache.set_clock(src_clock.clone());
-        sysvar_cache.set_epoch_schedule(src_epochschedule.clone());
-        sysvar_cache.set_fees(src_fees.clone());
-        sysvar_cache.set_rent(src_rent.clone());
-        sysvar_cache.set_epoch_rewards(src_rewards.clone());
-
         let transaction_accounts = vec![
             (
                 sysvar::clock::id(),

--- a/programs/bpf_loader/src/syscalls/sysvar.rs
+++ b/programs/bpf_loader/src/syscalls/sysvar.rs
@@ -16,6 +16,10 @@ fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
     )?;
     let var = translate_type_mut::<T>(memory_mapping, var_addr, check_aligned)?;
 
+    // this clone looks unecessary now, but it exists to zero out trailing alignment bytes
+    // it is unclear whether this should ever matter
+    // but there are tests using MemoryMapping that expect to see this
+    // we preserve the previous behavior out of an abundance of caution
     let sysvar: Arc<T> = sysvar?;
     *var = T::clone(sysvar.as_ref());
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5459,6 +5459,7 @@ dependencies = [
  "percentage",
  "rand 0.8.5",
  "rustc_version",
+ "serde",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-measure",


### PR DESCRIPTION
#### Problem

we have proposed a syscall, `sol_get_sysvar`/`SyscallGetSysvar`, a generic mechanism to fetch arbitrary slices of account data for a specially selected list of sysvars. this is intended primarily to enable the bpf versions of the stake and vote programs to access individual parts of the stake history and slot hashes sysvars, but it also functions as a drop-in replacement for all existing non-deprecated sysvar syscalls

see discussion in [SIMD-0127](https://github.com/solana-foundation/solana-improvement-documents/pull/127) for (much) more context

#### Summary of Changes

we change `SysvarCache` contents from arc-wrapped objects to u8 vectors containing the exact onchain account data for the sysvars. small (non-vector) sysvars are now deserialized on-demand as the cost is trivial and should not be incurred more than once per instruction. large (stake history and slot hashes) sysvars are kept around in the old format for the sake of the stake and vote programs, but will be removed after native to bpf conversion. we keep the deprecated fees and recent blockhashes sysvars, these can likely also be removed after native to bpf conversion

we wrap our return values in `Arc` to minimize change surface and preserve the existing interface

this pr is part one of two: a second pr will implement the syscall. a third and fourth will actually use the syscall for getting slices of `StakeHistory` and `SlotHashes`