### PR TITLE
Adds metrics for how long it takes to evict from the accounts read cache

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8239,6 +8239,7 @@ impl AccountsDb {
                 read_only_cache_misses,
                 read_only_cache_evicts,
                 read_only_cache_load_us,
+                read_only_cache_evict_us,
             ) = self.read_only_accounts_cache.get_and_reset_stats();
             datapoint_info!(
                 "accounts_db_store_timings",
@@ -8308,6 +8309,11 @@ impl AccountsDb {
                 (
                     "read_only_accounts_cache_load_us",
                     read_only_cache_load_us,
+                    i64
+                ),
+                (
+                    "read_only_accounts_cache_evict_us",
+                    read_only_cache_evict_us,
                     i64
                 ),
                 (

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -36,6 +36,7 @@ struct ReadOnlyCacheStats {
     misses: AtomicU64,
     evicts: AtomicU64,
     load_us: AtomicU64,
+    evict_us: AtomicU64,
 }
 
 impl ReadOnlyCacheStats {
@@ -44,15 +45,17 @@ impl ReadOnlyCacheStats {
         self.misses.store(0, Ordering::Relaxed);
         self.evicts.store(0, Ordering::Relaxed);
         self.load_us.store(0, Ordering::Relaxed);
+        self.evict_us.store(0, Ordering::Relaxed);
     }
 
-    fn get_and_reset_stats(&self) -> (u64, u64, u64, u64) {
+    fn get_and_reset_stats(&self) -> (u64, u64, u64, u64, u64) {
         let hits = self.hits.swap(0, Ordering::Relaxed);
         let misses = self.misses.swap(0, Ordering::Relaxed);
         let evicts = self.evicts.swap(0, Ordering::Relaxed);
         let load_us = self.load_us.swap(0, Ordering::Relaxed);
+        let evict_us = self.evict_us.swap(0, Ordering::Relaxed);
 
-        (hits, misses, evicts, load_us)
+        (hits, misses, evicts, load_us, evict_us)
     }
 }
 
@@ -162,14 +165,17 @@ impl ReadOnlyAccountsCache {
         };
         // Evict entries from the front of the queue.
         let mut num_evicts = 0;
-        while self.data_size.load(Ordering::Relaxed) > self.max_data_size {
-            let Some(&(pubkey, slot)) = self.queue.lock().unwrap().get_first() else {
-                break;
-            };
-            num_evicts += 1;
-            self.remove(pubkey, slot);
-        }
+        let (_, evict_us) = measure_us!({
+            while self.data_size.load(Ordering::Relaxed) > self.max_data_size {
+                let Some(&(pubkey, slot)) = self.queue.lock().unwrap().get_first() else {
+                    break;
+                };
+                num_evicts += 1;
+                self.remove(pubkey, slot);
+            }
+        });
         self.stats.evicts.fetch_add(num_evicts, Ordering::Relaxed);
+        self.stats.evict_us.fetch_add(evict_us, Ordering::Relaxed);
     }
 
     /// true if any pubkeys could have ever been stored into the cache at `slot`
@@ -208,7 +214,7 @@ impl ReadOnlyAccountsCache {
         self.data_size.load(Ordering::Relaxed)
     }
 
-    pub(crate) fn get_and_reset_stats(&self) -> (u64, u64, u64, u64) {
+    pub(crate) fn get_and_reset_stats(&self) -> (u64, u64, u64, u64, u64) {
         self.stats.get_and_reset_stats()
     }
 }


### PR DESCRIPTION
#### Problem

While evaluating evicting from the accounts read cache in the background (https://github.com/anza-xyz/agave/pull/575), we noticed that we currently do not time how long it takes to evict.


#### Summary of Changes

Add a metric for how long it takes to evict from the accounts read cache.