### PR TITLE
Reduce ProgramCache write lock contention

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -638,6 +638,7 @@ pub struct ProgramCacheForTxBatch {
     /// The epoch of the last rerooting
     pub latest_root_epoch: Epoch,
     pub hit_max_limit: bool,
+    pub loaded_missing: bool,
 }
 
 impl ProgramCacheForTxBatch {
@@ -654,6 +655,7 @@ impl ProgramCacheForTxBatch {
             upcoming_environments,
             latest_root_epoch,
             hit_max_limit: false,
+            loaded_missing: false,
         }
     }
 
@@ -669,6 +671,7 @@ impl ProgramCacheForTxBatch {
             upcoming_environments: cache.get_upcoming_environments_for_epoch(epoch),
             latest_root_epoch: cache.latest_root_epoch,
             hit_max_limit: false,
+            loaded_missing: false,
         }
     }
 
@@ -724,6 +727,10 @@ impl ProgramCacheForTxBatch {
         other.entries.iter().for_each(|(key, entry)| {
             self.replenish(*key, entry.clone());
         })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
     }
 }
 

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -639,6 +639,7 @@ pub struct ProgramCacheForTxBatch {
     pub latest_root_epoch: Epoch,
     pub hit_max_limit: bool,
     pub loaded_missing: bool,
+    pub merged_modified: bool,
 }
 
 impl ProgramCacheForTxBatch {
@@ -656,6 +657,7 @@ impl ProgramCacheForTxBatch {
             latest_root_epoch,
             hit_max_limit: false,
             loaded_missing: false,
+            merged_modified: false,
         }
     }
 
@@ -672,6 +674,7 @@ impl ProgramCacheForTxBatch {
             latest_root_epoch: cache.latest_root_epoch,
             hit_max_limit: false,
             loaded_missing: false,
+            merged_modified: false,
         }
     }
 
