### PR TITLE
Stops copying new PathBuf when querying storage files

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1195,7 +1195,7 @@ impl AccountStorageEntry {
     }
 
     pub fn get_path(&self) -> PathBuf {
-        self.accounts.get_path()
+        self.accounts.path().to_path_buf()
     }
 }
 
@@ -5494,13 +5494,13 @@ impl AccountsDb {
         let store = Arc::new(self.new_storage_entry(slot, Path::new(&paths[path_index]), size));
 
         debug!(
-            "creating store: {} slot: {} len: {} size: {} from: {} path: {:?}",
+            "creating store: {} slot: {} len: {} size: {} from: {} path: {}",
             store.append_vec_id(),
             slot,
             store.accounts.len(),
             store.accounts.capacity(),
             from,
-            store.accounts.get_path()
+            store.accounts.path().display(),
         );
 
         store
@@ -6776,7 +6776,7 @@ impl AccountsDb {
         if let Some(append_vec) = storage {
             // hash info about this storage
             append_vec.written_bytes().hash(hasher);
-            let storage_file = append_vec.accounts.get_path();
+            let storage_file = append_vec.accounts.path();
             slot.hash(hasher);
             storage_file.hash(hasher);
             let amod = std::fs::metadata(storage_file);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1194,8 +1194,9 @@ impl AccountStorageEntry {
         count
     }
 
-    pub fn get_path(&self) -> PathBuf {
-        self.accounts.path().to_path_buf()
+    /// Returns the path to the underlying accounts storage file
+    pub fn path(&self) -> &Path {
+        self.accounts.path()
     }
 }
 

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -15,7 +15,12 @@ use {
         clock::Slot,
         pubkey::Pubkey,
     },
-    std::{borrow::Borrow, io::Read, mem, path::PathBuf},
+    std::{
+        borrow::Borrow,
+        io::Read,
+        mem,
+        path::{Path, PathBuf},
+    },
     thiserror::Error,
 };
 
@@ -166,10 +171,10 @@ impl AccountsFile {
     }
 
     /// Return the path of the underlying account file.
-    pub fn get_path(&self) -> PathBuf {
+    pub fn path(&self) -> &Path {
         match self {
-            Self::AppendVec(av) => av.get_path(),
-            Self::TieredStorage(ts) => ts.path().to_path_buf(),
+            Self::AppendVec(av) => av.path(),
+            Self::TieredStorage(ts) => ts.path(),
         }
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -29,7 +29,7 @@ use {
         fs::{remove_file, OpenOptions},
         io::{Seek, SeekFrom, Write},
         mem,
-        path::PathBuf,
+        path::{Path, PathBuf},
         sync::{
             atomic::{AtomicU64, AtomicUsize, Ordering},
             Mutex,
@@ -615,8 +615,9 @@ impl AppendVec {
         Some((meta, stored_account.to_account_shared_data()))
     }
 
-    pub fn get_path(&self) -> PathBuf {
-        self.path.clone()
+    /// Returns the path to the file where the data is stored
+    pub fn path(&self) -> &Path {
+        self.path.as_path()
     }
 
     /// help with the math of offsets when navigating the on-disk layout in an AppendVec.

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -453,7 +453,7 @@ fn test_concurrent_snapshot_packaging(
                 .unwrap()
                 .get_snapshot_storages(None)
                 .into_iter()
-                .map(|s| s.get_path())
+                .map(|s| s.path().to_path_buf())
                 .collect();
 
             // Only save off the files returned by `get_snapshot_storages`. This is because

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -59,7 +59,7 @@ mod tests {
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory
-            let storage_path = storage_entry.get_path();
+            let storage_path = storage_entry.path();
             let file_name =
                 AccountsFile::file_name(storage_entry.slot(), storage_entry.append_vec_id());
             let output_path = output_dir.as_ref().join(file_name);

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -143,7 +143,7 @@ mod serde_snapshot_tests {
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory
-            let storage_path = storage_entry.get_path();
+            let storage_path = storage_entry.path();
             let file_name =
                 AccountsFile::file_name(storage_entry.slot(), storage_entry.append_vec_id());
             let output_path = output_dir.as_ref().join(file_name);

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -100,9 +100,9 @@ pub fn add_bank_snapshot(
         );
 
         let (_, measure_flush) = measure!(for storage in snapshot_storages {
-            storage
-                .flush()
-                .map_err(|err| AddBankSnapshotError::FlushStorage(err, storage.get_path()))?;
+            storage.flush().map_err(|err| {
+                AddBankSnapshotError::FlushStorage(err, storage.path().to_path_buf())
+            })?;
         });
 
         // We are constructing the snapshot directory to contain the full snapshot state information to allow

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -808,14 +808,16 @@ pub fn archive_snapshot_package(
                     storage.append_vec_id(),
                 ));
                 let mut header = tar::Header::new_gnu();
-                header
-                    .set_path(path_in_archive)
-                    .map_err(|err| E::ArchiveAccountStorageFile(err, storage.get_path()))?;
+                header.set_path(path_in_archive).map_err(|err| {
+                    E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
+                })?;
                 header.set_size(storage.capacity());
                 header.set_cksum();
                 archive
                     .append(&header, storage.accounts.data_for_archive())
-                    .map_err(|err| E::ArchiveAccountStorageFile(err, storage.get_path()))?;
+                    .map_err(|err| {
+                        E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
+                    })?;
             }
 
             archive.into_inner().map_err(E::FinishArchive)?;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1229,9 +1229,9 @@ pub fn hard_link_storages_to_snapshot(
 
     let mut account_paths: HashSet<PathBuf> = HashSet::new();
     for storage in snapshot_storages {
-        let storage_path = storage.accounts.get_path();
+        let storage_path = storage.accounts.path();
         let snapshot_hardlink_dir = get_snapshot_accounts_hardlink_dir(
-            &storage_path,
+            storage_path,
             bank_slot,
             &mut account_paths,
             &accounts_hardlinks_dir,
@@ -1240,8 +1240,12 @@ pub fn hard_link_storages_to_snapshot(
         // Use the storage slot and id to compose a consistent file name for the hard-link file.
         let hardlink_filename = AppendVec::file_name(storage.slot(), storage.append_vec_id());
         let hard_link_path = snapshot_hardlink_dir.join(hardlink_filename);
-        fs::hard_link(&storage_path, &hard_link_path).map_err(|err| {
-            HardLinkStoragesToSnapshotError::HardLinkStorage(err, storage_path, hard_link_path)
+        fs::hard_link(storage_path, &hard_link_path).map_err(|err| {
+            HardLinkStoragesToSnapshotError::HardLinkStorage(
+                err,
+                storage_path.to_path_buf(),
+                hard_link_path,
+            )
         })?;
     }
     Ok(())


### PR DESCRIPTION
#### Problem

When querying the path for a storage file, we always copy the path into a new PathBuf. The caller almost never needs a PathBuf though, so we're wasting cycles by making an unnecessary allocation.


#### Summary of Changes

Return a &Path instead of PathBuf.