### PR TITLE
ci: ignore RUSTSEC-2024-0336 -- v1.17

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -33,6 +33,9 @@ cargo_audit_ignores=(
 
   # mio
   --ignore RUSTSEC-2024-0019
+
+  # rustls -- complete_io
+  --ignore RUSTSEC-2024-0336
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem

https://rustsec.org/advisories/RUSTSEC-2024-0336

#### Summary of Changes
vuln is against rustls servers. our only non-client-side usage is in quinn, which does not call the affected function. ignore it since bumping drags in implicit dependency bumps and this is the stable branch
