### PR TITLE
Add --enable-bigtable-ledger-upload Support to solana-test-validator

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -423,9 +423,11 @@ fn main() {
         None
     };
 
-    let rpc_bigtable_config = if matches.is_present("enable_rpc_bigtable_ledger_storage") {
+    let rpc_bigtable_config = if matches.is_present("enable_rpc_bigtable_ledger_storage")
+        || matches.is_present("enable_bigtable_ledger_upload")
+    {
         Some(RpcBigtableConfig {
-            enable_bigtable_ledger_upload: false,
+            enable_bigtable_ledger_upload: matches.is_present("enable_bigtable_ledger_upload"),
             bigtable_instance_name: value_t_or_exit!(matches, "rpc_bigtable_instance", String),
             bigtable_app_profile_id: value_t_or_exit!(
                 matches,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2775,6 +2775,12 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .validator(is_parsable::<u64>)
                 .takes_value(true)
                 .help("Override the runtime's account lock limit per transaction"),
+        )
+        .arg(
+            Arg::with_name("enable_bigtable_ledger_upload")
+                .long("enable-bigtable-ledger-upload")
+                .takes_value(false)
+                .help("Enable ledger upload to BigTable"),
         );
 }
 

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2455,6 +2455,13 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 ),
         )
         .arg(
+            Arg::with_name("enable_bigtable_ledger_upload")
+                .long("enable-bigtable-ledger-upload")
+                .takes_value(false)
+                .hidden(hidden_unless_forced())
+                .help("Upload new confirmed blocks into a BigTable instance"),
+        )
+        .arg(
             Arg::with_name("rpc_bigtable_instance")
                 .long("rpc-bigtable-instance")
                 .value_name("INSTANCE_NAME")
@@ -2775,12 +2782,6 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .validator(is_parsable::<u64>)
                 .takes_value(true)
                 .help("Override the runtime's account lock limit per transaction"),
-        )
-        .arg(
-            Arg::with_name("enable_bigtable_ledger_upload")
-                .long("enable-bigtable-ledger-upload")
-                .takes_value(false)
-                .help("Enable ledger upload to BigTable"),
         );
 }
 


### PR DESCRIPTION
#### Problem
I required the _solana-test-validator_ to interface with Google BigTable to simulate production-like data storage and retrieval, but found that it  did not support the `--enable-bigtable-ledger-upload` flag as _solana-validator_ does

#### Summary of Changes
This pull request introduces a new command-line parameter, --enable-bigtable-ledger-upload, to the solana-test-validator. This PR provides developers the option to enable BigTable ledger uploads directly from the test validator, facilitating better integration and testing against Google Cloud's BigTable service.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
