### PR TITLE
remove a StorableAccounts impl

### DIFF
--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -42,7 +42,10 @@ fn bench_write_accounts_file(c: &mut Criterion) {
         })
         .take(accounts_count)
         .collect();
-        let accounts_refs: Vec<_> = accounts.iter().collect();
+        let accounts_refs: Vec<_> = accounts
+            .iter()
+            .map(|(pubkey, account)| (pubkey, account))
+            .collect();
         let storable_accounts = (Slot::MAX, accounts_refs.as_slice());
 
         group.bench_function(BenchmarkId::new("append_vec", accounts_count), |b| {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -80,7 +80,7 @@ use {
         accounts_hash::{
             AccountHash, AccountsHash, CalcAccountsHashConfig, HashStats, IncrementalAccountsHash,
         },
-        accounts_index::{AccountSecondaryIndexes, IndexKey, ScanConfig, ScanResult, ZeroLamport},
+        accounts_index::{AccountSecondaryIndexes, IndexKey, ScanConfig, ScanResult},
         accounts_partition::{self, Partition, PartitionIndex},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         ancestors::{Ancestors, AncestorsForSerialization},
@@ -88,7 +88,7 @@ use {
         epoch_accounts_hash::EpochAccountsHash,
         sorted_storages::SortedStorages,
         stake_rewards::StakeReward,
-        storable_accounts::{AccountForStorage, StorableAccounts},
+        storable_accounts::StorableAccounts,
     },
     solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
     solana_cost_model::cost_tracker::CostTracker,
@@ -5060,13 +5060,7 @@ impl Bank {
 
     /// fn store the single `account` with `pubkey`.
     /// Uses `store_accounts`, which works on a vector of accounts.
-    pub fn store_account<'a, T: ReadableAccount + Sync + ZeroLamport + 'a>(
-        &self,
-        pubkey: &'a Pubkey,
-        account: &'a T,
-    ) where
-        AccountForStorage<'a>: From<(&'a Pubkey, &'a T)>,
-    {
+    pub fn store_account(&self, pubkey: &Pubkey, account: &AccountSharedData) {
         self.store_accounts((self.slot(), &[(pubkey, account)][..]))
     }
 


### PR DESCRIPTION
#### Problem
stop mmapping storages.

#### Summary of Changes
For simplifying apis and optimizing implementations, remove an impl of `StorableAccounts`. This helps us better test and optimize the other impls.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
