### PR TITLE
[syscalls] Clean-up curve25519 msm length feature gate check

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1140,14 +1140,8 @@ declare_builtin_function!(
             curve_syscall_traits::*, edwards, ristretto, scalar,
         };
 
-        let restrict_msm_length = invoke_context
-            .feature_set
-            .is_active(&feature_set::curve25519_restrict_msm_length::id());
-        #[allow(clippy::collapsible_if)]
-        if restrict_msm_length {
-            if points_len > 512 {
-                return Err(Box::new(SyscallError::InvalidLength));
-            }
+        if points_len > 512 {
+            return Err(Box::new(SyscallError::InvalidLength));
         }
 
         match curve_id {


### PR DESCRIPTION
#### Problem
The feature `eca6zf6JJRjQsYYPkBHF3N32MTzur4n2WL4QiiacPCL` is now activated on all clusters.

#### Summary of Changes
Remove the unnecessary feature gate check.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
