### PR TITLE
Moves `0` for write_version in geyser when restoring from a snapshot

### DIFF
--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        account_storage::meta::{StoredAccountMeta, StoredMeta},
-        accounts_db::AccountsDb,
-    },
+    crate::{account_storage::meta::StoredAccountMeta, accounts_db::AccountsDb},
     solana_measure::measure::Measure,
     solana_metrics::*,
     solana_sdk::{
@@ -146,18 +143,7 @@ impl AccountsDb {
     ) {
         let notifier = self.accounts_update_notifier.as_ref().unwrap();
         let mut measure_notify = Measure::start("accountsdb-plugin-notifying-accounts");
-        let local_write_version = 0;
-        for mut account in accounts_to_stream {
-            // We do not need to rely on the specific write_version read from the append vec.
-            // So, overwrite the write_version with something that works.
-            // 'accounts_to_stream' is already a hashmap, so there is already only entry per pubkey.
-            // write_version is only used to order multiple entries with the same pubkey, so it doesn't matter what value it gets here.
-            // Passing 0 for everyone's write_version is sufficiently correct.
-            let meta = StoredMeta {
-                write_version_obsolete: local_write_version,
-                ..*account.meta()
-            };
-            account.set_meta(&meta);
+        for account in accounts_to_stream {
             let mut measure_pure_notify = Measure::start("accountsdb-plugin-notifying-accounts");
             notifier.notify_account_restore_from_snapshot(slot, &account);
             measure_pure_notify.stop();

--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -127,6 +127,13 @@ impl AccountsUpdateNotifierImpl {
         &self,
         stored_account_meta: &'a StoredAccountMeta,
     ) -> Option<ReplicaAccountInfoV3<'a>> {
+        // We do not need to rely on the specific write_version read from the append vec.
+        // So, overwrite the write_version with something that works.
+        // There is already only entry per pubkey.
+        // write_version is only used to order multiple entries with the same pubkey,
+        // so it doesn't matter what value it gets here.
+        // Passing 0 for everyone's write_version is sufficiently correct.
+        let write_version = 0;
         Some(ReplicaAccountInfoV3 {
             pubkey: stored_account_meta.pubkey().as_ref(),
             lamports: stored_account_meta.lamports(),
@@ -134,7 +141,7 @@ impl AccountsUpdateNotifierImpl {
             executable: stored_account_meta.executable(),
             rent_epoch: stored_account_meta.rent_epoch(),
             data: stored_account_meta.data(),
-            write_version: stored_account_meta.write_version(),
+            write_version,
             txn: None,
         })
     }


### PR DESCRIPTION
#### Problem

We are trying to move account storage files *away* from using mmaps internally. The function `StoredAccountMeta::set_meta()` updates the underlying mmap, which will not be possible once mmaps are removed. (It's also not supported for Tiered Storage at all.)
https://github.com/anza-xyz/agave/blob/70c4cb0ba1fbef2b3aa5796420ed285c46f5c4f6/accounts-db/src/account_storage/meta.rs#L174-L181

The only caller of `set_meta()` is in geyser, when restoring from a snapshot.

We use `set_meta` only to set the write version to zero. Instead, we can move this `0` literal inside `accountinfo_from_stored_account_meta()`, which is only called when restoring from a snapshot. This ensures we do not change behavior at all, *and* allows us to remove the call to `set_meta()`.


#### Summary of Changes

Moves where `0` is set for write version.

This PR is effectively a combination of #721 and #702.