### PR TITLE
chore: remove CODEOWNERS from master

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @anza-xyz/backport-reviewers @anza-xyz/releng


### PR DESCRIPTION
#### Problem

context: #957, https://discord.com/channels/428295358100013066/560503042458517505/1232683850631741541

it seems that those two teams will be added to all PRs if we use CODEOWNERS mechanism.

https://github.com/orgs/community/discussions/22866

#### Summary of Changes

this PR is a preparation for removing CODEOWNERS.