### PR TITLE
consensus: add dev-context-only-utils to tower

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6078,6 +6078,7 @@ dependencies = [
  "solana-quic-client",
  "solana-rpc",
  "solana-rpc-client",
+ "solana-runtime",
  "solana-sdk",
  "solana-streamer",
  "solana-tpu-client",

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -33,7 +33,7 @@ spl-token = { workspace = true, features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-accounts-db = { workspace = true }
-solana-core = { workspace = true }
+solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-local-cluster = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-test-validator = { workspace = true }

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -23,7 +23,7 @@ solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-client = { workspace = true }
 solana-connection-cache = { workspace = true }
-solana-core = { workspace = true }
+solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-faucet = { workspace = true }
 solana-genesis = { workspace = true }
 solana-gossip = { workspace = true }
@@ -36,7 +36,7 @@ solana-rpc = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-rpc-client-nonce-utils = { workspace = true }
-solana-runtime = { workspace = true }
+solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true }
 solana-streamer = { workspace = true }
 solana-tpu-client = { workspace = true }
@@ -54,3 +54,6 @@ tempfile = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+dev-context-only-utils = []

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -642,6 +642,7 @@ impl Tower {
         }
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn record_vote(&mut self, slot: Slot, hash: Hash) -> Option<Slot> {
         self.record_bank_vote_and_update_lockouts(slot, hash)
     }

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -38,4 +38,9 @@ solana-version = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
+solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-local-cluster = { workspace = true }
+solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+
+[features]
+dev-context-only-utils = []

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -45,8 +45,13 @@ assert_matches = { workspace = true }
 fs_extra = { workspace = true }
 gag = { workspace = true }
 serial_test = { workspace = true }
+solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-download-utils = { workspace = true }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+dev-context-only-utils = []

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -32,6 +32,7 @@ declare tainted_packages=(
   solana-accounts-bench
   solana-banking-bench
   agave-ledger-tool
+  solana-bench-tps
 )
 
 # convert to comma separeted (ref: https://stackoverflow.com/a/53839433)

--- a/transaction-dos/Cargo.toml
+++ b/transaction-dos/Cargo.toml
@@ -31,7 +31,9 @@ solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
 
 [dev-dependencies]
+solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-local-cluster = { workspace = true }
+solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
follow up from https://github.com/anza-xyz/agave/pull/355#discussion_r1535775469

Adds `dev-context-only-utils` to the previously `cfg(test)` fn