### PR TITLE
Syscall: `GetEpochStake`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -169,6 +169,7 @@ pub struct InvokeContext<'a> {
     pub programs_loaded_for_tx_batch: &'a ProgramCacheForTxBatch,
     pub programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
     pub feature_set: Arc<FeatureSet>,
+    pub get_epoch_stake_callback: &'a dyn Fn(&'a Pubkey) -> u64,
     pub timings: ExecuteDetailsTimings,
     pub blockhash: Hash,
     pub lamports_per_signature: u64,
@@ -186,6 +187,7 @@ impl<'a> InvokeContext<'a> {
         programs_loaded_for_tx_batch: &'a ProgramCacheForTxBatch,
         programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
         feature_set: Arc<FeatureSet>,
+        get_epoch_stake_callback: &'a dyn Fn(&'a Pubkey) -> u64,
         blockhash: Hash,
         lamports_per_signature: u64,
     ) -> Self {
@@ -199,6 +201,7 @@ impl<'a> InvokeContext<'a> {
             programs_loaded_for_tx_batch,
             programs_modified_by_tx,
             feature_set,
+            get_epoch_stake_callback,
             timings: ExecuteDetailsTimings::default(),
             blockhash,
             lamports_per_signature,
@@ -685,6 +688,7 @@ macro_rules! with_mock_invoke_context {
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
             Arc::new(FeatureSet::all_enabled()),
+            &|_| 0,
             Hash::default(),
             0,
         );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6804,6 +6804,10 @@ impl TransactionProcessingCallback for Bank {
         self.feature_set.clone()
     }
 
+    fn get_epoch_stake(&self, vote_address: &Pubkey) -> u64 {
+        self.epoch_vote_account_stake(vote_address)
+    }
+
     fn get_program_match_criteria(&self, program: &Pubkey) -> ProgramCacheMatchCriteria {
         if self.check_program_modification_slot {
             self.program_modification_slot(program)

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -180,6 +180,7 @@ impl Bank {
                 &programs_loaded,
                 &mut programs_modified,
                 self.feature_set.clone(),
+                &|_| 0,
                 Hash::default(),
                 0,
             );

--- a/sdk/program/src/epoch_stake.rs
+++ b/sdk/program/src/epoch_stake.rs
@@ -1,0 +1,21 @@
+use crate::{program_error::ProgramError, pubkey::Pubkey};
+
+/// Get the current epoch stake for a given vote account.
+/// Returns `0` for any provided pubkey that isn't a vote account.
+pub fn get_epoch_stake(vote_address: &Pubkey) -> Result<u64, ProgramError> {
+    let mut var = 0u64;
+    let var_addr = &mut var as *mut _ as *mut u8;
+
+    let vote_address = vote_address as *const _ as *const u8;
+
+    #[cfg(target_os = "solana")]
+    let result = unsafe { crate::syscalls::sol_syscall_get_epoch_stake(var_addr, vote_address) };
+
+    #[cfg(not(target_os = "solana"))]
+    let result = crate::program_stubs::sol_syscall_get_epoch_stake(var_addr, vote_address);
+
+    match result {
+        crate::entrypoint::SUCCESS => Ok(var),
+        e => Err(e.into()),
+    }
+}

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -491,6 +491,7 @@ pub mod entrypoint;
 pub mod entrypoint_deprecated;
 pub mod epoch_rewards;
 pub mod epoch_schedule;
+pub mod epoch_stake;
 pub mod feature;
 pub mod fee_calculator;
 pub mod hash;

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -61,6 +61,9 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_get_last_restart_slot(&self, _var_addr: *mut u8) -> u64 {
         UNSUPPORTED_SYSVAR
     }
+    fn sol_syscall_get_epoch_stake(&self, _var_addr: *mut u8, _vote_address: *const u8) -> u64 {
+        UNSUPPORTED_SYSVAR
+    }
     /// # Safety
     unsafe fn sol_memcpy(&self, dst: *mut u8, src: *const u8, n: usize) {
         // cannot be overlapping
@@ -169,6 +172,13 @@ pub(crate) fn sol_get_last_restart_slot(var_addr: *mut u8) -> u64 {
         .read()
         .unwrap()
         .sol_get_last_restart_slot(var_addr)
+}
+
+pub(crate) fn sol_syscall_get_epoch_stake(var_addr: *mut u8, vote_address: *const u8) -> u64 {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_syscall_get_epoch_stake(var_addr, vote_address)
 }
 
 pub(crate) fn sol_memcpy(dst: *mut u8, src: *const u8, n: usize) {

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -72,6 +72,7 @@ define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
 define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_remaining_compute_units() -> u64);
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
+define_syscall!(fn sol_syscall_get_epoch_stake(addr: *mut u8, vote_address: *const u8) -> u64);
 
 #[cfg(target_feature = "static-syscalls")]
 pub const fn sys_hash(name: &str) -> usize {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -801,6 +801,10 @@ pub mod abort_on_invalid_curve {
     solana_sdk::declare_id!("FuS3FPfJDKSNot99ECLXtp3rueq36hMNStJkPJwWodLh");
 }
 
+pub mod enable_syscall_get_epoch_stake {
+    solana_sdk::declare_id!("7mScTYkJXsbdrcwTQRs7oeCSXoJm4WjzBsRyf8bCU3Np");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -995,7 +999,8 @@ lazy_static! {
         (enable_tower_sync_ix::id(), "Enable tower sync vote instruction"),
         (chained_merkle_conflict_duplicate_proofs::id(), "generate duplicate proofs for chained merkle root conflicts"),
         (reward_full_priority_fee::id(), "Reward full priority fee to validators #34731"),
-        (abort_on_invalid_curve::id(), "Abort when elliptic curve syscalls invoked on invalid curve id SIMD-0137")
+        (abort_on_invalid_curve::id(), "Abort when elliptic curve syscalls invoked on invalid curve id SIMD-0137"),
+        (enable_syscall_get_epoch_stake::id(), "Enable syscall: sol_get_epoch_stake #884")
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -499,6 +499,7 @@ mod tests {
         accounts_map: HashMap<Pubkey, AccountSharedData>,
         rent_collector: RentCollector,
         feature_set: Arc<FeatureSet>,
+        epoch_stake: u64,
     }
 
     impl TransactionProcessingCallback for TestCallbacks {
@@ -521,6 +522,10 @@ mod tests {
         fn get_feature_set(&self) -> Arc<FeatureSet> {
             self.feature_set.clone()
         }
+
+        fn get_epoch_stake(&self, _vote_address: &Pubkey) -> u64 {
+            self.epoch_stake
+        }
     }
 
     fn load_accounts_with_fee_and_rent(
@@ -542,6 +547,7 @@ mod tests {
             accounts_map,
             rent_collector: rent_collector.clone(),
             feature_set: Arc::new(feature_set.clone()),
+            epoch_stake: 0,
         };
         load_accounts(
             &callbacks,
@@ -1030,6 +1036,7 @@ mod tests {
             accounts_map,
             rent_collector: RentCollector::default(),
             feature_set: Arc::new(FeatureSet::all_enabled()),
+            epoch_stake: 0,
         };
         load_accounts(
             &callbacks,

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -280,6 +280,7 @@ mod tests {
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
             Arc::new(FeatureSet::all_enabled()),
+            &|_| 0,
             Hash::default(),
             0,
         );
@@ -331,6 +332,7 @@ mod tests {
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
             Arc::new(FeatureSet::all_enabled()),
+            &|_| 0,
             Hash::default(),
             0,
         );
@@ -372,6 +374,7 @@ mod tests {
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
             Arc::new(FeatureSet::all_enabled()),
+            &|_| 0,
             Hash::default(),
             0,
         );
@@ -504,6 +507,7 @@ mod tests {
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
             Arc::new(FeatureSet::all_enabled()),
+            &|_| 0,
             Hash::default(),
             0,
         );
@@ -540,6 +544,7 @@ mod tests {
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
             Arc::new(FeatureSet::all_enabled()),
+            &|_| 0,
             Hash::default(),
             0,
         );
@@ -573,6 +578,7 @@ mod tests {
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
             Arc::new(FeatureSet::all_enabled()),
+            &|_| 0,
             Hash::default(),
             0,
         );
@@ -667,6 +673,7 @@ mod tests {
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
             Arc::new(FeatureSet::all_enabled()),
+            &|_| 0,
             Hash::default(),
             0,
         );

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -270,6 +270,7 @@ mod tests {
     pub struct MockBankCallback {
         rent_collector: RentCollector,
         feature_set: Arc<FeatureSet>,
+        epoch_stake: u64,
         pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
     }
 
@@ -300,6 +301,10 @@ mod tests {
 
         fn get_feature_set(&self) -> Arc<FeatureSet> {
             self.feature_set.clone()
+        }
+
+        fn get_epoch_stake(&self, _vote_address: &Pubkey) -> u64 {
+            self.epoch_stake
         }
 
         fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -19,6 +19,8 @@ pub trait TransactionProcessingCallback {
 
     fn get_feature_set(&self) -> Arc<FeatureSet>;
 
+    fn get_epoch_stake(&self, vote_address: &Pubkey) -> u64;
+
     fn get_program_match_criteria(&self, _program: &Pubkey) -> ProgramCacheMatchCriteria {
         ProgramCacheMatchCriteria::NoCriteria
     }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -531,6 +531,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             programs_loaded_for_tx_batch.latest_root_epoch,
         );
         let sysvar_cache = &self.sysvar_cache.read().unwrap();
+        let epoch_stake_callback = |pubkey| callback.get_epoch_stake(pubkey);
 
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
@@ -540,6 +541,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
             callback.get_feature_set(),
+            &epoch_stake_callback,
             blockhash,
             lamports_per_signature,
         );

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -783,6 +783,7 @@ mod tests {
     pub struct MockBankCallback {
         rent_collector: RentCollector,
         feature_set: Arc<FeatureSet>,
+        epoch_stake: u64,
         pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
     }
 
@@ -813,6 +814,10 @@ mod tests {
 
         fn get_feature_set(&self) -> Arc<FeatureSet> {
             self.feature_set.clone()
+        }
+
+        fn get_epoch_stake(&self, _vote_address: &Pubkey) -> u64 {
+            self.epoch_stake
         }
 
         fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -15,6 +15,7 @@ use {
 pub struct MockBankCallback {
     rent_collector: RentCollector,
     feature_set: Arc<FeatureSet>,
+    epoch_stake: u64,
     pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
 }
 
@@ -46,6 +47,10 @@ impl TransactionProcessingCallback for MockBankCallback {
 
     fn get_feature_set(&self) -> Arc<FeatureSet> {
         self.feature_set.clone()
+    }
+
+    fn get_epoch_stake(&self, _vote_address: &Pubkey) -> u64 {
+        self.epoch_stake
     }
 
     fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {


### PR DESCRIPTION
#### Problem
Currently, on-chain programs have no knowledge of the current epoch's stake and
how much active stake is delegated to a certain vote account.

If this data was available for querying by on-chain programs, it would unblock
many use cases, such as validator governance and secondary consensus mechanisms,
that were previously not possible on Solana.

Additionally, this would enable the Feature Gate program defined in
SIMD 0089 to tally vote account stake in
support for a pending feature gate.

#### Summary of Changes
Introduce a new callback function to the SVM to retrieve the delegated active 
stake for a vote account.

Add that callback to the program-runtime's `InvokeContext`.

Introduce a new syscall - `SyscallGetEpochStake` - that will use this callback 
to retrieve the vote account's stake.

[SIMD 0133](https://github.com/solana-foundation/solana-improvement-documents/pull/133)

Feature Gate Tracking Issue: https://github.com/anza-xyz/agave/issues/884
