### PR TITLE
hot storage AccountIndexWriterEntry needs values

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -755,7 +755,7 @@ impl HotStorageWriter {
         for i in skip..len {
             let (account, address, _account_hash) = accounts.get(i);
             let index_entry = AccountIndexWriterEntry {
-                address,
+                address: *address,
                 offset: HotAccountOffset::new(cursor)?,
             };
             address_range.update(address);
@@ -927,7 +927,7 @@ mod tests {
                         .write_bytes(&padding_buffer[0..padding_bytes(data.len()) as usize])
                         .unwrap();
                     AccountIndexWriterEntry {
-                        address,
+                        address: *address,
                         offset: HotAccountOffset::new(prev_offset).unwrap(),
                     }
                 })
@@ -1242,7 +1242,7 @@ mod tests {
         let index_writer_entries: Vec<_> = addresses
             .iter()
             .map(|address| AccountIndexWriterEntry {
-                address,
+                address: *address,
                 offset: HotAccountOffset::new(
                     rng.gen_range(0..u32::MAX) as usize * HOT_ACCOUNT_ALIGNMENT,
                 )
@@ -1280,7 +1280,7 @@ mod tests {
             let account_address = hot_storage
                 .get_account_address(IndexOffset(i as u32))
                 .unwrap();
-            assert_eq!(account_address, index_writer_entry.address);
+            assert_eq!(account_address, &index_writer_entry.address);
         }
     }
 

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -10,9 +10,9 @@ use {
 
 /// The in-memory struct for the writing index block.
 #[derive(Debug)]
-pub struct AccountIndexWriterEntry<'a, Offset: AccountOffset> {
+pub struct AccountIndexWriterEntry<Offset: AccountOffset> {
     /// The account address.
-    pub address: &'a Pubkey,
+    pub address: Pubkey,
     /// The offset to the account.
     pub offset: Offset,
 }
@@ -66,7 +66,7 @@ impl IndexBlockFormat {
             Self::AddressesThenOffsets => {
                 let mut bytes_written = 0;
                 for index_entry in index_entries {
-                    bytes_written += file.write_pod(index_entry.address)?;
+                    bytes_written += file.write_pod(&index_entry.address)?;
                 }
                 for index_entry in index_entries {
                     bytes_written += file.write_pod(&index_entry.offset)?;
@@ -172,7 +172,7 @@ mod tests {
         let index_entries: Vec<_> = addresses
             .iter()
             .map(|address| AccountIndexWriterEntry {
-                address,
+                address: *address,
                 offset: HotAccountOffset::new(
                     rng.gen_range(0..u32::MAX) as usize * HOT_ACCOUNT_ALIGNMENT,
                 )
@@ -204,7 +204,7 @@ mod tests {
             let address = indexer
                 .get_account_address(&mmap, &footer, IndexOffset(i as u32))
                 .unwrap();
-            assert_eq!(index_entry.address, address);
+            assert_eq!(index_entry.address, *address);
         }
     }
 


### PR DESCRIPTION
#### Problem
moving to not mmapping append vec files. Soon, lifetimes of borrowed account data will be limited to a callback.

#### Summary of Changes
collecting pubkeys to write will soon require a value since lifetime will be limited.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
