### PR TITLE
Renames fns to get_stored_account_meta()

### DIFF
--- a/accounts-db/benches/append_vec.rs
+++ b/accounts-db/benches/append_vec.rs
@@ -73,7 +73,7 @@ fn append_vec_sequential_read(bencher: &mut Bencher) {
     bencher.iter(|| {
         let (sample, pos) = indexes.pop().unwrap();
         println!("reading pos {sample} {pos}");
-        let (account, _next) = vec.get_account(pos).unwrap();
+        let (account, _next) = vec.get_stored_account_meta(pos).unwrap();
         let (_meta, test) = create_test_account(sample);
         assert_eq!(account.data(), test.data());
         indexes.push((sample, pos));
@@ -88,7 +88,7 @@ fn append_vec_random_read(bencher: &mut Bencher) {
     bencher.iter(|| {
         let random_index: usize = thread_rng().gen_range(0..indexes.len());
         let (sample, pos) = &indexes[random_index];
-        let (account, _next) = vec.get_account(*pos).unwrap();
+        let (account, _next) = vec.get_stored_account_meta(*pos).unwrap();
         let (_meta, test) = create_test_account(*sample);
         assert_eq!(account.data(), test.data());
     });
@@ -117,7 +117,7 @@ fn append_vec_concurrent_append_read(bencher: &mut Bencher) {
         let len = indexes.lock().unwrap().len();
         let random_index: usize = thread_rng().gen_range(0..len);
         let (sample, pos) = *indexes.lock().unwrap().get(random_index).unwrap();
-        let (account, _next) = vec.get_account(pos).unwrap();
+        let (account, _next) = vec.get_stored_account_meta(pos).unwrap();
         let (_meta, test) = create_test_account(sample);
         assert_eq!(account.data(), test.data());
     });
@@ -137,7 +137,7 @@ fn append_vec_concurrent_read_append(bencher: &mut Bencher) {
         }
         let random_index: usize = thread_rng().gen_range(0..len + 1);
         let (sample, pos) = *indexes1.lock().unwrap().get(random_index % len).unwrap();
-        let (account, _next) = vec1.get_account(pos).unwrap();
+        let (account, _next) = vec1.get_stored_account_meta(pos).unwrap();
         let (_meta, test) = create_test_account(sample);
         assert_eq!(account.data(), test.data());
     });

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1133,7 +1133,7 @@ impl AccountStorageEntry {
     }
 
     fn get_stored_account_meta(&self, offset: usize) -> Option<StoredAccountMeta> {
-        Some(self.accounts.get_account(offset)?.0)
+        Some(self.accounts.get_stored_account_meta(offset)?.0)
     }
 
     fn get_stored_account(&self, offset: usize) -> Option<AccountSharedData> {
@@ -8745,7 +8745,11 @@ impl AccountsDb {
             duplicates_this_slot
                 .into_iter()
                 .for_each(|(pubkey, (_slot, info))| {
-                    let duplicate = storage.accounts.get_account(info.offset()).unwrap().0;
+                    let duplicate = storage
+                        .accounts
+                        .get_stored_account_meta(info.offset())
+                        .unwrap()
+                        .0;
                     assert_eq!(&pubkey, duplicate.pubkey());
                     stored_size_alive = stored_size_alive.saturating_sub(duplicate.stored_size());
                     if !duplicate.is_zero_lamport() {

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -124,9 +124,9 @@ impl AccountsFile {
     /// Return (account metadata, next_index) pair for the account at the
     /// specified `offset` if any.  Otherwise return None.   Also return the
     /// index of the next entry.
-    pub fn get_account(&self, offset: usize) -> Option<(StoredAccountMeta<'_>, usize)> {
+    pub fn get_stored_account_meta(&self, offset: usize) -> Option<(StoredAccountMeta<'_>, usize)> {
         match self {
-            Self::AppendVec(av) => av.get_account(offset),
+            Self::AppendVec(av) => av.get_stored_account_meta(offset),
             // Note: The conversion here is needed as the AccountsDB currently
             // assumes all offsets are multiple of 8 while TieredStorage uses
             // IndexOffset that is equivalent to AccountInfo::reduced_offset.
@@ -307,7 +307,7 @@ impl<'a> Iterator for AccountsFileIter<'a> {
     type Item = StoredAccountMeta<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some((account, next_offset)) = self.file_entry.get_account(self.offset) {
+        if let Some((account, next_offset)) = self.file_entry.get_stored_account_meta(self.offset) {
             self.offset = next_offset;
             Some(account)
         } else {

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -3165,7 +3165,7 @@ pub mod tests {
         let data_size = None;
         let (_db, storages, _slots, _infos) = get_sample_storages(num_slots, data_size);
 
-        let account = storages[0].accounts.get_account(0).unwrap().0;
+        let account = storages[0].accounts.get_stored_account_meta(0).unwrap().0;
         let slot = 1;
         let capacity = 0;
         for i in 0..4usize {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -95,7 +95,7 @@ impl<'append_vec> Iterator for AppendVecAccountsIter<'append_vec> {
     type Item = StoredAccountMeta<'append_vec>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some((account, next_offset)) = self.append_vec.get_account(self.offset) {
+        if let Some((account, next_offset)) = self.append_vec.get_stored_account_meta(self.offset) {
             self.offset = next_offset;
             Some(account)
         } else {
@@ -435,7 +435,7 @@ impl AppendVec {
         // extend it to be reused here because it would allow attackers to accumulate
         // some measurable amount of memory needlessly.
         let mut num_accounts = 0;
-        while let Some((account, next_offset)) = self.get_account(offset) {
+        while let Some((account, next_offset)) = self.get_stored_account_meta(offset) {
             if !account.sanitize() {
                 return (false, num_accounts);
             }
@@ -519,7 +519,7 @@ impl AppendVec {
     /// Return stored account metadata for the account at `offset` if its data doesn't overrun
     /// the internal buffer. Otherwise return None. Also return the offset of the first byte
     /// after the requested data that falls on a 64-byte boundary.
-    pub fn get_account(&self, offset: usize) -> Option<(StoredAccountMeta, usize)> {
+    pub fn get_stored_account_meta(&self, offset: usize) -> Option<(StoredAccountMeta, usize)> {
         let (meta, next): (&StoredMeta, _) = self.get_type(offset)?;
         let (account_meta, next): (&AccountMeta, _) = self.get_type(next)?;
         let (hash, next): (&AccountHash, _) = self.get_type(next)?;
@@ -592,7 +592,7 @@ impl AppendVec {
         &self,
         offset: usize,
     ) -> Option<(StoredMeta, solana_sdk::account::AccountSharedData)> {
-        let r1 = self.get_account(offset);
+        let r1 = self.get_stored_account_meta(offset);
         let r2 = self.get_stored_account(offset);
         let r3 = self.get_account_meta(offset);
         let sizes = self.get_account_sizes(&[offset]);
@@ -719,7 +719,7 @@ impl AppendVec {
     /// Return a vector of account metadata for each account, starting from `offset`.
     pub fn accounts(&self, mut offset: usize) -> Vec<StoredAccountMeta> {
         let mut accounts = vec![];
-        while let Some((account, next)) = self.get_account(offset) {
+        while let Some((account, next)) = self.get_stored_account_meta(offset) {
             accounts.push(account);
             offset = next;
         }


### PR DESCRIPTION
#### Problem

Since #774, we now have `get_account()`, `get_stored_account()`, `get_stored_account_meta()`, and `get_account_shared_data()` methods, but `AppendVec::get_account()` returns a `StoredAccountMeta`. I find this a bit confusing. If we rename `get_account()`, I think that would help.


#### Summary of Changes

Renames the methods to `get_stored_account_meta()` and updates callers.