### PR TITLE
Populate EpochRewards with correct data

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -209,6 +209,7 @@ impl Bank {
         let CalculateValidatorRewardsResult {
             vote_rewards_accounts: vote_account_rewards,
             stake_reward_calculation: mut stake_rewards,
+            total_points,
         } = self
             .calculate_validator_rewards(
                 prev_epoch,
@@ -264,6 +265,7 @@ impl Bank {
             metrics,
         )
         .map(|point_value| {
+            let total_points = point_value.points;
             let (vote_rewards_accounts, stake_reward_calculation) = self
                 .calculate_stake_vote_rewards(
                     &reward_calculate_param,
@@ -276,6 +278,7 @@ impl Bank {
             CalculateValidatorRewardsResult {
                 vote_rewards_accounts,
                 stake_reward_calculation,
+                total_points,
             }
         })
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -90,6 +90,7 @@ impl Bank {
             foundation_rate,
             prev_epoch_duration_in_years,
             capitalization,
+            total_points,
         } = self.calculate_rewards_for_partitioning(
             prev_epoch,
             reward_calc_tracer,
@@ -243,6 +244,7 @@ impl Bank {
             foundation_rate,
             prev_epoch_duration_in_years,
             capitalization,
+            total_points,
         }
     }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -39,6 +39,7 @@ impl Bank {
         let CalculateRewardsAndDistributeVoteRewardsResult {
             total_rewards,
             distributed_rewards,
+            total_points,
             stake_rewards_by_partition,
         } = self.calculate_rewards_and_distribute_vote_rewards(
             parent_epoch,
@@ -159,6 +160,7 @@ impl Bank {
         CalculateRewardsAndDistributeVoteRewardsResult {
             total_rewards: validator_rewards_paid + total_stake_rewards_lamports,
             distributed_rewards: validator_rewards_paid,
+            total_points,
             stake_rewards_by_partition,
         }
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -49,11 +49,18 @@ impl Bank {
         let slot = self.slot();
         let credit_start = self.block_height() + self.get_reward_calculation_num_blocks();
 
+        let num_partitions = stake_rewards_by_partition.len() as u64;
+
         self.set_epoch_reward_status_active(stake_rewards_by_partition);
 
         // create EpochRewards sysvar that holds the balance of undistributed rewards with
         // (total_rewards, distributed_rewards, credit_start), total capital will increase by (total_rewards - distributed_rewards)
-        self.create_epoch_rewards_sysvar(total_rewards, distributed_rewards, credit_start);
+        self.create_epoch_rewards_sysvar(
+            total_rewards,
+            distributed_rewards,
+            credit_start,
+            num_partitions,
+        );
 
         datapoint_info!(
             "epoch-rewards-status-update",

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -62,6 +62,7 @@ impl Bank {
             distributed_rewards,
             credit_start,
             num_partitions,
+            total_points,
         );
 
         datapoint_info!(

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -215,7 +215,8 @@ mod tests {
         // Set up epoch_rewards sysvar with rewards with 1e9 lamports to distribute.
         let total_rewards = 1_000_000_000;
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
-        bank.create_epoch_rewards_sysvar(total_rewards, 0, 42, num_partitions);
+        let total_points = (total_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
+        bank.create_epoch_rewards_sysvar(total_rewards, 0, 42, num_partitions, total_points);
         let pre_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
         let expected_balance =
             bank.get_minimum_balance_for_rent_exemption(pre_epoch_rewards_account.data().len());

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -214,7 +214,8 @@ mod tests {
 
         // Set up epoch_rewards sysvar with rewards with 1e9 lamports to distribute.
         let total_rewards = 1_000_000_000;
-        bank.create_epoch_rewards_sysvar(total_rewards, 0, 42);
+        let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
+        bank.create_epoch_rewards_sysvar(total_rewards, 0, 42, num_partitions);
         let pre_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
         let expected_balance =
             bank.get_minimum_balance_for_rent_exemption(pre_epoch_rewards_account.data().len());

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -92,6 +92,10 @@ pub(super) struct CalculateRewardsAndDistributeVoteRewardsResult {
     pub(super) total_rewards: u64,
     /// distributed vote rewards
     pub(super) distributed_rewards: u64,
+    /// total rewards points calculated for the current epoch, where points
+    /// equals the sum of (delegated stake * credits observed) for all
+    /// delegations
+    pub(super) total_points: u128,
     /// stake rewards that still need to be distributed, grouped by partition
     pub(super) stake_rewards_by_partition: Vec<StakeRewards>,
 }

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -76,6 +76,7 @@ pub(super) struct PartitionedRewardsCalculation {
     pub(super) foundation_rate: f64,
     pub(super) prev_epoch_duration_in_years: f64,
     pub(super) capitalization: u64,
+    total_points: u128,
 }
 
 /// result of calculating the stake rewards at beginning of new epoch

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -5,7 +5,7 @@ mod epoch_rewards_hasher;
 mod sysvar;
 
 use {
-    super::Bank,
+    super::{Bank, StakeRewardCalculation},
     crate::{stake_account::StakeAccount, stake_history::StakeHistory},
     solana_accounts_db::{
         partitioned_rewards::PartitionedEpochRewardsConfig, stake_rewards::StakeReward,
@@ -48,6 +48,12 @@ pub(super) struct VoteRewardsAccounts {
     /// Some if account is to be stored.
     /// None if to be skipped.
     pub(super) accounts_to_store: Vec<Option<AccountSharedData>>,
+}
+
+#[derive(Debug, Default)]
+struct CalculateValidatorRewardsResult {
+    vote_rewards_accounts: VoteRewardsAccounts,
+    stake_reward_calculation: StakeRewardCalculation,
 }
 
 /// hold reward calc info to avoid recalculation across functions

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -54,6 +54,7 @@ pub(super) struct VoteRewardsAccounts {
 struct CalculateValidatorRewardsResult {
     vote_rewards_accounts: VoteRewardsAccounts,
     stake_reward_calculation: StakeRewardCalculation,
+    total_points: u128,
 }
 
 /// hold reward calc info to avoid recalculation across functions

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -40,12 +40,12 @@ impl Bank {
             .unwrap_or_default();
 
         let epoch_rewards = sysvar::epoch_rewards::EpochRewards {
+            distribution_starting_block_height,
+            num_partitions,
+            parent_blockhash,
+            total_points,
             total_rewards,
             distributed_rewards,
-            distribution_starting_block_height,
-            parent_blockhash,
-            num_partitions,
-            total_points,
             active: true,
         };
 

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -26,6 +26,7 @@ impl Bank {
         distributed_rewards: u64,
         distribution_starting_block_height: u64,
         num_partitions: u64,
+        total_points: u128,
     ) {
         assert!(self.is_partitioned_rewards_code_enabled());
 
@@ -44,8 +45,8 @@ impl Bank {
             distribution_starting_block_height,
             parent_blockhash,
             num_partitions,
+            total_points,
             active: true,
-            ..sysvar::epoch_rewards::EpochRewards::default()
         };
 
         self.update_sysvar_account(&sysvar::epoch_rewards::id(), |account| {
@@ -138,13 +139,14 @@ mod tests {
 
         let total_rewards = 1_000_000_000; // a large rewards so that the sysvar account is rent-exempted.
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
+        let total_points = (total_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
 
         // create epoch rewards sysvar
         let expected_epoch_rewards = sysvar::epoch_rewards::EpochRewards {
             distribution_starting_block_height: 42,
             num_partitions,
             parent_blockhash: Hash::default(),
-            total_points: 0,
+            total_points,
             total_rewards,
             distributed_rewards: 10,
             active: true,
@@ -156,7 +158,7 @@ mod tests {
             sysvar::epoch_rewards::EpochRewards::default()
         );
 
-        bank.create_epoch_rewards_sysvar(total_rewards, 10, 42, num_partitions);
+        bank.create_epoch_rewards_sysvar(total_rewards, 10, 42, num_partitions, total_points);
         let account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
         let expected_balance = bank.get_minimum_balance_for_rent_exemption(account.data().len());
         // Expected balance is the sysvar rent-exempt balance
@@ -170,13 +172,13 @@ mod tests {
         let bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), parent_slot + 1);
         // Also note that running `create_epoch_rewards_sysvar()` against a bank
         // with an existing EpochRewards sysvar clobbers the previous values
-        bank.create_epoch_rewards_sysvar(total_rewards, 10, 42, num_partitions);
+        bank.create_epoch_rewards_sysvar(total_rewards, 10, 42, num_partitions, total_points);
 
         let expected_epoch_rewards = sysvar::epoch_rewards::EpochRewards {
             distribution_starting_block_height: 42,
             num_partitions,
             parent_blockhash,
-            total_points: 0,
+            total_points,
             total_rewards,
             distributed_rewards: 10,
             active: true,
@@ -195,7 +197,7 @@ mod tests {
             distribution_starting_block_height: 42,
             num_partitions,
             parent_blockhash,
-            total_points: 0,
+            total_points,
             total_rewards,
             distributed_rewards: 20,
             active: true,

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -6,7 +6,7 @@ mod tests {
     use {
         super::*,
         solana_sdk::{
-            feature_set, genesis_config::create_genesis_config, hash::Hash, pubkey::Pubkey,
+            feature_set, genesis_config::create_genesis_config, pubkey::Pubkey,
             sysvar::epoch_rewards::EpochRewards,
         },
         std::sync::Arc,
@@ -123,7 +123,7 @@ mod tests {
         let expected_epoch_rewards = EpochRewards {
             distribution_starting_block_height: 42,
             num_partitions: 0,
-            parent_blockhash: Hash::default(),
+            parent_blockhash: bank1.parent().unwrap().last_blockhash(),
             total_points: 0,
             total_rewards: 100,
             distributed_rewards: 10,

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -121,11 +121,12 @@ mod tests {
         // inject a reward sysvar for test
         bank1.activate_feature(&feature_set::enable_partitioned_epoch_reward::id());
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
+        let total_points = 42_000; // total_points is arbitrary for the purposes of this test
         let expected_epoch_rewards = EpochRewards {
             distribution_starting_block_height: 42,
             num_partitions,
             parent_blockhash: bank1.parent().unwrap().last_blockhash(),
-            total_points: 0,
+            total_points,
             total_rewards: 100,
             distributed_rewards: 10,
             active: true,
@@ -135,6 +136,7 @@ mod tests {
             expected_epoch_rewards.distributed_rewards,
             expected_epoch_rewards.distribution_starting_block_height,
             num_partitions,
+            total_points,
         );
 
         bank1

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -120,9 +120,10 @@ mod tests {
 
         // inject a reward sysvar for test
         bank1.activate_feature(&feature_set::enable_partitioned_epoch_reward::id());
+        let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
         let expected_epoch_rewards = EpochRewards {
             distribution_starting_block_height: 42,
-            num_partitions: 0,
+            num_partitions,
             parent_blockhash: bank1.parent().unwrap().last_blockhash(),
             total_points: 0,
             total_rewards: 100,
@@ -133,6 +134,7 @@ mod tests {
             expected_epoch_rewards.total_rewards,
             expected_epoch_rewards.distributed_rewards,
             expected_epoch_rewards.distribution_starting_block_height,
+            num_partitions,
         );
 
         bank1


### PR DESCRIPTION
#### Problem
`Bank::begin_partitioned_rewards()` creates the EpochRewards sysvar with 3 default values, even though the data is all available at or after calculation.

#### Summary of Changes
Populate the remainder of EpochRewards with real data. Namely, these fields: `parent_blockhash`, `num_partitions`, and `total_points`.
Exposing `total_points` requires an unfortunate amount of helper-struct plumbing, with the current `calculation` architecture. We could look at refactoring this, perhaps as part of the recalculation work.

✅ Rebased ~~Sadly, because this touches the same dependency lists, this will have some dumb conflicts with #760. I'm happy to merge in either order.~~
