### PR TITLE
Refactor - ProgramCache tests

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -2185,24 +2185,21 @@ mod tests {
         // Testing fork 0 - 10 - 12 - 22 with current slot at 22
         let mut missing =
             get_entries_to_load(&cache, 22, &[program1, program2, program3, program4]);
-        let mut extracted = ProgramCacheForTxBatch::new(22, cache.environments.clone(), None, 0);
-        cache.extract(&mut missing, &mut extracted, true);
-
-        assert!(match_slot(&extracted, &program1, 20, 22));
-        assert!(match_slot(&extracted, &program4, 0, 22));
-
         assert_eq!(match_missing(&missing, &program2), false);
         assert_eq!(match_missing(&missing, &program3), false);
+        let mut extracted = ProgramCacheForTxBatch::new(22, cache.environments.clone(), None, 0);
+        cache.extract(&mut missing, &mut extracted, true);
+        assert!(match_slot(&extracted, &program1, 20, 22));
+        assert!(match_slot(&extracted, &program4, 0, 22));
 
         // Testing fork 0 - 5 - 11 - 15 - 16 with current slot at 15
         let mut missing =
             get_entries_to_load(&cache, 15, &[program1, program2, program3, program4]);
+        assert_eq!(match_missing(&missing, &program3), false);
         let mut extracted = ProgramCacheForTxBatch::new(15, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 15));
         assert!(match_slot(&extracted, &program2, 11, 15));
-
         // The effective slot of program4 deployed in slot 15 is 19. So it should not be usable in slot 16.
         // A delay visibility tombstone should be returned here.
         let tombstone = extracted
@@ -2211,42 +2208,34 @@ mod tests {
         assert_matches!(tombstone.program, ProgramCacheEntryType::DelayVisibility);
         assert_eq!(tombstone.deployment_slot, 15);
 
-        assert_eq!(match_missing(&missing, &program3), false);
-
         // Testing the same fork above, but current slot is now 18 (equal to effective slot of program4).
         let mut missing =
             get_entries_to_load(&cache, 18, &[program1, program2, program3, program4]);
+        assert_eq!(match_missing(&missing, &program3), false);
         let mut extracted = ProgramCacheForTxBatch::new(18, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 18));
         assert!(match_slot(&extracted, &program2, 11, 18));
-
         // The effective slot of program4 deployed in slot 15 is 18. So it should be usable in slot 18.
         assert!(match_slot(&extracted, &program4, 15, 18));
-
-        assert_eq!(match_missing(&missing, &program3), false);
 
         // Testing the same fork above, but current slot is now 23 (future slot than effective slot of program4).
         let mut missing =
             get_entries_to_load(&cache, 23, &[program1, program2, program3, program4]);
+        assert_eq!(match_missing(&missing, &program3), false);
         let mut extracted = ProgramCacheForTxBatch::new(23, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 23));
         assert!(match_slot(&extracted, &program2, 11, 23));
-
         // The effective slot of program4 deployed in slot 15 is 19. So it should be usable in slot 23.
         assert!(match_slot(&extracted, &program4, 15, 23));
-
-        assert_eq!(match_missing(&missing, &program3), false);
 
         // Testing fork 0 - 5 - 11 - 15 - 16 with current slot at 11
         let mut missing =
             get_entries_to_load(&cache, 11, &[program1, program2, program3, program4]);
+        assert_eq!(match_missing(&missing, &program3), false);
         let mut extracted = ProgramCacheForTxBatch::new(11, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 11));
         // program2 was updated at slot 11, but is not effective till slot 12. The result should contain a tombstone.
         let tombstone = extracted
