### PR TITLE
rework secondary index generation

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8571,7 +8571,7 @@ impl AccountsDb {
         let mut amount_to_top_off_rent = 0;
         let mut stored_size_alive = 0;
 
-        let (dirty_pubkeys, insert_time_us, mut generate_index_results) = if !secondary {
+        let (dirty_pubkeys, insert_time_us, mut generate_index_results) = {
             let mut items_local = Vec::default();
             storage.accounts.scan_index(|info| {
                 stored_size_alive += info.stored_size_aligned;
@@ -8609,9 +8609,10 @@ impl AccountsDb {
                     storage.approx_stored_count(),
                     items,
                 )
-        } else {
-            let accounts = storage.accounts.account_iter();
-            let items = accounts.map(|stored_account| {
+        };
+        if secondary {
+            // scan storage a second time to update the secondary index
+            storage.accounts.scan_accounts(|stored_account| {
                 stored_size_alive += stored_account.stored_size();
                 let pubkey = stored_account.pubkey();
                 self.accounts_index.update_secondary_indexes(
@@ -8619,39 +8620,8 @@ impl AccountsDb {
                     &stored_account,
                     &self.account_indexes,
                 );
-                if !stored_account.is_zero_lamport() {
-                    accounts_data_len += stored_account.data().len() as u64;
-                }
-
-                if let Some(amount_to_top_off_rent_this_account) = Self::stats_for_rent_payers(
-                    pubkey,
-                    stored_account.lamports(),
-                    stored_account.data().len(),
-                    stored_account.rent_epoch(),
-                    stored_account.executable(),
-                    rent_collector,
-                ) {
-                    amount_to_top_off_rent += amount_to_top_off_rent_this_account;
-                    num_accounts_rent_paying += 1;
-                    // remember this rent-paying account pubkey
-                    rent_paying_accounts_by_partition.push(*pubkey);
-                }
-
-                (
-                    *pubkey,
-                    AccountInfo::new(
-                        StorageLocation::AppendVec(store_id, stored_account.offset()), // will never be cached
-                        stored_account.lamports(),
-                    ),
-                )
             });
-            self.accounts_index
-                .insert_new_if_missing_into_primary_index(
-                    slot,
-                    storage.approx_stored_count(),
-                    items,
-                )
-        };
+        }
 
         if let Some(duplicates_this_slot) = std::mem::take(&mut generate_index_results.duplicates) {
             // there were duplicate pubkeys in this same slot


### PR DESCRIPTION
#### Problem
stop mmapping storage files.
We cannot iterate and return `StoredAccountMeta` for many accounts anymore. The loop for secondary index generation doesn't easily support reworking.

#### Summary of Changes
Always generate the primary index the same way, using `scan_index`. Then, if we're building secondary indexes, update the secondary index using `scan_accounts`. By far the largest cost of secondary indexes is the generation step. We were already calling this update once per account. We are scanning the entire storage a second time, but the performance is dominated by the secondary index generation so this should be negligible.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
