### PR TITLE
Remove intermediate Vec<_>'s in rocksdb multi_get functions

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3512,9 +3512,8 @@ impl Blockstore {
 
         let (all_ranges_start_index, _) = *completed_ranges.first().unwrap();
         let (_, all_ranges_end_index) = *completed_ranges.last().unwrap();
-        let keys: Vec<(Slot, u64)> = (all_ranges_start_index..=all_ranges_end_index)
-            .map(|index| (slot, u64::from(index)))
-            .collect();
+        let keys =
+            (all_ranges_start_index..=all_ranges_end_index).map(|index| (slot, u64::from(index)));
 
         let data_shreds: Result<Vec<Option<Vec<u8>>>> = self
             .data_shred_cf
@@ -3601,8 +3600,11 @@ impl Blockstore {
     /// Returns a mapping from each elements of `slots` to a list of the
     /// element's children slots.
     pub fn get_slots_since(&self, slots: &[Slot]) -> Result<HashMap<Slot, Vec<Slot>>> {
-        let slot_metas: Result<Vec<Option<SlotMeta>>> =
-            self.meta_cf.multi_get(slots.to_vec()).into_iter().collect();
+        let slot_metas: Result<Vec<Option<SlotMeta>>> = self
+            .meta_cf
+            .multi_get(slots.iter().copied())
+            .into_iter()
+            .collect();
         let slot_metas = slot_metas?;
 
         let result: HashMap<Slot, Vec<Slot>> = slots
@@ -5375,7 +5377,7 @@ pub mod tests {
         for (i, key) in keys.iter_mut().enumerate().take(TEST_PUT_ENTRY_COUNT) {
             *key = u64::try_from(i).unwrap();
         }
-        let values = blockstore.meta_cf.multi_get(keys);
+        let values = blockstore.meta_cf.multi_get(keys.into_iter());
         for (i, value) in values.iter().enumerate().take(TEST_PUT_ENTRY_COUNT) {
             let k = u64::try_from(i).unwrap();
             assert_eq!(

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -646,11 +646,15 @@ impl Rocks {
         Ok(())
     }
 
-    fn multi_get_cf(
+    fn multi_get_cf<'a, K, I>(
         &self,
         cf: &ColumnFamily,
-        keys: Vec<&[u8]>,
-    ) -> Vec<Result<Option<DBPinnableSlice>>> {
+        keys: I,
+    ) -> Vec<Result<Option<DBPinnableSlice>>>
+    where
+        K: AsRef<[u8]> + 'a + ?Sized,
+        I: IntoIterator<Item = &'a K>,
+    {
         let values = self
             .db
             .batched_multi_get_cf(cf, keys, false)

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1574,17 +1574,19 @@ where
         result
     }
 
-    pub fn multi_get_bytes(&self, keys: Vec<C::Index>) -> Vec<Result<Option<Vec<u8>>>> {
-        let rocks_keys: Vec<_> = keys.into_iter().map(|key| C::key(key)).collect();
+    pub fn multi_get_bytes(
+        &self,
+        keys: impl Iterator<Item = C::Index>,
+    ) -> Vec<Result<Option<Vec<u8>>>> {
+        let rocks_keys: Vec<_> = keys.map(|key| C::key(key)).collect();
         {
-            let ref_rocks_keys: Vec<_> = rocks_keys.iter().map(|k| &k[..]).collect();
             let is_perf_enabled = maybe_enable_rocksdb_perf(
                 self.column_options.rocks_perf_sample_interval,
                 &self.read_perf_status,
             );
             let result = self
                 .backend
-                .multi_get_cf(self.handle(), ref_rocks_keys)
+                .multi_get_cf(self.handle(), rocks_keys.iter())
                 .into_iter()
                 .map(|r| match r {
                     Ok(opt) => match opt {
@@ -1691,17 +1693,16 @@ impl<C> LedgerColumn<C>
 where
     C: TypedColumn + ColumnName,
 {
-    pub fn multi_get(&self, keys: Vec<C::Index>) -> Vec<Result<Option<C::Type>>> {
-        let rocks_keys: Vec<_> = keys.into_iter().map(|key| C::key(key)).collect();
+    pub fn multi_get(&self, keys: impl Iterator<Item = C::Index>) -> Vec<Result<Option<C::Type>>> {
+        let rocks_keys: Vec<_> = keys.map(|key| C::key(key)).collect();
         {
-            let ref_rocks_keys: Vec<_> = rocks_keys.iter().map(|k| &k[..]).collect();
             let is_perf_enabled = maybe_enable_rocksdb_perf(
                 self.column_options.rocks_perf_sample_interval,
                 &self.read_perf_status,
             );
             let result = self
                 .backend
-                .multi_get_cf(self.handle(), ref_rocks_keys)
+                .multi_get_cf(self.handle(), rocks_keys.iter())
                 .into_iter()
                 .map(|r| match r {
                     Ok(opt) => match opt {


### PR DESCRIPTION
#### Problem
Our wrappers around the rocksdb `multi_get()` functions create several intermediate vectors for the keys. For example, for the `multi_get_bytes()` call here:
https://github.com/anza-xyz/agave/blob/12d009ececd7190a9f9f940715832001c03be2f4/ledger/src/blockstore.rs#L3521

there are 4 vectors for the keys:
```
Vec<(u64, Slot)>    is converted to
Vec<Vec<u8>>        is converted to
Vec<&[u8]>          is converted to
Vec<*const c_char>
```
This is wasteful and unnecessary; only the 2nd and 4th vectors are strictly necessary. We need the `Vec<Vec<u8>>` to be allocated somewhere, and then `rust-rocksdb` creates a vector of pointers to those byte arrays.

#### Summary of Changes
Adjust the function parameters for several functions to accept iterators instead of allocated vectors.

There is probably some additional work that could be done to allocate a single `Vec<[u8; KEY_LEN]>` where `KEY_LEN` is the length of the key returned by `Column::key()`. This would mean only a single allocation which would also mean the keys are all contiguous. This would require some refactoring to the `Column` trait, so for now, I'm inclined to defer that work.