### PR TITLE
SVM: Hoist program cache recompilation up from Bank

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6352,6 +6352,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
+ "solana-bpf-loader-program",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-loader-v4-program",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1223,9 +1223,12 @@ impl Bank {
             }
         });
 
-        let (_, recompilation_time_us) = measure_us!(new
+        let (_, cache_preparation_time_us) = measure_us!(new
             .transaction_processor
-            .recompile_program_cache(&new, &new.compute_active_feature_set(true).0));
+            .prepare_program_cache_for_upcoming_feature_set(
+                &new,
+                &new.compute_active_feature_set(true).0
+            ));
 
         // Update sysvars before processing transactions
         let (_, update_sysvars_time_us) = measure_us!({
@@ -1261,7 +1264,7 @@ impl Bank {
                 feature_set_time_us,
                 ancestors_time_us,
                 update_epoch_time_us,
-                recompilation_time_us,
+                cache_preparation_time_us,
                 update_sysvars_time_us,
                 fill_sysvar_cache_time_us,
             },

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1223,75 +1223,9 @@ impl Bank {
             }
         });
 
-        let (_, recompilation_time_us) = measure_us!({
-            // Recompile loaded programs one at a time before the next epoch hits
-            let (_epoch, slot_index) = new.get_epoch_and_slot_index(new.slot());
-            let slots_in_epoch = new.get_slots_in_epoch(new.epoch());
-            let slots_in_recompilation_phase =
-                (solana_program_runtime::loaded_programs::MAX_LOADED_ENTRY_COUNT as u64)
-                    .min(slots_in_epoch)
-                    .checked_div(2)
-                    .unwrap();
-            let mut program_cache = new.transaction_processor.program_cache.write().unwrap();
-            if program_cache.upcoming_environments.is_some() {
-                if let Some((key, program_to_recompile)) = program_cache.programs_to_recompile.pop()
-                {
-                    let effective_epoch = program_cache.latest_root_epoch.saturating_add(1);
-                    drop(program_cache);
-                    if let Some(recompiled) = new.load_program(&key, false, effective_epoch) {
-                        recompiled.tx_usage_counter.fetch_add(
-                            program_to_recompile.tx_usage_counter.load(Relaxed),
-                            Relaxed,
-                        );
-                        recompiled.ix_usage_counter.fetch_add(
-                            program_to_recompile.ix_usage_counter.load(Relaxed),
-                            Relaxed,
-                        );
-                        let mut program_cache =
-                            new.transaction_processor.program_cache.write().unwrap();
-                        program_cache.assign_program(key, recompiled);
-                    }
-                }
-            } else if new.epoch() != program_cache.latest_root_epoch
-                || slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch
-            {
-                // Anticipate the upcoming program runtime environment for the next epoch,
-                // so we can try to recompile loaded programs before the feature transition hits.
-                drop(program_cache);
-                let (feature_set, _new_feature_activations) = new.compute_active_feature_set(true);
-                let mut program_cache = new.transaction_processor.program_cache.write().unwrap();
-                let program_runtime_environment_v1 = create_program_runtime_environment_v1(
-                    &feature_set,
-                    &new.runtime_config().compute_budget.unwrap_or_default(),
-                    false, /* deployment */
-                    false, /* debugging_features */
-                )
-                .unwrap();
-                let program_runtime_environment_v2 = create_program_runtime_environment_v2(
-                    &new.runtime_config().compute_budget.unwrap_or_default(),
-                    false, /* debugging_features */
-                );
-                let mut upcoming_environments = program_cache.environments.clone();
-                let changed_program_runtime_v1 =
-                    *upcoming_environments.program_runtime_v1 != program_runtime_environment_v1;
-                let changed_program_runtime_v2 =
-                    *upcoming_environments.program_runtime_v2 != program_runtime_environment_v2;
-                if changed_program_runtime_v1 {
-                    upcoming_environments.program_runtime_v1 =
-                        Arc::new(program_runtime_environment_v1);
-                }
-                if changed_program_runtime_v2 {
-                    upcoming_environments.program_runtime_v2 =
-                        Arc::new(program_runtime_environment_v2);
-                }
-                program_cache.upcoming_environments = Some(upcoming_environments);
-                program_cache.programs_to_recompile = program_cache
-                    .get_flattened_entries(changed_program_runtime_v1, changed_program_runtime_v2);
-                program_cache
-                    .programs_to_recompile
-                    .sort_by_cached_key(|(_id, program)| program.decayed_usage_counter(slot));
-            }
-        });
+        let (_, recompilation_time_us) = measure_us!(new
+            .transaction_processor
+            .recompile_program_cache(&new, &new.compute_active_feature_set(true).0));
 
         // Update sysvars before processing transactions
         let (_, update_sysvars_time_us) = measure_us!({

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -43,7 +43,7 @@ pub(crate) struct NewBankTimings {
     pub(crate) feature_set_time_us: u64,
     pub(crate) ancestors_time_us: u64,
     pub(crate) update_epoch_time_us: u64,
-    pub(crate) recompilation_time_us: u64,
+    pub(crate) cache_preparation_time_us: u64,
     pub(crate) update_sysvars_time_us: u64,
     pub(crate) fill_sysvar_cache_time_us: u64,
 }
@@ -153,7 +153,11 @@ pub(crate) fn report_new_bank_metrics(
         ("feature_set_us", timings.feature_set_time_us, i64),
         ("ancestors_us", timings.ancestors_time_us, i64),
         ("update_epoch_us", timings.update_epoch_time_us, i64),
-        ("recompilation_time_us", timings.recompilation_time_us, i64),
+        (
+            "cache_preparation_time_us",
+            timings.cache_preparation_time_us,
+            i64
+        ),
         ("update_sysvars_us", timings.update_sysvars_time_us, i64),
         (
             "fill_sysvar_cache_us",

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11964,7 +11964,7 @@ fn test_is_in_slot_hashes_history() {
 }
 
 #[test]
-fn test_feature_activation_loaded_programs_recompilation_phase() {
+fn test_feature_activation_loaded_programs_cache_preparation_phase() {
     solana_logger::setup();
 
     // Bank Setup

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -15,6 +15,7 @@ log = { workspace = true }
 percentage = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
+solana-bpf-loader-program = { workspace = true }
 solana-frozen-abi = { workspace = true }
 solana-frozen-abi-macro = { workspace = true }
 solana-loader-v4-program = { workspace = true }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -16,6 +16,8 @@ use {
     },
     log::debug,
     percentage::Percentage,
+    solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
+    solana_loader_v4_program::create_program_runtime_environment_v2,
     solana_measure::measure::Measure,
     solana_program_runtime::{
         compute_budget::ComputeBudget,
@@ -32,6 +34,7 @@ use {
         account::{AccountSharedData, ReadableAccount, PROGRAM_OWNERS},
         clock::{Epoch, Slot},
         epoch_schedule::EpochSchedule,
+        feature_set::FeatureSet,
         fee::FeeStructure,
         inner_instruction::{InnerInstruction, InnerInstructionsList},
         instruction::{CompiledInstruction, TRANSACTION_LEVEL_STACK_HEIGHT},
@@ -46,7 +49,10 @@ use {
         collections::{hash_map::Entry, HashMap, HashSet},
         fmt::{Debug, Formatter},
         rc::Rc,
-        sync::{atomic::Ordering, Arc, RwLock},
+        sync::{
+            atomic::Ordering::{self, Relaxed},
+            Arc, RwLock,
+        },
     },
 };
 
@@ -460,6 +466,83 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         }
 
         loaded_programs_for_txs.unwrap()
+    }
+
+    pub fn recompile_program_cache<CB: TransactionProcessingCallback>(
+        &self,
+        callbacks: &CB,
+        upcoming_feature_set: &FeatureSet,
+    ) {
+        // Recompile loaded programs one at a time before the next epoch hits
+        let (_epoch, slot_index) = self.epoch_schedule.get_epoch_and_slot_index(self.slot);
+        let slots_in_epoch = self.epoch_schedule.get_slots_in_epoch(self.epoch);
+        let slots_in_recompilation_phase =
+            (solana_program_runtime::loaded_programs::MAX_LOADED_ENTRY_COUNT as u64)
+                .min(slots_in_epoch)
+                .checked_div(2)
+                .unwrap();
+        let mut program_cache = self.program_cache.write().unwrap();
+        if program_cache.upcoming_environments.is_some() {
+            if let Some((key, program_to_recompile)) = program_cache.programs_to_recompile.pop() {
+                let effective_epoch = program_cache.latest_root_epoch.saturating_add(1);
+                drop(program_cache);
+                let program_cache_read = self.program_cache.read().unwrap();
+                if let Some(recompiled) = load_program_with_pubkey(
+                    callbacks,
+                    &program_cache_read,
+                    &key,
+                    self.slot,
+                    effective_epoch,
+                    &self.epoch_schedule,
+                    false,
+                ) {
+                    drop(program_cache_read);
+                    recompiled
+                        .tx_usage_counter
+                        .fetch_add(program_to_recompile.tx_usage_counter.load(Relaxed), Relaxed);
+                    recompiled
+                        .ix_usage_counter
+                        .fetch_add(program_to_recompile.ix_usage_counter.load(Relaxed), Relaxed);
+                    let mut program_cache = self.program_cache.write().unwrap();
+                    program_cache.assign_program(key, recompiled);
+                }
+            }
+        } else if self.epoch != program_cache.latest_root_epoch
+            || slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch
+        {
+            // Anticipate the upcoming program runtime environment for the next epoch,
+            // so we can try to recompile loaded programs before the feature transition hits.
+            drop(program_cache);
+            let mut program_cache = self.program_cache.write().unwrap();
+            let program_runtime_environment_v1 = create_program_runtime_environment_v1(
+                upcoming_feature_set,
+                &self.runtime_config.compute_budget.unwrap_or_default(),
+                false, /* deployment */
+                false, /* debugging_features */
+            )
+            .unwrap();
+            let program_runtime_environment_v2 = create_program_runtime_environment_v2(
+                &self.runtime_config.compute_budget.unwrap_or_default(),
+                false, /* debugging_features */
+            );
+            let mut upcoming_environments = program_cache.environments.clone();
+            let changed_program_runtime_v1 =
+                *upcoming_environments.program_runtime_v1 != program_runtime_environment_v1;
+            let changed_program_runtime_v2 =
+                *upcoming_environments.program_runtime_v2 != program_runtime_environment_v2;
+            if changed_program_runtime_v1 {
+                upcoming_environments.program_runtime_v1 = Arc::new(program_runtime_environment_v1);
+            }
+            if changed_program_runtime_v2 {
+                upcoming_environments.program_runtime_v2 = Arc::new(program_runtime_environment_v2);
+            }
+            program_cache.upcoming_environments = Some(upcoming_environments);
+            program_cache.programs_to_recompile = program_cache
+                .get_flattened_entries(changed_program_runtime_v1, changed_program_runtime_v2);
+            program_cache
+                .programs_to_recompile
+                .sort_by_cached_key(|(_id, program)| program.decayed_usage_counter(self.slot));
+        }
     }
 
     /// Execute a transaction using the provided loaded accounts and update

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -468,7 +468,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         loaded_programs_for_txs.unwrap()
     }
 
-    pub fn recompile_program_cache<CB: TransactionProcessingCallback>(
+    pub fn prepare_program_cache_for_upcoming_feature_set<CB: TransactionProcessingCallback>(
         &self,
         callbacks: &CB,
         upcoming_feature_set: &FeatureSet,


### PR DESCRIPTION
#### Problem
The program cache is an integral part of the SVM, but its API is being driven both
by Bank and SVM. Since the program cache exists directly on the SVM's
`TransactionBatchProcessor`, it makes sense to include any necessary program
cache operations within SVM.

#### Summary of Changes

- First, hoist the recompilation code up to SVM as a public API function, to be
   invoked by Bank.
- Second, rename "recompilation" to "cache preparation".
