### PR TITLE
Removes returned Result from infallible fns

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6532,7 +6532,7 @@ impl AccountsDb {
         &self,
         max_slot: Slot,
         config: &CalcAccountsHashConfig<'_>,
-    ) -> Result<(AccountsHash, u64), AccountsHashVerificationError> {
+    ) -> (AccountsHash, u64) {
         let mut collect = Measure::start("collect");
         let keys: Vec<_> = self
             .accounts_index
@@ -6626,7 +6626,7 @@ impl AccountsDb {
         );
 
         let accounts_hash = AccountsHash(accumulated_hash);
-        Ok((accounts_hash, total_lamports))
+        (accounts_hash, total_lamports)
     }
 
     /// This is only valid to call from tests.
@@ -6957,7 +6957,7 @@ impl AccountsDb {
         data_source: CalcAccountsHashDataSource,
         slot: Slot,
         config: &CalcAccountsHashConfig<'_>,
-    ) -> Result<(AccountsHash, u64), AccountsHashVerificationError> {
+    ) -> (AccountsHash, u64) {
         match data_source {
             CalcAccountsHashDataSource::Storages => {
                 if self.accounts_cache.contains_any_slots(slot) {
@@ -7000,9 +7000,9 @@ impl AccountsDb {
         slot: Slot,
         config: CalcAccountsHashConfig<'_>,
         expected_capitalization: Option<u64>,
-    ) -> Result<(AccountsHash, u64), AccountsHashVerificationError> {
+    ) -> (AccountsHash, u64) {
         let (accounts_hash, total_lamports) =
-            self.calculate_accounts_hash(data_source, slot, &config)?;
+            self.calculate_accounts_hash(data_source, slot, &config);
         if debug_verify {
             // calculate the other way (store or non-store) and verify results match.
             let data_source_other = match data_source {
@@ -7010,14 +7010,14 @@ impl AccountsDb {
                 CalcAccountsHashDataSource::Storages => CalcAccountsHashDataSource::IndexForTests,
             };
             let (accounts_hash_other, total_lamports_other) =
-                self.calculate_accounts_hash(data_source_other, slot, &config)?;
+                self.calculate_accounts_hash(data_source_other, slot, &config);
 
             let success = accounts_hash == accounts_hash_other
                 && total_lamports == total_lamports_other
                 && total_lamports == expected_capitalization.unwrap_or(total_lamports);
             assert!(success, "calculate_accounts_hash_with_verify mismatch. hashes: {}, {}; lamports: {}, {}; expected lamports: {:?}, data source: {:?}, slot: {}", accounts_hash.0, accounts_hash_other.0, total_lamports, total_lamports_other, expected_capitalization, data_source, slot);
         }
-        Ok((accounts_hash, total_lamports))
+        (accounts_hash, total_lamports)
     }
 
     /// run the accounts hash calculation and store the results
@@ -7033,21 +7033,19 @@ impl AccountsDb {
         rent_collector: &RentCollector,
         is_startup: bool,
     ) -> (AccountsHash, u64) {
-        let (accounts_hash, total_lamports) = self
-            .calculate_accounts_hash_with_verify(
-                data_source,
-                debug_verify,
-                slot,
-                CalcAccountsHashConfig {
-                    use_bg_thread_pool: !is_startup,
-                    ancestors: Some(ancestors),
-                    epoch_schedule,
-                    rent_collector,
-                    store_detailed_debug_info_on_failure: false,
-                },
-                expected_capitalization,
-            )
-            .unwrap(); // unwrap here will never fail
+        let (accounts_hash, total_lamports) = self.calculate_accounts_hash_with_verify(
+            data_source,
+            debug_verify,
+            slot,
+            CalcAccountsHashConfig {
+                use_bg_thread_pool: !is_startup,
+                ancestors: Some(ancestors),
+                epoch_schedule,
+                rent_collector,
+                store_detailed_debug_info_on_failure: false,
+            },
+            expected_capitalization,
+        );
         self.set_accounts_hash(slot, (accounts_hash, total_lamports));
         (accounts_hash, total_lamports)
     }
@@ -7059,13 +7057,13 @@ impl AccountsDb {
         storages: &SortedStorages<'_>,
         slot: Slot,
         stats: HashStats,
-    ) -> Result<(AccountsHash, /*capitalization*/ u64), AccountsHashVerificationError> {
-        let accounts_hash = self.calculate_accounts_hash_from_storages(config, storages, stats)?;
+    ) -> (AccountsHash, /*capitalization*/ u64) {
+        let accounts_hash = self.calculate_accounts_hash_from_storages(config, storages, stats);
         let old_accounts_hash = self.set_accounts_hash(slot, accounts_hash);
         if let Some(old_accounts_hash) = old_accounts_hash {
             warn!("Accounts hash was already set for slot {slot}! old: {old_accounts_hash:?}, new: {accounts_hash:?}");
         }
-        Ok(accounts_hash)
+        accounts_hash
     }
 
     /// Calculate the incremental accounts hash for `storages` and save the results at `slot`
@@ -7075,16 +7073,15 @@ impl AccountsDb {
         storages: &SortedStorages<'_>,
         slot: Slot,
         stats: HashStats,
-    ) -> Result<(IncrementalAccountsHash, /*capitalization*/ u64), AccountsHashVerificationError>
-    {
+    ) -> (IncrementalAccountsHash, /*capitalization*/ u64) {
         let incremental_accounts_hash =
-            self.calculate_incremental_accounts_hash(config, storages, stats)?;
+            self.calculate_incremental_accounts_hash(config, storages, stats);
         let old_incremental_accounts_hash =
             self.set_incremental_accounts_hash(slot, incremental_accounts_hash);
         if let Some(old_incremental_accounts_hash) = old_incremental_accounts_hash {
             warn!("Incremental accounts hash was already set for slot {slot}! old: {old_incremental_accounts_hash:?}, new: {incremental_accounts_hash:?}");
         }
-        Ok(incremental_accounts_hash)
+        incremental_accounts_hash
     }
 
     /// Set the accounts hash for `slot`
@@ -7189,7 +7186,7 @@ impl AccountsDb {
         bins: usize,
         bin_range: &Range<usize>,
         config: &CalcAccountsHashConfig<'_>,
-    ) -> Result<Vec<CacheHashDataFileReference>, AccountsHashVerificationError> {
+    ) -> Vec<CacheHashDataFileReference> {
         assert!(bin_range.start < bins);
         assert!(bin_range.end <= bins);
         assert!(bin_range.start < bin_range.end);
@@ -7226,7 +7223,7 @@ impl AccountsDb {
         time.stop();
         stats.scan_time_total_us += time.as_us();
 
-        Ok(result)
+        result
     }
 
     fn sort_slot_storage_scan(accum: &mut BinnedHashData) -> u64 {
@@ -7272,17 +7269,17 @@ impl AccountsDb {
         config: &CalcAccountsHashConfig<'_>,
         storages: &SortedStorages<'_>,
         stats: HashStats,
-    ) -> Result<(AccountsHash, u64), AccountsHashVerificationError> {
+    ) -> (AccountsHash, u64) {
         let (accounts_hash, capitalization) = self._calculate_accounts_hash_from_storages(
             config,
             storages,
             stats,
             CalcAccountsHashKind::Full,
-        )?;
+        );
         let AccountsHashKind::Full(accounts_hash) = accounts_hash else {
             panic!("calculate_accounts_hash_from_storages must return a FullAccountsHash");
         };
-        Ok((accounts_hash, capitalization))
+        (accounts_hash, capitalization)
     }
 
     /// Calculate the incremental accounts hash
@@ -7298,18 +7295,17 @@ impl AccountsDb {
         config: &CalcAccountsHashConfig<'_>,
         storages: &SortedStorages<'_>,
         stats: HashStats,
-    ) -> Result<(IncrementalAccountsHash, /* capitalization */ u64), AccountsHashVerificationError>
-    {
+    ) -> (IncrementalAccountsHash, /* capitalization */ u64) {
         let (accounts_hash, capitalization) = self._calculate_accounts_hash_from_storages(
             config,
             storages,
             stats,
             CalcAccountsHashKind::Incremental,
-        )?;
+        );
         let AccountsHashKind::Incremental(incremental_accounts_hash) = accounts_hash else {
             panic!("calculate_incremental_accounts_hash must return an IncrementalAccountsHash");
         };
-        Ok((incremental_accounts_hash, capitalization))
+        (incremental_accounts_hash, capitalization)
     }
 
     fn _calculate_accounts_hash_from_storages(
@@ -7318,7 +7314,7 @@ impl AccountsDb {
         storages: &SortedStorages<'_>,
         mut stats: HashStats,
         kind: CalcAccountsHashKind,
-    ) -> Result<(AccountsHashKind, u64), AccountsHashVerificationError> {
+    ) -> (AccountsHashKind, u64) {
         let total_time = Measure::start("");
         let _guard = self.active_stats.activate(ActiveStatItem::Hash);
         let storages_start_slot = storages.range().start;
@@ -7362,7 +7358,7 @@ impl AccountsDb {
                 PUBKEY_BINS_FOR_CALCULATING_HASHES,
                 &bounds,
                 config,
-            )?;
+            );
 
             let cache_hash_data_files = cache_hash_data_file_references
                 .iter()
@@ -7393,7 +7389,7 @@ impl AccountsDb {
                 }
             };
             info!("calculate_accounts_hash_from_storages: slot: {slot}, {accounts_hash:?}, capitalization: {capitalization}");
-            Ok((accounts_hash, capitalization))
+            (accounts_hash, capitalization)
         };
 
         let result = if use_bg_thread_pool {
@@ -7438,7 +7434,7 @@ impl AccountsDb {
                 &calc_config,
                 &sorted_storages,
                 HashStats::default(),
-            )?;
+            );
             let found_incremental_accounts_hash = self
                 .get_incremental_accounts_hash(slot)
                 .ok_or(AccountsHashVerificationError::MissingAccountsHash)?;
@@ -7459,7 +7455,7 @@ impl AccountsDb {
                     slot,
                     calc_config,
                     None,
-                )?;
+                );
 
             if calculated_lamports != total_lamports {
                 warn!(
@@ -9520,7 +9516,7 @@ pub mod tests {
             stats: &mut crate::accounts_hash::HashStats,
             bins: usize,
             bin_range: &Range<usize>,
-        ) -> Result<Vec<CacheHashDataFile>, AccountsHashVerificationError> {
+        ) -> Vec<CacheHashDataFile> {
             let temp_dir = TempDir::new().unwrap();
             let accounts_hash_cache_path = temp_dir.path().to_path_buf();
             self.scan_snapshot_stores_with_cache(
@@ -9531,12 +9527,10 @@ pub mod tests {
                 bin_range,
                 &CalcAccountsHashConfig::default(),
             )
-            .map(|references| {
-                references
-                    .iter()
-                    .map(|reference| reference.map().unwrap())
-                    .collect::<Vec<_>>()
-            })
+            .iter()
+            .map(CacheHashDataFileReference::map)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
         }
 
         fn get_storage_for_slot(&self, slot: Slot) -> Option<Arc<AccountStorageEntry>> {
@@ -9964,9 +9958,7 @@ pub mod tests {
         let bounds = Range { start: 2, end: 2 };
         let accounts_db = AccountsDb::new_single_for_tests();
 
-        accounts_db
-            .scan_snapshot_stores(&empty_storages(), &mut stats, 2, &bounds)
-            .unwrap();
+        accounts_db.scan_snapshot_stores(&empty_storages(), &mut stats, 2, &bounds);
     }
     #[test]
     #[should_panic(expected = "bin_range.end <= bins")]
@@ -9975,9 +9967,7 @@ pub mod tests {
         let bounds = Range { start: 1, end: 3 };
 
         let accounts_db = AccountsDb::new_single_for_tests();
-        accounts_db
-            .scan_snapshot_stores(&empty_storages(), &mut stats, 2, &bounds)
-            .unwrap();
+        accounts_db.scan_snapshot_stores(&empty_storages(), &mut stats, 2, &bounds);
     }
 
     #[test]
@@ -9987,9 +9977,7 @@ pub mod tests {
         let bounds = Range { start: 1, end: 0 };
 
         let accounts_db = AccountsDb::new_single_for_tests();
-        accounts_db
-            .scan_snapshot_stores(&empty_storages(), &mut stats, 2, &bounds)
-            .unwrap();
+        accounts_db.scan_snapshot_stores(&empty_storages(), &mut stats, 2, &bounds);
     }
 
     fn sample_storages_and_account_in_slot(
@@ -10180,17 +10168,15 @@ pub mod tests {
         let bins = 1;
         let mut stats = HashStats::default();
 
-        accounts_db
-            .scan_snapshot_stores(
-                &get_storage_refs(&storages),
-                &mut stats,
-                bins,
-                &Range {
-                    start: 0,
-                    end: bins,
-                },
-            )
-            .unwrap();
+        accounts_db.scan_snapshot_stores(
+            &get_storage_refs(&storages),
+            &mut stats,
+            bins,
+            &Range {
+                start: 0,
+                end: bins,
+            },
+        );
     }
 
     define_accounts_db_test!(test_accountsdb_scan_snapshot_stores, |accounts_db| {
@@ -10207,32 +10193,28 @@ pub mod tests {
         let bins = 1;
         let mut stats = HashStats::default();
 
-        let result = accounts_db
-            .scan_snapshot_stores(
-                &get_storage_refs(&storages),
-                &mut stats,
-                bins,
-                &Range {
-                    start: 0,
-                    end: bins,
-                },
-            )
-            .unwrap();
+        let result = accounts_db.scan_snapshot_stores(
+            &get_storage_refs(&storages),
+            &mut stats,
+            bins,
+            &Range {
+                start: 0,
+                end: bins,
+            },
+        );
         assert_scan(result, vec![vec![raw_expected.clone()]], bins, 0, bins);
 
         let bins = 2;
         let accounts_db = AccountsDb::new_single_for_tests();
-        let result = accounts_db
-            .scan_snapshot_stores(
-                &get_storage_refs(&storages),
-                &mut stats,
-                bins,
-                &Range {
-                    start: 0,
-                    end: bins,
-                },
-            )
-            .unwrap();
+        let result = accounts_db.scan_snapshot_stores(
+            &get_storage_refs(&storages),
+            &mut stats,
+            bins,
+            &Range {
+                start: 0,
+                end: bins,
+            },
+        );
         let mut expected = vec![Vec::new(); bins];
         expected[0].push(raw_expected[0]);
         expected[0].push(raw_expected[1]);
@@ -10242,17 +10224,15 @@ pub mod tests {
 
         let bins = 4;
         let accounts_db = AccountsDb::new_single_for_tests();
-        let result = accounts_db
-            .scan_snapshot_stores(
-                &get_storage_refs(&storages),
-                &mut stats,
-                bins,
-                &Range {
-                    start: 0,
-                    end: bins,
-                },
-            )
-            .unwrap();
+        let result = accounts_db.scan_snapshot_stores(
+            &get_storage_refs(&storages),
+            &mut stats,
+            bins,
+            &Range {
+                start: 0,
+                end: bins,
+            },
+        );
         let mut expected = vec![Vec::new(); bins];
         expected[0].push(raw_expected[0]);
         expected[1].push(raw_expected[1]);
@@ -10262,17 +10242,15 @@ pub mod tests {
 
         let bins = 256;
         let accounts_db = AccountsDb::new_single_for_tests();
-        let result = accounts_db
-            .scan_snapshot_stores(
-                &get_storage_refs(&storages),
-                &mut stats,
-                bins,
-                &Range {
-                    start: 0,
-                    end: bins,
-                },
-            )
-            .unwrap();
+        let result = accounts_db.scan_snapshot_stores(
+            &get_storage_refs(&storages),
+            &mut stats,
+            bins,
+            &Range {
+                start: 0,
+                end: bins,
+            },
+        );
         let mut expected = vec![Vec::new(); bins];
         expected[0].push(raw_expected[0]);
         expected[127].push(raw_expected[1]);
@@ -10294,17 +10272,15 @@ pub mod tests {
                 SortedStorages::new_debug(&storage_data[..], 0, MAX_ITEMS_PER_CHUNK as usize + 1);
 
             let mut stats = HashStats::default();
-            let result = accounts_db
-                .scan_snapshot_stores(
-                    &sorted_storages,
-                    &mut stats,
-                    bins,
-                    &Range {
-                        start: 0,
-                        end: bins,
-                    },
-                )
-                .unwrap();
+            let result = accounts_db.scan_snapshot_stores(
+                &sorted_storages,
+                &mut stats,
+                bins,
+                &Range {
+                    start: 0,
+                    end: bins,
+                },
+            );
 
             assert_scan(result, vec![vec![raw_expected]], bins, 0, bins);
         }
@@ -10319,17 +10295,15 @@ pub mod tests {
             // just the first bin of 2
             let bins = 2;
             let half_bins = bins / 2;
-            let result = accounts_db
-                .scan_snapshot_stores(
-                    &get_storage_refs(&storages),
-                    &mut stats,
-                    bins,
-                    &Range {
-                        start: 0,
-                        end: half_bins,
-                    },
-                )
-                .unwrap();
+            let result = accounts_db.scan_snapshot_stores(
+                &get_storage_refs(&storages),
+                &mut stats,
+                bins,
+                &Range {
+                    start: 0,
+                    end: half_bins,
+                },
+            );
             let mut expected = vec![Vec::new(); half_bins];
             expected[0].push(raw_expected[0]);
             expected[0].push(raw_expected[1]);
@@ -10337,17 +10311,15 @@ pub mod tests {
 
             // just the second bin of 2
             let accounts_db = AccountsDb::new_single_for_tests();
-            let result = accounts_db
-                .scan_snapshot_stores(
-                    &get_storage_refs(&storages),
-                    &mut stats,
-                    bins,
-                    &Range {
-                        start: 1,
-                        end: bins,
-                    },
-                )
-                .unwrap();
+            let result = accounts_db.scan_snapshot_stores(
+                &get_storage_refs(&storages),
+                &mut stats,
+                bins,
+                &Range {
+                    start: 1,
+                    end: bins,
+                },
+            );
 
             let mut expected = vec![Vec::new(); half_bins];
             let starting_bin_index = 0;
@@ -10360,17 +10332,15 @@ pub mod tests {
             let accounts_db = AccountsDb::new_single_for_tests();
 
             for (bin, expected_item) in raw_expected.iter().enumerate().take(bins) {
-                let result = accounts_db
-                    .scan_snapshot_stores(
-                        &get_storage_refs(&storages),
-                        &mut stats,
-                        bins,
-                        &Range {
-                            start: bin,
-                            end: bin + 1,
-                        },
-                    )
-                    .unwrap();
+                let result = accounts_db.scan_snapshot_stores(
+                    &get_storage_refs(&storages),
+                    &mut stats,
+                    bins,
+                    &Range {
+                        start: bin,
+                        end: bin + 1,
+                    },
+                );
                 let mut expected = vec![Vec::new(); 1];
                 expected[0].push(*expected_item);
                 assert_scan(result, vec![expected], bins, bin, 1);
@@ -10381,17 +10351,15 @@ pub mod tests {
             let range = 1;
             for bin in 0..bins {
                 let accounts_db = AccountsDb::new_single_for_tests();
-                let result = accounts_db
-                    .scan_snapshot_stores(
-                        &get_storage_refs(&storages),
-                        &mut stats,
-                        bins,
-                        &Range {
-                            start: bin,
-                            end: bin + range,
-                        },
-                    )
-                    .unwrap();
+                let result = accounts_db.scan_snapshot_stores(
+                    &get_storage_refs(&storages),
+                    &mut stats,
+                    bins,
+                    &Range {
+                        start: bin,
+                        end: bin + range,
+                    },
+                );
                 let mut expected = vec![];
                 if let Some(index) = bin_locations.iter().position(|&r| r == bin) {
                     expected = vec![Vec::new(); range];
@@ -10425,17 +10393,15 @@ pub mod tests {
             let mut stats = HashStats::default();
             let range = 1;
             let start = 127;
-            let result = accounts_db
-                .scan_snapshot_stores(
-                    &sorted_storages,
-                    &mut stats,
-                    bins,
-                    &Range {
-                        start,
-                        end: start + range,
-                    },
-                )
-                .unwrap();
+            let result = accounts_db.scan_snapshot_stores(
+                &sorted_storages,
+                &mut stats,
+                bins,
+                &Range {
+                    start,
+                    end: start + range,
+                },
+            );
             assert_eq!(result.len(), 1); // 2 chunks, but 1 is empty so not included
             let mut expected = vec![Vec::new(); range];
             expected[0].push(raw_expected[1]);
@@ -10451,13 +10417,11 @@ pub mod tests {
         |db| {
             let (storages, _size, _slot_expected) = sample_storage();
 
-            let result = db
-                .calculate_accounts_hash_from_storages(
-                    &CalcAccountsHashConfig::default(),
-                    &get_storage_refs(&storages),
-                    HashStats::default(),
-                )
-                .unwrap();
+            let result = db.calculate_accounts_hash_from_storages(
+                &CalcAccountsHashConfig::default(),
+                &get_storage_refs(&storages),
+                HashStats::default(),
+            );
             let expected_hash =
                 Hash::from_str("GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn").unwrap();
             let expected_accounts_hash = AccountsHash(expected_hash);
@@ -10475,13 +10439,11 @@ pub mod tests {
                 |item| &item.hash.0,
             );
             let sum = raw_expected.iter().map(|item| item.lamports).sum();
-            let result = db
-                .calculate_accounts_hash_from_storages(
-                    &CalcAccountsHashConfig::default(),
-                    &get_storage_refs(&storages),
-                    HashStats::default(),
-                )
-                .unwrap();
+            let result = db.calculate_accounts_hash_from_storages(
+                &CalcAccountsHashConfig::default(),
+                &get_storage_refs(&storages),
+                HashStats::default(),
+            );
 
             let expected_accounts_hash = AccountsHash(expected_hash);
             assert_eq!(result, (expected_accounts_hash, sum));
@@ -17509,13 +17471,11 @@ pub mod tests {
             accounts_db.clean_accounts(Some(slot - 1), false, None, &EpochSchedule::default());
             let (storages, _) = accounts_db.get_snapshot_storages(..=slot);
             let storages = SortedStorages::new(&storages);
-            accounts_db
-                .calculate_accounts_hash_from_storages(
-                    &CalcAccountsHashConfig::default(),
-                    &storages,
-                    HashStats::default(),
-                )
-                .unwrap()
+            accounts_db.calculate_accounts_hash_from_storages(
+                &CalcAccountsHashConfig::default(),
+                &storages,
+                HashStats::default(),
+            )
         };
         assert_eq!(full_accounts_hash.1, 1_110);
         let full_accounts_hash_slot = slot;
@@ -17582,13 +17542,11 @@ pub mod tests {
             let (storages, _) =
                 accounts_db.get_snapshot_storages(full_accounts_hash_slot + 1..=slot);
             let storages = SortedStorages::new(&storages);
-            accounts_db
-                .calculate_incremental_accounts_hash(
-                    &CalcAccountsHashConfig::default(),
-                    &storages,
-                    HashStats::default(),
-                )
-                .unwrap()
+            accounts_db.calculate_incremental_accounts_hash(
+                &CalcAccountsHashConfig::default(),
+                &storages,
+                HashStats::default(),
+            )
         };
         assert_eq!(incremental_accounts_hash.1, 1_100_000);
 

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -389,16 +389,13 @@ impl AccountsHashVerifier {
         };
 
         let slot = accounts_package.slot;
-        let ((accounts_hash, lamports), measure_hash_us) = measure_us!(accounts_package
-            .accounts
-            .accounts_db
-            .update_accounts_hash(
+        let ((accounts_hash, lamports), measure_hash_us) =
+            measure_us!(accounts_package.accounts.accounts_db.update_accounts_hash(
                 &calculate_accounts_hash_config,
                 &sorted_storages,
                 slot,
                 timings,
-            )
-            .unwrap()); // unwrap here will never fail
+            ));
 
         if accounts_package.expected_capitalization != lamports {
             // before we assert, run the hash calc again. This helps track down whether it could have been a failure in a race condition possibly with shrink.
@@ -466,18 +463,15 @@ impl AccountsHashVerifier {
             store_detailed_debug_info_on_failure: false,
         };
 
-        let (incremental_accounts_hash, measure_hash_us) = measure_us!(
-            accounts_package
-                .accounts
-                .accounts_db
-                .update_incremental_accounts_hash(
-                    &calculate_accounts_hash_config,
-                    &sorted_storages,
-                    accounts_package.slot,
-                    HashStats::default(),
-                )
-                .unwrap() // unwrap here will never fail
-        );
+        let (incremental_accounts_hash, measure_hash_us) = measure_us!(accounts_package
+            .accounts
+            .accounts_db
+            .update_incremental_accounts_hash(
+                &calculate_accounts_hash_config,
+                &sorted_storages,
+                accounts_package.slot,
+                HashStats::default(),
+            ));
 
         datapoint_info!(
             "accounts_hash_verifier",

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -325,8 +325,7 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
                         rent_collector: bank.rent_collector(),
                         store_detailed_debug_info_on_failure: false,
                     },
-                )
-                .unwrap();
+                );
             expected_epoch_accounts_hash = Some(EpochAccountsHash::from(accounts_hash));
             debug!(
                 "slot {}, expected epoch accounts hash: {:?}",

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -360,8 +360,7 @@ impl SnapshotRequestHandler {
                         rent_collector: snapshot_root_bank.rent_collector(),
                         store_detailed_debug_info_on_failure: false,
                     },
-                )
-                .unwrap();
+                );
             assert_eq!(previous_accounts_hash, this_accounts_hash);
             assert_eq!(capitalization, snapshot_root_bank.capitalization());
             this_accounts_hash

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6012,7 +6012,6 @@ impl Bank {
                 self.slot(),
                 HashStats::default(),
             )
-            .unwrap() // unwrap here will never fail
             .0
     }
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2334,8 +2334,7 @@ mod tests {
                 },
                 &SortedStorages::new(&other_incremental_snapshot_storages),
                 HashStats::default(),
-            )
-            .unwrap();
+            );
         assert_eq!(other_incremental_accounts_hash, incremental_accounts_hash);
     }
 


### PR DESCRIPTION
#### Problem

We've now removed `check_hash` from `CalcAccountsHashConfig`. Functions that took this config struct return a Result. But the only way they could return an Err was if `check_hash` was true. It's now not possible for check_hash to be true, so it's also not possible for these functions to return an error. Therefore, we can remove the `Result` return type from these functions.


#### Summary of Changes

Remove `Result` from now-infallible functions.