### PR TITLE
Adds metrics for how long it takes to store into the accounts read cache

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8229,6 +8229,7 @@ impl AccountsDb {
                 read_only_cache_misses,
                 read_only_cache_evicts,
                 read_only_cache_load_us,
+                read_only_cache_store_us,
                 read_only_cache_evict_us,
             ) = self.read_only_accounts_cache.get_and_reset_stats();
             datapoint_info!(
@@ -8299,6 +8300,11 @@ impl AccountsDb {
                 (
                     "read_only_accounts_cache_load_us",
                     read_only_cache_load_us,
+                    i64
+                ),
+                (
+                    "read_only_accounts_cache_store_us",
+                    read_only_cache_store_us,
                     i64
                 ),
                 (

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -3,7 +3,7 @@
 use {
     dashmap::{mapref::entry::Entry, DashMap},
     index_list::{Index, IndexList},
-    solana_measure::measure_us,
+    solana_measure::{measure::Measure, measure_us},
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::Slot,
@@ -36,6 +36,7 @@ struct ReadOnlyCacheStats {
     misses: AtomicU64,
     evicts: AtomicU64,
     load_us: AtomicU64,
+    store_us: AtomicU64,
     evict_us: AtomicU64,
 }
 
@@ -45,17 +46,19 @@ impl ReadOnlyCacheStats {
         self.misses.store(0, Ordering::Relaxed);
         self.evicts.store(0, Ordering::Relaxed);
         self.load_us.store(0, Ordering::Relaxed);
+        self.store_us.store(0, Ordering::Relaxed);
         self.evict_us.store(0, Ordering::Relaxed);
     }
 
-    fn get_and_reset_stats(&self) -> (u64, u64, u64, u64, u64) {
+    fn get_and_reset_stats(&self) -> (u64, u64, u64, u64, u64, u64) {
         let hits = self.hits.swap(0, Ordering::Relaxed);
         let misses = self.misses.swap(0, Ordering::Relaxed);
         let evicts = self.evicts.swap(0, Ordering::Relaxed);
         let load_us = self.load_us.swap(0, Ordering::Relaxed);
+        let store_us = self.store_us.swap(0, Ordering::Relaxed);
         let evict_us = self.evict_us.swap(0, Ordering::Relaxed);
 
-        (hits, misses, evicts, load_us, evict_us)
+        (hits, misses, evicts, load_us, store_us, evict_us)
     }
 }
 
@@ -139,6 +142,7 @@ impl ReadOnlyAccountsCache {
     }
 
     pub(crate) fn store(&self, pubkey: Pubkey, slot: Slot, account: AccountSharedData) {
+        let measure_store = Measure::start("");
         self.highest_slot_stored.fetch_max(slot, Ordering::Release);
         let key = (pubkey, slot);
         let account_size = self.account_size(&account);
@@ -174,8 +178,10 @@ impl ReadOnlyAccountsCache {
                 self.remove(pubkey, slot);
             }
         });
+        let store_us = measure_store.end_as_us();
         self.stats.evicts.fetch_add(num_evicts, Ordering::Relaxed);
         self.stats.evict_us.fetch_add(evict_us, Ordering::Relaxed);
+        self.stats.store_us.fetch_add(store_us, Ordering::Relaxed);
     }
 
     /// true if any pubkeys could have ever been stored into the cache at `slot`
@@ -214,7 +220,7 @@ impl ReadOnlyAccountsCache {
         self.data_size.load(Ordering::Relaxed)
     }
 
-    pub(crate) fn get_and_reset_stats(&self) -> (u64, u64, u64, u64, u64) {
+    pub(crate) fn get_and_reset_stats(&self) -> (u64, u64, u64, u64, u64, u64) {
         self.stats.get_and_reset_stats()
     }
 }


### PR DESCRIPTION
#### Problem

While evaluating evicting from the accounts read cache in the background (https://github.com/anza-xyz/agave/pull/575), we noticed that we currently do not time how long it takes to store.


#### Summary of Changes

Add a metric for how long it takes to store into the accounts read cache.