### PR TITLE
chore: Bump curve25519-dalek to v4, sha3 to v0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5",
+ "block-padding",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
@@ -900,7 +900,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
  "generic-array 0.14.7",
 ]
 
@@ -921,12 +920,6 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
@@ -1156,9 +1149,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "bytesize"
@@ -1723,14 +1716,44 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
-source = "git+https://github.com/solana-labs/curve25519-dalek.git?rev=b500cdc2a920cd5bff9e2dd974d7b97349d61464#b500cdc2a920cd5bff9e2dd974d7b97349d61464"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "platforms",
+ "rand_core 0.6.4",
+ "rustc_version 0.4.0",
  "serde",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1987,7 +2010,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.1",
  "ed25519",
  "rand 0.7.3",
  "serde",
@@ -2161,6 +2184,12 @@ name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
 
 [[package]]
 name = "filedescriptor"
@@ -4031,6 +4060,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "platforms"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
+
+[[package]]
 name = "plotters"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5155,18 +5190,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -6573,7 +6596,7 @@ dependencies = [
  "bincode",
  "bv",
  "caps",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "dlopen2",
  "fnv",
  "lazy_static",
@@ -6658,7 +6681,7 @@ dependencies = [
  "cc",
  "console_error_panic_hook",
  "console_log",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "getrandom 0.2.10",
  "itertools",
  "js-sys",
@@ -6680,7 +6703,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-logger",
@@ -7096,7 +7119,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "chrono",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "derivation-path",
  "digest 0.10.7",
  "ed25519-dalek",
@@ -7126,7 +7149,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "siphasher",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
@@ -7695,7 +7718,7 @@ version = "2.0.0"
 dependencies = [
  "bytemuck",
  "criterion",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "num-derive",
  "num-traits",
  "solana-program-runtime",
@@ -7708,7 +7731,7 @@ name = "solana-zk-token-proof-program-tests"
 version = "2.0.0"
 dependencies = [
  "bytemuck",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
  "solana-program-runtime",
  "solana-program-test",
  "solana-sdk",
@@ -7724,17 +7747,18 @@ dependencies = [
  "bincode",
  "bytemuck",
  "byteorder",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.2",
+ "digest 0.10.7",
  "getrandom 0.1.16",
  "itertools",
  "lazy_static",
  "merlin",
  "num-derive",
  "num-traits",
- "rand 0.7.3",
+ "rand 0.8.5",
  "serde",
  "serde_json",
- "sha3 0.9.1",
+ "sha3",
  "solana-program",
  "solana-sdk",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,8 +1716,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+source = "git+https://github.com/solana-labs/curve25519-dalek.git?rev=b500cdc2a920cd5bff9e2dd974d7b97349d61464#b500cdc2a920cd5bff9e2dd974d7b97349d61464"
 dependencies = [
  "byteorder",
  "digest 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ byte-unit = "4.0.19"
 bytecount = "0.6.7"
 bytemuck = "1.14.3"
 byteorder = "1.5.0"
-bytes = "1.5"
+bytes = "1.6"
 bzip2 = "0.4.4"
 caps = "0.5.5"
 cargo_metadata = "0.15.4"
@@ -186,7 +186,7 @@ criterion-stats = "0.3.0"
 crossbeam-channel = "0.5.12"
 csv = "1.3.0"
 ctrlc = "3.4.4"
-curve25519-dalek = "3.2.1"
+curve25519-dalek = { version = "4.1.2", features = ["rand_core", "digest"] }
 dashmap = "5.5.3"
 derivation-path = { version = "0.2.0", default-features = false }
 derivative = "2.2.0"
@@ -545,9 +545,9 @@ rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef"
 #
 # https://github.com/dalek-cryptography/curve25519-dalek/compare/3.2.1...solana-labs:curve25519-dalek:3.2.1-unpin-zeroize
 #
-[patch.crates-io.curve25519-dalek]
-git = "https://github.com/solana-labs/curve25519-dalek.git"
-rev = "b500cdc2a920cd5bff9e2dd974d7b97349d61464"
+# [patch.crates-io.curve25519-dalek]
+# git = "https://github.com/solana-labs/curve25519-dalek.git"
+# rev = "b500cdc2a920cd5bff9e2dd974d7b97349d61464"
 
 # Solana RPC nodes experience stalls when running with `tokio` containing this
 # commit:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -545,9 +545,9 @@ rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef"
 #
 # https://github.com/dalek-cryptography/curve25519-dalek/compare/3.2.1...solana-labs:curve25519-dalek:3.2.1-unpin-zeroize
 #
-# [patch.crates-io.curve25519-dalek]
-# git = "https://github.com/solana-labs/curve25519-dalek.git"
-# rev = "b500cdc2a920cd5bff9e2dd974d7b97349d61464"
+[patch.crates-io.curve25519-dalek]
+git = "https://github.com/solana-labs/curve25519-dalek.git"
+rev = "b500cdc2a920cd5bff9e2dd974d7b97349d61464"
 
 # Solana RPC nodes experience stalls when running with `tokio` containing this
 # commit:

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -167,9 +167,13 @@ impl TryFrom<&str> for Pubkey {
 pub fn bytes_are_curve_point<T: AsRef<[u8]>>(_bytes: T) -> bool {
     #[cfg(not(target_os = "solana"))]
     {
-        curve25519_dalek::edwards::CompressedEdwardsY::from_slice(_bytes.as_ref())
-            .decompress()
-            .is_some()
+        let Ok(compressed_edwards_y) =
+            curve25519_dalek::edwards::CompressedEdwardsY::from_slice(_bytes.as_ref())
+        else {
+            return false;
+        };
+
+        compressed_edwards_y.decompress().is_some()
     }
     #[cfg(target_os = "solana")]
     unimplemented!();

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -25,14 +25,15 @@ aes-gcm-siv = { workspace = true }
 bincode = { workspace = true }
 byteorder = { workspace = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }
+digest = { workspace = true, features = ["core-api"] }
 getrandom = { version = "0.1", features = ["dummy"] }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 merlin = { workspace = true }
-rand = { version = "0.7" }
+rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sha3 = "0.9"
+sha3 = { workspace = true }
 solana-sdk = { workspace = true }
 subtle = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }

--- a/zk-token-sdk/src/curve25519/edwards.rs
+++ b/zk-token-sdk/src/curve25519/edwards.rs
@@ -64,6 +64,7 @@ mod target_arch {
 
         fn try_from(pod: &PodEdwardsPoint) -> Result<Self, Self::Error> {
             CompressedEdwardsY::from_slice(&pod.0)
+                .map_err(|_| Curve25519Error::PodConversion)?
                 .decompress()
                 .ok_or(Curve25519Error::PodConversion)
         }
@@ -73,9 +74,10 @@ mod target_arch {
         type Point = Self;
 
         fn validate_point(&self) -> bool {
-            CompressedEdwardsY::from_slice(&self.0)
-                .decompress()
-                .is_some()
+            let Ok(point) = CompressedEdwardsY::from_slice(&self.0) else {
+                return false;
+            };
+            point.decompress().is_some()
         }
     }
 

--- a/zk-token-sdk/src/curve25519/ristretto.rs
+++ b/zk-token-sdk/src/curve25519/ristretto.rs
@@ -64,6 +64,7 @@ mod target_arch {
 
         fn try_from(pod: &PodRistrettoPoint) -> Result<Self, Self::Error> {
             CompressedRistretto::from_slice(&pod.0)
+                .map_err(|_| Curve25519Error::PodConversion)?
                 .decompress()
                 .ok_or(Curve25519Error::PodConversion)
         }
@@ -73,9 +74,11 @@ mod target_arch {
         type Point = Self;
 
         fn validate_point(&self) -> bool {
-            CompressedRistretto::from_slice(&self.0)
-                .decompress()
-                .is_some()
+            let Ok(point) = CompressedRistretto::from_slice(&self.0) else {
+                return false;
+            };
+
+            point.decompress().is_some()
         }
     }
 

--- a/zk-token-sdk/src/curve25519/scalar.rs
+++ b/zk-token-sdk/src/curve25519/scalar.rs
@@ -18,7 +18,7 @@ mod target_arch {
         type Error = Curve25519Error;
 
         fn try_from(pod: &PodScalar) -> Result<Self, Self::Error> {
-            Scalar::from_canonical_bytes(pod.0).ok_or(Curve25519Error::PodConversion)
+            Option::from(Scalar::from_canonical_bytes(pod.0)).ok_or(Curve25519Error::PodConversion)
         }
     }
 }

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -358,7 +358,7 @@ impl ElGamalPubkey {
     #[allow(non_snake_case)]
     pub fn new(secret: &ElGamalSecretKey) -> Self {
         let s = &secret.0;
-        assert!(s != &Scalar::zero());
+        assert!(s != &Scalar::ZERO);
 
         ElGamalPubkey(s.invert() * &(*H))
     }
@@ -379,7 +379,7 @@ impl ElGamalPubkey {
         }
 
         Some(ElGamalPubkey(
-            CompressedRistretto::from_slice(bytes).decompress()?,
+            CompressedRistretto::from_slice(bytes).ok()?.decompress()?,
         ))
     }
 
@@ -442,6 +442,7 @@ impl TryFrom<&[u8]> for ElGamalPubkey {
 
         Ok(ElGamalPubkey(
             CompressedRistretto::from_slice(bytes)
+                .map_err(|_| ElGamalError::PubkeyDeserialization)?
                 .decompress()
                 .ok_or(ElGamalError::PubkeyDeserialization)?,
         ))
@@ -552,7 +553,9 @@ impl ElGamalSecretKey {
     #[deprecated(note = "please use `try_from()` instead")]
     pub fn from_bytes(bytes: &[u8]) -> Option<ElGamalSecretKey> {
         match bytes.try_into() {
-            Ok(bytes) => Scalar::from_canonical_bytes(bytes).map(ElGamalSecretKey),
+            Ok(bytes) => Scalar::from_canonical_bytes(bytes)
+                .map(ElGamalSecretKey)
+                .into(),
             _ => None,
         }
     }
@@ -609,10 +612,11 @@ impl TryFrom<&[u8]> for ElGamalSecretKey {
     type Error = ElGamalError;
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         match bytes.try_into() {
-            Ok(bytes) => Ok(ElGamalSecretKey::from(
-                Scalar::from_canonical_bytes(bytes)
-                    .ok_or(ElGamalError::SecretKeyDeserialization)?,
-            )),
+            Ok(bytes) => {
+                let scalar: Scalar = Option::from(Scalar::from_canonical_bytes(bytes))
+                    .ok_or(ElGamalError::SecretKeyDeserialization)?;
+                Ok(ElGamalSecretKey::from(scalar))
+            }
             _ => Err(ElGamalError::SecretKeyDeserialization),
         }
     }
@@ -800,7 +804,7 @@ impl DecryptHandle {
         }
 
         Some(DecryptHandle(
-            CompressedRistretto::from_slice(bytes).decompress()?,
+            CompressedRistretto::from_slice(bytes).ok()?.decompress()?,
         ))
     }
 }

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -99,7 +99,9 @@ impl PedersenOpening {
 
     pub fn from_bytes(bytes: &[u8]) -> Option<PedersenOpening> {
         match bytes.try_into() {
-            Ok(bytes) => Scalar::from_canonical_bytes(bytes).map(PedersenOpening),
+            Ok(bytes) => Scalar::from_canonical_bytes(bytes)
+                .map(PedersenOpening)
+                .into(),
             _ => None,
         }
     }
@@ -194,7 +196,7 @@ impl PedersenCommitment {
         }
 
         Some(PedersenCommitment(
-            CompressedRistretto::from_slice(bytes).decompress()?,
+            CompressedRistretto::from_slice(bytes).ok()?.decompress()?,
         ))
     }
 }

--- a/zk-token-sdk/src/instruction/zero_balance.rs
+++ b/zk-token-sdk/src/instruction/zero_balance.rs
@@ -1,7 +1,7 @@
 //! The zero-balance proof instruction.
 //!
 //! A zero-balance proof is defined with respect to a twisted ElGamal ciphertext. The proof
-//! certifies that a given ciphertext encrypts the message 0 in the field (`Scalar::zero()`). To
+//! certifies that a given ciphertext encrypts the message 0 in the field (`Scalar::ZERO`). To
 //! generate the proof, a prover must provide the decryption key for the ciphertext.
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/range_proof/generators.rs
+++ b/zk-token-sdk/src/range_proof/generators.rs
@@ -4,7 +4,8 @@ use {
         digest::{ExtendableOutput, Update, XofReader},
         ristretto::RistrettoPoint,
     },
-    sha3::{Sha3XofReader, Shake256},
+    digest::core_api::XofReaderCoreWrapper,
+    sha3::{Shake256, Shake256ReaderCore},
 };
 
 #[cfg(not(target_os = "solana"))]
@@ -12,7 +13,7 @@ const MAX_GENERATOR_LENGTH: usize = u32::MAX as usize;
 
 /// Generators for Pedersen vector commitments that are used for inner-product proofs.
 struct GeneratorsChain {
-    reader: Sha3XofReader,
+    reader: XofReaderCoreWrapper<Shake256ReaderCore>,
 }
 
 impl GeneratorsChain {

--- a/zk-token-sdk/src/range_proof/inner_product.rs
+++ b/zk-token-sdk/src/range_proof/inner_product.rs
@@ -411,10 +411,12 @@ impl InnerProductProof {
         }
 
         let pos = 2 * lg_n * 32;
-        let a = Scalar::from_canonical_bytes(util::read32(&slice[pos..]))
+        let a = Option::from(Scalar::from_canonical_bytes(util::read32(&slice[pos..])))
             .ok_or(RangeProofVerificationError::Deserialization)?;
-        let b = Scalar::from_canonical_bytes(util::read32(&slice[pos + 32..]))
-            .ok_or(RangeProofVerificationError::Deserialization)?;
+        let b = Option::from(Scalar::from_canonical_bytes(util::read32(
+            &slice[pos + 32..],
+        )))
+        .ok_or(RangeProofVerificationError::Deserialization)?;
 
         Ok(InnerProductProof { L_vec, R_vec, a, b })
     }
@@ -442,7 +444,7 @@ mod tests {
         let b: Vec<_> = (0..n).map(|_| Scalar::random(&mut OsRng)).collect();
         let c = util::inner_product(&a, &b).unwrap();
 
-        let G_factors: Vec<Scalar> = iter::repeat(Scalar::one()).take(n).collect();
+        let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(n).collect();
 
         let y_inv = Scalar::random(&mut OsRng);
         let H_factors: Vec<Scalar> = util::exp_iter(y_inv).take(n).collect();
@@ -479,7 +481,7 @@ mod tests {
         assert!(proof
             .verify(
                 n,
-                iter::repeat(Scalar::one()).take(n),
+                iter::repeat(Scalar::ONE).take(n),
                 util::exp_iter(y_inv).take(n),
                 &P,
                 &Q,
@@ -494,7 +496,7 @@ mod tests {
         assert!(proof
             .verify(
                 n,
-                iter::repeat(Scalar::one()).take(n),
+                iter::repeat(Scalar::ONE).take(n),
                 util::exp_iter(y_inv).take(n),
                 &P,
                 &Q,

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -146,16 +146,16 @@ impl RangeProof {
 
         let mut i = 0;
         let mut exp_z = z * z;
-        let mut exp_y = Scalar::one();
+        let mut exp_y = Scalar::ONE;
 
         for (amount_i, n_i) in amounts.iter().zip(bit_lengths.iter()) {
-            let mut exp_2 = Scalar::one();
+            let mut exp_2 = Scalar::ONE;
 
             for j in 0..(*n_i) {
                 // `j` is guaranteed to be at most `u64::BITS` (a 6-bit number) and therefore,
                 // casting is lossless and right shift can be safely unwrapped
                 let a_L_j = Scalar::from(amount_i.checked_shr(j as u32).unwrap() & 1);
-                let a_R_j = a_L_j - Scalar::one();
+                let a_R_j = a_L_j - Scalar::ONE;
 
                 l_poly.0[i] = a_L_j - z;
                 l_poly.1[i] = s_L[i];
@@ -190,7 +190,7 @@ impl RangeProof {
         // z^2 * V_1 + z^3 * V_2 + ... + z^{m+1} * V_m + delta(y, z)*G + x*T_1 + x^2*T_2
         let x = transcript.challenge_scalar(b"x");
 
-        let mut agg_opening = Scalar::zero();
+        let mut agg_opening = Scalar::ZERO;
         let mut exp_z = z;
         for opening in openings {
             exp_z *= z;
@@ -221,7 +221,7 @@ impl RangeProof {
         let w = transcript.challenge_scalar(b"w");
         let Q = w * &(*G);
 
-        let G_factors: Vec<Scalar> = iter::repeat(Scalar::one()).take(nm).collect();
+        let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(nm).collect();
         let H_factors: Vec<Scalar> = util::exp_iter(y.invert()).take(nm).collect();
 
         // generate challenge `c` for consistency with the verifier's transcript
@@ -322,7 +322,7 @@ impl RangeProof {
         let value_commitment_scalars = util::exp_iter(z).take(m).map(|z_exp| c * zz * z_exp);
 
         let mega_check = RistrettoPoint::optional_multiscalar_mul(
-            iter::once(Scalar::one())
+            iter::once(Scalar::ONE)
                 .chain(iter::once(x))
                 .chain(iter::once(c * x))
                 .chain(iter::once(c * x * x))
@@ -384,11 +384,12 @@ impl RangeProof {
         let T_1 = CompressedRistretto(util::read32(&slice[2 * 32..]));
         let T_2 = CompressedRistretto(util::read32(&slice[3 * 32..]));
 
-        let t_x = Scalar::from_canonical_bytes(util::read32(&slice[4 * 32..]))
+        let t_x = Option::from(Scalar::from_canonical_bytes(util::read32(&slice[4 * 32..])))
             .ok_or(RangeProofVerificationError::Deserialization)?;
-        let t_x_blinding = Scalar::from_canonical_bytes(util::read32(&slice[5 * 32..]))
-            .ok_or(RangeProofVerificationError::Deserialization)?;
-        let e_blinding = Scalar::from_canonical_bytes(util::read32(&slice[6 * 32..]))
+        let t_x_blinding =
+            Option::from(Scalar::from_canonical_bytes(util::read32(&slice[5 * 32..])))
+                .ok_or(RangeProofVerificationError::Deserialization)?;
+        let e_blinding = Option::from(Scalar::from_canonical_bytes(util::read32(&slice[6 * 32..])))
             .ok_or(RangeProofVerificationError::Deserialization)?;
 
         let ipp_proof = InnerProductProof::from_bytes(&slice[7 * 32..])?;

--- a/zk-token-sdk/src/range_proof/util.rs
+++ b/zk-token-sdk/src/range_proof/util.rs
@@ -8,7 +8,7 @@ pub struct VecPoly1(pub Vec<Scalar>, pub Vec<Scalar>);
 
 impl VecPoly1 {
     pub fn zero(n: usize) -> Self {
-        VecPoly1(vec![Scalar::zero(); n], vec![Scalar::zero(); n])
+        VecPoly1(vec![Scalar::ZERO; n], vec![Scalar::ZERO; n])
     }
 
     pub fn inner_product(&self, rhs: &VecPoly1) -> Option<Poly2> {
@@ -29,7 +29,7 @@ impl VecPoly1 {
 
     pub fn eval(&self, x: Scalar) -> Vec<Scalar> {
         let n = self.0.len();
-        let mut out = vec![Scalar::zero(); n];
+        let mut out = vec![Scalar::ZERO; n];
         #[allow(clippy::needless_range_loop)]
         for i in 0..n {
             out[i] = self.0[i] + self.1[i] * x;
@@ -71,7 +71,7 @@ impl Iterator for ScalarExp {
 
 /// Return an iterator of the powers of `x`.
 pub fn exp_iter(x: Scalar) -> ScalarExp {
-    let next_exp_x = Scalar::one();
+    let next_exp_x = Scalar::ONE;
     ScalarExp { x, next_exp_x }
 }
 
@@ -80,7 +80,7 @@ pub fn add_vec(a: &[Scalar], b: &[Scalar]) -> Vec<Scalar> {
         // throw some error
         //println!("lengths of vectors don't match for vector addition");
     }
-    let mut out = vec![Scalar::zero(); b.len()];
+    let mut out = vec![Scalar::ZERO; b.len()];
     for i in 0..a.len() {
         out[i] = a[i] + b[i];
     }
@@ -100,7 +100,7 @@ pub fn read32(data: &[u8]) -> [u8; 32] {
 /// \\]
 /// Errors if the lengths of \\(\mathbf{a}\\) and \\(\mathbf{b}\\) are not equal.
 pub fn inner_product(a: &[Scalar], b: &[Scalar]) -> Option<Scalar> {
-    let mut out = Scalar::zero();
+    let mut out = Scalar::ZERO;
     if a.len() != b.len() {
         return None;
     }
@@ -122,7 +122,7 @@ pub fn sum_of_powers(x: &Scalar, n: usize) -> Scalar {
         return Scalar::from(n as u64);
     }
     let mut m = n;
-    let mut result = Scalar::one() + x;
+    let mut result = Scalar::ONE + x;
     let mut factor = *x;
     while m > 2 {
         factor = factor * factor;

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_ciphertext_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_ciphertext_equality_proof.rs
@@ -189,7 +189,7 @@ impl CiphertextCiphertextEqualityProof {
             vec![
                 &self.z_s,            // z_s
                 &(-&c),               // -c
-                &(-&Scalar::one()),   // -identity
+                &(-&Scalar::ONE),     // -identity
                 &(&w * &self.z_x),    // w * z_x
                 &(&w * &self.z_s),    // w * z_s
                 &(&w_negated * &c),   // -w * c

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
@@ -177,7 +177,7 @@ impl CiphertextCommitmentEqualityProof {
             vec![
                 &self.z_s,           // z_s
                 &(-&c),              // -c
-                &(-&Scalar::one()),  // -identity
+                &(-&Scalar::ONE),    // -identity
                 &(&w * &self.z_x),   // w * z_x
                 &(&w * &self.z_s),   // w * z_s
                 &(&w_negated * &c),  // -w * c

--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -358,7 +358,7 @@ impl FeeSigmaProof {
                 c_max_proof,
                 -c_max_proof * m,
                 -z_max,
-                Scalar::one(),
+                Scalar::ONE,
                 w * z_x,
                 w * z_delta_real,
                 -w * c_equality,

--- a/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof/handles_2.rs
+++ b/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof/handles_2.rs
@@ -172,7 +172,7 @@ impl GroupedCiphertext2HandlesValidityProof {
                 &self.z_r,           // z_r
                 &self.z_x,           // z_x
                 &(-&c),              // -c
-                &-(&Scalar::one()),  // -identity
+                &-(&Scalar::ONE),    // -identity
                 &(&w * &self.z_r),   // w * z_r
                 &(&w_negated * &c),  // -w * c
                 &w_negated,          // -w

--- a/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof/handles_3.rs
+++ b/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof/handles_3.rs
@@ -201,7 +201,7 @@ impl GroupedCiphertext3HandlesValidityProof {
                 &self.z_r,            // z_r
                 &self.z_x,            // z_x
                 &(-&c),               // -c
-                &-(&Scalar::one()),   // -identity
+                &-(&Scalar::ONE),     // -identity
                 &(&w * &self.z_r),    // w * z_r
                 &(&w_negated * &c),   // -w * c
                 &w_negated,           // -w

--- a/zk-token-sdk/src/sigma_proofs/mod.rs
+++ b/zk-token-sdk/src/sigma_proofs/mod.rs
@@ -31,7 +31,8 @@ fn ristretto_point_from_optional_slice(
     optional_slice
         .and_then(|slice| (slice.len() == RISTRETTO_POINT_LEN).then_some(slice))
         .map(CompressedRistretto::from_slice)
-        .ok_or(SigmaProofVerificationError::Deserialization)
+        .ok_or(SigmaProofVerificationError::Deserialization)?
+        .map_err(|_| SigmaProofVerificationError::Deserialization)
 }
 
 /// Deserializes an optional slice of bytes to a scalar.
@@ -45,6 +46,6 @@ fn canonical_scalar_from_optional_slice(
     optional_slice
         .and_then(|slice| (slice.len() == SCALAR_LEN).then_some(slice)) // if chunk is the wrong length, convert to None
         .and_then(|slice| slice.try_into().ok()) // convert to array
-        .and_then(Scalar::from_canonical_bytes)
+        .and_then(|slice| Option::from(Scalar::from_canonical_bytes(slice)))
         .ok_or(SigmaProofVerificationError::Deserialization)
 }

--- a/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
@@ -65,7 +65,7 @@ impl PubkeyValidityProof {
         // extract the relevant scalar and Ristretto points from the input
         let s = elgamal_keypair.secret().get_scalar();
 
-        assert!(s != &Scalar::zero());
+        assert!(s != &Scalar::ZERO);
         let s_inv = s.invert();
 
         // generate a random masking factor that also serves as a nonce
@@ -109,7 +109,7 @@ impl PubkeyValidityProof {
             .ok_or(SigmaProofVerificationError::Deserialization)?;
 
         let check = RistrettoPoint::vartime_multiscalar_mul(
-            vec![&self.z, &(-&c), &(-&Scalar::one())],
+            vec![&self.z, &(-&c), &(-&Scalar::ONE)],
             vec![&(*H), P, &Y],
         );
 

--- a/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
@@ -136,7 +136,7 @@ impl ZeroBalanceProof {
             vec![
                 &self.z,            // z
                 &(-&c),             // -c
-                &(-&Scalar::one()), // -identity
+                &(-&Scalar::ONE),   // -identity
                 &(&w * &self.z),    // w * z
                 &(&w_negated * &c), // -w * c
                 &w_negated,         // -w

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -64,7 +64,8 @@ mod target_arch {
         type Error = ElGamalError;
 
         fn try_from(pod: PodScalar) -> Result<Self, Self::Error> {
-            Scalar::from_canonical_bytes(pod.0).ok_or(ElGamalError::CiphertextDeserialization)
+            Option::from(Scalar::from_canonical_bytes(pod.0))
+                .ok_or(ElGamalError::CiphertextDeserialization)
         }
     }
 


### PR DESCRIPTION
#### Problem

> discussed with Sam earlier and we all agree that we should bump sha3 to the latest but we will need to update code base for some API breaking changes

#### Summary of Changes

Fixes https://github.com/anza-xyz/agave/issues/647

This PR fix #647 by:

- Bumping curve25519-dalek to v4
- Bumping sha3 to v0.10

Follow-up tasks:

- Bumping ed25519-dalek to v2 so we can remove all depends of curve25519-dalek v3