### PR TITLE
in get_pubkey_hash_account_for_slot use take_account earlier

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7605,13 +7605,12 @@ impl AccountsDb {
              loaded_account: LoadedAccount| {
                 // Storage may have duplicates so only keep the latest version for each key
                 let mut loaded_hash = loaded_account.loaded_hash();
+                let key = *loaded_account.pubkey();
+                let account = loaded_account.take_account();
                 if loaded_hash == AccountHash(Hash::default()) {
-                    loaded_hash = Self::hash_account(&loaded_account, loaded_account.pubkey())
+                    loaded_hash = Self::hash_account(&account, &key)
                 }
-                accum.insert(
-                    *loaded_account.pubkey(),
-                    (loaded_hash, loaded_account.take_account()),
-                );
+                accum.insert(key, (loaded_hash, account));
             },
         );
 


### PR DESCRIPTION
#### Problem
Trying to remove mmap on append vecs to relieve memory pressure.

#### Summary of Changes
call `take_account` earlier so that LoadedAccount doesn't have to impl `ReadableAccount` so that `data` doesn't always have to be available as &[u8]

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
