### PR TITLE
Fix - `ProgramCache::assign_program()` Closed => Loaded in same slot

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -776,17 +776,12 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             Ok(index) => {
                 let existing = slot_versions.get_mut(index).unwrap();
                 match (&existing.program, &entry.program) {
-                    // Add test for Closed => Loaded transition in same slot
                     (LoadedProgramType::Builtin(_), LoadedProgramType::Builtin(_))
-                    | (LoadedProgramType::Closed, LoadedProgramType::LegacyV0(_))
-                    | (LoadedProgramType::Closed, LoadedProgramType::LegacyV1(_))
-                    | (LoadedProgramType::Closed, LoadedProgramType::Typed(_))
                     | (LoadedProgramType::Unloaded(_), LoadedProgramType::LegacyV0(_))
                     | (LoadedProgramType::Unloaded(_), LoadedProgramType::LegacyV1(_))
                     | (LoadedProgramType::Unloaded(_), LoadedProgramType::Typed(_)) => {}
                     #[cfg(test)]
-                    (LoadedProgramType::Closed, LoadedProgramType::TestLoaded(_))
-                    | (LoadedProgramType::Unloaded(_), LoadedProgramType::TestLoaded(_)) => {}
+                    (LoadedProgramType::Unloaded(_), LoadedProgramType::TestLoaded(_)) => {}
                     _ => {
                         // Something is wrong, I can feel it ...
                         error!("ProgramCache::assign_program() failed key={:?} existing={:?} entry={:?}", key, slot_versions, entry);
@@ -1684,6 +1679,7 @@ mod tests {
 
     #[test_matrix(
         (
+            LoadedProgramType::Closed,
             LoadedProgramType::FailedVerification(Arc::new(BuiltinProgram::new_mock())),
             LoadedProgramType::TestLoaded(Arc::new(BuiltinProgram::new_mock())),
         ),
@@ -1697,7 +1693,6 @@ mod tests {
     )]
     #[test_matrix(
         (
-            LoadedProgramType::Closed,
             LoadedProgramType::Unloaded(Arc::new(BuiltinProgram::new_mock())),
         ),
         (
@@ -1746,10 +1741,6 @@ mod tests {
         );
     }
 
-    #[test_case(
-        LoadedProgramType::Closed,
-        LoadedProgramType::TestLoaded(Arc::new(BuiltinProgram::new_mock()))
-    )]
     #[test_case(
         LoadedProgramType::Unloaded(Arc::new(BuiltinProgram::new_mock())),
         LoadedProgramType::TestLoaded(Arc::new(BuiltinProgram::new_mock()))


### PR DESCRIPTION
#### Problem
Turns out the Closed => Loaded in same slot transition is not actually possible and was caused by a faulty test.

#### Summary of Changes
- Reverts `ProgramCache::assign_program()` Closed => Loaded in same slot transition
- Adds a test to show that invoking uninitialized but non-empty accounts belonging to a loader results in a Closed tombstone with the same deployment slot and effective slot
- Adds a test to show that after deployment a new loaded entry is inserted at the same deployment slot but a different effective slot
