### PR TITLE
cli: Move `allow(clippy::arithmetic_side_effects)` into modules

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::cli::CliError,
     solana_rpc_client::rpc_client::RpcClient,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         cli::{

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::arithmetic_side_effects)]
 macro_rules! ACCOUNT_STRING {
     () => {
         r#" Address is one of:

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         checks::*,

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         checks::*,

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         checks::{check_account_for_balance_with_commitment, get_fee_for_messages},

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         checks::{check_account_for_fee_with_commitment, check_unique_pubkeys},

--- a/cli/src/test_utils.rs
+++ b/cli/src/test_utils.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use {
     crate::{
         checks::{check_account_for_fee_with_commitment, check_unique_pubkeys},


### PR DESCRIPTION
The rest of the codebase has `clippy::arithmetic_side_effects` enabled. While CLI is not as critical as the rest of the validator code base, it seems nice to be precise about the arithmetic operations, and clippy helps with that if `arithmetic_side_effects` is enabled.

A blanket disable at the module level is suboptimal.  As we have a lot of operations already written, that generate warnings under `arithmetic_side_effects`, the first step is to move the lint control into individual modules, that we can then inspect one by one.