### PR TITLE
Track reserved account keys in bank

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7908,6 +7908,32 @@ fn test_compute_active_feature_set() {
 }
 
 #[test]
+fn test_reserved_account_keys() {
+    let bank0 = create_simple_test_arc_bank(100_000).0;
+    let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+    bank.feature_set = Arc::new(FeatureSet::default());
+
+    assert_eq!(
+        bank.get_reserved_account_keys().len(),
+        20,
+        "before activating the new feature, bank should already have active reserved keys"
+    );
+
+    // Activate `add_new_reserved_account_keys` feature
+    bank.store_account(
+        &feature_set::add_new_reserved_account_keys::id(),
+        &feature::create_account(&Feature::default(), 42),
+    );
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, true);
+
+    assert_eq!(
+        bank.get_reserved_account_keys().len(),
+        29,
+        "after activating the new feature, bank should have new active reserved keys"
+    );
+}
+
+#[test]
 fn test_program_replacement() {
     let mut bank = create_simple_test_bank(0);
 

--- a/sdk/src/reserved_account_keys.rs
+++ b/sdk/src/reserved_account_keys.rs
@@ -22,6 +22,16 @@ mod zk_token_proof_program {
     solana_sdk::declare_id!("ZkTokenProof1111111111111111111111111111111");
 }
 
+// ReservedAccountKeys is not serialized into or deserialized from bank
+// snapshots but the bank requires this trait to be implemented anyways.
+#[cfg(RUSTC_WITH_SPECIALIZATION)]
+impl ::solana_frozen_abi::abi_example::AbiExample for ReservedAccountKeys {
+    fn example() -> Self {
+        // ReservedAccountKeys is not Serialize so just rely on Default.
+        ReservedAccountKeys::default()
+    }
+}
+
 /// `ReservedAccountKeys` holds the set of currently active/inactive
 /// account keys that are reserved by the protocol and may not be write-locked
 /// during transaction processing.


### PR DESCRIPTION
#### Problem
The transaction scheduler and the runtime both demote transaction write locks for builtin programs and sysvars using a static list of reserved IDs. This change adds a dynamic set of reserved account keys to the bank that can be updated at epoch boundaries with feature gates (added here: https://github.com/anza-xyz/agave/pull/84)

#### Summary of Changes
Bank now has a field for tracking reserved account keys and this field is updated on epoch boundaries according to new feature activations

Feature Gate Issue: https://github.com/anza-xyz/agave/issues/540
<!-- Don't forget to add the "feature-gate" label -->
