### PR TITLE
Renames tiered storage get_account() to get_stored_account_meta()

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -132,7 +132,7 @@ impl AccountsFile {
             // IndexOffset that is equivalent to AccountInfo::reduced_offset.
             Self::TieredStorage(ts) => ts
                 .reader()?
-                .get_account(IndexOffset(AccountInfo::get_reduced_offset(offset)))
+                .get_stored_account_meta(IndexOffset(AccountInfo::get_reduced_offset(offset)))
                 .ok()?
                 .map(|(metas, index_offset)| {
                     (metas, AccountInfo::reduced_offset_to_offset(index_offset.0))

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -372,20 +372,22 @@ mod tests {
         let mut min_pubkey_ref = &MAX_PUBKEY;
         let mut max_pubkey_ref = &MIN_PUBKEY;
 
-        while let Some((stored_meta, next)) = reader.get_account(index_offset).unwrap() {
-            if let Some(account) = expected_accounts_map.get(stored_meta.pubkey()) {
+        while let Some((stored_account_meta, next)) =
+            reader.get_stored_account_meta(index_offset).unwrap()
+        {
+            if let Some(account) = expected_accounts_map.get(stored_account_meta.pubkey()) {
                 verify_test_account_with_footer(
-                    &stored_meta,
+                    &stored_account_meta,
                     *account,
-                    stored_meta.pubkey(),
+                    stored_account_meta.pubkey(),
                     footer,
                 );
-                verified_accounts.insert(stored_meta.pubkey());
-                if *min_pubkey_ref > *stored_meta.pubkey() {
-                    min_pubkey_ref = stored_meta.pubkey();
+                verified_accounts.insert(stored_account_meta.pubkey());
+                if *min_pubkey_ref > *stored_account_meta.pubkey() {
+                    min_pubkey_ref = stored_account_meta.pubkey();
                 }
-                if *max_pubkey_ref < *stored_meta.pubkey() {
-                    max_pubkey_ref = stored_meta.pubkey();
+                if *max_pubkey_ref < *stored_account_meta.pubkey() {
+                    max_pubkey_ref = stored_account_meta.pubkey();
                 }
             }
             index_offset = next;

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -525,7 +525,7 @@ impl HotStorageReader {
     }
 
     /// Returns the account located at the specified index offset.
-    pub fn get_account(
+    pub fn get_stored_account_meta(
         &self,
         index_offset: IndexOffset,
     ) -> TieredStorageResult<Option<(StoredAccountMeta<'_>, IndexOffset)>> {
@@ -563,7 +563,7 @@ impl HotStorageReader {
                 .account_entry_count
                 .saturating_sub(index_offset.0) as usize,
         );
-        while let Some((account, next)) = self.get_account(index_offset)? {
+        while let Some((account, next)) = self.get_stored_account_meta(index_offset)? {
             accounts.push(account);
             index_offset = next;
         }
@@ -1302,10 +1302,10 @@ pub mod tests {
     }
 
     #[test]
-    fn test_hot_storage_get_account() {
+    fn test_get_stored_account_meta() {
         // Generate a new temp path that is guaranteed to NOT already have a file.
         let temp_dir = TempDir::new().unwrap();
-        let path = temp_dir.path().join("test_hot_storage_get_account");
+        let path = temp_dir.path().join("test");
 
         let mut rng = rand::thread_rng();
 
@@ -1392,25 +1392,25 @@ pub mod tests {
         let hot_storage = HotStorageReader::new(file).unwrap();
 
         for i in 0..NUM_ACCOUNTS {
-            let (stored_meta, next) = hot_storage
-                .get_account(IndexOffset(i as u32))
+            let (stored_account_meta, next) = hot_storage
+                .get_stored_account_meta(IndexOffset(i as u32))
                 .unwrap()
                 .unwrap();
-            assert_eq!(stored_meta.lamports(), account_metas[i].lamports());
-            assert_eq!(stored_meta.data().len(), account_datas[i].len());
-            assert_eq!(stored_meta.data(), account_datas[i]);
+            assert_eq!(stored_account_meta.lamports(), account_metas[i].lamports());
+            assert_eq!(stored_account_meta.data().len(), account_datas[i].len());
+            assert_eq!(stored_account_meta.data(), account_datas[i]);
             assert_eq!(
-                *stored_meta.owner(),
+                *stored_account_meta.owner(),
                 owners[account_metas[i].owner_offset().0 as usize]
             );
-            assert_eq!(*stored_meta.pubkey(), addresses[i]);
+            assert_eq!(*stored_account_meta.pubkey(), addresses[i]);
 
             assert_eq!(i + 1, next.0 as usize);
         }
         // Make sure it returns None on NUM_ACCOUNTS to allow termination on
         // while loop in actual accounts-db read case.
         assert_matches!(
-            hot_storage.get_account(IndexOffset(NUM_ACCOUNTS as u32)),
+            hot_storage.get_stored_account_meta(IndexOffset(NUM_ACCOUNTS as u32)),
             Ok(None)
         );
     }
@@ -1466,31 +1466,31 @@ pub mod tests {
 
         let num_accounts = account_data_sizes.len();
         for i in 0..num_accounts {
-            let (stored_meta, next) = hot_storage
-                .get_account(IndexOffset(i as u32))
+            let (stored_account_meta, next) = hot_storage
+                .get_stored_account_meta(IndexOffset(i as u32))
                 .unwrap()
                 .unwrap();
 
             let (account, address, _account_hash) = storable_accounts.get(i);
-            verify_test_account(&stored_meta, account, address);
+            verify_test_account(&stored_account_meta, account, address);
 
             assert_eq!(i + 1, next.0 as usize);
         }
         // Make sure it returns None on NUM_ACCOUNTS to allow termination on
         // while loop in actual accounts-db read case.
         assert_matches!(
-            hot_storage.get_account(IndexOffset(num_accounts as u32)),
+            hot_storage.get_stored_account_meta(IndexOffset(num_accounts as u32)),
             Ok(None)
         );
 
         for stored_info in stored_infos {
-            let (stored_meta, _) = hot_storage
-                .get_account(IndexOffset(stored_info.offset as u32))
+            let (stored_account_meta, _) = hot_storage
+                .get_stored_account_meta(IndexOffset(stored_info.offset as u32))
                 .unwrap()
                 .unwrap();
 
             let (account, address, _account_hash) = storable_accounts.get(stored_info.offset);
-            verify_test_account(&stored_meta, account, address);
+            verify_test_account(&stored_account_meta, account, address);
         }
 
         // verify get_accounts

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -66,12 +66,12 @@ impl TieredStorageReader {
     }
 
     /// Returns the account located at the specified index offset.
-    pub fn get_account(
+    pub fn get_stored_account_meta(
         &self,
         index_offset: IndexOffset,
     ) -> TieredStorageResult<Option<(StoredAccountMeta<'_>, IndexOffset)>> {
         match self {
-            Self::Hot(hot) => hot.get_account(index_offset),
+            Self::Hot(hot) => hot.get_stored_account_meta(index_offset),
         }
     }
 


### PR DESCRIPTION
#### Problem

Tiered Storage soon will have multiple methods for fetching accounts (see #773). The current `get_account()` returns a `StoredAccountMeta`. This may be confusing/ambiguous going forward once `get_account_shared_data()` is added.


#### Summary of Changes

Renames the method from `get_account()` to `get_stored_account_meta()`.