### PR TITLE
cli: Remove `allow(clippy::arithmetic_side_effects)`

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::arithmetic_side_effects)]
-
 use {
     crate::cli::CliError,
     solana_rpc_client::rpc_client::RpcClient,
@@ -84,10 +82,19 @@ pub fn check_account_for_spend_and_fee_with_commitment(
     fee: u64,
     commitment: CommitmentConfig,
 ) -> Result<(), CliError> {
+    let required_balance =
+        balance
+            .checked_add(fee)
+            .ok_or(CliError::InsufficientFundsForSpendAndFee(
+                lamports_to_sol(balance),
+                lamports_to_sol(fee),
+                *account_pubkey,
+            ))?;
+
     if !check_account_for_balance_with_commitment(
         rpc_client,
         account_pubkey,
-        balance + fee,
+        required_balance,
         commitment,
     )
     .map_err(Into::<ClientError>::into)?

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::cli::CliError,
     solana_rpc_client::rpc_client::RpcClient,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         cli::{

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::arithmetic_side_effects)]
-
 use {
     crate::{
         cli::{
@@ -17,7 +15,10 @@ use {
     solana_cli_output::{cli_version::CliVersion, QuietDisplay, VerboseDisplay},
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client::rpc_client::RpcClient,
-    solana_rpc_client_api::{client_error::Error as ClientError, request::MAX_MULTIPLE_ACCOUNTS},
+    solana_rpc_client_api::{
+        client_error::Error as ClientError, request::MAX_MULTIPLE_ACCOUNTS,
+        response::RpcVoteAccountInfo,
+    },
     solana_sdk::{
         account::Account,
         clock::Slot,
@@ -147,7 +148,11 @@ impl fmt::Display for CliFeatures {
                     CliFeatureStatus::Inactive => style("inactive".to_string()).red(),
                     CliFeatureStatus::Pending => {
                         let current_epoch = self.epoch_schedule.get_epoch(self.current_slot);
-                        style(format!("pending until epoch {}", current_epoch + 1)).yellow()
+                        style(format!(
+                            "pending until epoch {}",
+                            current_epoch.saturating_add(1)
+                        ))
+                        .yellow()
                     }
                     CliFeatureStatus::Active(activation_slot) => {
                         let activation_epoch = self.epoch_schedule.get_epoch(activation_slot);
@@ -653,27 +658,36 @@ fn cluster_info_stats(rpc_client: &RpcClient) -> Result<ClusterInfoStats, Client
     let vote_stakes = vote_accounts
         .current
         .into_iter()
-        .map(|vote_account| {
-            total_active_stake += vote_account.activated_stake;
-            (vote_account.node_pubkey, vote_account.activated_stake)
-        })
+        .map(
+            |RpcVoteAccountInfo {
+                 node_pubkey,
+                 activated_stake,
+                 ..
+             }| {
+                total_active_stake = total_active_stake.saturating_add(activated_stake);
+                (node_pubkey.clone(), activated_stake)
+            },
+        )
         .collect::<HashMap<_, _>>();
 
     let mut cluster_info_stats: HashMap<(u32, CliVersion), StatsEntry> = HashMap::new();
-    let mut total_rpc_nodes = 0;
+    let mut total_rpc_nodes: u64 = 0;
     for (node_id, feature_set, is_rpc, version) in cluster_info_list {
         let feature_set = feature_set.unwrap_or(0);
-        let stats_entry = cluster_info_stats
+        let StatsEntry {
+            stake_lamports,
+            rpc_nodes_count,
+        } = cluster_info_stats
             .entry((feature_set, version))
             .or_default();
 
         if let Some(vote_stake) = vote_stakes.get(&node_id) {
-            stats_entry.stake_lamports += *vote_stake;
+            *stake_lamports = stake_lamports.saturating_add(*vote_stake);
         }
 
         if is_rpc {
-            stats_entry.rpc_nodes_count += 1;
-            total_rpc_nodes += 1;
+            *rpc_nodes_count = rpc_nodes_count.saturating_add(1);
+            total_rpc_nodes = total_rpc_nodes.saturating_add(1);
         }
     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::arithmetic_side_effects)]
 macro_rules! ACCOUNT_STRING {
     () => {
         r#" Address is one of:

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         checks::*,

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         checks::*,

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::arithmetic_side_effects)]
-
 use {
     crate::{
         checks::*,
@@ -53,6 +51,7 @@ use {
         fs::File,
         io::{Read, Write},
         mem::size_of,
+        num::Saturating,
         rc::Rc,
         sync::Arc,
     },
@@ -595,8 +594,17 @@ pub fn process_deploy_program(
 
     let mut write_messages = vec![];
     let chunk_size = calculate_max_chunk_size(&create_msg);
-    for (chunk, i) in program_data.chunks(chunk_size).zip(0..) {
-        write_messages.push(create_msg((i * chunk_size) as u32, chunk.to_vec()));
+    for (chunk, i) in program_data.chunks(chunk_size).zip(0usize..) {
+        write_messages.push(create_msg(
+            i.saturating_mul(chunk_size).try_into().map_err(|_| {
+                format!(
+                    "Program data size exceeds {}: {}",
+                    u32::MAX,
+                    program_data.len()
+                )
+            })?,
+            chunk.to_vec(),
+        ));
     }
 
     let final_messages = if *program_address != buffer_address {
@@ -805,24 +813,24 @@ fn check_payer(
     write_messages: &[Message],
     other_messages: &[Message],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut fee = 0;
+    let mut fee = Saturating(0);
     for message in initial_messages {
         fee += rpc_client.get_fee_for_message(message)?;
     }
     for message in other_messages {
         fee += rpc_client.get_fee_for_message(message)?;
     }
-    if !write_messages.is_empty() {
-        // Assume all write messages cost the same
-        if let Some(message) = write_messages.first() {
-            fee += rpc_client.get_fee_for_message(message)? * (write_messages.len() as u64);
-        }
+    // Assume all write messages cost the same
+    if let Some(message) = write_messages.first() {
+        fee += rpc_client
+            .get_fee_for_message(message)?
+            .saturating_mul(write_messages.len() as u64);
     }
     check_account_for_spend_and_fee_with_commitment(
         rpc_client,
         &config.payer.pubkey(),
         balance_needed,
-        fee,
+        fee.0,
         config.commitment,
     )?;
     Ok(())

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         checks::{check_account_for_balance_with_commitment, get_fee_for_messages},

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::arithmetic_side_effects)]
-
 use {
     crate::{
         checks::{check_account_for_balance_with_commitment, get_fee_for_messages},
@@ -118,7 +116,7 @@ where
             build_message,
         )?;
         if from_pubkey == fee_pubkey {
-            if from_balance == 0 || from_balance < spend + fee {
+            if from_balance == 0 || from_balance < spend.saturating_add(fee) {
                 return Err(CliError::InsufficientFundsForSpendAndFee(
                     lamports_to_sol(spend),
                     lamports_to_sol(fee),

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         checks::{check_account_for_fee_with_commitment, check_unique_pubkeys},

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::arithmetic_side_effects)]
-
 use {
     crate::{
         checks::{check_account_for_fee_with_commitment, check_unique_pubkeys},
@@ -2477,7 +2475,7 @@ pub fn get_epoch_boundary_timestamps(
                 break block_time;
             }
             Err(_) => {
-                epoch_start_slot += 1;
+                epoch_start_slot = epoch_start_slot.saturating_add(1);
             }
         }
     };
@@ -2491,7 +2489,8 @@ pub fn make_cli_reward(
 ) -> Option<CliEpochReward> {
     let wallclock_epoch_duration = epoch_end_time.checked_sub(epoch_start_time)?;
     if reward.post_balance > reward.amount {
-        let rate_change = reward.amount as f64 / (reward.post_balance - reward.amount) as f64;
+        let rate_change =
+            reward.amount as f64 / (reward.post_balance.saturating_sub(reward.amount)) as f64;
 
         let wallclock_epochs_per_year =
             (SECONDS_PER_DAY * 365) as f64 / wallclock_epoch_duration as f64;

--- a/cli/src/test_utils.rs
+++ b/cli/src/test_utils.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{

--- a/cli/src/test_utils.rs
+++ b/cli/src/test_utils.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::arithmetic_side_effects)]
-
 use {
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{
@@ -46,7 +44,7 @@ pub fn wait_n_slots(rpc_client: &RpcClient, n: u64) -> u64 {
     loop {
         sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT));
         let new_slot = rpc_client.get_slot().unwrap();
-        if new_slot - slot > n {
+        if new_slot.saturating_sub(slot) > n {
             return new_slot;
         }
     }
@@ -54,7 +52,7 @@ pub fn wait_n_slots(rpc_client: &RpcClient, n: u64) -> u64 {
 
 pub fn wait_for_next_epoch_plus_n_slots(rpc_client: &RpcClient, n: u64) -> (Epoch, u64) {
     let current_epoch = rpc_client.get_epoch_info().unwrap().epoch;
-    let next_epoch = current_epoch + 1;
+    let next_epoch = current_epoch.saturating_add(1);
     println!("waiting for epoch {next_epoch} plus {n} slots");
     loop {
         sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT));

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::arithmetic_side_effects)]
-
 use {
     crate::{
         cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},
@@ -331,7 +329,9 @@ pub fn process_set_validator_info(
         (validator_info::id(), false),
         (config.signers[0].pubkey(), true),
     ];
-    let data_len = ValidatorInfo::max_space() + ConfigKeys::serialized_size(keys.clone());
+    let data_len = ValidatorInfo::max_space()
+        .checked_add(ConfigKeys::serialized_size(keys.clone()))
+        .expect("ValidatorInfo and two keys fit into a u64");
     let lamports = rpc_client.get_minimum_balance_for_rent_exemption(data_len as usize)?;
 
     let signers = if balance == 0 {

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         checks::{check_account_for_fee_with_commitment, check_unique_pubkeys},

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::arithmetic_side_effects)]
-
 use {
     crate::{
         checks::{check_account_for_fee_with_commitment, check_unique_pubkeys},
@@ -1248,7 +1246,7 @@ pub fn process_show_vote_account(
             votes.push(vote.into());
         }
         for (epoch, credits, prev_credits) in vote_state.epoch_credits().iter().copied() {
-            let credits_earned = credits - prev_credits;
+            let credits_earned = credits.saturating_sub(prev_credits);
             let slots_in_epoch = epoch_schedule.get_slots_in_epoch(epoch);
             epoch_voting_history.push(CliEpochVotingHistory {
                 epoch,


### PR DESCRIPTION
#### Problem

The rest of the codebase has `clippy::arithmetic_side_effects` enabled.
While CLI is not as critical as the rest of the validator code base, it seems nice to be precise about the arithmetic operations, and clippy helps with that if `arithmetic_side_effects` is enabled.

A blanket disable at the module level is suboptimal.

#### Summary of Changes

As we have a lot of operations already written, that generate warnings under `arithmetic_side_effects`, the first step is to move the lint control into individual modules, that we can then inspect one by one.

Subsequent commits remove `allow(clippy::arithmetic_side_effects)` from all the modules one by one.

---

Not really sure who is the best reviewer for this.
Suggestions are welcome :)