### PR TITLE
Fix test_cli_program_extend_program

### DIFF
--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1051,7 +1051,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        no_extend: true,
         use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1102,7 +1102,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        no_extend: true,
         use_rpc: false,
     });
     process_command(&config).unwrap_err();
@@ -1138,7 +1138,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        no_extend: true,
         use_rpc: false,
     });
     process_command(&config).unwrap();

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -986,7 +986,6 @@ fn test_cli_program_close_program() {
 }
 
 #[test]
-#[ignore]
 fn test_cli_program_extend_program() {
     solana_logger::setup();
 


### PR DESCRIPTION
#### Problem
`test_cli_program_extend_program()` expects a program account to be too small for a specific program, but https://github.com/anza-xyz/agave/pull/791 extends during deploy by default.
The api is confusing because of the double negatives, eg `no_extend: false`, `!no_extend`

#### Summary of Changes
Set `no_extend: true` throughout `test_cli_program_extend_program()`

I'm okay with using the `--no-extend` flag, but I would recommend we rewrite the fields and logic to remove the double negatives.

I am not sure why the test passes sometimes. I printed out the length of the account after the command at L1091 and sometimes it's 4820 (the one-byte-too-small size) and sometimes it's 4821. With the change in this PR, it's always 4820.
Possibly the `extend` transaction hadn't actually completed by the time this was called? https://github.com/anza-xyz/agave/blob/5b3390b99a6e7665439c623062c1a1dda2803524/cli/src/program.rs#L2548-L2550
Commitment seems consistent across all commands and client, though.
The deploy command must be failing for some other reason in the cases the test passes.

Fixes #1114
