### PR TITLE
Require `Default` for account `get` fns.

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -61,7 +61,7 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
     }
 
     /// get all account fields at 'index'
-    pub fn get<Ret>(
+    pub fn get<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage, &AccountHash) -> Ret,
@@ -79,7 +79,7 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
     /// None if account at index has lamports == 0
     /// Otherwise, Some(account)
     /// This is the only way to access the account.
-    pub fn account<Ret>(
+    pub fn account<Ret: Default>(
         &self,
         index: usize,
         callback: impl FnMut(AccountForStorage<'a>) -> Ret,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9631,7 +9631,7 @@ pub mod tests {
     where
         AccountForStorage<'a>: From<&'a T>,
     {
-        fn account<Ret>(
+        fn account<Ret: Default>(
             &self,
             index: usize,
             mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -22,7 +22,7 @@ impl StakeReward {
 
 /// allow [StakeReward] to be passed to `StoreAccounts` directly without copies or vec construction
 impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -97,10 +97,13 @@ lazy_static! {
 /// All legacy callers do not have a unique slot per account to store.
 pub trait StorableAccounts<'a>: Sync {
     /// account at 'index'
-    fn account<Ret>(&self, index: usize, callback: impl FnMut(AccountForStorage<'a>) -> Ret)
-        -> Ret;
+    fn account<Ret: Default>(
+        &self,
+        index: usize,
+        callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+    ) -> Ret;
     /// None if account is zero lamports
-    fn account_default_if_zero_lamport<Ret>(
+    fn account_default_if_zero_lamport<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
@@ -163,7 +166,7 @@ impl<'a, T: ReadableAccount + Sync> StorableAccounts<'a> for StorableAccountsMov
 where
     AccountForStorage<'a>: From<(&'a Pubkey, &'a T)>,
 {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
@@ -187,7 +190,7 @@ impl<'a: 'b, 'b, T: ReadableAccount + Sync + 'a> StorableAccounts<'a>
 where
     AccountForStorage<'a>: From<(&'a Pubkey, &'a T)>,
 {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
@@ -209,7 +212,7 @@ impl<'a, T: ReadableAccount + Sync> StorableAccounts<'a> for (Slot, &'a [&'a (Pu
 where
     AccountForStorage<'a>: From<(&'a Pubkey, &'a T)>,
 {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
@@ -229,7 +232,7 @@ where
 }
 
 impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>]) {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
@@ -318,7 +321,7 @@ impl<'a> StorableAccountsBySlot<'a> {
 }
 
 impl<'a> StorableAccounts<'a> for StorableAccountsBySlot<'a> {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
@@ -351,7 +354,7 @@ impl<'a> StorableAccounts<'a> for StorableAccountsBySlot<'a> {
 /// this tuple contains a single different source slot that applies to all accounts
 /// accounts are StoredAccountMeta
 impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>], Slot) {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,


### PR DESCRIPTION
#### Problem
moving to not mmapping append vec files. Soon, lifetimes of borrowed account data will be limited to a callback.

#### Summary of Changes
Various `get()` fns will need to support `Default` for return values from callbacks. This pr takes care of the noise of adding that requirement. Follow on prs will require it. The storage get() fns will optionally call the callback depending on whether the offset is valid or not. The result is we need to be able to return a default value for the return type.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
