### PR TITLE
Adds get_account_shared_data() to tiered storage

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -144,7 +144,13 @@ impl AccountsFile {
     pub(crate) fn get_stored_account(&self, offset: usize) -> Option<AccountSharedData> {
         match self {
             Self::AppendVec(av) => av.get_stored_account(offset),
-            Self::TieredStorage(_) => unimplemented!(),
+            Self::TieredStorage(ts) => {
+                // Note: The conversion here is needed as the AccountsDB currently
+                // assumes all offsets are multiple of 8 while TieredStorage uses
+                // IndexOffset that is equivalent to AccountInfo::reduced_offset.
+                let index_offset = IndexOffset(AccountInfo::get_reduced_offset(offset));
+                ts.reader()?.get_account_shared_data(index_offset).ok()?
+            }
         }
     }
 

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -11,7 +11,7 @@ use {
             TieredStorageResult,
         },
     },
-    solana_sdk::pubkey::Pubkey,
+    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
     std::path::Path,
 };
 
@@ -72,6 +72,16 @@ impl TieredStorageReader {
     ) -> TieredStorageResult<Option<(StoredAccountMeta<'_>, IndexOffset)>> {
         match self {
             Self::Hot(hot) => hot.get_account(index_offset),
+        }
+    }
+
+    /// Returns the account located at the specified index offset.
+    pub fn get_account_shared_data(
+        &self,
+        index_offset: IndexOffset,
+    ) -> TieredStorageResult<Option<AccountSharedData>> {
+        match self {
+            Self::Hot(hot) => hot.get_account_shared_data(index_offset),
         }
     }
 


### PR DESCRIPTION
#### Problem

Tiered Storage does not yet implement the `get_stored_account()` API on AccountsFile. This is preventing us from updating accounts-db tests to also run against tiered storage.


#### Summary of Changes

Add `get_account_shared_data()` to tiered storage, and hook it up to AccountsFile.