### PR TITLE
streamer: parameterize quic server stream limits

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -258,6 +258,8 @@ mod tests {
             10,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             DEFAULT_TPU_COALESCE,
+            4,
+            5,
         )
         .unwrap();
 

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -81,6 +81,8 @@ mod tests {
             10,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             DEFAULT_TPU_COALESCE,
+            4,
+            5,
         )
         .unwrap();
 
@@ -161,6 +163,8 @@ mod tests {
             10,
             Duration::from_secs(1), // wait_for_chunk_timeout
             DEFAULT_TPU_COALESCE,
+            4,
+            5,
         )
         .unwrap();
 
@@ -219,6 +223,8 @@ mod tests {
             10,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             DEFAULT_TPU_COALESCE,
+            4,
+            5,
         )
         .unwrap();
 
@@ -243,6 +249,8 @@ mod tests {
             10,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             DEFAULT_TPU_COALESCE,
+            4,
+            5,
         )
         .unwrap();
 

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -410,6 +410,8 @@ pub fn spawn_server(
     max_unstaked_connections: usize,
     wait_for_chunk_timeout: Duration,
     coalesce: Duration,
+    min_staked_streams_per_100ms: u64,
+    max_unstaked_streams_per_100ms: u64,
 ) -> Result<(Endpoint, thread::JoinHandle<()>), QuicServerError> {
     let runtime = rt();
     let (endpoint, _stats, task) = {
@@ -427,6 +429,8 @@ pub fn spawn_server(
             max_unstaked_connections,
             wait_for_chunk_timeout,
             coalesce,
+            min_staked_streams_per_100ms,
+            max_unstaked_streams_per_100ms,
         )
     }?;
     let handle = thread::Builder::new()
@@ -476,6 +480,8 @@ mod test {
             MAX_UNSTAKED_CONNECTIONS,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             DEFAULT_TPU_COALESCE,
+            tpu_min_staked_streams_per_100ms(),
+            tpu_max_unstaked_streams_per_100ms(),
         )
         .unwrap();
         (t, exit, receiver, server_address)
@@ -532,6 +538,8 @@ mod test {
             MAX_UNSTAKED_CONNECTIONS,
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             DEFAULT_TPU_COALESCE,
+            tpu_min_staked_streams_per_100ms(),
+            tpu_max_unstaked_streams_per_100ms(),
         )
         .unwrap();
 
@@ -575,6 +583,8 @@ mod test {
             0, // Do not allow any connection from unstaked clients/nodes
             DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             DEFAULT_TPU_COALESCE,
+            tpu_min_staked_streams_per_100ms(),
+            tpu_max_unstaked_streams_per_100ms(),
         )
         .unwrap();
 


### PR DESCRIPTION
#### Problem
#738 bifurcates tpu and tpufwd stream limits, but does so by implicitly encoding the tpu port type into a configuration value of the quic streamer server. this is extremely error prone and a maintenance hazard

#### Summary of Changes
explicitly configure the stream limits when declaring the tpu port servers