### PR TITLE
Show staked vs nonstaked packets sent down/throttled

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -963,6 +963,19 @@ async fn handle_chunk(
                             .total_chunks_sent_for_batching
                             .fetch_add(chunks_sent, Ordering::Relaxed);
 
+                        match peer_type {
+                            ConnectionPeerType::Unstaked => {
+                                stats
+                                    .total_unstaked_packets_sent_for_batching
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                            ConnectionPeerType::Staked => {
+                                stats
+                                    .total_staked_packets_sent_for_batching
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+
                         trace!("sent {} byte packet for batching", bytes_sent);
                     }
                 } else {

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -969,7 +969,7 @@ async fn handle_chunk(
                                     .total_unstaked_packets_sent_for_batching
                                     .fetch_add(1, Ordering::Relaxed);
                             }
-                            ConnectionPeerType::Staked => {
+                            ConnectionPeerType::Staked(_) => {
                                 stats
                                     .total_staked_packets_sent_for_batching
                                     .fetch_add(1, Ordering::Relaxed);

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -795,6 +795,18 @@ async fn handle_connection(
                         >= max_streams_per_throttling_interval
                     {
                         stats.throttled_streams.fetch_add(1, Ordering::Relaxed);
+                        match params.peer_type {
+                            ConnectionPeerType::Unstaked => {
+                                stats
+                                    .throttled_unstaked_streams
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                            ConnectionPeerType::Staked(_) => {
+                                stats
+                                    .throttled_staked_streams
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
                         let _ = stream.stop(VarInt::from_u32(STREAM_STOP_CODE_THROTTLING));
                         continue;
                     }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -179,6 +179,8 @@ pub struct StreamStats {
     pub(crate) perf_track_overhead_us: AtomicU64,
     pub(crate) total_staked_packets_sent_for_batching: AtomicUsize,
     pub(crate) total_unstaked_packets_sent_for_batching: AtomicUsize,
+    pub(crate) throttled_staked_streams: AtomicUsize,
+    pub(crate) throttled_unstaked_streams: AtomicUsize,
 }
 
 impl StreamStats {
@@ -434,6 +436,7 @@ impl StreamStats {
                 i64
             ),
             (
+
                 "stream_load_ema",
                 self.stream_load_ema.load(Ordering::Relaxed),
                 i64
@@ -446,6 +449,16 @@ impl StreamStats {
             (
                 "stream_load_capacity_overflow",
                 self.stream_load_capacity_overflow.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "throttled_unstaked_streams",
+                self.throttled_unstaked_streams.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "throttled_staked_streams",
+                self.throttled_staked_streams.swap(0, Ordering::Relaxed),
                 i64
             ),
             (

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -177,6 +177,8 @@ pub struct StreamStats {
     pub(crate) stream_load_capacity_overflow: AtomicUsize,
     pub(crate) process_sampled_packets_us_hist: Mutex<histogram::Histogram>,
     pub(crate) perf_track_overhead_us: AtomicU64,
+    pub(crate) total_staked_packets_sent_for_batching: AtomicUsize,
+    pub(crate) total_unstaked_packets_sent_for_batching: AtomicUsize,
 }
 
 impl StreamStats {
@@ -335,6 +337,18 @@ impl StreamStats {
             (
                 "packets_sent_for_batching",
                 self.total_packets_sent_for_batching
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "staked_packets_sent_for_batching",
+                self.total_staked_packets_sent_for_batching
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "unstaked_packets_sent_for_batching",
+                self.total_unstaked_packets_sent_for_batching
                     .swap(0, Ordering::Relaxed),
                 i64
             ),

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -436,7 +436,6 @@ impl StreamStats {
                 i64
             ),
             (
-
                 "stream_load_ema",
                 self.stream_load_ema.load(Ordering::Relaxed),
                 i64


### PR DESCRIPTION
#### Problem

The current metrics cannot tell what are the portions of packets sent down and throttled from staked vs non-staked.


#### Summary of Changes

Add two metrics in streamer:

staked_packets_sent_for_batching
unstaked_packets_sent_for_batching
throttled_unstaked_streams
throttled_staked_streams

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
