### PR TITLE
hot storage tests don't use Option

### DIFF
--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -358,7 +358,9 @@ mod tests {
             storable_accounts.get(i, |(account, address, _account_hash)| {
                 expected_accounts_map.insert(
                     *address,
-                    account.map(|account| account.to_account_shared_data()),
+                    account
+                        .map(|account| account.to_account_shared_data())
+                        .unwrap_or_default(),
                 );
             });
         }
@@ -378,7 +380,7 @@ mod tests {
             if let Some(account) = expected_accounts_map.get(stored_account_meta.pubkey()) {
                 verify_test_account_with_footer(
                     &stored_account_meta,
-                    account.as_ref(),
+                    account,
                     stored_account_meta.pubkey(),
                     footer,
                 );

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -1563,7 +1563,13 @@ mod tests {
                 .unwrap();
 
             storable_accounts.get(i, |(account, address, _account_hash)| {
-                verify_test_account(&stored_account_meta, account.as_ref(), address);
+                verify_test_account(
+                    &stored_account_meta,
+                    &account
+                        .map(|account| account.to_account_shared_data())
+                        .unwrap_or_default(),
+                    address,
+                );
             });
 
             assert_eq!(i + 1, next.0 as usize);
@@ -1582,7 +1588,13 @@ mod tests {
                 .unwrap();
 
             storable_accounts.get(stored_info.offset, |(account, address, _account_hash)| {
-                verify_test_account(&stored_account_meta, account.as_ref(), address);
+                verify_test_account(
+                    &stored_account_meta,
+                    &account
+                        .map(|account| account.to_account_shared_data())
+                        .unwrap_or_default(),
+                    address,
+                );
             });
         }
 
@@ -1592,7 +1604,13 @@ mod tests {
         // first, we verify everything
         for (i, stored_meta) in accounts.iter().enumerate() {
             storable_accounts.get(i, |(account, address, _account_hash)| {
-                verify_test_account(stored_meta, account.as_ref(), address);
+                verify_test_account(
+                    stored_meta,
+                    &account
+                        .map(|account| account.to_account_shared_data())
+                        .unwrap_or_default(),
+                    address,
+                );
             });
         }
 

--- a/accounts-db/src/tiered_storage/test_utils.rs
+++ b/accounts-db/src/tiered_storage/test_utils.rs
@@ -5,7 +5,6 @@ use {
     crate::{
         account_storage::meta::{StoredAccountMeta, StoredMeta},
         accounts_hash::AccountHash,
-        tiered_storage::owners::OWNER_NO_OWNER,
     },
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount},
@@ -47,12 +46,11 @@ pub(super) fn create_test_account(seed: u64) -> (StoredMeta, AccountSharedData) 
 
 pub(super) fn verify_test_account(
     stored_meta: &StoredAccountMeta<'_>,
-    account: Option<&impl ReadableAccount>,
+    acc: &impl ReadableAccount,
     address: &Pubkey,
 ) {
-    let (lamports, owner, data, executable) = account
-        .map(|acc| (acc.lamports(), acc.owner(), acc.data(), acc.executable()))
-        .unwrap_or((0, &OWNER_NO_OWNER, &[], false));
+    let (lamports, owner, data, executable) =
+        (acc.lamports(), acc.owner(), acc.data(), acc.executable());
 
     assert_eq!(stored_meta.lamports(), lamports);
     assert_eq!(stored_meta.data().len(), data.len());
@@ -65,7 +63,7 @@ pub(super) fn verify_test_account(
 
 pub(super) fn verify_test_account_with_footer(
     stored_meta: &StoredAccountMeta<'_>,
-    account: Option<&impl ReadableAccount>,
+    account: &impl ReadableAccount,
     address: &Pubkey,
     footer: &TieredStorageFooter,
 ) {


### PR DESCRIPTION
#### Problem
moving to not mmapping append vec files. Soon, lifetimes of borrowed account data will be limited to a callback.

#### Summary of Changes
Rework `StorableAccountsWithHashes`. `account()` and `get()` to always return an account. If lamports=0, a default account will be returned. The easiest first step to take here is to fix the test fns for hot storage. That avoids unnecessary mess in that change.
The next change will be to push the removal of the `Option` further up the call chain.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
