### PR TITLE
Simd 118: add recalculation method and use when booting from snapshot

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1653,6 +1653,15 @@ impl Bank {
             HashSet::default(),
         );
 
+        let (thread_pool, _thread_pool_time) = measure!(
+            ThreadPoolBuilder::new()
+                .thread_name(|i| format!("solBnkNewFlds{i:02}"))
+                .build()
+                .expect("new rayon threadpool"),
+            "thread_pool_creation",
+        );
+        bank.recalculate_partitioned_rewards(null_tracer(), &thread_pool);
+
         bank.finish_init(
             genesis_config,
             additional_builtins,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1637,7 +1637,7 @@ impl Bank {
             accounts_data_size_initial,
             accounts_data_size_delta_on_chain: AtomicI64::new(0),
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
-            epoch_reward_status: fields.epoch_reward_status,
+            epoch_reward_status: EpochRewardStatus::default(),
             transaction_processor: TransactionBatchProcessor::default(),
             check_program_modification_slot: false,
             // collector_fee_details is not serialized to snapshot

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1653,13 +1653,10 @@ impl Bank {
             HashSet::default(),
         );
 
-        let (thread_pool, _thread_pool_time) = measure!(
-            ThreadPoolBuilder::new()
-                .thread_name(|i| format!("solBnkNewFlds{i:02}"))
-                .build()
-                .expect("new rayon threadpool"),
-            "thread_pool_creation",
-        );
+        let thread_pool = ThreadPoolBuilder::new()
+            .thread_name(|i| format!("solBnkNewFlds{i:02}"))
+            .build()
+            .expect("new rayon threadpool");
         bank.recalculate_partitioned_rewards(null_tracer(), &thread_pool);
 
         bank.finish_init(

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1010,8 +1010,10 @@ mod tests {
         assert_eq!(expected_stake_rewards.len(), recalculated_rewards.len());
         compare_stake_rewards(&expected_stake_rewards, &recalculated_rewards);
 
-        // Advance to first distribution slot
-        let new_slot = bank.slot() + 1;
+        // Advance to first distribution block, ie. child block of the epoch
+        // boundary; slot is advanced 2 to demonstrate that distribution works
+        // on block-height, not slot
+        let new_slot = bank.slot() + 2;
         let bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), new_slot));
 
         let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -559,12 +559,7 @@ impl Bank {
         let stakes = self.stakes_cache.stakes();
         let reward_calculate_param = self.get_epoch_reward_calculate_param_info(&stakes);
 
-        let (
-            _,
-            StakeRewardCalculation {
-                mut stake_rewards, ..
-            },
-        ) = self.calculate_stake_vote_rewards(
+        let (_, StakeRewardCalculation { stake_rewards, .. }) = self.calculate_stake_vote_rewards(
             &reward_calculate_param,
             rewarded_epoch,
             point_value,
@@ -574,7 +569,7 @@ impl Bank {
         );
         drop(stakes);
         hash_rewards_into_partitions(
-            std::mem::take(&mut stake_rewards),
+            stake_rewards,
             &epoch_rewards_sysvar.parent_blockhash,
             epoch_rewards_sysvar.num_partitions as usize,
         )
@@ -634,7 +629,7 @@ mod tests {
 
     fn create_reward_bank(
         expected_num_delegations: usize,
-        rewards_per_block: u64,
+        stake_account_stores_per_block: u64,
     ) -> (Bank, Vec<Pubkey>, Vec<Pubkey>) {
         let validator_keypairs = (0..expected_num_delegations)
             .map(|_| ValidatorVoteKeypairs::new_rand())
@@ -653,7 +648,7 @@ mod tests {
         accounts_db_config.test_partitioned_epoch_rewards =
             TestPartitionedEpochRewards::PartitionedEpochRewardsConfigRewardBlocks {
                 reward_calculation_num_blocks: 1,
-                stake_account_stores_per_block: rewards_per_block,
+                stake_account_stores_per_block,
             };
 
         let bank = Bank::new_with_paths(

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -968,4 +968,147 @@ mod tests {
             expected_reward_info,
         );
     }
+
+    fn compare_stake_rewards(
+        expected_stake_rewards: &[StakeRewards],
+        received_stake_rewards: &[StakeRewards],
+    ) {
+        for (i, partition) in received_stake_rewards.iter().enumerate() {
+            let expected_partition = &expected_stake_rewards[i];
+            assert_eq!(partition.len(), expected_partition.len());
+            for reward in partition {
+                assert!(expected_partition.iter().any(|x| x == reward));
+            }
+        }
+    }
+
+    #[test]
+    fn test_recalculate_stake_rewards() {
+        let expected_num_delegations = 4;
+        let num_rewards_per_block = 2;
+        // Distribute 4 rewards over 2 blocks
+        let (bank, _, _) = create_reward_bank(expected_num_delegations, num_rewards_per_block);
+        let rewarded_epoch = bank.epoch();
+
+        // Advance to next epoch boundary to update EpochStakes
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        let bank = new_bank_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            &Pubkey::default(),
+            SLOTS_PER_EPOCH,
+        );
+
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        let mut rewards_metrics = RewardsMetrics::default();
+        let PartitionedRewardsCalculation {
+            stake_rewards_by_partition:
+                StakeRewardCalculationPartitioned {
+                    stake_rewards_by_partition: expected_stake_rewards,
+                    ..
+                },
+            ..
+        } = bank.calculate_rewards_for_partitioning(
+            rewarded_epoch,
+            null_tracer(),
+            &thread_pool,
+            &mut rewards_metrics,
+        );
+
+        let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
+        let recalculated_rewards =
+            bank.recalculate_stake_rewards(&epoch_rewards_sysvar, null_tracer(), &thread_pool);
+        assert_eq!(expected_stake_rewards.len(), recalculated_rewards.len());
+        compare_stake_rewards(&expected_stake_rewards, &recalculated_rewards);
+
+        // Advance to first distribution slot
+        let bank = new_bank_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            &Pubkey::default(),
+            SLOTS_PER_EPOCH + 1,
+        );
+
+        let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
+        let recalculated_rewards =
+            bank.recalculate_stake_rewards(&epoch_rewards_sysvar, null_tracer(), &thread_pool);
+        assert_eq!(expected_stake_rewards.len(), recalculated_rewards.len());
+        // First partition has already been distributed, so recalculation
+        // returns 0 rewards
+        assert_eq!(recalculated_rewards[0].len(), 0);
+        let starting_index = (bank.block_height() + 1
+            - epoch_rewards_sysvar.distribution_starting_block_height)
+            as usize;
+        compare_stake_rewards(
+            &expected_stake_rewards[starting_index..],
+            &recalculated_rewards[starting_index..],
+        );
+
+        // Advance to last distribution slot
+        let bank = new_bank_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            &Pubkey::default(),
+            SLOTS_PER_EPOCH + 2,
+        );
+
+        let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
+        assert!(!epoch_rewards_sysvar.active);
+        // Recalculation would panic, tested separately
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_recalculate_stake_rewards_distribution_complete() {
+        let expected_num_delegations = 2;
+        let num_rewards_per_block = 2;
+        // Distribute 2 rewards over 1 block
+        let (bank, _, _) = create_reward_bank(expected_num_delegations, num_rewards_per_block);
+        let rewarded_epoch = bank.epoch();
+
+        // Advance to next epoch boundary to update EpochStakes
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        let bank = new_bank_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            &Pubkey::default(),
+            SLOTS_PER_EPOCH,
+        );
+
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        let mut rewards_metrics = RewardsMetrics::default();
+        let PartitionedRewardsCalculation {
+            stake_rewards_by_partition:
+                StakeRewardCalculationPartitioned {
+                    stake_rewards_by_partition: expected_stake_rewards,
+                    ..
+                },
+            ..
+        } = bank.calculate_rewards_for_partitioning(
+            rewarded_epoch,
+            null_tracer(),
+            &thread_pool,
+            &mut rewards_metrics,
+        );
+
+        let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
+        let recalculated_rewards =
+            bank.recalculate_stake_rewards(&epoch_rewards_sysvar, null_tracer(), &thread_pool);
+        assert_eq!(expected_stake_rewards.len(), recalculated_rewards.len());
+        compare_stake_rewards(&expected_stake_rewards, &recalculated_rewards);
+
+        // Advance to first distribution slot
+        let bank = new_bank_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            &Pubkey::default(),
+            SLOTS_PER_EPOCH + 1,
+        );
+
+        let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
+        assert!(!epoch_rewards_sysvar.active);
+        // Should panic
+        let _recalculated_rewards =
+            bank.recalculate_stake_rewards(&epoch_rewards_sysvar, null_tracer(), &thread_pool);
+    }
 }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -538,8 +538,8 @@ impl Bank {
     }
 
     /// Returns a vector of partitioned stake rewards. StakeRewards are
-    /// recalculated active EpochRewards sysvar, vote accounts from EpochStakes,
-    /// and stake accounts from StakesCache.
+    /// recalculated from an active EpochRewards sysvar, vote accounts from
+    /// EpochStakes, and stake accounts from StakesCache.
     fn recalculate_stake_rewards(
         &self,
         epoch_rewards_sysvar: &EpochRewards,
@@ -559,6 +559,11 @@ impl Bank {
         let stakes = self.stakes_cache.stakes();
         let reward_calculate_param = self.get_epoch_reward_calculate_param_info(&stakes);
 
+        // On recalculation, only the `StakeRewardCalculation::stake_rewards`
+        // field is relevant. It is assumed that vote-account rewards have
+        // already been calculated and delivered, while
+        // `StakeRewardCalculation::total_rewards` only reflects rewards that
+        // have not yet been distributed.
         let (_, StakeRewardCalculation { stake_rewards, .. }) = self.calculate_stake_vote_rewards(
             &reward_calculate_param,
             rewarded_epoch,

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -62,7 +62,7 @@ impl Bank {
 
         let num_partitions = stake_rewards_by_partition.len() as u64;
 
-        self.set_epoch_reward_status_active(stake_rewards_by_partition);
+        self.set_epoch_reward_status_active(self.block_height(), stake_rewards_by_partition);
 
         // create EpochRewards sysvar that holds the balance of undistributed rewards with
         // (total_rewards, distributed_rewards, credit_start), total capital will increase by (total_rewards - distributed_rewards)

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -267,7 +267,7 @@ mod tests {
 
         let stake_rewards = hash_rewards_into_partitions(stake_rewards, &Hash::new(&[1; 32]), 2);
 
-        bank.set_epoch_reward_status_active(stake_rewards);
+        bank.set_epoch_reward_status_active(bank.block_height(), stake_rewards);
 
         bank.distribute_partitioned_epoch_rewards();
     }
@@ -290,7 +290,7 @@ mod tests {
             bank.epoch_schedule().slots_per_epoch as usize + 1,
         );
 
-        bank.set_epoch_reward_status_active(stake_rewards);
+        bank.set_epoch_reward_status_active(bank.block_height(), stake_rewards);
 
         bank.distribute_partitioned_epoch_rewards();
     }
@@ -300,7 +300,7 @@ mod tests {
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
         let mut bank = Bank::new_for_tests(&genesis_config);
 
-        bank.set_epoch_reward_status_active(vec![]);
+        bank.set_epoch_reward_status_active(bank.block_height(), vec![]);
 
         bank.distribute_partitioned_epoch_rewards();
     }
@@ -406,7 +406,7 @@ mod tests {
 
         let stake_rewards_bucket =
             hash_rewards_into_partitions(stake_rewards, &Hash::new(&[1; 32]), 100);
-        bank.set_epoch_reward_status_active(stake_rewards_bucket.clone());
+        bank.set_epoch_reward_status_active(bank.block_height(), stake_rewards_bucket.clone());
 
         // Test partitioned stores
         let mut total_rewards = 0;

--- a/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
@@ -109,7 +109,7 @@ mod tests {
         let stake_rewards_bucket =
             hash_rewards_into_partitions(stake_rewards, &Hash::new(&[1; 32]), 10);
 
-        bank.set_epoch_reward_status_active(stake_rewards_bucket.clone());
+        bank.set_epoch_reward_status_active(bank.block_height(), stake_rewards_bucket.clone());
 
         // This call should panic, i.e. 15 is out of the num_credit_blocks
         let _range = &stake_rewards_bucket[15];

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -152,10 +152,11 @@ impl Bank {
 
     pub(crate) fn set_epoch_reward_status_active(
         &mut self,
+        start_block_height: u64,
         stake_rewards_by_partition: Vec<StakeRewards>,
     ) {
         self.epoch_reward_status = EpochRewardStatus::Active(StartBlockHeightAndRewards {
-            start_block_height: self.block_height,
+            start_block_height,
             stake_rewards_by_partition: Arc::new(stake_rewards_by_partition),
         });
     }
@@ -292,7 +293,7 @@ mod tests {
             .map(|_| StakeReward::new_random())
             .collect::<Vec<_>>();
 
-        bank.set_epoch_reward_status_active(vec![stake_rewards]);
+        bank.set_epoch_reward_status_active(bank.block_height(), vec![stake_rewards]);
         assert!(bank.get_reward_interval() == RewardInterval::InsideInterval);
 
         bank.force_reward_interval_end_for_tests();

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -3,8 +3,7 @@ mod tests {
     use {
         crate::{
             bank::{
-                epoch_accounts_hash_utils, partitioned_epoch_rewards::StartBlockHeightAndRewards,
-                test_utils as bank_test_utils, Bank, EpochRewardStatus,
+                epoch_accounts_hash_utils, test_utils as bank_test_utils, Bank, EpochRewardStatus,
             },
             genesis_utils::activate_all_features,
             runtime_config::RuntimeConfig,
@@ -30,7 +29,6 @@ mod tests {
             accounts_hash::{AccountsDeltaHash, AccountsHash},
             accounts_index::AccountSecondaryIndexes,
             epoch_accounts_hash::EpochAccountsHash,
-            stake_rewards::StakeReward,
         },
         solana_sdk::{
             epoch_schedule::EpochSchedule,
@@ -335,195 +333,135 @@ mod tests {
     #[test]
     fn test_extra_fields_eof() {
         solana_logger::setup();
-        let sample_rewards = (0..2)
-            .map(|_| StakeReward::new_random())
-            .collect::<Vec<_>>();
-        for epoch_reward_status_active in [None, Some(vec![]), Some(vec![sample_rewards])] {
-            let (genesis_config, _) = create_genesis_config(500);
+        let (genesis_config, _) = create_genesis_config(500);
 
-            let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
-            bank0.squash();
-            let mut bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        bank0.squash();
+        let mut bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
 
-            add_root_and_flush_write_cache(&bank0);
-            bank.rc
-                .accounts
-                .accounts_db
-                .set_accounts_delta_hash(bank.slot(), AccountsDeltaHash(Hash::new_unique()));
-            bank.rc.accounts.accounts_db.set_accounts_hash(
-                bank.slot(),
-                (AccountsHash(Hash::new_unique()), u64::default()),
-            );
+        add_root_and_flush_write_cache(&bank0);
+        bank.rc
+            .accounts
+            .accounts_db
+            .set_accounts_delta_hash(bank.slot(), AccountsDeltaHash(Hash::new_unique()));
+        bank.rc.accounts.accounts_db.set_accounts_hash(
+            bank.slot(),
+            (AccountsHash(Hash::new_unique()), u64::default()),
+        );
 
-            // Set extra fields
-            bank.fee_rate_governor.lamports_per_signature = 7000;
+        // Set extra fields
+        bank.fee_rate_governor.lamports_per_signature = 7000;
 
-            if let Some(rewards) = epoch_reward_status_active.as_ref() {
-                assert_eq!(bank.block_height(), 1);
-                bank.set_epoch_reward_status_active(bank.block_height(), rewards.clone());
-            }
+        // Serialize
+        let snapshot_storages = bank.get_snapshot_storages(None);
+        let mut buf = vec![];
+        let mut writer = Cursor::new(&mut buf);
 
-            // Serialize
-            let snapshot_storages = bank.get_snapshot_storages(None);
-            let mut buf = vec![];
-            let mut writer = Cursor::new(&mut buf);
+        crate::serde_snapshot::bank_to_stream(
+            SerdeStyle::Newer,
+            &mut std::io::BufWriter::new(&mut writer),
+            &bank,
+            &get_storages_to_serialize(&snapshot_storages),
+        )
+        .unwrap();
 
-            crate::serde_snapshot::bank_to_stream(
-                SerdeStyle::Newer,
-                &mut std::io::BufWriter::new(&mut writer),
-                &bank,
-                &get_storages_to_serialize(&snapshot_storages),
-            )
-            .unwrap();
+        // Deserialize
+        let rdr = Cursor::new(&buf[..]);
+        let mut reader = std::io::BufReader::new(&buf[rdr.position() as usize..]);
+        let mut snapshot_streams = SnapshotStreams {
+            full_snapshot_stream: &mut reader,
+            incremental_snapshot_stream: None,
+        };
+        let (_accounts_dir, dbank_paths) = get_temp_accounts_paths(4).unwrap();
+        let copied_accounts = TempDir::new().unwrap();
+        let storage_and_next_append_vec_id =
+            copy_append_vecs(&bank.rc.accounts.accounts_db, copied_accounts.path()).unwrap();
+        let dbank = crate::serde_snapshot::bank_from_streams(
+            SerdeStyle::Newer,
+            &mut snapshot_streams,
+            &dbank_paths,
+            storage_and_next_append_vec_id,
+            &genesis_config,
+            &RuntimeConfig::default(),
+            None,
+            None,
+            AccountSecondaryIndexes::default(),
+            None,
+            AccountShrinkThreshold::default(),
+            false,
+            Some(solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
+            None,
+            Arc::default(),
+        )
+        .unwrap();
 
-            // Deserialize
-            let rdr = Cursor::new(&buf[..]);
-            let mut reader = std::io::BufReader::new(&buf[rdr.position() as usize..]);
-            let mut snapshot_streams = SnapshotStreams {
-                full_snapshot_stream: &mut reader,
-                incremental_snapshot_stream: None,
-            };
-            let (_accounts_dir, dbank_paths) = get_temp_accounts_paths(4).unwrap();
-            let copied_accounts = TempDir::new().unwrap();
-            let storage_and_next_append_vec_id =
-                copy_append_vecs(&bank.rc.accounts.accounts_db, copied_accounts.path()).unwrap();
-            let dbank = crate::serde_snapshot::bank_from_streams(
-                SerdeStyle::Newer,
-                &mut snapshot_streams,
-                &dbank_paths,
-                storage_and_next_append_vec_id,
-                &genesis_config,
-                &RuntimeConfig::default(),
-                None,
-                None,
-                AccountSecondaryIndexes::default(),
-                None,
-                AccountShrinkThreshold::default(),
-                false,
-                Some(solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
-                None,
-                Arc::default(),
-            )
-            .unwrap();
-
-            assert_eq!(
-                bank.fee_rate_governor.lamports_per_signature,
-                dbank.fee_rate_governor.lamports_per_signature
-            );
-
-            // assert epoch_reward_status is the same as the set epoch reward status
-            let epoch_reward_status = dbank
-                .get_epoch_reward_status_to_serialize()
-                .unwrap_or(&EpochRewardStatus::Inactive);
-            if let Some(rewards) = epoch_reward_status_active {
-                assert_matches!(epoch_reward_status, EpochRewardStatus::Active(_));
-                if let EpochRewardStatus::Active(StartBlockHeightAndRewards {
-                    start_block_height,
-                    ref stake_rewards_by_partition,
-                }) = epoch_reward_status
-                {
-                    assert_eq!(*start_block_height, 1);
-                    assert_eq!(&rewards[..], &stake_rewards_by_partition[..]);
-                } else {
-                    unreachable!("Epoch reward status should NOT be inactive.");
-                }
-            } else {
-                assert_matches!(epoch_reward_status, EpochRewardStatus::Inactive);
-            }
-        }
+        assert_eq!(
+            bank.fee_rate_governor.lamports_per_signature,
+            dbank.fee_rate_governor.lamports_per_signature
+        );
     }
 
     #[test]
     fn test_extra_fields_full_snapshot_archive() {
         solana_logger::setup();
 
-        let sample_rewards = (0..2)
-            .map(|_| StakeReward::new_random())
-            .collect::<Vec<_>>();
-        for epoch_reward_status_active in [None, Some(vec![]), Some(vec![sample_rewards])] {
-            let (mut genesis_config, _) = create_genesis_config(500);
-            activate_all_features(&mut genesis_config);
+        let (mut genesis_config, _) = create_genesis_config(500);
+        activate_all_features(&mut genesis_config);
 
-            let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
-            let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
-            while !bank.is_complete() {
-                bank.fill_bank_with_ticks_for_tests();
-            }
-
-            // Set extra field
-            bank.fee_rate_governor.lamports_per_signature = 7000;
-
-            if let Some(rewards) = epoch_reward_status_active.as_ref() {
-                assert_eq!(bank.block_height(), 1);
-                bank.set_epoch_reward_status_active(bank.block_height(), rewards.clone());
-            }
-
-            let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
-            let bank_snapshots_dir = TempDir::new().unwrap();
-            let full_snapshot_archives_dir = TempDir::new().unwrap();
-            let incremental_snapshot_archives_dir = TempDir::new().unwrap();
-
-            // Serialize
-            let snapshot_archive_info = snapshot_bank_utils::bank_to_full_snapshot_archive(
-                &bank_snapshots_dir,
-                &bank,
-                None,
-                full_snapshot_archives_dir.path(),
-                incremental_snapshot_archives_dir.path(),
-                ArchiveFormat::Tar,
-                NonZeroUsize::new(1).unwrap(),
-                NonZeroUsize::new(1).unwrap(),
-            )
-            .unwrap();
-
-            // Deserialize
-            let (dbank, _) = snapshot_bank_utils::bank_from_snapshot_archives(
-                &[accounts_dir],
-                bank_snapshots_dir.path(),
-                &snapshot_archive_info,
-                None,
-                &genesis_config,
-                &RuntimeConfig::default(),
-                None,
-                None,
-                AccountSecondaryIndexes::default(),
-                None,
-                AccountShrinkThreshold::default(),
-                false,
-                false,
-                false,
-                false,
-                Some(solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
-                None,
-                Arc::default(),
-            )
-            .unwrap();
-
-            assert_eq!(
-                bank.fee_rate_governor.lamports_per_signature,
-                dbank.fee_rate_governor.lamports_per_signature
-            );
-
-            // assert epoch_reward_status is the same as the set epoch reward status
-            let epoch_reward_status = dbank
-                .get_epoch_reward_status_to_serialize()
-                .unwrap_or(&EpochRewardStatus::Inactive);
-            if let Some(rewards) = epoch_reward_status_active {
-                assert_matches!(epoch_reward_status, EpochRewardStatus::Active(_));
-                if let EpochRewardStatus::Active(StartBlockHeightAndRewards {
-                    start_block_height,
-                    ref stake_rewards_by_partition,
-                }) = epoch_reward_status
-                {
-                    assert_eq!(*start_block_height, 1);
-                    assert_eq!(&rewards[..], &stake_rewards_by_partition[..]);
-                } else {
-                    unreachable!("Epoch reward status should NOT be inactive.");
-                }
-            } else {
-                assert_matches!(epoch_reward_status, EpochRewardStatus::Inactive);
-            }
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        while !bank.is_complete() {
+            bank.fill_bank_with_ticks_for_tests();
         }
+
+        // Set extra field
+        bank.fee_rate_governor.lamports_per_signature = 7000;
+
+        let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
+        let bank_snapshots_dir = TempDir::new().unwrap();
+        let full_snapshot_archives_dir = TempDir::new().unwrap();
+        let incremental_snapshot_archives_dir = TempDir::new().unwrap();
+
+        // Serialize
+        let snapshot_archive_info = snapshot_bank_utils::bank_to_full_snapshot_archive(
+            &bank_snapshots_dir,
+            &bank,
+            None,
+            full_snapshot_archives_dir.path(),
+            incremental_snapshot_archives_dir.path(),
+            ArchiveFormat::Tar,
+            NonZeroUsize::new(1).unwrap(),
+            NonZeroUsize::new(1).unwrap(),
+        )
+        .unwrap();
+
+        // Deserialize
+        let (dbank, _) = snapshot_bank_utils::bank_from_snapshot_archives(
+            &[accounts_dir],
+            bank_snapshots_dir.path(),
+            &snapshot_archive_info,
+            None,
+            &genesis_config,
+            &RuntimeConfig::default(),
+            None,
+            None,
+            AccountSecondaryIndexes::default(),
+            None,
+            AccountShrinkThreshold::default(),
+            false,
+            false,
+            false,
+            false,
+            Some(solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
+            None,
+            Arc::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            bank.fee_rate_governor.lamports_per_signature,
+            dbank.fee_rate_governor.lamports_per_signature
+        );
     }
 
     #[test]

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -360,7 +360,7 @@ mod tests {
 
             if let Some(rewards) = epoch_reward_status_active.as_ref() {
                 assert_eq!(bank.block_height(), 1);
-                bank.set_epoch_reward_status_active(rewards.clone());
+                bank.set_epoch_reward_status_active(bank.block_height(), rewards.clone());
             }
 
             // Serialize
@@ -455,7 +455,7 @@ mod tests {
 
             if let Some(rewards) = epoch_reward_status_active.as_ref() {
                 assert_eq!(bank.block_height(), 1);
-                bank.set_epoch_reward_status_active(rewards.clone());
+                bank.set_epoch_reward_status_active(bank.block_height(), rewards.clone());
             }
 
             let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();


### PR DESCRIPTION
#### Problem
As per SIMD-0118, partitioned rewards should be recalculated on boot from snapshot. Partition and initial calculation info is available in the EpochRewards sysvar, and as of #1138, `Bank::get_epoch_reward_calculate_param_info` provides vote-account `credits_observed` from the EpochStakes cache. This is everything needed to recalculate undistributed stake-reward partitions.

#### Summary of Changes
Add `Bank::recalculate_partitioned_rewards` method. Recalculated partitions could differ from the original calculation in two ways:
1. Block partitions that have already been rewarded will be empty. This is because stake-account state is pulled from the StakesCache, which is modified as distribution occurs. (Specifically, stake `credits_observed` are updated to the new amount, so subsequent calculations determine no distribution needed.) Since only upcoming partitions need action (distribution), this is fine.
2. Rewards within a particular partition may appear in a different order. The runtime makes no guarantees about reward order, either in actual account updates or in block metadata storage, so this is fine.

Use recalculate_partitioned_rewards in `Bank::new_from_fields` to populate `Bank::epoch_reward_status`
