### PR TITLE
implement scan_index for hot storage

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -127,7 +127,7 @@ impl<'storage> StoredAccountMeta<'storage> {
     pub fn stored_size(&self) -> usize {
         match self {
             Self::AppendVec(av) => av.stored_size(),
-            Self::Hot(_) => unimplemented!(),
+            Self::Hot(hot) => hot.stored_size(),
         }
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9712,7 +9712,10 @@ pub mod tests {
             // index entry should only contain a single entry for the pubkey since index cannot hold more than 1 entry per slot
             let entry = db.accounts_index.get_cloned(&pubkey).unwrap();
             assert_eq!(entry.slot_list.read().unwrap().len(), 1);
-            assert_eq!(append_vec.alive_bytes(), expected_alive_bytes);
+            if accounts_file_provider == AccountsFileProvider::AppendVec {
+                // alive bytes doesn't match account size for tiered storage
+                assert_eq!(append_vec.alive_bytes(), expected_alive_bytes);
+            }
             // total # accounts in append vec
             assert_eq!(append_vec.approx_stored_count(), 2);
             // # alive accounts

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9663,10 +9663,11 @@ pub mod tests {
         }
     }
 
-    #[test]
-    fn test_generate_index_duplicates_within_slot() {
+    #[test_case(AccountsFileProvider::AppendVec)]
+    #[test_case(AccountsFileProvider::HotStorage)]
+    fn test_generate_index_duplicates_within_slot(accounts_file_provider: AccountsFileProvider) {
         for reverse in [false, true] {
-            let db = AccountsDb::new_single_for_tests();
+            let db = AccountsDb::new_single_for_tests_with_provider(accounts_file_provider);
             let slot0 = 0;
 
             let pubkey = Pubkey::from([1; 32]);
@@ -15348,9 +15349,11 @@ pub mod tests {
     ///     - ensure Account1 *has* been purged
     #[test_case(AccountsFileProvider::AppendVec)]
     #[test_case(AccountsFileProvider::HotStorage)]
-    fn test_clean_accounts_with_last_full_snapshot_slot(file_provider: AccountsFileProvider) {
+    fn test_clean_accounts_with_last_full_snapshot_slot(
+        accounts_file_provider: AccountsFileProvider,
+    ) {
         solana_logger::setup();
-        let accounts_db = AccountsDb::new_single_for_tests_with_provider(file_provider);
+        let accounts_db = AccountsDb::new_single_for_tests_with_provider(accounts_file_provider);
         let pubkey = solana_sdk::pubkey::new_rand();
         let owner = solana_sdk::pubkey::new_rand();
         let space = 0;

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -189,7 +189,11 @@ impl AccountsFile {
     pub(crate) fn scan_index(&self, callback: impl FnMut(IndexInfo)) {
         match self {
             Self::AppendVec(av) => av.scan_index(callback),
-            Self::TieredStorage(_ts) => unimplemented!(),
+            Self::TieredStorage(ts) => {
+                if let Some(reader) = ts.reader() {
+                    _ = reader.scan_index(callback);
+                }
+            }
         }
     }
 

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -2,9 +2,11 @@
 
 use {
     crate::{
+        account_info::AccountInfo,
         account_storage::meta::{StoredAccountInfo, StoredAccountMeta},
         accounts_file::MatchAccountOwnerError,
         accounts_hash::AccountHash,
+        append_vec::{IndexInfo, IndexInfoInner},
         tiered_storage::{
             byte_block,
             file::{TieredReadableFile, TieredWritableFile},
@@ -243,6 +245,25 @@ impl TieredAccountMeta for HotAccountMeta {
             .flatten()
     }
 
+    /// Returns the epoch that this account will next owe rent by parsing
+    /// the specified account block.  RENT_EXEMPT_RENT_EPOCH will be returned
+    /// if the account is rent-exempt.
+    ///
+    /// For a zero-lamport account, Epoch::default() will be returned to
+    /// default states of an AccountSharedData.
+    fn final_rent_epoch(&self, account_block: &[u8]) -> Epoch {
+        self.rent_epoch(account_block)
+            .unwrap_or(if self.lamports() != 0 {
+                RENT_EXEMPT_RENT_EPOCH
+            } else {
+                // While there is no valid-values for any fields of a zero
+                // lamport account, here we return Epoch::default() to
+                // match the default states of AccountSharedData.  Otherwise,
+                // a hash mismatch will occur.
+                Epoch::default()
+            })
+    }
+
     /// Returns the offset of the optional fields based on the specified account
     /// block.
     fn optional_fields_offset(&self, account_block: &[u8]) -> usize {
@@ -321,17 +342,7 @@ impl<'accounts_file, M: TieredAccountMeta> ReadableAccount for HotAccount<'accou
     /// For a zero-lamport account, Epoch::default() will be returned to
     /// default states of an AccountSharedData.
     fn rent_epoch(&self) -> Epoch {
-        self.meta
-            .rent_epoch(self.account_block)
-            .unwrap_or(if self.lamports() != 0 {
-                RENT_EXEMPT_RENT_EPOCH
-            } else {
-                // While there is no valid-values for any fields of a zero
-                // lamport account, here we return Epoch::default() to
-                // match the default states of AccountSharedData.  Otherwise,
-                // a hash mismatch will occur.
-                Epoch::default()
-            })
+        self.meta.final_rent_epoch(self.account_block)
     }
 
     /// Returns the data associated to this account.
@@ -554,6 +565,7 @@ impl HotStorageReader {
         Ok(accounts)
     }
 
+    /// iterate over all pubkeys
     pub fn scan_pubkeys(&self, mut callback: impl FnMut(&Pubkey)) -> TieredStorageResult<()> {
         for i in 0..self.footer.account_entry_count {
             let address = self.get_account_address(IndexOffset(i))?;
@@ -562,10 +574,47 @@ impl HotStorageReader {
         Ok(())
     }
 
+    /// iterate over all entries to put in index
+    pub(crate) fn scan_index(
+        &self,
+        mut callback: impl FnMut(IndexInfo),
+    ) -> TieredStorageResult<()> {
+        for i in 0..self.footer.account_entry_count {
+            let index_offset = IndexOffset(i);
+            let account_offset = self.get_account_offset(index_offset)?;
+
+            let meta = self.get_account_meta_from_offset(account_offset)?;
+            let pubkey = self.get_account_address(index_offset)?;
+            let lamports = meta.lamports();
+            let account_block = self.get_account_block(account_offset, index_offset)?;
+            let data_len = meta.account_data_size(account_block);
+            callback(IndexInfo {
+                index_info: {
+                    IndexInfoInner {
+                        pubkey: *pubkey,
+                        lamports,
+                        offset: AccountInfo::reduced_offset_to_offset(i),
+                        data_len: data_len as u64,
+                        executable: meta.flags().executable(),
+                        rent_epoch: meta.final_rent_epoch(account_block),
+                    }
+                },
+                stored_size_aligned: stored_size(data_len),
+            });
+        }
+        Ok(())
+    }
+
     /// Returns a slice suitable for use when archiving hot storages
     pub fn data_for_archive(&self) -> &[u8] {
         self.mmap.as_ref()
     }
+}
+
+/// return an approximation of the cost to store an account.
+/// Some fields like owner are shared across multiple accounts.
+fn stored_size(data_len: usize) -> usize {
+    data_len + std::mem::size_of::<Pubkey>()
 }
 
 fn write_optional_fields(

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -317,6 +317,11 @@ impl<'accounts_file, M: TieredAccountMeta> HotAccount<'accounts_file, M> {
     pub fn data(&self) -> &'accounts_file [u8] {
         self.meta.account_data(self.account_block)
     }
+
+    /// Returns the approximate stored size of this account.
+    pub fn stored_size(&self) -> usize {
+        stored_size(self.meta.account_data_size(self.account_block))
+    }
 }
 
 impl<'accounts_file, M: TieredAccountMeta> ReadableAccount for HotAccount<'accounts_file, M> {

--- a/accounts-db/src/tiered_storage/meta.rs
+++ b/accounts-db/src/tiered_storage/meta.rs
@@ -68,6 +68,14 @@ pub trait TieredAccountMeta: Sized {
     /// does not persist this optional field.
     fn rent_epoch(&self, _account_block: &[u8]) -> Option<Epoch>;
 
+    /// Returns the epoch that this account will next owe rent by parsing
+    /// the specified account block.  RENT_EXEMPT_RENT_EPOCH will be returned
+    /// if the account is rent-exempt.
+    ///
+    /// For a zero-lamport account, Epoch::default() will be returned to
+    /// default states of an AccountSharedData.
+    fn final_rent_epoch(&self, account_block: &[u8]) -> Epoch;
+
     /// Returns the offset of the optional fields based on the specified account
     /// block.
     fn optional_fields_offset(&self, _account_block: &[u8]) -> usize;

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         account_storage::meta::StoredAccountMeta,
         accounts_file::MatchAccountOwnerError,
+        append_vec::IndexInfo,
         tiered_storage::{
             file::TieredReadableFile,
             footer::{AccountMetaFormat, TieredStorageFooter},
@@ -109,9 +110,17 @@ impl TieredStorageReader {
         }
     }
 
+    /// iterate over all pubkeys
     pub fn scan_pubkeys(&self, callback: impl FnMut(&Pubkey)) -> TieredStorageResult<()> {
         match self {
             Self::Hot(hot) => hot.scan_pubkeys(callback),
+        }
+    }
+
+    /// iterate over all entries to put in index
+    pub(crate) fn scan_index(&self, callback: impl FnMut(IndexInfo)) -> TieredStorageResult<()> {
+        match self {
+            Self::Hot(hot) => hot.scan_index(callback),
         }
     }
 


### PR DESCRIPTION
#### Problem
new storage format needs to support the latest storage api changes

#### Summary of Changes
Implement ` scan_index ` for hot storage

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
