### PR TITLE
accounts db/background store

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8231,6 +8231,7 @@ impl AccountsDb {
                 read_only_cache_evicts,
                 read_only_cache_load_us,
                 read_only_cache_store_us,
+                read_only_cache_store_bg_us,
                 read_only_cache_evict_us,
             ) = self.read_only_accounts_cache.get_and_reset_stats();
             datapoint_info!(
@@ -8306,6 +8307,11 @@ impl AccountsDb {
                 (
                     "read_only_accounts_cache_store_us",
                     read_only_cache_store_us,
+                    i64
+                ),
+                (
+                    "read_only_accounts_cache_store_bg_us",
+                    read_only_cache_store_bg_us,
                     i64
                 ),
                 (

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -13579,26 +13579,35 @@ pub mod tests {
         db.clean_accounts_for_tests();
         db.add_root(2);
 
+        let assert_read_only_cache_len = |len| {
+            // wait for background thread to store the accounts to the cache
+            thread::sleep(Duration::from_millis(100));
+            assert_eq!(db.read_only_accounts_cache.cache_len(), len);
+        };
+
         assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
         let account = db
             .load_with_fixed_root(&Ancestors::default(), &account_key)
             .map(|(account, _)| account)
             .unwrap();
         assert_eq!(account.lamports(), 1);
-        assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+        assert_read_only_cache_len(1);
+
         let account = db
             .load_with_fixed_root(&Ancestors::default(), &account_key)
             .map(|(account, _)| account)
             .unwrap();
         assert_eq!(account.lamports(), 1);
-        assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+        assert_read_only_cache_len(1);
+
         db.store_cached((2, &[(&account_key, &zero_lamport_account)][..]), None);
-        assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+        assert_read_only_cache_len(1);
+
         let account = db
             .load_with_fixed_root(&Ancestors::default(), &account_key)
             .map(|(account, _)| account);
         assert!(account.is_none());
-        assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+        assert_read_only_cache_len(1);
     }
 
     #[test]

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5374,8 +5374,8 @@ impl AccountsDb {
             However, by the assumption for contradiction above ,  'A' has already been updated in 'S' which means '(S, A)'
             must exist in the write cache, which is a contradiction.
             */
-            self.read_only_accounts_cache
-                .store(*pubkey, slot, account.clone());
+            let to_store = Arc::new((*pubkey, slot, account.clone()));
+            self.read_only_accounts_cache.store(to_store);
         }
         Some((account, slot))
     }

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -586,7 +586,7 @@ mod tests {
         }
 
         // wait for background thread to store the accounts
-        thread::sleep(Duration::from_millis(1000));
+        thread::sleep(Duration::from_millis(100));
 
         // we haven't exceeded the max cache size yet, so no evictions should've happened
         assert_eq!(cache.cache_len(), MAX_ENTRIES);

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -121,7 +121,7 @@ impl ReadOnlyAccountsCache {
         let highest_slot_stored = Arc::new(AtomicU64::default());
         let stats = Arc::new(ReadOnlyCacheStats::default());
         let (store_sender, store_receiver) =
-            crossbeam_channel::unbounded::<Arc<AccountToStoreInCache>>();
+            crossbeam_channel::bounded::<Arc<AccountToStoreInCache>>(1);
         let store_processor = Self::spawn_store_processor(
             store_receiver,
             max_data_size_lo,
@@ -211,7 +211,7 @@ impl ReadOnlyAccountsCache {
         let (pubkey, slot, account) = to_store;
         highest_slot_stored.fetch_max(*slot, Ordering::Release);
         let key = (*pubkey, *slot);
-        let account_size = Self::account_size(&account);
+        let account_size = Self::account_size(account);
         data_size.fetch_add(account_size, Ordering::Relaxed);
         // self.queue is modified while holding a reference to the cache entry;
         // so that another thread cannot write to the same key.


### PR DESCRIPTION
#### Problem

Extend the idea of https://github.com/anza-xyz/agave/pull/575

We can do ALL readonly cache "store" in background. 

![image](https://github.com/anza-xyz/agave/assets/219428/f62530e9-b2a3-46bf-b74b-7625d9218945)

The above graph shows the `store` time in the foreground (red) and background (blue). The foreground store time is lower and has almost no jitter, which should be good for a better and more consistent block processing time. 

#### Summary of Changes

- move read-cache store to background
- wait for background thread to fix test

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
