### PR TITLE
[anza migration]: update repo url

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -93,7 +93,7 @@ module.exports = {
           position: "right",
         },
         {
-          href: "https://github.com/solana-labs/solana",
+          href: "https://github.com/anza-xyz/agave/",
           // label: "GitHub",
           className: "header-link-icon header-github-link",
           "aria-label": "GitHub repository",


### PR DESCRIPTION
#### Problem

Url is set to old repo

#### Summary of Changes

Updated url
