### PR TITLE
Reduce default from 8 to 1 TVU receive socket/threads

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -126,7 +126,7 @@ const MIN_NUM_STAKED_NODES: usize = 500;
 // Must have at least one socket to monitor the TVU port
 // The unsafes are safe because we're using fixed, known non-zero values
 pub const MINIMUM_NUM_TVU_SOCKETS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1) };
-pub const DEFAULT_NUM_TVU_SOCKETS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(8) };
+pub const DEFAULT_NUM_TVU_SOCKETS: NonZeroUsize = MINIMUM_NUM_TVU_SOCKETS;
 
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum ClusterInfoError {


### PR DESCRIPTION
#### Problem
We currently create 8 sockets/threads to pull out turbine shreds. Using 8 of these sockets is excessive, and actually leads to more inefficiencies (ie less densely packed `PacketBatch`) as some data below will show. We have a 1ms coalesce duration as part of the receiver, but given that we have 8 receivers all running independently, this 1ms coalesce doesn't mean much since they're all competing for packets. Part of work for https://github.com/anza-xyz/agave/issues/35

#### Summary of Changes
Reduce the default value of sockets/threads from 8 to 1.

One potential concern I could see for reducing the number of receivers would be if network load increased and over-burdened the single streamer. However, `bench-streamer` would indicate that the streamer can handle MUCH higher loads than what we're seeing
```
$ cargo run --release -- --num-recv-sockets 1
    Finished release [optimized] target(s) in 0.27s
     Running `/home/sol/src/agave/target/release/solana-bench-streamer --num-recv-sockets 1`
performance: 879154.6507920896 (PPS)
```
This is a micro-benchmark so its' results need to be noted with caution, but again, this is several orders of magnitude greater than the current mnb load of 2500-3000 inbound shreds per second.

#### Testing / Data
I've been running two nodes in an A/B setup; one node with the change and one without. The nodes were restarted with this change around 18:00 UTC on 2024/04/22. We'll examine `shred_sigverify` stats, as this is where the receivers all send their packets and where some of the gains can be observed.

For starters, we see similar values for `num_packets`, ignoring the restart spike around 18:00. This is not surprising / a basic sanity check:
<img width="1187" alt="image" src="https://github.com/anza-xyz/agave/assets/5400107/37ce338b-d1d1-4b81-90c4-286cee4a772c">

However, `num_batches` is significantly smaller for the node running this branch. To simplify, this graphs shows `num_packets` / `num_batches` to yield packets-per-batch:
<img width="1182" alt="image" src="https://github.com/anza-xyz/agave/assets/5400107/12c432d3-73cc-46cc-a2ab-5b0a78e5604b">
- The tip of master node is seeing something like 1.16 packets per batch. So, something like one 2-packet-batch to every five 1-packet-batches.
- The experiment node is showing ~3.5 packets per batch

More packets per batches means better locality, which we can see with a ~20% drop in total time spent via `elapsed_micros`:
<img width="1189" alt="image" src="https://github.com/anza-xyz/agave/assets/5400107/91b9fc6e-a967-4550-8d06-16a1d0d86392">

And less total time with the same number of packets also means a similar ~20% drop in average spent time per packet