### PR TITLE
Use poh grace ticks when new reset bank is pending

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -272,6 +272,7 @@ pub struct ValidatorConfig {
     pub ip_echo_server_threads: NonZeroUsize,
     pub replay_forks_threads: NonZeroUsize,
     pub replay_transactions_threads: NonZeroUsize,
+    pub delay_leader_block_for_pending_fork: bool,
 }
 
 impl Default for ValidatorConfig {
@@ -342,6 +343,7 @@ impl Default for ValidatorConfig {
             ip_echo_server_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             replay_transactions_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
+            delay_leader_block_for_pending_fork: false,
         }
     }
 }
@@ -942,6 +944,7 @@ impl Validator {
                 bank.clone(),
                 None,
                 bank.ticks_per_slot(),
+                config.delay_leader_block_for_pending_fork,
                 blockstore.clone(),
                 blockstore.get_new_shred_signal(0),
                 &leader_schedule_cache,

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -71,6 +71,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         ip_echo_server_threads: config.ip_echo_server_threads,
         replay_forks_threads: config.replay_forks_threads,
         replay_transactions_threads: config.replay_transactions_threads,
+        delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
     }
 }
 

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1499,6 +1499,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         )
         .arg(
             Arg::with_name("delay_leader_block_for_pending_fork")
+                .hidden(hidden_unless_forced())
                 .long("delay-leader-block-for-pending-fork")
                 .takes_value(false)
                 .help(

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1498,6 +1498,19 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Disables the banking trace"),
         )
         .arg(
+            Arg::with_name("delay_leader_block_for_pending_fork")
+                .long("delay-leader-block-for-pending-fork")
+                .takes_value(false)
+                .help(
+                    "Delay leader block creation while replaying a block which descends from the \
+                    current fork and has a lower slot than our next leader slot. If we don't \
+                    delay here, our new leader block will be on a different fork from the \
+                    block we are replaying and there is a high chance that the cluster will \
+                    confirm that block's fork rather than our leader block's fork because it \
+                    was created before we started creating ours.",
+                ),
+        )
+        .arg(
             Arg::with_name("block_verification_method")
                 .long("block-verification-method")
                 .hidden(hidden_unless_forced())

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1481,6 +1481,8 @@ pub fn main() {
         ip_echo_server_threads,
         replay_forks_threads,
         replay_transactions_threads,
+        delay_leader_block_for_pending_fork: matches
+            .is_present("delay_leader_block_for_pending_fork"),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem
I've observed that a lot of skipped slots are caused when a leader "A" tries to skip the previous leader "B" when producing its blocks but the previous leader had actually already started broadcasting shreds for its blocks. In this case, there's a race between the forks of leader A and B and it's almost certain that leader B's fork will be confirmed because its block will likely be finished and replayed by the cluster before leader A's block that only just started being produced.

#### Summary of Changes
Currently when leader A skips all of leader B's blocks, it doesn't use grace ticks when deciding when to start building its block. After this PR, when a leader skips all of the previous leader's blocks and has ticked to its leader slot (without grace ticks) it will first check if it has received any shreds for a potential new reset bank. If it has received some shreds, it will apply grace ticks to wait a bit longer to allow time for the corresponding bank for those shreds to be frozen (or marked dead). If it hasn't received any shreds, it can go ahead with producing its block without waiting for grace ticks as before.

- Added new hidden validator cli arg `--delay-leader-block-for-pending-fork` which allows validators to opt into this new behavior.
- Added new metric `poh_recorder-detected_pending_fork` which reports when a pending fork was detected and whether or not the validator yielded

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
