### PR TITLE
[zk-token-sdk] Add ctxt extraction functions for grouped ElGamal ciphertexts

### DIFF
--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -27,7 +27,7 @@ const ELGAMAL_PUBKEY_MAX_BASE64_LEN: usize = 44;
 pub(crate) const DECRYPT_HANDLE_LEN: usize = RISTRETTO_POINT_LEN;
 
 /// Byte length of an ElGamal ciphertext
-const ELGAMAL_CIPHERTEXT_LEN: usize = PEDERSEN_COMMITMENT_LEN + DECRYPT_HANDLE_LEN;
+pub(crate) const ELGAMAL_CIPHERTEXT_LEN: usize = PEDERSEN_COMMITMENT_LEN + DECRYPT_HANDLE_LEN;
 
 /// Maximum length of a base64 encoded ElGamal ciphertext
 const ELGAMAL_CIPHERTEXT_MAX_BASE64_LEN: usize = 88;

--- a/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
@@ -1,12 +1,15 @@
 //! Plain Old Data types for the Grouped ElGamal encryption scheme.
 
 #[cfg(not(target_os = "solana"))]
-use crate::{encryption::grouped_elgamal::GroupedElGamalCiphertext, errors::ElGamalError};
+use crate::encryption::grouped_elgamal::GroupedElGamalCiphertext;
 use {
-    crate::zk_token_elgamal::pod::{
-        elgamal::{ElGamalCiphertext, DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN},
-        pedersen::{PedersenCommitment, PEDERSEN_COMMITMENT_LEN},
-        Pod, Zeroable,
+    crate::{
+        errors::ElGamalError,
+        zk_token_elgamal::pod::{
+            elgamal::{ElGamalCiphertext, DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN},
+            pedersen::{PedersenCommitment, PEDERSEN_COMMITMENT_LEN},
+            Pod, Zeroable,
+        },
     },
     std::fmt,
 };

--- a/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
@@ -89,6 +89,8 @@ impl TryFrom<GroupedElGamalCiphertext2Handles> for GroupedElGamalCiphertext<2> {
     }
 }
 
+impl_extract!(TYPE = GroupedElGamalCiphertext2Handles);
+
 /// The `GroupedElGamalCiphertext` type with three decryption handles as a `Pod`
 #[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
 #[repr(transparent)]

--- a/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
@@ -11,6 +11,44 @@ use {
     std::fmt,
 };
 
+macro_rules! impl_extract {
+    (TYPE = $type:ident) => {
+        impl $type {
+            /// Extract the commitment component from a grouped ciphertext
+            pub fn extract_commitment(&self) -> PedersenCommitment {
+                // `GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES` guaranteed to be at least `PEDERSEN_COMMITMENT_LEN`
+                let commitment = self.0[..PEDERSEN_COMMITMENT_LEN].try_into().unwrap();
+                PedersenCommitment(commitment)
+            }
+
+            /// Extract a regular ElGamal ciphertext using the decrypt handle at a specified index.
+            pub fn try_extract_ciphertext(
+                &self,
+                index: usize,
+            ) -> Result<ElGamalCiphertext, ElGamalError> {
+                let mut ciphertext_bytes = [0u8; ELGAMAL_CIPHERTEXT_LEN];
+                ciphertext_bytes[..PEDERSEN_COMMITMENT_LEN]
+                    .copy_from_slice(&self.0[..PEDERSEN_COMMITMENT_LEN]);
+
+                let handle_start = DECRYPT_HANDLE_LEN
+                    .checked_mul(index)
+                    .and_then(|n| n.checked_add(PEDERSEN_COMMITMENT_LEN))
+                    .ok_or(ElGamalError::CiphertextDeserialization)?;
+                let handle_end = handle_start
+                    .checked_add(DECRYPT_HANDLE_LEN)
+                    .ok_or(ElGamalError::CiphertextDeserialization)?;
+                ciphertext_bytes[PEDERSEN_COMMITMENT_LEN..].copy_from_slice(
+                    self.0
+                        .get(handle_start..handle_end)
+                        .ok_or(ElGamalError::CiphertextDeserialization)?,
+                );
+
+                Ok(ElGamalCiphertext(ciphertext_bytes))
+            }
+        }
+    };
+}
+
 /// Byte length of a grouped ElGamal ciphertext with 2 handles
 const GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES: usize =
     PEDERSEN_COMMITMENT_LEN + DECRYPT_HANDLE_LEN + DECRYPT_HANDLE_LEN;
@@ -84,33 +122,4 @@ impl TryFrom<GroupedElGamalCiphertext3Handles> for GroupedElGamalCiphertext<3> {
     }
 }
 
-impl GroupedElGamalCiphertext3Handles {
-    /// Extract the commitment component from a grouped ciphertext
-    pub fn extract_commitment(&self) -> PedersenCommitment {
-        // `GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES` guaranteed to be at least `PEDERSEN_COMMITMENT_LEN`
-        let commitment = self.0[..PEDERSEN_COMMITMENT_LEN].try_into().unwrap();
-        PedersenCommitment(commitment)
-    }
-
-    /// Extract a regular ElGamal ciphertext using the decrypt handle at a specified index.
-    pub fn try_extract_ciphertext(&self, index: usize) -> Result<ElGamalCiphertext, ElGamalError> {
-        let mut ciphertext_bytes = [0u8; ELGAMAL_CIPHERTEXT_LEN];
-        ciphertext_bytes[..PEDERSEN_COMMITMENT_LEN]
-            .copy_from_slice(&self.0[..PEDERSEN_COMMITMENT_LEN]);
-
-        let handle_start = DECRYPT_HANDLE_LEN
-            .checked_mul(index)
-            .and_then(|n| n.checked_add(PEDERSEN_COMMITMENT_LEN))
-            .ok_or(ElGamalError::CiphertextDeserialization)?;
-        let handle_end = handle_start
-            .checked_add(DECRYPT_HANDLE_LEN)
-            .ok_or(ElGamalError::CiphertextDeserialization)?;
-        ciphertext_bytes[PEDERSEN_COMMITMENT_LEN..].copy_from_slice(
-            self.0
-                .get(handle_start..handle_end)
-                .ok_or(ElGamalError::CiphertextDeserialization)?,
-        );
-
-        Ok(ElGamalCiphertext(ciphertext_bytes))
-    }
-}
+impl_extract!(TYPE = GroupedElGamalCiphertext3Handles);


### PR DESCRIPTION
#### Problem
Extracting Pedersen commitments or specific ElGamal ciphertexts from a grouped ElGamal ciphertext is a useful and common operation. However, we do not have an easy function for applications to call for this logic. For example, in the SPL token-2022 program, this logic is hardcoded in.

#### Summary of Changes
Add functions to extract Pedersen commitments and specific ElGamal ciphertexts in the zk-token-sdk.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
