### PR TITLE
Simd 118: load stake accounts on distribution

### DIFF
--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -74,19 +74,20 @@ impl StakeReward {
             validator_stake_lamports,
         );
 
+        let reward_lamports: i64 = rng.gen_range(1..200);
         let validator_stake_account = stake_state::create_account(
             &validator_staking_keypair.pubkey(),
             &validator_voting_keypair.pubkey(),
             &validator_vote_account,
             &rent,
-            validator_stake_lamports,
+            validator_stake_lamports + reward_lamports as u64,
         );
 
         Self {
             stake_pubkey: Pubkey::new_unique(),
             stake_reward_info: RewardInfo {
                 reward_type: solana_sdk::reward_type::RewardType::Staking,
-                lamports: rng.gen_range(1..200),
+                lamports: reward_lamports,
                 post_balance: 0,  /* unused atm */
                 commission: None, /* unused atm */
             },

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -171,6 +171,7 @@ pub(crate) struct RewardsStoreMetrics {
     pub(crate) store_stake_accounts_count: usize,
     pub(crate) total_stake_accounts_count: usize,
     pub(crate) distributed_rewards: u64,
+    pub(crate) burned_rewards: u64,
     pub(crate) pre_capitalization: u64,
     pub(crate) post_capitalization: u64,
 }
@@ -199,6 +200,7 @@ pub(crate) fn report_partitioned_reward_metrics(bank: &Bank, timings: RewardsSto
             i64
         ),
         ("distributed_rewards", timings.distributed_rewards, i64),
+        ("burned_rewards", timings.burned_rewards, i64),
         ("pre_capitalization", timings.pre_capitalization, i64),
         ("post_capitalization", timings.post_capitalization, i64),
     );

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -28,7 +28,7 @@ enum DistributionError {
     ArithmeticOverflow,
 
     #[error("stake account set_state failed")]
-    UnabletToSetState,
+    UnableToSetState,
 }
 
 struct DistributionStorageResults {
@@ -162,7 +162,7 @@ impl Bank {
                 partitioned_stake_reward.stake,
                 flags,
             ))
