### PR TITLE
init timing crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7380,6 +7380,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-timing"
+version = "2.0.0"
+
+[[package]]
 name = "solana-tokens"
 version = "2.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ members = [
     "svm",
     "test-validator",
     "thin-client",
+    "timing",
     "tokens",
     "tpu-client",
     "transaction-dos",

--- a/timing/Cargo.toml
+++ b/timing/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "solana-timing"
+description = "Solana Timing"
+documentation = "https://docs.rs/solana-timing"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[lib]
+name = "solana_timing"
+
+[dependencies]

--- a/timing/src/lib.rs
+++ b/timing/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
#### Problem

The `solana-program-runtime` is one of the lowest-level libraries in the Agave
client, yet, many other crates depend directly on it for simple types, such as
`ComputeBudget`, `ExecuteTimings`, and `RuntimeConfig`.

#### Summary of Changes

Evict one of the most common types - `ExecuteTimings` - to a new crate:
`solana-timing`.