### PR TITLE
Assortment of small partitioned-epoch rewards cleanups

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -181,7 +181,7 @@ impl Bank {
     }
 
     /// Calculate rewards from previous epoch to prepare for partitioned distribution.
-    pub(in crate::bank) fn calculate_rewards_for_partitioning(
+    pub(super) fn calculate_rewards_for_partitioning(
         &self,
         prev_epoch: Epoch,
         reward_calc_tracer: Option<impl Fn(&RewardCalculationEvent) + Send + Sync>,

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -118,8 +118,13 @@ impl Bank {
                 if let Some(curr_stake_account) = self.get_account_with_fixed_root(&stake_pubkey) {
                     let pre_lamport = curr_stake_account.lamports();
                     let post_lamport = post_stake_account.lamports();
-                    assert_eq!(pre_lamport + u64::try_from(reward_amount).unwrap(), post_lamport,
-                               "stake account balance has changed since the reward calculation! account: {stake_pubkey}, pre balance: {pre_lamport}, post balance: {post_lamport}, rewards: {reward_amount}");
+                    assert_eq!(
+                        pre_lamport + u64::try_from(reward_amount).unwrap(),
+                        post_lamport,
+                        "stake account balance has changed since the reward calculation! \
+                         account: {stake_pubkey}, pre balance: {pre_lamport}, \
+                         post balance: {post_lamport}, rewards: {reward_amount}"
+                    );
                 }
             }
         }

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -56,6 +56,8 @@ impl Bank {
         assert!(self.is_partitioned_rewards_code_enabled());
 
         let mut epoch_rewards = self.get_epoch_rewards_sysvar();
+        assert!(epoch_rewards.active);
+
         epoch_rewards.distribute(distributed);
 
         self.update_sysvar_account(&sysvar::epoch_rewards::id(), |account| {

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -2,9 +2,7 @@ use {
     super::Bank,
     log::info,
     solana_sdk::{
-        account::{
-            create_account_shared_data_with_fields as create_account, from_account, ReadableAccount,
-        },
+        account::{create_account_shared_data_with_fields as create_account, from_account},
         sysvar,
     },
 };
@@ -15,10 +13,7 @@ impl Bank {
         if let Some(account) = self.get_account(&sysvar::epoch_rewards::id()) {
             let epoch_rewards: sysvar::epoch_rewards::EpochRewards =
                 from_account(&account).unwrap();
-            info!(
-                "{prefix} epoch_rewards sysvar: {:?}",
-                (account.lamports(), epoch_rewards)
-            );
+            info!("{prefix} epoch_rewards sysvar: {:?}", epoch_rewards);
         } else {
             info!("{prefix} epoch_rewards sysvar: none");
         }
@@ -105,7 +100,8 @@ mod tests {
         super::*,
         crate::bank::tests::create_genesis_config,
         solana_sdk::{
-            epoch_schedule::EpochSchedule, feature_set, hash::Hash, native_token::LAMPORTS_PER_SOL,
+            account::ReadableAccount, epoch_schedule::EpochSchedule, feature_set, hash::Hash,
+            native_token::LAMPORTS_PER_SOL,
         },
     };
 


### PR DESCRIPTION
#### Problem
While moving forward on SIMD-0018 implementation, I discovered a handful of small things to clean up.

#### Summary of Changes
- Limit the pub-ness of `calculate_rewards_for_partitioning`. This just got missed in #553 when I moved in the `compare` submodule
- Wrap long string literal that is hard to read
- Remove sysvar account balance from log; the balance is a waste of bytes, now that it doesn't change on distribution
- Update solana_account_decoder to stringify EpochRewards::parent_blockhash
- Add EpochRewards sysvar getter, which will be helpful for partition recalculation work

If you want me to break any of this up into separate PRs, I totally get it; these things aren't really related. Just let me know.
