### PR TITLE
Removes write version from store-tool

### DIFF
--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -50,9 +50,8 @@ fn main() {
             break;
         }
         info!(
-            "  account: {:?} version: {} lamports: {} data: {} hash: {:?}",
+            "  account: {:?} lamports: {} data: {} hash: {:?}",
             account.pubkey(),
-            account.write_version(),
             account.lamports(),
             account.data_len(),
             account.hash()
@@ -69,7 +68,6 @@ fn main() {
 fn is_account_zeroed(account: &StoredAccountMeta) -> bool {
     account.hash() == &AccountHash(Hash::default())
         && account.data_len() == 0
-        && account.write_version() == 0
         && account.pubkey() == &Pubkey::default()
         && account.to_account_shared_data() == AccountSharedData::default()
 }


### PR DESCRIPTION
#### Problem

We're trying to remove write version everywhere. The store-tool currently display and checks write version. Since it is now obsolete, we can remove it.


#### Summary of Changes

Remove write version from store-tool.