### PR TITLE
get_stored_account_meta_callback returns Option

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -137,24 +137,27 @@ impl AccountsFile {
     }
 
     /// calls `callback` with the account located at the specified index offset.
-    pub fn get_stored_account_meta_callback<'a>(
+    pub fn get_stored_account_meta_callback<'a, Ret>(
         &'a self,
         offset: usize,
-        callback: impl FnMut(StoredAccountMeta<'a>),
-    ) {
+        callback: impl FnMut(StoredAccountMeta<'a>) -> Ret,
+    ) -> Option<Ret> {
         match self {
             Self::AppendVec(av) => av.get_stored_account_meta_callback(offset, callback),
             // Note: The conversion here is needed as the AccountsDB currently
             // assumes all offsets are multiple of 8 while TieredStorage uses
             // IndexOffset that is equivalent to AccountInfo::reduced_offset.
-            Self::TieredStorage(ts) => {
-                if let Some(reader) = ts.reader() {
-                    _ = reader.get_stored_account_meta_callback(
-                        IndexOffset(AccountInfo::get_reduced_offset(offset)),
-                        callback,
-                    );
-                }
-            }
+            Self::TieredStorage(ts) => ts
+                .reader()
+                .and_then(|reader| {
+                    reader
+                        .get_stored_account_meta_callback(
+                            IndexOffset(AccountInfo::get_reduced_offset(offset)),
+                            callback,
+                        )
+                        .ok()
+                })
+                .flatten(),
         }
     }
 

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -148,16 +148,12 @@ impl AccountsFile {
             // assumes all offsets are multiple of 8 while TieredStorage uses
             // IndexOffset that is equivalent to AccountInfo::reduced_offset.
             Self::TieredStorage(ts) => ts
-                .reader()
-                .and_then(|reader| {
-                    reader
-                        .get_stored_account_meta_callback(
-                            IndexOffset(AccountInfo::get_reduced_offset(offset)),
-                            callback,
-                        )
-                        .ok()
-                })
-                .flatten(),
+                .reader()?
+                .get_stored_account_meta_callback(
+                    IndexOffset(AccountInfo::get_reduced_offset(offset)),
+                    callback,
+                )
+                .ok()?,
         }
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -541,14 +541,13 @@ impl AppendVec {
     }
 
     /// calls `callback` with the account located at the specified index offset.
-    pub fn get_stored_account_meta_callback<'a>(
+    pub fn get_stored_account_meta_callback<'a, Ret>(
         &'a self,
         offset: usize,
-        mut callback: impl FnMut(StoredAccountMeta<'a>),
-    ) {
-        if let Some((account, _offset)) = self.get_stored_account_meta(offset) {
-            callback(account)
-        }
+        mut callback: impl FnMut(StoredAccountMeta<'a>) -> Ret,
+    ) -> Option<Ret> {
+        self.get_stored_account_meta(offset)
+            .map(|(account, _offset)| callback(account))
     }
 
     /// return an `AccountSharedData` for an account at `offset`.

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -527,15 +527,13 @@ impl HotStorageReader {
     }
 
     /// calls `callback` with the account located at the specified index offset.
-    pub fn get_stored_account_meta_callback<'a>(
+    pub fn get_stored_account_meta_callback<'a, Ret>(
         &'a self,
         index_offset: IndexOffset,
-        mut callback: impl FnMut(StoredAccountMeta<'a>),
-    ) -> TieredStorageResult<()> {
-        if let Some((account, _offset)) = self.get_stored_account_meta(index_offset)? {
-            callback(account)
-        }
-        Ok(())
+        mut callback: impl FnMut(StoredAccountMeta<'a>) -> Ret,
+    ) -> TieredStorageResult<Option<Ret>> {
+        let account = self.get_stored_account_meta(index_offset)?;
+        Ok(account.map(|(account, _offset)| callback(account)))
     }
 
     /// Returns the account located at the specified index offset.

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -86,11 +86,11 @@ impl TieredStorageReader {
     }
 
     /// calls `callback` with the account located at the specified index offset.
-    pub fn get_stored_account_meta_callback<'a>(
+    pub fn get_stored_account_meta_callback<'a, Ret>(
         &'a self,
         index_offset: IndexOffset,
-        callback: impl FnMut(StoredAccountMeta<'a>),
-    ) -> TieredStorageResult<()> {
+        callback: impl FnMut(StoredAccountMeta<'a>) -> Ret,
+    ) -> TieredStorageResult<Option<Ret>> {
         match self {
             Self::Hot(hot) => hot.get_stored_account_meta_callback(index_offset, callback),
         }


### PR DESCRIPTION
#### Problem
moving to not mmapping append vec files. Soon, lifetimes of borrowed account data will be limited to a callback.

#### Summary of Changes
`get_stored_account_meta_callback` now returns `Option<Ret>`. Return value is None when offset is invalid. While storing, 
all accounts should be present. But, the api must support `Option`, ugh.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
