### PR TITLE
remove token-2022 dep from rpc-client-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6941,6 +6941,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
+ "solana-inline-spl",
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6944,7 +6944,6 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022",
  "thiserror",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5660,7 +5660,6 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022",
  "thiserror",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5657,6 +5657,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
+ "solana-inline-spl",
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -22,7 +22,6 @@ solana-account-decoder = { workspace = true }
 solana-sdk = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
-spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -19,6 +19,7 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 solana-account-decoder = { workspace = true }
+solana-inline-spl = { workspace = true }
 solana-sdk = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -1,7 +1,7 @@
 #![allow(deprecated)]
 use {
     crate::version_req::VersionReq,
-    solana_inline_spl::token::{Account, GenericTokenAccount},
+    solana_inline_spl::token_2022::{Account, GenericTokenAccount},
     solana_sdk::account::{AccountSharedData, ReadableAccount},
     std::borrow::Cow,
     thiserror::Error,

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -1,10 +1,5 @@
 #![allow(deprecated)]
-use {
-    crate::version_req::VersionReq,
-    solana_sdk::account::{AccountSharedData, ReadableAccount},
-    std::borrow::Cow,
-    thiserror::Error,
-};
+use {crate::version_req::VersionReq, std::borrow::Cow, thiserror::Error};
 
 const MAX_DATA_SIZE: usize = 128;
 const MAX_DATA_BASE58_SIZE: usize = 175;

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -1,7 +1,7 @@
 #![allow(deprecated)]
 use {
     crate::version_req::VersionReq,
-    solana_inline_spl::token_2022::{Account, GenericTokenAccount},
+    solana_inline_spl::{token::GenericTokenAccount, token_2022::Account},
     solana_sdk::account::{AccountSharedData, ReadableAccount},
     std::borrow::Cow,
     thiserror::Error,

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -1,5 +1,11 @@
 #![allow(deprecated)]
-use {crate::version_req::VersionReq, std::borrow::Cow, thiserror::Error};
+use {
+    crate::version_req::VersionReq,
+    solana_inline_spl::token::{Account, GenericTokenAccount},
+    solana_sdk::account::{AccountSharedData, ReadableAccount},
+    std::borrow::Cow,
+    thiserror::Error,
+};
 
 const MAX_DATA_SIZE: usize = 128;
 const MAX_DATA_BASE58_SIZE: usize = 175;

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -2,7 +2,6 @@
 use {
     crate::version_req::VersionReq,
     solana_sdk::account::{AccountSharedData, ReadableAccount},
-    spl_token_2022::{generic_token_account::GenericTokenAccount, state::Account},
     std::borrow::Cow,
     thiserror::Error,
 };
@@ -76,14 +75,6 @@ impl RpcFilterType {
                 }
             }
             RpcFilterType::TokenAccountState => Ok(()),
-        }
-    }
-
-    pub fn allows(&self, account: &AccountSharedData) -> bool {
-        match self {
-            RpcFilterType::DataSize(size) => account.data().len() as u64 == *size,
-            RpcFilterType::Memcmp(compare) => compare.bytes_match(account.data()),
-            RpcFilterType::TokenAccountState => Account::valid_account_data(account.data()),
         }
     }
 }

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -72,6 +72,15 @@ impl RpcFilterType {
             RpcFilterType::TokenAccountState => Ok(()),
         }
     }
+
+    #[deprecated = "Use solana_rpc::filter::filter_allows instead"]
+    pub fn allows(&self, account: &AccountSharedData) -> bool {
+        match self {
+            RpcFilterType::DataSize(size) => account.data().len() as u64 == *size,
+            RpcFilterType::Memcmp(compare) => compare.bytes_match(account.data()),
+            RpcFilterType::TokenAccountState => Account::valid_account_data(account.data()),
+        }
+    }
 }
 
 #[derive(Error, PartialEq, Eq, Debug)]

--- a/rpc/src/filter.rs
+++ b/rpc/src/filter.rs
@@ -1,5 +1,5 @@
 use {
-    solana_inline_spl::token::{Account, GenericTokenAccount},
+    solana_inline_spl::{token::GenericTokenAccount, token_2022::Account},
     solana_rpc_client_api::filter::RpcFilterType,
     solana_sdk::account::{AccountSharedData, ReadableAccount},
 };

