### PR TITLE
add file_provider to accounts_db

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1424,6 +1424,9 @@ pub struct AccountsDb {
     /// debug feature to scan every append vec and verify refcounts are equal
     exhaustively_verify_refcounts: bool,
 
+    /// storage format to use for new storages
+    accounts_file_provider: AccountsFileProvider,
+
     /// this will live here until the feature for partitioned epoch rewards is activated.
     /// At that point, this and other code can be deleted.
     pub partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig,
@@ -2401,6 +2404,7 @@ impl AccountsDb {
             accounts_update_notifier: None,
             log_dead_slots: AtomicBool::new(true),
             exhaustively_verify_refcounts: false,
+            accounts_file_provider: AccountsFileProvider::default(),
             partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig::default(),
             epoch_accounts_hash_manager: EpochAccountsHashManager::new_invalid(),
             test_skip_rewrites_but_include_in_bank_hash: false,
@@ -2543,7 +2547,7 @@ impl AccountsDb {
             slot,
             self.next_id(),
             size,
-            AccountsFileProvider::AppendVec,
+            self.accounts_file_provider,
         )
     }
 

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -287,8 +287,9 @@ impl<'a> Iterator for AccountsFileIter<'a> {
 }
 
 /// An enum that creates AccountsFile instance with the specified format.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub enum AccountsFileProvider {
+    #[default]
     AppendVec,
     HotStorage,
 }


### PR DESCRIPTION
#### Problem
new storage format is coming soon

#### Summary of Changes
add `file_provider` to `AccountsDb` and add a default for `AccountsFileProvider`. This can then be plumbed through for tests, cli arg, etc.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
