### PR TITLE
Skip reporting TPU sigverify stats if no packets received

### DIFF
--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -96,7 +96,12 @@ struct SigVerifierStats {
 }
 
 impl SigVerifierStats {
-    fn report(&self, name: &'static str) {
+    fn maybe_report(&self, name: &'static str) {
+        // No need to report a datapoint if no batches/packets received
+        if self.total_batches == 0 {
+            return;
+        }
+
         datapoint_info!(
             name,
             (
@@ -443,7 +448,7 @@ impl SigVerifyStage {
                         }
                     }
                     if last_print.elapsed().as_secs() > 2 {
-                        stats.report(metrics_name);
+                        stats.maybe_report(metrics_name);
                         stats = SigVerifierStats::default();
                         last_print = Instant::now();
                     }


### PR DESCRIPTION
#### Problem
No point in submitting datapoints that are empty, especially for nodes that are not leaders and should never receive TPU traffic