### PR TITLE
remove StorableAccounts.pubkey()

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -64,9 +64,8 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
     pub fn get<Ret>(
         &self,
         index: usize,
-        mut callback: impl FnMut((AccountForStorage, &Pubkey, &AccountHash)) -> Ret,
+        mut callback: impl FnMut(AccountForStorage, &AccountHash) -> Ret,
     ) -> Ret {
-        let pubkey = self.accounts.pubkey(index);
         let hash = if self.accounts.has_hash() {
             self.accounts.hash(index)
         } else {
@@ -74,7 +73,7 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
             item[index].borrow()
         };
         self.accounts
-            .account_default_if_zero_lamport(index, |account| callback((account, pubkey, hash)))
+            .account_default_if_zero_lamport(index, |account| callback(account, hash))
     }
 
     /// None if account at index has lamports == 0

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -754,7 +754,7 @@ impl AppendVec {
             if stop {
                 break;
             }
-            accounts.get(i, |(account, pubkey, hash)| {
+            accounts.get(i, |account, hash| {
                 let account_meta = AccountMeta {
                     lamports: account.lamports(),
                     owner: *account.owner(),
@@ -763,7 +763,7 @@ impl AppendVec {
                 };
 
                 let stored_meta = StoredMeta {
-                    pubkey: *pubkey,
+                    pubkey: *account.pubkey(),
                     data_len: account.data().len() as u64,
                     write_version_obsolete: 0,
                 };
@@ -954,9 +954,9 @@ pub mod tests {
         assert_eq!(storable.len(), pubkeys.len());
         assert!(!storable.is_empty());
         (0..2).for_each(|i| {
-            storable.get(i, |(_, pubkey, hash)| {
+            storable.get(i, |account, hash| {
                 assert_eq!(hash, &hashes[i]);
-                assert_eq!(pubkey, &pubkeys[i]);
+                assert_eq!(account.pubkey(), &pubkeys[i]);
             });
         });
     }

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -22,9 +22,6 @@ impl StakeReward {
 
 /// allow [StakeReward] to be passed to `StoreAccounts` directly without copies or vec construction
 impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
-    fn pubkey(&self, index: usize) -> &Pubkey {
-        &self.1[index].stake_pubkey
-    }
     fn account<Ret>(
         &self,
         index: usize,

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -355,8 +355,8 @@ mod tests {
 
         let mut expected_accounts_map = HashMap::new();
         for i in 0..num_accounts {
-            storable_accounts.get(i, |(account, address, _account_hash)| {
-                expected_accounts_map.insert(*address, account.to_account_shared_data());
+            storable_accounts.get(i, |account, _account_hash| {
+                expected_accounts_map.insert(*account.pubkey(), account.to_account_shared_data());
             });
         }
 

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -747,12 +747,12 @@ impl HotStorageWriter {
         let total_input_accounts = len - skip;
         let mut stored_infos = Vec::with_capacity(total_input_accounts);
         for i in skip..len {
-            accounts.get::<TieredStorageResult<()>>(i, |(account, address, _account_hash)| {
+            accounts.get::<TieredStorageResult<()>>(i, |account, _account_hash| {
                 let index_entry = AccountIndexWriterEntry {
-                    address: *address,
+                    address: *account.pubkey(),
                     offset: HotAccountOffset::new(cursor)?,
                 };
-                address_range.update(address);
+                address_range.update(account.pubkey());
 
                 // Obtain necessary fields from the account, or default fields
                 // for a zero-lamport account in the None case.
@@ -1559,11 +1559,11 @@ mod tests {
                 .unwrap()
                 .unwrap();
 
-            storable_accounts.get(i, |(account, address, _account_hash)| {
+            storable_accounts.get(i, |account, _account_hash| {
                 verify_test_account(
                     &stored_account_meta,
                     &account.to_account_shared_data(),
-                    address,
+                    account.pubkey(),
                 );
             });
 
@@ -1582,11 +1582,11 @@ mod tests {
                 .unwrap()
                 .unwrap();
 
-            storable_accounts.get(stored_info.offset, |(account, address, _account_hash)| {
+            storable_accounts.get(stored_info.offset, |account, _account_hash| {
                 verify_test_account(
                     &stored_account_meta,
                     &account.to_account_shared_data(),
-                    address,
+                    account.pubkey(),
                 );
             });
         }
@@ -1596,8 +1596,12 @@ mod tests {
 
         // first, we verify everything
         for (i, stored_meta) in accounts.iter().enumerate() {
-            storable_accounts.get(i, |(account, address, _account_hash)| {
-                verify_test_account(stored_meta, &account.to_account_shared_data(), address);
+            storable_accounts.get(i, |account, _account_hash| {
+                verify_test_account(
+                    stored_meta,
+                    &account.to_account_shared_data(),
+                    account.pubkey(),
+                );
             });
         }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5047,7 +5047,7 @@ impl Bank {
         (0..accounts.len()).for_each(|i| {
             accounts.account(i, |account| {
                 self.stakes_cache.check_and_store(
-                    accounts.pubkey(i),
+                    account.pubkey(),
                     &account,
                     new_warmup_cooldown_rate_epoch,
                 )


### PR DESCRIPTION
#### Problem
moving to not mmapping append vec files. Soon, lifetimes of borrowed account data will be limited to a callback.

#### Summary of Changes
remove StorableAccounts.pubkey()
This simplifies the api and allows the single call for `account()` to get a pubkey and the account itself. Everyone who uses the api needs both pieces of data.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
