### PR TITLE
consensus: restrict switching proofs from greatest common ancestor

### DIFF
--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -269,6 +269,15 @@ impl VoteSimulator {
             .push((lockout_interval.0, *vote_account_pubkey));
     }
 
+    pub fn clear_lockout_intervals(&mut self, slot: Slot) {
+        self.progress
+            .entry(slot)
+            .or_insert_with(|| ForkProgress::new(Hash::default(), None, None, 0, 0))
+            .fork_stats
+            .lockout_intervals
+            .clear()
+    }
+
     pub fn can_progress_on_fork(
         &mut self,
         my_pubkey: &Pubkey,


### PR DESCRIPTION
For a validator who voted on `last_voted_slot` and is trying to switch to `switch_slot`, we add an additional restriction for switching proof construction.

Votes from other validators on `candidate_slot` must pass this additional restriction for inclusion in the proof:
`gca(last_voted_slot, switch_slot) >= gca(last_voted_slot, candidate_slot)` where `gca` is the greatest common ancestor (by slot #)  