### PR TITLE
cli: Introduce `WithComputeUnitConfig` for specifying more than compute unit price

### DIFF
--- a/cli/src/compute_budget.rs
+++ b/cli/src/compute_budget.rs
@@ -74,27 +74,6 @@ pub(crate) fn simulate_and_update_compute_unit_limit(
     ))
 }
 
-pub(crate) fn set_compute_budget_ixs_if_needed(
-    ixs: &mut Vec<Instruction>,
-    compute_unit_price: Option<u64>,
-) {
-    let Some(compute_unit_price) = compute_unit_price else {
-        return;
-    };
-
-    // Default to the max compute unit limit because later transactions will be
-    // simulated to get the exact compute units consumed.
-    ixs.insert(
-        0,
-        ComputeBudgetInstruction::set_compute_unit_limit(MAX_COMPUTE_UNIT_LIMIT),
-    );
-
-    ixs.insert(
-        0,
-        ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price),
-    );
-}
-
 pub(crate) trait WithComputeUnitPrice {
     fn with_compute_unit_price(self, compute_unit_price: Option<&u64>) -> Self;
 }
@@ -104,6 +83,31 @@ impl WithComputeUnitPrice for Vec<Instruction> {
         if let Some(compute_unit_price) = compute_unit_price {
             self.push(ComputeBudgetInstruction::set_compute_unit_price(
                 *compute_unit_price,
+            ));
+        }
+        self
+    }
+}
+
+pub(crate) struct ComputeUnitConfig {
+    pub(crate) compute_unit_price: Option<u64>,
+}
+
+pub(crate) trait WithComputeUnitConfig {
+    fn with_compute_unit_config(self, config: &ComputeUnitConfig) -> Self;
+}
+
+impl WithComputeUnitConfig for Vec<Instruction> {
+    fn with_compute_unit_config(mut self, config: &ComputeUnitConfig) -> Self {
+        if let Some(compute_unit_price) = config.compute_unit_price {
+            self.push(ComputeBudgetInstruction::set_compute_unit_price(
+                compute_unit_price,
+            ));
+
+            // Default to the max compute unit limit because later transactions will be
+            // simulated to get the exact compute units consumed.
+            self.push(ComputeBudgetInstruction::set_compute_unit_limit(
+                MAX_COMPUTE_UNIT_LIMIT,
             ));
         }
         self

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -2220,29 +2220,30 @@ fn cli_program_deploy_with_args(compute_unit_price: Option<u64>) {
 
     if let Some(compute_unit_price) = compute_unit_price {
         for tx in [&initial_tx, &write_tx, &final_tx] {
-            for i in [0, 1] {
+            let ix_len = tx.message.instructions.len();
+            for i in [1, 2] {
                 assert_eq!(
-                    tx.message.instructions[i].program_id(&tx.message.account_keys),
+                    tx.message.instructions[ix_len - i].program_id(&tx.message.account_keys),
                     &compute_budget::id()
                 );
             }
 
             assert_matches!(
-                try_from_slice_unchecked(&tx.message.instructions[0].data),
+                try_from_slice_unchecked(&tx.message.instructions[ix_len - 2].data),
                 Ok(ComputeBudgetInstruction::SetComputeUnitPrice(price)) if price == compute_unit_price
             );
         }
 
         assert_matches!(
-            try_from_slice_unchecked(&initial_tx.message.instructions[1].data),
+            try_from_slice_unchecked(&initial_tx.message.instructions.last().unwrap().data),
             Ok(ComputeBudgetInstruction::SetComputeUnitLimit(2820))
         );
         assert_matches!(
-            try_from_slice_unchecked(&write_tx.message.instructions[1].data),
+            try_from_slice_unchecked(&write_tx.message.instructions.last().unwrap().data),
             Ok(ComputeBudgetInstruction::SetComputeUnitLimit(2670))
         );
         assert_matches!(
-            try_from_slice_unchecked(&final_tx.message.instructions[1].data),
+            try_from_slice_unchecked(&final_tx.message.instructions.last().unwrap().data),
             Ok(ComputeBudgetInstruction::SetComputeUnitLimit(2970))
         );
     } else {


### PR DESCRIPTION
#### Problem

The current `WithComputeUnitPrice` trait only allows setting the compute unit price for list of instructions, but we also want to customize the compute unit limit.

#### Summary of Changes

As a start, create a new `WithComputeUnitConfig` trait which only allows setting the compute unit price. The next step is to add the compute unit limit, either as the default, a fixed number, or as a simulated amount.

Note that this changes the compute budget instructions to go to the *end* rather than the beginning. This is because we may get a transaction with an advance nonce instruction, which must be in the beginning, and compute budget instructions can be anywhere.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->