### PR TITLE
Add tests to check for duplicate ports

### DIFF
--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -222,6 +222,10 @@ impl ContactInfo {
         self.shred_version = shred_version
     }
 
+    pub fn get_num_sockets(&self) -> usize {
+        self.sockets.len()
+    }
+
     get_socket!(gossip, SOCKET_TAG_GOSSIP);
     get_socket!(rpc, SOCKET_TAG_RPC);
     get_socket!(rpc_pubsub, SOCKET_TAG_RPC_PUBSUB);


### PR DESCRIPTION
#### Problem

No test coverage to detect if ports are duplicate between services.

#### Summary of Changes

Add tests for Node constructors

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
