### PR TITLE
[banks-server, rpc] fix: Enable CPI tracking by default

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -195,7 +195,7 @@ fn simulate_transaction(
         units_consumed,
         return_data,
         inner_instructions,
-    } = bank.simulate_transaction_unchecked(&sanitized_transaction, false);
+    } = bank.simulate_transaction_unchecked(&sanitized_transaction, true);
 
     let simulation_details = TransactionSimulationDetails {
         logs,

--- a/rpc-client-api/src/config.rs
+++ b/rpc-client-api/src/config.rs
@@ -32,7 +32,7 @@ pub struct RpcSimulateTransactionAccountsConfig {
     pub addresses: Vec<String>,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcSimulateTransactionConfig {
     #[serde(default)]
@@ -46,6 +46,20 @@ pub struct RpcSimulateTransactionConfig {
     pub min_context_slot: Option<Slot>,
     #[serde(default)]
     pub inner_instructions: bool,
+}
+
+impl Default for RpcSimulateTransactionConfig {
+    fn default() -> Self {
+        Self {
+            sig_verify: false,
+            replace_recent_blockhash: false,
+            commitment: None,
+            encoding: None,
+            accounts: None,
+            min_context_slot: None,
+            inner_instructions: true,
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3707,8 +3707,8 @@ pub mod rpc_full {
                     post_simulation_accounts: _,
                     units_consumed,
                     return_data,
-                    inner_instructions: _, // Always `None` due to `enable_cpi_recording = false`
-                } = preflight_bank.simulate_transaction(&transaction, false)
+                    inner_instructions,
+                } = preflight_bank.simulate_transaction(&transaction, true)
                 {
                     match err {
                         TransactionError::BlockhashNotFound => {
@@ -3726,7 +3726,7 @@ pub mod rpc_full {
                             accounts: None,
                             units_consumed: Some(units_consumed),
                             return_data: return_data.map(|return_data| return_data.into()),
-                            inner_instructions: None,
+                            inner_instructions,
                             replacement_blockhash: None,
                         },
                     }


### PR DESCRIPTION
#### Problem

Before this change, simulating a transaction from banks-client (with `BanksClient::simulate_transaction`) did not include inner instructions in `TransactionSimulationDetails`. That's because the CPI tracking feature was not enabled by default in `RpcSimulateTransactionConfig`.

Not enabling it by default makes it impossible to test "compression" (logging events through noop program) in Rust tests (with solana-program-test), because there is no way to enable that feature through solana-program-test or solana-banks-client.

Enabling it makes such test cases possible[0]. It makes it easy to simulate a transaction, then fetch and serialize an associated event logged through noop program in Rust tests, without having to do it in JS/TS or relying on external indexers.

[0] https://github.com/Lightprotocol/light-protocol/blob/9e8c13e26c1e019f92b32025c580809ea04fd375/test-utils/src/lib.rs#L212-L232

#### Summary of Changes

* Always set `enable_cpi_tracking` to `true` in banks-server.
* Set `instruction_data` in `Default` impl of `RpcSimulateTransactionConfig` to `true`.
