### PR TITLE
Banking forwarder share per-account forwardable packets batcher

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -624,6 +624,7 @@ impl BankingStage {
         Self { bank_thread_hdls }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn spawn_thread_local_multi_iterator_thread(
         id: u32,
         packet_receiver: BankingPacketReceiver,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -54,6 +54,7 @@ use {
 pub mod committer;
 pub mod consumer;
 pub mod forwarder;
+pub mod forward_packet_batches_by_accounts;
 pub mod leader_slot_metrics;
 pub mod qos_service;
 pub mod unprocessed_packet_batches;
@@ -61,7 +62,6 @@ pub mod unprocessed_transaction_storage;
 
 mod consume_worker;
 mod decision_maker;
-mod forward_packet_batches_by_accounts;
 mod forward_worker;
 mod immutable_deserialized_packet;
 mod latest_unprocessed_votes;

--- a/core/src/banking_stage/forward_packet_batches_by_accounts.rs
+++ b/core/src/banking_stage/forward_packet_batches_by_accounts.rs
@@ -45,6 +45,10 @@ impl ForwardBatch {
     pub fn is_empty(&self) -> bool {
         self.forwardable_packets.is_empty()
     }
+
+    pub fn reset(&mut self) {
+        self.forwardable_packets.clear();
+    }
 }
 
 /// To avoid forward queue being saturated by transactions for single hot account,
@@ -125,6 +129,14 @@ impl ForwardPacketBatchesByAccounts {
 
     pub fn iter_batches(&self) -> impl Iterator<Item = &ForwardBatch> {
         self.forward_batches.iter()
+    }
+
+    pub fn reset(&mut self) {
+        for forward_batch in self.forward_batches.iter_mut() {
+            forward_batch.reset();
+        }
+
+        self.cost_tracker.reset();
     }
 
     // Successfully added packet should be placed into the batch where no block/vote/account limits

--- a/core/src/banking_stage/forward_packet_batches_by_accounts.rs
+++ b/core/src/banking_stage/forward_packet_batches_by_accounts.rs
@@ -148,14 +148,15 @@ impl ForwardPacketBatchesByAccounts {
         tx_cost: &TransactionCost,
         updated_costs: &UpdatedCosts,
     ) -> usize {
-        let batch_index_by_block_limit =
-            match updated_costs.updated_block_cost.checked_div(match tx_cost {
+        let Some(batch_index_by_block_limit) =
+            updated_costs.updated_block_cost.checked_div(match tx_cost {
                 TransactionCost::SimpleVote { .. } => self.batch_vote_limit,
                 TransactionCost::Transaction(_) => self.batch_block_limit,
-            }) {
-                Some(quotient) => quotient,
-                None => unreachable!("batch vote or block limit must not be zero"),
-            };
+            })
+        else {
+            unreachable!("batch vote limit or block limit must not be zero")
+        };
+
         let batch_index_by_account_limit =
             updated_costs.updated_costliest_account_cost / self.batch_account_limit;
 

--- a/core/src/banking_stage/forward_packet_batches_by_accounts.rs
+++ b/core/src/banking_stage/forward_packet_batches_by_accounts.rs
@@ -148,10 +148,13 @@ impl ForwardPacketBatchesByAccounts {
         tx_cost: &TransactionCost,
         updated_costs: &UpdatedCosts,
     ) -> usize {
-        let batch_index_by_block_limit = updated_costs.updated_block_cost
-            / match tx_cost {
+        let batch_index_by_block_limit =
+            match updated_costs.updated_block_cost.checked_div(match tx_cost {
                 TransactionCost::SimpleVote { .. } => self.batch_vote_limit,
                 TransactionCost::Transaction(_) => self.batch_block_limit,
+            }) {
+                Some(quotient) => quotient,
+                None => unreachable!("batch vote or block limit must not be zero"),
             };
         let batch_index_by_account_limit =
             updated_costs.updated_costliest_account_cost / self.batch_account_limit;

--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -54,26 +54,6 @@ impl Forwarder {
     pub fn handle_forwarding(
         &self,
         unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
-        hold: bool,
-        slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
-        banking_stage_stats: &BankingStageStats,
-        tracer_packet_stats: &mut TracerPacketStats,
-    ) {
-        let mut forward_packet_batches_by_accounts =
-            ForwardPacketBatchesByAccounts::new_with_default_batch_limits();
-        self.handle_forwarding_2(
-            unprocessed_transaction_storage,
-            &mut forward_packet_batches_by_accounts,
-            hold,
-            slot_metrics_tracker,
-            banking_stage_stats,
-            tracer_packet_stats,
-        );
-    }
-
-    pub fn handle_forwarding_2(
-        &self,
-        unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
         forward_packet_batches_by_accounts: &mut ForwardPacketBatchesByAccounts,
         hold: bool,
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
@@ -405,6 +385,7 @@ mod tests {
                     unprocessed_packet_batches,
                     ThreadType::Transactions,
                 ),
+                &mut ForwardPacketBatchesByAccounts::new_with_default_batch_limits(),
                 true,
                 &mut LeaderSlotMetricsTracker::new(0),
                 &stats,
@@ -482,6 +463,7 @@ mod tests {
             let stats = BankingStageStats::default();
             forwarder.handle_forwarding(
                 &mut unprocessed_packet_batches,
+                &mut ForwardPacketBatchesByAccounts::new_with_default_batch_limits(),
                 hold,
                 &mut LeaderSlotMetricsTracker::new(0),
                 &stats,

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -102,6 +102,18 @@ impl Default for CostTracker {
 }
 
 impl CostTracker {
+    pub fn reset(&mut self) {
+        self.cost_by_writable_accounts.clear();
+        self.block_cost = 0;
+        self.vote_cost = 0;
+        self.transaction_count = 0;
+        self.account_data_size = 0;
+        self.transaction_signature_count = 0;
+        self.secp256k1_instruction_signature_count = 0;
+        self.ed25519_instruction_signature_count = 0;
+        self.in_flight_transaction_count = 0;
+    }
+
     /// allows to adjust limits initiated during construction
     pub fn set_limits(
         &mut self,


### PR DESCRIPTION
#### Problem

Follow-up of #1156, instead of allocating `ForwardPacketBatchesByAccounts` every time forwarding is called, sharing it between calls.

#### Summary of Changes
- further reduce memory (re)allocation by sharing single instance of `ForwardPacketBatchesByAccounts` between forwarding calls
- updated multi-iterator and central schedulers to do that. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
