### PR TITLE
intset for SlotOffsets

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -765,7 +765,7 @@ pub type AtomicAccountsFileId = AtomicU32;
 pub type AccountsFileId = u32;
 
 type AccountSlots = HashMap<Pubkey, HashSet<Slot>>;
-type SlotOffsets = HashMap<Slot, HashSet<usize>>;
+type SlotOffsets = HashMap<Slot, IntSet<usize>>;
 type ReclaimResult = (AccountSlots, SlotOffsets);
 type PubkeysRemovedFromAccountsIndex = HashSet<Pubkey>;
 type ShrinkCandidates = IntSet<Slot>;


### PR DESCRIPTION
#### Problem
clean is inefficient and can be very slow.
A big offender is `remove_dead_accounts`.

#### Summary of Changes
HashSet<int> is usually faster when implemented as IntSet, so do that. There is noise in clean's `remove_dead_accounts_remove_us`, but the #s with this change are better.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
