### PR TITLE
Extend HTTP client to use reqwest with middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,6 +3389,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "min-max-heap"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4602,6 +4612,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding 2.3.1",
@@ -4623,6 +4634,21 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.25.2",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "task-local-extensions",
+ "thiserror",
 ]
 
 [[package]]
@@ -6889,6 +6915,7 @@ dependencies = [
  "jsonrpc-http-server",
  "log",
  "reqwest",
+ "reqwest-middleware",
  "semver 1.0.22",
  "serde",
  "serde_derive",
@@ -6906,10 +6933,12 @@ dependencies = [
 name = "solana-rpc-client-api"
 version = "2.0.0"
 dependencies = [
+ "anyhow",
  "base64 0.22.0",
  "bs58",
  "jsonrpc-core",
  "reqwest",
+ "reqwest-middleware",
  "semver 1.0.22",
  "serde",
  "serde_derive",
@@ -8098,9 +8127,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -8216,6 +8245,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "task-local-extensions"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
+dependencies = [
+ "pin-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,6 +286,7 @@ rayon = "1.9.0"
 reed-solomon-erasure = "6.0.0"
 regex = "1.10.3"
 reqwest = { version = "0.11.23", default-features = false }
+reqwest-middleware = "0.2.5"
 rolling-file = "0.2.0"
 rpassword = "7.3"
 rustc_version = "0.4"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2886,6 +2886,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "min-max-heap"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3992,6 +4002,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding 2.3.1",
@@ -4013,6 +4024,21 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.25.2",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "task-local-extensions",
+ "thiserror",
 ]
 
 [[package]]
@@ -5614,6 +5640,7 @@ dependencies = [
  "indicatif",
  "log",
  "reqwest",
+ "reqwest-middleware",
  "semver",
  "serde",
  "serde_derive",
@@ -5631,10 +5658,12 @@ dependencies = [
 name = "solana-rpc-client-api"
 version = "2.0.0"
 dependencies = [
+ "anyhow",
  "base64 0.22.0",
  "bs58",
  "jsonrpc-core",
  "reqwest",
+ "reqwest-middleware",
  "semver",
  "serde",
  "serde_derive",
@@ -7092,6 +7121,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "task-local-extensions"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
+dependencies = [
+ "pin-utils",
 ]
 
 [[package]]

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -10,10 +10,12 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+anyhow = { workspace = true }
 base64 = { workspace = true }
 bs58 = { workspace = true }
 jsonrpc-core = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest-middleware = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -17,6 +17,7 @@ bs58 = { workspace = true }
 indicatif = { workspace = true, optional = true }
 log = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest-middleware = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/rpc-client/src/http_sender.rs
+++ b/rpc-client/src/http_sender.rs
@@ -27,7 +27,7 @@ use {
 };
 
 pub struct HttpSender {
-    client: Arc<reqwest::Client>,
+    client: Arc<reqwest_middleware::ClientWithMiddleware>,
     url: String,
     request_id: AtomicU64,
     stats: RwLock<RpcTransportStats>,
@@ -62,6 +62,21 @@ impl HttpSender {
     ///
     /// Most flexible way to create a sender. Pass a created `reqwest::Client`.
     pub fn new_with_client<U: ToString>(url: U, client: reqwest::Client) -> Self {
+        Self {
+            client: Arc::new(reqwest_middleware::ClientBuilder::new(client).build()),
+            url: url.to_string(),
+            request_id: AtomicU64::new(0),
+            stats: RwLock::new(RpcTransportStats::default()),
+        }
+    }
+
+    /// Create an HTTP RPC sender.
+    ///
+    /// Most flexible way to create a sender with middleware. Pass a created `reqwest_middleware::ClientWithMiddleware`.
+    pub fn new_with_client_with_middleware<U: ToString>(
+        url: U,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             client: Arc::new(client),
             url: url.to_string(),


### PR DESCRIPTION
#### Problem
current HTTP client setup lacks the flexibility to efficiently capture metrics and handle errors during HTTP communications. This limitation hampers our ability to monitor, debug, etc, particularly in production environments where detailed insights and quick adaptability are crucial.

#### Summary of Changes
Client Enhancement: Modified the HttpSender class in `rpc-client/src/http_sender.rs` to use `reqwest_middleware::ClientWithMiddleware` instead of `reqwest::Client`. This change enables middleware features like request retries, logging, and metrics collection without altering the existing interface.

