### PR TITLE
Removes hashes from StorableAccountsWithHashes

### DIFF
--- a/accounts-db/benches/append_vec.rs
+++ b/accounts-db/benches/append_vec.rs
@@ -4,8 +4,7 @@ extern crate test;
 use {
     rand::{thread_rng, Rng},
     solana_accounts_db::{
-        account_storage::meta::{StorableAccountsWithHashes, StoredAccountInfo, StoredMeta},
-        accounts_hash::AccountHash,
+        account_storage::meta::{StorableAccountsWithoutHashes, StoredAccountInfo, StoredMeta},
         append_vec::{
             test_utils::{create_test_account, get_append_vec_path},
             AppendVec,
@@ -14,7 +13,6 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::Slot,
-        hash::Hash,
     },
     std::{
         sync::{Arc, Mutex},
@@ -31,14 +29,13 @@ fn append_account(
     vec: &AppendVec,
     storage_meta: StoredMeta,
     account: &AccountSharedData,
-    hash: AccountHash,
 ) -> Option<StoredAccountInfo> {
     let slot_ignored = Slot::MAX;
     let accounts = [(&storage_meta.pubkey, account)];
     let slice = &accounts[..];
     let accounts = (slot_ignored, slice);
-    let storable_accounts = StorableAccountsWithHashes::new_with_hashes(&accounts, vec![&hash]);
-    let res = vec.append_accounts(&storable_accounts, 0);
+    let storable_accounts = StorableAccountsWithoutHashes::new(&accounts);
+    let res = vec.append_accounts(storable_accounts.accounts, 0);
     res.and_then(|res| res.first().cloned())
 }
 
@@ -48,7 +45,7 @@ fn append_vec_append(bencher: &mut Bencher) {
     let vec = AppendVec::new(&path.path, true, 64 * 1024);
     bencher.iter(|| {
         let (meta, account) = create_test_account(0);
-        if append_account(&vec, meta, &account, AccountHash(Hash::default())).is_none() {
+        if append_account(&vec, meta, &account).is_none() {
             vec.reset();
         }
     });
@@ -58,8 +55,7 @@ fn add_test_accounts(vec: &AppendVec, size: usize) -> Vec<(usize, usize)> {
     (0..size)
         .filter_map(|sample| {
             let (meta, account) = create_test_account(sample);
-            append_account(vec, meta, &account, AccountHash(Hash::default()))
-                .map(|info| (sample, info.offset))
+            append_account(vec, meta, &account).map(|info| (sample, info.offset))
         })
         .collect()
 }
@@ -104,7 +100,7 @@ fn append_vec_concurrent_append_read(bencher: &mut Bencher) {
     spawn(move || loop {
         let sample = indexes1.lock().unwrap().len();
         let (meta, account) = create_test_account(sample);
-        if let Some(info) = append_account(&vec1, meta, &account, AccountHash(Hash::default())) {
+        if let Some(info) = append_account(&vec1, meta, &account) {
             indexes1.lock().unwrap().push((sample, info.offset))
         } else {
             break;
@@ -144,7 +140,7 @@ fn append_vec_concurrent_read_append(bencher: &mut Bencher) {
     bencher.iter(|| {
         let sample: usize = thread_rng().gen_range(0..256);
         let (meta, account) = create_test_account(sample);
-        if let Some(info) = append_account(&vec, meta, &account, AccountHash(Hash::default())) {
+        if let Some(info) = append_account(&vec, meta, &account) {
             indexes.lock().unwrap().push((sample, info.offset))
         }
     });

--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -2,13 +2,12 @@
 use {
     criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput},
     solana_accounts_db::{
-        account_storage::meta::StorableAccountsWithHashes,
-        accounts_hash::AccountHash,
+        account_storage::meta::StorableAccountsWithoutHashes,
         append_vec::{self, AppendVec},
         tiered_storage::hot::HotStorageWriter,
     },
     solana_sdk::{
-        account::AccountSharedData, clock::Slot, hash::Hash, pubkey::Pubkey,
+        account::AccountSharedData, clock::Slot, pubkey::Pubkey,
         rent_collector::RENT_EXEMPT_RENT_EPOCH,
     },
 };
@@ -46,10 +45,7 @@ fn bench_write_accounts_file(c: &mut Criterion) {
         .collect();
         let accounts_refs: Vec<_> = accounts.iter().collect();
         let accounts_data = (Slot::MAX, accounts_refs.as_slice());
-        let storable_accounts = StorableAccountsWithHashes::new_with_hashes(
-            &accounts_data,
-            vec![AccountHash(Hash::default()); accounts_count],
-        );
+        let storable_accounts = StorableAccountsWithoutHashes::new(&accounts_data);
 
         group.bench_function(BenchmarkId::new("append_vec", accounts_count), |b| {
             b.iter_batched_ref(
@@ -59,7 +55,9 @@ fn bench_write_accounts_file(c: &mut Criterion) {
                     AppendVec::new(path, true, file_size)
                 },
                 |append_vec| {
-                    let res = append_vec.append_accounts(&storable_accounts, 0).unwrap();
+                    let res = append_vec
+                        .append_accounts(storable_accounts.accounts, 0)
+                        .unwrap();
                     let accounts_written_count = res.len();
                     assert_eq!(accounts_written_count, accounts_count);
                 },
@@ -77,7 +75,9 @@ fn bench_write_accounts_file(c: &mut Criterion) {
                     HotStorageWriter::new(path).unwrap()
                 },
                 |hot_storage| {
-                    let res = hot_storage.write_accounts(&storable_accounts, 0).unwrap();
+                    let res = hot_storage
+                        .write_accounts(storable_accounts.accounts, 0)
+                        .unwrap();
                     let accounts_written_count = res.len();
                     assert_eq!(accounts_written_count, accounts_count);
                 },

--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -7,7 +7,7 @@ use {
         tiered_storage::hot::{HotAccount, HotAccountMeta},
     },
     solana_sdk::{account::ReadableAccount, hash::Hash, pubkey::Pubkey, stake_history::Epoch},
-    std::{borrow::Borrow, marker::PhantomData},
+    std::marker::PhantomData,
 };
 
 pub type StoredMetaWriteVersion = u64;
@@ -25,55 +25,27 @@ lazy_static! {
 /// Goal is to eliminate copies and data reshaping given various code paths that store accounts.
 /// This struct contains what is needed to store accounts to a storage
 /// 1. account & pubkey (StorableAccounts)
-/// 2. hash per account (Maybe in StorableAccounts, otherwise has to be passed in separately)
-pub struct StorableAccountsWithHashes<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>> {
+pub struct StorableAccountsWithoutHashes<'a: 'b, 'b, U: StorableAccounts<'a>> {
     /// accounts to store
     /// always has pubkey and account
     /// may also have hash per account
-    pub(crate) accounts: &'b U,
-    /// if accounts does not have hash, this has a hash per account
-    hashes: Option<Vec<V>>,
+    pub accounts: &'b U,
     _phantom: PhantomData<&'a ()>,
 }
 
-impl<'a: 'b, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>
-    StorableAccountsWithHashes<'a, 'b, U, V>
-{
+impl<'a: 'b, 'b, U: StorableAccounts<'a>> StorableAccountsWithoutHashes<'a, 'b, U> {
     /// used when accounts contains hash already
     pub fn new(accounts: &'b U) -> Self {
-        assert!(accounts.has_hash());
         Self {
             accounts,
-            hashes: None,
-            _phantom: PhantomData,
-        }
-    }
-    /// used when accounts does NOT contains hash
-    /// In this case, hashes have to be passed in separately.
-    pub fn new_with_hashes(accounts: &'b U, hashes: Vec<V>) -> Self {
-        assert!(!accounts.has_hash());
-        assert_eq!(accounts.len(), hashes.len());
-        Self {
-            accounts,
-            hashes: Some(hashes),
             _phantom: PhantomData,
         }
     }
 
     /// get all account fields at 'index'
-    pub fn get<Ret>(
-        &self,
-        index: usize,
-        mut callback: impl FnMut(AccountForStorage, &AccountHash) -> Ret,
-    ) -> Ret {
-        let hash = if self.accounts.has_hash() {
-            self.accounts.hash(index)
-        } else {
-            let item = self.hashes.as_ref().unwrap();
-            item[index].borrow()
-        };
+    pub fn get<Ret>(&self, index: usize, callback: impl FnMut(AccountForStorage) -> Ret) -> Ret {
         self.accounts
-            .account_default_if_zero_lamport(index, |account| callback(account, hash))
+            .account_default_if_zero_lamport(index, callback)
     }
 
     /// None if account at index has lamports == 0

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -13,11 +13,7 @@ pub mod readable;
 mod test_utils;
 
 use {
-    crate::{
-        account_storage::meta::{StorableAccountsWithHashes, StoredAccountInfo},
-        accounts_hash::AccountHash,
-        storable_accounts::StorableAccounts,
-    },
+    crate::{account_storage::meta::StoredAccountInfo, storable_accounts::StorableAccounts},
     error::TieredStorageError,
     footer::{AccountBlockFormat, AccountMetaFormat},
     hot::{HotStorageWriter, HOT_FORMAT},
@@ -25,7 +21,6 @@ use {
     owners::OwnersBlockFormat,
     readable::TieredStorageReader,
     std::{
-        borrow::Borrow,
         fs, io,
         path::{Path, PathBuf},
         sync::{
@@ -110,9 +105,9 @@ impl TieredStorage {
     ///
     /// Note that this function can only be called once per a TieredStorage
     /// instance.  Otherwise, it will trigger panic.
-    pub fn write_accounts<'a, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>(
+    pub fn write_accounts<'a>(
         &self,
-        accounts: &StorableAccountsWithHashes<'a, 'b, U, V>,
+        accounts: &impl StorableAccounts<'a>,
         skip: usize,
         format: &TieredStorageFormat,
     ) -> TieredStorageResult<Vec<StoredAccountInfo>> {
@@ -173,6 +168,7 @@ impl TieredStorage {
 mod tests {
     use {
         super::*,
+        crate::account_storage::meta::StorableAccountsWithoutHashes,
         file::TieredStorageMagicNumber,
         footer::TieredStorageFooter,
         hot::HOT_FORMAT,
@@ -180,7 +176,6 @@ mod tests {
         solana_sdk::{
             account::{AccountSharedData, ReadableAccount},
             clock::Slot,
-            hash::Hash,
             pubkey::Pubkey,
             system_instruction::MAX_PERMITTED_DATA_LENGTH,
         },
@@ -207,10 +202,9 @@ mod tests {
         let slot_ignored = Slot::MAX;
         let account_refs = Vec::<(&Pubkey, &AccountSharedData)>::new();
         let account_data = (slot_ignored, account_refs.as_slice());
-        let storable_accounts =
-            StorableAccountsWithHashes::new_with_hashes(&account_data, Vec::<AccountHash>::new());
+        let storable_accounts = StorableAccountsWithoutHashes::new(&account_data);
 
-        let result = tiered_storage.write_accounts(&storable_accounts, 0, &HOT_FORMAT);
+        let result = tiered_storage.write_accounts(storable_accounts.accounts, 0, &HOT_FORMAT);
 
         match (&result, &expected_result) {
             (
@@ -338,16 +332,12 @@ mod tests {
 
         // Slot information is not used here
         let account_data = (Slot::MAX, &account_refs[..]);
-        let hashes: Vec<_> = std::iter::repeat_with(|| AccountHash(Hash::new_unique()))
-            .take(account_data_sizes.len())
-            .collect();
-
-        let storable_accounts = StorableAccountsWithHashes::new_with_hashes(&account_data, hashes);
+        let storable_accounts = StorableAccountsWithoutHashes::new(&account_data);
 
         let temp_dir = tempdir().unwrap();
         let tiered_storage_path = temp_dir.path().join(path_suffix);
         let tiered_storage = TieredStorage::new_writable(tiered_storage_path);
-        _ = tiered_storage.write_accounts(&storable_accounts, 0, &format);
+        _ = tiered_storage.write_accounts(storable_accounts.accounts, 0, &format);
 
         let reader = tiered_storage.reader().unwrap();
         let num_accounts = storable_accounts.len();
@@ -355,7 +345,7 @@ mod tests {
 
         let mut expected_accounts_map = HashMap::new();
         for i in 0..num_accounts {
-            storable_accounts.get(i, |account, _account_hash| {
+            storable_accounts.get(i, |account| {
                 expected_accounts_map.insert(*account.pubkey(), account.to_account_shared_data());
             });
         }

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -5,8 +5,8 @@ use {
         account_info::AccountInfo,
         account_storage::meta::{StoredAccountInfo, StoredAccountMeta},
         accounts_file::MatchAccountOwnerError,
-        accounts_hash::AccountHash,
         append_vec::{IndexInfo, IndexInfoInner},
+        storable_accounts::StorableAccounts,
         tiered_storage::{
             byte_block,
             file::{TieredReadableFile, TieredWritableFile},
@@ -17,8 +17,7 @@ use {
             },
             mmap_utils::{get_pod, get_slice},
             owners::{OwnerOffset, OwnersBlockFormat, OwnersTable},
-            StorableAccounts, StorableAccountsWithHashes, TieredStorageError, TieredStorageFormat,
-            TieredStorageResult,
+            TieredStorageError, TieredStorageFormat, TieredStorageResult,
         },
     },
     bytemuck::{Pod, Zeroable},
@@ -30,7 +29,7 @@ use {
         rent_collector::RENT_EXEMPT_RENT_EPOCH,
         stake_history::Epoch,
     },
-    std::{borrow::Borrow, option::Option, path::Path},
+    std::{option::Option, path::Path},
 };
 
 pub const HOT_FORMAT: TieredStorageFormat = TieredStorageFormat {
@@ -743,9 +742,9 @@ impl HotStorageWriter {
     /// Persists `accounts` into the underlying hot accounts file associated
     /// with this HotStorageWriter.  The first `skip` number of accounts are
     /// *not* persisted.
-    pub fn write_accounts<'a, 'b, U: StorableAccounts<'a>, V: Borrow<AccountHash>>(
+    pub fn write_accounts<'a>(
         &mut self,
-        accounts: &StorableAccountsWithHashes<'a, 'b, U, V>,
+        accounts: &impl StorableAccounts<'a>,
         skip: usize,
     ) -> TieredStorageResult<Vec<StoredAccountInfo>> {
         let mut footer = new_hot_footer();
@@ -755,11 +754,11 @@ impl HotStorageWriter {
         let mut address_range = AccountAddressRange::default();
 
         // writing accounts blocks
-        let len = accounts.accounts.len();
+        let len = accounts.len();
         let total_input_accounts = len - skip;
         let mut stored_infos = Vec::with_capacity(total_input_accounts);
         for i in skip..len {
-            accounts.get::<TieredStorageResult<()>>(i, |account, _account_hash| {
+            accounts.account_default_if_zero_lamport::<TieredStorageResult<()>>(i, |account| {
                 let index_entry = AccountIndexWriterEntry {
                     address: *account.pubkey(),
                     offset: HotAccountOffset::new(cursor)?,
@@ -838,15 +837,18 @@ impl HotStorageWriter {
 mod tests {
     use {
         super::*,
-        crate::tiered_storage::{
-            byte_block::ByteBlockWriter,
-            file::{TieredStorageMagicNumber, TieredWritableFile},
-            footer::{AccountBlockFormat, AccountMetaFormat, TieredStorageFooter, FOOTER_SIZE},
-            hot::{HotAccountMeta, HotStorageReader},
-            index::{AccountIndexWriterEntry, IndexBlockFormat, IndexOffset},
-            meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
-            owners::{OwnersBlockFormat, OwnersTable},
-            test_utils::{create_test_account, verify_test_account},
+        crate::{
+            account_storage::meta::StorableAccountsWithoutHashes,
+            tiered_storage::{
+                byte_block::ByteBlockWriter,
+                file::{TieredStorageMagicNumber, TieredWritableFile},
+                footer::{AccountBlockFormat, AccountMetaFormat, TieredStorageFooter, FOOTER_SIZE},
+                hot::{HotAccountMeta, HotStorageReader},
+                index::{AccountIndexWriterEntry, IndexBlockFormat, IndexOffset},
+                meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
+                owners::{OwnersBlockFormat, OwnersTable},
+                test_utils::{create_test_account, verify_test_account},
+            },
         },
         assert_matches::assert_matches,
         memoffset::offset_of,
@@ -1547,18 +1549,15 @@ mod tests {
 
         // Slot information is not used here
         let account_data = (Slot::MAX, &account_refs[..]);
-        let hashes: Vec<_> = std::iter::repeat_with(|| AccountHash(Hash::new_unique()))
-            .take(account_data_sizes.len())
-            .collect();
-
-        let storable_accounts =
-            StorableAccountsWithHashes::new_with_hashes(&account_data, hashes.clone());
+        let storable_accounts = StorableAccountsWithoutHashes::new(&account_data);
 
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("test_write_account_and_index_blocks");
         let stored_infos = {
             let mut writer = HotStorageWriter::new(&path).unwrap();
-            writer.write_accounts(&storable_accounts, 0).unwrap()
+            writer
+                .write_accounts(storable_accounts.accounts, 0)
+                .unwrap()
         };
 
         let file = TieredReadableFile::new(&path).unwrap();
@@ -1571,7 +1570,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
 
-            storable_accounts.get(i, |account, _account_hash| {
+            storable_accounts.get(i, |account| {
                 verify_test_account(
                     &stored_account_meta,
                     &account.to_account_shared_data(),
@@ -1594,7 +1593,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
 
-            storable_accounts.get(stored_info.offset, |account, _account_hash| {
+            storable_accounts.get(stored_info.offset, |account| {
                 verify_test_account(
                     &stored_account_meta,
                     &account.to_account_shared_data(),
@@ -1608,7 +1607,7 @@ mod tests {
 
         // first, we verify everything
         for (i, stored_meta) in accounts.iter().enumerate() {
-            storable_accounts.get(i, |account, _account_hash| {
+            storable_accounts.get(i, |account| {
                 verify_test_account(
                     stored_meta,
                     &account.to_account_shared_data(),


### PR DESCRIPTION
#### Problem

We no longer store account hashes in storages, yet we still haul 'em around and sometimes (re)calculate them. This is unnecessary.

`StorableAccountsWithHashes` has a field for the account hashes, which was used when storing accounts. Now, we always store a default account hash, so the account hashes here in `StorableAccountsWithHashes` are unnecessary and can be removed.


#### Summary of Changes

* Removes the `hashes` field in `StorableAccountsWithHashes`
* Renames the struct to `StorableAccountsWithoutHashes`
* Removes `StorableAccountsWithoutHashes::new_with_hashes()`
* Updates AppendVec and TieredStorage to use `StorableAccounts` directly
* Updates callers

Note, there's a lot of changes due to moving/renaming/removing fields/types/methods. I'll add comments to the parts that I think are important. 

Note 2, the entirety of `StorableAccountsWith/WithoutHashes` is being removed. This will be done over multiple PRs. I'll try to point out these pieces as well.