### PR TITLE
allows gossip pull requests with new contact-info

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1955,14 +1955,17 @@ impl ClusterInfo {
             requests
                 .into_par_iter()
                 .with_min_len(1024)
-                .filter(|(_, _, caller)| match caller.contact_info() {
-                    None => false,
-                    Some(caller) if caller.pubkey() == &self_pubkey => {
-                        warn!("PullRequest ignored, I'm talking to myself");
-                        self.stats.window_request_loopback.add_relaxed(1);
-                        false
+                .filter(|(_, _, caller)| match &caller.data {
+                    CrdsData::LegacyContactInfo(_) | CrdsData::ContactInfo(_) => {
+                        if caller.pubkey() == self_pubkey {
+                            warn!("PullRequest ignored, I'm talking to myself");
+                            self.stats.window_request_loopback.add_relaxed(1);
+                            false
+                        } else {
+                            true
+                        }
                     }
-                    Some(_) => true,
+                    _ => false,
                 })
                 .map(|(from_addr, filter, caller)| PullData {
                     from_addr,

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -656,7 +656,7 @@ impl CrdsValue {
             CrdsData::RestartHeaviestFork(_) => CrdsValueLabel::RestartHeaviestFork(self.pubkey()),
         }
     }
-    pub fn contact_info(&self) -> Option<&LegacyContactInfo> {
+    pub(crate) fn contact_info(&self) -> Option<&LegacyContactInfo> {
         match &self.data {
             CrdsData::LegacyContactInfo(contact_info) => Some(contact_info),
             _ => None,


### PR DESCRIPTION

#### Problem
Current code is only allowing gossip pull requests with legacy contact-info:
https://github.com/anza-xyz/agave/blob/8c5a33a81/gossip/src/cluster_info.rs#L1958-L1966



#### Summary of Changes
Working towards migrating to the new contact-info, the commit allows gossip pull requests with both legacy and new contact-infos.
