### PR TITLE
client: Resend transactions using same mechanism as initial send

### DIFF
--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -145,8 +145,11 @@ fn create_transaction_confirmation_task(
                                 })
                             {
                                 num_confirmed_transactions.fetch_add(1, Ordering::Relaxed);
-                                if let Some(error) = status.err {
-                                    errors_map.insert(data.index, error);
+                                match status.err {
+                                    Some(TransactionError::AlreadyProcessed) | None => {}
+                                    Some(error) => {
+                                        errors_map.insert(data.index, error);
+                                    }
                                 }
                             };
                         }


### PR DESCRIPTION
#### Problem

There are still issues with deploying programs. Even against a local validator, it takes multiple resends to get a program deployment through. For large amounts of transactions, using `send_wire_transaction_batch` seems to be flaky, especially against public networks.

#### Summary of Changes

This contains a couple of changes, and can be viewed commit by commit. The concept is to have the TPU client resend transactions at a pace of 100 transactions per second, same as the initial send, and to avoid using `send_wire_transaction_batch`.

And to make sends a bit smoother and retry sooner, all sends now timeout after 5 seconds, even the initial send. This allows the resends to start immediately after the initial send, so we can simplify the code and avoid concurrently sending and resending the same transactions. This doesn't totally resolve issues with deploys mainnet unfortunately, since just getting the transaction to the leader over TPU is nearly impossible, but it makes sends much more consistent against testnet.

I tested by alternating the old and new code to send 5,000 transactions on testnet. The transactions were unique self-transfers with 1 million micro-lamports per CU. Runs were cancelled after 5 minutes. Results:

* without: 160s, (cancelled with 174 txs left), (cancelled with 48 txs left), 150s, (cancelled with 32 txs left)
* with: 71s, 62s, 210s, 61s, 290s

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
