### PR TITLE
use callback for account and account_default_if_zero_lamport

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -73,8 +73,8 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
             let item = self.hashes.as_ref().unwrap();
             item[index].borrow()
         };
-        let account = self.accounts.account_default_if_zero_lamport(index);
-        callback((account, pubkey, hash))
+        self.accounts
+            .account_default_if_zero_lamport(index, |account| callback((account, pubkey, hash)))
     }
 
     /// None if account at index has lamports == 0
@@ -83,9 +83,10 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
     pub fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl FnMut(Option<AccountForStorage<'a>>) -> Ret,
+        callback: impl FnMut(Option<AccountForStorage<'a>>) -> Ret,
     ) -> Ret {
-        callback(self.accounts.account_default_if_zero_lamport(index))
+        self.accounts
+            .account_default_if_zero_lamport(index, callback)
     }
 
     /// # accounts to write

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -25,9 +25,13 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
     fn pubkey(&self, index: usize) -> &Pubkey {
         &self.1[index].stake_pubkey
     }
-    fn account(&self, index: usize) -> AccountForStorage<'a> {
+    fn account<Ret>(
+        &self,
+        index: usize,
+        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+    ) -> Ret {
         let entry = &self.1[index];
-        (&entry.stake_account).into()
+        callback((&entry.stake_account).into())
     }
     fn slot(&self, _index: usize) -> Slot {
         // per-index slot is not unique per slot when per-account slot is not included in the source data

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5185,11 +5185,13 @@ impl Bank {
         let mut m = Measure::start("stakes_cache.check_and_store");
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
         (0..accounts.len()).for_each(|i| {
-            self.stakes_cache.check_and_store(
-                accounts.pubkey(i),
-                &accounts.account(i),
-                new_warmup_cooldown_rate_epoch,
-            )
+            accounts.account(i, |account| {
+                self.stakes_cache.check_and_store(
+                    accounts.pubkey(i),
+                    &account,
+                    new_warmup_cooldown_rate_epoch,
+                )
+            })
         });
         self.rc.accounts.store_accounts_cached(accounts);
         m.stop();


### PR DESCRIPTION
#### Problem
moving to not mmapping append vec files. Soon, lifetimes of borrowed account data will be limited to a callback.

#### Summary of Changes
Rework `StorableAccounts`. `account()` and `account_default_if_zero_lamport)` to use a callback.
The next change will push the callback up to getting the data from the storage. This change was done to simplify the diff and take one step at a time.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
