### PR TITLE
Remove duplicated code with a CliCommandInfo constructor

### DIFF
--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -481,14 +481,11 @@ pub fn parse_address_lookup_table_subcommand(
         ("get", Some(matches)) => {
             let lookup_table_pubkey = pubkey_of(matches, "lookup_table_address").unwrap();
 
-            CliCommandInfo {
-                command: CliCommand::AddressLookupTable(
-                    AddressLookupTableCliCommand::ShowLookupTable {
-                        lookup_table_pubkey,
-                    },
-                ),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::AddressLookupTable(
+                AddressLookupTableCliCommand::ShowLookupTable {
+                    lookup_table_pubkey,
+                },
+            ))
         }
         _ => unreachable!(),
     };

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -461,6 +461,15 @@ pub struct CliCommandInfo {
     pub signers: CliSigners,
 }
 
+impl CliCommandInfo {
+    pub fn without_signers(command: CliCommand) -> Self {
+        Self {
+            command,
+            signers: vec![],
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum CliError {
     #[error("Bad parameter: {0}")]
@@ -603,14 +612,12 @@ pub fn parse_command(
         ("block-production", Some(matches)) => parse_show_block_production(matches),
         ("block-time", Some(matches)) => parse_get_block_time(matches),
         ("catchup", Some(matches)) => parse_catchup(matches, wallet_manager),
-        ("cluster-date", Some(_matches)) => Ok(CliCommandInfo {
-            command: CliCommand::ClusterDate,
-            signers: vec![],
-        }),
-        ("cluster-version", Some(_matches)) => Ok(CliCommandInfo {
-            command: CliCommand::ClusterVersion,
-            signers: vec![],
-        }),
+        ("cluster-date", Some(_matches)) => {
+            Ok(CliCommandInfo::without_signers(CliCommand::ClusterDate))
+        }
+        ("cluster-version", Some(_matches)) => {
+            Ok(CliCommandInfo::without_signers(CliCommand::ClusterVersion))
+        }
         ("epoch", Some(matches)) => parse_get_epoch(matches),
         ("epoch-info", Some(matches)) => parse_get_epoch_info(matches),
         ("feature", Some(matches)) => {
@@ -618,32 +625,25 @@ pub fn parse_command(
         }
         ("fees", Some(matches)) => {
             let blockhash = value_of::<Hash>(matches, "blockhash");
-            Ok(CliCommandInfo {
-                command: CliCommand::Fees { blockhash },
-                signers: vec![],
-            })
+            Ok(CliCommandInfo::without_signers(CliCommand::Fees {
+                blockhash,
+            }))
         }
-        ("first-available-block", Some(_matches)) => Ok(CliCommandInfo {
-            command: CliCommand::FirstAvailableBlock,
-            signers: vec![],
-        }),
-        ("genesis-hash", Some(_matches)) => Ok(CliCommandInfo {
-            command: CliCommand::GetGenesisHash,
-            signers: vec![],
-        }),
-        ("gossip", Some(_matches)) => Ok(CliCommandInfo {
-            command: CliCommand::ShowGossip,
-            signers: vec![],
-        }),
+        ("first-available-block", Some(_matches)) => Ok(CliCommandInfo::without_signers(
+            CliCommand::FirstAvailableBlock,
+        )),
+        ("genesis-hash", Some(_matches)) => {
+            Ok(CliCommandInfo::without_signers(CliCommand::GetGenesisHash))
+        }
+        ("gossip", Some(_matches)) => Ok(CliCommandInfo::without_signers(CliCommand::ShowGossip)),
         ("inflation", Some(matches)) => {
             parse_inflation_subcommand(matches, default_signer, wallet_manager)
         }
         ("largest-accounts", Some(matches)) => parse_largest_accounts(matches),
         ("leader-schedule", Some(matches)) => parse_leader_schedule(matches),
-        ("live-slots", Some(_matches)) => Ok(CliCommandInfo {
-            command: CliCommand::LiveSlots,
-            signers: vec![],
-        }),
+        ("live-slots", Some(_matches)) => {
+            Ok(CliCommandInfo::without_signers(CliCommand::LiveSlots))
+        }
         ("logs", Some(matches)) => parse_logs(matches, wallet_manager),
         ("ping", Some(matches)) => parse_cluster_ping(matches, default_signer, wallet_manager),
         ("rent", Some(matches)) => {
@@ -651,13 +651,10 @@ pub fn parse_command(
                 .unwrap()
                 .length();
             let use_lamports_unit = matches.is_present("lamports");
-            Ok(CliCommandInfo {
-                command: CliCommand::Rent {
-                    data_length,
-                    use_lamports_unit,
-                },
-                signers: vec![],
-            })
+            Ok(CliCommandInfo::without_signers(CliCommand::Rent {
+                data_length,
+                use_lamports_unit,
+            }))
         }
         ("slot", Some(matches)) => parse_get_slot(matches),
         ("stakes", Some(matches)) => parse_show_stakes(matches, wallet_manager),
@@ -699,10 +696,9 @@ pub fn parse_command(
         }
         ("wait-for-max-stake", Some(matches)) => {
             let max_stake_percent = value_t_or_exit!(matches, "max_percent", f32);
-            Ok(CliCommandInfo {
-                command: CliCommand::WaitForMaxStake { max_stake_percent },
-                signers: vec![],
-            })
+            Ok(CliCommandInfo::without_signers(
+                CliCommand::WaitForMaxStake { max_stake_percent },
+            ))
         }
         // Stake Commands
         ("create-stake-account", Some(matches)) => {
@@ -806,10 +802,9 @@ pub fn parse_command(
         ("airdrop", Some(matches)) => parse_airdrop(matches, default_signer, wallet_manager),
         ("balance", Some(matches)) => parse_balance(matches, default_signer, wallet_manager),
         ("confirm", Some(matches)) => match matches.value_of("signature").unwrap().parse() {
-            Ok(signature) => Ok(CliCommandInfo {
-                command: CliCommand::Confirm(signature),
-                signers: vec![],
-            }),
+            Ok(signature) => Ok(CliCommandInfo::without_signers(CliCommand::Confirm(
+                signature,
+            ))),
             _ => Err(CliError::BadParameter("Invalid signature".to_string())),
         },
         ("create-address-with-seed", Some(matches)) => {
@@ -821,10 +816,9 @@ pub fn parse_command(
         ("decode-transaction", Some(matches)) => parse_decode_transaction(matches),
         ("resolve-signer", Some(matches)) => {
             let signer_path = resolve_signer(matches, "signer", wallet_manager)?;
-            Ok(CliCommandInfo {
-                command: CliCommand::ResolveSigner(signer_path),
-                signers: vec![],
-            })
+            Ok(CliCommandInfo::without_signers(CliCommand::ResolveSigner(
+                signer_path,
+            )))
         }
         ("transfer", Some(matches)) => parse_transfer(matches, default_signer, wallet_manager),
         ("sign-offchain-message", Some(matches)) => {
@@ -1866,13 +1860,10 @@ mod tests {
                 .get_matches_from(vec!["test", "airdrop", "50", &pubkey_string]);
         assert_eq!(
             parse_command(&test_airdrop, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Airdrop {
-                    pubkey: Some(pubkey),
-                    lamports: 50_000_000_000,
-                },
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Airdrop {
+                pubkey: Some(pubkey),
+                lamports: 50_000_000_000,
+            })
         );
 
         // Test Balance Subcommand, incl pubkey and keypair-file inputs
@@ -1883,13 +1874,10 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_balance, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Balance {
-                    pubkey: Some(keypair.pubkey()),
-                    use_lamports_unit: false,
-                },
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Balance {
+                pubkey: Some(keypair.pubkey()),
+                use_lamports_unit: false,
+            })
         );
         let test_balance = test_commands.clone().get_matches_from(vec![
             "test",
@@ -1899,13 +1887,10 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_balance, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Balance {
-                    pubkey: Some(keypair.pubkey()),
-                    use_lamports_unit: true,
-                },
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Balance {
+                pubkey: Some(keypair.pubkey()),
+                use_lamports_unit: true,
+            })
         );
         let test_balance =
             test_commands
@@ -1931,10 +1916,7 @@ mod tests {
                 .get_matches_from(vec!["test", "confirm", &signature_string]);
         assert_eq!(
             parse_command(&test_confirm, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Confirm(signature),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Confirm(signature))
         );
         let test_bad_signature = test_commands
             .clone()
@@ -1959,14 +1941,11 @@ mod tests {
             ]);
             assert_eq!(
                 parse_command(&test_create_address_with_seed, &default_signer, &mut None).unwrap(),
-                CliCommandInfo {
-                    command: CliCommand::CreateAddressWithSeed {
-                        from_pubkey: Some(from_pubkey),
-                        seed: "seed".to_string(),
-                        program_id: *program_id
-                    },
-                    signers: vec![],
-                }
+                CliCommandInfo::without_signers(CliCommand::CreateAddressWithSeed {
+                    from_pubkey: Some(from_pubkey),
+                    seed: "seed".to_string(),
+                    program_id: *program_id
+                })
             );
         }
         let test_create_address_with_seed = test_commands.clone().get_matches_from(vec![
@@ -1994,10 +1973,7 @@ mod tests {
                 .get_matches_from(vec!["test", "resolve-signer", &keypair_file]);
         assert_eq!(
             parse_command(&test_resolve_signer, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::ResolveSigner(Some(keypair_file.clone())),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::ResolveSigner(Some(keypair_file.clone())))
         );
         // Test ResolveSigner Subcommand, SignerSource::Pubkey (Presigner)
         let test_resolve_signer =
@@ -2006,10 +1982,7 @@ mod tests {
                 .get_matches_from(vec!["test", "resolve-signer", &pubkey_string]);
         assert_eq!(
             parse_command(&test_resolve_signer, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::ResolveSigner(Some(pubkey.to_string())),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::ResolveSigner(Some(pubkey.to_string())))
         );
 
         // Test SignOffchainMessage

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -529,16 +529,13 @@ pub fn parse_catchup(
     }
     let follow = matches.is_present("follow");
     let log = matches.is_present("log");
-    Ok(CliCommandInfo {
-        command: CliCommand::Catchup {
-            node_pubkey,
-            node_json_rpc_url,
-            follow,
-            our_localhost_port,
-            log,
-        },
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::Catchup {
+        node_pubkey,
+        node_json_rpc_url,
+        follow,
+        our_localhost_port,
+        log,
+    }))
 }
 
 pub fn parse_cluster_ping(
@@ -571,46 +568,32 @@ pub fn parse_cluster_ping(
 
 pub fn parse_get_block(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let slot = value_of(matches, "slot");
-    Ok(CliCommandInfo {
-        command: CliCommand::GetBlock { slot },
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::GetBlock {
+        slot,
+    }))
 }
 
 pub fn parse_get_block_time(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let slot = value_of(matches, "slot");
-    Ok(CliCommandInfo {
-        command: CliCommand::GetBlockTime { slot },
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::GetBlockTime {
+        slot,
+    }))
 }
 
 pub fn parse_get_epoch(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    Ok(CliCommandInfo {
-        command: CliCommand::GetEpoch,
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::GetEpoch))
 }
 
 pub fn parse_get_epoch_info(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    Ok(CliCommandInfo {
-        command: CliCommand::GetEpochInfo,
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::GetEpochInfo))
 }
 
 pub fn parse_get_slot(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    Ok(CliCommandInfo {
-        command: CliCommand::GetSlot,
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::GetSlot))
 }
 
 pub fn parse_get_block_height(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    Ok(CliCommandInfo {
-        command: CliCommand::GetBlockHeight,
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::GetBlockHeight))
 }
 
 pub fn parse_largest_accounts(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
@@ -621,32 +604,26 @@ pub fn parse_largest_accounts(matches: &ArgMatches<'_>) -> Result<CliCommandInfo
     } else {
         None
     };
-    Ok(CliCommandInfo {
-        command: CliCommand::LargestAccounts { filter },
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::LargestAccounts { filter },
+    ))
 }
 
 pub fn parse_supply(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let print_accounts = matches.is_present("print_accounts");
-    Ok(CliCommandInfo {
-        command: CliCommand::Supply { print_accounts },
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::Supply {
+        print_accounts,
+    }))
 }
 
 pub fn parse_total_supply(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    Ok(CliCommandInfo {
-        command: CliCommand::TotalSupply,
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::TotalSupply))
 }
 
 pub fn parse_get_transaction_count(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    Ok(CliCommandInfo {
-        command: CliCommand::GetTransactionCount,
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::GetTransactionCount,
+    ))
 }
 
 pub fn parse_show_stakes(
@@ -657,14 +634,11 @@ pub fn parse_show_stakes(
     let vote_account_pubkeys =
         pubkeys_of_multiple_signers(matches, "vote_account_pubkeys", wallet_manager)?;
     let withdraw_authority = pubkey_of(matches, "withdraw_authority");
-    Ok(CliCommandInfo {
-        command: CliCommand::ShowStakes {
-            use_lamports_unit,
-            vote_account_pubkeys,
-            withdraw_authority,
-        },
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::ShowStakes {
+        use_lamports_unit,
+        vote_account_pubkeys,
+        withdraw_authority,
+    }))
 }
 
 pub fn parse_show_validators(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
@@ -688,8 +662,8 @@ pub fn parse_show_validators(matches: &ArgMatches<'_>) -> Result<CliCommandInfo,
         _ => unreachable!(),
     };
 
-    Ok(CliCommandInfo {
-        command: CliCommand::ShowValidators {
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::ShowValidators {
             use_lamports_unit,
             sort_order,
             reverse_sort,
@@ -697,8 +671,7 @@ pub fn parse_show_validators(matches: &ArgMatches<'_>) -> Result<CliCommandInfo,
             keep_unstaked_delinquents,
             delinquent_slot_distance,
         },
-        signers: vec![],
-    })
+    ))
 }
 
 pub fn parse_transaction_history(
@@ -726,16 +699,15 @@ pub fn parse_transaction_history(
     let limit = value_t_or_exit!(matches, "limit", usize);
     let show_transactions = matches.is_present("show_transactions");
 
-    Ok(CliCommandInfo {
-        command: CliCommand::TransactionHistory {
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::TransactionHistory {
             address,
             before,
             until,
             limit,
             show_transactions,
         },
-        signers: vec![],
-    })
+    ))
 }
 
 pub fn process_catchup(
@@ -1021,10 +993,9 @@ pub fn process_first_available_block(rpc_client: &RpcClient) -> ProcessResult {
 
 pub fn parse_leader_schedule(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let epoch = value_of(matches, "epoch");
-    Ok(CliCommandInfo {
-        command: CliCommand::LeaderSchedule { epoch },
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::LeaderSchedule { epoch },
+    ))
 }
 
 pub fn process_leader_schedule(
@@ -1191,10 +1162,9 @@ pub fn parse_show_block_production(matches: &ArgMatches<'_>) -> Result<CliComman
     let epoch = value_t!(matches, "epoch", Epoch).ok();
     let slot_limit = value_t!(matches, "slot_limit", u64).ok();
 
-    Ok(CliCommandInfo {
-        command: CliCommand::ShowBlockProduction { epoch, slot_limit },
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::ShowBlockProduction { epoch, slot_limit },
+    ))
 }
 
 pub fn process_show_block_production(
@@ -1624,10 +1594,7 @@ pub fn parse_logs(
         Some(address) => RpcTransactionLogsFilter::Mentions(vec![address.to_string()]),
     };
 
-    Ok(CliCommandInfo {
-        command: CliCommand::Logs { filter },
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::Logs { filter }))
 }
 
 pub fn process_logs(config: &CliConfig, filter: &RpcTransactionLogsFilter) -> ProcessResult {
@@ -2255,10 +2222,7 @@ mod tests {
             .get_matches_from(vec!["test", "cluster-date"]);
         assert_eq!(
             parse_command(&test_cluster_version, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::ClusterDate,
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::ClusterDate)
         );
 
         let test_cluster_version = test_commands
@@ -2266,19 +2230,13 @@ mod tests {
             .get_matches_from(vec!["test", "cluster-version"]);
         assert_eq!(
             parse_command(&test_cluster_version, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::ClusterVersion,
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::ClusterVersion)
         );
 
         let test_fees = test_commands.clone().get_matches_from(vec!["test", "fees"]);
         assert_eq!(
             parse_command(&test_fees, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Fees { blockhash: None },
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Fees { blockhash: None })
         );
 
         let blockhash = Hash::new_unique();
@@ -2290,12 +2248,9 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_fees, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Fees {
-                    blockhash: Some(blockhash)
-                },
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Fees {
+                blockhash: Some(blockhash)
+            })
         );
 
         let slot = 100;
@@ -2305,10 +2260,7 @@ mod tests {
                 .get_matches_from(vec!["test", "block-time", &slot.to_string()]);
         assert_eq!(
             parse_command(&test_get_block_time, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::GetBlockTime { slot: Some(slot) },
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::GetBlockTime { slot: Some(slot) })
         );
 
         let test_get_epoch = test_commands
@@ -2316,10 +2268,7 @@ mod tests {
             .get_matches_from(vec!["test", "epoch"]);
         assert_eq!(
             parse_command(&test_get_epoch, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::GetEpoch,
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::GetEpoch)
         );
 
         let test_get_epoch_info = test_commands
@@ -2327,10 +2276,7 @@ mod tests {
             .get_matches_from(vec!["test", "epoch-info"]);
         assert_eq!(
             parse_command(&test_get_epoch_info, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::GetEpochInfo,
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::GetEpochInfo)
         );
 
         let test_get_genesis_hash = test_commands
@@ -2338,19 +2284,13 @@ mod tests {
             .get_matches_from(vec!["test", "genesis-hash"]);
         assert_eq!(
             parse_command(&test_get_genesis_hash, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::GetGenesisHash,
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::GetGenesisHash)
         );
 
         let test_get_slot = test_commands.clone().get_matches_from(vec!["test", "slot"]);
         assert_eq!(
             parse_command(&test_get_slot, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::GetSlot,
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::GetSlot)
         );
 
         let test_total_supply = test_commands
@@ -2358,10 +2298,7 @@ mod tests {
             .get_matches_from(vec!["test", "total-supply"]);
         assert_eq!(
             parse_command(&test_total_supply, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::TotalSupply,
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::TotalSupply)
         );
 
         let test_transaction_count = test_commands
@@ -2369,10 +2306,7 @@ mod tests {
             .get_matches_from(vec!["test", "transaction-count"]);
         assert_eq!(
             parse_command(&test_transaction_count, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::GetTransactionCount,
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::GetTransactionCount)
         );
 
         let test_ping = test_commands.clone().get_matches_from(vec![

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -540,13 +540,10 @@ pub fn parse_feature_subcommand(
             let display_all =
                 matches.is_present("display_all") || features.len() < FEATURE_NAMES.len();
             features.sort();
-            CliCommandInfo {
-                command: CliCommand::Feature(FeatureCliCommand::Status {
-                    features,
-                    display_all,
-                }),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Feature(FeatureCliCommand::Status {
+                features,
+                display_all,
+            }))
         }
         _ => unreachable!(),
     };

--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -66,10 +66,9 @@ pub fn parse_inflation_subcommand(
         }
         _ => InflationCliCommand::Show,
     };
-    Ok(CliCommandInfo {
-        command: CliCommand::Inflation(command),
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::Inflation(
+        command,
+    )))
 }
 
 pub fn process_inflation_subcommand(

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -273,10 +273,9 @@ pub fn parse_get_nonce(
     let nonce_account_pubkey =
         pubkey_of_signer(matches, "nonce_account_pubkey", wallet_manager)?.unwrap();
 
-    Ok(CliCommandInfo {
-        command: CliCommand::GetNonce(nonce_account_pubkey),
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::GetNonce(
+        nonce_account_pubkey,
+    )))
 }
 
 pub fn parse_new_nonce(
@@ -316,13 +315,12 @@ pub fn parse_show_nonce_account(
         pubkey_of_signer(matches, "nonce_account_pubkey", wallet_manager)?.unwrap();
     let use_lamports_unit = matches.is_present("lamports");
 
-    Ok(CliCommandInfo {
-        command: CliCommand::ShowNonceAccount {
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::ShowNonceAccount {
             nonce_account_pubkey,
             use_lamports_unit,
         },
-        signers: vec![],
-    })
+    ))
 }
 
 pub fn parse_withdraw_from_nonce_account(
@@ -818,10 +816,7 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_get_nonce, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::GetNonce(nonce_account_keypair.pubkey()),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::GetNonce(nonce_account_keypair.pubkey()))
         );
 
         // Test NewNonce SubCommand
@@ -876,13 +871,10 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_show_nonce_account, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::ShowNonceAccount {
-                    nonce_account_pubkey: nonce_account_keypair.pubkey(),
-                    use_lamports_unit: false,
-                },
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::ShowNonceAccount {
+                nonce_account_pubkey: nonce_account_keypair.pubkey(),
+                use_lamports_unit: false,
+            })
         );
 
         // Test WithdrawFromNonceAccount Subcommand

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -861,25 +861,21 @@ pub fn parse_program_subcommand(
                     .pubkey()
             };
 
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::Show {
-                    account_pubkey: pubkey_of(matches, "account"),
-                    authority_pubkey,
-                    get_programs: matches.is_present("programs"),
-                    get_buffers: matches.is_present("buffers"),
-                    all: matches.is_present("all"),
-                    use_lamports_unit: matches.is_present("lamports"),
-                }),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Program(ProgramCliCommand::Show {
+                account_pubkey: pubkey_of(matches, "account"),
+                authority_pubkey,
+                get_programs: matches.is_present("programs"),
+                get_buffers: matches.is_present("buffers"),
+                all: matches.is_present("all"),
+                use_lamports_unit: matches.is_present("lamports"),
+            }))
         }
-        ("dump", Some(matches)) => CliCommandInfo {
-            command: CliCommand::Program(ProgramCliCommand::Dump {
+        ("dump", Some(matches)) => {
+            CliCommandInfo::without_signers(CliCommand::Program(ProgramCliCommand::Dump {
                 account_pubkey: pubkey_of(matches, "account"),
                 output_location: matches.value_of("output_location").unwrap().to_string(),
-            }),
-            signers: vec![],
-        },
+            }))
+        }
         ("close", Some(matches)) => {
             let account_pubkey = if matches.is_present("buffers") {
                 None
@@ -3596,17 +3592,14 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_command, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::Show {
-                    account_pubkey: Some(buffer_pubkey),
-                    authority_pubkey: default_keypair.pubkey(),
-                    get_programs: false,
-                    get_buffers: false,
-                    all: false,
-                    use_lamports_unit: false,
-                }),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Program(ProgramCliCommand::Show {
+                account_pubkey: Some(buffer_pubkey),
+                authority_pubkey: default_keypair.pubkey(),
+                get_programs: false,
+                get_buffers: false,
+                all: false,
+                use_lamports_unit: false,
+            }))
         );
 
         let test_command = test_commands.clone().get_matches_from(vec![
@@ -3619,17 +3612,14 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_command, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::Show {
-                    account_pubkey: None,
-                    authority_pubkey: default_keypair.pubkey(),
-                    get_programs: true,
-                    get_buffers: false,
-                    all: true,
-                    use_lamports_unit: true,
-                }),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Program(ProgramCliCommand::Show {
+                account_pubkey: None,
+                authority_pubkey: default_keypair.pubkey(),
+                get_programs: true,
+                get_buffers: false,
+                all: true,
+                use_lamports_unit: true,
+            }))
         );
 
         let test_command = test_commands.clone().get_matches_from(vec![
@@ -3642,17 +3632,14 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_command, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::Show {
-                    account_pubkey: None,
-                    authority_pubkey: default_keypair.pubkey(),
-                    get_programs: false,
-                    get_buffers: true,
-                    all: true,
-                    use_lamports_unit: true,
-                }),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Program(ProgramCliCommand::Show {
+                account_pubkey: None,
+                authority_pubkey: default_keypair.pubkey(),
+                get_programs: false,
+                get_buffers: true,
+                all: true,
+                use_lamports_unit: true,
+            }))
         );
 
         let test_command = test_commands.clone().get_matches_from(vec![
@@ -3665,17 +3652,14 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_command, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::Show {
-                    account_pubkey: None,
-                    authority_pubkey: authority_keypair.pubkey(),
-                    get_programs: false,
-                    get_buffers: true,
-                    all: false,
-                    use_lamports_unit: false,
-                }),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Program(ProgramCliCommand::Show {
+                account_pubkey: None,
+                authority_pubkey: authority_keypair.pubkey(),
+                get_programs: false,
+                get_buffers: true,
+                all: false,
+                use_lamports_unit: false,
+            }))
         );
 
         let test_command = test_commands.clone().get_matches_from(vec![
@@ -3688,17 +3672,14 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_command, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::Show {
-                    account_pubkey: None,
-                    authority_pubkey: authority_keypair.pubkey(),
-                    get_programs: false,
-                    get_buffers: true,
-                    all: false,
-                    use_lamports_unit: false,
-                }),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::Program(ProgramCliCommand::Show {
+                account_pubkey: None,
+                authority_pubkey: authority_keypair.pubkey(),
+                get_programs: false,
+                get_buffers: true,
+                all: false,
+                use_lamports_unit: false,
+            }))
         );
     }
 

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -397,22 +397,18 @@ pub fn parse_program_v4_subcommand(
                         .pubkey()
                 };
 
-            CliCommandInfo {
-                command: CliCommand::ProgramV4(ProgramV4CliCommand::Show {
-                    account_pubkey: pubkey_of(matches, "account"),
-                    authority,
-                    all: matches.is_present("all"),
-                }),
-                signers: vec![],
-            }
+            CliCommandInfo::without_signers(CliCommand::ProgramV4(ProgramV4CliCommand::Show {
+                account_pubkey: pubkey_of(matches, "account"),
+                authority,
+                all: matches.is_present("all"),
+            }))
         }
-        ("dump", Some(matches)) => CliCommandInfo {
-            command: CliCommand::ProgramV4(ProgramV4CliCommand::Dump {
+        ("dump", Some(matches)) => {
+            CliCommandInfo::without_signers(CliCommand::ProgramV4(ProgramV4CliCommand::Dump {
                 account_pubkey: pubkey_of(matches, "account"),
                 output_location: matches.value_of("output_location").unwrap().to_string(),
-            }),
-            signers: vec![],
-        },
+            }))
+        }
         _ => unreachable!(),
     };
     Ok(response)

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1373,37 +1373,34 @@ pub fn parse_show_stake_account(
     } else {
         None
     };
-    Ok(CliCommandInfo {
-        command: CliCommand::ShowStakeAccount {
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::ShowStakeAccount {
             pubkey: stake_account_pubkey,
             use_lamports_unit,
             with_rewards,
             use_csv,
         },
-        signers: vec![],
-    })
+    ))
 }
 
 pub fn parse_show_stake_history(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let use_lamports_unit = matches.is_present("lamports");
     let limit_results = value_of(matches, "limit").unwrap();
-    Ok(CliCommandInfo {
-        command: CliCommand::ShowStakeHistory {
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::ShowStakeHistory {
             use_lamports_unit,
             limit_results,
         },
-        signers: vec![],
-    })
+    ))
 }
 
 pub fn parse_stake_minimum_delegation(
     matches: &ArgMatches<'_>,
 ) -> Result<CliCommandInfo, CliError> {
     let use_lamports_unit = matches.is_present("lamports");
-    Ok(CliCommandInfo {
-        command: CliCommand::StakeMinimumDelegation { use_lamports_unit },
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::StakeMinimumDelegation { use_lamports_unit },
+    ))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -261,10 +261,9 @@ pub fn parse_get_validator_info_command(
     matches: &ArgMatches<'_>,
 ) -> Result<CliCommandInfo, CliError> {
     let info_pubkey = pubkey_of(matches, "info_pubkey");
-    Ok(CliCommandInfo {
-        command: CliCommand::GetValidatorInfo(info_pubkey),
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::GetValidatorInfo(info_pubkey),
+    ))
 }
 
 pub fn process_set_validator_info(

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -675,15 +675,14 @@ pub fn parse_vote_get_account_command(
     } else {
         None
     };
-    Ok(CliCommandInfo {
-        command: CliCommand::ShowVoteAccount {
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::ShowVoteAccount {
             pubkey: vote_account_pubkey,
             use_lamports_unit,
             use_csv,
             with_rewards,
         },
-        signers: vec![],
-    })
+    ))
 }
 
 pub fn parse_withdraw_from_vote_account(

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -407,14 +407,11 @@ pub fn parse_account(
     let account_pubkey = pubkey_of_signer(matches, "account_pubkey", wallet_manager)?.unwrap();
     let output_file = matches.value_of("output_file");
     let use_lamports_unit = matches.is_present("lamports");
-    Ok(CliCommandInfo {
-        command: CliCommand::ShowAccount {
-            pubkey: account_pubkey,
-            output_file: output_file.map(ToString::to_string),
-            use_lamports_unit,
-        },
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(CliCommand::ShowAccount {
+        pubkey: account_pubkey,
+        output_file: output_file.map(ToString::to_string),
+        use_lamports_unit,
+    }))
 }
 
 pub fn parse_airdrop(
@@ -465,10 +462,9 @@ pub fn parse_decode_transaction(matches: &ArgMatches<'_>) -> Result<CliCommandIn
 
     let encoded_transaction = EncodedTransaction::Binary(blob, binary_encoding);
     if let Some(transaction) = encoded_transaction.decode() {
-        Ok(CliCommandInfo {
-            command: CliCommand::DecodeTransaction(transaction),
-            signers: vec![],
-        })
+        Ok(CliCommandInfo::without_signers(
+            CliCommand::DecodeTransaction(transaction),
+        ))
     } else {
         Err(CliError::BadParameter(
             "Unable to decode transaction".to_string(),
@@ -542,10 +538,9 @@ pub fn parse_find_program_derived_address(
         })
         .unwrap_or_default();
 
-    Ok(CliCommandInfo {
-        command: CliCommand::FindProgramDerivedAddress { seeds, program_id },
-        signers: vec![],
-    })
+    Ok(CliCommandInfo::without_signers(
+        CliCommand::FindProgramDerivedAddress { seeds, program_id },
+    ))
 }
 
 pub fn parse_transfer(


### PR DESCRIPTION
#### Problem

Setting no signers is the most common case to construct a CliCommandInfo struct, 

#### Summary of Changes

Make a constructor function to do that and reduce code.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
