### PR TITLE
Use same stakes for everything in get_epoch_reward_calculate_param_info

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2421,7 +2421,7 @@ impl Bank {
         &self,
         stakes: &'a Stakes<StakeAccount<Delegation>>,
     ) -> EpochRewardCalculateParamInfo<'a> {
-        let stake_history = self.stakes_cache.stakes().history().clone();
+        let stake_history = stakes.history().clone();
 
         let stake_delegations = self.filter_stake_delegations(stakes);
 


### PR DESCRIPTION
#### Problem
It's not clear why `get_epoch_reward_calculate_param_info()` repulls `stake_cache.stakes()` when `Stakes` are already being passed into the method. This seems brittle; if a caller passes in `Stakes` from a different source or bank, `stake_history` could be inconsistent.

#### Summary of Changes
Use the same `stakes` as the other two values.

@jeffwashington , git blame says you wrote this function. Am I missing something here about why the distinct `stakes()`?