### PR TITLE
Simd 118: use vote state from EpochStakes in calculation

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -41,9 +41,7 @@ use {
         bank::{
             builtins::{BuiltinPrototype, BUILTINS},
             metrics::*,
-            partitioned_epoch_rewards::{
-                EpochRewardCalculateParamInfo, EpochRewardStatus, StakeRewards, VoteRewardsAccounts,
-            },
+            partitioned_epoch_rewards::{EpochRewardStatus, StakeRewards, VoteRewardsAccounts},
         },
         bank_forks::BankForks,
         epoch_stakes::{EpochStakes, NodeVoteAccounts},
@@ -2395,24 +2393,6 @@ impl Bank {
             vote_with_stake_delegations_map,
             invalid_vote_keys,
             vote_accounts_cache_miss_count: vote_accounts_cache_miss_count.into_inner(),
-        }
-    }
-
-    /// calculate and return some reward calc info to avoid recalculation across functions
-    fn get_epoch_reward_calculate_param_info<'a>(
-        &self,
-        stakes: &'a Stakes<StakeAccount<Delegation>>,
-    ) -> EpochRewardCalculateParamInfo<'a> {
-        let stake_history = stakes.history().clone();
-
-        let stake_delegations = self.filter_stake_delegations(stakes);
-
-        let cached_vote_accounts = stakes.vote_accounts();
-
-        EpochRewardCalculateParamInfo {
-            stake_history,
-            stake_delegations,
-            cached_vote_accounts,
         }
     }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -534,6 +534,7 @@ mod tests {
         rayon::ThreadPoolBuilder,
         solana_sdk::{
             account::{accounts_equal, ReadableAccount, WritableAccount},
+            epoch_schedule::EpochSchedule,
             native_token::{sol_to_lamports, LAMPORTS_PER_SOL},
             reward_type::RewardType,
             signature::Signer,
@@ -544,17 +545,22 @@ mod tests {
         std::sync::RwLockReadGuard,
     };
 
+    const SLOTS_PER_EPOCH: u64 = 32;
+
     /// Helper function to create a bank that pays some rewards
     fn create_reward_bank(expected_num_delegations: usize) -> (Bank, Vec<Pubkey>, Vec<Pubkey>) {
         let validator_keypairs = (0..expected_num_delegations)
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
 
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config_with_vote_accounts(
+        let GenesisConfigInfo {
+            mut genesis_config, ..
+        } = create_genesis_config_with_vote_accounts(
             1_000_000_000,
             &validator_keypairs,
             vec![2_000_000_000; expected_num_delegations],
         );
+        genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
 
         let bank = Bank::new_for_tests(&genesis_config);
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -308,15 +308,10 @@ impl Bank {
 
         // Use `EpochStakes` for vote accounts
         let leader_schedule_epoch = self.epoch_schedule().get_leader_schedule_epoch(self.slot());
-        let epoch_stakes = self.epoch_stakes(leader_schedule_epoch)
+        let cached_vote_accounts = self.epoch_stakes(leader_schedule_epoch)
             .expect("calculation should always run after Bank::update_epoch_stakes(leader_schedule_epoch)")
-            .stakes();
-        {
-            // TODO: check how long this takes; remove if `stakes` are replaced
-            // with delegations from EpochStakes
-            assert!(crate::stakes::delegations_eq(stakes, epoch_stakes));
-        }
-        let cached_vote_accounts = epoch_stakes.vote_accounts();
+            .stakes()
+            .vote_accounts();
 
         EpochRewardCalculateParamInfo {
             stake_history,

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -524,7 +524,11 @@ mod tests {
     use {
         super::*,
         crate::{
-            bank::{null_tracer, tests::create_genesis_config, VoteReward},
+            bank::{
+                null_tracer,
+                tests::{create_genesis_config, new_bank_from_parent_with_bank_forks},
+                VoteReward,
+            },
             genesis_utils::{
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
             },
@@ -663,6 +667,15 @@ mod tests {
         let expected_num_delegations = 100;
         let bank = create_reward_bank(expected_num_delegations).0;
 
+        // Advance to next epoch boundary to update EpochStakes
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        let bank = new_bank_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            &Pubkey::default(),
+            SLOTS_PER_EPOCH,
+        );
+
         // Calculate rewards
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let mut rewards_metrics = RewardsMetrics::default();
@@ -704,6 +717,15 @@ mod tests {
 
         let expected_num_delegations = 100;
         let (bank, _, _) = create_reward_bank(expected_num_delegations);
+
+        // Advance to next epoch boundary to update EpochStakes
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        let bank = new_bank_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            &Pubkey::default(),
+            SLOTS_PER_EPOCH,
+        );
 
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let rewards_metrics = RewardsMetrics::default();
@@ -754,6 +776,15 @@ mod tests {
 
         let expected_num_delegations = 1;
         let (bank, voters, stakers) = create_reward_bank(expected_num_delegations);
+
+        // Advance to next epoch boundary to update EpochStakes
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        let bank = new_bank_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            &Pubkey::default(),
+            SLOTS_PER_EPOCH,
+        );
 
         let vote_pubkey = voters.first().unwrap();
         let mut vote_account = bank

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -542,6 +542,18 @@ impl PartialEq<StakesEnum> for StakesEnum {
     }
 }
 
+pub(crate) fn delegations_eq(stakes: &Stakes<StakeAccount>, stakes_enum: &StakesEnum) -> bool {
+    let stakes_delegations = Stakes::<Delegation>::from(stakes.clone()).stake_delegations;
+    match stakes_enum {
+        StakesEnum::Accounts(stakes) => {
+            let stakes_enum_delegations =
+                Stakes::<Delegation>::from(stakes.clone()).stake_delegations;
+            stakes_enum_delegations == stakes_delegations
+        }
+        StakesEnum::Delegations(stakes) => stakes.stake_delegations == stakes_delegations,
+    }
+}
+
 // In order to maintain backward compatibility, the StakesEnum in EpochStakes
 // and SerializableVersionedBank should be serialized as Stakes<Delegation>.
 pub(crate) mod serde_stakes_enum_compat {
@@ -619,7 +631,13 @@ pub(crate) mod tests {
         super::*,
         rand::Rng,
         rayon::ThreadPoolBuilder,
-        solana_sdk::{account::WritableAccount, pubkey::Pubkey, rent::Rent, stake},
+        solana_sdk::{
+            account::WritableAccount,
+            account_utils::StateMut,
+            pubkey::Pubkey,
+            rent::Rent,
+            stake::{self, state::StakeStateV2},
+        },
         solana_stake_program::stake_state,
         solana_vote_program::vote_state::{self, VoteState, VoteStateVersions},
     };
@@ -1042,6 +1060,52 @@ pub(crate) mod tests {
                 *expected_warmed_stake
             );
         }
+    }
+
+    #[test]
+    fn test_delegations_eq() {
+        let stakes_cache = StakesCache::new(Stakes {
+            epoch: 42,
+            ..Stakes::default()
+        });
+
+        let mut vote_accounts = vec![];
+        let mut stake_accounts = vec![];
+
+        for i in 0..4 {
+            let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
+                create_staked_node_accounts(i);
+            stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
+            vote_accounts.push((vote_pubkey, vote_account));
+            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None);
+            stake_accounts.push((stake_pubkey, stake_account));
+        }
+
+        let mut stakes = stakes_cache.0.read().unwrap().clone();
+        let stakes_enum = StakesEnum::Accounts(stakes.clone());
+        assert!(delegations_eq(&stakes, &stakes_enum));
+
+        let delegations: Stakes<Delegation> = stakes.clone().into();
+        let delegations_stakes_enum = StakesEnum::Delegations(delegations);
+        assert!(delegations_eq(&stakes, &delegations_stakes_enum));
+
+        // modify one delegation in `stakes`
+        let (stake_pubkey, mut stake_account) = stake_accounts.last().unwrap().clone();
+        let StakeStateV2::Stake(meta, mut stake, flags) =
+            stake_state::from(&stake_account).unwrap()
+        else {
+            unreachable!()
+        };
+        stake.delegation.stake += 42;
+
+        stake_account
+            .set_state(&StakeStateV2::Stake(meta, stake, flags))
+            .unwrap();
+        let new_delegation = stake_account.try_into().unwrap();
+        stakes.upsert_stake_delegation(stake_pubkey, new_delegation, None);
+
+        assert!(!delegations_eq(&stakes, &stakes_enum));
+        assert!(!delegations_eq(&stakes, &delegations_stakes_enum));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Stake-reward calculation methods assume that the caller is interested in existing VoteState (specifically, the last epoch in the VoteState::epoch_credits list). This is only true when rewards are calculated at the epoch-boundary block. To support recalculation in later blocks, calculation needs to have access to the VoteState such as it was at the epoch boundary.

The VoteState itself contains previous epoch-credit information, and https://github.com/anza-xyz/agave/pull/1102 was a way to expose this data to calculation methods. However, that approach requires that vote accounts never be destroyed during the period in which recalculation might occur, which would probably necessitate a change to the Vote Program.

Meanwhile, `EpochStakes` cached in the bank and snapshots already preserves vote account state from the previous epoch.

#### Summary of Changes
Use the vote accounts from EpochStakes in partitioned epoch rewards calculation.
Note: this works for epoch-boundary calculation because EpochStakes is updated before calculation: https://github.com/anza-xyz/agave/blob/be80b9225981e336308d957937548403e1409a98/runtime/src/bank.rs#L1423-L1435

~~Currently includes a check that the operative stakes (from `StakesCache`) are identical to those from the EpochStakes. This isn't important for the existing implementation, where calculation is still all in the epoch-boundary block and EpochStakes and StakesCache are therefore equivalent, but will be helpful for recalculation. If you'd like me to punt this bit to the next PR, which adds recalculation, let me know.~~ Removed

Closes #1102 