### PR TITLE
corrected to not use hardcoded connections count for unstaked

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -172,8 +172,8 @@ async fn run_server(
     let unstaked_connection_table: Arc<Mutex<ConnectionTable>> =
         Arc::new(Mutex::new(ConnectionTable::new()));
     let stream_load_ema = Arc::new(StakedStreamLoadEMA::new(
-        max_unstaked_connections > 0,
         stats.clone(),
+        max_unstaked_connections,
     ));
     let staked_connection_table: Arc<Mutex<ConnectionTable>> =
         Arc::new(Mutex::new(ConnectionTable::new()));

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -54,9 +54,13 @@ impl StakedStreamLoadEMA {
                 500
             });
 
-        let max_unstaked_load_in_throttling_window = Percentage::from(MAX_UNSTAKED_STREAMS_PERCENT)
-            .apply_to(MAX_STREAMS_PER_MS * STREAM_THROTTLING_INTERVAL_MS)
-            .saturating_div(max_num_unstaked_connections);
+        let max_unstaked_load_in_throttling_window = if allow_unstaked_streams {
+            Percentage::from(MAX_UNSTAKED_STREAMS_PERCENT)
+                .apply_to(MAX_STREAMS_PER_MS * STREAM_THROTTLING_INTERVAL_MS)
+                .saturating_div(max_num_unstaked_connections)
+        } else {
+            0
+        };
 
         Self {
             current_load_ema: AtomicU64::default(),

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -418,12 +418,12 @@ pub mod test {
             10000
         );
 
-        // At 1/40000 stake weight, and minimum load, it should still allow
+        // At 1/400000 stake weight, and minimum load, it should still allow
         // max_unstaked_load_in_throttling_window + 1 streams.
         assert_eq!(
             load_ema.available_load_capacity_in_throttling_duration(
                 ConnectionPeerType::Staked(1),
-                40000
+                400000
             ),
             load_ema
                 .max_unstaked_load_in_throttling_window


### PR DESCRIPTION
The max unstaked connections can be passed in value in spawn_server. This will make the QOS incorrectly accounting for the real passed in unstaked max connection count. This is used by jito-relayers.


Do not use the hardcoded one.