### PR TITLE
reworks shred::merkle::Shred{Code,Data}::get_chained_merkle_root_offset

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -733,28 +733,19 @@ pub mod layout {
 
     pub(crate) fn get_chained_merkle_root(shred: &[u8]) -> Option<Hash> {
         let offset = match get_shred_variant(shred).ok()? {
-            ShredVariant::LegacyCode | ShredVariant::LegacyData => None,
+            ShredVariant::LegacyCode | ShredVariant::LegacyData => return None,
             ShredVariant::MerkleCode {
                 proof_size,
-                chained: true,
+                chained,
                 resigned,
-            } => merkle::ShredCode::get_chained_merkle_root_offset(proof_size, resigned).ok(),
+            } => merkle::ShredCode::get_chained_merkle_root_offset(proof_size, chained, resigned),
             ShredVariant::MerkleData {
                 proof_size,
-                chained: true,
+                chained,
                 resigned,
-            } => merkle::ShredData::get_chained_merkle_root_offset(proof_size, resigned).ok(),
-            ShredVariant::MerkleCode {
-                proof_size: _,
-                chained: false,
-                resigned: _,
-            } => None,
-            ShredVariant::MerkleData {
-                proof_size: _,
-                chained: false,
-                resigned: _,
-            } => None,
-        }?;
+            } => merkle::ShredData::get_chained_merkle_root_offset(proof_size, chained, resigned),
+        }
+        .ok()?;
         shred
             .get(offset..offset + SIZE_OF_MERKLE_ROOT)
             .map(Hash::new)

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -189,20 +189,25 @@ impl ShredData {
     fn chained_merkle_root_offset(&self) -> Result<usize, Error> {
         let ShredVariant::MerkleData {
             proof_size,
-            chained: true,
+            chained,
             resigned,
         } = self.common_header.shred_variant
         else {
             return Err(Error::InvalidShredVariant);
         };
-        Self::get_chained_merkle_root_offset(proof_size, resigned)
+        Self::get_chained_merkle_root_offset(proof_size, chained, resigned)
     }
 
     pub(super) fn get_chained_merkle_root_offset(
         proof_size: u8,
+        chained: bool,
         resigned: bool,
     ) -> Result<usize, Error> {
-        Ok(Self::SIZE_OF_HEADERS + Self::capacity(proof_size, /*chained:*/ true, resigned)?)
+        if !chained {
+            return Err(Error::InvalidShredVariant);
+        }
+        debug_assert!(chained);
+        Ok(Self::SIZE_OF_HEADERS + Self::capacity(proof_size, chained, resigned)?)
     }
 
     pub(super) fn chained_merkle_root(&self) -> Result<Hash, Error> {
@@ -375,20 +380,25 @@ impl ShredCode {
     fn chained_merkle_root_offset(&self) -> Result<usize, Error> {
         let ShredVariant::MerkleCode {
             proof_size,
-            chained: true,
+            chained,
             resigned,
         } = self.common_header.shred_variant
         else {
             return Err(Error::InvalidShredVariant);
         };
-        Self::get_chained_merkle_root_offset(proof_size, resigned)
+        Self::get_chained_merkle_root_offset(proof_size, chained, resigned)
     }
 
     pub(super) fn get_chained_merkle_root_offset(
         proof_size: u8,
+        chained: bool,
         resigned: bool,
     ) -> Result<usize, Error> {
-        Ok(Self::SIZE_OF_HEADERS + Self::capacity(proof_size, /*chained:*/ true, resigned)?)
+        if !chained {
+            return Err(Error::InvalidShredVariant);
+        }
+        debug_assert!(chained);
+        Ok(Self::SIZE_OF_HEADERS + Self::capacity(proof_size, chained, resigned)?)
     }
 
     pub(super) fn chained_merkle_root(&self) -> Result<Hash, Error> {


### PR DESCRIPTION

#### Problem
`Shred{Code,Data}::get_chained_merkle_root_offset` is only applicable to "chained" Merkle shreds however the code or API does not enforce this.



#### Summary of Changes
The commit explicitly checks for "chained" variant in `Shred{Code,Data}::get_chained_merkle_root_offset`.
