### PR TITLE
Syscall: `GetEpochStake`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7334,6 +7334,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk",
  "solana-system-program",
+ "solana-vote",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5615,6 +5615,7 @@ dependencies = [
  "solana-poseidon",
  "solana-program-runtime",
  "solana-sdk",
+ "solana-vote",
  "solana-zk-token-sdk",
  "solana_rbpf",
  "test-case",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6729,6 +6729,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
+ "solana-vote",
  "solana_rbpf",
  "test-case",
  "thiserror",

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -28,6 +28,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-sdk = { workspace = true }
+solana-vote = { workspace = true }
 solana_rbpf = { workspace = true }
 thiserror = { workspace = true }
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -36,6 +36,7 @@ use {
             IndexOfAccount, InstructionAccount, TransactionAccount, TransactionContext,
         },
     },
+    solana_vote::vote_account::VoteAccountsHashMap,
     std::{
         alloc::Layout,
         cell::RefCell,
@@ -148,6 +149,7 @@ pub struct EnvironmentConfig<'a> {
     pub blockhash: Hash,
     pub feature_set: Arc<FeatureSet>,
     pub lamports_per_signature: u64,
+    vote_accounts: Option<&'a VoteAccountsHashMap>,
     sysvar_cache: &'a SysvarCache,
 }
 impl<'a> EnvironmentConfig<'a> {
@@ -155,12 +157,14 @@ impl<'a> EnvironmentConfig<'a> {
         blockhash: Hash,
         feature_set: Arc<FeatureSet>,
         lamports_per_signature: u64,
+        vote_accounts: Option<&'a VoteAccountsHashMap>,
         sysvar_cache: &'a SysvarCache,
     ) -> Self {
         Self {
             blockhash,
             feature_set,
             lamports_per_signature,
+            vote_accounts,
             sysvar_cache,
         }
     }
@@ -614,6 +618,11 @@ impl<'a> InvokeContext<'a> {
         self.environment_config.sysvar_cache
     }
 
+    /// Get cached vote accounts.
+    pub fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+        self.environment_config.vote_accounts
+    }
+
     // Should alignment be enforced during user pointer translation
     pub fn get_check_aligned(&self) -> bool {
         self.transaction_context
@@ -712,6 +721,7 @@ macro_rules! with_mock_invoke_context {
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
             0,
+            /* vote_accounts */ None,
             &sysvar_cache,
         );
         let program_cache_for_tx_batch = ProgramCacheForTxBatch::default();

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -39,7 +39,7 @@ use {
     solana_vote::vote_account::VoteAccountsHashMap,
     std::{
         alloc::Layout,
-        cell::RefCell,
+        cell::{Ref, RefCell},
         fmt::{self, Debug},
         rc::Rc,
         sync::{atomic::Ordering, Arc},
@@ -599,6 +599,11 @@ impl<'a> InvokeContext<'a> {
     /// Get this invocation's compute budget
     pub fn get_compute_budget(&self) -> &ComputeBudget {
         &self.compute_budget
+    }
+
+    /// Get this invocation's compute meter.
+    pub fn get_compute_meter(&self) -> Ref<u64> {
+        self.compute_meter.borrow()
     }
 
     /// Get the current feature set.

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -147,24 +147,27 @@ impl BpfAllocator {
 
 pub struct EnvironmentConfig<'a> {
     pub blockhash: Hash,
+    epoch_total_stake: Option<u64>,
+    epoch_vote_accounts: Option<&'a VoteAccountsHashMap>,
     pub feature_set: Arc<FeatureSet>,
     pub lamports_per_signature: u64,
-    vote_accounts: Option<&'a VoteAccountsHashMap>,
     sysvar_cache: &'a SysvarCache,
 }
 impl<'a> EnvironmentConfig<'a> {
     pub fn new(
         blockhash: Hash,
+        epoch_total_stake: Option<u64>,
+        epoch_vote_accounts: Option<&'a VoteAccountsHashMap>,
         feature_set: Arc<FeatureSet>,
         lamports_per_signature: u64,
-        vote_accounts: Option<&'a VoteAccountsHashMap>,
         sysvar_cache: &'a SysvarCache,
     ) -> Self {
         Self {
             blockhash,
+            epoch_total_stake,
+            epoch_vote_accounts,
             feature_set,
             lamports_per_signature,
-            vote_accounts,
             sysvar_cache,
         }
     }
@@ -618,9 +621,14 @@ impl<'a> InvokeContext<'a> {
         self.environment_config.sysvar_cache
     }
 
-    /// Get cached vote accounts.
-    pub fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
-        self.environment_config.vote_accounts
+    /// Get cached epoch total stake.
+    pub fn get_epoch_total_stake(&self) -> Option<u64> {
+        self.environment_config.epoch_total_stake
+    }
+
+    /// Get cached epoch vote accounts.
+    pub fn get_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+        self.environment_config.epoch_vote_accounts
     }
 
     // Should alignment be enforced during user pointer translation
@@ -719,9 +727,10 @@ macro_rules! with_mock_invoke_context {
         });
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            None,
+            None,
             Arc::new(FeatureSet::all_enabled()),
             0,
-            /* vote_accounts */ None,
             &sysvar_cache,
         );
         let program_cache_for_tx_batch = ProgramCacheForTxBatch::default();

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -39,7 +39,7 @@ use {
     solana_vote::vote_account::VoteAccountsHashMap,
     std::{
         alloc::Layout,
-        cell::{Ref, RefCell},
+        cell::RefCell,
         fmt::{self, Debug},
         rc::Rc,
         sync::{atomic::Ordering, Arc},
@@ -599,11 +599,6 @@ impl<'a> InvokeContext<'a> {
     /// Get this invocation's compute budget
     pub fn get_compute_budget(&self) -> &ComputeBudget {
         &self.compute_budget
-    }
-
-    /// Get this invocation's compute meter.
-    pub fn get_compute_meter(&self) -> Ref<u64> {
-        self.compute_meter.borrow()
     }
 
     /// Get the current feature set.

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -29,6 +29,7 @@ assert_matches = { workspace = true }
 memoffset = { workspace = true }
 rand = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
+solana-vote = { workspace = true }
 test-case = { workspace = true }
 
 [lib]

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -2103,7 +2103,8 @@ mod tests {
                 last_restart_slot::LastRestartSlot,
             },
         },
-        std::{mem, str::FromStr},
+        solana_vote::vote_account::VoteAccount,
+        std::{collections::HashMap, mem, str::FromStr},
         test_case::test_case,
     };
 
@@ -4739,6 +4740,160 @@ mod tests {
             assert_matches!(
                 result,
                 Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::InvalidLength
+            );
+        }
+    }
+
+    #[test]
+    fn test_syscall_get_epoch_stake() {
+        let config = Config::default();
+        let compute_budget = ComputeBudget::default();
+        let sysvar_cache = Arc::<SysvarCache>::default();
+
+        let expected_epoch_stake = 55_000_000_000u64;
+        let expected_cus = compute_budget.syscall_base_cost
+            + (PUBKEY_BYTES as u64) / compute_budget.cpi_bytes_per_unit
+            + compute_budget.mem_op_base_cost;
+
+        let vote_address = Pubkey::new_unique();
+        let mut vote_accounts_map = HashMap::new();
+        vote_accounts_map.insert(
+            vote_address,
+            (
+                expected_epoch_stake,
+                VoteAccount::try_from(AccountSharedData::new(
+                    0,
+                    0,
+                    &solana_sdk::vote::program::id(),
+                ))
+                .unwrap(),
+            ),
+        );
+
+        with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
+        invoke_context.environment_config = EnvironmentConfig::new(
+            Hash::default(),
+            Arc::<FeatureSet>::default(),
+            0,
+            Some(&vote_accounts_map),
+            &sysvar_cache,
+        );
+
+        {
+            // The syscall aborts the virtual machine if not all bytes in VM
+            // memory range `[vote_addr, vote_addr + 32)` are readable.
+            let vote_address_var = 0x100000000;
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![
+                    // Invalid read-only memory region.
+                    MemoryRegion::new_readonly(&[2; 31], vote_address_var),
+                ],
+                &config,
+                &SBPFVersion::V2,
+            )
+            .unwrap();
+
+            let result = SyscallGetEpochStake::rust(
+                &mut invoke_context,
+                vote_address_var,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            );
+
+            assert_access_violation!(result, vote_address_var, 32);
+
+            // Compute units, as specified by SIMD-0133.
+            // cu = syscall_base_cost
+            //     + floor(32/cpi_bytes_per_unit)
+            //     + mem_op_base_cost
+            assert_eq!(
+                invoke_context.get_compute_meter().to_owned(),
+                compute_budget.compute_unit_limit - expected_cus
+            );
+        }
+
+        invoke_context.mock_set_remaining(compute_budget.compute_unit_limit);
+        {
+            // Otherwise, the syscall returns a `u64` integer representing the
+            // total active stake delegated to the vote account at the provided
+            // address.
+            let vote_address_var = 0x100000000;
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![MemoryRegion::new_readonly(
+                    bytes_of(&vote_address),
+                    vote_address_var,
+                )],
+                &config,
+                &SBPFVersion::V2,
+            )
+            .unwrap();
+
+            let result = SyscallGetEpochStake::rust(
+                &mut invoke_context,
+                vote_address_var,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            )
+            .unwrap();
+
+            assert_eq!(result, expected_epoch_stake);
+
+            // Compute units, as specified by SIMD-0133.
+            // cu = syscall_base_cost
+            //     + floor(32/cpi_bytes_per_unit)
+            //     + mem_op_base_cost
+            assert_eq!(
+                invoke_context.get_compute_meter().to_owned(),
+                compute_budget.compute_unit_limit - expected_cus
+            );
+        }
+
+        invoke_context.mock_set_remaining(compute_budget.compute_unit_limit);
+        {
+            // If the provided vote address corresponds to an account that is
+            // not a vote account or does not exist, the syscall will write
+            // `0` for active stake.
+            let vote_address_var = 0x100000000;
+            let not_a_vote_address = Pubkey::new_unique(); // Not a vote account.
+
+            let mut memory_mapping = MemoryMapping::new(
+                vec![MemoryRegion::new_readonly(
+                    bytes_of(&not_a_vote_address),
+                    vote_address_var,
+                )],
+                &config,
+                &SBPFVersion::V2,
+            )
+            .unwrap();
+
+            let result = SyscallGetEpochStake::rust(
+                &mut invoke_context,
+                vote_address_var,
+                0,
+                0,
+                0,
+                0,
+                &mut memory_mapping,
+            )
+            .unwrap();
+
+            assert_eq!(result, 0); // `0` for active stake.
+
+            // Compute units, as specified by SIMD-0133.
+            // cu = syscall_base_cost
+            //     + floor(32/cpi_bytes_per_unit)
+            //     + mem_op_base_cost
+            assert_eq!(
+                invoke_context.get_compute_meter().to_owned(),
+                compute_budget.compute_unit_limit - expected_cus
             );
         }
     }

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -39,7 +39,8 @@ use {
             self, abort_on_invalid_curve, blake3_syscall_enabled, curve25519_syscall_enabled,
             disable_deploy_of_alloc_free_syscall, disable_fees_sysvar,
             enable_alt_bn128_compression_syscall, enable_alt_bn128_syscall,
-            enable_big_mod_exp_syscall, enable_partitioned_epoch_reward, enable_poseidon_syscall,
+            enable_big_mod_exp_syscall, enable_get_epoch_stake_syscall,
+            enable_partitioned_epoch_reward, enable_poseidon_syscall,
             error_on_syscall_bpf_function_hash_collisions, get_sysvar_syscall_enabled,
             last_restart_slot_sysvar, reject_callx_r10, remaining_compute_units_syscall_enabled,
             switch_to_new_elf_parser,
@@ -50,7 +51,7 @@ use {
         precompiles::is_precompile,
         program::MAX_RETURN_DATA,
         program_stubs::is_nonoverlapping,
-        pubkey::{Pubkey, PubkeyError, MAX_SEEDS, MAX_SEED_LEN},
+        pubkey::{Pubkey, PubkeyError, MAX_SEEDS, MAX_SEED_LEN, PUBKEY_BYTES},
         secp256k1_recover::{
             Secp256k1RecoverError, SECP256K1_PUBLIC_KEY_LENGTH, SECP256K1_SIGNATURE_LENGTH,
         },
@@ -282,6 +283,8 @@ pub fn create_program_runtime_environment_v1<'a>(
     let remaining_compute_units_syscall_enabled =
         feature_set.is_active(&remaining_compute_units_syscall_enabled::id());
     let get_sysvar_syscall_enabled = feature_set.is_active(&get_sysvar_syscall_enabled::id());
+    let enable_get_epoch_stake_syscall =
+        feature_set.is_active(&enable_get_epoch_stake_syscall::id());
     // !!! ATTENTION !!!
     // When adding new features for RBPF here,
     // also add them to `Bank::apply_builtin_program_feature_transitions()`.
@@ -474,6 +477,14 @@ pub fn create_program_runtime_environment_v1<'a>(
         get_sysvar_syscall_enabled,
         *b"sol_get_sysvar",
         SyscallGetSysvar::vm,
+    )?;
+
+    // Get Epoch Stake
+    register_feature_gated_function!(
+        result,
+        enable_get_epoch_stake_syscall,
+        *b"sol_get_epoch_stake",
+        SyscallGetEpochStake::vm,
     )?;
 
     // Log data
@@ -2006,6 +2017,59 @@ declare_builtin_function!(
         }
         hash_result.copy_from_slice(hasher.result().as_ref());
         Ok(0)
+    }
+);
+
+declare_builtin_function!(
+    // Get Epoch Stake Syscall
+    SyscallGetEpochStake,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        vote_address: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        // Compute units, as specified by SIMD-0133.
+        // cu = syscall_base_cost
+        //     + floor(32/cpi_bytes_per_unit)
+        //     + mem_op_base_cost
+        let compute_budget = invoke_context.get_compute_budget();
+        let compute_units = compute_budget
+            .syscall_base_cost
+            .saturating_add(
+                (PUBKEY_BYTES as u64)
+                    .checked_div(compute_budget.cpi_bytes_per_unit)
+                    .unwrap_or(u64::MAX),
+            )
+            .saturating_add(compute_budget.mem_op_base_cost);
+
+        consume_compute_meter(invoke_context, compute_units)?;
+
+        // Control flow, as specified by SIMD-0133.
+        // * The syscall aborts the virtual machine if not all bytes in VM
+        //   memory range `[vote_addr, vote_addr + 32)` are readable.
+        // * Otherwise, the syscall returns a `u64` integer representing the
+        //   total active stake delegated to the vote account at the provided
+        //   address.
+        //   * If the provided vote address corresponds to an account that is
+        //     not a vote account or does not exist, the syscall will return
+        //     `0` for active stake.
+        let check_aligned = invoke_context.get_check_aligned();
+        let vote_address = translate_type::<Pubkey>(memory_mapping, vote_address, check_aligned)?;
+
+        Ok(
+            if let Some(vote_accounts) = invoke_context.get_vote_accounts() {
+                vote_accounts
+                    .get(vote_address)
+                    .map(|(stake, _)| *stake)
+                    .unwrap_or(0)
+            } else {
+                0
+            },
+        )
     }
 );
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5400,6 +5400,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
+ "solana-vote",
  "solana_rbpf",
  "thiserror",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6311,6 +6311,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk",
  "solana-system-program",
