### PR TITLE
removes redundant collect::<Vec<_>> in Rocks::multi_get_cf

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5377,7 +5377,7 @@ pub mod tests {
         for (i, key) in keys.iter_mut().enumerate().take(TEST_PUT_ENTRY_COUNT) {
             *key = u64::try_from(i).unwrap();
         }
-        let values = blockstore.meta_cf.multi_get(keys.into_iter());
+        let values = blockstore.meta_cf.multi_get(keys);
         for (i, value) in values.iter().enumerate().take(TEST_PUT_ENTRY_COUNT) {
             let k = u64::try_from(i).unwrap();
             assert_eq!(


### PR DESCRIPTION

#### Problem
`Rocks::multi_get_cf` collects an iterator into a vector:
https://github.com/anza-xyz/agave/blob/6b45dc95d/ledger/src/blockstore_db.rs#L661-L666

which is then immediately converted into an iterator:
https://github.com/anza-xyz/agave/blob/6b45dc95d/ledger/src/blockstore_db.rs#L1589-L1590
https://github.com/anza-xyz/agave/blob/6b45dc95d/ledger/src/blockstore_db.rs#L1705-L1706

The redundant `collect::<Vec<_>>` can be avoided by returning an iterator from `multi_get_cf`.


#### Summary of Changes
* removed redundant `collect::<Vec<_>>` in `Rocks::multi_get_cf`.
* also minor style changes.