### PR TITLE
Runtime: Core BPF Migration: Add support for upgrading Core BPF programs

### DIFF
--- a/runtime/src/bank/builtin_programs.rs
+++ b/runtime/src/bank/builtin_programs.rs
@@ -199,7 +199,7 @@ mod tests_core_bpf_migration {
 
         // Run the post-migration program checks.
         assert!(bank.feature_set.is_active(feature_id));
-        test_context.run_program_checks_post_migration(&bank, migration_slot);
+        test_context.run_program_checks(&bank, migration_slot);
 
         // Advance one slot so that the new BPF builtin program becomes
         // effective in the program cache.
@@ -231,7 +231,7 @@ mod tests_core_bpf_migration {
 
         // Run the post-migration program checks again.
         assert!(bank.feature_set.is_active(feature_id));
-        test_context.run_program_checks_post_migration(&bank, migration_slot);
+        test_context.run_program_checks(&bank, migration_slot);
 
         // Again, successfully invoke the new BPF builtin program.
         bank.process_transaction(&Transaction::new(

--- a/runtime/src/bank/builtins/core_bpf_migration/error.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/error.rs
@@ -24,6 +24,15 @@ pub enum CoreBpfMigrationError {
     /// Program has a data account
     #[error("Data account exists for program {0:?}")]
     ProgramHasDataAccount(Pubkey),
+    /// Program has no data account
+    #[error("Data account does not exist for program {0:?}")]
+    ProgramHasNoDataAccount(Pubkey),
+    /// Invalid program account
+    #[error("Invalid program account: {0:?}")]
+    InvalidProgramAccount(Pubkey),
+    /// Invalid program data account
+    #[error("Invalid program data account: {0:?}")]
+    InvalidProgramDataAccount(Pubkey),
     /// Invalid buffer account
     #[error("Invalid buffer account: {0:?}")]
     InvalidBufferAccount(Pubkey),

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -1,6 +1,8 @@
 pub(crate) mod error;
 mod source_buffer;
 mod target_builtin;
+#[allow(unused)] // Removed in later commit.
+mod target_core_bpf;
 
 use {
     crate::bank::Bank,

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -1,7 +1,6 @@
 pub(crate) mod error;
 mod source_buffer;
 mod target_builtin;
-#[allow(unused)] // Removed in later commit.
 mod target_core_bpf;
 
 use {
@@ -24,6 +23,7 @@ use {
     source_buffer::SourceBuffer,
     std::sync::atomic::Ordering::Relaxed,
     target_builtin::TargetBuiltin,
+    target_core_bpf::TargetCoreBpf,
 };
 
 /// Identifies the type of built-in program targeted for Core BPF migration.
@@ -310,6 +310,86 @@ impl Bank {
 
         Ok(())
     }
+
+    /// Upgrade a Core BPF program.
+    /// To use this function, add a feature-gated callsite to bank's
+    /// `apply_feature_activations` function, similar to below.
+    ///
+    /// ```ignore
+    /// if new_feature_activations.contains(&feature_set::test_upgrade_program::id()) {
+    ///     self.upgrade_core_bpf_program(
+    ///        &core_bpf_program_address,
+    ///        &source_buffer_address,
+    ///        "test_upgrade_core_bpf_program",
+    ///     );
+    /// }
+    /// ```
+    #[allow(dead_code)] // Only used when an upgrade is configured.
+    pub(crate) fn upgrade_core_bpf_program(
+        &mut self,
+        core_bpf_program_address: &Pubkey,
+        source_buffer_address: &Pubkey,
+        datapoint_name: &'static str,
+    ) -> Result<(), CoreBpfMigrationError> {
+        datapoint_info!(datapoint_name, ("slot", self.slot, i64));
+
+        let target = TargetCoreBpf::new_checked(self, core_bpf_program_address)?;
+        let source = SourceBuffer::new_checked(self, source_buffer_address)?;
+
+        // Attempt serialization first before modifying the bank.
+        let new_target_program_data_account =
+            self.new_target_program_data_account(&source, target.upgrade_authority_address)?;
+
+        // Gather old and new account data sizes, for updating the bank's
+        // accounts data size delta off-chain.
+        // Since the program account is not replaced, only the program data
+        // account and the source buffer account are involved.
+        let old_data_size = checked_add(
+            target.program_data_account.data().len(),
+            source.buffer_account.data().len(),
+        )?;
+        let new_data_size = new_target_program_data_account.data().len();
+
+        // Deploy the new target Core BPF program.
+        // This step will validate the program ELF against the current runtime
+        // environment, as well as update the program cache.
+        self.directly_invoke_loader_v3_deploy(
+            &target.program_address,
+            new_target_program_data_account.data(),
+        )?;
+
+        // Calculate the lamports to burn.
+        // The target program account _and_ the target program data account
+        // will both be replaced, so burn both their lamports.
+        // The source buffer account will be cleared, so burn its lamports.
+        // The two new program accounts will need to be funded.
+        let lamports_to_burn = checked_add(
+            target.program_data_account.lamports(),
+            source.buffer_account.lamports(),
+        )?;
+        let lamports_to_fund = new_target_program_data_account.lamports();
+
+        // Update the bank's capitalization.
+        if lamports_to_burn > lamports_to_fund {
+            self.capitalization
+                .fetch_sub(checked_sub(lamports_to_burn, lamports_to_fund)?, Relaxed);
+        } else {
+            self.capitalization
+                .fetch_add(checked_sub(lamports_to_fund, lamports_to_burn)?, Relaxed);
+        }
+
+        // Store the new program data account and clear the source buffer account.
+        self.store_account(
+            &target.program_data_address,
+            &new_target_program_data_account,
+        );
+        self.store_account(&source.buffer_address, &AccountSharedData::default());
+
+        // Update the account data size delta.
+        self.calculate_and_update_accounts_data_size_delta_off_chain(old_data_size, new_data_size);
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -415,6 +495,34 @@ pub(crate) mod tests {
                     + resulting_program_data_len as i64
                     + resulting_programdata_data_len as i64
                     - builtin_account.data().len() as i64
+                    - source_buffer_account.data().len() as i64;
+            (
+                expected_post_migration_capitalization,
+                expected_post_migration_accounts_data_size_delta_off_chain,
+            )
+        }
+
+        // Given a bank, calculate the expected capitalization and accounts data
+        // size delta off-chain after an upgrade, using the values stored in
+        // the test context.
+        fn calculate_post_upgrade_capitalization_and_accounts_data_size_delta_off_chain(
+            &self,
+            bank: &Bank,
+        ) -> (u64, i64) {
+            let program_data_account = bank
+                .get_account(&get_program_data_address(&self.target_program_address))
+                .unwrap_or_default();
+            let source_buffer_account = bank.get_account(&self.source_buffer_address).unwrap();
+            let resulting_programdata_data_len =
+                UpgradeableLoaderState::size_of_programdata_metadata() + self.elf.len();
+            let expected_post_migration_capitalization = bank.capitalization()
+                - program_data_account.lamports()
+                - source_buffer_account.lamports()
+                + bank.get_minimum_balance_for_rent_exemption(resulting_programdata_data_len);
+            let expected_post_migration_accounts_data_size_delta_off_chain =
+                bank.accounts_data_size_delta_off_chain.load(Relaxed)
+                    + resulting_programdata_data_len as i64
+                    - program_data_account.data().len() as i64
                     - source_buffer_account.data().len() as i64;
             (
                 expected_post_migration_capitalization,
@@ -739,6 +847,179 @@ pub(crate) mod tests {
             .unwrap();
 
         let program_data_address = get_program_data_address(&builtin_id);
+        let program_data_account = bank.get_account(&program_data_address).unwrap();
+        let program_data_account_state: UpgradeableLoaderState =
+            program_data_account.state().unwrap();
+        assert_eq!(
+            program_data_account_state,
+            UpgradeableLoaderState::ProgramData {
+                upgrade_authority_address: None,
+                slot: bank.slot(),
+            },
+        );
+    }
+
+    fn set_up_test_core_bpf_program(
+        bank: &mut Bank,
+        program_address: &Pubkey,
+        upgrade_authority_address: Option<Pubkey>,
+    ) {
+        // This will be checked by `TargetCoreBpf::new_checked`, but set
+        // up the mock Core BPF program and ensure it exists as configured.
+        let programdata_address = get_program_data_address(program_address);
+        let program_account = {
+            let data = bincode::serialize(&UpgradeableLoaderState::Program {
+                programdata_address,
+            })
+            .unwrap();
+            let space = data.len();
+            let lamports = bank.get_minimum_balance_for_rent_exemption(space);
+            let owner = &bpf_loader_upgradeable::id();
+
+            let mut account = AccountSharedData::new(lamports, space, owner);
+            account.data_as_mut_slice().copy_from_slice(&data);
+            bank.store_account_and_update_capitalization(program_address, &account);
+            account
+        };
+        let program_data_account = {
+            let elf = [4u8; 20]; // Mock ELF to start.
+            let programdata_metadata_size = UpgradeableLoaderState::size_of_programdata_metadata();
+            let space = programdata_metadata_size + elf.len();
+            let lamports = bank.get_minimum_balance_for_rent_exemption(space);
+            let owner = &bpf_loader_upgradeable::id();
+
+            let programdata_metadata = UpgradeableLoaderState::ProgramData {
+                slot: 0,
+                upgrade_authority_address,
+            };
+
+            let mut account = AccountSharedData::new_data_with_space(
+                lamports,
+                &programdata_metadata,
+                space,
+                owner,
+            )
+            .unwrap();
+            account.data_as_mut_slice()[programdata_metadata_size..].copy_from_slice(&elf);
+            bank.store_account_and_update_capitalization(&programdata_address, &account);
+            account
+        };
+        assert_eq!(
+            &bank.get_account(program_address).unwrap(),
+            &program_account
+        );
+        assert_eq!(
+            &bank.get_account(&programdata_address).unwrap(),
+            &program_data_account
+        );
+    }
+
+    #[test_case(Some(Pubkey::new_unique()); "with_upgrade_authority")]
+    #[test_case(None; "without_upgrade_authority")]
+    fn test_upgrade_core_bpf_program(upgrade_authority_address: Option<Pubkey>) {
+        let mut bank = create_simple_test_bank(0);
+
+        let core_bpf_program_address = Pubkey::new_unique();
+        let source_buffer_address = Pubkey::new_unique();
+
+        set_up_test_core_bpf_program(
+            &mut bank,
+            &core_bpf_program_address,
+            upgrade_authority_address,
+        );
+
+        let test_context = TestContext::new(
+            &bank,
+            &core_bpf_program_address,
+            &source_buffer_address,
+            upgrade_authority_address,
+        );
+        let TestContext {
+            source_buffer_address,
+            ..
+        } = test_context;
+
+        let (
+            expected_post_upgrade_capitalization,
+            expected_post_upgrade_accounts_data_size_delta_off_chain,
+        ) = test_context
+            .calculate_post_upgrade_capitalization_and_accounts_data_size_delta_off_chain(&bank);
+
+        // Perform the upgrade.
+        let upgrade_slot = bank.slot();
+        bank.upgrade_core_bpf_program(
+            &core_bpf_program_address,
+            &source_buffer_address,
+            "test_upgrade_core_bpf_program",
+        )
+        .unwrap();
+
+        // Run the post-upgrade program checks.
+        test_context.run_program_checks(&bank, upgrade_slot);
+
+        // Check the bank's capitalization.
+        assert_eq!(bank.capitalization(), expected_post_upgrade_capitalization);
+
+        // Check the bank's accounts data size delta off-chain.
+        assert_eq!(
+            bank.accounts_data_size_delta_off_chain.load(Relaxed),
+            expected_post_upgrade_accounts_data_size_delta_off_chain
+        );
+    }
+
+    #[test]
+    fn test_upgrade_fail_authority_mismatch() {
+        let mut bank = create_simple_test_bank(0);
+
+        let program_address = Pubkey::new_unique();
+        let source_buffer_address = Pubkey::new_unique();
+
+        let upgrade_authority_address = Some(Pubkey::new_unique());
+
+        set_up_test_core_bpf_program(&mut bank, &program_address, upgrade_authority_address);
+
+        let _test_context = TestContext::new(
+            &bank,
+            &program_address,
+            &source_buffer_address,
+            Some(Pubkey::new_unique()), // Mismatch.
+        );
+
+        assert_matches!(
+            bank.upgrade_core_bpf_program(
+                &program_address,
+                &source_buffer_address,
+                "test_upgrade_core_bpf_program"
+            )
+            .unwrap_err(),
+            CoreBpfMigrationError::UpgradeAuthorityMismatch(_, _)
+        )
+    }
+
+    #[test]
+    fn test_upgrade_none_authority_with_some_buffer_authority() {
+        let mut bank = create_simple_test_bank(0);
+
+        let program_address = Pubkey::new_unique();
+        let source_buffer_address = Pubkey::new_unique();
+
+        set_up_test_core_bpf_program(&mut bank, &program_address, None);
+
+        let _test_context = TestContext::new(
+            &bank,
+            &program_address,
+            &source_buffer_address,
+            Some(Pubkey::new_unique()), // Not `None`.
+        );
+
+        bank.upgrade_core_bpf_program(
+            &program_address,
+            &source_buffer_address,
+            "test_upgrade_core_bpf_program",
+        )
+        .unwrap();
+
+        let program_data_address = get_program_data_address(&program_address);
         let program_data_account = bank.get_account(&program_data_address).unwrap();
         let program_data_account_state: UpgradeableLoaderState =
             program_data_account.state().unwrap();

--- a/runtime/src/bank/builtins/core_bpf_migration/target_core_bpf.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_core_bpf.rs
@@ -1,0 +1,288 @@
+use {
+    super::error::CoreBpfMigrationError,
+    crate::bank::Bank,
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount},
+        bpf_loader_upgradeable::{self, get_program_data_address, UpgradeableLoaderState},
+        pubkey::Pubkey,
+    },
+};
+
+/// The account details of a Core BPF program slated to be upgraded.
+#[derive(Debug)]
+pub(crate) struct TargetCoreBpf {
+    pub program_address: Pubkey,
+    pub program_data_address: Pubkey,
+    pub program_data_account: AccountSharedData,
+    pub upgrade_authority_address: Option<Pubkey>,
+}
+
+impl TargetCoreBpf {
+    /// Collects the details of a Core BPF program and verifies it is properly
+    /// configured.
+    /// The program account should exist with a pointer to its data account.
+    /// The program data account should exist with the correct state
+    /// (a ProgramData header and the program ELF).
+    pub(crate) fn new_checked(
+        bank: &Bank,
+        program_address: &Pubkey,
+    ) -> Result<Self, CoreBpfMigrationError> {
+        let program_data_address = get_program_data_address(program_address);
+
+        // The program account should exist.
+        let program_account = bank
+            .get_account_with_fixed_root(program_address)
+            .ok_or(CoreBpfMigrationError::AccountNotFound(*program_address))?;
+
+        // The program account should be owned by the upgradeable loader.
+        if program_account.owner() != &bpf_loader_upgradeable::id() {
+            return Err(CoreBpfMigrationError::IncorrectOwner(*program_address));
+        }
+
+        // The program account should have a pointer to its data account.
+        match program_account.deserialize_data::<UpgradeableLoaderState>()? {
+            UpgradeableLoaderState::Program {
+                programdata_address,
+            } if programdata_address == program_data_address => (),
+            _ => {
+                return Err(CoreBpfMigrationError::InvalidProgramAccount(
+                    *program_address,
+                ))
+            }
+        }
+
+        // The program data account should exist.
+        let program_data_account = bank
+            .get_account_with_fixed_root(&program_data_address)
+            .ok_or(CoreBpfMigrationError::ProgramHasNoDataAccount(
+                *program_address,
+            ))?;
+
+        // The program data account should be owned by the upgradeable loader.
+        if program_data_account.owner() != &bpf_loader_upgradeable::id() {
+            return Err(CoreBpfMigrationError::IncorrectOwner(program_data_address));
+        }
+
+        // The program data account should have the correct state.
+        let programdata_metadata_size = UpgradeableLoaderState::size_of_programdata_metadata();
+        if program_data_account.data().len() >= programdata_metadata_size {
+            if let UpgradeableLoaderState::ProgramData {
+                upgrade_authority_address,
+                ..
+            } = bincode::deserialize(&program_data_account.data()[..programdata_metadata_size])?
+            {
+                return Ok(Self {
+                    program_address: *program_address,
+                    program_data_address,
+                    program_data_account,
+                    upgrade_authority_address,
+                });
+            }
+        }
+        Err(CoreBpfMigrationError::InvalidProgramDataAccount(
+            program_data_address,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::bank::tests::create_simple_test_bank,
+        assert_matches::assert_matches,
+        solana_sdk::{account::WritableAccount, bpf_loader_upgradeable},
+    };
+
+    fn store_account(bank: &Bank, address: &Pubkey, data: &[u8], owner: &Pubkey) {
+        let space = data.len();
+        let lamports = bank.get_minimum_balance_for_rent_exemption(space);
+        let mut account = AccountSharedData::new(lamports, space, owner);
+        account.set_executable(true);
+        account.data_as_mut_slice().copy_from_slice(data);
+        bank.store_account_and_update_capitalization(address, &account);
+    }
+
+    #[test]
+    fn test_target_core_bpf() {
+        let bank = create_simple_test_bank(0);
+
+        let program_address = Pubkey::new_unique();
+        let program_data_address = get_program_data_address(&program_address);
+
+        // Fail if the program account does not exist.
+        assert_matches!(
+            TargetCoreBpf::new_checked(&bank, &program_address).unwrap_err(),
+            CoreBpfMigrationError::AccountNotFound(..)
+        );
+
+        // Fail if the program account is not owned by the upgradeable loader.
+        store_account(
+            &bank,
+            &program_address,
+            &bincode::serialize(&UpgradeableLoaderState::Program {
+                programdata_address: program_data_address,
+            })
+            .unwrap(),
+            &Pubkey::new_unique(), // Not the upgradeable loader
+        );
+        assert_matches!(
+            TargetCoreBpf::new_checked(&bank, &program_address).unwrap_err(),
+            CoreBpfMigrationError::IncorrectOwner(..)
+        );
+
+        // Fail if the program account does not have the correct state.
+        store_account(
+            &bank,
+            &program_address,
+            &[4u8; 200], // Not the correct state
+            &bpf_loader_upgradeable::id(),
+        );
+        assert_matches!(
+            TargetCoreBpf::new_checked(&bank, &program_address).unwrap_err(),
+            CoreBpfMigrationError::BincodeError(..)
+        );
+
+        // Fail if the program account does not have the correct state.
+        // This time, valid `UpgradeableLoaderState` but not a program account.
+        store_account(
+            &bank,
+            &program_address,
+            &bincode::serialize(&UpgradeableLoaderState::ProgramData {
+                slot: 0,
+                upgrade_authority_address: Some(Pubkey::new_unique()),
+            })
+            .unwrap(),
+            &bpf_loader_upgradeable::id(),
+        );
+        assert_matches!(
+            TargetCoreBpf::new_checked(&bank, &program_address).unwrap_err(),
+            CoreBpfMigrationError::InvalidProgramAccount(..)
+        );
+
+        // Fail if the program account does not have the correct state.
+        // This time, valid `UpgradeableLoaderState::Program` but it points to
+        // the wrong program data account.
+        store_account(
+            &bank,
+            &program_address,
+            &bincode::serialize(&UpgradeableLoaderState::Program {
+                programdata_address: Pubkey::new_unique(), // Not the correct program data account
+            })
+            .unwrap(),
+            &bpf_loader_upgradeable::id(),
+        );
+
+        // Store the proper program account.
+        store_account(
+            &bank,
+            &program_address,
+            &bincode::serialize(&UpgradeableLoaderState::Program {
+                programdata_address: program_data_address,
+            })
+            .unwrap(),
+            &bpf_loader_upgradeable::id(),
+        );
+
+        // Fail if the program data account does not exist.
+        assert_matches!(
+            TargetCoreBpf::new_checked(&bank, &program_address).unwrap_err(),
+            CoreBpfMigrationError::ProgramHasNoDataAccount(..)
+        );
+
+        // Fail if the program data account is not owned by the upgradeable loader.
+        store_account(
+            &bank,
+            &program_data_address,
+            &bincode::serialize(&UpgradeableLoaderState::ProgramData {
+                slot: 0,
+                upgrade_authority_address: Some(Pubkey::new_unique()),
+            })
+            .unwrap(),
+            &Pubkey::new_unique(), // Not the upgradeable loader
+        );
+        assert_matches!(
+            TargetCoreBpf::new_checked(&bank, &program_address).unwrap_err(),
+            CoreBpfMigrationError::IncorrectOwner(..)
+        );
+
+        // Fail if the program data account does not have the correct state.
+        store_account(
+            &bank,
+            &program_data_address,
+            &[4u8; 200], // Not the correct state
+            &bpf_loader_upgradeable::id(),
+        );
+        assert_matches!(
+            TargetCoreBpf::new_checked(&bank, &program_address).unwrap_err(),
+            CoreBpfMigrationError::BincodeError(..)
+        );
+
+        // Fail if the program data account does not have the correct state.
+        // This time, valid `UpgradeableLoaderState` but not a program data account.
+        store_account(
+            &bank,
+            &program_data_address,
+            &bincode::serialize(&UpgradeableLoaderState::Program {
+                programdata_address: program_data_address,
+            })
+            .unwrap(),
+            &bpf_loader_upgradeable::id(),
+        );
+        assert_matches!(
+            TargetCoreBpf::new_checked(&bank, &program_address).unwrap_err(),
+            CoreBpfMigrationError::InvalidProgramDataAccount(..)
+        );
+
+        // Success
+        let elf = vec![4u8; 200];
+        let test_success = |upgrade_authority_address: Option<Pubkey>| {
+            // BPF Loader always writes ELF bytes after
+            // `UpgradeableLoaderState::size_of_programdata_metadata()`.
+            let programdata_metadata_size = UpgradeableLoaderState::size_of_programdata_metadata();
+            let data_len = programdata_metadata_size + elf.len();
+            let mut data = vec![0u8; data_len];
+            bincode::serialize_into(
+                &mut data[..programdata_metadata_size],
+                &UpgradeableLoaderState::ProgramData {
+                    slot: 0,
+                    upgrade_authority_address,
+                },
+            )
+            .unwrap();
+            data[programdata_metadata_size..].copy_from_slice(&elf);
+
+            store_account(
+                &bank,
+                &program_data_address,
+                &data,
+                &bpf_loader_upgradeable::id(),
+            );
+
+            let target_core_bpf = TargetCoreBpf::new_checked(&bank, &program_address).unwrap();
+
+            assert_eq!(target_core_bpf.program_address, program_address);
+            assert_eq!(target_core_bpf.program_data_address, program_data_address);
+            assert_eq!(
+                bincode::deserialize::<UpgradeableLoaderState>(
+                    &target_core_bpf.program_data_account.data()[..programdata_metadata_size]
+                )
+                .unwrap(),
+                UpgradeableLoaderState::ProgramData {
+                    slot: 0,
+                    upgrade_authority_address
+                },
+            );
+            assert_eq!(
+                &target_core_bpf.program_data_account.data()[programdata_metadata_size..],
+                elf.as_slice()
+            );
+        };
+
+        // With authority
+        test_success(Some(Pubkey::new_unique()));
+
+        // Without authority
+        test_success(None);
+    }
+}


### PR DESCRIPTION
#### Problem
The runtime is almost ready to support Core BPF programs, including the act of
migrating existing builtins to Core BPF. However, because Core BPF programs are 
relied upon by the network, sometimes these programs will need to be upgraded to 
support consensus-breaking feature-gated changes.

The runtime requires a mechanism for allowing contributors to upgrade Core BPF
programs using feature-gates.

#### Summary of Changes
First introduce a struct for loading and checking an existing Core BPF program,
which should be a BPF Loader V3 program. Note that this new "loader" is based 
on the `SourceUpgradeableBpf` struct that was added in [`3627038`](https://github.com/anza-xyz/agave/commit/36270385417d3373385dbae68a75c9d3beb3ad3b)
but later removed in favor of source buffer accounts.

Next add a function to Bank's `core_bpf_migration` module to support upgrading 
Core BPF programs on feature activation.