### PR TITLE
[zk-sdk] Rename and remove `transcript` functions for new zk-sdk structure

### DIFF
--- a/zk-sdk/src/range_proof/inner_product.rs
+++ b/zk-sdk/src/range_proof/inner_product.rs
@@ -75,7 +75,7 @@ impl InnerProductProof {
             return Err(RangeProofGenerationError::InvalidBitSize);
         }
 
-        transcript.innerproduct_domain_separator(n as u64);
+        transcript.inner_product_proof_domain_separator(n as u64);
 
         let lg_n = n.next_power_of_two().trailing_zeros() as usize;
         let mut L_vec = Vec::with_capacity(lg_n);
@@ -233,7 +233,7 @@ impl InnerProductProof {
             return Err(RangeProofVerificationError::InvalidBitSize);
         }
 
-        transcript.innerproduct_domain_separator(n as u64);
+        transcript.inner_product_proof_domain_separator(n as u64);
 
         // 1. Recompute x_k,...,x_1 based on the proof transcript
 

--- a/zk-sdk/src/range_proof/mod.rs
+++ b/zk-sdk/src/range_proof/mod.rs
@@ -101,6 +101,8 @@ impl RangeProof {
         let bp_gens = RangeProofGens::new(nm)
             .map_err(|_| RangeProofGenerationError::MaximumGeneratorLengthExceeded)?;
 
+        transcript.range_proof_domain_separator(nm as u64);
+
         // bit-decompose values and generate their Pedersen vector commitment
         let a_blinding = Scalar::random(&mut OsRng);
         let mut A = a_blinding * &(*H);
@@ -275,6 +277,8 @@ impl RangeProof {
         if !nm.is_power_of_two() {
             return Err(RangeProofVerificationError::InvalidBitSize);
         }
+
+        transcript.range_proof_domain_separator(nm as u64);
 
         // append proof data to transcript and derive appropriate challenge scalars
         transcript.validate_and_append_point(b"A", &self.A)?;

--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
@@ -56,7 +56,7 @@ impl BatchedGroupedCiphertext2HandlesValidityProof {
         opening_hi: &PedersenOpening,
         transcript: &mut Transcript,
     ) -> Self {
-        transcript.batched_grouped_ciphertext_validity_proof_domain_separator();
+        transcript.batched_grouped_ciphertext_validity_proof_domain_separator(2);
 
         let t = transcript.challenge_scalar(b"t");
 
@@ -90,7 +90,7 @@ impl BatchedGroupedCiphertext2HandlesValidityProof {
         auditor_handle_hi: &DecryptHandle,
         transcript: &mut Transcript,
     ) -> Result<(), ValidityProofVerificationError> {
-        transcript.batched_grouped_ciphertext_validity_proof_domain_separator();
+        transcript.batched_grouped_ciphertext_validity_proof_domain_separator(2);
 
         let t = transcript.challenge_scalar(b"t");
 

--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
@@ -57,7 +57,7 @@ impl BatchedGroupedCiphertext3HandlesValidityProof {
         opening_hi: &PedersenOpening,
         transcript: &mut Transcript,
     ) -> Self {
-        transcript.batched_grouped_ciphertext_validity_proof_domain_separator();
+        transcript.batched_grouped_ciphertext_validity_proof_domain_separator(3);
 
         let t = transcript.challenge_scalar(b"t");
 
@@ -97,7 +97,7 @@ impl BatchedGroupedCiphertext3HandlesValidityProof {
         auditor_handle_hi: &DecryptHandle,
         transcript: &mut Transcript,
     ) -> Result<(), ValidityProofVerificationError> {
-        transcript.batched_grouped_ciphertext_validity_proof_domain_separator();
+        transcript.batched_grouped_ciphertext_validity_proof_domain_separator(3);
 
         let t = transcript.challenge_scalar(b"t");
 

--- a/zk-sdk/src/sigma_proofs/ciphertext_ciphertext_equality.rs
+++ b/zk-sdk/src/sigma_proofs/ciphertext_ciphertext_equality.rs
@@ -74,7 +74,7 @@ impl CiphertextCiphertextEqualityProof {
         amount: u64,
         transcript: &mut Transcript,
     ) -> Self {
-        transcript.equality_proof_domain_separator();
+        transcript.ciphertext_ciphertext_equality_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_source = source_keypair.pubkey().get_point();
@@ -141,7 +141,7 @@ impl CiphertextCiphertextEqualityProof {
         destination_ciphertext: &ElGamalCiphertext,
         transcript: &mut Transcript,
     ) -> Result<(), EqualityProofVerificationError> {
-        transcript.equality_proof_domain_separator();
+        transcript.ciphertext_ciphertext_equality_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_source = source_pubkey.get_point();

--- a/zk-sdk/src/sigma_proofs/ciphertext_commitment_equality.rs
+++ b/zk-sdk/src/sigma_proofs/ciphertext_commitment_equality.rs
@@ -78,7 +78,7 @@ impl CiphertextCommitmentEqualityProof {
         amount: u64,
         transcript: &mut Transcript,
     ) -> Self {
-        transcript.equality_proof_domain_separator();
+        transcript.ciphertext_commitment_equality_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_source = source_keypair.pubkey().get_point();
@@ -139,7 +139,7 @@ impl CiphertextCommitmentEqualityProof {
         destination_commitment: &PedersenCommitment,
         transcript: &mut Transcript,
     ) -> Result<(), EqualityProofVerificationError> {
-        transcript.equality_proof_domain_separator();
+        transcript.ciphertext_commitment_equality_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_source = source_pubkey.get_point();

--- a/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_2.rs
@@ -77,7 +77,7 @@ impl GroupedCiphertext2HandlesValidityProof {
         opening: &PedersenOpening,
         transcript: &mut Transcript,
     ) -> Self {
-        transcript.grouped_ciphertext_validity_proof_domain_separator();
+        transcript.grouped_ciphertext_validity_proof_domain_separator(2);
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_dest = destination_pubkey.get_point();
@@ -135,7 +135,7 @@ impl GroupedCiphertext2HandlesValidityProof {
         auditor_handle: &DecryptHandle,
         transcript: &mut Transcript,
     ) -> Result<(), ValidityProofVerificationError> {
-        transcript.grouped_ciphertext_validity_proof_domain_separator();
+        transcript.grouped_ciphertext_validity_proof_domain_separator(2);
 
         // include Y_0, Y_1, Y_2 to transcript and extract challenges
         transcript.validate_and_append_point(b"Y_0", &self.Y_0)?;

--- a/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_3.rs
@@ -84,7 +84,7 @@ impl GroupedCiphertext3HandlesValidityProof {
         opening: &PedersenOpening,
         transcript: &mut Transcript,
     ) -> Self {
-        transcript.grouped_ciphertext_validity_proof_domain_separator();
+        transcript.grouped_ciphertext_validity_proof_domain_separator(3);
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_source = source_pubkey.get_point();
@@ -150,7 +150,7 @@ impl GroupedCiphertext3HandlesValidityProof {
         auditor_handle: &DecryptHandle,
         transcript: &mut Transcript,
     ) -> Result<(), ValidityProofVerificationError> {
-        transcript.grouped_ciphertext_validity_proof_domain_separator();
+        transcript.grouped_ciphertext_validity_proof_domain_separator(3);
 
         // include `Y_0`, `Y_1`, `Y_2` to transcript and extract challenges
         transcript.validate_and_append_point(b"Y_0", &self.Y_0)?;

--- a/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
+++ b/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
@@ -124,6 +124,7 @@ impl PercentageWithCapProof {
         max_value: u64,
         transcript: &mut Transcript,
     ) -> Self {
+        transcript.percentage_with_cap_proof_domain_separator();
         let mut transcript_percentage_above_max = transcript.clone();
         let mut transcript_percentage_below_max = transcript.clone();
 
@@ -343,6 +344,8 @@ impl PercentageWithCapProof {
         max_value: u64,
         transcript: &mut Transcript,
     ) -> Result<(), PercentageWithCapProofVerificationError> {
+        transcript.percentage_with_cap_proof_domain_separator();
+
         // extract the relevant scalar and Ristretto points from the input
         let m = Scalar::from(max_value);
 

--- a/zk-sdk/src/sigma_proofs/zero_ciphertext.rs
+++ b/zk-sdk/src/sigma_proofs/zero_ciphertext.rs
@@ -66,7 +66,7 @@ impl ZeroCiphertextProof {
         ciphertext: &ElGamalCiphertext,
         transcript: &mut Transcript,
     ) -> Self {
-        transcript.zero_balance_proof_domain_separator();
+        transcript.zero_ciphertext_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the input
         let P = elgamal_keypair.pubkey().get_point();
@@ -105,7 +105,7 @@ impl ZeroCiphertextProof {
         ciphertext: &ElGamalCiphertext,
         transcript: &mut Transcript,
     ) -> Result<(), ZeroCiphertextProofVerificationError> {
-        transcript.zero_balance_proof_domain_separator();
+        transcript.zero_ciphertext_proof_domain_separator();
 
         // extract the relevant scalar and Ristretto points from the input
         let P = elgamal_pubkey.get_point();

--- a/zk-sdk/src/transcript.rs
+++ b/zk-sdk/src/transcript.rs
@@ -11,9 +11,6 @@ pub trait TranscriptProtocol {
     /// Append a domain separator for a length-`n` inner product proof.
     fn inner_product_proof_domain_separator(&mut self, n: u64);
 
-    /// Append a domain separator for close account proof.
-    fn close_account_proof_domain_separator(&mut self);
-
     /// Append a domain separator for withdraw proof.
     fn withdraw_proof_domain_separator(&mut self);
 
@@ -65,10 +62,6 @@ impl TranscriptProtocol for Transcript {
     fn inner_product_proof_domain_separator(&mut self, n: u64) {
         self.append_message(b"dom-sep", b"inner-product");
         self.append_u64(b"n", n);
-    }
-
-    fn close_account_proof_domain_separator(&mut self) {
-        self.append_message(b"dom-sep", b"CloseAccountProof");
     }
 
     fn withdraw_proof_domain_separator(&mut self) {

--- a/zk-sdk/src/transcript.rs
+++ b/zk-sdk/src/transcript.rs
@@ -11,12 +11,6 @@ pub trait TranscriptProtocol {
     /// Append a domain separator for a length-`n` inner product proof.
     fn inner_product_proof_domain_separator(&mut self, n: u64);
 
-    /// Append a domain separator for withdraw proof.
-    fn withdraw_proof_domain_separator(&mut self);
-
-    /// Append a domain separator for transfer proof.
-    fn transfer_proof_domain_separator(&mut self);
-
     /// Append a `scalar` with the given `label`.
     fn append_scalar(&mut self, label: &'static [u8], scalar: &Scalar);
 
@@ -62,14 +56,6 @@ impl TranscriptProtocol for Transcript {
     fn inner_product_proof_domain_separator(&mut self, n: u64) {
         self.append_message(b"dom-sep", b"inner-product");
         self.append_u64(b"n", n);
-    }
-
-    fn withdraw_proof_domain_separator(&mut self) {
-        self.append_message(b"dom-sep", b"WithdrawProof");
-    }
-
-    fn transfer_proof_domain_separator(&mut self) {
-        self.append_message(b"dom-sep", b"TransferProof");
     }
 
     fn append_scalar(&mut self, label: &'static [u8], scalar: &Scalar) {

--- a/zk-sdk/src/transcript.rs
+++ b/zk-sdk/src/transcript.rs
@@ -5,16 +5,11 @@ use {
 };
 
 pub trait TranscriptProtocol {
-    /// Append a domain separator for an `n`-bit rangeproof for ElGamalKeypair
-    /// ciphertext using a decryption key
-    fn rangeproof_from_key_domain_separator(&mut self, n: u64);
-
-    /// Append a domain separator for an `n`-bit rangeproof for ElGamalKeypair
-    /// ciphertext using an opening
-    fn rangeproof_from_opening_domain_separator(&mut self, n: u64);
+    /// Append a domain separator for an `n`-bit range proof
+    fn range_proof_domain_separator(&mut self, n: u64);
 
     /// Append a domain separator for a length-`n` inner product proof.
-    fn innerproduct_domain_separator(&mut self, n: u64);
+    fn inner_product_proof_domain_separator(&mut self, n: u64);
 
     /// Append a domain separator for close account proof.
     fn close_account_proof_domain_separator(&mut self);
@@ -62,18 +57,13 @@ pub trait TranscriptProtocol {
 }
 
 impl TranscriptProtocol for Transcript {
-    fn rangeproof_from_key_domain_separator(&mut self, n: u64) {
-        self.append_message(b"dom-sep", b"rangeproof from opening v1");
+    fn range_proof_domain_separator(&mut self, n: u64) {
+        self.append_message(b"dom-sep", b"range-proof");
         self.append_u64(b"n", n);
     }
 
-    fn rangeproof_from_opening_domain_separator(&mut self, n: u64) {
-        self.append_message(b"dom-sep", b"rangeproof from opening v1");
-        self.append_u64(b"n", n);
-    }
-
-    fn innerproduct_domain_separator(&mut self, n: u64) {
-        self.append_message(b"dom-sep", b"ipp v1");
+    fn inner_product_proof_domain_separator(&mut self, n: u64) {
+        self.append_message(b"dom-sep", b"inner-product");
         self.append_u64(b"n", n);
     }
 

--- a/zk-sdk/src/transcript.rs
+++ b/zk-sdk/src/transcript.rs
@@ -23,8 +23,8 @@ pub trait TranscriptProtocol {
     /// Append a domain separator for ciphertext-commitment equality proof.
     fn ciphertext_commitment_equality_proof_domain_separator(&mut self);
 
-    /// Append a domain separator for zero-balance proof.
-    fn zero_balance_proof_domain_separator(&mut self);
+    /// Append a domain separator for zero-ciphertext proof.
+    fn zero_ciphertext_proof_domain_separator(&mut self);
 
     /// Append a domain separator for grouped ciphertext validity proof.
     fn grouped_ciphertext_validity_proof_domain_separator(&mut self);
@@ -97,8 +97,8 @@ impl TranscriptProtocol for Transcript {
         self.append_message(b"dom-sep", b"ciphertext-commitment-equality-proof")
     }
 
-    fn zero_balance_proof_domain_separator(&mut self) {
-        self.append_message(b"dom-sep", b"zero-balance-proof")
+    fn zero_ciphertext_proof_domain_separator(&mut self) {
+        self.append_message(b"dom-sep", b"zero-ciphertext-proof")
     }
 
     fn grouped_ciphertext_validity_proof_domain_separator(&mut self) {

--- a/zk-sdk/src/transcript.rs
+++ b/zk-sdk/src/transcript.rs
@@ -17,8 +17,11 @@ pub trait TranscriptProtocol {
     /// Append a `point` with the given `label`.
     fn append_point(&mut self, label: &'static [u8], point: &CompressedRistretto);
 
-    /// Append a domain separator for equality proof.
-    fn equality_proof_domain_separator(&mut self);
+    /// Append a domain separator for ciphertext-ciphertext equality proof.
+    fn ciphertext_ciphertext_equality_proof_domain_separator(&mut self);
+
+    /// Append a domain separator for ciphertext-commitment equality proof.
+    fn ciphertext_commitment_equality_proof_domain_separator(&mut self);
 
     /// Append a domain separator for zero-balance proof.
     fn zero_balance_proof_domain_separator(&mut self);
@@ -86,8 +89,12 @@ impl TranscriptProtocol for Transcript {
         Scalar::from_bytes_mod_order_wide(&buf)
     }
 
-    fn equality_proof_domain_separator(&mut self) {
-        self.append_message(b"dom-sep", b"equality-proof")
+    fn ciphertext_ciphertext_equality_proof_domain_separator(&mut self) {
+        self.append_message(b"dom-sep", b"ciphertext-ciphertext-equality-proof")
+    }
+
+    fn ciphertext_commitment_equality_proof_domain_separator(&mut self) {
+        self.append_message(b"dom-sep", b"ciphertext-commitment-equality-proof")
     }
 
     fn zero_balance_proof_domain_separator(&mut self) {

--- a/zk-sdk/src/transcript.rs
+++ b/zk-sdk/src/transcript.rs
@@ -27,10 +27,10 @@ pub trait TranscriptProtocol {
     fn zero_ciphertext_proof_domain_separator(&mut self);
 
     /// Append a domain separator for grouped ciphertext validity proof.
-    fn grouped_ciphertext_validity_proof_domain_separator(&mut self);
+    fn grouped_ciphertext_validity_proof_domain_separator(&mut self, handles: u64);
 
     /// Append a domain separator for batched grouped ciphertext validity proof.
-    fn batched_grouped_ciphertext_validity_proof_domain_separator(&mut self);
+    fn batched_grouped_ciphertext_validity_proof_domain_separator(&mut self, handles: u64);
 
     /// Append a domain separator for fee sigma proof.
     fn fee_sigma_proof_domain_separator(&mut self);
@@ -101,12 +101,14 @@ impl TranscriptProtocol for Transcript {
         self.append_message(b"dom-sep", b"zero-ciphertext-proof")
     }
 
-    fn grouped_ciphertext_validity_proof_domain_separator(&mut self) {
-        self.append_message(b"dom-sep", b"validity-proof")
+    fn grouped_ciphertext_validity_proof_domain_separator(&mut self, handles: u64) {
+        self.append_message(b"dom-sep", b"validity-proof");
+        self.append_u64(b"handles", handles);
     }
 
-    fn batched_grouped_ciphertext_validity_proof_domain_separator(&mut self) {
-        self.append_message(b"dom-sep", b"batched-validity-proof")
+    fn batched_grouped_ciphertext_validity_proof_domain_separator(&mut self, handles: u64) {
+        self.append_message(b"dom-sep", b"batched-validity-proof");
+        self.append_u64(b"handles", handles);
     }
 
     fn fee_sigma_proof_domain_separator(&mut self) {

--- a/zk-sdk/src/transcript.rs
+++ b/zk-sdk/src/transcript.rs
@@ -32,8 +32,8 @@ pub trait TranscriptProtocol {
     /// Append a domain separator for batched grouped ciphertext validity proof.
     fn batched_grouped_ciphertext_validity_proof_domain_separator(&mut self, handles: u64);
 
-    /// Append a domain separator for fee sigma proof.
-    fn fee_sigma_proof_domain_separator(&mut self);
+    /// Append a domain separator for percentage with cap proof.
+    fn percentage_with_cap_proof_domain_separator(&mut self);
 
     /// Append a domain separator for public-key proof.
     fn pubkey_proof_domain_separator(&mut self);
@@ -111,8 +111,8 @@ impl TranscriptProtocol for Transcript {
         self.append_u64(b"handles", handles);
     }
 
-    fn fee_sigma_proof_domain_separator(&mut self) {
-        self.append_message(b"dom-sep", b"fee-sigma-proof")
+    fn percentage_with_cap_proof_domain_separator(&mut self) {
+        self.append_message(b"dom-sep", b"percentage-with-cap-proof")
     }
 
     fn pubkey_proof_domain_separator(&mut self) {


### PR DESCRIPTION
#### Problem
This is a little embarrassing, but the `transcript` module contains very outdated functions that we don't really use in the sdk. In addition, we need to update it for https://github.com/anza-xyz/agave/issues/671.

#### Summary of Changes
[7fd7a57](https://github.com/anza-xyz/agave/pull/1160/commits/7fd7a57478c157ca49afb772bbde2dbae334f895): There were two domain separator functions for range proof as a relic of the design of zk-tokens way back when the project first started. These functions are not used and were never really removed. A more embarrassing fact is that a domain separator function dedicated for the current range proof does not exist and is not used. Domain separation is only used as an additional safety measure and the existing range proof construction should be fine. However, we should definitely add a dedicated domain separator for range proof, so I removed the two unused functions and added one for the current range proof. I also updated `innerproduct_domain_separator` to `inner_product_proof_domain_separator`.

[8a3dc39](https://github.com/anza-xyz/agave/pull/1160/commits/8a3dc391bc54a2a98bace42aa552809e5a49cc5a): Close account proof does not exist any more, so it was removed...

[fc0edb9](https://github.com/anza-xyz/agave/pull/1160/commits/fc0edb969ba99a8b94c17e206f3eb073e68f275f): Withdraw and transfer proofs are to be removed, according to https://github.com/anza-xyz/agave/issues/671, so their domain separator functions were removed.

[5fde079](https://github.com/anza-xyz/agave/pull/1160/commits/5fde07965ef7e2ba7350aee28b1661f1558011e0): Divided up equality proof domain separator functions for the `ciphertext-ciphertext` and `ciphertext-commitment` cases.

[3851aed](https://github.com/anza-xyz/agave/pull/1160/commits/3851aed8c87f1303b88cb59393b439f91198e2fd): Renamed `zero_balance_proof_domain_separator` to `zero_ciphertext_proof_domain_separator`.

[0bf9f18](https://github.com/anza-xyz/agave/pull/1160/commits/0bf9f18039c04283f03515c676685b59890911ae): Since there are now ciphertext validity proofs for both 2 and 3 handles, I modified the domain separator function to take in the number of handles as a paramter.

[2e68f2d](https://github.com/anza-xyz/agave/pull/1160/commits/2e68f2d731d727590cd764361078c146ec1b7efb): Renamed `fee_sigma_proof_domain_separator` to `percentage_with_cap_proof_domain_separator`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
