### PR TITLE
Removes AppendVec::file_name()

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -21,7 +21,6 @@ use {
     memmap2::MmapMut,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
-        clock::Slot,
         hash::Hash,
         pubkey::Pubkey,
         stake_history::Epoch,
@@ -377,10 +376,6 @@ impl AppendVec {
 
     pub fn capacity(&self) -> u64 {
         self.file_size
-    }
-
-    pub fn file_name(slot: Slot, id: impl std::fmt::Display) -> String {
-        format!("{slot}.{id}")
     }
 
     pub fn new_from_file(path: impl Into<PathBuf>, current_len: usize) -> Result<(Self, usize)> {
@@ -839,6 +834,7 @@ pub mod tests {
         rand::{thread_rng, Rng},
         solana_sdk::{
             account::{Account, AccountSharedData, WritableAccount},
+            clock::Slot,
             timing::duration_as_ms,
         },
         std::{mem::ManuallyDrop, time::Instant},

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -21,7 +21,6 @@ use {
         account_storage::AccountStorageMap,
         accounts_db::{AccountStorageEntry, AtomicAccountsFileId},
         accounts_file::{AccountsFile, AccountsFileError},
-        append_vec::AppendVec,
         hardened_unpack::{self, ParallelSelector, UnpackError},
         shared_buffer_reader::{SharedBuffer, SharedBufferReader},
         utils::{move_and_async_delete_path, ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR},
@@ -1240,7 +1239,7 @@ pub fn hard_link_storages_to_snapshot(
         )?;
         // The appendvec could be recycled, so its filename may not be consistent to the slot and id.
         // Use the storage slot and id to compose a consistent file name for the hard-link file.
-        let hardlink_filename = AppendVec::file_name(storage.slot(), storage.append_vec_id());
+        let hardlink_filename = AccountsFile::file_name(storage.slot(), storage.append_vec_id());
         let hard_link_path = snapshot_hardlink_dir.join(hardlink_filename);
         fs::hard_link(storage_path, &hard_link_path).map_err(|err| {
             HardLinkStoragesToSnapshotError::HardLinkStorage(

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -425,7 +425,7 @@ pub(crate) fn get_slot_and_append_vec_id(filename: &str) -> Result<(Slot, usize)
 mod tests {
     use {
         super::*, crate::snapshot_utils::SNAPSHOT_VERSION_FILENAME,
-        solana_accounts_db::append_vec::AppendVec,
+        solana_accounts_db::accounts_file::AccountsFile,
     };
 
     #[test]
@@ -450,8 +450,9 @@ mod tests {
         let expected_slot = 12345;
         let expected_id = 9987;
         let (slot, id) =
-            get_slot_and_append_vec_id(&AppendVec::file_name(expected_slot, expected_id)).unwrap();
+            get_slot_and_append_vec_id(&AccountsFile::file_name(expected_slot, expected_id))
+                .unwrap();
         assert_eq!(expected_slot, slot);
-        assert_eq!(expected_id, id);
+        assert_eq!(expected_id as usize, id);
     }
 }


### PR DESCRIPTION
#### Problem

There's already a function for getting the file name for a storage: `AccountStorageEntry::file_name()`. And AccountStorageEntry is also what holds the slot and id. AppendVec doesn't know about this info, so use AccountsFile instead.


#### Summary of Changes

Replace calls to AppendVec::file_name() with AccountsFile::file_name().