### PR TITLE
frozen-abi: remove im crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6161,7 +6161,6 @@ dependencies = [
  "bv",
  "either",
  "generic-array 0.14.7",
- "im",
  "log",
  "memmap2",
  "rustc_version 0.4.0",

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = { workspace = true }
 block-buffer = { workspace = true }
 either = { workspace = true, features = ["use_std"] }
 generic-array = { workspace = true, features = ["serde", "more_lengths"] }
-im = { workspace = true, features = ["rayon", "serde"] }
 memmap2 = { workspace = true }
 subtle = { workspace = true }
 

--- a/frozen-abi/src/abi_example.rs
+++ b/frozen-abi/src/abi_example.rs
@@ -416,21 +416,6 @@ impl<
     }
 }
 
-#[cfg(not(target_os = "solana"))]
-impl<
-        T: Clone + std::cmp::Eq + std::hash::Hash + AbiExample,
-        S: Clone + AbiExample,
-        H: std::hash::BuildHasher + Default,
-    > AbiExample for im::HashMap<T, S, H>
-{
-    fn example() -> Self {
-        info!("AbiExample for (HashMap<T, S, H>): {}", type_name::<Self>());
-        let mut map = im::HashMap::default();
-        map.insert(T::example(), S::example());
-        map
-    }
-}
-
 impl<T: std::cmp::Ord + AbiExample, S: AbiExample> AbiExample for BTreeMap<T, S> {
     fn example() -> Self {
         info!("AbiExample for (BTreeMap<T, S>): {}", type_name::<Self>());

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5086,7 +5086,6 @@ dependencies = [
  "bv",
  "either",
  "generic-array 0.14.7",
- "im",
  "log",
  "memmap2",
  "rustc_version",


### PR DESCRIPTION
#### Problem
I don't think AbiExample needs to be implemented for im::HashMap because I don't see im::HashMap being used anywhere that AbiExample gets used. Please correct me if I'm wrong.

`im` is an annoying dependency because it's slow to compile.


#### Summary of Changes
Remove the `AbiExample for im::HashMap` impl and remove the im dependency from `solana-frozen-abi`
