### PR TITLE
SVM: move bpf-loader-program to dev-dependencies

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6351,7 +6351,6 @@ dependencies = [
  "percentage",
  "rustc_version",
  "serde",
- "solana-bpf-loader-program",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-loader-v4-program",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -14,7 +14,6 @@ itertools = { workspace = true }
 log = { workspace = true }
 percentage = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
-solana-bpf-loader-program = { workspace = true }
 solana-frozen-abi = { workspace = true }
 solana-frozen-abi-macro = { workspace = true }
 solana-loader-v4-program = { workspace = true }
@@ -32,6 +31,7 @@ name = "solana_svm"
 bincode = { workspace = true }
 libsecp256k1 = { workspace = true }
 rand = { workspace = true }
+solana-bpf-loader-program = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 


### PR DESCRIPTION
### Problem
solana-bpf-loader-program is only needed as a dev dependency

### Summary of Changes
Move it to dev-dependencies