### PR TITLE
Change DEFAULT_TPU_CONNECTION_POOL_SIZE to 1

### DIFF
--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -21,7 +21,11 @@ use {
 
 pub const DEFAULT_TPU_ENABLE_UDP: bool = false;
 pub const DEFAULT_TPU_USE_QUIC: bool = true;
-pub const DEFAULT_TPU_CONNECTION_POOL_SIZE: usize = 4;
+
+/// The default connection count is set to 1 -- it should
+/// be sufficient for most use cases. Validators can use
+/// --tpu-connection-pool-size to override this default value.
+pub const DEFAULT_TPU_CONNECTION_POOL_SIZE: usize = 1;
 
 pub type Result<T> = std::result::Result<T, TpuSenderError>;
 


### PR DESCRIPTION
#### Problem

DEFAULT_TPU_CONNECTION_POOL_SIZE was set to 4 to maximize the performance when we do local performance testing with bench-tps. With the server side QOS restrictions per stake node and unstaked node, the benefit of more connections is less obvious while having more connections increase the load on the server especially during leader change.
This only change the default to 1. Validators still can use existing --tpu-connection-pool-size to override the default value.

#### Summary of Changes

Change DEFAULT_TPU_CONNECTION_POOL_SIZE to 1.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
