### PR TITLE
Don't reset working bank in some cases

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1017,7 +1017,9 @@ impl ReplayStage {
                 let mut reset_bank_time = Measure::start("reset_bank");
                 // Reset onto a fork
                 if let Some(reset_bank) = reset_bank {
-                    if last_reset != reset_bank.last_blockhash() {
+                    if last_reset != reset_bank.last_blockhash()
+                        && poh_recorder.read().unwrap().is_reset_allowed(&my_pubkey)
+                    {
                         info!(
                             "vote bank: {:?} reset bank: {:?}",
                             vote_bank


### PR DESCRIPTION
#### Problem
If a leader freezes a new bank that it would like to reset to while it's producing a block, it will always immediately stop producing that block and abandon it in favor of resetting to that new bank and then ticking to a subsequent leader slot. It's not always ideal that the working bank is abandoned.

For example, if the working bank is a descendant of another of the leader's blocks, the working bank could have votes for the leader's fork that could impact fork choice. By finishing the working bank, the leader could actually cause its fork to be heavier than the fork of the bank it was about to reset to.

#### Summary of Changes
Before resetting the working bank, first check if the working bank is a descendant of another of the leader's blocks. If it is, don't allow clearing the working bank.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
