### PR TITLE
runtime/Optimize accounts loading (cache)

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5388,6 +5388,68 @@ impl AccountsDb {
         self.read_only_accounts_cache.reset_for_tests();
     }
 
+    /// Load account with `pubkey`. `callback` is used to decide whether to
+    /// store the account into read cache after loading.
+    ///
+    /// Return the account and the slot when the account was last stored.
+    /// Return None for ZeroLamport accounts.
+    pub fn load_account_with(
+        &self,
+        ancestors: &Ancestors,
+        pubkey: &Pubkey,
+        callback: impl Fn(&AccountSharedData) -> bool,
+    ) -> Option<(AccountSharedData, Slot)> {
+        let (slot, storage_location, _maybe_account_accesor) =
+            self.read_index_for_accessor_or_load_slow(ancestors, pubkey, None, false)?;
+        // Notice the subtle `?` at previous line, we bail out pretty early if missing.
+
+        let in_write_cache = storage_location.is_cached();
+        if !in_write_cache {
+            let result = self.read_only_accounts_cache.load(*pubkey, slot);
+            if let Some(account) = result {
+                if account.is_zero_lamport() {
+                    return None;
+                }
+                return Some((account, slot));
+            }
+        }
+
+        let (mut account_accessor, slot) = self.retry_to_get_account_accessor(
+            slot,
+            storage_location,
+            ancestors,
+            pubkey,
+            None,
+            LoadHint::Unspecified,
+        )?;
+
+        // note that the account being in the cache could be different now than it was previously
+        // since the cache could be flushed in between the 2 calls.
+        let in_write_cache = matches!(account_accessor, LoadedAccountAccessor::Cached(_));
+        let account = account_accessor.check_and_get_loaded_account_shared_data();
+        if account.is_zero_lamport() {
+            return None;
+        }
+
+        if !in_write_cache && callback(&account) {
+            /*
+            We show this store into the read-only cache for account 'A' and future loads of 'A' from the read-only cache are
+            safe/reflect 'A''s latest state on this fork.
+            This safety holds if during replay of slot 'S', we show we only read 'A' from the write cache,
+            not the read-only cache, after it's been updated in replay of slot 'S'.
+            Assume for contradiction this is not true, and we read 'A' from the read-only cache *after* it had been updated in 'S'.
+            This means an entry '(S, A)' was added to the read-only cache after 'A' had been updated in 'S'.
+            Now when '(S, A)' was being added to the read-only cache, it must have been true that  'is_cache == false',
+            which means '(S', A)' does not exist in the write cache yet.
+            However, by the assumption for contradiction above ,  'A' has already been updated in 'S' which means '(S, A)'
+            must exist in the write cache, which is a contradiction.
+            */
+            self.read_only_accounts_cache
+                .store(*pubkey, slot, account.clone());
+        }
+        Some((account, slot))
+    }
+
     /// if 'load_into_read_cache_only', then return value is meaningless.
     ///   The goal is to get the account into the read-only cache.
     fn do_load_with_populate_read_cache(
@@ -13556,6 +13618,51 @@ pub mod tests {
             .map(|(account, _)| account);
         assert!(account.is_none());
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+    }
+
+    #[test]
+    fn test_load_with_read_only_accounts_cache() {
+        let db = Arc::new(AccountsDb::new_single_for_tests());
+
+        let account_key = Pubkey::new_unique();
+        let zero_lamport_account =
+            AccountSharedData::new(0, 0, AccountSharedData::default().owner());
+        let slot1_account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
+        db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]), None);
+        db.store_cached((1, &[(&account_key, &slot1_account)][..]), None);
+
+        db.add_root(0);
+        db.add_root(1);
+        db.clean_accounts_for_tests();
+        db.flush_accounts_cache(true, None);
+        db.clean_accounts_for_tests();
+        db.add_root(2);
+
+        assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
+        let (account, slot) = db
+            .load_account_with(&Ancestors::default(), &account_key, |_| false)
+            .unwrap();
+        assert_eq!(account.lamports(), 1);
+        assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
+        assert_eq!(slot, 1);
+
+        let (account, slot) = db
+            .load_account_with(&Ancestors::default(), &account_key, |_| true)
+            .unwrap();
+        assert_eq!(account.lamports(), 1);
+        assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+        assert_eq!(slot, 1);
+
+        db.store_cached((2, &[(&account_key, &zero_lamport_account)][..]), None);
+        let account = db.load_account_with(&Ancestors::default(), &account_key, |_| false);
+        assert!(account.is_none());
+        assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+
+        db.read_only_accounts_cache.reset_for_tests();
+        assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
+        let account = db.load_account_with(&Ancestors::default(), &account_key, |_| true);
+        assert!(account.is_none());
+        assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
     }
 
     #[test]

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -971,6 +971,10 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         }
     }
 
