### PR TITLE
Move native program default cost from program creates to sdk crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5643,6 +5643,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-builtin-cost-info"
+version = "2.0.0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "rustc_version 0.4.0",
+ "solana-logger",
+ "solana-sdk",
+ "static_assertions",
+ "test-case",
+]
+
+[[package]]
 name = "solana-cargo-build-bpf"
 version = "2.0.0"
 dependencies = [
@@ -5960,6 +5973,7 @@ dependencies = [
  "serial_test",
  "solana-accounts-db",
  "solana-bloom",
+ "solana-builtin-cost-info",
  "solana-client",
  "solana-core",
  "solana-cost-model",
@@ -6014,18 +6028,13 @@ dependencies = [
  "lazy_static",
  "log",
  "rustc_version 0.4.0",
- "solana-address-lookup-table-program",
- "solana-bpf-loader-program",
- "solana-compute-budget-program",
- "solana-config-program",
+ "solana-builtin-cost-info",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-loader-v4-program",
  "solana-logger",
  "solana-metrics",
  "solana-program-runtime",
  "solana-sdk",
- "solana-stake-program",
  "solana-system-program",
  "solana-vote-program",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "bench-tps",
     "bloom",
     "bucket_map",
+    "builtin-cost-info",
     "cargo-registry",
     "clap-utils",
     "clap-v3-utils",
@@ -318,6 +319,7 @@ solana-bench-tps = { path = "bench-tps", version = "=2.0.0" }
 solana-bloom = { path = "bloom", version = "=2.0.0" }
 solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.0.0" }
 solana-bucket-map = { path = "bucket_map", version = "=2.0.0" }
+solana-builtin-cost-info = { path = "builtin-cost-info", version = "=2.0.0" }
 agave-cargo-registry = { path = "cargo-registry", version = "=2.0.0" }
 solana-clap-utils = { path = "clap-utils", version = "=2.0.0" }
 solana-clap-v3-utils = { path = "clap-v3-utils", version = "=2.0.0" }

--- a/builtin-cost-info/Cargo.toml
+++ b/builtin-cost-info/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "solana-cost-model"
-description = "Solana cost model"
-documentation = "https://docs.rs/solana-cost-model"
+name = "solana-builtin-cost-info"
+description = "Solana builtin programs cost info"
+documentation = "https://docs.rs/solana-builtin-cost-info"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
@@ -12,22 +12,15 @@ edition = { workspace = true }
 [dependencies]
 lazy_static = { workspace = true }
 log = { workspace = true }
-solana-builtin-cost-info = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
-solana-metrics = { workspace = true }
-solana-program-runtime = { workspace = true }
 solana-sdk = { workspace = true }
-solana-vote-program = { workspace = true }
 
 [lib]
 crate-type = ["lib"]
-name = "solana_cost_model"
+name = "solana_builtin_cost_info"
 
 [dev-dependencies]
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
-solana-system-program = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/builtin-cost-info/Cargo.toml
+++ b/builtin-cost-info/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+publish = false
 
 [dependencies]
 lazy_static = { workspace = true }

--- a/builtin-cost-info/build.rs
+++ b/builtin-cost-info/build.rs
@@ -1,0 +1,1 @@
+../frozen-abi/build.rs

--- a/builtin-cost-info/src/lib.rs
+++ b/builtin-cost-info/src/lib.rs
@@ -1,28 +1,24 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
-use {
-    lazy_static::lazy_static,
-    solana_sdk::{ed25519_program, pubkey::Pubkey, secp256k1_program},
-    std::collections::HashMap,
-};
+use {lazy_static::lazy_static, solana_sdk::pubkey::Pubkey, std::collections::HashMap};
 
 // Number of compute units for each built-in programs
 lazy_static! {
     /// Number of compute units for each built-in programs
     pub static ref BUILT_IN_INSTRUCTION_COSTS: HashMap<Pubkey, u64> = [
-        (solana_sdk::stake::program::id(), solana_sdk::stake::instruction::DEFAULT_COMPUTE_UNITS),
-        (solana_sdk::config::program::id(), solana_sdk::config::program::DEFAULT_COMPUTE_UNITS),
-        (solana_sdk::vote::program::id(), solana_sdk::vote::instruction::DEFAULT_COMPUTE_UNITS),
-        (solana_sdk::system_program::id(), solana_sdk::system_program::DEFAULT_COMPUTE_UNITS),
-        (solana_sdk::compute_budget::id(), solana_sdk::compute_budget::DEFAULT_COMPUTE_UNITS),
         (solana_sdk::address_lookup_table::program::id(), solana_sdk::address_lookup_table::instruction::DEFAULT_COMPUTE_UNITS),
-        (solana_sdk::bpf_loader_upgradeable::id(), solana_sdk::bpf_loader_upgradeable::DEFAULT_COMPUTE_UNITS),
-        (solana_sdk::bpf_loader_deprecated::id(), solana_sdk::bpf_loader_deprecated::DEFAULT_COMPUTE_UNITS),
         (solana_sdk::bpf_loader::id(), solana_sdk::bpf_loader::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::bpf_loader_deprecated::id(), solana_sdk::bpf_loader_deprecated::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::bpf_loader_upgradeable::id(), solana_sdk::bpf_loader_upgradeable::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::compute_budget::id(), solana_sdk::compute_budget::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::config::program::id(), solana_sdk::config::program::DEFAULT_COMPUTE_UNITS),
         (solana_sdk::loader_v4::id(), solana_sdk::loader_v4::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::stake::program::id(), solana_sdk::stake::instruction::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::system_program::id(), solana_sdk::system_program::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::vote::program::id(), solana_sdk::vote::instruction::DEFAULT_COMPUTE_UNITS),
         // Note: These are precompile, run directly in bank during sanitizing;
-        (secp256k1_program::id(), 0),
-        (ed25519_program::id(), 0),
+        (solana_sdk::ed25519_program::id(), 0),
+        (solana_sdk::secp256k1_program::id(), 0),
     ]
     .iter()
     .cloned()

--- a/builtin-cost-info/src/lib.rs
+++ b/builtin-cost-info/src/lib.rs
@@ -1,0 +1,30 @@
+#![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
+#![allow(clippy::arithmetic_side_effects)]
+use {
+    lazy_static::lazy_static,
+    solana_sdk::{ed25519_program, pubkey::Pubkey, secp256k1_program},
+    std::collections::HashMap,
+};
+
+// Number of compute units for each built-in programs
+lazy_static! {
+    /// Number of compute units for each built-in programs
+    pub static ref BUILT_IN_INSTRUCTION_COSTS: HashMap<Pubkey, u64> = [
+        (solana_sdk::stake::program::id(), solana_sdk::stake::instruction::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::config::program::id(), solana_sdk::config::program::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::vote::program::id(), solana_sdk::vote::instruction::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::system_program::id(), solana_sdk::system_program::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::compute_budget::id(), solana_sdk::compute_budget::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::address_lookup_table::program::id(), solana_sdk::address_lookup_table::instruction::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::bpf_loader_upgradeable::id(), solana_sdk::bpf_loader_upgradeable::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::bpf_loader_deprecated::id(), solana_sdk::bpf_loader_deprecated::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::bpf_loader::id(), solana_sdk::bpf_loader::DEFAULT_COMPUTE_UNITS),
+        (solana_sdk::loader_v4::id(), solana_sdk::loader_v4::DEFAULT_COMPUTE_UNITS),
+        // Note: These are precompile, run directly in bank during sanitizing;
+        (secp256k1_program::id(), 0),
+        (ed25519_program::id(), 0),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,6 +42,7 @@ serde_bytes = { workspace = true }
 serde_derive = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-bloom = { workspace = true }
+solana-builtin-cost-info = { workspace = true }
 solana-client = { workspace = true }
 solana-cost-model = { workspace = true }
 solana-entry = { workspace = true }

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -1,5 +1,4 @@
 use {
-    solana_cost_model::block_cost_limits::BUILT_IN_INSTRUCTION_COSTS,
     solana_perf::packet::Packet,
     solana_runtime::compute_budget_details::{ComputeBudgetDetails, GetComputeBudgetDetails},
     solana_sdk::{
@@ -108,7 +107,9 @@ impl ImmutableDeserializedPacket {
     pub fn compute_unit_limit_above_static_builtins(&self) -> bool {
         let mut static_builtin_cost_sum: u64 = 0;
         for (program_id, _) in self.transaction.get_message().program_instructions_iter() {
-            if let Some(ix_cost) = BUILT_IN_INSTRUCTION_COSTS.get(program_id) {
+            if let Some(ix_cost) =
+                solana_builtin_cost_info::BUILT_IN_INSTRUCTION_COSTS.get(program_id)
+            {
                 saturating_add_assign!(static_builtin_cost_sum, *ix_cost);
             }
         }

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -1,4 +1,5 @@
 use {
+    solana_builtin_cost_info::BUILT_IN_INSTRUCTION_COSTS,
     solana_perf::packet::Packet,
     solana_runtime::compute_budget_details::{ComputeBudgetDetails, GetComputeBudgetDetails},
     solana_sdk::{
@@ -107,9 +108,7 @@ impl ImmutableDeserializedPacket {
     pub fn compute_unit_limit_above_static_builtins(&self) -> bool {
         let mut static_builtin_cost_sum: u64 = 0;
         for (program_id, _) in self.transaction.get_message().program_instructions_iter() {
-            if let Some(ix_cost) =
-                solana_builtin_cost_info::BUILT_IN_INSTRUCTION_COSTS.get(program_id)
-            {
+            if let Some(ix_cost) = BUILT_IN_INSTRUCTION_COSTS.get(program_id) {
                 saturating_add_assign!(static_builtin_cost_sum, *ix_cost);
             }
         }

--- a/cost-model/src/block_cost_limits.rs
+++ b/cost-model/src/block_cost_limits.rs
@@ -1,13 +1,5 @@
 //! defines block cost related limits
 //!
-use {
-    lazy_static::lazy_static,
-    solana_sdk::{
-        address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
-        compute_budget, ed25519_program, loader_v4, pubkey::Pubkey, secp256k1_program,
-    },
-    std::collections::HashMap,
-};
 
 /// Static configurations:
 ///
@@ -32,28 +24,6 @@ pub const ED25519_VERIFY_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 76;
 pub const WRITE_LOCK_UNITS: u64 = COMPUTE_UNIT_TO_US_RATIO * 10;
 /// Number of data bytes per compute units
 pub const INSTRUCTION_DATA_BYTES_COST: u64 = 140 /*bytes per us*/ / COMPUTE_UNIT_TO_US_RATIO;
-// Number of compute units for each built-in programs
-lazy_static! {
-    /// Number of compute units for each built-in programs
-    pub static ref BUILT_IN_INSTRUCTION_COSTS: HashMap<Pubkey, u64> = [
-        (solana_stake_program::id(), solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS),
-        (solana_config_program::id(), solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS),
-        (solana_vote_program::id(), solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS),
-        (solana_system_program::id(), solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS),
-        (compute_budget::id(), solana_compute_budget_program::DEFAULT_COMPUTE_UNITS),
-        (address_lookup_table::program::id(), solana_address_lookup_table_program::processor::DEFAULT_COMPUTE_UNITS),
-        (bpf_loader_upgradeable::id(), solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS),
-        (bpf_loader_deprecated::id(), solana_bpf_loader_program::DEPRECATED_LOADER_COMPUTE_UNITS),
-        (bpf_loader::id(), solana_bpf_loader_program::DEFAULT_LOADER_COMPUTE_UNITS),
-        (loader_v4::id(), solana_loader_v4_program::DEFAULT_COMPUTE_UNITS),
-        // Note: These are precompile, run directly in bank during sanitizing;
-        (secp256k1_program::id(), 0),
-        (ed25519_program::id(), 0),
-    ]
-    .iter()
-    .cloned()
-    .collect();
-}
 
 /// Statically computed data:
 ///

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -8,6 +8,7 @@
 use {
     crate::{block_cost_limits::*, transaction_cost::*},
     log::*,
+    solana_builtin_cost_info::BUILT_IN_INSTRUCTION_COSTS,
     solana_program_runtime::{
         compute_budget::DEFAULT_HEAP_COST,
         compute_budget_processor::{

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -23,7 +23,7 @@ impl TransactionCost {
             Self::SimpleVote { .. } => {
                 const _: () = assert!(
                     SIMPLE_VOTE_USAGE_COST
-                        == solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS
+                        == solana_sdk::vote::instruction::DEFAULT_COMPUTE_UNITS
                             + block_cost_limits::SIGNATURE_COST
                             + 2 * block_cost_limits::WRITE_LOCK_UNITS
                             + 8
@@ -37,7 +37,7 @@ impl TransactionCost {
 
     pub fn programs_execution_cost(&self) -> u64 {
         match self {
-            Self::SimpleVote { .. } => solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS,
+            Self::SimpleVote { .. } => solana_sdk::vote::instruction::DEFAULT_COMPUTE_UNITS,
             Self::Transaction(usage_cost) => usage_cost.programs_execution_cost,
         }
     }

--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -1,3 +1,4 @@
+pub use solana_sdk::address_lookup_table::instruction::DEFAULT_COMPUTE_UNITS;
 use {
     solana_program_runtime::{declare_process_instruction, ic_msg, invoke_context::InvokeContext},
     solana_sdk::{
@@ -18,8 +19,6 @@ use {
     },
     std::convert::TryFrom,
 };
-
-pub const DEFAULT_COMPUTE_UNITS: u64 = 750;
 
 declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context| {
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -1,9 +1,8 @@
-pub use solana_sdk::address_lookup_table::instruction::DEFAULT_COMPUTE_UNITS;
 use {
     solana_program_runtime::{declare_process_instruction, ic_msg, invoke_context::InvokeContext},
     solana_sdk::{
         address_lookup_table::{
-            instruction::ProgramInstruction,
+            instruction::{ProgramInstruction, DEFAULT_COMPUTE_UNITS},
             program::{check_id, id},
             state::{
                 AddressLookupTable, LookupTableMeta, LookupTableStatus, ProgramState,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -4,11 +4,6 @@
 pub mod serialization;
 pub mod syscalls;
 
-pub use solana_sdk::{
-    bpf_loader::DEFAULT_COMPUTE_UNITS as DEFAULT_LOADER_COMPUTE_UNITS,
-    bpf_loader_deprecated::DEFAULT_COMPUTE_UNITS as DEPRECATED_LOADER_COMPUTE_UNITS,
-    bpf_loader_upgradeable::DEFAULT_COMPUTE_UNITS as UPGRADEABLE_LOADER_COMPUTE_UNITS,
-};
 use {
     solana_measure::measure::Measure,
     solana_program_runtime::{
@@ -408,17 +403,17 @@ pub fn process_instruction_inner(
         drop(program_account);
         let program_id = instruction_context.get_last_program_key(transaction_context)?;
         return if bpf_loader_upgradeable::check_id(program_id) {
-            invoke_context.consume_checked(UPGRADEABLE_LOADER_COMPUTE_UNITS)?;
+            invoke_context.consume_checked(bpf_loader_upgradeable::DEFAULT_COMPUTE_UNITS)?;
             process_loader_upgradeable_instruction(invoke_context)
         } else if bpf_loader::check_id(program_id) {
-            invoke_context.consume_checked(DEFAULT_LOADER_COMPUTE_UNITS)?;
+            invoke_context.consume_checked(bpf_loader::DEFAULT_COMPUTE_UNITS)?;
             ic_logger_msg!(
                 log_collector,
                 "BPF loader management instructions are no longer supported",
             );
             Err(InstructionError::UnsupportedProgramId)
         } else if bpf_loader_deprecated::check_id(program_id) {
-            invoke_context.consume_checked(DEPRECATED_LOADER_COMPUTE_UNITS)?;
+            invoke_context.consume_checked(bpf_loader_deprecated::DEFAULT_COMPUTE_UNITS)?;
             ic_logger_msg!(log_collector, "Deprecated loader is no longer supported");
             Err(InstructionError::UnsupportedProgramId)
         } else {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -4,6 +4,11 @@
 pub mod serialization;
 pub mod syscalls;
 
+pub use solana_sdk::{
+    bpf_loader::DEFAULT_COMPUTE_UNITS as DEFAULT_LOADER_COMPUTE_UNITS,
+    bpf_loader_deprecated::DEFAULT_COMPUTE_UNITS as DEPRECATED_LOADER_COMPUTE_UNITS,
+    bpf_loader_upgradeable::DEFAULT_COMPUTE_UNITS as UPGRADEABLE_LOADER_COMPUTE_UNITS,
+};
 use {
     solana_measure::measure::Measure,
     solana_program_runtime::{
@@ -53,10 +58,6 @@ use {
     },
     syscalls::{create_program_runtime_environment_v1, morph_into_deployment_environment_v1},
 };
-
-pub const DEFAULT_LOADER_COMPUTE_UNITS: u64 = 570;
-pub const DEPRECATED_LOADER_COMPUTE_UNITS: u64 = 1_140;
-pub const UPGRADEABLE_LOADER_COMPUTE_UNITS: u64 = 2_370;
 
 #[allow(clippy::too_many_arguments)]
 pub fn load_program_from_bytes(

--- a/programs/compute-budget/src/lib.rs
+++ b/programs/compute-budget/src/lib.rs
@@ -1,6 +1,5 @@
 use solana_program_runtime::declare_process_instruction;
-
-pub const DEFAULT_COMPUTE_UNITS: u64 = 150;
+pub use solana_sdk::compute_budget::DEFAULT_COMPUTE_UNITS;
 
 declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |_invoke_context| {
     // Do nothing, compute budget instructions handled by the runtime

--- a/programs/compute-budget/src/lib.rs
+++ b/programs/compute-budget/src/lib.rs
@@ -1,5 +1,7 @@
-use solana_program_runtime::declare_process_instruction;
-pub use solana_sdk::compute_budget::DEFAULT_COMPUTE_UNITS;
+use {
+    solana_program_runtime::declare_process_instruction,
+    solana_sdk::compute_budget::DEFAULT_COMPUTE_UNITS,
+};
 
 declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |_invoke_context| {
     // Do nothing, compute budget instructions handled by the runtime

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -1,5 +1,6 @@
 //! Config program
 
+pub use solana_sdk::config::program::DEFAULT_COMPUTE_UNITS;
 use {
     crate::ConfigKeys,
     bincode::deserialize,
@@ -10,8 +11,6 @@ use {
     },
     std::collections::BTreeSet,
 };
-
-pub const DEFAULT_COMPUTE_UNITS: u64 = 450;
 
 declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context| {
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -1,13 +1,12 @@
 //! Config program
 
-pub use solana_sdk::config::program::DEFAULT_COMPUTE_UNITS;
 use {
     crate::ConfigKeys,
     bincode::deserialize,
     solana_program_runtime::{declare_process_instruction, ic_msg},
     solana_sdk::{
-        instruction::InstructionError, program_utils::limited_deserialize, pubkey::Pubkey,
-        transaction_context::IndexOfAccount,
+        config::program::DEFAULT_COMPUTE_UNITS, instruction::InstructionError,
+        program_utils::limited_deserialize, pubkey::Pubkey, transaction_context::IndexOfAccount,
     },
     std::collections::BTreeSet,
 };

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -1,4 +1,3 @@
-pub use solana_sdk::loader_v4::DEFAULT_COMPUTE_UNITS;
 use {
     solana_measure::measure::Measure,
     solana_program_runtime::{
@@ -23,7 +22,10 @@ use {
     solana_sdk::{
         entrypoint::SUCCESS,
         instruction::InstructionError,
-        loader_v4::{self, LoaderV4State, LoaderV4Status, DEPLOYMENT_COOLDOWN_IN_SLOTS},
+        loader_v4::{
+            self, LoaderV4State, LoaderV4Status, DEFAULT_COMPUTE_UNITS,
+            DEPLOYMENT_COOLDOWN_IN_SLOTS,
+        },
         loader_v4_instruction::LoaderV4Instruction,
         program_utils::limited_deserialize,
         pubkey::Pubkey,

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -1,3 +1,4 @@
+pub use solana_sdk::loader_v4::DEFAULT_COMPUTE_UNITS;
 use {
     solana_measure::measure::Measure,
     solana_program_runtime::{
@@ -35,8 +36,6 @@ use {
         sync::{atomic::Ordering, Arc},
     },
 };
-
-pub const DEFAULT_COMPUTE_UNITS: u64 = 2_000;
 
 pub fn get_state(data: &[u8]) -> Result<&LoaderV4State, InstructionError> {
     unsafe {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4784,6 +4784,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-builtin-programs"
+version = "2.0.0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "rustc_version",
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-clap-utils"
 version = "2.0.0"
 dependencies = [
@@ -4940,6 +4950,7 @@ dependencies = [
  "serde_derive",
  "solana-accounts-db",
  "solana-bloom",
+ "solana-builtin-programs",
  "solana-client",
  "solana-cost-model",
  "solana-entry",
@@ -4988,18 +4999,12 @@ dependencies = [
  "lazy_static",
  "log",
  "rustc_version",
- "solana-address-lookup-table-program",
- "solana-bpf-loader-program",
- "solana-compute-budget-program",
- "solana-config-program",
+ "solana-builtin-programs",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-loader-v4-program",
  "solana-metrics",
  "solana-program-runtime",
  "solana-sdk",
- "solana-stake-program",
- "solana-system-program",
  "solana-vote-program",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4784,7 +4784,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-builtin-programs"
+name = "solana-builtin-cost-info"
 version = "2.0.0"
 dependencies = [
  "lazy_static",
@@ -4950,7 +4950,7 @@ dependencies = [
  "serde_derive",
  "solana-accounts-db",
  "solana-bloom",
- "solana-builtin-programs",
+ "solana-builtin-cost-info",
  "solana-client",
  "solana-cost-model",
  "solana-entry",
@@ -4999,7 +4999,7 @@ dependencies = [
  "lazy_static",
  "log",
  "rustc_version",
- "solana-builtin-programs",
+ "solana-builtin-cost-info",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-metrics",

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -47,7 +47,7 @@ fn get_optional_pubkey<'a>(
     )
 }
 
-pub const DEFAULT_COMPUTE_UNITS: u64 = 750;
+pub use solana_sdk::stake::instruction::DEFAULT_COMPUTE_UNITS;
 
 declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context| {
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -13,7 +13,7 @@ use {
         program_utils::limited_deserialize,
         pubkey::Pubkey,
         stake::{
-            instruction::{LockupArgs, StakeError, StakeInstruction},
+            instruction::{LockupArgs, StakeError, StakeInstruction, DEFAULT_COMPUTE_UNITS},
             program::id,
             state::{Authorized, Lockup},
         },
@@ -46,8 +46,6 @@ fn get_optional_pubkey<'a>(
         },
     )
 }
-
-pub use solana_sdk::stake::instruction::DEFAULT_COMPUTE_UNITS;
 
 declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context| {
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -7,7 +7,7 @@ use solana_sdk::{
     account_utils::StateMut,
     nonce, system_program,
 };
-pub use system_program::id;
+pub use system_program::{id, DEFAULT_COMPUTE_UNITS};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SystemAccountKind {

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -7,7 +7,7 @@ use solana_sdk::{
     account_utils::StateMut,
     nonce, system_program,
 };
-pub use system_program::{id, DEFAULT_COMPUTE_UNITS};
+pub use system_program::id;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SystemAccountKind {

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -295,7 +295,7 @@ fn transfer_with_seed(
     )
 }
 
-pub const DEFAULT_COMPUTE_UNITS: u64 = 150;
+pub use system_program::DEFAULT_COMPUTE_UNITS;
 
 declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context| {
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -14,7 +14,7 @@ use {
         program_utils::limited_deserialize,
         pubkey::Pubkey,
         system_instruction::{SystemError, SystemInstruction, MAX_PERMITTED_DATA_LENGTH},
-        system_program,
+        system_program::{self, DEFAULT_COMPUTE_UNITS},
         transaction_context::{
             BorrowedAccount, IndexOfAccount, InstructionContext, TransactionContext,
         },
@@ -294,8 +294,6 @@ fn transfer_with_seed(
         instruction_context,
     )
 }
-
-pub use system_program::DEFAULT_COMPUTE_UNITS;
 
 declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context| {
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -14,6 +14,7 @@ use {
         program_utils::limited_deserialize,
         pubkey::Pubkey,
         transaction_context::{BorrowedAccount, InstructionContext, TransactionContext},
+        vote::instruction::DEFAULT_COMPUTE_UNITS,
     },
     std::collections::HashSet,
 };
@@ -49,8 +50,6 @@ fn process_authorize_with_seed_instruction(
         &invoke_context.feature_set,
     )
 }
-
-pub use solana_sdk::vote::instruction::DEFAULT_COMPUTE_UNITS;
 
 declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context| {
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -50,9 +50,7 @@ fn process_authorize_with_seed_instruction(
     )
 }
 
-// Citing `runtime/src/block_cost_limit.rs`, vote has statically defined 2100
-// units; can consume based on instructions in the future like `bpf_loader` does.
-pub const DEFAULT_COMPUTE_UNITS: u64 = 2_100;
+pub use solana_sdk::vote::instruction::DEFAULT_COMPUTE_UNITS;
 
 declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context| {
     let transaction_context = &invoke_context.transaction_context;

--- a/sdk/program/src/address_lookup_table/instruction.rs
+++ b/sdk/program/src/address_lookup_table/instruction.rs
@@ -9,6 +9,8 @@ use {
     serde::{Deserialize, Serialize},
 };
 
+pub const DEFAULT_COMPUTE_UNITS: u64 = 750;
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum ProgramInstruction {
     /// Create an address lookup table

--- a/sdk/program/src/bpf_loader.rs
+++ b/sdk/program/src/bpf_loader.rs
@@ -22,3 +22,4 @@
 //! [ubpfl]: crate::bpf_loader_upgradeable
 
 crate::declare_id!("BPFLoader2111111111111111111111111111111111");
+pub const DEFAULT_COMPUTE_UNITS: u64 = 570;

--- a/sdk/program/src/bpf_loader_deprecated.rs
+++ b/sdk/program/src/bpf_loader_deprecated.rs
@@ -12,3 +12,4 @@
 //! version located in `entrypoint_deprecated.rs`.
 
 crate::declare_id!("BPFLoader1111111111111111111111111111111111");
+pub const DEFAULT_COMPUTE_UNITS: u64 = 1_140;

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -23,6 +23,7 @@ use crate::{
 };
 
 crate::declare_id!("BPFLoaderUpgradeab1e11111111111111111111111");
+pub const DEFAULT_COMPUTE_UNITS: u64 = 2_370;
 
 /// Upgradeable loader account states
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, AbiExample)]

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -557,6 +557,7 @@ pub use wasm_bindgen::prelude::wasm_bindgen;
 pub mod config {
     pub mod program {
         crate::declare_id!("Config1111111111111111111111111111111111111");
+        pub const DEFAULT_COMPUTE_UNITS: u64 = 450;
     }
 }
 

--- a/sdk/program/src/loader_v4.rs
+++ b/sdk/program/src/loader_v4.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 
 crate::declare_id!("LoaderV411111111111111111111111111111111111");
+pub const DEFAULT_COMPUTE_UNITS: u64 = 2_000;
 
 /// Cooldown before a program can be un-/redeployed again
 pub const DEPLOYMENT_COOLDOWN_IN_SLOTS: u64 = 750;

--- a/sdk/program/src/stake/instruction.rs
+++ b/sdk/program/src/stake/instruction.rs
@@ -81,6 +81,8 @@ impl<E> DecodeError<E> for StakeError {
     }
 }
 
+pub const DEFAULT_COMPUTE_UNITS: u64 = 750;
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum StakeInstruction {
     /// Initialize a stake with lockup and authorization information

--- a/sdk/program/src/system_program.rs
+++ b/sdk/program/src/system_program.rs
@@ -3,3 +3,4 @@
 //! [np]: https://docs.solanalabs.com/runtime/programs#system-program
 
 crate::declare_id!("11111111111111111111111111111111");
+pub const DEFAULT_COMPUTE_UNITS: u64 = 150;

--- a/sdk/program/src/vote/instruction.rs
+++ b/sdk/program/src/vote/instruction.rs
@@ -20,6 +20,8 @@ use {
     serde_derive::{Deserialize, Serialize},
 };
 
+pub const DEFAULT_COMPUTE_UNITS: u64 = 2_100;
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum VoteInstruction {
     /// Initialize a vote account

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -8,6 +8,7 @@ use {
 };
 
 crate::declare_id!("ComputeBudget111111111111111111111111111111");
+pub const DEFAULT_COMPUTE_UNITS: u64 = 150;
 
 /// Compute Budget Instructions
 #[derive(


### PR DESCRIPTION
#### Problem
`BUILT_IN_INSTRUCTION_COSTS` in cost-model gets each native programs' const default cost by importing all program crates. This makes it has dependencies on all solana-*-program, and all call sites as well. This creates circular dependencies, for example, `solana-runtime-program` will not be able to access `BUILT_IN_INSTRUCTION_COSTS`.

#### Summary of Changes
- move all native program's `pub const DEFAULT_UNITS ...` to sdk, alone side with `declare_id!(...)`. Arguably static cost of native program ( and/or their instructions ) is better by declaring next to its program-id, and this information should be public available via sdk.
- move `BUILT_IN_INSTRUCTION_COSTS` into its own crate which only depends on `solana-sdk`, so it can be shared always by almost all other crates.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
