### PR TITLE
program: remove unused serde_json dep

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5409,7 +5409,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "serde_json",
  "sha2 0.10.8",
  "sha3 0.10.8",
  "solana-frozen-abi",

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -30,7 +30,6 @@ rustversion = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
 serde_derive = { workspace = true }
-serde_json = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
 solana-frozen-abi = { workspace = true }


### PR DESCRIPTION
#### Problem

solana-program depends on serde_json but only needs it as a dev dependency, and it's already in the dev-dependencies table.

#### Summary of Changes

Remove it from the dependencies table
