### PR TITLE
quic: delay calling set_max_concurrent_uni_streams/set_receive_window

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -347,14 +347,9 @@ fn handle_and_cache_new_connection(
         params.total_stake,
     ) as u64)
     {
+        let remote_addr = connection.remote_address();
         let receive_window =
             compute_recieve_window(params.max_stake, params.min_stake, params.peer_type);
-
-        if let Ok(receive_window) = receive_window {
-            connection.set_receive_window(receive_window);
-        }
-
-        let remote_addr = connection.remote_address();
 
         debug!(
             "Peer type {:?}, total stake {}, max streams {} receive_window {:?} from peer {}",
@@ -376,7 +371,12 @@ fn handle_and_cache_new_connection(
             )
         {
             drop(connection_table_l);
+
+            if let Ok(receive_window) = receive_window {
+                connection.set_receive_window(receive_window);
+            }
             connection.set_max_concurrent_uni_streams(max_uni_streams);
+
             tokio::spawn(handle_connection(
                 connection,
                 remote_addr,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -347,7 +347,6 @@ fn handle_and_cache_new_connection(
         params.total_stake,
     ) as u64)
     {
-        connection.set_max_concurrent_uni_streams(max_uni_streams);
         let receive_window =
             compute_recieve_window(params.max_stake, params.min_stake, params.peer_type);
 
@@ -377,6 +376,7 @@ fn handle_and_cache_new_connection(
             )
         {
             drop(connection_table_l);
+            connection.set_max_concurrent_uni_streams(max_uni_streams);
             tokio::spawn(handle_connection(
                 connection,
                 remote_addr,


### PR DESCRIPTION
Delay calling connection.set_max_concurrent_uni_streams() and connection.set_receive_window() to when we know we've accepted the connection. Avoids a short window where the peer could start transmitting even if we're going to drop the connection, and avoids taking the connection mutex and waking a task.