### PR TITLE
Uses same lifetime name for local AccountForStorage in callback

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -82,7 +82,7 @@ impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
     pub fn account<Ret>(
         &self,
         index: usize,
-        callback: impl for<'c> FnMut(AccountForStorage<'c>) -> Ret,
+        callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret {
         self.accounts
             .account_default_if_zero_lamport(index, callback)

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9634,7 +9634,7 @@ pub mod tests {
         fn account<Ret>(
             &self,
             index: usize,
-            mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
+            mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
         ) -> Ret {
             callback(self.1[index].1.into())
         }

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -25,7 +25,7 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
+        mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret {
         let entry = &self.1[index];
         callback((&self.1[index].stake_pubkey, &entry.stake_account).into())

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -100,13 +100,13 @@ pub trait StorableAccounts<'a>: Sync {
     fn account<Ret>(
         &self,
         index: usize,
-        callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
+        callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret;
     /// None if account is zero lamports
     fn account_default_if_zero_lamport<Ret>(
         &self,
         index: usize,
-        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
+        mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret {
         self.account(index, |account| {
             callback(if account.lamports() != 0 {
@@ -169,7 +169,7 @@ where
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
+        mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret {
         callback((self.accounts[index].0, self.accounts[index].1).into())
     }
@@ -193,7 +193,7 @@ where
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl for<'c> FnMut(AccountForStorage<'c>) -> Ret,
+        mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret {
         callback((self.1[index].0, self.1[index].1).into())
     }
@@ -215,7 +215,7 @@ where
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
+        mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret {
         callback((&self.1[index].0, &self.1[index].1).into())
     }
@@ -235,7 +235,7 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>]) {
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
+        mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret {
         callback(self.1[index].into())
     }
@@ -324,7 +324,7 @@ impl<'a> StorableAccounts<'a> for StorableAccountsBySlot<'a> {
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
+        mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret {
         let indexes = self.find_internal_index(index);
         callback(self.slots_and_accounts[indexes.0].1[indexes.1].into())
@@ -357,7 +357,7 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>], Slot) 
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl for<'b> FnMut(AccountForStorage<'b>) -> Ret,
+        mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret {
         callback(self.1[index].into())
     }


### PR DESCRIPTION
#### Problem

The lifetime names on the AccountForStorage in the callback of `account()` was inconsistent. I find this confusing, or at least it could be *less* confusing.


#### Summary of Changes

Give them all the same name.