### PR TITLE
SVM: evict `program_modification_slot`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6745,7 +6745,7 @@ impl Bank {
     /// Returns an error if the program's account state can not be found or parsed.
     fn program_modification_slot(&self, pubkey: &Pubkey) -> transaction::Result<Slot> {
         let program = self
-            .get_account_with_fixed_root(pubkey)
+            .get_account(pubkey)
             .ok_or(TransactionError::ProgramAccountNotFound)?;
         if bpf_loader_upgradeable::check_id(program.owner()) {
             if let Ok(UpgradeableLoaderState::Program {
@@ -6753,7 +6753,7 @@ impl Bank {
             }) = program.state()
             {
                 let programdata = self
-                    .get_account_with_fixed_root(&programdata_address)
+                    .get_account(&programdata_address)
                     .ok_or(TransactionError::ProgramAccountNotFound)?;
                 if let Ok(UpgradeableLoaderState::ProgramData {
                     slot,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -109,6 +109,8 @@ use {
             create_account_shared_data_with_fields as create_account, from_account, Account,
             AccountSharedData, InheritableAccountFields, ReadableAccount, WritableAccount,
         },
+        account_utils::StateMut,
+        bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{
             BankId, Epoch, Slot, SlotCount, SlotIndex, UnixTimestamp, DEFAULT_HASHES_PER_TICK,
             DEFAULT_TICKS_PER_SECOND, INITIAL_RENT_EPOCH, MAX_PROCESSING_AGE,
@@ -131,6 +133,7 @@ use {
         incinerator,
         inflation::Inflation,
         inner_instruction::InnerInstructions,
+        loader_v4,
         message::{AccountKeys, SanitizedMessage},
         native_loader,
         native_token::LAMPORTS_PER_SOL,
@@ -6735,6 +6738,40 @@ impl Bank {
         self.transaction_processor
             .add_builtin(self, program_id, name, builtin)
     }
+
+    /// Find the slot in which the program was most recently modified.
+    /// Returns slot 0 for programs deployed with v1/v2 loaders, since programs deployed
+    /// with those loaders do not retain deployment slot information.
+    /// Returns an error if the program's account state can not be found or parsed.
+    fn program_modification_slot(&self, pubkey: &Pubkey) -> transaction::Result<Slot> {
+        let program = self
+            .get_account_with_fixed_root(pubkey)
+            .ok_or(TransactionError::ProgramAccountNotFound)?;
+        if bpf_loader_upgradeable::check_id(program.owner()) {
+            if let Ok(UpgradeableLoaderState::Program {
+                programdata_address,
+            }) = program.state()
+            {
+                let programdata = self
+                    .get_account_with_fixed_root(&programdata_address)
+                    .ok_or(TransactionError::ProgramAccountNotFound)?;
+                if let Ok(UpgradeableLoaderState::ProgramData {
+                    slot,
+                    upgrade_authority_address: _,
+                }) = programdata.state()
+                {
+                    return Ok(slot);
+                }
+            }
+            Err(TransactionError::ProgramAccountNotFound)
+        } else if loader_v4::check_id(program.owner()) {
+            let state = solana_loader_v4_program::get_state(program.data())
+                .map_err(|_| TransactionError::ProgramAccountNotFound)?;
+            Ok(state.slot)
+        } else {
+            Ok(0)
+        }
+    }
 }
 
 impl TransactionProcessingCallback for Bank {
@@ -6768,8 +6805,7 @@ impl TransactionProcessingCallback for Bank {
 
     fn get_program_match_criteria(&self, program: &Pubkey) -> ProgramCacheMatchCriteria {
         if self.check_program_modification_slot {
-            self.transaction_processor
-                .program_modification_slot(self, program)
+            self.program_modification_slot(program)
                 .map_or(ProgramCacheMatchCriteria::Tombstone, |slot| {
                     ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot)
                 })

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -70,6 +70,7 @@ use {
         incinerator,
         instruction::{AccountMeta, CompiledInstruction, Instruction, InstructionError},
         loader_upgradeable_instruction::UpgradeableLoaderInstruction,
+        loader_v4::{LoaderV4State, LoaderV4Status},
         message::{Message, MessageHeader, SanitizedMessage},
         native_loader,
         native_token::{sol_to_lamports, LAMPORTS_PER_SOL},
@@ -13099,4 +13100,86 @@ fn test_deploy_last_epoch_slot() {
     let transaction = Transaction::new(&signers, message, bank.last_blockhash());
     let result_with_feature_enabled = bank.process_transaction(&transaction);
     assert_eq!(result_with_feature_enabled, Ok(()));
+}
+
+#[test]
+fn test_program_modification_slot_account_not_found() {
+    let genesis_config = GenesisConfig::default();
+    let bank = Bank::new_for_tests(&genesis_config);
+    let key = Pubkey::new_unique();
+
+    let result = bank.program_modification_slot(&key);
+    assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
+
+    let mut account_data = AccountSharedData::default();
+    account_data.set_owner(bpf_loader_upgradeable::id());
+    bank.store_account(&key, &account_data);
+
+    let result = bank.program_modification_slot(&key);
+    assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
+
+    let state = UpgradeableLoaderState::Program {
+        programdata_address: Pubkey::new_unique(),
+    };
+    account_data.set_data(bincode::serialize(&state).unwrap());
+    bank.store_account(&key, &account_data);
+
+    let result = bank.program_modification_slot(&key);
+    assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
+
+    account_data.set_owner(loader_v4::id());
+    bank.store_account(&key, &account_data);
+
+    let result = bank.program_modification_slot(&key);
+    assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
+}
+
+#[test]
+fn test_program_modification_slot_success() {
+    let genesis_config = GenesisConfig::default();
+    let bank = Bank::new_for_tests(&genesis_config);
+    let key1 = Pubkey::new_unique();
+    let key2 = Pubkey::new_unique();
+    let mut account_data = AccountSharedData::default();
+    account_data.set_owner(bpf_loader_upgradeable::id());
+
+    let state = UpgradeableLoaderState::Program {
+        programdata_address: key2,
+    };
+    account_data.set_data(bincode::serialize(&state).unwrap());
+    bank.store_account(&key1, &account_data);
+
+    let state = UpgradeableLoaderState::ProgramData {
+        slot: 77,
+        upgrade_authority_address: None,
+    };
+    let mut account_data = AccountSharedData::default();
+    account_data.set_data(bincode::serialize(&state).unwrap());
+    bank.store_account(&key2, &account_data);
+
+    let result = bank.program_modification_slot(&key1);
+    assert_eq!(result.unwrap(), 77);
+
+    let mut account_data = AccountSharedData::default();
+    account_data.set_owner(loader_v4::id());
+    let state = LoaderV4State {
+        slot: 58,
+        authority_address: Pubkey::new_unique(),
+        status: LoaderV4Status::Deployed,
+    };
+
+    let encoded = unsafe {
+        std::mem::transmute::<&LoaderV4State, &[u8; LoaderV4State::program_data_offset()]>(&state)
+    };
+    account_data.set_data(encoded.to_vec());
+    bank.store_account(&key1, &account_data);
+
+    let result = bank.program_modification_slot(&key1);
+    assert_eq!(result.unwrap(), 58);
+
+    account_data.set_owner(Pubkey::new_unique());
+    bank.store_account(&key2, &account_data);
+
+    let result = bank.program_modification_slot(&key2);
+    assert_eq!(result.unwrap(), 0);
 }


### PR DESCRIPTION
#### Problem
The SVM's utility function `program_modification_slot` is only used by the 
validator runtime, not the SVM, to determine a program's last modified slot.

Only functions that are required by the SVM should be included in the SVM crate.


#### Summary of Changes
Evict `program_modification_slot` from SVM and place it in `Bank` - the only 
location it's used.