### PR TITLE
Removes unused hashes params from store functions

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -11,7 +11,6 @@ use {
             ShrinkCollectAliveSeparatedByRefs, ShrinkStatsSub,
         },
         accounts_file::AccountsFile,
-        accounts_hash::AccountHash,
         accounts_index::AccountsIndexScanResult,
         active_stats::ActiveStatItem,
         storable_accounts::{StorableAccounts, StorableAccountsBySlot},
@@ -449,11 +448,9 @@ impl AccountsDb {
         let target_slot = accounts_to_write.target_slot();
         let (shrink_in_progress, create_and_insert_store_elapsed_us) =
             measure_us!(self.get_store_for_shrink(target_slot, bytes));
-        let (store_accounts_timing, rewrite_elapsed_us) = measure_us!(self.store_accounts_frozen(
-            accounts_to_write,
-            None::<Vec<AccountHash>>,
-            shrink_in_progress.new_storage(),
-        ));
+        let (store_accounts_timing, rewrite_elapsed_us) = measure_us!(
+            self.store_accounts_frozen(accounts_to_write, shrink_in_progress.new_storage(),)
+        );
 
         write_ancient_accounts.metrics.accumulate(&ShrinkStatsSub {
             store_accounts_timing,
@@ -999,6 +996,7 @@ pub mod tests {
                 },
                 ShrinkCollectRefs,
             },
+            accounts_hash::AccountHash,
             accounts_index::UpsertReclaim,
             append_vec::{aligned_stored_size, AppendVec, AppendVecStoredAccountMeta},
             storable_accounts::StorableAccountsBySlot,

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -345,20 +345,15 @@ impl<'a> SnapshotMinimizer<'a> {
         let mut shrink_in_progress = None;
         if aligned_total > 0 {
             let mut accounts = Vec::with_capacity(keep_accounts.len());
-            let mut hashes = Vec::with_capacity(keep_accounts.len());
 
             for alive_account in keep_accounts {
                 accounts.push(alive_account);
-                hashes.push(alive_account.hash());
             }
 
             shrink_in_progress = Some(self.accounts_db().get_store_for_shrink(slot, aligned_total));
             let new_storage = shrink_in_progress.as_ref().unwrap().new_storage();
-            self.accounts_db().store_accounts_frozen(
-                (slot, &accounts[..]),
-                Some(hashes),
-                new_storage,
-            );
+            self.accounts_db()
+                .store_accounts_frozen((slot, &accounts[..]), new_storage);
 
             new_storage.flush().unwrap();
         }


### PR DESCRIPTION
#### Problem

Now that we've removed account hashes as part of storing accounts, we no longer need to create/pass hashes to the various `store` functions.


#### Summary of Changes

Removes unused hashes params from store functions.