### PR TITLE
Program Runtime: Unify transaction batch program caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5434,7 +5434,6 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-nohash-hasher",
- "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-stake-program",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -41,7 +41,6 @@ solana-inline-spl = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-nohash-hasher = { workspace = true }
-solana-program-runtime = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-sdk = { workspace = true }
 solana-stake-program = { workspace = true, optional = true }

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -817,7 +817,6 @@ mod tests {
     use {
         super::*,
         assert_matches::assert_matches,
-        solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
         solana_sdk::{
             account::{AccountSharedData, WritableAccount},
             address_lookup_table::state::LookupTableMeta,
@@ -868,7 +867,7 @@ mod tests {
                 executed_units: 0,
                 accounts_data_len_delta: 0,
             },
-            programs_modified_by_tx: Box::<ProgramCacheForTxBatch>::default(),
+            programs_modified_by_tx: std::collections::HashMap::new(),
         }
     }
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -599,6 +599,7 @@ impl Consumer {
                 None, // account_overrides
                 self.log_messages_bytes_limit,
                 true,
+                true,
             ));
         execute_and_commit_timings.load_execute_us = load_execute_us;
 

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -536,17 +536,17 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
 
     // Adding `DELAY_VISIBILITY_SLOT_OFFSET` to slots to accommodate for delay visibility of the program
