### PR TITLE
CLI: Auto-extend program accounts by default

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -277,7 +277,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .long("auto-extend-program")
                                 .takes_value(false)
                                 .help(
-                                    "Automatically extend the program data account size to match the updated program's data size",
+                                    "Automatically extend the program data account's size to match the updated program's data size",
                                 ),
                         ),
                 )
@@ -2511,7 +2511,6 @@ fn do_process_program_upgrade(
         let additional_bytes = program_len
             .sub(program_data_account.data.len())
             .saturating_add(metadata_size);
-        println!("additional_bytes: {}", additional_bytes);
         if auto_extend_program {
             Some(bpf_loader_upgradeable::extend_program(
                 program_id,

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -3036,7 +3036,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false
+                    no_extend: false,
                     use_rpc: false,
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
@@ -3070,7 +3070,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false
+                    no_extend: false,
                     use_rpc: false,
                 }),
                 signers: vec![
@@ -3106,7 +3106,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false
+                    no_extend: false,
                     use_rpc: false,
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
@@ -3141,7 +3141,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false
+                    no_extend: false,
                     use_rpc: false,
                 }),
                 signers: vec![
@@ -3179,7 +3179,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false
+                    no_extend: false,
                     use_rpc: false,
                 }),
                 signers: vec![
@@ -3213,7 +3213,7 @@ mod tests {
                     allow_excessive_balance: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false
+                    no_extend: false,
                     use_rpc: false,
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
@@ -3245,7 +3245,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 1,
-                    no_extend: false
+                    no_extend: false,
                     use_rpc: false,
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2502,7 +2502,7 @@ fn do_process_program_upgrade(
     let program_data_address = get_program_data_address(program_id);
     let program_data_account = rpc_client.get_account(&program_data_address);
     let program_len_with_metadata = UpgradeableLoaderState::size_of_programdata(program_len);
-    // Check - auto extend program data account in case of insufficient space .
+    // Check - auto extend program data account in case of insufficient space
     // if no-extend flag is set then
     // throw an err along with a message including additional bytes required
     let add_program_extend_ix = match program_data_account {

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -71,7 +71,6 @@ use {
         fs::File,
         io::{Read, Write},
         mem::size_of,
-        ops::Sub,
         path::PathBuf,
         rc::Rc,
         str::FromStr,
@@ -2553,7 +2552,7 @@ fn do_process_program_upgrade(
                 let program_len = UpgradeableLoaderState::size_of_programdata(program_len);
                 let account_data_len = program_data_account.data.len();
                 if program_len > account_data_len {
-                    let additional_bytes = program_len.sub(account_data_len);
+                    let additional_bytes = program_len.saturating_sub(account_data_len);
                     let additional_bytes: u32 = additional_bytes.try_into().map_err(|_| {
                         format!(
                             "Cannot auto-extend Program Data Account space due to size limit \

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2503,6 +2503,7 @@ fn do_process_program_upgrade(
     let program_data_account = rpc_client.get_account(&program_data_address)?;
 
     //CHECK: if passed program size is greater than the current program data account size,
+    //auto extend the program data account .if no-auto-extend-program flag is set then
     //throw an err along with a message including additional bytes required
     let add_program_extend_ix = if program_len > program_data_account.data.len() {
         let metadata_size = UpgradeableLoaderState::size_of_programdata_metadata();

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -273,7 +273,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 ),
                         )
                         .arg(Arg::with_name("use_rpc").long("use-rpc").help(
-                            "Send transactions to the configured RPC instead of validator TPUs",
+                            "Send write transactions to the configured RPC instead of validator TPUs",
                         ))
                         .arg(compute_unit_price_arg())
                         .arg(

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2514,7 +2514,8 @@ fn do_process_program_upgrade(
                     if additional_bytes > u32::MAX as usize {
                         let err_string = format!(
                             r#"Cannot auto-extend Program Data Account space due to size limit
-please extend it manually by using the command: solana program extend {} {},"#,
+please extend it manually by runinng the command solana program extend {} <BYTES> multiple times 
+using chunks of additional bytes required:{}"#,
                             program_id, additional_bytes
                         );
 

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2502,8 +2502,7 @@ fn do_process_program_upgrade(
     let program_data_address = get_program_data_address(program_id);
     let program_data_account = rpc_client.get_account(&program_data_address)?;
 
-    //CHECK: if passed program size is greater than the current program data account size,
-    //auto extend the program data account .if no-auto-extend-program flag is set then
+    //CHECK: auto extend program data account in case of insufficient space .if no-auto-extend-program flag is set then
     //throw an err along with a message including additional bytes required
     let add_program_extend_ix = if program_len > program_data_account.data.len() {
         let metadata_size = UpgradeableLoaderState::size_of_programdata_metadata();

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -99,7 +99,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -148,7 +148,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     process_command(&config).unwrap();
     let account1 = rpc_client
@@ -206,7 +206,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     let err = process_command(&config).unwrap_err();
     assert_eq!(
@@ -232,7 +232,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     process_command(&config).unwrap_err();
 }
@@ -296,7 +296,7 @@ fn test_cli_program_deploy_no_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -326,7 +326,7 @@ fn test_cli_program_deploy_no_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     process_command(&config).unwrap_err();
 }
@@ -391,7 +391,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -443,7 +443,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -489,7 +489,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -567,7 +567,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -649,7 +649,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     process_command(&config).unwrap_err();
 
@@ -669,7 +669,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -776,7 +776,7 @@ fn test_cli_program_close_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -889,7 +889,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -939,7 +939,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     process_command(&config).unwrap_err();
 
@@ -974,7 +974,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     process_command(&config).unwrap();
 }
@@ -1329,7 +1329,7 @@ fn test_cli_program_write_buffer() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let error = process_command(&config).unwrap_err();
@@ -1459,7 +1459,7 @@ fn test_cli_program_set_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap_err();
@@ -1507,7 +1507,7 @@ fn test_cli_program_set_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1593,7 +1593,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     process_command(&config).unwrap_err();
 
@@ -1613,7 +1613,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     process_command(&config).unwrap();
 }
@@ -1699,7 +1699,7 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1933,7 +1933,7 @@ fn test_cli_program_show() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        use_rpc: false,
+        auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let min_slot = rpc_client.get_slot().unwrap();
@@ -2210,7 +2210,7 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
         skip_fee_check: false,
         compute_unit_price,
         max_sign_attempts: 5,
-        use_rpc,
+        auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -2311,4 +2311,121 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
             &system_program::id()
         );
     }
+}
+
+#[test]
+fn test_cli_program_deploy_with_compute_unit_price() {
+    cli_program_deploy_with_args(Some(1000));
+    cli_program_deploy_with_args(None);
+}
+
+#[test]
+fn test_cli_program_upgrade_auto_extend_program_data_account() {
+    solana_logger::setup();
+
+    let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    noop_path.push("tests");
+    noop_path.push("fixtures");
+    noop_path.push("noop");
+    noop_path.set_extension("so");
+
+    let mut noop_large_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    noop_large_path.push("tests");
+    noop_large_path.push("fixtures");
+    noop_large_path.push("noop_large");
+    noop_large_path.set_extension("so");
+
+    let mint_keypair = Keypair::new();
+    let mint_pubkey = mint_keypair.pubkey();
+    let faucet_addr = run_local_faucet(mint_keypair, None);
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
+
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+
+    let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
+    let mut program_data = Vec::new();
+    file.read_to_end(&mut program_data).unwrap();
+    let max_len = program_data.len();
+    let minimum_balance_for_programdata = rpc_client
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
+            max_len,
+        ))
+        .unwrap();
+    let minimum_balance_for_program = rpc_client
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())
+        .unwrap();
+    let upgrade_authority = Keypair::new();
+
+    let mut config = CliConfig::recent_for_tests();
+    let keypair = Keypair::new();
+    config.json_rpc_url = test_validator.rpc_url();
+    config.signers = vec![&keypair];
+    config.command = CliCommand::Airdrop {
+        pubkey: None,
+        lamports: 100 * minimum_balance_for_programdata + minimum_balance_for_program,
+    };
+    process_command(&config).unwrap();
+
+    // Deploy the upgradeable program
+    let program_keypair = Keypair::new();
+    config.signers = vec![&keypair, &upgrade_authority, &program_keypair];
+    config.command = CliCommand::Program(ProgramCliCommand::Deploy {
+        program_location: Some(noop_path.to_str().unwrap().to_string()),
+        fee_payer_signer_index: 0,
+        program_signer_index: Some(2),
+        program_pubkey: Some(program_keypair.pubkey()),
+        buffer_signer_index: None,
+        buffer_pubkey: None,
+        allow_excessive_balance: false,
+        upgrade_authority_signer_index: 1,
+        is_final: false,
+        max_len: None, // Use None to check that it defaults to the max length
+        skip_fee_check: false,
+        compute_unit_price: None,
+        max_sign_attempts: 5,
+        auto_extend_program: false,
+    });
+    config.output_format = OutputFormat::JsonCompact;
+    process_command(&config).unwrap();
+
+    let (programdata_pubkey, _) = Pubkey::find_program_address(
+        &[program_keypair.pubkey().as_ref()],
+        &bpf_loader_upgradeable::id(),
+    );
+
+    let programdata_account = rpc_client.get_account(&programdata_pubkey).unwrap();
+    let expected_len = UpgradeableLoaderState::size_of_programdata(max_len);
+    assert_eq!(expected_len, programdata_account.data.len());
+
+    // Wait one slot to avoid "Program was deployed in this block already" error
+    wait_n_slots(&rpc_client, 1);
+
+    // Extend program for larger program, minus 1 required byte
+    let mut file = File::open(noop_large_path.to_str().unwrap()).unwrap();
+    let mut new_program_data = Vec::new();
+    file.read_to_end(&mut new_program_data).unwrap();
+
+    let programdata_account = rpc_client.get_account(&programdata_pubkey).unwrap();
+    assert_eq!(expected_len, programdata_account.data.len());
+
+    config.signers = vec![&keypair, &upgrade_authority];
+    config.command = CliCommand::Program(ProgramCliCommand::Deploy {
+        program_location: Some(noop_large_path.to_str().unwrap().to_string()),
+        fee_payer_signer_index: 0,
+        program_signer_index: None,
+        program_pubkey: Some(program_keypair.pubkey()),
+        buffer_signer_index: None,
+        buffer_pubkey: None,
+        allow_excessive_balance: false,
+        upgrade_authority_signer_index: 1,
+        is_final: false,
+        max_len: None,
+        skip_fee_check: false,
+        compute_unit_price: None,
+        max_sign_attempts: 5,
+        auto_extend_program: true,
+    });
+    process_command(&config).unwrap();
 }

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -2402,7 +2402,6 @@ fn test_cli_program_upgrade_auto_extend_program_data_account() {
     // Wait one slot to avoid "Program was deployed in this block already" error
     wait_n_slots(&rpc_client, 1);
 
-    // Extend program for larger program, minus 1 required byte
     let mut file = File::open(noop_large_path.to_str().unwrap()).unwrap();
     let mut new_program_data = Vec::new();
     file.read_to_end(&mut new_program_data).unwrap();
@@ -2425,6 +2424,7 @@ fn test_cli_program_upgrade_auto_extend_program_data_account() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        // Enable auto_extend_program
         auto_extend_program: true,
     });
     process_command(&config).unwrap();

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -99,7 +99,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -148,7 +148,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     process_command(&config).unwrap();
     let account1 = rpc_client
@@ -206,7 +206,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     let err = process_command(&config).unwrap_err();
     assert_eq!(
@@ -232,7 +232,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     process_command(&config).unwrap_err();
 }
@@ -296,7 +296,7 @@ fn test_cli_program_deploy_no_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -326,7 +326,7 @@ fn test_cli_program_deploy_no_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     process_command(&config).unwrap_err();
 }
@@ -391,7 +391,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -443,7 +443,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -489,7 +489,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -567,7 +567,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -649,7 +649,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     process_command(&config).unwrap_err();
 
@@ -669,7 +669,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -776,7 +776,7 @@ fn test_cli_program_close_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -889,7 +889,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -939,7 +939,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     process_command(&config).unwrap_err();
 
@@ -974,7 +974,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     process_command(&config).unwrap();
 }
@@ -1329,7 +1329,7 @@ fn test_cli_program_write_buffer() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let error = process_command(&config).unwrap_err();
@@ -1459,7 +1459,7 @@ fn test_cli_program_set_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap_err();
@@ -1507,7 +1507,7 @@ fn test_cli_program_set_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1593,7 +1593,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     process_command(&config).unwrap_err();
 
@@ -1613,7 +1613,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     process_command(&config).unwrap();
 }
@@ -1699,7 +1699,7 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1933,7 +1933,7 @@ fn test_cli_program_show() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let min_slot = rpc_client.get_slot().unwrap();
@@ -2210,7 +2210,7 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
         skip_fee_check: false,
         compute_unit_price,
         max_sign_attempts: 5,
-        no_auto_extend_program: false,
+        no_extend: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -2317,122 +2317,4 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
 fn test_cli_program_deploy_with_compute_unit_price() {
     cli_program_deploy_with_args(Some(1000));
     cli_program_deploy_with_args(None);
-}
-
-#[test]
-fn test_cli_program_upgrade_results_in_error_if_no_extend_program_flag_is_set() {
-    solana_logger::setup();
-
-    let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    noop_path.push("tests");
-    noop_path.push("fixtures");
-    noop_path.push("noop");
-    noop_path.set_extension("so");
-
-    let mut noop_large_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    noop_large_path.push("tests");
-    noop_large_path.push("fixtures");
-    noop_large_path.push("noop_large");
-    noop_large_path.set_extension("so");
-
-    let mint_keypair = Keypair::new();
-    let mint_pubkey = mint_keypair.pubkey();
-    let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator =
-        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
-
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
-
-    let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
-    let mut program_data = Vec::new();
-    file.read_to_end(&mut program_data).unwrap();
-    let max_len = program_data.len();
-    let minimum_balance_for_programdata = rpc_client
-        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
-            max_len,
-        ))
-        .unwrap();
-    let minimum_balance_for_program = rpc_client
-        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())
-        .unwrap();
-    let upgrade_authority = Keypair::new();
-
-    let mut config = CliConfig::recent_for_tests();
-    let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
-    config.signers = vec![&keypair];
-    config.command = CliCommand::Airdrop {
-        pubkey: None,
-        lamports: 100 * minimum_balance_for_programdata + minimum_balance_for_program,
-    };
-    process_command(&config).unwrap();
-
-    // Deploy the upgradeable program
-    let program_keypair = Keypair::new();
-    config.signers = vec![&keypair, &upgrade_authority, &program_keypair];
-    config.command = CliCommand::Program(ProgramCliCommand::Deploy {
-        program_location: Some(noop_path.to_str().unwrap().to_string()),
-        fee_payer_signer_index: 0,
-        program_signer_index: Some(2),
-        program_pubkey: Some(program_keypair.pubkey()),
-        buffer_signer_index: None,
-        buffer_pubkey: None,
-        allow_excessive_balance: false,
-        upgrade_authority_signer_index: 1,
-        is_final: false,
-        max_len: None, // Use None to check that it defaults to the max length
-        skip_fee_check: false,
-        compute_unit_price: None,
-        max_sign_attempts: 5,
-        no_auto_extend_program: false,
-    });
-    config.output_format = OutputFormat::JsonCompact;
-    process_command(&config).unwrap();
-
-    let (programdata_pubkey, _) = Pubkey::find_program_address(
-        &[program_keypair.pubkey().as_ref()],
-        &bpf_loader_upgradeable::id(),
-    );
-
-    let programdata_account = rpc_client.get_account(&programdata_pubkey).unwrap();
-    let expected_len = UpgradeableLoaderState::size_of_programdata(max_len);
-    assert_eq!(expected_len, programdata_account.data.len());
-
-    // Wait one slot to avoid "Program was deployed in this block already" error
-    wait_n_slots(&rpc_client, 1);
-
-    let mut file = File::open(noop_large_path.to_str().unwrap()).unwrap();
-    let mut new_program_data = Vec::new();
-    file.read_to_end(&mut new_program_data).unwrap();
-
-    let programdata_account = rpc_client.get_account(&programdata_pubkey).unwrap();
-    assert_eq!(expected_len, programdata_account.data.len());
-
-    config.signers = vec![&keypair, &upgrade_authority];
-    config.command = CliCommand::Program(ProgramCliCommand::Deploy {
-        program_location: Some(noop_large_path.to_str().unwrap().to_string()),
-        fee_payer_signer_index: 0,
-        program_signer_index: None,
-        program_pubkey: Some(program_keypair.pubkey()),
-        buffer_signer_index: None,
-        buffer_pubkey: None,
-        allow_excessive_balance: false,
-        upgrade_authority_signer_index: 1,
-        is_final: false,
-        max_len: None,
-        skip_fee_check: false,
-        compute_unit_price: None,
-        max_sign_attempts: 5,
-        // set no_auto_extend_program
-        no_auto_extend_program: true,
-    });
-    let err = process_command(&config).unwrap_err();
-    let err_string_to_match = format!(
-        r#"Program Data Account space is not enough
-please extend the program data account with command: solana program extend {} 3184,
-please disable the --no-extend-program flag to automatically extend the program account size"#,
-        program_keypair.pubkey()
-    );
-    assert_eq!(err.to_string(), err_string_to_match);
 }

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -99,7 +99,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -148,7 +148,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     process_command(&config).unwrap();
     let account1 = rpc_client
