### PR TITLE
Adds verify_accounts_hash_and_lamports_for_tests()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9446,6 +9446,15 @@ impl AccountsDb {
             0
         }
     }
+
+    pub fn verify_accounts_hash_and_lamports_for_tests(
+        &self,
+        slot: Slot,
+        total_lamports: u64,
+        config: VerifyAccountsHashAndLamportsConfig,
+    ) -> Result<(), AccountsHashVerificationError> {
+        self.verify_accounts_hash_and_lamports(slot, total_lamports, None, config)
+    }
 }
 
 // These functions/fields are only usable from a dev context (i.e. tests and benches)
@@ -12349,14 +12358,14 @@ pub mod tests {
         );
 
         assert_matches!(
-            db.verify_accounts_hash_and_lamports(some_slot, 1, None, config.clone()),
+            db.verify_accounts_hash_and_lamports_for_tests(some_slot, 1, config.clone()),
             Ok(_)
         );
 
         db.accounts_hashes.lock().unwrap().remove(&some_slot);
 
         assert_matches!(
-            db.verify_accounts_hash_and_lamports(some_slot, 1, None, config.clone()),
+            db.verify_accounts_hash_and_lamports_for_tests(some_slot, 1, config.clone()),
             Err(AccountsHashVerificationError::MissingAccountsHash)
         );
 
@@ -12366,7 +12375,7 @@ pub mod tests {
         );
 
         assert_matches!(
-            db.verify_accounts_hash_and_lamports(some_slot, 1, None, config),
+            db.verify_accounts_hash_and_lamports_for_tests(some_slot, 1, config),
             Err(AccountsHashVerificationError::MismatchedAccountsHash)
         );
     }
@@ -12414,12 +12423,12 @@ pub mod tests {
             db.update_accounts_hash_for_tests(some_slot, &ancestors, true, true);
 
             assert_matches!(
-                db.verify_accounts_hash_and_lamports(some_slot, 2, None, config.clone()),
+                db.verify_accounts_hash_and_lamports_for_tests(some_slot, 2, config.clone()),
                 Ok(_)
             );
 
             assert_matches!(
-                db.verify_accounts_hash_and_lamports(some_slot, 10, None, config),
+                db.verify_accounts_hash_and_lamports_for_tests(some_slot, 10, config),
                 Err(AccountsHashVerificationError::MismatchedTotalLamports(expected, actual)) if expected == 2 && actual == 10
             );
         }
@@ -12445,7 +12454,7 @@ pub mod tests {
         );
 
         assert_matches!(
-            db.verify_accounts_hash_and_lamports(some_slot, 0, None, config),
+            db.verify_accounts_hash_and_lamports_for_tests(some_slot, 0, config),
             Ok(_)
         );
     }
@@ -12483,7 +12492,7 @@ pub mod tests {
         );
 
         assert_matches!(
-            db.verify_accounts_hash_and_lamports(some_slot, 1, None, config),
+            db.verify_accounts_hash_and_lamports_for_tests(some_slot, 1, config),
             Err(AccountsHashVerificationError::MismatchedAccountsHash)
         );
     }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -546,7 +546,7 @@ mod serde_snapshot_tests {
         );
 
         accounts
-            .verify_accounts_hash_and_lamports(4, 1222, None, config)
+            .verify_accounts_hash_and_lamports_for_tests(4, 1222, config)
             .unwrap();
     }
 
@@ -834,12 +834,12 @@ mod serde_snapshot_tests {
 
             accounts.update_accounts_hash_for_tests(current_slot, &no_ancestors, false, false);
             accounts
-                .verify_accounts_hash_and_lamports(current_slot, 22300, None, config.clone())
+                .verify_accounts_hash_and_lamports_for_tests(current_slot, 22300, config.clone())
                 .unwrap();
 
             let accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
             accounts
-                .verify_accounts_hash_and_lamports(current_slot, 22300, None, config)
+                .verify_accounts_hash_and_lamports_for_tests(current_slot, 22300, config)
                 .unwrap();
 
             // repeating should be no-op


### PR DESCRIPTION
#### Problem

We need to pass in the snapshot storages as a function parameter to `verify_accounts_hash_and_lamports()` as the fix for startup verification accounts hash mismatch issues due to storages getting cleaned away prematurely.

When we change the function signature by adding a new parameter, it'll require changing a bunch of tests as well. To minimize that noise, and reduce accidentally breaking tests, we could create a test wrapper. Then we'd only need to update a single location for all the tests.


#### Summary of Changes

Add `verify_accounts_hash_and_lamports_for_tests()`, which is a wrapper to call `verify_accounts_hash_and_lamports_for_tests()`. This will be updated by future PRs.