### PR TITLE
Removes check_hash from CalcAccountsHashConfig

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -167,8 +167,6 @@ impl AccountHashesFile {
 pub struct CalcAccountsHashConfig<'a> {
     /// true to use a thread pool dedicated to bg operations
     pub use_bg_thread_pool: bool,
-    /// verify every hash in append vec/write cache with a recalculated hash
-    pub check_hash: bool,
     /// 'ancestors' is used to get storages
     pub ancestors: Option<&'a Ancestors>,
     /// does hash calc need to consider account data that exists in the write cache?

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -382,7 +382,6 @@ impl AccountsHashVerifier {
 
         let calculate_accounts_hash_config = CalcAccountsHashConfig {
             use_bg_thread_pool: true,
-            check_hash: false,
             ancestors: None,
             epoch_schedule: &accounts_package.epoch_schedule,
             rent_collector: &accounts_package.rent_collector,
@@ -399,7 +398,7 @@ impl AccountsHashVerifier {
                 slot,
                 timings,
             )
-            .unwrap()); // unwrap here will never fail since check_hash = false
+            .unwrap()); // unwrap here will never fail
 
         if accounts_package.expected_capitalization != lamports {
             // before we assert, run the hash calc again. This helps track down whether it could have been a failure in a race condition possibly with shrink.
@@ -461,7 +460,6 @@ impl AccountsHashVerifier {
 
         let calculate_accounts_hash_config = CalcAccountsHashConfig {
             use_bg_thread_pool: true,
-            check_hash: false,
             ancestors: None,
             epoch_schedule: &accounts_package.epoch_schedule,
             rent_collector: &accounts_package.rent_collector,
@@ -478,7 +476,7 @@ impl AccountsHashVerifier {
                     accounts_package.slot,
                     HashStats::default(),
                 )
-                .unwrap() // unwrap here will never fail since check_hash = false
+                .unwrap() // unwrap here will never fail
         );
 
         datapoint_info!(

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -320,7 +320,6 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
                     bank.slot(),
                     &CalcAccountsHashConfig {
                         use_bg_thread_pool: false,
-                        check_hash: false,
                         ancestors: Some(&bank.ancestors),
                         epoch_schedule: bank.epoch_schedule(),
                         rent_collector: bank.rent_collector(),

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -347,8 +347,6 @@ impl SnapshotRequestHandler {
         flush_accounts_cache_time.stop();
 
         let accounts_hash_for_testing = previous_accounts_hash.map(|previous_accounts_hash| {
-            let check_hash = false;
-
             let (this_accounts_hash, capitalization) = snapshot_root_bank
                 .accounts()
                 .accounts_db
@@ -357,7 +355,6 @@ impl SnapshotRequestHandler {
                     snapshot_root_bank.slot(),
                     &CalcAccountsHashConfig {
                         use_bg_thread_pool: true,
-                        check_hash,
                         ancestors: None,
                         epoch_schedule: snapshot_root_bank.epoch_schedule(),
                         rent_collector: snapshot_root_bank.rent_collector(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5996,7 +5996,6 @@ impl Bank {
     pub fn update_incremental_accounts_hash(&self, base_slot: Slot) -> IncrementalAccountsHash {
         let config = CalcAccountsHashConfig {
             use_bg_thread_pool: true,
-            check_hash: false,
             ancestors: None, // does not matter, will not be used
             epoch_schedule: &self.epoch_schedule,
             rent_collector: &self.rent_collector,
@@ -6013,7 +6012,7 @@ impl Bank {
                 self.slot(),
                 HashStats::default(),
             )
-            .unwrap() // unwrap here will never fail since check_hash = false
+            .unwrap() // unwrap here will never fail
             .0
     }
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2327,7 +2327,6 @@ mod tests {
             .calculate_incremental_accounts_hash(
                 &CalcAccountsHashConfig {
                     use_bg_thread_pool: false,
-                    check_hash: false,
                     ancestors: None,
                     epoch_schedule: deserialized_bank.epoch_schedule(),
                     rent_collector: deserialized_bank.rent_collector(),


### PR DESCRIPTION
#### Problem

We'd like to remove `check_hash` from `CalcAccountsHashConfig`, because we no longer store account hashes with accounts. Thus we cannot compare with the stored account hashes, since they are all default values. 

No one uses `check_hash` anymore, so it's now safe to remove 🎉 


#### Summary of Changes

Remove it.