### PR TITLE
Fixes race in RwLockSecondaryIndexEntry::insert_if_not_exists()

### DIFF
--- a/accounts-db/src/secondary_index.rs
+++ b/accounts-db/src/secondary_index.rs
@@ -79,15 +79,10 @@ impl SecondaryIndexEntry for RwLockSecondaryIndexEntry {
             return;
         }
 
-        let mut w_account_keys = self.account_keys.write().unwrap();
-
-        // check again if the key exists, as another thread may've inserted it
-        if w_account_keys.contains(key) {
-            return;
+        let was_newly_inserted = self.account_keys.write().unwrap().insert(*key);
+        if was_newly_inserted {
+            inner_keys_count.fetch_add(1, Ordering::Relaxed);
         }
-
-        w_account_keys.insert(*key);
-        inner_keys_count.fetch_add(1, Ordering::Relaxed);
     }
 
     fn remove_inner_key(&self, key: &Pubkey) -> bool {

--- a/accounts-db/src/secondary_index.rs
+++ b/accounts-db/src/secondary_index.rs
@@ -74,12 +74,20 @@ pub struct RwLockSecondaryIndexEntry {
 
 impl SecondaryIndexEntry for RwLockSecondaryIndexEntry {
     fn insert_if_not_exists(&self, key: &Pubkey, inner_keys_count: &AtomicU64) {
-        let exists = self.account_keys.read().unwrap().contains(key);
-        if !exists {
-            let mut w_account_keys = self.account_keys.write().unwrap();
-            w_account_keys.insert(*key);
-            inner_keys_count.fetch_add(1, Ordering::Relaxed);
-        };
+        if self.account_keys.read().unwrap().contains(key) {
+            // the key already exists, so nothing to do here
+            return;
+        }
+
+        let mut w_account_keys = self.account_keys.write().unwrap();
+
+        // check again if the key exists, as another thread may've inserted it
+        if w_account_keys.contains(key) {
+            return;
+        }
+
+        w_account_keys.insert(*key);
+        inner_keys_count.fetch_add(1, Ordering::Relaxed);
     }
 
     fn remove_inner_key(&self, key: &Pubkey) -> bool {


### PR DESCRIPTION
#### Problem

There's a race condition in `RwLockSecondaryIndexEntry::insert_if_not_exists()` if multiple threads try to insert a key. The secondary index will be fine, but we'll have incorrect stats/metrics.

`RwLockSecondaryIndexEntry` is the type of `spl_token_owner_index`, and this fn is called when generating the index at startup, and also when upserting into the index. 


#### Summary of Changes

Only increment the stats if the key was newly inserted.