### PR TITLE
clippy: ExactSizeIterator

### DIFF
--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -459,7 +459,7 @@ mod tests {
     fn sync_update<'a>(
         prioritization_fee_cache: &PrioritizationFeeCache,
         bank: Arc<Bank>,
-        txs: impl Iterator<Item = &'a SanitizedTransaction> + ExactSizeIterator,
+        txs: impl ExactSizeIterator<Item = &'a SanitizedTransaction>,
     ) {
         let expected_update_count = prioritization_fee_cache
             .metrics


### PR DESCRIPTION
Rust v1.78.0 was released. There are new clippy lints that need to be addressed before we can upgrade. Here's one:

```
warning: this bound is already specified as the supertrait of `ExactSizeIterator`
   --> runtime/src/prioritization_fee_cache.rs:462:19
    |
462 |         txs: impl Iterator<Item = &'a SanitizedTransaction> + ExactSizeIterator,
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#implied_bounds_in_impls
    = note: `#[warn(clippy::implied_bounds_in_impls)]` on by default
help: try removing this bound
    |
462 -         txs: impl Iterator<Item = &'a SanitizedTransaction> + ExactSizeIterator,
462 +         txs: impl ExactSizeIterator<Item = &'a SanitizedTransaction>,
```