### PR TITLE
Make WindowService compare Duration's directly for metrics reporting

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -552,7 +552,8 @@ impl WindowService {
                         }
                     }
 
-                    if last_print.elapsed().as_secs() > 2 {
+                    const METRICS_INTERVAL: Duration = Duration::from_secs(2);
+                    if last_print.elapsed() > METRICS_INTERVAL {
                         metrics.report_metrics("blockstore-insert-shreds");
                         metrics = BlockstoreInsertionMetrics::default();
                         ws_metrics.report_metrics("recv-window-insert-shreds");


### PR DESCRIPTION
#### Problem
The previous code converted to seconds and compared against an integer. However, it use > instead of >=. The result is that despite the comparison being 2, the metrics was actually reported every 3 seconds. Note the timestamps in logs from this node:
```
[2024-05-02T00:00:03.932975060Z INFO  solana_metrics::metrics] datapoint: blockstore-insert-shreds ...
[2024-05-02T00:00:06.940056413Z INFO  solana_metrics::metrics] datapoint: blockstore-insert-shreds ...
[2024-05-02T00:00:09.942365278Z INFO  solana_metrics::metrics] datapoint: blockstore-insert-shreds ...
[2024-05-02T00:00:12.945235208Z INFO  solana_metrics::metrics] datapoint: blockstore-insert-shreds ...
[2024-05-02T00:00:15.945579823Z INFO  solana_metrics::metrics] datapoint: blockstore-insert-shreds ...
```

#### Summary of Changes
Declare a constant `Duration`, and compare `last_print.elapsed()` against that instead of manually pulling out the number of seconds.

NOTE: This change will adjust the reporting interval for these metrics from 3 to 2 seconds. This could make comparing metrics between versions kind of messy, I see two options:
a. Adjust `METRICS_INTERVAL` to be `Duration::from_secs(3)` to match existing behavior
b. BP this change to other branches to that they begin to report on 2-second instead of 3-second interval as well

My change as-is implies b. as I believe the intention was to have 2 second reporting interval. Also of note, there are a number of other places where we do the same things, such as here:
https://github.com/anza-xyz/agave/blob/b1b6b9d6312c8113a36e2f1f4883fbcfa466eb6d/core/src/sigverify_stage.rs#L445-L449