### PR TITLE
remove `fn data()` from `StoredAccountMeta`

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -139,13 +139,6 @@ impl<'storage> StoredAccountMeta<'storage> {
         }
     }
 
-    pub fn data(&self) -> &'storage [u8] {
-        match self {
-            Self::AppendVec(av) => av.data(),
-            Self::Hot(hot) => hot.data(),
-        }
-    }
-
     pub fn data_len(&self) -> u64 {
         match self {
             Self::AppendVec(av) => av.data_len(),


### PR DESCRIPTION
#### Problem
Trying to remove mmap on append vecs to relieve memory pressure.

#### Summary of Changes
Remove `fn data()` from `StoredAccountMeta`. That removes the main thing we don't want to copy per account entry.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
