### PR TITLE
remove redundant schema def of epoch

### DIFF
--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -878,7 +878,6 @@ impl borsh0_10::BorshSchema for Delegation {
         <Pubkey as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
         <u64 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
         <Epoch as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-        <Epoch as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
         <f64 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }


### PR DESCRIPTION
#### Problem

`Epoch` def is added to `BorshSchema` twice. 


#### Summary of Changes

Remove the redundant `Epoch` def addition to `BorshSchema`.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
