### PR TITLE
abs responds to exit

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -613,6 +613,9 @@ impl AccountsBackgroundService {
                     // Grab the current root bank
                     let bank = bank_forks.read().unwrap().root_bank();
 
+                    if exit.load(Ordering::Relaxed) {
+                        break;
+                    }
                     // Purge accounts of any dead slots
                     request_handlers
                         .pruned_banks_request_handler
@@ -621,6 +624,9 @@ impl AccountsBackgroundService {
                             &mut removed_slots_count,
                             &mut total_remove_slots_time,
                         );
+                    if exit.load(Ordering::Relaxed) {
+                        break;
+                    }
 
                     let non_snapshot_time = last_snapshot_end_time
                         .map(|last_snapshot_end_time: Instant| {
@@ -694,10 +700,16 @@ impl AccountsBackgroundService {
                             // as any later snapshots that are taken are of
                             // slots >= bank.slot()
                             bank.force_flush_accounts_cache();
+                            if exit.load(Ordering::Relaxed) {
+                                break;
+                            }
                             bank.clean_accounts(last_full_snapshot_slot);
                             last_cleaned_block_height = bank.block_height();
                             // See justification below for why we skip 'shrink' here.
                             if bank.is_startup_verification_complete() {
+                                if exit.load(Ordering::Relaxed) {
+                                    break;
+                                }
                                 bank.shrink_ancient_slots();
                             }
                         }
@@ -709,6 +721,9 @@ impl AccountsBackgroundService {
                         // progress, or (2) could get snapshot storages that were newer than what
                         // was in the snapshot itself.
                         if bank.is_startup_verification_complete() {
+                            if exit.load(Ordering::Relaxed) {
+                                break;
+                            }
                             bank.shrink_candidate_slots();
                         }
                     }


### PR DESCRIPTION
#### Problem
when running ledger-tool, sometimes startup background operations take a long time (clean, shrink, etc.).

#### Summary of Changes
Abort the accounts background service loop in between operations when `exit` is set.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