-    let mut loaded_programs =
+    let mut program_cache_for_tx_batch =
         bank.new_program_cache_for_tx_batch_for_slot(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
     for key in cached_account_keys {
-        loaded_programs.replenish(
+        program_cache_for_tx_batch.replenish(
             key,
             bank.load_program(&key, false, bank.epoch())
                 .expect("Couldn't find program account"),
         );
         debug!("Loaded program {}", key);
     }
-    invoke_context.programs_loaded_for_tx_batch = &loaded_programs;
+    invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 
     invoke_context
         .transaction_context

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -185,13 +185,14 @@ pub struct SerializedAccountMetadata {
 pub struct InvokeContext<'a> {
     /// Information about the currently executing transaction.
     pub transaction_context: &'a mut TransactionContext,
+    /// The local program cache for the transaction batch.
+    pub program_cache_for_tx_batch: &'a ProgramCacheForTxBatch,
     /// Runtime configurations used to provision the invocation environment.
     pub environment_config: EnvironmentConfig<'a>,
     log_collector: Option<Rc<RefCell<LogCollector>>>,
     compute_budget: ComputeBudget,
     current_compute_budget: ComputeBudget,
     compute_meter: RefCell<u64>,
-    pub programs_loaded_for_tx_batch: &'a ProgramCacheForTxBatch,
     pub programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
     pub timings: ExecuteDetailsTimings,
     pub syscall_context: Vec<Option<SyscallContext>>,
@@ -202,20 +203,20 @@ impl<'a> InvokeContext<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         transaction_context: &'a mut TransactionContext,
+        program_cache_for_tx_batch: &'a ProgramCacheForTxBatch,
         environment_config: EnvironmentConfig<'a>,
         log_collector: Option<Rc<RefCell<LogCollector>>>,
         compute_budget: ComputeBudget,
-        programs_loaded_for_tx_batch: &'a ProgramCacheForTxBatch,
         programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
     ) -> Self {
         Self {
             transaction_context,
+            program_cache_for_tx_batch,
             environment_config,
             log_collector,
             current_compute_budget: compute_budget,
             compute_budget,
             compute_meter: RefCell::new(compute_budget.compute_unit_limit),
-            programs_loaded_for_tx_batch,
             programs_modified_by_tx,
             timings: ExecuteDetailsTimings::default(),
             syscall_context: Vec::new(),
@@ -228,7 +229,7 @@ impl<'a> InvokeContext<'a> {
         // the cache of the cache of the programs that are loaded for the transaction batch.
         self.programs_modified_by_tx
             .find(pubkey)
-            .or_else(|| self.programs_loaded_for_tx_batch.find(pubkey))
+            .or_else(|| self.program_cache_for_tx_batch.find(pubkey))
     }
 
     pub fn get_environments_for_slot(
@@ -238,7 +239,7 @@ impl<'a> InvokeContext<'a> {
         let epoch_schedule = self.environment_config.sysvar_cache.get_epoch_schedule()?;
         let epoch = epoch_schedule.get_epoch(effective_slot);
         Ok(self
-            .programs_loaded_for_tx_batch
+            .program_cache_for_tx_batch
             .get_environments_for_epoch(epoch))
     }
 
@@ -491,7 +492,7 @@ impl<'a> InvokeContext<'a> {
         // The Murmur3 hash value (used by RBPF) of the string "entrypoint"
         const ENTRYPOINT_KEY: u32 = 0x71E3CF81;
         let entry = self
-            .programs_loaded_for_tx_batch
+            .program_cache_for_tx_batch
             .find(&builtin_id)
             .ok_or(InstructionError::UnsupportedProgramId)?;
         let function = match &entry.program {
@@ -517,7 +518,7 @@ impl<'a> InvokeContext<'a> {
         let empty_memory_mapping =
             MemoryMapping::new(Vec::new(), &mock_config, &SBPFVersion::V1).unwrap();
         let mut vm = EbpfVm::new(
-            self.programs_loaded_for_tx_batch
+            self.program_cache_for_tx_batch
                 .environments
                 .program_runtime_v2
                 .clone(),
@@ -711,14 +712,14 @@ macro_rules! with_mock_invoke_context {
             0,
             &sysvar_cache,
         );
-        let programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
+        let program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let mut $invoke_context = InvokeContext::new(
             &mut $transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             Some(LogCollector::new_ref()),
             compute_budget,
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
     };
@@ -775,12 +776,12 @@ pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut Invo
         false
     };
     with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
-    let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
-    programs_loaded_for_tx_batch.replenish(
+    let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+    program_cache_for_tx_batch.replenish(
         *loader_id,
         Arc::new(ProgramCacheEntry::new_builtin(0, 0, builtin_function)),
     );
-    invoke_context.programs_loaded_for_tx_batch = &programs_loaded_for_tx_batch;
+    invoke_context.program_cache_for_tx_batch = &program_cache_for_tx_batch;
     pre_adjustments(&mut invoke_context);
     let result = invoke_context.process_instruction(
         instruction_data,
@@ -1032,12 +1033,12 @@ mod tests {
             })
             .collect::<Vec<_>>();
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
-        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        program_cache_for_tx_batch.replenish(
             callee_program_id,
             Arc::new(ProgramCacheEntry::new_builtin(0, 1, MockBuiltin::vm)),
         );
-        invoke_context.programs_loaded_for_tx_batch = &programs_loaded_for_tx_batch;
+        invoke_context.program_cache_for_tx_batch = &program_cache_for_tx_batch;
 
         // Account modification tests
         let cases = vec![
@@ -1181,12 +1182,12 @@ mod tests {
             },
         ];
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
-        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        program_cache_for_tx_batch.replenish(
             program_key,
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
-        invoke_context.programs_loaded_for_tx_batch = &programs_loaded_for_tx_batch;
+        invoke_context.program_cache_for_tx_batch = &program_cache_for_tx_batch;
 
         // Test: Resize the account to *the same size*, so not consuming any additional size; this must succeed
         {

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -228,7 +228,7 @@ impl<'a> InvokeContext<'a> {
         // First lookup the cache of the programs modified by the current transaction. If not found, lookup
         // the cache of the cache of the programs that are loaded for the transaction batch.
         self.programs_modified_by_tx
-            .find(pubkey)
+            .find_modified(pubkey)
             .or_else(|| self.program_cache_for_tx_batch.find(pubkey))
     }
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -165,7 +165,7 @@ macro_rules! deploy_program {
         $drop
         load_program_metrics.program_id = $program_id.to_string();
         load_program_metrics.submit_datapoint(&mut $invoke_context.timings);
-        $invoke_context.programs_modified_by_tx.store_modified_entry($program_id, Arc::new(executor));
+        $invoke_context.program_cache_for_tx_batch.store_modified_entry($program_id, Arc::new(executor));
     }};
 }
 
@@ -1109,14 +1109,16 @@ fn process_loader_upgradeable_instruction(
                                 &log_collector,
                             )?;
                             let clock = invoke_context.get_sysvar_cache().get_clock()?;
-                            invoke_context.programs_modified_by_tx.store_modified_entry(
-                                program_key,
-                                Arc::new(ProgramCacheEntry::new_tombstone(
-                                    clock.slot,
-                                    ProgramCacheEntryOwner::LoaderV3,
-                                    ProgramCacheEntryType::Closed,
-                                )),
-                            );
+                            invoke_context
+                                .program_cache_for_tx_batch
+                                .store_modified_entry(
+                                    program_key,
+                                    Arc::new(ProgramCacheEntry::new_tombstone(
+                                        clock.slot,
+                                        ProgramCacheEntryOwner::LoaderV3,
+                                        ProgramCacheEntryType::Closed,
+                                    )),
+                                );
                         }
                         _ => {
                             ic_logger_msg!(log_collector, "Invalid Program account");
@@ -1537,10 +1539,10 @@ pub mod test_utils {
                     false,
                 ) {
                     invoke_context
-                        .programs_modified_by_tx
+                        .program_cache_for_tx_batch
                         .set_slot_for_tests(DELAY_VISIBILITY_SLOT_OFFSET);
                     invoke_context
-                        .programs_modified_by_tx
+                        .program_cache_for_tx_batch
                         .store_modified_entry(*pubkey, Arc::new(loaded_program));
                 }
             }
@@ -3771,7 +3773,7 @@ mod tests {
             latest_access_slot: AtomicU64::new(0),
         };
         invoke_context
-            .programs_modified_by_tx
+            .program_cache_for_tx_batch
             .store_modified_entry(program_id, Arc::new(program));
 
         assert_matches!(
@@ -3780,7 +3782,7 @@ mod tests {
         );
 
         let updated_program = invoke_context
-            .programs_modified_by_tx
+            .program_cache_for_tx_batch
             .find_modified(&program_id)
             .expect("Didn't find upgraded program in the cache");
 
@@ -3815,7 +3817,7 @@ mod tests {
             latest_access_slot: AtomicU64::new(0),
         };
         invoke_context
-            .programs_modified_by_tx
+            .program_cache_for_tx_batch
             .store_modified_entry(program_id, Arc::new(program));
 
         let program_id2 = Pubkey::new_unique();
@@ -3825,7 +3827,7 @@ mod tests {
         );
 
         let program2 = invoke_context
-            .programs_modified_by_tx
+            .program_cache_for_tx_batch
             .find_modified(&program_id2)
             .expect("Didn't find upgraded program in the cache");
 

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -456,7 +456,7 @@ pub fn process_instruction_deploy(
         );
     }
     invoke_context
-        .programs_modified_by_tx
+        .program_cache_for_tx_batch
         .store_modified_entry(*program.get_key(), Arc::new(executor));
     Ok(())
 }
@@ -657,7 +657,7 @@ mod tests {
                     if let Ok(loaded_program) = ProgramCacheEntry::new(
                         &loader_v4::id(),
                         invoke_context
-                            .programs_modified_by_tx
+                            .program_cache_for_tx_batch
                             .environments
                             .program_runtime_v2
                             .clone(),
@@ -667,9 +667,11 @@ mod tests {
                         account.data().len(),
                         &mut load_program_metrics,
                     ) {
-                        invoke_context.programs_modified_by_tx.set_slot_for_tests(0);
                         invoke_context
-                            .programs_modified_by_tx
+                            .program_cache_for_tx_batch
+                            .set_slot_for_tests(0);
+                        invoke_context
+                            .program_cache_for_tx_batch
                             .store_modified_entry(*pubkey, Arc::new(loaded_program));
                     }
                 }
@@ -704,7 +706,7 @@ mod tests {
             Entrypoint::vm,
             |invoke_context| {
                 invoke_context
-                    .programs_modified_by_tx
+                    .program_cache_for_tx_batch
                     .environments
                     .program_runtime_v2 = Arc::new(create_program_runtime_environment_v2(
                     &ComputeBudget::default(),

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -457,7 +457,7 @@ pub fn process_instruction_deploy(
     }
     invoke_context
         .programs_modified_by_tx
-        .replenish(*program.get_key(), Arc::new(executor));
+        .store_modified_entry(*program.get_key(), Arc::new(executor));
     Ok(())
 }
 
@@ -670,7 +670,7 @@ mod tests {
                         invoke_context.programs_modified_by_tx.set_slot_for_tests(0);
                         invoke_context
                             .programs_modified_by_tx
-                            .replenish(*pubkey, Arc::new(loaded_program));
+                            .store_modified_entry(*pubkey, Arc::new(loaded_program));
                     }
                 }
             }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4679,7 +4679,6 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-nohash-hasher",
- "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-svm",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4151,14 +4151,12 @@ impl Bank {
                 programs_modified_by_tx,
             } = execution_result
             {
-                if details.status.is_ok()
-                    && !programs_modified_by_tx.get_modified_entries().is_empty()
-                {
+                if details.status.is_ok() && !programs_modified_by_tx.is_empty() {
                     cache
                         .get_or_insert_with(|| {
                             self.transaction_processor.program_cache.write().unwrap()
                         })
-                        .merge(programs_modified_by_tx.get_modified_entries());
+                        .merge(programs_modified_by_tx);
                 }
             }
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4151,12 +4151,14 @@ impl Bank {
                 programs_modified_by_tx,
             } = execution_result
             {
-                if details.status.is_ok() && !programs_modified_by_tx.is_empty() {
+                if details.status.is_ok()
+                    && !programs_modified_by_tx.get_modified_entries().is_empty()
+                {
                     cache
                         .get_or_insert_with(|| {
                             self.transaction_processor.program_cache.write().unwrap()
                         })
-                        .merge(programs_modified_by_tx);
+                        .merge(programs_modified_by_tx.get_modified_entries());
                 }
             }
         }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -129,9 +129,8 @@ impl Bank {
     /// cache.
     ///
     /// Invoking the loader's `direct_deploy_program` function will update the
-    /// program cache in the currently executing context (ie. `programs_loaded`
-    /// and `programs_modified`), but the runtime must also propagate those
-    /// updates to the currently active cache.
+    /// program cache in the currently executing context, but the runtime must
+    /// also propagate those updates to the currently active cache.
     fn directly_invoke_loader_v3_deploy(
         &self,
         builtin_program_id: &Pubkey,
@@ -142,16 +141,16 @@ impl Bank {
         let elf = &programdata[progradata_metadata_size..];
         // Set up the two `LoadedProgramsForTxBatch` instances, as if
         // processing a new transaction batch.
-        let programs_loaded = ProgramCacheForTxBatch::new_from_cache(
+        let program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
             self.slot,
             self.epoch,
             &self.transaction_processor.program_cache.read().unwrap(),
         );
         let mut programs_modified = ProgramCacheForTxBatch::new(
             self.slot,
-            programs_loaded.environments.clone(),
-            programs_loaded.upcoming_environments.clone(),
-            programs_loaded.latest_root_epoch,
+            program_cache_for_tx_batch.environments.clone(),
+            program_cache_for_tx_batch.upcoming_environments.clone(),
+            program_cache_for_tx_batch.latest_root_epoch,
         );
 
         // Configure a dummy `InvokeContext` from the runtime's current
@@ -175,10 +174,10 @@ impl Bank {
 
             let mut dummy_invoke_context = InvokeContext::new(
                 &mut dummy_transaction_context,
+                &program_cache_for_tx_batch,
                 EnvironmentConfig::new(Hash::default(), self.feature_set.clone(), 0, &sysvar_cache),
                 None,
                 compute_budget,
-                &programs_loaded,
                 &mut programs_modified,
             );
 

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -197,7 +197,7 @@ impl Bank {
             .program_cache
             .write()
             .unwrap()
-            .merge(&programs_modified);
+            .merge(programs_modified.get_modified_entries());
 
         Ok(())
     }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -141,16 +141,10 @@ impl Bank {
         let elf = &programdata[progradata_metadata_size..];
         // Set up the two `LoadedProgramsForTxBatch` instances, as if
         // processing a new transaction batch.
-        let program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
             self.slot,
             self.epoch,
             &self.transaction_processor.program_cache.read().unwrap(),
-        );
-        let mut programs_modified = ProgramCacheForTxBatch::new(
-            self.slot,
-            program_cache_for_tx_batch.environments.clone(),
-            program_cache_for_tx_batch.upcoming_environments.clone(),
-            program_cache_for_tx_batch.latest_root_epoch,
         );
 
         // Configure a dummy `InvokeContext` from the runtime's current
@@ -174,11 +168,10 @@ impl Bank {
 
             let mut dummy_invoke_context = InvokeContext::new(
                 &mut dummy_transaction_context,
-                &program_cache_for_tx_batch,
+                &mut program_cache_for_tx_batch,
                 EnvironmentConfig::new(Hash::default(), self.feature_set.clone(), 0, &sysvar_cache),
                 None,
                 compute_budget,
-                &mut programs_modified,
             );
 
             solana_bpf_loader_program::direct_deploy_program(
@@ -197,7 +190,7 @@ impl Bank {
             .program_cache
             .write()
             .unwrap()
-            .merge(programs_modified.get_modified_entries());
+            .merge(program_cache_for_tx_batch.get_modified_entries());
 
         Ok(())
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -39,7 +39,7 @@ use {
         compute_budget::ComputeBudget,
         compute_budget_processor::{self, MAX_COMPUTE_UNIT_LIMIT},
         declare_process_instruction,
-        loaded_programs::{ProgramCacheEntry, ProgramCacheEntryType, ProgramCacheForTxBatch},
+        loaded_programs::{ProgramCacheEntry, ProgramCacheEntryType},
         prioritization_fee::{PrioritizationFeeDetails, PrioritizationFeeType},
         timings::ExecuteTimings,
     },
@@ -242,7 +242,7 @@ fn new_execution_result(
             executed_units: 0,
             accounts_data_len_delta: 0,
         },
-        programs_modified_by_tx: Box::<ProgramCacheForTxBatch>::default(),
+        programs_modified_by_tx: std::collections::HashMap::new(),
     }
 }
 

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -273,7 +273,6 @@ mod tests {
             ]),
         ));
         let sysvar_cache = SysvarCache::default();
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
@@ -282,11 +281,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -327,7 +325,6 @@ mod tests {
                 ),
             ]),
         ));
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
@@ -336,11 +333,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -371,7 +367,6 @@ mod tests {
                 ),
             ]),
         ));
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
@@ -380,11 +375,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -506,7 +500,6 @@ mod tests {
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
         let sysvar_cache = SysvarCache::default();
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
@@ -515,11 +508,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -545,7 +537,6 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
@@ -554,11 +545,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -581,7 +571,6 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
@@ -590,11 +579,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -678,7 +666,6 @@ mod tests {
             mock_program_id,
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
@@ -687,11 +674,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -241,8 +241,8 @@ mod tests {
         ];
         let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3);
         let program_indices = vec![vec![2]];
-        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        program_cache_for_tx_batch.replenish(
             mock_system_program_id,
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
@@ -282,10 +282,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
@@ -336,10 +336,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
@@ -380,10 +380,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
@@ -476,8 +476,8 @@ mod tests {
         ];
         let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3);
         let program_indices = vec![vec![2]];
-        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        program_cache_for_tx_batch.replenish(
             mock_program_id,
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
@@ -515,10 +515,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
@@ -554,10 +554,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
@@ -590,10 +590,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
@@ -673,8 +673,8 @@ mod tests {
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
         let sysvar_cache = SysvarCache::default();
-        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        program_cache_for_tx_batch.replenish(
             mock_program_id,
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
@@ -687,10 +687,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -281,7 +281,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         if details.status.is_ok() {
                             program_cache_for_tx_batch
                                 .borrow_mut()
-                                .merge(programs_modified_by_tx);
+                                .merge(programs_modified_by_tx.get_modified_entries());
                         }
                     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -198,13 +198,13 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             program_accounts_map.insert(*builtin_program, 0);
         }
 
-        let programs_loaded_for_tx_batch = Rc::new(RefCell::new(self.replenish_program_cache(
+        let program_cache_for_tx_batch = Rc::new(RefCell::new(self.replenish_program_cache(
             callbacks,
             &program_accounts_map,
             limit_to_load_programs,
         )));
 
-        if programs_loaded_for_tx_batch.borrow().hit_max_limit {
+        if program_cache_for_tx_batch.borrow().hit_max_limit {
             const ERROR: TransactionError = TransactionError::ProgramCacheHitMaxLimit;
             let loaded_transactions = vec![(Err(ERROR), None); sanitized_txs.len()];
             let execution_results =
@@ -224,7 +224,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             error_counters,
             &self.fee_structure,
             account_overrides,
-            &programs_loaded_for_tx_batch.borrow(),
+            &program_cache_for_tx_batch.borrow(),
         );
         load_time.stop();
 
@@ -268,7 +268,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         timings,
                         error_counters,
                         log_messages_bytes_limit,
-                        &programs_loaded_for_tx_batch.borrow(),
+                        &program_cache_for_tx_batch.borrow(),
                     );
 
                     if let TransactionExecutionResult::Executed {
@@ -279,7 +279,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         // Update batch specific cache of the loaded programs with the modifications
                         // made by the transaction, if it executed successfully.
                         if details.status.is_ok() {
-                            programs_loaded_for_tx_batch
+                            program_cache_for_tx_batch
                                 .borrow_mut()
                                 .merge(programs_modified_by_tx);
                         }
@@ -296,8 +296,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         // ProgramCache entries. Note that loaded_missing is deliberately defined, so that there's
         // still at least one other batch, which will evict the program cache, even after the
         // occurrences of cooperative loading.
-        if programs_loaded_for_tx_batch.borrow().loaded_missing
-            || programs_loaded_for_tx_batch.borrow().merged_modified
+        if program_cache_for_tx_batch.borrow().loaded_missing
+            || program_cache_for_tx_batch.borrow().merged_modified
         {
             const SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE: u8 = 90;
             self.program_cache
@@ -476,7 +476,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         timings: &mut ExecuteTimings,
         error_counters: &mut TransactionErrorMetrics,
         log_messages_bytes_limit: Option<usize>,
-        programs_loaded_for_tx_batch: &ProgramCacheForTxBatch,
+        program_cache_for_tx_batch: &ProgramCacheForTxBatch,
     ) -> TransactionExecutionResult {
         let transaction_accounts = std::mem::take(&mut loaded_transaction.accounts);
 
@@ -527,14 +527,15 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let mut executed_units = 0u64;
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::new(
             self.slot,
-            programs_loaded_for_tx_batch.environments.clone(),
-            programs_loaded_for_tx_batch.upcoming_environments.clone(),
-            programs_loaded_for_tx_batch.latest_root_epoch,
+            program_cache_for_tx_batch.environments.clone(),
+            program_cache_for_tx_batch.upcoming_environments.clone(),
+            program_cache_for_tx_batch.latest_root_epoch,
         );
         let sysvar_cache = &self.sysvar_cache.read().unwrap();
 
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            program_cache_for_tx_batch,
             EnvironmentConfig::new(
                 blockhash,
                 callback.get_feature_set(),
@@ -543,7 +544,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             ),
             log_collector.clone(),
             compute_budget,
-            programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
 
@@ -892,7 +892,7 @@ mod tests {
         };
 
         let sanitized_message = new_unchecked_sanitized_message(message);
-        let loaded_programs = ProgramCacheForTxBatch::default();
+        let program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         let mock_bank = MockBankCallback::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
@@ -925,7 +925,7 @@ mod tests {
             &mut ExecuteTimings::default(),
             &mut TransactionErrorMetrics::default(),
             None,
-            &loaded_programs,
+            &program_cache_for_tx_batch,
         );
 
         let TransactionExecutionResult::Executed {
@@ -947,7 +947,7 @@ mod tests {
             &mut ExecuteTimings::default(),
             &mut TransactionErrorMetrics::default(),
             Some(2),
-            &loaded_programs,
+            &program_cache_for_tx_batch,
         );
 
         let TransactionExecutionResult::Executed {
@@ -978,7 +978,7 @@ mod tests {
             &mut ExecuteTimings::default(),
             &mut TransactionErrorMetrics::default(),
             None,
-            &loaded_programs,
+            &program_cache_for_tx_batch,
         );
 
         let TransactionExecutionResult::Executed {
@@ -1016,7 +1016,7 @@ mod tests {
         };
 
         let sanitized_message = new_unchecked_sanitized_message(message);
-        let loaded_programs = ProgramCacheForTxBatch::default();
+        let program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         let mock_bank = MockBankCallback::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
@@ -1051,7 +1051,7 @@ mod tests {
             &mut ExecuteTimings::default(),
             &mut error_metrics,
             None,
-            &loaded_programs,
+            &program_cache_for_tx_batch,
         );
 
         assert_eq!(error_metrics.instruction_error, 1);

--- a/svm/src/transaction_results.rs
+++ b/svm/src/transaction_results.rs
@@ -6,12 +6,14 @@
 pub use solana_sdk::inner_instruction::{InnerInstruction, InnerInstructionsList};
 use {
     crate::nonce_info::{NonceFull, NonceInfo},
-    solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
+    solana_program_runtime::loaded_programs::ProgramCacheEntry,
     solana_sdk::{
+        pubkey::Pubkey,
         rent_debits::RentDebits,
         transaction::{self, TransactionError},
         transaction_context::TransactionReturnData,
     },
+    std::{collections::HashMap, sync::Arc},
 };
 
 pub struct TransactionResults {
@@ -34,7 +36,7 @@ pub struct TransactionResults {
 pub enum TransactionExecutionResult {
     Executed {
         details: TransactionExecutionDetails,
-        programs_modified_by_tx: Box<ProgramCacheForTxBatch>,
+        programs_modified_by_tx: HashMap<Pubkey, Arc<ProgramCacheEntry>>,
     },
     NotExecuted(TransactionError),
 }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -464,6 +464,7 @@ fn svm_integration() {
         None,
         None,
         false,
+        true,
     );
 
     assert_eq!(result.execution_results.len(), 5);


### PR DESCRIPTION
#### Problem
The `InvokeContext` requires callers to provide two instances of a local 
per-transaction-batch program cache. One cache instance is read-only and built 
from the global program cache, while the other is mutable and comprises _only_ 
modified entries.

In fact, the mutable local cache instance never contains entries from the global 
cache, only the modified entries during transaction execution (for example, 
program deployments).

This configuration is brittle, since one may not know which cache instance 
should be used in which use case. It's also not immediately clear what the 
relationship is between these two cache instances.

If the tracking of read-only entries from the global cache and modified entries 
in the transaction batch were unified in their tracking (within _one single_ 
local cache instance), it would be much easier to avoid footguns.

#### Summary of Changes
First rename the `loaded_programs_for_tx_batch` local cache instance to 
`program_cache_for_tx_batch`, which will serve as the unified local cache 
instance.

Then, introduce the concept of `modified_entries` to the local 
`ProgramCacheForTxBatch` struct, to use specifically for tracking modified 
entries, such as deployments. Also offer a few helpers for working with this new 
field.

Then, drop the `programs_modified_by_tx` cache instance (in the `InvokeContext`) 
in favor of the new `modified_entries` field on `program_cache_for_tx_batch`. 
This effectively unifies the two cache instances.

Finally, since the unified cache unlocks a bit more flexibility within SVM, 
hoist the act of updating the global program cache with modified entries up to 
SVM.
