### PR TITLE
account_default_if_zero_lamport always returns a value

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -64,7 +64,7 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
     pub fn get<Ret>(
         &self,
         index: usize,
-        mut callback: impl FnMut((Option<AccountForStorage>, &Pubkey, &AccountHash)) -> Ret,
+        mut callback: impl FnMut((AccountForStorage, &Pubkey, &AccountHash)) -> Ret,
     ) -> Ret {
         let pubkey = self.accounts.pubkey(index);
         let hash = if self.accounts.has_hash() {
@@ -83,7 +83,7 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
     pub fn account<Ret>(
         &self,
         index: usize,
-        callback: impl FnMut(Option<AccountForStorage<'a>>) -> Ret,
+        callback: impl FnMut(AccountForStorage<'a>) -> Ret,
     ) -> Ret {
         self.accounts
             .account_default_if_zero_lamport(index, callback)

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5989,9 +5989,7 @@ impl AccountsDb {
 
                 // See if an account overflows the append vecs in the slot.
                 accounts_and_meta_to_store.account(infos.len(), |account| {
-                    let data_len = account
-                        .map(|account| account.data().len())
-                        .unwrap_or_default();
+                    let data_len = account.data().len();
                     let data_len = (data_len + STORE_META_OVERHEAD) as u64;
                     if !self.has_space_available(slot, data_len) {
                         info!(
@@ -6015,11 +6013,7 @@ impl AccountsDb {
 
                 infos.push(AccountInfo::new(
                     StorageLocation::AppendVec(store_id, stored_account_info.offset),
-                    accounts_and_meta_to_store.account(i, |account| {
-                        account
-                            .map(|account| account.lamports())
-                            .unwrap_or_default()
-                    }),
+                    accounts_and_meta_to_store.account(i, |account| account.lamports()),
                 ));
             }
             // restore the state to available
@@ -6399,9 +6393,7 @@ impl AccountsDb {
             .map(|(i, txn)| {
                 let mut account_info = AccountInfo::default();
                 accounts_and_meta_to_store.account_default_if_zero_lamport(i, |account| {
-                    let account = account
-                        .map(|account| account.to_account_shared_data())
-                        .unwrap_or_default();
+                    let account = account.to_account_shared_data();
                     let pubkey = accounts_and_meta_to_store.pubkey(i);
                     account_info = AccountInfo::new(StorageLocation::Cached, account.lamports());
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -753,30 +753,22 @@ impl AppendVec {
                 break;
             }
             accounts.get(i, |(account, pubkey, hash)| {
-                let account_meta = account
-                    .map(|account| AccountMeta {
-                        lamports: account.lamports(),
-                        owner: *account.owner(),
-                        rent_epoch: account.rent_epoch(),
-                        executable: account.executable(),
-                    })
-                    .unwrap_or_default();
+                let account_meta = AccountMeta {
+                    lamports: account.lamports(),
+                    owner: *account.owner(),
+                    rent_epoch: account.rent_epoch(),
+                    executable: account.executable(),
+                };
 
                 let stored_meta = StoredMeta {
                     pubkey: *pubkey,
-                    data_len: account
-                        .map(|account| account.data().len())
-                        .unwrap_or_default() as u64,
+                    data_len: account.data().len() as u64,
                     write_version_obsolete: 0,
                 };
                 let meta_ptr = &stored_meta as *const StoredMeta;
                 let account_meta_ptr = &account_meta as *const AccountMeta;
                 let data_len = stored_meta.data_len as usize;
-                let data_ptr = account
-                    .as_ref()
-                    .map(|account| account.data())
-                    .unwrap_or_default()
-                    .as_ptr();
+                let data_ptr = account.data().as_ptr();
                 let hash_ptr = bytemuck::bytes_of(hash).as_ptr();
                 let ptrs = [
                     (meta_ptr as *const u8, mem::size_of::<StoredMeta>()),
@@ -983,7 +975,7 @@ pub mod tests {
         let accounts2 = (slot, &accounts[..]);
         let storable = StorableAccountsWithHashes::new_with_hashes(&accounts2, hashes.clone());
         storable.account(0, |get_account| {
-            assert!(get_account.is_none());
+            assert!(accounts_equal(&get_account, &AccountSharedData::default()));
         });
 
         // non-zero lamports, data should be correct
@@ -998,7 +990,7 @@ pub mod tests {
         let accounts2 = (slot, &accounts[..]);
         let storable = StorableAccountsWithHashes::new_with_hashes(&accounts2, hashes);
         storable.account(0, |get_account| {
-            assert!(accounts_equal(&account, &get_account.unwrap()));
+            assert!(accounts_equal(&account, &get_account));
         });
     }
 

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -356,12 +356,7 @@ mod tests {
         let mut expected_accounts_map = HashMap::new();
         for i in 0..num_accounts {
             storable_accounts.get(i, |(account, address, _account_hash)| {
-                expected_accounts_map.insert(
-                    *address,
-                    account
-                        .map(|account| account.to_account_shared_data())
-                        .unwrap_or_default(),
-                );
+                expected_accounts_map.insert(*address, account.to_account_shared_data());
             });
         }
 

--- a/accounts-db/src/tiered_storage/owners.rs
+++ b/accounts-db/src/tiered_storage/owners.rs
@@ -16,10 +16,6 @@ use {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
 pub struct OwnerOffset(pub u32);
 
-lazy_static! {
-    pub static ref OWNER_NO_OWNER: Pubkey = Pubkey::default();
-}
-
 /// Owner block holds a set of unique addresses of account owners,
 /// and an account meta has a owner_offset field for accessing
 /// it's owner address.


### PR DESCRIPTION
#### Problem
moving to not mmapping append vec files. Soon, lifetimes of borrowed account data will be limited to a callback.

#### Summary of Changes
Rework `StorableAccounts`.`account_default_if_zero_lamport()` to always return a value.
This simplifies the api and allows a callback to work better when the data's lifetime is limited. Life time changes are coming soon.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
