### PR TITLE
Removes StoredAccountMeta::set_meta()

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -84,15 +84,6 @@ impl<'storage> StoredAccountMeta<'storage> {
         }
     }
 
-    pub fn set_meta(&mut self, meta: &'storage StoredMeta) {
-        match self {
-            Self::AppendVec(av) => av.set_meta(meta),
-            // Hot account does not support this API as it does not
-            // use the same in-memory layout as StoredMeta.
-            Self::Hot(_) => unreachable!(),
-        }
-    }
-
     pub(crate) fn sanitize(&self) -> bool {
         match self {
             Self::AppendVec(av) => av.sanitize(),

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -128,10 +128,6 @@ impl<'append_vec> AppendVecStoredAccountMeta<'append_vec> {
         self.meta
     }
 
-    pub fn set_meta(&mut self, meta: &'append_vec StoredMeta) {
-        self.meta = meta;
-    }
-
     pub(crate) fn sanitize(&self) -> bool {
         self.sanitize_executable() && self.sanitize_lamports()
     }


### PR DESCRIPTION
#### Problem

We are trying to move account storage files *away* from using mmaps internally. The function `StoredAccountMeta::set_meta()` updates the underlying mmap, which will not be possible once mmaps are removed. (It's also not supported for Tiered Storage at all.)

There are no callers of `set_meta()`.


#### Summary of Changes

Removes StoredAccountMeta::set_meta()