### PR TITLE
[zk-token-sdk] Refactor `AuthenticatedEncryptionError` and `ElGamalError` to errors module

### DIFF
--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -2,16 +2,8 @@
 //!
 //! This module is a simple wrapper of the `Aes128GcmSiv` implementation specialized for SPL
 //! token-2022 where the plaintext is always `u64`.
-#[cfg(not(target_os = "solana"))]
 use {
-    aes_gcm_siv::{
-        aead::{Aead, NewAead},
-        Aes128GcmSiv,
-    },
-    rand::{rngs::OsRng, Rng},
-    thiserror::Error,
-};
-use {
+    crate::errors::AuthenticatedEncryptionError,
     base64::{prelude::BASE64_STANDARD, Engine},
     sha3::{Digest, Sha3_512},
     solana_sdk::{
@@ -30,6 +22,14 @@ use {
     subtle::ConstantTimeEq,
     zeroize::Zeroize,
 };
+#[cfg(not(target_os = "solana"))]
+use {
+    aes_gcm_siv::{
+        aead::{Aead, NewAead},
+        Aes128GcmSiv,
+    },
+    rand::{rngs::OsRng, Rng},
+};
 
 /// Byte length of an authenticated encryption secret key
 pub const AE_KEY_LEN: usize = 16;
@@ -43,18 +43,6 @@ const CIPHERTEXT_LEN: usize = 24;
 /// Byte length of a complete authenticated encryption ciphertext component that includes the
 /// ciphertext and nonce components
 const AE_CIPHERTEXT_LEN: usize = 36;
-
-#[derive(Error, Clone, Debug, Eq, PartialEq)]
-pub enum AuthenticatedEncryptionError {
-    #[error("key derivation method not supported")]
-    DerivationMethodNotSupported,
-    #[error("seed length too short for derivation")]
-    SeedLengthTooShort,
-    #[error("seed length too long for derivation")]
-    SeedLengthTooLong,
-    #[error("failed to deserialize")]
-    Deserialization,
-}
 
 struct AuthenticatedEncryption;
 impl AuthenticatedEncryption {

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -21,6 +21,7 @@ use {
                 Pedersen, PedersenCommitment, PedersenOpening, G, H, PEDERSEN_COMMITMENT_LEN,
             },
         },
+        errors::ElGamalError,
         RISTRETTO_POINT_LEN, SCALAR_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
@@ -41,7 +42,6 @@ use {
     },
     std::convert::TryInto,
     subtle::{Choice, ConstantTimeEq},
-    thiserror::Error,
     zeroize::Zeroize,
 };
 #[cfg(not(target_os = "solana"))]
@@ -69,24 +69,6 @@ const ELGAMAL_SECRET_KEY_LEN: usize = SCALAR_LEN;
 
 /// Byte length of an ElGamal keypair
 pub const ELGAMAL_KEYPAIR_LEN: usize = ELGAMAL_PUBKEY_LEN + ELGAMAL_SECRET_KEY_LEN;
-
-#[derive(Error, Clone, Debug, Eq, PartialEq)]
-pub enum ElGamalError {
-    #[error("key derivation method not supported")]
-    DerivationMethodNotSupported,
-    #[error("seed length too short for derivation")]
-    SeedLengthTooShort,
-    #[error("seed length too long for derivation")]
-    SeedLengthTooLong,
-    #[error("failed to deserialize ciphertext")]
-    CiphertextDeserialization,
-    #[error("failed to deserialize public key")]
-    PubkeyDeserialization,
-    #[error("failed to deserialize keypair")]
-    KeypairDeserialization,
-    #[error("failed to deserialize secret key")]
-    SecretKeyDeserialization,
-}
 
 /// Algorithm handle for the twisted ElGamal encryption scheme
 pub struct ElGamal;

--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -1,4 +1,5 @@
 //! Errors related to proving and verifying proofs.
+#[cfg(not(target_os = "solana"))]
 use {
     crate::{
         encryption::elgamal::ElGamalError,
@@ -8,6 +9,7 @@ use {
     thiserror::Error,
 };
 
+#[cfg(not(target_os = "solana"))]
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ProofGenerationError {
     #[error("not enough funds in account")]
@@ -26,6 +28,7 @@ pub enum ProofGenerationError {
     ProofLength,
 }
 
+#[cfg(not(target_os = "solana"))]
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ProofVerificationError {
     #[error("range proof verification failed")]
@@ -51,35 +54,42 @@ pub enum SigmaProofType {
     PubkeyValidityProof,
 }
 
+#[cfg(not(target_os = "solana"))]
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum TranscriptError {
     #[error("point is the identity")]
     ValidationError,
 }
 
+#[cfg(not(target_os = "solana"))]
 impl From<EqualityProofVerificationError> for ProofVerificationError {
     fn from(err: EqualityProofVerificationError) -> Self {
         Self::SigmaProof(SigmaProofType::EqualityProof, err.0)
     }
 }
 
+#[cfg(not(target_os = "solana"))]
 impl From<FeeSigmaProofVerificationError> for ProofVerificationError {
     fn from(err: FeeSigmaProofVerificationError) -> Self {
         Self::SigmaProof(SigmaProofType::FeeSigmaProof, err.0)
     }
 }
 
+#[cfg(not(target_os = "solana"))]
 impl From<ZeroBalanceProofVerificationError> for ProofVerificationError {
     fn from(err: ZeroBalanceProofVerificationError) -> Self {
         Self::SigmaProof(SigmaProofType::ZeroBalanceProof, err.0)
     }
 }
+
+#[cfg(not(target_os = "solana"))]
 impl From<ValidityProofVerificationError> for ProofVerificationError {
     fn from(err: ValidityProofVerificationError) -> Self {
         Self::SigmaProof(SigmaProofType::ValidityProof, err.0)
     }
 }
 
+#[cfg(not(target_os = "solana"))]
 impl From<PubkeyValidityProofVerificationError> for ProofVerificationError {
     fn from(err: PubkeyValidityProofVerificationError) -> Self {
         Self::SigmaProof(SigmaProofType::PubkeyValidityProof, err.0)

--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -1,13 +1,23 @@
 //! Errors related to proving and verifying proofs.
 #[cfg(not(target_os = "solana"))]
-use {
-    crate::{
-        encryption::elgamal::ElGamalError,
-        range_proof::errors::{RangeProofGenerationError, RangeProofVerificationError},
-        sigma_proofs::errors::*,
-    },
-    thiserror::Error,
+use crate::{
+    encryption::elgamal::ElGamalError,
+    range_proof::errors::{RangeProofGenerationError, RangeProofVerificationError},
+    sigma_proofs::errors::*,
 };
+use thiserror::Error;
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum AuthenticatedEncryptionError {
+    #[error("key derivation method not supported")]
+    DerivationMethodNotSupported,
+    #[error("seed length too short for derivation")]
+    SeedLengthTooShort,
+    #[error("seed length too long for derivation")]
+    SeedLengthTooLong,
+    #[error("failed to deserialize")]
+    Deserialization,
+}
 
 #[cfg(not(target_os = "solana"))]
 #[derive(Error, Clone, Debug, Eq, PartialEq)]

--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -1,7 +1,6 @@
 //! Errors related to proving and verifying proofs.
 #[cfg(not(target_os = "solana"))]
 use crate::{
-    encryption::elgamal::ElGamalError,
     range_proof::errors::{RangeProofGenerationError, RangeProofVerificationError},
     sigma_proofs::errors::*,
 };
@@ -17,6 +16,24 @@ pub enum AuthenticatedEncryptionError {
     SeedLengthTooLong,
     #[error("failed to deserialize")]
     Deserialization,
+}
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum ElGamalError {
+    #[error("key derivation method not supported")]
+    DerivationMethodNotSupported,
+    #[error("seed length too short for derivation")]
+    SeedLengthTooShort,
+    #[error("seed length too long for derivation")]
+    SeedLengthTooLong,
+    #[error("failed to deserialize ciphertext")]
+    CiphertextDeserialization,
+    #[error("failed to deserialize public key")]
+    PubkeyDeserialization,
+    #[error("failed to deserialize keypair")]
+    KeypairDeserialization,
+    #[error("failed to deserialize secret key")]
+    SecretKeyDeserialization,
 }
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -23,16 +23,14 @@ pub(crate) mod macros;
 #[cfg(not(target_os = "solana"))]
 pub mod encryption;
 #[cfg(not(target_os = "solana"))]
-pub mod errors;
-#[cfg(not(target_os = "solana"))]
 mod range_proof;
 #[cfg(not(target_os = "solana"))]
 mod sigma_proofs;
 #[cfg(not(target_os = "solana"))]
 mod transcript;
 
-// TODO: re-organize visibility
 pub mod curve25519;
+pub mod errors;
 pub mod instruction;
 pub mod zk_token_elgamal;
 pub mod zk_token_proof_instruction;

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -49,7 +49,7 @@ impl From<PodRistrettoPoint> for pod::DecryptHandle {
 mod target_arch {
     use {
         super::pod,
-        crate::{curve25519::scalar::PodScalar, encryption::elgamal::ElGamalError},
+        crate::{curve25519::scalar::PodScalar, errors::ElGamalError},
         curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
         std::convert::TryFrom,
     };

--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -1,7 +1,7 @@
 //! Plain Old Data types for the AES128-GCM-SIV authenticated encryption scheme.
 
 #[cfg(not(target_os = "solana"))]
-use crate::encryption::auth_encryption::{self as decoded, AuthenticatedEncryptionError};
+use crate::{encryption::auth_encryption as decoded, errors::AuthenticatedEncryptionError};
 use {
     crate::zk_token_elgamal::pod::{impl_from_str, Pod, Zeroable},
     base64::{prelude::BASE64_STANDARD, Engine},

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -2,7 +2,10 @@
 
 #[cfg(not(target_os = "solana"))]
 use {
-    crate::encryption::elgamal::{self as decoded, ElGamalError},
+    crate::{
+        encryption::elgamal::{self as decoded},
+        errors::ElGamalError,
+    },
     curve25519_dalek::ristretto::CompressedRistretto,
 };
 use {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
@@ -1,7 +1,7 @@
 //! Plain Old Data types for the Grouped ElGamal encryption scheme.
 
 #[cfg(not(target_os = "solana"))]
-use crate::encryption::{elgamal::ElGamalError, grouped_elgamal::GroupedElGamalCiphertext};
+use crate::{encryption::grouped_elgamal::GroupedElGamalCiphertext, errors::ElGamalError};
 use {
     crate::zk_token_elgamal::pod::{
         elgamal::DECRYPT_HANDLE_LEN, pedersen::PEDERSEN_COMMITMENT_LEN, Pod, Zeroable,

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -3,7 +3,7 @@ use crate::zk_token_elgamal::pod::{
     Zeroable,
 };
 #[cfg(not(target_os = "solana"))]
-use crate::{encryption::elgamal::ElGamalError, instruction::transfer as decoded};
+use crate::{errors::ElGamalError, instruction::transfer as decoded};
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]

--- a/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
@@ -2,7 +2,7 @@
 
 #[cfg(not(target_os = "solana"))]
 use {
-    crate::encryption::{elgamal::ElGamalError, pedersen as decoded},
+    crate::{encryption::pedersen as decoded, errors::ElGamalError},
     curve25519_dalek::ristretto::CompressedRistretto,
 };
 use {


### PR DESCRIPTION
#### Problem
Currently, error types `AuthenticatedEncryptionError` and `ElGamalError` lives in the `encryption` module, which is excluded from sbf target. However, it would be nice to use these types to handle errors in the `zk_token_elgamal` module as well (e.g. https://github.com/anza-xyz/agave/pull/588), which should be included for sbf target.

#### Summary of Changes
Refactor these error types into the `errors` module so that both `encryption` and `zk_token_elgamal` submodules can access it.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
