### PR TITLE
Prioritize blocked task messaging over idle tasks

### DIFF
--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -643,6 +643,10 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
         // heuristic's caveat for the first task of linearized runs, which is described above.
         let (mut runnable_task_sender, runnable_task_receiver) =
             chained_channel::unbounded::<Task, SchedulingContext>(context.clone());
+        // Create two handler-to-scheduler channels to prioritize the finishing of blocked tasks,
+        // because it is more likely that a blocked task will have more blocked tasks behind it,
+        // which should be scheduled while minimizing the delay to clear buffered linearized runs
+        // as fast as possible.
         let (finished_blocked_task_sender, finished_blocked_task_receiver) =
             crossbeam_channel::unbounded::<Box<ExecutedTask>>();
         let (finished_idle_task_sender, finished_idle_task_receiver) =


### PR DESCRIPTION
#### Problem

Unified scheduler is slow. ;)

#### Summary of Changes

Add very primitive (under 100 loc pr) yet effective adaptive behavioral heuristic (i.e. no constant knob) at the scheduler layer to complement `SchedulingStateMachine`'s buffer bloat ignorance.

EDIT: phew just wrote the commentary. the irony is that the accompanied unit test took longer time to write than the actual code changes. Moreover the commented monologue prose took even longer time to write than the unit test.. lol

#### Perf numbers

at least ~5% consistent perf improvement is observed

(see https://github.com/solana-labs/solana/pull/35286#user-content-steps if you want to reproduce the results)

before (just after #129 is merged):

```
ledger processed in 21 seconds, 954 ms
ledger processed in 21 seconds, 643 ms
ledger processed in 21 seconds, 895 ms
```

after:

```
ledger processed in 20 seconds, 264 ms
ledger processed in 19 seconds, 983 ms
ledger processed in 20 seconds, 16 ms
```

### (for the record) the merged commit

before(ad316fdbf72758538d85e11cb397fb750f15591a):

```
ledger processed in 21 seconds, 75 ms
ledger processed in 21 seconds, 92 ms
ledger processed in 21 seconds, 64 ms
```

after(fb465b378827fe1f04ce261863587413249a7d31):

```
ledger processed in 19 seconds, 490 ms
ledger processed in 19 seconds, 277 ms
ledger processed in 19 seconds, 281 ms
```

context: extracted from https://github.com/anza-xyz/agave/pull/593