### PR TITLE
correct empty point submission check for metric submission

### DIFF
--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -686,10 +686,11 @@ mod test {
 
         agent.flush();
 
-        // We are expecting `max_points_per_sec - 1` data points from `submit()` and two more metric
+        // We are expecting `max_points_per_sec - 1` data points from `submit()` and one more metric
         // stats data points.  One from the timeout when all the `submit()`ed values are sent when 1
-        // second is elapsed, and then one more from the explicit `flush()`.
-        assert_eq!(writer.points_written(), max_points_per_sec + 1);
+        // second is elapsed, and the explicit `flush()` won't submit any point due to the fact that
+        // there is no additional points left to submit (empty flush doesn't submit stats data point).
+        assert_eq!(writer.points_written(), max_points_per_sec);
     }
 
     #[test]

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -280,7 +280,10 @@ impl MetricsAgent {
             counters,
         );
 
-        if !combined_points.is_empty() {
+        // `combined_points`` always contain a `metric` point for how many real
+        // datapoints are submitted at the end. Therefore, to skip empty point
+        // submission, `combined_points.len()` must be larger than 1.
+        if combined_points.len() > 1 {
             writer.write(combined_points);
         }
 


### PR DESCRIPTION
#### Problem

In https://github.com/anza-xyz/agave/pull/842, the fix that check empty point
is not correct since combined-points alwasy append a 'metric' point at the end. 

#### Summary of Changes

fix empty point check by len() > 1


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
