### PR TITLE
Fix typo

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -978,7 +978,7 @@ pub struct CliKeyedEpochReward {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CliEpochRewardshMetadata {
+pub struct CliEpochRewardsMetadata {
     pub epoch: Epoch,
     pub effective_slot: Slot,
     pub block_time: UnixTimestamp,
@@ -988,7 +988,7 @@ pub struct CliEpochRewardshMetadata {
 #[serde(rename_all = "camelCase")]
 pub struct CliKeyedEpochRewards {
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub epoch_metadata: Option<CliEpochRewardshMetadata>,
+    pub epoch_metadata: Option<CliEpochRewardsMetadata>,
     pub rewards: Vec<CliKeyedEpochReward>,
 }
 

--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -7,7 +7,7 @@ use {
         keypair::*,
     },
     solana_cli_output::{
-        CliEpochRewardshMetadata, CliInflation, CliKeyedEpochReward, CliKeyedEpochRewards,
+        CliEpochRewardsMetadata, CliInflation, CliKeyedEpochReward, CliKeyedEpochRewards,
     },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client::rpc_client::RpcClient,
@@ -128,7 +128,7 @@ fn process_rewards(
             });
         }
         let block_time = rpc_client.get_block_time(first_reward.effective_slot)?;
-        Some(CliEpochRewardshMetadata {
+        Some(CliEpochRewardsMetadata {
             epoch: first_reward.epoch,
             effective_slot: first_reward.effective_slot,
             block_time,


### PR DESCRIPTION
#### Problem
`solana_cli_output` struct has a typo in its name. It's fairly inconsequential, but might as well fix.

#### Summary of Changes
Fix typo
