### PR TITLE
wip: `StorableAccounts` uses callback for lifetime

### DIFF
--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -22,11 +22,11 @@ impl StakeReward {
 
 /// allow [StakeReward] to be passed to `StoreAccounts` directly without copies or vec construction
 impl<'a> StorableAccounts<'a, AccountSharedData> for (Slot, &'a [StakeReward]) {
-    fn pubkey(&self, index: usize) -> &Pubkey {
-        &self.1[index].stake_pubkey
+    fn pubkey(&self, index: usize, mut callback: impl FnMut(&Pubkey)) {
+        callback(&self.1[index].stake_pubkey)
     }
-    fn account(&self, index: usize) -> &AccountSharedData {
-        &self.1[index].stake_account
+    fn account(&self, index: usize, mut callback: impl FnMut(&AccountSharedData)) {
+        callback(&self.1[index].stake_account)
     }
     fn slot(&self, _index: usize) -> Slot {
         // per-index slot is not unique per slot when per-account slot is not included in the source data

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -10,9 +10,9 @@ use {
 
 /// The in-memory struct for the writing index block.
 #[derive(Debug)]
-pub struct AccountIndexWriterEntry<'a, Offset: AccountOffset> {
+pub struct AccountIndexWriterEntry<Offset: AccountOffset> {
     /// The account address.
-    pub address: &'a Pubkey,
+    pub address: Pubkey,
     /// The offset to the account.
     pub offset: Offset,
 }
@@ -66,7 +66,7 @@ impl IndexBlockFormat {
             Self::AddressesThenOffsets => {
                 let mut bytes_written = 0;
                 for index_entry in index_entries {
-                    bytes_written += file.write_pod(index_entry.address)?;
+                    bytes_written += file.write_pod(&index_entry.address)?;
                 }
                 for index_entry in index_entries {
                     bytes_written += file.write_pod(&index_entry.offset)?;

--- a/accounts-db/src/tiered_storage/meta.rs
+++ b/accounts-db/src/tiered_storage/meta.rs
@@ -137,29 +137,29 @@ const MAX_ACCOUNT_ADDRESS: Pubkey = Pubkey::new_from_array([0xFFu8; 32]);
 
 #[derive(Debug)]
 /// A struct that maintains an address-range using its min and max fields.
-pub struct AccountAddressRange<'a> {
+pub struct AccountAddressRange {
     /// The minimum address observed via update()
-    pub min: &'a Pubkey,
+    pub min: Pubkey,
     /// The maximum address observed via update()
-    pub max: &'a Pubkey,
+    pub max: Pubkey,
 }
 
-impl Default for AccountAddressRange<'_> {
+impl Default for AccountAddressRange {
     fn default() -> Self {
         Self {
-            min: &MAX_ACCOUNT_ADDRESS,
-            max: &MIN_ACCOUNT_ADDRESS,
+            min: MAX_ACCOUNT_ADDRESS,
+            max: MIN_ACCOUNT_ADDRESS,
         }
     }
 }
 
-impl<'a> AccountAddressRange<'a> {
-    pub fn update(&mut self, address: &'a Pubkey) {
-        if *self.min > *address {
-            self.min = address;
+impl AccountAddressRange {
+    pub fn update(&mut self, address: &Pubkey) {
+        if &self.min > address {
+            self.min = *address;
         }
-        if *self.max < *address {
-            self.max = address;
+        if &self.max < address {
+            self.max = *address;
         }
     }
 }

--- a/accounts-db/src/tiered_storage/owners.rs
+++ b/accounts-db/src/tiered_storage/owners.rs
@@ -54,7 +54,7 @@ impl OwnersBlockFormat {
             Self::AddressesOnly => {
                 let mut bytes_written = 0;
                 for address in &owners_table.owners_set {
-                    bytes_written += file.write_pod(*address)?;
+                    bytes_written += file.write_pod(address)?;
                 }
 
                 Ok(bytes_written)
@@ -85,19 +85,19 @@ impl OwnersBlockFormat {
 /// The in-memory representation of owners block for write.
 /// It manages a set of unique addresses of account owners.
 #[derive(Debug, Default)]
-pub struct OwnersTable<'a> {
-    owners_set: IndexSet<&'a Pubkey>,
+pub struct OwnersTable {
+    owners_set: IndexSet<Pubkey>,
 }
 
 /// OwnersBlock is persisted as a consecutive bytes of pubkeys without any
 /// meta-data.  For each account meta, it has a owner_offset field to
 /// access its owner's address in the OwnersBlock.
-impl<'a> OwnersTable<'a> {
+impl OwnersTable {
     /// Add the specified pubkey as the owner into the OwnersWriterTable
     /// if the specified pubkey has not existed in the OwnersWriterTable
     /// yet.  In any case, the function returns its OwnerOffset.
-    pub fn insert(&mut self, pubkey: &'a Pubkey) -> OwnerOffset {
-        let (offset, _existed) = self.owners_set.insert_full(pubkey);
+    pub fn insert(&mut self, pubkey: &Pubkey) -> OwnerOffset {
+        let (offset, _existed) = self.owners_set.insert_full(*pubkey);
 
         OwnerOffset(offset as u32)
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5170,11 +5170,15 @@ impl Bank {
         let mut m = Measure::start("stakes_cache.check_and_store");
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
         (0..accounts.len()).for_each(|i| {
-            self.stakes_cache.check_and_store(
-                accounts.pubkey(i),
-                accounts.account(i),
-                new_warmup_cooldown_rate_epoch,
-            )
+            accounts.pubkey(i, |pubkey| {
+                accounts.account(i, |account| {
+                    self.stakes_cache.check_and_store(
+                        pubkey,
+                        account,
+                        new_warmup_cooldown_rate_epoch,
+                    );
+                });
+            });
         });
         self.rc.accounts.store_accounts_cached(accounts);
         m.stop();


### PR DESCRIPTION
#### Problem
Trying to remove mmap on append vecs to relieve memory pressure.

#### Summary of Changes
`StorableAccount` will not be able to support `fn account(...) -> &Account`.
Use a callback to maintain the lifetime.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
