### PR TITLE
use previously calculated `stored_size`

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -14,7 +14,6 @@ use {
         accounts_hash::AccountHash,
         accounts_index::{AccountsIndexScanResult, ZeroLamport},
         active_stats::ActiveStatItem,
-        append_vec::aligned_stored_size,
         storable_accounts::{StorableAccounts, StorableAccountsBySlot},
     },
     rand::{thread_rng, Rng},
@@ -822,7 +821,7 @@ impl<'a> PackedAncientStorage<'a> {
                     // look at each account and stop when we exceed the ideal size
                     while partial_inner_index_max_exclusive < alive_accounts.accounts.len() {
                         let account = alive_accounts.accounts[partial_inner_index_max_exclusive];
-                        let account_size = aligned_stored_size(account.data().len());
+                        let account_size = account.stored_size();
                         let new_size = bytes_total.saturating_add(account_size);
                         if new_size > ideal_size && bytes_total > 0 {
                             full = true;


### PR DESCRIPTION
#### Problem
Trying to remove mmap on append vecs to relieve memory pressure. Also working towards using hot storage format.

#### Summary of Changes
There already a `stored_size` on an account while doing ancient packing. Use that instead of recalculating it. This is especially important because the stored size may be different when we have mixed storage types.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
