### PR TITLE
Add all validators as entrypoint to local cluster

### DIFF
--- a/local-cluster/src/cluster.rs
+++ b/local-cluster/src/cluster.rs
@@ -59,10 +59,10 @@ pub trait Cluster {
         &mut self,
         pubkey: &Pubkey,
         cluster_validator_info: &mut ClusterValidatorInfo,
-    ) -> (Node, Option<ContactInfo>);
+    ) -> (Node, Vec<ContactInfo>);
     fn restart_node_with_context(
         cluster_validator_info: ClusterValidatorInfo,
-        restart_context: (Node, Option<ContactInfo>),
+        restart_context: (Node, Vec<ContactInfo>),
         socket_addr_space: SocketAddrSpace,
     ) -> ClusterValidatorInfo;
     fn add_node(&mut self, pubkey: &Pubkey, cluster_validator_info: ClusterValidatorInfo);

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -586,7 +586,7 @@ impl LocalCluster {
         let alive_node_contact_infos = self.discover_nodes(socket_addr_space, test_name);
         info!(
             "{} looking minimum root {} on all nodes",
-            min_root, test_name
+            test_name, min_root
         );
         cluster_tests::check_min_slot_is_rooted(
             min_root,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -914,6 +914,10 @@ impl Cluster for LocalCluster {
         cluster_validator_info.config.rpc_addrs =
             Some((node.info.rpc().unwrap(), node.info.rpc_pubsub().unwrap()));
 
+        if pubkey == self.entry_point_info.pubkey() {
+            self.entry_point_info = node.info.clone();
+        }
+
         let entry_point_infos: Vec<ContactInfo> = self
             .validators
             .values()

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -918,15 +918,23 @@ impl Cluster for LocalCluster {
             self.entry_point_info = node.info.clone();
         }
 
-        let entry_point_infos: Vec<ContactInfo> = self
+        let mut is_entrypoint_alive = false;
+        let mut entry_point_infos: Vec<ContactInfo> = self
             .validators
             .values()
             .map(|validator| {
                 // Should not be restarting a validator that is still alive
                 assert!(validator.info.contact_info.pubkey() != pubkey);
+                if validator.info.contact_info.pubkey() == self.entry_point_info.pubkey() {
+                    is_entrypoint_alive = true;
+                }
                 validator.info.contact_info.clone()
             })
             .collect();
+
+        if !is_entrypoint_alive {
+            entry_point_infos.push(self.entry_point_info.clone());
+        }
 
         (node, entry_point_infos)
     }


### PR DESCRIPTION
#### Problem
When you have the following pattern:

1. Killing the entrypoint/leader
2. Kill validator `A` not the leader
3. Restarting validator `A`

Because the entrypoint is dead, validator `A` can't discover the cluster. Then that means `A` must have the same ports for gossip OR tvu  as before the restart otherwise validator `A` won't be discoverable/receive any shreds from turbine.

#### Summary of Changes

Add all alive validators as entrypoints to `A` on restart so it's not dependent on only the initial entrypoint

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
