### PR TITLE
hot owners accumulation needs to be byval

### DIFF
--- a/accounts-db/src/tiered_storage/owners.rs
+++ b/accounts-db/src/tiered_storage/owners.rs
@@ -54,7 +54,7 @@ impl OwnersBlockFormat {
             Self::AddressesOnly => {
                 let mut bytes_written = 0;
                 for address in &owners_table.owners_set {
-                    bytes_written += file.write_pod(*address)?;
+                    bytes_written += file.write_pod(address)?;
                 }
 
                 Ok(bytes_written)
@@ -85,19 +85,19 @@ impl OwnersBlockFormat {
 /// The in-memory representation of owners block for write.
 /// It manages a set of unique addresses of account owners.
 #[derive(Debug, Default)]
-pub struct OwnersTable<'a> {
-    owners_set: IndexSet<&'a Pubkey>,
+pub struct OwnersTable {
+    owners_set: IndexSet<Pubkey>,
 }
 
 /// OwnersBlock is persisted as a consecutive bytes of pubkeys without any
 /// meta-data.  For each account meta, it has a owner_offset field to
 /// access its owner's address in the OwnersBlock.
-impl<'a> OwnersTable<'a> {
+impl OwnersTable {
     /// Add the specified pubkey as the owner into the OwnersWriterTable
     /// if the specified pubkey has not existed in the OwnersWriterTable
     /// yet.  In any case, the function returns its OwnerOffset.
-    pub fn insert(&mut self, pubkey: &'a Pubkey) -> OwnerOffset {
-        let (offset, _existed) = self.owners_set.insert_full(pubkey);
+    pub fn insert(&mut self, pubkey: &Pubkey) -> OwnerOffset {
+        let (offset, _existed) = self.owners_set.insert_full(*pubkey);
 
         OwnerOffset(offset as u32)
     }


### PR DESCRIPTION
#### Problem
moving to not mmapping append vec files

#### Summary of Changes
When we store hot accounts, we can no longer hold refs to owner pubkeys. We need to copy them.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
