### PR TITLE
quic: do ordered reads, save 1 BTreeMap allocation per packet

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -842,7 +842,7 @@ async fn handle_connection(
                         while !stream_exit.load(Ordering::Relaxed) {
                             if let Ok(chunk) = tokio::time::timeout(
                                 exit_check_interval,
-                                stream.read_chunk(PACKET_DATA_SIZE, false),
+                                stream.read_chunk(PACKET_DATA_SIZE, true),
                             )
                             .await
                             {


### PR DESCRIPTION
Unordered reads cause a BTreeMap allocation for each packet inside quinn in Assembler::ensure_ordering. https://github.com/quinn-rs/quinn/blob/main/quinn-proto/src/connection/assembler.rs#L41

Most streams will fit in one datagram and will therefore be ordered by definition. Switch to ordered reads to avoid the allocation.
<img width="1039" alt="Screen Shot 2024-04-11 at 10 20 57 am" src="https://github.com/solana-labs/solana/assets/62002/a75e97c1-3799-4fd3-b82d-ee9d21e348b2">
