### PR TITLE
Removes write version from StorableAccountsWithHashesAndWriteVersions

### DIFF
--- a/accounts-db/benches/append_vec.rs
+++ b/accounts-db/benches/append_vec.rs
@@ -4,9 +4,7 @@ extern crate test;
 use {
     rand::{thread_rng, Rng},
     solana_accounts_db::{
-        account_storage::meta::{
-            StorableAccountsWithHashesAndWriteVersions, StoredAccountInfo, StoredMeta,
-        },
+        account_storage::meta::{StorableAccountsWithHashes, StoredAccountInfo, StoredMeta},
         accounts_hash::AccountHash,
         append_vec::{
             test_utils::{create_test_account, get_append_vec_path},
@@ -39,12 +37,7 @@ fn append_account(
     let accounts = [(&storage_meta.pubkey, account)];
     let slice = &accounts[..];
     let accounts = (slot_ignored, slice);
-    let storable_accounts =
-        StorableAccountsWithHashesAndWriteVersions::new_with_hashes_and_write_versions(
-            &accounts,
-            vec![&hash],
-            vec![storage_meta.write_version_obsolete],
-        );
+    let storable_accounts = StorableAccountsWithHashes::new_with_hashes(&accounts, vec![&hash]);
     let res = vec.append_accounts(&storable_accounts, 0);
     res.and_then(|res| res.first().cloned())
 }

--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -2,7 +2,7 @@
 use {
     criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput},
     solana_accounts_db::{
-        account_storage::meta::StorableAccountsWithHashesAndWriteVersions,
+        account_storage::meta::StorableAccountsWithHashes,
         accounts_hash::AccountHash,
         append_vec::{self, AppendVec},
         tiered_storage::hot::HotStorageWriter,
@@ -46,12 +46,10 @@ fn bench_write_accounts_file(c: &mut Criterion) {
         .collect();
         let accounts_refs: Vec<_> = accounts.iter().collect();
         let accounts_data = (Slot::MAX, accounts_refs.as_slice());
-        let storable_accounts =
-            StorableAccountsWithHashesAndWriteVersions::new_with_hashes_and_write_versions(
-                &accounts_data,
-                vec![AccountHash(Hash::default()); accounts_count],
-                vec![0; accounts_count],
-            );
+        let storable_accounts = StorableAccountsWithHashes::new_with_hashes(
+            &accounts_data,
+            vec![AccountHash(Hash::default()); accounts_count],
+        );
 
         group.bench_function(BenchmarkId::new("append_vec", accounts_count), |b| {
             b.iter_batched_ref(

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -1,9 +1,7 @@
 use {
     crate::{
         account_info::AccountInfo,
-        account_storage::meta::{
-            StorableAccountsWithHashesAndWriteVersions, StoredAccountInfo, StoredAccountMeta,
-        },
+        account_storage::meta::{StorableAccountsWithHashes, StoredAccountInfo, StoredAccountMeta},
         accounts_db::AccountsFileId,
         accounts_hash::AccountHash,
         append_vec::{AppendVec, AppendVecError, IndexInfo},
@@ -229,7 +227,7 @@ impl AccountsFile {
         V: Borrow<AccountHash>,
     >(
         &self,
-        accounts: &StorableAccountsWithHashesAndWriteVersions<'a, 'b, T, U, V>,
+        accounts: &StorableAccountsWithHashes<'a, 'b, T, U, V>,
         skip: usize,
     ) -> Option<Vec<StoredAccountInfo>> {
         match self {

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1174,7 +1174,6 @@ pub mod tests {
                                     storage,
                                     &pk,
                                     &account,
-                                    0,
                                     true,
                                     Some(&db.accounts_index),
                                 );
@@ -1282,7 +1281,6 @@ pub mod tests {
                                     storage,
                                     &pk,
                                     &account,
-                                    0,
                                     true,
                                     Some(&db.accounts_index),
                                 );
@@ -1514,12 +1512,10 @@ pub mod tests {
                                 storages.iter().for_each(|storage| {
                                     let pk = solana_sdk::pubkey::new_rand();
                                     let alive = false;
-                                    let write_version = 0;
                                     append_single_account_with_default_hash(
                                         storage,
                                         &pk,
                                         &AccountSharedData::default(),
-                                        write_version,
                                         alive,
                                         Some(&db.accounts_index),
                                     );
@@ -1663,7 +1659,6 @@ pub mod tests {
                 &storage,
                 &pk_with_1_ref,
                 &account_with_1_ref,
-                0,
                 true,
                 Some(&db.accounts_index),
             );
@@ -1676,7 +1671,6 @@ pub mod tests {
                 &ignored_storage,
                 pk_with_2_refs,
                 &account_with_2_refs.to_account_shared_data(),
-                0,
                 true,
                 Some(&db.accounts_index),
             );
@@ -1843,7 +1837,6 @@ pub mod tests {
                 &storage,
                 &pk_with_1_ref,
                 &account_with_1_ref,
-                0,
                 true,
                 Some(&db.accounts_index),
             );


### PR DESCRIPTION
#### Problem

Now that we no longer use the write version when storing accounts (see #476), and `StorableAccounts` no longer contains anything about write version either (see #542), `StorableAccountsWithHashesAndWriteVersions` does not need to care either.


#### Summary of Changes

Remove write version from StorableAccountsWithHashesAndWriteVersions.