### PR TITLE
runtime/Optimize accounts loading (one pass)

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6735,6 +6735,17 @@ impl TransactionProcessingCallback for Bank {
             .ok()
     }
 
+    fn load_account_with(
+        &self,
+        pubkey: &Pubkey,
+        callback: impl for<'a> Fn(&'a AccountSharedData) -> bool,
+    ) -> Option<(AccountSharedData, Slot)> {
+        self.rc
+            .accounts
+            .accounts_db
+            .load_account_with(&self.ancestors, pubkey, callback)
+    }
+
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         self.rc
             .accounts

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -242,7 +242,7 @@ impl Bank {
         let source = SourceBuffer::new_checked(self, &config.source_buffer_address)?;
 
         // Attempt serialization first before modifying the bank.
-        let new_target_program_account = self.new_target_program_account(&target)?;
+        let mut new_target_program_account = self.new_target_program_account(&target)?;
         let new_target_program_data_account =
             self.new_target_program_data_account(&source, config.upgrade_authority_address)?;
 
@@ -267,6 +267,12 @@ impl Bank {
             &target.program_address,
             new_target_program_data_account.data(),
         )?;
+
+        // After successfully deployed the `Builtin` program, we need to mark
+        // the builtin program account as executable. This is required for
+        // transaction account loading, when "fake program account" optimization
+        // is disabled.
+        new_target_program_account.set_executable(true);
 
         // Calculate the lamports to burn.
         // The target program account will be replaced, so burn its lamports.

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7135,12 +7135,10 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         invocation_message.clone(),
         bank.last_blockhash(),
     );
+    // See comments below for Test buffer invocation.
     assert_eq!(
         bank.process_transaction(&transaction),
-        Err(TransactionError::InstructionError(
-            0,
-            InstructionError::InvalidAccountData
-        )),
+        Err(TransactionError::InvalidProgramForExecution),
     );
     {
         let program_cache = bank.transaction_processor.program_cache.read().unwrap();
@@ -7159,12 +7157,14 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     let instruction = Instruction::new_with_bytes(buffer_address, &[], Vec::new());
     let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
     let transaction = Transaction::new(&[&binding], message, bank.last_blockhash());
+    // This is a slightly change of behavior for this PR. In the old code, we
+    // short-circuit buffer account to fake it and mark it executable. So it
+    // passed program execution check but failed with `Err(InstructionError(0, InvalidAccountData))`.
+    // With this PR, we don't do that. The buffer account will NOT be executable. A different error is throw `Err(InvalidProgramForExecution)`.
+    // This will NOT break consensus fortunately! Changing to `Err(InvalidProgramForExecution)` won't affect bank hash!
     assert_eq!(
         bank.process_transaction(&transaction),
-        Err(TransactionError::InstructionError(
-            0,
-            InstructionError::InvalidAccountData,
-        )),
+        Err(TransactionError::InvalidProgramForExecution),
     );
     {
         let program_cache = bank.transaction_processor.program_cache.read().unwrap();

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1137,7 +1137,6 @@ mod tests {
         let fee_payer_rent_debit = 42;
 
         let mut error_metrics = TransactionErrorMetrics::default();
-        let loaded_programs = ProgramCacheForTxBatch::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1156,7 +1155,8 @@ mod tests {
             None,
             &FeatureSet::default(),
             &RentCollector::default(),
-            &loaded_programs,
+            &[],
+            &mut HashMap::default(),
         );
 
         let expected_rent_debits = {

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -11,7 +11,7 @@ use {
         account::{AccountSharedData, ReadableAccount},
         account_utils::StateMut,
         bpf_loader, bpf_loader_deprecated,
-        bpf_loader_upgradeable::{self, UpgradeableLoaderState},
+        bpf_loader_upgradeable::UpgradeableLoaderState,
         clock::Slot,
         instruction::InstructionError,
         loader_v4::{self, LoaderV4State, LoaderV4Status},
@@ -92,12 +92,6 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
     if bpf_loader::check_id(program_account.owner()) {
         return Some(ProgramAccountLoadResult::ProgramOfLoaderV2(program_account));
     }
-
-    assert!(
-        bpf_loader_upgradeable::check_id(program_account.owner()),
-        "unexpected program account owner {}",
-        program_account.owner(),
-    );
 
     if let Ok(UpgradeableLoaderState::Program {
         programdata_address,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -11,7 +11,7 @@ use {
         account::{AccountSharedData, ReadableAccount},
         account_utils::StateMut,
         bpf_loader, bpf_loader_deprecated,
-        bpf_loader_upgradeable::UpgradeableLoaderState,
+        bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::Slot,
         instruction::InstructionError,
         loader_v4::{self, LoaderV4State, LoaderV4Status},

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,10 +1,18 @@
-use solana_sdk::{account::AccountSharedData, pubkey::Pubkey};
+use solana_sdk::{account::AccountSharedData, clock::Slot, pubkey::Pubkey};
 
 /// Runtime callbacks for transaction processing.
 pub trait TransactionProcessingCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize>;
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
+
+    // If `callback` returns `true`, the account will be stored into read cache after loading.
+    // Otherwise, it will skip read cache.
+    fn load_account_with(
+        &self,
+        pubkey: &Pubkey,
+        callback: impl for<'a> Fn(&'a AccountSharedData) -> bool,
+    ) -> Option<(AccountSharedData, Slot)>;
 
     fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {}
 }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -192,6 +192,10 @@ fn deploy_program(name: String, mock_bank: &mut MockBankCallback) -> Pubkey {
     account_data.set_data(bincode::serialize(&state).unwrap());
     account_data.set_lamports(25);
     account_data.set_owner(bpf_loader_upgradeable::id());
+    // We are no longer faking executable accounts. Executable accounts will be
+    // loaded from accounts-db, which would require executable flag to be
+    // marked.
+    account_data.set_executable(true);
     mock_bank
         .account_shared_data
         .borrow_mut()

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -47,6 +47,15 @@ impl TransactionProcessingCallback for MockBankCallback {
         }
     }
 
+    fn load_account_with(
+        &self,
+        pubkey: &Pubkey,
+        _callback: impl for<'a> Fn(&'a AccountSharedData) -> bool,
+    ) -> Option<(AccountSharedData, Slot)> {
+        let account = self.account_shared_data.borrow().get(pubkey).cloned()?;
+        Some((account, 100))
+    }
+
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         self.account_shared_data.borrow().get(pubkey).cloned()
     }


### PR DESCRIPTION
#### Problem

During transaction execution, we load accounts twice - first during filtering program accounts, and second for loading the actual accounts before execution. And by default, loading program accounts will insert the loaded program accounts into read cache, which pollutes read cache unnecessarily. This is inefficient and can be optimized. 

This is an alternative idea for https://github.com/anza-xyz/agave/pull/1056 and https://github.com/anza-xyz/agave/pull/1180

#### Summary of Changes

- Add a new API for account-db `load_with()`, which takes a callback to indicate whether to insert the loaded account into `read_cache`.
- Update program account loads and transaction accounts loads to use the new API to do finer control on whether to insert the account into `read_cache` after loading.
- Implement one pass for loading the account. 
- Remove the filtering pass completely. 
- Reorder loading account before program cache replenish.

#### Performance Comparision
![image](https://github.com/anza-xyz/agave/assets/219428/993745c1-1cd0-4a6b-a5d6-71b664008078)

- account load time (top-left); prog_cache time (top-right), replay time (bottom)
- blue (this PR), red (master)

Account loading time increased, program cache time decreased. The decrease of program cache time is more than the increase of accounts loading time. Total replay time decreased. 





Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