@@ -206,7 +206,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     let err = process_command(&config).unwrap_err();
     assert_eq!(
@@ -232,7 +232,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     process_command(&config).unwrap_err();
 }
@@ -296,7 +296,7 @@ fn test_cli_program_deploy_no_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -326,7 +326,7 @@ fn test_cli_program_deploy_no_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     process_command(&config).unwrap_err();
 }
@@ -391,7 +391,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -443,7 +443,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -489,7 +489,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -567,7 +567,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -649,7 +649,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     process_command(&config).unwrap_err();
 
@@ -669,7 +669,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -776,7 +776,7 @@ fn test_cli_program_close_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -889,7 +889,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -939,7 +939,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     process_command(&config).unwrap_err();
 
@@ -974,7 +974,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     process_command(&config).unwrap();
 }
@@ -1329,7 +1329,7 @@ fn test_cli_program_write_buffer() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let error = process_command(&config).unwrap_err();
@@ -1459,7 +1459,7 @@ fn test_cli_program_set_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap_err();
@@ -1507,7 +1507,7 @@ fn test_cli_program_set_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1593,7 +1593,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     process_command(&config).unwrap_err();
 
@@ -1613,7 +1613,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     process_command(&config).unwrap();
 }
@@ -1699,7 +1699,7 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1933,7 +1933,7 @@ fn test_cli_program_show() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let min_slot = rpc_client.get_slot().unwrap();
@@ -2210,7 +2210,7 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
         skip_fee_check: false,
         compute_unit_price,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -2320,7 +2320,7 @@ fn test_cli_program_deploy_with_compute_unit_price() {
 }
 
 #[test]
