### PR TITLE
Add --log-messages-bytes-limit arg to ledger-tool

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -27,7 +27,11 @@ use {
 pub fn parse_process_options(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -> ProcessOptions {
     let new_hard_forks = hardforks_of(arg_matches, "hard_forks");
     let accounts_db_config = Some(get_accounts_db_config(ledger_path, arg_matches));
-    let runtime_config = RuntimeConfig::default();
+    let log_messages_bytes_limit = value_t!(arg_matches, "log_messages_bytes_limit", usize).ok();
+    let runtime_config = RuntimeConfig {
+        log_messages_bytes_limit,
+        ..RuntimeConfig::default()
+    };
 
     if arg_matches.is_present("skip_poh_verify") {
         eprintln!("--skip-poh-verify is deprecated.  Replace with --skip-verification.");

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -764,6 +764,13 @@ fn main() {
         .multiple(true)
         .help("Specify the configuration file for the Geyser plugin.");
 
+    let log_messages_bytes_limit_arg = Arg::with_name("log_messages_bytes_limit")
+        .long("log-messages-bytes-limit")
+        .takes_value(true)
+        .validator(is_parsable::<usize>)
+        .value_name("BYTES")
+        .help("Maximum number of bytes written to the program log before truncation");
+
     let accounts_data_encoding_arg = Arg::with_name("encoding")
         .long("encoding")
         .takes_value(true)
@@ -993,6 +1000,7 @@ fn main() {
                 .arg(&max_genesis_archive_unpacked_size_arg)
                 .arg(&debug_key_arg)
                 .arg(&geyser_plugin_args)
+                .arg(&log_messages_bytes_limit_arg)
                 .arg(&use_snapshot_archives_at_startup)
                 .arg(
                     Arg::with_name("skip_poh_verify")
@@ -1151,6 +1159,7 @@ fn main() {
                 .arg(&maximum_full_snapshot_archives_to_retain)
                 .arg(&maximum_incremental_snapshot_archives_to_retain)
                 .arg(&geyser_plugin_args)
+                .arg(&log_messages_bytes_limit_arg)
                 .arg(&use_snapshot_archives_at_startup)
                 .arg(
                     Arg::with_name("snapshot_slot")
@@ -1363,6 +1372,7 @@ fn main() {
                 .arg(&halt_at_slot_arg)
                 .arg(&hard_forks_arg)
                 .arg(&geyser_plugin_args)
+                .arg(&log_messages_bytes_limit_arg)
                 .arg(&accounts_data_encoding_arg)
                 .arg(&use_snapshot_archives_at_startup)
                 .arg(&max_genesis_archive_unpacked_size_arg)
@@ -1425,6 +1435,7 @@ fn main() {
                 .arg(&hard_forks_arg)
                 .arg(&max_genesis_archive_unpacked_size_arg)
                 .arg(&geyser_plugin_args)
+                .arg(&log_messages_bytes_limit_arg)
                 .arg(&use_snapshot_archives_at_startup)
                 .arg(
                     Arg::with_name("warp_epoch")


### PR DESCRIPTION
#### Problem
`agave-ledger-tool` supports `--geyser-plugin-config` option, but not `--log-messages-bytes-limit`, which can be useful for replaying ledger (using `agave-ledger-tool verify`, for example) to retrieve truncated logs for txs.

#### Summary of Changes
Added `--log-messages-bytes-limit` to all `agave-ledger-tool` supporting `--geyser-plugin-config`.

This should be backported to v1.17 and v1.18, because we need it for ledger snapshots created with v1.17.
