### PR TITLE
break out parameters to hash_account

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7571,7 +7571,14 @@ impl AccountsDb {
                 |accum: &DashMap<Pubkey, AccountHash>, loaded_account: LoadedAccount| {
                     let mut loaded_hash = loaded_account.loaded_hash();
                     if loaded_hash == AccountHash(Hash::default()) {
-                        loaded_hash = Self::hash_account(&loaded_account, loaded_account.pubkey())
+                        loaded_hash = Self::hash_account_data(
+                            loaded_account.lamports(),
+                            loaded_account.owner(),
+                            loaded_account.executable(),
+                            loaded_account.rent_epoch(),
+                            loaded_account.data(),
+                            loaded_account.pubkey(),
+                        )
                     }
                     accum.insert(*loaded_account.pubkey(), loaded_hash);
                 },


### PR DESCRIPTION
#### Problem
Trying to remove mmap on append vecs to relieve memory pressure.

#### Summary of Changes
we need to hash the account when calculating delta hash at snapshot load. We would like to make getting `data` optional for efficiency and removing mmap. So, break apart `hash_account` call to use the individual pieces.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
