### PR TITLE
ignore flaky test: test_hard_fork_with_gap_in_roots

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2232,6 +2232,7 @@ fn create_snapshot_to_hard_fork(
 }
 
 #[test]
+#[ignore]
 #[serial]
 fn test_hard_fork_with_gap_in_roots() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);


### PR DESCRIPTION
#### Problem
PR #823 has caused the test: `test_hard_fork_with_gap_in_roots` to be flaky and the test: `test_invalid_forks_persisted_on_restart` to fail consistently. 

Buildkite link: https://buildkite.com/organizations/anza/analytics/suites/agave/tests/018d9c52-ab10-74c0-b12d-9ebd22a1cb3a?branch=master#failed

However, @behzadnouri found that propagating `ContactInfo` more frequently resulted in these tests succeeding consistently. See: https://github.com/anza-xyz/agave/pull/823#discussion_r1575382916

We should not make these changes right now for 2 reasons:
1) Switching to use `ContactInfo` at the end of a Pull Request will make master incompatible with mainnet. So, we need to wait for the cluster to upgrade to v1.18
2) These two tests failing as a result of slower contact info propagation is a general concern. These tests rely on contact-info propagation by a certain time which is not guaranteed. Furthermore, they're relying on propagation via the Pull path which is not ideal.

Tracking issue here: https://github.com/anza-xyz/agave/issues/982

#### Summary of Changes
ignore the `test_invalid_forks_persisted_on_restart` test