### PR TITLE
[zk-token-sdk] Make transfer modules public

### DIFF
--- a/zk-token-sdk/src/instruction/transfer/mod.rs
+++ b/zk-token-sdk/src/instruction/transfer/mod.rs
@@ -1,6 +1,6 @@
-mod encryption;
-mod with_fee;
-mod without_fee;
+pub mod encryption;
+pub mod with_fee;
+pub mod without_fee;
 
 #[cfg(not(target_os = "solana"))]
 use {


### PR DESCRIPTION
#### Problem
Currently, the submodules in the transfer modules are not public, but they should really be public for downstream. For example, in the spl-token program, `TransferPubkeys` and `TransferProofContext` types are [hard-coded](https://github.com/solana-labs/solana-program-library/blob/master/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs#L194) since these types are not public.

#### Summary of Changes
Make the submodules in the transfer module public.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
