### PR TITLE
accounts db/refactor accounts db test- make combine_ancient_slots and shrink_ancient tests to work for both append-vec and hot-storages

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -102,6 +102,9 @@ impl AccountStorage {
             self.no_shrink_in_progress(),
             "self.no_shrink_in_progress(): {slot}"
         );
+
+        println!("{:?}", self.map);
+
         self.map.get(&slot).is_none()
     }
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -982,7 +982,8 @@ pub fn is_ancient(storage: &AccountsFile) -> bool {
     match storage {
         AccountsFile::AppendVec(_) => storage.capacity() >= get_ancient_append_vec_capacity(),
         AccountsFile::TieredStorage(_) => {
-            unimplemented!("is_ancient() is not supported for hot storage!")
+            // HotStorage doesn't support reserved size. Return true for now so that every slot is a candidate for 'ancient'?
+            true
         }
     }
 }


### PR DESCRIPTION
#### Problem

make combine_ancient_slots and shrink_ancient tests to work for both append-vec and hot-storages.

[NOTE] Current ancient storage algorithm is tired with shrink. It is based on the max_size of the storage to find candidate ancient slot. But this scheme won't work with HotStorage. We need to revisit the ancient storage algorithm for HotStorage...



#### Summary of Changes

- refactor several accounts-db related test fn to support passing different type of account files
- make combine_ancient_slots and shrink_ancient tests to work for both append-vec and hot-storages.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
