### PR TITLE
wip: add AppendVecFileBacking

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -28,14 +28,14 @@ use {
     },
     std::{
         convert::TryFrom,
-        fs::{remove_file, OpenOptions},
+        fs::{remove_file, File, OpenOptions},
         io::{Seek, SeekFrom, Write},
         mem,
         path::{Path, PathBuf},
         ptr,
         sync::{
             atomic::{AtomicU64, AtomicUsize, Ordering},
-            Mutex,
+            Mutex, RwLock,
         },
     },
     thiserror::Error,
@@ -232,6 +232,27 @@ struct AccountOffsets {
     stored_size_aligned: usize,
 }
 
+#[derive(Debug, AbiExample)]
+pub struct FileReader {
+    pub file: File,
+    pub offset: u64,
+    pub buffer: Vec<u8>,
+}
+
+#[derive(Debug, AbiExample)]
+pub enum FileOrMMap {
+    Map(MmapMut),
+    File(FileReader),
+}
+
+#[derive(Debug, AbiExample)]
+pub enum AppendVecFileBacking {
+    /// A file-backed block of memory that is used to store the data for each appended item.
+    MapOnly(MmapMut),
+    /// Either a file or a mmap file
+    FileOrMap(RwLock<FileOrMMap>),
+}
+
 /// A thread-safe, file-backed block of memory used to store `Account` instances. Append operations
 /// are serialized such that only one thread updates the internal `append_lock` at a time. No
 /// restrictions are placed on reading. That is, one may read items from one thread while another
@@ -241,8 +262,7 @@ pub struct AppendVec {
     /// The file path where the data is stored.
     path: PathBuf,
 
-    /// A file-backed block of memory that is used to store the data for each appended item.
-    map: MmapMut,
+    backing: AppendVecFileBacking,
 
     /// A lock used to serialize append operations.
     append_lock: Mutex<()>,
@@ -319,7 +339,7 @@ impl AppendVec {
 
         AppendVec {
             path: file,
-            map,
+            backing: AppendVecFileBacking::MapOnly(map),
             // This mutex forces append to be single threaded, but concurrent with reads
             // See UNSAFE usage in `append_ptr`
             append_lock: Mutex::new(()),
@@ -350,7 +370,12 @@ impl AppendVec {
     }
 
     pub fn flush(&self) -> Result<()> {
-        self.map.flush()?;
+        match &self.backing {
+            AppendVecFileBacking::FileOrMap(_file) => {
+                panic!("");
+            }
+            AppendVecFileBacking::MapOnly(map) => map.flush()?,
+        }
         Ok(())
     }
 
@@ -423,7 +448,7 @@ impl AppendVec {
 
         Ok(AppendVec {
             path,
-            map,
+            backing: AppendVecFileBacking::MapOnly(map),
             append_lock: Mutex::new(()),
             current_len: AtomicUsize::new(current_len),
             file_size,
@@ -460,30 +485,44 @@ impl AppendVec {
         if overflow || next > self.len() {
             return None;
         }
-        let data = &self.map[offset..next];
-        let next = u64_align!(next);
+        match &self.backing {
+            AppendVecFileBacking::FileOrMap(_file) => {
+                panic!("");
+            }
+            AppendVecFileBacking::MapOnly(map) => {
+                let data = &map[offset..next];
+                let next = u64_align!(next);
 
-        Some((
-            //UNSAFE: This unsafe creates a slice that represents a chunk of self.map memory
-            //The lifetime of this slice is tied to &self, since it points to self.map memory
-            unsafe { std::slice::from_raw_parts(data.as_ptr(), size) },
-            next,
-        ))
+                Some((
+                    //UNSAFE: This unsafe creates a slice that represents a chunk of self.map memory
+                    //The lifetime of this slice is tied to &self, since it points to self.map memory
+                    unsafe { std::slice::from_raw_parts(data.as_ptr(), size) },
+                    next,
+                ))
+            }
+        }
     }
 
     /// Copy `len` bytes from `src` to the first 64-byte boundary after position `offset` of
     /// the internal buffer. Then update `offset` to the first byte after the copied data.
     fn append_ptr(&self, offset: &mut usize, src: *const u8, len: usize) {
         let pos = u64_align!(*offset);
-        let data = &self.map[pos..(pos + len)];
-        //UNSAFE: This mut append is safe because only 1 thread can append at a time
-        //Mutex<()> guarantees exclusive write access to the memory occupied in
-        //the range.
-        unsafe {
-            let dst = data.as_ptr() as *mut _;
-            ptr::copy(src, dst, len);
-        };
-        *offset = pos + len;
+        match &self.backing {
+            AppendVecFileBacking::FileOrMap(_file) => {
+                panic!("");
+            }
+            AppendVecFileBacking::MapOnly(map) => {
+                let data = &map[pos..(pos + len)];
+                //UNSAFE: This mut append is safe because only 1 thread can append at a time
+                //Mutex<()> guarantees exclusive write access to the memory occupied in
+                //the range.
+                unsafe {
+                    let dst = data.as_ptr() as *mut _;
+                    ptr::copy(src, dst, len);
+                };
+                *offset = pos + len;
+            }
+        }
     }
 
     /// Copy each value in `vals`, in order, to the first 64-byte boundary after position `offset`.
@@ -826,7 +865,12 @@ impl AppendVec {
 
     /// Returns a slice suitable for use when archiving append vecs
     pub fn data_for_archive(&self) -> &[u8] {
-        self.map.as_ref()
+        match &self.backing {
+            AppendVecFileBacking::FileOrMap(_file) => {
+                panic!("");
+            }
+            AppendVecFileBacking::MapOnly(map) => map.as_ref(),
+        }
     }
 }
 


### PR DESCRIPTION
#### Problem
trying to get rid of mmaps on append vecs.

#### Summary of Changes
introduce `AppendVecFileBacking`. This can hold always a mmap, or a rwlock protected enum of mmap or file and buffer.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
