### PR TITLE
Uses `0` for write version at startup for geyser

### DIFF
--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -134,7 +134,7 @@ impl AccountsUpdateNotifierImpl {
             executable: stored_account_meta.executable(),
             rent_epoch: stored_account_meta.rent_epoch(),
             data: stored_account_meta.data(),
-            write_version: stored_account_meta.write_version(),
+            write_version: 0,
             txn: None,
         })
     }


### PR DESCRIPTION
#### Problem

We're trying to remove write version everywhere. The only remaining use of write version is for geyser. As an incremental step, we'd like to remove the `write_version()` method on `StoredAccountMeta`. Both to prevent new uses, and also because Tiered Storage does not support getting/setting a write version at all.

At startup, when loading from a snapshot, geyser is notified of all accounts. Currently this uses the write version from each account. The observation is that at startup we know (1) there is only a single version of each account, and (2) there are no concurrent slots/banks getting replayed. This means we'll never have concurrent updates to the same account and would need to disambiguate between them which is newer. This allows us to set the write version to `0`.


#### Summary of Changes

Use `0` for write version at startup.

Also note that we are manually setting the write version to 0 on the StoredAccountMeta just before `accountinfo_from_stored_account_meta()` is called:
https://github.com/anza-xyz/agave/blob/9706a6464665f7ebd6ead47f0d12f853ccacbab9/accounts-db/src/accounts_db/geyser_plugin_utils.rs#L124-L135
So the current behavior is unchanged with this PR.

Related to #702