### PR TITLE
Refactors duplicate code in accounts startup verification

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3129,21 +3129,13 @@ impl Bank {
     /// return false if bg hash verification has not completed yet
     /// if hash verification failed, a panic will occur
     pub fn is_startup_verification_complete(&self) -> bool {
-        self.rc
-            .accounts
-            .accounts_db
-            .verify_accounts_hash_in_bg
-            .check_complete()
+        self.has_initial_accounts_hash_verification_completed()
     }
 
     /// This can occur because it completed in the background
     /// or if the verification was run in the foreground.
     pub fn set_startup_verification_complete(&self) {
-        self.rc
-            .accounts
-            .accounts_db
-            .verify_accounts_hash_in_bg
-            .verification_complete()
+        self.set_initial_accounts_hash_verification_completed();
     }
 
     pub fn get_fee_for_message_with_lamports_per_signature(


### PR DESCRIPTION
#### Problem

There's duplicate code in `Bank` for checking if the initial accounts hash calculation has completed.


#### Summary of Changes

Have the `xxx_startup_verification_complete()` functions call the `xxx_initial_accounts_hash_verification_complete()` functions. 

A follow-up PR can then easily remove duplicate functions from callers.