### PR TITLE
Deprecate `solana_program::sdk_ids` module

### DIFF
--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -19,7 +19,7 @@ use {
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::Slot,
         pubkey::Pubkey,
-        sdk_ids,
+        reserved_account_keys::ReservedAccountKeys,
     },
     std::{
         collections::HashSet,
@@ -60,9 +60,8 @@ impl<'a> SnapshotMinimizer<'a> {
 
         minimizer.add_accounts(Self::get_active_bank_features, "active bank features");
         minimizer.add_accounts(Self::get_inactive_bank_features, "inactive bank features");
-        minimizer.add_accounts(Self::get_builtins, "builtin accounts");
         minimizer.add_accounts(Self::get_static_runtime_accounts, "static runtime accounts");
-        minimizer.add_accounts(Self::get_sdk_accounts, "sdk accounts");
+        minimizer.add_accounts(Self::get_reserved_accounts, "reserved accounts");
 
         minimizer.add_accounts(
             Self::get_rent_collection_accounts,
@@ -109,19 +108,6 @@ impl<'a> SnapshotMinimizer<'a> {
         });
     }
 
-    /// Used to get builtin accounts in `minimize`
-    fn get_builtins(&self) {
-        self.bank
-            .get_transaction_processor()
-            .builtin_program_ids
-            .read()
-            .unwrap()
-            .iter()
-            .for_each(|program_id| {
-                self.minimized_account_set.insert(*program_id);
-            });
-    }
-
     /// Used to get static runtime accounts in `minimize`
     fn get_static_runtime_accounts(&self) {
         static_ids::STATIC_IDS.iter().for_each(|pubkey| {
@@ -129,11 +115,11 @@ impl<'a> SnapshotMinimizer<'a> {
         });
     }
 
-    /// Used to get sdk accounts in `minimize`
-    fn get_sdk_accounts(&self) {
-        sdk_ids::SDK_IDS.iter().for_each(|pubkey| {
+    /// Used to get reserved accounts in `minimize`
+    fn get_reserved_accounts(&self) {
+        ReservedAccountKeys::all_keys_iter().for_each(|pubkey| {
             self.minimized_account_set.insert(*pubkey);
-        });
+        })
     }
 
     /// Used to get rent collection accounts in `minimize`

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -561,6 +561,10 @@ pub mod config {
 }
 
 /// A vector of Solana SDK IDs.
+#[deprecated(
+    since = "2.0.0",
+    note = "Please use `solana_sdk::reserved_account_keys::ReservedAccountKeys` instead"
+)]
 pub mod sdk_ids {
     use {
         crate::{

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -37,12 +37,10 @@ extern crate self as solana_sdk;
 
 #[cfg(feature = "full")]
 pub use signer::signers;
-// These solana_program imports could be *-imported, but that causes a bunch of
-// confusing duplication in the docs due to a rustdoc bug. #26211
-#[allow(deprecated)]
-pub use solana_program::address_lookup_table_account;
 #[cfg(not(target_os = "solana"))]
 pub use solana_program::program_stubs;
+// These solana_program imports could be *-imported, but that causes a bunch of
+// confusing duplication in the docs due to a rustdoc bug. #26211
 pub use solana_program::{
     account_info, address_lookup_table, alt_bn128, big_mod_exp, blake3, borsh, borsh0_10, borsh0_9,
     borsh1, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, clock, config,
@@ -51,11 +49,13 @@ pub use solana_program::{
     fee_calculator, impl_sysvar_get, incinerator, instruction, keccak, lamports,
     loader_instruction, loader_upgradeable_instruction, loader_v4, loader_v4_instruction, message,
     msg, native_token, nonce, poseidon, program, program_error, program_memory, program_option,
-    program_pack, rent, sanitize, sdk_ids, secp256k1_program, secp256k1_recover, serde_varint,
+    program_pack, rent, sanitize, secp256k1_program, secp256k1_recover, serde_varint,
     serialize_utils, short_vec, slot_hashes, slot_history, stable_layout, stake, stake_history,
     syscalls, system_instruction, system_program, sysvar, unchecked_div_by_const, vote,
     wasm_bindgen,
 };
+#[allow(deprecated)]
+pub use solana_program::{address_lookup_table_account, sdk_ids};
 
 pub mod account;
 pub mod account_utils;


### PR DESCRIPTION
#### Problem
The public `solana_program::sdk_ids` module uses static lists of sysvar keys and should be removed in favor of using the new `ReservedAccountKeys` struct.

#### Summary of Changes
- Deprecated `solana_program::sdk_ids`
- Updated snapshot minimizer and ALT scanner to use reserved account keys

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
