### PR TITLE
remove accounts() and all_accounts()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1204,10 +1204,6 @@ impl AccountStorageEntry {
         }
     }
 
-    pub fn all_accounts(&self) -> Vec<StoredAccountMeta> {
-        self.accounts.accounts(0)
-    }
-
     fn remove_accounts(
         &self,
         num_bytes: usize,
@@ -12697,7 +12693,7 @@ pub mod tests {
         accounts.store_for_tests(current_slot, &[(&pubkey3, &zero_lamport_account)]);
 
         let snapshot_stores = accounts.get_snapshot_storages(..=current_slot).0;
-        let total_accounts: usize = snapshot_stores.iter().map(|s| s.all_accounts().len()).sum();
+        let total_accounts: usize = snapshot_stores.iter().map(|s| s.accounts_count()).sum();
         assert!(!snapshot_stores.is_empty());
         assert!(total_accounts > 0);
 
@@ -12711,7 +12707,7 @@ pub mod tests {
         accounts.print_accounts_stats("Post-D clean");
 
         let total_accounts_post_clean: usize =
-            snapshot_stores.iter().map(|s| s.all_accounts().len()).sum();
+            snapshot_stores.iter().map(|s| s.accounts_count()).sum();
         assert_eq!(total_accounts, total_accounts_post_clean);
 
         // should clean all 3 pubkeys

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -230,24 +230,6 @@ impl AccountsFile {
         }
     }
 
-    /// Return a vector of account metadata for each account, starting from `offset`.
-    pub fn accounts(&self, offset: usize) -> Vec<StoredAccountMeta> {
-        match self {
-            Self::AppendVec(av) => av.accounts(offset),
-            // Note: The conversion here is needed as the AccountsDB currently
-            // assumes all offsets are multiple of 8 while TieredStorage uses
-            // IndexOffset that is equivalent to AccountInfo::reduced_offset.
-            Self::TieredStorage(ts) => ts
-                .reader()
-                .and_then(|reader| {
-                    reader
-                        .accounts(IndexOffset(AccountInfo::get_reduced_offset(offset)))
-                        .ok()
-                })
-                .unwrap_or_default(),
-        }
-    }
-
     /// Copy each account metadata, account and hash to the internal buffer.
     /// If there is no room to write the first entry, None is returned.
     /// Otherwise, returns the starting offset of each account metadata.

--- a/accounts-db/src/append_vec/test_utils.rs
+++ b/accounts-db/src/append_vec/test_utils.rs
@@ -36,6 +36,8 @@ pub fn get_append_vec_path(path: &str) -> TempFile {
     TempFile { path: buf }
 }
 
+/// return a test account.
+/// Note that `sample`=0 returns a fully default account with a default pubkey.
 pub fn create_test_account(sample: usize) -> (StoredMeta, AccountSharedData) {
     let data_len = sample % 256;
     let mut account = AccountSharedData::new(sample as u64, 0, &Pubkey::default());

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -120,17 +120,6 @@ impl TieredStorageReader {
         }
     }
 
-    /// Return a vector of account metadata for each account, starting from
-    /// `index_offset`
-    pub fn accounts(
-        &self,
-        index_offset: IndexOffset,
-    ) -> TieredStorageResult<Vec<StoredAccountMeta>> {
-        match self {
-            Self::Hot(hot) => hot.accounts(index_offset),
-        }
-    }
-
     /// iterate over all pubkeys
     pub fn scan_pubkeys(&self, callback: impl FnMut(&Pubkey)) -> TieredStorageResult<()> {
         match self {


### PR DESCRIPTION
#### Problem
Trying to get rid of mmaps for storages.
We need to deprecate use of fns that return stored_account_meta.

#### Summary of Changes
remove `accounts()` and `all_accounts()`. These return lifetimes we can no longer support.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
