### PR TITLE
feat: migrate epoch stakes bank snapshot field

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -521,7 +521,7 @@ pub(crate) struct BankFieldsToSerialize<'a> {
     pub(crate) epoch_schedule: EpochSchedule,
     pub(crate) inflation: Inflation,
     pub(crate) stakes: &'a StakesCache,
-    pub(crate) epoch_stakes: &'a HashMap<Epoch, EpochStakes>,
+    pub(crate) epoch_stakes: HashMap<Epoch, EpochStakes>,
     pub(crate) is_delta: bool,
     pub(crate) accounts_data_len: u64,
 }
@@ -1745,7 +1745,7 @@ impl Bank {
             epoch_schedule: self.epoch_schedule.clone(),
             inflation: *self.inflation.read().unwrap(),
             stakes: &self.stakes_cache,
-            epoch_stakes: &self.epoch_stakes,
+            epoch_stakes: self.epoch_stakes.clone(),
             is_delta: self.is_delta.load(Relaxed),
             accounts_data_len: self.load_accounts_data_size(),
         }

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -150,6 +150,11 @@ impl Bank {
             .is_active(&feature_set::enable_partitioned_epoch_reward::id())
     }
 
+    pub(crate) fn is_epoch_stakes_snapshot_migration_feature_enabled(&self) -> bool {
+        self.feature_set
+            .is_active(&feature_set::migrate_epoch_stakes_snapshot_field::id())
+    }
+
     pub(crate) fn set_epoch_reward_status_active(
         &mut self,
         stake_rewards_by_partition: Vec<StakeRewards>,

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -18,10 +18,10 @@ pub struct NodeVoteAccounts {
 #[derive(Clone, Debug, Serialize, Deserialize, AbiExample, PartialEq)]
 pub struct EpochStakes {
     #[serde(with = "crate::stakes::serde_stakes_enum_compat")]
-    stakes: Arc<StakesEnum>,
-    total_stake: u64,
-    node_id_to_vote_accounts: Arc<NodeIdToVoteAccounts>,
-    epoch_authorized_voters: Arc<EpochAuthorizedVoters>,
+    pub(crate) stakes: Arc<StakesEnum>,
+    pub(crate) total_stake: u64,
+    pub(crate) node_id_to_vote_accounts: Arc<NodeIdToVoteAccounts>,
+    pub(crate) epoch_authorized_voters: Arc<EpochAuthorizedVoters>,
 }
 
 impl EpochStakes {

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -6,7 +6,7 @@ use {
         account_utils::StateMut,
         instruction::InstructionError,
         pubkey::Pubkey,
-        stake::state::{Delegation, StakeStateV2},
+        stake::state::{Delegation, Stake, StakeStateV2},
     },
     std::marker::PhantomData,
     thiserror::Error,
@@ -52,6 +52,13 @@ impl StakeAccount<Delegation> {
         // Safe to unwrap here because StakeAccount<Delegation> will always
         // only wrap a stake-state which is a delegation.
         self.stake_state.delegation().unwrap()
+    }
+
+    #[inline]
+    pub(crate) fn stake(&self) -> Stake {
+        // Safe to unwrap here because StakeAccount<Delegation> will always
+        // only wrap a stake-state.
+        self.stake_state.stake().unwrap()
     }
 }
 

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -369,8 +369,13 @@ pub mod fix_recent_blockhashes {
 pub mod update_rewards_from_cached_accounts {
     solana_sdk::declare_id!("28s7i3htzhahXQKqmS2ExzbEoUypg9krwvtK2M9UWXh9");
 }
+
 pub mod enable_partitioned_epoch_reward {
     solana_sdk::declare_id!("9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK");
+}
+
+pub mod migrate_epoch_stakes_snapshot_field {
+    solana_sdk::declare_id!("11111111111111111111111111111111");
 }
 
 pub mod spl_token_v3_4_0 {
@@ -887,6 +892,7 @@ lazy_static! {
         (fix_recent_blockhashes::id(), "stop adding hashes for skipped slots to recent blockhashes"),
         (update_rewards_from_cached_accounts::id(), "update rewards from cached accounts"),
         (enable_partitioned_epoch_reward::id(), "enable partitioned rewards at epoch boundary #32166"),
+        (migrate_epoch_stakes_snapshot_field::id(), "enable new epoch stakes snapshot serialization format #???"),
         (spl_token_v3_4_0::id(), "SPL Token Program version 3.4.0 release #24740"),
         (spl_associated_token_account_v1_1_0::id(), "SPL Associated Token Account Program version 1.1.0 release #24741"),
         (default_units_per_instruction::id(), "Default max tx-wide compute units calculated per instruction"),


### PR DESCRIPTION
#### Problem
Epoch stakes are not serialized into bank snapshots with the stake `credits_observed` field which is highly desired for implementing snapshot recovery of partitioned epoch rewards state.

#### Summary of Changes
- New `migrate_epoch_stakes_snapshot_field` feature
- Serialize a new struct `VersionedEpochStakes` at the end of bank snapshots if the `migrate_epoch_stakes_snapshot_field` feature is enabled
- When deserializing bank snapshots, try to deserialize the new struct and if it exists, add the deserialized epoch entries to the bank epoch stakes deserialized from the old field

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
