### PR TITLE
[zk-sdk] Create `zk-sdk` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7690,6 +7690,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-zk-sdk"
+version = "2.0.0"
+
+[[package]]
 name = "solana-zk-token-proof-program"
 version = "2.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ members = [
     "watchtower",
     "wen-restart",
     "zk-keygen",
+    "zk-sdk",
     "zk-token-sdk",
 ]
 
@@ -390,6 +391,7 @@ solana-vote = { path = "vote", version = "=2.0.0" }
 solana-vote-program = { path = "programs/vote", version = "=2.0.0" }
 solana-wen-restart = { path = "wen-restart", version = "=2.0.0" }
 solana-zk-keygen = { path = "zk-keygen", version = "=2.0.0" }
+solana-zk-sdk = { path = "zk-sdk", version = "=2.0.0" }
 solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=2.0.0" }
 solana-zk-token-sdk = { path = "zk-token-sdk", version = "=2.0.0" }
 solana_rbpf = "=0.8.0"
@@ -475,6 +477,7 @@ crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd2
 # There is a similar override in `programs/sbf/Cargo.toml`.  Please keep both
 # comments and the overrides in sync.
 solana-program = { path = "sdk/program" }
+solana-zk-sdk = { path = "zk-sdk" }
 solana-zk-token-sdk = { path = "zk-token-sdk" }
 #
 # === zeroize versioning issues ===

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "solana-zk-sdk"
+description = "Solana ZK SDK"
+documentation = "https://docs.rs/solana-zk-sdk"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+
+[dev-dependencies]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/zk-sdk/src/lib.rs
+++ b/zk-sdk/src/lib.rs
@@ -1,0 +1,2 @@
+//! The `solana-zk-sdk` crate contains tools to create and verify zero-knowledge proofs on
+//! encrypted data.


### PR DESCRIPTION
#### Problem
There are a number of breaking changes that must be made to the solana-zk-token-sdk (https://github.com/anza-xyz/agave/issues/671) that break downstream (essentially just spl). To lift the CI spl downstream check, we need to wait until we have a v2.0 release. However, confidential transfers in the token extensions is high priority and it would be really great if we can include these changes as part of the v2.0 release. Furthermore, the necessary changes we would need includes renaming `solana-zk-token-sdk` to `solana-zk-sdk`. It would actually make things a lot simpler if we publish a new `solana-zk-sdk`, migrate the logic from `solana-zk-token-sdk` to it, and then deprecate `solana-zk-token-sdk` in the future.

#### Summary of Changes
Create the `zk-sdk` crate. I don't have anything in the crate yet. Each submodules from the `zk-token-sdk` will be moved into the new crate incrementally.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
