### PR TITLE
get_unique_accounts_from_storage uses scan_index

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -14,6 +14,7 @@ use {
             ALIGN_BOUNDARY_OFFSET,
         },
         accounts_hash::AccountHash,
+        accounts_index::ZeroLamport,
         storable_accounts::StorableAccounts,
         u64_align,
     },
@@ -664,6 +665,10 @@ impl AppendVec {
                 // eof
                 break;
             };
+            if account_meta.lamports == 0 && stored_meta.pubkey == Pubkey::default() {
+                // we passed the last useful account
+                return;
+            }
             let next = Self::next_account_offset(offset, stored_meta);
             if next.offset_to_end_of_data > self.len() {
                 // data doesn't fit, so don't include this account
@@ -693,9 +698,15 @@ impl AppendVec {
         while self
             .get_stored_account_meta_callback(offset, |account| {
                 offset += account.stored_size();
-                callback(account)
+                if account.is_zero_lamport() && account.pubkey() == &Pubkey::default() {
+                    // we passed the last useful account
+                    return false;
+                }
+
+                callback(account);
+                true
             })
-            .is_some()
+            .unwrap_or_default()
         {}
     }
 


### PR DESCRIPTION
#### Problem
stop mmapping storage files.
We need to move away from apis that return refs to storage data.

#### Summary of Changes
`get_unique_accounts_from_storage` uses `scan_index`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
