### PR TITLE
Deprecate `is_sysvar_id` function

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2778,7 +2778,7 @@ fn main() {
                         for (pubkey, warped_account) in all_accounts {
                             // Don't output sysvars; it's always updated but not related to
                             // inflation.
-                            if solana_sdk::sysvar::is_sysvar_id(&pubkey) {
+                            if solana_sdk::sysvar::check_id(warped_account.owner()) {
                                 continue;
                             }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4366,7 +4366,7 @@ fn test_bank_get_program_accounts() {
     assert!(
         genesis_accounts
             .iter()
-            .any(|(pubkey, _, _)| solana_sdk::sysvar::is_sysvar_id(pubkey)),
+            .any(|(_, account, _)| solana_sdk::sysvar::check_id(account.owner())),
         "no sysvars found"
     );
 

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -58,6 +58,7 @@ lazy_static! {
     };
 }
 
+#[allow(deprecated)]
 pub fn is_builtin_key_or_sysvar(key: &Pubkey) -> bool {
     if MAYBE_BUILTIN_KEY_OR_SYSVAR[key.0[0] as usize] {
         return sysvar::is_sysvar_id(key) || BUILTIN_PROGRAMS_KEYS.contains(key);

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -118,6 +118,10 @@ lazy_static! {
 }
 
 /// Returns `true` of the given `Pubkey` is a sysvar account.
+#[deprecated(
+    since = "2.0.0",
+    note = "please check the account's owner or use solana_sdk::reserved_account_keys::ReservedAccountKeys instead"
+)]
 pub fn is_sysvar_id(id: &Pubkey) -> bool {
     ALL_IDS.iter().any(|key| key == id)
 }


### PR DESCRIPTION
#### Problem
The public `is_sysvar_id` function uses static lists of sysvar keys and should be removed in favor of using the new `ReservedAccountKeys` struct.

#### Summary of Changes
- Deprecated `is_sysvar_id`
- Removed all uses of `is_sysvar_id` in ledger tool and the bigtable client

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
