### PR TITLE
SVM: move `TransactionProcessingCallback` into its own module

### DIFF
--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -20,7 +20,7 @@ use {
         signature::{Keypair, Signer},
         transaction::Transaction,
     },
-    solana_svm::transaction_processor::TransactionProcessingCallback,
+    solana_svm::transaction_processing_callback::TransactionProcessingCallback,
     std::{sync::Arc, thread::sleep, time::Duration},
     test::Bencher,
 };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -167,9 +167,9 @@ use {
         account_loader::{TransactionCheckResult, TransactionLoadResult},
         account_overrides::AccountOverrides,
         transaction_error_metrics::TransactionErrorMetrics,
+        transaction_processing_callback::TransactionProcessingCallback,
         transaction_processor::{
             ExecutionRecordingConfig, TransactionBatchProcessor, TransactionLogMessages,
-            TransactionProcessingCallback,
         },
         transaction_results::{
             TransactionExecutionDetails, TransactionExecutionResult, TransactionResults,

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         account_overrides::AccountOverrides, account_rent_state::RentState,
         transaction_error_metrics::TransactionErrorMetrics,
-        transaction_processor::TransactionProcessingCallback,
+        transaction_processing_callback::TransactionProcessingCallback,
     },
     itertools::Itertools,
     log::warn,
@@ -455,7 +455,7 @@ mod tests {
         super::*,
         crate::{
             transaction_account_state_info::TransactionAccountStateInfo,
-            transaction_processor::TransactionProcessingCallback,
+            transaction_processing_callback::TransactionProcessingCallback,
         },
         nonce::state::Versions as NonceVersions,
         solana_program_runtime::{

--- a/svm/src/lib.rs
+++ b/svm/src/lib.rs
@@ -8,6 +8,7 @@ pub mod message_processor;
 pub mod runtime_config;
 pub mod transaction_account_state_info;
 pub mod transaction_error_metrics;
+pub mod transaction_processing_callback;
 pub mod transaction_processor;
 pub mod transaction_results;
 

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,0 +1,38 @@
+use {
+    crate::transaction_error_metrics::TransactionErrorMetrics,
+    solana_program_runtime::loaded_programs::ProgramCacheMatchCriteria,
+    solana_sdk::{
+        account::AccountSharedData, feature_set::FeatureSet, hash::Hash, message::SanitizedMessage,
+        pubkey::Pubkey, rent_collector::RentCollector, transaction,
+    },
+    std::sync::Arc,
+};
+
+/// Runtime callbacks for transaction processing.
+pub trait TransactionProcessingCallback {
+    fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize>;
+
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
+
+    fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64);
+
+    fn get_rent_collector(&self) -> &RentCollector;
+
+    fn get_feature_set(&self) -> Arc<FeatureSet>;
+
+    fn check_account_access(
+        &self,
+        _message: &SanitizedMessage,
+        _account_index: usize,
+        _account: &AccountSharedData,
+        _error_counters: &mut TransactionErrorMetrics,
+    ) -> transaction::Result<()> {
+        Ok(())
+    }
+
+    fn get_program_match_criteria(&self, _program: &Pubkey) -> ProgramCacheMatchCriteria {
+        ProgramCacheMatchCriteria::NoCriteria
+    }
+
+    fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {}
+}

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -34,9 +34,8 @@ use {
         account_loader::TransactionCheckResult,
         runtime_config::RuntimeConfig,
         transaction_error_metrics::TransactionErrorMetrics,
-        transaction_processor::{
-            ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingCallback,
-        },
+        transaction_processing_callback::TransactionProcessingCallback,
+        transaction_processor::{ExecutionRecordingConfig, TransactionBatchProcessor},
         transaction_results::TransactionExecutionResult,
     },
     std::{

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -7,7 +7,7 @@ use {
         pubkey::Pubkey,
         rent_collector::RentCollector,
     },
-    solana_svm::transaction_processor::TransactionProcessingCallback,
+    solana_svm::transaction_processing_callback::TransactionProcessingCallback,
     std::{cell::RefCell, collections::HashMap, sync::Arc},
 };
 


### PR DESCRIPTION
#### Problem
As the SVM continues to grow, we should do our very best to ensure the 
entrypoint - 
`TransactionBatchProcessor::load_and_execute_sanitized_transactions` - remains 
as simple as possible. It should make use of other adjacent components to 
accomplish its goal.

In that spirit, we can modularize the components it needs, starting with the 
`TransactionProcessingCallback`.

#### Summary of Changes
Move `TransactionProcessingCallback` into its own module within the SVM.