### PR TITLE
Removes setting write version for geyser when restoring from a snapshot

### DIFF
--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        account_storage::meta::{StoredAccountMeta, StoredMeta},
-        accounts_db::AccountsDb,
-    },
+    crate::{account_storage::meta::StoredAccountMeta, accounts_db::AccountsDb},
     solana_measure::measure::Measure,
     solana_metrics::*,
     solana_sdk::{
@@ -116,25 +113,14 @@ impl AccountsDb {
         &self,
         slot: Slot,
         notified_accounts: &mut HashSet<Pubkey>,
-        mut accounts_to_stream: HashMap<Pubkey, StoredAccountMeta>,
+        accounts_to_stream: HashMap<Pubkey, StoredAccountMeta>,
         notify_stats: &mut GeyserPluginNotifyAtSnapshotRestoreStats,
     ) {
         let notifier = self.accounts_update_notifier.as_ref().unwrap();
         let mut measure_notify = Measure::start("accountsdb-plugin-notifying-accounts");
-        let local_write_version = 0;
-        for (_, mut account) in accounts_to_stream.drain() {
-            // We do not need to rely on the specific write_version read from the append vec.
-            // So, overwrite the write_version with something that works.
-            // 'accounts_to_stream' is already a hashmap, so there is already only entry per pubkey.
-            // write_version is only used to order multiple entries with the same pubkey, so it doesn't matter what value it gets here.
-            // Passing 0 for everyone's write_version is sufficiently correct.
-            let meta = StoredMeta {
-                write_version_obsolete: local_write_version,
-                ..*account.meta()
-            };
-            account.set_meta(&meta);
+        for account in accounts_to_stream.values() {
             let mut measure_pure_notify = Measure::start("accountsdb-plugin-notifying-accounts");
-            notifier.notify_account_restore_from_snapshot(slot, &account);
+            notifier.notify_account_restore_from_snapshot(slot, account);
             measure_pure_notify.stop();
 
             notify_stats.total_pure_notify += measure_pure_notify.as_us() as usize;


### PR DESCRIPTION
#### Problem

We are trying to move account storage files *away* from using mmaps internally. The function `StoredAccountMeta::set_meta()` updates the underlying mmap, which will not be possible once mmaps are removed. (It's also not supported for Tiered Storage at all.)
https://github.com/anza-xyz/agave/blob/70c4cb0ba1fbef2b3aa5796420ed285c46f5c4f6/accounts-db/src/account_storage/meta.rs#L174-L181

The only caller of `set_meta()` is in geyser, when restoring from a snapshot.

Back when the call to `set_meta()` was added (in PR https://github.com/solana-labs/solana/pull/29623), we already knew that write version shouldn't be an issue. With the account write cache, we'll never have more than one version of an account written per slot to a storage file. And when restoring from a snapshot, we only will notify geyser with the latest version of each account (i.e. the version in the highest slot number). So we'll never need to disambiguate which account is "newer" for geyser when restoring from a snapshot (because there will only be one, and it will be the newest).

Now also, we always store zero for the write version to the append vecs. Geyser is the last piece that uses write version. Since geyser will still increment write version for its notifications, post-restore notifications will have a higher write version. (And really, geyser apps should be monitoring for `notify_end_of_restore_from_snapshot()` to know when account notifications from snapshots has ended.)


#### Summary of Changes

Removes setting write version for geyser when restoring from a snapshot (i.e. stop calling `StoredAccountMeta::set_meta()`).