### PR TITLE
Fix - Reloading of unload entries after finishing the recompilation phase

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -818,6 +818,9 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             &entry.program,
             ProgramCacheEntryType::DelayVisibility
         ));
+        // This function always returns `true` during normal operation.
+        // Only during the recompilation phase this can return `false`
+        // for entries with `upcoming_environments`.
         fn is_current_env(
             environments: &ProgramRuntimeEnvironments,
             env_opt: Option<&ProgramRuntimeEnvironment>,
@@ -835,6 +838,9 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                 .cmp(&entry.effective_slot)
                 .then(at.deployment_slot.cmp(&entry.deployment_slot))
                 .then(
+                    // This `.then()` has no effect during normal operation.
+                    // Only during the recompilation phase this does allow entries
+                    // which only differ in their environment to be interleaved in `slot_versions`.
                     is_current_env(&self.environments, at.program.get_environment()).cmp(
                         &is_current_env(&self.environments, entry.program.get_environment()),
                     ),

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1743,34 +1743,34 @@ mod tests {
     #[test_matrix(
         (
             ProgramCacheEntryType::Closed,
-            ProgramCacheEntryType::FailedVerification(Arc::new(BuiltinProgram::new_mock())),
+            ProgramCacheEntryType::FailedVerification(get_mock_env()),
             new_loaded_entry(get_mock_env()),
         ),
         (
-            ProgramCacheEntryType::FailedVerification(Arc::new(BuiltinProgram::new_mock())),
+            ProgramCacheEntryType::FailedVerification(get_mock_env()),
             ProgramCacheEntryType::Closed,
-            ProgramCacheEntryType::Unloaded(Arc::new(BuiltinProgram::new_mock())),
+            ProgramCacheEntryType::Unloaded(get_mock_env()),
             new_loaded_entry(get_mock_env()),
             ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
         )
     )]
     #[test_matrix(
         (
-            ProgramCacheEntryType::Unloaded(Arc::new(BuiltinProgram::new_mock())),
+            ProgramCacheEntryType::Unloaded(get_mock_env()),
         ),
         (
-            ProgramCacheEntryType::FailedVerification(Arc::new(BuiltinProgram::new_mock())),
+            ProgramCacheEntryType::FailedVerification(get_mock_env()),
             ProgramCacheEntryType::Closed,
-            ProgramCacheEntryType::Unloaded(Arc::new(BuiltinProgram::new_mock())),
+            ProgramCacheEntryType::Unloaded(get_mock_env()),
             ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
         )
     )]
     #[test_matrix(
         (ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),),
         (
-            ProgramCacheEntryType::FailedVerification(Arc::new(BuiltinProgram::new_mock())),
+            ProgramCacheEntryType::FailedVerification(get_mock_env()),
             ProgramCacheEntryType::Closed,
-            ProgramCacheEntryType::Unloaded(Arc::new(BuiltinProgram::new_mock())),
+            ProgramCacheEntryType::Unloaded(get_mock_env()),
             new_loaded_entry(get_mock_env()),
         )
     )]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12035,11 +12035,11 @@ fn test_feature_activation_loaded_programs_recompilation_phase() {
         assert_eq!(slot_versions.len(), 2);
         assert!(Arc::ptr_eq(
             slot_versions[0].program.get_environment().unwrap(),
-            &current_env
+            &upcoming_env
         ));
         assert!(Arc::ptr_eq(
             slot_versions[1].program.get_environment().unwrap(),
-            &upcoming_env
+            &current_env
         ));
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12030,7 +12030,7 @@ fn test_feature_activation_loaded_programs_recompilation_phase() {
     goto_end_of_slot(bank.clone());
     let bank = new_from_parent_with_fork_next_slot(bank, bank_forks.as_ref());
     {
-        let program_cache = bank.transaction_processor.program_cache.read().unwrap();
+        let program_cache = bank.transaction_processor.program_cache.write().unwrap();
         let slot_versions = program_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
         assert_eq!(slot_versions.len(), 2);
         assert!(Arc::ptr_eq(
@@ -12109,6 +12109,21 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
     let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
 
     // Load the program with the new environment.
+    let transaction = Transaction::new(&signers, message.clone(), bank.last_blockhash());
+    assert!(bank.process_transaction(&transaction).is_ok());
+
+    {
+        // Prune for rerooting and thus finishing the recompilation phase.
+        let mut program_cache = bank.transaction_processor.program_cache.write().unwrap();
+        program_cache.prune(bank.slot(), bank.epoch());
+
+        // Unload all (which is only the entry with the new environment)
+        program_cache.sort_and_unload(percentage::Percentage::from(0));
+    }
+
+    // Reload the unloaded program with the new environment.
+    goto_end_of_slot(bank.clone());
+    let bank = new_from_parent_with_fork_next_slot(bank, bank_forks.as_ref());
     let transaction = Transaction::new(&signers, message, bank.last_blockhash());
     assert!(bank.process_transaction(&transaction).is_ok());
 }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -827,18 +827,19 @@ mod tests {
     }
 
     #[test]
-    fn test_load_program_effective_slot() {
+    fn test_load_program_environment() {
         let key = Pubkey::new_unique();
         let mock_bank = MockBankCallback::default();
         let mut account_data = AccountSharedData::default();
-        account_data.set_owner(loader_v4::id());
+        account_data.set_owner(bpf_loader::id());
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
-        batch_processor
-            .program_cache
-            .write()
-            .unwrap()
-            .upcoming_environments = Some(ProgramRuntimeEnvironments::default());
+        let upcoming_environments = ProgramRuntimeEnvironments::default();
+        let current_environments = {
+            let mut program_cache = batch_processor.program_cache.write().unwrap();
+            program_cache.upcoming_environments = Some(upcoming_environments.clone());
+            program_cache.environments.clone()
+        };
         mock_bank
             .account_shared_data
             .borrow_mut()
@@ -846,17 +847,31 @@ mod tests {
 
         let program_cache = batch_processor.program_cache.read().unwrap();
 
-        let result = load_program_with_pubkey(
-            &mock_bank,
-            &program_cache,
-            &key,
-            200,
-            20,
-            &batch_processor.epoch_schedule,
-            false,
-        );
-
-        let slot = batch_processor.epoch_schedule.get_first_slot_in_epoch(20);
-        assert_eq!(result.unwrap().effective_slot, slot);
+        for is_upcoming_env in [false, true] {
+            let result = load_program_with_pubkey(
+                &mock_bank,
+                &program_cache,
+                &key,
+                200,
+                is_upcoming_env as u64,
+                &batch_processor.epoch_schedule,
+                false,
+            )
+            .unwrap();
+            assert_ne!(
+                is_upcoming_env,
+                Arc::ptr_eq(
+                    result.program.get_environment().unwrap(),
+                    &current_environments.program_runtime_v1,
+                )
+            );
+            assert_eq!(
+                is_upcoming_env,
+                Arc::ptr_eq(
+                    result.program.get_environment().unwrap(),
+                    &upcoming_environments.program_runtime_v1,
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
#### Problem
Currently the epoch boundary recompilation phase does adjust the effective slot of recompiled entries to be the first slot of the next epoch. However, when reloading unloaded entries, their new loaded entry has an unadjusted effective slot, which will not be matched in `assign_program()`.

#### Summary of Changes
- Adds a reproducer for the condition.
- Differentiates the two versions of an entry (for previous and upcoming feature set) by `get_environment()` instead of adjusting the `effective_slot`.
- Changes the tests of `assign_program()` to always use the unifed `get_mock_env()` instead of creating random environments with `Arc::new(BuiltinProgram::new_mock())`.
- Swaps the order of environments in `test_feature_activation_loaded_programs_recompilation_phase()`.
- Turns `test_load_program_effective_slot()` into `test_load_program_environment()`.