-fn test_cli_program_upgrade_auto_extend_program_data_account() {
+fn test_cli_program_upgrade_results_in_error_if_no_extend_program_flag_is_set() {
     solana_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -2385,7 +2385,7 @@ fn test_cli_program_upgrade_auto_extend_program_data_account() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend_program: false,
+        no_auto_extend_program: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -2424,8 +2424,15 @@ fn test_cli_program_upgrade_auto_extend_program_data_account() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        // Enable auto_extend_program
-        auto_extend_program: true,
+        // set no_auto_extend_program
+        no_auto_extend_program: true,
     });
-    process_command(&config).unwrap();
+    let err = process_command(&config).unwrap_err();
+    let err_string_to_match = format!(
+        r#"Program Data Account space is not enough
+please extend the program data account with command: solana program extend {} 3184,
+please disable the --no-extend-program flag to automatically extend the program account size"#,
+        program_keypair.pubkey()
+    );
+    assert_eq!(err.to_string(), err_string_to_match);
 }

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -100,6 +100,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -149,6 +150,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
     let account1 = rpc_client
@@ -207,6 +209,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     let err = process_command(&config).unwrap_err();
     assert_eq!(
@@ -233,6 +236,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     process_command(&config).unwrap_err();
 }
@@ -297,6 +301,7 @@ fn test_cli_program_deploy_no_authority() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -327,6 +332,7 @@ fn test_cli_program_deploy_no_authority() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     process_command(&config).unwrap_err();
 }
