### PR TITLE
Reduce deserialization allocations/copies

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1308,8 +1308,9 @@ fn update_caller_account(
             // never points to an invalid address.
             //
             // Note that the capacity can be smaller than the original length only if the account is
-            // reallocated using the AccountSharedData API directly (deprecated). BorrowedAccount
-            // and CoW don't trigger this, see BorrowedAccount::make_data_mut.
+            // reallocated using the AccountSharedData API directly (deprecated) or using
+            // BorrowedAccount::set_data_from_slice(), which implements an optimization to avoid an
+            // extra allocation.
             let min_capacity = caller_account.original_data_len;
             if callee_account.capacity() < min_capacity {
                 callee_account

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -543,7 +543,13 @@ impl AccountSharedData {
     }
 
     pub fn reserve(&mut self, additional: usize) {
-        self.data_mut().reserve(additional)
+        if let Some(data) = Arc::get_mut(&mut self.data) {
+            data.reserve(additional)
+        } else {
+            let mut data = Vec::with_capacity(self.data.len().saturating_add(additional));
+            data.extend_from_slice(&self.data);
+            self.data = Arc::new(data);
+        }
     }
 
     pub fn capacity(&self) -> usize {

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -869,13 +869,10 @@ impl<'a> BorrowedAccount<'a> {
         self.can_data_be_changed()?;
         self.touch()?;
         self.update_accounts_resize_delta(data.len())?;
-        // Calling make_data_mut() here guarantees that set_data_from_slice()
-        // copies in places, extending the account capacity if necessary but
-        // never reducing it. This is required as the account migh be directly
-        // mapped into a MemoryRegion, and therefore reducing capacity would
-        // leave a hole in the vm address space. After CPI or upon program
-        // termination, the runtime will zero the extra capacity.
-        self.make_data_mut();
+        // Note that we intentionally don't call self.make_data_mut() here.  make_data_mut() will
+        // allocate + memcpy the current data if self.account is shared. We don't need the memcpy
+        // here tho because account.set_data_from_slice(data) is going to replace the content
+        // anyway.
         self.account.set_data_from_slice(data);
 
         Ok(())


### PR DESCRIPTION
This removes an allocation and a copy in AccountSharedData::reserve(). Calling data_mut().reserve(additional) used to result in _two_ allocs and memcpys: the first to unshare the underlying vector, and the second upon calling reserve since Arc::make_mut clones so it uses capacity == len. With this change we now manually "unshare" allocating with capacity = len + additional, therefore saving on extra alloc and memcpy.

Additionally we skip another extra copy in AccountSharedData::set_data_from_slice(). We used call make_data_mut() from set_data_from_slice() from the days when direct mapping couldn't deal with accounts getting shrunk. That changed in https://github.com/solana-labs/solana/pull/32649 (see the `if callee_account.capacity() < min_capacity check in cpi.rs:update_caller_account()`). We now don't call make_data_mut() anymore before set_data_from_slice(), saving the cost of a memcpy since set_data_from_slice() overrides the whole account content anyway.

These two changes improve deserialization perf.
 
Before:
<img width="2052" alt="Screenshot 2024-05-06 at 4 54 16 pm" src="https://github.com/anza-xyz/agave/assets/62002/1f284a3a-c420-482f-bae8-57115dc95c75">

After:
<img width="2054" alt="Screenshot 2024-05-06 at 4 55 20 pm" src="https://github.com/anza-xyz/agave/assets/62002/1f8c0028-1308-47f2-a190-f937c295519f">

On my mnb node this reduces cost of deserialization from 16% to 5%. It improves overall replay perf by 6%, although I expect the saving to be even larger on nodes with a lot of stake which seem to struggle more with memory allocations.