### PR TITLE
make the LogCollector fields public

### DIFF
--- a/program-runtime/src/log_collector.rs
+++ b/program-runtime/src/log_collector.rs
@@ -4,10 +4,10 @@ use std::{cell::RefCell, rc::Rc};
 const LOG_MESSAGES_BYTES_LIMIT: usize = 10 * 1000;
 
 pub struct LogCollector {
-    messages: Vec<String>,
-    bytes_written: usize,
-    bytes_limit: Option<usize>,
-    limit_warning: bool,
+    pub messages: Vec<String>,
+    pub bytes_written: usize,
+    pub bytes_limit: Option<usize>,
+    pub limit_warning: bool,
 }
 
 impl Default for LogCollector {


### PR DESCRIPTION
#### Problem
I need to use [Refcell::replace](https://doc.rust-lang.org/std/cell/struct.RefCell.html#method.replace) on the collected logs instead of `.take()`, because I want to control the bytes_limit. This requires being able to construct a plain `LogCollector` instead of using `new_ref_with_limit()` which returns an `Rc<RefCell<LogCollector>>`.

I'd also like to be able to use a preallocated Vec for the `messages` field. At this point it seems simplest to just make all four fields public.

#### Summary of Changes
Makes the LogCollector fields pub
