### PR TITLE
[zk-token-sdk] Expose `ProofVerificationError` type in sbf target build

### DIFF
--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -1,10 +1,10 @@
 //! Errors related to proving and verifying proofs.
 #[cfg(not(target_os = "solana"))]
-use crate::{
-    range_proof::errors::{RangeProofGenerationError, RangeProofVerificationError},
-    sigma_proofs::errors::*,
+use crate::range_proof::errors::RangeProofGenerationError;
+use {
+    crate::{range_proof::errors::RangeProofVerificationError, sigma_proofs::errors::*},
+    thiserror::Error,
 };
-use thiserror::Error;
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum AuthenticatedEncryptionError {
@@ -55,7 +55,6 @@ pub enum ProofGenerationError {
     ProofLength,
 }
 
-#[cfg(not(target_os = "solana"))]
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ProofVerificationError {
     #[error("range proof verification failed")]
@@ -81,7 +80,6 @@ pub enum SigmaProofType {
     PubkeyValidityProof,
 }
 
-#[cfg(not(target_os = "solana"))]
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum TranscriptError {
     #[error("point is the identity")]

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -22,9 +22,7 @@
 pub(crate) mod macros;
 #[cfg(not(target_os = "solana"))]
 pub mod encryption;
-#[cfg(not(target_os = "solana"))]
 mod range_proof;
-#[cfg(not(target_os = "solana"))]
 mod sigma_proofs;
 #[cfg(not(target_os = "solana"))]
 mod transcript;

--- a/zk-token-sdk/src/range_proof/errors.rs
+++ b/zk-token-sdk/src/range_proof/errors.rs
@@ -1,6 +1,7 @@
 //! Errors related to proving and verifying range proofs.
 use {crate::errors::TranscriptError, thiserror::Error};
 
+#[cfg(not(target_os = "solana"))]
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum RangeProofGenerationError {
     #[error("maximum generator length exceeded")]
@@ -37,6 +38,7 @@ pub enum RangeProofVerificationError {
     VectorLengthMismatch,
 }
 
+#[cfg(not(target_os = "solana"))]
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum RangeProofGeneratorError {
     #[error("maximum generator length exceeded")]

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -13,11 +13,6 @@
 #[cfg(not(target_os = "solana"))]
 use {
     crate::encryption::pedersen::{Pedersen, PedersenCommitment, PedersenOpening},
-    curve25519_dalek::traits::MultiscalarMul,
-    rand::rngs::OsRng,
-    subtle::{Choice, ConditionallySelectable},
-};
-use {
     crate::{
         encryption::pedersen::{G, H},
         range_proof::{
@@ -28,20 +23,27 @@ use {
         transcript::TranscriptProtocol,
     },
     core::iter,
+    curve25519_dalek::traits::MultiscalarMul,
     curve25519_dalek::{
         ristretto::{CompressedRistretto, RistrettoPoint},
         scalar::Scalar,
         traits::{IsIdentity, VartimeMultiscalarMul},
     },
     merlin::Transcript,
+    rand::rngs::OsRng,
+    subtle::{Choice, ConditionallySelectable},
 };
 
 pub mod errors;
+#[cfg(not(target_os = "solana"))]
 pub mod generators;
+#[cfg(not(target_os = "solana"))]
 pub mod inner_product;
+#[cfg(not(target_os = "solana"))]
 pub mod util;
 
 #[allow(non_snake_case)]
+#[cfg(not(target_os = "solana"))]
 #[derive(Clone)]
 pub struct RangeProof {
     pub A: CompressedRistretto,       // 32 bytes
@@ -55,6 +57,7 @@ pub struct RangeProof {
 }
 
 #[allow(non_snake_case)]
+#[cfg(not(target_os = "solana"))]
 impl RangeProof {
     /// Create an aggregated range proof.
     ///
@@ -410,6 +413,7 @@ impl RangeProof {
 /// \\[
 /// \delta(y,z) = (z - z^{2}) \langle \mathbf{1}, {\mathbf{y}}^{n \cdot m} \rangle - \sum_{j=0}^{m-1} z^{j+3} \cdot \langle \mathbf{1}, {\mathbf{2}}^{n \cdot m} \rangle
 /// \\]
+#[cfg(not(target_os = "solana"))]
 fn delta(bit_lengths: &[usize], y: &Scalar, z: &Scalar) -> Scalar {
     let nm: usize = bit_lengths.iter().sum();
     let sum_y = util::sum_of_powers(y, nm);

--- a/zk-token-sdk/src/sigma_proofs/mod.rs
+++ b/zk-token-sdk/src/sigma_proofs/mod.rs
@@ -5,13 +5,21 @@
 //!
 //! [`ZK Token proof`]: https://docs.solanalabs.com/runtime/zk-token-proof
 
-pub mod batched_grouped_ciphertext_validity_proof;
-pub mod ciphertext_ciphertext_equality_proof;
-pub mod ciphertext_commitment_equality_proof;
 pub mod errors;
+
+#[cfg(not(target_os = "solana"))]
+pub mod batched_grouped_ciphertext_validity_proof;
+#[cfg(not(target_os = "solana"))]
+pub mod ciphertext_ciphertext_equality_proof;
+#[cfg(not(target_os = "solana"))]
+pub mod ciphertext_commitment_equality_proof;
+#[cfg(not(target_os = "solana"))]
 pub mod fee_proof;
+#[cfg(not(target_os = "solana"))]
 pub mod grouped_ciphertext_validity_proof;
+#[cfg(not(target_os = "solana"))]
 pub mod pubkey_proof;
+#[cfg(not(target_os = "solana"))]
 pub mod zero_balance_proof;
 
 #[cfg(not(target_os = "solana"))]


### PR DESCRIPTION
#### Problem
Currently, the error types in the zk-token-sdk related to proof verification is excluded from the sbf target build. However, there is no reason for this to be the case since proof verification is often applicable for on-chain programs.

#### Summary of Changes
Include the error types related to proof verification to sbf target build.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
