### PR TITLE
scheduler forward packets

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -18,6 +18,7 @@ use {
     crate::{
         banking_stage::{
             consume_worker::ConsumeWorker,
+            forward_worker::ForwardWorker,
             packet_deserializer::PacketDeserializer,
             transaction_scheduler::{
                 prio_graph_scheduler::PrioGraphScheduler,
@@ -582,6 +583,34 @@ impl BankingStage {
             )
         }
 
+        // Spawn the forward worker threads.
+        let (forward_work_sender, forward_work_receiver) = unbounded();
+        let (finished_forward_work_sender, finished_forwrard_work_receiver) = unbounded();
+        for id in 0..num_workers {
+            let id = id + 2;
+            let forwarder = Forwarder::new(
+                poh_recorder.clone(),
+                bank_forks.clone(),
+                cluster_info.clone(),
+                connection_cache.clone(),
+                data_budget.clone(),
+            );
+            let forward_worker = ForwardWorker::new(
+                forward_work_receiver.clone(),
+                ForwardOption::ForwardTransaction, // non-votes through central scheduler
+                forwarder,
+                finished_forward_work_sender.clone(),
+            );
+            bank_thread_hdls.push(
+                Builder::new()
+                    .name(format!("solFwWorker{id:02}"))
+                    .spawn(move || {
+                        let _ = forward_worker.run();
+                    })
+                    .unwrap(),
+            );
+        }
+
         // Spawn the central scheduler thread
         bank_thread_hdls.push({
             let packet_deserializer =
@@ -593,6 +622,8 @@ impl BankingStage {
                 bank_forks,
                 scheduler,
                 worker_metrics,
+                forward_work_sender,
+                finished_forwrard_work_receiver,
             );
             Builder::new()
                 .name("solBnkTxSched".to_string())

--- a/core/src/banking_stage/forward_packet_batches_by_accounts.rs
+++ b/core/src/banking_stage/forward_packet_batches_by_accounts.rs
@@ -83,10 +83,6 @@ impl ForwardBatch {
     pub fn is_empty(&self) -> bool {
         self.forwardable_packets.is_empty()
     }
-
-    pub fn take_packets(self) -> Vec<Arc<ImmutableDeserializedPacket>> {
-        self.forwardable_packets
-    }
 }
 
 /// To avoid forward queue being saturated by transactions for single hot account,
@@ -133,10 +129,6 @@ impl ForwardPacketBatchesByAccounts {
 
     pub fn iter_batches(&self) -> impl Iterator<Item = &ForwardBatch> {
         self.forward_batches.iter()
-    }
-
-    pub fn take_iter_batches(self) -> impl Iterator<Item = ForwardBatch> {
-        self.forward_batches.into_iter()
     }
 }
 

--- a/core/src/banking_stage/forward_packet_batches_by_accounts.rs
+++ b/core/src/banking_stage/forward_packet_batches_by_accounts.rs
@@ -83,6 +83,10 @@ impl ForwardBatch {
     pub fn is_empty(&self) -> bool {
         self.forwardable_packets.is_empty()
     }
+
+    pub fn take_packets(self) -> Vec<Arc<ImmutableDeserializedPacket>> {
+        self.forwardable_packets
+    }
 }
 
 /// To avoid forward queue being saturated by transactions for single hot account,
@@ -129,6 +133,10 @@ impl ForwardPacketBatchesByAccounts {
 
     pub fn iter_batches(&self) -> impl Iterator<Item = &ForwardBatch> {
         self.forward_batches.iter()
+    }
+
+    pub fn take_iter_batches(self) -> impl Iterator<Item = ForwardBatch> {
+        self.forward_batches.into_iter()
     }
 }
 

--- a/core/src/banking_stage/forward_worker.rs
+++ b/core/src/banking_stage/forward_worker.rs
@@ -86,7 +86,6 @@ mod tests {
         super::*,
         crate::banking_stage::{
             immutable_deserialized_packet::ImmutableDeserializedPacket,
-            scheduler_messages::TransactionId,
             tests::{create_slow_genesis_config, new_test_cluster_info, simulate_poh},
         },
         crossbeam_channel::unbounded,
@@ -200,9 +199,6 @@ mod tests {
             system_transaction::transfer(mint_keypair, &pubkey2, 2, genesis_config.hash()),
         ];
 
-        let id1 = TransactionId::new(1);
-        let id2 = TransactionId::new(0);
-
         let packets = to_packet_batches(&txs, 2);
         assert_eq!(packets.len(), 1);
         let packets = packets[0]
@@ -211,14 +207,8 @@ mod tests {
             .map(|p| ImmutableDeserializedPacket::new(p).unwrap())
             .map(Arc::new)
             .collect();
-        forward_sender
-            .send(ForwardWork {
-                packets,
-                ids: vec![id1, id2],
-            })
-            .unwrap();
+        forward_sender.send(ForwardWork { packets }).unwrap();
         let forwarded = forwarded_receiver.recv().unwrap();
-        assert_eq!(forwarded.work.ids, vec![id1, id2]);
         assert!(forwarded.successful);
 
         drop(test_frame);

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -48,7 +48,6 @@ pub struct ConsumeWork {
 /// Message: [Scheduler -> Worker]
 /// Transactions to be forwarded to the next leader(s)
 pub struct ForwardWork {
-    pub ids: Vec<TransactionId>,
     pub packets: Vec<Arc<ImmutableDeserializedPacket>>,
 }
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -365,19 +365,17 @@ impl SchedulerController {
         let remaining_queue_capacity = self.container.remaining_queue_capacity();
 
         const MAX_PACKET_RECEIVE_TIME: Duration = Duration::from_millis(100);
-        let (recv_timeout, should_buffer) = match decision {
-            BufferedPacketsDecision::Consume(_) => (
+        let recv_timeout = match decision {
+            BufferedPacketsDecision::Consume(_) => {
                 if self.container.is_empty() {
                     MAX_PACKET_RECEIVE_TIME
                 } else {
                     Duration::ZERO
-                },
-                true,
-            ),
-            BufferedPacketsDecision::Forward => (MAX_PACKET_RECEIVE_TIME, false),
-            BufferedPacketsDecision::ForwardAndHold | BufferedPacketsDecision::Hold => {
-                (MAX_PACKET_RECEIVE_TIME, true)
+                }
             }
+            BufferedPacketsDecision::Forward
+            | BufferedPacketsDecision::ForwardAndHold
+            | BufferedPacketsDecision::Hold => MAX_PACKET_RECEIVE_TIME,
         };
 
         let (received_packet_results, receive_time_us) = measure_us!(self
@@ -396,21 +394,11 @@ impl SchedulerController {
                     saturating_add_assign!(count_metrics.num_received, num_received_packets);
                 });
 
-                if should_buffer {
-                    let (_, buffer_time_us) = measure_us!(
-                        self.buffer_packets(receive_packet_results.deserialized_packets)
-                    );
-                    self.timing_metrics.update(|timing_metrics| {
-                        saturating_add_assign!(timing_metrics.buffer_time_us, buffer_time_us);
-                    });
-                } else {
-                    self.count_metrics.update(|count_metrics| {
-                        saturating_add_assign!(
-                            count_metrics.num_dropped_on_receive,
-                            num_received_packets
-                        );
-                    });
-                }
+                let (_, buffer_time_us) =
+                    measure_us!(self.buffer_packets(receive_packet_results.deserialized_packets));
+                self.timing_metrics.update(|timing_metrics| {
+                    saturating_add_assign!(timing_metrics.buffer_time_us, buffer_time_us);
+                });
             }
             Err(RecvTimeoutError::Timeout) => {}
             Err(RecvTimeoutError::Disconnected) => return false,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -267,7 +267,7 @@ impl SchedulerController {
                 let immutable_packet = state.packet().clone();
 
                 // If not already forwarded and can be forwarded, add to forwardable packets.
-                if !state.forwarded()
+                if state.should_forward()
                     && forwardable_packets.try_add_packet(
                         sanitized_transaction,
                         immutable_packet,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -275,7 +275,7 @@ impl SchedulerController {
             );
 
             for (id, filter_result) in ids.iter().zip(&filter_array[..chunk_size]) {
-                if !*filter_result || !hold {
+                if !*filter_result {
                     self.container.remove_by_id(&id.id);
                     continue;
                 }

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -214,7 +214,7 @@ impl SchedulerController {
     }
 
     /// Forward packets to the next leader.
-    fn forward_packets(&self, _hold: bool) {
+    fn forward_packets(&mut self, _hold: bool) {
         todo!()
     }
 
@@ -367,6 +367,8 @@ impl SchedulerController {
     }
 
     fn buffer_packets(&mut self, packets: Vec<ImmutableDeserializedPacket>) {
+        // Convert to Arcs
+        let packets: Vec<_> = packets.into_iter().map(Arc::new).collect();
         // Sanitize packets, generate IDs, and insert into the container.
         let bank = self.bank_forks.read().unwrap().working_bank();
         let last_slot_in_epoch = bank.epoch_schedule().get_last_slot_in_epoch(bank.epoch());
@@ -379,30 +381,41 @@ impl SchedulerController {
         let mut error_counts = TransactionErrorMetrics::default();
         for chunk in packets.chunks(CHUNK_SIZE) {
             let mut post_sanitization_count: usize = 0;
-            let (transactions, fee_budget_limits_vec): (Vec<_>, Vec<_>) = chunk
+
+            let mut arc_packets = Vec::with_capacity(chunk.len());
+            let mut transactions = Vec::with_capacity(chunk.len());
+            let mut fee_budget_limits_vec = Vec::with_capacity(chunk.len());
+
+            chunk
                 .iter()
                 .filter_map(|packet| {
-                    packet.build_sanitized_transaction(
-                        feature_set,
-                        vote_only,
-                        bank.as_ref(),
-                        bank.get_reserved_account_keys(),
-                    )
+                    packet
+                        .build_sanitized_transaction(
+                            feature_set,
+                            vote_only,
+                            bank.as_ref(),
+                            bank.get_reserved_account_keys(),
+                        )
+                        .map(|tx| (packet.clone(), tx))
                 })
                 .inspect(|_| saturating_add_assign!(post_sanitization_count, 1))
-                .filter(|tx| {
+                .filter(|(_packet, tx)| {
                     SanitizedTransaction::validate_account_locks(
                         tx.message(),
                         transaction_account_lock_limit,
                     )
                     .is_ok()
                 })
-                .filter_map(|tx| {
+                .filter_map(|(packet, tx)| {
                     process_compute_budget_instructions(tx.message().program_instructions_iter())
-                        .map(|compute_budget| (tx, compute_budget.into()))
+                        .map(|compute_budget| (packet, tx, compute_budget.into()))
                         .ok()
                 })
-                .unzip();
+                .for_each(|(packet, tx, fee_budget_limits)| {
+                    arc_packets.push(packet);
+                    transactions.push(tx);
+                    fee_budget_limits_vec.push(fee_budget_limits);
+                });
 
             let check_results = bank.check_transactions(
                 &transactions,
@@ -415,8 +428,9 @@ impl SchedulerController {
             let mut post_transaction_check_count: usize = 0;
             let mut num_dropped_on_capacity: usize = 0;
             let mut num_buffered: usize = 0;
-            for ((transaction, fee_budget_limits), _) in transactions
+            for (((packet, transaction), fee_budget_limits), _) in arc_packets
                 .into_iter()
+                .zip(transactions)
                 .zip(fee_budget_limits_vec)
                 .zip(check_results)
                 .filter(|(_, check_result)| check_result.0.is_ok())
@@ -434,6 +448,7 @@ impl SchedulerController {
                 if self.container.insert_new_transaction(
                     transaction_id,
                     transaction_ttl,
+                    packet,
                     priority,
                     cost,
                 ) {

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -259,6 +259,7 @@ impl SchedulerController {
             for (id, filter_result) in ids.iter().zip(&filter_array[..chunk_size]) {
                 if !*filter_result || !hold {
                     self.container.remove_by_id(&id.id);
+                    continue;
                 }
 
                 ids_to_add_back.push(*id); // add back to the queue at end

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -616,6 +616,8 @@ mod tests {
 
         consume_work_receivers: Vec<Receiver<ConsumeWork>>,
         finished_consume_work_sender: Sender<FinishedConsumeWork>,
+        _forward_work_receiver: Receiver<ForwardWork>,
+        _finished_forward_work_sender: Sender<FinishedForwardWork>,
     }
 
     fn create_test_frame(num_threads: usize) -> (TestFrame, SchedulerController) {
@@ -649,6 +651,8 @@ mod tests {
 
         let (consume_work_senders, consume_work_receivers) = create_channels(num_threads);
         let (finished_consume_work_sender, finished_consume_work_receiver) = unbounded();
+        let (forward_work_sender, forward_work_receiver) = unbounded();
+        let (finished_forward_work_sender, finished_forward_work_receiver) = unbounded();
 
         let test_frame = TestFrame {
             bank,
@@ -660,9 +664,10 @@ mod tests {
             banking_packet_sender,
             consume_work_receivers,
             finished_consume_work_sender,
+            _forward_work_receiver: forward_work_receiver,
+            _finished_forward_work_sender: finished_forward_work_sender,
         };
-        let (forward_work_sender, _forward_work_receiver) = unbounded();
-        let (_finished_forward_work_sender, finished_forward_work_receiver) = unbounded();
+
         let scheduler_controller = SchedulerController::new(
             decision_maker,
             packet_deserializer,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -16,11 +16,13 @@ use {
         consume_worker::ConsumeWorkerMetrics,
         consumer::Consumer,
         decision_maker::{BufferedPacketsDecision, DecisionMaker},
+        forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
         immutable_deserialized_packet::ImmutableDeserializedPacket,
         packet_deserializer::PacketDeserializer,
+        scheduler_messages::{FinishedForwardWork, ForwardWork},
         TOTAL_BUFFERED_PACKETS,
     },
-    crossbeam_channel::RecvTimeoutError,
+    crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     solana_cost_model::cost_model::CostModel,
     solana_measure::measure_us,
     solana_program_runtime::compute_budget_processor::process_compute_budget_instructions,
@@ -60,6 +62,10 @@ pub(crate) struct SchedulerController {
     timing_metrics: SchedulerTimingMetrics,
     /// Metric report handles for the worker threads.
     worker_metrics: Vec<Arc<ConsumeWorkerMetrics>>,
+    /// Channel to send forward workers batches of packets to forward.
+    forward_work_sender: Sender<ForwardWork>,
+    /// Channel to receive finished forwarded work (to re-insert IDs into the queue).
+    finished_forward_work_receiver: Receiver<FinishedForwardWork>,
 }
 
 impl SchedulerController {
@@ -69,6 +75,8 @@ impl SchedulerController {
         bank_forks: Arc<RwLock<BankForks>>,
         scheduler: PrioGraphScheduler,
         worker_metrics: Vec<Arc<ConsumeWorkerMetrics>>,
+        forward_work_sender: Sender<ForwardWork>,
+        finished_forward_work_receiver: Receiver<FinishedForwardWork>,
     ) -> Self {
         Self {
             decision_maker,
@@ -81,6 +89,8 @@ impl SchedulerController {
             count_metrics: SchedulerCountMetrics::default(),
             timing_metrics: SchedulerTimingMetrics::default(),
             worker_metrics,
+            forward_work_sender,
+            finished_forward_work_receiver,
         }
     }
 
@@ -214,8 +224,48 @@ impl SchedulerController {
     }
 
     /// Forward packets to the next leader.
-    fn forward_packets(&mut self, _hold: bool) {
-        todo!()
+    fn forward_packets(&mut self, hold: bool) {
+        let bank = self.bank_forks.read().unwrap().working_bank();
+        let feature_set = &bank.feature_set;
+        let mut forwardable_packets =
+            ForwardPacketBatchesByAccounts::new_with_default_batch_limits();
+        let mut already_forwarded_ids = Vec::new();
+        while let Some(id) = self.container.pop() {
+            let Some(state) = self.container.get_transaction_state(&id.id) else {
+                continue;
+            };
+
+            if state.forwarded() {
+                already_forwarded_ids.push(id);
+                continue;
+            }
+
+            if forwardable_packets.try_add_packet(
+                &state.transaction_ttl().transaction,
+                state.packet().clone(),
+                feature_set,
+            ) {
+                already_forwarded_ids.push(id);
+                break;
+            }
+        }
+
+        // Push into worker queue.
+        for batch in forwardable_packets.take_iter_batches() {
+            let packets = batch.take_packets();
+            let forward_work = ForwardWork { packets };
+            self.forward_work_sender.send(forward_work).unwrap();
+        }
+
+        if hold {
+            for priority_id in already_forwarded_ids {
+                self.container.push_id_into_queue(priority_id);
+            }
+        } else {
+            for priority_id in already_forwarded_ids {
+                self.container.remove_by_id(&priority_id.id);
+            }
+        }
     }
 
     /// Clears the transaction state container.
@@ -303,6 +353,9 @@ impl SchedulerController {
                 receive_completed_time_us
             );
         });
+
+        // Receive completed forward work. Don't need to do anything with it.
+        while let Ok(_finished_forward_work) = self.finished_forward_work_receiver.try_recv() {}
 
         Ok(())
     }
@@ -620,12 +673,16 @@ mod tests {
             consume_work_receivers,
             finished_consume_work_sender,
         };
+        let (forward_work_sender, _forward_work_receiver) = unbounded();
+        let (_finished_forward_work_sender, finished_forward_work_receiver) = unbounded();
         let scheduler_controller = SchedulerController::new(
             decision_maker,
             packet_deserializer,
             bank_forks,
             PrioGraphScheduler::new(consume_work_senders, finished_consume_work_receiver),
             vec![], // no actual workers with metrics to report, this can be empty
+            forward_work_sender,
+            finished_forward_work_receiver,
         );
 
         (test_frame, scheduler_controller)

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -172,15 +172,15 @@ impl SchedulerController {
                 });
             }
             BufferedPacketsDecision::Forward => {
-                let (_, clear_time_us) = measure_us!(self.clear_container());
+                let (_, forward_time_us) = measure_us!(self.forward_packets(false));
                 self.timing_metrics.update(|timing_metrics| {
-                    saturating_add_assign!(timing_metrics.clear_time_us, clear_time_us);
+                    saturating_add_assign!(timing_metrics.forward_time_us, forward_time_us);
                 });
             }
             BufferedPacketsDecision::ForwardAndHold => {
-                let (_, clean_time_us) = measure_us!(self.clean_queue());
+                let (_, forward_time_us) = measure_us!(self.forward_packets(true));
                 self.timing_metrics.update(|timing_metrics| {
-                    saturating_add_assign!(timing_metrics.clean_time_us, clean_time_us);
+                    saturating_add_assign!(timing_metrics.forward_time_us, forward_time_us);
                 });
             }
             BufferedPacketsDecision::Hold => {}
@@ -213,8 +213,14 @@ impl SchedulerController {
         }
     }
 
+    /// Forward packets to the next leader.
+    fn forward_packets(&self, _hold: bool) {
+        todo!()
+    }
+
     /// Clears the transaction state container.
     /// This only clears pending transactions, and does **not** clear in-flight transactions.
+    #[allow(dead_code)]
     fn clear_container(&mut self) {
         let mut num_dropped_on_clear: usize = 0;
         while let Some(id) = self.container.pop() {
@@ -230,6 +236,7 @@ impl SchedulerController {
     /// Clean unprocessable transactions from the queue. These will be transactions that are
     /// expired, already processed, or are no longer sanitizable.
     /// This only clears pending transactions, and does **not** clear in-flight transactions.
+    #[allow(dead_code)]
     fn clean_queue(&mut self) {
         // Clean up any transactions that have already been processed, are too old, or do not have
         // valid nonce accounts.

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -59,6 +59,8 @@ pub struct SchedulerCountMetricsInner {
     pub num_finished: usize,
     /// Number of transactions that were retryable.
     pub num_retryable: usize,
+    /// Number of transactions that were scheduled to be forwarded.
+    pub num_forwarded: usize,
 
     /// Number of transactions that were immediately dropped on receive.
     pub num_dropped_on_receive: usize,
@@ -122,6 +124,7 @@ impl SchedulerCountMetricsInner {
             ),
             ("num_finished", self.num_finished, i64),
             ("num_retryable", self.num_retryable, i64),
+            ("num_forwarded", self.num_forwarded, i64),
             ("num_dropped_on_receive", self.num_dropped_on_receive, i64),
             (
                 "num_dropped_on_sanitization",
@@ -162,6 +165,7 @@ impl SchedulerCountMetricsInner {
             || self.num_schedule_filtered_out != 0
             || self.num_finished != 0
             || self.num_retryable != 0
+            || self.num_forwarded != 0
             || self.num_dropped_on_receive != 0
             || self.num_dropped_on_sanitization != 0
             || self.num_dropped_on_validate_locks != 0
@@ -179,6 +183,7 @@ impl SchedulerCountMetricsInner {
         self.num_schedule_filtered_out = 0;
         self.num_finished = 0;
         self.num_retryable = 0;
+        self.num_forwarded = 0;
         self.num_dropped_on_receive = 0;
         self.num_dropped_on_sanitization = 0;
         self.num_dropped_on_validate_locks = 0;

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -266,10 +266,8 @@ pub struct SchedulerTimingMetricsInner {
     pub schedule_filter_time_us: u64,
     /// Time spent scheduling transactions.
     pub schedule_time_us: u64,
-    /// Time spent clearing transactions from the container.
-    pub clear_time_us: u64,
-    /// Time spent cleaning expired or processed transactions from the container.
-    pub clean_time_us: u64,
+    /// Time spent forwarding transactions.
+    pub forward_time_us: u64,
     /// Time spent receiving completed transactions.
     pub receive_completed_time_us: u64,
 }
@@ -309,8 +307,7 @@ impl SchedulerTimingMetricsInner {
             ("buffer_time_us", self.buffer_time_us, i64),
             ("schedule_filter_time_us", self.schedule_filter_time_us, i64),
             ("schedule_time_us", self.schedule_time_us, i64),
-            ("clear_time_us", self.clear_time_us, i64),
-            ("clean_time_us", self.clean_time_us, i64),
+            ("forward_time_us", self.forward_time_us, i64),
             (
                 "receive_completed_time_us",
                 self.receive_completed_time_us,
@@ -329,8 +326,7 @@ impl SchedulerTimingMetricsInner {
         self.buffer_time_us = 0;
         self.schedule_filter_time_us = 0;
         self.schedule_time_us = 0;
-        self.clear_time_us = 0;
-        self.clean_time_us = 0;
+        self.forward_time_us = 0;
         self.receive_completed_time_us = 0;
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -97,6 +97,16 @@ impl TransactionState {
         }
     }
 
+    /// Mark the packet as forwarded.
+    /// This is used to prevent the packet from being forwarded multiple times.
+    pub(crate) fn mark_forwarded(&mut self) {
+        match self {
+            Self::Unprocessed { forwarded, .. } => *forwarded = true,
+            Self::Pending { forwarded, .. } => *forwarded = true,
+            Self::Transitioning => unreachable!(),
+        }
+    }
+
     /// Return the packet of the transaction.
     pub(crate) fn packet(&self) -> &Arc<ImmutableDeserializedPacket> {
         match self {

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -65,6 +65,11 @@ impl TransactionStateContainer {
         self.priority_queue.pop_max()
     }
 
+    /// Get immutable transaction state by id.
+    pub(crate) fn get_transaction_state(&self, id: &TransactionId) -> Option<&TransactionState> {
+        self.id_to_transaction_state.get(id)
+    }
+
     /// Get mutable transaction state by id.
     pub(crate) fn get_mut_transaction_state(
         &mut self,

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -65,11 +65,6 @@ impl TransactionStateContainer {
         self.priority_queue.pop_max()
     }
 
-    /// Get immutable transaction state by id.
-    pub(crate) fn get_transaction_state(&self, id: &TransactionId) -> Option<&TransactionState> {
-        self.id_to_transaction_state.get(id)
-    }
-
     /// Get mutable transaction state by id.
     pub(crate) fn get_mut_transaction_state(
         &mut self,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -353,7 +353,7 @@ impl ValidatorConfig {
         Self {
             enforce_ulimit_nofile: false,
             rpc_config: JsonRpcConfig::default_for_test(),
-            block_production_method: BlockProductionMethod::ThreadLocalMultiIterator,
+            block_production_method: BlockProductionMethod::default(),
             replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             replay_transactions_threads: NonZeroUsize::new(get_max_thread_count())
                 .expect("thread count is non-zero"),

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -16,7 +16,7 @@ use {
         },
         optimistic_confirmation_verifier::OptimisticConfirmationVerifier,
         replay_stage::DUPLICATE_THRESHOLD,
-        validator::{BlockProductionMethod, BlockVerificationMethod, ValidatorConfig},
+        validator::{BlockVerificationMethod, ValidatorConfig},
     },
     solana_download_utils::download_snapshot_archive,
     solana_entry::entry::create_ticks,
@@ -346,16 +346,11 @@ fn test_forwarding() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     // Set up a cluster where one node is never the leader, so all txs sent to this node
     // will be have to be forwarded in order to be confirmed
-    // Only ThreadLocalMultiIterator banking stage forwards transactions,
-    // so must use that block-production-method.
     let mut config = ClusterConfig {
         node_stakes: vec![DEFAULT_NODE_STAKE * 100, DEFAULT_NODE_STAKE],
         cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + DEFAULT_NODE_STAKE * 100,
         validator_configs: make_identical_validator_configs(
-            &ValidatorConfig {
-                block_production_method: BlockProductionMethod::ThreadLocalMultiIterator,
-                ..ValidatorConfig::default_for_test()
-            },
+            &ValidatorConfig::default_for_test(),
             2,
         ),
         ..ClusterConfig::default()
@@ -4365,10 +4360,7 @@ fn test_leader_failure_4() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     error!("test_leader_failure_4");
     let num_nodes = 4;
-    let validator_config = ValidatorConfig {
-        block_production_method: BlockProductionMethod::ThreadLocalMultiIterator,
-        ..ValidatorConfig::default_for_test()
-    };
+    let validator_config = ValidatorConfig::default_for_test();
     let mut config = ClusterConfig {
         cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
         node_stakes: vec![DEFAULT_NODE_STAKE; 4],


### PR DESCRIPTION
#### Problem
- swqos was built with the assumption that transactions are forwarded by validator nodes
- without swqos being used, forwarding was in process of being deprecated since behavior (without swqow stuff) was useless
- major push in past weeks has led to operators adopting swqos forwarding side-deals
- the new scheduler does not support forwarding for above reasons
- the lack of support would make operators need to make a choice between swqos side deals and the new scheduler, which is less than ideal under the current circumstances

#### Summary of Changes
- Add support for forwarding transactions in the new scheduler

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
