### PR TITLE
Move recv timer to start before crossbream receiver recv_timeout()

### DIFF
--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -361,9 +361,9 @@ fn recv_send(
 pub fn recv_packet_batches(
     recvr: &PacketBatchReceiver,
 ) -> Result<(Vec<PacketBatch>, usize, Duration)> {
+    let recv_start = Instant::now();
     let timer = Duration::new(1, 0);
     let packet_batch = recvr.recv_timeout(timer)?;
-    let recv_start = Instant::now();
     trace!("got packets");
     let mut num_packets = packet_batch.len();
     let mut packet_batches = vec![packet_batch];


### PR DESCRIPTION
#### Problem
The timer starting after recv_timeout() means the measured time will NOT include time spent waiting for the first PacketBatch from the receiver. Spotted by @alessandrod 

#### Summary of Changes
Move the timer to more properly measure this time.