@@ -392,6 +398,7 @@ fn test_cli_program_deploy_with_authority() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -444,6 +451,7 @@ fn test_cli_program_deploy_with_authority() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -490,6 +498,7 @@ fn test_cli_program_deploy_with_authority() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -568,6 +577,7 @@ fn test_cli_program_deploy_with_authority() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -650,6 +660,7 @@ fn test_cli_program_deploy_with_authority() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     process_command(&config).unwrap_err();
 
@@ -670,6 +681,7 @@ fn test_cli_program_deploy_with_authority() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -777,6 +789,7 @@ fn test_cli_program_close_program() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -890,6 +903,7 @@ fn test_cli_program_extend_program() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -940,6 +954,7 @@ fn test_cli_program_extend_program() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     process_command(&config).unwrap_err();
 
@@ -975,6 +990,7 @@ fn test_cli_program_extend_program() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
 }
@@ -1330,6 +1346,7 @@ fn test_cli_program_write_buffer() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let error = process_command(&config).unwrap_err();
@@ -1460,6 +1477,7 @@ fn test_cli_program_set_buffer_authority() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap_err();
@@ -1508,6 +1526,7 @@ fn test_cli_program_set_buffer_authority() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1594,6 +1613,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     process_command(&config).unwrap_err();
 
