### PR TITLE
clippy: clone_from()

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -976,7 +976,7 @@ mod tests {
                 });
 
                 // this was wiped out by the last call to batch_insert..., so recreate it.
-                hashed = hashed_raw.clone();
+                hashed.clone_from(&hashed_raw);
                 let mut duplicates = Vec::default();
                 if reuse_type == 0 {
                     Bucket::<u64>::batch_insert_non_duplicates_reusing_file(

--- a/cargo-registry/src/crate_handler.rs
+++ b/cargo-registry/src/crate_handler.rs
@@ -339,7 +339,7 @@ impl UnpackedCrate {
         Program::from(self).deploy(client, signer)?;
 
         let mut entry: IndexEntry = self.meta.clone().into();
-        entry.cksum = self.cksum.clone();
+        entry.cksum.clone_from(&self.cksum);
         index.insert_entry(entry)?;
 
         info!("Successfully deployed the program");

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1340,7 +1340,7 @@ pub fn process_show_block_production(
         let pubkey = format_labeled_address(pubkey, &config.address_labels);
         for slot_index in leader_slots.iter() {
             if *slot_index >= start_slot_index && *slot_index <= end_slot_index {
-                leader_per_slot_index[*slot_index - start_slot_index] = pubkey.clone();
+                leader_per_slot_index[*slot_index - start_slot_index].clone_from(&pubkey);
             }
         }
     }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2830,8 +2830,9 @@ fn send_deploy_messages(
                         // changing the instruction data for a compute budget
                         // instruction.
                         assert_eq!(msg.program_id(ix_index), Some(&compute_budget::id()));
-                        msg.instructions[ix_index].data =
-                            message.instructions[ix_index].data.clone();
+                        msg.instructions[ix_index]
+                            .data
+                            .clone_from(&message.instructions[ix_index].data);
                     }
                 }
             }

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -65,7 +65,7 @@ fn full_battery_tests(
     let json_rpc_url = test_validator.rpc_url();
 
     let mut config_payer = CliConfig::recent_for_tests();
-    config_payer.json_rpc_url = json_rpc_url.clone();
+    config_payer.json_rpc_url.clone_from(&json_rpc_url);
     let payer = Keypair::new();
     config_payer.signers = vec![&payer];
 
@@ -146,7 +146,7 @@ fn full_battery_tests(
     };
 
     // New nonce
-    config_payer.signers = authorized_signers.clone();
+    config_payer.signers.clone_from(&authorized_signers);
     config_payer.command = CliCommand::NewNonce {
         nonce_account,
         nonce_authority: index,

--- a/ledger/src/rooted_slot_iterator.rs
+++ b/ledger/src/rooted_slot_iterator.rs
@@ -57,7 +57,7 @@ impl<'a> Iterator for RootedSlotIterator<'a> {
             .unwrap_or(None);
 
         if let Some(ref slot_meta) = slot_meta {
-            self.next_slots = slot_meta.next_slots.clone();
+            self.next_slots.clone_from(&slot_meta.next_slots);
         }
 
         if slot_meta.is_none() && slot_skipped {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2135,7 +2135,10 @@ fn test_hard_fork_invalidates_tower() {
         Some(&hard_forks),
     );
 
-    validator_a_info.config.new_hard_forks = hard_fork_slots.clone();
+    validator_a_info
+        .config
+        .new_hard_forks
+        .clone_from(&hard_fork_slots);
     validator_a_info.config.wait_for_supermajority = Some(hard_fork_slot);
     validator_a_info.config.expected_shred_version = Some(expected_shred_version);
 
@@ -4775,8 +4778,10 @@ fn test_duplicate_with_pruned_ancestor() {
     // Make sure we don't send duplicate votes
     majority_validator_info.config.wait_to_vote_slot = Some(fork_slot + fork_length);
     // Fix the leader schedule so we can produce blocks
-    majority_validator_info.config.fixed_leader_schedule =
-        minority_validator_info.config.fixed_leader_schedule.clone();
+    majority_validator_info
+        .config
+        .fixed_leader_schedule
+        .clone_from(&minority_validator_info.config.fixed_leader_schedule);
     cluster.restart_node(
         &majority_pubkey,
         majority_validator_info,

--- a/sdk/program/src/program_option.rs
+++ b/sdk/program/src/program_option.rs
@@ -874,7 +874,7 @@ impl<T: Clone> Clone for COption<T> {
     fn clone_from(&mut self, source: &Self) {
         match (self, source) {
             (COption::Some(to), COption::Some(from)) => to.clone_from(from),
-            (to, from) => *to = from.clone(),
+            (to, from) => to.clone_from(from),
         }
     }
 }

--- a/turbine/src/broadcast_stage/broadcast_metrics.rs
+++ b/turbine/src/broadcast_stage/broadcast_metrics.rs
@@ -199,7 +199,7 @@ mod test {
     impl BroadcastStats for TestStats {
         fn update(&mut self, new_stats: &TestStats) {
             self.count += new_stats.count;
-            self.sender = new_stats.sender.clone();
+            self.sender.clone_from(&new_stats.sender);
         }
         fn report_stats(&mut self, slot: Slot, slot_start: Instant, _was_interrupted: bool) {
             self.sender


### PR DESCRIPTION
Rust v1.78.0 was released. There are new clippy lints that need to be addressed before we can upgrade. Here's one:

```
error: assigning the result of `Clone::clone()` may be inefficient
   --> bucket_map/src/bucket.rs:979:17
    |
979 |                 hashed = hashed_raw.clone();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `hashed.clone_from(&hashed_raw)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
    = note: `-D clippy::assigning-clones` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::assigning_clones)]`
```