### PR TITLE
obtains node's client version from the new contact-info

### DIFF
--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -208,6 +208,11 @@ impl ContactInfo {
         self.shred_version
     }
 
+    #[inline]
+    pub(crate) fn version(&self) -> &solana_version::Version {
+        &self.version
+    }
+
     pub fn set_pubkey(&mut self, pubkey: Pubkey) {
         self.pubkey = pubkey
     }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5263,6 +5263,7 @@ pub mod tests {
     #[test]
     fn test_rpc_get_cluster_nodes() {
         let rpc = RpcHandler::start();
+        let version = solana_version::Version::default();
         let request = create_test_request("getClusterNodes", None);
         let result: Value = parse_success_result(rpc.handle_request_sync(request));
         let expected = json!([{
@@ -5273,8 +5274,8 @@ pub mod tests {
             "tpuQuic": "127.0.0.1:8009",
             "rpc": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PORT),
             "pubsub": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PUBSUB_PORT),
-            "version": null,
-            "featureSet": null,
+            "version": format!("{version}"),
+            "featureSet": version.feature_set,
         }, {
             "pubkey": rpc.leader_pubkey().to_string(),
             "gossip": "127.0.0.1:1235",
@@ -5283,8 +5284,8 @@ pub mod tests {
             "tpuQuic": "127.0.0.1:1240",
             "rpc": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PORT),
             "pubsub": format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PUBSUB_PORT),
-            "version": null,
-            "featureSet": null,
+            "version": format!("{version}"),
+            "featureSet": version.feature_set,
         }]);
         assert_eq!(result, expected);
     }

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -50,6 +50,19 @@ fn compute_commit(sha1: Option<&'static str>) -> Option<u32> {
     u32::from_str_radix(sha1?.get(..8)?, /*radix:*/ 16).ok()
 }
 
+impl From<LegacyVersion2> for Version {
+    fn from(version: LegacyVersion2) -> Self {
+        Self {
+            major: version.major,
+            minor: version.minor,
+            patch: version.patch,
+            commit: version.commit.unwrap_or_default(),
+            feature_set: version.feature_set,
+            client: Version::default().client,
+        }
+    }
+}
+
 impl Default for Version {
     fn default() -> Self {
         let feature_set = u32::from_le_bytes(


### PR DESCRIPTION


#### Problem
The new contact-info embeds client version and can be used directly to lookup the client version.

#### Summary of Changes
Obtain node's client version from the new contact-info.