### PR TITLE
cli: Update help text for deploy's `--use-rpc`

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -271,7 +271,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 ),
                         )
                         .arg(Arg::with_name("use_rpc").long("use-rpc").help(
-                            "Send transactions to the configured RPC instead of validator TPUs",
+                            "Send write transactions to the configured RPC instead of validator TPUs",
                         ))
                         .arg(compute_unit_price_arg()),
                 )


### PR DESCRIPTION
#### Problem

As mentioned at https://github.com/anza-xyz/agave/pull/928#discussion_r1576568431, the new help text isn't correct.

#### Summary of Changes

Clarify that only the write transactions are different with the `--use-rpc` flag

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
