### PR TITLE
sdk: make qualifier_attr dep optional

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -33,7 +33,9 @@ full = [
     "sha3",
     "digest",
 ]
-dev-context-only-utils = []
+dev-context-only-utils = [
+  "qualifier_attr"
+]
 
 [dependencies]
 base64 = { workspace = true }
@@ -61,7 +63,7 @@ num-traits = { workspace = true }
 num_enum = { workspace = true }
 pbkdf2 = { workspace = true }
 qstring = { workspace = true }
-qualifier_attr = { workspace = true }
+qualifier_attr = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 rand0-7 = { package = "rand", version = "0.7", optional = true }
 rustversion = { workspace = true }


### PR DESCRIPTION
#### Problem
`solana-sdk` depends on `qualifier_attr` but only uses it when the `dev-context-only-utils` feature is activated.

#### Summary of Changes
Makes `qualifier_attr` a dependency only when `dev-context-only-utils` is selected