### PR TITLE
cli::program_v4: Remove `allow(clippy::arithmetic_side_effects)`

### DIFF
--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::arithmetic_side_effects)]
-
 use {
     crate::{
         checks::*,
@@ -53,6 +51,7 @@ use {
         fs::File,
         io::{Read, Write},
         mem::size_of,
+        num::Saturating,
         rc::Rc,
         sync::Arc,
     },
@@ -591,8 +590,17 @@ pub fn process_deploy_program(
 
     let mut write_messages = vec![];
     let chunk_size = calculate_max_chunk_size(&create_msg);
-    for (chunk, i) in program_data.chunks(chunk_size).zip(0..) {
-        write_messages.push(create_msg((i * chunk_size) as u32, chunk.to_vec()));
+    for (chunk, i) in program_data.chunks(chunk_size).zip(0usize..) {
+        write_messages.push(create_msg(
+            i.saturating_mul(chunk_size).try_into().map_err(|_| {
+                format!(
+                    "Program data size exceeds {}: {}",
+                    u32::MAX,
+                    program_data.len()
+                )
+            })?,
+            chunk.to_vec(),
+        ));
     }
 
     let final_messages = if *program_address != buffer_address {
@@ -801,24 +809,24 @@ fn check_payer(
     write_messages: &[Message],
     other_messages: &[Message],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut fee = 0;
+    let mut fee = Saturating(0);
     for message in initial_messages {
         fee += rpc_client.get_fee_for_message(message)?;
     }
     for message in other_messages {
         fee += rpc_client.get_fee_for_message(message)?;
     }
-    if !write_messages.is_empty() {
-        // Assume all write messages cost the same
-        if let Some(message) = write_messages.first() {
-            fee += rpc_client.get_fee_for_message(message)? * (write_messages.len() as u64);
-        }
+    // Assume all write messages cost the same
+    if let Some(message) = write_messages.first() {
+        fee += rpc_client
+            .get_fee_for_message(message)?
+            .saturating_mul(write_messages.len() as u64);
     }
     check_account_for_spend_and_fee_with_commitment(
         rpc_client,
         &config.payer.pubkey(),
         balance_needed,
-        fee,
+        fee.0,
         config.commitment,
     )?;
     Ok(())


### PR DESCRIPTION
---

Note for reviewers:

Here is an example of a change where we can do better than just doing saturating multiplication and addition.
In both cases, we could check and fail with a more meaningful error message.
I still think that it is an improvement over the current state:
1. `#![allow(clippy::arithmetic_side_effects)]` is gone.
2. If we wrap, we may still send the transaction in some cases that are incorrect that the saturating math would catch.

Let me know if you think this needs to be fixed further.