### PR TITLE
Do not start cache warmer if no rpc service uses the tpu cache

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -292,9 +292,7 @@ impl Tvu {
             tower_storage,
         );
 
-        let connection_cache_use_quic = connection_cache
-            .map(|cc| cc.use_quic())
-            .unwrap_or(false);
+        let connection_cache_use_quic = connection_cache.map(|cc| cc.use_quic()).unwrap_or(false);
         let warm_quic_cache_service = if connection_cache_use_quic {
             Some(WarmQuicCacheService::new(
                 connection_cache.unwrap().clone(),

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -292,18 +292,19 @@ impl Tvu {
             tower_storage,
         );
 
-        let warm_quic_cache_service =
-            connection_cache
-                .filter(|cache| cache.use_quic())
-                .map(|cache| {
-                    WarmQuicCacheService::new(
-                        cache.clone(),
-                        cluster_info.clone(),
-                        poh_recorder.clone(),
-                        exit.clone(),
-                    )
-                });
-
+        let connection_cache_use_quic = connection_cache
+            .map(|cc| cc.use_quic())
+            .unwrap_or(false);
+        let warm_quic_cache_service = if connection_cache_use_quic {
+            Some(WarmQuicCacheService::new(
+                connection_cache.clone(),
+                cluster_info.clone(),
+                poh_recorder.clone(),
+                exit.clone(),
+            ))
+        } else {
+            None
+        };
         let (cost_update_sender, cost_update_receiver) = unbounded();
         let cost_update_service = CostUpdateService::new(blockstore.clone(), cost_update_receiver);
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -150,7 +150,7 @@ impl Tvu {
         wait_to_vote_slot: Option<Slot>,
         accounts_background_request_sender: AbsRequestSender,
         log_messages_bytes_limit: Option<usize>,
-        connection_cache: &Arc<ConnectionCache>,
+        connection_cache: Option<&Arc<ConnectionCache>>,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         banking_tracer: Arc<BankingTracer>,
         turbine_quic_endpoint_sender: AsyncSender<(SocketAddr, Bytes)>,
@@ -292,16 +292,18 @@ impl Tvu {
             tower_storage,
         );
 
-        let warm_quic_cache_service = if connection_cache.use_quic() {
-            Some(WarmQuicCacheService::new(
-                connection_cache.clone(),
-                cluster_info.clone(),
-                poh_recorder.clone(),
-                exit.clone(),
-            ))
-        } else {
-            None
-        };
+        let warm_quic_cache_service =
+            connection_cache
+                .filter(|cache| cache.use_quic())
+                .map(|cache| {
+                    WarmQuicCacheService::new(
+                        cache.clone(),
+                        cluster_info.clone(),
+                        poh_recorder.clone(),
+                        exit.clone(),
+                    )
+                });
+
         let (cost_update_sender, cost_update_receiver) = unbounded();
         let cost_update_service = CostUpdateService::new(blockstore.clone(), cost_update_receiver);
 
@@ -509,7 +511,7 @@ pub mod tests {
             None,
             AbsRequestSender::default(),
             None,
-            &Arc::new(ConnectionCache::new("connection_cache_test")),
+            Some(&Arc::new(ConnectionCache::new("connection_cache_test"))),
             &ignored_prioritization_fee_cache,
             BankingTracer::new_disabled(),
             turbine_quic_endpoint_sender,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -297,7 +297,7 @@ impl Tvu {
             .unwrap_or(false);
         let warm_quic_cache_service = if connection_cache_use_quic {
             Some(WarmQuicCacheService::new(
-                connection_cache.clone(),
+                connection_cache.unwrap().clone(),
                 cluster_info.clone(),
                 poh_recorder.clone(),
                 exit.clone(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1325,7 +1325,7 @@ impl Validator {
             config.wait_to_vote_slot,
             accounts_background_request_sender,
             config.runtime_config.log_messages_bytes_limit,
-            &connection_cache,
+            json_rpc_service.is_some().then_some(&connection_cache), // for the cache warmer only used for STS for RPC service
             &prioritization_fee_cache,
             banking_tracer.clone(),
             turbine_quic_endpoint_sender.clone(),


### PR DESCRIPTION
#### Problem
The cache warmer is warming connections to TPU port. TPU port is only used for STS from RPC service. If RPC is not enabled, we are uselessly warming the cache and increase the load on leaders.

#### Summary of Changes
Do cache warming only when RPC service is enabled.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
