### PR TITLE
blockstore: scaffolding for chained merkle root conflict detection

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -169,6 +169,11 @@ fn run_check_duplicate(
             shred_slot,
             &root_bank,
         );
+        let chained_merkle_conflict_duplicate_proofs = cluster_nodes::check_feature_activation(
+            &feature_set::chained_merkle_conflict_duplicate_proofs::id(),
+            shred_slot,
+            &root_bank,
+        );
         let (shred1, shred2) = match shred {
             PossibleDuplicateShred::LastIndexConflict(shred, conflict)
             | PossibleDuplicateShred::ErasureConflict(shred, conflict) => {
@@ -180,6 +185,24 @@ fn run_check_duplicate(
             }
             PossibleDuplicateShred::MerkleRootConflict(shred, conflict) => {
                 if merkle_conflict_duplicate_proofs {
+                    // Although this proof can be immediately stored on detection, we wait until
+                    // here in order to check the feature flag, as storage in blockstore can
+                    // preclude the detection of other duplicate proofs in this slot
+                    if blockstore.has_duplicate_shreds_in_slot(shred_slot) {
+                        return Ok(());
+                    }
+                    blockstore.store_duplicate_slot(
+                        shred_slot,
+                        conflict.clone(),
+                        shred.clone().into_payload(),
+                    )?;
+                    (shred, conflict)
+                } else {
+                    return Ok(());
+                }
+            }
+            PossibleDuplicateShred::ChainedMerkleRootConflict(shred, conflict) => {
+                if chained_merkle_conflict_duplicate_proofs {
                     // Although this proof can be immediately stored on detection, we wait until
                     // here in order to check the feature flag, as storage in blockstore can
                     // preclude the detection of other duplicate proofs in this slot

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -151,6 +151,8 @@ pub enum BlockstoreError {
     MissingTransactionMetadata,
     #[error("transaction-index overflow")]
     TransactionIndexOverflow,
+    #[error("invalid erasure config")]
+    InvalidErasureConfig,
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -392,6 +392,14 @@ impl ErasureMeta {
         self.first_coding_index..self.first_coding_index + num_coding
     }
 
+    pub(crate) fn next_fec_set_index(&self) -> Option<u32> {
+        let num_data = u64::try_from(self.config.num_data).ok()?;
+        self.set_index
+            .checked_add(num_data)
+            .map(u32::try_from)?
+            .ok()
+    }
+
     pub(crate) fn status(&self, index: &Index) -> ErasureMetaStatus {
         use ErasureMetaStatus::*;
 

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -292,10 +292,14 @@ impl ShredId {
 }
 
 /// Tuple which identifies erasure coding set that the shred belongs to.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub(crate) struct ErasureSetId(Slot, /*fec_set_index:*/ u32);
 
 impl ErasureSetId {
+    pub(crate) fn new(slot: Slot, fec_set_index: u32) -> Self {
+        Self(slot, fec_set_index)
+    }
+
     pub(crate) fn slot(&self) -> Slot {
         self.0
     }
@@ -310,7 +314,6 @@ impl ErasureSetId {
 macro_rules! dispatch {
     ($vis:vis fn $name:ident(&self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
         #[inline]
-        #[allow(dead_code)]
         $vis fn $name(&self $(, $arg:$ty)?) $(-> $out)? {
             match self {
                 Self::ShredCode(shred) => shred.$name($($arg, )?),
@@ -728,7 +731,6 @@ pub mod layout {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn get_chained_merkle_root(shred: &[u8]) -> Option<Hash> {
         let offset = match get_shred_variant(shred).ok()? {
             ShredVariant::LegacyCode | ShredVariant::LegacyData => None,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -773,6 +773,10 @@ pub mod enable_gossip_duplicate_proof_ingestion {
     solana_sdk::declare_id!("FNKCMBzYUdjhHyPdsKG2LSmdzH8TCHXn3ytj8RNBS4nG");
 }
 
+pub mod chained_merkle_conflict_duplicate_proofs {
+    solana_sdk::declare_id!("chaie9S2zVfuxJKNRGkyTDokLwWxx6kD2ZLsqQHaDD8");
+}
+
 pub mod enable_chained_merkle_shreds {
     solana_sdk::declare_id!("7uZBkJXJ1HkuP6R3MJfZs7mLwymBcDbKdqbF51ZWLier");
 }
@@ -981,6 +985,7 @@ lazy_static! {
         (remove_rounding_in_fee_calculation::id(), "Removing unwanted rounding in fee calculation #34982"),
         (deprecate_unused_legacy_vote_plumbing::id(), "Deprecate unused legacy vote tx plumbing"),
         (enable_tower_sync_ix::id(), "Enable tower sync vote instruction"),
+        (chained_merkle_conflict_duplicate_proofs::id(), "generate duplicate proofs for chained merkle root conflicts"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -774,7 +774,7 @@ pub mod enable_gossip_duplicate_proof_ingestion {
 }
 
 pub mod chained_merkle_conflict_duplicate_proofs {
-    solana_sdk::declare_id!("chaie9S2zVfuxJKNRGkyTDokLwWxx6kD2ZLsqQHaDD8");
+    solana_sdk::declare_id!("mustrekeyVfuxJKNRGkyTDokLwWxx6kD2ZLsqQHaDD8");
 }
 
 pub mod enable_chained_merkle_shreds {


### PR DESCRIPTION
Split from #102 
The scaffolding needed to detect chained merkle root conflicts for sending duplicate proofs:
* feature gate
* window service processing
* find previous consecutive erasure set 
* check forward / backwards chaining

Contributes to https://github.com/solana-labs/solana/issues/34897