### PR TITLE
Renames fns to get_account_shared_data()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -822,7 +822,7 @@ impl<'a> LoadedAccountAccessor<'a> {
                 // from the storage map after we grabbed the storage entry, the recycler should not
                 // reset the storage entry until we drop the reference to the storage entry.
                 maybe_storage_entry
-                            .get_stored_account(*offset)
+                            .get_account_shared_data(*offset)
                     .expect("If a storage entry was found in the storage map, it must not have been reset yet")
             }
             _ => self.check_and_get_loaded_account().take_account(),
@@ -1136,8 +1136,8 @@ impl AccountStorageEntry {
         Some(self.accounts.get_stored_account_meta(offset)?.0)
     }
 
-    fn get_stored_account(&self, offset: usize) -> Option<AccountSharedData> {
-        self.accounts.get_stored_account(offset)
+    fn get_account_shared_data(&self, offset: usize) -> Option<AccountSharedData> {
+        self.accounts.get_account_shared_data(offset)
     }
 
     fn add_account(&self, num_bytes: usize) {

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -141,9 +141,9 @@ impl AccountsFile {
     }
 
     /// return an `AccountSharedData` for an account at `offset`, if any.  Otherwise return None.
-    pub(crate) fn get_stored_account(&self, offset: usize) -> Option<AccountSharedData> {
+    pub(crate) fn get_account_shared_data(&self, offset: usize) -> Option<AccountSharedData> {
         match self {
-            Self::AppendVec(av) => av.get_stored_account(offset),
+            Self::AppendVec(av) => av.get_account_shared_data(offset),
             Self::TieredStorage(ts) => {
                 // Note: The conversion here is needed as the AccountsDB currently
                 // assumes all offsets are multiple of 8 while TieredStorage uses

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -540,7 +540,7 @@ impl AppendVec {
 
     /// return an `AccountSharedData` for an account at `offset`.
     /// This fn can efficiently return exactly what is needed by a caller.
-    pub(crate) fn get_stored_account(&self, offset: usize) -> Option<AccountSharedData> {
+    pub(crate) fn get_account_shared_data(&self, offset: usize) -> Option<AccountSharedData> {
         let (meta, next) = self.get_type::<StoredMeta>(offset)?;
         let (account_meta, next) = self.get_type::<AccountMeta>(next)?;
         let next = next + std::mem::size_of::<AccountHash>();
@@ -593,7 +593,7 @@ impl AppendVec {
         offset: usize,
     ) -> Option<(StoredMeta, solana_sdk::account::AccountSharedData)> {
         let r1 = self.get_stored_account_meta(offset);
-        let r2 = self.get_stored_account(offset);
+        let r2 = self.get_account_shared_data(offset);
         let r3 = self.get_account_meta(offset);
         let sizes = self.get_account_sizes(&[offset]);
         if r1.is_some() {


### PR DESCRIPTION
#### Problem

Since #774, we now have `get_account()`, `get_stored_account()`, `get_stored_account_meta()`, and `get_account_shared_data()` methods, but `AppendVec::get_stored_account()` returns an `AccountSharedData`. I find this a bit confusing. If we rename `get_stored_account()`, I think that would help.


#### Summary of Changes

Renames the methods to `get_account_shared_data()` and updates callers.