### PR TITLE
Removes deprecated MINIMUM_STAKE_DELEGATION

### DIFF
--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -31,7 +31,6 @@ pub fn get_minimum_delegation(feature_set: &FeatureSet) -> u64 {
         const MINIMUM_DELEGATION_SOL: u64 = 1;
         MINIMUM_DELEGATION_SOL * LAMPORTS_PER_SOL
     } else {
-        #[allow(deprecated)]
-        solana_sdk::stake::MINIMUM_STAKE_DELEGATION
+        1
     }
 }

--- a/sdk/program/src/stake/deprecated.rs
+++ b/sdk/program/src/stake/deprecated.rs
@@ -1,5 +1,0 @@
-#[deprecated(
-    since = "1.11.0",
-    note = "please use `solana_program::stake::tools::get_minimum_delegation()` instead"
-)]
-pub const MINIMUM_STAKE_DELEGATION: u64 = 1;

--- a/sdk/program/src/stake/mod.rs
+++ b/sdk/program/src/stake/mod.rs
@@ -9,9 +9,6 @@ pub mod stake_flags;
 pub mod state;
 pub mod tools;
 
-mod deprecated;
-pub use deprecated::*;
-
 pub mod program {
     crate::declare_id!("Stake11111111111111111111111111111111111111");
 }


### PR DESCRIPTION
#### Problem

`MINIMUM_STAKE_DELEGATION` was deprecated in v1.11 and can be removed.


#### Summary of Changes

Remove it.