@@ -2255,8 +2244,6 @@ mod tests {
         assert_matches!(tombstone.program, ProgramCacheEntryType::DelayVisibility);
         assert_eq!(tombstone.deployment_slot, 11);
         assert!(match_slot(&extracted, &program4, 5, 11));
-
-        assert_eq!(match_missing(&missing, &program3), false);
 
         cache.prune(5, 0);
 
@@ -2278,22 +2265,19 @@ mod tests {
         // Testing fork 11 - 15 - 16- 19 - 22 with root at 5 and current slot at 22
         let mut missing =
             get_entries_to_load(&cache, 21, &[program1, program2, program3, program4]);
+        assert_eq!(match_missing(&missing, &program3), false);
         let mut extracted = ProgramCacheForTxBatch::new(21, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         // Since the fork was pruned, we should not find the entry deployed at slot 20.
         assert!(match_slot(&extracted, &program1, 0, 21));
         assert!(match_slot(&extracted, &program2, 11, 21));
         assert!(match_slot(&extracted, &program4, 15, 21));
-
-        assert_eq!(match_missing(&missing, &program3), false);
 
         // Testing fork 0 - 5 - 11 - 25 - 27 with current slot at 27
         let mut missing =
             get_entries_to_load(&cache, 27, &[program1, program2, program3, program4]);
         let mut extracted = ProgramCacheForTxBatch::new(27, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 27));
         assert!(match_slot(&extracted, &program2, 11, 27));
         assert!(match_slot(&extracted, &program3, 25, 27));
@@ -2319,15 +2303,12 @@ mod tests {
         // Testing fork 16, 19, 23, with root at 15, current slot at 23
         let mut missing =
             get_entries_to_load(&cache, 23, &[program1, program2, program3, program4]);
+        assert_eq!(match_missing(&missing, &program3), false);
         let mut extracted = ProgramCacheForTxBatch::new(23, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 23));
         assert!(match_slot(&extracted, &program2, 11, 23));
         assert!(match_slot(&extracted, &program4, 15, 23));
-
-        // program3 was deployed on slot 25, which has been pruned
-        assert_eq!(match_missing(&missing, &program3), false);
     }
 
     #[test]
@@ -2370,25 +2351,21 @@ mod tests {
 
         // Testing fork 0 - 5 - 11 - 15 - 16 - 19 - 21 - 23 with current slot at 19
         let mut missing = get_entries_to_load(&cache, 12, &[program1, program2, program3]);
+        assert_eq!(match_missing(&missing, &program3), false);
         let mut extracted = ProgramCacheForTxBatch::new(12, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 12));
         assert!(match_slot(&extracted, &program2, 11, 12));
-
-        assert_eq!(match_missing(&missing, &program3), false);
 
         // Test the same fork, but request the program modified at a later slot than what's in the cache.
         let mut missing = get_entries_to_load(&cache, 12, &[program1, program2, program3]);
         missing.get_mut(0).unwrap().1 .0 = ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(5);
         missing.get_mut(1).unwrap().1 .0 = ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(5);
+        assert_eq!(match_missing(&missing, &program3), false);
         let mut extracted = ProgramCacheForTxBatch::new(12, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
-        assert!(match_slot(&extracted, &program2, 11, 12));
-
         assert_eq!(match_missing(&missing, &program1), true);
-        assert_eq!(match_missing(&missing, &program3), false);
+        assert!(match_slot(&extracted, &program2, 11, 12));
     }
 
     #[test]
@@ -2444,32 +2421,26 @@ mod tests {
 
         // Testing fork 0 - 5 - 11 - 15 - 16 - 19 - 21 - 23 with current slot at 19
         let mut missing = get_entries_to_load(&cache, 19, &[program1, program2, program3]);
+        assert_eq!(match_missing(&missing, &program3), false);
         let mut extracted = ProgramCacheForTxBatch::new(19, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 19));
         assert!(match_slot(&extracted, &program2, 11, 19));
-
-        assert_eq!(match_missing(&missing, &program3), false);
 
         // Testing fork 0 - 5 - 11 - 25 - 27 with current slot at 27
         let mut missing = get_entries_to_load(&cache, 27, &[program1, program2, program3]);
         let mut extracted = ProgramCacheForTxBatch::new(27, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 27));
         assert!(match_slot(&extracted, &program2, 11, 27));
-
         assert_eq!(match_missing(&missing, &program3), true);
 
         // Testing fork 0 - 10 - 20 - 22 with current slot at 22
         let mut missing = get_entries_to_load(&cache, 22, &[program1, program2, program3]);
