### PR TITLE
Cli: flip no_extend to auto_extend internally

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -277,7 +277,7 @@ impl ProgramSubCommands for App<'_, '_> {
                         .arg(compute_unit_price_arg())
                         .arg(
                             Arg::with_name("no_auto_extend")
-                                .long("no-extend")
+                                .long("no-auto-extend")
                                 .takes_value(false)
                                 .help("Don't automatically extend the program's data account size"),
                         ),

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -99,7 +99,7 @@ pub enum ProgramCliCommand {
         skip_fee_check: bool,
         compute_unit_price: Option<u64>,
         max_sign_attempts: usize,
-        no_extend: bool,
+        auto_extend: bool,
         use_rpc: bool,
     },
     Upgrade {
@@ -276,7 +276,7 @@ impl ProgramSubCommands for App<'_, '_> {
                         ))
                         .arg(compute_unit_price_arg())
                         .arg(
-                            Arg::with_name("no_extend")
+                            Arg::with_name("no_auto_extend")
                                 .long("no-extend")
                                 .takes_value(false)
                                 .help("Don't automatically extend the program's data account size"),
@@ -672,7 +672,7 @@ pub fn parse_program_subcommand(
             let compute_unit_price = value_of(matches, "compute_unit_price");
             let max_sign_attempts = value_of(matches, "max_sign_attempts").unwrap();
 
-            let no_extend = matches.is_present("no_extend");
+            let auto_extend = !matches.is_present("no_auto_extend");
 
             CliCommandInfo {
                 command: CliCommand::Program(ProgramCliCommand::Deploy {
@@ -692,7 +692,7 @@ pub fn parse_program_subcommand(
                     compute_unit_price,
                     max_sign_attempts,
                     use_rpc: matches.is_present("use_rpc"),
-                    no_extend,
+                    auto_extend,
                 }),
                 signers: signer_info.signers,
             }
@@ -980,7 +980,7 @@ pub fn process_program_subcommand(
             skip_fee_check,
             compute_unit_price,
             max_sign_attempts,
-            no_extend,
+            auto_extend,
             use_rpc,
         } => process_program_deploy(
             rpc_client,
@@ -998,7 +998,7 @@ pub fn process_program_subcommand(
             *skip_fee_check,
             *compute_unit_price,
             *max_sign_attempts,
-            *no_extend,
+            *auto_extend,
             *use_rpc,
         ),
         ProgramCliCommand::Upgrade {
@@ -1177,7 +1177,7 @@ fn process_program_deploy(
     skip_fee_check: bool,
     compute_unit_price: Option<u64>,
     max_sign_attempts: usize,
-    no_extend: bool,
+    auto_extend: bool,
     use_rpc: bool,
 ) -> ProcessResult {
     let fee_payer_signer = config.signers[fee_payer_signer_index];
@@ -1363,7 +1363,7 @@ fn process_program_deploy(
             skip_fee_check,
             compute_unit_price,
             max_sign_attempts,
-            no_extend,
+            auto_extend,
             use_rpc,
         )
     };
@@ -2504,7 +2504,7 @@ fn do_process_program_upgrade(
     skip_fee_check: bool,
     compute_unit_price: Option<u64>,
     max_sign_attempts: usize,
-    no_extend: bool,
+    auto_extend: bool,
     use_rpc: bool,
 ) -> ProcessResult {
     let blockhash = rpc_client.get_latest_blockhash()?;
@@ -2541,7 +2541,7 @@ fn do_process_program_upgrade(
                 )
             };
 
-        if !no_extend {
+        if auto_extend {
             // Attempt to look up the existing program's size, and automatically
             // add an extend instruction if the program data account is too small.
             let program_data_address = get_program_data_address(program_id);
@@ -3003,7 +3003,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false,
+                    auto_extend: true,
                     use_rpc: false,
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
@@ -3035,7 +3035,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false,
+                    auto_extend: true,
                     use_rpc: false,
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
@@ -3069,7 +3069,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false,
+                    auto_extend: true,
                     use_rpc: false,
                 }),
                 signers: vec![
@@ -3105,7 +3105,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false,
+                    auto_extend: true,
                     use_rpc: false,
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
@@ -3140,7 +3140,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false,
+                    auto_extend: true,
                     use_rpc: false,
                 }),
                 signers: vec![
@@ -3178,7 +3178,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false,
+                    auto_extend: true,
                     use_rpc: false,
                 }),
                 signers: vec![
@@ -3212,7 +3212,7 @@ mod tests {
                     allow_excessive_balance: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false,
+                    auto_extend: true,
                     use_rpc: false,
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
@@ -3244,7 +3244,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 1,
-                    no_extend: false,
+                    auto_extend: true,
                     use_rpc: false,
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
@@ -3275,7 +3275,7 @@ mod tests {
                     skip_fee_check: false,
                     compute_unit_price: None,
                     max_sign_attempts: 5,
-                    no_extend: false,
+                    auto_extend: true,
                     use_rpc: true,
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
@@ -4019,7 +4019,7 @@ mod tests {
                 skip_fee_check: false,
                 compute_unit_price: None,
                 max_sign_attempts: 5,
-                no_extend: false,
+                auto_extend: true,
                 use_rpc: false,
             }),
             signers: vec![&default_keypair],

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -824,7 +824,7 @@ fn test_cli_program_upgrade_auto_extend() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend: false, // --no-extend present (true)
+        auto_extend: false, // --no-auto-extend flag is present (true)
         use_rpc: false,
     });
     process_command(&config).unwrap_err();
@@ -846,7 +846,7 @@ fn test_cli_program_upgrade_auto_extend() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        auto_extend: true, // --no-extend not present (false)
+        auto_extend: true, // --no-auto-extend flag is not present (false)
         use_rpc: false,
     });
     let response = process_command(&config);

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -100,7 +100,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -150,7 +150,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     process_command(&config).unwrap();
@@ -209,7 +209,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     let err = process_command(&config).unwrap_err();
@@ -236,7 +236,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     process_command(&config).unwrap_err();
@@ -301,7 +301,7 @@ fn test_cli_program_deploy_no_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -332,7 +332,7 @@ fn test_cli_program_deploy_no_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     process_command(&config).unwrap_err();
@@ -398,7 +398,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -451,7 +451,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     let response = process_command(&config);
@@ -498,7 +498,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     process_command(&config).unwrap();
@@ -577,7 +577,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     process_command(&config).unwrap();
@@ -660,7 +660,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     process_command(&config).unwrap_err();
@@ -681,7 +681,7 @@ fn test_cli_program_deploy_with_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     let response = process_command(&config);
@@ -801,7 +801,7 @@ fn test_cli_program_upgrade_auto_extend() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -824,7 +824,7 @@ fn test_cli_program_upgrade_auto_extend() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: true, // --no-extend (true)
+        auto_extend: false, // --no-extend present (true)
         use_rpc: false,
     });
     process_command(&config).unwrap_err();
