### PR TITLE
cli-output: {QuietDisplay, VerboseDisplay} => FormatFor{Mode,Json}

### DIFF
--- a/cli-output/src/lib.rs
+++ b/cli-output/src/lib.rs
@@ -4,14 +4,9 @@ pub mod cli_version;
 pub mod display;
 pub use cli_output::*;
 
-pub trait QuietDisplay: std::fmt::Display {
-    fn write_str(&self, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
-        write!(w, "{self}")
-    }
-}
-
-pub trait VerboseDisplay: std::fmt::Display {
-    fn write_str(&self, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
-        write!(w, "{self}")
-    }
+#[doc(hidden)]
+// Crates used by macros.  Reexporting them here allows macros to be invoked in any context, without
+// requiring the users to import specific crates and/or modules.
+pub mod reexport {
+    pub use serde_json;
 }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -22,7 +22,7 @@ use {
             build_balance_message, format_labeled_address, new_spinner_progress_bar,
             writeln_name_value,
         },
-        *,
+        impl_format_for_mode_trivial, *,
     },
     solana_pubsub_client::pubsub_client::PubsubClient,
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
@@ -2265,8 +2265,7 @@ impl fmt::Display for CliRentCalculation {
     }
 }
 
-impl QuietDisplay for CliRentCalculation {}
-impl VerboseDisplay for CliRentCalculation {}
+impl_format_for_mode_trivial!(CliRentCalculation);
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum RentLengthValue {

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -12,7 +12,7 @@ use {
     solana_clap_utils::{
         fee_payer::*, hidden_unless_forced, input_parsers::*, input_validators::*, keypair::*,
     },
-    solana_cli_output::{cli_version::CliVersion, QuietDisplay, VerboseDisplay},
+    solana_cli_output::{cli_version::CliVersion, impl_format_for_mode_trivial},
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::{
@@ -188,8 +188,7 @@ impl fmt::Display for CliFeatures {
     }
 }
 
-impl QuietDisplay for CliFeatures {}
-impl VerboseDisplay for CliFeatures {}
+impl_format_for_mode_trivial!(CliFeatures);
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -388,8 +387,7 @@ impl fmt::Display for CliClusterFeatureSets {
     }
 }
 
-impl QuietDisplay for CliClusterFeatureSets {}
-impl VerboseDisplay for CliClusterFeatureSets {}
+impl_format_for_mode_trivial!(CliClusterFeatureSets);
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -6,8 +6,8 @@ use {
     solana_account_decoder::{UiAccount, UiAccountData, UiAccountEncoding},
     solana_accounts_db::accounts_index::ScanConfig,
     solana_cli_output::{
-        display::writeln_transaction, CliAccount, CliAccountNewConfig, OutputFormat, QuietDisplay,
-        VerboseDisplay,
+        display::writeln_transaction, impl_format_for_mode_trivial, CliAccount,
+        CliAccountNewConfig, OutputFormat,
     },
     solana_entry::entry::Entry,
     solana_ledger::blockstore::Blockstore,
@@ -52,8 +52,7 @@ pub struct SlotBounds<'a> {
     pub roots: SlotInfo,
 }
 
-impl VerboseDisplay for SlotBounds<'_> {}
-impl QuietDisplay for SlotBounds<'_> {}
+impl_format_for_mode_trivial!(SlotBounds<'_>);
 
 impl Display for SlotBounds<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -113,8 +112,7 @@ pub struct CliEntries {
     pub slot: Slot,
 }
 
-impl QuietDisplay for CliEntries {}
-impl VerboseDisplay for CliEntries {}
+impl_format_for_mode_trivial!(CliEntries);
 
 impl fmt::Display for CliEntries {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -176,8 +174,7 @@ pub struct CliBlockWithEntries {
     pub slot: Slot,
 }
 
-impl QuietDisplay for CliBlockWithEntries {}
-impl VerboseDisplay for CliBlockWithEntries {}
+impl_format_for_mode_trivial!(CliBlockWithEntries);
 
 impl fmt::Display for CliBlockWithEntries {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -8,7 +8,7 @@ use {
         create_vm, load_program_from_bytes, serialization::serialize_parameters,
         syscalls::create_program_runtime_environment_v1,
     },
-    solana_cli_output::{OutputFormat, QuietDisplay, VerboseDisplay},
+    solana_cli_output::{impl_format_for_mode_trivial, OutputFormat},
     solana_ledger::{blockstore_options::AccessType, use_snapshot_archives_at_startup},
     solana_program_runtime::{
         invoke_context::InvokeContext,
@@ -242,6 +242,8 @@ struct Output {
     log: Vec<String>,
 }
 
+impl_format_for_mode_trivial!(Output);
+
 impl fmt::Display for Output {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Program output:")?;
@@ -254,9 +256,6 @@ impl fmt::Display for Output {
         Ok(())
     }
 }
-
-impl QuietDisplay for Output {}
-impl VerboseDisplay for Output {}
 
 // Replace with std::lazy::Lazy when stabilized.
 // https://github.com/rust-lang/rust/issues/74465


### PR DESCRIPTION
#### Problem

`Serialize + fmt:Display + QuietDisplay + VerboseDisplay` is not object safe, and `Serialize` is not object safe.  Meaning that it is less ergonomic in certain cases.

#### Summary of Changes

Using a single trait `FormatForMode` is object safe.  Unlike a collection of 4 traits, as in `Serialize + fmt:Display + QuietDisplay + VerboseDisplay`, which is not object safe.  An object safe trait allows, for example, to write a closure that takes a `&dyn FormatForMode` as an argument.

It still seems suspicious that we collect all the output into a `String` before we output it.  Wouldn't it be better to write it via a `&mut dyn io::Write` instance as it is produced?  It would affect the error reporting, but, possibly, in a good way, as we would print everything up to the actual error to the console.