### PR TITLE
client: Remove unnecessary progress bar update

### DIFF
--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -336,14 +336,6 @@ async fn confirm_transactions_till_block_height_and_resend_unexpired_transaction
             );
         }
 
-        if let Some(progress_bar) = progress_bar {
-            let progress = progress_from_context_and_block_height(context, max_valid_block_height);
-            progress.set_message_for_confirmed_transactions(
-                progress_bar,
-                "Checking transaction status...",
-            );
-        }
-
         // wait till all transactions are confirmed or we have surpassed max processing age for the last sent transaction
         while !unconfirmed_transaction_map.is_empty()
             && current_block_height.load(Ordering::Relaxed) <= max_valid_block_height


### PR DESCRIPTION
#### Problem

As mentioned in https://github.com/anza-xyz/agave/pull/358#discussion_r1580532890, during send_and_confirm_transactions_in_parallel, there are two immediate updates to the progress bar, making one of them unnecessary.

#### Summary of Changes

Remove the second one, which contains less information

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
