### PR TITLE
implement get_account_sizes for hot storages

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        account_info::AccountInfo,
         accounts_hash::AccountHash,
         append_vec::AppendVecStoredAccountMeta,
         storable_accounts::StorableAccounts,
@@ -134,7 +135,7 @@ impl<'storage> StoredAccountMeta<'storage> {
     pub fn offset(&self) -> usize {
         match self {
             Self::AppendVec(av) => av.offset(),
-            Self::Hot(hot) => hot.index().0 as usize,
+            Self::Hot(hot) => AccountInfo::reduced_offset_to_offset(hot.index().0),
         }
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -14000,9 +14000,10 @@ pub mod tests {
         }
     }
 
-    #[test]
-    fn test_alive_bytes() {
-        let accounts_db = AccountsDb::new_single_for_tests();
+    #[test_case(AccountsFileProvider::AppendVec)]
+    #[test_case(AccountsFileProvider::HotStorage)]
+    fn test_alive_bytes(accounts_file_provider: AccountsFileProvider) {
+        let accounts_db = AccountsDb::new_single_for_tests_with_provider(accounts_file_provider);
         let slot: Slot = 0;
         let num_keys = 10;
 
@@ -14033,7 +14034,12 @@ pub mod tests {
             let reclaims = [account_info];
             accounts_db.remove_dead_accounts(reclaims.iter(), None, true);
             let after_size = storage0.alive_bytes.load(Ordering::Acquire);
-            assert_eq!(before_size, after_size + account.stored_size());
+            if storage0.count() == 0 && AccountsFileProvider::HotStorage == accounts_file_provider {
+                // when `remove_dead_accounts` reaches 0 accounts, all bytes are marked as dead
+                assert_eq!(after_size, 0);
+            } else {
+                assert_eq!(before_size, after_size + account.stored_size());
+            }
         }
     }
 

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -178,10 +178,14 @@ impl AccountsFile {
         AccountsFileIter::new(self)
     }
 
+    /// for each offset in `sorted_offsets`, return the account size
     pub(crate) fn get_account_sizes(&self, sorted_offsets: &[usize]) -> Vec<usize> {
         match self {
             Self::AppendVec(av) => av.get_account_sizes(sorted_offsets),
-            Self::TieredStorage(_) => unimplemented!(),
+            Self::TieredStorage(ts) => ts
+                .reader()
+                .and_then(|reader| reader.get_account_sizes(sorted_offsets).ok())
+                .unwrap_or_default(),
         }
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -674,7 +674,7 @@ impl AppendVec {
     /// for each offset in `sorted_offsets`, get the size of the account. No other information is needed for the account.
     pub(crate) fn get_account_sizes(&self, sorted_offsets: &[usize]) -> Vec<usize> {
         let mut result = Vec::with_capacity(sorted_offsets.len());
-        for offset in sorted_offsets.iter().cloned() {
+        for &offset in sorted_offsets {
             let Some((stored_meta, _)) = self.get_type::<StoredMeta>(offset) else {
                 break;
             };

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -579,6 +579,23 @@ impl HotStorageReader {
         Ok(())
     }
 
+    /// for each offset in `sorted_offsets`, return the account size
+    pub(crate) fn get_account_sizes(
+        &self,
+        sorted_offsets: &[usize],
+    ) -> TieredStorageResult<Vec<usize>> {
+        let mut result = Vec::with_capacity(sorted_offsets.len());
+        for &offset in sorted_offsets {
+            let index_offset = IndexOffset(AccountInfo::get_reduced_offset(offset));
+            let account_offset = self.get_account_offset(index_offset)?;
+            let meta = self.get_account_meta_from_offset(account_offset)?;
+            let account_block = self.get_account_block(account_offset, index_offset)?;
+            let data_len = meta.account_data_size(account_block);
+            result.push(stored_size(data_len));
+        }
+        Ok(result)
+    }
+
     /// iterate over all entries to put in index
     pub(crate) fn scan_index(
         &self,

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -124,6 +124,16 @@ impl TieredStorageReader {
         }
     }
 
+    /// for each offset in `sorted_offsets`, return the account size
+    pub(crate) fn get_account_sizes(
+        &self,
+        sorted_offsets: &[usize],
+    ) -> TieredStorageResult<Vec<usize>> {
+        match self {
+            Self::Hot(hot) => hot.get_account_sizes(sorted_offsets),
+        }
+    }
+
     /// Returns a slice suitable for use when archiving tiered storages
     pub fn data_for_archive(&self) -> &[u8] {
         match self {


### PR DESCRIPTION
#### Problem
new storage format needs to support the latest storage api changes

#### Summary of Changes
Implement ` get_account_sizes ` for hot storage.
This pr also works on the `stored_size` concept.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
