### PR TITLE
remove get_stored_account_meta()

### DIFF
--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -171,7 +171,6 @@ mod tests {
         file::TieredStorageMagicNumber,
         footer::TieredStorageFooter,
         hot::HOT_FORMAT,
-        index::IndexOffset,
         solana_sdk::{
             account::{AccountSharedData, ReadableAccount},
             clock::Slot,
@@ -371,7 +370,6 @@ mod tests {
             });
         }
 
-        let mut index_offset = IndexOffset(0);
         let mut verified_accounts = HashSet::new();
         let footer = reader.footer();
 
@@ -404,35 +402,6 @@ mod tests {
         assert_eq!(footer.max_account_address, max_pubkey);
         assert!(!verified_accounts.is_empty());
         assert_eq!(verified_accounts.len(), expected_accounts_map.len());
-
-        // try again with get_stored_account_meta
-        verified_accounts = HashSet::new();
-        min_pubkey = MAX_PUBKEY;
-        max_pubkey = MIN_PUBKEY;
-        while let Some((stored_account_meta, next)) =
-            reader.get_stored_account_meta(index_offset).unwrap()
-        {
-            if let Some(account) = expected_accounts_map.get(stored_account_meta.pubkey()) {
-                verify_test_account_with_footer(
-                    &stored_account_meta,
-                    account,
-                    stored_account_meta.pubkey(),
-                    footer,
-                );
-                verified_accounts.insert(*stored_account_meta.pubkey());
-                if min_pubkey > *stored_account_meta.pubkey() {
-                    min_pubkey = *stored_account_meta.pubkey();
-                }
-                if max_pubkey < *stored_account_meta.pubkey() {
-                    max_pubkey = *stored_account_meta.pubkey();
-                }
-            }
-            index_offset = next;
-        }
-        assert_eq!(footer.min_account_address, min_pubkey);
-        assert_eq!(footer.max_account_address, max_pubkey);
-        assert!(!verified_accounts.is_empty());
-        assert_eq!(verified_accounts.len(), expected_accounts_map.len())
     }
 
     #[test]

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -530,15 +530,6 @@ impl HotStorageReader {
         index_offset: IndexOffset,
         mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>) -> Ret,
     ) -> TieredStorageResult<Option<Ret>> {
-        let account = self.get_stored_account_meta(index_offset)?;
-        Ok(account.map(|(account, _offset)| callback(account)))
-    }
-
-    /// Returns the account located at the specified index offset.
-    pub fn get_stored_account_meta(
-        &self,
-        index_offset: IndexOffset,
-    ) -> TieredStorageResult<Option<(StoredAccountMeta<'_>, IndexOffset)>> {
         if index_offset.0 >= self.footer.account_entry_count {
             return Ok(None);
         }
@@ -550,16 +541,13 @@ impl HotStorageReader {
         let owner = self.get_owner_address(meta.owner_offset())?;
         let account_block = self.get_account_block(account_offset, index_offset)?;
 
-        Ok(Some((
-            StoredAccountMeta::Hot(HotAccount {
-                meta,
-                address,
-                owner,
-                index: index_offset,
-                account_block,
-            }),
-            IndexOffset(index_offset.0.saturating_add(1)),
-        )))
+        Ok(Some(callback(StoredAccountMeta::Hot(HotAccount {
+            meta,
+            address,
+            owner,
+            index: index_offset,
+            account_block,
+        }))))
     }
 
     /// Returns the account located at the specified index offset.

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -66,16 +66,6 @@ impl TieredStorageReader {
     }
 
     /// Returns the account located at the specified index offset.
-    pub fn get_stored_account_meta(
-        &self,
-        index_offset: IndexOffset,
-    ) -> TieredStorageResult<Option<(StoredAccountMeta<'_>, IndexOffset)>> {
-        match self {
-            Self::Hot(hot) => hot.get_stored_account_meta(index_offset),
-        }
-    }
-
-    /// Returns the account located at the specified index offset.
     pub fn get_account_shared_data(
         &self,
         index_offset: IndexOffset,


### PR DESCRIPTION
#### Problem
Trying to get rid of mmaps for storages.
We need to deprecate use of fns that return stored_account_meta.

#### Summary of Changes
remove `get_stored_account_meta()`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
