### PR TITLE
fix references on get_stored_account_meta_callback

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -205,7 +205,10 @@ impl AccountsFile {
     }
 
     /// Iterate over all accounts and call `callback` with each account.
-    pub(crate) fn scan_accounts(&self, callback: impl for<'local> FnMut(StoredAccountMeta<'local>)) {
+    pub(crate) fn scan_accounts(
+        &self,
+        callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
+    ) {
         match self {
             Self::AppendVec(av) => av.scan_accounts(callback),
             Self::TieredStorage(ts) => {

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -135,10 +135,10 @@ impl AccountsFile {
     }
 
     /// calls `callback` with the account located at the specified index offset.
-    pub fn get_stored_account_meta_callback<'a, Ret>(
-        &'a self,
+    pub fn get_stored_account_meta_callback<Ret>(
+        &self,
         offset: usize,
-        callback: impl FnMut(StoredAccountMeta<'a>) -> Ret,
+        callback: impl for<'local> FnMut(StoredAccountMeta<'local>) -> Ret,
     ) -> Option<Ret> {
         match self {
             Self::AppendVec(av) => av.get_stored_account_meta_callback(offset, callback),
@@ -205,7 +205,7 @@ impl AccountsFile {
     }
 
     /// Iterate over all accounts and call `callback` with each account.
-    pub(crate) fn scan_accounts(&self, callback: impl for<'a> FnMut(StoredAccountMeta<'a>)) {
+    pub(crate) fn scan_accounts(&self, callback: impl for<'local> FnMut(StoredAccountMeta<'local>)) {
         match self {
             Self::AppendVec(av) => av.scan_accounts(callback),
             Self::TieredStorage(ts) => {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -543,10 +543,10 @@ impl AppendVec {
     }
 
     /// calls `callback` with the account located at the specified index offset.
-    pub fn get_stored_account_meta_callback<'a, Ret>(
-        &'a self,
+    pub fn get_stored_account_meta_callback<Ret>(
+        &self,
         offset: usize,
-        mut callback: impl FnMut(StoredAccountMeta<'a>) -> Ret,
+        mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>) -> Ret,
     ) -> Option<Ret> {
         self.get_stored_account_meta(offset)
             .map(|(account, _offset)| callback(account))
@@ -688,7 +688,7 @@ impl AppendVec {
 
     /// Iterate over all accounts and call `callback` with each account.
     #[allow(clippy::blocks_in_conditions)]
-    pub(crate) fn scan_accounts(&self, mut callback: impl for<'a> FnMut(StoredAccountMeta<'a>)) {
+    pub(crate) fn scan_accounts(&self, mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>)) {
         let mut offset = 0;
         while self
             .get_stored_account_meta_callback(offset, |account| {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -688,7 +688,10 @@ impl AppendVec {
 
     /// Iterate over all accounts and call `callback` with each account.
     #[allow(clippy::blocks_in_conditions)]
-    pub(crate) fn scan_accounts(&self, mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>)) {
+    pub(crate) fn scan_accounts(
+        &self,
+        mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
+    ) {
         let mut offset = 0;
         while self
             .get_stored_account_meta_callback(offset, |account| {

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -525,10 +525,10 @@ impl HotStorageReader {
     }
 
     /// calls `callback` with the account located at the specified index offset.
-    pub fn get_stored_account_meta_callback<'a, Ret>(
-        &'a self,
+    pub fn get_stored_account_meta_callback<Ret>(
+        &self,
         index_offset: IndexOffset,
-        mut callback: impl FnMut(StoredAccountMeta<'a>) -> Ret,
+        mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>) -> Ret,
     ) -> TieredStorageResult<Option<Ret>> {
         let account = self.get_stored_account_meta(index_offset)?;
         Ok(account.map(|(account, _offset)| callback(account)))
@@ -633,7 +633,7 @@ impl HotStorageReader {
     /// Iterate over all accounts and call `callback` with each account.
     pub(crate) fn scan_accounts(
         &self,
-        mut callback: impl for<'a> FnMut(StoredAccountMeta<'a>),
+        mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
     ) -> TieredStorageResult<()> {
         for i in 0..self.footer.account_entry_count {
             self.get_stored_account_meta_callback(IndexOffset(i), &mut callback)?;

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -86,10 +86,10 @@ impl TieredStorageReader {
     }
 
     /// calls `callback` with the account located at the specified index offset.
-    pub fn get_stored_account_meta_callback<'a, Ret>(
-        &'a self,
+    pub fn get_stored_account_meta_callback<Ret>(
+        &self,
         index_offset: IndexOffset,
-        callback: impl FnMut(StoredAccountMeta<'a>) -> Ret,
+        callback: impl for<'local> FnMut(StoredAccountMeta<'local>) -> Ret,
     ) -> TieredStorageResult<Option<Ret>> {
         match self {
             Self::Hot(hot) => hot.get_stored_account_meta_callback(index_offset, callback),
@@ -148,7 +148,7 @@ impl TieredStorageReader {
     /// Iterate over all accounts and call `callback` with each account.
     pub(crate) fn scan_accounts(
         &self,
-        callback: impl for<'a> FnMut(StoredAccountMeta<'a>),
+        callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
     ) -> TieredStorageResult<()> {
         match self {
             Self::Hot(hot) => hot.scan_accounts(callback),


### PR DESCRIPTION
#### Problem
stop mmapping storage files.
The lifetimes are wrong on `get_stored_account_meta_callback`.

#### Summary of Changes
Fix references so callback data doesn't have lifetime of `self`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
