### PR TITLE
get_stored_account_meta_callback returns Ret

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -61,7 +61,7 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
     }
 
     /// get all account fields at 'index'
-    pub fn get<Ret>(
+    pub fn get<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage, &AccountHash) -> Ret,
@@ -79,7 +79,7 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
     /// None if account at index has lamports == 0
     /// Otherwise, Some(account)
     /// This is the only way to access the account.
-    pub fn account<Ret>(
+    pub fn account<Ret: Default>(
         &self,
         index: usize,
         callback: impl FnMut(AccountForStorage<'a>) -> Ret,

--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -82,7 +82,7 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
     pub fn account<Ret: Default>(
         &self,
         index: usize,
-        callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        callback: impl for<'c> FnMut(AccountForStorage<'c>) -> Ret,
     ) -> Ret {
         self.accounts
             .account_default_if_zero_lamport(index, callback)

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9631,7 +9631,7 @@ pub mod tests {
     where
         AccountForStorage<'a>: From<&'a T>,
     {
-        fn account<Ret>(
+        fn account<Ret: Default>(
             &self,
             index: usize,
             mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9634,7 +9634,7 @@ pub mod tests {
         fn account<Ret: Default>(
             &self,
             index: usize,
-            mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+            mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
         ) -> Ret {
             callback(self.1[index].1.into())
         }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -185,7 +185,7 @@ pub(crate) enum ScanAccountStorageData {
 pub(crate) struct AliveAccounts<'a> {
     /// slot the accounts are currently stored in
     pub(crate) slot: Slot,
-    pub(crate) accounts: Vec<&'a StoredAccountMeta<'a>>,
+    pub(crate) accounts: Vec<&'a AccountFromStorage>,
     pub(crate) bytes: usize,
 }
 
@@ -225,12 +225,12 @@ pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
     fn add(
         &mut self,
         ref_count: u64,
-        account: &'a StoredAccountMeta<'a>,
+        account: &'a AccountFromStorage,
         slot_list: &[(Slot, AccountInfo)],
     );
     fn len(&self) -> usize;
     fn alive_bytes(&self) -> usize;
-    fn alive_accounts(&self) -> &Vec<&'a StoredAccountMeta<'a>>;
+    fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage>;
 }
 
 impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
@@ -248,7 +248,7 @@ impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
     fn add(
         &mut self,
         _ref_count: u64,
-        account: &'a StoredAccountMeta<'a>,
+        account: &'a AccountFromStorage,
         _slot_list: &[(Slot, AccountInfo)],
     ) {
         self.accounts.push(account);
@@ -260,7 +260,7 @@ impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
     fn alive_bytes(&self) -> usize {
         self.bytes
     }
-    fn alive_accounts(&self) -> &Vec<&'a StoredAccountMeta<'a>> {
+    fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage> {
         &self.accounts
     }
 }
@@ -282,7 +282,7 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
     fn add(
         &mut self,
         ref_count: u64,
-        account: &'a StoredAccountMeta<'a>,
+        account: &'a AccountFromStorage,
         slot_list: &[(Slot, AccountInfo)],
     ) {
         let other = if ref_count == 1 {
@@ -313,7 +313,7 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
             .saturating_add(self.many_refs_old_alive.alive_bytes())
             .saturating_add(self.many_refs_this_is_newest_alive.alive_bytes())
     }
-    fn alive_accounts(&self) -> &Vec<&'a StoredAccountMeta<'a>> {
+    fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage> {
         unimplemented!("illegal use");
     }
 }
@@ -396,7 +396,7 @@ impl CurrentAncientAccountsFile {
 
         let previous_available = self.accounts_file().accounts.remaining_bytes();
         let timing = db.store_accounts_frozen(
-            (self.slot(), accounts, accounts_to_store.slot()),
+            (self.slot(), accounts, accounts_to_store.slot(), db),
             None::<Vec<AccountHash>>,
             self.accounts_file(),
         );
@@ -533,8 +533,31 @@ struct LoadAccountsIndexForShrink<'a, T: ShrinkCollectRefs<'a>> {
     index_entries_being_shrunk: Vec<AccountMapEntry<AccountInfo>>,
 }
 
-pub struct GetUniqueAccountsResult<'a> {
-    pub stored_accounts: Vec<StoredAccountMeta<'a>>,
+#[derive(Debug)]
+pub struct AccountFromStorage {
+    // pub slot: Slot, // would like to get rid of slot here
+    pub index_info: AccountInfo,
+    pub data_len: u64,
+    pub pubkey: Pubkey,
+}
+
+impl ZeroLamport for AccountFromStorage {
+    fn is_zero_lamport(&self) -> bool {
+        self.index_info.is_zero_lamport()
+    }
+}
+
+impl AccountFromStorage {
+    pub fn pubkey(&self) -> &Pubkey {
+        &self.pubkey
+    }
+    pub fn stored_size(&self) -> usize {
+        aligned_stored_size(self.data_len as usize)
+    }
+}
+
+pub struct GetUniqueAccountsResult {
+    pub stored_accounts: Vec<AccountFromStorage>,
     pub capacity: u64,
 }
 
@@ -3690,7 +3713,7 @@ impl AccountsDb {
     /// return sum of account size for all alive accounts
     fn load_accounts_index_for_shrink<'a, T: ShrinkCollectRefs<'a>>(
         &self,
-        accounts: &'a [StoredAccountMeta<'a>],
+        accounts: &'a [AccountFromStorage],
         stats: &ShrinkStats,
         slot_to_shrink: Slot,
     ) -> LoadAccountsIndexForShrink<'a, T> {
@@ -3753,16 +3776,30 @@ impl AccountsDb {
     pub fn get_unique_accounts_from_storage<'a>(
         &self,
         store: &'a Arc<AccountStorageEntry>,
-    ) -> GetUniqueAccountsResult<'a> {
+    ) -> GetUniqueAccountsResult {
         let mut stored_accounts: HashMap<Pubkey, StoredAccountMeta> = HashMap::new();
         let capacity = store.capacity();
         store.accounts.account_iter().for_each(|account| {
             stored_accounts.insert(*account.pubkey(), account);
         });
 
+        // let slot = store.slot();
         // sort by pubkey to keep account index lookups close
         let mut stored_accounts = stored_accounts.drain().map(|(_k, v)| v).collect::<Vec<_>>();
         stored_accounts.sort_unstable_by(|a, b| a.pubkey().cmp(b.pubkey()));
+
+        let stored_accounts = stored_accounts
+            .into_iter()
+            .map(|v| AccountFromStorage {
+                /* slot, */
+                index_info: AccountInfo::new(
+                    StorageLocation::AppendVec(0, v.offset()),
+                    v.lamports(),
+                ),
+                pubkey: *v.pubkey(),
+                data_len: v.data_len(),
+            })
+            .collect::<Vec<_>>();
 
         GetUniqueAccountsResult {
             stored_accounts,
@@ -3774,7 +3811,7 @@ impl AccountsDb {
         &self,
         store: &'a Arc<AccountStorageEntry>,
         stats: &ShrinkStats,
-    ) -> GetUniqueAccountsResult<'a> {
+    ) -> GetUniqueAccountsResult {
         let (result, storage_read_elapsed_us) =
             measure_us!(self.get_unique_accounts_from_storage(store));
         stats
@@ -3788,7 +3825,7 @@ impl AccountsDb {
     pub(crate) fn shrink_collect<'a: 'b, 'b, T: ShrinkCollectRefs<'b>>(
         &self,
         store: &'a Arc<AccountStorageEntry>,
-        unique_accounts: &'b GetUniqueAccountsResult<'b>,
+        unique_accounts: &'b GetUniqueAccountsResult,
         stats: &ShrinkStats,
     ) -> ShrinkCollect<'b, T> {
         let slot = store.slot();
@@ -3999,7 +4036,12 @@ impl AccountsDb {
             // without use of rather wide locks in this whole function, because we're
             // mutating rooted slots; There should be no writers to them.
             stats_sub.store_accounts_timing = self.store_accounts_frozen(
-                (slot, &shrink_collect.alive_accounts.alive_accounts()[..]),
+                (
+                    slot,
+                    &shrink_collect.alive_accounts.alive_accounts()[..],
+                    slot,
+                    self,
+                ),
                 None::<Vec<AccountHash>>,
                 shrink_in_progress.new_storage(),
             );
@@ -4262,7 +4304,7 @@ impl AccountsDb {
     /// returns the pubkeys that are in 'accounts' that are already in 'existing_ancient_pubkeys'
     /// Also updated 'existing_ancient_pubkeys' to include all pubkeys in 'accounts' since they will soon be written into the ancient slot.
     fn get_keys_to_unref_ancient<'a>(
-        accounts: &'a [&StoredAccountMeta<'_>],
+        accounts: &'a [&AccountFromStorage],
         existing_ancient_pubkeys: &mut HashSet<Pubkey>,
     ) -> HashSet<&'a Pubkey> {
         let mut unref = HashSet::<&Pubkey>::default();
@@ -4284,7 +4326,7 @@ impl AccountsDb {
     /// As a side effect, on exit, 'existing_ancient_pubkeys' will now contain all pubkeys in 'accounts'.
     fn unref_accounts_already_in_storage(
         &self,
-        accounts: &[&StoredAccountMeta<'_>],
+        accounts: &[&AccountFromStorage],
         existing_ancient_pubkeys: &mut HashSet<Pubkey>,
     ) {
         let unref = Self::get_keys_to_unref_ancient(accounts, existing_ancient_pubkeys);

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -137,24 +137,28 @@ impl AccountsFile {
     }
 
     /// calls `callback` with the account located at the specified index offset.
-    pub fn get_stored_account_meta_callback<'a>(
+    pub fn get_stored_account_meta_callback<'a, Ret: Default>(
         &'a self,
         offset: usize,
-        callback: impl FnMut(StoredAccountMeta<'a>),
-    ) {
+        callback: impl FnMut(StoredAccountMeta<'a>) -> Ret,
+    ) -> Ret {
         match self {
             Self::AppendVec(av) => av.get_stored_account_meta_callback(offset, callback),
             // Note: The conversion here is needed as the AccountsDB currently
             // assumes all offsets are multiple of 8 while TieredStorage uses
             // IndexOffset that is equivalent to AccountInfo::reduced_offset.
-            Self::TieredStorage(ts) => {
-                if let Some(reader) = ts.reader() {
-                    _ = reader.get_stored_account_meta_callback(
-                        IndexOffset(AccountInfo::get_reduced_offset(offset)),
-                        callback,
-                    );
-                }
-            }
+            Self::TieredStorage(ts) => ts
+                .reader()
+                .map(|reader| {
+                    reader
+                        .get_stored_account_meta_callback(
+                            IndexOffset(AccountInfo::get_reduced_offset(offset)),
+                            callback,
+                        )
+                        .ok()
+                })
+                .flatten()
+                .unwrap_or_default(),
         }
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -541,14 +541,14 @@ impl AppendVec {
     }
 
     /// calls `callback` with the account located at the specified index offset.
-    pub fn get_stored_account_meta_callback<'a>(
+    pub fn get_stored_account_meta_callback<'a, Ret: Default>(
         &'a self,
         offset: usize,
-        mut callback: impl FnMut(StoredAccountMeta<'a>),
-    ) {
-        if let Some((account, _offset)) = self.get_stored_account_meta(offset) {
-            callback(account)
-        }
+        mut callback: impl FnMut(StoredAccountMeta<'a>) -> Ret,
+    ) -> Ret {
+        self.get_stored_account_meta(offset)
+            .map(|(account, _offset)| callback(account))
+            .unwrap_or_default()
     }
 
     /// return an `AccountSharedData` for an account at `offset`.

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -22,7 +22,7 @@ impl StakeReward {
 
 /// allow [StakeReward] to be passed to `StoreAccounts` directly without copies or vec construction
 impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -25,7 +25,7 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
     fn account<Ret: Default>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         let entry = &self.1[index];
         callback((&self.1[index].stake_pubkey, &entry.stake_account).into())

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -97,10 +97,13 @@ lazy_static! {
 /// All legacy callers do not have a unique slot per account to store.
 pub trait StorableAccounts<'a>: Sync {
     /// account at 'index'
-    fn account<Ret>(&self, index: usize, callback: impl FnMut(AccountForStorage<'a>) -> Ret)
-        -> Ret;
+    fn account<Ret: Default>(
+        &self,
+        index: usize,
+        callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+    ) -> Ret;
     /// None if account is zero lamports
-    fn account_default_if_zero_lamport<Ret>(
+    fn account_default_if_zero_lamport<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
@@ -163,7 +166,7 @@ impl<'a, T: ReadableAccount + Sync> StorableAccounts<'a> for StorableAccountsMov
 where
     AccountForStorage<'a>: From<(&'a Pubkey, &'a T)>,
 {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
@@ -187,7 +190,7 @@ impl<'a: 'b, 'b, T: ReadableAccount + Sync + 'a> StorableAccounts<'a>
 where
     AccountForStorage<'a>: From<(&'a Pubkey, &'a T)>,
 {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
@@ -209,7 +212,7 @@ impl<'a, T: ReadableAccount + Sync> StorableAccounts<'a> for (Slot, &'a [&'a (Pu
 where
     AccountForStorage<'a>: From<(&'a Pubkey, &'a T)>,
 {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
@@ -229,7 +232,7 @@ where
 }
 
 impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>]) {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
@@ -318,7 +321,7 @@ impl<'a> StorableAccountsBySlot<'a> {
 }
 
 impl<'a> StorableAccounts<'a> for StorableAccountsBySlot<'a> {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
@@ -351,7 +354,7 @@ impl<'a> StorableAccounts<'a> for StorableAccountsBySlot<'a> {
 /// this tuple contains a single different source slot that applies to all accounts
 /// accounts are StoredAccountMeta
 impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>], Slot) {
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -97,7 +97,7 @@ lazy_static! {
 /// All legacy callers do not have a unique slot per account to store.
 pub trait StorableAccounts<'a>: Sync {
     /// account at 'index'
-    fn account<Ret>(
+    fn account<Ret: Default>(
         &self,
         index: usize,
         callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -97,16 +97,16 @@ lazy_static! {
 /// All legacy callers do not have a unique slot per account to store.
 pub trait StorableAccounts<'a>: Sync {
     /// account at 'index'
-    fn account<Ret: Default>(
+    fn account<Ret>(
         &self,
         index: usize,
-        callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret;
     /// None if account is zero lamports
     fn account_default_if_zero_lamport<Ret: Default>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         self.account(index, |account| {
             callback(if account.lamports() != 0 {
@@ -169,7 +169,7 @@ where
     fn account<Ret: Default>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         callback((self.accounts[index].0, self.accounts[index].1).into())
     }
@@ -193,7 +193,7 @@ where
     fn account<Ret: Default>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'c> FnMut(AccountForStorage<'c>) -> Ret,
     ) -> Ret {
         callback((self.1[index].0, self.1[index].1).into())
     }
@@ -215,7 +215,7 @@ where
     fn account<Ret: Default>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         callback((&self.1[index].0, &self.1[index].1).into())
     }
@@ -235,7 +235,7 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>]) {
     fn account<Ret: Default>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         callback(self.1[index].into())
     }
@@ -324,7 +324,7 @@ impl<'a> StorableAccounts<'a> for StorableAccountsBySlot<'a> {
     fn account<Ret: Default>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         let indexes = self.find_internal_index(index);
         callback(self.slots_and_accounts[indexes.0].1[indexes.1].into())
@@ -357,7 +357,7 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>], Slot) 
     fn account<Ret: Default>(
         &self,
         index: usize,
-        mut callback: impl FnMut(AccountForStorage<'a>) -> Ret,
+        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
     ) -> Ret {
         callback(self.1[index].into())
     }

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -759,10 +759,16 @@ impl HotStorageWriter {
         let total_input_accounts = len - skip;
         let mut stored_infos = Vec::with_capacity(total_input_accounts);
         for i in skip..len {
-            accounts.get::<TieredStorageResult<()>>(i, |account, _account_hash| {
+            let mut result = Ok(());
+            accounts.get::<()>(i, |account, _account_hash| {
+                let offset = HotAccountOffset::new(cursor);
+                let Ok(offset) = offset else {
+                    result = offset.map(|_| ());
+                    return;
+                };
                 let index_entry = AccountIndexWriterEntry {
                     address: *account.pubkey(),
-                    offset: HotAccountOffset::new(cursor)?,
+                    offset,
                 };
                 address_range.update(account.pubkey());
 
@@ -781,7 +787,11 @@ impl HotStorageWriter {
                 };
                 let owner_offset = owners_table.insert(owner);
                 let stored_size =
-                    self.write_account(lamports, owner_offset, data, executable, rent_epoch)?;
+                    self.write_account(lamports, owner_offset, data, executable, rent_epoch);
+                let Ok(stored_size) = stored_size else {
+                    result = stored_size.map(|_| ());
+                    return;
+                };
                 cursor += stored_size;
 
                 stored_infos.push(StoredAccountInfo {
@@ -799,8 +809,8 @@ impl HotStorageWriter {
                     size: stored_size + footer.index_block_format.entry_size::<HotAccountOffset>(),
                 });
                 index.push(index_entry);
-                Ok(())
-            })?;
+            });
+            result?;
         }
         footer.account_entry_count = total_input_accounts as u32;
 

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -527,15 +527,15 @@ impl HotStorageReader {
     }
 
     /// calls `callback` with the account located at the specified index offset.
-    pub fn get_stored_account_meta_callback<'a>(
+    pub fn get_stored_account_meta_callback<'a, Ret: Default>(
         &'a self,
         index_offset: IndexOffset,
-        mut callback: impl FnMut(StoredAccountMeta<'a>),
-    ) -> TieredStorageResult<()> {
-        if let Some((account, _offset)) = self.get_stored_account_meta(index_offset)? {
-            callback(account)
-        }
-        Ok(())
+        mut callback: impl FnMut(StoredAccountMeta<'a>) -> Ret,
+    ) -> TieredStorageResult<Ret> {
+        let account = self.get_stored_account_meta(index_offset)?;
+        Ok(account
+            .map(|(account, _offset)| callback(account))
+            .unwrap_or_default())
     }
 
     /// Returns the account located at the specified index offset.

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -86,11 +86,11 @@ impl TieredStorageReader {
     }
 
     /// calls `callback` with the account located at the specified index offset.
-    pub fn get_stored_account_meta_callback<'a>(
+    pub fn get_stored_account_meta_callback<'a, Ret: Default>(
         &'a self,
         index_offset: IndexOffset,
-        callback: impl FnMut(StoredAccountMeta<'a>),
-    ) -> TieredStorageResult<()> {
+        callback: impl FnMut(StoredAccountMeta<'a>) -> Ret,
+    ) -> TieredStorageResult<Ret> {
         match self {
             Self::Hot(hot) => hot.get_stored_account_meta_callback(index_offset, callback),
         }


### PR DESCRIPTION
#### Problem
moving to not mmapping append vec files. Soon, lifetimes of borrowed account data will be limited to a callback.

#### Summary of Changes
Hook up `get_stored_account_meta_callback` through to writing accounts.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
