### PR TITLE
[zk-keygen] Remove deprecated functions

### DIFF
--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -17,7 +17,7 @@ edition = { workspace = true }
 
 [dependencies]
 bs58 = { workspace = true }
-clap = { version = "3.1.5", features = ["cargo", "derive", "deprecated"] }
+clap = { version = "3.1.5", features = ["cargo", "derive"] }
 dirs-next = { workspace = true }
 num_cpus = { workspace = true }
 solana-clap-v3-utils = { workspace = true }

--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -17,7 +17,7 @@ edition = { workspace = true }
 
 [dependencies]
 bs58 = { workspace = true }
-clap = { version = "3.1.5", features = ["cargo", "derive"] }
+clap = { version = "3.1.5", features = ["cargo", "derive", "deprecated"] }
 dirs-next = { workspace = true }
 num_cpus = { workspace = true }
 solana-clap-v3-utils = { workspace = true }

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, Arg, ArgMatches, Command},

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -158,9 +158,9 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             let key_type: KeyType = value_of(matches, "type").unwrap();
 
             let mut path = dirs_next::home_dir().expect("home directory");
-            let outfile = if matches.is_present("outfile") {
+            let outfile = if matches.try_contains_id("outfile")? {
                 matches.value_of("outfile")
-            } else if matches.is_present(NO_OUTFILE_ARG.name) {
+            } else if matches.try_contains_id(NO_OUTFILE_ARG.name)? {
                 None
             } else {
                 path.extend([".config", "solana", key_type.default_file_name()]);
@@ -181,7 +181,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             let (passphrase, passphrase_message) = acquire_passphrase_and_message(matches).unwrap();
             let seed = Seed::new(&mnemonic, &passphrase);
 
-            let silent = matches.is_present("silent");
+            let silent = matches.try_contains_id("silent")?;
 
             match key_type {
                 KeyType::ElGamal => {
@@ -230,7 +230,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             let key_type: KeyType = value_of(matches, "type").unwrap();
 
             let mut path = dirs_next::home_dir().expect("home directory");
-            let path = if matches.is_present("keypair") {
+            let path = if matches.try_contains_id("keypair")? {
                 matches.value_of("keypair").unwrap()
             } else {
                 path.extend([".config", "solana", key_type.default_file_name()]);
@@ -253,7 +253,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             let key_type: KeyType = value_of(matches, "type").unwrap();
 
             let mut path = dirs_next::home_dir().expect("home directory");
-            let outfile = if matches.is_present("outfile") {
+            let outfile = if matches.try_contains_id("outfile")? {
                 matches.value_of("outfile").unwrap()
             } else {
                 path.extend([".config", "solana", key_type.default_file_name()]);
@@ -271,7 +271,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                         elgamal_keypair_from_path(matches, path, name, true)?
                     } else {
                         let skip_validation =
-                            matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+                            matches.try_contains_id(SKIP_SEED_PHRASE_VALIDATION_ARG.name)?;
                         elgamal_keypair_from_seed_phrase(name, skip_validation, true, None, true)?
                     };
                     output_encodable_key(&keypair, outfile, "recovered ElGamal keypair")?;
@@ -281,7 +281,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                         ae_key_from_path(matches, path, name)?
                     } else {
                         let skip_validation =
-                            matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+                            matches.try_contains_id(SKIP_SEED_PHRASE_VALIDATION_ARG.name)?;
                         ae_key_from_seed_phrase(name, skip_validation, None, true)?
                     };
                     output_encodable_key(&key, outfile, "recovered AES128 key")?;

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -1,6 +1,6 @@
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
-    clap::{crate_description, crate_name, Arg, ArgMatches, Command},
+    clap::{crate_description, crate_name, Arg, ArgMatches, Command, PossibleValue},
     solana_clap_v3_utils::{
         input_parsers::{signer::SignerSourceParserBuilder, value_of, STDOUT_OUTFILE_TOKEN},
         keygen::{
@@ -49,7 +49,7 @@ fn app(crate_version: &str) -> Command {
                     Arg::new("type")
                         .index(1)
                         .takes_value(true)
-                        .possible_values(["elgamal", "aes128"])
+                        .value_parser(clap::value_parser!(KeyType))
                         .value_name("TYPE")
                         .required(true)
                         .help("The type of encryption key")
@@ -83,7 +83,9 @@ fn app(crate_version: &str) -> Command {
                     Arg::new("type")
                         .index(1)
                         .takes_value(true)
-                        .possible_values(["elgamal"])
+                        .value_parser([
+                            PossibleValue::new("elgamal")
+                        ])
                         .value_name("TYPE")
                         .required(true)
                         .help("The type of keypair")
@@ -109,7 +111,7 @@ fn app(crate_version: &str) -> Command {
                     Arg::new("type")
                         .index(1)
                         .takes_value(true)
-                        .possible_values(["elgamal", "aes128"])
+                        .value_parser(clap::value_parser!(KeyType))
                         .value_name("TYPE")
                         .required(true)
                         .help("The type of keypair")
@@ -293,6 +295,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
     Ok(())
 }
 
+#[derive(Clone)]
 enum KeyType {
     ElGamal,
     Aes128,

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -2,8 +2,7 @@ use {
     bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, Arg, ArgMatches, Command},
     solana_clap_v3_utils::{
-        input_parsers::{value_of, STDOUT_OUTFILE_TOKEN},
-        input_validators::is_prompt_signer_source,
+        input_parsers::{signer::SignerSourceParserBuilder, value_of, STDOUT_OUTFILE_TOKEN},
         keygen::{
             check_for_overwrite,
             mnemonic::{acquire_language, acquire_passphrase_and_message, WORD_COUNT_ARG},
@@ -120,7 +119,7 @@ fn app(crate_version: &str) -> Command {
                         .index(2)
                         .value_name("KEYPAIR")
                         .takes_value(true)
-                        .validator(is_prompt_signer_source)
+                        .value_parser(SignerSourceParserBuilder::default().allow_prompt().allow_legacy().build())
                         .help("`prompt:` URI scheme or `ASK` keyword"),
                 )
                 .arg(


### PR DESCRIPTION
#### Problem
The `zk-keygen` cli tool still contains deprecated functions from clap-v2.

#### Summary of Changes
Remove deprecated functions.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
