### PR TITLE
clippy: cloned()

### DIFF
--- a/bucket_map/src/restart.rs
+++ b/bucket_map/src/restart.rs
@@ -221,7 +221,7 @@ impl Restart {
                     paths.remove(&id)
                 });
                 RestartableBucket {
-                    restart: restart.map(Arc::clone),
+                    restart: restart.cloned(),
                     index,
                     path,
                 }


### PR DESCRIPTION
Rust v1.78.0 was released. There are new clippy lints that need to be addressed before we can upgrade. Here's one:

```
error: you are explicitly cloning with `.map()`
   --> bucket_map/src/restart.rs:224:30
    |
224 |                     restart: restart.map(Arc::clone),
    |                              ^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `restart.cloned()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone
```