### PR TITLE
implement scan_pubkeys for hot storage

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -197,7 +197,11 @@ impl AccountsFile {
     pub(crate) fn scan_pubkeys(&self, callback: impl FnMut(&Pubkey)) {
         match self {
             Self::AppendVec(av) => av.scan_pubkeys(callback),
-            Self::TieredStorage(_) => unimplemented!(),
+            Self::TieredStorage(ts) => {
+                if let Some(reader) = ts.reader() {
+                    _ = reader.scan_pubkeys(callback);
+                }
+            }
         }
     }
 

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -554,6 +554,14 @@ impl HotStorageReader {
         Ok(accounts)
     }
 
+    pub fn scan_pubkeys(&self, mut callback: impl FnMut(&Pubkey)) -> TieredStorageResult<()> {
+        for i in 0..self.footer.account_entry_count {
+            let address = self.get_account_address(IndexOffset(i))?;
+            callback(address);
+        }
+        Ok(())
+    }
+
     /// Returns a slice suitable for use when archiving hot storages
     pub fn data_for_archive(&self) -> &[u8] {
         self.mmap.as_ref()

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -109,6 +109,12 @@ impl TieredStorageReader {
         }
     }
 
+    pub fn scan_pubkeys(&self, callback: impl FnMut(&Pubkey)) -> TieredStorageResult<()> {
+        match self {
+            Self::Hot(hot) => hot.scan_pubkeys(callback),
+        }
+    }
+
     /// Returns a slice suitable for use when archiving tiered storages
     pub fn data_for_archive(&self) -> &[u8] {
         match self {


### PR DESCRIPTION
#### Problem
new storage format needs to support the latest storage api changes

#### Summary of Changes
make it possible to test various storage formats.
Implement `scan_pubkeys` for hot storage

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
