### PR TITLE
Limit max concurrent connections

### DIFF
--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -154,7 +154,7 @@ mod tests {
         let (sender, receiver) = unbounded();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let (s, exit, keypair) = server_args();
-        let (_, _, t) = solana_streamer::nonblocking::quic::spawn_server(
+        let (_, _, t, _) = solana_streamer::nonblocking::quic::spawn_server(
             "quic_streamer_test",
             s.try_clone().unwrap(),
             &keypair,

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -154,7 +154,12 @@ mod tests {
         let (sender, receiver) = unbounded();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let (s, exit, keypair) = server_args();
-        let (_, _, t, _) = solana_streamer::nonblocking::quic::spawn_server(
+        let solana_streamer::nonblocking::quic::SpawnNonBlockingServerResult {
+            endpoint: _,
+            stats: _,
+            thread: t,
+            max_concurrent_connections: _,
+        } = solana_streamer::nonblocking::quic::spawn_server(
             "quic_streamer_test",
             s.try_clone().unwrap(),
             &keypair,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1337,7 +1337,7 @@ pub mod test {
         let keypair = Keypair::new();
         let server_address = s.local_addr().unwrap();
         let staked_nodes = Arc::new(RwLock::new(option_staked_nodes.unwrap_or_default()));
-        let (_, stats, t) = spawn_server(
+        let (_, stats, t, _) = spawn_server(
             "quic_streamer_test",
             s,
             &keypair,
@@ -1773,7 +1773,7 @@ pub mod test {
         let keypair = Keypair::new();
         let server_address = s.local_addr().unwrap();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
-        let (_, _, t) = spawn_server(
+        let (_, _, t, _) = spawn_server(
             "quic_streamer_test",
             s,
             &keypair,
@@ -1803,7 +1803,7 @@ pub mod test {
         let keypair = Keypair::new();
         let server_address = s.local_addr().unwrap();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
-        let (_, stats, t) = spawn_server(
+        let (_, stats, t, _) = spawn_server(
             "quic_streamer_test",
             s,
             &keypair,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -146,7 +146,7 @@ pub fn spawn_server(
 
     let endpoint = Endpoint::new(
         EndpointConfig::default(),
-        Some(config.clone()),
+        Some(config),
         sock,
         Arc::new(TokioRuntime),
     )

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -61,7 +61,7 @@ impl rustls::server::ClientCertVerifier for SkipClientVerification {
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
 pub(crate) fn configure_server(
     identity_keypair: &Keypair,
-    max_concurrent_connections: u32,
+    max_concurrent_connections: usize,
 ) -> Result<(ServerConfig, String), QuicServerError> {
     let (cert, priv_key) = new_dummy_x509_certificate(identity_keypair);
     let cert_chain_pem_parts = vec![Pem {
@@ -77,7 +77,7 @@ pub(crate) fn configure_server(
     server_tls_config.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
 
     let mut server_config = ServerConfig::with_crypto(Arc::new(server_tls_config));
-    server_config.concurrent_connections(max_concurrent_connections);
+    server_config.concurrent_connections(max_concurrent_connections as u32);
     server_config.use_retry(true);
     let config = Arc::get_mut(&mut server_config.transport).unwrap();
 
@@ -120,7 +120,7 @@ pub enum QuicServerError {
 
 pub struct EndpointKeyUpdater {
     endpoint: Endpoint,
-    max_concurrent_connections: u32,
+    max_concurrent_connections: usize,
 }
 
 impl NotifyKeyUpdate for EndpointKeyUpdater {
@@ -516,7 +516,7 @@ pub fn spawn_server(
     coalesce: Duration,
 ) -> Result<SpawnServerResult, QuicServerError> {
     let runtime = rt(format!("{thread_name}Rt"));
-    let (endpoint, _stats, task, max_concurrent_connections) = {
+    let result = {
         let _guard = runtime.enter();
         crate::nonblocking::quic::spawn_server(
             metrics_name,
@@ -536,17 +536,17 @@ pub fn spawn_server(
     let handle = thread::Builder::new()
         .name(thread_name.into())
         .spawn(move || {
-            if let Err(e) = runtime.block_on(task) {
+            if let Err(e) = runtime.block_on(result.thread) {
                 warn!("error from runtime.block_on: {:?}", e);
             }
         })
         .unwrap();
     let updater = EndpointKeyUpdater {
-        endpoint: endpoint.clone(),
-        max_concurrent_connections,
+        endpoint: result.endpoint.clone(),
+        max_concurrent_connections: result.max_concurrent_connections,
     };
     Ok(SpawnServerResult {
-        endpoint,
+        endpoint: result.endpoint,
         thread: handle,
         key_updater: Arc::new(updater),
     })


### PR DESCRIPTION
#### Problem
A client can create many connections quickly to overwhelm the server before the application can make decision to reject the busy connections requests.

#### Summary of Changes
Setting the concurrent_connections in the ServerConfig so that Quinn layer can quickly check the connection count and reject in its layer. Set the concurrent connections limit 25% higher than the user set one to leave buffer so that for the application layer can still get to make a decision in normal cases.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
