### PR TITLE
Refactor - Remove `program_accounts_map` from account_loader

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -253,7 +253,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             error_counters,
             &self.fee_structure,
             account_overrides,
-            &program_accounts_map,
             &programs_loaded_for_tx_batch.borrow(),
         );
         load_time.stop();


### PR DESCRIPTION
#### Problem
`program_accounts_map` is currently collected in the `TransactionBatchProcessor`and then wired all the way through account_loader.rs until `account_shared_data_from_program()` where it is actually not needed because we can just use `loaded_program.account_owner()` instead.

#### Summary of Changes
Removes `program_accounts_map` from account_loader.rs
