### PR TITLE
get rid of AccountIter

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -115,25 +115,6 @@ impl AccountsFile {
         format!("{slot}.{id}")
     }
 
-    /// Return (account metadata, next_index) pair for the account at the
-    /// specified `offset` if any.  Otherwise return None.   Also return the
-    /// index of the next entry.
-    pub fn get_stored_account_meta(&self, offset: usize) -> Option<(StoredAccountMeta<'_>, usize)> {
-        match self {
-            Self::AppendVec(av) => av.get_stored_account_meta(offset),
-            // Note: The conversion here is needed as the AccountsDB currently
-            // assumes all offsets are multiple of 8 while TieredStorage uses
-            // IndexOffset that is equivalent to AccountInfo::reduced_offset.
-            Self::TieredStorage(ts) => ts
-                .reader()?
-                .get_stored_account_meta(IndexOffset(AccountInfo::get_reduced_offset(offset)))
-                .ok()?
-                .map(|(metas, index_offset)| {
-                    (metas, AccountInfo::reduced_offset_to_offset(index_offset.0))
-                }),
-        }
-    }
-
     /// calls `callback` with the account located at the specified index offset.
     pub fn get_stored_account_meta_callback<Ret>(
         &self,
@@ -197,11 +178,6 @@ impl AccountsFile {
             Self::AppendVec(av) => av.path(),
             Self::TieredStorage(ts) => ts.path(),
         }
-    }
-
-    /// Return iterator for account metadata
-    pub fn account_iter(&self) -> AccountsFileIter {
-        AccountsFileIter::new(self)
     }
 
     /// Iterate over all accounts and call `callback` with each account.
@@ -309,33 +285,6 @@ impl AccountsFile {
                 .reader()
                 .expect("must be a reader when archiving")
                 .data_for_archive(),
-        }
-    }
-}
-
-pub struct AccountsFileIter<'a> {
-    file_entry: &'a AccountsFile,
-    offset: usize,
-}
-
-impl<'a> AccountsFileIter<'a> {
-    pub fn new(file_entry: &'a AccountsFile) -> Self {
-        Self {
-            file_entry,
-            offset: 0,
-        }
-    }
-}
-
-impl<'a> Iterator for AccountsFileIter<'a> {
-    type Item = StoredAccountMeta<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some((account, next_offset)) = self.file_entry.get_stored_account_meta(self.offset) {
-            self.offset = next_offset;
-            Some(account)
-        } else {
-            None
         }
     }
 }

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -45,9 +45,11 @@ fn main() {
     info!("store: len: {} capacity: {}", store.len(), store.capacity());
     let mut num_accounts: usize = 0;
     let mut stored_accounts_len: usize = 0;
-    for account in store.account_iter() {
-        if is_account_zeroed(&account) {
-            break;
+    let mut quit = false;
+    store.scan_accounts(|account| {
+        if is_account_zeroed(&account) || quit {
+            quit = true;
+            return;
         }
         info!(
             "  account: {:?} lamports: {} data: {} hash: {:?}",
@@ -58,7 +60,7 @@ fn main() {
         );
         num_accounts = num_accounts.saturating_add(1);
         stored_accounts_len = stored_accounts_len.saturating_add(account.stored_size());
-    }
+    });
     info!(
         "num_accounts: {} stored_accounts_len: {}",
         num_accounts, stored_accounts_len


### PR DESCRIPTION
#### Problem
stop mmapping storage files

#### Summary of Changes
get rid of AccountIter, which returns `StoredAccountMeta<'_>`.
We can't support lifetimes like this anymore. `scan_accounts` does the same thing in a supportable format.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
