### PR TITLE
patches flaky Merkle shreds test

### DIFF
--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1929,10 +1929,10 @@ mod test {
                     .chain(
                         shreds
                             .iter()
+                            .sorted_unstable_by_key(|shred| shred.fec_set_index())
                             .dedup_by(|shred, other| shred.fec_set_index() == other.fec_set_index())
                             .map(|shred| (shred.fec_set_index(), shred.merkle_root().unwrap())),
                     )
-                    .sorted()
                     .tuple_windows()
                     .map(|((_, merkle_root), (fec_set_index, _))| (fec_set_index, merkle_root))
                     .collect();


### PR DESCRIPTION
#### Problem
Expected `chained_merkle_roots` are constructed incorrectly in the test causing flaky test.

#### Summary of Changes
Patched expected `chained_merkle_roots`.