### PR TITLE
accounts db/refactor accounts db test - add macro for accounts-db panic test

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9701,23 +9701,6 @@ pub mod tests {
         };
     }
 
-    macro_rules! define_accounts_db_test_should_panic {
-        ($name:ident, $panic_message:literal, |$accounts_db:ident| $inner: tt) => {
-            #[test_case(AccountsFileProvider::AppendVec; "append_vec")]
-            #[test_case(AccountsFileProvider::HotStorage; "hot_storage")]
-            #[should_panic(expected = $panic_message)]
-            fn $name(accounts_file_provider: AccountsFileProvider) {
-                fn run_test($accounts_db: AccountsDb) {
-                    $inner
-                }
-
-                let accounts_db =
-                    AccountsDb::new_single_for_tests_with_provider(accounts_file_provider);
-                run_test(accounts_db);
-            }
-        };
-    }
-
     fn run_generate_index_duplicates_within_slot_test(db: AccountsDb, reverse: bool) {
         let slot0 = 0;
 


### PR DESCRIPTION

#### Problem

add macro for accounts-db panic test 

Continued on #784

#### Summary of Changes

1. add macro for accounts-db panic test 
2. convert double remove test for both account file provider


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
