### PR TITLE
Add get-recent-prioritization-fees command to cli

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -104,6 +104,51 @@ impl OutputFormat {
     }
 }
 
+#[derive(Serialize)]
+pub struct CliPrioritizationFeeStats {
+    pub fees: Vec<CliPrioritizationFee>,
+    pub min: u64,
+    pub max: u64,
+    pub average: u64,
+    pub num_slots: u64,
+}
+
+impl QuietDisplay for CliPrioritizationFeeStats {}
+impl VerboseDisplay for CliPrioritizationFeeStats {
+    fn write_str(&self, f: &mut dyn std::fmt::Write) -> fmt::Result {
+        writeln!(f, "{:<11} prioritization_fee", "slot")?;
+        for fee in &self.fees {
+            write!(f, "{}", fee)?;
+        }
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for CliPrioritizationFeeStats {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(
+            f,
+            "Fees in recent {} slots: Min: {} Max: {} Average: {}",
+            self.num_slots, self.min, self.max, self.average
+        )
+    }
+}
+
+#[derive(Serialize)]
+pub struct CliPrioritizationFee {
+    pub slot: Slot,
+    pub prioritization_fee: u64,
+}
+
+impl QuietDisplay for CliPrioritizationFee {}
+impl VerboseDisplay for CliPrioritizationFee {}
+
+impl fmt::Display for CliPrioritizationFee {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "{:<11} {}", self.slot, self.prioritization_fee)
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct CliAccount {
     #[serde(flatten)]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -69,6 +69,10 @@ pub enum CliCommand {
     GetBlock {
         slot: Option<Slot>,
     },
+    GetRecentPrioritizationFees {
+        accounts: Vec<Pubkey>,
+        limit_num_slots: Option<Slot>,
+    },
     GetBlockTime {
         slot: Option<Slot>,
     },
@@ -609,6 +613,9 @@ pub fn parse_command(
         }
         // Cluster Query Commands
         ("block", Some(matches)) => parse_get_block(matches),
+        ("recent-prioritization-fees", Some(matches)) => {
+            parse_get_recent_prioritization_fees(matches)
+        }
         ("block-height", Some(matches)) => parse_get_block_height(matches),
         ("block-production", Some(matches)) => parse_show_block_production(matches),
         ("block-time", Some(matches)) => parse_get_block_time(matches),
@@ -905,6 +912,10 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::FirstAvailableBlock => process_first_available_block(&rpc_client),
         CliCommand::GetBlock { slot } => process_get_block(&rpc_client, config, *slot),
         CliCommand::GetBlockTime { slot } => process_get_block_time(&rpc_client, config, *slot),
+        CliCommand::GetRecentPrioritizationFees {
+            accounts,
+            limit_num_slots,
+        } => process_get_recent_priority_fees(&rpc_client, config, accounts, *limit_num_slots),
         CliCommand::GetEpoch => process_get_epoch(&rpc_client, config),
         CliCommand::GetEpochInfo => process_get_epoch_info(&rpc_client, config),
         CliCommand::GetGenesisHash => process_get_genesis_hash(&rpc_client),


### PR DESCRIPTION
#### Problem

No method to get recent prioritization fees in the CLI

#### Summary of Changes

Add a command

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
