### PR TITLE
[clap-v3-utils] Add functions to directly parse from `SignerSource`

### DIFF
--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -1,8 +1,8 @@
 use {
     crate::keypair::{
         keypair_from_seed_phrase, keypair_from_source, pubkey_from_path, pubkey_from_source,
-        resolve_signer_from_path, signer_from_path, signer_from_source, ASK_KEYWORD,
-        SKIP_SEED_PHRASE_VALIDATION_ARG,
+        resolve_signer_from_path, resolve_signer_from_source, signer_from_path, signer_from_source,
+        ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
     clap::{builder::ValueParser, ArgMatches},
     solana_remote_wallet::{
@@ -178,6 +178,19 @@ impl SignerSource {
                 .filter_map(|source| pubkey_from_source(matches, source, name, wallet_manager).ok())
                 .collect();
             Ok(Some(pubkeys))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn try_resolve(
+        matches: &ArgMatches,
+        name: &str,
+        wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
+    ) -> Result<Option<String>, Box<dyn std::error::Error>> {
+        let source = matches.try_get_one::<Self>(name)?;
+        if let Some(source) = source {
+            resolve_signer_from_source(matches, source, name, wallet_manager)
         } else {
             Ok(None)
         }


### PR DESCRIPTION
#### Problem
Using the way we have set up in clap-v3-utils with `SignerSource`, downstream cli tools must parse `keypair`, signer`, or `pubkey` from signer source arguments in two steps:
1. parse the signer source
2. extract the `keypair`, `signer`, or `pubkey` from the signer source

```
let signer_source = matches.get_one::<SignerSource>("program_id).unwrap(); // step 1
let desired_pubkey = pubkey_from_source(matches, source, "program_id, &mut wallet_manager); // step 2
```

In an overwhelming number of cases, the cli tools proceed with steps 1 and 2 together. This requirement to parse arguments in two steps have resulted in more verbose code (for example, https://github.com/solana-labs/solana-program-library/pull/6625. It would really simplify and make the code less verbose if there were utility functions that performs steps 1 and 2 together.

There exist functions like `pubkey_of` and `signer_of` that does this. Unfortunately, these functions parse the signer source arguments as `String` and hence results in a downcast error if the argument is defined using the updated `SignerSourceParserBuilder`.

#### Summary of Changes
Added utility functions `try_get_{keypair, keypairs, signer, signers, pubkey, pubkeys}` and `try_resolve` functions as static functions to `SignerSource`. These functions perform the steps 1 and 2 described above and should really help in making cli code easier and more concise.

This change was included in an old PR on clap-v3-utils https://github.com/solana-labs/solana/pull/33478, but I did not include it in subsequent PRs because I thought we don't necessarily need it. Now, after making some updates to a couple of cli tools, it seems like these functions would make life a lot easier.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
