### PR TITLE
Refactors stored accounts info

### DIFF
--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -54,7 +54,7 @@ fn bench_write_accounts_file(c: &mut Criterion) {
                 },
                 |append_vec| {
                     let res = append_vec.append_accounts(&storable_accounts, 0).unwrap();
-                    let accounts_written_count = res.len();
+                    let accounts_written_count = res.offsets.len();
                     assert_eq!(accounts_written_count, accounts_count);
                 },
                 BatchSize::SmallInput,
@@ -72,7 +72,7 @@ fn bench_write_accounts_file(c: &mut Criterion) {
                 },
                 |hot_storage| {
                     let res = hot_storage.write_accounts(&storable_accounts, 0).unwrap();
-                    let accounts_written_count = res.len();
+                    let accounts_written_count = res.offsets.len();
                     assert_eq!(accounts_written_count, accounts_count);
                 },
                 BatchSize::SmallInput,

--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -9,12 +9,6 @@ use {
 };
 
 pub type StoredMetaWriteVersion = u64;
-// A tuple that stores offset and size respectively
-#[derive(Debug, Clone)]
-pub struct StoredAccountInfo {
-    pub offset: usize,
-    pub size: usize,
-}
 
 lazy_static! {
     static ref DEFAULT_ACCOUNT_HASH: AccountHash = AccountHash(Hash::default());

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         account_info::AccountInfo,
-        account_storage::meta::{StoredAccountInfo, StoredAccountMeta},
+        account_storage::meta::StoredAccountMeta,
         accounts_db::AccountsFileId,
         append_vec::{AppendVec, AppendVecError, IndexInfo},
         storable_accounts::StorableAccounts,
@@ -268,7 +268,7 @@ impl AccountsFile {
         &self,
         accounts: &impl StorableAccounts<'a>,
         skip: usize,
-    ) -> Option<Vec<StoredAccountInfo>> {
+    ) -> Option<StoredAccountsInfo> {
         match self {
             Self::AppendVec(av) => av.append_accounts(accounts, skip),
             // Note: The conversion here is needed as the AccountsDB currently
@@ -276,11 +276,11 @@ impl AccountsFile {
             // IndexOffset that is equivalent to AccountInfo::reduced_offset.
             Self::TieredStorage(ts) => ts
                 .write_accounts(accounts, skip, &HOT_FORMAT)
-                .map(|mut infos| {
-                    infos.iter_mut().for_each(|info| {
-                        info.offset = AccountInfo::reduced_offset_to_offset(info.offset as u32);
+                .map(|mut stored_accounts_info| {
+                    stored_accounts_info.offsets.iter_mut().for_each(|offset| {
+                        *offset = AccountInfo::reduced_offset_to_offset(*offset as u32);
                     });
-                    infos
+                    stored_accounts_info
                 })
                 .ok(),
         }
@@ -342,6 +342,15 @@ impl AccountsFileProvider {
             Self::HotStorage => AccountsFile::TieredStorage(TieredStorage::new_writable(path)),
         }
     }
+}
+
+/// Information after storing accounts
+#[derive(Debug)]
+pub struct StoredAccountsInfo {
+    /// offset in the storage where each account was stored
+    pub offsets: Vec<usize>,
+    /// total size of all the stored accounts
+    pub size: usize,
 }
 
 #[cfg(test)]

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -7,9 +7,12 @@
 use {
     crate::{
         account_storage::meta::{
-            AccountMeta, StoredAccountInfo, StoredAccountMeta, StoredMeta, StoredMetaWriteVersion,
+            AccountMeta, StoredAccountMeta, StoredMeta, StoredMetaWriteVersion,
         },
-        accounts_file::{AccountsFileError, MatchAccountOwnerError, Result, ALIGN_BOUNDARY_OFFSET},
+        accounts_file::{
+            AccountsFileError, MatchAccountOwnerError, Result, StoredAccountsInfo,
+            ALIGN_BOUNDARY_OFFSET,
+        },
         accounts_hash::AccountHash,
         storable_accounts::StorableAccounts,
         u64_align,
@@ -748,14 +751,14 @@ impl AppendVec {
         &self,
         accounts: &impl StorableAccounts<'a>,
         skip: usize,
-    ) -> Option<Vec<StoredAccountInfo>> {
+    ) -> Option<StoredAccountsInfo> {
         let _lock = self.append_lock.lock().unwrap();
         let default_hash: Hash = Hash::default(); // [0_u8; 32];
         let mut offset = self.len();
         let len = accounts.len();
         // Here we have `len - skip` number of accounts.  The +1 extra capacity
-        // is for storing the aligned offset of the last entry to that is used
-        // to compute the StoredAccountInfo of the last entry.
+        // is for storing the aligned offset of the last-plus-one entry,
+        // which is used to compute the size of the last stored account.
         let offsets_len = len - skip + 1;
         let mut offsets = Vec::with_capacity(offsets_len);
         let mut stop = false;
@@ -787,31 +790,25 @@ impl AppendVec {
                     (hash_ptr, mem::size_of::<AccountHash>()),
                     (data_ptr, data_len),
                 ];
-                if let Some(res) = self.append_ptrs_locked(&mut offset, &ptrs) {
-                    offsets.push(res)
+                if let Some(start_offset) = self.append_ptrs_locked(&mut offset, &ptrs) {
+                    offsets.push(start_offset)
                 } else {
                     stop = true;
                 }
             });
         }
 
-        if offsets.is_empty() {
-            None
-        } else {
-            let mut rv = Vec::with_capacity(offsets.len());
-
-            // The last entry in this offset needs to be the u64 aligned offset, because that's
+        (!offsets.is_empty()).then(|| {
+            // The last entry in the offsets needs to be the u64 aligned `offset`, because that's
             // where the *next* entry will begin to be stored.
+            // This is used to compute the size of the last stored account; make sure to remove
+            // it afterwards!
             offsets.push(u64_align!(offset));
-            for offsets in offsets.windows(2) {
-                rv.push(StoredAccountInfo {
-                    offset: offsets[0],
-                    size: offsets[1] - offsets[0],
-                });
-            }
+            let size = offsets.windows(2).map(|offset| offset[1] - offset[0]).sum();
+            offsets.pop();
 
-            Some(rv)
-        }
+            StoredAccountsInfo { offsets, size }
+        })
     }
 
     /// Returns a slice suitable for use when archiving append vecs
@@ -846,7 +843,7 @@ pub mod tests {
             let storable_accounts = (slot_ignored, slice);
 
             self.append_accounts(&storable_accounts, 0)
-                .map(|res| res[0].offset)
+                .map(|res| res.offsets[0])
         }
     }
 

--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -174,12 +174,14 @@ impl TieredStorageFooter {
         Self::new_from_footer_block(&file)
     }
 
-    pub fn write_footer_block(&self, file: &mut TieredWritableFile) -> TieredStorageResult<()> {
-        // SAFETY: The footer does not contain any uninitialized bytes.
-        unsafe { file.write_type(self)? };
-        file.write_pod(&TieredStorageMagicNumber::default())?;
+    pub fn write_footer_block(&self, file: &mut TieredWritableFile) -> TieredStorageResult<usize> {
+        let mut bytes_written = 0;
 
-        Ok(())
+        // SAFETY: The footer does not contain any uninitialized bytes.
+        bytes_written += unsafe { file.write_type(self)? };
+        bytes_written += file.write_pod(&TieredStorageMagicNumber::default())?;
+
+        Ok(bytes_written)
     }
 
     pub fn new_from_footer_block(file: &TieredReadableFile) -> TieredStorageResult<Self> {


### PR DESCRIPTION
#### Problem

After accounts are stored, we return information about the offsets for each account, and the size. We use the size of each account written to update the AccountStorageEntry with the total size of the storage itself. This size is used by `shrink`, among others.

With tiered storage, the size of a single written account is not as straight forward. For one example, the `owners` field of each account is deduplicated in the storage file itself. 

Since we only need the total size written, we can use that for both AppendVec and TieredStorage. The code just needs some refactoring.


#### Summary of Changes

Refactors stored accounts info.