### PR TITLE
DocUpdate/Add bash header to validator startup script

### DIFF
--- a/docs/src/operations/setup-a-validator.md
+++ b/docs/src/operations/setup-a-validator.md
@@ -409,6 +409,7 @@ nano /home/sol/bin/validator.sh
 Copy and paste the following contents into `validator.sh` then save the file:
 
 ```
+#!/bin/bash
 exec agave-validator \
     --identity validator-keypair.json \
     --vote-account vote-account-keypair.json \


### PR DESCRIPTION
#### Problem
Without the #!/bin/header the systemctl will not launch the process.

#### Summary of Changes
Add #!bin/bash to the suggested validator.sh startup script in the doc.

Fixes #

