### PR TITLE
removes #[derive(Ord, PartialOrd)] from LegacyContactInfo

### DIFF
--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -284,7 +284,7 @@ fn spy(
         if let Some(num) = num_nodes {
             // Only consider validators and archives for `num_nodes`
             let mut nodes: Vec<_> = tvu_peers.iter().collect();
-            nodes.sort();
+            nodes.sort_unstable_by_key(|node| node.pubkey());
             nodes.dedup();
 
             if nodes.len() >= num {

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -16,9 +16,7 @@ use {
 };
 
 /// Structure representing a node on the network
-#[derive(
-    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, AbiExample, Deserialize, Serialize,
-)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, AbiExample, Deserialize, Serialize)]
 pub struct LegacyContactInfo {
     id: Pubkey,
     /// gossip address


### PR DESCRIPTION

#### Problem
`Ord` and `PartialOrd` traits are not necessary for `LegacyContactInfo` and removing them will simplify new `ContactInfo` migration.


#### Summary of Changes
Removed `#[derive(Ord, PartialOrd)]` from `LegacyContactInfo`.