+    pub fn contains_key(&self, key: &Pubkey) -> bool {
+        self.entries.contains_key(key)
+    }
+
     /// Extracts a subset of the programs relevant to a transaction batch
     /// and returns which program accounts the accounts DB needs to load.
     pub fn extract(

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -971,10 +971,6 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         }
     }
 
-    pub fn contains_key(&self, key: &Pubkey) -> bool {
-        self.entries.contains_key(key)
-    }
-
     /// Extracts a subset of the programs relevant to a transaction batch
     /// and returns which program accounts the accounts DB needs to load.
     pub fn extract(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6704,6 +6704,7 @@ impl Bank {
             effective_epoch,
             self.epoch_schedule(),
             reload,
+            &HashMap::default(),
         )
     }
 
@@ -6762,6 +6763,17 @@ impl TransactionProcessingCallback for Bank {
             .accounts_db
             .account_matches_owners(&self.ancestors, account, owners)
             .ok()
+    }
+
+    fn load_account_with(
+        &self,
+        pubkey: &Pubkey,
+        callback: impl for<'a> Fn(&'a AccountSharedData) -> bool,
+    ) -> Option<(AccountSharedData, Slot)> {
+        self.rc
+            .accounts
+            .accounts_db
+            .load_account_with(&self.ancestors, pubkey, callback)
     }
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -116,7 +116,7 @@ pub(crate) fn load_accounts<CB: TransactionProcessingCallback>(
     fee_structure: &FeeStructure,
     account_overrides: Option<&AccountOverrides>,
     loaded_programs: &ProgramCacheForTxBatch,
-    accounts_map: &HashMap<Pubkey, (AccountSharedData, Slot)>,
+    accounts_map: &HashMap<Pubkey, Option<(AccountSharedData, Slot)>>,
 ) -> Vec<TransactionLoadResult> {
     let feature_set = callbacks.get_feature_set();
     txs.iter()
@@ -184,17 +184,17 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
     error_counters: &mut TransactionErrorMetrics,
     account_overrides: Option<&AccountOverrides>,
     loaded_programs: &ProgramCacheForTxBatch,
-    accounts_map: &HashMap<Pubkey, (AccountSharedData, Slot)>,
+    accounts_map: &HashMap<Pubkey, Option<(AccountSharedData, Slot)>>,
 ) -> Result<LoadedTransaction> {
     let feature_set = callbacks.get_feature_set();
 
     let load_account = |pubkey, should_cache| {
-        let (account, _slot) = if let Some(found) = accounts_map.get(pubkey) {
-            found.clone()
+        let maybe_found = if let Some(found) = accounts_map.get(pubkey) {
+            found.as_ref().cloned()
         } else {
-            callbacks.load_account_with(pubkey, |_| should_cache)?
+            callbacks.load_account_with(pubkey, |_| should_cache)
         };
-        Some(account)
+        maybe_found.map(|x| x.0)
     };
 
     // There is no way to predict what program will execute without an error

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -11,14 +11,14 @@ use {
         account::{AccountSharedData, ReadableAccount},
         account_utils::StateMut,
         bpf_loader, bpf_loader_deprecated,
-        bpf_loader_upgradeable::UpgradeableLoaderState,
+        bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{Epoch, Slot},
         epoch_schedule::EpochSchedule,
         instruction::InstructionError,
         loader_v4::{self, LoaderV4State, LoaderV4Status},
         pubkey::Pubkey,
     },
-    std::sync::Arc,
+    std::{collections::HashMap, sync::Arc},
 };
 
 #[derive(Debug)]
@@ -68,9 +68,14 @@ pub(crate) fn load_program_from_bytes(
 pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
     callbacks: &CB,
     pubkey: &Pubkey,
+    accounts_map: &HashMap<Pubkey, Option<(AccountSharedData, Slot)>>,
 ) -> Option<ProgramAccountLoadResult> {
-    let program_account = callbacks.get_account_shared_data(pubkey)?;
-
+    let maybe_found = if let Some(found) = accounts_map.get(pubkey) {
+        found.as_ref().cloned()
+    } else {
+        callbacks.load_account_with(pubkey, |_| false)
+    };
+    let (program_account, _slot) = maybe_found?;
     if loader_v4::check_id(program_account.owner()) {
         return Some(
             solana_loader_v4_program::get_state(program_account.data())
@@ -92,6 +97,12 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
     if bpf_loader::check_id(program_account.owner()) {
         return Some(ProgramAccountLoadResult::ProgramOfLoaderV2(program_account));
     }
+
+    assert!(
+        bpf_loader_upgradeable::check_id(program_account.owner()),
+        "unexpected program account owner {}",
+        program_account.owner(),
+    );
 
     if let Ok(UpgradeableLoaderState::Program {
         programdata_address,
@@ -121,6 +132,8 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
 /// If the account doesn't exist it returns `None`. If the account does exist, it must be a program
 /// account (belong to one of the program loaders). Returns `Some(InvalidAccountData)` if the program
 /// account is `Closed`, contains invalid data or any of the programdata accounts are invalid.
+///
+/// 'accounts_map' contains a cache of the accounts that has been loaded before during transaction accounts filtering.
 pub fn load_program_with_pubkey<CB: TransactionProcessingCallback, FG: ForkGraph>(
     callbacks: &CB,
     program_cache: &ProgramCache<FG>,
@@ -129,6 +142,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback, FG: ForkGraph
     effective_epoch: Epoch,
     epoch_schedule: &EpochSchedule,
     reload: bool,
+    accounts_map: &HashMap<Pubkey, Option<(AccountSharedData, Slot)>>,
 ) -> Option<Arc<ProgramCacheEntry>> {
     let environments = program_cache.get_environments_for_epoch(effective_epoch);
     let mut load_program_metrics = LoadProgramMetrics {
@@ -136,7 +150,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback, FG: ForkGraph
         ..LoadProgramMetrics::default()
     };
 
-    let mut loaded_program = match load_program_accounts(callbacks, pubkey)? {
+    let mut loaded_program = match load_program_accounts(callbacks, pubkey, accounts_map)? {
         ProgramAccountLoadResult::InvalidAccountData(owner) => Ok(
             ProgramCacheEntry::new_tombstone(slot, owner, ProgramCacheEntryType::Closed),
         ),
@@ -286,6 +300,15 @@ mod tests {
             }
         }
 
+        fn load_account_with(
+            &self,
+            pubkey: &Pubkey,
+            _callback: impl FnMut(&AccountSharedData) -> bool,
+        ) -> Option<(AccountSharedData, Slot)> {
+            let account = self.account_shared_data.borrow().get(pubkey).cloned()?;
+            Some((account, 100))
+        }
+
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
             self.account_shared_data.borrow().get(pubkey).cloned()
         }
@@ -316,7 +339,7 @@ mod tests {
         let mock_bank = MockBankCallback::default();
         let key = Pubkey::new_unique();
 
-        let result = load_program_accounts(&mock_bank, &key);
+        let result = load_program_accounts(&mock_bank, &key, &HashMap::default());
         assert!(result.is_none());
 
         let mut account_data = AccountSharedData::default();
@@ -330,7 +353,7 @@ mod tests {
             .borrow_mut()
             .insert(key, account_data.clone());
 
-        let result = load_program_accounts(&mock_bank, &key);
+        let result = load_program_accounts(&mock_bank, &key, &HashMap::default());
         assert!(matches!(
             result,
             Some(ProgramAccountLoadResult::InvalidAccountData(_))
@@ -342,7 +365,7 @@ mod tests {
             .borrow_mut()
             .insert(key, account_data);
 
-        let result = load_program_accounts(&mock_bank, &key);
+        let result = load_program_accounts(&mock_bank, &key, &HashMap::default());
 
         assert!(matches!(
             result,
@@ -361,7 +384,7 @@ mod tests {
             .borrow_mut()
             .insert(key, account_data.clone());
 
-        let result = load_program_accounts(&mock_bank, &key);
+        let result = load_program_accounts(&mock_bank, &key, &HashMap::default());
         assert!(matches!(
             result,
             Some(ProgramAccountLoadResult::InvalidAccountData(_))
@@ -372,7 +395,7 @@ mod tests {
             .account_shared_data
             .borrow_mut()
             .insert(key, account_data.clone());
-        let result = load_program_accounts(&mock_bank, &key);
+        let result = load_program_accounts(&mock_bank, &key, &HashMap::default());
         assert!(matches!(
             result,
             Some(ProgramAccountLoadResult::InvalidAccountData(_))
@@ -394,7 +417,7 @@ mod tests {
             .borrow_mut()
             .insert(key, account_data.clone());
 
-        let result = load_program_accounts(&mock_bank, &key);
+        let result = load_program_accounts(&mock_bank, &key, &HashMap::default());
 
         match result {
             Some(ProgramAccountLoadResult::ProgramOfLoaderV4(data, slot)) => {
@@ -417,7 +440,7 @@ mod tests {
             .borrow_mut()
             .insert(key, account_data.clone());
 
-        let result = load_program_accounts(&mock_bank, &key);
+        let result = load_program_accounts(&mock_bank, &key, &HashMap::default());
         match result {
             Some(ProgramAccountLoadResult::ProgramOfLoaderV1(data))
             | Some(ProgramAccountLoadResult::ProgramOfLoaderV2(data)) => {
@@ -456,7 +479,7 @@ mod tests {
             .borrow_mut()
             .insert(key2, account_data2.clone());
 
-        let result = load_program_accounts(&mock_bank, &key1);
+        let result = load_program_accounts(&mock_bank, &key1, &HashMap::default());
 
         match result {
             Some(ProgramAccountLoadResult::ProgramOfLoaderV3(data1, data2, slot)) => {
@@ -532,6 +555,7 @@ mod tests {
             50,
             &batch_processor.epoch_schedule,
             false,
+            &HashMap::default(),
         );
         assert!(result.is_none());
     }
@@ -558,6 +582,7 @@ mod tests {
             20,
             &batch_processor.epoch_schedule,
             false,
+            &HashMap::default(),
         );
 
         let loaded_program = ProgramCacheEntry::new_tombstone(
@@ -599,6 +624,7 @@ mod tests {
             20,
             &batch_processor.epoch_schedule,
             false,
+            &HashMap::default(),
         );
         let loaded_program = ProgramCacheEntry::new_tombstone(
             0,
@@ -631,6 +657,7 @@ mod tests {
             20,
             &batch_processor.epoch_schedule,
             false,
+            &HashMap::default(),
         );
 
         let environments = ProgramRuntimeEnvironments::default();
@@ -687,6 +714,7 @@ mod tests {
             0,
             &batch_processor.epoch_schedule,
             false,
+            &HashMap::default(),
         );
         let loaded_program = ProgramCacheEntry::new_tombstone(
             0,
@@ -729,6 +757,7 @@ mod tests {
             20,
             &batch_processor.epoch_schedule,
             false,
+            &HashMap::default(),
         );
 
         let data = account_data.data();
@@ -781,6 +810,7 @@ mod tests {
             0,
             &batch_processor.epoch_schedule,
             false,
+            &HashMap::default(),
         );
         let loaded_program = ProgramCacheEntry::new_tombstone(
             0,
@@ -819,6 +849,7 @@ mod tests {
             20,
             &batch_processor.epoch_schedule,
             false,
+            &HashMap::default(),
         );
 
         let data = account_data.data()[LoaderV4State::program_data_offset()..].to_vec();
@@ -869,6 +900,7 @@ mod tests {
             20,
             &batch_processor.epoch_schedule,
             false,
+            &HashMap::default(),
         );
 
         let slot = batch_processor.epoch_schedule.get_first_slot_in_epoch(20);

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,8 +1,8 @@
 use {
     solana_program_runtime::loaded_programs::ProgramCacheMatchCriteria,
     solana_sdk::{
-        account::AccountSharedData, feature_set::FeatureSet, hash::Hash, pubkey::Pubkey,
-        rent_collector::RentCollector,
+        account::AccountSharedData, clock::Slot, feature_set::FeatureSet, hash::Hash,
+        pubkey::Pubkey, rent_collector::RentCollector,
     },
     std::sync::Arc,
 };
@@ -12,6 +12,14 @@ pub trait TransactionProcessingCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize>;
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
+
+    // If `callback` returns `true`, the account will be stored into read cache after loading.
+    // Otherwise, it will skip read cache.
+    fn load_account_with(
+        &self,
+        pubkey: &Pubkey,
+        callback: impl for<'a> Fn(&'a AccountSharedData) -> bool,
+    ) -> Option<(AccountSharedData, Slot)>;
 
     fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64);
 

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -1,6 +1,7 @@
 use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
+        clock::Slot,
         feature_set::FeatureSet,
         hash::Hash,
         native_loader,
@@ -29,6 +30,15 @@ impl TransactionProcessingCallback for MockBankCallback {
         } else {
             None
         }
+    }
+
+    fn load_account_with(
+        &self,
+        pubkey: &Pubkey,
+        _callback: impl for<'a> Fn(&'a AccountSharedData) -> bool,
+    ) -> Option<(AccountSharedData, Slot)> {
+        let account = self.account_shared_data.borrow().get(pubkey).cloned()?;
+        Some((account, 100))
     }
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {


### PR DESCRIPTION
#### Problem

During transaction execution, we load accounts twice - first during filtering program accounts, and second for loading the actual accounts before execution. And by default, loading program accounts will insert the loaded program accounts into read cache, which pollutes read cache unnecessarily. This is inefficient and can be optimized. 

This is a PR after https://github.com/anza-xyz/agave/pull/1056

In #1056, we check program cache before loading the accounts. However, this can lead to an infinite loop. The current design of program cache relies on supplying valid program accounts for `replenish`.

In this PR, we revert the checking of program cache. 

#### Summary of Changes

- Add a new API for account-db `load_with()`, which takes a callback to indicate whether to insert the loaded account into `read_cache`.
- Update program account loads and transaction accounts loads to use the new API to do finer control on whether to insert the account into `read_cache` after loading.
- Cache the account loaded during filtering and use the cached accounts in program account and regular account loader later when possible.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
