### PR TITLE
transaction-status: fix `disableConfidentialTransferNonConfidentialCredits` parsing

### DIFF
--- a/transaction-status/src/parse_token/extension/confidential_transfer.rs
+++ b/transaction-status/src/parse_token/extension/confidential_transfer.rs
@@ -318,7 +318,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 "multisigOwner",
             );
             Ok(ParsedInstructionEnum {
-                instruction_type: "disableNonConfidentialTransferConfidentialCredits".to_string(),
+                instruction_type: "disableConfidentialTransferNonConfidentialCredits".to_string(),
                 info: value,
             })
         }


### PR DESCRIPTION
#### Problem
The transaction-status crate marks Token-2022's Confidential Transfer instruction `DisableNonConfidentialCredits` as instruction type `disableNonConfidentialTransferConfidentialCredits`.

It should follow the same pattern as its counterpart, `enableConfidentialTransferNonConfidentialCredits`, and be `disableConfidentialTransferNonConfidentialCredits` (with the "Non" slid backward).

#### Summary of Changes
Update the instruction name.
