### PR TITLE
Remove `ThinClient` from `LocalCluster`

### DIFF
--- a/local-cluster/src/cluster.rs
+++ b/local-cluster/src/cluster.rs
@@ -1,5 +1,4 @@
 use {
-    solana_client::thin_client::ThinClient,
     solana_core::validator::{Validator, ValidatorConfig},
     solana_gossip::{cluster_info::Node, contact_info::ContactInfo},
     solana_ledger::shred::Shred,

--- a/local-cluster/src/cluster.rs
+++ b/local-cluster/src/cluster.rs
@@ -41,7 +41,7 @@ impl ClusterValidatorInfo {
 
 pub trait Cluster {
     fn get_node_pubkeys(&self) -> Vec<Pubkey>;
-    fn get_validator_client(&self, pubkey: &Pubkey) -> Option<ThinClient>;
+    fn get_validator_client(&self, pubkey: &Pubkey) -> Option<QuicTpuClient>;
     fn build_tpu_quic_client(&self) -> Result<QuicTpuClient>;
     fn build_tpu_quic_client_with_commitment(
         &self,

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -4,12 +4,10 @@
 /// discover the rest of the network.
 use log::*;
 use {
+    crate::cluster::QuicTpuClient,
     rand::{thread_rng, Rng},
     rayon::{prelude::*, ThreadPool},
-    solana_client::{
-        connection_cache::{ConnectionCache, Protocol},
-        thin_client::ThinClient,
-    },
+    solana_client::connection_cache::{ConnectionCache, Protocol},
     solana_core::consensus::{
         tower_storage::{FileTowerStorage, SavedTower, SavedTowerVersions, TowerStorage},
         VOTE_THRESHOLD_DEPTH,
@@ -24,8 +22,8 @@ use {
         gossip_service::{self, discover_cluster, GossipService},
     },
     solana_ledger::blockstore::Blockstore,
+    solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{
-        client::SyncClient,
         clock::{self, Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
         commitment_config::CommitmentConfig,
         epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
@@ -40,6 +38,7 @@ use {
         transport::TransportError,
     },
     solana_streamer::socket::SocketAddrSpace,
+    solana_tpu_client::tpu_client::{TpuClient, TpuClientConfig, TpuSenderError},
     solana_vote::vote_transaction::VoteTransaction,
     solana_vote_program::vote_transaction,
     std::{
@@ -89,9 +88,11 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher + Sync + Send>(
             return;
         }
         let random_keypair = Keypair::new();
-        let (rpc, tpu) = get_client_facing_addr(connection_cache.protocol(), ingress_node);
-        let client = ThinClient::new(rpc, tpu, connection_cache.clone());
+
+        let client = new_tpu_quic_client(ingress_node, connection_cache.clone()).unwrap();
+
         let bal = client
+            .rpc_client()
             .poll_get_balance_with_commitment(
                 &funding_keypair.pubkey(),
                 CommitmentConfig::processed(),
@@ -99,21 +100,22 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher + Sync + Send>(
             .expect("balance in source");
         assert!(bal > 0);
         let (blockhash, _) = client
+            .rpc_client()
             .get_latest_blockhash_with_commitment(CommitmentConfig::confirmed())
             .unwrap();
-        let mut transaction =
+        let transaction =
             system_transaction::transfer(funding_keypair, &random_keypair.pubkey(), 1, blockhash);
         let confs = VOTE_THRESHOLD_DEPTH + 1;
-        let sig = client
-            .retry_transfer_until_confirmed(funding_keypair, &mut transaction, 10, confs)
-            .unwrap();
+        let sig = client.send_and_confirm_transaction(&transaction).unwrap();
         for validator in &cluster_nodes {
             if ignore_nodes.contains(validator.pubkey()) {
                 continue;
             }
-            let (rpc, tpu) = get_client_facing_addr(connection_cache.protocol(), validator);
-            let client = ThinClient::new(rpc, tpu, connection_cache.clone());
-            client.poll_for_signature_confirmation(&sig, confs).unwrap();
+            let client = new_tpu_quic_client(validator, connection_cache.clone()).unwrap();
+            client
+                .rpc_client()
+                .poll_for_signature_confirmation(&sig, confs)
+                .unwrap();
         }
     });
 }
@@ -123,10 +125,10 @@ pub fn verify_balances<S: ::std::hash::BuildHasher>(
     node: &ContactInfo,
     connection_cache: Arc<ConnectionCache>,
 ) {
-    let (rpc, tpu) = get_client_facing_addr(connection_cache.protocol(), node);
-    let client = ThinClient::new(rpc, tpu, connection_cache);
+    let client = new_tpu_quic_client(node, connection_cache.clone()).unwrap();
     for (pk, b) in expected_balances {
         let bal = client
+            .rpc_client()
             .poll_get_balance_with_commitment(&pk, CommitmentConfig::processed())
             .expect("balance in source");
         assert_eq!(bal, b);
@@ -140,12 +142,13 @@ pub fn send_many_transactions(
     max_tokens_per_transfer: u64,
     num_txs: u64,
 ) -> HashMap<Pubkey, u64> {
-    let (rpc, tpu) = get_client_facing_addr(connection_cache.protocol(), node);
-    let client = ThinClient::new(rpc, tpu, connection_cache.clone());
+    let client = new_tpu_quic_client(node, connection_cache.clone()).unwrap();
+
     let mut expected_balances = HashMap::new();
     for _ in 0..num_txs {
         let random_keypair = Keypair::new();
         let bal = client
+            .rpc_client()
             .poll_get_balance_with_commitment(
                 &funding_keypair.pubkey(),
                 CommitmentConfig::processed(),
@@ -153,20 +156,19 @@ pub fn send_many_transactions(
             .expect("balance in source");
         assert!(bal > 0);
         let (blockhash, _) = client
+            .rpc_client()
             .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
             .unwrap();
         let transfer_amount = thread_rng().gen_range(1..max_tokens_per_transfer);
 
-        let mut transaction = system_transaction::transfer(
+        let transaction = system_transaction::transfer(
             funding_keypair,
             &random_keypair.pubkey(),
             transfer_amount,
             blockhash,
         );
 
-        client
-            .retry_transfer(funding_keypair, &mut transaction, 5)
-            .unwrap();
+        client.try_send_transaction(&transaction).unwrap();
 
         expected_balances.insert(random_keypair.pubkey(), transfer_amount);
     }
@@ -238,14 +240,14 @@ pub fn kill_entry_and_spend_and_verify_rest(
     )
     .unwrap();
     assert!(cluster_nodes.len() >= nodes);
-    let (rpc, tpu) = get_client_facing_addr(connection_cache.protocol(), entry_point_info);
-    let client = ThinClient::new(rpc, tpu, connection_cache.clone());
+    let client = new_tpu_quic_client(entry_point_info, connection_cache.clone()).unwrap();
 
     // sleep long enough to make sure we are in epoch 3
     let first_two_epoch_slots = MINIMUM_SLOTS_PER_EPOCH * (3 + 1);
 
     for ingress_node in &cluster_nodes {
         client
+            .rpc_client()
             .poll_get_balance_with_commitment(ingress_node.pubkey(), CommitmentConfig::processed())
             .unwrap_or_else(|err| panic!("Node {} has no balance: {}", ingress_node.pubkey(), err));
     }
@@ -266,9 +268,10 @@ pub fn kill_entry_and_spend_and_verify_rest(
             continue;
         }
 
-        let (rpc, tpu) = get_client_facing_addr(connection_cache.protocol(), ingress_node);
-        let client = ThinClient::new(rpc, tpu, connection_cache.clone());
+        let client = new_tpu_quic_client(ingress_node, connection_cache.clone()).unwrap();
+
         let balance = client
+            .rpc_client()
             .poll_get_balance_with_commitment(
                 &funding_keypair.pubkey(),
                 CommitmentConfig::processed(),
@@ -286,9 +289,10 @@ pub fn kill_entry_and_spend_and_verify_rest(
 
             let random_keypair = Keypair::new();
             let (blockhash, _) = client
+                .rpc_client()
                 .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
                 .unwrap();
-            let mut transaction = system_transaction::transfer(
+            let transaction = system_transaction::transfer(
                 funding_keypair,
                 &random_keypair.pubkey(),
                 1,
@@ -297,12 +301,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
 
             let confs = VOTE_THRESHOLD_DEPTH + 1;
             let sig = {
-                let sig = client.retry_transfer_until_confirmed(
-                    funding_keypair,
-                    &mut transaction,
-                    5,
-                    confs,
-                );
+                let sig = client.send_and_confirm_transaction(&transaction);
                 match sig {
                     Err(e) => {
                         result = Err(e);
@@ -353,10 +352,11 @@ pub fn check_min_slot_is_rooted(
     let loop_start = Instant::now();
     let loop_timeout = Duration::from_secs(180);
     for ingress_node in contact_infos.iter() {
-        let (rpc, tpu) = get_client_facing_addr(connection_cache.protocol(), ingress_node);
-        let client = ThinClient::new(rpc, tpu, connection_cache.clone());
+        let client = new_tpu_quic_client(ingress_node, connection_cache.clone()).unwrap();
+
         loop {
             let root_slot = client
+                .rpc_client()
                 .get_slot_with_commitment(CommitmentConfig::finalized())
                 .unwrap_or(0);
             if root_slot >= min_slot || last_print.elapsed().as_secs() > 3 {
@@ -394,9 +394,10 @@ pub fn check_for_new_roots(
         assert!(loop_start.elapsed() < loop_timeout);
 
         for (i, ingress_node) in contact_infos.iter().enumerate() {
-            let (rpc, tpu) = get_client_facing_addr(connection_cache.protocol(), ingress_node);
-            let client = ThinClient::new(rpc, tpu, connection_cache.clone());
+            let client = new_tpu_quic_client(ingress_node, connection_cache.clone()).unwrap();
+
             let root_slot = client
+                .rpc_client()
                 .get_slot_with_commitment(CommitmentConfig::finalized())
                 .unwrap_or(0);
             roots[i].insert(root_slot);
@@ -427,13 +428,15 @@ pub fn check_no_new_roots(
         .iter()
         .enumerate()
         .map(|(i, ingress_node)| {
-            let (rpc, tpu) = get_client_facing_addr(connection_cache.protocol(), ingress_node);
-            let client = ThinClient::new(rpc, tpu, connection_cache.clone());
+            let client = new_tpu_quic_client(ingress_node, connection_cache.clone()).unwrap();
+
             let initial_root = client
+                .rpc_client()
                 .get_slot()
                 .unwrap_or_else(|_| panic!("get_slot for {} failed", ingress_node.pubkey()));
             roots[i] = initial_root;
             client
+                .rpc_client()
                 .get_slot_with_commitment(CommitmentConfig::processed())
                 .unwrap_or_else(|_| panic!("get_slot for {} failed", ingress_node.pubkey()))
         })
@@ -446,9 +449,10 @@ pub fn check_no_new_roots(
     let mut reached_end_slot = false;
     loop {
         for contact_info in contact_infos {
-            let (rpc, tpu) = get_client_facing_addr(connection_cache.protocol(), contact_info);
-            let client = ThinClient::new(rpc, tpu, connection_cache.clone());
+            let client = new_tpu_quic_client(contact_info, connection_cache.clone()).unwrap();
+
             current_slot = client
+                .rpc_client()
                 .get_slot_with_commitment(CommitmentConfig::processed())
                 .unwrap_or_else(|_| panic!("get_slot for {} failed", contact_infos[0].pubkey()));
             if current_slot > end_slot {
@@ -472,10 +476,11 @@ pub fn check_no_new_roots(
     }
 
     for (i, ingress_node) in contact_infos.iter().enumerate() {
-        let (rpc, tpu) = get_client_facing_addr(connection_cache.protocol(), ingress_node);
-        let client = ThinClient::new(rpc, tpu, connection_cache.clone());
+        let client = new_tpu_quic_client(ingress_node, connection_cache.clone()).unwrap();
+
         assert_eq!(
             client
+                .rpc_client()
                 .get_slot()
                 .unwrap_or_else(|_| panic!("get_slot for {} failed", ingress_node.pubkey())),
             roots[i]
@@ -494,9 +499,11 @@ fn poll_all_nodes_for_signature(
         if validator.pubkey() == entry_point_info.pubkey() {
             continue;
         }
-        let (rpc, tpu) = get_client_facing_addr(connection_cache.protocol(), validator);
-        let client = ThinClient::new(rpc, tpu, connection_cache.clone());
-        client.poll_for_signature_confirmation(sig, confs)?;
+        let client = new_tpu_quic_client(validator, connection_cache.clone()).unwrap();
+
+        client
+            .rpc_client()
+            .poll_for_signature_confirmation(sig, confs)?;
     }
 
     Ok(())
@@ -676,5 +683,25 @@ pub fn submit_vote_to_cluster_gossip(
         node_keypair.pubkey(),
         gossip_addr,
         socket_addr_space,
+    )
+}
+
+pub fn new_tpu_quic_client(
+    contact_info: &ContactInfo,
+    connection_cache: Arc<ConnectionCache>,
+) -> Result<QuicTpuClient, TpuSenderError> {
+    let rpc_pubsub_url = format!("ws://{}/", contact_info.rpc_pubsub().unwrap());
+    let rpc_url = format!("http://{}", contact_info.rpc().unwrap());
+
+    let cache = match &*connection_cache {
+        ConnectionCache::Quic(cache) => cache,
+        ConnectionCache::Udp(_) => panic!("Expected a Quic ConnectionCache. Got UDP"),
+    };
+
+    TpuClient::new_with_connection_cache(
+        Arc::new(RpcClient::new(rpc_url)),
+        rpc_pubsub_url.as_str(),
+        TpuClientConfig::default(),
+        cache.clone(),
     )
 }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -685,7 +685,7 @@ impl LocalCluster {
             *dest_pubkey
         );
         client
-            .try_send_transaction_blocking(&tx)
+            .send_and_confirm_transaction(&tx)
             .expect("client transfer should succeed");
         client
             .rpc_client()

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -685,7 +685,7 @@ impl LocalCluster {
             *dest_pubkey
         );
         client
-            .try_send_transaction(&tx)
+            .try_send_transaction_blocking(&tx)
             .expect("client transfer should succeed");
         client
             .rpc_client()
@@ -759,7 +759,7 @@ impl LocalCluster {
                     .0,
             );
             client
-                .try_send_transaction_blocking(&transaction)
+                .try_send_transaction(&transaction)
                 .expect("should fund vote");
             client
                 .rpc_client()

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -759,7 +759,7 @@ impl LocalCluster {
                     .0,
             );
             client
-                .try_send_transaction(&transaction)
+                .try_send_transaction_blocking(&transaction)
                 .expect("should fund vote");
             client
                 .rpc_client()

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -792,7 +792,7 @@ impl LocalCluster {
             );
 
             client
-                .try_send_transaction(&transaction)
+                .send_and_confirm_transaction(&transaction)
                 .expect("delegate stake");
             client
                 .rpc_client()

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -8,9 +8,7 @@ use {
     itertools::izip,
     log::*,
     solana_accounts_db::utils::create_accounts_run_and_snapshot_dirs,
-    solana_client::{
-        connection_cache::ConnectionCache, rpc_client::RpcClient, thin_client::ThinClient,
-    },
+    solana_client::{connection_cache::ConnectionCache, rpc_client::RpcClient},
     solana_core::{
         consensus::tower_storage::FileTowerStorage,
         validator::{Validator, ValidatorConfig, ValidatorStartProgress},
@@ -914,13 +912,10 @@ impl Cluster for LocalCluster {
         self.validators.keys().cloned().collect()
     }
 
-    fn get_validator_client(&self, pubkey: &Pubkey) -> Option<ThinClient> {
-        self.validators.get(pubkey).map(|f| {
-            let (rpc, tpu) = cluster_tests::get_client_facing_addr(
-                self.connection_cache.protocol(),
-                &f.info.contact_info,
-            );
-            ThinClient::new(rpc, tpu, self.connection_cache.clone())
+    fn get_validator_client(&self, pubkey: &Pubkey) -> Option<QuicTpuClient> {
+        self.validators.get(pubkey).map(|_| {
+            self.build_tpu_quic_client()
+                .expect("should build tpu quic client")
         })
     }
 

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -501,12 +501,10 @@ impl LocalCluster {
                 &validator_pubkey,
                 stake * 2 + 2,
             );
-
             info!(
                 "validator {} balance {}",
                 validator_pubkey, validator_balance
             );
-
             Self::setup_vote_and_stake_accounts(
                 &client,
                 voting_keypair.as_ref().unwrap(),

--- a/local-cluster/src/local_cluster_snapshot_utils.rs
+++ b/local-cluster/src/local_cluster_snapshot_utils.rs
@@ -76,6 +76,7 @@ impl LocalCluster {
             .get_validator_client(self.entry_point_info.pubkey())
             .unwrap();
         let last_slot = client
+            .rpc_client()
             .get_slot_with_commitment(CommitmentConfig::processed())
             .expect("Couldn't get slot");
 

--- a/local-cluster/src/local_cluster_snapshot_utils.rs
+++ b/local-cluster/src/local_cluster_snapshot_utils.rs
@@ -7,7 +7,7 @@ use {
         },
         snapshot_utils,
     },
-    solana_sdk::{client::SyncClient, commitment_config::CommitmentConfig},
+    solana_sdk::commitment_config::CommitmentConfig,
     std::{
         path::Path,
         thread::sleep,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -367,6 +367,7 @@ fn test_restart_node() {
             ticks_per_slot,
             slots_per_epoch,
             stakers_slot_offset: slots_per_epoch,
+            skip_warmup_slots: true,
             ..ClusterConfig::default()
         },
         SocketAddrSpace::Unspecified,
@@ -1227,6 +1228,7 @@ fn test_snapshot_restart_tower() {
             safe_clone_config(&leader_snapshot_test_config.validator_config),
             safe_clone_config(&validator_snapshot_test_config.validator_config),
         ],
+        skip_warmup_slots: true,
         ..ClusterConfig::default()
     };
 

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -701,6 +701,23 @@ where
         self.exit.store(true, Ordering::Relaxed);
         self.leader_tpu_service.join().await;
     }
+
+    pub fn get_connection_cache(&self) -> Arc<ConnectionCache<P, M, C>>
+    where
+        P: ConnectionPool<NewConnectionConfig = C>,
+        M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+        C: NewConnectionConfig,
+    {
+        self.connection_cache.clone()
+    }
+
+    pub fn get_leader_tpu_service(&self) -> &LeaderTpuService {
+        &self.leader_tpu_service
+    }
+
+    pub fn get_fanout_slots(&self) -> u64 {
+        self.fanout_slots
+    }
 }
 
 impl<P, M, C> Drop for TpuClient<P, M, C> {
@@ -777,7 +794,7 @@ impl LeaderTpuService {
         self.recent_slots.estimated_current_slot()
     }
 
-    fn leader_tpu_sockets(&self, fanout_slots: u64) -> Vec<SocketAddr> {
+    pub fn leader_tpu_sockets(&self, fanout_slots: u64) -> Vec<SocketAddr> {
         let current_slot = self.recent_slots.estimated_current_slot();
         self.leader_tpu_cache
             .read()

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -702,13 +702,13 @@ where
         self.leader_tpu_service.join().await;
     }
 
-    pub fn get_connection_cache(&self) -> Arc<ConnectionCache<P, M, C>>
+    pub fn get_connection_cache(&self) -> &Arc<ConnectionCache<P, M, C>>
     where
         P: ConnectionPool<NewConnectionConfig = C>,
         M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
         C: NewConnectionConfig,
     {
-        self.connection_cache.clone()
+        &self.connection_cache
     }
 
     pub fn get_leader_tpu_service(&self) -> &LeaderTpuService {

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -26,7 +26,7 @@ use {
         epoch_info::EpochInfo,
         pubkey::Pubkey,
         quic::QUIC_PORT_OFFSET,
-        signature::{Signature, SignerError},
+        signature::SignerError,
         transaction::Transaction,
         transport::{Result as TransportResult, TransportError},
     },
@@ -487,31 +487,6 @@ where
         } else {
             Ok(())
         }
-    }
-
-    pub async fn send_and_confirm_transaction(
-        &self,
-        transaction: &Transaction,
-    ) -> TransportResult<Signature> {
-        let pending_confirmations: usize = 0;
-        let wire_transaction =
-            bincode::serialize(&transaction).expect("transaction serialization failed");
-        let _ = self.send_wire_transaction(wire_transaction).await;
-
-        if let Ok(confirmed_blocks) = self
-            .rpc_client()
-            .poll_for_signature_confirmation(&transaction.signatures[0], pending_confirmations)
-            .await
-        {
-            if confirmed_blocks >= pending_confirmations {
-                return Ok(transaction.signatures[0]);
-            }
-        }
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "failed to confirm transaction".to_string(),
-        )
-        .into())
     }
 
     /// Create a new client that disconnects when dropped

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -116,36 +116,11 @@ where
             .tpu_client
             .get_leader_tpu_service()
             .leader_tpu_sockets(self.tpu_client.get_fanout_slots());
-        let cc = self.tpu_client.get_connection_cache();
+        let cache = self.tpu_client.get_connection_cache();
         for tpu_address in &leaders {
-            let conn = cc.get_connection(tpu_address);
-            match conn.send_data_async(wire_transaction.clone()) {
-                Ok(_) => println!("tpuclient send_data success"),
-                Err(err) => println!("tpuclient send_data failed: {err}"),
-            }
+            let conn = cache.get_connection(tpu_address);
+            conn.send_data_async(wire_transaction.clone())?;
         }
-
-        // match self.rpc_client().poll_for_signature_confirmation(
-        //     &transaction.signatures[0],
-        //     pending_confirmations,
-        // ) {
-        //     Ok(confirmed_blocks) => {
-        //         println!("tpuclient confirmed blocks found: {confirmed_blocks}");
-        //         // println!("thinclient num confirmed: {num_confirmed}");
-        //         // num_confirmed = confirmed_blocks;
-        //         if confirmed_blocks >= pending_confirmations {
-        //             println!("tpuclient confirmed blocks >= pending confirmations {confirmed_blocks} > {pending_confirmations}");
-        //             return Ok(transaction.signatures[0]);
-        //         }
-        //         // Since network has seen the transaction, wait longer to receive
-        //         // all pending confirmations. Resending the transaction could result into
-        //         // extra transaction fees
-        //         // wait_time = wait_time.max(
-        //         //     MAX_PROCESSING_AGE * pending_confirmations.saturating_sub(num_confirmed),
-        //         // );
-        //     }
-        //     Err(err) => println!("tpuclient error polling for signature confirmation: err: {err}"),
-        // }
 
         if let Ok(confirmed_blocks) = self
             .rpc_client()

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -104,7 +104,11 @@ where
         self.invoke(self.tpu_client.try_send_transaction(transaction))
     }
 
-    pub fn try_send_transaction_blocking(
+    /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
+    /// size
+    /// Waits for signature confirmation before returning
+    /// Returns the transaction signature
+    pub fn send_and_confirm_transaction(
         &self,
         transaction: &Transaction,
     ) -> TransportResult<Signature> {
@@ -165,13 +169,6 @@ where
             self.tpu_client
                 .try_send_wire_transaction_batch(wire_transactions),
         )
-    }
-
-    pub fn send_and_confirm_transaction(
-        &self,
-        transaction: &Transaction,
-    ) -> TransportResult<Signature> {
-        self.invoke(self.tpu_client.send_and_confirm_transaction(transaction))
     }
 
     /// Create a new client that disconnects when dropped

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -6,7 +6,10 @@ use {
         ConnectionCache, ConnectionManager, ConnectionPool, NewConnectionConfig,
     },
     solana_rpc_client::rpc_client::RpcClient,
-    solana_sdk::{clock::Slot, transaction::Transaction, transport::Result as TransportResult},
+    solana_sdk::{
+        clock::Slot, signature::Signature, transaction::Transaction,
+        transport::Result as TransportResult,
+    },
     std::{
         collections::VecDeque,
         net::UdpSocket,
@@ -113,6 +116,13 @@ where
     /// Returns the last error if all sends fail
     pub fn try_send_wire_transaction(&self, wire_transaction: Vec<u8>) -> TransportResult<()> {
         self.invoke(self.tpu_client.try_send_wire_transaction(wire_transaction))
+    }
+
+    pub fn send_and_confirm_transaction(
+        &self,
+        transaction: &Transaction,
+    ) -> TransportResult<Signature> {
+        self.invoke(self.tpu_client.send_and_confirm_transaction(transaction))
     }
 
     /// Create a new client that disconnects when dropped


### PR DESCRIPTION
A Followup PR to: https://github.com/anza-xyz/agave/pull/258.
This is the 10th PR on the way to remove ThinClient completely.

#### Problem
`ThinClient` is deprecated. Replacing with `TpuClient`

#### Summary of Changes
Replace `ThinClient` with `TpuClient` in `LocalCluster`
Specifically, we use a Quic TpuClient, not a UDP TpuClient

#### Notes
This works but I can't say for sure why it works. 
I had initially replaced all of `ThinClient` within `LocalCluster` with the nonblocking version of `TpuClient`. I had made the switch such that `transfer_with_client()` calls `TpuClient.try_send_transaction()` which calls `send_wire_transaction_to_addr()`. `send_wire_transaction_to_addr()` uses a non-blocking connection from the connection_cache to send the transaction. 

However, using the changes above, I consistently ran into an issue with any test that called `add_validator()` more than once. Under the hood, `add_validator()` calls `transfer_with_client()`. `transfer_with_client()` transfers some amount of lamports to a destination account (aka the account associated with the validator we are trying to add). However in the `LocalCluster` tests, `transfer_with_client()` would consistently fail when adding the second validator with `add_validator()`. It would always fail with: `transport custom error: "ConnectError(EndpointStopping)`. 

I noticed that `ThinClient` used a blocking connection when sending transactions with `retry_transfer()` (which was used to send a transaction within `transfer_with_client()`. So, I switched over to using the blocking `TpuClient` and that seems to work well. I had to make a few changes to expose the leader schedule, connection cache, and fanout slots from the `nonblocking/tpu_client` up to the blocking `tpu_client`. 

I am still working on investigating. But thinks its probably a good idea to get some eyes on this since it does work as expected now.