### PR TITLE
 wip: add AppendVecFileBacking

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -59,14 +59,34 @@ pub enum AccountsFile {
     TieredStorage(TieredStorage),
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum StorageAccess {
+    /// ancient storages are created by appending
+    MMap,
+    /// ancient storages are created by 1-shot write to pack multiple accounts together more efficiently with new formats
+    #[default]
+    File,
+}
+
 impl AccountsFile {
     /// Create an AccountsFile instance from the specified path.
     ///
     /// The second element of the returned tuple is the number of accounts in the
     /// accounts file.
-    pub fn new_from_file(path: impl Into<PathBuf>, current_len: usize) -> Result<(Self, usize)> {
-        let (av, num_accounts) = AppendVec::new_from_file(path, current_len)?;
+    pub fn new_from_file(
+        path: impl Into<PathBuf>,
+        current_len: usize,
+        storage_access: StorageAccess,
+    ) -> Result<(Self, usize)> {
+        let (av, num_accounts) = AppendVec::new_from_file(path, current_len, storage_access)?;
         Ok((Self::AppendVec(av), num_accounts))
+    }
+
+    pub fn close_map(&self) {
+        match self {
+            Self::AppendVec(av) => av.close_map(),
+            Self::TieredStorage(_) => {}
+        }
     }
 
     pub fn flush(&self) -> Result<()> {

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -592,6 +592,9 @@ impl AccountsDb {
             if shrink_in_progress.is_none() {
                 dropped_roots.push(slot);
             }
+            if let Some(store) = shrink_in_progress.as_ref().map(|sip| sip.new_storage()) {
+                store.accounts.close_map();
+            }
             self.remove_old_stores_shrink(
                 &shrink_collect,
                 &self.shrink_ancient_stats.shrink_stats,

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -643,8 +643,11 @@ impl HotStorageReader {
     }
 
     /// Returns a slice suitable for use when archiving hot storages
-    pub fn data_for_archive(&self) -> &[u8] {
-        self.mmap.as_ref()
+    pub fn data_for_archive<T>(
+        &self,
+        mut callback: impl for<'local> FnMut(&'local [u8]) -> T,
+    ) -> TieredStorageResult<T> {
+        Ok(callback(self.mmap.as_ref()))
     }
 }
 

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -145,9 +145,12 @@ impl TieredStorageReader {
     }
 
     /// Returns a slice suitable for use when archiving tiered storages
-    pub fn data_for_archive(&self) -> &[u8] {
+    pub fn data_for_archive<T>(
+        &self,
+        callback: impl for<'local> FnMut(&'local [u8]) -> T,
+    ) -> TieredStorageResult<T> {
         match self {
-            Self::Hot(hot) => hot.data_for_archive(),
+            Self::Hot(hot) => hot.data_for_archive(callback),
         }
     }
 }

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -40,7 +40,12 @@ fn main() {
     // When the AppendVec is dropped, the backing file will be removed.  We do not want to remove
     // the backing file here in the store-tool, so prevent dropping.
     let store = ManuallyDrop::new(
-        AppendVec::new_from_file_unchecked(file, len).expect("new AppendVec from file"),
+        AppendVec::new_from_file_unchecked(
+            file,
+            len,
+            solana_accounts_db::accounts_file::StorageAccess::default(),
+        )
+        .expect("new AppendVec from file"),
     );
     info!("store: len: {} capacity: {}", store.len(), store.capacity());
     let mut num_accounts: usize = 0;

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -10,7 +10,9 @@ use {
         use_snapshot_archives_at_startup::{self, UseSnapshotArchivesAtStartup},
     },
     log::*,
-    solana_accounts_db::accounts_update_notifier_interface::AccountsUpdateNotifier,
+    solana_accounts_db::{
+        accounts_file::StorageAccess, accounts_update_notifier_interface::AccountsUpdateNotifier,
+    },
     solana_runtime::{
         accounts_background_service::AbsRequestSender,
         bank_forks::BankForks,
@@ -292,6 +294,7 @@ fn bank_forks_from_snapshot(
             process_options.accounts_db_config.clone(),
             accounts_update_notifier,
             exit,
+            StorageAccess::default(),
         )
         .map_err(|err| BankForksUtilsError::BankFromSnapshotsDirectory {
             source: err,

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -26,7 +26,7 @@ mod tests {
                 get_temp_accounts_paths, AccountShrinkThreshold, AccountStorageEntry, AccountsDb,
                 AtomicAccountsFileId,
             },
-            accounts_file::{AccountsFile, AccountsFileError},
+            accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
             accounts_hash::{AccountsDeltaHash, AccountsHash},
             accounts_index::AccountSecondaryIndexes,
             epoch_accounts_hash::EpochAccountsHash,
@@ -47,12 +47,14 @@ mod tests {
             sync::{Arc, RwLock},
         },
         tempfile::TempDir,
+        test_case::test_case,
     };
 
     /// Simulates the unpacking & storage reconstruction done during snapshot unpacking
     fn copy_append_vecs<P: AsRef<Path>>(
         accounts_db: &AccountsDb,
         output_dir: P,
+        storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_snapshot_storages(RangeFull).0;
         let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
@@ -66,8 +68,11 @@ mod tests {
             std::fs::copy(storage_path, &output_path)?;
 
             // Read new file into append-vec and build new entry
-            let (accounts_file, num_accounts) =
-                AccountsFile::new_from_file(output_path, storage_entry.accounts.len())?;
+            let (accounts_file, num_accounts) = AccountsFile::new_from_file(
+                output_path,
+                storage_entry.accounts.len(),
+                storage_access,
+            )?;
             let new_storage_entry = AccountStorageEntry::new_existing(
                 storage_entry.slot(),
                 storage_entry.append_vec_id(),
@@ -96,6 +101,7 @@ mod tests {
         update_accounts_hash: bool,
         incremental_snapshot_persistence: bool,
         initial_epoch_accounts_hash: bool,
+        storage_access: StorageAccess,
     ) {
         solana_logger::setup();
         let (mut genesis_config, _) = create_genesis_config(500);
@@ -252,8 +258,12 @@ mod tests {
         status_cache.add_root(2);
         // Create a directory to simulate AppendVecs unpackaged from a snapshot tar
         let copied_accounts = TempDir::new().unwrap();
-        let storage_and_next_append_vec_id =
-            copy_append_vecs(&bank2.rc.accounts.accounts_db, copied_accounts.path()).unwrap();
+        let storage_and_next_append_vec_id = copy_append_vecs(
+            &bank2.rc.accounts.accounts_db,
+            copied_accounts.path(),
+            storage_access,
+        )
+        .unwrap();
         let mut snapshot_streams = SnapshotStreams {
             full_snapshot_stream: &mut reader,
             incremental_snapshot_stream: None,
@@ -303,8 +313,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_bank_serialize_newer() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_bank_serialize_newer(storage_access: StorageAccess) {
         for (reserialize_accounts_hash, update_accounts_hash) in
             [(false, false), (true, false), (true, true)]
         {
@@ -321,6 +332,7 @@ mod tests {
                         update_accounts_hash,
                         incremental_snapshot_persistence,
                         initial_epoch_accounts_hash,
+                        storage_access,
                     )
                 }
             }
@@ -332,8 +344,9 @@ mod tests {
         bank.flush_accounts_cache_slot_for_tests()
     }
 
-    #[test]
-    fn test_extra_fields_eof() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_extra_fields_eof(storage_access: StorageAccess) {
         solana_logger::setup();
         let sample_rewards = (0..2)
             .map(|_| StakeReward::new_random())
@@ -385,8 +398,12 @@ mod tests {
             };
             let (_accounts_dir, dbank_paths) = get_temp_accounts_paths(4).unwrap();
             let copied_accounts = TempDir::new().unwrap();
-            let storage_and_next_append_vec_id =
-                copy_append_vecs(&bank.rc.accounts.accounts_db, copied_accounts.path()).unwrap();
+            let storage_and_next_append_vec_id = copy_append_vecs(
+                &bank.rc.accounts.accounts_db,
+                copied_accounts.path(),
+                storage_access,
+            )
+            .unwrap();
             let dbank = crate::serde_snapshot::bank_from_streams(
                 SerdeStyle::Newer,
                 &mut snapshot_streams,
@@ -526,8 +543,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_blank_extra_fields() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_blank_extra_fields(storage_access: StorageAccess) {
         solana_logger::setup();
         let (genesis_config, _) = create_genesis_config(500);
 
@@ -569,8 +587,12 @@ mod tests {
         };
         let (_accounts_dir, dbank_paths) = get_temp_accounts_paths(4).unwrap();
         let copied_accounts = TempDir::new().unwrap();
-        let storage_and_next_append_vec_id =
-            copy_append_vecs(&bank.rc.accounts.accounts_db, copied_accounts.path()).unwrap();
+        let storage_and_next_append_vec_id = copy_append_vecs(
+            &bank.rc.accounts.accounts_db,
+            copied_accounts.path(),
+            storage_access,
+        )
+        .unwrap();
         let dbank = crate::serde_snapshot::bank_from_streams(
             SerdeStyle::Newer,
             &mut snapshot_streams,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -21,7 +21,7 @@ use {
             AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig,
             AccountsFileId, AtomicAccountsFileId, BankHashStats, IndexGenerationInfo,
         },
-        accounts_file::AccountsFile,
+        accounts_file::{AccountsFile, StorageAccess},
         accounts_hash::AccountsHash,
         accounts_index::AccountSecondaryIndexes,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
@@ -647,8 +647,10 @@ pub(crate) fn reconstruct_single_storage(
     append_vec_path: &Path,
     current_len: usize,
     append_vec_id: AccountsFileId,
+    storage_access: StorageAccess,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
-    let (accounts_file, num_accounts) = AccountsFile::new_from_file(append_vec_path, current_len)?;
+    let (accounts_file, num_accounts) =
+        AccountsFile::new_from_file(append_vec_path, current_len, storage_access)?;
     Ok(Arc::new(AccountStorageEntry::new_existing(
         *slot,
         append_vec_id,
@@ -731,6 +733,7 @@ pub(crate) fn remap_and_reconstruct_single_storage(
     append_vec_path: &Path,
     next_append_vec_id: &AtomicAccountsFileId,
     num_collisions: &AtomicUsize,
+    storage_access: StorageAccess,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
     let (remapped_append_vec_id, remapped_append_vec_path) = remap_append_vec_file(
         slot,
@@ -744,6 +747,7 @@ pub(crate) fn remap_and_reconstruct_single_storage(
         &remapped_append_vec_path,
         current_len,
         remapped_append_vec_id,
+        storage_access,
     )?;
     Ok(storage)
 }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -19,7 +19,7 @@ mod serde_snapshot_tests {
                 AccountStorageEntry, AccountsDb, AtomicAccountsFileId,
                 VerifyAccountsHashAndLamportsConfig,
             },
-            accounts_file::{AccountsFile, AccountsFileError},
+            accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
             accounts_hash::AccountsHash,
             accounts_index::AccountSecondaryIndexes,
             ancestors::Ancestors,
@@ -137,6 +137,7 @@ mod serde_snapshot_tests {
     fn copy_append_vecs<P: AsRef<Path>>(
         accounts_db: &AccountsDb,
         output_dir: P,
+        storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_snapshot_storages(RangeFull).0;
         let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
@@ -150,8 +151,11 @@ mod serde_snapshot_tests {
             std::fs::copy(storage_path, &output_path)?;
 
             // Read new file into append-vec and build new entry
-            let (accounts_file, num_accounts) =
-                AccountsFile::new_from_file(output_path, storage_entry.accounts.len())?;
+            let (accounts_file, num_accounts) = AccountsFile::new_from_file(
+                output_path,
+                storage_entry.accounts.len(),
+                storage_access,
+            )?;
             let new_storage_entry = AccountStorageEntry::new_existing(
                 storage_entry.slot(),
                 storage_entry.append_vec_id(),
@@ -174,7 +178,11 @@ mod serde_snapshot_tests {
         })
     }
 
-    fn reconstruct_accounts_db_via_serialization(accounts: &AccountsDb, slot: Slot) -> AccountsDb {
+    fn reconstruct_accounts_db_via_serialization(
+        accounts: &AccountsDb,
+        slot: Slot,
+        storage_access: StorageAccess,
+    ) -> AccountsDb {
         let mut writer = Cursor::new(vec![]);
         let snapshot_storages = accounts.get_snapshot_storages(..=slot).0;
         accountsdb_to_stream(
@@ -192,7 +200,7 @@ mod serde_snapshot_tests {
 
         // Simulate obtaining a copy of the AppendVecs from a tarball
         let storage_and_next_append_vec_id =
-            copy_append_vecs(accounts, copied_accounts.path()).unwrap();
+            copy_append_vecs(accounts, copied_accounts.path(), storage_access).unwrap();
         let mut accounts_db = accountsdb_from_stream(
             SerdeStyle::Newer,
             &mut reader,
@@ -225,7 +233,7 @@ mod serde_snapshot_tests {
         }
     }
 
-    fn test_accounts_serialize_style(serde_style: SerdeStyle) {
+    fn test_accounts_serialize_style(serde_style: SerdeStyle, storage_access: StorageAccess) {
         solana_logger::setup();
         let (_accounts_dir, paths) = get_temp_accounts_paths(4).unwrap();
         let accounts_db = AccountsDb::new_for_tests(paths, &ClusterType::Development);
@@ -255,8 +263,12 @@ mod serde_snapshot_tests {
         let copied_accounts = TempDir::new().unwrap();
 
         // Simulate obtaining a copy of the AppendVecs from a tarball
-        let storage_and_next_append_vec_id =
-            copy_append_vecs(&accounts.accounts_db, copied_accounts.path()).unwrap();
+        let storage_and_next_append_vec_id = copy_append_vecs(
+            &accounts.accounts_db,
+            copied_accounts.path(),
+            storage_access,
+        )
+        .unwrap();
 
         let buf = writer.into_inner();
         let mut reader = BufReader::new(&buf[..]);
@@ -277,13 +289,15 @@ mod serde_snapshot_tests {
         assert_eq!(accounts_hash, daccounts_hash);
     }
 
-    #[test]
-    fn test_accounts_serialize_newer() {
-        test_accounts_serialize_style(SerdeStyle::Newer)
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_accounts_serialize_newer(storage_access: StorageAccess) {
+        test_accounts_serialize_style(SerdeStyle::Newer, storage_access)
     }
 
-    #[test]
-    fn test_remove_unrooted_slot_snapshot() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_remove_unrooted_slot_snapshot(storage_access: StorageAccess) {
         solana_logger::setup();
         let unrooted_slot = 9;
         let unrooted_bank_id = 9;
@@ -305,7 +319,7 @@ mod serde_snapshot_tests {
         db.update_accounts_hash_for_tests(new_root, &linear_ancestors(new_root), false, false);
 
         // Simulate reconstruction from snapshot
-        let db = reconstruct_accounts_db_via_serialization(&db, new_root);
+        let db = reconstruct_accounts_db_via_serialization(&db, new_root, storage_access);
 
         // Check root account exists
         db.assert_load_account(new_root, key2, 1);
@@ -317,8 +331,9 @@ mod serde_snapshot_tests {
             .is_none());
     }
 
-    #[test]
-    fn test_accounts_db_serialize1() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_accounts_db_serialize1(storage_access: StorageAccess) {
         for pass in 0..2 {
             solana_logger::setup();
             let accounts = AccountsDb::new_single_for_tests();
@@ -395,7 +410,8 @@ mod serde_snapshot_tests {
             accounts.check_storage(1, 11);
             accounts.check_storage(2, 31);
 
-            let daccounts = reconstruct_accounts_db_via_serialization(&accounts, latest_slot);
+            let daccounts =
+                reconstruct_accounts_db_via_serialization(&accounts, latest_slot, storage_access);
 
             assert_eq!(
                 daccounts.write_version.load(Ordering::Acquire),
@@ -431,8 +447,9 @@ mod serde_snapshot_tests {
         }
     }
 
-    #[test]
-    fn test_accounts_db_serialize_zero_and_free() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_accounts_db_serialize_zero_and_free(storage_access: StorageAccess) {
         solana_logger::setup();
 
         let some_lamport = 223;
@@ -474,7 +491,8 @@ mod serde_snapshot_tests {
             false,
             false,
         );
-        let accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
+        let accounts =
+            reconstruct_accounts_db_via_serialization(&accounts, current_slot, storage_access);
 
         accounts.print_accounts_stats("reconstructed");
 
@@ -550,28 +568,32 @@ mod serde_snapshot_tests {
             .unwrap();
     }
 
-    #[test]
-    fn test_accounts_purge_chained_purge_before_snapshot_restore() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_accounts_purge_chained_purge_before_snapshot_restore(storage_access: StorageAccess) {
         solana_logger::setup();
         with_chained_zero_lamport_accounts(|accounts, current_slot| {
             accounts.clean_accounts_for_tests();
-            reconstruct_accounts_db_via_serialization(&accounts, current_slot)
+            reconstruct_accounts_db_via_serialization(&accounts, current_slot, storage_access)
         });
     }
 
-    #[test]
-    fn test_accounts_purge_chained_purge_after_snapshot_restore() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_accounts_purge_chained_purge_after_snapshot_restore(storage_access: StorageAccess) {
         solana_logger::setup();
         with_chained_zero_lamport_accounts(|accounts, current_slot| {
-            let accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
+            let accounts =
+                reconstruct_accounts_db_via_serialization(&accounts, current_slot, storage_access);
             accounts.print_accounts_stats("after_reconstruct");
             accounts.clean_accounts_for_tests();
-            reconstruct_accounts_db_via_serialization(&accounts, current_slot)
+            reconstruct_accounts_db_via_serialization(&accounts, current_slot, storage_access)
         });
     }
 
-    #[test]
-    fn test_accounts_purge_long_chained_after_snapshot_restore() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_accounts_purge_long_chained_after_snapshot_restore(storage_access: StorageAccess) {
         solana_logger::setup();
         let old_lamport = 223;
         let zero_lamport = 0;
@@ -628,7 +650,8 @@ mod serde_snapshot_tests {
             false,
             false,
         );
-        let accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
+        let accounts =
+            reconstruct_accounts_db_via_serialization(&accounts, current_slot, storage_access);
         accounts.print_count_and_status("before purge zero");
         accounts.clean_accounts_for_tests();
         accounts.print_count_and_status("after purge zero");
@@ -638,8 +661,9 @@ mod serde_snapshot_tests {
         accounts.assert_load_account(current_slot, purged_pubkey2, 0);
     }
 
-    #[test]
-    fn test_accounts_clean_after_snapshot_restore_then_old_revives() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_accounts_clean_after_snapshot_restore_then_old_revives(storage_access: StorageAccess) {
         solana_logger::setup();
         let old_lamport = 223;
         let zero_lamport = 0;
@@ -744,7 +768,8 @@ mod serde_snapshot_tests {
             false,
             false,
         );
-        let accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
+        let accounts =
+            reconstruct_accounts_db_via_serialization(&accounts, current_slot, storage_access);
         accounts.clean_accounts_for_tests();
 
         info!("pubkey: {}", pubkey1);
@@ -772,8 +797,9 @@ mod serde_snapshot_tests {
         accounts.assert_load_account(current_slot, dummy_pubkey, dummy_lamport);
     }
 
-    #[test]
-    fn test_shrink_stale_slots_processed() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_shrink_stale_slots_processed(storage_access: StorageAccess) {
         solana_logger::setup();
 
         for startup in &[false, true] {
@@ -837,7 +863,8 @@ mod serde_snapshot_tests {
                 .verify_accounts_hash_and_lamports_for_tests(current_slot, 22300, config.clone())
                 .unwrap();
 
-            let accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
+            let accounts =
+                reconstruct_accounts_db_via_serialization(&accounts, current_slot, storage_access);
             accounts
                 .verify_accounts_hash_and_lamports_for_tests(current_slot, 22300, config)
                 .unwrap();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -32,6 +32,7 @@ use {
             AccountShrinkThreshold, AccountStorageEntry, AccountsDbConfig, AtomicAccountsFileId,
             CalcAccountsHashDataSource,
         },
+        accounts_file::StorageAccess,
         accounts_hash::AccountsHash,
         accounts_index::AccountSecondaryIndexes,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
@@ -233,6 +234,7 @@ pub struct BankFromDirTimings {
 pub fn bank_fields_from_snapshot_archives(
     full_snapshot_archives_dir: impl AsRef<Path>,
     incremental_snapshot_archives_dir: impl AsRef<Path>,
+    storage_access: StorageAccess,
 ) -> snapshot_utils::Result<BankFieldsToDeserialize> {
     let full_snapshot_archive_info =
         get_highest_full_snapshot_archive_info(&full_snapshot_archives_dir).ok_or_else(|| {
@@ -255,6 +257,7 @@ pub fn bank_fields_from_snapshot_archives(
             &full_snapshot_archive_info,
             incremental_snapshot_archive_info.as_ref(),
             &account_paths,
+            storage_access,
         )?;
 
     bank_fields_from_snapshots(
@@ -308,6 +311,10 @@ pub fn bank_from_snapshot_archives(
             full_snapshot_archive_info,
             incremental_snapshot_archive_info,
             account_paths,
+            accounts_db_config
+                .as_ref()
+                .map(|config| config.storage_access)
+                .unwrap_or_default(),
         )?;
 
     let mut storage = unarchived_full_snapshot.storage;
@@ -498,6 +505,7 @@ pub fn bank_from_snapshot_dir(
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: Arc<AtomicBool>,
+    storage_access: StorageAccess,
 ) -> snapshot_utils::Result<(Bank, BankFromDirTimings)> {
     info!(
         "Loading bank from snapshot dir: {}",
@@ -516,7 +524,8 @@ pub fn bank_from_snapshot_dir(
         rebuild_storages_from_snapshot_dir(
             bank_snapshot,
             account_paths,
-            next_append_vec_id.clone()
+            next_append_vec_id.clone(),
+            storage_access,
         )?,
         "rebuild storages from snapshot dir"
     );
@@ -585,7 +594,10 @@ pub fn bank_from_latest_snapshot_dir(
     let bank_snapshot = get_highest_bank_snapshot_post(&bank_snapshots_dir).ok_or_else(|| {
         SnapshotError::NoSnapshotSlotDir(bank_snapshots_dir.as_ref().to_path_buf())
     })?;
-
+    let storage_access = accounts_db_config
+        .as_ref()
+        .map(|config| config.storage_access)
+        .unwrap_or_default();
     let (bank, _) = bank_from_snapshot_dir(
         account_paths,
         &bank_snapshot,
@@ -600,6 +612,7 @@ pub fn bank_from_latest_snapshot_dir(
         accounts_db_config,
         accounts_update_notifier,
         exit,
+        storage_access,
     )?;
 
     Ok(bank)
@@ -1342,6 +1355,7 @@ mod tests {
             transaction::SanitizedTransaction,
         },
         std::sync::{atomic::Ordering, Arc, RwLock},
+        test_case::test_case,
     };
 
     fn new_bank_from_parent_with_bank_forks(
@@ -2010,8 +2024,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_bank_fields_from_snapshot() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_bank_fields_from_snapshot(storage_access: StorageAccess) {
         let collector = Pubkey::new_unique();
         let key1 = Keypair::new();
 
@@ -2067,8 +2082,12 @@ mod tests {
         )
         .unwrap();
 
-        let bank_fields =
-            bank_fields_from_snapshot_archives(&all_snapshots_dir, &all_snapshots_dir).unwrap();
+        let bank_fields = bank_fields_from_snapshot_archives(
+            &all_snapshots_dir,
+            &all_snapshots_dir,
+            storage_access,
+        )
+        .unwrap();
         assert_eq!(bank_fields.slot, bank2.slot());
         assert_eq!(bank_fields.parent_slot, bank2.parent_slot());
     }
@@ -2390,8 +2409,9 @@ mod tests {
         assert_eq!(other_incremental_accounts_hash, incremental_accounts_hash);
     }
 
-    #[test]
-    fn test_bank_from_snapshot_dir() {
+    #[test_case(StorageAccess::MMap)]
+    #[test_case(StorageAccess::File)]
+    fn test_bank_from_snapshot_dir(storage_access: StorageAccess) {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 3, 0);
@@ -2413,6 +2433,7 @@ mod tests {
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
             Arc::default(),
+            storage_access,
         )
         .unwrap();
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -20,7 +20,7 @@ use {
     solana_accounts_db::{
         account_storage::AccountStorageMap,
         accounts_db::{AccountStorageEntry, AtomicAccountsFileId},
-        accounts_file::{AccountsFile, AccountsFileError},
+        accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
         hardened_unpack::{self, ParallelSelector, UnpackError},
         shared_buffer_reader::{SharedBuffer, SharedBufferReader},
         utils::{move_and_async_delete_path, ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR},
@@ -1289,6 +1289,7 @@ pub fn verify_and_unarchive_snapshots(
     full_snapshot_archive_info: &FullSnapshotArchiveInfo,
     incremental_snapshot_archive_info: Option<&IncrementalSnapshotArchiveInfo>,
     account_paths: &[PathBuf],
+    storage_access: StorageAccess,
 ) -> Result<(
     UnarchivedSnapshot,
     Option<UnarchivedSnapshot>,
@@ -1311,6 +1312,7 @@ pub fn verify_and_unarchive_snapshots(
         full_snapshot_archive_info.archive_format(),
         parallel_divisions,
         next_append_vec_id.clone(),
+        storage_access,
     )?;
 
     let unarchived_incremental_snapshot =
@@ -1324,6 +1326,7 @@ pub fn verify_and_unarchive_snapshots(
                 incremental_snapshot_archive_info.archive_format(),
                 parallel_divisions,
                 next_append_vec_id.clone(),
+                storage_access,
             )?;
             Some(unarchived_incremental_snapshot)
         } else {
@@ -1449,6 +1452,7 @@ fn unarchive_snapshot(
     archive_format: ArchiveFormat,
     parallel_divisions: usize,
     next_append_vec_id: Arc<AtomicAccountsFileId>,
+    storage_access: StorageAccess,
 ) -> Result<UnarchivedSnapshot> {
     let unpack_dir = tempfile::Builder::new()
         .prefix(unpacked_snapshots_dir_prefix)
@@ -1474,6 +1478,7 @@ fn unarchive_snapshot(
             num_rebuilder_threads,
             next_append_vec_id,
             SnapshotFrom::Archive,
+            storage_access,
         )?,
         measure_name
     );
@@ -1524,6 +1529,7 @@ pub fn rebuild_storages_from_snapshot_dir(
     snapshot_info: &BankSnapshotInfo,
     account_paths: &[PathBuf],
     next_append_vec_id: Arc<AtomicAccountsFileId>,
+    storage_access: StorageAccess,
 ) -> Result<AccountStorageMap> {
     let bank_snapshot_dir = &snapshot_info.snapshot_dir;
     let accounts_hardlinks = bank_snapshot_dir.join(SNAPSHOT_ACCOUNTS_HARDLINKS);
@@ -1596,6 +1602,7 @@ pub fn rebuild_storages_from_snapshot_dir(
         num_rebuilder_threads,
         next_append_vec_id,
         SnapshotFrom::Dir,
+        storage_access,
     )?;
 
     let RebuiltSnapshotStorage {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -829,11 +829,11 @@ pub fn archive_snapshot_package(
                 })?;
                 header.set_size(storage.capacity());
                 header.set_cksum();
-                archive
-                    .append(&header, storage.accounts.data_for_archive())
-                    .map_err(|err| {
+                storage.accounts.data_for_archive(|data| {
+                    archive.append(&header, data).map_err(|err| {
                         E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
-                    })?;
+                    })
+                })?;
             }
 
             archive.into_inner().map_err(E::FinishArchive)?;

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -17,6 +17,7 @@ use {
     solana_accounts_db::{
         account_storage::{AccountStorageMap, AccountStorageReference},
         accounts_db::{AccountStorageEntry, AccountsFileId, AtomicAccountsFileId},
+        accounts_file::StorageAccess,
     },
     solana_sdk::clock::Slot,
     std::{
@@ -67,6 +68,8 @@ pub(crate) struct SnapshotStorageRebuilder {
     num_collisions: AtomicUsize,
     /// Rebuild from the snapshot files or archives
     snapshot_from: SnapshotFrom,
+    /// true if all append vecs must be mmapped
+    storage_access: StorageAccess,
 }
 
 impl SnapshotStorageRebuilder {
@@ -76,6 +79,7 @@ impl SnapshotStorageRebuilder {
         num_threads: usize,
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_from: SnapshotFrom,
+        storage_access: StorageAccess,
     ) -> Result<RebuiltSnapshotStorage, SnapshotError> {
         let (snapshot_version_path, snapshot_file_path, append_vec_files) =
             Self::get_version_and_snapshot_files(&file_receiver);
@@ -95,6 +99,7 @@ impl SnapshotStorageRebuilder {
             snapshot_storage_lengths,
             append_vec_files,
             snapshot_from,
+            storage_access,
         )?;
 
         Ok(RebuiltSnapshotStorage {
@@ -111,6 +116,7 @@ impl SnapshotStorageRebuilder {
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_storage_lengths: HashMap<Slot, HashMap<usize, usize>>,
         snapshot_from: SnapshotFrom,
+        storage_access: StorageAccess,
     ) -> Self {
         let storage = DashMap::with_capacity(snapshot_storage_lengths.len());
         let storage_paths: DashMap<_, _> = snapshot_storage_lengths
@@ -129,6 +135,7 @@ impl SnapshotStorageRebuilder {
             processed_slot_count: AtomicUsize::new(0),
             num_collisions: AtomicUsize::new(0),
             snapshot_from,
+            storage_access,
         }
     }
 
@@ -202,6 +209,7 @@ impl SnapshotStorageRebuilder {
         snapshot_storage_lengths: HashMap<Slot, HashMap<usize, usize>>,
         append_vec_files: Vec<PathBuf>,
         snapshot_from: SnapshotFrom,
+        storage_access: StorageAccess,
     ) -> Result<AccountStorageMap, SnapshotError> {
         let rebuilder = Arc::new(SnapshotStorageRebuilder::new(
             file_receiver,
@@ -209,6 +217,7 @@ impl SnapshotStorageRebuilder {
             next_append_vec_id,
             snapshot_storage_lengths,
             snapshot_from,
+            storage_access,
         ));
 
         let thread_pool = rebuilder.build_thread_pool();
@@ -318,12 +327,14 @@ impl SnapshotStorageRebuilder {
                         path.as_path(),
                         &self.next_append_vec_id,
                         &self.num_collisions,
+                        self.storage_access,
                     )?,
                     SnapshotFrom::Dir => reconstruct_single_storage(
                         &slot,
                         path.as_path(),
                         current_len,
                         old_append_vec_id as AccountsFileId,
+                        self.storage_access,
                     )?,
                 };
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -241,6 +241,7 @@ impl Stakes<StakeAccount> {
             // but it does it in background threads, so effectively it's faster.
             .try_fold(ImHashMap::new, |mut map, (pubkey, delegation)| {
                 let Some(stake_account) = get_account(pubkey) else {
+                    log::error!("{}", line!());
                     return Err(Error::StakeAccountNotFound(*pubkey));
                 };
 
@@ -265,6 +266,7 @@ impl Stakes<StakeAccount> {
                     map.insert(*pubkey, stake_account);
                     Ok(map)
                 } else {
+                    log::error!("{}", line!());
                     Err(Error::InvalidDelegation(*pubkey))
                 }
             })
@@ -276,6 +278,7 @@ impl Stakes<StakeAccount> {
         // (sub 2s) improvements.
         for (pubkey, vote_account) in stakes.vote_accounts.iter() {
             let Some(account) = get_account(pubkey) else {
+                log::error!("{}", line!());
                 return Err(Error::VoteAccountNotFound(*pubkey));
             };
             let vote_account = vote_account.account();


### PR DESCRIPTION
#### Problem
trying to get rid of mmaps on append vecs.

#### Summary of Changes
introduce `AppendVecFileBacking`. This can hold always a mmap, or a rwlock protected enum of mmap or file and buffer.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