@@ -1614,6 +1634,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
 }
@@ -1700,6 +1721,7 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1934,6 +1956,7 @@ fn test_cli_program_show() {
         compute_unit_price: None,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let min_slot = rpc_client.get_slot().unwrap();
@@ -2211,6 +2234,7 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
         compute_unit_price,
         max_sign_attempts: 5,
         no_extend: false,
+        use_rpc,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -2311,10 +2335,4 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
             &system_program::id()
         );
     }
-}
-
-#[test]
-fn test_cli_program_deploy_with_compute_unit_price() {
-    cli_program_deploy_with_args(Some(1000));
-    cli_program_deploy_with_args(None);
 }

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -251,6 +251,7 @@ fn run_transactions_dos(
             max_sign_attempts: 5,
             use_rpc: false,
             skip_fee_check: true, // skip_fee_check
+            no_extend: false,
         });
 
         process_command(&config).expect("deploy didn't pass");


### PR DESCRIPTION
issue #564 
#### Problem
When you deploy a program, it initially takes up 2x the program size. At a later date if you try to deploy larger than the currently allocated size, you get the following error:

Error: Deploying program failed: Error processing Instruction 0: account data too small for instruction
The correct way to solve this is to use solana program extend <PROGRAM_ID> <MORE_BYTES> to extend the program, then deploy it again.

Developers attempting to calculate this amount over and over again have become frustrated and some have just spent the money to allocate way more than they should. Some even as much as 10mb. This is bad both for the cluster and developer experience.

#### Summary of Changes
1. Add Checks in do_process_program_upgrade fn to calculate additional bytes required to extend the program and throw an error if auto-extend-program flag is not passed with message to use solana program extend <Program id> <additional bytes>
2. Add --auto-extend-program flag to solana program deploy command and use this to auto extend solana program data account in case of overflow


