### PR TITLE
Runtime: Core BPF Migration: Wire migration into feature transitions

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -39,7 +39,7 @@ pub use solana_sdk::reward_type::RewardType;
 use {
     crate::{
         bank::{
-            builtins::{BuiltinPrototype, BUILTINS},
+            builtins::{BuiltinPrototype, BUILTINS, STATELESS_BUILTINS},
             metrics::*,
             partitioned_epoch_rewards::{
                 EpochRewardCalculateParamInfo, EpochRewardStatus, StakeRewards, VoteRewardsAccounts,
@@ -5182,7 +5182,17 @@ impl Bank {
                 .iter()
                 .chain(additional_builtins.unwrap_or(&[]).iter())
             {
-                if builtin.enable_feature_id.is_none() {
+                // The builtin should be added if it has no enable feature ID
+                // and it has not been migrated to Core BPF.
+                //
+                // If a program was previously migrated to Core BPF, accountsDB
+                // from snapshot should contain the BPF program accounts.
+                let builtin_is_bpf = |program_id: &Pubkey| {
+                    self.get_account(program_id)
+                        .map(|a| a.owner() == &bpf_loader_upgradeable::id())
+                        .unwrap_or(false)
+                };
+                if builtin.enable_feature_id.is_none() && !builtin_is_bpf(&builtin.program_id) {
                     self.transaction_processor.add_builtin(
                         self,
                         builtin.program_id,
@@ -6540,14 +6550,58 @@ impl Bank {
         new_feature_activations: &HashSet<Pubkey>,
     ) {
         for builtin in BUILTINS.iter() {
+            // The `builtin_is_bpf` flag is used to handle the case where a
+            // builtin is scheduled to be enabled by one feature gate and
+            // later migrated to Core BPF by another.
+            //
+            // There should never be a case where a builtin is set to be
+            // migrated to Core BPF and is also set to be enabled on feature
+            // activation on the same feature gate. However, the
+            // `builtin_is_bpf` flag will handle this case as well, electing
+            // to first attempt the migration to Core BPF.
+            //
+            // The migration to Core BPF will fail gracefully because the
+            // program account will not exist. The builtin will subsequently
+            // be enabled, but it will never be migrated to Core BPF.
+            //
+            // Using the same feature gate for both enabling and migrating a
+            // builtin to Core BPF should be strictly avoided.
+            let mut builtin_is_bpf = false;
+            if let Some(core_bpf_migration_config) = &builtin.core_bpf_migration_config {
+                // If the builtin is set to be migrated to Core BPF on feature
+                // activation, perform the migration and do not add the program
+                // to the bank's builtins. The migration will remove it from
+                // the builtins list and the cache.
+                if new_feature_activations.contains(&core_bpf_migration_config.feature_id) {
+                    if let Err(e) = self
+                        .migrate_builtin_to_core_bpf(&builtin.program_id, core_bpf_migration_config)
+                    {
+                        warn!(
+                            "Failed to migrate builtin {} to Core BPF: {}",
+                            builtin.name, e
+                        );
+                    } else {
+                        builtin_is_bpf = true;
+                    }
+                } else {
+                    // If the builtin has already been migrated to Core BPF, do not
+                    // add it to the bank's builtins.
+                    builtin_is_bpf = self
+                        .get_account(&builtin.program_id)
+                        .map(|a| a.owner() == &bpf_loader_upgradeable::id())
+                        .unwrap_or(false);
+                }
+            };
+
             if let Some(feature_id) = builtin.enable_feature_id {
-                let should_apply_action_for_feature_transition =
-                    if only_apply_transitions_for_new_features {
+                let should_enable_builtin_on_feature_transition = !builtin_is_bpf
+                    && if only_apply_transitions_for_new_features {
                         new_feature_activations.contains(&feature_id)
                     } else {
                         self.feature_set.is_active(&feature_id)
                     };
-                if should_apply_action_for_feature_transition {
+
+                if should_enable_builtin_on_feature_transition {
                     self.transaction_processor.add_builtin(
                         self,
                         builtin.program_id,
@@ -6561,6 +6615,26 @@ impl Bank {
                 }
             }
         }
+
+        // Migrate any necessary stateless builtins to core BPF.
+        // Stateless builtins do not have an `enable_feature_id` since they
+        // do not exist on-chain.
+        for stateless_builtin in STATELESS_BUILTINS.iter() {
+            if let Some(core_bpf_migration_config) = &stateless_builtin.core_bpf_migration_config {
+                if new_feature_activations.contains(&core_bpf_migration_config.feature_id) {
+                    if let Err(e) = self.migrate_builtin_to_core_bpf(
+                        &stateless_builtin.program_id,
+                        core_bpf_migration_config,
+                    ) {
+                        warn!(
+                            "Failed to migrate stateless builtin {} to Core BPF: {}",
+                            stateless_builtin.name, e
+                        );
+                    }
+                }
+            }
+        }
+
         for precompile in get_precompiles() {
             let should_add_precompile = precompile
                 .feature

--- a/runtime/src/bank/builtin_programs.rs
+++ b/runtime/src/bank/builtin_programs.rs
@@ -62,3 +62,458 @@ mod tests {
         bank.finish_init(&genesis_config, None, false);
     }
 }
+
+#[cfg(test)]
+mod tests_core_bpf_migration {
+    use {
+        crate::bank::{
+            builtins::{
+                core_bpf_migration::{tests::TestContext, CoreBpfMigrationConfig},
+                BuiltinPrototype, StatelessBuiltinPrototype, BUILTINS, STATELESS_BUILTINS,
+            },
+            test_utils::goto_end_of_slot,
+            tests::{create_genesis_config, new_bank_from_parent_with_bank_forks},
+            Bank,
+        },
+        solana_sdk::{
+            account::{AccountSharedData, ReadableAccount, WritableAccount},
+            bpf_loader_upgradeable::{self, get_program_data_address, UpgradeableLoaderState},
+            feature::{self, Feature},
+            feature_set::FeatureSet,
+            instruction::Instruction,
+            message::Message,
+            native_loader,
+            native_token::LAMPORTS_PER_SOL,
+            pubkey::Pubkey,
+            signature::Signer,
+            transaction::Transaction,
+        },
+        std::sync::Arc,
+        test_case::test_case,
+    };
+
+    const TEST_ELF: &[u8] =
+        include_bytes!("../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
+
+    enum TestPrototype<'a> {
+        Builtin(&'a BuiltinPrototype),
+        Stateless(&'a StatelessBuiltinPrototype),
+    }
+    impl<'a> TestPrototype<'a> {
+        fn deconstruct(&'a self) -> (&'a Pubkey, &'a CoreBpfMigrationConfig) {
+            match self {
+                Self::Builtin(prototype) => (
+                    &prototype.program_id,
+                    prototype.core_bpf_migration_config.as_ref().unwrap(),
+                ),
+                Self::Stateless(prototype) => (
+                    &prototype.program_id,
+                    prototype.core_bpf_migration_config.as_ref().unwrap(),
+                ),
+            }
+        }
+    }
+
+    // This test can't be used to the `compute_budget` program, unless a valid
+    // `compute_budget` program is provided as the replacement (source).
+    // See program_runtime::compute_budget_processor::process_compute_budget_instructions`.`
+    // It also can't test the `bpf_loader_upgradeable` program, as it's used in
+    // the SVM's loader to invoke programs.
+    // See `solana_svm::account_loader::load_transaction_accounts`.
+    #[test_case(TestPrototype::Builtin(&BUILTINS[0]); "system")]
+    #[test_case(TestPrototype::Builtin(&BUILTINS[1]); "vote")]
+    #[test_case(TestPrototype::Builtin(&BUILTINS[2]); "stake")]
+    #[test_case(TestPrototype::Builtin(&BUILTINS[3]); "config")]
+    #[test_case(TestPrototype::Builtin(&BUILTINS[4]); "bpf_loader_deprecated")]
+    #[test_case(TestPrototype::Builtin(&BUILTINS[5]); "bpf_loader")]
+    #[test_case(TestPrototype::Builtin(&BUILTINS[8]); "address_lookup_table")]
+    #[test_case(TestPrototype::Stateless(&STATELESS_BUILTINS[0]); "feature_gate")]
+    fn test_core_bpf_migration(prototype: TestPrototype) {
+        let (genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let mut root_bank = Bank::new_for_tests(&genesis_config);
+
+        let (builtin_id, config) = prototype.deconstruct();
+        let feature_id = &config.feature_id;
+        let source_buffer_address = &config.source_buffer_address;
+        let upgrade_authority_address = Some(Pubkey::new_unique());
+
+        // Add the feature to the bank's inactive feature set.
+        let mut feature_set = FeatureSet::all_enabled();
+        feature_set.inactive.insert(*feature_id);
+        root_bank.feature_set = Arc::new(feature_set);
+
+        // Initialize the source buffer account.
+        let test_context = TestContext::new(
+            &root_bank,
+            builtin_id,
+            source_buffer_address,
+            upgrade_authority_address,
+        );
+
+        let (bank, bank_forks) = root_bank.wrap_with_bank_forks_for_tests();
+
+        // Advance to the next epoch without activating the feature.
+        let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
+
+        // Assert the feature was not activated and the program was not
+        // migrated.
+        assert!(!bank.feature_set.is_active(feature_id));
+        assert!(bank.get_account(source_buffer_address).is_some());
+
+        // Store the account to activate the feature.
+        bank.store_account_and_update_capitalization(
+            feature_id,
+            &feature::create_account(&Feature::default(), 42),
+        );
+
+        // Advance the bank to cross the epoch boundary and activate the
+        // feature.
+        goto_end_of_slot(bank.clone());
+        let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 96);
+
+        // Run the post-migration program checks.
+        assert!(bank.feature_set.is_active(feature_id));
+        test_context.run_program_checks_post_migration(&bank, 96);
+
+        // Advance one slot so that the new BPF builtin program becomes
+        // effective in the program cache.
+        goto_end_of_slot(bank.clone());
+        let next_slot = bank.slot() + 1;
+        let bank =
+            new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), next_slot);
+
+        // Successfully invoke the new BPF builtin program.
+        bank.process_transaction(&Transaction::new(
+            &vec![&mint_keypair],
+            Message::new(
+                &[Instruction::new_with_bytes(*builtin_id, &[], Vec::new())],
+                Some(&mint_keypair.pubkey()),
+            ),
+            bank.last_blockhash(),
+        ))
+        .unwrap();
+
+        // Simulate crossing another epoch boundary for a new bank.
+        goto_end_of_slot(bank.clone());
+        let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 224);
+
+        // Run the post-migration program checks again.
+        assert!(bank.feature_set.is_active(feature_id));
+        test_context.run_program_checks_post_migration(&bank, 96);
+
+        // Again, successfully invoke the new BPF builtin program.
+        bank.process_transaction(&Transaction::new(
+            &vec![&mint_keypair],
+            Message::new(
+                &[Instruction::new_with_bytes(*builtin_id, &[], Vec::new())],
+                Some(&mint_keypair.pubkey()),
+            ),
+            bank.last_blockhash(),
+        ))
+        .unwrap();
+    }
+
+    // Simulate a failure to migrate the program.
+    // Here we want to see that the bank handles the failure gracefully and
+    // advances to the next epoch without issue.
+    #[test]
+    fn test_core_bpf_migration_failure() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(0);
+        let mut root_bank = Bank::new_for_tests(&genesis_config);
+
+        let test_prototype = TestPrototype::Builtin(&BUILTINS[0]); // System program
+        let (builtin_id, config) = test_prototype.deconstruct();
+        let feature_id = &config.feature_id;
+        let source_buffer_address = &config.source_buffer_address;
+        let upgrade_authority_address = Some(Pubkey::new_unique());
+
+        // Add the feature to the bank's inactive feature set.
+        let mut feature_set = FeatureSet::all_enabled();
+        feature_set.inactive.insert(*feature_id);
+        root_bank.feature_set = Arc::new(feature_set);
+
+        // Initialize the source buffer account.
+        let _test_context = TestContext::new(
+            &root_bank,
+            builtin_id,
+            source_buffer_address,
+            upgrade_authority_address,
+        );
+
+        let (bank, bank_forks) = root_bank.wrap_with_bank_forks_for_tests();
+
+        // Intentionally nuke the source buffer account to force the migration
+        // to fail.
+        bank.store_account_and_update_capitalization(
+            source_buffer_address,
+            &AccountSharedData::default(),
+        );
+
+        // Activate the feature.
+        bank.store_account_and_update_capitalization(
+            feature_id,
+            &feature::create_account(&Feature::default(), 42),
+        );
+
+        // Advance the bank to cross the epoch boundary and activate the
+        // feature.
+        goto_end_of_slot(bank.clone());
+        let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
+
+        // Assert the feature _was_ activated but the program was not migrated.
+        assert!(bank.feature_set.is_active(feature_id));
+        assert!(bank
+            .transaction_processor
+            .builtin_program_ids
+            .read()
+            .unwrap()
+            .contains(builtin_id));
+        assert_eq!(
+            bank.get_account(builtin_id).unwrap().owner(),
+            &native_loader::id()
+        );
+
+        // Simulate crossing an epoch boundary again.
+        goto_end_of_slot(bank.clone());
+        let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 96);
+
+        // Again, assert the feature is still active and the program still was
+        // not migrated.
+        assert!(bank.feature_set.is_active(feature_id));
+        assert!(bank
+            .transaction_processor
+            .builtin_program_ids
+            .read()
+            .unwrap()
+            .contains(builtin_id));
+        assert_eq!(
+            bank.get_account(builtin_id).unwrap().owner(),
+            &native_loader::id()
+        );
+    }
+
+    // Simulate creating a bank from a snapshot after a migration feature was
+    // activated, but the migration failed.
+    // Here we want to see that the bank recognizes the failed migration and
+    // adds the original builtin to the new bank.
+    #[test]
+    fn test_core_bpf_migration_init_after_failed_migration() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(0);
+
+        let test_prototype = TestPrototype::Builtin(&BUILTINS[0]); // System program
+        let (builtin_id, config) = test_prototype.deconstruct();
+        let feature_id = &config.feature_id;
+
+        // Since the test feature IDs aren't included in the SDK, the only way
+        // to simulate loading from snapshot with this feature active is to
+        // create a bank, overwrite the feature set with the feature active,
+        // then re-run the `finish_init` method.
+        let mut bank = Bank::new_for_tests(&genesis_config);
+
+        // Set up the feature set with the migration feature marked as active.
+        let mut feature_set = FeatureSet::all_enabled();
+        feature_set.active.insert(*feature_id, 0);
+        bank.feature_set = Arc::new(feature_set);
+        bank.store_account_and_update_capitalization(
+            feature_id,
+            &feature::create_account(
+                &Feature {
+                    activated_at: Some(0),
+                },
+                42,
+            ),
+        );
+
+        // Run `finish_init` to simulate starting up from a snapshot.
+        // Clear all builtins to simulate a fresh bank init.
+        bank.transaction_processor
+            .program_cache
+            .write()
+            .unwrap()
+            .remove_programs(
+                bank.transaction_processor
+                    .builtin_program_ids
+                    .read()
+                    .unwrap()
+                    .clone()
+                    .into_iter(),
+            );
+        bank.transaction_processor
+            .builtin_program_ids
+            .write()
+            .unwrap()
+            .clear();
+        bank.finish_init(&genesis_config, None, false);
+
+        // Assert the feature is active and the bank still added the builtin.
+        assert!(bank.feature_set.is_active(feature_id));
+        assert!(bank
+            .transaction_processor
+            .builtin_program_ids
+            .read()
+            .unwrap()
+            .contains(builtin_id));
+        assert_eq!(
+            bank.get_account(builtin_id).unwrap().owner(),
+            &native_loader::id()
+        );
+
+        // Simulate crossing an epoch boundary for a new bank.
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        goto_end_of_slot(bank.clone());
+        let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
+
+        // Assert the feature is active but the builtin was not migrated.
+        assert!(bank.feature_set.is_active(feature_id));
+        assert!(bank
+            .transaction_processor
+            .builtin_program_ids
+            .read()
+            .unwrap()
+            .contains(builtin_id));
+        assert_eq!(
+            bank.get_account(builtin_id).unwrap().owner(),
+            &native_loader::id()
+        );
+    }
+
+    // Simulate creating a bank from a snapshot after a migration feature was
+    // activated and the migration was successful.
+    // Here we want to see that the bank recognizes the migration and
+    // _does not_ add the original builtin to the new bank.
+    #[test]
+    fn test_core_bpf_migration_init_after_successful_migration() {
+        let (mut genesis_config, _mint_keypair) = create_genesis_config(0);
+
+        let test_prototype = TestPrototype::Builtin(&BUILTINS[0]); // System program
+        let (builtin_id, config) = test_prototype.deconstruct();
+        let feature_id = &config.feature_id;
+
+        let upgrade_authority_address = Some(Pubkey::new_unique());
+        let elf = TEST_ELF;
+        let program_data_metadata_size = UpgradeableLoaderState::size_of_programdata_metadata();
+        let program_data_size = program_data_metadata_size + elf.len();
+
+        // Set up a post-migration builtin.
+        let builtin_program_data_address = get_program_data_address(builtin_id);
+        let builtin_program_account = AccountSharedData::new_data(
+            100_000,
+            &UpgradeableLoaderState::Program {
+                programdata_address: builtin_program_data_address,
+            },
+            &bpf_loader_upgradeable::id(),
+        )
+        .unwrap();
+        let mut builtin_program_data_account = AccountSharedData::new_data_with_space(
+            100_000,
+            &UpgradeableLoaderState::ProgramData {
+                slot: 0,
+                upgrade_authority_address,
+            },
+            program_data_size,
+            &bpf_loader_upgradeable::id(),
+        )
+        .unwrap();
+        builtin_program_data_account.data_as_mut_slice()[program_data_metadata_size..]
+            .copy_from_slice(elf);
+        genesis_config
+            .accounts
+            .insert(*builtin_id, builtin_program_account.into());
+        genesis_config.accounts.insert(
+            builtin_program_data_address,
+            builtin_program_data_account.into(),
+        );
+
+        // Use this closure to run checks on the builtin.
+        let check_builtin_is_bpf = |bank: &Bank| {
+            // The bank's transaction processor should not contain the builtin
+            // in its list of builtin program IDs.
+            assert!(!bank
+                .transaction_processor
+                .builtin_program_ids
+                .read()
+                .unwrap()
+                .contains(builtin_id));
+            // The builtin should be owned by the upgradeable loader and have
+            // the correct state.
+            let fetched_builtin_program_account = bank.get_account(builtin_id).unwrap();
+            assert_eq!(
+                fetched_builtin_program_account.owner(),
+                &bpf_loader_upgradeable::id()
+            );
+            assert_eq!(
+                bincode::deserialize::<UpgradeableLoaderState>(
+                    fetched_builtin_program_account.data()
+                )
+                .unwrap(),
+                UpgradeableLoaderState::Program {
+                    programdata_address: builtin_program_data_address
+                }
+            );
+            // The builtin's program data should be owned by the upgradeable
+            // loader and have the correct state.
+            let fetched_builtin_program_data_account =
+                bank.get_account(&builtin_program_data_address).unwrap();
+            assert_eq!(
+                fetched_builtin_program_data_account.owner(),
+                &bpf_loader_upgradeable::id()
+            );
+            assert_eq!(
+                bincode::deserialize::<UpgradeableLoaderState>(
+                    &fetched_builtin_program_data_account.data()[..program_data_metadata_size]
+                )
+                .unwrap(),
+                UpgradeableLoaderState::ProgramData {
+                    slot: 0,
+                    upgrade_authority_address
+                }
+            );
+            assert_eq!(
+                &fetched_builtin_program_data_account.data()[program_data_metadata_size..],
+                elf,
+            );
+        };
+
+        // Create a new bank.
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        check_builtin_is_bpf(&bank);
+
+        // Now, add the feature ID as active, and run `finish_init` again to
+        // make sure the feature is idempotent.
+        let mut feature_set = FeatureSet::all_enabled();
+        feature_set.active.insert(*feature_id, 0);
+        bank.feature_set = Arc::new(feature_set);
+        bank.store_account_and_update_capitalization(
+            feature_id,
+            &feature::create_account(
+                &Feature {
+                    activated_at: Some(0),
+                },
+                42,
+            ),
+        );
+
+        // Run `finish_init` to simulate starting up from a snapshot.
+        // Clear all builtins to simulate a fresh bank init.
+        bank.transaction_processor
+            .program_cache
+            .write()
+            .unwrap()
+            .remove_programs(
+                bank.transaction_processor
+                    .builtin_program_ids
+                    .read()
+                    .unwrap()
+                    .clone()
+                    .into_iter(),
+            );
+        bank.transaction_processor
+            .builtin_program_ids
+            .write()
+            .unwrap()
+            .clear();
+        bank.finish_init(&genesis_config, None, false);
+
+        check_builtin_is_bpf(&bank);
+    }
+}

--- a/runtime/src/bank/builtins/core_bpf_migration/error.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/error.rs
@@ -24,12 +24,6 @@ pub enum CoreBpfMigrationError {
     /// Program has a data account
     #[error("Data account exists for program {0:?}")]
     ProgramHasDataAccount(Pubkey),
-    /// Program has no data account
-    #[error("Data account does not exist for program {0:?}")]
-    ProgramHasNoDataAccount(Pubkey),
-    /// Invalid program account
-    #[error("Invalid program account: {0:?}")]
-    InvalidProgramAccount(Pubkey),
     /// Invalid buffer account
     #[error("Invalid buffer account: {0:?}")]
     InvalidBufferAccount(Pubkey),

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -299,11 +299,18 @@ pub(crate) mod tests {
             clock::Slot,
             native_loader,
         },
+        std::{fs::File, io::Read},
         test_case::test_case,
     };
 
-    const TEST_ELF: &[u8] =
-        include_bytes!("../../../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
+    fn test_elf() -> Vec<u8> {
+        let mut elf = Vec::new();
+        File::open("../programs/bpf_loader/test_elfs/out/noop_aligned.so")
+            .unwrap()
+            .read_to_end(&mut elf)
+            .unwrap();
+        elf
+    }
 
     pub(crate) struct TestContext {
         builtin_id: Pubkey,
@@ -320,7 +327,7 @@ pub(crate) mod tests {
             source_buffer_address: &Pubkey,
             upgrade_authority_address: Option<Pubkey>,
         ) -> Self {
-            let elf = TEST_ELF.to_vec();
+            let elf = test_elf();
 
             let source_buffer_account = {
                 // BPF Loader always writes ELF bytes after

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // Removed in later commit
 pub(crate) mod error;
 mod source_buffer;
 mod target_builtin;
@@ -27,6 +26,7 @@ use {
 /// Identifies the type of built-in program targeted for Core BPF migration.
 /// The type of target determines whether the program should have a program
 /// account or not, which is checked before migration.
+#[allow(dead_code)] // Remove after first migration is configured.
 #[derive(Debug, PartialEq)]
 pub(crate) enum CoreBpfMigrationTargetType {
     /// A standard (stateful) builtin program must have a program account.

--- a/runtime/src/bank/builtins/prototypes.rs
+++ b/runtime/src/bank/builtins/prototypes.rs
@@ -45,7 +45,6 @@ impl solana_frozen_abi::abi_example::AbiExample for BuiltinPrototype {
 /// features are activated.
 /// These are built-in programs that don't actually exist, but their address
 /// is reserved.
-#[allow(dead_code)] // Removed in later commit
 #[derive(Debug)]
 pub struct StatelessBuiltinPrototype {
     pub(crate) core_bpf_migration_config: Option<CoreBpfMigrationConfig>,


### PR DESCRIPTION
This is chunk 7/7 of the broken up PR #79.

#### Problem

Now that the full migration path is in place, it's time to wire it up to the
runtime's feature activation process.

The bank requires two main pieces of functionality:

- Migrate a builtin program to BPF on feature transition.
- Abstain from adding a builtin to a new `Bank` after it has been migrated.

#### Summary of Changes

Add logic to evaluate a `BuiltinPrototype` for a contained 
`Some(CoreBpfMigrationConfig)` and use that configuration to call into
`migrate_builtin_to_core_bpf` from `apply_builtin_program_feature_transitions` 
to migrate the program to Core BPF.

Add a check to `finish_init` to ensure a builtin is not added to the list if it 
was migrated to Core BPF.

Add some test coverage!