### PR TITLE
Program-Runtime: Add `EnvironmentConfig` to `InvokeContext`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -325,7 +325,7 @@ fn load_program<'a>(
     };
     let account_size = contents.len();
     let program_runtime_environment = create_program_runtime_environment_v1(
-        &invoke_context.feature_set,
+        &invoke_context.environment_config.feature_set,
         invoke_context.get_compute_budget(),
         false, /* deployment */
         true,  /* debugging_features */

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -325,7 +325,7 @@ fn load_program<'a>(
     };
     let account_size = contents.len();
     let program_runtime_environment = create_program_runtime_environment_v1(
-        &invoke_context.environment_config.feature_set,
+        invoke_context.get_feature_set(),
         invoke_context.get_compute_budget(),
         false, /* deployment */
         true,  /* debugging_features */

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -196,7 +196,6 @@ pub struct InvokeContext<'a> {
     pub programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
     pub feature_set: Arc<FeatureSet>,
     pub timings: ExecuteDetailsTimings,
-    pub blockhash: Hash,
     pub lamports_per_signature: u64,
     pub syscall_context: Vec<Option<SyscallContext>>,
     traces: Vec<Vec<[u64; 12]>>,
@@ -213,7 +212,6 @@ impl<'a> InvokeContext<'a> {
         programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
     ) -> Self {
         // Temporary
-        let blockhash = environment_config.blockhash;
         let feature_set = environment_config.feature_set.clone();
         let lamports_per_signature = environment_config.lamports_per_signature;
         let sysvar_cache = environment_config.sysvar_cache;
@@ -230,7 +228,6 @@ impl<'a> InvokeContext<'a> {
             programs_modified_by_tx,
             feature_set,
             timings: ExecuteDetailsTimings::default(),
-            blockhash,
             lamports_per_signature,
             syscall_context: Vec::new(),
             traces: Vec::new(),

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -196,7 +196,6 @@ pub struct InvokeContext<'a> {
     pub programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
     pub feature_set: Arc<FeatureSet>,
     pub timings: ExecuteDetailsTimings,
-    pub lamports_per_signature: u64,
     pub syscall_context: Vec<Option<SyscallContext>>,
     traces: Vec<Vec<[u64; 12]>>,
 }
@@ -213,7 +212,6 @@ impl<'a> InvokeContext<'a> {
     ) -> Self {
         // Temporary
         let feature_set = environment_config.feature_set.clone();
-        let lamports_per_signature = environment_config.lamports_per_signature;
         let sysvar_cache = environment_config.sysvar_cache;
         //
         Self {
@@ -228,7 +226,6 @@ impl<'a> InvokeContext<'a> {
             programs_modified_by_tx,
             feature_set,
             timings: ExecuteDetailsTimings::default(),
-            lamports_per_signature,
             syscall_context: Vec::new(),
             traces: Vec::new(),
         }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -194,7 +194,6 @@ pub struct InvokeContext<'a> {
     compute_meter: RefCell<u64>,
     pub programs_loaded_for_tx_batch: &'a ProgramCacheForTxBatch,
     pub programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
-    pub feature_set: Arc<FeatureSet>,
     pub timings: ExecuteDetailsTimings,
     pub syscall_context: Vec<Option<SyscallContext>>,
     traces: Vec<Vec<[u64; 12]>>,
@@ -211,7 +210,6 @@ impl<'a> InvokeContext<'a> {
         programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
     ) -> Self {
         // Temporary
-        let feature_set = environment_config.feature_set.clone();
         let sysvar_cache = environment_config.sysvar_cache;
         //
         Self {
@@ -224,7 +222,6 @@ impl<'a> InvokeContext<'a> {
             compute_meter: RefCell::new(compute_budget.compute_unit_limit),
             programs_loaded_for_tx_batch,
             programs_modified_by_tx,
-            feature_set,
             timings: ExecuteDetailsTimings::default(),
             syscall_context: Vec::new(),
             traces: Vec::new(),

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -594,6 +594,18 @@ impl<'a> InvokeContext<'a> {
         &self.current_compute_budget
     }
 
+    /// Get the current feature set.
+    pub fn get_feature_set(&self) -> &FeatureSet {
+        &self.environment_config.feature_set
+    }
+
+    /// Set feature set.
+    ///
+    /// Only use for tests and benchmarks.
+    pub fn mock_set_feature_set(&mut self, feature_set: Arc<FeatureSet>) {
+        self.environment_config.feature_set = feature_set;
+    }
+
     /// Get cached sysvars
     pub fn get_sysvar_cache(&self) -> &SysvarCache {
         self.environment_config.sysvar_cache

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -187,7 +187,6 @@ pub struct InvokeContext<'a> {
     pub transaction_context: &'a mut TransactionContext,
     /// Runtime configurations used to provision the invocation environment.
     pub environment_config: EnvironmentConfig<'a>,
-    sysvar_cache: &'a SysvarCache,
     log_collector: Option<Rc<RefCell<LogCollector>>>,
     compute_budget: ComputeBudget,
     current_compute_budget: ComputeBudget,
@@ -209,13 +208,9 @@ impl<'a> InvokeContext<'a> {
         programs_loaded_for_tx_batch: &'a ProgramCacheForTxBatch,
         programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
     ) -> Self {
-        // Temporary
-        let sysvar_cache = environment_config.sysvar_cache;
-        //
         Self {
             transaction_context,
             environment_config,
-            sysvar_cache,
             log_collector,
             current_compute_budget: compute_budget,
             compute_budget,
@@ -240,7 +235,7 @@ impl<'a> InvokeContext<'a> {
         &self,
         effective_slot: Slot,
     ) -> Result<&ProgramRuntimeEnvironments, InstructionError> {
-        let epoch_schedule = self.sysvar_cache.get_epoch_schedule()?;
+        let epoch_schedule = self.environment_config.sysvar_cache.get_epoch_schedule()?;
         let epoch = epoch_schedule.get_epoch(effective_slot);
         Ok(self
             .programs_loaded_for_tx_batch
@@ -601,7 +596,7 @@ impl<'a> InvokeContext<'a> {
 
     /// Get cached sysvars
     pub fn get_sysvar_cache(&self) -> &SysvarCache {
-        self.sysvar_cache
+        self.environment_config.sysvar_cache
     }
 
     // Should alignment be enforced during user pointer translation

--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -61,8 +61,7 @@ impl Processor {
         let table_key = *lookup_table_account.get_key();
         let lookup_table_owner = *lookup_table_account.get_owner();
         if !invoke_context
-            .environment_config
-            .feature_set
+            .get_feature_set()
             .is_active(&feature_set::relax_authority_signer_check_for_lookup_table_creation::id())
             && !lookup_table_account.get_data().is_empty()
         {
@@ -75,8 +74,7 @@ impl Processor {
             instruction_context.try_borrow_instruction_account(transaction_context, 1)?;
         let authority_key = *authority_account.get_key();
         if !invoke_context
-            .environment_config
-            .feature_set
+            .get_feature_set()
             .is_active(&feature_set::relax_authority_signer_check_for_lookup_table_creation::id())
             && !authority_account.is_signer()
         {
@@ -129,8 +127,7 @@ impl Processor {
         }
 
         if invoke_context
-            .environment_config
-            .feature_set
+            .get_feature_set()
             .is_active(&feature_set::relax_authority_signer_check_for_lookup_table_creation::id())
             && check_id(&lookup_table_owner)
         {

--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -61,6 +61,7 @@ impl Processor {
         let table_key = *lookup_table_account.get_key();
         let lookup_table_owner = *lookup_table_account.get_owner();
         if !invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::relax_authority_signer_check_for_lookup_table_creation::id())
             && !lookup_table_account.get_data().is_empty()
@@ -74,6 +75,7 @@ impl Processor {
             instruction_context.try_borrow_instruction_account(transaction_context, 1)?;
         let authority_key = *authority_account.get_key();
         if !invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::relax_authority_signer_check_for_lookup_table_creation::id())
             && !authority_account.is_signer()
@@ -127,6 +129,7 @@ impl Processor {
         }
 
         if invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::relax_authority_signer_check_for_lookup_table_creation::id())
             && check_id(&lookup_table_owner)

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -957,6 +957,7 @@ fn process_loader_upgradeable_instruction(
         }
         UpgradeableLoaderInstruction::SetAuthorityChecked => {
             if !invoke_context
+                .environment_config
                 .feature_set
                 .is_active(&enable_bpf_loader_set_authority_checked_ix::id())
             {
@@ -1352,6 +1353,7 @@ fn execute<'a, 'b: 'a>(
     #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
     let use_jit = executable.get_compiled_program().is_some();
     let direct_mapping = invoke_context
+        .environment_config
         .feature_set
         .is_active(&bpf_account_data_direct_mapping::id());
 
@@ -1505,7 +1507,7 @@ pub mod test_utils {
     pub fn load_all_invoked_programs(invoke_context: &mut InvokeContext) {
         let mut load_program_metrics = LoadProgramMetrics::default();
         let program_runtime_environment = create_program_runtime_environment_v1(
-            &invoke_context.feature_set,
+            &invoke_context.environment_config.feature_set,
             invoke_context.get_compute_budget(),
             false, /* deployment */
             false, /* debugging_features */

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -957,8 +957,7 @@ fn process_loader_upgradeable_instruction(
         }
         UpgradeableLoaderInstruction::SetAuthorityChecked => {
             if !invoke_context
-                .environment_config
-                .feature_set
+                .get_feature_set()
                 .is_active(&enable_bpf_loader_set_authority_checked_ix::id())
             {
                 return Err(InstructionError::InvalidInstructionData);
@@ -1353,8 +1352,7 @@ fn execute<'a, 'b: 'a>(
     #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
     let use_jit = executable.get_compiled_program().is_some();
     let direct_mapping = invoke_context
-        .environment_config
-        .feature_set
+        .get_feature_set()
         .is_active(&bpf_account_data_direct_mapping::id());
 
     let mut serialize_time = Measure::start("serialize");
@@ -1507,7 +1505,7 @@ pub mod test_utils {
     pub fn load_all_invoked_programs(invoke_context: &mut InvokeContext) {
         let mut load_program_metrics = LoadProgramMetrics::default();
         let program_runtime_environment = create_program_runtime_environment_v1(
-            &invoke_context.environment_config.feature_set,
+            invoke_context.get_feature_set(),
             invoke_context.get_compute_budget(),
             false, /* deployment */
             false, /* debugging_features */

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -107,6 +107,7 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
         account_metadata: &SerializedAccountMetadata,
     ) -> Result<CallerAccount<'a, 'b>, Error> {
         let direct_mapping = invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::bpf_account_data_direct_mapping::id());
 
@@ -244,6 +245,7 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
         account_metadata: &SerializedAccountMetadata,
     ) -> Result<CallerAccount<'a, 'b>, Error> {
         let direct_mapping = invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::bpf_account_data_direct_mapping::id());
 
@@ -452,6 +454,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
 
         let ix_data_len = ix.data.len() as u64;
         if invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::loosen_cpi_size_restriction::id())
         {
@@ -666,6 +669,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
 
         let ix_data_len = ix_c.data_len;
         if invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::loosen_cpi_size_restriction::id())
         {
@@ -866,6 +870,7 @@ where
         .accounts_metadata;
 
     let direct_mapping = invoke_context
+        .environment_config
         .feature_set
         .is_active(&feature_set::bpf_account_data_direct_mapping::id());
 
@@ -961,6 +966,7 @@ fn check_instruction_size(
     invoke_context: &mut InvokeContext,
 ) -> Result<(), Error> {
     if invoke_context
+        .environment_config
         .feature_set
         .is_active(&feature_set::loosen_cpi_size_restriction::id())
     {
@@ -998,10 +1004,12 @@ fn check_account_infos(
     invoke_context: &mut InvokeContext,
 ) -> Result<(), Error> {
     if invoke_context
+        .environment_config
         .feature_set
         .is_active(&feature_set::loosen_cpi_size_restriction::id())
     {
         let max_cpi_account_infos = if invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::increase_tx_account_lock_limit::id())
         {
@@ -1041,6 +1049,7 @@ fn check_authorized_program(
             && !(bpf_loader_upgradeable::is_upgrade_instruction(instruction_data)
                 || bpf_loader_upgradeable::is_set_authority_instruction(instruction_data)
                 || (invoke_context
+                    .environment_config
                     .feature_set
                     .is_active(&enable_bpf_loader_set_authority_checked_ix::id())
                     && bpf_loader_upgradeable::is_set_authority_checked_instruction(
@@ -1048,7 +1057,10 @@ fn check_authorized_program(
                     ))
                 || bpf_loader_upgradeable::is_close_instruction(instruction_data)))
         || is_precompile(program_id, |feature_id: &Pubkey| {
-            invoke_context.feature_set.is_active(feature_id)
+            invoke_context
+                .environment_config
+                .feature_set
+                .is_active(feature_id)
         })
     {
         return Err(Box::new(SyscallError::ProgramNotSupported(*program_id)));
@@ -1122,6 +1134,7 @@ fn cpi_common<S: SyscallInvokeSigned>(
     //
     // Synchronize the callee's account changes so the caller can see them.
     let direct_mapping = invoke_context
+        .environment_config
         .feature_set
         .is_active(&feature_set::bpf_account_data_direct_mapping::id());
 
@@ -1629,7 +1642,7 @@ mod tests {
                 .map(|a| (a.0, a.1))
                 .collect::<Vec<TransactionAccount>>();
             with_mock_invoke_context!($invoke_context, $transaction_context, transaction_accounts);
-            let feature_set = Arc::make_mut(&mut $invoke_context.feature_set);
+            let feature_set = Arc::make_mut(&mut $invoke_context.environment_config.feature_set);
             feature_set.deactivate(&bpf_account_data_direct_mapping::id());
             $invoke_context
                 .transaction_context

--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -69,8 +69,7 @@ declare_builtin_function!(
         mem_op_consume(invoke_context, n)?;
 
         if invoke_context
-            .environment_config
-            .feature_set
+            .get_feature_set()
             .is_active(&feature_set::bpf_account_data_direct_mapping::id())
         {
             let cmp_result = translate_type_mut::<i32>(
@@ -126,8 +125,7 @@ declare_builtin_function!(
         mem_op_consume(invoke_context, n)?;
 
         if invoke_context
-            .environment_config
-            .feature_set
+            .get_feature_set()
             .is_active(&feature_set::bpf_account_data_direct_mapping::id())
         {
             memset_non_contiguous(dst_addr, c as u8, n, memory_mapping)
@@ -152,8 +150,7 @@ fn memmove(
     memory_mapping: &MemoryMapping,
 ) -> Result<u64, Error> {
     if invoke_context
-        .environment_config
-        .feature_set
+        .get_feature_set()
         .is_active(&feature_set::bpf_account_data_direct_mapping::id())
     {
         memmove_non_contiguous(dst_addr, src_addr, n, memory_mapping)

--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -69,6 +69,7 @@ declare_builtin_function!(
         mem_op_consume(invoke_context, n)?;
 
         if invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::bpf_account_data_direct_mapping::id())
         {
@@ -125,6 +126,7 @@ declare_builtin_function!(
         mem_op_consume(invoke_context, n)?;
 
         if invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::bpf_account_data_direct_mapping::id())
         {
@@ -150,6 +152,7 @@ fn memmove(
     memory_mapping: &MemoryMapping,
 ) -> Result<u64, Error> {
     if invoke_context
+        .environment_config
         .feature_set
         .is_active(&feature_set::bpf_account_data_direct_mapping::id())
     {

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -918,8 +918,7 @@ declare_builtin_function!(
             }
             _ => {
                 if invoke_context
-                    .environment_config
-                    .feature_set
+                    .get_feature_set()
                     .is_active(&abort_on_invalid_curve::id())
                 {
                     Err(SyscallError::InvalidAttribute.into())
@@ -1036,8 +1035,7 @@ declare_builtin_function!(
                 }
                 _ => {
                     if invoke_context
-                        .environment_config
-                        .feature_set
+                        .get_feature_set()
                         .is_active(&abort_on_invalid_curve::id())
                     {
                         Err(SyscallError::InvalidAttribute.into())
@@ -1136,8 +1134,7 @@ declare_builtin_function!(
                 }
                 _ => {
                     if invoke_context
-                        .environment_config
-                        .feature_set
+                        .get_feature_set()
                         .is_active(&abort_on_invalid_curve::id())
                     {
                         Err(SyscallError::InvalidAttribute.into())
@@ -1149,8 +1146,7 @@ declare_builtin_function!(
 
             _ => {
                 if invoke_context
-                    .environment_config
-                    .feature_set
+                    .get_feature_set()
                     .is_active(&abort_on_invalid_curve::id())
                 {
                     Err(SyscallError::InvalidAttribute.into())
@@ -1265,8 +1261,7 @@ declare_builtin_function!(
 
             _ => {
                 if invoke_context
-                    .environment_config
-                    .feature_set
+                    .get_feature_set()
                     .is_active(&abort_on_invalid_curve::id())
                 {
                     Err(SyscallError::InvalidAttribute.into())
@@ -1618,8 +1613,7 @@ declare_builtin_function!(
         };
 
         let simplify_alt_bn128_syscall_error_codes = invoke_context
-            .environment_config
-            .feature_set
+            .get_feature_set()
             .is_active(&feature_set::simplify_alt_bn128_syscall_error_codes::id());
 
         let result_point = match calculation(input) {
@@ -1777,8 +1771,7 @@ declare_builtin_function!(
             .collect::<Result<Vec<_>, Error>>()?;
 
         let simplify_alt_bn128_syscall_error_codes = invoke_context
-            .environment_config
-            .feature_set
+            .get_feature_set()
             .is_active(&feature_set::simplify_alt_bn128_syscall_error_codes::id());
 
         let hash = match poseidon::hashv(parameters, endianness, inputs.as_slice()) {
@@ -1873,8 +1866,7 @@ declare_builtin_function!(
         )?;
 
         let simplify_alt_bn128_syscall_error_codes = invoke_context
-            .environment_config
-            .feature_set
+            .get_feature_set()
             .is_active(&feature_set::simplify_alt_bn128_syscall_error_codes::id());
 
         match op {
@@ -2492,7 +2484,7 @@ mod tests {
         // many small unaligned allocs
         {
             prepare_mockup!(invoke_context, program_id, bpf_loader::id());
-            invoke_context.environment_config.feature_set = Arc::new(FeatureSet::default());
+            invoke_context.mock_set_feature_set(Arc::new(FeatureSet::default()));
             mock_create_vm!(vm, Vec::new(), Vec::new(), &mut invoke_context);
             let mut vm = vm.unwrap();
             let invoke_context = &mut vm.context_object_pointer;

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -918,6 +918,7 @@ declare_builtin_function!(
             }
             _ => {
                 if invoke_context
+                    .environment_config
                     .feature_set
                     .is_active(&abort_on_invalid_curve::id())
                 {
@@ -1035,6 +1036,7 @@ declare_builtin_function!(
                 }
                 _ => {
                     if invoke_context
+                        .environment_config
                         .feature_set
                         .is_active(&abort_on_invalid_curve::id())
                     {
@@ -1134,6 +1136,7 @@ declare_builtin_function!(
                 }
                 _ => {
                     if invoke_context
+                        .environment_config
                         .feature_set
                         .is_active(&abort_on_invalid_curve::id())
                     {
@@ -1146,6 +1149,7 @@ declare_builtin_function!(
 
             _ => {
                 if invoke_context
+                    .environment_config
                     .feature_set
                     .is_active(&abort_on_invalid_curve::id())
                 {
@@ -1261,6 +1265,7 @@ declare_builtin_function!(
 
             _ => {
                 if invoke_context
+                    .environment_config
                     .feature_set
                     .is_active(&abort_on_invalid_curve::id())
                 {
@@ -1613,6 +1618,7 @@ declare_builtin_function!(
         };
 
         let simplify_alt_bn128_syscall_error_codes = invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::simplify_alt_bn128_syscall_error_codes::id());
 
@@ -1771,6 +1777,7 @@ declare_builtin_function!(
             .collect::<Result<Vec<_>, Error>>()?;
 
         let simplify_alt_bn128_syscall_error_codes = invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::simplify_alt_bn128_syscall_error_codes::id());
 
@@ -1866,6 +1873,7 @@ declare_builtin_function!(
         )?;
 
         let simplify_alt_bn128_syscall_error_codes = invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::simplify_alt_bn128_syscall_error_codes::id());
 
@@ -2484,7 +2492,7 @@ mod tests {
         // many small unaligned allocs
         {
             prepare_mockup!(invoke_context, program_id, bpf_loader::id());
-            invoke_context.feature_set = Arc::new(FeatureSet::default());
+            invoke_context.environment_config.feature_set = Arc::new(FeatureSet::default());
             mock_create_vm!(vm, Vec::new(), Vec::new(), &mut invoke_context);
             let mut vm = vm.unwrap();
             let invoke_context = &mut vm.context_object_pointer;

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -119,7 +119,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
     with_mock_invoke_context!(invoke_context, bpf_loader::id(), 10000001);
 
     let program_runtime_environment = create_program_runtime_environment_v1(
-        &invoke_context.environment_config.feature_set,
+        invoke_context.get_feature_set(),
         &ComputeBudget::default(),
         true,
         false,
@@ -238,7 +238,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
         .get_feature_set()
         .is_active(&bpf_account_data_direct_mapping::id());
     let program_runtime_environment = create_program_runtime_environment_v1(
-        &invoke_context.environment_config.feature_set,
+        invoke_context.get_feature_set(),
         &ComputeBudget::default(),
         true,
         false,
@@ -295,7 +295,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     .unwrap();
 
     let program_runtime_environment = create_program_runtime_environment_v1(
-        &invoke_context.environment_config.feature_set,
+        invoke_context.get_feature_set(),
         &ComputeBudget::default(),
         true,
         false,

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -119,7 +119,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
     with_mock_invoke_context!(invoke_context, bpf_loader::id(), 10000001);
 
     let program_runtime_environment = create_program_runtime_environment_v1(
-        &invoke_context.feature_set,
+        &invoke_context.environment_config.feature_set,
         &ComputeBudget::default(),
         true,
         false,
@@ -235,10 +235,10 @@ fn bench_create_vm(bencher: &mut Bencher) {
     invoke_context.mock_set_remaining(BUDGET);
 
     let direct_mapping = invoke_context
-        .feature_set
+        .get_feature_set()
         .is_active(&bpf_account_data_direct_mapping::id());
     let program_runtime_environment = create_program_runtime_environment_v1(
-        &invoke_context.feature_set,
+        &invoke_context.environment_config.feature_set,
         &ComputeBudget::default(),
         true,
         false,
@@ -280,7 +280,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     invoke_context.mock_set_remaining(BUDGET);
 
     let direct_mapping = invoke_context
-        .feature_set
+        .get_feature_set()
         .is_active(&bpf_account_data_direct_mapping::id());
 
     // Serialize account data
@@ -295,7 +295,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     .unwrap();
 
     let program_runtime_environment = create_program_runtime_environment_v1(
-        &invoke_context.feature_set,
+        &invoke_context.environment_config.feature_set,
         &ComputeBudget::default(),
         true,
         false,

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -145,7 +145,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &clock,
                 &stake_history,
                 &signers,
-                &invoke_context.feature_set,
+                &invoke_context.environment_config.feature_set,
             )
         }
         StakeInstruction::Split(lamports) => {
@@ -310,7 +310,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             set_lockup(&mut me, &lockup, &signers, &clock)
         }
         StakeInstruction::GetMinimumDelegation => {
-            let feature_set = invoke_context.feature_set.as_ref();
+            let feature_set = invoke_context.environment_config.feature_set.as_ref();
             let minimum_delegation = crate::get_minimum_delegation(feature_set);
             let minimum_delegation = Vec::from(minimum_delegation.to_le_bytes());
             invoke_context
@@ -335,6 +335,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         StakeInstruction::Redelegate => {
             let mut me = get_stake_account()?;
             if invoke_context
+                .environment_config
                 .feature_set
                 .is_active(&feature_set::stake_redelegate_instruction::id())
             {
@@ -460,7 +461,7 @@ mod tests {
             expected_result,
             Entrypoint::vm,
             |invoke_context| {
-                invoke_context.feature_set = Arc::clone(&feature_set);
+                invoke_context.environment_config.feature_set = Arc::clone(&feature_set);
             },
             |_invoke_context| {},
         )
@@ -6889,11 +6890,12 @@ mod tests {
             Ok(()),
             Entrypoint::vm,
             |invoke_context| {
-                invoke_context.feature_set = Arc::clone(&feature_set);
+                invoke_context.environment_config.feature_set = Arc::clone(&feature_set);
             },
             |invoke_context| {
                 let expected_minimum_delegation =
-                    crate::get_minimum_delegation(&invoke_context.feature_set).to_le_bytes();
+                    crate::get_minimum_delegation(&invoke_context.environment_config.feature_set)
+                        .to_le_bytes();
                 let actual_minimum_delegation =
                     invoke_context.transaction_context.get_return_data().1;
                 assert_eq!(expected_minimum_delegation, actual_minimum_delegation);

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -145,7 +145,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &clock,
                 &stake_history,
                 &signers,
-                &invoke_context.environment_config.feature_set,
+                invoke_context.get_feature_set(),
             )
         }
         StakeInstruction::Split(lamports) => {
@@ -310,7 +310,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             set_lockup(&mut me, &lockup, &signers, &clock)
         }
         StakeInstruction::GetMinimumDelegation => {
-            let feature_set = invoke_context.environment_config.feature_set.as_ref();
+            let feature_set = invoke_context.get_feature_set();
             let minimum_delegation = crate::get_minimum_delegation(feature_set);
             let minimum_delegation = Vec::from(minimum_delegation.to_le_bytes());
             invoke_context
@@ -335,8 +335,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         StakeInstruction::Redelegate => {
             let mut me = get_stake_account()?;
             if invoke_context
-                .environment_config
-                .feature_set
+                .get_feature_set()
                 .is_active(&feature_set::stake_redelegate_instruction::id())
             {
                 instruction_context.check_number_of_instruction_accounts(3)?;
@@ -461,7 +460,7 @@ mod tests {
             expected_result,
             Entrypoint::vm,
             |invoke_context| {
-                invoke_context.environment_config.feature_set = Arc::clone(&feature_set);
+                invoke_context.mock_set_feature_set(Arc::clone(&feature_set));
             },
             |_invoke_context| {},
         )
@@ -6890,12 +6889,11 @@ mod tests {
             Ok(()),
             Entrypoint::vm,
             |invoke_context| {
-                invoke_context.environment_config.feature_set = Arc::clone(&feature_set);
+                invoke_context.mock_set_feature_set(Arc::clone(&feature_set));
             },
             |invoke_context| {
                 let expected_minimum_delegation =
-                    crate::get_minimum_delegation(&invoke_context.environment_config.feature_set)
-                        .to_le_bytes();
+                    crate::get_minimum_delegation(invoke_context.get_feature_set()).to_le_bytes();
                 let actual_minimum_delegation =
                     invoke_context.transaction_context.get_return_data().1;
                 assert_eq!(expected_minimum_delegation, actual_minimum_delegation);

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -64,8 +64,7 @@ pub(crate) fn new_warmup_cooldown_rate_epoch(invoke_context: &InvokeContext) -> 
         .get_epoch_schedule()
         .unwrap();
     invoke_context
-        .environment_config
-        .feature_set
+        .get_feature_set()
         .new_warmup_cooldown_rate_epoch(epoch_schedule.as_ref())
 }
 
@@ -95,8 +94,7 @@ fn redelegate_stake(
     // If stake is currently active:
     if stake.stake(clock.epoch, stake_history, new_rate_activation_epoch) != 0 {
         let stake_lamports_ok = if invoke_context
-            .environment_config
-            .feature_set
+            .get_feature_set()
             .is_active(&feature_set::stake_redelegate_instruction::id())
         {
             // When a stake account is redelegated, the delegated lamports from the source stake
@@ -303,8 +301,7 @@ fn deactivate_stake(
     epoch: Epoch,
 ) -> Result<(), InstructionError> {
     if invoke_context
-        .environment_config
-        .feature_set
+        .get_feature_set()
         .is_active(&feature_set::stake_redelegate_instruction::id())
     {
         if stake_flags.contains(StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED) {
@@ -406,7 +403,7 @@ pub fn split(
         StakeStateV2::Stake(meta, mut stake, stake_flags) => {
             meta.authorized.check(signers, StakeAuthorize::Staker)?;
             let minimum_delegation =
-                crate::get_minimum_delegation(&invoke_context.environment_config.feature_set);
+                crate::get_minimum_delegation(invoke_context.get_feature_set());
             let is_active = {
                 let clock = invoke_context.get_sysvar_cache().get_clock()?;
                 let status = get_stake_status(invoke_context, &stake, &clock)?;
@@ -692,7 +689,7 @@ pub fn redelegate(
     let ValidatedDelegatedInfo { stake_amount } = validate_delegated_amount(
         &uninitialized_stake_account,
         &uninitialized_stake_meta,
-        &invoke_context.environment_config.feature_set,
+        invoke_context.get_feature_set(),
     )?;
     uninitialized_stake_account.set_state(&StakeStateV2::Stake(
         uninitialized_stake_meta,

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -64,6 +64,7 @@ pub(crate) fn new_warmup_cooldown_rate_epoch(invoke_context: &InvokeContext) -> 
         .get_epoch_schedule()
         .unwrap();
     invoke_context
+        .environment_config
         .feature_set
         .new_warmup_cooldown_rate_epoch(epoch_schedule.as_ref())
 }
@@ -94,6 +95,7 @@ fn redelegate_stake(
     // If stake is currently active:
     if stake.stake(clock.epoch, stake_history, new_rate_activation_epoch) != 0 {
         let stake_lamports_ok = if invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::stake_redelegate_instruction::id())
         {
@@ -301,6 +303,7 @@ fn deactivate_stake(
     epoch: Epoch,
 ) -> Result<(), InstructionError> {
     if invoke_context
+        .environment_config
         .feature_set
         .is_active(&feature_set::stake_redelegate_instruction::id())
     {
@@ -402,7 +405,8 @@ pub fn split(
     match stake_state {
         StakeStateV2::Stake(meta, mut stake, stake_flags) => {
             meta.authorized.check(signers, StakeAuthorize::Staker)?;
-            let minimum_delegation = crate::get_minimum_delegation(&invoke_context.feature_set);
+            let minimum_delegation =
+                crate::get_minimum_delegation(&invoke_context.environment_config.feature_set);
             let is_active = {
                 let clock = invoke_context.get_sysvar_cache().get_clock()?;
                 let status = get_stake_status(invoke_context, &stake, &clock)?;
@@ -688,7 +692,7 @@ pub fn redelegate(
     let ValidatedDelegatedInfo { stake_amount } = validate_delegated_amount(
         &uninitialized_stake_account,
         &uninitialized_stake_meta,
-        &invoke_context.feature_set,
+        &invoke_context.environment_config.feature_set,
     )?;
     uninitialized_stake_account.set_state(&StakeStateV2::Stake(
         uninitialized_stake_meta,

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -42,7 +42,8 @@ pub fn advance_nonce_account(
                 );
                 return Err(InstructionError::MissingRequiredSignature);
             }
-            let next_durable_nonce = DurableNonce::from_blockhash(&invoke_context.blockhash);
+            let next_durable_nonce =
+                DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash);
             if data.durable_nonce == next_durable_nonce {
                 ic_msg!(
                     invoke_context,
@@ -106,7 +107,8 @@ pub fn withdraw_nonce_account(
         }
         State::Initialized(ref data) => {
             if lamports == from.get_lamports() {
-                let durable_nonce = DurableNonce::from_blockhash(&invoke_context.blockhash);
+                let durable_nonce =
+                    DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash);
                 if data.durable_nonce == durable_nonce {
                     ic_msg!(
                         invoke_context,
@@ -177,7 +179,8 @@ pub fn initialize_nonce_account(
                 );
                 return Err(InstructionError::InsufficientFunds);
             }
-            let durable_nonce = DurableNonce::from_blockhash(&invoke_context.blockhash);
+            let durable_nonce =
+                DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash);
             let data = nonce::state::Data::new(
                 *nonce_authority,
                 durable_nonce,
@@ -306,7 +309,8 @@ mod test {
 
     macro_rules! set_invoke_context_blockhash {
         ($invoke_context:expr, $seed:expr) => {
-            $invoke_context.blockhash = hash(&bincode::serialize(&$seed).unwrap());
+            $invoke_context.environment_config.blockhash =
+                hash(&bincode::serialize(&$seed).unwrap());
             $invoke_context.lamports_per_signature = ($seed as u64).saturating_mul(100);
         };
     }
@@ -343,7 +347,7 @@ mod test {
         let versions = nonce_account.get_state::<Versions>().unwrap();
         let data = nonce::state::Data::new(
             data.authority,
-            DurableNonce::from_blockhash(&invoke_context.blockhash),
+            DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
             invoke_context.lamports_per_signature,
         );
         // First nonce instruction drives state from Uninitialized to Initialized
@@ -353,7 +357,7 @@ mod test {
         let versions = nonce_account.get_state::<Versions>().unwrap();
         let data = nonce::state::Data::new(
             data.authority,
-            DurableNonce::from_blockhash(&invoke_context.blockhash),
+            DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
             invoke_context.lamports_per_signature,
         );
         // Second nonce instruction consumes and replaces stored nonce
@@ -363,7 +367,7 @@ mod test {
         let versions = nonce_account.get_state::<Versions>().unwrap();
         let data = nonce::state::Data::new(
             data.authority,
-            DurableNonce::from_blockhash(&invoke_context.blockhash),
+            DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
             invoke_context.lamports_per_signature,
         );
         // Third nonce instruction for fun and profit
@@ -422,7 +426,7 @@ mod test {
         let versions = nonce_account.get_state::<Versions>().unwrap();
         let data = nonce::state::Data::new(
             authority,
-            DurableNonce::from_blockhash(&invoke_context.blockhash),
+            DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
             invoke_context.lamports_per_signature,
         );
         assert_eq!(versions.state(), &State::Initialized(data));
@@ -734,7 +738,7 @@ mod test {
         let versions = nonce_account.get_state::<Versions>().unwrap();
         let data = nonce::state::Data::new(
             authority,
-            DurableNonce::from_blockhash(&invoke_context.blockhash),
+            DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
             invoke_context.lamports_per_signature,
         );
         assert_eq!(versions.state(), &State::Initialized(data.clone()));
@@ -763,7 +767,7 @@ mod test {
         let versions = nonce_account.get_state::<Versions>().unwrap();
         let data = nonce::state::Data::new(
             data.authority,
-            DurableNonce::from_blockhash(&invoke_context.blockhash),
+            DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
             invoke_context.lamports_per_signature,
         );
         assert_eq!(versions.state(), &State::Initialized(data));
@@ -955,7 +959,7 @@ mod test {
             initialize_nonce_account(&mut nonce_account, &authorized, &rent, &invoke_context);
         let data = nonce::state::Data::new(
             authorized,
-            DurableNonce::from_blockhash(&invoke_context.blockhash),
+            DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
             invoke_context.lamports_per_signature,
         );
         assert_eq!(result, Ok(()));
@@ -1024,7 +1028,7 @@ mod test {
         let authority = Pubkey::default();
         let data = nonce::state::Data::new(
             authority,
-            DurableNonce::from_blockhash(&invoke_context.blockhash),
+            DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
             invoke_context.lamports_per_signature,
         );
         authorize_nonce_account(&mut nonce_account, &authority, &signers, &invoke_context).unwrap();
@@ -1104,7 +1108,8 @@ mod test {
                     .get_account_at_index(NONCE_ACCOUNT_INDEX)
                     .unwrap()
                     .borrow(),
-                DurableNonce::from_blockhash(&invoke_context.blockhash).as_hash(),
+                DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash)
+                    .as_hash(),
             ),
             Some(_)
         );
@@ -1165,7 +1170,8 @@ mod test {
                     .get_account_at_index(NONCE_ACCOUNT_INDEX)
                     .unwrap()
                     .borrow(),
-                DurableNonce::from_blockhash(&invoke_context.blockhash).as_hash(),
+                DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash)
+                    .as_hash(),
             ),
             None
         );

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -55,7 +55,7 @@ pub fn advance_nonce_account(
             let new_data = nonce::state::Data::new(
                 data.authority,
                 next_durable_nonce,
-                invoke_context.lamports_per_signature,
+                invoke_context.environment_config.lamports_per_signature,
             );
             account.set_state(&Versions::new(State::Initialized(new_data)))
         }
@@ -184,7 +184,7 @@ pub fn initialize_nonce_account(
             let data = nonce::state::Data::new(
                 *nonce_authority,
                 durable_nonce,
-                invoke_context.lamports_per_signature,
+                invoke_context.environment_config.lamports_per_signature,
             );
             let state = State::Initialized(data);
             account.set_state(&Versions::new(state))
@@ -311,7 +311,8 @@ mod test {
         ($invoke_context:expr, $seed:expr) => {
             $invoke_context.environment_config.blockhash =
                 hash(&bincode::serialize(&$seed).unwrap());
-            $invoke_context.lamports_per_signature = ($seed as u64).saturating_mul(100);
+            $invoke_context.environment_config.lamports_per_signature =
+                ($seed as u64).saturating_mul(100);
         };
     }
 
@@ -348,7 +349,7 @@ mod test {
         let data = nonce::state::Data::new(
             data.authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.lamports_per_signature,
+            invoke_context.environment_config.lamports_per_signature,
         );
         // First nonce instruction drives state from Uninitialized to Initialized
         assert_eq!(versions.state(), &State::Initialized(data.clone()));
@@ -358,7 +359,7 @@ mod test {
         let data = nonce::state::Data::new(
             data.authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.lamports_per_signature,
+            invoke_context.environment_config.lamports_per_signature,
         );
         // Second nonce instruction consumes and replaces stored nonce
         assert_eq!(versions.state(), &State::Initialized(data.clone()));
@@ -368,7 +369,7 @@ mod test {
         let data = nonce::state::Data::new(
             data.authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.lamports_per_signature,
+            invoke_context.environment_config.lamports_per_signature,
         );
         // Third nonce instruction for fun and profit
         assert_eq!(versions.state(), &State::Initialized(data));
@@ -427,7 +428,7 @@ mod test {
         let data = nonce::state::Data::new(
             authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.lamports_per_signature,
+            invoke_context.environment_config.lamports_per_signature,
         );
         assert_eq!(versions.state(), &State::Initialized(data));
         // Nonce account did not sign
@@ -739,7 +740,7 @@ mod test {
         let data = nonce::state::Data::new(
             authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.lamports_per_signature,
+            invoke_context.environment_config.lamports_per_signature,
         );
         assert_eq!(versions.state(), &State::Initialized(data.clone()));
         let withdraw_lamports = 42;
@@ -768,7 +769,7 @@ mod test {
         let data = nonce::state::Data::new(
             data.authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.lamports_per_signature,
+            invoke_context.environment_config.lamports_per_signature,
         );
         assert_eq!(versions.state(), &State::Initialized(data));
         assert_eq!(nonce_account.get_lamports(), from_expect_lamports);
@@ -960,7 +961,7 @@ mod test {
         let data = nonce::state::Data::new(
             authorized,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.lamports_per_signature,
+            invoke_context.environment_config.lamports_per_signature,
         );
         assert_eq!(result, Ok(()));
         let versions = nonce_account.get_state::<Versions>().unwrap();
@@ -1029,7 +1030,7 @@ mod test {
         let data = nonce::state::Data::new(
             authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.lamports_per_signature,
+            invoke_context.environment_config.lamports_per_signature,
         );
         authorize_nonce_account(&mut nonce_account, &authority, &signers, &invoke_context).unwrap();
         let versions = nonce_account.get_state::<Versions>().unwrap();

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -1578,7 +1578,7 @@ mod tests {
             Ok(()),
             Entrypoint::vm,
             |invoke_context: &mut InvokeContext| {
-                invoke_context.blockhash = hash(&serialize(&0).unwrap());
+                invoke_context.environment_config.blockhash = hash(&serialize(&0).unwrap());
             },
             |_invoke_context| {},
         );
@@ -1925,7 +1925,7 @@ mod tests {
             Err(SystemError::NonceNoRecentBlockhashes.into()),
             Entrypoint::vm,
             |invoke_context: &mut InvokeContext| {
-                invoke_context.blockhash = hash(&serialize(&0).unwrap());
+                invoke_context.environment_config.blockhash = hash(&serialize(&0).unwrap());
             },
             |_invoke_context| {},
         );

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -46,7 +46,7 @@ fn process_authorize_with_seed_instruction(
         authorization_type,
         &expected_authority_keys,
         &clock,
-        &invoke_context.feature_set,
+        &invoke_context.environment_config.feature_set,
     )
 }
 
@@ -80,7 +80,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &vote_init,
                 &signers,
                 &clock,
-                &invoke_context.feature_set,
+                &invoke_context.environment_config.feature_set,
             )
         }
         VoteInstruction::Authorize(voter_pubkey, vote_authorize) => {
@@ -92,7 +92,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 vote_authorize,
                 &signers,
                 &clock,
-                &invoke_context.feature_set,
+                &invoke_context.environment_config.feature_set,
             )
         }
         VoteInstruction::AuthorizeWithSeed(args) => {
@@ -136,7 +136,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &mut me,
                 node_pubkey,
                 &signers,
-                &invoke_context.feature_set,
+                &invoke_context.environment_config.feature_set,
             )
         }
         VoteInstruction::UpdateCommission(commission) => {
@@ -148,7 +148,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &signers,
                 sysvar_cache.get_epoch_schedule()?.as_ref(),
                 sysvar_cache.get_clock()?.as_ref(),
-                &invoke_context.feature_set,
+                &invoke_context.environment_config.feature_set,
             )
         }
         VoteInstruction::Vote(vote) | VoteInstruction::VoteSwitch(vote, _) => {
@@ -162,7 +162,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &clock,
                 &vote,
                 &signers,
-                &invoke_context.feature_set,
+                &invoke_context.environment_config.feature_set,
             )
         }
         VoteInstruction::UpdateVoteState(vote_state_update)
@@ -176,7 +176,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &clock,
                 vote_state_update,
                 &signers,
-                &invoke_context.feature_set,
+                &invoke_context.environment_config.feature_set,
             )
         }
         VoteInstruction::CompactUpdateVoteState(vote_state_update)
@@ -190,12 +190,13 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &clock,
                 vote_state_update,
                 &signers,
-                &invoke_context.feature_set,
+                &invoke_context.environment_config.feature_set,
             )
         }
         VoteInstruction::TowerSync(tower_sync)
         | VoteInstruction::TowerSyncSwitch(tower_sync, _) => {
             if !invoke_context
+                .environment_config
                 .feature_set
                 .is_active(&feature_set::enable_tower_sync_ix::id())
             {
@@ -210,7 +211,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &clock,
                 tower_sync,
                 &signers,
-                &invoke_context.feature_set,
+                &invoke_context.environment_config.feature_set,
             )
         }
         VoteInstruction::Withdraw(lamports) => {
@@ -228,7 +229,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &signers,
                 &rent_sysvar,
                 &clock_sysvar,
-                &invoke_context.feature_set,
+                &invoke_context.environment_config.feature_set,
             )
         }
         VoteInstruction::AuthorizeChecked(vote_authorize) => {
@@ -247,7 +248,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 vote_authorize,
                 &signers,
                 &clock,
-                &invoke_context.feature_set,
+                &invoke_context.environment_config.feature_set,
             )
         }
     }
@@ -337,7 +338,8 @@ mod tests {
             expected_result,
             Entrypoint::vm,
             |invoke_context| {
-                invoke_context.feature_set = std::sync::Arc::new(FeatureSet::default());
+                invoke_context.environment_config.feature_set =
+                    std::sync::Arc::new(FeatureSet::default());
             },
             |_invoke_context| {},
         )

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -46,7 +46,7 @@ fn process_authorize_with_seed_instruction(
         authorization_type,
         &expected_authority_keys,
         &clock,
-        &invoke_context.environment_config.feature_set,
+        invoke_context.get_feature_set(),
     )
 }
 
@@ -80,7 +80,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &vote_init,
                 &signers,
                 &clock,
-                &invoke_context.environment_config.feature_set,
+                invoke_context.get_feature_set(),
             )
         }
         VoteInstruction::Authorize(voter_pubkey, vote_authorize) => {
@@ -92,7 +92,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 vote_authorize,
                 &signers,
                 &clock,
-                &invoke_context.environment_config.feature_set,
+                invoke_context.get_feature_set(),
             )
         }
         VoteInstruction::AuthorizeWithSeed(args) => {
@@ -136,7 +136,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &mut me,
                 node_pubkey,
                 &signers,
-                &invoke_context.environment_config.feature_set,
+                invoke_context.get_feature_set(),
             )
         }
         VoteInstruction::UpdateCommission(commission) => {
@@ -148,7 +148,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &signers,
                 sysvar_cache.get_epoch_schedule()?.as_ref(),
                 sysvar_cache.get_clock()?.as_ref(),
-                &invoke_context.environment_config.feature_set,
+                invoke_context.get_feature_set(),
             )
         }
         VoteInstruction::Vote(vote) | VoteInstruction::VoteSwitch(vote, _) => {
@@ -162,7 +162,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &clock,
                 &vote,
                 &signers,
-                &invoke_context.environment_config.feature_set,
+                invoke_context.get_feature_set(),
             )
         }
         VoteInstruction::UpdateVoteState(vote_state_update)
@@ -176,7 +176,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &clock,
                 vote_state_update,
                 &signers,
-                &invoke_context.environment_config.feature_set,
+                invoke_context.get_feature_set(),
             )
         }
         VoteInstruction::CompactUpdateVoteState(vote_state_update)
@@ -190,14 +190,13 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &clock,
                 vote_state_update,
                 &signers,
-                &invoke_context.environment_config.feature_set,
+                invoke_context.get_feature_set(),
             )
         }
         VoteInstruction::TowerSync(tower_sync)
         | VoteInstruction::TowerSyncSwitch(tower_sync, _) => {
             if !invoke_context
-                .environment_config
-                .feature_set
+                .get_feature_set()
                 .is_active(&feature_set::enable_tower_sync_ix::id())
             {
                 return Err(InstructionError::InvalidInstructionData);
@@ -211,7 +210,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &clock,
                 tower_sync,
                 &signers,
-                &invoke_context.environment_config.feature_set,
+                invoke_context.get_feature_set(),
             )
         }
         VoteInstruction::Withdraw(lamports) => {
@@ -229,7 +228,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &signers,
                 &rent_sysvar,
                 &clock_sysvar,
-                &invoke_context.environment_config.feature_set,
+                invoke_context.get_feature_set(),
             )
         }
         VoteInstruction::AuthorizeChecked(vote_authorize) => {
@@ -248,7 +247,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 vote_authorize,
                 &signers,
                 &clock,
-                &invoke_context.environment_config.feature_set,
+                invoke_context.get_feature_set(),
             )
         }
     }
@@ -338,8 +337,7 @@ mod tests {
             expected_result,
             Entrypoint::vm,
             |invoke_context| {
-                invoke_context.environment_config.feature_set =
-                    std::sync::Arc::new(FeatureSet::default());
+                invoke_context.mock_set_feature_set(std::sync::Arc::new(FeatureSet::default()));
             },
             |_invoke_context| {},
         )

--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -51,8 +51,7 @@ where
     // if instruction data is exactly 5 bytes, then read proof from an account
     let context_data = if instruction_data.len() == INSTRUCTION_DATA_LENGTH_WITH_PROOF_ACCOUNT {
         if !invoke_context
-            .environment_config
-            .feature_set
+            .get_feature_set()
             .is_active(&feature_set::enable_zk_proof_from_account::id())
         {
             return Err(InstructionError::InvalidInstructionData);
@@ -185,8 +184,7 @@ fn process_close_proof_context(invoke_context: &mut InvokeContext) -> Result<(),
 
 declare_process_instruction!(Entrypoint, 0, |invoke_context| {
     let enable_zk_transfer_with_fee = invoke_context
-        .environment_config
-        .feature_set
+        .get_feature_set()
         .is_active(&feature_set::enable_zk_transfer_with_fee::id());
 
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -51,6 +51,7 @@ where
     // if instruction data is exactly 5 bytes, then read proof from an account
     let context_data = if instruction_data.len() == INSTRUCTION_DATA_LENGTH_WITH_PROOF_ACCOUNT {
         if !invoke_context
+            .environment_config
             .feature_set
             .is_active(&feature_set::enable_zk_proof_from_account::id())
         {
@@ -184,6 +185,7 @@ fn process_close_proof_context(invoke_context: &mut InvokeContext) -> Result<(),
 
 declare_process_instruction!(Entrypoint, 0, |invoke_context| {
     let enable_zk_transfer_with_fee = invoke_context
+        .environment_config
         .feature_set
         .is_active(&feature_set::enable_zk_transfer_with_fee::id());
 

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -8,7 +8,8 @@ use {
     error::CoreBpfMigrationError,
     num_traits::{CheckedAdd, CheckedSub},
     solana_program_runtime::{
-        invoke_context::InvokeContext, loaded_programs::ProgramCacheForTxBatch,
+        invoke_context::{EnvironmentConfig, InvokeContext},
+        loaded_programs::ProgramCacheForTxBatch,
         sysvar_cache::SysvarCache,
     },
     solana_sdk::{
@@ -174,14 +175,11 @@ impl Bank {
 
             let mut dummy_invoke_context = InvokeContext::new(
                 &mut dummy_transaction_context,
-                &sysvar_cache,
+                EnvironmentConfig::new(Hash::default(), self.feature_set.clone(), 0, &sysvar_cache),
                 None,
                 compute_budget,
                 &programs_loaded,
                 &mut programs_modified,
-                self.feature_set.clone(),
-                Hash::default(),
-                0,
             );
 
             solana_bpf_loader_program::direct_deploy_program(

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -148,6 +148,7 @@ mod tests {
         solana_program_runtime::{
             compute_budget::ComputeBudget,
             declare_process_instruction,
+            invoke_context::EnvironmentConfig,
             loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
             sysvar_cache::SysvarCache,
         },
@@ -272,16 +273,19 @@ mod tests {
         ));
         let sysvar_cache = SysvarCache::default();
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
+        let environment_config = EnvironmentConfig::new(
+            Hash::default(),
+            Arc::new(FeatureSet::all_enabled()),
+            0,
+            &sysvar_cache,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &sysvar_cache,
+            environment_config,
             None,
             ComputeBudget::default(),
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
-            Arc::new(FeatureSet::all_enabled()),
-            Hash::default(),
-            0,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -323,16 +327,19 @@ mod tests {
             ]),
         ));
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
+        let environment_config = EnvironmentConfig::new(
+            Hash::default(),
+            Arc::new(FeatureSet::all_enabled()),
+            0,
+            &sysvar_cache,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &sysvar_cache,
+            environment_config,
             None,
             ComputeBudget::default(),
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
-            Arc::new(FeatureSet::all_enabled()),
-            Hash::default(),
-            0,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -364,16 +371,19 @@ mod tests {
             ]),
         ));
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
+        let environment_config = EnvironmentConfig::new(
+            Hash::default(),
+            Arc::new(FeatureSet::all_enabled()),
+            0,
+            &sysvar_cache,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &sysvar_cache,
+            environment_config,
             None,
             ComputeBudget::default(),
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
-            Arc::new(FeatureSet::all_enabled()),
-            Hash::default(),
-            0,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -496,16 +506,19 @@ mod tests {
         ));
         let sysvar_cache = SysvarCache::default();
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
+        let environment_config = EnvironmentConfig::new(
+            Hash::default(),
+            Arc::new(FeatureSet::all_enabled()),
+            0,
+            &sysvar_cache,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &sysvar_cache,
+            environment_config,
             None,
             ComputeBudget::default(),
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
-            Arc::new(FeatureSet::all_enabled()),
-            Hash::default(),
-            0,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -532,16 +545,19 @@ mod tests {
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
+        let environment_config = EnvironmentConfig::new(
+            Hash::default(),
+            Arc::new(FeatureSet::all_enabled()),
+            0,
+            &sysvar_cache,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &sysvar_cache,
+            environment_config,
             None,
             ComputeBudget::default(),
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
-            Arc::new(FeatureSet::all_enabled()),
-            Hash::default(),
-            0,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -565,16 +581,19 @@ mod tests {
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
+        let environment_config = EnvironmentConfig::new(
+            Hash::default(),
+            Arc::new(FeatureSet::all_enabled()),
+            0,
+            &sysvar_cache,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &sysvar_cache,
+            environment_config,
             None,
             ComputeBudget::default(),
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
-            Arc::new(FeatureSet::all_enabled()),
-            Hash::default(),
-            0,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -659,16 +678,19 @@ mod tests {
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
+        let environment_config = EnvironmentConfig::new(
+            Hash::default(),
+            Arc::new(FeatureSet::all_enabled()),
+            0,
+            &sysvar_cache,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &sysvar_cache,
+            environment_config,
             None,
             ComputeBudget::default(),
             &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
-            Arc::new(FeatureSet::all_enabled()),
-            Hash::default(),
-            0,
         );
         let result = MessageProcessor::process_message(
             &message,

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -47,8 +47,9 @@ impl MessageProcessor {
             .zip(program_indices.iter())
             .enumerate()
         {
-            let is_precompile =
-                is_precompile(program_id, |id| invoke_context.feature_set.is_active(id));
+            let is_precompile = is_precompile(program_id, |id| {
+                invoke_context.environment_config.feature_set.is_active(id)
+            });
 
             // Fixup the special instructions key if present
             // before the account pre-values are taken care of

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -48,7 +48,7 @@ impl MessageProcessor {
             .enumerate()
         {
             let is_precompile = is_precompile(program_id, |id| {
-                invoke_context.environment_config.feature_set.is_active(id)
+                invoke_context.get_feature_set().is_active(id)
             });
 
             // Fixup the special instructions key if present

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -19,7 +19,7 @@ use {
     solana_measure::measure::Measure,
     solana_program_runtime::{
         compute_budget::ComputeBudget,
-        invoke_context::InvokeContext,
+        invoke_context::{EnvironmentConfig, InvokeContext},
         loaded_programs::{
             ForkGraph, ProgramCache, ProgramCacheEntry, ProgramCacheForTxBatch,
             ProgramCacheMatchCriteria,
@@ -534,14 +534,16 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            sysvar_cache,
+            EnvironmentConfig::new(
+                blockhash,
+                callback.get_feature_set(),
+                lamports_per_signature,
+                sysvar_cache,
+            ),
             log_collector.clone(),
             compute_budget,
             programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
-            callback.get_feature_set(),
-            blockhash,
-            lamports_per_signature,
         );
 
         let mut process_message_time = Measure::start("process_message_time");


### PR DESCRIPTION
#### Problem
The `InvokeContext` and its contructor are become quite bloated. 

There are a number of contextual configurations the runtime must pipe into an 
`InvokeContext` instance in order to configure proper instruction execution - 
such as the latest blockhash, the current runtime feature set, and a "cache" of 
sysvar data.

These configs can be grouped into a common configuration object.

#### Summary of Changes
Introduce a `EnvironmentConfig` struct to group these runtime context values
in the `InvokeContext`.

Commit history is divided to ensure maximum ease of review.
   
1. Introduce the `EnvironmentConfig` struct and refactor the `InvokeContext`
   constructor to use it.
2. Pop `blockhash` from `InvokeContext` in favor of the value stored in the
   environment config.
3. Pop `lamports_per_signature` from `InvokeContext` in favor of the value
   stored in the environment config.
4. Pop `feature_set` from `InvokeContext` in favor of the value stored in the
   environment config.
5. Pop `sysvar_cache` from `InvokeContext` in favor of the value stored in 
   the environment config.
