### PR TITLE
cli tests: correct program data account test check

### DIFF
--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -459,7 +459,7 @@ fn test_cli_program_deploy_with_authority() {
         minimum_balance_for_programdata
     );
     assert_eq!(programdata_account.owner, bpf_loader_upgradeable::id());
-    assert!(program_account.executable);
+    assert!(!programdata_account.executable);
     assert_eq!(
         programdata_account.data[UpgradeableLoaderState::size_of_programdata_metadata()..],
         program_data[..]


### PR DESCRIPTION
#### Problem

When going through #337 to narrow down root cause for #436, I noticed one small 
error in a CLI unit test.

The original test was checking the program _data_ account's executable field 
here, not the program account.

#### Solution

Correct the one line in the test to check the program data account.