### PR TITLE
quic server: set initial window to PACKET_DATA_SIZE

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -84,11 +84,7 @@ pub(crate) fn configure_server(
         (QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS.saturating_mul(2)) as u32;
     config.max_concurrent_uni_streams(MAX_CONCURRENT_UNI_STREAMS.into());
     config.stream_receive_window((PACKET_DATA_SIZE as u32).into());
-    config.receive_window(
-        (PACKET_DATA_SIZE as u32)
-            .saturating_mul(MAX_CONCURRENT_UNI_STREAMS)
-            .into(),
-    );
+    config.receive_window((PACKET_DATA_SIZE as u32).into());
     let timeout = IdleTimeout::try_from(QUIC_MAX_TIMEOUT).unwrap();
     config.max_idle_timeout(Some(timeout));
 


### PR DESCRIPTION
Start small so spam doesn't use too many resources. Then we grow the window once we figure out a connection's stake.