### PR TITLE
cli: Add `--use-rpc` flag to program deploy and write-buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Release channels have their own copy of this changelog:
   * `central-scheduler` as default option for `--block-production-method` (#34891)
   * `solana-rpc-client-api`: `RpcFilterError` depends on `base64` version 0.22, so users may need to upgrade to `base64` version 0.22
   * Changed default value for `--health-check-slot-distance` from 150 to 128
-  * CLI: Can specify `--with-compute-unit-price` and `--max-sign-attempts` during program deployment
+  * CLI: Can specify `--with-compute-unit-price`, `--max-sign-attempts`, and `--use-rpc` during program deployment
   * RPC's `simulateTransaction` now returns an extra `replacementBlockhash` field in the response
     when the `replaceRecentBlockhash` config param is `true` (#380)
 
@@ -42,7 +42,7 @@ Release channels have their own copy of this changelog:
     double the size. Program accounts must be extended with `solana program extend`
     before an upgrade if they need to accommodate larger programs.
   * Interface for `gossip_service::get_client()` has changed. `gossip_service::get_multi_client()` has been removed.
-  * CLI: Can specify `--with-compute-unit-price` and `--max-sign-attempts` during program deployment
+  * CLI: Can specify `--with-compute-unit-price`, `--max-sign-attempts`, and `--use-rpc` during program deployment
 * Upgrade Notes
   * `solana-program` and `solana-sdk` default to support for Borsh v1, with
 limited backward compatibility for v0.10 and v0.9. Please upgrade to Borsh v1.

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -99,6 +99,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -147,6 +148,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
     let account1 = rpc_client
@@ -204,6 +206,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     let err = process_command(&config).unwrap_err();
     assert_eq!(
@@ -229,6 +232,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap_err();
 }
@@ -292,6 +296,7 @@ fn test_cli_program_deploy_no_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -321,6 +326,7 @@ fn test_cli_program_deploy_no_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap_err();
 }
@@ -385,6 +391,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -436,6 +443,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -481,6 +489,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -558,6 +567,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
     let program_account = rpc_client.get_account(&program_pubkey).unwrap();
@@ -639,6 +649,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap_err();
 
@@ -658,6 +669,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -764,6 +776,7 @@ fn test_cli_program_close_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -876,6 +889,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -925,6 +939,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap_err();
 
@@ -959,6 +974,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
 }
@@ -1025,6 +1041,7 @@ fn test_cli_program_write_buffer() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -1063,6 +1080,7 @@ fn test_cli_program_write_buffer() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1128,6 +1146,7 @@ fn test_cli_program_write_buffer() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1169,6 +1188,7 @@ fn test_cli_program_write_buffer() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1246,6 +1266,7 @@ fn test_cli_program_write_buffer() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -1290,6 +1311,7 @@ fn test_cli_program_write_buffer() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
     config.signers = vec![&keypair, &buffer_keypair];
@@ -1307,6 +1329,7 @@ fn test_cli_program_write_buffer() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let error = process_command(&config).unwrap_err();
@@ -1381,6 +1404,7 @@ fn test_cli_program_set_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
@@ -1435,6 +1459,7 @@ fn test_cli_program_set_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap_err();
@@ -1482,6 +1507,7 @@ fn test_cli_program_set_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1540,6 +1566,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
@@ -1566,6 +1593,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap_err();
 
@@ -1585,6 +1613,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
 }
@@ -1670,6 +1699,7 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     process_command(&config).unwrap();
@@ -1839,6 +1869,7 @@ fn test_cli_program_show() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
 
@@ -1902,6 +1933,7 @@ fn test_cli_program_show() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
     let min_slot = rpc_client.get_slot().unwrap();
@@ -2032,6 +2064,7 @@ fn test_cli_program_dump() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(&config).unwrap();
 
@@ -2077,6 +2110,7 @@ fn create_buffer_with_offline_authority<'a>(
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
+        use_rpc: false,
     });
     process_command(config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_signer.pubkey()).unwrap();
@@ -2104,7 +2138,10 @@ fn create_buffer_with_offline_authority<'a>(
 }
 
 #[allow(clippy::assertions_on_constants)]
-fn cli_program_deploy_with_args(compute_unit_price: Option<u64>) {
+#[test_case(None, false; "default")]
+#[test_case(Some(10), false; "with_compute_unit_price")]
+#[test_case(None, true; "use_rpc")]
+fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: bool) {
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
     noop_path.push("fixtures");
@@ -2173,6 +2210,7 @@ fn cli_program_deploy_with_args(compute_unit_price: Option<u64>) {
         skip_fee_check: false,
         compute_unit_price,
         max_sign_attempts: 5,
+        use_rpc,
     });
     config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
@@ -2273,10 +2311,4 @@ fn cli_program_deploy_with_args(compute_unit_price: Option<u64>) {
             &system_program::id()
         );
     }
-}
-
-#[test]
-fn test_cli_program_deploy_with_compute_unit_price() {
-    cli_program_deploy_with_args(Some(1000));
-    cli_program_deploy_with_args(None);
 }

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -249,6 +249,7 @@ fn run_transactions_dos(
             max_len: None,
             compute_unit_price: None,
             max_sign_attempts: 5,
+            use_rpc: false,
             skip_fee_check: true, // skip_fee_check
         });
 


### PR DESCRIPTION
#### Problem

There's no way to send program deployment transactions through RPC.

#### Summary of Changes

The `send_and_confirm_transactions_in_parallel` function will use the RPC client if no TPU client is provided, so keep it simple, and don't provide the TPU client is `--use-rpc` is set.

Note that this only affects the QUIC code path, and not the UDP code path, which should be OK because the UDP code path is broken anyway.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
