### PR TITLE
Disable cache warmer  for tpu connection cache if no RPC/STS uses it.

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -150,7 +150,7 @@ impl Tvu {
         wait_to_vote_slot: Option<Slot>,
         accounts_background_request_sender: AbsRequestSender,
         log_messages_bytes_limit: Option<usize>,
-        connection_cache: &Arc<ConnectionCache>,
+        connection_cache: Option<&Arc<ConnectionCache>>,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         banking_tracer: Arc<BankingTracer>,
         turbine_quic_endpoint_sender: AsyncSender<(SocketAddr, Bytes)>,
@@ -292,16 +292,18 @@ impl Tvu {
             tower_storage,
         );
 
-        let warm_quic_cache_service = if connection_cache.use_quic() {
-            Some(WarmQuicCacheService::new(
-                connection_cache.clone(),
-                cluster_info.clone(),
-                poh_recorder.clone(),
-                exit.clone(),
-            ))
-        } else {
-            None
-        };
+        let warm_quic_cache_service =
+            connection_cache
+                .filter(|cache| cache.use_quic())
+                .map(|cache| {
+                    WarmQuicCacheService::new(
+                        cache.clone(),
+                        cluster_info.clone(),
+                        poh_recorder.clone(),
+                        exit.clone(),
+                    )
+                });
+
         let (cost_update_sender, cost_update_receiver) = unbounded();
         let cost_update_service = CostUpdateService::new(blockstore.clone(), cost_update_receiver);
 
@@ -509,7 +511,7 @@ pub mod tests {
             None,
             AbsRequestSender::default(),
             None,
-            &Arc::new(ConnectionCache::new("connection_cache_test")),
+            Some(&Arc::new(ConnectionCache::new("connection_cache_test"))),
             &ignored_prioritization_fee_cache,
             BankingTracer::new_disabled(),
             turbine_quic_endpoint_sender,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1325,7 +1325,7 @@ impl Validator {
             config.wait_to_vote_slot,
             accounts_background_request_sender,
             config.runtime_config.log_messages_bytes_limit,
-            &connection_cache,
+            json_rpc_service.is_some().then_some(&connection_cache), // for the cache warmer only used for STS for RPC service
             &prioritization_fee_cache,
             banking_tracer.clone(),
             turbine_quic_endpoint_sender.clone(),


### PR DESCRIPTION
#### Problem
The tpu cache is only used by STS started by RPC service. If no RPC service is enabled, no need to start the cache warmer. Which is having unnecessary load on the leaders.

#### Summary of Changes
Start the cache warmer conditionally.

This is built upon https://github.com/anza-xyz/agave/pull/878.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
