### PR TITLE
[zk-sdk] Remove unnecessary exclusion of solana target

### DIFF
--- a/zk-sdk/src/encryption/mod.rs
+++ b/zk-sdk/src/encryption/mod.rs
@@ -10,7 +10,6 @@
 //! - Basic type-wrapper around the AES-GCM-SIV symmetric authenticated encryption scheme
 //! implemented by [aes-gcm-siv](https://docs.rs/aes-gcm-siv/latest/aes_gcm_siv/) crate.
 
-#[cfg(not(target_os = "solana"))]
 #[macro_use]
 pub(crate) mod macros;
 pub mod auth_encryption;


### PR DESCRIPTION
#### Problem
Sorry I missed this from the previous PR. The `encryption` module is already excluded from the sbf target, but the `macros` submodule is excluded from the sbf target redundantly.

#### Summary of Changes
Remove the line that excludes `macros` from sbf target.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