+        assert_eq!(match_missing(&missing, &program2), false);
         let mut extracted = ProgramCacheForTxBatch::new(22, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 20, 22));
-
-        assert_eq!(match_missing(&missing, &program2), false);
         assert_eq!(match_missing(&missing, &program3), true);
     }
 
@@ -2591,16 +2562,14 @@ mod tests {
         let mut missing = get_entries_to_load(&cache, 20, &[program1, program2]);
         let mut extracted = ProgramCacheForTxBatch::new(20, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 20));
         assert!(match_slot(&extracted, &program2, 10, 20));
 
         let mut missing = get_entries_to_load(&cache, 6, &[program1, program2]);
+        assert_eq!(match_missing(&missing, &program2), false);
         let mut extracted = ProgramCacheForTxBatch::new(6, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 5, 6));
-        assert_eq!(match_missing(&missing, &program2), false);
 
         // Pruning slot 5 will remove program1 entry deployed at slot 5.
         // On fork chaining from slot 5, the entry deployed at slot 0 will become visible.
@@ -2609,27 +2578,24 @@ mod tests {
         let mut missing = get_entries_to_load(&cache, 20, &[program1, program2]);
         let mut extracted = ProgramCacheForTxBatch::new(20, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 20));
         assert!(match_slot(&extracted, &program2, 10, 20));
 
         let mut missing = get_entries_to_load(&cache, 6, &[program1, program2]);
+        assert_eq!(match_missing(&missing, &program2), false);
         let mut extracted = ProgramCacheForTxBatch::new(6, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 6));
-        assert_eq!(match_missing(&missing, &program2), false);
 
         // Pruning slot 10 will remove program2 entry deployed at slot 10.
         // As there is no other entry for program2, extract() will return it as missing.
         cache.prune_by_deployment_slot(10);
 
         let mut missing = get_entries_to_load(&cache, 20, &[program1, program2]);
+        assert_eq!(match_missing(&missing, &program2), false);
         let mut extracted = ProgramCacheForTxBatch::new(20, cache.environments.clone(), None, 0);
         cache.extract(&mut missing, &mut extracted, true);
-
         assert!(match_slot(&extracted, &program1, 0, 20));
-        assert_eq!(match_missing(&missing, &program2), false);
     }
 
     #[test]

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -2446,6 +2446,20 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_nonexistent() {
+        let mut cache = new_mock_cache::<TestForkGraphSpecific>();
+        let fork_graph = TestForkGraphSpecific::default();
+        let fork_graph = Arc::new(RwLock::new(fork_graph));
+        cache.set_fork_graph(fork_graph);
+
+        let program1 = Pubkey::new_unique();
+        let mut missing = vec![(program1, (ProgramCacheMatchCriteria::NoCriteria, 1))];
+        let mut extracted = ProgramCacheForTxBatch::new(0, cache.environments.clone(), None, 0);
+        cache.extract(&mut missing, &mut extracted, true);
+        assert!(match_missing(&missing, &program1, true));
+    }
+
+    #[test]
     fn test_unloaded() {
         let mut cache = new_mock_cache::<TestForkGraph>();
         for program_cache_entry_type in [


### PR DESCRIPTION
#### Problem
The `ProgramCache` tests currently feed in lists of missing programs containing entries which are nonexistent in the `Slot` which is being extracted. However, in [integration this never happens](https://github.com/anza-xyz/agave/blob/15f2dad30304766f4689f04e9086019acf576e20/svm/src/program_loader.rs#L521) as we don't try to load programs from nonexistent accounts. Instead this case should only be tested in a single dedicated unit test.

With this PR developing alternatives for the second level index should become easier.

#### Summary of Changes
- Adds `get_entries_to_load()` which generates the missing list automatically depending on what exists in the loading `Slot`.
- Differentiates nonexistent accounts from unloaded entries in `match_missing()` with a `expected_result` parameter.
- Adds `test_extract_nonexistent()` which is now the only place covering this case.