### PR TITLE
Marks append vec test utils as DCOU

### DIFF
--- a/accounts-db/src/append_vec/test_utils.rs
+++ b/accounts-db/src/append_vec/test_utils.rs
@@ -1,4 +1,5 @@
 //! Helpers for AppendVec tests and benches
+#![cfg(feature = "dev-context-only-utils")]
 use {
     super::StoredMeta,
     rand::{distributions::Alphanumeric, Rng},


### PR DESCRIPTION
#### Problem

AppendVec's test_utils module can be called by non-tests.


#### Summary of Changes

Mark it as DCOU.