### PR TITLE
Check EpochRewards::active within the Stake Program

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -469,11 +469,9 @@ mod tests {
         )
     }
 
-    fn process_instruction_as_one_arg(
-        feature_set: Arc<FeatureSet>,
+    fn get_default_transaction_accounts(
         instruction: &Instruction,
-        expected_result: Result<(), InstructionError>,
-    ) -> Vec<AccountSharedData> {
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         let mut pubkeys: HashSet<Pubkey> = instruction
             .accounts
             .iter()
@@ -482,7 +480,7 @@ mod tests {
         pubkeys.insert(clock::id());
         pubkeys.insert(epoch_schedule::id());
         #[allow(deprecated)]
-        let transaction_accounts = pubkeys
+        pubkeys
             .iter()
             .map(|pubkey| {
                 (
@@ -510,7 +508,15 @@ mod tests {
                     },
                 )
             })
-            .collect();
+            .collect()
+    }
+
+    fn process_instruction_as_one_arg(
+        feature_set: Arc<FeatureSet>,
+        instruction: &Instruction,
+        expected_result: Result<(), InstructionError>,
+    ) -> Vec<AccountSharedData> {
+        let transaction_accounts = get_default_transaction_accounts(instruction);
         process_instruction(
             Arc::clone(&feature_set),
             &instruction.data,

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -84,11 +84,13 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
     let signers = instruction_context.get_signers(transaction_context)?;
     match limited_deserialize(data) {
         Ok(StakeInstruction::Initialize(authorized, lockup)) => {
+            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 1)?;
             initialize(&mut me, &authorized, &lockup, &rent)
         }
         Ok(StakeInstruction::Authorize(authorized_pubkey, stake_authorize)) => {
+            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
@@ -106,6 +108,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         Ok(StakeInstruction::AuthorizeWithSeed(args)) => {
+            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
             let clock =
@@ -127,6 +130,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         Ok(StakeInstruction::DelegateStake) => {
+            error_during_epoch_rewards()?;
             let me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
             let clock =
@@ -151,6 +155,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         Ok(StakeInstruction::Split(lamports)) => {
+            error_during_epoch_rewards()?;
             let me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
             drop(me);
@@ -165,6 +170,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         Ok(StakeInstruction::Merge) => {
+            error_during_epoch_rewards()?;
             let me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
             let clock =
@@ -187,6 +193,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         Ok(StakeInstruction::Withdraw(lamports)) => {
+            error_during_epoch_rewards()?;
             let me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
             let clock =
@@ -216,17 +223,20 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         Ok(StakeInstruction::Deactivate) => {
+            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
             deactivate(invoke_context, &mut me, &clock, &signers)
         }
         Ok(StakeInstruction::SetLockup(lockup)) => {
+            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let clock = invoke_context.get_sysvar_cache().get_clock()?;
             set_lockup(&mut me, &lockup, &signers, &clock)
         }
         Ok(StakeInstruction::InitializeChecked) => {
+            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(4)?;
             let staker_pubkey = transaction_context.get_key_of_account_at_index(
@@ -248,6 +258,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             initialize(&mut me, &authorized, &Lockup::default(), &rent)
         }
         Ok(StakeInstruction::AuthorizeChecked(stake_authorize)) => {
+            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
@@ -271,6 +282,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         Ok(StakeInstruction::AuthorizeCheckedWithSeed(args)) => {
+            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
             let clock =
@@ -299,6 +311,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         Ok(StakeInstruction::SetLockupChecked(lockup_checked)) => {
+            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let custodian_pubkey =
                 get_optional_pubkey(transaction_context, instruction_context, 2, true)?;
@@ -320,6 +333,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 .set_return_data(id(), minimum_delegation)
         }
         Ok(StakeInstruction::DeactivateDelinquent) => {
+            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(3)?;
 
@@ -335,6 +349,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         Ok(StakeInstruction::Redelegate) => {
+            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             if invoke_context
                 .feature_set

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -82,14 +82,14 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
     };
 
     let signers = instruction_context.get_signers(transaction_context)?;
-    match limited_deserialize(data) {
-        Ok(StakeInstruction::Initialize(authorized, lockup)) => {
+    match limited_deserialize(data)? {
+        StakeInstruction::Initialize(authorized, lockup) => {
             error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 1)?;
             initialize(&mut me, &authorized, &lockup, &rent)
         }
-        Ok(StakeInstruction::Authorize(authorized_pubkey, stake_authorize)) => {
+        StakeInstruction::Authorize(authorized_pubkey, stake_authorize) => {
             error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let clock =
@@ -107,7 +107,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 custodian_pubkey,
             )
         }
-        Ok(StakeInstruction::AuthorizeWithSeed(args)) => {
+        StakeInstruction::AuthorizeWithSeed(args) => {
             error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
@@ -129,7 +129,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 custodian_pubkey,
             )
         }
-        Ok(StakeInstruction::DelegateStake) => {
+        StakeInstruction::DelegateStake => {
             error_during_epoch_rewards()?;
             let me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
@@ -154,7 +154,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &invoke_context.feature_set,
             )
         }
-        Ok(StakeInstruction::Split(lamports)) => {
+        StakeInstruction::Split(lamports) => {
             error_during_epoch_rewards()?;
             let me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
@@ -169,7 +169,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &signers,
             )
         }
-        Ok(StakeInstruction::Merge) => {
+        StakeInstruction::Merge => {
             error_during_epoch_rewards()?;
             let me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
@@ -192,7 +192,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &signers,
             )
         }
-        Ok(StakeInstruction::Withdraw(lamports)) => {
+        StakeInstruction::Withdraw(lamports) => {
             error_during_epoch_rewards()?;
             let me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
@@ -222,20 +222,20 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 new_warmup_cooldown_rate_epoch(invoke_context),
             )
         }
-        Ok(StakeInstruction::Deactivate) => {
+        StakeInstruction::Deactivate => {
             error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
             deactivate(invoke_context, &mut me, &clock, &signers)
         }
-        Ok(StakeInstruction::SetLockup(lockup)) => {
+        StakeInstruction::SetLockup(lockup) => {
             error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let clock = invoke_context.get_sysvar_cache().get_clock()?;
             set_lockup(&mut me, &lockup, &signers, &clock)
         }
-        Ok(StakeInstruction::InitializeChecked) => {
+        StakeInstruction::InitializeChecked => {
             error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(4)?;
@@ -257,7 +257,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 1)?;
             initialize(&mut me, &authorized, &Lockup::default(), &rent)
         }
-        Ok(StakeInstruction::AuthorizeChecked(stake_authorize)) => {
+        StakeInstruction::AuthorizeChecked(stake_authorize) => {
             error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let clock =
@@ -281,7 +281,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 custodian_pubkey,
             )
         }
-        Ok(StakeInstruction::AuthorizeCheckedWithSeed(args)) => {
+        StakeInstruction::AuthorizeCheckedWithSeed(args) => {
             error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
@@ -310,7 +310,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 custodian_pubkey,
             )
         }
-        Ok(StakeInstruction::SetLockupChecked(lockup_checked)) => {
+        StakeInstruction::SetLockupChecked(lockup_checked) => {
             error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let custodian_pubkey =
@@ -324,7 +324,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             let clock = invoke_context.get_sysvar_cache().get_clock()?;
             set_lockup(&mut me, &lockup, &signers, &clock)
         }
-        Ok(StakeInstruction::GetMinimumDelegation) => {
+        StakeInstruction::GetMinimumDelegation => {
             let feature_set = invoke_context.feature_set.as_ref();
             let minimum_delegation = crate::get_minimum_delegation(feature_set);
             let minimum_delegation = Vec::from(minimum_delegation.to_le_bytes());
@@ -332,7 +332,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 .transaction_context
                 .set_return_data(id(), minimum_delegation)
         }
-        Ok(StakeInstruction::DeactivateDelinquent) => {
+        StakeInstruction::DeactivateDelinquent => {
             error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(3)?;
@@ -348,7 +348,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 clock.epoch,
             )
         }
-        Ok(StakeInstruction::Redelegate) => {
+        StakeInstruction::Redelegate => {
             error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             if invoke_context
@@ -369,7 +369,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 Err(InstructionError::InvalidInstructionData)
             }
         }
-        Err(err) => Err(err),
     }
 });
 

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -82,15 +82,18 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
     };
 
     let signers = instruction_context.get_signers(transaction_context)?;
-    match limited_deserialize(data)? {
+
+    let stake_instruction: StakeInstruction = limited_deserialize(data)?;
+    if !matches!(stake_instruction, StakeInstruction::GetMinimumDelegation) {
+        error_during_epoch_rewards()?;
+    }
+    match stake_instruction {
         StakeInstruction::Initialize(authorized, lockup) => {
-            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 1)?;
             initialize(&mut me, &authorized, &lockup, &rent)
         }
         StakeInstruction::Authorize(authorized_pubkey, stake_authorize) => {
-            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
@@ -108,7 +111,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         StakeInstruction::AuthorizeWithSeed(args) => {
-            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
             let clock =
@@ -130,7 +132,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         StakeInstruction::DelegateStake => {
-            error_during_epoch_rewards()?;
             let me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
             let clock =
@@ -155,7 +156,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         StakeInstruction::Split(lamports) => {
-            error_during_epoch_rewards()?;
             let me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
             drop(me);
@@ -170,7 +170,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         StakeInstruction::Merge => {
-            error_during_epoch_rewards()?;
             let me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
             let clock =
@@ -193,7 +192,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         StakeInstruction::Withdraw(lamports) => {
-            error_during_epoch_rewards()?;
             let me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
             let clock =
@@ -223,20 +221,17 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         StakeInstruction::Deactivate => {
-            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
             deactivate(invoke_context, &mut me, &clock, &signers)
         }
         StakeInstruction::SetLockup(lockup) => {
-            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let clock = invoke_context.get_sysvar_cache().get_clock()?;
             set_lockup(&mut me, &lockup, &signers, &clock)
         }
         StakeInstruction::InitializeChecked => {
-            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(4)?;
             let staker_pubkey = transaction_context.get_key_of_account_at_index(
@@ -258,7 +253,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             initialize(&mut me, &authorized, &Lockup::default(), &rent)
         }
         StakeInstruction::AuthorizeChecked(stake_authorize) => {
-            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
@@ -282,7 +276,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         StakeInstruction::AuthorizeCheckedWithSeed(args) => {
-            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(2)?;
             let clock =
@@ -311,7 +304,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         StakeInstruction::SetLockupChecked(lockup_checked) => {
-            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             let custodian_pubkey =
                 get_optional_pubkey(transaction_context, instruction_context, 2, true)?;
@@ -333,7 +325,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 .set_return_data(id(), minimum_delegation)
         }
         StakeInstruction::DeactivateDelinquent => {
-            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             instruction_context.check_number_of_instruction_accounts(3)?;
 
@@ -349,7 +340,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         StakeInstruction::Redelegate => {
-            error_during_epoch_rewards()?;
             let mut me = get_stake_account()?;
             if invoke_context
                 .feature_set

--- a/sdk/program/src/stake/instruction.rs
+++ b/sdk/program/src/stake/instruction.rs
@@ -70,6 +70,9 @@ pub enum StakeError {
 
     #[error("redelegated stake must be fully activated before deactivation")]
     RedelegatedStakeMustFullyActivateBeforeDeactivationIsPermitted,
+
+    #[error("stake action is not permitted while the epoch rewards period is active")]
+    EpochRewardsActive,
 }
 
 impl<E> DecodeError<E> for StakeError {


### PR DESCRIPTION
#### Problem
As per SIMD-0118, credits to stake accounts should be allowed during the rewards interval. The current implementation Errors all transactions that load a stake account as writable, overly restrictive.

#### Summary of Changes
- Check whether EpochRewards::active and return new StakeError for all instructions except GetMinimumDelegation
Note: this implements the specification in the SIMD, but I think this could be relaxed on a handful of instructions, like Authorize and SetLockup. It's possible that even Initialize, DelegateStake, and Deactivate could be supported during the rewards interval as well, depending on cache state for recalculation (boot from snapshot). At any rate, unless either of you feel strongly about doing that now, I'll make any of those changes in a separate PR.
- (edit) The following moved to separate PR, which I will link.
~~Remove existing `check_account_access()` call in SVM
I did leave this method in the `TransactionProcessingCallback` trait, however. It's a generic-enough name that it could be used for something other than rewards-period restriction.~~

Towards #426 
