### PR TITLE
histo for cost tracker metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6032,6 +6032,7 @@ dependencies = [
 name = "solana-cost-model"
 version = "2.0.0"
 dependencies = [
+ "histogram",
  "lazy_static",
  "log",
  "rustc_version 0.4.0",

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+histogram = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 solana-address-lookup-table-program = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4995,6 +4995,7 @@ dependencies = [
 name = "solana-cost-model"
 version = "2.0.0"
 dependencies = [
+ "histogram",
  "lazy_static",
  "log",
  "rustc_version",


### PR DESCRIPTION
#### Problem
It would be nice to have more insight into committed transaction costs (both estimated and actual)

#### Summary of Changes

- Add histo to track estimated and actual cost of committed transactions
- Output the min, mean, max, and 90th percentile estimated & actual tx costs for each slot