### PR TITLE
program-runtime: hoist `RuntimeConfig` up to SVM

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -73,7 +73,6 @@ use {
         poh_recorder::PohRecorder,
         poh_service::{self, PohService},
     },
-    solana_program_runtime::runtime_config::RuntimeConfig,
     solana_rayon_threadlimit::get_max_thread_count,
     solana_rpc::{
         max_slots::MaxSlots,
@@ -98,6 +97,7 @@ use {
         bank_forks::BankForks,
         commitment::BlockCommitmentCache,
         prioritization_fee_cache::PrioritizationFeeCache,
+        runtime_config::RuntimeConfig,
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_bank_utils::{self, DISABLED_SNAPSHOT_ARCHIVE_INTERVAL},
         snapshot_config::SnapshotConfig,

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -15,7 +15,6 @@ use {
         snapshot_packager_service::SnapshotPackagerService,
     },
     solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
-    solana_program_runtime::runtime_config::RuntimeConfig,
     solana_runtime::{
         accounts_background_service::{
             AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService, DroppedSlotsReceiver,
@@ -24,6 +23,7 @@ use {
         bank::{epoch_accounts_hash_utils, Bank},
         bank_forks::BankForks,
         genesis_utils::{self, GenesisConfigInfo},
+        runtime_config::RuntimeConfig,
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_bank_utils,
         snapshot_config::SnapshotConfig,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -17,7 +17,6 @@ use {
         snapshot_packager_service::SnapshotPackagerService,
     },
     solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
-    solana_program_runtime::runtime_config::RuntimeConfig,
     solana_runtime::{
         accounts_background_service::{
             AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService,
@@ -26,6 +25,7 @@ use {
         bank::Bank,
         bank_forks::BankForks,
         genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo},
+        runtime_config::RuntimeConfig,
         snapshot_archive_info::FullSnapshotArchiveInfo,
         snapshot_bank_utils::{self, DISABLED_SNAPSHOT_ARCHIVE_INTERVAL},
         snapshot_config::SnapshotConfig,

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -12,7 +12,7 @@ use {
         blockstore_processor::ProcessOptions,
         use_snapshot_archives_at_startup::{self, UseSnapshotArchivesAtStartup},
     },
-    solana_program_runtime::runtime_config::RuntimeConfig,
+    solana_runtime::runtime_config::RuntimeConfig,
     solana_sdk::clock::Slot,
     std::{
         collections::HashSet,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -27,10 +27,7 @@ use {
     },
     solana_measure::{measure, measure::Measure},
     solana_metrics::datapoint_error,
-    solana_program_runtime::{
-        runtime_config::RuntimeConfig,
-        timings::{ExecuteTimingType, ExecuteTimings, ThreadExecuteTimings},
-    },
+    solana_program_runtime::timings::{ExecuteTimingType, ExecuteTimings, ThreadExecuteTimings},
     solana_rayon_threadlimit::{get_max_thread_count, get_thread_count},
     solana_runtime::{
         accounts_background_service::{AbsRequestSender, SnapshotRequestKind},
@@ -40,6 +37,7 @@ use {
         commitment::VOTE_THRESHOLD_SIZE,
         installed_scheduler_pool::BankWithScheduler,
         prioritization_fee_cache::PrioritizationFeeCache,
+        runtime_config::RuntimeConfig,
         transaction_batch::TransactionBatch,
     },
     solana_sdk::{

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -16,7 +16,6 @@ pub mod invoke_context;
 pub mod loaded_programs;
 pub mod log_collector;
 pub mod prioritization_fee;
-pub mod runtime_config;
 pub mod stable_log;
 pub mod sysvar_cache;
 pub mod timings;

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -17,8 +17,7 @@ use {
     solana_bpf_loader_program::serialization::serialize_parameters,
     solana_program_runtime::{
         compute_budget::ComputeBudget, ic_msg, invoke_context::BuiltinFunctionWithContext,
-        loaded_programs::LoadedProgram, runtime_config::RuntimeConfig, stable_log,
-        timings::ExecuteTimings,
+        loaded_programs::LoadedProgram, stable_log, timings::ExecuteTimings,
     },
     solana_runtime::{
         accounts_background_service::{AbsRequestSender, SnapshotRequestKind},
@@ -26,6 +25,7 @@ use {
         bank_forks::BankForks,
         commitment::BlockCommitmentCache,
         genesis_utils::{create_genesis_config_with_leader_ex, GenesisConfigInfo},
+        runtime_config::RuntimeConfig,
     },
     solana_sdk::{
         account::{create_account_shared_data_for_test, Account, AccountSharedData},

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -49,6 +49,7 @@ use {
         bank_forks::BankForks,
         epoch_stakes::{EpochStakes, NodeVoteAccounts},
         installed_scheduler_pool::{BankWithScheduler, InstalledSchedulerRwLock},
+        runtime_config::RuntimeConfig,
         serde_snapshot::BankIncrementalSnapshotPersistence,
         snapshot_hash::SnapshotHash,
         stake_account::StakeAccount,
@@ -101,7 +102,6 @@ use {
         loaded_programs::{
             LoadedProgram, LoadedProgramMatchCriteria, LoadedProgramType, ProgramCache,
         },
-        runtime_config::RuntimeConfig,
         timings::{ExecuteTimingType, ExecuteTimings},
     },
     solana_sdk::{

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -195,6 +195,7 @@ mod tests {
             genesis_utils::{
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
             },
+            runtime_config::RuntimeConfig,
         },
         assert_matches::assert_matches,
         solana_accounts_db::{
@@ -204,7 +205,6 @@ mod tests {
             accounts_index::AccountSecondaryIndexes,
             partitioned_rewards::TestPartitionedEpochRewards,
         },
-        solana_program_runtime::runtime_config::RuntimeConfig,
         solana_sdk::{
             epoch_schedule::EpochSchedule,
             native_token::LAMPORTS_PER_SOL,

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -7,6 +7,7 @@ mod tests {
                 test_utils as bank_test_utils, Bank, EpochRewardStatus,
             },
             genesis_utils::activate_all_features,
+            runtime_config::RuntimeConfig,
             serde_snapshot::{
                 reserialize_bank_with_new_accounts_hash, BankIncrementalSnapshotPersistence,
                 SerdeAccountsHash, SerdeIncrementalAccountsHash, SerdeStyle, SnapshotStreams,
@@ -31,7 +32,6 @@ mod tests {
             epoch_accounts_hash::EpochAccountsHash,
             stake_rewards::StakeReward,
         },
-        solana_program_runtime::runtime_config::RuntimeConfig,
         solana_sdk::{
             epoch_schedule::EpochSchedule,
             genesis_config::create_genesis_config,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -42,3 +42,6 @@ extern crate serde_derive;
 
 #[macro_use]
 extern crate solana_frozen_abi_macro;
+
+// Don't make crates import the SVM if all they need is this module.
+pub use solana_svm::runtime_config;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -4,6 +4,7 @@ use {
     crate::{
         bank::{builtins::BuiltinPrototype, Bank, BankFieldsToDeserialize, BankRc},
         epoch_stakes::EpochStakes,
+        runtime_config::RuntimeConfig,
         serde_snapshot::storage::SerializableAccountStorageEntry,
         snapshot_utils::{
             self, SnapshotError, StorageAndNextAccountsFileId, BANK_SNAPSHOT_PRE_FILENAME_EXTENSION,
@@ -28,7 +29,6 @@ use {
         epoch_accounts_hash::EpochAccountsHash,
     },
     solana_measure::measure::Measure,
-    solana_program_runtime::runtime_config::RuntimeConfig,
     solana_sdk::{
         clock::{Epoch, Slot, UnixTimestamp},
         deserialize_utils::default_on_eof,

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         bank::{builtins::BuiltinPrototype, Bank, BankFieldsToDeserialize, BankSlotDelta},
+        runtime_config::RuntimeConfig,
         serde_snapshot::{
             bank_from_streams, bank_to_stream, fields_from_streams,
             BankIncrementalSnapshotPersistence, SerdeStyle,
@@ -36,7 +37,6 @@ use {
         utils::delete_contents_of_path,
     },
     solana_measure::{measure, measure::Measure},
-    solana_program_runtime::runtime_config::RuntimeConfig,
     solana_sdk::{
         clock::Slot,
         feature_set,

--- a/svm/src/lib.rs
+++ b/svm/src/lib.rs
@@ -5,6 +5,7 @@ pub mod account_loader;
 pub mod account_overrides;
 pub mod account_rent_state;
 pub mod message_processor;
+pub mod runtime_config;
 pub mod transaction_account_state_info;
 pub mod transaction_error_metrics;
 pub mod transaction_processor;

--- a/svm/src/runtime_config.rs
+++ b/svm/src/runtime_config.rs
@@ -1,4 +1,4 @@
-use crate::compute_budget::ComputeBudget;
+use solana_program_runtime::compute_budget::ComputeBudget;
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 impl ::solana_frozen_abi::abi_example::AbiExample for RuntimeConfig {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -5,6 +5,7 @@ use {
         },
         account_overrides::AccountOverrides,
         message_processor::MessageProcessor,
+        runtime_config::RuntimeConfig,
         transaction_account_state_info::TransactionAccountStateInfo,
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_results::{
@@ -23,7 +24,6 @@ use {
             DELAY_VISIBILITY_SLOT_OFFSET,
         },
         log_collector::LogCollector,
-        runtime_config::RuntimeConfig,
         sysvar_cache::SysvarCache,
         timings::{ExecuteDetailsTimings, ExecuteTimingType, ExecuteTimings},
     },

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -12,7 +12,6 @@ use {
         loaded_programs::{
             BlockRelation, ForkGraph, LoadedProgram, ProgramCache, ProgramRuntimeEnvironments,
         },
-        runtime_config::RuntimeConfig,
         solana_rbpf::{
             program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
             vm::Config,
@@ -35,6 +34,7 @@ use {
     },
     solana_svm::{
         account_loader::TransactionCheckResult,
+        runtime_config::RuntimeConfig,
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_processor::{
             ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingCallback,

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -29,12 +29,12 @@ use {
         create_new_tmp_ledger,
     },
     solana_net_utils::PortRange,
-    solana_program_runtime::{compute_budget::ComputeBudget, runtime_config::RuntimeConfig},
+    solana_program_runtime::compute_budget::ComputeBudget,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_rpc_client::{nonblocking, rpc_client::RpcClient},
     solana_runtime::{
         bank_forks::BankForks, genesis_utils::create_genesis_config_with_leader_ex,
-        snapshot_config::SnapshotConfig,
+        runtime_config::RuntimeConfig, snapshot_config::SnapshotConfig,
     },
     solana_sdk::{
         account::{Account, AccountSharedData, WritableAccount},

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -50,7 +50,6 @@ use {
     },
     solana_perf::recycler::enable_recycler_warming,
     solana_poh::poh_service,
-    solana_program_runtime::runtime_config::RuntimeConfig,
     solana_rpc::{
         rpc::{JsonRpcConfig, RpcBigtableConfig},
         rpc_pubsub_service::PubSubConfig,
@@ -58,6 +57,7 @@ use {
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::config::RpcLeaderScheduleConfig,
     solana_runtime::{
+        runtime_config::RuntimeConfig,
         snapshot_bank_utils::DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_utils::{self, ArchiveFormat, SnapshotVersion},


### PR DESCRIPTION
#### Problem

The `RuntimeConfig` type is not used anywhere in the program runtime.
It's lowest-level use is in the SVM, and then it's funneled through the runtime
to the SVM by many higher-level crates.

Higher-level crates shouldn't need to import the entire SVM (or program runtime)
just for this type. As it turns out, the crates which need it already import the
runtime.

#### Summary of Changes

Hoist `RuntimeConfig` out of the program runtime and into the SVM.

Re-export `RuntimeConfig` from the runtime so other crates need not import
the entire SVM.