### PR TITLE
Fix flaky snapshot test by disabling rent

### DIFF
--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -37,7 +37,6 @@ mod tests {
             genesis_config::create_genesis_config,
             hash::Hash,
             pubkey::Pubkey,
-            rent::Rent,
             signature::{Keypair, Signer},
         },
         std::{
@@ -100,16 +99,16 @@ mod tests {
     ) {
         solana_logger::setup();
         let (mut genesis_config, _) = create_genesis_config(500);
-        genesis_config.rent = Rent::free();
         genesis_config.epoch_schedule = EpochSchedule::custom(400, 400, false);
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let deposit_amount = bank0.get_minimum_balance_for_rent_exemption(0);
         let eah_start_slot = epoch_accounts_hash_utils::calculation_start(&bank0);
         let bank1 = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         bank0.squash();
 
         // Create an account on a non-root fork
         let key1 = Keypair::new();
-        bank_test_utils::deposit(&bank1, &key1.pubkey(), 5).unwrap();
+        bank_test_utils::deposit(&bank1, &key1.pubkey(), deposit_amount).unwrap();
 
         // If setting an initial EAH, then the bank being snapshotted must be in the EAH calculation
         // window.  Otherwise `bank_to_stream()` below will *not* include the EAH in the bank snapshot,
@@ -123,8 +122,8 @@ mod tests {
 
         // Test new account
         let key2 = Pubkey::new_unique();
-        bank_test_utils::deposit(&bank2, &key2, 10).unwrap();
-        assert_eq!(bank2.get_balance(&key2), 10);
+        bank_test_utils::deposit(&bank2, &key2, deposit_amount).unwrap();
+        assert_eq!(bank2.get_balance(&key2), deposit_amount);
 
         let key3 = Pubkey::new_unique();
         bank_test_utils::deposit(&bank2, &key3, 0).unwrap();
@@ -279,7 +278,7 @@ mod tests {
         .unwrap();
         dbank.status_cache = Arc::new(RwLock::new(status_cache));
         assert_eq!(dbank.get_balance(&key1.pubkey()), 0);
-        assert_eq!(dbank.get_balance(&key2), 10);
+        assert_eq!(dbank.get_balance(&key2), deposit_amount);
         assert_eq!(dbank.get_balance(&key3), 0);
         if let Some(incremental_snapshot_persistence) = incremental.clone() {
             assert_eq!(dbank.get_accounts_hash(), None,);


### PR DESCRIPTION
#### Problem
I've seen the snapshot test fail due to eager rent collection adjusting account balances that are later asserted in the test. This only happens about 1/4000 runs because it requires a randomly generated keypair to have a pubkey in the slot (1-102)/432,000 partition for eager rent collection

#### Summary of Changes
Use rent exempt amounts in test

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
