### PR TITLE
Refactor - `ProgramCache::begin_cooperative_loading_task()`

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -544,12 +544,16 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         return ret;
                     }
                 }
-                // Figure out which program needs to be loaded next.
+                // Figure out which programs are already loaded and which aren't.
                 let program_to_load = program_cache.extract(
                     &mut missing_programs,
                     loaded_programs_for_txs.as_mut().unwrap(),
                     is_first_round,
                 );
+                if let Some((key, _usage_counter)) = &program_to_load {
+                    // Tell the others that we selected this loading task.
+                    program_cache.begin_cooperative_loading_task(self.slot, *key);
+                }
                 let task_waiter = Arc::clone(&program_cache.loading_task_waiter);
                 (program_to_load, task_waiter.cookie(), task_waiter)
                 // Unlock the global cache again.


### PR DESCRIPTION
#### Problem
Currently `ProgramCache::extract()` is `&mut self` only because it also signals which `cooperative_loading_task` it chose to the other TX batches. That however could be done in a separate method, just like `ProgramCache::finish_cooperative_loading_task()` was pulled out of `ProgramCache::extract()`. It would make writing tests a little easier because `ProgramCache::extract()` would not squat on loading tasks anymore.

#### Summary of Changes
- Adds `ProgramCache::begin_cooperative_loading_task()`.
- Makes `ProgramCache::extract()` `&self` instead of `&mut self`.