### PR TITLE
calculated fee details can be cleared out by lamports_per_signature

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4111,7 +4111,7 @@ impl Bank {
                         message.recent_blockhash(),
                     )?;
                 let fee = self.get_fee_for_message_with_lamports_per_signature(
-                    tx.message(),
+                    message,
                     lamports_per_signature,
                 );
 
@@ -4185,10 +4185,10 @@ impl Bank {
     }
 
     fn get_details_from_execution_result<'a>(
-        &'a self,
+        &self,
         execution_result: &'a TransactionExecutionResult,
         transaction_blockhash: &Hash,
-    ) -> Result<(&transaction::Result<()>, bool, u64)> {
+    ) -> Result<(&'a transaction::Result<()>, bool, u64)> {
         let (execution_status, durable_nonce_fee) = match &execution_result {
             TransactionExecutionResult::Executed { details, .. } => {
                 Ok((&details.status, details.durable_nonce_fee.as_ref()))

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4098,32 +4098,18 @@ impl Bank {
         txs: &[SanitizedTransaction],
         execution_results: &[TransactionExecutionResult],
     ) -> Vec<Result<()>> {
-        let hash_queue = self.blockhash_queue.read().unwrap();
         let mut fees = 0;
 
         let results = txs
             .iter()
             .zip(execution_results)
             .map(|(tx, execution_result)| {
-                let (execution_status, durable_nonce_fee) = match &execution_result {
-                    TransactionExecutionResult::Executed { details, .. } => {
-                        Ok((&details.status, details.durable_nonce_fee.as_ref()))
-                    }
-                    TransactionExecutionResult::NotExecuted(err) => Err(err.clone()),
-                }?;
-
-                let (lamports_per_signature, is_nonce) = durable_nonce_fee
-                    .map(|durable_nonce_fee| durable_nonce_fee.lamports_per_signature())
-                    .map(|maybe_lamports_per_signature| (maybe_lamports_per_signature, true))
-                    .unwrap_or_else(|| {
-                        (
-                            hash_queue.get_lamports_per_signature(tx.message().recent_blockhash()),
-                            false,
-                        )
-                    });
-
-                let lamports_per_signature =
-                    lamports_per_signature.ok_or(TransactionError::BlockhashNotFound)?;
+                let message = tx.message();
+                let (execution_status, is_nonce, lamports_per_signature) = self
+                    .get_details_from_execution_result(
+                        execution_result,
+                        message.recent_blockhash(),
+                    )?;
                 let fee = self.get_fee_for_message_with_lamports_per_signature(
                     tx.message(),
                     lamports_per_signature,
@@ -4158,35 +4144,35 @@ impl Bank {
             .iter()
             .zip(execution_results)
             .map(|(tx, execution_result)| {
-                let (execution_status, durable_nonce_fee) = match &execution_result {
-                    TransactionExecutionResult::Executed { details, .. } => {
-                        Ok((&details.status, details.durable_nonce_fee.as_ref()))
-                    }
-                    TransactionExecutionResult::NotExecuted(err) => Err(err.clone()),
-                }?;
-                let is_nonce = durable_nonce_fee.is_some();
-
                 let message = tx.message();
-                let fee_details = self.fee_structure.calculate_fee_details(
-                    message,
-                    &process_compute_budget_instructions(message.program_instructions_iter())
-                        .unwrap_or_default()
-                        .into(),
-                    self.feature_set
-                        .is_active(&include_loaded_accounts_data_size_in_fee_calculation::id()),
-                );
+                let (execution_status, is_nonce, lamports_per_signature) = self
+                    .get_details_from_execution_result(
+                        execution_result,
+                        message.recent_blockhash(),
+                    )?;
 
-                self.check_execution_status_and_charge_fee(
-                    message,
-                    execution_status,
-                    is_nonce,
-                    fee_details.total_fee(
+                if !FeeStructure::to_clear_transaction_fee(lamports_per_signature) {
+                    let fee_details = self.fee_structure.calculate_fee_details(
+                        message,
+                        &process_compute_budget_instructions(message.program_instructions_iter())
+                            .unwrap_or_default()
+                            .into(),
                         self.feature_set
-                            .is_active(&remove_rounding_in_fee_calculation::id()),
-                    ),
-                )?;
+                            .is_active(&include_loaded_accounts_data_size_in_fee_calculation::id()),
+                    );
 
-                accumulated_fee_details.accumulate(&fee_details);
+                    self.check_execution_status_and_charge_fee(
+                        message,
+                        execution_status,
+                        is_nonce,
+                        fee_details.total_fee(
+                            self.feature_set
+                                .is_active(&remove_rounding_in_fee_calculation::id()),
+                        ),
+                    )?;
+
+                    accumulated_fee_details.accumulate(&fee_details);
+                }
                 Ok(())
             })
             .collect();
@@ -4196,6 +4182,34 @@ impl Bank {
             .unwrap()
             .accumulate(&accumulated_fee_details);
         results
+    }
+
+    fn get_details_from_execution_result<'a>(
+        &'a self,
+        execution_result: &'a TransactionExecutionResult,
+        transaction_blockhash: &Hash,
+    ) -> Result<(&transaction::Result<()>, bool, u64)> {
+        let (execution_status, durable_nonce_fee) = match &execution_result {
+            TransactionExecutionResult::Executed { details, .. } => {
+                Ok((&details.status, details.durable_nonce_fee.as_ref()))
+            }
+            TransactionExecutionResult::NotExecuted(err) => Err(err.clone()),
+        }?;
+
+        let (lamports_per_signature, is_nonce) = durable_nonce_fee
+            .map(|durable_nonce_fee| durable_nonce_fee.lamports_per_signature())
+            .map(|maybe_lamports_per_signature| (maybe_lamports_per_signature, true))
+            .unwrap_or_else(|| {
+                let hash_queue = self.blockhash_queue.read().unwrap();
+                (
+                    hash_queue.get_lamports_per_signature(transaction_blockhash),
+                    false,
+                )
+            });
+
+        let lamports_per_signature =
+            lamports_per_signature.ok_or(TransactionError::BlockhashNotFound)?;
+        Ok((execution_status, is_nonce, lamports_per_signature))
     }
 
     fn check_execution_status_and_charge_fee(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4116,7 +4116,7 @@ impl Bank {
                 );
 
                 self.check_execution_status_and_charge_fee(
-                    tx.message(),
+                    message,
                     execution_status,
                     is_nonce,
                     fee,

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -110,6 +110,12 @@ impl FeeStructure {
             .saturating_mul(heap_cost)
     }
 
+    /// Backward compatibility - lamports_per_sisgnature == 0 means to clear
+    /// transaction fee to zero
+    pub fn to_clear_transaction_fee(lamports_per_signature: u64) -> bool {
+        lamports_per_signature == 0
+    }
+
     /// Calculate fee for `SanitizedMessage`
     #[cfg(not(target_os = "solana"))]
     pub fn calculate_fee(
@@ -120,20 +126,16 @@ impl FeeStructure {
         include_loaded_account_data_size_in_fee: bool,
         remove_rounding_in_fee_calculation: bool,
     ) -> u64 {
-        // Fee based on compute units and signatures
-        let congestion_multiplier = if lamports_per_signature == 0 {
-            0 // test only
+        if Self::to_clear_transaction_fee(lamports_per_signature) {
+            0
         } else {
-            1 // multiplier that has no effect
-        };
-
-        self.calculate_fee_details(
-            message,
-            budget_limits,
-            include_loaded_account_data_size_in_fee,
-        )
-        .total_fee(remove_rounding_in_fee_calculation)
-        .saturating_mul(congestion_multiplier)
+            self.calculate_fee_details(
+                message,
+                budget_limits,
+                include_loaded_account_data_size_in_fee,
+            )
+            .total_fee(remove_rounding_in_fee_calculation)
+        }
     }
 
     /// Calculate fee details for `SanitizedMessage`

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -110,7 +110,7 @@ impl FeeStructure {
             .saturating_mul(heap_cost)
     }
 
-    /// Backward compatibility - lamports_per_sisgnature == 0 means to clear
+    /// Backward compatibility - lamports_per_signature == 0 means to clear
     /// transaction fee to zero
     pub fn to_clear_transaction_fee(lamports_per_signature: u64) -> bool {
         lamports_per_signature == 0


### PR DESCRIPTION
#### Problem

To backward support existing behavior that `lamports_per_signature==0` means to clear transaction fee to zero - a widely adapted practice in tests, bank should honor same behavior when calculating and collecting FeeDetails.

#### Summary of Changes
- add function to explicitly states the use of lamports_per_signature is to determine if to zero out transaction fee.
- refactor out sharable code

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
