### PR TITLE
Simd 118: refactor calculate_stake_rewards to specify epoch

### DIFF
--- a/programs/stake/src/points.rs
+++ b/programs/stake/src/points.rs
@@ -115,8 +115,8 @@ pub(crate) fn calculate_stake_points_and_credits(
 ) -> CalculatedStakePoints {
     let credits_in_stake = stake.credits_observed;
     let credits_in_vote = new_vote_state.credits();
-    // if there is no newer credits since observed, return no point
-    if let Some(result) = compare_stake_vote_credits(
+    // if there is no newer credits since observed, return zero points
+    if let Some(result) = zero_stake_points(
         credits_in_vote,
         credits_in_stake,
         &inflation_point_calc_tracer,
@@ -149,8 +149,8 @@ pub(crate) fn calculate_stake_points_and_credits_through_epoch(
 ) -> CalculatedStakePoints {
     let credits_in_stake = stake.credits_observed;
     let credits_in_vote = new_vote_state.credits_for_recent_epoch(max_epoch);
-    // if there is no newer credits since observed, return no point
-    if let Some(result) = compare_stake_vote_credits(
+    // if there is no newer credits since observed, return zero points
+    if let Some(result) = zero_stake_points(
         credits_in_vote,
         credits_in_stake,
         &inflation_point_calc_tracer,
@@ -177,7 +177,10 @@ pub(crate) fn calculate_stake_points_and_credits_through_epoch(
     }
 }
 
-fn compare_stake_vote_credits(
+/// Given a set of vote and stake credits, determines whether stake points ought
+/// to be zero. Returns zero points if there were no credits earned since the
+/// last observation
+fn zero_stake_points(
     credits_in_vote: u64,
     credits_in_stake: u64,
     inflation_point_calc_tracer: &Option<impl Fn(&InflationPointCalculationEvent)>,

--- a/programs/stake/src/points.rs
+++ b/programs/stake/src/points.rs
@@ -103,9 +103,9 @@ fn calculate_stake_points(
     .points
 }
 
-/// for a given stake and vote_state, calculate how many
-///   points were earned (credits * stake) and new value
-///   for credits_observed were the points paid
+/// For a given Stake and VoteState, calculate how many credits
+/// the stake account observed in the last epoch, and calculate the points
+/// (credits * stake) the stake account earned.
 pub(crate) fn calculate_stake_points_and_credits(
     stake: &Stake,
     new_vote_state: &VoteState,
@@ -127,6 +127,9 @@ pub(crate) fn calculate_stake_points_and_credits(
     )
 }
 
+/// For a given Stake and VoteState, determine how many credits the stake
+/// account observed through a particular past epoch, and calculate the points
+/// (credits * stake) the stake account earned.
 pub(crate) fn calculate_stake_points_and_credits_through_epoch(
     max_epoch: Epoch,
     stake: &Stake,

--- a/programs/stake/src/rewards.rs
+++ b/programs/stake/src/rewards.rs
@@ -3,8 +3,8 @@
 
 use {
     crate::points::{
-        calculate_stake_points_and_credits, CalculatedStakePoints, InflationPointCalculationEvent,
-        PointValue, SkippedReason,
+        calculate_stake_points_and_credits_through_epoch, CalculatedStakePoints,
+        InflationPointCalculationEvent, PointValue, SkippedReason,
     },
     solana_sdk::{
         account::{AccountSharedData, WritableAccount},
@@ -138,7 +138,8 @@ fn calculate_stake_rewards(
         points,
         new_credits_observed,
         mut force_credits_update_with_skipped_reward,
-    } = calculate_stake_points_and_credits(
+    } = calculate_stake_points_and_credits_through_epoch(
+        rewarded_epoch,
         stake,
         vote_state,
         stake_history,
@@ -228,7 +229,10 @@ fn calculate_stake_rewards(
 mod tests {
     use {
         super::*,
-        crate::{points::null_tracer, stake_state::new_stake},
+        crate::{
+            points::{calculate_stake_points_and_credits, null_tracer},
+            stake_state::new_stake,
+        },
         solana_sdk::{native_token, pubkey::Pubkey},
     };
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -631,7 +631,7 @@ mod tests {
         let expected_rewards = 100_000_000_000;
 
         let calculated_rewards = bank.calculate_validator_rewards(
-            1,
+            0,
             expected_rewards,
             null_tracer(),
             &thread_pool,

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -736,6 +736,18 @@ impl VoteState {
         }
     }
 
+    /// Number of "credits" owed to this account for a particular epoch.
+    /// Iterates VoteState::epoch_credits in reverse order, so will be most
+    /// performant for a recent epoch. Returns zero if epoch cannot be found.
+    pub fn credits_for_recent_epoch(&self, desired_epoch: Epoch) -> u64 {
+        for (epoch, credits, _prev_credits) in self.epoch_credits.iter().rev() {
+            if *epoch == desired_epoch {
+                return *credits;
+            }
+        }
+        return 0;
+    }
+
     /// Number of "credits" owed to this account from the mining pool on a per-epoch basis,
     ///  starting from credits observed.
     /// Each tuple of (Epoch, u64, u64) is read as (epoch, credits, prev_credits), where

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -745,7 +745,7 @@ impl VoteState {
                 return *credits;
             }
         }
-        return 0;
+        0
     }
 
     /// Number of "credits" owed to this account from the mining pool on a per-epoch basis,

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -740,12 +740,12 @@ impl VoteState {
     /// Iterates VoteState::epoch_credits in reverse order, so will be most
     /// performant for a recent epoch. Returns zero if epoch cannot be found.
     pub fn credits_for_recent_epoch(&self, desired_epoch: Epoch) -> u64 {
-        for (epoch, credits, _prev_credits) in self.epoch_credits.iter().rev() {
-            if *epoch == desired_epoch {
-                return *credits;
-            }
-        }
-        0
+        self.epoch_credits
+            .iter()
+            .rev()
+            .find(|(epoch, _, _)| *epoch == desired_epoch)
+            .map(|(_, credits, _)| *credits)
+            .unwrap_or(0)
     }
 
     /// Number of "credits" owed to this account from the mining pool on a per-epoch basis,


### PR DESCRIPTION
#### Problem
Stake-reward calculation methods assume that the caller is interested in the last epoch in the VoteState::epoch_credits list. This is only true when rewards are calculated at the epoch-boundary block. To support recalculation in later blocks, there needs to be a VoteState api that exposes the credits for the last full epoch, and stake-rewards methods that support its use

#### Summary of Changes
Probably best reviewed by commit

- Add `VoteState::credits_for_recent_epoch`. This could be slightly more performant for finding the last full epoch by indexing directly to the second-to-last item when a new epoch has already begun, but I preferred this approach since it can be used both in the epoch-boundary block and in later blocks.
- Add `compare_stake_vote_credits()` helper that does not call `VoteState::credits()`, ie make assumptions about which epoch to pull from VoteState
- Add `handle_epoch_credits()` helper that does not necessarily iterate through all `VoteState::epoch_credits()`
- Add `calculate_stake_points_and_credits_through_epoch()` method that uses helpers to calculate stake points through a particular `max_epoch`
- Use this method in `calculate_stake_rewards()`, where we already receive the rewarded_epoch -- this PR doesn't change any existing behavior. (The test that needed to be fixed was passing the wrong epoch number, taking advantage of the last-epoch assumptions happening under the hood.)

This refactor is the foundation for a `recalculate_partitions` method: you can see a wip version of that here: https://github.com/CriesofCarrots/solana/commit/6e98df733726ee4d6db487ed157ccb58d7a99c7d
The gist is that this refactor enables the following flow in a block that is not the epoch boundary (and yes, the depth of this is painful):
`bank::partitioned_epoch_rewards::calculation::calculate_stake_vote_rewards()` >
`solana_stake_program::rewards::redeem_rewards()` >
`solana_stake_program::redeem_stake_rewards()` >
`solana_stake_program::calculate_stake_rewards()`
