### PR TITLE
runtime/Optimize accounts loading (cache+skip program cache)

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5392,6 +5392,68 @@ impl AccountsDb {
         self.read_only_accounts_cache.reset_for_tests();
     }
 
+    /// Load account with `pubkey`. `callback` is used to decide whether to
+    /// store the account into read cache after loading.
+    ///
+    /// Return the account and the slot when the account was last stored.
+    /// Return None for ZeroLamport accounts.
+    pub fn load_account_with(
+        &self,
+        ancestors: &Ancestors,
+        pubkey: &Pubkey,
+        callback: impl Fn(&AccountSharedData) -> bool,
+    ) -> Option<(AccountSharedData, Slot)> {
+        let (slot, storage_location, _maybe_account_accesor) =
+            self.read_index_for_accessor_or_load_slow(ancestors, pubkey, None, false)?;
+        // Notice the subtle `?` at previous line, we bail out pretty early if missing.
+
+        let in_write_cache = storage_location.is_cached();
+        if !in_write_cache {
+            let result = self.read_only_accounts_cache.load(*pubkey, slot);
+            if let Some(account) = result {
+                if account.is_zero_lamport() {
+                    return None;
+                }
+                return Some((account, slot));
+            }
+        }
+
+        let (mut account_accessor, slot) = self.retry_to_get_account_accessor(
+            slot,
+            storage_location,
+            ancestors,
+            pubkey,
+            None,
+            LoadHint::Unspecified,
+        )?;
+
+        // note that the account being in the cache could be different now than it was previously
+        // since the cache could be flushed in between the 2 calls.
+        let in_write_cache = matches!(account_accessor, LoadedAccountAccessor::Cached(_));
+        let account = account_accessor.check_and_get_loaded_account_shared_data();
+        if account.is_zero_lamport() {
+            return None;
+        }
+
+        if !in_write_cache && callback(&account) {
+            /*
+            We show this store into the read-only cache for account 'A' and future loads of 'A' from the read-only cache are
+            safe/reflect 'A''s latest state on this fork.
+            This safety holds if during replay of slot 'S', we show we only read 'A' from the write cache,
+            not the read-only cache, after it's been updated in replay of slot 'S'.
+            Assume for contradiction this is not true, and we read 'A' from the read-only cache *after* it had been updated in 'S'.
+            This means an entry '(S, A)' was added to the read-only cache after 'A' had been updated in 'S'.
+            Now when '(S, A)' was being added to the read-only cache, it must have been true that  'is_cache == false',
+            which means '(S', A)' does not exist in the write cache yet.
+            However, by the assumption for contradiction above ,  'A' has already been updated in 'S' which means '(S, A)'
+            must exist in the write cache, which is a contradiction.
+            */
+            self.read_only_accounts_cache
+                .store(*pubkey, slot, account.clone());
+        }
+        Some((account, slot))
+    }
+
     /// if 'load_into_read_cache_only', then return value is meaningless.
     ///   The goal is to get the account into the read-only cache.
     fn do_load_with_populate_read_cache(
@@ -13550,6 +13612,51 @@ pub mod tests {
             .map(|(account, _)| account);
         assert!(account.is_none());
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+    }
+
+    #[test]
+    fn test_load_with_read_only_accounts_cache() {
+        let db = Arc::new(AccountsDb::new_single_for_tests());
+
+        let account_key = Pubkey::new_unique();
+        let zero_lamport_account =
+            AccountSharedData::new(0, 0, AccountSharedData::default().owner());
+        let slot1_account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
+        db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]), None);
+        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None);
+
+        db.add_root(0);
+        db.add_root(1);
+        db.clean_accounts_for_tests();
+        db.flush_accounts_cache(true, None);
+        db.clean_accounts_for_tests();
+        db.add_root(2);
+
+        assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
+        let (account, slot) = db
+            .load_account_with(&Ancestors::default(), &account_key, |_| false)
+            .unwrap();
+        assert_eq!(account.lamports(), 1);
+        assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
+        assert_eq!(slot, 1);
+
+        let (account, slot) = db
+            .load_account_with(&Ancestors::default(), &account_key, |_| true)
+            .unwrap();
+        assert_eq!(account.lamports(), 1);
+        assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+        assert_eq!(slot, 1);
+
+        db.store_cached((2, &[(&account_key, &zero_lamport_account)][..]), None);
+        let account = db.load_account_with(&Ancestors::default(), &account_key, |_| false);
+        assert!(account.is_none());
+        assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+
+        db.read_only_accounts_cache.reset_for_tests();
+        assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
+        let account = db.load_account_with(&Ancestors::default(), &account_key, |_| true);
+        assert!(account.is_none());
+        assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
     }
 
     #[test]

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -971,6 +971,10 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         }
     }
 
