### PR TITLE
Extract  LoadProgramMetrics::submit_datapoint into new crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6523,7 +6523,7 @@ dependencies = [
 
 [[package]]
 name = "solana-load-program-metrics-submit"
-version = "0.0.1"
+version = "2.0.0"
 dependencies = [
  "log",
  "solana-metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6523,7 +6523,7 @@ dependencies = [
 
 [[package]]
 name = "solana-load-program-metrics-submit"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "log",
  "solana-metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5718,6 +5718,7 @@ dependencies = [
  "scopeguard",
  "solana-compute-budget",
  "solana-curve25519",
+ "solana-load-program-metrics-submit",
  "solana-measure",
  "solana-poseidon",
  "solana-program-runtime",
@@ -6521,12 +6522,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-load-program-metrics-submit"
+version = "0.0.1"
+dependencies = [
+ "log",
+ "solana-metrics",
+ "solana-program-runtime",
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-loader-v4-program"
 version = "2.1.0"
 dependencies = [
  "bincode",
  "log",
  "solana-compute-budget",
+ "solana-load-program-metrics-submit",
  "solana-measure",
  "solana-program-runtime",
  "solana-sdk",
@@ -7470,6 +7482,7 @@ dependencies = [
  "solana-compute-budget-program",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-load-program-metrics-submit",
  "solana-loader-v4-program",
  "solana-logger",
  "solana-measure",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6872,7 +6872,6 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-logger",
  "solana-measure",
- "solana-metrics",
  "solana-sdk",
  "solana-type-overrides",
  "solana-vote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -358,7 +358,7 @@ solana-gossip = { path = "gossip", version = "=2.1.0" }
 solana-inline-spl = { path = "inline-spl", version = "=2.1.0" }
 solana-ledger = { path = "ledger", version = "=2.1.0" }
 solana-loader-v4-program = { path = "programs/loader-v4", version = "=2.1.0" }
-solana-load-program-metrics-submit = { path = "load-program-metrics-submit", version = "=0.0.1" }
+solana-load-program-metrics-submit = { path = "load-program-metrics-submit", version = "=2.1.0" }
 solana-local-cluster = { path = "local-cluster", version = "=2.1.0" }
 solana-logger = { path = "logger", version = "=2.1.0" }
 solana-measure = { path = "measure", version = "=2.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "keygen",
     "ledger",
     "ledger-tool",
+    "load-program-metrics-submit",
     "local-cluster",
     "log-analyzer",
     "logger",
@@ -357,6 +358,7 @@ solana-gossip = { path = "gossip", version = "=2.1.0" }
 solana-inline-spl = { path = "inline-spl", version = "=2.1.0" }
 solana-ledger = { path = "ledger", version = "=2.1.0" }
 solana-loader-v4-program = { path = "programs/loader-v4", version = "=2.1.0" }
+solana-load-program-metrics-submit = { path = "load-program-metrics-submit", version = "=0.0.1" }
 solana-local-cluster = { path = "local-cluster", version = "=2.1.0" }
 solana-logger = { path = "logger", version = "=2.1.0" }
 solana-measure = { path = "measure", version = "=2.1.0" }

--- a/load-program-metrics-submit/Cargo.toml
+++ b/load-program-metrics-submit/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-load-program-metrics-submit"
+description = "Utility crate not intended for external use."
+documentation = "https://docs.rs/solana-load-program-metrics-submit"
+version = "0.0.1"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+log = { workspace = true }
+solana-metrics = { workspace = true }
+solana-program-runtime = { workspace = true }
+solana-sdk = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/load-program-metrics-submit/Cargo.toml
+++ b/load-program-metrics-submit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-load-program-metrics-submit"
 description = "Utility crate not intended for external use."
 documentation = "https://docs.rs/solana-load-program-metrics-submit"
-version = "0.0.1"
+version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/load-program-metrics-submit/src/lib.rs
+++ b/load-program-metrics-submit/src/lib.rs
@@ -1,0 +1,29 @@
+use {
+    solana_metrics::datapoint_trace,
+    solana_program_runtime::{loaded_programs::LoadProgramMetrics, timings::ExecuteDetailsTimings},
+    solana_sdk::saturating_add_assign,
+};
+
+pub fn submit_datapoint(metrics: LoadProgramMetrics, timings: &mut ExecuteDetailsTimings) {
+    saturating_add_assign!(
+        timings.create_executor_register_syscalls_us,
+        metrics.register_syscalls_us
+    );
+    saturating_add_assign!(timings.create_executor_load_elf_us, metrics.load_elf_us);
+    saturating_add_assign!(
+        timings.create_executor_verify_code_us,
+        metrics.verify_code_us
+    );
+    saturating_add_assign!(
+        timings.create_executor_jit_compile_us,
+        metrics.jit_compile_us
+    );
+    datapoint_trace!(
+        "create_executor_trace",
+        ("program_id", metrics.program_id, String),
+        ("register_syscalls_us", metrics.register_syscalls_us, i64),
+        ("load_elf_us", metrics.load_elf_us, i64),
+        ("verify_code_us", metrics.verify_code_us, i64),
+        ("jit_compile_us", metrics.jit_compile_us, i64),
+    );
+}

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -26,7 +26,6 @@ solana-compute-budget = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-measure = { workspace = true }
-solana-metrics = { workspace = true }
 solana-sdk = { workspace = true }
 solana-type-overrides = { workspace = true }
 solana-vote = { workspace = true }

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -5,9 +5,6 @@
 #[macro_use]
 extern crate eager;
 
-#[macro_use]
-extern crate solana_metrics;
-
 pub use solana_rbpf;
 pub mod invoke_context;
 pub mod loaded_programs;

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        invoke_context::{BuiltinFunctionWithContext, InvokeContext},
-        timings::ExecuteDetailsTimings,
-    },
+    crate::invoke_context::{BuiltinFunctionWithContext, InvokeContext},
     log::{debug, error, log_enabled, trace},
     percentage::PercentageInteger,
     solana_measure::measure::Measure,
@@ -291,26 +288,6 @@ pub struct LoadProgramMetrics {
     pub verify_code_us: u64,
     /// Microseconds it took to `executable.jit_compile`
     pub jit_compile_us: u64,
-}
-
-impl LoadProgramMetrics {
-    pub fn submit_datapoint(&self, timings: &mut ExecuteDetailsTimings) {
-        saturating_add_assign!(
-            timings.create_executor_register_syscalls_us,
-            self.register_syscalls_us
-        );
-        saturating_add_assign!(timings.create_executor_load_elf_us, self.load_elf_us);
-        saturating_add_assign!(timings.create_executor_verify_code_us, self.verify_code_us);
-        saturating_add_assign!(timings.create_executor_jit_compile_us, self.jit_compile_us);
-        datapoint_trace!(
-            "create_executor_trace",
-            ("program_id", self.program_id, String),
-            ("register_syscalls_us", self.register_syscalls_us, i64),
-            ("load_elf_us", self.load_elf_us, i64),
-            ("verify_code_us", self.verify_code_us, i64),
-            ("jit_compile_us", self.jit_compile_us, i64),
-        );
-    }
 }
 
 impl PartialEq for ProgramCacheEntry {

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -17,6 +17,7 @@ log = { workspace = true }
 scopeguard = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-curve25519 = { workspace = true }
+solana-load-program-metrics-submit = { workspace = true }
 solana-measure = { workspace = true }
 solana-poseidon = { workspace = true }
 solana-program-runtime = { workspace = true }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -165,7 +165,7 @@ macro_rules! deploy_program {
         }
         $drop
         load_program_metrics.program_id = $program_id.to_string();
-        load_program_metrics.submit_datapoint(&mut $invoke_context.timings);
+        ::solana_load_program_metrics_submit::submit_datapoint(load_program_metrics, &mut $invoke_context.timings);
         $invoke_context.program_cache_for_tx_batch.store_modified_entry($program_id, Arc::new(executor));
     }};
 }

--- a/programs/loader-v4/Cargo.toml
+++ b/programs/loader-v4/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 [dependencies]
 log = { workspace = true }
 solana-compute-budget = { workspace = true }
+solana-load-program-metrics-submit = { workspace = true }
 solana-measure = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-sdk = { workspace = true }

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -1,5 +1,6 @@
 use {
     solana_compute_budget::compute_budget::ComputeBudget,
+    solana_load_program_metrics_submit::submit_datapoint,
     solana_measure::measure::Measure,
     solana_program_runtime::{
         ic_logger_msg,
@@ -432,7 +433,7 @@ pub fn process_instruction_deploy(
         ic_logger_msg!(log_collector, "{}", err);
         InstructionError::InvalidAccountData
     })?;
-    load_program_metrics.submit_datapoint(&mut invoke_context.timings);
+    submit_datapoint(load_program_metrics, &mut invoke_context.timings);
     if let Some(mut source_program) = source_program {
         let rent = invoke_context.get_sysvar_cache().get_rent()?;
         let required_lamports = rent.minimum_balance(source_program.get_data().len());

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5348,7 +5348,6 @@ dependencies = [
  "serde",
  "solana-compute-budget",
  "solana-measure",
- "solana-metrics",
  "solana-sdk",
  "solana-type-overrides",
  "solana-vote",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4669,6 +4669,7 @@ dependencies = [
  "scopeguard",
  "solana-compute-budget",
  "solana-curve25519",
+ "solana-load-program-metrics-submit",
  "solana-measure",
  "solana-poseidon",
  "solana-program-runtime",
@@ -5146,11 +5147,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-load-program-metrics-submit"
+version = "0.0.1"
+dependencies = [
+ "log",
+ "solana-metrics",
+ "solana-program-runtime",
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-loader-v4-program"
 version = "2.1.0"
 dependencies = [
  "log",
  "solana-compute-budget",
+ "solana-load-program-metrics-submit",
  "solana-measure",
  "solana-program-runtime",
  "solana-sdk",
@@ -6283,6 +6295,7 @@ dependencies = [
  "serde_derive",
  "solana-bpf-loader-program",
  "solana-compute-budget",
+ "solana-load-program-metrics-submit",
  "solana-loader-v4-program",
  "solana-measure",
  "solana-metrics",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5148,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "solana-load-program-metrics-submit"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "log",
  "solana-metrics",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5148,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "solana-load-program-metrics-submit"
-version = "0.0.1"
+version = "2.0.0"
 dependencies = [
  "log",
  "solana-metrics",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -20,8 +20,8 @@ solana-bpf-loader-program = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
-solana-loader-v4-program = { workspace = true }
 solana-load-program-metrics-submit = { workspace = true }
+solana-loader-v4-program = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-program-runtime = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -21,6 +21,7 @@ solana-compute-budget = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-loader-v4-program = { workspace = true }
+solana-load-program-metrics-submit = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-program-runtime = { workspace = true }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -1,5 +1,6 @@
 use {
     crate::transaction_processing_callback::TransactionProcessingCallback,
+    solana_load_program_metrics_submit::submit_datapoint,
     solana_program_runtime::{
         loaded_programs::{
             LoadProgramMetrics, ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
@@ -213,7 +214,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     });
 
     let mut timings = ExecuteDetailsTimings::default();
-    load_program_metrics.submit_datapoint(&mut timings);
+    submit_datapoint(load_program_metrics, &mut timings);
     loaded_program.update_access_slot(slot);
     Some(Arc::new(loaded_program))
 }


### PR DESCRIPTION
#### Problem
See item 2 in #480 

#### Summary of Changes
This moves `LoadProgramMetrics::submit_datapoint` into a new crate as a free function. This new crate is called `solana-load-program-metrics-submit`. We can call it something else if anyone has strong feelings but I think the big dumb name is fine, and bikeshedding is best avoided. The crate is not meant for direct use by the public anyway.

I checked if we could just move `submit_datapoint` into an existing crate, but the crates that already rely on it (svm, bpf-loader and loader-v4) don't have an appropriate common dependency to move it into.

Lastly this PR removes the now-unused metrics dependency from program-runtime 🎉

Fixes #480 
