### PR TITLE
removes gossip::LegacyContactInfo from public interface

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -24,7 +24,7 @@ use {
         cluster_info_metrics::{
             submit_gossip_stats, Counter, GossipStats, ScopedTimer, TimedGuard,
         },
-        contact_info::{self, ContactInfo, Error as ContactInfoError, LegacyContactInfo},
+        contact_info::{self, ContactInfo, Error as ContactInfoError},
         crds::{Crds, Cursor, GossipRoute},
         crds_gossip::CrdsGossip,
         crds_gossip_error::CrdsGossipError,
@@ -38,6 +38,7 @@ use {
         duplicate_shred::DuplicateShred,
         epoch_slots::EpochSlots,
         gossip_error::GossipError,
+        legacy_contact_info::LegacyContactInfo,
         ping_pong::{self, PingCache, Pong},
         restart_crds_values::{
             RestartHeaviestFork, RestartLastVotedForkSlots, RestartLastVotedForkSlotsError,

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -1,5 +1,6 @@
+pub use solana_client::connection_cache::Protocol;
 use {
-    crate::crds_value::MAX_WALLCLOCK,
+    crate::{crds_value::MAX_WALLCLOCK, legacy_contact_info::LegacyContactInfo},
     assert_matches::{assert_matches, debug_assert_matches},
     serde::{Deserialize, Deserializer, Serialize},
     solana_sdk::{
@@ -17,9 +18,6 @@ use {
         time::{SystemTime, UNIX_EPOCH},
     },
     thiserror::Error,
-};
-pub use {
-    crate::legacy_contact_info::LegacyContactInfo, solana_client::connection_cache::Protocol,
 };
 
 pub const SOCKET_ADDR_UNSPECIFIED: SocketAddr =

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -83,6 +83,7 @@ impl Signable for CrdsValue {
 #[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample, AbiEnumVisitor)]
 pub enum CrdsData {
+    #[allow(private_interfaces)]
     LegacyContactInfo(LegacyContactInfo),
     Vote(VoteIndex, Vote),
     LowestSlot(/*DEPRECATED:*/ u8, LowestSlot),

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -17,7 +17,7 @@ use {
 
 /// Structure representing a node on the network
 #[derive(Clone, Debug, Eq, PartialEq, AbiExample, Deserialize, Serialize)]
-pub struct LegacyContactInfo {
+pub(crate) struct LegacyContactInfo {
     id: Pubkey,
     /// gossip address
     gossip: SocketAddr,
@@ -104,6 +104,7 @@ macro_rules! socketaddr_any {
     };
 }
 
+#[cfg(test)]
 impl Default for LegacyContactInfo {
     fn default() -> Self {
         LegacyContactInfo {
@@ -126,17 +127,17 @@ impl Default for LegacyContactInfo {
 
 impl LegacyContactInfo {
     #[inline]
-    pub fn pubkey(&self) -> &Pubkey {
+    pub(crate) fn pubkey(&self) -> &Pubkey {
         &self.id
     }
 
     #[inline]
-    pub fn wallclock(&self) -> u64 {
+    pub(crate) fn wallclock(&self) -> u64 {
         self.wallclock
     }
 
     #[inline]
-    pub fn shred_version(&self) -> u16 {
+    pub(crate) fn shred_version(&self) -> u16 {
         self.shred_version
     }
 

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -20,7 +20,7 @@ pub mod epoch_slots;
 pub mod gossip_error;
 pub mod gossip_service;
 #[macro_use]
-pub mod legacy_contact_info;
+mod legacy_contact_info;
 pub mod ping_pong;
 mod push_active_set;
 mod received_cache;


### PR DESCRIPTION
#### Problem
`LegacyContactInfo` is deprecated and no longer used outside of gossip crate.

#### Summary of Changes
Removed `LegacyContactInfo` from public interface.