### PR TITLE
Transaction Status: Add support for `token-group` and `token-metadata` interface instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7498,6 +7498,7 @@ dependencies = [
  "spl-token",
  "spl-token-2022",
  "spl-token-group-interface",
+ "spl-token-metadata-interface",
  "thiserror",
 ]
 
@@ -7856,8 +7857,10 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5db7e4efb1107b0b8e52a13f035437cdcb36ef99c58f6d467f089d9b2915a"
 dependencies = [
+ "base64 0.21.7",
  "borsh 0.10.3",
  "bytemuck",
+ "serde",
  "solana-program",
  "solana-zk-token-sdk",
  "spl-program-error",
@@ -7961,6 +7964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16aa8f64b6e0eaab3f5034e84d867c8435d8216497b4543a4978a31f4b6e8a8"
 dependencies = [
  "borsh 0.10.3",
+ "serde",
  "solana-program",
  "spl-discriminator",
  "spl-pod",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7857,10 +7857,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5db7e4efb1107b0b8e52a13f035437cdcb36ef99c58f6d467f089d9b2915a"
 dependencies = [
- "base64 0.21.7",
  "borsh 0.10.3",
  "bytemuck",
- "serde",
  "solana-program",
  "solana-zk-token-sdk",
  "spl-program-error",
@@ -7964,7 +7962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16aa8f64b6e0eaab3f5034e84d867c8435d8216497b4543a4978a31f4b6e8a8"
 dependencies = [
  "borsh 0.10.3",
- "serde",
  "solana-program",
  "spl-discriminator",
  "spl-pod",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7497,6 +7497,7 @@ dependencies = [
  "spl-memo",
  "spl-token",
  "spl-token-2022",
+ "spl-token-group-interface",
  "thiserror",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6480,6 +6480,8 @@ dependencies = [
  "spl-memo",
  "spl-token",
  "spl-token-2022",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface",
  "thiserror",
 ]
 
@@ -6766,8 +6768,10 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5db7e4efb1107b0b8e52a13f035437cdcb36ef99c58f6d467f089d9b2915a"
 dependencies = [
+ "base64 0.21.7",
  "borsh 0.10.3",
  "bytemuck",
+ "serde",
  "solana-program",
  "solana-zk-token-sdk",
  "spl-program-error",
@@ -6871,6 +6875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16aa8f64b6e0eaab3f5034e84d867c8435d8216497b4543a4978a31f4b6e8a8"
 dependencies = [
  "borsh 0.10.3",
+ "serde",
  "solana-program",
  "spl-discriminator",
  "spl-pod",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6768,10 +6768,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5db7e4efb1107b0b8e52a13f035437cdcb36ef99c58f6d467f089d9b2915a"
 dependencies = [
- "base64 0.21.7",
  "borsh 0.10.3",
  "bytemuck",
- "serde",
  "solana-program",
  "solana-zk-token-sdk",
  "spl-program-error",
@@ -6875,7 +6873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16aa8f64b6e0eaab3f5034e84d867c8435d8216497b4543a4978a31f4b6e8a8"
 dependencies = [
  "borsh 0.10.3",
- "serde",
  "solana-program",
  "spl-discriminator",
  "spl-pod",

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -29,6 +29,7 @@ spl-memo = { workspace = true, features = ["no-entrypoint"] }
 spl-token = { workspace = true, features = ["no-entrypoint"] }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 spl-token-group-interface = { workspace = true }
+spl-token-metadata-interface = { workspace = true, features = ["serde-traits"] }
 thiserror = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -29,7 +29,7 @@ spl-memo = { workspace = true, features = ["no-entrypoint"] }
 spl-token = { workspace = true, features = ["no-entrypoint"] }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 spl-token-group-interface = { workspace = true }
-spl-token-metadata-interface = { workspace = true, features = ["serde-traits"] }
+spl-token-metadata-interface = { workspace = true }
 thiserror = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -28,6 +28,7 @@ spl-associated-token-account = { workspace = true, features = ["no-entrypoint"] 
 spl-memo = { workspace = true, features = ["no-entrypoint"] }
 spl-token = { workspace = true, features = ["no-entrypoint"] }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
+spl-token-group-interface = { workspace = true }
 thiserror = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -6,7 +6,7 @@ use {
         confidential_transfer::*, confidential_transfer_fee::*, cpi_guard::*,
         default_account_state::*, group_member_pointer::*, group_pointer::*,
         interest_bearing_mint::*, memo_transfer::*, metadata_pointer::*, mint_close_authority::*,
-        permanent_delegate::*, reallocate::*, transfer_fee::*, transfer_hook::*,
+        permanent_delegate::*, reallocate::*, token_group::*, transfer_fee::*, transfer_hook::*,
     },
     serde_json::{json, Map, Value},
     solana_account_decoder::parse_token::{token_amount_to_ui_amount, UiAccountState},
@@ -22,6 +22,7 @@ use {
             pubkey::Pubkey,
         },
     },
+    spl_token_group_interface::instruction::TokenGroupInstruction,
 };
 
 mod extension;
@@ -682,6 +683,12 @@ pub fn parse_token(
                 )
             }
         }
+    } else if let Ok(token_group_instruction) = TokenGroupInstruction::unpack(&instruction.data) {
+        parse_token_group_instruction(
+            &token_group_instruction,
+            &instruction.accounts,
+            account_keys,
+        )
     } else {
         Err(ParseInstructionError::InstructionNotParsable(
             ParsableProgram::SplToken,

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -6,7 +6,8 @@ use {
         confidential_transfer::*, confidential_transfer_fee::*, cpi_guard::*,
         default_account_state::*, group_member_pointer::*, group_pointer::*,
         interest_bearing_mint::*, memo_transfer::*, metadata_pointer::*, mint_close_authority::*,
-        permanent_delegate::*, reallocate::*, token_group::*, transfer_fee::*, transfer_hook::*,
+        permanent_delegate::*, reallocate::*, token_group::*, token_metadata::*, transfer_fee::*,
+        transfer_hook::*,
     },
     serde_json::{json, Map, Value},
     solana_account_decoder::parse_token::{token_amount_to_ui_amount, UiAccountState},
@@ -23,6 +24,7 @@ use {
         },
     },
     spl_token_group_interface::instruction::TokenGroupInstruction,
+    spl_token_metadata_interface::instruction::TokenMetadataInstruction,
 };
 
 mod extension;
@@ -686,6 +688,14 @@ pub fn parse_token(
     } else if let Ok(token_group_instruction) = TokenGroupInstruction::unpack(&instruction.data) {
         parse_token_group_instruction(
             &token_group_instruction,
+            &instruction.accounts,
+            account_keys,
+        )
+    } else if let Ok(token_metadata_instruction) =
+        TokenMetadataInstruction::unpack(&instruction.data)
+    {
+        parse_token_metadata_instruction(
+            &token_metadata_instruction,
             &instruction.accounts,
             account_keys,
         )

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -30,8 +30,6 @@ pub fn parse_token(
     instruction: &CompiledInstruction,
     account_keys: &AccountKeys,
 ) -> Result<ParsedInstructionEnum, ParseInstructionError> {
-    let token_instruction = TokenInstruction::unpack(&instruction.data)
-        .map_err(|_| ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken))?;
     match instruction.accounts.iter().max() {
         Some(index) if (*index as usize) < account_keys.len() => {}
         _ => {
@@ -41,641 +39,653 @@ pub fn parse_token(
             ));
         }
     }
-    match token_instruction {
-        TokenInstruction::InitializeMint {
-            decimals,
-            mint_authority,
-            freeze_authority,
-        } => {
-            check_num_token_accounts(&instruction.accounts, 2)?;
-            let mut value = json!({
-                "mint": account_keys[instruction.accounts[0] as usize].to_string(),
-                "decimals": decimals,
-                "mintAuthority": mint_authority.to_string(),
-                "rentSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
-            });
-            let map = value.as_object_mut().unwrap();
-            if let COption::Some(freeze_authority) = freeze_authority {
-                map.insert(
-                    "freezeAuthority".to_string(),
-                    json!(freeze_authority.to_string()),
-                );
-            }
-            Ok(ParsedInstructionEnum {
-                instruction_type: "initializeMint".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::InitializeMint2 {
-            decimals,
-            mint_authority,
-            freeze_authority,
-        } => {
-            check_num_token_accounts(&instruction.accounts, 1)?;
-            let mut value = json!({
-                "mint": account_keys[instruction.accounts[0] as usize].to_string(),
-                "decimals": decimals,
-                "mintAuthority": mint_authority.to_string(),
-            });
-            let map = value.as_object_mut().unwrap();
-            if let COption::Some(freeze_authority) = freeze_authority {
-                map.insert(
-                    "freezeAuthority".to_string(),
-                    json!(freeze_authority.to_string()),
-                );
-            }
-            Ok(ParsedInstructionEnum {
-                instruction_type: "initializeMint2".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::InitializeAccount => {
-            check_num_token_accounts(&instruction.accounts, 4)?;
-            Ok(ParsedInstructionEnum {
-                instruction_type: "initializeAccount".to_string(),
-                info: json!({
-                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "owner": account_keys[instruction.accounts[2] as usize].to_string(),
-                    "rentSysvar": account_keys[instruction.accounts[3] as usize].to_string(),
-                }),
-            })
-        }
-        TokenInstruction::InitializeAccount2 { owner } => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            Ok(ParsedInstructionEnum {
-                instruction_type: "initializeAccount2".to_string(),
-                info: json!({
-                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "owner": owner.to_string(),
-                    "rentSysvar": account_keys[instruction.accounts[2] as usize].to_string(),
-                }),
-            })
-        }
-        TokenInstruction::InitializeAccount3 { owner } => {
-            check_num_token_accounts(&instruction.accounts, 2)?;
-            Ok(ParsedInstructionEnum {
-                instruction_type: "initializeAccount3".to_string(),
-                info: json!({
-                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "owner": owner.to_string(),
-                }),
-            })
-        }
-        TokenInstruction::InitializeMultisig { m } => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            let mut signers: Vec<String> = vec![];
-            for i in instruction.accounts[2..].iter() {
-                signers.push(account_keys[*i as usize].to_string());
-            }
-            Ok(ParsedInstructionEnum {
-                instruction_type: "initializeMultisig".to_string(),
-                info: json!({
-                    "multisig": account_keys[instruction.accounts[0] as usize].to_string(),
+    if let Ok(token_instruction) = TokenInstruction::unpack(&instruction.data) {
+        match token_instruction {
+            TokenInstruction::InitializeMint {
+                decimals,
+                mint_authority,
+                freeze_authority,
+            } => {
+                check_num_token_accounts(&instruction.accounts, 2)?;
+                let mut value = json!({
+                    "mint": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "decimals": decimals,
+                    "mintAuthority": mint_authority.to_string(),
                     "rentSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "signers": signers,
-                    "m": m,
-                }),
-            })
-        }
-        TokenInstruction::InitializeMultisig2 { m } => {
-            check_num_token_accounts(&instruction.accounts, 2)?;
-            let mut signers: Vec<String> = vec![];
-            for i in instruction.accounts[1..].iter() {
-                signers.push(account_keys[*i as usize].to_string());
+                });
+                let map = value.as_object_mut().unwrap();
+                if let COption::Some(freeze_authority) = freeze_authority {
+                    map.insert(
+                        "freezeAuthority".to_string(),
+                        json!(freeze_authority.to_string()),
+                    );
+                }
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "initializeMint".to_string(),
+                    info: value,
+                })
             }
-            Ok(ParsedInstructionEnum {
-                instruction_type: "initializeMultisig2".to_string(),
-                info: json!({
-                    "multisig": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "signers": signers,
-                    "m": m,
-                }),
-            })
-        }
-        #[allow(deprecated)]
-        TokenInstruction::Transfer { amount } => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            let mut value = json!({
-                "source": account_keys[instruction.accounts[0] as usize].to_string(),
-                "destination": account_keys[instruction.accounts[1] as usize].to_string(),
-                "amount": amount.to_string(),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                2,
-                account_keys,
-                &instruction.accounts,
-                "authority",
-                "multisigAuthority",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "transfer".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::Approve { amount } => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            let mut value = json!({
-                "source": account_keys[instruction.accounts[0] as usize].to_string(),
-                "delegate": account_keys[instruction.accounts[1] as usize].to_string(),
-                "amount": amount.to_string(),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                2,
-                account_keys,
-                &instruction.accounts,
-                "owner",
-                "multisigOwner",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "approve".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::Revoke => {
-            check_num_token_accounts(&instruction.accounts, 2)?;
-            let mut value = json!({
-                "source": account_keys[instruction.accounts[0] as usize].to_string(),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                1,
-                account_keys,
-                &instruction.accounts,
-                "owner",
-                "multisigOwner",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "revoke".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::SetAuthority {
-            authority_type,
-            new_authority,
-        } => {
-            check_num_token_accounts(&instruction.accounts, 2)?;
-            let owned = match authority_type {
-                AuthorityType::MintTokens
-                | AuthorityType::FreezeAccount
-                | AuthorityType::TransferFeeConfig
-                | AuthorityType::WithheldWithdraw
-                | AuthorityType::CloseMint
-                | AuthorityType::InterestRate
-                | AuthorityType::PermanentDelegate
-                | AuthorityType::ConfidentialTransferMint
-                | AuthorityType::TransferHookProgramId
-                | AuthorityType::ConfidentialTransferFeeConfig
-                | AuthorityType::MetadataPointer
-                | AuthorityType::GroupPointer
-                | AuthorityType::GroupMemberPointer => "mint",
-                AuthorityType::AccountOwner | AuthorityType::CloseAccount => "account",
-            };
-            let mut value = json!({
-                owned: account_keys[instruction.accounts[0] as usize].to_string(),
-                "authorityType": Into::<UiAuthorityType>::into(authority_type),
-                "newAuthority": map_coption_pubkey(new_authority),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                1,
-                account_keys,
-                &instruction.accounts,
-                "authority",
-                "multisigAuthority",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "setAuthority".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::MintTo { amount } => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            let mut value = json!({
-                "mint": account_keys[instruction.accounts[0] as usize].to_string(),
-                "account": account_keys[instruction.accounts[1] as usize].to_string(),
-                "amount": amount.to_string(),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                2,
-                account_keys,
-                &instruction.accounts,
-                "mintAuthority",
-                "multisigMintAuthority",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "mintTo".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::Burn { amount } => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            let mut value = json!({
-                "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                "mint": account_keys[instruction.accounts[1] as usize].to_string(),
-                "amount": amount.to_string(),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                2,
-                account_keys,
-                &instruction.accounts,
-                "authority",
-                "multisigAuthority",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "burn".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::CloseAccount => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            let mut value = json!({
-                "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                "destination": account_keys[instruction.accounts[1] as usize].to_string(),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                2,
-                account_keys,
-                &instruction.accounts,
-                "owner",
-                "multisigOwner",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "closeAccount".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::FreezeAccount => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            let mut value = json!({
-                "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                "mint": account_keys[instruction.accounts[1] as usize].to_string(),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                2,
-                account_keys,
-                &instruction.accounts,
-                "freezeAuthority",
-                "multisigFreezeAuthority",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "freezeAccount".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::ThawAccount => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            let mut value = json!({
-                "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                "mint": account_keys[instruction.accounts[1] as usize].to_string(),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                2,
-                account_keys,
-                &instruction.accounts,
-                "freezeAuthority",
-                "multisigFreezeAuthority",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "thawAccount".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::TransferChecked { amount, decimals } => {
-            check_num_token_accounts(&instruction.accounts, 4)?;
-            let mut value = json!({
-                "source": account_keys[instruction.accounts[0] as usize].to_string(),
-                "mint": account_keys[instruction.accounts[1] as usize].to_string(),
-                "destination": account_keys[instruction.accounts[2] as usize].to_string(),
-                "tokenAmount": token_amount_to_ui_amount(amount, decimals),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                3,
-                account_keys,
-                &instruction.accounts,
-                "authority",
-                "multisigAuthority",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "transferChecked".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::ApproveChecked { amount, decimals } => {
-            check_num_token_accounts(&instruction.accounts, 4)?;
-            let mut value = json!({
-                "source": account_keys[instruction.accounts[0] as usize].to_string(),
-                "mint": account_keys[instruction.accounts[1] as usize].to_string(),
-                "delegate": account_keys[instruction.accounts[2] as usize].to_string(),
-                "tokenAmount": token_amount_to_ui_amount(amount, decimals),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                3,
-                account_keys,
-                &instruction.accounts,
-                "owner",
-                "multisigOwner",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "approveChecked".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::MintToChecked { amount, decimals } => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            let mut value = json!({
-                "mint": account_keys[instruction.accounts[0] as usize].to_string(),
-                "account": account_keys[instruction.accounts[1] as usize].to_string(),
-                "tokenAmount": token_amount_to_ui_amount(amount, decimals),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                2,
-                account_keys,
-                &instruction.accounts,
-                "mintAuthority",
-                "multisigMintAuthority",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "mintToChecked".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::BurnChecked { amount, decimals } => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            let mut value = json!({
-                "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                "mint": account_keys[instruction.accounts[1] as usize].to_string(),
-                "tokenAmount": token_amount_to_ui_amount(amount, decimals),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                2,
-                account_keys,
-                &instruction.accounts,
-                "authority",
-                "multisigAuthority",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "burnChecked".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::SyncNative => {
-            check_num_token_accounts(&instruction.accounts, 1)?;
-            Ok(ParsedInstructionEnum {
-                instruction_type: "syncNative".to_string(),
-                info: json!({
-                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                }),
-            })
-        }
-        TokenInstruction::GetAccountDataSize { extension_types } => {
-            check_num_token_accounts(&instruction.accounts, 1)?;
-            let mut value = json!({
-                "mint": account_keys[instruction.accounts[0] as usize].to_string(),
-            });
-            let map = value.as_object_mut().unwrap();
-            if !extension_types.is_empty() {
-                map.insert(
-                    "extensionTypes".to_string(),
-                    json!(extension_types
-                        .into_iter()
-                        .map(UiExtensionType::from)
-                        .collect::<Vec<_>>()),
+            TokenInstruction::InitializeMint2 {
+                decimals,
+                mint_authority,
+                freeze_authority,
+            } => {
+                check_num_token_accounts(&instruction.accounts, 1)?;
+                let mut value = json!({
+                    "mint": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "decimals": decimals,
+                    "mintAuthority": mint_authority.to_string(),
+                });
+                let map = value.as_object_mut().unwrap();
+                if let COption::Some(freeze_authority) = freeze_authority {
+                    map.insert(
+                        "freezeAuthority".to_string(),
+                        json!(freeze_authority.to_string()),
+                    );
+                }
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "initializeMint2".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::InitializeAccount => {
+                check_num_token_accounts(&instruction.accounts, 4)?;
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "initializeAccount".to_string(),
+                    info: json!({
+                        "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                        "owner": account_keys[instruction.accounts[2] as usize].to_string(),
+                        "rentSysvar": account_keys[instruction.accounts[3] as usize].to_string(),
+                    }),
+                })
+            }
+            TokenInstruction::InitializeAccount2 { owner } => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "initializeAccount2".to_string(),
+                    info: json!({
+                        "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                        "owner": owner.to_string(),
+                        "rentSysvar": account_keys[instruction.accounts[2] as usize].to_string(),
+                    }),
+                })
+            }
+            TokenInstruction::InitializeAccount3 { owner } => {
+                check_num_token_accounts(&instruction.accounts, 2)?;
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "initializeAccount3".to_string(),
+                    info: json!({
+                        "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                        "owner": owner.to_string(),
+                    }),
+                })
+            }
+            TokenInstruction::InitializeMultisig { m } => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                let mut signers: Vec<String> = vec![];
+                for i in instruction.accounts[2..].iter() {
+                    signers.push(account_keys[*i as usize].to_string());
+                }
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "initializeMultisig".to_string(),
+                    info: json!({
+                        "multisig": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "rentSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
+                        "signers": signers,
+                        "m": m,
+                    }),
+                })
+            }
+            TokenInstruction::InitializeMultisig2 { m } => {
+                check_num_token_accounts(&instruction.accounts, 2)?;
+                let mut signers: Vec<String> = vec![];
+                for i in instruction.accounts[1..].iter() {
+                    signers.push(account_keys[*i as usize].to_string());
+                }
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "initializeMultisig2".to_string(),
+                    info: json!({
+                        "multisig": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "signers": signers,
+                        "m": m,
+                    }),
+                })
+            }
+            #[allow(deprecated)]
+            TokenInstruction::Transfer { amount } => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                let mut value = json!({
+                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "destination": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "amount": amount.to_string(),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    2,
+                    account_keys,
+                    &instruction.accounts,
+                    "authority",
+                    "multisigAuthority",
                 );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "transfer".to_string(),
+                    info: value,
+                })
             }
-            Ok(ParsedInstructionEnum {
-                instruction_type: "getAccountDataSize".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::InitializeImmutableOwner => {
-            check_num_token_accounts(&instruction.accounts, 1)?;
-            Ok(ParsedInstructionEnum {
-                instruction_type: "initializeImmutableOwner".to_string(),
-                info: json!({
+            TokenInstruction::Approve { amount } => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                let mut value = json!({
+                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "delegate": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "amount": amount.to_string(),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    2,
+                    account_keys,
+                    &instruction.accounts,
+                    "owner",
+                    "multisigOwner",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "approve".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::Revoke => {
+                check_num_token_accounts(&instruction.accounts, 2)?;
+                let mut value = json!({
+                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    1,
+                    account_keys,
+                    &instruction.accounts,
+                    "owner",
+                    "multisigOwner",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "revoke".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::SetAuthority {
+                authority_type,
+                new_authority,
+            } => {
+                check_num_token_accounts(&instruction.accounts, 2)?;
+                let owned = match authority_type {
+                    AuthorityType::MintTokens
+                    | AuthorityType::FreezeAccount
+                    | AuthorityType::TransferFeeConfig
+                    | AuthorityType::WithheldWithdraw
+                    | AuthorityType::CloseMint
+                    | AuthorityType::InterestRate
+                    | AuthorityType::PermanentDelegate
+                    | AuthorityType::ConfidentialTransferMint
+                    | AuthorityType::TransferHookProgramId
+                    | AuthorityType::ConfidentialTransferFeeConfig
+                    | AuthorityType::MetadataPointer
+                    | AuthorityType::GroupPointer
+                    | AuthorityType::GroupMemberPointer => "mint",
+                    AuthorityType::AccountOwner | AuthorityType::CloseAccount => "account",
+                };
+                let mut value = json!({
+                    owned: account_keys[instruction.accounts[0] as usize].to_string(),
+                    "authorityType": Into::<UiAuthorityType>::into(authority_type),
+                    "newAuthority": map_coption_pubkey(new_authority),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    1,
+                    account_keys,
+                    &instruction.accounts,
+                    "authority",
+                    "multisigAuthority",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "setAuthority".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::MintTo { amount } => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                let mut value = json!({
+                    "mint": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "account": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "amount": amount.to_string(),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    2,
+                    account_keys,
+                    &instruction.accounts,
+                    "mintAuthority",
+                    "multisigMintAuthority",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "mintTo".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::Burn { amount } => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                let mut value = json!({
                     "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                }),
-            })
-        }
-        TokenInstruction::AmountToUiAmount { amount } => {
-            check_num_token_accounts(&instruction.accounts, 1)?;
-            Ok(ParsedInstructionEnum {
-                instruction_type: "amountToUiAmount".to_string(),
-                info: json!({
+                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "amount": amount.to_string(),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    2,
+                    account_keys,
+                    &instruction.accounts,
+                    "authority",
+                    "multisigAuthority",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "burn".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::CloseAccount => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                let mut value = json!({
+                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "destination": account_keys[instruction.accounts[1] as usize].to_string(),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    2,
+                    account_keys,
+                    &instruction.accounts,
+                    "owner",
+                    "multisigOwner",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "closeAccount".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::FreezeAccount => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                let mut value = json!({
+                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    2,
+                    account_keys,
+                    &instruction.accounts,
+                    "freezeAuthority",
+                    "multisigFreezeAuthority",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "freezeAccount".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::ThawAccount => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                let mut value = json!({
+                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    2,
+                    account_keys,
+                    &instruction.accounts,
+                    "freezeAuthority",
+                    "multisigFreezeAuthority",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "thawAccount".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::TransferChecked { amount, decimals } => {
+                check_num_token_accounts(&instruction.accounts, 4)?;
+                let mut value = json!({
+                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "destination": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "tokenAmount": token_amount_to_ui_amount(amount, decimals),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    3,
+                    account_keys,
+                    &instruction.accounts,
+                    "authority",
+                    "multisigAuthority",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "transferChecked".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::ApproveChecked { amount, decimals } => {
+                check_num_token_accounts(&instruction.accounts, 4)?;
+                let mut value = json!({
+                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "delegate": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "tokenAmount": token_amount_to_ui_amount(amount, decimals),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    3,
+                    account_keys,
+                    &instruction.accounts,
+                    "owner",
+                    "multisigOwner",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "approveChecked".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::MintToChecked { amount, decimals } => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                let mut value = json!({
                     "mint": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "amount": amount,
-                }),
-            })
-        }
-        TokenInstruction::UiAmountToAmount { ui_amount } => {
-            check_num_token_accounts(&instruction.accounts, 1)?;
-            Ok(ParsedInstructionEnum {
-                instruction_type: "uiAmountToAmount".to_string(),
-                info: json!({
+                    "account": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "tokenAmount": token_amount_to_ui_amount(amount, decimals),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    2,
+                    account_keys,
+                    &instruction.accounts,
+                    "mintAuthority",
+                    "multisigMintAuthority",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "mintToChecked".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::BurnChecked { amount, decimals } => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                let mut value = json!({
+                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "tokenAmount": token_amount_to_ui_amount(amount, decimals),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    2,
+                    account_keys,
+                    &instruction.accounts,
+                    "authority",
+                    "multisigAuthority",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "burnChecked".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::SyncNative => {
+                check_num_token_accounts(&instruction.accounts, 1)?;
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "syncNative".to_string(),
+                    info: json!({
+                        "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                    }),
+                })
+            }
+            TokenInstruction::GetAccountDataSize { extension_types } => {
+                check_num_token_accounts(&instruction.accounts, 1)?;
+                let mut value = json!({
                     "mint": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "uiAmount": ui_amount,
-                }),
-            })
-        }
-        TokenInstruction::InitializeMintCloseAuthority { close_authority } => {
-            parse_initialize_mint_close_authority_instruction(
-                close_authority,
-                &instruction.accounts,
-                account_keys,
-            )
-        }
-        TokenInstruction::TransferFeeExtension(transfer_fee_instruction) => {
-            parse_transfer_fee_instruction(
-                transfer_fee_instruction,
-                &instruction.accounts,
-                account_keys,
-            )
-        }
-        TokenInstruction::ConfidentialTransferExtension => parse_confidential_transfer_instruction(
-            &instruction.data[1..],
-            &instruction.accounts,
-            account_keys,
-        ),
-        TokenInstruction::DefaultAccountStateExtension => {
-            if instruction.data.len() <= 2 {
-                return Err(ParseInstructionError::InstructionNotParsable(
-                    ParsableProgram::SplToken,
-                ));
+                });
+                let map = value.as_object_mut().unwrap();
+                if !extension_types.is_empty() {
+                    map.insert(
+                        "extensionTypes".to_string(),
+                        json!(extension_types
+                            .into_iter()
+                            .map(UiExtensionType::from)
+                            .collect::<Vec<_>>()),
+                    );
+                }
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "getAccountDataSize".to_string(),
+                    info: value,
+                })
             }
-            parse_default_account_state_instruction(
-                &instruction.data[1..],
-                &instruction.accounts,
-                account_keys,
-            )
-        }
-        TokenInstruction::Reallocate { extension_types } => {
-            parse_reallocate_instruction(extension_types, &instruction.accounts, account_keys)
-        }
-        TokenInstruction::MemoTransferExtension => {
-            if instruction.data.len() < 2 {
-                return Err(ParseInstructionError::InstructionNotParsable(
-                    ParsableProgram::SplToken,
-                ));
+            TokenInstruction::InitializeImmutableOwner => {
+                check_num_token_accounts(&instruction.accounts, 1)?;
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "initializeImmutableOwner".to_string(),
+                    info: json!({
+                        "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                    }),
+                })
             }
-            parse_memo_transfer_instruction(
-                &instruction.data[1..],
-                &instruction.accounts,
-                account_keys,
-            )
-        }
-        TokenInstruction::CreateNativeMint => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            Ok(ParsedInstructionEnum {
-                instruction_type: "createNativeMint".to_string(),
-                info: json!({
-                    "payer": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "nativeMint": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "systemProgram": account_keys[instruction.accounts[2] as usize].to_string(),
-                }),
-            })
-        }
-        TokenInstruction::InitializeNonTransferableMint => {
-            check_num_token_accounts(&instruction.accounts, 1)?;
-            Ok(ParsedInstructionEnum {
-                instruction_type: "initializeNonTransferableMint".to_string(),
-                info: json!({
-                    "mint": account_keys[instruction.accounts[0] as usize].to_string(),
-                }),
-            })
-        }
-        TokenInstruction::InterestBearingMintExtension => {
-            if instruction.data.len() < 2 {
-                return Err(ParseInstructionError::InstructionNotParsable(
-                    ParsableProgram::SplToken,
-                ));
+            TokenInstruction::AmountToUiAmount { amount } => {
+                check_num_token_accounts(&instruction.accounts, 1)?;
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "amountToUiAmount".to_string(),
+                    info: json!({
+                        "mint": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "amount": amount,
+                    }),
+                })
             }
-            parse_interest_bearing_mint_instruction(
-                &instruction.data[1..],
-                &instruction.accounts,
-                account_keys,
-            )
-        }
-        TokenInstruction::CpiGuardExtension => {
-            if instruction.data.len() < 2 {
-                return Err(ParseInstructionError::InstructionNotParsable(
-                    ParsableProgram::SplToken,
-                ));
+            TokenInstruction::UiAmountToAmount { ui_amount } => {
+                check_num_token_accounts(&instruction.accounts, 1)?;
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "uiAmountToAmount".to_string(),
+                    info: json!({
+                        "mint": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "uiAmount": ui_amount,
+                    }),
+                })
             }
-            parse_cpi_guard_instruction(&instruction.data[1..], &instruction.accounts, account_keys)
-        }
-        TokenInstruction::InitializePermanentDelegate { delegate } => {
-            parse_initialize_permanent_delegate_instruction(
-                delegate,
-                &instruction.accounts,
-                account_keys,
-            )
-        }
-        TokenInstruction::TransferHookExtension => {
-            if instruction.data.len() < 2 {
-                return Err(ParseInstructionError::InstructionNotParsable(
-                    ParsableProgram::SplToken,
-                ));
+            TokenInstruction::InitializeMintCloseAuthority { close_authority } => {
+                parse_initialize_mint_close_authority_instruction(
+                    close_authority,
+                    &instruction.accounts,
+                    account_keys,
+                )
             }
-            parse_transfer_hook_instruction(
-                &instruction.data[1..],
-                &instruction.accounts,
-                account_keys,
-            )
-        }
-        TokenInstruction::ConfidentialTransferFeeExtension => {
-            if instruction.data.len() < 2 {
-                return Err(ParseInstructionError::InstructionNotParsable(
-                    ParsableProgram::SplToken,
-                ));
+            TokenInstruction::TransferFeeExtension(transfer_fee_instruction) => {
+                parse_transfer_fee_instruction(
+                    transfer_fee_instruction,
+                    &instruction.accounts,
+                    account_keys,
+                )
             }
-            parse_confidential_transfer_fee_instruction(
-                &instruction.data[1..],
-                &instruction.accounts,
-                account_keys,
-            )
-        }
-        TokenInstruction::WithdrawExcessLamports => {
-            check_num_token_accounts(&instruction.accounts, 3)?;
-            let mut value = json!({
-                "source": account_keys[instruction.accounts[0] as usize].to_string(),
-                "destination": account_keys[instruction.accounts[1] as usize].to_string(),
-            });
-            let map = value.as_object_mut().unwrap();
-            parse_signers(
-                map,
-                2,
-                account_keys,
-                &instruction.accounts,
-                "authority",
-                "multisigAuthority",
-            );
-            Ok(ParsedInstructionEnum {
-                instruction_type: "withdrawExcessLamports".to_string(),
-                info: value,
-            })
-        }
-        TokenInstruction::MetadataPointerExtension => {
-            if instruction.data.len() < 2 {
-                return Err(ParseInstructionError::InstructionNotParsable(
-                    ParsableProgram::SplToken,
-                ));
+            TokenInstruction::ConfidentialTransferExtension => {
+                parse_confidential_transfer_instruction(
+                    &instruction.data[1..],
+                    &instruction.accounts,
+                    account_keys,
+                )
             }
-            parse_metadata_pointer_instruction(
-                &instruction.data[1..],
-                &instruction.accounts,
-                account_keys,
-            )
-        }
-        TokenInstruction::GroupPointerExtension => {
-            if instruction.data.len() < 2 {
-                return Err(ParseInstructionError::InstructionNotParsable(
-                    ParsableProgram::SplToken,
-                ));
+            TokenInstruction::DefaultAccountStateExtension => {
+                if instruction.data.len() <= 2 {
+                    return Err(ParseInstructionError::InstructionNotParsable(
+                        ParsableProgram::SplToken,
+                    ));
+                }
+                parse_default_account_state_instruction(
+                    &instruction.data[1..],
+                    &instruction.accounts,
+                    account_keys,
+                )
             }
-            parse_group_pointer_instruction(
-                &instruction.data[1..],
-                &instruction.accounts,
-                account_keys,
-            )
-        }
-        TokenInstruction::GroupMemberPointerExtension => {
-            if instruction.data.len() < 2 {
-                return Err(ParseInstructionError::InstructionNotParsable(
-                    ParsableProgram::SplToken,
-                ));
+            TokenInstruction::Reallocate { extension_types } => {
+                parse_reallocate_instruction(extension_types, &instruction.accounts, account_keys)
             }
-            parse_group_member_pointer_instruction(
-                &instruction.data[1..],
-                &instruction.accounts,
-                account_keys,
-            )
+            TokenInstruction::MemoTransferExtension => {
+                if instruction.data.len() < 2 {
+                    return Err(ParseInstructionError::InstructionNotParsable(
+                        ParsableProgram::SplToken,
+                    ));
+                }
+                parse_memo_transfer_instruction(
+                    &instruction.data[1..],
+                    &instruction.accounts,
+                    account_keys,
+                )
+            }
+            TokenInstruction::CreateNativeMint => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "createNativeMint".to_string(),
+                    info: json!({
+                        "payer": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "nativeMint": account_keys[instruction.accounts[1] as usize].to_string(),
+                        "systemProgram": account_keys[instruction.accounts[2] as usize].to_string(),
+                    }),
+                })
+            }
+            TokenInstruction::InitializeNonTransferableMint => {
+                check_num_token_accounts(&instruction.accounts, 1)?;
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "initializeNonTransferableMint".to_string(),
+                    info: json!({
+                        "mint": account_keys[instruction.accounts[0] as usize].to_string(),
+                    }),
+                })
+            }
+            TokenInstruction::InterestBearingMintExtension => {
+                if instruction.data.len() < 2 {
+                    return Err(ParseInstructionError::InstructionNotParsable(
+                        ParsableProgram::SplToken,
+                    ));
+                }
+                parse_interest_bearing_mint_instruction(
+                    &instruction.data[1..],
+                    &instruction.accounts,
+                    account_keys,
+                )
+            }
+            TokenInstruction::CpiGuardExtension => {
+                if instruction.data.len() < 2 {
+                    return Err(ParseInstructionError::InstructionNotParsable(
+                        ParsableProgram::SplToken,
+                    ));
+                }
+                parse_cpi_guard_instruction(
+                    &instruction.data[1..],
+                    &instruction.accounts,
+                    account_keys,
+                )
+            }
+            TokenInstruction::InitializePermanentDelegate { delegate } => {
+                parse_initialize_permanent_delegate_instruction(
+                    delegate,
+                    &instruction.accounts,
+                    account_keys,
+                )
+            }
+            TokenInstruction::TransferHookExtension => {
+                if instruction.data.len() < 2 {
+                    return Err(ParseInstructionError::InstructionNotParsable(
+                        ParsableProgram::SplToken,
+                    ));
+                }
+                parse_transfer_hook_instruction(
+                    &instruction.data[1..],
+                    &instruction.accounts,
+                    account_keys,
+                )
+            }
+            TokenInstruction::ConfidentialTransferFeeExtension => {
+                if instruction.data.len() < 2 {
+                    return Err(ParseInstructionError::InstructionNotParsable(
+                        ParsableProgram::SplToken,
+                    ));
+                }
+                parse_confidential_transfer_fee_instruction(
+                    &instruction.data[1..],
+                    &instruction.accounts,
+                    account_keys,
+                )
+            }
+            TokenInstruction::WithdrawExcessLamports => {
+                check_num_token_accounts(&instruction.accounts, 3)?;
+                let mut value = json!({
+                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "destination": account_keys[instruction.accounts[1] as usize].to_string(),
+                });
+                let map = value.as_object_mut().unwrap();
+                parse_signers(
+                    map,
+                    2,
+                    account_keys,
+                    &instruction.accounts,
+                    "authority",
+                    "multisigAuthority",
+                );
+                Ok(ParsedInstructionEnum {
+                    instruction_type: "withdrawExcessLamports".to_string(),
+                    info: value,
+                })
+            }
+            TokenInstruction::MetadataPointerExtension => {
+                if instruction.data.len() < 2 {
+                    return Err(ParseInstructionError::InstructionNotParsable(
+                        ParsableProgram::SplToken,
+                    ));
+                }
+                parse_metadata_pointer_instruction(
+                    &instruction.data[1..],
+                    &instruction.accounts,
+                    account_keys,
+                )
+            }
+            TokenInstruction::GroupPointerExtension => {
+                if instruction.data.len() < 2 {
+                    return Err(ParseInstructionError::InstructionNotParsable(
+                        ParsableProgram::SplToken,
+                    ));
+                }
+                parse_group_pointer_instruction(
+                    &instruction.data[1..],
+                    &instruction.accounts,
+                    account_keys,
+                )
+            }
+            TokenInstruction::GroupMemberPointerExtension => {
+                if instruction.data.len() < 2 {
+                    return Err(ParseInstructionError::InstructionNotParsable(
+                        ParsableProgram::SplToken,
+                    ));
+                }
+                parse_group_member_pointer_instruction(
+                    &instruction.data[1..],
+                    &instruction.accounts,
+                    account_keys,
+                )
+            }
         }
+    } else {
+        Err(ParseInstructionError::InstructionNotParsable(
+            ParsableProgram::SplToken,
+        ))
     }
 }
 

--- a/transaction-status/src/parse_token/extension/mod.rs
+++ b/transaction-status/src/parse_token/extension/mod.rs
@@ -12,5 +12,6 @@ pub(super) mod metadata_pointer;
 pub(super) mod mint_close_authority;
 pub(super) mod permanent_delegate;
 pub(super) mod reallocate;
+pub(super) mod token_group;
 pub(super) mod transfer_fee;
 pub(super) mod transfer_hook;

--- a/transaction-status/src/parse_token/extension/mod.rs
+++ b/transaction-status/src/parse_token/extension/mod.rs
@@ -13,5 +13,6 @@ pub(super) mod mint_close_authority;
 pub(super) mod permanent_delegate;
 pub(super) mod reallocate;
 pub(super) mod token_group;
+pub(super) mod token_metadata;
 pub(super) mod transfer_fee;
 pub(super) mod transfer_hook;

--- a/transaction-status/src/parse_token/extension/token_group.rs
+++ b/transaction-status/src/parse_token/extension/token_group.rs
@@ -17,19 +17,13 @@ pub(in crate::parse_token) fn parse_token_group_instruction(
                 max_size,
                 update_authority,
             } = group;
-            let mut value = json!({
+            let value = json!({
                 "group": account_keys[account_indexes[0] as usize].to_string(),
                 "maxSize": u32::from(*max_size),
                 "mint": account_keys[account_indexes[1] as usize].to_string(),
                 "mintAuthority": account_keys[account_indexes[2] as usize].to_string(),
+                "updateAuthority": Option::<Pubkey>::from(*update_authority).map(|v| v.to_string())
             });
-            let map = value.as_object_mut().unwrap();
-            if let Some(update_authority) = Option::<Pubkey>::from(*update_authority) {
-                map.insert(
-                    "updateAuthority".to_string(),
-                    json!(update_authority.to_string()),
-                );
-            }
             Ok(ParsedInstructionEnum {
                 instruction_type: "initializeTokenGroup".to_string(),
                 info: value,
@@ -51,14 +45,11 @@ pub(in crate::parse_token) fn parse_token_group_instruction(
         TokenGroupInstruction::UpdateGroupAuthority(update) => {
             check_num_token_accounts(account_indexes, 2)?;
             let UpdateGroupAuthority { new_authority } = update;
-            let mut value = json!({
+            let value = json!({
                 "group": account_keys[account_indexes[0] as usize].to_string(),
                 "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
+                "newAuthority": Option::<Pubkey>::from(*new_authority).map(|v| v.to_string())
             });
-            let map = value.as_object_mut().unwrap();
-            if let Some(new_authority) = Option::<Pubkey>::from(*new_authority) {
-                map.insert("newAuthority".to_string(), json!(new_authority.to_string()));
-            }
             Ok(ParsedInstructionEnum {
                 instruction_type: "updateTokenGroupAuthority".to_string(),
                 info: value,
@@ -96,6 +87,7 @@ mod test {
         let member_address = Pubkey::new_unique();
 
         // InitializeGroup
+        // Initialize with an update authority.
         let max_size = 300;
         let ix = spl_token_group_interface::instruction::initialize_group(
             &spl_token_2022::id(),
@@ -121,6 +113,34 @@ mod test {
                     "mint": group_mint.to_string(),
                     "mintAuthority": group_mint_authority.to_string(),
                     "updateAuthority": group_update_authority.to_string(),
+                })
+            }
+        );
+        // Initialize without an update authority.
+        let ix = spl_token_group_interface::instruction::initialize_group(
+            &spl_token_2022::id(),
+            &group_address,
+            &group_mint,
+            &group_mint_authority,
+            None,
+            max_size,
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initializeTokenGroup".to_string(),
+                info: json!({
+                    "group": group_address.to_string(),
+                    "maxSize": max_size,
+                    "mint": group_mint.to_string(),
+                    "mintAuthority": group_mint_authority.to_string(),
+                    "updateAuthority": null,
                 })
             }
         );
@@ -152,6 +172,7 @@ mod test {
         );
 
         // UpdateGroupAuthority
+        // Update authority to a new authority.
         let new_authority = Pubkey::new_unique();
         let ix = spl_token_group_interface::instruction::update_group_authority(
             &spl_token_2022::id(),
@@ -173,6 +194,30 @@ mod test {
                     "group": group_address.to_string(),
                     "updateAuthority": group_update_authority.to_string(),
                     "newAuthority": new_authority.to_string(),
+                })
+            }
+        );
+        // Update authority to None.
+        let ix = spl_token_group_interface::instruction::update_group_authority(
+            &spl_token_2022::id(),
+            &group_address,
+            &group_update_authority,
+            None,
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "updateTokenGroupAuthority".to_string(),
+                info: json!({
+                    "group": group_address.to_string(),
+                    "updateAuthority": group_update_authority.to_string(),
+                    "newAuthority": null,
                 })
             }
         );

--- a/transaction-status/src/parse_token/extension/token_group.rs
+++ b/transaction-status/src/parse_token/extension/token_group.rs
@@ -1,0 +1,209 @@
+use {
+    super::*,
+    spl_token_group_interface::instruction::{
+        InitializeGroup, TokenGroupInstruction, UpdateGroupAuthority, UpdateGroupMaxSize,
+    },
+};
+
+pub(in crate::parse_token) fn parse_token_group_instruction(
+    instruction: &TokenGroupInstruction,
+    account_indexes: &[u8],
+    account_keys: &AccountKeys,
+) -> Result<ParsedInstructionEnum, ParseInstructionError> {
+    match instruction {
+        TokenGroupInstruction::InitializeGroup(group) => {
+            check_num_token_accounts(account_indexes, 3)?;
+            let InitializeGroup {
+                max_size,
+                update_authority,
+            } = group;
+            let mut value = json!({
+                "group": account_keys[account_indexes[0] as usize].to_string(),
+                "maxSize": u32::from(*max_size),
+                "mint": account_keys[account_indexes[1] as usize].to_string(),
+                "mintAuthority": account_keys[account_indexes[2] as usize].to_string(),
+            });
+            let map = value.as_object_mut().unwrap();
+            if let Some(update_authority) = Option::<Pubkey>::from(*update_authority) {
+                map.insert(
+                    "updateAuthority".to_string(),
+                    json!(update_authority.to_string()),
+                );
+            }
+            Ok(ParsedInstructionEnum {
+                instruction_type: "initializeTokenGroup".to_string(),
+                info: value,
+            })
+        }
+        TokenGroupInstruction::UpdateGroupMaxSize(update) => {
+            check_num_token_accounts(account_indexes, 2)?;
+            let UpdateGroupMaxSize { max_size } = update;
+            let value = json!({
+                "group": account_keys[account_indexes[0] as usize].to_string(),
+                "maxSize": u32::from(*max_size),
+                "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
+            });
+            Ok(ParsedInstructionEnum {
+                instruction_type: "updateTokenGroupMaxSize".to_string(),
+                info: value,
+            })
+        }
+        TokenGroupInstruction::UpdateGroupAuthority(update) => {
+            check_num_token_accounts(account_indexes, 2)?;
+            let UpdateGroupAuthority { new_authority } = update;
+            let mut value = json!({
+                "group": account_keys[account_indexes[0] as usize].to_string(),
+                "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
+            });
+            let map = value.as_object_mut().unwrap();
+            if let Some(new_authority) = Option::<Pubkey>::from(*new_authority) {
+                map.insert("newAuthority".to_string(), json!(new_authority.to_string()));
+            }
+            Ok(ParsedInstructionEnum {
+                instruction_type: "updateTokenGroupAuthority".to_string(),
+                info: value,
+            })
+        }
+        TokenGroupInstruction::InitializeMember(_) => {
+            check_num_token_accounts(account_indexes, 5)?;
+            let value = json!({
+                "member": account_keys[account_indexes[0] as usize].to_string(),
+                "memberMint": account_keys[account_indexes[1] as usize].to_string(),
+                "memberMintAuthority": account_keys[account_indexes[2] as usize].to_string(),
+                "group": account_keys[account_indexes[3] as usize].to_string(),
+                "groupUpdateAuthority": account_keys[account_indexes[4] as usize].to_string(),
+            });
+            Ok(ParsedInstructionEnum {
+                instruction_type: "initializeTokenGroupMember".to_string(),
+                info: value,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {super::*, solana_sdk::pubkey::Pubkey, spl_token_2022::solana_program::message::Message};
+
+    #[test]
+    fn test_parse_token_group_instruction() {
+        let group_mint = Pubkey::new_unique();
+        let group_mint_authority = Pubkey::new_unique();
+        let group_update_authority = Pubkey::new_unique();
+        let group_address = Pubkey::new_unique();
+        let member_mint = Pubkey::new_unique();
+        let member_mint_authority = Pubkey::new_unique();
+        let member_address = Pubkey::new_unique();
+
+        // InitializeGroup
+        let max_size = 300;
+        let ix = spl_token_group_interface::instruction::initialize_group(
+            &spl_token_2022::id(),
+            &group_address,
+            &group_mint,
+            &group_mint_authority,
+            Some(group_update_authority),
+            max_size,
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initializeTokenGroup".to_string(),
+                info: json!({
+                    "group": group_address.to_string(),
+                    "maxSize": max_size,
+                    "mint": group_mint.to_string(),
+                    "mintAuthority": group_mint_authority.to_string(),
+                    "updateAuthority": group_update_authority.to_string(),
+                })
+            }
+        );
+
+        // UpdateGroupMaxSize
+        let new_max_size = 500;
+        let ix = spl_token_group_interface::instruction::update_group_max_size(
+            &spl_token_2022::id(),
+            &group_address,
+            &group_update_authority,
+            new_max_size,
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "updateTokenGroupMaxSize".to_string(),
+                info: json!({
+                    "group": group_address.to_string(),
+                    "maxSize": new_max_size,
+                    "updateAuthority": group_update_authority.to_string(),
+                })
+            }
+        );
+
+        // UpdateGroupAuthority
+        let new_authority = Pubkey::new_unique();
+        let ix = spl_token_group_interface::instruction::update_group_authority(
+            &spl_token_2022::id(),
+            &group_address,
+            &group_update_authority,
+            Some(new_authority),
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "updateTokenGroupAuthority".to_string(),
+                info: json!({
+                    "group": group_address.to_string(),
+                    "updateAuthority": group_update_authority.to_string(),
+                    "newAuthority": new_authority.to_string(),
+                })
+            }
+        );
+
+        // InitializeMember
+        let ix = spl_token_group_interface::instruction::initialize_member(
+            &spl_token_2022::id(),
+            &member_address,
+            &member_mint,
+            &member_mint_authority,
+            &group_address,
+            &group_update_authority,
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initializeTokenGroupMember".to_string(),
+                info: json!({
+                    "member": member_address.to_string(),
+                    "memberMint": member_mint.to_string(),
+                    "memberMintAuthority": member_mint_authority.to_string(),
+                    "group": group_address.to_string(),
+                    "groupUpdateAuthority": group_update_authority.to_string(),
+                })
+            }
+        );
+    }
+}

--- a/transaction-status/src/parse_token/extension/token_metadata.rs
+++ b/transaction-status/src/parse_token/extension/token_metadata.rs
@@ -1,9 +1,21 @@
 use {
     super::*,
-    spl_token_metadata_interface::instruction::{
-        Emit, Initialize, RemoveKey, TokenMetadataInstruction, UpdateAuthority, UpdateField,
+    spl_token_metadata_interface::{
+        instruction::{
+            Emit, Initialize, RemoveKey, TokenMetadataInstruction, UpdateAuthority, UpdateField,
+        },
+        state::Field,
     },
 };
+
+fn token_metadata_field_to_string(field: &Field) -> String {
+    match field {
+        Field::Name => "name".to_string(),
+        Field::Symbol => "symbol".to_string(),
+        Field::Uri => "uri".to_string(),
+        Field::Key(key) => key.clone(),
+    }
+}
 
 pub(in crate::parse_token) fn parse_token_metadata_instruction(
     instruction: &TokenMetadataInstruction,
@@ -34,7 +46,7 @@ pub(in crate::parse_token) fn parse_token_metadata_instruction(
             let value = json!({
                 "metadata": account_keys[account_indexes[0] as usize].to_string(),
                 "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
-                "field": field,
+                "field": token_metadata_field_to_string(field),
                 "value": value,
             });
             Ok(ParsedInstructionEnum {
@@ -186,9 +198,7 @@ mod test {
                 info: json!({
                     "metadata": metadata.to_string(),
                     "updateAuthority": update_authority.to_string(),
-                    "field": {
-                        "key": "new_field",
-                    },
+                    "field": "new_field",
                     "value": "new_value",
                 })
             }

--- a/transaction-status/src/parse_token/extension/token_metadata.rs
+++ b/transaction-status/src/parse_token/extension/token_metadata.rs
@@ -1,0 +1,347 @@
+use {
+    super::*,
+    spl_token_metadata_interface::instruction::{
+        Emit, Initialize, RemoveKey, TokenMetadataInstruction, UpdateAuthority, UpdateField,
+    },
+};
+
+pub(in crate::parse_token) fn parse_token_metadata_instruction(
+    instruction: &TokenMetadataInstruction,
+    account_indexes: &[u8],
+    account_keys: &AccountKeys,
+) -> Result<ParsedInstructionEnum, ParseInstructionError> {
+    match instruction {
+        TokenMetadataInstruction::Initialize(metadata) => {
+            check_num_token_accounts(account_indexes, 4)?;
+            let Initialize { name, symbol, uri } = metadata;
+            let value = json!({
+                "metadata": account_keys[account_indexes[0] as usize].to_string(),
+                "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
+                "mint": account_keys[account_indexes[2] as usize].to_string(),
+                "mintAuthority": account_keys[account_indexes[3] as usize].to_string(),
+                "name": name,
+                "symbol": symbol,
+                "uri": uri,
+            });
+            Ok(ParsedInstructionEnum {
+                instruction_type: "initializeTokenMetadata".to_string(),
+                info: value,
+            })
+        }
+        TokenMetadataInstruction::UpdateField(update) => {
+            check_num_token_accounts(account_indexes, 2)?;
+            let UpdateField { field, value } = update;
+            let value = json!({
+                "metadata": account_keys[account_indexes[0] as usize].to_string(),
+                "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
+                "field": field,
+                "value": value,
+            });
+            Ok(ParsedInstructionEnum {
+                instruction_type: "updateTokenMetadataField".to_string(),
+                info: value,
+            })
+        }
+        TokenMetadataInstruction::RemoveKey(remove) => {
+            check_num_token_accounts(account_indexes, 2)?;
+            let RemoveKey { key, idempotent } = remove;
+            let value = json!({
+                "metadata": account_keys[account_indexes[0] as usize].to_string(),
+                "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
+                "key": key,
+                "idempotent": *idempotent,
+            });
+            Ok(ParsedInstructionEnum {
+                instruction_type: "removeTokenMetadataKey".to_string(),
+                info: value,
+            })
+        }
+        TokenMetadataInstruction::UpdateAuthority(update) => {
+            check_num_token_accounts(account_indexes, 2)?;
+            let UpdateAuthority { new_authority } = update;
+            let mut value = json!({
+                "metadata": account_keys[account_indexes[0] as usize].to_string(),
+                "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
+            });
+            let map = value.as_object_mut().unwrap();
+            if let Some(new_authority) = Option::<Pubkey>::from(*new_authority) {
+                map.insert("newAuthority".to_string(), json!(new_authority.to_string()));
+            }
+            Ok(ParsedInstructionEnum {
+                instruction_type: "updateTokenMetadataAuthority".to_string(),
+                info: value,
+            })
+        }
+        TokenMetadataInstruction::Emit(emit) => {
+            check_num_token_accounts(account_indexes, 1)?;
+            let Emit { start, end } = emit;
+            let mut value = json!({
+                "metadata": account_keys[account_indexes[0] as usize].to_string(),
+            });
+            let map = value.as_object_mut().unwrap();
+            if let Some(start) = *start {
+                map.insert("start".to_string(), json!(start));
+            }
+            if let Some(end) = *end {
+                map.insert("end".to_string(), json!(end));
+            }
+            Ok(ParsedInstructionEnum {
+                instruction_type: "emitTokenMetadata".to_string(),
+                info: value,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {super::*, solana_sdk::pubkey::Pubkey, spl_token_2022::solana_program::message::Message};
+
+    #[test]
+    fn test_parse_token_metadata_instruction() {
+        let mint = Pubkey::new_unique();
+        let mint_authority = Pubkey::new_unique();
+        let update_authority = Pubkey::new_unique();
+        let metadata = Pubkey::new_unique();
+
+        let name = "Mega Token".to_string();
+        let symbol = "MEGA".to_string();
+        let uri = "https://mega.com".to_string();
+
+        // Initialize
+        let ix = spl_token_metadata_interface::instruction::initialize(
+            &spl_token_2022::id(),
+            &metadata,
+            &update_authority,
+            &mint,
+            &mint_authority,
+            name.clone(),
+            symbol.clone(),
+            uri.clone(),
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initializeTokenMetadata".to_string(),
+                info: json!({
+                    "metadata": metadata.to_string(),
+                    "updateAuthority": update_authority.to_string(),
+                    "mint": mint.to_string(),
+                    "mintAuthority": mint_authority.to_string(),
+                    "name": name,
+                    "symbol": symbol,
+                    "uri": uri,
+                })
+            }
+        );
+
+        // UpdateField
+        // Update one of the fixed fields.
+        let ix = spl_token_metadata_interface::instruction::update_field(
+            &spl_token_2022::id(),
+            &metadata,
+            &update_authority,
+            spl_token_metadata_interface::state::Field::Uri,
+            "https://ultra-mega.com".to_string(),
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "updateTokenMetadataField".to_string(),
+                info: json!({
+                    "metadata": metadata.to_string(),
+                    "updateAuthority": update_authority.to_string(),
+                    "field": "uri",
+                    "value": "https://ultra-mega.com",
+                })
+            }
+        );
+        // Add a new field
+        let ix = spl_token_metadata_interface::instruction::update_field(
+            &spl_token_2022::id(),
+            &metadata,
+            &update_authority,
+            spl_token_metadata_interface::state::Field::Key("new_field".to_string()),
+            "new_value".to_string(),
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "updateTokenMetadataField".to_string(),
+                info: json!({
+                    "metadata": metadata.to_string(),
+                    "updateAuthority": update_authority.to_string(),
+                    "field": {
+                        "key": "new_field",
+                    },
+                    "value": "new_value",
+                })
+            }
+        );
+
+        // RemoveKey
+        let ix = spl_token_metadata_interface::instruction::remove_key(
+            &spl_token_2022::id(),
+            &metadata,
+            &update_authority,
+            "new_field".to_string(),
+            false,
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "removeTokenMetadataKey".to_string(),
+                info: json!({
+                    "metadata": metadata.to_string(),
+                    "updateAuthority": update_authority.to_string(),
+                    "key": "new_field",
+                    "idempotent": false,
+                })
+            }
+        );
+
+        // UpdateAuthority
+        let new_authority = Pubkey::new_unique();
+        let ix = spl_token_metadata_interface::instruction::update_authority(
+            &spl_token_2022::id(),
+            &metadata,
+            &update_authority,
+            Some(new_authority).try_into().unwrap(),
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "updateTokenMetadataAuthority".to_string(),
+                info: json!({
+                    "metadata": metadata.to_string(),
+                    "updateAuthority": update_authority.to_string(),
+                    "newAuthority": new_authority.to_string(),
+                })
+            }
+        );
+
+        // Emit
+        // Emit with start and end.
+        let ix = spl_token_metadata_interface::instruction::emit(
+            &spl_token_2022::id(),
+            &metadata,
+            Some(1),
+            Some(2),
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "emitTokenMetadata".to_string(),
+                info: json!({
+                    "metadata": metadata.to_string(),
+                    "start": 1,
+                    "end": 2,
+                })
+            }
+        );
+        // Emit with only start.
+        let ix = spl_token_metadata_interface::instruction::emit(
+            &spl_token_2022::id(),
+            &metadata,
+            Some(1),
+            None,
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "emitTokenMetadata".to_string(),
+                info: json!({
+                    "metadata": metadata.to_string(),
+                    "start": 1,
+                })
+            }
+        );
+        // Emit with only end.
+        let ix = spl_token_metadata_interface::instruction::emit(
+            &spl_token_2022::id(),
+            &metadata,
+            None,
+            Some(2),
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "emitTokenMetadata".to_string(),
+                info: json!({
+                    "metadata": metadata.to_string(),
+                    "end": 2,
+                })
+            }
+        );
+        // Emit with neither start nor end.
+        let ix = spl_token_metadata_interface::instruction::emit(
+            &spl_token_2022::id(),
+            &metadata,
+            None,
+            None,
+        );
+        let mut message = Message::new(&[ix], None);
+        let compiled_instruction = &mut message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "emitTokenMetadata".to_string(),
+                info: json!({
+                    "metadata": metadata.to_string(),
+                })
+            }
+        );
+    }
+}


### PR DESCRIPTION
#### Problem
The `transaction-status` crate, used by the RPC to parse instructions with 
`jsonParsed` encoding, supports _most_ of the Token-2022 extensions. However, it 
doesn't support the extensions that implement interfaces - such as 
`TokenMetadata` and `TokenGroup`.

Developers would benefit from being able to view parsed instructions - such as 
`initializeTokenMetadata` and `updateGroupMaxSize` - in RPC `jsonParsed` 
instructions.

#### Summary of Changes
Add support for the Token Group and Token Metadata interface within 
`parse_token` to enable parsing of interface instructions.