### PR TITLE
retains chained Merkle root across leader slots

### DIFF
--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -66,6 +66,8 @@ pub enum Error {
     Blockstore(#[from] solana_ledger::blockstore::BlockstoreError),
     #[error(transparent)]
     ClusterInfo(#[from] solana_gossip::cluster_info::ClusterInfoError),
+    #[error("Duplicate slot broadcast: {0}")]
+    DuplicateSlotBroadcast(Slot),
     #[error("Invalid Merkle root, slot: {slot}, index: {index}")]
     InvalidMerkleRoot { slot: Slot, index: u64 },
     #[error(transparent)]

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -26,15 +26,6 @@ pub(super) struct ReceiveResults {
     pub last_tick_height: u64,
 }
 
-#[derive(Clone)]
-pub struct UnfinishedSlotInfo {
-    pub(super) chained_merkle_root: Hash,
-    pub next_shred_index: u32,
-    pub(crate) next_code_index: u32,
-    pub slot: Slot,
-    pub parent: Slot,
-}
-
 pub(super) fn recv_slot_entries(receiver: &Receiver<WorkingBankEntry>) -> Result<ReceiveResults> {
     let target_serialized_batch_byte_count: u64 =
         32 * ShredData::capacity(/*merkle_proof_size*/ None).unwrap() as u64;


### PR DESCRIPTION
#### Problem
Looking up Merkle root of the last erasure batch for the parent block can fail if the slot meta are not yet available in blockstore.
When a leader generates blocks for its consecutive leader slots, instead of using blockstore, it can retain chained Merkle root across its leader slots.

#### Summary of Changes
Retain chained Merkle roots across leader slots.