### PR TITLE
Refactor - Rename `LoadedProgram` to `ProgramCacheEntry`

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -816,7 +816,7 @@ mod tests {
     use {
         super::*,
         assert_matches::assert_matches,
-        solana_program_runtime::loaded_programs::LoadedProgramsForTxBatch,
+        solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
         solana_sdk::{
             account::{AccountSharedData, WritableAccount},
             address_lookup_table::state::LookupTableMeta,
@@ -867,7 +867,7 @@ mod tests {
                 executed_units: 0,
                 accounts_data_len_delta: 0,
             },
-            programs_modified_by_tx: Box::<LoadedProgramsForTxBatch>::default(),
+            programs_modified_by_tx: Box::<ProgramCacheForTxBatch>::default(),
         }
     }
 

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -12,7 +12,9 @@ use {
     solana_ledger::{blockstore_options::AccessType, use_snapshot_archives_at_startup},
     solana_program_runtime::{
         invoke_context::InvokeContext,
-        loaded_programs::{LoadProgramMetrics, LoadedProgramType, DELAY_VISIBILITY_SLOT_OFFSET},
+        loaded_programs::{
+            LoadProgramMetrics, ProgramCacheEntryType, DELAY_VISIBILITY_SLOT_OFFSET,
+        },
         with_mock_invoke_context,
     },
     solana_rbpf::{
@@ -344,7 +346,7 @@ fn load_program<'a>(
         );
         match result {
             Ok(loaded_program) => match loaded_program.program {
-                LoadedProgramType::Loaded(program) => Ok(program),
+                ProgramCacheEntryType::Loaded(program) => Ok(program),
                 _ => unreachable!(),
             },
             Err(err) => Err(format!("Loading executable failed: {err:?}")),

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -17,7 +17,7 @@ use {
     solana_bpf_loader_program::serialization::serialize_parameters,
     solana_program_runtime::{
         compute_budget::ComputeBudget, ic_msg, invoke_context::BuiltinFunctionWithContext,
-        loaded_programs::LoadedProgram, stable_log, timings::ExecuteTimings,
+        loaded_programs::ProgramCacheEntry, stable_log, timings::ExecuteTimings,
     },
     solana_runtime::{
         accounts_background_service::{AbsRequestSender, SnapshotRequestKind},
@@ -463,7 +463,7 @@ pub fn read_file<P: AsRef<Path>>(path: P) -> Vec<u8> {
 
 pub struct ProgramTest {
     accounts: Vec<(Pubkey, AccountSharedData)>,
-    builtin_programs: Vec<(Pubkey, &'static str, LoadedProgram)>,
+    builtin_programs: Vec<(Pubkey, &'static str, ProgramCacheEntry)>,
     compute_max_units: Option<u64>,
     prefer_bpf: bool,
     deactivate_feature_set: HashSet<Pubkey>,
@@ -728,7 +728,7 @@ impl ProgramTest {
         self.builtin_programs.push((
             program_id,
             program_name,
-            LoadedProgram::new_builtin(0, program_name.len(), builtin_function),
+            ProgramCacheEntry::new_builtin(0, program_name.len(), builtin_function),
         ));
     }
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4281,7 +4281,7 @@ fn test_cpi_deprecated_loader_realloc() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_cpi_change_account_data_memory_allocation() {
-    use solana_program_runtime::{declare_process_instruction, loaded_programs::LoadedProgram};
+    use solana_program_runtime::{declare_process_instruction, loaded_programs::ProgramCacheEntry};
 
     solana_logger::setup();
 
@@ -4331,7 +4331,7 @@ fn test_cpi_change_account_data_memory_allocation() {
         &bank,
         builtin_program_id,
         "test_cpi_change_account_data_memory_allocation_builtin",
-        LoadedProgram::new_builtin(0, 42, MockBuiltin::vm),
+        ProgramCacheEntry::new_builtin(0, 42, MockBuiltin::vm),
     );
 
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -1,6 +1,6 @@
 use {
     crate::bank::Bank,
-    solana_program_runtime::loaded_programs::LoadedProgramStats,
+    solana_program_runtime::loaded_programs::ProgramCacheStats,
     solana_sdk::clock::{Epoch, Slot},
     std::sync::atomic::{
         AtomicU64,
@@ -205,7 +205,7 @@ pub(crate) fn report_partitioned_reward_metrics(bank: &Bank, timings: RewardsSto
 }
 
 /// Logs the measurement values
-pub(crate) fn report_loaded_programs_stats(stats: &LoadedProgramStats, slot: Slot) {
+pub(crate) fn report_loaded_programs_stats(stats: &ProgramCacheStats, slot: Slot) {
     let hits = stats.hits.load(Ordering::Relaxed);
     let misses = stats.misses.load(Ordering::Relaxed);
     let evictions: u64 = stats.evictions.values().sum();

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -39,7 +39,7 @@ use {
         compute_budget::ComputeBudget,
         compute_budget_processor::{self, MAX_COMPUTE_UNIT_LIMIT},
         declare_process_instruction,
-        loaded_programs::{LoadedProgram, LoadedProgramType, LoadedProgramsForTxBatch},
+        loaded_programs::{ProgramCacheEntry, ProgramCacheEntryType, ProgramCacheForTxBatch},
         prioritization_fee::{PrioritizationFeeDetails, PrioritizationFeeType},
         timings::ExecuteTimings,
     },
@@ -242,7 +242,7 @@ fn new_execution_result(
             executed_units: 0,
             accounts_data_len_delta: 0,
         },
-        programs_modified_by_tx: Box::<LoadedProgramsForTxBatch>::default(),
+        programs_modified_by_tx: Box::<ProgramCacheForTxBatch>::default(),
     }
 }
 
@@ -4709,13 +4709,13 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
             &bank,
             vote_id,
             "mock_program1",
-            LoadedProgram::new_builtin(0, 0, MockBuiltin::vm),
+            ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm),
         );
         bank.transaction_processor.add_builtin(
             &bank,
             stake_id,
             "mock_program2",
-            LoadedProgram::new_builtin(0, 0, MockBuiltin::vm),
+            ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm),
         );
         {
             let stakes = bank.stakes_cache.stakes();
@@ -6305,7 +6305,7 @@ fn test_fuzz_instructions() {
                 &bank,
                 key,
                 name.as_str(),
-                LoadedProgram::new_builtin(0, 0, MockBuiltin::vm),
+                ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm),
             );
             (key, name.as_bytes().to_vec())
         })
@@ -7106,7 +7106,7 @@ fn test_bank_load_program() {
     bank.store_account_and_update_capitalization(&key1, &program_account);
     bank.store_account_and_update_capitalization(&programdata_key, &programdata_account);
     let program = bank.load_program(&key1, false, bank.epoch()).unwrap();
-    assert_matches!(program.program, LoadedProgramType::Loaded(_));
+    assert_matches!(program.program, ProgramCacheEntryType::Loaded(_));
     assert_eq!(
         program.account_size,
         program_account.data().len() + programdata_account.data().len()
@@ -7220,7 +7220,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         assert_eq!(slot_versions[0].effective_slot, 0);
         assert!(matches!(
             slot_versions[0].program,
-            LoadedProgramType::Closed,
+            ProgramCacheEntryType::Closed,
         ));
     }
 
@@ -7244,7 +7244,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         assert_eq!(slot_versions[0].effective_slot, 0);
         assert!(matches!(
             slot_versions[0].program,
-            LoadedProgramType::Closed,
+            ProgramCacheEntryType::Closed,
         ));
     }
 
@@ -7346,13 +7346,13 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         assert_eq!(slot_versions[0].effective_slot, 0);
         assert!(matches!(
             slot_versions[0].program,
-            LoadedProgramType::Closed,
+            ProgramCacheEntryType::Closed,
         ));
         assert_eq!(slot_versions[1].deployment_slot, 0);
         assert_eq!(slot_versions[1].effective_slot, 1);
         assert!(matches!(
             slot_versions[1].program,
-            LoadedProgramType::Loaded(_),
+            ProgramCacheEntryType::Loaded(_),
         ));
     }
 

--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -229,12 +229,12 @@ Steps of `load_and_execute_sanitized_transactions`
    5. Make two local variables that will be used as output parameters
       of `MessageProcessor::process_message`. One will contain the
       number of executed units (the number of compute unites consumed
-      in the transaction). Another is a container of `LoadedProgramsForTxBatch`.
+      in the transaction). Another is a container of `ProgramCacheForTxBatch`.
       The latter is initialized with the slot, and
       the clone of environments of `programs_loaded_for_tx_batch`
-         - `programs_loaded_for_tx_batch` contains a reference to all the `LoadedProgram`s
+         - `programs_loaded_for_tx_batch` contains a reference to all the `ProgramCacheEntry`s
             necessary for the transaction. It maintains an `Arc` to the programs in the global
-            `LoadedPrograms` data structure.
+            `ProgramCacheEntrys` data structure.
       6. Call `MessageProcessor::process_message` to execute the
       transaction. `MessageProcessor` is contained in
       solana-program-runtime crate. The result of processing message

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -8,7 +8,7 @@ use {
     log::warn,
     solana_program_runtime::{
         compute_budget_processor::process_compute_budget_instructions,
-        loaded_programs::{LoadedProgram, LoadedProgramsForTxBatch},
+        loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
     },
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
@@ -114,7 +114,7 @@ pub(crate) fn load_accounts<CB: TransactionProcessingCallback>(
     error_counters: &mut TransactionErrorMetrics,
     fee_structure: &FeeStructure,
     account_overrides: Option<&AccountOverrides>,
-    loaded_programs: &LoadedProgramsForTxBatch,
+    loaded_programs: &ProgramCacheForTxBatch,
 ) -> Vec<TransactionLoadResult> {
     let feature_set = callbacks.get_feature_set();
     txs.iter()
@@ -180,7 +180,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
     fee: u64,
     error_counters: &mut TransactionErrorMetrics,
     account_overrides: Option<&AccountOverrides>,
-    loaded_programs: &LoadedProgramsForTxBatch,
+    loaded_programs: &ProgramCacheForTxBatch,
 ) -> Result<LoadedTransaction> {
     let feature_set = callbacks.get_feature_set();
 
@@ -408,7 +408,7 @@ fn get_requested_loaded_accounts_data_size_limit(
     )
 }
 
-fn account_shared_data_from_program(loaded_program: &LoadedProgram) -> AccountSharedData {
+fn account_shared_data_from_program(loaded_program: &ProgramCacheEntry) -> AccountSharedData {
     // It's an executable program account. The program is already loaded in the cache.
     // So the account data is not needed. Return a dummy AccountSharedData with meta
     // information.
@@ -461,7 +461,7 @@ mod tests {
         solana_program_runtime::{
             compute_budget::ComputeBudget,
             compute_budget_processor,
-            loaded_programs::{LoadedProgram, LoadedProgramsForTxBatch},
+            loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
             prioritization_fee::{PrioritizationFeeDetails, PrioritizationFeeType},
         },
         solana_sdk::{
@@ -550,7 +550,7 @@ mod tests {
             error_counters,
             fee_structure,
             None,
-            &LoadedProgramsForTxBatch::default(),
+            &ProgramCacheForTxBatch::default(),
         )
     }
 
@@ -1038,7 +1038,7 @@ mod tests {
             &mut error_counters,
             &FeeStructure::default(),
             account_overrides,
-            &LoadedProgramsForTxBatch::default(),
+            &ProgramCacheForTxBatch::default(),
         )
     }
 
@@ -1429,7 +1429,7 @@ mod tests {
         let sanitized_message = new_unchecked_sanitized_message(message);
         let mock_bank = TestCallbacks::default();
         let mut error_counter = TransactionErrorMetrics::default();
-        let loaded_programs = LoadedProgramsForTxBatch::default();
+        let loaded_programs = ProgramCacheForTxBatch::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1472,7 +1472,7 @@ mod tests {
         mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
         let mut error_counter = TransactionErrorMetrics::default();
-        let loaded_programs = LoadedProgramsForTxBatch::default();
+        let loaded_programs = ProgramCacheForTxBatch::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1536,8 +1536,8 @@ mod tests {
         mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
         let mut error_counter = TransactionErrorMetrics::default();
-        let mut loaded_programs = LoadedProgramsForTxBatch::default();
-        loaded_programs.replenish(key2.pubkey(), Arc::new(LoadedProgram::default()));
+        let mut loaded_programs = ProgramCacheForTxBatch::default();
+        loaded_programs.replenish(key2.pubkey(), Arc::new(ProgramCacheEntry::default()));
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1579,7 +1579,7 @@ mod tests {
         mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
         let mut error_counter = TransactionErrorMetrics::default();
-        let loaded_programs = LoadedProgramsForTxBatch::default();
+        let loaded_programs = ProgramCacheForTxBatch::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1621,7 +1621,7 @@ mod tests {
         mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
         let mut error_counter = TransactionErrorMetrics::default();
-        let loaded_programs = LoadedProgramsForTxBatch::default();
+        let loaded_programs = ProgramCacheForTxBatch::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1670,7 +1670,7 @@ mod tests {
         account_data.set_lamports(200);
         mock_bank.accounts_map.insert(key2.pubkey(), account_data);
         let mut error_counter = TransactionErrorMetrics::default();
-        let loaded_programs = LoadedProgramsForTxBatch::default();
+        let loaded_programs = ProgramCacheForTxBatch::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1737,7 +1737,7 @@ mod tests {
         account_data.set_lamports(200);
         mock_bank.accounts_map.insert(key2.pubkey(), account_data);
         let mut error_counter = TransactionErrorMetrics::default();
-        let loaded_programs = LoadedProgramsForTxBatch::default();
+        let loaded_programs = ProgramCacheForTxBatch::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1793,7 +1793,7 @@ mod tests {
             .accounts_map
             .insert(key3.pubkey(), AccountSharedData::default());
         let mut error_counter = TransactionErrorMetrics::default();
-        let loaded_programs = LoadedProgramsForTxBatch::default();
+        let loaded_programs = ProgramCacheForTxBatch::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1854,7 +1854,7 @@ mod tests {
         mock_bank.accounts_map.insert(key3.pubkey(), account_data);
 
         let mut error_counter = TransactionErrorMetrics::default();
-        let loaded_programs = LoadedProgramsForTxBatch::default();
+        let loaded_programs = ProgramCacheForTxBatch::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1941,7 +1941,7 @@ mod tests {
         mock_bank.accounts_map.insert(key3.pubkey(), account_data);
 
         let mut error_counter = TransactionErrorMetrics::default();
-        let loaded_programs = LoadedProgramsForTxBatch::default();
+        let loaded_programs = ProgramCacheForTxBatch::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -2025,7 +2025,7 @@ mod tests {
             &mut error_counters,
             &FeeStructure::default(),
             None,
-            &LoadedProgramsForTxBatch::default(),
+            &ProgramCacheForTxBatch::default(),
         );
 
         let compute_budget = ComputeBudget::new(u64::from(
@@ -2091,7 +2091,7 @@ mod tests {
         mock_bank.accounts_map.insert(key3.pubkey(), account_data);
 
         let mut error_counter = TransactionErrorMetrics::default();
-        let loaded_programs = LoadedProgramsForTxBatch::default();
+        let loaded_programs = ProgramCacheForTxBatch::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -2181,7 +2181,7 @@ mod tests {
             &mut TransactionErrorMetrics::default(),
             &fee_structure,
             None,
-            &LoadedProgramsForTxBatch::default(),
+            &ProgramCacheForTxBatch::default(),
         );
 
         assert_eq!(
@@ -2199,7 +2199,7 @@ mod tests {
             &mut TransactionErrorMetrics::default(),
             &fee_structure,
             None,
-            &LoadedProgramsForTxBatch::default(),
+            &ProgramCacheForTxBatch::default(),
         );
 
         assert_eq!(result, vec![(Err(TransactionError::AccountNotFound), None)]);
@@ -2217,7 +2217,7 @@ mod tests {
             &mut TransactionErrorMetrics::default(),
             &fee_structure,
             None,
-            &LoadedProgramsForTxBatch::default(),
+            &ProgramCacheForTxBatch::default(),
         );
 
         assert_eq!(

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -148,7 +148,7 @@ mod tests {
         solana_program_runtime::{
             compute_budget::ComputeBudget,
             declare_process_instruction,
-            loaded_programs::{LoadedProgram, LoadedProgramsForTxBatch},
+            loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
             sysvar_cache::SysvarCache,
         },
         solana_sdk::{
@@ -239,10 +239,10 @@ mod tests {
         ];
         let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3);
         let program_indices = vec![vec![2]];
-        let mut programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
+        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
         programs_loaded_for_tx_batch.replenish(
             mock_system_program_id,
-            Arc::new(LoadedProgram::new_builtin(0, 0, MockBuiltin::vm)),
+            Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
         let account_keys = (0..transaction_context.get_number_of_accounts())
             .map(|index| {
@@ -271,7 +271,7 @@ mod tests {
             ]),
         ));
         let sysvar_cache = SysvarCache::default();
-        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &sysvar_cache,
@@ -322,7 +322,7 @@ mod tests {
                 ),
             ]),
         ));
-        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &sysvar_cache,
@@ -363,7 +363,7 @@ mod tests {
                 ),
             ]),
         ));
-        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &sysvar_cache,
@@ -465,10 +465,10 @@ mod tests {
         ];
         let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3);
         let program_indices = vec![vec![2]];
-        let mut programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
+        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
         programs_loaded_for_tx_batch.replenish(
             mock_program_id,
-            Arc::new(LoadedProgram::new_builtin(0, 0, MockBuiltin::vm)),
+            Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
         let account_metas = vec![
             AccountMeta::new(
@@ -495,7 +495,7 @@ mod tests {
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
         let sysvar_cache = SysvarCache::default();
-        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &sysvar_cache,
@@ -531,7 +531,7 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
-        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &sysvar_cache,
@@ -564,7 +564,7 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
-        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &sysvar_cache,
@@ -653,12 +653,12 @@ mod tests {
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
         let sysvar_cache = SysvarCache::default();
-        let mut programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
+        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
         programs_loaded_for_tx_batch.replenish(
             mock_program_id,
-            Arc::new(LoadedProgram::new_builtin(0, 0, MockBuiltin::vm)),
+            Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
-        let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &sysvar_cache,

--- a/svm/src/transaction_results.rs
+++ b/svm/src/transaction_results.rs
@@ -5,7 +5,7 @@
 )]
 pub use solana_sdk::inner_instruction::{InnerInstruction, InnerInstructionsList};
 use {
-    solana_program_runtime::loaded_programs::LoadedProgramsForTxBatch,
+    solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
     solana_sdk::{
         nonce_info::{NonceFull, NonceInfo},
         rent_debits::RentDebits,
@@ -34,7 +34,7 @@ pub struct TransactionResults {
 pub enum TransactionExecutionResult {
     Executed {
         details: TransactionExecutionDetails,
-        programs_modified_by_tx: Box<LoadedProgramsForTxBatch>,
+        programs_modified_by_tx: Box<ProgramCacheForTxBatch>,
     },
     NotExecuted(TransactionError),
 }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -10,7 +10,7 @@ use {
         compute_budget::ComputeBudget,
         invoke_context::InvokeContext,
         loaded_programs::{
-            BlockRelation, ForkGraph, LoadedProgram, ProgramCache, ProgramRuntimeEnvironments,
+            BlockRelation, ForkGraph, ProgramCache, ProgramCacheEntry, ProgramRuntimeEnvironments,
         },
         solana_rbpf::{
             program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
@@ -236,7 +236,7 @@ fn register_builtins(
         mock_bank,
         bpf_loader_upgradeable::id(),
         BPF_LOADER_NAME,
-        LoadedProgram::new_builtin(
+        ProgramCacheEntry::new_builtin(
             DEPLOYMENT_SLOT,
             BPF_LOADER_NAME.len(),
             solana_bpf_loader_program::Entrypoint::vm,
@@ -249,7 +249,7 @@ fn register_builtins(
         mock_bank,
         solana_system_program::id(),
         SYSTEM_PROGRAM_NAME,
-        LoadedProgram::new_builtin(
+        ProgramCacheEntry::new_builtin(
             DEPLOYMENT_SLOT,
             SYSTEM_PROGRAM_NAME.len(),
             solana_system_program::system_processor::Entrypoint::vm,


### PR DESCRIPTION
#### Problem
See: https://github.com/anza-xyz/agave/pull/606#discussion_r1558075238

`LoadedPrograms` has been renamed to `ProgramCache` in #339 already.

#### Summary of Changes
- `LoadedProgramOwner` => `ProgramCacheEntryOwner`
- `LoadedProgramType` => `ProgramCacheEntryType`
- `LoadedProgram` => `ProgramCacheEntry`
- `LoadedProgramStats` => `ProgramCacheStats`
- `LoadedProgramMatchCriteria` => `ProgramCacheMatchCriteria`
- `LoadedProgramsForTxBatch` => `ProgramCacheForTxBatch`
