### PR TITLE
Set max concurrent uni streams accordingly -- do not over allocate open uni streams

### DIFF
--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -27,7 +27,7 @@ use {
         signature::{Keypair, Signer},
     },
     solana_streamer::{
-        nonblocking::quic::{compute_max_allowed_uni_streams, ConnectionPeerType},
+        nonblocking::quic::{ConnectionPeerType, UniStreamQosUtil},
         streamer::StakedNodes,
         tls_certificates::new_dummy_x509_certificate,
     },
@@ -135,7 +135,7 @@ impl QuicConfig {
                         },
                     )
                 });
-        compute_max_allowed_uni_streams(client_type, total_stake)
+        UniStreamQosUtil::compute_max_allowed_uni_streams(client_type, total_stake)
     }
 
     pub fn update_client_certificate(&mut self, keypair: &Keypair, _ipaddr: IpAddr) {

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -325,7 +325,7 @@ impl UniStreamQosUtil {
     ) -> u64 {
         let max_streams_per_throttle_window =
             ema.available_load_capacity_in_throttling_duration(peer_type, total_stake);
-        (UniStreamQosUtil::compute_max_allowed_uni_streams(peer_type, total_stake) as u64)
+        (Self::compute_max_allowed_uni_streams(peer_type, total_stake) as u64)
             .min(max_streams_per_throttle_window)
     }
 
@@ -896,17 +896,17 @@ async fn handle_connection(
                             sleep(throttle_duration).await;
                         }
                     }
-                    let max_concurrent_uni_streams_per_interval = VarInt::from_u64(
+                    let max_uni_streams_in_interval = VarInt::from_u64(
                         UniStreamQosUtil::max_concurrent_uni_streams_per_throttling_interval(
                             max_streams_per_throttling_interval,
                             max_concurrent_uni_streams,
                         ));
 
-                    if let Ok(max_concurrent_uni_streams_per_interval) = max_concurrent_uni_streams_per_interval {
+                    if let Ok(max_uni_streams_in_interval) = max_uni_streams_in_interval {
                         // Update max concurrent uni streams if needed
-                        if max_concurrent_uni_streams != max_uni_streams {
-                            connection.set_max_concurrent_uni_streams(max_concurrent_uni_streams_per_interval);
-                            max_uni_streams = max_concurrent_uni_streams_per_interval;
+                        if max_uni_streams_in_interval != max_uni_streams {
+                            connection.set_max_concurrent_uni_streams(max_uni_streams_in_interval);
+                            max_uni_streams = max_uni_streams_in_interval;
                         }
                     }
                     stream_load_ema.increment_load(params.peer_type);

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -896,18 +896,17 @@ async fn handle_connection(
                             sleep(throttle_duration).await;
                         }
                     }
-                    let max_concurrent_uni_streams =
+                    let max_concurrent_uni_streams_per_interval = VarInt::from_u64(
                         UniStreamQosUtil::max_concurrent_uni_streams_per_throttling_interval(
                             max_streams_per_throttling_interval,
                             max_concurrent_uni_streams,
-                        );
-                    let max_concurrent_uni_streams = VarInt::from_u64(max_concurrent_uni_streams);
+                        ));
 
-                    if let Ok(max_concurrent_uni_streams) = max_concurrent_uni_streams {
+                    if let Ok(max_concurrent_uni_streams_per_interval) = max_concurrent_uni_streams_per_interval {
                         // Update max concurrent uni streams if needed
                         if max_concurrent_uni_streams != max_uni_streams {
-                            connection.set_max_concurrent_uni_streams(max_concurrent_uni_streams);
-                            max_uni_streams = max_concurrent_uni_streams;
+                            connection.set_max_concurrent_uni_streams(max_concurrent_uni_streams_per_interval);
+                            max_uni_streams = max_concurrent_uni_streams_per_interval;
                         }
                     }
                     stream_load_ema.increment_load(params.peer_type);

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -900,7 +900,8 @@ async fn handle_connection(
                         UniStreamQosUtil::max_concurrent_uni_streams_per_throttling_interval(
                             max_streams_per_throttling_interval,
                             max_concurrent_uni_streams,
-                        ));
+                        ),
+                    );
 
                     if let Ok(max_uni_streams_in_interval) = max_uni_streams_in_interval {
                         // Update max concurrent uni streams if needed

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -902,7 +902,7 @@ async fn handle_connection(
                             max_concurrent_uni_streams,
                         );
                     let max_concurrent_uni_streams =
-                        VarInt::from_u64(max_concurrent_uni_streams as u64);
+                        VarInt::from_u64(max_concurrent_uni_streams);
 
                     if let Ok(max_concurrent_uni_streams) = max_concurrent_uni_streams {
                         // Update max concurrent uni streams if needed

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -901,8 +901,7 @@ async fn handle_connection(
                             max_streams_per_throttling_interval,
                             max_concurrent_uni_streams,
                         );
-                    let max_concurrent_uni_streams =
-                        VarInt::from_u64(max_concurrent_uni_streams);
+                    let max_concurrent_uni_streams = VarInt::from_u64(max_concurrent_uni_streams);
 
                     if let Ok(max_concurrent_uni_streams) = max_concurrent_uni_streams {
                         // Update max concurrent uni streams if needed


### PR DESCRIPTION
#### Problem

We can over allocate max concurrent open uni streams than the total streams allowed within a throttle window.
For example, an unstaked node might be eligible for 2 uni streams per throttle window, but we might allocate the 128 concurrent uni streams for it.

This has two problems: allocating resources on the server side unnecessarily and allow the client to open concurrent uni streams which will be throttled on server side, more timeout error on client side and more load on the server side.
#### Summary of Changes

Do not allow more open concurrent uni streams than the one permitted in a throttle window.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
