### PR TITLE
Program-Runtime: Add `ComputeMeter` to wrap compute monitoring

### DIFF
--- a/program-runtime/src/compute_meter.rs
+++ b/program-runtime/src/compute_meter.rs
@@ -47,7 +47,12 @@ impl ComputeMeter {
         &self.current_budget
     }
 
-    pub(crate) fn update_current_budget(&mut self, budget: ComputeBudget) {
-        self.current_budget = budget;
+    pub(crate) fn update_current_budget(&mut self) {
+        self.current_budget = self.budget;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_budget_for_tests(&mut self, budget: ComputeBudget) {
+        self.budget = budget
     }
 }

--- a/program-runtime/src/compute_meter.rs
+++ b/program-runtime/src/compute_meter.rs
@@ -42,4 +42,12 @@ impl ComputeMeter {
     pub(crate) fn mock_set_remaining(&self, remaining: u64) {
         *self.meter.borrow_mut() = remaining;
     }
+
+    pub(crate) fn get_current_budget(&self) -> &ComputeBudget {
+        &self.current_budget
+    }
+
+    pub(crate) fn update_current_budget(&mut self, budget: ComputeBudget) {
+        self.current_budget = budget;
+    }
 }

--- a/program-runtime/src/compute_meter.rs
+++ b/program-runtime/src/compute_meter.rs
@@ -1,0 +1,45 @@
+use {
+    crate::compute_budget::ComputeBudget, solana_sdk::instruction::InstructionError,
+    std::cell::RefCell,
+};
+
+pub(crate) struct ComputeMeter {
+    budget: ComputeBudget,
+    current_budget: ComputeBudget,
+    meter: RefCell<u64>,
+}
+
+impl ComputeMeter {
+    pub(crate) fn new(budget: ComputeBudget) -> Self {
+        Self {
+            budget,
+            current_budget: budget,
+            meter: RefCell::new(budget.compute_unit_limit),
+        }
+    }
+
+    pub(crate) fn consume(&mut self, amount: u64) {
+        // 1 to 1 instruction to compute unit mapping
+        // ignore overflow, Ebpf will bail if exceeded
+        let mut meter = self.meter.borrow_mut();
+        *meter = meter.saturating_sub(amount);
+    }
+
+    pub(crate) fn consume_checked(&self, amount: u64) -> Result<(), Box<dyn std::error::Error>> {
+        let mut meter = self.meter.borrow_mut();
+        let exceeded = *meter < amount;
+        *meter = meter.saturating_sub(amount);
+        if exceeded {
+            return Err(Box::new(InstructionError::ComputationalBudgetExceeded));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn get_remaining(&self) -> u64 {
+        *self.meter.borrow()
+    }
+
+    pub(crate) fn mock_set_remaining(&self, remaining: u64) {
+        *self.meter.borrow_mut() = remaining;
+    }
+}

--- a/program-runtime/src/compute_meter.rs
+++ b/program-runtime/src/compute_meter.rs
@@ -5,7 +5,6 @@ use {
 
 pub(crate) struct ComputeMeter {
     budget: ComputeBudget,
-    current_budget: ComputeBudget,
     meter: RefCell<u64>,
 }
 
@@ -13,7 +12,6 @@ impl ComputeMeter {
     pub(crate) fn new(budget: ComputeBudget) -> Self {
         Self {
             budget,
-            current_budget: budget,
             meter: RefCell::new(budget.compute_unit_limit),
         }
     }
@@ -43,12 +41,8 @@ impl ComputeMeter {
         *self.meter.borrow_mut() = remaining;
     }
 
-    pub(crate) fn get_current_budget(&self) -> &ComputeBudget {
-        &self.current_budget
-    }
-
-    pub(crate) fn update_current_budget(&mut self) {
-        self.current_budget = self.budget;
+    pub(crate) fn get_budget(&self) -> &ComputeBudget {
+        &self.budget
     }
 
     #[cfg(test)]

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -192,7 +192,6 @@ pub struct InvokeContext<'a> {
     compute_meter: ComputeMeter,
     log_collector: Option<Rc<RefCell<LogCollector>>>,
     compute_budget: ComputeBudget,
-    current_compute_budget: ComputeBudget,
     pub programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
     pub timings: ExecuteDetailsTimings,
     pub syscall_context: Vec<Option<SyscallContext>>,
@@ -215,7 +214,6 @@ impl<'a> InvokeContext<'a> {
             environment_config,
             compute_meter: ComputeMeter::new(compute_budget),
             log_collector,
-            current_compute_budget: compute_budget,
             compute_budget,
             programs_modified_by_tx,
             timings: ExecuteDetailsTimings::default(),
@@ -258,7 +256,8 @@ impl<'a> InvokeContext<'a> {
             .get_instruction_context_stack_height()
             == 0
         {
-            self.current_compute_budget = self.compute_budget;
+            self.compute_meter
+                .update_current_budget(self.compute_budget);
         } else {
             let contains = (0..self
                 .transaction_context
@@ -586,7 +585,7 @@ impl<'a> InvokeContext<'a> {
 
     /// Get this invocation's compute budget
     pub fn get_compute_budget(&self) -> &ComputeBudget {
-        &self.current_compute_budget
+        self.compute_meter.get_current_budget()
     }
 
     /// Get the current feature set.

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -254,7 +254,6 @@ impl<'a> InvokeContext<'a> {
             .get_instruction_context_stack_height()
             == 0
         {
-            self.compute_meter.update_current_budget();
         } else {
             let contains = (0..self
                 .transaction_context
@@ -582,7 +581,7 @@ impl<'a> InvokeContext<'a> {
 
     /// Get this invocation's compute budget
     pub fn get_compute_budget(&self) -> &ComputeBudget {
-        self.compute_meter.get_current_budget()
+        self.compute_meter.get_budget()
     }
 
     /// Get the current feature set.

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -11,6 +11,7 @@ extern crate solana_metrics;
 pub use solana_rbpf;
 pub mod compute_budget;
 pub mod compute_budget_processor;
+mod compute_meter;
 pub mod invoke_context;
 pub mod loaded_programs;
 pub mod log_collector;


### PR DESCRIPTION
#### Problem
In the quest to simplify the `InvokeContext` and its constructor, the fields
required for managing the computational budget and meter can be refactored for
simplicity.

The compute meter is the primary component of the `InvokeContext`, while the
compute _budget_ is merely a configuration parameter.

Additionally, `InvokeContext` has long made use of two compute budgets, which
no longer seem necessary to exist in separation.

#### Summary of Changes
Introduce a unified field - `compute_meter` - to the `InvokeContext`, with a
struct that stores the compute budget(s) and the active compute meter.

Then, remove the unnecessary double-budget in the compute meter.