### PR TITLE
add get_account_sizes

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7902,10 +7902,9 @@ impl AccountsDb {
                 }
                 else {
                     let mut offsets = offsets.iter().cloned().collect::<Vec<_>>();
+                    // sort so offsets are in order. This improves efficiency of loading the accounts.
                     offsets.sort_unstable();
-                    let dead_bytes = offsets.iter().map(|offset| {
-                        let account = store.accounts.get_account(*offset).unwrap();
-                        account.0.stored_size()}).sum();
+                    let dead_bytes = store.accounts.get_account_sizes(&offsets).iter().sum();
                     store.remove_accounts(dead_bytes, reset_accounts, offsets.len());
                     if Self::is_shrinking_productive(*slot, &store)
                         && self.is_candidate_for_shrink(&store, false)

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -178,6 +178,13 @@ impl AccountsFile {
         AccountsFileIter::new(self)
     }
 
+    pub(crate) fn get_account_sizes(&self, sorted_offsets: &[usize]) -> Vec<usize> {
+        match self {
+            Self::AppendVec(av) => av.get_account_sizes(sorted_offsets),
+            Self::TieredStorage(_) => unimplemented!(),
+        }
+    }
+
     /// iterate over all entries to put in index
     pub(crate) fn scan_index(&self, callback: impl FnMut(IndexInfo)) {
         match self {


### PR DESCRIPTION
#### Problem
clean is inefficient and can be very slow.
A big offender is `remove_dead_accounts`.

#### Summary of Changes
Add `get_account_sizes` to storage so that we can efficiently get sizes of many sorted offsets. The overall reduction for `remove_dead_accounts_remove_us` is from ~90s to ~70s on the ledger-tool clean on a mnb snapshot I've been testing. The creation of the apis and structure allows tiered storage to satisfy these requests more efficiently. The changes also allow us to stop mmapping the append vecs and satisfy the various scanning and random access requests efficiently.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
