### PR TITLE
Deprecate static lists of reserved keys

### DIFF
--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -565,6 +565,7 @@ pub mod config {
     since = "2.0.0",
     note = "Please use `solana_sdk::reserved_account_keys::ReservedAccountKeys` instead"
 )]
+#[allow(deprecated)]
 pub mod sdk_ids {
     use {
         crate::{

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -11,6 +11,8 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 
+#[allow(deprecated)]
+pub use builtins::{BUILTIN_PROGRAMS_KEYS, MAYBE_BUILTIN_KEY_OR_SYSVAR};
 use {
     crate::{
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
@@ -21,41 +23,48 @@ use {
         sanitize::{Sanitize, SanitizeError},
         short_vec, system_instruction, system_program, sysvar, wasm_bindgen,
     },
-    lazy_static::lazy_static,
     std::{collections::HashSet, convert::TryFrom, str::FromStr},
 };
 
-lazy_static! {
-    // This will be deprecated and so this list shouldn't be modified
-    pub static ref BUILTIN_PROGRAMS_KEYS: [Pubkey; 10] = {
-        let parse = |s| Pubkey::from_str(s).unwrap();
-        [
-            parse("Config1111111111111111111111111111111111111"),
-            parse("Feature111111111111111111111111111111111111"),
-            parse("NativeLoader1111111111111111111111111111111"),
-            parse("Stake11111111111111111111111111111111111111"),
-            parse("StakeConfig11111111111111111111111111111111"),
-            parse("Vote111111111111111111111111111111111111111"),
-            system_program::id(),
-            bpf_loader::id(),
-            bpf_loader_deprecated::id(),
-            bpf_loader_upgradeable::id(),
-        ]
-    };
-}
+#[deprecated(
+    since = "2.0.0",
+    note = "please use `solana_sdk::reserved_account_keys::ReservedAccountKeys` instead"
+)]
+#[allow(deprecated)]
+mod builtins {
+    use {super::*, lazy_static::lazy_static};
 
-lazy_static! {
-    // Each element of a key is a u8. We use key[0] as an index into this table of 256 boolean
-    // elements, to store whether or not the first element of any key is present in the static
-    // lists of built-in-program keys or system ids. By using this lookup table, we can very
-    // quickly determine that a key under consideration cannot be in either of these lists (if
-    // the value is "false"), or might be in one of these lists (if the value is "true")
-    pub static ref MAYBE_BUILTIN_KEY_OR_SYSVAR: [bool; 256] = {
-        let mut temp_table: [bool; 256] = [false; 256];
-        BUILTIN_PROGRAMS_KEYS.iter().for_each(|key| temp_table[key.0[0] as usize] = true);
-        sysvar::ALL_IDS.iter().for_each(|key| temp_table[key.0[0] as usize] = true);
-        temp_table
-    };
+    lazy_static! {
+        pub static ref BUILTIN_PROGRAMS_KEYS: [Pubkey; 10] = {
+            let parse = |s| Pubkey::from_str(s).unwrap();
+            [
+                parse("Config1111111111111111111111111111111111111"),
+                parse("Feature111111111111111111111111111111111111"),
+                parse("NativeLoader1111111111111111111111111111111"),
+                parse("Stake11111111111111111111111111111111111111"),
+                parse("StakeConfig11111111111111111111111111111111"),
+                parse("Vote111111111111111111111111111111111111111"),
+                system_program::id(),
+                bpf_loader::id(),
+                bpf_loader_deprecated::id(),
+                bpf_loader_upgradeable::id(),
+            ]
+        };
+    }
+
+    lazy_static! {
+        // Each element of a key is a u8. We use key[0] as an index into this table of 256 boolean
+        // elements, to store whether or not the first element of any key is present in the static
+        // lists of built-in-program keys or system ids. By using this lookup table, we can very
+        // quickly determine that a key under consideration cannot be in either of these lists (if
+        // the value is "false"), or might be in one of these lists (if the value is "true")
+        pub static ref MAYBE_BUILTIN_KEY_OR_SYSVAR: [bool; 256] = {
+            let mut temp_table: [bool; 256] = [false; 256];
+            BUILTIN_PROGRAMS_KEYS.iter().for_each(|key| temp_table[key.0[0] as usize] = true);
+            sysvar::ALL_IDS.iter().for_each(|key| temp_table[key.0[0] as usize] = true);
+            temp_table
+        };
+    }
 }
 
 #[deprecated(

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -81,10 +81,9 @@
 //!
 //! [sysvardoc]: https://docs.solanalabs.com/runtime/sysvars
 
-use {
-    crate::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey},
-    lazy_static::lazy_static,
-};
+use crate::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
+#[allow(deprecated)]
+pub use sysvar_ids::ALL_IDS;
 
 pub mod clock;
 pub mod epoch_rewards;
@@ -99,22 +98,29 @@ pub mod slot_hashes;
 pub mod slot_history;
 pub mod stake_history;
 
-lazy_static! {
-    // This will be deprecated and so this list shouldn't be modified
-    pub static ref ALL_IDS: Vec<Pubkey> = vec![
-        clock::id(),
-        epoch_schedule::id(),
-        #[allow(deprecated)]
-        fees::id(),
-        #[allow(deprecated)]
-        recent_blockhashes::id(),
-        rent::id(),
-        rewards::id(),
-        slot_hashes::id(),
-        slot_history::id(),
-        stake_history::id(),
-        instructions::id(),
-    ];
+#[deprecated(
+    since = "2.0.0",
+    note = "please use `solana_sdk::reserved_account_keys::ReservedAccountKeys` instead"
+)]
+mod sysvar_ids {
+    use {super::*, lazy_static::lazy_static};
+    lazy_static! {
+        // This will be deprecated and so this list shouldn't be modified
+        pub static ref ALL_IDS: Vec<Pubkey> = vec![
+            clock::id(),
+            epoch_schedule::id(),
+            #[allow(deprecated)]
+            fees::id(),
+            #[allow(deprecated)]
+            recent_blockhashes::id(),
+            rent::id(),
+            rewards::id(),
+            slot_hashes::id(),
+            slot_history::id(),
+            stake_history::id(),
+            instructions::id(),
+        ];
+    }
 }
 
 /// Returns `true` of the given `Pubkey` is a sysvar account.
@@ -122,6 +128,7 @@ lazy_static! {
     since = "2.0.0",
     note = "please check the account's owner or use solana_sdk::reserved_account_keys::ReservedAccountKeys instead"
 )]
+#[allow(deprecated)]
 pub fn is_sysvar_id(id: &Pubkey) -> bool {
     ALL_IDS.iter().any(|key| key == id)
 }

--- a/sdk/src/reserved_account_keys.rs
+++ b/sdk/src/reserved_account_keys.rs
@@ -188,6 +188,7 @@ lazy_static! {
 
 #[cfg(test)]
 mod tests {
+    #![allow(deprecated)]
     use {
         super::*,
         solana_program::{message::legacy::BUILTIN_PROGRAMS_KEYS, sysvar::ALL_IDS},


### PR DESCRIPTION
#### Problem
Static lists are publicly exposed in the sdk crates and should be deprecated in favor of using `ReservedAccountKeys`

#### Summary of Changes
Deprecating `lazy_static` static variables is a little tricky because of the macro magic they use. This PR wraps the static lists in a deprecated module and then re-exports the lists to avoid breaking the API. This little trick allows users of the static lists to receive proper deprecation warnings.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
