### PR TITLE
blockstore: store first received coding shred index in ErasureMeta

### DIFF
--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -126,7 +126,7 @@ pub struct ErasureMeta {
     /// First coding index in the FEC set
     first_coding_index: u64,
     /// Index of the first received coding shred in the FEC set
-    first_received_coding_index: usize,
+    first_received_coding_index: u64,
     /// Erasure configuration for this erasure set
     config: ErasureConfig,
 }
@@ -347,7 +347,7 @@ impl ErasureMeta {
                     num_coding: usize::from(shred.num_coding_shreds().ok()?),
                 };
                 let first_coding_index = u64::from(shred.first_coding_index()?);
-                let first_received_coding_index = usize::try_from(shred.index()).ok()?;
+                let first_received_coding_index = u64::from(shred.index());
                 let erasure_meta = ErasureMeta {
                     set_index: u64::from(shred.fec_set_index()),
                     config,
@@ -725,5 +725,55 @@ mod test {
         };
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_erasure_meta_transition() {
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        struct OldErasureMeta {
+            set_index: u64,
+            first_coding_index: u64,
+            #[serde(rename = "size")]
+            __unused_size: usize,
+            config: ErasureConfig,
+        }
+
+        let set_index = 64;
+        let erasure_config = ErasureConfig {
+            num_data: 8,
+            num_coding: 16,
+        };
+        let mut old_erasure_meta = OldErasureMeta {
+            set_index,
+            first_coding_index: set_index,
+            __unused_size: 0,
+            config: erasure_config,
+        };
+        let mut new_erasure_meta = ErasureMeta {
+            set_index,
+            first_coding_index: set_index,
+            first_received_coding_index: 0,
+            config: erasure_config,
+        };
+
+        assert_eq!(
+            bincode::serialized_size(&old_erasure_meta).unwrap(),
+            bincode::serialized_size(&new_erasure_meta).unwrap(),
+        );
+
+        assert_eq!(
+            bincode::deserialize::<ErasureMeta>(&bincode::serialize(&old_erasure_meta).unwrap())
+                .unwrap(),
+            new_erasure_meta
+        );
+
+        new_erasure_meta.first_received_coding_index = u64::from(u32::max_value());
+        old_erasure_meta.__unused_size = usize::try_from(u32::max_value()).unwrap();
+
+        assert_eq!(
+            bincode::deserialize::<OldErasureMeta>(&bincode::serialize(&new_erasure_meta).unwrap())
+                .unwrap(),
+            old_erasure_meta
+        );
     }
 }


### PR DESCRIPTION
Reuse the `__unused_size : usize` field in `ErasureMeta` to store the index of the first received coding shred for the FEC set. 

Split from https://github.com/anza-xyz/agave/pull/835/
Contributes to https://github.com/solana-labs/solana/issues/34897
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
