### PR TITLE
SVM: move `feature_set` out of callbacks

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1108,12 +1108,12 @@ impl Bank {
 
         let (epoch_stakes, epoch_stakes_time_us) = measure_us!(parent.epoch_stakes.clone());
 
+        let (rewards_pool_pubkeys, rewards_pool_pubkeys_time_us) =
+            measure_us!(parent.rewards_pool_pubkeys.clone());
+
         let (transaction_processor, builtin_program_ids_time_us) = measure_us!(
             TransactionBatchProcessor::new_from(&parent.transaction_processor, slot, epoch)
         );
-
-        let (rewards_pool_pubkeys, rewards_pool_pubkeys_time_us) =
-            measure_us!(parent.rewards_pool_pubkeys.clone());
 
         let (transaction_debug_keys, transaction_debug_keys_time_us) =
             measure_us!(parent.transaction_debug_keys.clone());
@@ -3740,6 +3740,7 @@ impl Bank {
             .load_and_execute_sanitized_transactions(
                 self,
                 sanitized_txs,
+                &self.feature_set,
                 &mut check_results,
                 &mut error_counters,
                 recording_config,
@@ -6806,10 +6807,6 @@ impl TransactionProcessingCallback for Bank {
 
     fn get_rent_collector(&self) -> &RentCollector {
         &self.rent_collector
-    }
-
-    fn get_feature_set(&self) -> Arc<FeatureSet> {
-        self.feature_set.clone()
     }
 
     fn get_program_match_criteria(&self, program: &Pubkey) -> ProgramCacheMatchCriteria {

--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -80,7 +80,7 @@ Validator and in third-party applications.
 
 The interface to SVM is represented by the
 `transaction_processor::TransactionBatchProcessor` struct.  To create
-a `TransactionBatchProcessor` object the client need to specify the
+a `TransactionBatchProcessor` object the client needs to specify the
 `slot`, `epoch`, `epoch_schedule`, `fee_structure`, `runtime_config`,
 and `program_cache`.
 
@@ -138,6 +138,9 @@ following arguments
         - a Hash of the message
         - a boolean flag `is_simple_vote_tx` -- explain
         - a vector of `Signature`  -- explain which signatures are in this vector
+    - `feature_set: &FeatureSet` The current runtime feature set, used to
+      determine conditional feature-gated SVM functionality to enable based on
+      the cluster's feature set.
     - `check_results` is a mutable slice of `TransactionCheckResult`
     - `error_counters` is a mutable reference to `TransactionErrorMetrics`
     - `recording_config` is a value of `ExecutionRecordingConfig` configuration parameters

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -246,8 +246,8 @@ mod tests {
             solana_rbpf::program::BuiltinProgram,
         },
         solana_sdk::{
-            account::WritableAccount, bpf_loader, bpf_loader_upgradeable, feature_set::FeatureSet,
-            hash::Hash, rent_collector::RentCollector,
+            account::WritableAccount, bpf_loader, bpf_loader_upgradeable, hash::Hash,
+            rent_collector::RentCollector,
         },
         std::{
             cell::RefCell,
@@ -269,7 +269,6 @@ mod tests {
     #[derive(Default, Clone)]
     pub struct MockBankCallback {
         rent_collector: RentCollector,
-        feature_set: Arc<FeatureSet>,
         pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
     }
 
@@ -296,10 +295,6 @@ mod tests {
 
         fn get_rent_collector(&self) -> &RentCollector {
             &self.rent_collector
-        }
-
-        fn get_feature_set(&self) -> Arc<FeatureSet> {
-            self.feature_set.clone()
         }
 
         fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -2,10 +2,9 @@ use {
     crate::transaction_error_metrics::TransactionErrorMetrics,
     solana_program_runtime::loaded_programs::ProgramCacheMatchCriteria,
     solana_sdk::{
-        account::AccountSharedData, feature_set::FeatureSet, hash::Hash, message::SanitizedMessage,
-        pubkey::Pubkey, rent_collector::RentCollector, transaction,
+        account::AccountSharedData, hash::Hash, message::SanitizedMessage, pubkey::Pubkey,
+        rent_collector::RentCollector, transaction,
     },
-    std::sync::Arc,
 };
 
 /// Runtime callbacks for transaction processing.
@@ -17,8 +16,6 @@ pub trait TransactionProcessingCallback {
     fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64);
 
     fn get_rent_collector(&self) -> &RentCollector;
-
-    fn get_feature_set(&self) -> Arc<FeatureSet>;
 
     fn check_account_access(
         &self,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -23,6 +23,7 @@ use {
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{Clock, Epoch, Slot, UnixTimestamp},
         epoch_schedule::EpochSchedule,
+        feature_set::FeatureSet,
         hash::Hash,
         instruction::AccountMeta,
         pubkey::Pubkey,
@@ -457,6 +458,7 @@ fn svm_integration() {
     let result = batch_processor.load_and_execute_sanitized_transactions(
         &mock_bank,
         &transactions,
+        &FeatureSet::default(),
         check_results.as_mut_slice(),
         &mut error_counter,
         recording_config,

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -1,20 +1,18 @@
 use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
-        feature_set::FeatureSet,
         hash::Hash,
         native_loader,
         pubkey::Pubkey,
         rent_collector::RentCollector,
     },
     solana_svm::transaction_processing_callback::TransactionProcessingCallback,
-    std::{cell::RefCell, collections::HashMap, sync::Arc},
+    std::{cell::RefCell, collections::HashMap},
 };
 
 #[derive(Default)]
 pub struct MockBankCallback {
     rent_collector: RentCollector,
-    feature_set: Arc<FeatureSet>,
     pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
 }
 
@@ -42,10 +40,6 @@ impl TransactionProcessingCallback for MockBankCallback {
 
     fn get_rent_collector(&self) -> &RentCollector {
         &self.rent_collector
-    }
-
-    fn get_feature_set(&self) -> Arc<FeatureSet> {
-        self.feature_set.clone()
     }
 
     fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {


### PR DESCRIPTION
#### Problem
SVM requires a valid list of Solana runtime features in order to determine whether or
not to use feature-gated functionality. This feature set is currently provided via runtime
callbacks.

SVM's runtime callbacks can be de-cluttered by instead requiring the feature set to be
provided when processing a batch of transactions.

#### Summary of Changes
Move `feature_set` out of callbacks and into the SVM entrypoint
`load_and_execute_sanitized_transactions`.