### PR TITLE
add get_stored_account_meta_callback to storage

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8735,17 +8735,17 @@ impl AccountsDb {
             duplicates_this_slot
                 .into_iter()
                 .for_each(|(pubkey, (_slot, info))| {
-                    let duplicate = storage
+                    storage
                         .accounts
-                        .get_stored_account_meta(info.offset())
-                        .unwrap()
-                        .0;
-                    assert_eq!(&pubkey, duplicate.pubkey());
-                    stored_size_alive = stored_size_alive.saturating_sub(duplicate.stored_size());
-                    if !duplicate.is_zero_lamport() {
-                        accounts_data_len =
-                            accounts_data_len.saturating_sub(duplicate.data().len() as u64);
-                    }
+                        .get_stored_account_meta_callback(info.offset(), |duplicate| {
+                            assert_eq!(&pubkey, duplicate.pubkey());
+                            stored_size_alive =
+                                stored_size_alive.saturating_sub(duplicate.stored_size());
+                            if !duplicate.is_zero_lamport() {
+                                accounts_data_len =
+                                    accounts_data_len.saturating_sub(duplicate.data().len() as u64);
+                            }
+                        });
                 });
         }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -538,6 +538,17 @@ impl AppendVec {
         ))
     }
 
+    /// calls `callback` with the account located at the specified index offset.
+    pub fn get_stored_account_meta_callback<'a>(
+        &'a self,
+        offset: usize,
+        mut callback: impl FnMut(StoredAccountMeta<'a>),
+    ) {
+        if let Some((account, _offset)) = self.get_stored_account_meta(offset) {
+            callback(account)
+        }
+    }
+
     /// return an `AccountSharedData` for an account at `offset`.
     /// This fn can efficiently return exactly what is needed by a caller.
     pub(crate) fn get_account_shared_data(&self, offset: usize) -> Option<AccountSharedData> {

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -526,6 +526,18 @@ impl HotStorageReader {
         Ok(data)
     }
 
+    /// calls `callback` with the account located at the specified index offset.
+    pub fn get_stored_account_meta_callback<'a>(
+        &'a self,
+        index_offset: IndexOffset,
+        mut callback: impl FnMut(StoredAccountMeta<'a>),
+    ) -> TieredStorageResult<()> {
+        if let Some((account, _offset)) = self.get_stored_account_meta(index_offset)? {
+            callback(account)
+        }
+        Ok(())
+    }
+
     /// Returns the account located at the specified index offset.
     pub fn get_stored_account_meta(
         &self,

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -85,6 +85,17 @@ impl TieredStorageReader {
         }
     }
 
+    /// calls `callback` with the account located at the specified index offset.
+    pub fn get_stored_account_meta_callback<'a>(
+        &'a self,
+        index_offset: IndexOffset,
+        callback: impl FnMut(StoredAccountMeta<'a>),
+    ) -> TieredStorageResult<()> {
+        match self {
+            Self::Hot(hot) => hot.get_stored_account_meta_callback(index_offset, callback),
+        }
+    }
+
     /// Returns Ok(index_of_matching_owner) if the account owner at
     /// `account_offset` is one of the pubkeys in `owners`.
     ///


### PR DESCRIPTION
#### Problem
moving to not mmapping append vec files. Soon, lifetimes of borrowed account data will be limited to a callback.

#### Summary of Changes
Add `get_stored_account_meta_callback(offset)` and implement a single caller. `get_stored_account_meta_callback()` can return an account with a lifetime scoped to the callback.
Soon, storages will not be mmapped. This will mean lifetimes are different (and shorter). 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
