### PR TITLE
RPC: fix numNonVoteTransactions in getPerformanceSamples

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2376,7 +2376,7 @@ fn test_insufficient_funds() {
     // transaction_count returns the count of all committed transactions since
     // bank_transaction_count_fix was activated, regardless of success
     assert_eq!(bank.transaction_count(), 2);
-    assert_eq!(bank.non_vote_transaction_count_since_restart(), 1);
+    assert_eq!(bank.non_vote_transaction_count_since_restart(), 2);
 
     let mint_pubkey = mint_keypair.pubkey();
     assert_eq!(bank.get_balance(&mint_pubkey), mint_amount - amount);


### PR DESCRIPTION
#### Problem
The value `numNonVoteTransactions` returned in the RPC `getPerformanceSamples` endpoint was actually reporting the number of _successful_ non vote transactions that were executed. That field is documented in the RPC docs with the following statement:

> To get a number of voting transactions compute numTransactions - numNonVoteTransaction" 

But before this fix, `numTransactions - numNonVoteTransaction` is actually computing the number of vote transactions + errored non-vote transactions.

#### Summary of Changes
- Increment `executed_non_vote_transactions_count` whether the non-vote tx failed or succeeded. This value will get fixed on restart since we don't persist the value in snapshots

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
