### PR TITLE
Vote: remove vote program dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7599,7 +7599,6 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-sdk",
- "solana-vote-program",
  "thiserror",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6566,7 +6566,6 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-sdk",
- "solana-vote-program",
  "thiserror",
 ]
 

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -18,7 +18,6 @@ serde_derive = { workspace = true }
 solana-frozen-abi = { workspace = true }
 solana-frozen-abi-macro = { workspace = true }
 solana-sdk = { workspace = true }
-solana-vote-program = { workspace = true }
 thiserror = { workspace = true }
 
 [lib]

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -5,8 +5,8 @@ use {
         account::{AccountSharedData, ReadableAccount},
         instruction::InstructionError,
         pubkey::Pubkey,
+        vote::state::VoteState,
     },
-    solana_vote_program::vote_state::VoteState,
     std::{
         cmp::Ordering,
         collections::{hash_map::Entry, HashMap},
@@ -241,7 +241,7 @@ impl TryFrom<AccountSharedData> for VoteAccount {
 impl TryFrom<AccountSharedData> for VoteAccountInner {
     type Error = Error;
     fn try_from(account: AccountSharedData) -> Result<Self, Self::Error> {
-        if !solana_vote_program::check_id(account.owner()) {
+        if !solana_sdk::vote::program::check_id(account.owner()) {
             return Err(Error::InvalidOwner(*account.owner()));
         }
         Ok(Self {
@@ -325,8 +325,11 @@ mod tests {
         super::*,
         bincode::Options,
         rand::Rng,
-        solana_sdk::{pubkey::Pubkey, sysvar::clock::Clock},
-        solana_vote_program::vote_state::{VoteInit, VoteStateVersions},
+        solana_sdk::{
+            pubkey::Pubkey,
+            sysvar::clock::Clock,
+            vote::state::{VoteInit, VoteStateVersions},
+        },
         std::iter::repeat_with,
     };
 
@@ -351,7 +354,7 @@ mod tests {
         let account = AccountSharedData::new_data(
             rng.gen(), // lamports
             &VoteStateVersions::new_current(vote_state.clone()),
-            &solana_vote_program::id(), // owner
+            &solana_sdk::vote::program::id(), // owner
         )
         .unwrap();
         (account, vote_state)

--- a/vote/src/vote_parser.rs
+++ b/vote/src/vote_parser.rs
@@ -6,8 +6,8 @@ use {
         pubkey::Pubkey,
         signature::Signature,
         transaction::{SanitizedTransaction, Transaction},
+        vote::instruction::VoteInstruction,
     },
-    solana_vote_program::vote_instruction::VoteInstruction,
 };
 
 pub type ParsedVote = (Pubkey, VoteTransaction, Option<Hash>, Signature);
@@ -17,7 +17,7 @@ pub fn parse_sanitized_vote_transaction(tx: &SanitizedTransaction) -> Option<Par
     // Check first instruction for a vote
     let message = tx.message();
     let (program_id, first_instruction) = message.program_instructions_iter().next()?;
-    if !solana_vote_program::check_id(program_id) {
+    if !solana_sdk::vote::program::check_id(program_id) {
         return None;
     }
     let first_account = usize::from(*first_instruction.accounts.first()?);
@@ -34,7 +34,7 @@ pub fn parse_vote_transaction(tx: &Transaction) -> Option<ParsedVote> {
     let first_instruction = message.instructions.first()?;
     let program_id_index = usize::from(first_instruction.program_id_index);
     let program_id = message.account_keys.get(program_id_index)?;
-    if !solana_vote_program::check_id(program_id) {
+    if !solana_sdk::vote::program::check_id(program_id) {
         return None;
     }
     let first_account = usize::from(*first_instruction.accounts.first()?);
@@ -82,13 +82,45 @@ mod test {
     use {
         super::*,
         solana_sdk::{
+            clock::Slot,
             hash::hash,
             signature::{Keypair, Signer},
-        },
-        solana_vote_program::{
-            vote_instruction, vote_state::Vote, vote_transaction::new_vote_transaction,
+            vote::{instruction as vote_instruction, state::Vote},
         },
     };
+
+    // Reimplemented locally from Vote program.
+    fn new_vote_transaction(
+        slots: Vec<Slot>,
+        bank_hash: Hash,
+        blockhash: Hash,
+        node_keypair: &Keypair,
+        vote_keypair: &Keypair,
+        authorized_voter_keypair: &Keypair,
+        switch_proof_hash: Option<Hash>,
+    ) -> Transaction {
+        let votes = Vote::new(slots, bank_hash);
+        let vote_ix = if let Some(switch_proof_hash) = switch_proof_hash {
+            vote_instruction::vote_switch(
+                &vote_keypair.pubkey(),
+                &authorized_voter_keypair.pubkey(),
+                votes,
+                switch_proof_hash,
+            )
+        } else {
+            vote_instruction::vote(
+                &vote_keypair.pubkey(),
+                &authorized_voter_keypair.pubkey(),
+                votes,
+            )
+        };
+
+        let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&node_keypair.pubkey()));
+
+        vote_tx.partial_sign(&[node_keypair], blockhash);
+        vote_tx.partial_sign(&[authorized_voter_keypair], blockhash);
+        vote_tx
+    }
 
     fn run_test_parse_vote_transaction(input_hash: Option<Hash>) {
         let node_keypair = Keypair::new();

--- a/vote/src/vote_transaction.rs
+++ b/vote/src/vote_transaction.rs
@@ -1,9 +1,7 @@
-use {
-    solana_sdk::{
-        clock::{Slot, UnixTimestamp},
-        hash::Hash,
-    },
-    solana_vote_program::vote_state::{TowerSync, Vote, VoteStateUpdate},
+use solana_sdk::{
+    clock::{Slot, UnixTimestamp},
+    hash::Hash,
+    vote::state::{TowerSync, Vote, VoteStateUpdate},
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
#### Problem
The `solana-vote` crate depends on the `solana-vote-program` for various API
types and helpers, but it can actually depend on the SDK directly. Without
the vote program dependency, compile time is reduced, and types from
`solana-vote` can be used in `program-runtime`, which would otherwise create
a cyclical dependency.

#### Summary of Changes
Change imports for vote types to pull directly from the SDK and drop the
dependency on vote program.

Note this was almost seamless, but `new_vote_transaction` had to be
reimplemented locally, but only for test purposes. Considering this was for
tests only, it felt much easier than porting over all transaction helpers to
`solana-vote` and updating the other crates in the monorepo.