### PR TITLE
cli: Warn on sizes above 10MB during `solana rent`

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -57,7 +57,7 @@ use {
         signature::Signature,
         slot_history,
         stake::{self, state::StakeStateV2},
-        system_instruction,
+        system_instruction::{self, MAX_PERMITTED_DATA_LENGTH},
         sysvar::{
             self,
             slot_history::SlotHistory,
@@ -2181,8 +2181,8 @@ pub fn process_calculate_rent(
     data_length: usize,
     use_lamports_unit: bool,
 ) -> ProcessResult {
-    if data_length > 10_000_000 {
-        println!("Warning: Account's maximum size is 10 MB".to_string());
+    if data_length > MAX_PERMITTED_DATA_LENGTH.try_into().unwrap() {
+        eprintln!("Warning: Maximum account size is {MAX_PERMITTED_DATA_LENGTH} bytes, {data_length} provided");
     }
     let rent_account = rpc_client.get_account(&sysvar::rent::id())?;
     let rent: Rent = rent_account.deserialize_data()?;

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -2181,6 +2181,9 @@ pub fn process_calculate_rent(
     data_length: usize,
     use_lamports_unit: bool,
 ) -> ProcessResult {
+    if data_length > 10_000_000 {
+        println!("Warning: Account's maximum size is 10 MB".to_string());
+    }
     let rent_account = rpc_client.get_account(&sysvar::rent::id())?;
     let rent: Rent = rent_account.deserialize_data()?;
     let rent_exempt_minimum_lamports = rent.minimum_balance(data_length);


### PR DESCRIPTION
#### Problem
The CLI command `$ solana rent <DATA_LENGTH_OR_MONIKER>` calculates the rent even if DATA_LENGTH is greater than 10 MB - which is the maximum size for a single account. The CLI tool should give a warning to avoid misleading the user.

#### Summary of Changes
Added the check for it.
