### PR TITLE
ci: don't self-update rustup when using the rust-version script

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -45,7 +45,7 @@ export ci_docker_image="anzaxyz/ci:rust_${rust_stable}_${rust_nightly}"
     declare toolchain=$1
     if ! cargo +"$toolchain" -V > /dev/null; then
       echo "$0: Missing toolchain? Installing...: $toolchain" >&2
-      rustup install "$toolchain"
+      rustup install "$toolchain" --no-self-update
       cargo +"$toolchain" -V
     fi
   }

--- a/cli-config/src/lib.rs
+++ b/cli-config/src/lib.rs
@@ -117,3 +117,5 @@ where
 
     Ok(())
 }
+
+// fake updates

--- a/cli-config/src/lib.rs
+++ b/cli-config/src/lib.rs
@@ -117,5 +117,3 @@ where
 
     Ok(())
 }
-
-// fake updates


### PR DESCRIPTION
#### Problem

we have some issues with Windows pipelines when setting up Rust version.
context: https://discord.com/channels/428295358100013066/560503042458517505/1237118149510566011

I found an issue in rustup repo: https://github.com/rust-lang/rustup/issues/3709

I think it's harmless to adopt the workaround as our standard process. (even a better idea :trollface:)

#### Summary of Changes

add `--no-self-update` to rust-version

the successful build: https://github.com/anza-xyz/agave/actions/runs/8979866592/job/24662583658?pr=1209
