### PR TITLE
tests had invalid storage offset

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9778,7 +9778,7 @@ pub mod tests {
             executable: false,
             rent_epoch: 0,
         };
-        let offset = 3;
+        let offset = 3 * std::mem::size_of::<u64>();
         let hash = AccountHash(Hash::new(&[2; 32]));
         let stored_meta = StoredMeta {
             // global write version
@@ -9880,7 +9880,7 @@ pub mod tests {
             executable,
             rent_epoch,
         };
-        let offset = 99;
+        let offset = 99 * std::mem::size_of::<u64>(); // offset needs to be 8 byte aligned
         let stored_size = 101;
         let hash = AccountHash(Hash::new_unique());
         let stored_account = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
@@ -12131,7 +12131,7 @@ pub mod tests {
             rent_epoch,
             data: data.clone(),
         };
-        let offset = 99;
+        let offset = 99 * std::mem::size_of::<u64>(); // offset needs to be 8 byte aligned
         let stored_size = 101;
         let hash = AccountHash(Hash::new_unique());
         let stored_account = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -393,7 +393,7 @@ pub mod tests {
             rent_epoch,
         };
         let data = Vec::default();
-        let offset = 99;
+        let offset = 99 * std::mem::size_of::<u64>(); // offset needs to be 8 byte aligned
         let stored_size = 101;
         let hash = AccountHash(Hash::new_unique());
         let stored_account = StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
@@ -448,7 +448,7 @@ pub mod tests {
                         ));
                     }
                     for entry in 0..entries {
-                        let offset = 99;
+                        let offset = 99 * std::mem::size_of::<u64>(); // offset needs to be 8 byte aligned
                         let stored_size = 101;
                         let raw = &raw[entry as usize];
                         raw2.push(StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
@@ -550,7 +550,7 @@ pub mod tests {
                 ));
             }
             for entry in 0..entries {
-                let offset = 99;
+                let offset = 99 * std::mem::size_of::<u64>(); // offset needs to be 8 byte aligned
                 let stored_size = 101;
                 raw2.push(StoredAccountMeta::AppendVec(AppendVecStoredAccountMeta {
                     meta: &raw[entry as usize].2,


### PR DESCRIPTION
#### Problem
offsets in the index have to be 8 byte aligned since append vecs always stored on 8 byte aligned boundaries. This has not been important before now. Changes coming soon expose these offsets as sloppy and cause failures.

#### Summary of Changes
Set offsets to be 8 byte aligned.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
