### PR TITLE
Fixes pedantic clippy ptr cast lints in bucket-map

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -351,7 +351,7 @@ impl<O: BucketOccupied> BucketStorage<O> {
             &slice[..size]
         };
         let ptr = {
-            let ptr = slice.as_ptr() as *const T;
+            let ptr = slice.as_ptr().cast();
             debug_assert!(ptr as usize % std::mem::align_of::<T>() == 0);
             ptr
         };
@@ -376,7 +376,7 @@ impl<O: BucketOccupied> BucketStorage<O> {
             &mut slice[..size]
         };
         let ptr = {
-            let ptr = slice.as_mut_ptr() as *mut T;
+            let ptr = slice.as_mut_ptr().cast();
             debug_assert!(ptr as usize % std::mem::align_of::<T>() == 0);
             ptr
         };
@@ -484,7 +484,7 @@ impl<O: BucketOccupied> BucketStorage<O> {
                 let src_slice: &[u8] = &old_map[old_ix..old_ix + old_bucket.cell_size as usize];
 
                 unsafe {
-                    let dst = dst_slice.as_ptr() as *mut u8;
+                    let dst = dst_slice.as_ptr() as *mut _;
                     let src = src_slice.as_ptr();
                     std::ptr::copy_nonoverlapping(src, dst, old_bucket.cell_size as usize);
                 };

--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -468,14 +468,14 @@ impl<T: Copy + PartialEq + 'static> IndexEntryPlaceInBucket<T> {
 
 fn get_from_bytes<T>(item_slice: &[u8]) -> &T {
     debug_assert!(std::mem::size_of::<T>() <= item_slice.len());
-    let item = item_slice.as_ptr() as *const T;
+    let item = item_slice.as_ptr().cast();
     debug_assert!(item as usize % std::mem::align_of::<T>() == 0);
     unsafe { &*item }
 }
 
 fn get_mut_from_bytes<T>(item_slice: &mut [u8]) -> &mut T {
     debug_assert!(std::mem::size_of::<T>() <= item_slice.len());
-    let item = item_slice.as_mut_ptr() as *mut T;
+    let item = item_slice.as_mut_ptr().cast();
     debug_assert!(item as usize % std::mem::align_of::<T>() == 0);
     unsafe { &mut *item }
 }


### PR DESCRIPTION
#### Problem

When running pedantic clippy, it found some ptr-cast related lints in bucket-map. Specifically this one: https://rust-lang.github.io/rust-clippy/master/index.html#/ptr_as_ptr.


#### Summary of Changes

Use `ptr::cast()` to handle pointer casting safer.