### PR TITLE
clippy: multiple bound locations

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2824,12 +2824,12 @@ impl AccountsDb {
     }
 
     #[must_use]
-    pub fn purge_keys_exact<'a, C: 'a>(
+    pub fn purge_keys_exact<'a, C>(
         &'a self,
         pubkey_to_slot_set: impl Iterator<Item = &'a (Pubkey, C)>,
     ) -> (Vec<(Slot, AccountInfo)>, PubkeysRemovedFromAccountsIndex)
     where
-        C: Contains<'a, Slot>,
+        C: Contains<'a, Slot> + 'a,
     {
         let mut reclaims = Vec::new();
         let mut dead_keys = Vec::new();

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1457,7 +1457,7 @@ impl Database {
     }
 
     #[inline]
-    pub fn cf_handle<C: ColumnName>(&self) -> &ColumnFamily
+    pub fn cf_handle<C>(&self) -> &ColumnFamily
     where
         C: Column + ColumnName,
     {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8279,7 +8279,7 @@ enum AcceptableScanResults {
     Both,
 }
 
-fn test_store_scan_consistency<F: 'static>(
+fn test_store_scan_consistency<F>(
     update_f: F,
     drop_callback: Option<Box<dyn DropCallback + Send + Sync>>,
     acceptable_scan_results: AcceptableScanResults,
@@ -8291,7 +8291,8 @@ fn test_store_scan_consistency<F: 'static>(
             Arc<HashSet<Pubkey>>,
             Pubkey,
             u64,
-        ) + std::marker::Send,
+        ) + std::marker::Send
+        + 'static,
 {
     solana_logger::setup();
     // Set up initial bank

--- a/sdk/src/hash.rs
+++ b/sdk/src/hash.rs
@@ -4,18 +4,3 @@
 //! [`Hash`]: struct@Hash
 
 pub use solana_program::hash::*;
-
-/// Random hash value for tests and benchmarks.
-#[deprecated(
-    since = "1.17.0",
-    note = "Please use `Hash::new_unique()` for testing, or fill 32 bytes with any source of randomness"
-)]
-#[cfg(feature = "full")]
-pub fn new_rand<R: ?Sized>(rng: &mut R) -> Hash
-where
-    R: rand0_7::Rng,
-{
-    let mut buf = [0u8; HASH_BYTES];
-    rng.fill(&mut buf);
-    Hash::new(&buf)
-}


### PR DESCRIPTION
Rust v1.78.0 was released. There are new clippy lints that need to be addressed before we can upgrade. Here's one:

```
warning: bound is defined in more than one place
    --> accounts-db/src/accounts_db.rs:2827:33
     |
2827 |     pub fn purge_keys_exact<'a, C: 'a>(
     |                                 ^
...
2832 |         C: Contains<'a, Slot>,
     |         ^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#multiple_bound_locations
     = note: `#[warn(clippy::multiple_bound_locations)]` on by default
```