### PR TITLE
[DRAFT]: Concept sysvar handler & slot hashes entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6686,6 +6686,7 @@ dependencies = [
  "solana-logger",
  "solana-sdk-macro",
  "static_assertions",
+ "test-case",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -21,6 +21,7 @@ num-derive = { workspace = true }
 num-traits = { workspace = true }
 percentage = { workspace = true }
 rand = { workspace = true }
+serde = { workspace = true }
 solana-frozen-abi = { workspace = true }
 solana-frozen-abi-macro = { workspace = true }
 solana-measure = { workspace = true }
@@ -31,7 +32,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-serde = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 test-case = { workspace = true }

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -1,15 +1,15 @@
 #[allow(deprecated)]
-use solana_sdk::sysvar::{
-    fees::Fees, last_restart_slot::LastRestartSlot, recent_blockhashes::RecentBlockhashes,
-};
+use solana_sdk::sysvar::{fees::Fees, recent_blockhashes::RecentBlockhashes};
 use {
     crate::invoke_context::InvokeContext,
+    serde::de::DeserializeOwned,
     solana_sdk::{
         instruction::InstructionError,
         pubkey::Pubkey,
         sysvar::{
-            clock::Clock, epoch_rewards::EpochRewards, epoch_schedule::EpochSchedule, rent::Rent,
-            slot_hashes::SlotHashes, stake_history::StakeHistory, Sysvar, SysvarId,
+            clock::Clock, epoch_rewards::EpochRewards, epoch_schedule::EpochSchedule,
+            last_restart_slot::LastRestartSlot, rent::Rent, slot_hashes::SlotHashes,
+            stake_history::StakeHistory, Sysvar, SysvarId,
         },
         transaction_context::{IndexOfAccount, InstructionContext, TransactionContext},
     },
@@ -26,112 +26,144 @@ impl ::solana_frozen_abi::abi_example::AbiExample for SysvarCache {
 
 #[derive(Default, Clone, Debug)]
 pub struct SysvarCache {
-    clock: Option<Arc<Clock>>,
-    epoch_schedule: Option<Arc<EpochSchedule>>,
-    epoch_rewards: Option<Arc<EpochRewards>>,
+    // full account data as provided by bank, including any trailing zeroes
+    // the setters MUST NOT be changed to serialize an object representation
+    // it is required that the syscall be able to access the full buffer
+    // TODO enforce this in tests
+    clock: Option<Vec<u8>>,
+    epoch_schedule: Option<Vec<u8>>,
+    epoch_rewards: Option<Vec<u8>>,
+    rent: Option<Vec<u8>>,
+    slot_hashes: Option<Vec<u8>>,
+    stake_history: Option<Vec<u8>>,
+    last_restart_slot: Option<Vec<u8>>,
+
+    // object representations of large sysvars for convenience
+    // these are used by the stake and vote builtin programs
+    // these should be removed once those programs are ported to bpf
+    slot_hashes_obj: Option<Arc<SlotHashes>>,
+    stake_history_obj: Option<Arc<StakeHistory>>,
+
+    // deprecated sysvars, these should be removed once practical
     #[allow(deprecated)]
-    fees: Option<Arc<Fees>>,
-    rent: Option<Arc<Rent>>,
-    slot_hashes: Option<Arc<SlotHashes>>,
+    fees: Option<Fees>,
     #[allow(deprecated)]
-    recent_blockhashes: Option<Arc<RecentBlockhashes>>,
-    stake_history: Option<Arc<StakeHistory>>,
-    last_restart_slot: Option<Arc<LastRestartSlot>>,
+    recent_blockhashes: Option<RecentBlockhashes>,
 }
 
 impl SysvarCache {
-    pub fn get_clock(&self) -> Result<Arc<Clock>, InstructionError> {
-        self.clock
+    fn sysvar_id_to_buffer(&self, sysvar_id: &Pubkey) -> &Option<Vec<u8>> {
+        if *sysvar_id == Clock::id() {
+            &self.clock
+        } else if *sysvar_id == EpochSchedule::id() {
+            &self.epoch_schedule
+        } else if *sysvar_id == EpochRewards::id() {
+            &self.epoch_rewards
+        } else if *sysvar_id == Rent::id() {
+            &self.rent
+        } else if *sysvar_id == SlotHashes::id() {
+            &self.slot_hashes
+        } else if *sysvar_id == StakeHistory::id() {
+            &self.stake_history
+        } else if *sysvar_id == LastRestartSlot::id() {
+            &self.last_restart_slot
+        } else {
+            &None
+        }
+    }
+
+    pub fn read_sysvar_into(
+        &self,
+        sysvar_id: &Pubkey,
+        length: usize,
+        offset: usize,
+        out_buf: &mut [u8],
+    ) -> Result<(), InstructionError> {
+        if let Some(ref sysvar_buf) = self.sysvar_id_to_buffer(sysvar_id) {
+            if length == 0 {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+
+            match length.checked_add(offset) {
+                Some(limit) if limit <= sysvar_buf.len() => (),
+                _ => return Err(InstructionError::InvalidInstructionData),
+            }
+
+            if length != out_buf.len() {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+
+            if let Some(sysvar_slice) = offset
+                .checked_add(length)
+                .and_then(|limit| sysvar_buf.get(offset..limit))
+            {
+                out_buf.copy_from_slice(sysvar_slice);
+            } else {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+
+            Ok(())
+        } else {
+            Err(InstructionError::UnsupportedSysvar)
+        }
+    }
+
+    // most if not all of the obj getter functions can be removed once builtins transition to bpf
+    fn get_sysvar_obj<T: DeserializeOwned>(
+        &self,
+        sysvar_id: &Pubkey,
+    ) -> Result<T, InstructionError> {
+        if let Some(ref sysvar_buf) = self.sysvar_id_to_buffer(sysvar_id) {
+            bincode::deserialize(sysvar_buf).map_err(|_| InstructionError::UnsupportedSysvar)
+        } else {
+            Err(InstructionError::UnsupportedSysvar)
+        }
+    }
+
+    pub fn get_clock(&self) -> Result<Clock, InstructionError> {
+        self.get_sysvar_obj(&Clock::id())
+    }
+
+    pub fn get_epoch_schedule(&self) -> Result<EpochSchedule, InstructionError> {
+        self.get_sysvar_obj(&EpochSchedule::id())
+    }
+
+    pub fn get_epoch_rewards(&self) -> Result<EpochRewards, InstructionError> {
+        self.get_sysvar_obj(&EpochRewards::id())
+    }
+
+    pub fn get_rent(&self) -> Result<Rent, InstructionError> {
+        self.get_sysvar_obj(&Rent::id())
+    }
+
+    pub fn get_last_restart_slot(&self) -> Result<LastRestartSlot, InstructionError> {
+        self.get_sysvar_obj(&LastRestartSlot::id())
+    }
+
+    pub fn get_stake_history(&self) -> Result<Arc<StakeHistory>, InstructionError> {
+        self.stake_history_obj
             .clone()
             .ok_or(InstructionError::UnsupportedSysvar)
     }
 
-    pub fn set_clock(&mut self, clock: Clock) {
-        self.clock = Some(Arc::new(clock));
-    }
-
-    pub fn get_epoch_schedule(&self) -> Result<Arc<EpochSchedule>, InstructionError> {
-        self.epoch_schedule
+    pub fn get_slot_hashes(&self) -> Result<Arc<SlotHashes>, InstructionError> {
+        self.slot_hashes_obj
             .clone()
             .ok_or(InstructionError::UnsupportedSysvar)
-    }
-
-    pub fn set_epoch_schedule(&mut self, epoch_schedule: EpochSchedule) {
-        self.epoch_schedule = Some(Arc::new(epoch_schedule));
-    }
-
-    pub fn get_epoch_rewards(&self) -> Result<Arc<EpochRewards>, InstructionError> {
-        self.epoch_rewards
-            .clone()
-            .ok_or(InstructionError::UnsupportedSysvar)
-    }
-
-    pub fn set_epoch_rewards(&mut self, epoch_rewards: EpochRewards) {
-        self.epoch_rewards = Some(Arc::new(epoch_rewards));
     }
 
     #[deprecated]
     #[allow(deprecated)]
-    pub fn get_fees(&self) -> Result<Arc<Fees>, InstructionError> {
+    pub fn get_fees(&self) -> Result<Fees, InstructionError> {
         self.fees.clone().ok_or(InstructionError::UnsupportedSysvar)
     }
 
     #[deprecated]
     #[allow(deprecated)]
-    pub fn set_fees(&mut self, fees: Fees) {
-        self.fees = Some(Arc::new(fees));
-    }
-
-    pub fn get_rent(&self) -> Result<Arc<Rent>, InstructionError> {
-        self.rent.clone().ok_or(InstructionError::UnsupportedSysvar)
-    }
-
-    pub fn set_rent(&mut self, rent: Rent) {
-        self.rent = Some(Arc::new(rent));
-    }
-
-    pub fn get_last_restart_slot(&self) -> Result<Arc<LastRestartSlot>, InstructionError> {
-        self.last_restart_slot
-            .clone()
-            .ok_or(InstructionError::UnsupportedSysvar)
-    }
-
-    pub fn set_last_restart_slot(&mut self, last_restart_slot: LastRestartSlot) {
-        self.last_restart_slot = Some(Arc::new(last_restart_slot));
-    }
-
-    pub fn get_slot_hashes(&self) -> Result<Arc<SlotHashes>, InstructionError> {
-        self.slot_hashes
-            .clone()
-            .ok_or(InstructionError::UnsupportedSysvar)
-    }
-
-    pub fn set_slot_hashes(&mut self, slot_hashes: SlotHashes) {
-        self.slot_hashes = Some(Arc::new(slot_hashes));
-    }
-
-    #[deprecated]
-    #[allow(deprecated)]
-    pub fn get_recent_blockhashes(&self) -> Result<Arc<RecentBlockhashes>, InstructionError> {
+    pub fn get_recent_blockhashes(&self) -> Result<RecentBlockhashes, InstructionError> {
         self.recent_blockhashes
             .clone()
             .ok_or(InstructionError::UnsupportedSysvar)
-    }
-
-    #[deprecated]
-    #[allow(deprecated)]
-    pub fn set_recent_blockhashes(&mut self, recent_blockhashes: RecentBlockhashes) {
-        self.recent_blockhashes = Some(Arc::new(recent_blockhashes));
-    }
-
-    pub fn get_stake_history(&self) -> Result<Arc<StakeHistory>, InstructionError> {
-        self.stake_history
-            .clone()
-            .ok_or(InstructionError::UnsupportedSysvar)
-    }
-
-    pub fn set_stake_history(&mut self, stake_history: StakeHistory) {
-        self.stake_history = Some(Arc::new(stake_history));
     }
 
     pub fn fill_missing_entries<F: FnMut(&Pubkey, &mut dyn FnMut(&[u8]))>(
@@ -140,23 +172,58 @@ impl SysvarCache {
     ) {
         if self.clock.is_none() {
             get_account_data(&Clock::id(), &mut |data: &[u8]| {
-                if let Ok(clock) = bincode::deserialize(data) {
-                    self.set_clock(clock);
+                if bincode::deserialize::<Clock>(data).is_ok() {
+                    self.clock = Some(data.to_vec());
                 }
             });
         }
+
         if self.epoch_schedule.is_none() {
             get_account_data(&EpochSchedule::id(), &mut |data: &[u8]| {
-                if let Ok(epoch_schedule) = bincode::deserialize(data) {
-                    self.set_epoch_schedule(epoch_schedule);
+                if bincode::deserialize::<EpochSchedule>(data).is_ok() {
+                    self.epoch_schedule = Some(data.to_vec());
                 }
             });
         }
 
         if self.epoch_rewards.is_none() {
             get_account_data(&EpochRewards::id(), &mut |data: &[u8]| {
-                if let Ok(epoch_rewards) = bincode::deserialize(data) {
-                    self.set_epoch_rewards(epoch_rewards);
+                if bincode::deserialize::<EpochRewards>(data).is_ok() {
+                    self.epoch_rewards = Some(data.to_vec());
+                }
+            });
+        }
+
+        if self.rent.is_none() {
+            get_account_data(&Rent::id(), &mut |data: &[u8]| {
+                if bincode::deserialize::<Rent>(data).is_ok() {
+                    self.rent = Some(data.to_vec());
+                }
+            });
+        }
+
+        if self.slot_hashes.is_none() {
+            get_account_data(&SlotHashes::id(), &mut |data: &[u8]| {
+                if let Ok(obj) = bincode::deserialize::<SlotHashes>(data) {
+                    self.slot_hashes = Some(data.to_vec());
+                    self.slot_hashes_obj = Some(Arc::new(obj));
+                }
+            });
+        }
+
+        if self.stake_history.is_none() {
+            get_account_data(&StakeHistory::id(), &mut |data: &[u8]| {
+                if let Ok(obj) = bincode::deserialize::<StakeHistory>(data) {
+                    self.stake_history = Some(data.to_vec());
+                    self.stake_history_obj = Some(Arc::new(obj));
+                }
+            });
+        }
+
+        if self.last_restart_slot.is_none() {
+            get_account_data(&LastRestartSlot::id(), &mut |data: &[u8]| {
+                if bincode::deserialize::<LastRestartSlot>(data).is_ok() {
+                    self.last_restart_slot = Some(data.to_vec());
                 }
             });
         }
@@ -165,50 +232,23 @@ impl SysvarCache {
         if self.fees.is_none() {
             get_account_data(&Fees::id(), &mut |data: &[u8]| {
                 if let Ok(fees) = bincode::deserialize(data) {
-                    self.set_fees(fees);
+                    self.fees = Some(fees);
                 }
             });
         }
-        if self.rent.is_none() {
-            get_account_data(&Rent::id(), &mut |data: &[u8]| {
-                if let Ok(rent) = bincode::deserialize(data) {
-                    self.set_rent(rent);
-                }
-            });
-        }
-        if self.slot_hashes.is_none() {
-            get_account_data(&SlotHashes::id(), &mut |data: &[u8]| {
-                if let Ok(slot_hashes) = bincode::deserialize(data) {
-                    self.set_slot_hashes(slot_hashes);
-                }
-            });
-        }
+
         #[allow(deprecated)]
         if self.recent_blockhashes.is_none() {
             get_account_data(&RecentBlockhashes::id(), &mut |data: &[u8]| {
                 if let Ok(recent_blockhashes) = bincode::deserialize(data) {
-                    self.set_recent_blockhashes(recent_blockhashes);
-                }
-            });
-        }
-        if self.stake_history.is_none() {
-            get_account_data(&StakeHistory::id(), &mut |data: &[u8]| {
-                if let Ok(stake_history) = bincode::deserialize(data) {
-                    self.set_stake_history(stake_history);
-                }
-            });
-        }
-        if self.last_restart_slot.is_none() {
-            get_account_data(&LastRestartSlot::id(), &mut |data: &[u8]| {
-                if let Ok(last_restart_slot) = bincode::deserialize(data) {
-                    self.set_last_restart_slot(last_restart_slot);
+                    self.recent_blockhashes = Some(recent_blockhashes);
                 }
             });
         }
     }
 
     pub fn reset(&mut self) {
-        *self = SysvarCache::default();
+        *self = Self::default();
     }
 }
 
@@ -237,7 +277,7 @@ pub mod get_sysvar_with_account_check {
         invoke_context: &InvokeContext,
         instruction_context: &InstructionContext,
         instruction_account_index: IndexOfAccount,
-    ) -> Result<Arc<Clock>, InstructionError> {
+    ) -> Result<Clock, InstructionError> {
         check_sysvar_account::<Clock>(
             invoke_context.transaction_context,
             instruction_context,
@@ -250,7 +290,7 @@ pub mod get_sysvar_with_account_check {
         invoke_context: &InvokeContext,
         instruction_context: &InstructionContext,
         instruction_account_index: IndexOfAccount,
-    ) -> Result<Arc<Rent>, InstructionError> {
+    ) -> Result<Rent, InstructionError> {
         check_sysvar_account::<Rent>(
             invoke_context.transaction_context,
             instruction_context,
@@ -277,7 +317,7 @@ pub mod get_sysvar_with_account_check {
         invoke_context: &InvokeContext,
         instruction_context: &InstructionContext,
         instruction_account_index: IndexOfAccount,
-    ) -> Result<Arc<RecentBlockhashes>, InstructionError> {
+    ) -> Result<RecentBlockhashes, InstructionError> {
         check_sysvar_account::<RecentBlockhashes>(
             invoke_context.transaction_context,
             instruction_context,
@@ -303,7 +343,7 @@ pub mod get_sysvar_with_account_check {
         invoke_context: &InvokeContext,
         instruction_context: &InstructionContext,
         instruction_account_index: IndexOfAccount,
-    ) -> Result<Arc<LastRestartSlot>, InstructionError> {
+    ) -> Result<LastRestartSlot, InstructionError> {
         check_sysvar_account::<LastRestartSlot>(
             invoke_context.transaction_context,
             instruction_context,

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -357,6 +357,10 @@ mod tests {
     // sysvar cache provides the full account data of a sysvar
     // the setters MUST NOT be changed to serialize an object representation
     // it is required that the syscall be able to access the full buffer as it exists onchain
+    // this is meant to cover the cases:
+    // * account data is larger than struct sysvar
+    // * vector sysvar has fewer than its maximum entries
+    // if at any point the data is roundtripped through bincode, the vector will shrink
     #[test_case(Clock::default(); "clock")]
     #[test_case(EpochSchedule::default(); "epoch_schedule")]
     #[test_case(EpochRewards::default(); "epoch_rewards")]
@@ -366,7 +370,7 @@ mod tests {
     #[test_case(LastRestartSlot::default(); "last_restart_slot")]
     fn test_sysvar_cache_preserves_bytes<T: Sysvar>(_: T) {
         let id = T::id();
-        let size = T::size_of();
+        let size = T::size_of().saturating_mul(2);
         let in_buf = vec![0; size];
         let mut out_buf = vec![0xff; size];
 

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -51,19 +51,19 @@ pub struct SysvarCache {
 impl SysvarCache {
     // this is exposed for SyscallGetSysvar and should not otherwise be used
     pub fn sysvar_id_to_buffer(&self, sysvar_id: &Pubkey) -> &Option<Vec<u8>> {
-        if *sysvar_id == Clock::id() {
+        if Clock::check_id(sysvar_id) {
             &self.clock
-        } else if *sysvar_id == EpochSchedule::id() {
+        } else if EpochSchedule::check_id(sysvar_id) {
             &self.epoch_schedule
-        } else if *sysvar_id == EpochRewards::id() {
+        } else if EpochRewards::check_id(sysvar_id) {
             &self.epoch_rewards
-        } else if *sysvar_id == Rent::id() {
+        } else if Rent::check_id(sysvar_id) {
             &self.rent
-        } else if *sysvar_id == SlotHashes::id() {
+        } else if SlotHashes::check_id(sysvar_id) {
             &self.slot_hashes
-        } else if *sysvar_id == StakeHistory::id() {
+        } else if StakeHistory::check_id(sysvar_id) {
             &self.stake_history
-        } else if *sysvar_id == LastRestartSlot::id() {
+        } else if LastRestartSlot::check_id(sysvar_id) {
             &self.last_restart_slot
         } else {
             &None

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -202,7 +202,7 @@ macro_rules! processor {
 }
 
 fn get_sysvar<T: Default + Sysvar + Sized + serde::de::DeserializeOwned + Clone>(
-    sysvar: Result<Arc<T>, InstructionError>,
+    sysvar: Result<T, InstructionError>,
     var_addr: *mut u8,
 ) -> u64 {
     let invoke_context = get_invoke_context();

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -3386,23 +3386,6 @@ mod tests {
         let mut src_restart = create_filled_type::<LastRestartSlot>(false);
         src_restart.last_restart_slot = 1;
 
-        let mut sysvar_cache = SysvarCache::default();
-        sysvar_cache.fill_missing_entries(|pubkey, callback| {
-            if *pubkey == sysvar::clock::id() {
-                callback(&bincode::serialize(&src_clock.clone()).unwrap())
-            } else if *pubkey == sysvar::epoch_schedule::id() {
-                callback(&bincode::serialize(&src_epochschedule.clone()).unwrap())
-            } else if *pubkey == sysvar::fees::id() {
-                callback(&bincode::serialize(&src_fees.clone()).unwrap())
-            } else if *pubkey == sysvar::rent::id() {
-                callback(&bincode::serialize(&src_rent.clone()).unwrap())
-            } else if *pubkey == sysvar::epoch_rewards::id() {
-                callback(&bincode::serialize(&src_rewards.clone()).unwrap())
-            } else if *pubkey == sysvar::last_restart_slot::id() {
-                callback(&bincode::serialize(&src_restart.clone()).unwrap())
-            }
-        });
-
         let transaction_accounts = vec![
             (
                 sysvar::clock::id(),
@@ -3809,11 +3792,6 @@ mod tests {
         let src_history_ser = bincode::serialize(&src_history).unwrap();
         src_history_buf[..src_history_ser.len()].copy_from_slice(&src_history_ser[..]);
 
-        let mut sysvar_cache = SysvarCache::default();
-        sysvar_cache.fill_missing_entries(|_pubkey, callback| {
-            callback(&bincode::serialize(&src_history.clone()).unwrap())
-        });
-
         let transaction_accounts = vec![(
             sysvar::stake_history::id(),
             create_account_shared_data_for_test(&src_history),
@@ -3873,11 +3851,6 @@ mod tests {
         let mut src_hashes_buf = vec![0; SlotHashes::size_of()];
         let src_hashes_ser = bincode::serialize(&src_hashes).unwrap();
         src_hashes_buf[..src_hashes_ser.len()].copy_from_slice(&src_hashes_ser[..]);
-
-        let mut sysvar_cache = SysvarCache::default();
-        sysvar_cache.fill_missing_entries(|_pubkey, callback| {
-            callback(&bincode::serialize(&src_hashes.clone()).unwrap())
-        });
 
         let transaction_accounts = vec![(
             sysvar::slot_hashes::id(),

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -3474,9 +3474,9 @@ mod tests {
             let result = SyscallGetSysvar::rust(
                 &mut invoke_context,
                 clock_id_va,
-                Clock::size_of() as u64,
-                0,
                 got_clock_buf_va,
+                0,
+                Clock::size_of() as u64,
                 0,
                 &mut memory_mapping,
             );
@@ -3544,9 +3544,9 @@ mod tests {
             let result = SyscallGetSysvar::rust(
                 &mut invoke_context,
                 epochschedule_id_va,
-                EpochSchedule::size_of() as u64,
-                0,
                 got_epochschedule_buf_va,
+                0,
+                EpochSchedule::size_of() as u64,
                 0,
                 &mut memory_mapping,
             );
@@ -3640,9 +3640,9 @@ mod tests {
             let result = SyscallGetSysvar::rust(
                 &mut invoke_context,
                 rent_id_va,
-                Rent::size_of() as u64,
-                0,
                 got_rent_buf_va,
+                0,
+                Rent::size_of() as u64,
                 0,
                 &mut memory_mapping,
             );
@@ -3704,9 +3704,9 @@ mod tests {
             let result = SyscallGetSysvar::rust(
                 &mut invoke_context,
                 rewards_id_va,
-                EpochRewards::size_of() as u64,
-                0,
                 got_rewards_buf_va,
+                0,
+                EpochRewards::size_of() as u64,
                 0,
                 &mut memory_mapping,
             );
@@ -3763,9 +3763,9 @@ mod tests {
             let result = SyscallGetSysvar::rust(
                 &mut invoke_context,
                 restart_id_va,
-                LastRestartSlot::size_of() as u64,
-                0,
                 got_restart_buf_va,
+                0,
+                LastRestartSlot::size_of() as u64,
                 0,
                 &mut memory_mapping,
             );
@@ -3838,9 +3838,9 @@ mod tests {
             let result = SyscallGetSysvar::rust(
                 &mut invoke_context,
                 history_id_va,
-                StakeHistory::size_of() as u64,
-                0,
                 got_history_buf_va,
+                0,
+                StakeHistory::size_of() as u64,
                 0,
                 &mut memory_mapping,
             );
@@ -3903,9 +3903,9 @@ mod tests {
             let result = SyscallGetSysvar::rust(
                 &mut invoke_context,
                 hashes_id_va,
-                SlotHashes::size_of() as u64,
-                0,
                 got_hashes_buf_va,
+                0,
+                SlotHashes::size_of() as u64,
                 0,
                 &mut memory_mapping,
             );

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -3789,8 +3789,7 @@ mod tests {
         let src_history = src_history;
 
         let mut src_history_buf = vec![0; StakeHistory::size_of()];
-        let src_history_ser = bincode::serialize(&src_history).unwrap();
-        src_history_buf[..src_history_ser.len()].copy_from_slice(&src_history_ser[..]);
+        bincode::serialize_into(&mut src_history_buf, &src_history).unwrap();
 
         let transaction_accounts = vec![(
             sysvar::stake_history::id(),
@@ -3849,8 +3848,7 @@ mod tests {
         let src_hashes = src_hashes;
 
         let mut src_hashes_buf = vec![0; SlotHashes::size_of()];
-        let src_hashes_ser = bincode::serialize(&src_hashes).unwrap();
-        src_hashes_buf[..src_hashes_ser.len()].copy_from_slice(&src_hashes_ser[..]);
+        bincode::serialize_into(&mut src_hashes_buf, &src_hashes).unwrap();
 
         let transaction_accounts = vec![(
             sysvar::slot_hashes::id(),

--- a/programs/bpf_loader/src/syscalls/sysvar.rs
+++ b/programs/bpf_loader/src/syscalls/sysvar.rs
@@ -182,7 +182,6 @@ declare_builtin_function!(
         )?;
 
         let sysvar_id = translate_type::<Pubkey>(memory_mapping, sysvar_id_addr, check_aligned)?;
-
         let var = translate_slice_mut::<u8>(memory_mapping, var_addr, length, check_aligned)?;
 
         let cache = invoke_context.get_sysvar_cache();

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5456,6 +5456,7 @@ dependencies = [
  "percentage",
  "rand 0.8.5",
  "rustc_version",
+ "serde",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-measure",

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -65,7 +65,7 @@ pub(crate) fn new_warmup_cooldown_rate_epoch(invoke_context: &InvokeContext) -> 
         .unwrap();
     invoke_context
         .feature_set
-        .new_warmup_cooldown_rate_epoch(epoch_schedule.as_ref())
+        .new_warmup_cooldown_rate_epoch(&epoch_schedule)
 }
 
 fn get_stake_status(

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -146,8 +146,8 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &mut me,
                 commission,
                 &signers,
-                sysvar_cache.get_epoch_schedule()?.as_ref(),
-                sysvar_cache.get_clock()?.as_ref(),
+                &sysvar_cache.get_epoch_schedule()?,
+                &sysvar_cache.get_clock()?,
                 &invoke_context.feature_set,
             )
         }

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -156,7 +156,7 @@ mod tests {
             bank1_cached_slot_hashes
         );
         assert_eq!(
-            *bank1_sysvar_cache.get_epoch_rewards().unwrap(),
+            bank1_sysvar_cache.get_epoch_rewards().unwrap(),
             expected_epoch_rewards,
         );
     }

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -83,6 +83,7 @@ array-bytes = { workspace = true }
 assert_matches = { workspace = true }
 serde_json = { workspace = true }
 static_assertions = { workspace = true }
+test-case = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -43,6 +43,15 @@ pub trait SyscallStubs: Sync + Send {
         sol_log("SyscallStubs: sol_invoke_signed() not available");
         Ok(())
     }
+    fn sol_get_sysvar(
+        &self,
+        _sysvar_id_addr: *const u8,
+        _length: u64,
+        _offset: u64,
+        _var_addr: *mut u8,
+    ) -> u64 {
+        UNSUPPORTED_SYSVAR
+    }
     fn sol_get_clock_sysvar(&self, _var_addr: *mut u8) -> u64 {
         UNSUPPORTED_SYSVAR
     }
@@ -143,6 +152,19 @@ pub(crate) fn sol_invoke_signed(
         .read()
         .unwrap()
         .sol_invoke_signed(instruction, account_infos, signers_seeds)
+}
+
+#[allow(dead_code)]
+pub(crate) fn sol_get_sysvar(
+    sysvar_id_addr: *const u8,
+    length: u64,
+    offset: u64,
+    var_addr: *mut u8,
+) -> u64 {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_get_sysvar(sysvar_id_addr, length, offset, var_addr)
 }
 
 pub(crate) fn sol_get_clock_sysvar(var_addr: *mut u8) -> u64 {

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -46,9 +46,9 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_get_sysvar(
         &self,
         _sysvar_id_addr: *const u8,
-        _length: u64,
-        _offset: u64,
         _var_addr: *mut u8,
+        _offset: u64,
+        _length: u64,
     ) -> u64 {
         UNSUPPORTED_SYSVAR
     }
@@ -157,14 +157,14 @@ pub(crate) fn sol_invoke_signed(
 #[allow(dead_code)]
 pub(crate) fn sol_get_sysvar(
     sysvar_id_addr: *const u8,
-    length: u64,
-    offset: u64,
     var_addr: *mut u8,
+    offset: u64,
+    length: u64,
 ) -> u64 {
     SYSCALL_STUBS
         .read()
         .unwrap()
-        .sol_get_sysvar(sysvar_id_addr, length, offset, var_addr)
+        .sol_get_sysvar(sysvar_id_addr, var_addr, offset, length)
 }
 
 pub(crate) fn sol_get_clock_sysvar(var_addr: *mut u8) -> u64 {

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -46,11 +46,6 @@ define_syscall!(fn sol_sha256(vals: *const u8, val_len: u64, hash_result: *mut u
 define_syscall!(fn sol_keccak256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_secp256k1_recover(hash: *const u8, recovery_id: u64, signature: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_blake3(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
-define_syscall!(fn sol_get_clock_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_epoch_schedule_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_fees_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_rent_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_last_restart_slot(addr: *mut u8) -> u64);
 define_syscall!(fn sol_memcpy_(dst: *mut u8, src: *const u8, n: u64));
 define_syscall!(fn sol_memmove_(dst: *mut u8, src: *const u8, n: u64));
 define_syscall!(fn sol_memcmp_(s1: *const u8, s2: *const u8, n: u64, result: *mut i32));
@@ -68,10 +63,20 @@ define_syscall!(fn sol_curve_multiscalar_mul(curve_id: u64, scalars_addr: *const
 define_syscall!(fn sol_curve_pairing_map(curve_id: u64, point: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_alt_bn128_group_op(group_op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
 define_syscall!(fn sol_big_mod_exp(params: *const u8, result: *mut u8) -> u64);
-define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
 define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_remaining_compute_units() -> u64);
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
+define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, length: u64, offset: u64, addr: *mut u8) -> u64);
+
+// these are to be deprecated once they are superceded by sol_get_sysvar
+define_syscall!(fn sol_get_clock_sysvar(addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_epoch_schedule_sysvar(addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_rent_sysvar(addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_last_restart_slot(addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
+
+// this cannot go through sol_get_sysvar but can be removed once no longer in use
+define_syscall!(fn sol_get_fees_sysvar(addr: *mut u8) -> u64);
 
 #[cfg(target_feature = "static-syscalls")]
 pub const fn sys_hash(name: &str) -> usize {

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -66,7 +66,7 @@ define_syscall!(fn sol_big_mod_exp(params: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_remaining_compute_units() -> u64);
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
-define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, length: u64, offset: u64, addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, result: *mut u8, offset: u64, length: u64) -> u64);
 
 // these are to be deprecated once they are superceded by sol_get_sysvar
 define_syscall!(fn sol_get_clock_sysvar(addr: *mut u8) -> u64);

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -81,9 +81,12 @@
 //!
 //! [sysvardoc]: https://docs.solanalabs.com/runtime/sysvars
 
-use crate::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
 #[allow(deprecated)]
 pub use sysvar_ids::ALL_IDS;
+use {
+    crate::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey},
+    std::alloc::{alloc, Layout},
+};
 
 pub mod clock;
 pub mod epoch_rewards;
@@ -249,12 +252,44 @@ macro_rules! impl_sysvar_get {
     };
 }
 
+/// Handler for retrieving a slice of sysvar data from the `sol_get_sysvar`
+/// syscall.
+fn get_sysvar<'a>(sysvar_id: &Pubkey, offset: u64, length: u64) -> Result<&'a [u8], ProgramError> {
+    let sysvar_id = sysvar_id as *const _ as *const u8;
+
+    // Allocate the memory region for the sysvar data to be written to.
+    let var = unsafe {
+        let length = length as usize;
+        let layout = Layout::from_size_align(length, std::mem::align_of::<u8>())
+            .map_err(|_| ProgramError::InvalidArgument)?;
+        let ptr = alloc(layout);
+        if ptr.is_null() {
+            return Err(ProgramError::InvalidArgument);
+        }
+        std::slice::from_raw_parts_mut(ptr, length)
+    };
+
+    let var_addr = var as *mut _ as *mut u8;
+
+    #[cfg(target_os = "solana")]
+    let result = unsafe { crate::syscalls::sol_get_sysvar(sysvar_id, var_addr, offset, length) };
+
+    #[cfg(not(target_os = "solana"))]
+    let result = crate::program_stubs::sol_get_sysvar(sysvar_id, var_addr, offset, length);
+
+    match result {
+        crate::entrypoint::SUCCESS => Ok(var),
+        e => Err(e.into()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
         super::*,
         crate::{clock::Epoch, program_error::ProgramError, pubkey::Pubkey},
         std::{cell::RefCell, rc::Rc},
+        test_case::test_case,
     };
 
     #[repr(C)]
@@ -306,5 +341,32 @@ mod tests {
         let mut small_data = vec![];
         account_info.data = Rc::new(RefCell::new(&mut small_data));
         assert_eq!(test_sysvar.to_account_info(&mut account_info), None);
+    }
+
+    // As long as we use a test sysvar ID and we're _not_ testing from a BPF
+    // context, the `sol_get_sysvar` syscall will always return
+    // `ProgramError::UnsupportedSysvar`, since the ID will not match any
+    // sysvars in the Sysvar Cache.
+    // Under this condition, we can test the pointer allocation by keying on
+    // `ProgramError::InvalidArgument`.
+    // Also, `offset` is only used in the syscall, _not_ the pointer
+    // allocation.
+    #[test_case(0)]
+    #[test_case(2)]
+    #[test_case(64)]
+    #[test_case(99)]
+    #[test_case(1024)]
+    #[test_case(1234)]
+    #[test_case(65_536)]
+    #[test_case(70_000)]
+    #[test_case(70_001)]
+    #[test_case(4_294_967_296)]
+    #[test_case(8_000_000_000)]
+    #[test_case(8_000_000_001)]
+    fn test_get_sysvar_alloc(length: u64) {
+        assert_eq!(
+            get_sysvar(&crate::sysvar::tests::id(), 0, length).unwrap_err(),
+            ProgramError::UnsupportedSysvar,
+        );
     }
 }

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -46,7 +46,12 @@
 //! ```
 
 pub use crate::slot_hashes::SlotHashes;
-use crate::{account_info::AccountInfo, program_error::ProgramError, sysvar::Sysvar};
+use crate::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    slot_hashes::SlotHash,
+    sysvar::{Sysvar, SysvarEntries},
+};
 
 crate::declare_sysvar_id!("SysvarS1otHashes111111111111111111111111111", SlotHashes);
 
@@ -60,6 +65,13 @@ impl Sysvar for SlotHashes {
         // This sysvar is too large to bincode::deserialize in-program
         Err(ProgramError::UnsupportedSysvar)
     }
+}
+
+impl SysvarEntries<SlotHash> for SlotHashes {
+    // Rust's `serde::Serialize` will serialize a `usize` as a `u64` on 64-bit
+    // systems for vector length prefixes.
+    const DISCRIMINATOR_SIZE: usize = 8;
+    const ENTRY_SIZE: usize = std::mem::size_of::<SlotHash>();
 }
 
 #[cfg(test)]

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -795,7 +795,9 @@ pub mod deprecate_unused_legacy_vote_plumbing {
 
 pub mod reward_full_priority_fee {
     solana_sdk::declare_id!("3opE3EzAKnUftUDURkzMgwpNgimBAypW1mNDYH4x4Zg7");
-}
+
+pub mod get_sysvar_syscall_enabled {
+    solana_sdk::declare_id!("CLCoTADvV64PSrnR6QXty6Fwrt9Xc6EdxSJE4wLRePjq");
 
 lazy_static! {
     /// Map of feature identifiers to user-visible description
@@ -991,6 +993,7 @@ lazy_static! {
         (enable_tower_sync_ix::id(), "Enable tower sync vote instruction"),
         (chained_merkle_conflict_duplicate_proofs::id(), "generate duplicate proofs for chained merkle root conflicts"),
         (reward_full_priority_fee::id(), "Reward full priority fee to validators #34731"),
+        (get_sysvar_syscall_enabled::id(), "Enable syscall for fetching Sysvar bytes #615"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -795,9 +795,11 @@ pub mod deprecate_unused_legacy_vote_plumbing {
 
 pub mod reward_full_priority_fee {
     solana_sdk::declare_id!("3opE3EzAKnUftUDURkzMgwpNgimBAypW1mNDYH4x4Zg7");
+}
 
 pub mod get_sysvar_syscall_enabled {
     solana_sdk::declare_id!("CLCoTADvV64PSrnR6QXty6Fwrt9Xc6EdxSJE4wLRePjq");
+}
 
 lazy_static! {
     /// Map of feature identifiers to user-visible description

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -2306,22 +2306,13 @@ mod tests {
         let cached_fees = sysvar_cache.get_fees();
         let cached_rent = sysvar_cache.get_rent();
 
-        assert_eq!(
-            cached_clock.expect("clock sysvar missing in cache"),
-            clock.into()
-        );
+        assert_eq!(cached_clock.expect("clock sysvar missing in cache"), clock);
         assert_eq!(
             cached_epoch_schedule.expect("epoch_schedule sysvar missing in cache"),
-            epoch_schedule.into()
+            epoch_schedule
         );
-        assert_eq!(
-            cached_fees.expect("fees sysvar missing in cache"),
-            fees.into()
-        );
-        assert_eq!(
-            cached_rent.expect("rent sysvar missing in cache"),
-            rent.into()
-        );
+        assert_eq!(cached_fees.expect("fees sysvar missing in cache"), fees);
+        assert_eq!(cached_rent.expect("rent sysvar missing in cache"), rent);
         assert!(sysvar_cache.get_slot_hashes().is_err());
         assert!(sysvar_cache.get_epoch_rewards().is_err());
     }
@@ -2395,22 +2386,13 @@ mod tests {
         let cached_fees = sysvar_cache.get_fees();
         let cached_rent = sysvar_cache.get_rent();
 
-        assert_eq!(
-            cached_clock.expect("clock sysvar missing in cache"),
-            clock.into()
-        );
+        assert_eq!(cached_clock.expect("clock sysvar missing in cache"), clock);
         assert_eq!(
             cached_epoch_schedule.expect("epoch_schedule sysvar missing in cache"),
-            epoch_schedule.into()
+            epoch_schedule
         );
-        assert_eq!(
-            cached_fees.expect("fees sysvar missing in cache"),
-            fees.into()
-        );
-        assert_eq!(
-            cached_rent.expect("rent sysvar missing in cache"),
-            rent.into()
-        );
+        assert_eq!(cached_fees.expect("fees sysvar missing in cache"), fees);
+        assert_eq!(cached_rent.expect("rent sysvar missing in cache"), rent);
         assert!(sysvar_cache.get_slot_hashes().is_err());
         assert!(sysvar_cache.get_epoch_rewards().is_err());
     }


### PR DESCRIPTION
@2501babe I've based this concept PR on top of your recent implementation
for SIMD 0127. Just check out my last three commits. They fit nicely on top of
your new syscall!

---

The first commit introduces a handler for the new `sol_get_sysvar` syscall
from SIMD 0127.

We can choose to use it in the `Sysvar` trait in the existing `get` method, like so.

```rust
fn get() -> Result<Self, ProgramError> {
    let data = get_sysvar(&Self::id(), 0, Self::size_of() as u64)?;
    bincode::deserialize(data).map_err(|_| ProgramError::InvalidArgument)
}
```

Or we can roll a new method and deprecate `get`.

```rust
#[deprecated(since = "2.0.0", note = "Please use `Sysvar::load`.")]
fn get() -> Result<Self, ProgramError> {
    Err(ProgramError::UnsupportedSysvar)
}

/// (New)
fn load() -> Result<Self, ProgramError> {
    let data = get_sysvar(&Self::id(), 0, Self::size_of() as u64)?;
    bincode::deserialize(data).map_err(|_| ProgramError::InvalidArgument)
}
```

The idea is you could apply this to all sysvars under the unified syscall.

---

The second commit is a concept of a trait that uses the handler to fetch a
slice of entries.

The third is `SlotHashes` implementing the trait!

```rust
use solana_program::{
    account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey,
    slot_hashes::SlotHashes, sysvar::SysvarEntries,
};

/* ... */

fn process_instruction(
    _program_id: &Pubkey,
    _accounts: &[AccountInfo],
    _instruction_data: &[u8],
) -> ProgramResult {
    // `SysvarEntries::get_entries`
    //
    let slot_hashes_entries =
        SlotHashes::get_entries(1 /* Skip the first one */, 3 /* Load 3 entries */)?;

    for (slot, hash) in slot_hashes_entries.iter() {
        msg!("Slot Hashes Entry {}: {:?}", slot, hash.to_bytes());
    }

    Ok(())
}

```