### PR TITLE
add appendvec.scan_accounts

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4891,7 +4891,7 @@ impl AccountsDb {
                 .storage
                 .get_slot_storage_entry_shrinking_in_progress_ok(slot)
             {
-                storage.accounts.account_iter().for_each(|account| {
+                storage.accounts.scan_accounts(|account| {
                     let loaded_account = LoadedAccount::Stored(account);
                     let data = (scan_account_storage_data
                         == ScanAccountStorageData::DataRefForStorage)
@@ -16592,11 +16592,10 @@ pub mod tests {
     ) -> Vec<(Pubkey, AccountSharedData)> {
         storages
             .flat_map(|storage| {
-                let vec = storage
-                    .accounts
-                    .account_iter()
-                    .map(|account| (*account.pubkey(), account.to_account_shared_data()))
-                    .collect::<Vec<_>>();
+                let mut vec = Vec::default();
+                storage.accounts.scan_accounts(|account| {
+                    vec.push((*account.pubkey(), account.to_account_shared_data()));
+                });
                 // make sure scan_pubkeys results match
                 // Note that we assume traversals are both in the same order, but this doesn't have to be true.
                 let mut compare = Vec::default();

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -204,6 +204,18 @@ impl AccountsFile {
         AccountsFileIter::new(self)
     }
 
+    /// Iterate over all accounts and call `callback` with each account.
+    pub(crate) fn scan_accounts(&self, callback: impl for<'a> FnMut(StoredAccountMeta<'a>)) {
+        match self {
+            Self::AppendVec(av) => av.scan_accounts(callback),
+            Self::TieredStorage(ts) => {
+                if let Some(reader) = ts.reader() {
+                    _ = reader.scan_accounts(callback);
+                }
+            }
+        }
+    }
+
     /// for each offset in `sorted_offsets`, return the account size
     pub(crate) fn get_account_sizes(&self, sorted_offsets: &[usize]) -> Vec<usize> {
         match self {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -686,6 +686,19 @@ impl AppendVec {
         }
     }
 
+    /// Iterate over all accounts and call `callback` with each account.
+    #[allow(clippy::blocks_in_conditions)]
+    pub(crate) fn scan_accounts(&self, mut callback: impl for<'a> FnMut(StoredAccountMeta<'a>)) {
+        let mut offset = 0;
+        while self
+            .get_stored_account_meta_callback(offset, |account| {
+                offset += account.stored_size();
+                callback(account)
+            })
+            .is_some()
+        {}
+    }
+
     /// for each offset in `sorted_offsets`, get the size of the account. No other information is needed for the account.
     pub(crate) fn get_account_sizes(&self, sorted_offsets: &[usize]) -> Vec<usize> {
         let mut result = Vec::with_capacity(sorted_offsets.len());

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -630,6 +630,17 @@ impl HotStorageReader {
         Ok(result)
     }
 
+    /// Iterate over all accounts and call `callback` with each account.
+    pub(crate) fn scan_accounts(
+        &self,
+        mut callback: impl for<'a> FnMut(StoredAccountMeta<'a>),
+    ) -> TieredStorageResult<()> {
+        for i in 0..self.footer.account_entry_count {
+            self.get_stored_account_meta_callback(IndexOffset(i), &mut callback)?;
+        }
+        Ok(())
+    }
+
     /// iterate over all entries to put in index
     pub(crate) fn scan_index(
         &self,

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -145,6 +145,16 @@ impl TieredStorageReader {
         }
     }
 
+    /// Iterate over all accounts and call `callback` with each account.
+    pub(crate) fn scan_accounts(
+        &self,
+        callback: impl for<'a> FnMut(StoredAccountMeta<'a>),
+    ) -> TieredStorageResult<()> {
+        match self {
+            Self::Hot(hot) => hot.scan_accounts(callback),
+        }
+    }
+
     /// for each offset in `sorted_offsets`, return the account size
     pub(crate) fn get_account_sizes(
         &self,


### PR DESCRIPTION
#### Problem
stop mmapping storages

#### Summary of Changes
add `scan_accounts` api, which allows use of `StoredAccountMeta` without lifetime issues. More callers will be updated later.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
