### PR TITLE
Move Stats::submit to solana-runtime

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -177,7 +177,7 @@ pub struct LoadedProgram {
 
 /// Global cache statistics for [ProgramCache].
 #[derive(Debug, Default)]
-pub struct Stats {
+pub struct LoadedProgramStats {
     /// a program was already in the cache
     pub hits: AtomicU64,
     /// a program was not found and loaded instead
@@ -202,9 +202,9 @@ pub struct Stats {
     pub empty_entries: AtomicU64,
 }
 
-impl Stats {
+impl LoadedProgramStats {
     pub fn reset(&mut self) {
-        *self = Stats::default();
+        *self = LoadedProgramStats::default();
     }
 }
 
@@ -561,7 +561,7 @@ pub struct ProgramCache<FG: ForkGraph> {
     /// List of loaded programs which should be recompiled before the next epoch (but don't have to).
     pub programs_to_recompile: Vec<(Pubkey, Arc<LoadedProgram>)>,
     /// Statistics counters
-    pub stats: Stats,
+    pub stats: LoadedProgramStats,
     /// Reference to the block store
     pub fork_graph: Option<Arc<RwLock<FG>>>,
     /// Coordinates TX batches waiting for others to complete their task during cooperative loading
@@ -706,7 +706,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             environments: ProgramRuntimeEnvironments::default(),
             upcoming_environments: None,
             programs_to_recompile: Vec::default(),
-            stats: Stats::default(),
+            stats: LoadedProgramStats::default(),
             fork_graph: None,
             loading_task_waiter: Arc::new(LoadingTaskWaiter::default()),
         }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -206,20 +206,18 @@ impl LoadedProgramStats {
     pub fn reset(&mut self) {
         *self = LoadedProgramStats::default();
     }
-    pub fn log(&self, stats_calculated: LoadedProgramStatsCalculated) {
-        let LoadedProgramStatsCalculated {
-            hits,
-            misses,
-            evictions,
-            reloads,
-            insertions,
-            lost_insertions,
-            replacements,
-            one_hit_wonders,
-            prunes_orphan,
-            prunes_environment,
-            empty_entries,
-        } = stats_calculated;
+    pub fn log(&self) {
+        let hits = self.hits.load(Ordering::Relaxed);
+        let misses = self.misses.load(Ordering::Relaxed);
+        let evictions: u64 = self.evictions.values().sum();
+        let reloads = self.reloads.load(Ordering::Relaxed);
+        let insertions = self.insertions.load(Ordering::Relaxed);
+        let lost_insertions = self.lost_insertions.load(Ordering::Relaxed);
+        let replacements = self.replacements.load(Ordering::Relaxed);
+        let one_hit_wonders = self.one_hit_wonders.load(Ordering::Relaxed);
+        let prunes_orphan = self.prunes_orphan.load(Ordering::Relaxed);
+        let prunes_environment = self.prunes_environment.load(Ordering::Relaxed);
+        let empty_entries = self.empty_entries.load(Ordering::Relaxed);
         debug!(
             "Loaded Programs Cache Stats -- Hits: {}, Misses: {}, Evictions: {}, Reloads: {}, Insertions: {} Lost-Insertions: {}, Replacements: {}, One-Hit-Wonders: {}, Prunes-Orphan: {}, Prunes-Environment: {}, Empty: {}",
             hits, misses, evictions, reloads, insertions, lost_insertions, replacements, one_hit_wonders, prunes_orphan, prunes_environment, empty_entries
@@ -243,34 +241,6 @@ impl LoadedProgramStats {
             );
         }
     }
-}
-
-/// Like [LoadedProgramStats], but the `AtomicU64` fields are already loaded
-/// and the `evictions` field is summed.
-#[derive(Debug, Default)]
-pub struct LoadedProgramStatsCalculated {
-    /// a program was already in the cache
-    pub hits: u64,
-    /// a program was not found and loaded instead
-    pub misses: u64,
-    /// a compiled executable was unloaded
-    pub evictions: u64,
-    /// an unloaded program was loaded again (opposite of eviction)
-    pub reloads: u64,
-    /// a program was loaded or un/re/deployed
-    pub insertions: u64,
-    /// a program was loaded but can not be extracted on its own fork anymore
-    pub lost_insertions: u64,
-    /// a program which was already in the cache was reloaded by mistake
-    pub replacements: u64,
-    /// a program was only used once before being unloaded
-    pub one_hit_wonders: u64,
-    /// a program became unreachable in the fork graph because of rerooting
-    pub prunes_orphan: u64,
-    /// a program got pruned because it was not recompiled for the next epoch
-    pub prunes_environment: u64,
-    /// the [SecondLevel] was empty because all slot versions got pruned
-    pub empty_entries: u64,
 }
 
 /// Time measurements for loading a single [LoadedProgram].

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -36,6 +36,8 @@
 #[allow(deprecated)]
 use solana_sdk::recent_blockhashes_account;
 pub use solana_sdk::reward_type::RewardType;
+use crate::bank_utils::submit_loaded_programs_stats;
+
 use {
     crate::{
         bank::{
@@ -1360,13 +1362,15 @@ impl Bank {
             },
         );
 
-        parent
-            .transaction_processor
-            .program_cache
-            .read()
-            .unwrap()
-            .stats
-            .submit(parent.slot());
+        submit_loaded_programs_stats(
+            &parent
+                .transaction_processor
+                .program_cache
+                .read()
+                .unwrap()
+                .stats,
+            parent.slot(),
+        );
 
         new.transaction_processor
             .program_cache

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -46,7 +46,6 @@ use {
             },
         },
         bank_forks::BankForks,
-        bank_utils::submit_loaded_programs_stats,
         epoch_stakes::{EpochStakes, NodeVoteAccounts},
         installed_scheduler_pool::{BankWithScheduler, InstalledSchedulerRwLock},
         runtime_config::RuntimeConfig,
@@ -1361,7 +1360,7 @@ impl Bank {
             },
         );
 
-        submit_loaded_programs_stats(
+        report_loaded_programs_stats(
             &parent
                 .transaction_processor
                 .program_cache

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -36,8 +36,6 @@
 #[allow(deprecated)]
 use solana_sdk::recent_blockhashes_account;
 pub use solana_sdk::reward_type::RewardType;
-use crate::bank_utils::submit_loaded_programs_stats;
-
 use {
     crate::{
         bank::{
@@ -48,6 +46,7 @@ use {
             },
         },
         bank_forks::BankForks,
+        bank_utils::submit_loaded_programs_stats,
         epoch_stakes::{EpochStakes, NodeVoteAccounts},
         installed_scheduler_pool::{BankWithScheduler, InstalledSchedulerRwLock},
         runtime_config::RuntimeConfig,

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -1,6 +1,5 @@
 use {
     crate::bank::Bank,
-    log::{debug, log_enabled, trace},
     solana_program_runtime::loaded_programs::{LoadedProgramStats, LoadedProgramStatsCalculated},
     solana_sdk::clock::{Epoch, Slot},
     std::sync::atomic::{
@@ -233,17 +232,5 @@ pub(crate) fn report_loaded_programs_stats(stats: &LoadedProgramStats, slot: Slo
         ("prunes_environment", prunes_environment, i64),
         ("empty_entries", empty_entries, i64),
     );
-    stats.log(LoadedProgramStatsCalculated {
-        hits,
-        misses,
-        evictions,
-        reloads,
-        insertions,
-        lost_insertions,
-        replacements,
-        one_hit_wonders,
-        prunes_orphan,
-        prunes_environment,
-        empty_entries,
-    });
+    stats.log();
 }

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -1,7 +1,7 @@
 use {
     crate::bank::Bank,
     log::{debug, log_enabled, trace},
-    solana_program_runtime::loaded_programs::LoadedProgramStats,
+    solana_program_runtime::loaded_programs::{LoadedProgramStats, LoadedProgramStatsCalculated},
     solana_sdk::clock::{Epoch, Slot},
     std::sync::atomic::{
         AtomicU64,
@@ -233,26 +233,17 @@ pub(crate) fn report_loaded_programs_stats(stats: &LoadedProgramStats, slot: Slo
         ("prunes_environment", prunes_environment, i64),
         ("empty_entries", empty_entries, i64),
     );
-    debug!(
-            "Loaded Programs Cache Stats -- Hits: {}, Misses: {}, Evictions: {}, Reloads: {}, Insertions: {} Lost-Insertions: {}, Replacements: {}, One-Hit-Wonders: {}, Prunes-Orphan: {}, Prunes-Environment: {}, Empty: {}",
-            hits, misses, evictions, reloads, insertions, lost_insertions, replacements, one_hit_wonders, prunes_orphan, prunes_environment, empty_entries
-        );
-    if log_enabled!(log::Level::Trace) && !stats.evictions.is_empty() {
-        let mut evictions = stats.evictions.iter().collect::<Vec<_>>();
-        evictions.sort_by_key(|e| e.1);
-        let evictions = evictions
-            .into_iter()
-            .rev()
-            .map(|(program_id, evictions)| {
-                format!("  {:<44}  {}", program_id.to_string(), evictions)
-            })
-            .collect::<Vec<_>>();
-        let evictions = evictions.join("\n");
-        trace!(
-            "Eviction Details:\n  {:<44}  {}\n{}",
-            "Program",
-            "Count",
-            evictions
-        );
-    }
+    stats.log(LoadedProgramStatsCalculated {
+        hits,
+        misses,
+        evictions,
+        reloads,
+        insertions,
+        lost_insertions,
+        replacements,
+        one_hit_wonders,
+        prunes_orphan,
+        prunes_environment,
+        empty_entries,
+    });
 }

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -1,6 +1,6 @@
 use {
     crate::bank::Bank,
-    solana_program_runtime::loaded_programs::{LoadedProgramStats, LoadedProgramStatsCalculated},
+    solana_program_runtime::loaded_programs::LoadedProgramStats,
     solana_sdk::clock::{Epoch, Slot},
     std::sync::atomic::{
         AtomicU64,

--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -8,7 +8,7 @@ use {
 };
 use {
     log::{debug, log_enabled, trace},
-    solana_program_runtime::loaded_programs::Stats,
+    solana_program_runtime::loaded_programs::LoadedProgramStats,
     solana_sdk::{clock::Slot, transaction::SanitizedTransaction},
     solana_svm::transaction_results::TransactionResults,
     solana_vote::{vote_parser, vote_sender_types::ReplayVoteSender},
@@ -64,7 +64,7 @@ pub fn find_and_send_votes(
 }
 
 /// Logs the measurement values
-pub fn submit_loaded_programs_stats(stats: &Stats, slot: Slot) {
+pub fn submit_loaded_programs_stats(stats: &LoadedProgramStats, slot: Slot) {
     let hits = stats.hits.load(Ordering::Relaxed);
     let misses = stats.misses.load(Ordering::Relaxed);
     let evictions: u64 = stats.evictions.values().sum();

--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -7,9 +7,7 @@ use {
     solana_sdk::{pubkey::Pubkey, signature::Signer},
 };
 use {
-    solana_sdk::transaction::SanitizedTransaction,
-    solana_svm::transaction_results::TransactionResults,
-    solana_vote::{vote_parser, vote_sender_types::ReplayVoteSender},
+    log::{debug, log_enabled, trace}, solana_program_runtime::loaded_programs::Stats, solana_sdk::{clock::Slot, transaction::SanitizedTransaction}, solana_svm::transaction_results::TransactionResults, solana_vote::{vote_parser, vote_sender_types::ReplayVoteSender}, std::sync::atomic::Ordering
 };
 
 #[cfg(feature = "dev-context-only-utils")]
@@ -57,5 +55,57 @@ pub fn find_and_send_votes(
                     }
                 }
             });
+    }
+}
+
+/// Logs the measurement values
+pub fn submit_loaded_programs_stats(stats: &Stats, slot: Slot) {
+    let hits = stats.hits.load(Ordering::Relaxed);
+    let misses = stats.misses.load(Ordering::Relaxed);
+    let evictions: u64 = stats.evictions.values().sum();
+    let reloads = stats.reloads.load(Ordering::Relaxed);
+    let insertions = stats.insertions.load(Ordering::Relaxed);
+    let lost_insertions = stats.lost_insertions.load(Ordering::Relaxed);
+    let replacements = stats.replacements.load(Ordering::Relaxed);
+    let one_hit_wonders = stats.one_hit_wonders.load(Ordering::Relaxed);
+    let prunes_orphan = stats.prunes_orphan.load(Ordering::Relaxed);
+    let prunes_environment = stats.prunes_environment.load(Ordering::Relaxed);
+    let empty_entries = stats.empty_entries.load(Ordering::Relaxed);
+    datapoint_info!(
+        "loaded-programs-cache-stats",
+        ("slot", slot, i64),
+        ("hits", hits, i64),
+        ("misses", misses, i64),
+        ("evictions", evictions, i64),
+        ("reloads", reloads, i64),
+        ("insertions", insertions, i64),
+        ("lost_insertions", lost_insertions, i64),
+        ("replace_entry", replacements, i64),
+        ("one_hit_wonders", one_hit_wonders, i64),
+        ("prunes_orphan", prunes_orphan, i64),
+        ("prunes_environment", prunes_environment, i64),
+        ("empty_entries", empty_entries, i64),
+    );
+    debug!(
+            "Loaded Programs Cache Stats -- Hits: {}, Misses: {}, Evictions: {}, Reloads: {}, Insertions: {} Lost-Insertions: {}, Replacements: {}, One-Hit-Wonders: {}, Prunes-Orphan: {}, Prunes-Environment: {}, Empty: {}",
+            hits, misses, evictions, reloads, insertions, lost_insertions, replacements, one_hit_wonders, prunes_orphan, prunes_environment, empty_entries
+        );
+    if log_enabled!(log::Level::Trace) && !stats.evictions.is_empty() {
+        let mut evictions = stats.evictions.iter().collect::<Vec<_>>();
+        evictions.sort_by_key(|e| e.1);
+        let evictions = evictions
+            .into_iter()
+            .rev()
+            .map(|(program_id, evictions)| {
+                format!("  {:<44}  {}", program_id.to_string(), evictions)
+            })
+            .collect::<Vec<_>>();
+        let evictions = evictions.join("\n");
+        trace!(
+            "Eviction Details:\n  {:<44}  {}\n{}",
+            "Program",
+            "Count",
+            evictions
+        );
     }
 }

--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -7,7 +7,12 @@ use {
     solana_sdk::{pubkey::Pubkey, signature::Signer},
 };
 use {
-    log::{debug, log_enabled, trace}, solana_program_runtime::loaded_programs::Stats, solana_sdk::{clock::Slot, transaction::SanitizedTransaction}, solana_svm::transaction_results::TransactionResults, solana_vote::{vote_parser, vote_sender_types::ReplayVoteSender}, std::sync::atomic::Ordering
+    log::{debug, log_enabled, trace},
+    solana_program_runtime::loaded_programs::Stats,
+    solana_sdk::{clock::Slot, transaction::SanitizedTransaction},
+    solana_svm::transaction_results::TransactionResults,
+    solana_vote::{vote_parser, vote_sender_types::ReplayVoteSender},
+    std::sync::atomic::Ordering,
 };
 
 #[cfg(feature = "dev-context-only-utils")]

--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -7,12 +7,9 @@ use {
     solana_sdk::{pubkey::Pubkey, signature::Signer},
 };
 use {
-    log::{debug, log_enabled, trace},
-    solana_program_runtime::loaded_programs::LoadedProgramStats,
-    solana_sdk::{clock::Slot, transaction::SanitizedTransaction},
+    solana_sdk::transaction::SanitizedTransaction,
     solana_svm::transaction_results::TransactionResults,
     solana_vote::{vote_parser, vote_sender_types::ReplayVoteSender},
-    std::sync::atomic::Ordering,
 };
 
 #[cfg(feature = "dev-context-only-utils")]
@@ -60,57 +57,5 @@ pub fn find_and_send_votes(
                     }
                 }
             });
-    }
-}
-
-/// Logs the measurement values
-pub fn submit_loaded_programs_stats(stats: &LoadedProgramStats, slot: Slot) {
-    let hits = stats.hits.load(Ordering::Relaxed);
-    let misses = stats.misses.load(Ordering::Relaxed);
-    let evictions: u64 = stats.evictions.values().sum();
-    let reloads = stats.reloads.load(Ordering::Relaxed);
-    let insertions = stats.insertions.load(Ordering::Relaxed);
-    let lost_insertions = stats.lost_insertions.load(Ordering::Relaxed);
-    let replacements = stats.replacements.load(Ordering::Relaxed);
-    let one_hit_wonders = stats.one_hit_wonders.load(Ordering::Relaxed);
-    let prunes_orphan = stats.prunes_orphan.load(Ordering::Relaxed);
-    let prunes_environment = stats.prunes_environment.load(Ordering::Relaxed);
-    let empty_entries = stats.empty_entries.load(Ordering::Relaxed);
-    datapoint_info!(
-        "loaded-programs-cache-stats",
-        ("slot", slot, i64),
-        ("hits", hits, i64),
-        ("misses", misses, i64),
-        ("evictions", evictions, i64),
-        ("reloads", reloads, i64),
-        ("insertions", insertions, i64),
-        ("lost_insertions", lost_insertions, i64),
-        ("replace_entry", replacements, i64),
-        ("one_hit_wonders", one_hit_wonders, i64),
-        ("prunes_orphan", prunes_orphan, i64),
-        ("prunes_environment", prunes_environment, i64),
-        ("empty_entries", empty_entries, i64),
-    );
-    debug!(
-            "Loaded Programs Cache Stats -- Hits: {}, Misses: {}, Evictions: {}, Reloads: {}, Insertions: {} Lost-Insertions: {}, Replacements: {}, One-Hit-Wonders: {}, Prunes-Orphan: {}, Prunes-Environment: {}, Empty: {}",
-            hits, misses, evictions, reloads, insertions, lost_insertions, replacements, one_hit_wonders, prunes_orphan, prunes_environment, empty_entries
-        );
-    if log_enabled!(log::Level::Trace) && !stats.evictions.is_empty() {
-        let mut evictions = stats.evictions.iter().collect::<Vec<_>>();
-        evictions.sort_by_key(|e| e.1);
-        let evictions = evictions
-            .into_iter()
-            .rev()
-            .map(|(program_id, evictions)| {
-                format!("  {:<44}  {}", program_id.to_string(), evictions)
-            })
-            .collect::<Vec<_>>();
-        let evictions = evictions.join("\n");
-        trace!(
-            "Eviction Details:\n  {:<44}  {}\n{}",
-            "Program",
-            "Count",
-            evictions
-        );
     }
 }


### PR DESCRIPTION
#### Problem

See item 3 in #480:

> Move loaded_programs::Stats::submit to solana-runtime as a free function (Stats::submit is only used in bank.rs)

#### Summary of Changes

Makes Stats::submit a free function and moves it to bank_utils.rs in solana-runtime
