### PR TITLE
ledger-tool: Remove blockstore json command

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -347,12 +347,6 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
             .about("Print all the duplicate slots in the ledger")
             .settings(&hidden)
             .arg(&starting_slot_arg),
-        SubCommand::with_name("json")
-            .about("Print the ledger in JSON format")
-            .settings(&hidden)
-            .arg(&starting_slot_arg)
-            .arg(&ending_slot_arg)
-            .arg(&allow_dead_slots_arg),
         SubCommand::with_name("latest-optimistic-slots")
             .about(
                 "Output up to the most recent <num-slots> optimistic slots with their hashes \
@@ -717,21 +711,6 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 println!("{slot}");
             }
         }
-        ("json", Some(arg_matches)) => {
-            let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
-            let ending_slot = value_t!(arg_matches, "ending_slot", Slot).unwrap_or(Slot::MAX);
-            let allow_dead_slots = arg_matches.is_present("allow_dead_slots");
-            output_ledger(
-                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary),
-                starting_slot,
-                ending_slot,
-                allow_dead_slots,
-                OutputFormat::Json,
-                None,
-                std::u64::MAX,
-                true,
-            );
-        }
         ("latest-optimistic-slots", Some(arg_matches)) => {
             let blockstore =
                 crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
@@ -858,12 +837,14 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             let num_slots = value_t!(arg_matches, "num_slots", Slot).ok();
             let allow_dead_slots = arg_matches.is_present("allow_dead_slots");
             let only_rooted = arg_matches.is_present("only_rooted");
+            let output_format = OutputFormat::from_matches(arg_matches, "output_format", false);
+
             output_ledger(
                 crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary),
                 starting_slot,
                 ending_slot,
                 allow_dead_slots,
-                OutputFormat::Display,
+                output_format,
                 num_slots,
                 verbose_level,
                 only_rooted,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1534,7 +1534,6 @@ fn main() {
         | ("copy", Some(_))
         | ("dead-slots", Some(_))
         | ("duplicate-slots", Some(_))
-        | ("json", Some(_))
         | ("latest-optimistic-slots", Some(_))
         | ("list-roots", Some(_))
         | ("parse_full_frozen", Some(_))


### PR DESCRIPTION
#### Problem
This command is basically an exact duplicate of the print command, except print had `OutputFormat::Display` hard-coded whereas the json command had `OutputFormat::Json` hard-coded.

#### Summary of Changes
Instead of hard-coded values, parse value of `--output-format` from CLI to avoid the extra command

#### Change of Behavior
Some minor changes of behavior between `agave-ledger-tool print --output json` and `agave-ledger-tool json`:
- `print` has additional flags for limiting number of slots and only allowing rooted slots
- `print` parses verbosity level from CLI, `json` previously set max verbosity, which means entries and signatures / accounts / etc are all printed
- The `output_slot()` function outputs "raw" json as opposed to parsed json. Many of these items are `Pubkey` / `Signature` / `Hash`, which are output as byte arrays ... not very helpful for working with others tooling (ie pasting a pubkey into explorer)
    - I have been looking at tackling this issue as well and will do so in subsequent PR. The idea is to make `slot` and `print` commands use the same block output method as `bigtable block` command
    
So, my justification for removing the `json` command is that it is redundant (json should be flag, not an extra command to match other CLI functionality) AND that the existing `json` command's output is basically noise in its' current state