### PR TITLE
rpc: Return accurate last valid block height

### DIFF
--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -125,6 +125,10 @@ impl BlockhashQueue {
         })
     }
 
+    #[deprecated(
+        since = "2.0.0",
+        note = "Please use `solana_program::clock::MAX_PROCESSING_AGE`"
+    )]
     pub fn get_max_age(&self) -> usize {
         self.max_age
     }

--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -58,6 +58,7 @@ impl BlockhashQueue {
     }
 
     /// Check if the age of the hash is within the queue's max age
+    #[deprecated(since = "2.0.0", note = "Please use `is_hash_valid_for_age` instead")]
     pub fn is_hash_valid(&self, hash: &Hash) -> bool {
         self.ages.get(hash).is_some()
     }
@@ -141,28 +142,30 @@ mod tests {
     #[test]
     fn test_register_hash() {
         let last_hash = Hash::default();
-        let mut hash_queue = BlockhashQueue::new(100);
-        assert!(!hash_queue.is_hash_valid(&last_hash));
+        let max_age = 100;
+        let mut hash_queue = BlockhashQueue::new(max_age);
+        assert!(!hash_queue.is_hash_valid_for_age(&last_hash, max_age));
         hash_queue.register_hash(&last_hash, 0);
-        assert!(hash_queue.is_hash_valid(&last_hash));
+        assert!(hash_queue.is_hash_valid_for_age(&last_hash, max_age));
         assert_eq!(hash_queue.last_hash_index, 1);
     }
 
     #[test]
     fn test_reject_old_last_hash() {
-        let mut hash_queue = BlockhashQueue::new(100);
+        let max_age = 100;
+        let mut hash_queue = BlockhashQueue::new(max_age);
         let last_hash = hash(&serialize(&0).unwrap());
         for i in 0..102 {
             let last_hash = hash(&serialize(&i).unwrap());
             hash_queue.register_hash(&last_hash, 0);
         }
         // Assert we're no longer able to use the oldest hash.
-        assert!(!hash_queue.is_hash_valid(&last_hash));
+        assert!(!hash_queue.is_hash_valid_for_age(&last_hash, max_age));
         assert!(!hash_queue.is_hash_valid_for_age(&last_hash, 0));
 
         // Assert we are not able to use the oldest remaining hash.
         let last_valid_hash = hash(&serialize(&1).unwrap());
-        assert!(hash_queue.is_hash_valid(&last_valid_hash));
+        assert!(hash_queue.is_hash_valid_for_age(&last_valid_hash, max_age));
         assert!(!hash_queue.is_hash_valid_for_age(&last_valid_hash, 0));
     }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -61,7 +61,7 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         account_utils::StateMut,
-        clock::{Slot, UnixTimestamp, MAX_RECENT_BLOCKHASHES},
+        clock::{Slot, UnixTimestamp, MAX_PROCESSING_AGE},
         commitment_config::{CommitmentConfig, CommitmentLevel},
         epoch_info::EpochInfo,
         epoch_schedule::EpochSchedule,
@@ -3676,8 +3676,7 @@ pub mod rpc_full {
                 // It provides a fallback timeout for durable-nonce transaction retries in case of
                 // malicious packing of the retry queue. Durable-nonce transactions are otherwise
                 // retried until the nonce is advanced.
-                last_valid_block_height =
-                    preflight_bank.block_height() + MAX_RECENT_BLOCKHASHES as u64;
+                last_valid_block_height = preflight_bank.block_height() + MAX_PROCESSING_AGE as u64;
             }
 
             if !skip_preflight {
@@ -4775,7 +4774,7 @@ pub mod tests {
                 self,
                 state::{AddressLookupTable, LookupTableMeta},
             },
-            clock::MAX_RECENT_BLOCKHASHES,
+            clock::MAX_PROCESSING_AGE,
             compute_budget::ComputeBudgetInstruction,
             fee_calculator::{FeeRateGovernor, DEFAULT_BURN_PERCENT},
             hash::{hash, Hash},
@@ -6764,8 +6763,8 @@ pub mod tests {
                     "feeCalculator": {
                         "lamportsPerSignature": TEST_SIGNATURE_FEE,
                     },
-                    "lastValidSlot": MAX_RECENT_BLOCKHASHES,
-                    "lastValidBlockHeight": MAX_RECENT_BLOCKHASHES,
+                    "lastValidSlot": MAX_PROCESSING_AGE,
+                    "lastValidBlockHeight": MAX_PROCESSING_AGE,
                 },
             },
             "id": 1

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3075,7 +3075,7 @@ impl Bank {
 
     pub fn is_blockhash_valid(&self, hash: &Hash) -> bool {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
-        blockhash_queue.is_hash_valid(hash)
+        blockhash_queue.is_hash_valid_for_age(hash, MAX_PROCESSING_AGE)
     }
 
     pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> u64 {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3161,7 +3161,7 @@ impl Bank {
         // length is made variable by epoch
         blockhash_queue
             .get_hash_age(blockhash)
-            .map(|age| self.slot + blockhash_queue.get_max_age() as u64 - age)
+            .map(|age| self.slot + MAX_PROCESSING_AGE as u64 - age)
     }
 
     pub fn get_blockhash_last_valid_block_height(&self, blockhash: &Hash) -> Option<Slot> {
@@ -3170,7 +3170,7 @@ impl Bank {
         // length is made variable by epoch
         blockhash_queue
             .get_hash_age(blockhash)
-            .map(|age| self.block_height + blockhash_queue.get_max_age() as u64 - age)
+            .map(|age| self.block_height + MAX_PROCESSING_AGE as u64 - age)
     }
 
     pub fn confirmed_last_blockhash(&self) -> Hash {


### PR DESCRIPTION
#### Problem

The last valid block height reported by RPC uses the size of the blockhash queue instead of the max processing age, doubling the age. Clients that retry until that block height has passed are waiting twice as long as they should before resending.

#### Summary of Changes

This aims to keep it pretty simple by deprecating `is_hash_valid` and `get_max_age`, which are based on the size of the queue, in favor of using `is_hash_valid_for_age` and `MAX_PROCESSING_AGE`. These functions were not used outside of the bank, so the fix is really at the bank level.

The functions on the bank that change, `is_blockhash_valid` and `get_blockhash_last_valid_block_height`, are only used by clients.

Fixes https://github.com/solana-labs/solana/issues/24526
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
