### PR TITLE
Ignore test_cli_program_extend_program

### DIFF
--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -986,6 +986,7 @@ fn test_cli_program_close_program() {
 }
 
 #[test]
+#[ignore]
 fn test_cli_program_extend_program() {
     solana_logger::setup();
 


### PR DESCRIPTION
#### Problem
`test_cli_program_extend_program()` is flaky in CI and wasting tons of agent time.

#### Summary of Changes
Temporarily ignore it