@@ -725,6 +728,7 @@ impl ProgramCacheForTxBatch {
 
     pub fn merge(&mut self, other: &Self) {
         other.entries.iter().for_each(|(key, entry)| {
+            self.merged_modified = true;
             self.replenish(*key, entry.clone());
         })
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4162,7 +4162,7 @@ impl Bank {
                 programs_modified_by_tx,
             } = execution_result
             {
-                if details.status.is_ok() {
+                if details.status.is_ok() && !programs_modified_by_tx.is_empty() {
                     let mut cache = self.transaction_processor.program_cache.write().unwrap();
                     cache.merge(programs_modified_by_tx);
                 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4156,6 +4156,7 @@ impl Bank {
 
         let mut store_executors_which_were_deployed_time =
             Measure::start("store_executors_which_were_deployed_time");
+        let mut cache = None;
         for execution_result in &execution_results {
             if let TransactionExecutionResult::Executed {
                 details,
@@ -4163,11 +4164,15 @@ impl Bank {
             } = execution_result
             {
                 if details.status.is_ok() && !programs_modified_by_tx.is_empty() {
-                    let mut cache = self.transaction_processor.program_cache.write().unwrap();
-                    cache.merge(programs_modified_by_tx);
+                    cache
+                        .get_or_insert_with(|| {
+                            self.transaction_processor.program_cache.write().unwrap()
+                        })
+                        .merge(programs_modified_by_tx);
                 }
             }
         }
+        drop(cache);
         store_executors_which_were_deployed_time.stop();
         saturating_add_assign!(
             timings.execute_accessories.update_executors_us,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -292,14 +292,20 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         execution_time.stop();
 
-        const SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE: u8 = 90;
-        self.program_cache
-            .write()
-            .unwrap()
-            .evict_using_2s_random_selection(
-                Percentage::from(SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE),
-                self.slot,
-            );
+        // Skip eviction when there's no chance this particular tx batch has increased the size of
+        // ProgramCache entries. Note that this flag is deliberately defined, so that there's still
+        // at least one other batch, which will evict the program cache, even after the occurrences
+        // of cooperative loading.
+        if programs_loaded_for_tx_batch.borrow().loaded_missing {
+            const SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE: u8 = 90;
+            self.program_cache
+                .write()
+                .unwrap()
+                .evict_using_2s_random_selection(
+                    Percentage::from(SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE),
+                    self.slot,
+                );
+        }
 
         debug!(
             "load: {}us execute: {}us txs_len={}",
@@ -395,6 +401,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 }
                 // Submit our last completed loading task.
                 if let Some((key, program)) = program_to_store.take() {
+                    loaded_programs_for_txs.as_mut().unwrap().loaded_missing = true;
                     if program_cache.finish_cooperative_loading_task(self.slot, key, program)
                         && limit_to_load_programs
                     {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -293,10 +293,12 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         execution_time.stop();
 
         // Skip eviction when there's no chance this particular tx batch has increased the size of
-        // ProgramCache entries. Note that this flag is deliberately defined, so that there's still
-        // at least one other batch, which will evict the program cache, even after the occurrences
-        // of cooperative loading.
-        if programs_loaded_for_tx_batch.borrow().loaded_missing {
+        // ProgramCache entries. Note that loaded_missing is deliberately defined, so that there's
+        // still at least one other batch, which will evict the program cache, even after the
+        // occurrences of cooperative loading.
+        if programs_loaded_for_tx_batch.borrow().loaded_missing
+            || programs_loaded_for_tx_batch.borrow().merged_modified
+        {
             const SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE: u8 = 90;
             self.program_cache
                 .write()


### PR DESCRIPTION
#### Problem

`ProgramCache`'s current locking behavior is needlessly hurting the unified scheduler's performance.

Unified scheduler is a new transaction scheduler for the block verification (i.e. the replaying stage). It doesn't employ batching at all as a design choice. Technically, the unified scheduler still is using `TransactionBatch`es but only with 1 transaction for each. That means it bares all the extra overheads, which has been amortized by batching.

Sidenote: I believe these overheads are all solvable (but not SOON except this one...). Also note that it's already 1.8x faster than the to-be-replaced `blockstore_processor` after this pr.

Among all those overhead sources, one of the most visible one is `ProgramCache`'s write-lock contentions. Currently, `ProgramCache` is write-locking _**3 times** unconditionally per 1-tx batch_ (for loading by `replenish_program_cache()`, for evictions by `load_and_execute_sanitized_transactions()`, for updated program commiting by `commit_transactions()`). so, it acutely hampers the unified scheduler concurrency.

#### Summary of Changes

Reduce `write-lock` of `ProgramCache` to bare-minimal. Now the usual case is 1 time for loading by `replenish_program_cache()`, while the worst case is still remaining at 3 times.

roughly ~5% consistent improvement. also note that `blockstore-processor` isn't affected while both are taking the same code-path.

#### perf improvements

##### before

```
# --block-verification-method unified-scheduler
ledger processed in 19 seconds, 182 ms
ledger processed in 19 seconds, 375 ms
ledger processed in 19 seconds, 460 ms

# --block-verification-method blockstore-processor
ledger processed in 32 seconds, 845 ms
ledger processed in 32 seconds, 786 ms
ledger processed in 32 seconds, 853 ms
```

##### after

after-the-pr's speedup-factor is now 1.8x:

```
irb(main):001:0> 32.691/17.970
=> 1.8191986644407347
```

```
# --block-verification-method unified-scheduler
ledger processed in 18 seconds, 77 ms
ledger processed in 17 seconds, 926 ms
ledger processed in 18 seconds, 126 ms

# --block-verification-method blockstore-processor
ledger processed in 32 seconds, 773 ms
ledger processed in 32 seconds, 691 ms
ledger processed in 32 seconds, 451 ms
```

### (for the record) the merged commit

before(3f7b352c417bf1efbf29a40455b08116ac8ca762):

```
ledger processed in 19 seconds, 347 ms
ledger processed in 19 seconds, 314 ms
ledger processed in 19 seconds, 278 ms
```

after(90bea332b2dcc789c53588dff2d138f7e2ef651b):

```
ledger processed in 18 seconds, 29 ms
ledger processed in 18 seconds, 78 ms
ledger processed in 18 seconds, 114 ms
```



context: extracted from https://github.com/anza-xyz/agave/pull/593

cc: @apfitzge 