### PR TITLE
introduce AccountFromStorage for shrink

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -184,7 +184,7 @@ pub(crate) enum ScanAccountStorageData {
 pub(crate) struct AliveAccounts<'a> {
     /// slot the accounts are currently stored in
     pub(crate) slot: Slot,
-    pub(crate) accounts: Vec<&'a StoredAccountMeta<'a>>,
+    pub(crate) accounts: Vec<&'a AccountFromStorage>,
     pub(crate) bytes: usize,
 }
 
@@ -224,12 +224,12 @@ pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
     fn add(
         &mut self,
         ref_count: u64,
-        account: &'a StoredAccountMeta<'a>,
+        account: &'a AccountFromStorage,
         slot_list: &[(Slot, AccountInfo)],
     );
     fn len(&self) -> usize;
     fn alive_bytes(&self) -> usize;
-    fn alive_accounts(&self) -> &Vec<&'a StoredAccountMeta<'a>>;
+    fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage>;
 }
 
 impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
@@ -247,7 +247,7 @@ impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
     fn add(
         &mut self,
         _ref_count: u64,
-        account: &'a StoredAccountMeta<'a>,
+        account: &'a AccountFromStorage,
         _slot_list: &[(Slot, AccountInfo)],
     ) {
         self.accounts.push(account);
@@ -259,7 +259,7 @@ impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
     fn alive_bytes(&self) -> usize {
         self.bytes
     }
-    fn alive_accounts(&self) -> &Vec<&'a StoredAccountMeta<'a>> {
+    fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage> {
         &self.accounts
     }
 }
@@ -281,7 +281,7 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
     fn add(
         &mut self,
         ref_count: u64,
-        account: &'a StoredAccountMeta<'a>,
+        account: &'a AccountFromStorage,
         slot_list: &[(Slot, AccountInfo)],
     ) {
         let other = if ref_count == 1 {
@@ -312,7 +312,7 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
             .saturating_add(self.many_refs_old_alive.alive_bytes())
             .saturating_add(self.many_refs_this_is_newest_alive.alive_bytes())
     }
-    fn alive_accounts(&self) -> &Vec<&'a StoredAccountMeta<'a>> {
+    fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage> {
         unimplemented!("illegal use");
     }
 }
@@ -396,7 +396,7 @@ impl CurrentAncientAccountsFile {
         let previous_available = self.accounts_file().accounts.remaining_bytes();
 
         let accounts = [(accounts_to_store.slot(), accounts)];
-        let storable_accounts = StorableAccountsBySlot::new(self.slot(), &accounts);
+        let storable_accounts = StorableAccountsBySlot::new(self.slot(), &accounts, db);
         let timing = db.store_accounts_frozen(storable_accounts, self.accounts_file());
         let bytes_written =
             previous_available.saturating_sub(self.accounts_file().accounts.remaining_bytes());
@@ -532,8 +532,46 @@ struct LoadAccountsIndexForShrink<'a, T: ShrinkCollectRefs<'a>> {
     index_entries_being_shrunk: Vec<AccountMapEntry<AccountInfo>>,
 }
 
-pub struct GetUniqueAccountsResult<'a> {
-    pub stored_accounts: Vec<StoredAccountMeta<'a>>,
+/// reference an account found during scanning a storage. This is a byval struct to replace
+/// `StoredAccountMeta`
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub struct AccountFromStorage {
+    pub index_info: AccountInfo,
+    pub data_len: u64,
+    pub pubkey: Pubkey,
+}
+
+impl ZeroLamport for AccountFromStorage {
+    fn is_zero_lamport(&self) -> bool {
+        self.index_info.is_zero_lamport()
+    }
+}
+
+impl AccountFromStorage {
+    pub fn pubkey(&self) -> &Pubkey {
+        &self.pubkey
+    }
+    pub fn stored_size(&self) -> usize {
+        aligned_stored_size(self.data_len as usize)
+    }
+    pub fn data_len(&self) -> usize {
+        self.data_len as usize
+    }
+    pub fn new(account: &StoredAccountMeta) -> Self {
+        let storage_id = 0;
+        AccountFromStorage {
+            index_info: AccountInfo::new(
+                StorageLocation::AppendVec(storage_id, account.offset()),
+                account.lamports(),
+            ),
+            pubkey: *account.pubkey(),
+            data_len: account.data_len() as u64,
+        }
+    }
+}
+
+pub struct GetUniqueAccountsResult {
+    pub stored_accounts: Vec<AccountFromStorage>,
     pub capacity: u64,
 }
 
@@ -3687,7 +3725,7 @@ impl AccountsDb {
     /// return sum of account size for all alive accounts
     fn load_accounts_index_for_shrink<'a, T: ShrinkCollectRefs<'a>>(
         &self,
-        accounts: &'a [StoredAccountMeta<'a>],
+        accounts: &'a [AccountFromStorage],
         stats: &ShrinkStats,
         slot_to_shrink: Slot,
     ) -> LoadAccountsIndexForShrink<'a, T> {
@@ -3747,10 +3785,10 @@ impl AccountsDb {
 
     /// get all accounts in all the storages passed in
     /// for duplicate pubkeys, the account with the highest write_value is returned
-    pub fn get_unique_accounts_from_storage<'a>(
+    pub fn get_unique_accounts_from_storage(
         &self,
-        store: &'a Arc<AccountStorageEntry>,
-    ) -> GetUniqueAccountsResult<'a> {
+        store: &Arc<AccountStorageEntry>,
+    ) -> GetUniqueAccountsResult {
         let mut stored_accounts: HashMap<Pubkey, StoredAccountMeta> = HashMap::new();
         let capacity = store.capacity();
         store.accounts.account_iter().for_each(|account| {
@@ -3761,17 +3799,29 @@ impl AccountsDb {
         let mut stored_accounts = stored_accounts.drain().map(|(_k, v)| v).collect::<Vec<_>>();
         stored_accounts.sort_unstable_by(|a, b| a.pubkey().cmp(b.pubkey()));
 
+        let stored_accounts = stored_accounts
+            .into_iter()
+            .map(|v| AccountFromStorage {
+                index_info: AccountInfo::new(
+                    StorageLocation::AppendVec(0, v.offset()),
+                    v.lamports(),
+                ),
+                pubkey: *v.pubkey(),
+                data_len: v.data_len() as u64,
+            })
+            .collect::<Vec<_>>();
+
         GetUniqueAccountsResult {
             stored_accounts,
             capacity,
         }
     }
 
-    pub(crate) fn get_unique_accounts_from_storage_for_shrink<'a>(
+    pub(crate) fn get_unique_accounts_from_storage_for_shrink(
         &self,
-        store: &'a Arc<AccountStorageEntry>,
+        store: &Arc<AccountStorageEntry>,
         stats: &ShrinkStats,
-    ) -> GetUniqueAccountsResult<'a> {
+    ) -> GetUniqueAccountsResult {
         let (result, storage_read_elapsed_us) =
             measure_us!(self.get_unique_accounts_from_storage(store));
         stats
@@ -3785,7 +3835,7 @@ impl AccountsDb {
     pub(crate) fn shrink_collect<'a: 'b, 'b, T: ShrinkCollectRefs<'b>>(
         &self,
         store: &'a Arc<AccountStorageEntry>,
-        unique_accounts: &'b GetUniqueAccountsResult<'b>,
+        unique_accounts: &'b GetUniqueAccountsResult,
         stats: &ShrinkStats,
     ) -> ShrinkCollect<'b, T> {
         let slot = store.slot();
@@ -3996,7 +4046,7 @@ impl AccountsDb {
             // without use of rather wide locks in this whole function, because we're
             // mutating rooted slots; There should be no writers to them.
             let accounts = [(slot, &shrink_collect.alive_accounts.alive_accounts()[..])];
-            let storable_accounts = StorableAccountsBySlot::new(slot, &accounts);
+            let storable_accounts = StorableAccountsBySlot::new(slot, &accounts, self);
             stats_sub.store_accounts_timing =
                 self.store_accounts_frozen(storable_accounts, shrink_in_progress.new_storage());
 
@@ -4258,7 +4308,7 @@ impl AccountsDb {
     /// returns the pubkeys that are in 'accounts' that are already in 'existing_ancient_pubkeys'
     /// Also updated 'existing_ancient_pubkeys' to include all pubkeys in 'accounts' since they will soon be written into the ancient slot.
     fn get_keys_to_unref_ancient<'a>(
-        accounts: &'a [&StoredAccountMeta<'_>],
+        accounts: &'a [&AccountFromStorage],
         existing_ancient_pubkeys: &mut HashSet<Pubkey>,
     ) -> HashSet<&'a Pubkey> {
         let mut unref = HashSet::<&Pubkey>::default();
@@ -4280,7 +4330,7 @@ impl AccountsDb {
     /// As a side effect, on exit, 'existing_ancient_pubkeys' will now contain all pubkeys in 'accounts'.
     fn unref_accounts_already_in_storage(
         &self,
-        accounts: &[&StoredAccountMeta<'_>],
+        accounts: &[&AccountFromStorage],
         existing_ancient_pubkeys: &mut HashSet<Pubkey>,
     ) {
         let unref = Self::get_keys_to_unref_ancient(accounts, existing_ancient_pubkeys);
@@ -9764,9 +9814,11 @@ pub mod tests {
             stored_size: account_size,
             hash: &hash,
         });
-        let map = vec![&account];
+        let account_from_storage = AccountFromStorage::new(&account);
+        let map_from_storage = vec![&account_from_storage];
         let alive_total_bytes = account.stored_size();
-        let to_store = AccountsToStore::new(available_bytes, &map, alive_total_bytes, slot0);
+        let to_store =
+            AccountsToStore::new(available_bytes, &map_from_storage, alive_total_bytes, slot0);
         // Done: setup 'to_store'
 
         // there has to be an existing append vec at this slot for a new current ancient at the slot to make sense
@@ -9884,27 +9936,35 @@ pub mod tests {
             hash: &hash,
         });
         let mut existing_ancient_pubkeys = HashSet::default();
-        let accounts = [&stored_account];
+        let account_from_storage = AccountFromStorage::new(&stored_account);
+        let accounts_from_storage = [&account_from_storage];
         // pubkey NOT in existing_ancient_pubkeys, so do NOT unref, but add to existing_ancient_pubkeys
-        let unrefs =
-            AccountsDb::get_keys_to_unref_ancient(&accounts, &mut existing_ancient_pubkeys);
+        let unrefs = AccountsDb::get_keys_to_unref_ancient(
+            &accounts_from_storage,
+            &mut existing_ancient_pubkeys,
+        );
         assert!(unrefs.is_empty());
         assert_eq!(
             existing_ancient_pubkeys.iter().collect::<Vec<_>>(),
             vec![&pubkey]
         );
         // pubkey already in existing_ancient_pubkeys, so DO unref
-        let unrefs =
-            AccountsDb::get_keys_to_unref_ancient(&accounts, &mut existing_ancient_pubkeys);
+        let unrefs = AccountsDb::get_keys_to_unref_ancient(
+            &accounts_from_storage,
+            &mut existing_ancient_pubkeys,
+        );
         assert_eq!(
             existing_ancient_pubkeys.iter().collect::<Vec<_>>(),
             vec![&pubkey]
         );
         assert_eq!(unrefs.iter().cloned().collect::<Vec<_>>(), vec![&pubkey]);
         // pubkey2 NOT in existing_ancient_pubkeys, so do NOT unref, but add to existing_ancient_pubkeys
-        let accounts = [&stored_account2];
-        let unrefs =
-            AccountsDb::get_keys_to_unref_ancient(&accounts, &mut existing_ancient_pubkeys);
+        let account_from_storage2 = AccountFromStorage::new(&stored_account2);
+        let accounts_from_storage = [&account_from_storage2];
+        let unrefs = AccountsDb::get_keys_to_unref_ancient(
+            &accounts_from_storage,
+            &mut existing_ancient_pubkeys,
+        );
         assert!(unrefs.is_empty());
         assert_eq!(
             existing_ancient_pubkeys.iter().sorted().collect::<Vec<_>>(),
@@ -9914,8 +9974,10 @@ pub mod tests {
                 .collect::<Vec<_>>()
         );
         // pubkey2 already in existing_ancient_pubkeys, so DO unref
-        let unrefs =
-            AccountsDb::get_keys_to_unref_ancient(&accounts, &mut existing_ancient_pubkeys);
+        let unrefs = AccountsDb::get_keys_to_unref_ancient(
+            &accounts_from_storage,
+            &mut existing_ancient_pubkeys,
+        );
         assert_eq!(
             existing_ancient_pubkeys.iter().sorted().collect::<Vec<_>>(),
             vec![&pubkey, &pubkey2]
@@ -9925,9 +9987,13 @@ pub mod tests {
         );
         assert_eq!(unrefs.iter().cloned().collect::<Vec<_>>(), vec![&pubkey2]);
         // pubkey3/4 NOT in existing_ancient_pubkeys, so do NOT unref, but add to existing_ancient_pubkeys
-        let accounts = [&stored_account3, &stored_account4];
-        let unrefs =
-            AccountsDb::get_keys_to_unref_ancient(&accounts, &mut existing_ancient_pubkeys);
+        let account_from_storage3 = AccountFromStorage::new(&stored_account3);
+        let account_from_storage4 = AccountFromStorage::new(&stored_account4);
+        let accounts_from_storage = [&account_from_storage3, &account_from_storage4];
+        let unrefs = AccountsDb::get_keys_to_unref_ancient(
+            &accounts_from_storage,
+            &mut existing_ancient_pubkeys,
+        );
         assert!(unrefs.is_empty());
         assert_eq!(
             existing_ancient_pubkeys.iter().sorted().collect::<Vec<_>>(),
@@ -9937,8 +10003,10 @@ pub mod tests {
                 .collect::<Vec<_>>()
         );
         // pubkey3/4 already in existing_ancient_pubkeys, so DO unref
-        let unrefs =
-            AccountsDb::get_keys_to_unref_ancient(&accounts, &mut existing_ancient_pubkeys);
+        let unrefs = AccountsDb::get_keys_to_unref_ancient(
+            &accounts_from_storage,
+            &mut existing_ancient_pubkeys,
+        );
         assert_eq!(
             existing_ancient_pubkeys.iter().sorted().collect::<Vec<_>>(),
             vec![&pubkey, &pubkey2, &pubkey3, &pubkey4]
@@ -16914,6 +16982,21 @@ pub mod tests {
             .for_each(|slot| assert!(db.storage.get_slot_storage_entry(slot).is_none()));
     }
 
+    pub fn get_account_from_account_from_storage(
+        account: &AccountFromStorage,
+        db: &AccountsDb,
+        slot: Slot,
+    ) -> AccountSharedData {
+        let storage = db
+            .storage
+            .get_slot_storage_entry_shrinking_in_progress_ok(slot)
+            .unwrap();
+        storage
+            .accounts
+            .get_account_shared_data(account.index_info.offset())
+            .unwrap()
+    }
+
     #[test]
     fn test_combine_ancient_slots_append() {
         solana_logger::setup();
@@ -16992,7 +17075,14 @@ pub mod tests {
                                 .enumerate()
                                 .find_map(|(i, stored_ancient)| {
                                     (stored_ancient.pubkey() == original.pubkey()).then_some({
-                                        assert!(accounts_equal(stored_ancient, &original));
+                                        assert!(accounts_equal(
+                                            &get_account_from_account_from_storage(
+                                                stored_ancient,
+                                                &db,
+                                                ancient_slot
+                                            ),
+                                            &original
+                                        ));
                                         i
                                     })
                                 })

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -5,10 +5,11 @@
 //! Otherwise, an ancient append vec is the same as any other append vec
 use {
     crate::{
-        account_storage::{meta::StoredAccountMeta, ShrinkInProgress},
+        account_storage::ShrinkInProgress,
         accounts_db::{
-            AccountStorageEntry, AccountsDb, AliveAccounts, GetUniqueAccountsResult, ShrinkCollect,
-            ShrinkCollectAliveSeparatedByRefs, ShrinkStatsSub,
+            AccountFromStorage, AccountStorageEntry, AccountsDb, AliveAccounts,
+            GetUniqueAccountsResult, ShrinkCollect, ShrinkCollectAliveSeparatedByRefs,
+            ShrinkStatsSub,
         },
         accounts_file::AccountsFile,
         accounts_index::AccountsIndexScanResult,
@@ -561,7 +562,7 @@ impl AccountsDb {
     fn get_unique_accounts_from_storage_for_combining_ancient_slots<'a>(
         &self,
         ancient_slots: &'a [SlotInfo],
-    ) -> Vec<(&'a SlotInfo, GetUniqueAccountsResult<'a>)> {
+    ) -> Vec<(&'a SlotInfo, GetUniqueAccountsResult)> {
         let mut accounts_to_combine = Vec::with_capacity(ancient_slots.len());
 
         for info in ancient_slots {
@@ -614,7 +615,7 @@ impl AccountsDb {
     /// 'accounts_per_storage' should be sorted by slot
     fn calc_accounts_to_combine<'a>(
         &self,
-        accounts_per_storage: &'a Vec<(&'a SlotInfo, GetUniqueAccountsResult<'a>)>,
+        accounts_per_storage: &'a Vec<(&'a SlotInfo, GetUniqueAccountsResult)>,
     ) -> AccountsToCombine<'a> {
         let mut accounts_keep_slots = HashMap::default();
         let len = accounts_per_storage.len();
@@ -703,7 +704,7 @@ impl AccountsDb {
             bytes: bytes_total,
             accounts: accounts_to_write,
         } = packed;
-        let accounts_to_write = StorableAccountsBySlot::new(target_slot, accounts_to_write);
+        let accounts_to_write = StorableAccountsBySlot::new(target_slot, accounts_to_write, self);
 
         self.shrink_ancient_stats
             .bytes_ancient_created
@@ -767,7 +768,7 @@ struct AccountsToCombine<'a> {
 /// intended contents of a packed ancient storage
 struct PackedAncientStorage<'a> {
     /// accounts to move into this storage, along with the slot the accounts are currently stored in
-    accounts: Vec<(Slot, &'a [&'a StoredAccountMeta<'a>])>,
+    accounts: Vec<(Slot, &'a [&'a AccountFromStorage])>,
     /// total bytes required to hold 'accounts'
     bytes: u64,
 }
@@ -874,7 +875,7 @@ pub enum StorageSelector {
 /// We need 1-2 of these slices constructed based on available bytes and individual account sizes.
 /// The slice arithmetic across both hashes and account data gets messy. So, this struct abstracts that.
 pub struct AccountsToStore<'a> {
-    accounts: &'a [&'a StoredAccountMeta<'a>],
+    accounts: &'a [&'a AccountFromStorage],
     /// if 'accounts' contains more items than can be contained in the primary storage, then we have to split these accounts.
     /// 'index_first_item_overflow' specifies the index of the first item in 'accounts' that will go into the overflow storage
     index_first_item_overflow: usize,
@@ -890,7 +891,7 @@ impl<'a> AccountsToStore<'a> {
     /// available_bytes: how many bytes remain in the primary storage. Excess accounts will be directed to an overflow storage
     pub fn new(
         mut available_bytes: u64,
-        accounts: &'a [&'a StoredAccountMeta<'a>],
+        accounts: &'a [&'a AccountFromStorage],
         alive_total_bytes: usize,
         slot: Slot,
     ) -> Self {
@@ -939,7 +940,7 @@ impl<'a> AccountsToStore<'a> {
     }
 
     /// get the accounts to store in the given 'storage'
-    pub fn get(&self, storage: StorageSelector) -> &[&'a StoredAccountMeta<'a>] {
+    pub fn get(&self, storage: StorageSelector) -> &[&'a AccountFromStorage] {
         let range = match storage {
             StorageSelector::Primary => 0..self.index_first_item_overflow,
             StorageSelector::Overflow => self.index_first_item_overflow..self.accounts.len(),
@@ -992,14 +993,15 @@ pub mod tests {
                 tests::{
                     append_single_account_with_default_hash, compare_all_accounts,
                     create_db_with_storages_and_index, create_storages_and_update_index,
-                    get_all_accounts, remove_account_for_tests, CAN_RANDOMLY_SHRINK_FALSE,
+                    get_account_from_account_from_storage, get_all_accounts,
+                    remove_account_for_tests, CAN_RANDOMLY_SHRINK_FALSE,
                 },
                 ShrinkCollectRefs,
             },
             accounts_hash::AccountHash,
             accounts_index::UpsertReclaim,
             append_vec::{aligned_stored_size, AppendVec, AppendVecStoredAccountMeta},
-            storable_accounts::StorableAccountsBySlot,
+            storable_accounts::{tests::build_accounts_from_storage, StorableAccountsBySlot},
         },
         solana_sdk::{
             account::{AccountSharedData, ReadableAccount, WritableAccount},
@@ -1044,22 +1046,31 @@ pub mod tests {
     }
 
     fn unique_to_accounts<'a>(
-        one: impl Iterator<Item = &'a GetUniqueAccountsResult<'a>>,
+        one: impl Iterator<Item = &'a GetUniqueAccountsResult>,
+        db: &AccountsDb,
+        slot: Slot,
     ) -> Vec<(Pubkey, AccountSharedData)> {
         one.flat_map(|result| {
-            result
-                .stored_accounts
-                .iter()
-                .map(|result| (*result.pubkey(), result.to_account_shared_data()))
+            result.stored_accounts.iter().map(|result| {
+                (
+                    *result.pubkey(),
+                    get_account_from_account_from_storage(result, db, slot),
+                )
+            })
         })
         .collect()
     }
 
     pub(crate) fn compare_all_vec_accounts<'a>(
-        one: impl Iterator<Item = &'a GetUniqueAccountsResult<'a>>,
-        two: impl Iterator<Item = &'a GetUniqueAccountsResult<'a>>,
+        one: impl Iterator<Item = &'a GetUniqueAccountsResult>,
+        two: impl Iterator<Item = &'a GetUniqueAccountsResult>,
+        db: &AccountsDb,
+        slot: Slot,
     ) {
-        compare_all_accounts(&unique_to_accounts(one), &unique_to_accounts(two));
+        compare_all_accounts(
+            &unique_to_accounts(one, db, slot),
+            &unique_to_accounts(two, db, slot),
+        );
     }
 
     #[test]
@@ -1084,7 +1095,9 @@ pub mod tests {
             .accounts(0)
             .pop()
             .unwrap()];
-        let accounts = accounts.iter().collect::<Vec<_>>();
+        let accounts_stored_meta = accounts.iter().collect::<Vec<_>>();
+        let accounts_byval = build_accounts_from_storage(accounts_stored_meta.iter().copied());
+        let accounts = accounts_byval.iter().collect::<Vec<_>>();
         let packed_contents = vec![PackedAncientStorage {
             bytes: 0,
             accounts: vec![(slots.start, &accounts[..])],
@@ -1191,19 +1204,20 @@ pub mod tests {
 
                 let original_results = storages
                     .iter()
-                    .map(|store| db.get_unique_accounts_from_storage(store))
+                    .map(|store| (store.slot(), db.get_unique_accounts_from_storage(store)))
                     .collect::<Vec<_>>();
+                let original_results_all_accounts = vec_unique_to_accounts(&original_results, &db);
 
-                let slots_vec = slots.collect::<Vec<_>>();
+                let slots_vec = slots.clone().collect::<Vec<_>>();
                 let accounts_to_combine = original_results
                     .iter()
                     .zip(slots_vec.iter().cloned())
-                    .map(|(accounts, slot)| AliveAccounts {
+                    .map(|((_slot, accounts), slot)| AliveAccounts {
                         accounts: accounts.stored_accounts.iter().collect::<Vec<_>>(),
                         bytes: accounts
                             .stored_accounts
                             .iter()
-                            .map(|account| aligned_stored_size(account.data().len()))
+                            .map(|account| aligned_stored_size(account.data_len()))
                             .sum(),
                         slot,
                     })
@@ -1216,20 +1230,26 @@ pub mod tests {
                 let storages_needed = result.len();
                 assert_eq!(storages_needed, expected_storages, "num_slots: {num_slots}, expected_storages: {expected_storages}, storages_needed: {storages_needed}, ideal_size: {ideal_size}");
                 compare_all_accounts(
-                    &packed_to_compare(&result)[..],
-                    &unique_to_compare(&original_results)[..],
+                    &packed_to_compare(&result, &db)[..],
+                    &original_results_all_accounts,
                 );
             }
         }
     }
 
-    fn packed_to_compare(packed: &[PackedAncientStorage]) -> Vec<(Pubkey, AccountSharedData)> {
+    fn packed_to_compare(
+        packed: &[PackedAncientStorage],
+        db: &AccountsDb,
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         packed
             .iter()
             .flat_map(|packed| {
-                packed.accounts.iter().flat_map(|(_slot, stored_metas)| {
+                packed.accounts.iter().flat_map(|(slot, stored_metas)| {
                     stored_metas.iter().map(|stored_meta| {
-                        (*stored_meta.pubkey(), stored_meta.to_account_shared_data())
+                        (
+                            *stored_meta.pubkey(),
+                            get_account_from_account_from_storage(stored_meta, db, *slot),
+                        )
                     })
                 })
             })
@@ -1291,14 +1311,15 @@ pub mod tests {
 
                 let original_results = storages
                     .iter()
-                    .map(|store| db.get_unique_accounts_from_storage(store))
+                    .map(|store| (store.slot(), db.get_unique_accounts_from_storage(store)))
                     .collect::<Vec<_>>();
+                let original_results_all_accounts = vec_unique_to_accounts(&original_results, &db);
 
-                let slots_vec = slots.collect::<Vec<_>>();
+                let slots_vec = slots.clone().collect::<Vec<_>>();
                 let accounts_to_combine = original_results
                     .iter()
                     .zip(slots_vec.iter().cloned())
-                    .map(|(accounts, slot)| AliveAccounts {
+                    .map(|((_slot, accounts), slot)| AliveAccounts {
                         accounts: accounts.stored_accounts.iter().collect::<Vec<_>>(),
                         bytes: accounts
                             .stored_accounts
@@ -1357,22 +1378,11 @@ pub mod tests {
                 });
 
                 compare_all_accounts(
-                    &packed_to_compare(&result)[..],
-                    &unique_to_compare(&original_results)[..],
+                    &packed_to_compare(&result, &db)[..],
+                    &original_results_all_accounts,
                 );
             }
         }
-    }
-
-    fn unique_to_compare(unique: &[GetUniqueAccountsResult]) -> Vec<(Pubkey, AccountSharedData)> {
-        unique
-            .iter()
-            .flat_map(|unique| {
-                unique.stored_accounts.iter().map(|stored_meta| {
-                    (*stored_meta.pubkey(), stored_meta.to_account_shared_data())
-                })
-            })
-            .collect::<Vec<_>>()
     }
 
     #[derive(EnumIter, Debug, PartialEq, Eq)]
@@ -1651,7 +1661,8 @@ pub mod tests {
                 .stored_accounts
                 .first()
                 .unwrap();
-            let account_shared_data_with_2_refs = account_with_2_refs.to_account_shared_data();
+            let account_shared_data_with_2_refs =
+                get_account_from_account_from_storage(account_with_2_refs, &db, slot1);
             let pk_with_2_refs = account_with_2_refs.pubkey();
             let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
             account_with_1_ref.checked_add_lamports(1).unwrap();
@@ -1720,7 +1731,7 @@ pub mod tests {
                 .accounts;
             let one_ref_accounts_account_shared_data = one_ref_accounts
                 .iter()
-                .map(|account| account.to_account_shared_data())
+                .map(|account| get_account_from_account_from_storage(account, &db, slot1))
                 .collect::<Vec<_>>();
 
             assert_eq!(
@@ -1835,7 +1846,8 @@ pub mod tests {
                 .stored_accounts
                 .first()
                 .unwrap();
-            let account_shared_data_with_2_refs = account_with_2_refs.to_account_shared_data();
+            let account_shared_data_with_2_refs =
+                get_account_from_account_from_storage(account_with_2_refs, &db, slot1);
             let pk_with_2_refs = account_with_2_refs.pubkey();
             let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
             _ = account_with_1_ref.checked_add_lamports(1);
@@ -1901,7 +1913,7 @@ pub mod tests {
                 .accounts;
             let one_ref_accounts_account_shared_data = one_ref_accounts
                 .iter()
-                .map(|account| account.to_account_shared_data())
+                .map(|account| get_account_from_account_from_storage(account, &db, slot1))
                 .collect::<Vec<_>>();
             assert_eq!(
                 one_ref_accounts
@@ -1976,16 +1988,22 @@ pub mod tests {
                 let results =
                     db.get_unique_accounts_from_storage_for_combining_ancient_slots(&infos);
 
-                let all_accounts = get_all_accounts(&db, slots);
+                let all_accounts = get_all_accounts(&db, slots.clone());
                 assert_eq!(all_accounts.len(), num_slots);
 
                 compare_all_vec_accounts(
                     original_results.iter(),
                     results.iter().map(|(_, accounts)| accounts),
+                    &db,
+                    slots.start,
                 );
                 compare_all_accounts(
                     &all_accounts,
-                    &unique_to_accounts(results.iter().map(|(_, accounts)| accounts)),
+                    &unique_to_accounts(
+                        results.iter().map(|(_, accounts)| accounts),
+                        &db,
+                        slots.start,
+                    ),
                 );
 
                 let map = |info: &SlotInfo| {
@@ -2033,7 +2051,7 @@ pub mod tests {
             executable: false,
             rent_epoch: 0,
         };
-        let offset = 3;
+        let offset = 3 * std::mem::size_of::<u64>();
         let hash = AccountHash(Hash::new(&[2; 32]));
         let stored_meta = StoredMeta {
             // global write version
@@ -2051,19 +2069,21 @@ pub mod tests {
             stored_size: account_size,
             hash: &hash,
         });
-        let map = vec![&account];
+        let map = [&account];
+        let map_accounts_from_storage = build_accounts_from_storage(map.iter().copied());
         for (selector, available_bytes) in [
             (StorageSelector::Primary, account_size),
             (StorageSelector::Overflow, account_size - 1),
         ] {
             let slot = 1;
             let alive_total_bytes = account_size;
+            let temp = map_accounts_from_storage.iter().collect::<Vec<_>>();
             let accounts_to_store =
-                AccountsToStore::new(available_bytes as u64, &map, alive_total_bytes, slot);
+                AccountsToStore::new(available_bytes as u64, &temp, alive_total_bytes, slot);
             let accounts = accounts_to_store.get(selector);
             assert_eq!(
-                accounts.iter().collect::<Vec<_>>(),
-                map.iter().collect::<Vec<_>>(),
+                accounts.to_vec(),
+                map_accounts_from_storage.iter().collect::<Vec<_>>(),
                 "mismatch"
             );
             let accounts = accounts_to_store.get(get_opposite(&selector));
@@ -2118,6 +2138,7 @@ pub mod tests {
         let GetUniqueAccountsResult {
             stored_accounts: after_stored_accounts,
             capacity: after_capacity,
+            ..
         } = db.get_unique_accounts_from_storage(&after_store);
         assert_eq!(created_accounts.capacity, after_capacity);
         assert_eq!(created_accounts.stored_accounts.len(), 1);
@@ -2730,6 +2751,40 @@ pub mod tests {
         PackedStorages,
     }
 
+    pub fn build_accounts_from_storage_with_slot(
+        accounts: &[(Slot, &[&StoredAccountMeta])],
+    ) -> Vec<(Slot, Vec<AccountFromStorage>)> {
+        accounts
+            .iter()
+            .map(|(slot, accounts)| {
+                (
+                    *slot,
+                    accounts
+                        .iter()
+                        .map(|account| AccountFromStorage::new(account))
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .collect()
+    }
+    pub fn build_refs_accounts_from_storage_with_slot(
+        accounts: &[(Slot, Vec<AccountFromStorage>)],
+    ) -> Vec<(Slot, Vec<&AccountFromStorage>)> {
+        accounts
+            .iter()
+            .map(|(slot, accounts)| (*slot, accounts.iter().collect()))
+            .collect::<Vec<_>>()
+    }
+
+    pub fn build_refs_accounts_from_storage_with_slot2<'a>(
+        accounts: &'a [(Slot, Vec<&'a AccountFromStorage>)],
+    ) -> Vec<(Slot, &'a [&'a AccountFromStorage])> {
+        accounts
+            .iter()
+            .map(|(slot, accounts)| (*slot, &accounts[..]))
+            .collect::<Vec<_>>()
+    }
+
     #[test]
     fn test_write_ancient_accounts() {
         for data_size in [None, Some(10_000_000)] {
@@ -2754,13 +2809,20 @@ pub mod tests {
                             .iter()
                             .map(|(slot, accounts)| (*slot, accounts.iter().collect::<Vec<_>>()))
                             .collect::<Vec<_>>();
-                        let accounts = accounts_vecs2
+                        let accounts_stored_account_meta = accounts_vecs2
                             .iter()
                             .map(|(slot, accounts)| (*slot, &accounts[..]))
                             .collect::<Vec<_>>();
+                        let accounts_byval =
+                            build_accounts_from_storage_with_slot(&accounts_stored_account_meta);
+                        let accounts_byval2 =
+                            build_refs_accounts_from_storage_with_slot(&accounts_byval);
+                        let accounts =
+                            build_refs_accounts_from_storage_with_slot2(&accounts_byval2);
 
                         let target_slot = slots.clone().nth(combine_into).unwrap_or(slots.start);
-                        let accounts_to_write = StorableAccountsBySlot::new(target_slot, &accounts);
+                        let accounts_to_write =
+                            StorableAccountsBySlot::new(target_slot, &accounts, &db);
 
                         let bytes = storages
                             .iter()
@@ -2974,8 +3036,9 @@ pub mod tests {
                     .collect::<Vec<_>>();
                 let original_results = original_stores
                     .iter()
-                    .map(|store| db.get_unique_accounts_from_storage(store))
+                    .map(|store| (store.slot(), db.get_unique_accounts_from_storage(store)))
                     .collect::<Vec<_>>();
+                let original_results_all_accounts = vec_unique_to_accounts(&original_results, &db);
 
                 let tuning = PackedAncientStorageTuning {
                     percent_of_alive_shrunk_data: 0,
@@ -3018,25 +3081,30 @@ pub mod tests {
                     .collect::<Vec<_>>();
                 let results = stores
                     .iter()
-                    .map(|store| db.get_unique_accounts_from_storage(store))
+                    .map(|store| (store.slot(), db.get_unique_accounts_from_storage(store)))
                     .collect::<Vec<_>>();
                 let all_accounts = get_all_accounts(&db, slot1..(slot1 + num_slots as Slot));
-                compare_all_accounts(&vec_unique_to_accounts(&original_results), &all_accounts);
+                compare_all_accounts(&original_results_all_accounts, &all_accounts);
                 compare_all_accounts(
-                    &vec_unique_to_accounts(&results),
+                    &vec_unique_to_accounts(&results, &db),
                     &get_all_accounts(&db, slot1..(slot1 + num_slots as Slot)),
                 );
             }
         }
     }
 
-    fn vec_unique_to_accounts(one: &[GetUniqueAccountsResult]) -> Vec<(Pubkey, AccountSharedData)> {
+    fn vec_unique_to_accounts(
+        one: &[(Slot, GetUniqueAccountsResult)],
+        db: &AccountsDb,
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         one.iter()
-            .flat_map(|result| {
-                result
-                    .stored_accounts
-                    .iter()
-                    .map(|result| (*result.pubkey(), result.to_account_shared_data()))
+            .flat_map(|(slot, result)| {
+                result.stored_accounts.iter().map(|result| {
+                    (
+                        *result.pubkey(),
+                        get_account_from_account_from_storage(result, db, *slot),
+                    )
+                })
             })
             .collect()
     }
@@ -3162,7 +3230,8 @@ pub mod tests {
 
         storages[0]
             .accounts
-            .get_stored_account_meta_callback(0, |account| {
+            .get_stored_account_meta_callback(0, |stored_account_meta| {
+                let account = AccountFromStorage::new(&stored_account_meta);
                 let slot = 1;
                 let capacity = 0;
                 for i in 0..4usize {

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -1,6 +1,10 @@
 //! trait for abstracting underlying storage of pubkey and account pairs to be written
 use {
-    crate::{account_storage::meta::StoredAccountMeta, accounts_index::ZeroLamport},
+    crate::{
+        account_storage::meta::StoredAccountMeta,
+        accounts_db::{AccountFromStorage, AccountsDb},
+        accounts_index::ZeroLamport,
+    },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::{Epoch, Slot},
@@ -158,7 +162,7 @@ impl<'a: 'b, 'b> StorableAccounts<'a> for (Slot, &'b [(&'a Pubkey, &'a AccountSh
 pub struct StorableAccountsBySlot<'a> {
     target_slot: Slot,
     /// each element is (source slot, accounts moving FROM source slot)
-    slots_and_accounts: &'a [(Slot, &'a [&'a StoredAccountMeta<'a>])],
+    slots_and_accounts: &'a [(Slot, &'a [&'a AccountFromStorage])],
 
     /// This is calculated based off slots_and_accounts.
     /// cumulative offset of all account slices prior to this one
@@ -169,13 +173,15 @@ pub struct StorableAccountsBySlot<'a> {
     contains_multiple_slots: bool,
     /// total len of all accounts, across all slots_and_accounts
     len: usize,
+    db: &'a AccountsDb,
 }
 
 impl<'a> StorableAccountsBySlot<'a> {
     /// each element of slots_and_accounts is (source slot, accounts moving FROM source slot)
     pub fn new(
         target_slot: Slot,
-        slots_and_accounts: &'a [(Slot, &'a [&'a StoredAccountMeta<'a>])],
+        slots_and_accounts: &'a [(Slot, &'a [&'a AccountFromStorage])],
+        db: &'a AccountsDb,
     ) -> Self {
         let mut cumulative_len = 0usize;
         let mut starting_offsets = Vec::with_capacity(slots_and_accounts.len());
@@ -195,6 +201,7 @@ impl<'a> StorableAccountsBySlot<'a> {
             starting_offsets,
             contains_multiple_slots,
             len: cumulative_len,
+            db,
         }
     }
     /// given an overall index for all accounts in self:
@@ -217,14 +224,40 @@ impl<'a> StorableAccountsBySlot<'a> {
     }
 }
 
+/// Shared code to get a storage from (db, slot) then look up the account using offset, then calling `callback`
+/// The account will only be valid during the lifetime of the callback.
+fn callback_that_loads_account<Ret>(
+    db: &AccountsDb,
+    slot: Slot,
+    offset: usize,
+    mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
+) -> Ret {
+    let storage = db
+        .storage
+        .get_slot_storage_entry_shrinking_in_progress_ok(slot)
+        .unwrap();
+    storage
+        .accounts
+        .get_stored_account_meta_callback(offset, |account: StoredAccountMeta| {
+            callback((&account).into())
+        })
+        .expect("account has to exist to be able to store it")
+}
+
 impl<'a> StorableAccounts<'a> for StorableAccountsBySlot<'a> {
     fn account<Ret>(
         &self,
         index: usize,
-        mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
+        callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret {
         let indexes = self.find_internal_index(index);
-        callback(self.slots_and_accounts[indexes.0].1[indexes.1].into())
+        let data = self.slots_and_accounts[indexes.0].1[indexes.1];
+        callback_that_loads_account(
+            self.db,
+            self.slot(index),
+            data.index_info.offset(),
+            callback,
+        )
     }
     fn slot(&self, index: usize) -> Slot {
         let indexes = self.find_internal_index(index);
@@ -246,7 +279,10 @@ pub mod tests {
     use {
         super::*,
         crate::{
+            account_info::{AccountInfo, StorageLocation},
             account_storage::meta::{AccountMeta, StoredAccountMeta, StoredMeta},
+            accounts_db::{get_temp_accounts_paths, AccountStorageEntry},
+            accounts_file::AccountsFileProvider,
             accounts_hash::AccountHash,
             append_vec::AppendVecStoredAccountMeta,
         },
@@ -254,9 +290,12 @@ pub mod tests {
             account::{accounts_equal, AccountSharedData, WritableAccount},
             hash::Hash,
         },
+        std::sync::Arc,
     };
 
-    /// this is no longer used. It is very tricky to get these right. There are already tests for this. It is likely worth it to leave this here for a while until everything has settled.
+    /// this is used in the test for generation of storages
+    /// this is no longer used in the validator.
+    /// It is very tricky to get these right. There are already tests for this. It is likely worth it to leave this here for a while until everything has settled.
     impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>]) {
         fn account<Ret>(
             &self,
@@ -324,6 +363,29 @@ pub mod tests {
         }
     }
 
+    /// this tuple contains a single different source slot that applies to all accounts
+    /// accounts are StoredAccountMeta
+    impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a AccountFromStorage], Slot, &AccountsDb) {
+        fn account<Ret>(
+            &self,
+            index: usize,
+            callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
+        ) -> Ret {
+            let data = self.1[index];
+            callback_that_loads_account(self.3, self.2, data.index_info.offset(), callback)
+        }
+        fn slot(&self, _index: usize) -> Slot {
+            // same other slot for all accounts
+            self.2
+        }
+        fn target_slot(&self) -> Slot {
+            self.0
+        }
+        fn len(&self) -> usize {
+            self.1.len()
+        }
+    }
+
     fn compare<'a>(a: &impl StorableAccounts<'a>, b: &impl StorableAccounts<'a>) {
         assert_eq!(a.target_slot(), b.target_slot());
         assert_eq!(a.len(), b.len());
@@ -340,6 +402,7 @@ pub mod tests {
 
     #[test]
     fn test_contains_multiple_slots() {
+        let db = AccountsDb::new_single_for_tests();
         let pk = Pubkey::from([1; 32]);
         let slot = 0;
         let lamports = 1;
@@ -370,8 +433,23 @@ pub mod tests {
             hash: &hash,
         });
 
-        let test3 = (slot, &vec![&stored_account, &stored_account][..], slot);
+        let account_from_storage = AccountFromStorage::new(&stored_account);
+
+        let test3 = (
+            slot,
+            &vec![&account_from_storage, &account_from_storage][..],
+            slot,
+            &db,
+        );
         assert!(!test3.contains_multiple_slots());
+    }
+
+    pub fn build_accounts_from_storage<'a>(
+        accounts: impl Iterator<Item = &'a StoredAccountMeta<'a>>,
+    ) -> Vec<AccountFromStorage> {
+        accounts
+            .map(|account| AccountFromStorage::new(account))
+            .collect()
     }
 
     #[test]
@@ -380,6 +458,7 @@ pub mod tests {
         for target_slot in 0..max_slots {
             for entries in 0..2 {
                 for starting_slot in 0..max_slots {
+                    let db = AccountsDb::new_single_for_tests();
                     let data = Vec::default();
                     let hash = AccountHash(Hash::new_unique());
                     let mut raw = Vec::new();
@@ -426,25 +505,56 @@ pub mod tests {
                         }));
                         raw4.push((raw.0, raw.1.clone()));
                     }
+                    let raw2_accounts_from_storage = build_accounts_from_storage(raw2.iter());
 
                     let mut two = Vec::new();
                     let mut three = Vec::new();
+                    let mut three_accounts_from_storage_byval = Vec::new();
                     let mut four_pubkey_and_account_value = Vec::new();
                     raw.iter()
-                        .zip(raw2.iter().zip(raw4.iter()))
-                        .for_each(|(raw, (raw2, raw4))| {
+                        .zip(
+                            raw2.iter()
+                                .zip(raw4.iter().zip(raw2_accounts_from_storage.iter())),
+                        )
+                        .for_each(|(raw, (raw2, (raw4, raw2_accounts_from_storage)))| {
                             two.push((&raw.0, &raw.1)); // 2 item tuple
                             three.push(raw2);
+                            three_accounts_from_storage_byval.push(*raw2_accounts_from_storage);
                             four_pubkey_and_account_value.push(raw4);
                         });
                     let test2 = (target_slot, &two[..]);
                     let test4 = (target_slot, &four_pubkey_and_account_value[..]);
 
                     let source_slot = starting_slot % max_slots;
-                    let test3 = (target_slot, &three[..], source_slot);
+
+                    let storage = setup_sample_storage(&db, source_slot);
+                    if let Some(offsets) = storage
+                        .accounts
+                        .append_accounts(&(source_slot, &three[..]), 0)
+                    {
+                        three_accounts_from_storage_byval
+                            .iter_mut()
+                            .zip(offsets.offsets.iter())
+                            .for_each(|(account, offset)| {
+                                account.index_info = AccountInfo::new(
+                                    StorageLocation::AppendVec(0, *offset),
+                                    if account.is_zero_lamport() { 0 } else { 1 },
+                                )
+                            });
+                    }
+                    let three_accounts_from_storage =
+                        three_accounts_from_storage_byval.iter().collect::<Vec<_>>();
+
+                    let test3 = (
+                        target_slot,
+                        &three_accounts_from_storage[..],
+                        source_slot,
+                        &db,
+                    );
                     let old_slot = starting_slot;
-                    let for_slice = [(old_slot, &three[..])];
-                    let test_moving_slots2 = StorableAccountsBySlot::new(target_slot, &for_slice);
+                    let for_slice = [(old_slot, &three_accounts_from_storage[..])];
+                    let test_moving_slots2 =
+                        StorableAccountsBySlot::new(target_slot, &for_slice, &db);
                     compare(&test2, &test3);
                     compare(&test2, &test4);
                     compare(&test2, &test_moving_slots2);
@@ -467,6 +577,22 @@ pub mod tests {
                 }
             }
         }
+    }
+
+    fn setup_sample_storage(db: &AccountsDb, slot: Slot) -> Arc<AccountStorageEntry> {
+        let id = 2;
+        let file_size = 10_000;
+        let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
+        let data = AccountStorageEntry::new(
+            &paths[0],
+            slot,
+            id,
+            file_size,
+            AccountsFileProvider::AppendVec,
+        );
+        let storage = Arc::new(data);
+        db.storage.insert(slot, storage.clone());
+        storage
     }
 
     #[test]
@@ -503,6 +629,7 @@ pub mod tests {
                     },
                 ));
             }
+
             for entry in 0..entries {
                 let offset = 99 * std::mem::size_of::<u64>(); // offset needs to be 8 byte aligned
                 let stored_size = 101;
@@ -515,6 +642,11 @@ pub mod tests {
                     hash: &hashes[entry as usize],
                 }));
             }
+
+            let raw2_account_from_storage = raw2
+                .iter()
+                .map(|account| AccountFromStorage::new(account))
+                .collect::<Vec<_>>();
             let raw2_refs = raw2.iter().collect::<Vec<_>>();
 
             // enumerate through permutations of # entries (ie. accounts) in each slot. Each one is 0..=entries.
@@ -523,11 +655,12 @@ pub mod tests {
                 for entries1 in 0..=remaining1 {
                     let remaining2 = entries.saturating_sub(entries0 + entries1);
                     for entries2 in 0..=remaining2 {
+                        let db = AccountsDb::new_single_for_tests();
                         let remaining3 = entries.saturating_sub(entries0 + entries1 + entries2);
                         let entries_by_level = [entries0, entries1, entries2, remaining3];
                         let mut overall_index = 0;
                         let mut expected_slots = Vec::default();
-                        let slots_and_accounts = entries_by_level
+                        let slots_and_accounts_byval = entries_by_level
                             .iter()
                             .enumerate()
                             .filter_map(|(slot, count)| {
@@ -535,22 +668,51 @@ pub mod tests {
                                 let count = *count as usize;
                                 (overall_index < raw2.len()).then(|| {
                                     let range = overall_index..(overall_index + count);
-                                    let result = &raw2_refs[range.clone()];
+                                    let mut result =
+                                        raw2_account_from_storage[range.clone()].to_vec();
+                                    let storage = setup_sample_storage(&db, slot);
+                                    if let Some(offsets) = storage
+                                        .accounts
+                                        .append_accounts(&(slot, &raw2_refs[range.clone()]), 0)
+                                    {
+                                        result.iter_mut().zip(offsets.offsets.iter()).for_each(
+                                            |(account, offset)| {
+                                                account.index_info = AccountInfo::new(
+                                                    StorageLocation::AppendVec(0, *offset),
+                                                    if account.is_zero_lamport() { 0 } else { 1 },
+                                                )
+                                            },
+                                        );
+                                    }
+
                                     range.for_each(|_| expected_slots.push(slot));
                                     overall_index += count;
                                     (slot, result)
                                 })
                             })
                             .collect::<Vec<_>>();
-                        let storable = StorableAccountsBySlot::new(99, &slots_and_accounts[..]);
+                        let slots_and_accounts_ref1 = slots_and_accounts_byval
+                            .iter()
+                            .map(|(slot, accounts)| (*slot, accounts.iter().collect::<Vec<_>>()))
+                            .collect::<Vec<_>>();
+                        let slots_and_accounts = slots_and_accounts_ref1
+                            .iter()
+                            .map(|(slot, accounts)| (*slot, &accounts[..]))
+                            .collect::<Vec<_>>();
+
+                        let storable =
+                            StorableAccountsBySlot::new(99, &slots_and_accounts[..], &db);
                         assert_eq!(99, storable.target_slot());
                         assert_eq!(entries0 != entries, storable.contains_multiple_slots());
                         (0..entries).for_each(|index| {
                             let index = index as usize;
+                            let mut called = false;
                             storable.account(index, |account| {
+                                called = true;
                                 assert!(accounts_equal(&account, &raw2[index]));
                                 assert_eq!(account.pubkey(), raw2[index].pubkey());
                             });
+                            assert!(called);
                             assert_eq!(storable.slot(index), expected_slots[index]);
                         })
                     }

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -232,6 +232,7 @@ fn callback_that_loads_account<Ret>(
     offset: usize,
     mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
 ) -> Ret {
+    // note we do not use file id here. We just want the normal unshrunk storage for this slot.
     let storage = db
         .storage
         .get_slot_storage_entry_shrinking_in_progress_ok(slot)
@@ -363,8 +364,9 @@ pub mod tests {
         }
     }
 
+    /// this is no longer used. It is very tricky to get these right. There are already tests for this. It is likely worth it to leave this here for a while until everything has settled.
     /// this tuple contains a single different source slot that applies to all accounts
-    /// accounts are StoredAccountMeta
+    /// accounts are AccountFromStorage
     impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a AccountFromStorage], Slot, &AccountsDb) {
         fn account<Ret>(
             &self,

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -236,7 +236,7 @@ fn callback_that_loads_account<Ret>(
     let storage = db
         .storage
         .get_slot_storage_entry_shrinking_in_progress_ok(slot)
-        .unwrap();
+        .expect("source slot has to have a storage to be able to store accounts");
     storage
         .accounts
         .get_stored_account_meta_callback(offset, |account: StoredAccountMeta| {

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -530,6 +530,8 @@ pub mod tests {
                     let source_slot = starting_slot % max_slots;
 
                     let storage = setup_sample_storage(&db, source_slot);
+                    // since we're no longer storing `StoredAccountMeta`, we have to actually store the
+                    // accounts so they can be looked up later in `db`
                     if let Some(offsets) = storage
                         .accounts
                         .append_accounts(&(source_slot, &three[..]), 0)
@@ -672,6 +674,8 @@ pub mod tests {
                                     let range = overall_index..(overall_index + count);
                                     let mut result =
                                         raw2_account_from_storage[range.clone()].to_vec();
+                                    // since we're no longer storing `StoredAccountMeta`, we have to actually store the
+                                    // accounts so they can be looked up later in `db`
                                     let storage = setup_sample_storage(&db, slot);
                                     if let Some(offsets) = storage
                                         .accounts

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -349,7 +349,9 @@ impl<'a> SnapshotMinimizer<'a> {
             let new_storage = shrink_in_progress.as_ref().unwrap().new_storage();
 
             let accounts = [(slot, &keep_accounts[..])];
-            let storable_accounts = StorableAccountsBySlot::new(slot, &accounts);
+            let storable_accounts =
+                StorableAccountsBySlot::new(slot, &accounts, self.accounts_db());
+
             self.accounts_db()
                 .store_accounts_frozen(storable_accounts, new_storage);
 


### PR DESCRIPTION
#### Problem
moving append vecs to file i/o instead of mmap
shrinking and ancient handling both grab refs to accounts (`StoredAccountMeta`) and hold them a long time. This is not acceptable anymore

#### Summary of Changes
Introduce `AccountFromStorage` to refer to an account and enable shrink to work on a byval struct. One instance will be created for each account found during the initial scan operation of the storage(s) to shrink/pack. `AccountFromStorage` plus slot and db are enough to lookup an account when it needs to be written again at the end of the operation.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