+    pub fn contains_key(&self, key: &Pubkey) -> bool {
+        self.entries.contains_key(key)
+    }
+
     /// Extracts a subset of the programs relevant to a transaction batch
     /// and returns which program accounts the accounts DB needs to load.
     pub fn extract(

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -19,6 +19,7 @@ use {
         loader_v4, native_loader,
         pubkey::Pubkey,
         saturating_add_assign,
+        sysvar::recent_blockhashes::Entry,
     },
     std::{
         collections::HashMap,
@@ -1061,6 +1062,12 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             );
         }
         cooperative_loading_task
+    }
+
+    pub fn clear_cooperative_loading_task_lock(&mut self, key: &Pubkey) {
+        if let Some(ref mut second_level) = self.entries.get_mut(key) {
+            second_level.cooperative_loading_lock = None;
+        }
     }
 
     /// Called by Bank::replenish_program_cache() for each program that is done loading.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6737,6 +6737,7 @@ impl Bank {
             effective_epoch,
             self.epoch_schedule(),
             reload,
+            &HashMap::default(),
         )
     }
 
@@ -6795,6 +6796,17 @@ impl TransactionProcessingCallback for Bank {
             .accounts_db
             .account_matches_owners(&self.ancestors, account, owners)
             .ok()
+    }
+
+    fn load_account_with(
+        &self,
+        pubkey: &Pubkey,
+        callback: impl for<'a> Fn(&'a AccountSharedData) -> bool,
+    ) -> Option<(AccountSharedData, Slot)> {
+        self.rc
+            .accounts
+            .accounts_db
+            .load_account_with(&self.ancestors, pubkey, callback)
     }
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -116,7 +116,7 @@ pub(crate) fn load_accounts<CB: TransactionProcessingCallback>(
     fee_structure: &FeeStructure,
     account_overrides: Option<&AccountOverrides>,
     loaded_programs: &ProgramCacheForTxBatch,
-    accounts_map: &HashMap<Pubkey, (AccountSharedData, Slot)>,
+    accounts_map: &HashMap<Pubkey, Option<(AccountSharedData, Slot)>>,
 ) -> Vec<TransactionLoadResult> {
     let feature_set = callbacks.get_feature_set();
     txs.iter()
@@ -184,12 +184,12 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
     error_counters: &mut TransactionErrorMetrics,
     account_overrides: Option<&AccountOverrides>,
     loaded_programs: &ProgramCacheForTxBatch,
-    accounts_map: &HashMap<Pubkey, (AccountSharedData, Slot)>,
+    accounts_map: &HashMap<Pubkey, Option<(AccountSharedData, Slot)>>,
 ) -> Result<LoadedTransaction> {
     let feature_set = callbacks.get_feature_set();
 
     let load_account = |pubkey, should_cache| {
-        let (account, _slot) = if let Some(found) = accounts_map.get(pubkey) {
+        let (account, _slot) = if let Some(Some(found)) = accounts_map.get(pubkey) {
             found.clone()
         } else {
             callbacks.load_account_with(pubkey, |_| should_cache)?

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -189,12 +189,12 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
     let feature_set = callbacks.get_feature_set();
 
     let load_account = |pubkey, should_cache| {
-        let (account, _slot) = if let Some(Some(found)) = accounts_map.get(pubkey) {
-            found.clone()
+        let maybe_found = if let Some(found) = accounts_map.get(pubkey) {
+            found.as_ref().cloned()
         } else {
-            callbacks.load_account_with(pubkey, |_| should_cache)?
+            callbacks.load_account_with(pubkey, |_| should_cache)
         };
-        Some(account)
+        maybe_found.map(|x| x.0)
     };
 
     // There is no way to predict what program will execute without an error

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -68,9 +68,9 @@ pub(crate) fn load_program_from_bytes(
 pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
     callbacks: &CB,
     pubkey: &Pubkey,
-    accounts_map: &HashMap<Pubkey, (AccountSharedData, Slot)>,
+    accounts_map: &HashMap<Pubkey, Option<(AccountSharedData, Slot)>>,
 ) -> Option<ProgramAccountLoadResult> {
-    let (program_account, _slot) = if let Some(found) = accounts_map.get(pubkey) {
+    let (program_account, _slot) = if let Some(Some(found)) = accounts_map.get(pubkey) {
         found.clone()
     } else {
         callbacks.load_account_with(pubkey, |_| false)?
@@ -136,7 +136,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback, FG: ForkGraph
     effective_epoch: Epoch,
     epoch_schedule: &EpochSchedule,
     reload: bool,
-    accounts_map: &HashMap<Pubkey, (AccountSharedData, Slot)>,
+    accounts_map: &HashMap<Pubkey, Option<(AccountSharedData, Slot)>>,
 ) -> Option<Arc<ProgramCacheEntry>> {
     let environments = program_cache.get_environments_for_epoch(effective_epoch);
     let mut load_program_metrics = LoadProgramMetrics {

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -70,12 +70,12 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
     pubkey: &Pubkey,
     accounts_map: &HashMap<Pubkey, Option<(AccountSharedData, Slot)>>,
 ) -> Option<ProgramAccountLoadResult> {
-    let (program_account, _slot) = if let Some(Some(found)) = accounts_map.get(pubkey) {
-        found.clone()
+    let maybe_found = if let Some(found) = accounts_map.get(pubkey) {
+        found.as_ref().cloned()
     } else {
-        callbacks.load_account_with(pubkey, |_| false)?
+        callbacks.load_account_with(pubkey, |_| false)
     };
-
+    let (program_account, _slot) = maybe_found?;
     if loader_v4::check_id(program_account.owner()) {
         return Some(
             solana_loader_v4_program::get_state(program_account.data())

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -11,7 +11,7 @@ use {
         account::{AccountSharedData, ReadableAccount},
         account_utils::StateMut,
         bpf_loader, bpf_loader_deprecated,
-        bpf_loader_upgradeable::UpgradeableLoaderState,
+        bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{Epoch, Slot},
         epoch_schedule::EpochSchedule,
         instruction::InstructionError,
@@ -97,6 +97,12 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
     if bpf_loader::check_id(program_account.owner()) {
         return Some(ProgramAccountLoadResult::ProgramOfLoaderV2(program_account));
     }
+
+    assert!(
+        bpf_loader_upgradeable::check_id(program_account.owner()),
+        "unexpected program account owner {}",
+        program_account.owner(),
+    );
 
     if let Ok(UpgradeableLoaderState::Program {
         programdata_address,

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,8 +1,8 @@
 use {
     solana_program_runtime::loaded_programs::ProgramCacheMatchCriteria,
     solana_sdk::{
-        account::AccountSharedData, feature_set::FeatureSet, hash::Hash, pubkey::Pubkey,
-        rent_collector::RentCollector,
+        account::AccountSharedData, clock::Slot, feature_set::FeatureSet, hash::Hash,
+        pubkey::Pubkey, rent_collector::RentCollector,
     },
     std::sync::Arc,
 };
@@ -12,6 +12,14 @@ pub trait TransactionProcessingCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize>;
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
+
+    // If `callback` returns `true`, the account will be stored into read cache after loading.
+    // Otherwise, it will skip read cache.
+    fn load_account_with(
+        &self,
+        pubkey: &Pubkey,
+        callback: impl for<'a> Fn(&'a AccountSharedData) -> bool,
+    ) -> Option<(AccountSharedData, Slot)>;
 
     fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64);
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -496,6 +496,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         missing_programs.retain(|x| x.0 != key);
                         // Notify other threads which might be waiting on us for current cooperative_loading_task of empty program account
                         task_waiter.notify();
+                        if missing_programs.is_empty() {
+                            // break out possible infinite loop
+                            break;
+                        }
                         continue;
                     }
                 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -494,6 +494,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     }
                     None => {
                         missing_programs.retain(|x| x.0 != key);
+                        // Notify other threads which might be waiting on us for current cooperative_loading_task of empty program account
+                        task_waiter.notify();
                         continue;
                     }
                 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -188,7 +188,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         limit_to_load_programs: bool,
     ) -> LoadAndExecuteSanitizedTransactionsOutput {
         let mut program_cache_time = Measure::start("program_cache");
-        let mut program_accounts_map = Self::filter_executable_program_accounts(
+        // TODO: pass `_accounts_map` down to load_program and load_account.
+        let (mut program_accounts_map, accounts_map) = self.filter_executable_program_accounts(
             callbacks,
             sanitized_txs,
             check_results,
@@ -202,6 +203,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             callbacks,
             &program_accounts_map,
             limit_to_load_programs,
+            &accounts_map,
         )));
 
         if programs_loaded_for_tx_batch.borrow().hit_max_limit {
@@ -225,6 +227,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             &self.fee_structure,
             account_overrides,
             &programs_loaded_for_tx_batch.borrow(),
+            &accounts_map,
         );
         load_time.stop();
 
@@ -329,35 +332,69 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         }
     }
 
-    /// Returns a map from executable program accounts (all accounts owned by any loader)
-    /// to their usage counters, for the transactions with a valid blockhash or nonce.
+    /// Returns a map from executable program accounts (all accounts owned by
+    /// any loader) to their usage counters, and a map for loaded accounts, for
+    /// the transactions with a valid blockhash or nonce.
     fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
+        &self,
         callbacks: &CB,
         txs: &[SanitizedTransaction],
         check_results: &mut [TransactionCheckResult],
         program_owners: &[Pubkey],
-    ) -> HashMap<Pubkey, u64> {
-        let mut result: HashMap<Pubkey, u64> = HashMap::new();
+    ) -> (
+        HashMap<Pubkey, u64>,
+        HashMap<Pubkey, (AccountSharedData, Slot)>,
+    ) {
+        let mut program_accounts: HashMap<Pubkey, u64> = HashMap::new();
+        let mut accounts_map: HashMap<Pubkey, (AccountSharedData, Slot)> = HashMap::new();
+
         check_results.iter_mut().zip(txs).for_each(|etx| {
             if let ((Ok(()), _nonce, lamports_per_signature), tx) = etx {
                 if lamports_per_signature.is_some() {
-                    tx.message()
-                        .account_keys()
-                        .iter()
-                        .for_each(|key| match result.entry(*key) {
-                            Entry::Occupied(mut entry) => {
-                                let count = entry.get_mut();
+                    tx.message().account_keys().iter().for_each(|key| {
+                        match program_accounts.entry(*key) {
+                            Entry::Occupied(mut prog_entry) => {
+                                // Already seen it before in program_accounts, increase the counter.
+                                let count = prog_entry.get_mut();
                                 saturating_add_assign!(*count, 1);
                             }
-                            Entry::Vacant(entry) => {
-                                if callbacks
-                                    .account_matches_owners(key, program_owners)
-                                    .is_some()
-                                {
-                                    entry.insert(1);
+                            Entry::Vacant(prog_entry) => {
+                                if self.program_cache.read().unwrap().contains_key(key) {
+                                    // Found in program cache, must be a program_account, insert into program_map.
+                                    prog_entry.insert(1);
+                                } else {
+                                    match accounts_map.entry(*key) {
+                                        Entry::Occupied(account_entry) => {
+                                            // Found in accounts_map, check owner
+                                            let owner = account_entry.get().0.owner();
+                                            if program_owners.contains(owner) {
+                                                // Owner is in program_owners. insert into program_map.
+                                                prog_entry.insert(1);
+                                            }
+                                        }
+                                        Entry::Vacant(account_entry) => {
+                                            // Not found in accounts_map. Load the account. When loading if
+                                            // owner is in program_owners, don't store into read_cache.
+                                            let loaded_account = callbacks
+                                                .load_account_with(key, |account| {
+                                                    !program_owners.contains(account.owner())
+                                                });
+
+                                            if let Some(loaded_account) = loaded_account {
+                                                // Save the account in accounts_map for later instruction/program account load. Insert
+                                                // it into program_map if owner is in program_owners.
+                                                if program_owners.contains(loaded_account.0.owner())
+                                                {
+                                                    prog_entry.insert(1);
+                                                }
+                                                account_entry.insert(loaded_account);
+                                            }
+                                        }
+                                    }
                                 }
                             }
-                        });
+                        }
+                    });
                 } else {
                     // If the transaction's nonce account was not valid, and blockhash is not found,
                     // the transaction will fail to process. Let's not load any programs from the
@@ -366,7 +403,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 }
             }
         });
-        result
+        (program_accounts, accounts_map)
     }
 
     fn replenish_program_cache<CB: TransactionProcessingCallback>(
@@ -374,6 +411,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         callback: &CB,
         program_accounts_map: &HashMap<Pubkey, u64>,
         limit_to_load_programs: bool,
+        accounts_map: &HashMap<Pubkey, (AccountSharedData, Slot)>,
     ) -> ProgramCacheForTxBatch {
         let mut missing_programs: Vec<(Pubkey, (ProgramCacheMatchCriteria, u64))> =
             program_accounts_map
@@ -440,6 +478,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     self.epoch,
                     &self.epoch_schedule,
                     false,
+                    accounts_map,
                 )
                 .expect("called load_program_with_pubkey() with nonexistent account");
                 program.tx_usage_counter.store(count, Ordering::Relaxed);
@@ -799,6 +838,15 @@ mod tests {
             }
         }
 
+        fn load_account_with(
+            &self,
+            pubkey: &Pubkey,
+            _callback: impl FnMut(&AccountSharedData) -> bool,
+        ) -> Option<(AccountSharedData, Slot)> {
+            let account = self.account_shared_data.borrow().get(pubkey).cloned()?;
+            Some((account, 100))
+        }
+
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
             self.account_shared_data.borrow().get(pubkey).cloned()
         }
@@ -1066,7 +1114,12 @@ mod tests {
         let mut account_maps: HashMap<Pubkey, u64> = HashMap::new();
         account_maps.insert(key, 4);
 
-        batch_processor.replenish_program_cache(&mock_bank, &account_maps, true);
+        batch_processor.replenish_program_cache(
+            &mock_bank,
+            &account_maps,
+            true,
+            &HashMap::default(),
+        );
     }
 
     #[test]
@@ -1092,6 +1145,7 @@ mod tests {
                 &mock_bank,
                 &account_maps,
                 limit_to_load_programs,
+                &HashMap::default(),
             );
             assert!(!result.hit_max_limit);
             let program = result.find(&key).unwrap();
@@ -1179,7 +1233,8 @@ mod tests {
         ];
         let owners = vec![owner1, owner2];
 
-        let result = TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
+        let transaction_processor = TransactionBatchProcessor::<TestForkGraph>::default();
+        let (result, accounts_map) = transaction_processor.filter_executable_program_accounts(
             &mock_bank,
             &transactions,
             lock_results.as_mut_slice(),
@@ -1193,6 +1248,17 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[&key1], 2);
         assert_eq!(result[&key2], 1);
+
+        assert_eq!(accounts_map.len(), 2);
+        let (account1, slot1) = accounts_map.get(&key1).unwrap();
+        assert_eq!(account1.lamports(), 93);
+        assert_eq!(account1.owner(), &owner1);
+        assert_eq!(*slot1, 100);
+
+        let (account2, slot2) = accounts_map.get(&key2).unwrap();
+        assert_eq!(account2.lamports(), 90);
+        assert_eq!(account2.owner(), &owner2);
+        assert_eq!(*slot2, 100);
     }
 
     #[test]
@@ -1264,13 +1330,13 @@ mod tests {
         let sanitized_tx2 = SanitizedTransaction::from_transaction_for_tests(tx2);
 
         let owners = &[program1_pubkey, program2_pubkey];
-        let programs =
-            TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
-                &bank,
-                &[sanitized_tx1, sanitized_tx2],
-                &mut [(Ok(()), None, Some(0)), (Ok(()), None, Some(0))],
-                owners,
-            );
+        let transaction_processor = TransactionBatchProcessor::<TestForkGraph>::default();
+        let (programs, accounts_map) = transaction_processor.filter_executable_program_accounts(
+            &bank,
+            &[sanitized_tx1, sanitized_tx2],
+            &mut [(Ok(()), None, Some(0)), (Ok(()), None, Some(0))],
+            owners,
+        );
 
         // The result should contain only account3_pubkey, and account4_pubkey as the program accounts
         assert_eq!(programs.len(), 2);
@@ -1286,6 +1352,19 @@ mod tests {
                 .expect("failed to find the program account"),
             &1
         );
+
+        // `accounts_map` should contain all the accounts in the transactions.
+        assert_eq!(accounts_map.len(), 6);
+        for k in [
+            non_program_pubkey1,
+            non_program_pubkey2,
+            account1_pubkey,
+            account2_pubkey,
+            account3_pubkey,
+            account4_pubkey,
+        ] {
+            assert!(accounts_map.contains_key(&k));
+        }
     }
 
     #[test]
@@ -1359,13 +1438,13 @@ mod tests {
 
         let owners = &[program1_pubkey, program2_pubkey];
         let mut lock_results = vec![(Ok(()), None, Some(0)), (Ok(()), None, None)];
-        let programs =
-            TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
-                &bank,
-                &[sanitized_tx1, sanitized_tx2],
-                &mut lock_results,
-                owners,
-            );
+        let transaction_processor = TransactionBatchProcessor::<TestForkGraph>::default();
+        let (programs, accounts_map) = transaction_processor.filter_executable_program_accounts(
+            &bank,
+            &[sanitized_tx1, sanitized_tx2],
+            &mut lock_results,
+            owners,
+        );
 
         // The result should contain only account3_pubkey as the program accounts
         assert_eq!(programs.len(), 1);
@@ -1376,6 +1455,22 @@ mod tests {
             &1
         );
         assert_eq!(lock_results[1].0, Err(TransactionError::BlockhashNotFound));
+
+        // `accounts_map` should contain only the accounts in the transaction with valid blockhash.
+        assert_eq!(accounts_map.len(), 4);
+        for k in [
+            non_program_pubkey1,
+            account1_pubkey,
+            account2_pubkey,
+            account3_pubkey,
+        ] {
+            assert!(accounts_map.contains_key(&k));
+        }
+
+        // `accounts_map` should not contain the accounts in the transaction with invalid blockhash.
+        for k in [non_program_pubkey2, account4_pubkey] {
+            assert!(!accounts_map.contains_key(&k));
+        }
     }
 
     #[test]

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -1,6 +1,7 @@
 use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
+        clock::Slot,
         feature_set::FeatureSet,
         hash::Hash,
         native_loader,
@@ -29,6 +30,15 @@ impl TransactionProcessingCallback for MockBankCallback {
         } else {
             None
         }
+    }
+
+    fn load_account_with(
+        &self,
+        pubkey: &Pubkey,
+        _callback: impl for<'a> Fn(&'a AccountSharedData) -> bool,
+    ) -> Option<(AccountSharedData, Slot)> {
+        let account = self.account_shared_data.borrow().get(pubkey).cloned()?;
+        Some((account, 100))
     }
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {


### PR DESCRIPTION
#### Problem

During transaction execution, we load accounts twice - first during filtering program accounts, and second for loading the actual accounts before execution. And by default, loading program accounts will insert the loaded program accounts into read cache, which pollutes read cache unnecessarily. This is inefficient and can be optimized. 


#### Summary of Changes
- Add a new API for account-db `load_with()`, which takes a callback to indicate whether to insert the loaded account into `read_cache`.
- Update program account loads and transaction accounts loads to use the new API to do finer control on whether to insert the account into `read_cache` after loading.
- Cache the account loaded during filtering and use the cached accounts in program account and regular account loader later when possible.



#### Performance Comparision

![image](https://github.com/anza-xyz/agave/assets/219428/cb7ee453-3bbe-4439-b7c6-c849bc09b3a7)


- account load time (top-left); prog_cache time (top-right), replay time (bottom)
- blue (this PR), red (master)
Accounts loading time is reduced by **40%**. Program cache time shows slight improvement.  Replay time shows improvement too.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