+ "solana-vote",
 ]
 
 [[package]]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6838,6 +6838,10 @@ impl TransactionProcessingCallback for Bank {
         self.feature_set.clone()
     }
 
+    fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+        self.epoch_vote_accounts(self.epoch())
+    }
+
     fn get_program_match_criteria(&self, program: &Pubkey) -> ProgramCacheMatchCriteria {
         if self.check_program_modification_slot {
             self.program_modification_slot(program)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6155,6 +6155,13 @@ impl Bank {
         Some(self.epoch_stakes.get(&epoch)?.stakes().staked_nodes())
     }
 
+    /// Get the total epoch stake for the given epoch.
+    pub fn epoch_total_stake(&self, epoch: Epoch) -> Option<u64> {
+        self.epoch_stakes
+            .get(&epoch)
+            .map(|epoch_stakes| epoch_stakes.total_stake())
+    }
+
     /// vote accounts for the specific epoch along with the stake
     ///   attributed to each account
     pub fn epoch_vote_accounts(&self, epoch: Epoch) -> Option<&VoteAccountsHashMap> {
@@ -6838,7 +6845,11 @@ impl TransactionProcessingCallback for Bank {
         self.feature_set.clone()
     }
 
-    fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+    fn get_epoch_total_stake(&self) -> Option<u64> {
+        self.epoch_total_stake(self.epoch())
+    }
+
+    fn get_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
         self.epoch_vote_accounts(self.epoch())
     }
 

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -203,7 +203,13 @@ impl Bank {
             let mut dummy_invoke_context = InvokeContext::new(
                 &mut dummy_transaction_context,
                 &program_cache_for_tx_batch,
-                EnvironmentConfig::new(Hash::default(), self.feature_set.clone(), 0, &sysvar_cache),
+                EnvironmentConfig::new(
+                    Hash::default(),
+                    self.feature_set.clone(),
+                    0,
+                    None,
+                    &sysvar_cache,
+                ),
                 None,
                 compute_budget,
                 &mut programs_modified,

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -205,9 +205,10 @@ impl Bank {
                 &program_cache_for_tx_batch,
                 EnvironmentConfig::new(
                     Hash::default(),
+                    None,
+                    None,
                     self.feature_set.clone(),
                     0,
-                    None,
                     &sysvar_cache,
                 ),
                 None,

--- a/sdk/program/src/epoch_stake.rs
+++ b/sdk/program/src/epoch_stake.rs
@@ -1,17 +1,30 @@
+//! API for retrieving epoch stake information.
+//!
+//! On-chain programs can use this API to retrieve the total stake for the
+//! current epoch or the stake for a specific vote account using the
+//! `sol_get_epoch_stake` syscall.
+
 use crate::pubkey::Pubkey;
+
+fn get_epoch_stake(var_addr: *const u8) -> u64 {
+    #[cfg(target_os = "solana")]
+    let result = unsafe { crate::syscalls::sol_get_epoch_stake(var_addr) };
+
+    #[cfg(not(target_os = "solana"))]
+    let result = crate::program_stubs::sol_get_epoch_stake(var_addr);
+
+    result
+}
+
+/// Get the current epoch's total stake.
+pub fn get_epoch_total_stake() -> u64 {
+    get_epoch_stake(std::ptr::null::<Pubkey>() as *const u8)
+}
 
 /// Get the current epoch stake for a given vote address.
 ///
 /// If the provided vote address corresponds to an account that is not a vote
 /// account or does not exist, returns `0` for active stake.
-pub fn get_epoch_stake(vote_address: &Pubkey) -> u64 {
-    let vote_address = vote_address as *const _ as *const u8;
-
-    #[cfg(target_os = "solana")]
-    let result = unsafe { crate::syscalls::sol_get_epoch_stake(vote_address) };
-
-    #[cfg(not(target_os = "solana"))]
-    let result = crate::program_stubs::sol_get_epoch_stake(vote_address);
-
-    result
+pub fn get_epoch_stake_for_vote_account(vote_address: &Pubkey) -> u64 {
+    get_epoch_stake(vote_address as *const _ as *const u8)
 }

--- a/sdk/program/src/epoch_stake.rs
+++ b/sdk/program/src/epoch_stake.rs
@@ -1,0 +1,17 @@
+use crate::pubkey::Pubkey;
+
+/// Get the current epoch stake for a given vote address.
+///
+/// If the provided vote address corresponds to an account that is not a vote
+/// account or does not exist, returns `0` for active stake.
+pub fn get_epoch_stake(vote_address: &Pubkey) -> u64 {
+    let vote_address = vote_address as *const _ as *const u8;
+
+    #[cfg(target_os = "solana")]
+    let result = unsafe { crate::syscalls::sol_get_epoch_stake(vote_address) };
+
+    #[cfg(not(target_os = "solana"))]
+    let result = crate::program_stubs::sol_get_epoch_stake(vote_address);
+
+    result
+}

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -493,6 +493,7 @@ pub mod entrypoint;
 pub mod entrypoint_deprecated;
 pub mod epoch_rewards;
 pub mod epoch_schedule;
+pub mod epoch_stake;
 pub mod feature;
 pub mod fee_calculator;
 pub mod hash;

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -70,6 +70,9 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_get_last_restart_slot(&self, _var_addr: *mut u8) -> u64 {
         UNSUPPORTED_SYSVAR
     }
+    fn sol_get_epoch_stake(&self, _vote_address: *const u8) -> u64 {
+        0
+    }
     /// # Safety
     unsafe fn sol_memcpy(&self, dst: *mut u8, src: *const u8, n: usize) {
         // cannot be overlapping
@@ -191,6 +194,13 @@ pub(crate) fn sol_get_last_restart_slot(var_addr: *mut u8) -> u64 {
         .read()
         .unwrap()
         .sol_get_last_restart_slot(var_addr)
+}
+
+pub(crate) fn sol_get_epoch_stake(vote_address: *const u8) -> u64 {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_get_epoch_stake(vote_address)
 }
 
 pub(crate) fn sol_memcpy(dst: *mut u8, src: *const u8, n: usize) {

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -66,6 +66,7 @@ define_syscall!(fn sol_big_mod_exp(params: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_remaining_compute_units() -> u64);
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
 define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, result: *mut u8, offset: u64, length: u64) -> u64);
+define_syscall!(fn sol_get_epoch_stake(vote_address: *const u8) -> u64);
 
 // these are to be deprecated once they are superceded by sol_get_sysvar
 define_syscall!(fn sol_get_clock_sysvar(addr: *mut u8) -> u64);

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -817,6 +817,10 @@ pub mod migrate_config_program_to_core_bpf {
     solana_sdk::declare_id!("2Fr57nzzkLYXW695UdDxDeR5fhnZWSttZeZYemrnpGFV");
 }
 
+pub mod enable_get_epoch_stake_syscall {
+    solana_sdk::declare_id!("7mScTYkJXsbdrcwTQRs7oeCSXoJm4WjzBsRyf8bCU3Np");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -1016,6 +1020,7 @@ lazy_static! {
         (migrate_feature_gate_program_to_core_bpf::id(), "Migrate Feature Gate program to Core BPF (programify) #1003"),
         (vote_only_full_fec_sets::id(), "vote only full fec sets"),
         (migrate_config_program_to_core_bpf::id(), "Migrate Config program to Core BPF #1378"),
+        (enable_get_epoch_stake_syscall::id(), "Enable syscall: sol_get_epoch_stake #884"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -25,6 +25,7 @@ solana-metrics = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 solana-system-program = { workspace = true }
+solana-vote = { workspace = true }
 
 [lib]
 crate-type = ["lib"]

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -513,6 +513,7 @@ mod tests {
             transaction::{Result, SanitizedTransaction, Transaction, TransactionError},
             transaction_context::{TransactionAccount, TransactionContext},
         },
+        solana_vote::vote_account::VoteAccountsHashMap,
         std::{borrow::Cow, collections::HashMap, convert::TryFrom, sync::Arc},
     };
 
@@ -542,6 +543,10 @@ mod tests {
 
         fn get_feature_set(&self) -> Arc<FeatureSet> {
             self.feature_set.clone()
+        }
+
+        fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+            None
         }
     }
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -545,7 +545,11 @@ mod tests {
             self.feature_set.clone()
         }
 
-        fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+        fn get_epoch_total_stake(&self) -> Option<u64> {
+            None
+        }
+
+        fn get_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
             None
         }
     }

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -275,9 +275,10 @@ mod tests {
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            None,
+            None,
             Arc::new(FeatureSet::all_enabled()),
             0,
-            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -330,9 +331,10 @@ mod tests {
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            None,
+            None,
             Arc::new(FeatureSet::all_enabled()),
             0,
-            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -375,9 +377,10 @@ mod tests {
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            None,
+            None,
             Arc::new(FeatureSet::all_enabled()),
             0,
-            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -511,9 +514,10 @@ mod tests {
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            None,
+            None,
             Arc::new(FeatureSet::all_enabled()),
             0,
-            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -551,9 +555,10 @@ mod tests {
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            None,
+            None,
             Arc::new(FeatureSet::all_enabled()),
             0,
-            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -588,9 +593,10 @@ mod tests {
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            None,
+            None,
             Arc::new(FeatureSet::all_enabled()),
             0,
-            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -686,9 +692,10 @@ mod tests {
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            None,
+            None,
             Arc::new(FeatureSet::all_enabled()),
             0,
-            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -277,6 +277,7 @@ mod tests {
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
             0,
+            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -331,6 +332,7 @@ mod tests {
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
             0,
+            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -375,6 +377,7 @@ mod tests {
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
             0,
+            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -510,6 +513,7 @@ mod tests {
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
             0,
+            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -549,6 +553,7 @@ mod tests {
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
             0,
+            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -585,6 +590,7 @@ mod tests {
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
             0,
+            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -682,6 +688,7 @@ mod tests {
             Hash::default(),
             Arc::new(FeatureSet::all_enabled()),
             0,
+            None,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -232,6 +232,7 @@ mod tests {
             account::WritableAccount, bpf_loader, bpf_loader_upgradeable, feature_set::FeatureSet,
             hash::Hash, rent_collector::RentCollector,
         },
+        solana_vote::vote_account::VoteAccountsHashMap,
         std::{
             cell::RefCell,
             collections::HashMap,
@@ -283,6 +284,10 @@ mod tests {
 
         fn get_feature_set(&self) -> Arc<FeatureSet> {
             self.feature_set.clone()
+        }
+
+        fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+            None
         }
 
         fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -286,7 +286,11 @@ mod tests {
             self.feature_set.clone()
         }
 
-        fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+        fn get_epoch_total_stake(&self) -> Option<u64> {
+            None
+        }
+
+        fn get_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
             None
         }
 

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -20,7 +20,9 @@ pub trait TransactionProcessingCallback {
 
     fn get_feature_set(&self) -> Arc<FeatureSet>;
 
-    fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap>;
+    fn get_epoch_total_stake(&self) -> Option<u64>;
+
+    fn get_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap>;
 
     fn get_program_match_criteria(&self, _program: &Pubkey) -> ProgramCacheMatchCriteria {
         ProgramCacheMatchCriteria::NoCriteria

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -4,6 +4,7 @@ use {
         account::AccountSharedData, feature_set::FeatureSet, hash::Hash, pubkey::Pubkey,
         rent_collector::RentCollector,
     },
+    solana_vote::vote_account::VoteAccountsHashMap,
     std::sync::Arc,
 };
 
@@ -18,6 +19,8 @@ pub trait TransactionProcessingCallback {
     fn get_rent_collector(&self) -> &RentCollector;
 
     fn get_feature_set(&self) -> Arc<FeatureSet>;
+
+    fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap>;
 
     fn get_program_match_criteria(&self, _program: &Pubkey) -> ProgramCacheMatchCriteria {
         ProgramCacheMatchCriteria::NoCriteria

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -858,6 +858,7 @@ mod tests {
             transaction::{SanitizedTransaction, Transaction, TransactionError},
             transaction_context::TransactionContext,
         },
+        solana_vote::vote_account::VoteAccountsHashMap,
         std::{
             env,
             fs::{self, File},
@@ -919,6 +920,10 @@ mod tests {
 
         fn get_feature_set(&self) -> Arc<FeatureSet> {
             self.feature_set.clone()
+        }
+
+        fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+            None
         }
 
         fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -626,9 +626,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             program_cache_for_tx_batch,
             EnvironmentConfig::new(
                 blockhash,
+                callback.get_epoch_total_stake(),
+                callback.get_epoch_vote_accounts(),
                 callback.get_feature_set(),
                 lamports_per_signature,
-                callback.get_vote_accounts(),
                 sysvar_cache,
             ),
             log_collector.clone(),
@@ -923,7 +924,11 @@ mod tests {
             self.feature_set.clone()
         }
 
-        fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+        fn get_epoch_total_stake(&self) -> Option<u64> {
+            None
+        }
+
+        fn get_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
             None
         }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -628,6 +628,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 blockhash,
                 callback.get_feature_set(),
                 lamports_per_signature,
+                callback.get_vote_accounts(),
                 sysvar_cache,
             ),
             log_collector.clone(),

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -467,6 +467,7 @@ fn execute_fixture_as_instr(
         mock_bank.blockhash,
         mock_bank.feature_set.clone(),
         mock_bank.lamports_per_sginature,
+        None,
         sysvar_cache,
     );
 

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -465,9 +465,10 @@ fn execute_fixture_as_instr(
     let sysvar_cache = &batch_processor.sysvar_cache.read().unwrap();
     let env_config = EnvironmentConfig::new(
         mock_bank.blockhash,
+        None,
+        None,
         mock_bank.feature_set.clone(),
         mock_bank.lamports_per_sginature,
-        None,
         sysvar_cache,
     );
 

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -11,6 +11,7 @@ use {
         slot_hashes::Slot,
     },
     solana_svm::transaction_processing_callback::TransactionProcessingCallback,
+    solana_vote::vote_account::VoteAccountsHashMap,
     std::{cell::RefCell, cmp::Ordering, collections::HashMap, sync::Arc},
 };
 
@@ -67,6 +68,10 @@ impl TransactionProcessingCallback for MockBankCallback {
 
     fn get_feature_set(&self) -> Arc<FeatureSet> {
         self.feature_set.clone()
+    }
+
+    fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+        None
     }
 
     fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -70,7 +70,11 @@ impl TransactionProcessingCallback for MockBankCallback {
         self.feature_set.clone()
     }
 
-    fn get_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+    fn get_epoch_total_stake(&self) -> Option<u64> {
+        None
+    }
+
+    fn get_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
         None
     }
 


### PR DESCRIPTION
#### Problem
Currently, on-chain programs have no knowledge of the current epoch's stake and
how much active stake is delegated to a certain vote account.

If this data was available for querying by on-chain programs, it would unblock
many use cases, such as validator governance and secondary consensus mechanisms,
that were previously not possible on Solana.

Additionally, this would enable the Feature Gate program defined in
SIMD 0089 to tally vote account stake in
support for a pending feature gate.

#### Summary of Changes

- Introduce a new callback function to the SVM to retrieve the total epoch stake.
- Introduce another new callback function to the SVM to retrieve the list of cached
   vote accounts.
- Optionally require the cached total stake and list of vote accounts in the invoke
   context's `EnvironmentConfig`.
- Introduce a new syscall - `SyscallGetEpochStake` - that will use these fields on the
   invoke context to retrieve total epoch stake or a given vote account's epoch stake.

[SIMD 0133](https://github.com/solana-foundation/solana-improvement-documents/pull/133)

Feature Gate Tracking Issue: https://github.com/anza-xyz/agave/issues/884
