### PR TITLE
metrics/check for empty points submission before calling writer.write

### DIFF
--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -271,14 +271,18 @@ impl MetricsAgent {
         let now = Instant::now();
         let secs_since_last_write = now.duration_since(last_write_time).as_secs();
 
-        writer.write(Self::combine_points(
+        let combined_points = Self::combine_points(
             max_points,
             max_points_per_sec,
             secs_since_last_write,
             points_buffered,
             points,
             counters,
-        ));
+        );
+
+        if !combined_points.is_empty() {
+            writer.write(combined_points);
+        }
 
         now
     }


### PR DESCRIPTION
#### Problem

```
   0: rust_begin_unwind
             at /rustc/f688dd684faca5b31b156fac2c6e0ae81fc9bc90/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_fmt
             at /rustc/f688dd684faca5b31b156fac2c6e0ae81fc9bc90/library/core/src/panicking.rs:72:14
   2: core::panicking::assert_failed_inner
             at /rustc/f688dd684faca5b31b156fac2c6e0ae81fc9bc90/library/core/src/panicking.rs:342:17
   3: core::panicking::assert_failed
             at /rustc/f688dd684faca5b31b156fac2c6e0ae81fc9bc90/library/core/src/panicking.rs:297:5
   4: solana_metrics::metrics::test::test_flush_before_drop
             at ./src/metrics.rs:726:9
   5: solana_metrics::metrics::test::test_flush_before_drop::{{closure}}
             at ./src/metrics.rs:719:32
   6: core::ops::function::FnOnce::call_once
             at /rustc/f688dd684faca5b31b156fac2c6e0ae81fc9bc90/library/core/src/ops/function.rs:250:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/f688dd684faca5b31b156fac2c6e0ae81fc9bc90/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
test metrics::test::test_flush_before_drop ... FAILED
```

`test_flush_before_drop` fails from time to time on CI. 

The reason for the failure is on the assert, which expects two points to be
written. The two points expected are 'point 1' and a 'metrics' point, which
indicates how many points are submitted, such as. 

```
DataPoint { name: "point 1", timestamp: SystemTime { tv_sec: 1713288972, tv_nsec: 247586691 }, tags: [], fields: [] }
DataPoint { name: "metrics", timestamp: SystemTime { tv_sec: 1713288972, tv_nsec: 247701960 }, tags: [], fields: [("points_written", "1i"), ("num_points", "1i"), ("points_lost", "0i"), ("points_buffered", "0i"), ("secs_since_last_write", "0i") 
```


However, depending on when the flush is called, there is a chance that extra
flush is called with empty points, then one extra point will be written.

```
DataPoint { name: "metrics", timestamp: SystemTime { tv_sec: 1713288972, tv_nsec: 247767965 }, tags: [], fields: [("points_written", "0i"), ("num_points", "0i"), ("points_lost", "0i"), ("points_buffered", "0i"), ("secs_since_last_write", "0i") 
```

Submitting a metrics for empty 'points_written' is a waste. We should avoid it.



#### Summary of Changes

When points to submit are empty, i.e. nothing to submit, don't call
writer.write().


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
