### PR TITLE
shrinking and appending ancients use StorableAccountsBySlot

### DIFF
--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -294,28 +294,6 @@ impl<'a> StorableAccounts<'a> for StorableAccountsBySlot<'a> {
     }
 }
 
-/// this tuple contains a single different source slot that applies to all accounts
-/// accounts are StoredAccountMeta
-impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>], Slot) {
-    fn account<Ret>(
-        &self,
-        index: usize,
-        mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
-    ) -> Ret {
-        callback(self.1[index].into())
-    }
-    fn slot(&self, _index: usize) -> Slot {
-        // same other slot for all accounts
-        self.2
-    }
-    fn target_slot(&self) -> Slot {
-        self.0
-    }
-    fn len(&self) -> usize {
-        self.1.len()
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use {
@@ -346,6 +324,29 @@ pub mod tests {
         fn slot(&self, _index: usize) -> Slot {
             // per-index slot is not unique per slot when per-account slot is not included in the source data
             self.target_slot()
+        }
+        fn target_slot(&self) -> Slot {
+            self.0
+        }
+        fn len(&self) -> usize {
+            self.1.len()
+        }
+    }
+
+    /// this is no longer used. It is very tricky to get these right. There are already tests for this. It is likely worth it to leave this here for a while until everything has settled.
+    /// this tuple contains a single different source slot that applies to all accounts
+    /// accounts are StoredAccountMeta
+    impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountMeta<'a>], Slot) {
+        fn account<Ret>(
+            &self,
+            index: usize,
+            mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
+        ) -> Ret {
+            callback(self.1[index].into())
+        }
+        fn slot(&self, _index: usize) -> Slot {
+            // same other slot for all accounts
+            self.2
         }
         fn target_slot(&self) -> Slot {
             self.0

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -11,6 +11,7 @@ use {
     solana_accounts_db::{
         accounts_db::{AccountStorageEntry, AccountsDb, GetUniqueAccountsResult, PurgeStats},
         accounts_partition,
+        storable_accounts::StorableAccountsBySlot,
     },
     solana_measure::measure,
     solana_sdk::{
@@ -346,8 +347,11 @@ impl<'a> SnapshotMinimizer<'a> {
         if aligned_total > 0 {
             shrink_in_progress = Some(self.accounts_db().get_store_for_shrink(slot, aligned_total));
             let new_storage = shrink_in_progress.as_ref().unwrap().new_storage();
+
+            let accounts = [(slot, &keep_accounts[..])];
+            let storable_accounts = StorableAccountsBySlot::new(slot, &accounts);
             self.accounts_db()
-                .store_accounts_frozen((slot, &keep_accounts[..]), new_storage);
+                .store_accounts_frozen(storable_accounts, new_storage);
 
             new_storage.flush().unwrap();
         }


### PR DESCRIPTION
#### Problem
stop mmapping storages.

#### Summary of Changes
For simplifying apis and optimizing implementations, use `StorableAccountsBySlot` for all shrink writes. This also allows the `StorableAccounts` impl to use cache storage lookups for the same slot in repeated `accounts()` calls later when we stop mmapping.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