--- a/rpc/src/filter.rs
+++ b/rpc/src/filter.rs
@@ -1,0 +1,13 @@
+use {
+    solana_rpc_client_api::filter::RpcFilterType,
+    solana_sdk::account::AccountSharedData,
+    spl_token_2022::{generic_token_account::GenericTokenAccount, state::Account},
+};
+
+pub fn filter_allows(filter: &RpcFilterType, account: &AccountSharedData) -> bool {
+    match filter {
+        RpcFilterType::DataSize(size) => account.data().len() as u64 == *size,
+        RpcFilterType::Memcmp(compare) => compare.bytes_match(account.data()),
+        RpcFilterType::TokenAccountState => Account::valid_account_data(account.data()),
+    }
+}

--- a/rpc/src/filter.rs
+++ b/rpc/src/filter.rs
@@ -1,8 +1,7 @@
 use {
-    solana_rpc_client_api::filter::RpcFilterType,
     solana_inline_spl::token::{Account, GenericTokenAccount},
+    solana_rpc_client_api::filter::RpcFilterType,
     solana_sdk::account::{AccountSharedData, ReadableAccount},
-    spl_token_2022::{generic_token_account::GenericTokenAccount, state::Account},
 };
 
 pub fn filter_allows(filter: &RpcFilterType, account: &AccountSharedData) -> bool {

--- a/rpc/src/filter.rs
+++ b/rpc/src/filter.rs
@@ -1,5 +1,6 @@
 use {
     solana_rpc_client_api::filter::RpcFilterType,
+    solana_inline_spl::token::{Account, GenericTokenAccount},
     solana_sdk::account::{AccountSharedData, ReadableAccount},
     spl_token_2022::{generic_token_account::GenericTokenAccount, state::Account},
 };

--- a/rpc/src/filter.rs
+++ b/rpc/src/filter.rs
@@ -1,6 +1,6 @@
 use {
     solana_rpc_client_api::filter::RpcFilterType,
-    solana_sdk::account::AccountSharedData,
+    solana_sdk::account::{AccountSharedData, ReadableAccount},
     spl_token_2022::{generic_token_account::GenericTokenAccount, state::Account},
 };
 

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 mod cluster_tpu_info;
+pub mod filter;
 pub mod max_slots;
 pub mod optimistically_confirmed_bank_tracker;
 pub mod parsed_token_accounts;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2039,7 +2039,7 @@ impl JsonRpcRequestProcessor {
         let filter_closure = |account: &AccountSharedData| {
             filters
                 .iter()
-                .all(|filter_type| filter_type.allows(account))
+                .all(|filter_type| filter_allows(filter_type, account))
         };
         if self
             .config
@@ -2116,7 +2116,7 @@ impl JsonRpcRequestProcessor {
                         account.owner() == program_id
                             && filters
                                 .iter()
-                                .all(|filter_type| filter_type.allows(account))
+                                .all(|filter_type| filter_allows(filter_type, account))
                     },
                     &ScanConfig::default(),
                     bank.byte_limit_for_scans(),
@@ -2166,7 +2166,7 @@ impl JsonRpcRequestProcessor {
                         account.owner() == program_id
                             && filters
                                 .iter()
-                                .all(|filter_type| filter_type.allows(account))
+                                .all(|filter_type| filter_allows(filter_type, account))
                     },
                     &ScanConfig::default(),
                     bank.byte_limit_for_scans(),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1,7 +1,8 @@
 //! The `rpc` module implements the Solana RPC interface.
 use {
     crate::{
-        max_slots::MaxSlots, optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
+        filter::filter_allows, max_slots::MaxSlots,
+        optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
         parsed_token_accounts::*, rpc_cache::LargestAccountsCache, rpc_health::*,
     },
     base64::{prelude::BASE64_STANDARD, Engine},

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -416,7 +416,7 @@ fn filter_program_results(
     let keyed_accounts = accounts.into_iter().filter(move |(_, account)| {
         filters
             .iter()
-            .all(|filter_type| filter_type.allows(account))
+            .all(|filter_type| filter_allows(filter_type, account))
     });
     let accounts = if is_known_spl_token_id(&params.pubkey)
         && params.encoding == UiAccountEncoding::JsonParsed

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -2,6 +2,7 @@
 
 use {
     crate::{
+        filter::filter_allows,
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
         parsed_token_accounts::{get_parsed_token_account, get_parsed_token_accounts},
         rpc_pubsub_service::PubSubConfig,


### PR DESCRIPTION
#### Problem

`solana-rpc-client-api` depends on `spl-token-2022` for the `allows()` method of `RpcFilterType`. `spl-token-2022` is a  very heavy dependency and anyway the `allows()` method is for the RPC server, not the client.

#### Summary of Changes
- Copies `RpcFilterType::allows` to `solana-rpc` as a free function `filter_allows`
- Deprecates `RpcFilterType::allows`
- Removes `spl-token-2022` dependency from `solana-rpc-client-api` by using the spl-inline crate instead