@@ -846,7 +846,7 @@ fn test_cli_program_upgrade_auto_extend() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false, // --no-extend (false)
+        auto_extend: true, // --no-extend not present (false)
         use_rpc: false,
     });
     let response = process_command(&config);
@@ -937,7 +937,7 @@ fn test_cli_program_close_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1051,7 +1051,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: true,
+        auto_extend: false,
         use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1102,7 +1102,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: true,
+        auto_extend: false,
         use_rpc: false,
     });
     process_command(&config).unwrap_err();
@@ -1138,7 +1138,7 @@ fn test_cli_program_extend_program() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: true,
+        auto_extend: false,
         use_rpc: false,
     });
     process_command(&config).unwrap();
@@ -1494,7 +1494,7 @@ fn test_cli_program_write_buffer() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1625,7 +1625,7 @@ fn test_cli_program_set_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1674,7 +1674,7 @@ fn test_cli_program_set_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -1761,7 +1761,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     process_command(&config).unwrap_err();
@@ -1782,7 +1782,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     process_command(&config).unwrap();
@@ -1869,7 +1869,7 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -2104,7 +2104,7 @@ fn test_cli_program_show() {
         skip_fee_check: false,
         compute_unit_price: None,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc: false,
     });
     config.output_format = OutputFormat::JsonCompact;
@@ -2382,7 +2382,7 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
         skip_fee_check: false,
         compute_unit_price,
         max_sign_attempts: 5,
-        no_extend: false,
+        auto_extend: true,
         use_rpc,
     });
     config.output_format = OutputFormat::JsonCompact;

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -251,7 +251,7 @@ fn run_transactions_dos(
             max_sign_attempts: 5,
             use_rpc: false,
             skip_fee_check: true, // skip_fee_check
-            no_extend: false,
+            auto_extend: true,
         });
 
         process_command(&config).expect("deploy didn't pass");


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/791 adds some unintuitive double-negative logic to the CLI (eg `!no_extend`)

#### Summary of Changes
Change internal logic: no_extend > auto_extend
