### PR TITLE
add `data_len()` to `LoadedAccount`

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -937,6 +937,11 @@ impl<'a> LoadedAccount<'a> {
             LoadedAccount::Cached(_) => true,
         }
     }
+
+    /// data_len can be calculated without having access to `&data` in future implementations
+    pub fn data_len(&self) -> usize {
+        self.data().len()
+    }
 }
 
 impl<'a> ReadableAccount for LoadedAccount<'a> {
@@ -9119,11 +9124,12 @@ impl AccountsDb {
                                 maybe_storage_entry.map(|entry| (entry, account_info.offset())),
                             );
                             let loaded_account = accessor.check_and_get_loaded_account();
-                            accounts_data_len_from_duplicates += loaded_account.data().len();
+                            let data_len = loaded_account.data_len();
+                            accounts_data_len_from_duplicates += data_len;
                             if let Some(lamports_to_top_off) = Self::stats_for_rent_payers(
                                 pubkey,
                                 loaded_account.lamports(),
-                                loaded_account.data().len(),
+                                data_len,
                                 loaded_account.rent_epoch(),
                                 loaded_account.executable(),
                                 rent_collector,


### PR DESCRIPTION
#### Problem
Trying to remove mmap on append vecs to relieve memory pressure.

#### Summary of Changes
add `data_len()`, which can be satisfied without having access to the data itself.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
