### PR TITLE
Replaces StorableAccountsWithHashes in TieredStorage

### DIFF
--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -79,7 +79,9 @@ fn bench_write_accounts_file(c: &mut Criterion) {
                     HotStorageWriter::new(path).unwrap()
                 },
                 |hot_storage| {
-                    let res = hot_storage.write_accounts(&storable_accounts, 0).unwrap();
+                    let res = hot_storage
+                        .write_accounts(storable_accounts.accounts, 0)
+                        .unwrap();
                     let accounts_written_count = res.len();
                     assert_eq!(accounts_written_count, accounts_count);
                 },

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -277,7 +277,7 @@ impl AccountsFile {
             // assumes all offsets are multiple of 8 while TieredStorage uses
             // IndexOffset that is equivalent to AccountInfo::reduced_offset.
             Self::TieredStorage(ts) => ts
-                .write_accounts(accounts, skip, &HOT_FORMAT)
+                .write_accounts(accounts.accounts, skip, &HOT_FORMAT)
                 .map(|mut infos| {
                     infos.iter_mut().for_each(|info| {
                         info.offset = AccountInfo::reduced_offset_to_offset(info.offset as u32);


### PR DESCRIPTION
#### Problem

We no longer store account hashes in storages, yet we still haul 'em around and sometimes (re)calculate them. This is unnecessary.

TieredStorage never stores account hashes, so the hashes in `StorableAccountsWithHashes` are unnecessary. Since that was the only reason to use `StorableAccountsWithHashes`, it can be replaced back with the simpler `StorableAccounts`.


#### Summary of Changes

Updates TieredStorage  to use `StorableAccounts` directly