### PR TITLE
Add field to validator-new datapoint for Validator::new() time

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -512,6 +512,8 @@ impl Validator {
         tpu_enable_udp: bool,
         admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
     ) -> Result<Self, String> {
+        let start_time = Instant::now();
+
         let id = identity_keypair.pubkey();
         assert_eq!(&id, node.info.pubkey());
 
@@ -1403,6 +1405,7 @@ impl Validator {
             ("id", id.to_string(), String),
             ("version", solana_version::version!(), String),
             ("cluster_type", genesis_config.cluster_type as u32, i64),
+            ("elapsed_ms", start_time.elapsed().as_millis() as i64, i64),
             ("waited_for_supermajority", waited_for_supermajority, bool),
             ("expected_shred_version", config.expected_shred_version, Option<i64>),
         );


### PR DESCRIPTION
#### Problem
Startup time is a pretty important metric; some of the sub-pieces are instrumented out but it is hard to tell what the total amount of time is.

#### Summary of Changes
Add a field that measure the total time from start to finish in `Validator::new()`