### PR TITLE
hot storage test uses `scan_accounts`

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -1605,15 +1605,20 @@ mod tests {
         let accounts = hot_storage.accounts(IndexOffset(0)).unwrap();
 
         // first, we verify everything
-        for (i, stored_meta) in accounts.iter().enumerate() {
-            storable_accounts.account_default_if_zero_lamport(i, |account| {
-                verify_test_account(
-                    stored_meta,
-                    &account.to_account_shared_data(),
-                    account.pubkey(),
-                );
-            });
-        }
+        let mut i = 0;
+        hot_storage
+            .scan_accounts(|stored_meta| {
+                storable_accounts.account_default_if_zero_lamport(i, |account| {
+                    verify_test_account(
+                        &stored_meta,
+                        &account.to_account_shared_data(),
+                        account.pubkey(),
+                    );
+                });
+                verify_test_account(&stored_meta, &accounts[i], stored_meta.pubkey());
+                i += 1;
+            })
+            .unwrap();
 
         // second, we verify various initial position
         let total_stored_accounts = accounts.len();


### PR DESCRIPTION
#### Problem
Trying to get rid of mmaps for storages.
We need to deprecate use of fns that return stored_account_meta.

#### Summary of Changes
replace use of `accounts` in a test. Trying to get rid of enumeration and `accounts()`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
