### PR TITLE
add `for<>` to callback on get fns

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -82,7 +82,7 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
     pub fn account<Ret>(
         &self,
         index: usize,
-        callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        callback: impl for<'c> FnMut(AccountForStorage<'c>) -> Ret,
     ) -> Ret {
         self.accounts
             .account_default_if_zero_lamport(index, callback)

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9634,7 +9634,7 @@ pub mod tests {
         fn account<Ret>(
             &self,
             index: usize,
-            mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+            mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
         ) -> Ret {
             callback(self.1[index].1.into())
         }

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -25,7 +25,7 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         let entry = &self.1[index];
         callback((&self.1[index].stake_pubkey, &entry.stake_account).into())

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -97,13 +97,16 @@ lazy_static! {
 /// All legacy callers do not have a unique slot per account to store.
 pub trait StorableAccounts<'a>: Sync {
     /// account at 'index'
-    fn account<Ret>(&self, index: usize, callback: impl FnMut(AccountForStorage<'a>) -> Ret)
-        -> Ret;
+    fn account<Ret>(
+        &self,
+        index: usize,
+        callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
+    ) -> Ret;
     /// None if account is zero lamports
     fn account_default_if_zero_lamport<Ret>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         self.account(index, |account| {
             callback(if account.lamports() != 0 {
@@ -166,7 +169,7 @@ where
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         callback((self.accounts[index].0, self.accounts[index].1).into())
     }
@@ -190,7 +193,7 @@ where
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'c> FnMut(AccountForStorage<'c>) -> Ret,
     ) -> Ret {
         callback((self.1[index].0, self.1[index].1).into())
     }
@@ -212,7 +215,7 @@ where
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         callback((&self.1[index].0, &self.1[index].1).into())
     }
@@ -232,7 +235,7 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>]) {
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         callback(self.1[index].into())
     }
@@ -321,7 +324,7 @@ impl<'a> StorableAccounts<'a> for StorableAccountsBySlot<'a> {
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         let indexes = self.find_internal_index(index);
         callback(self.slots_and_accounts[indexes.0].1[indexes.1].into())
@@ -354,7 +357,7 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>], Slot) 
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         callback(self.1[index].into())
     }


### PR DESCRIPTION
#### Problem
moving to not mmapping append vec files. Soon, lifetimes of borrowed account data will be limited to a callback.

#### Summary of Changes
Various `get()` fns will need to support `for<>` behavior for local lifetimes that only last during the callback itself. Follow on prs will require it. This pr makes the `for` change only with no side effects.
The basic idea is that the lifetime of the account reference passed into the callback will be unrelated to any lifetime of &self or any other lifetime we have available. `for` syntax enables that.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