-            .map_err(|_| DistributionError::UnabletToSetState)?;
+            .map_err(|_| DistributionError::UnableToSetState)?;
         let mut stake_reward_info = partitioned_stake_reward.stake_reward_info;
         stake_reward_info.post_balance = account.lamports();
         Ok(StakeReward {

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -227,6 +227,7 @@ mod tests {
             tests::create_genesis_config,
         },
         rand::Rng,
+        solana_accounts_db::stake_rewards::StakeReward,
         solana_sdk::{
             account::from_account,
             epoch_schedule::EpochSchedule,
@@ -417,9 +418,11 @@ mod tests {
                 .collect();
             let DistributionStorageResults {
                 lamports_distributed,
+                updated_stake_rewards,
                 ..
             } = bank.store_stake_accounts_in_partition(converted_rewards);
-            let num_history_updates = bank.update_reward_history_in_partition(&stake_rewards);
+            let num_history_updates =
+                bank.update_reward_history_in_partition(&updated_stake_rewards);
             assert_eq!(stake_rewards.len(), num_history_updates);
             total_rewards += lamports_distributed;
             total_num_updates += num_history_updates;

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -120,6 +120,7 @@ impl Bank {
             store_stake_accounts_us,
             store_stake_accounts_count: this_partition_stake_rewards.len(),
             distributed_rewards: lamports_distributed,
+            burned_rewards: lamports_burned,
         };
 
         report_partitioned_reward_metrics(self, metrics);

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Bank, EpochRewardStatus},
+    super::{Bank, EpochRewardStatus, StakeRewards},
     crate::bank::metrics::{report_partitioned_reward_metrics, RewardsStoreMetrics},
     solana_accounts_db::stake_rewards::StakeReward,
     solana_measure::measure_us,
@@ -53,7 +53,7 @@ impl Bank {
     /// Store the rewards to AccountsDB, update reward history record and total capitalization.
     fn distribute_epoch_rewards_in_partition(
         &self,
-        all_stake_rewards: &[Vec<StakeReward>],
+        all_stake_rewards: &[StakeRewards],
         partition_index: u64,
     ) {
         let pre_capitalization = self.capitalization();

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -6,7 +6,7 @@ use {
         bank::metrics::{report_partitioned_reward_metrics, RewardsStoreMetrics},
         stake_account::StakeAccount,
     },
-    log::debug,
+    log::error,
     solana_accounts_db::stake_rewards::StakeReward,
     solana_measure::measure_us,
     solana_sdk::{
@@ -200,7 +200,7 @@ impl Bank {
                     updated_stake_rewards.push(stake_reward);
                 }
                 Err(err) => {
-                    debug!(
+                    error!(
                         "bank::distribution::store_stake_accounts_in_partition() failed for {}: {:?}",
                         stake_pubkey, err
                     );

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -401,6 +401,9 @@ mod tests {
             expected_rewards += 1;
         }
 
+        // Push extra StakeReward to simulate non-existent account
+        stake_rewards.push(StakeReward::new_random());
+
         let stake_rewards_bucket =
             hash_rewards_into_partitions(stake_rewards, &Hash::new(&[1; 32]), 100);
         bank.set_epoch_reward_status_active(stake_rewards_bucket.clone());
@@ -423,7 +426,7 @@ mod tests {
             } = bank.store_stake_accounts_in_partition(converted_rewards);
             let num_history_updates =
                 bank.update_reward_history_in_partition(&updated_stake_rewards);
-            assert_eq!(stake_rewards.len(), num_history_updates);
+            assert_eq!(updated_stake_rewards.len(), num_history_updates);
             total_rewards += lamports_distributed;
             total_num_updates += num_history_updates;
         }

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -98,7 +98,7 @@ impl Bank {
             DistributionStorageResults {
                 lamports_distributed,
                 lamports_burned,
-                ..
+                updated_stake_rewards,
             },
             store_stake_accounts_us,
         ) = measure_us!(self.store_stake_accounts_in_partition(converted_rewards));
@@ -110,7 +110,7 @@ impl Bank {
         self.update_epoch_rewards_sysvar(lamports_distributed + lamports_burned);
 
         // update reward history for this partitioned distribution
-        self.update_reward_history_in_partition(this_partition_stake_rewards);
+        self.update_reward_history_in_partition(&updated_stake_rewards);
 
         let metrics = RewardsStoreMetrics {
             pre_capitalization,

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -4,7 +4,20 @@ use {
     solana_accounts_db::stake_rewards::StakeReward,
     solana_measure::measure_us,
     std::sync::atomic::Ordering::Relaxed,
+    thiserror::Error,
 };
+
+#[derive(Serialize, Deserialize, Debug, Error, PartialEq, Eq, Clone)]
+enum DistributionError {
+    #[error("stake account not found")]
+    AccountNotFound,
+
+    #[error("rewards arithmetic overflowed")]
+    ArithmeticOverflow,
+
+    #[error("stake account set_state failed")]
+    UnabletToSetState,
+}
 
 impl Bank {
     /// Process reward distribution for the block if it is inside reward interval.

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -12,11 +12,12 @@ use {
     },
     solana_sdk::{
         account::AccountSharedData,
+        account_utils::StateMut,
         clock::Slot,
         feature_set,
         pubkey::Pubkey,
         reward_info::RewardInfo,
-        stake::state::{Delegation, Stake},
+        stake::state::{Delegation, Stake, StakeStateV2},
     },
     solana_vote::vote_account::VoteAccounts,
     std::sync::Arc,
@@ -32,6 +33,20 @@ struct PartitionedStakeReward {
     /// fields are available on calculation, but RewardInfo::post_balance must
     /// be updated based on current account state before recording.
     pub stake_reward_info: RewardInfo,
+}
+
+impl PartitionedStakeReward {
+    fn maybe_from(stake_reward: &StakeReward) -> Option<Self> {
+        if let Ok(StakeStateV2::Stake(_meta, stake, _flags)) = stake_reward.stake_account.state() {
+            Some(Self {
+                stake_pubkey: stake_reward.stake_pubkey,
+                stake,
+                stake_reward_info: stake_reward.stake_reward_info,
+            })
+        } else {
+            None
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -11,12 +11,31 @@ use {
         partitioned_rewards::PartitionedEpochRewardsConfig, stake_rewards::StakeReward,
     },
     solana_sdk::{
-        account::AccountSharedData, clock::Slot, feature_set, pubkey::Pubkey,
-        reward_info::RewardInfo, stake::state::Delegation,
+        account::AccountSharedData,
+        clock::Slot,
+        feature_set,
+        pubkey::Pubkey,
+        reward_info::RewardInfo,
+        stake::state::{Delegation, Stake},
     },
     solana_vote::vote_account::VoteAccounts,
     std::sync::Arc,
 };
+
+#[derive(AbiExample, Debug, Serialize, Deserialize, Clone, PartialEq)]
+struct PartitionedStakeReward {
+    /// Stake account address
+    pub stake_pubkey: Pubkey,
+    /// `Stake` state to be stored in account
+    pub stake: Stake,
+    /// RewardInfo for recording in the Bank on distribution. Most of these
+    /// fields are available on calculation, but RewardInfo::post_balance must
+    /// be updated based on current account state before recording.
+    pub stake_reward_info: RewardInfo,
+}
+
+#[allow(dead_code)]
+type PartitionedStakeRewards = Vec<PartitionedStakeReward>;
 
 #[derive(AbiExample, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct StartBlockHeightAndRewards {

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -49,7 +49,6 @@ impl PartitionedStakeReward {
     }
 }
 
-#[allow(dead_code)]
 type PartitionedStakeRewards = Vec<PartitionedStakeReward>;
 
 #[derive(AbiExample, Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
#### Problem
As per [SIMD-0118](https://github.com/solana-foundation/solana-improvement-documents/blob/44feb6ab1d28d8b1ac2288025a0d098e72e7f7a6/proposals/0118-partitioned-epoch-reward-distribution.md), partitioned epoch rewards need to support stake-account credits during the rewards period. This means that the stake account needs to be loaded on distribution, so that the resulting lamports balance is correct.

Existing code loads the stake account on calculation, applies the reward, and then caches the complete account. On distribution, all the cached accounts are stored wholesale in the bank.

#### Summary of Changes
- Add `PartitionedStakeReward` struct that will ultimately replace `StakeReward` in the module
- For now, continue using `StakeReward` to pass rewards into the `distribution` pipeline/module (because that's how they're stored in the Bank). Convert these to `PartitionedStakeRewards`. This is a performance hit, but will go away as soon as Bank::epoch_rewards_status is updated.
- Use `PartitionedStakeRewards` for `store_stake_accounts_in_partition()`
- Load stake accounts from the StakesCache in `store_stake_accounts_in_partition()` and only overwrite the `Stake` part of the state.
Note: this also updates the RewardInfo::post_balance for recording in the bank.
- Add error type and return result from `build_updated_stake_reward()`. This is the most controversial part of the change, I think. We *should* be able to assert that stake accounts can be credited rewards, because they are checked in calculation and then restricted to only certain mutations by the stake program. However (a) the expects felt icky; and (b) I was trying to duplicate the behavior in calculation, which doesn't panic but skips rewards for accounts that error in `stake_stake::redeem_rewards()`.

Best reviewed by commit.
Sorry this is so many lines. Most of the changes are in the tests module, though.

However, a warning that this does kick off part of the partitioned epoch rewards that is gnarly and breaky, since we need to replace a bunch of the existing types and make changes to the snapshot. Lots of interdependency; it's hard to separate into small chunks.
Case in point, the conversion between `StakeReward` and `PartitionedStakeReward` is gross, but this is the best way I could think of to separate off the essential `distribution` changes without also having to do all the `calculation` changes in the same PR.
