### PR TITLE
cli: Use --use-rpc flag correctly during program deployments

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2815,7 +2815,7 @@ fn send_deploy_messages(
                         solana_client::tpu_client::TpuClientConfig::default(),
                         cache,
                     );
-                    let tpu_client = use_rpc.then(|| rpc_client
+                    let tpu_client = (!use_rpc).then(|| rpc_client
                         .runtime()
                         .block_on(tpu_client_fut)
                         .expect("Should return a valid tpu client")


### PR DESCRIPTION
#### Problem

As noticed in https://github.com/anza-xyz/agave/pull/928#discussion_r1576906616, the logic for `--use-rpc` is unfortunately backwards, since it's creating the tpu client if `use_rpc` is true, when we only want to create it when it's false.

#### Summary of Changes

Reverse the logic with a `!`

Big thanks to @amilkov3 for noticing and reporting this
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
