### PR TITLE
refactor: simplify fee payer determination

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -726,16 +726,12 @@ impl Accounts {
 
             let message = tx.message();
             let loaded_transaction = tx_load_result.as_mut().unwrap();
-            let mut fee_payer_index = None;
             for (i, (address, account)) in (0..message.account_keys().len())
                 .zip(loaded_transaction.accounts.iter_mut())
                 .filter(|(i, _)| message.is_non_loader_key(*i))
             {
-                if fee_payer_index.is_none() {
-                    fee_payer_index = Some(i);
-                }
-                let is_fee_payer = Some(i) == fee_payer_index;
                 if message.is_writable(i) {
+                    let is_fee_payer = i == 0;
                     let is_nonce_account = prepare_if_nonce_account(
                         address,
                         account,

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -219,24 +219,20 @@ fn write_transaction<W: io::Write>(
     write_signatures(w, &transaction.signatures, sigverify_status, prefix)?;
 
     let reserved_account_keys = ReservedAccountKeys::new_all_activated().active;
-    let mut fee_payer_index = None;
     for (account_index, account) in account_keys.iter().enumerate() {
-        if fee_payer_index.is_none() && message.is_non_loader_key(account_index) {
-            fee_payer_index = Some(account_index)
-        }
-
         let account_meta = CliAccountMeta {
             is_signer: message.is_signer(account_index),
             is_writable: message.is_maybe_writable(account_index, Some(&reserved_account_keys)),
             is_invoked: message.is_invoked(account_index),
         };
 
+        let is_fee_payer = account_index == 0;
         write_account(
             w,
             account_index,
             *account,
             format_account_mode(account_meta),
-            Some(account_index) == fee_payer_index,
+            is_fee_payer,
             prefix,
         )?;
     }

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -167,9 +167,10 @@ impl SanitizedMessage {
 
     /// Returns the fee payer for the transaction
     pub fn fee_payer(&self) -> &Pubkey {
-        self.account_keys()
-            .get(0)
-            .expect("sanitized message always has non-program fee payer at index 0")
+        self.account_keys().get(0).expect(
+            "sanitized messages always have a fee payer at index 0 \
+            which is not invoked as a program",
+        )
     }
 
     /// The hash of a recent block, used for timing out a transaction

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -167,10 +167,9 @@ impl SanitizedMessage {
 
     /// Returns the fee payer for the transaction
     pub fn fee_payer(&self) -> &Pubkey {
-        self.account_keys().get(0).expect(
-            "sanitized messages always have a fee payer at index 0 \
-            which is not invoked as a program",
-        )
+        self.account_keys()
+            .get(0)
+            .expect("sanitized messages always have a fee payer at index 0")
     }
 
     /// The hash of a recent block, used for timing out a transaction

--- a/sdk/src/nonce_info.rs
+++ b/sdk/src/nonce_info.rs
@@ -66,26 +66,16 @@ impl NonceFull {
     }
     pub fn from_partial(
         partial: &NoncePartial,
-        message: &SanitizedMessage,
+        _message: &SanitizedMessage,
         accounts: &[TransactionAccount],
         rent_debits: &RentDebits,
     ) -> transaction::Result<Self> {
-        let fee_payer = (0..message.account_keys().len()).find_map(|i| {
-            if let Some((k, a)) = &accounts.get(i) {
-                if message.is_non_loader_key(i) {
-                    return Some((k, a));
-                }
-            }
-            None
-        });
-
-        if let Some((fee_payer_address, fee_payer_account)) = fee_payer {
-            let mut fee_payer_account = fee_payer_account.clone();
-            let rent_debit = rent_debits.get_account_rent_debit(fee_payer_address);
+        if let Some((fee_payer_address, mut fee_payer_account)) = accounts.first().cloned() {
+            let rent_debit = rent_debits.get_account_rent_debit(&fee_payer_address);
             fee_payer_account.set_lamports(fee_payer_account.lamports().saturating_add(rent_debit));
 
             let nonce_address = *partial.address();
-            if *fee_payer_address == nonce_address {
+            if fee_payer_address == nonce_address {
                 Ok(Self::new(nonce_address, fee_payer_account, None))
             } else {
                 Ok(Self::new(

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -5,7 +5,6 @@ use {
         transaction_processing_callback::TransactionProcessingCallback,
     },
     itertools::Itertools,
-    log::warn,
     solana_program_runtime::{
         compute_budget_processor::process_compute_budget_instructions,
         loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
@@ -281,11 +280,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                     error_counters,
                 )?;
 
-                if !validated_fee_payer && message.is_non_loader_key(i) {
-                    if i != 0 {
-                        warn!("Payer index should be 0! {:?}", message);
-                    }
-
+                if i == 0 {
                     validate_fee_payer(
                         key,
                         &mut account,


### PR DESCRIPTION
#### Problem
There are a few places with overly complex code for determining the account index of a transaction's fee payer. The logic attempts to handle the case where a transaction's account list actually begins with 1 or more invoked programs but this is actually impossible because message sanitization rejects any transactions which have instructions which invoke the first account as a program.

#### Summary of Changes
- Simplify fee payer index determination by directly using account index 0

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
