### PR TITLE
Make unified schedler abort on tx execution errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7534,6 +7534,7 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "derivative",
+ "lazy_static",
  "log",
  "qualifier_attr",
  "solana-ledger",

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -107,7 +107,9 @@ fn test_scheduler_waited_by_drop_bank_service() {
     // Delay transaction execution to ensure transaction execution happens after termintion has
     // been started
     let lock_to_stall = LOCK_TO_STALL.lock().unwrap();
-    pruned_bank.schedule_transaction_executions([(&tx, &0)].into_iter());
+    pruned_bank
+        .schedule_transaction_executions([(&tx, &0)].into_iter())
+        .unwrap();
     drop(pruned_bank);
     assert_eq!(pool_raw.pooled_scheduler_count(), 0);
     drop(lock_to_stall);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -338,11 +338,29 @@ fn process_batches(
             "process_batches()/schedule_batches_for_execution({} batches)",
             batches.len()
         );
-        // scheduling always succeeds here without being blocked on actual transaction executions.
-        // The transaction execution errors will be collected via the blocking fn called
-        // BankWithScheduler::wait_for_completed_scheduler(), if any.
-        schedule_batches_for_execution(bank, batches);
-        Ok(())
+        // Scheduling usually succeeds (immediately returns `Ok(())`) here without being blocked on
+        // the actual transaction executions.
+        //
+        // As an exception, this code path could propagate the transaction execution _errors of
+        // previously-scheduled transactions_ to notify the replay stage. Then, the replay stage
+        // will bail out the further processing of the malformed (possibly malicious) block
+        // immediately, not to waste any system resources. Note that this propagation is of early
+        // hints. Even if errors won't be propagated in this way, they are guaranteed to be
+        // propagated eventually via the blocking fn called
+        // BankWithScheduler::wait_for_completed_scheduler().
+        //
+        // To recite, the returned error is completely unrelated to the argument's `batches` at the
+        // hand. While being awkward, the _async_ unified scheduler is abusing this existing error
+        // propagation code path to the replay stage for compatibility and ease of integration,
+        // exploiting the fact that the replay stage doesn't care _which transaction the returned
+        // error is originating from_.
+        //
+        // In the future, more proper error propagation mechanism will be introduced once after we
+        // fully transition to the unified scheduler for the block verification. That one would be
+        // a push based one from the unified scheduler to the replay stage to eliminate the current
+        // overhead: 1 read lock per batch in
+        // `BankWithScheduler::schedule_transaction_executions()`.
+        schedule_batches_for_execution(bank, batches)
     } else {
         debug!(
             "process_batches()/rebatch_and_execute_batches({} batches)",
@@ -364,7 +382,7 @@ fn process_batches(
 fn schedule_batches_for_execution(
     bank: &BankWithScheduler,
     batches: &[TransactionBatchWithIndexes],
-) {
+) -> Result<()> {
     for TransactionBatchWithIndexes {
         batch,
         transaction_indexes,
@@ -375,8 +393,9 @@ fn schedule_batches_for_execution(
                 .sanitized_transactions()
                 .iter()
                 .zip(transaction_indexes.iter()),
-        );
+        )?;
     }
+    Ok(())
 }
 
 fn rebatch_transactions<'a>(
@@ -2138,7 +2157,8 @@ pub mod tests {
                 self, create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs,
             },
             installed_scheduler_pool::{
-                MockInstalledScheduler, MockUninstalledScheduler, SchedulingContext,
+                MockInstalledScheduler, MockUninstalledScheduler, SchedulerAborted,
+                SchedulingContext,
             },
         },
         solana_sdk::{
@@ -4740,8 +4760,7 @@ pub mod tests {
         assert_eq!(batch3.transaction_indexes, vec![43, 44]);
     }
 
-    #[test]
-    fn test_schedule_batches_for_execution() {
+    fn do_test_schedule_batches_for_execution(should_succeed: bool) {
         solana_logger::setup();
         let dummy_leader_pubkey = solana_sdk::pubkey::new_rand();
         let GenesisConfigInfo {
@@ -4762,10 +4781,23 @@ pub mod tests {
             .times(1)
             .in_sequence(&mut seq.lock().unwrap())
             .return_const(context);
-        mocked_scheduler
-            .expect_schedule_execution()
-            .times(txs.len())
-            .returning(|_| ());
+        if should_succeed {
+            mocked_scheduler
+                .expect_schedule_execution()
+                .times(txs.len())
+                .returning(|(_, _)| Ok(()));
+        } else {
+            // mocked_scheduler isn't async; so short-circuiting behavior is quite visible in that
+            // .times(1) is called instead of .times(txs.len()), not like the succeeding case
+            mocked_scheduler
+                .expect_schedule_execution()
+                .times(1)
+                .returning(|(_, _)| Err(SchedulerAborted));
+            mocked_scheduler
+                .expect_recover_error_after_abort()
+                .times(1)
+                .returning(|| TransactionError::InsufficientFundsForFee);
+        }
         mocked_scheduler
             .expect_wait_for_termination()
             .with(mockall::predicate::eq(true))
@@ -4794,7 +4826,7 @@ pub mod tests {
         let replay_tx_thread_pool = create_thread_pool(1);
         let mut batch_execution_timing = BatchExecutionTiming::default();
         let ignored_prioritization_fee_cache = PrioritizationFeeCache::new(0u64);
-        assert!(process_batches(
+        let result = process_batches(
             &bank,
             &replay_tx_thread_pool,
             &[batch_with_indexes],
@@ -4802,9 +4834,23 @@ pub mod tests {
             None,
             &mut batch_execution_timing,
             None,
-            &ignored_prioritization_fee_cache
-        )
-        .is_ok());
+            &ignored_prioritization_fee_cache,
+        );
+        if should_succeed {
+            assert_matches!(result, Ok(()));
+        } else {
+            assert_matches!(result, Err(TransactionError::InsufficientFundsForFee));
+        }
+    }
+
+    #[test]
+    fn test_schedule_batches_for_execution_success() {
+        do_test_schedule_batches_for_execution(true);
+    }
+
+    #[test]
+    fn test_schedule_batches_for_execution_failure() {
+        do_test_schedule_batches_for_execution(false);
     }
 
     #[test]

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -116,16 +116,17 @@ pub trait InstalledScheduler: Send + Sync + Debug + 'static {
     /// previously-scheduled bad transaction, which terminates further block verification. So,
     /// almost always, the returned error isn't due to the merely scheduling of the current
     /// transaction itself. At this point, calling this does nothing anymore while it's still safe
-    /// to do. As soon as notified, callers is expected to stop processing upcoming transactions of
-    /// the same `SchedulingContext` (i.e. same block). Internally, the aborted scheduler will be
-    /// disposed cleanly, not repooled, after `wait_for_termination()` is called, much like
+    /// to do. As soon as notified, callers are expected to stop processing upcoming transactions
+    /// of the same `SchedulingContext` (i.e. same block). Internally, the aborted scheduler will
+    /// be disposed cleanly, not repooled, after `wait_for_termination()` is called like
     /// not-aborted schedulers.
     ///
     /// Caller can acquire the error by calling a separate function called
     /// `recover_error_after_abort()`, which requires `&mut self`, instead of `&self`. This
-    /// separation and convoluted returned value semantics explained above are intentional to
+    /// separation and the convoluted returned value semantics explained above are intentional to
     /// optimize the fast code-path of normal transaction scheduling to be multi-threaded at the
-    /// cost of far slower error code-path.
+    /// cost of far slower error code-path while giving implementors increased flexibility by
+    /// having &mut.
     fn schedule_execution<'a>(
         &'a self,
         transaction_with_index: &'a (&'a SanitizedTransaction, usize),

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -27,7 +27,7 @@ use {
     solana_sdk::{
         hash::Hash,
         slot_history::Slot,
-        transaction::{Result, SanitizedTransaction},
+        transaction::{Result, SanitizedTransaction, TransactionError},
     },
     std::{
         fmt::Debug,
@@ -41,6 +41,10 @@ use {mockall::automock, qualifier_attr::qualifiers};
 pub trait InstalledSchedulerPool: Send + Sync + Debug {
     fn take_scheduler(&self, context: SchedulingContext) -> InstalledSchedulerBox;
 }
+
+#[derive(Debug)]
+pub struct SchedulerAborted;
+pub type ScheduleResult = std::result::Result<(), SchedulerAborted>;
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// Schedules, executes, and commits transactions under encapsulated implementation
@@ -101,17 +105,50 @@ pub trait InstalledScheduler: Send + Sync + Debug + 'static {
     fn id(&self) -> SchedulerId;
     fn context(&self) -> &SchedulingContext;
 
-    // Calling this is illegal as soon as wait_for_termination is called.
+    /// Schedule transaction for execution.
+    ///
+    /// This non-blocking function will return immediately without waiting for actual execution.
+    ///
+    /// Calling this is illegal as soon as `wait_for_termination()` is called. It would result in
+    /// fatal logic error.
+    ///
+    /// Note that the returned result indicates whether the scheduler has been aborted due to a
+    /// previously-scheduled bad transaction, which terminates further block verification. So,
+    /// almost always, the returned error isn't due to the merely scheduling of the current
+    /// transaction itself. At this point, calling this does nothing anymore while it's still safe
+    /// to do. As soon as notified, callers is expected to stop processing upcoming transactions of
+    /// the same `SchedulingContext` (i.e. same block). Internally, the aborted scheduler will be
+    /// disposed cleanly, not repooled, after `wait_for_termination()` is called, much like
+    /// not-aborted schedulers.
+    ///
+    /// Caller can acquire the error by calling a separate function called
+    /// `recover_error_after_abort()`, which requires `&mut self`, instead of `&self`. This
+    /// separation and convoluted returned value semantics explained above are intentional to
+    /// optimize the fast code-path of normal transaction scheduling to be multi-threaded at the
+    /// cost of far slower error code-path.
     fn schedule_execution<'a>(
         &'a self,
         transaction_with_index: &'a (&'a SanitizedTransaction, usize),
-    );
+    ) -> ScheduleResult;
+
+    /// Return the error which caused the scheduler to abort.
+    ///
+    /// Note that this must not be called until it's observed that `schedule_execution()` has
+    /// returned `Err(SchedulerAborted)`. Violating this will `panic!()`.
+    ///
+    /// That said, calling this multiple times is completely acceptable after the error observation
+    /// from `schedule_execution()`. While it's not guaranteed, the same `.clone()`-ed errors of
+    /// the first bad transaction are usually returned across invocations.
+    fn recover_error_after_abort(&mut self) -> TransactionError;
 
     /// Wait for a scheduler to terminate after processing.
     ///
     /// This function blocks the current thread while waiting for the scheduler to complete all of
     /// the executions for the scheduled transactions and to return the finalized
-    /// `ResultWithTimings`. Along with the result, this function also makes the scheduler itself
+    /// `ResultWithTimings`. This function still blocks for short period of time even in the case
+    /// of aborted schedulers to gracefully shutdown the scheduler (like thread joining).
+    ///
+    /// Along with the result being returned, this function also makes the scheduler itself
     /// uninstalled from the bank by transforming the consumed self.
     ///
     /// If no transaction is scheduled, the result and timing will be `Ok(())` and
@@ -286,11 +323,15 @@ impl BankWithScheduler {
         self.inner.scheduler.read().unwrap().is_some()
     }
 
+    /// Schedule the transaction as long as the scheduler hasn't been aborted.
+    ///
+    /// If the scheduler has been aborted, this doesn't schedule the transaction, instead just
+    /// return the error of prior scheduled transaction.
     // 'a is needed; anonymous_lifetime_in_impl_trait isn't stabilized yet...
     pub fn schedule_transaction_executions<'a>(
         &self,
         transactions_with_indexes: impl ExactSizeIterator<Item = (&'a SanitizedTransaction, &'a usize)>,
-    ) {
+    ) -> Result<()> {
         trace!(
             "schedule_transaction_executions(): {} txs",
             transactions_with_indexes.len()
@@ -300,8 +341,25 @@ impl BankWithScheduler {
         let scheduler = scheduler_guard.as_ref().unwrap();
 
         for (sanitized_transaction, &index) in transactions_with_indexes {
-            scheduler.schedule_execution(&(sanitized_transaction, index));
+            if scheduler
+                .schedule_execution(&(sanitized_transaction, index))
+                .is_err()
+            {
+                drop(scheduler_guard);
+                // This write lock isn't atomic with the above the read lock. So, another thread
+                // could have called .recover_error_after_abort() while we're literally stuck at
+                // the gaps of these locks (i.e. this comment in source code wise) under extreme
+                // race conditions. Thus, .recover_error_after_abort() is made idempotetnt for that
+                // consideration in mind.
+                //
+                // Lastly, this non-atomic nature is intentional for optimizing the fast code-path
+                let mut scheduler_guard = self.inner.scheduler.write().unwrap();
+                let scheduler = scheduler_guard.as_mut().unwrap();
+                return Err(scheduler.recover_error_after_abort());
+            }
         }
+
+        Ok(())
     }
 
     // take needless &mut only to communicate its semantic mutability to humans...
@@ -550,8 +608,7 @@ mod tests {
         assert_matches!(bank.wait_for_completed_scheduler(), Some(_));
     }
 
-    #[test]
-    fn test_schedule_executions() {
+    fn do_test_schedule_execution(should_succeed: bool) {
         solana_logger::setup();
 
         let GenesisConfigInfo {
@@ -570,14 +627,40 @@ mod tests {
             bank.clone(),
             [true].into_iter(),
             Some(|mocked: &mut MockInstalledScheduler| {
-                mocked
-                    .expect_schedule_execution()
-                    .times(1)
-                    .returning(|(_, _)| ());
+                if should_succeed {
+                    mocked
+                        .expect_schedule_execution()
+                        .times(1)
+                        .returning(|(_, _)| Ok(()));
+                } else {
+                    mocked
+                        .expect_schedule_execution()
+                        .times(1)
+                        .returning(|(_, _)| Err(SchedulerAborted));
+                    mocked
+                        .expect_recover_error_after_abort()
+                        .times(1)
+                        .returning(|| TransactionError::InsufficientFundsForFee);
+                }
             }),
         );
 
         let bank = BankWithScheduler::new(bank, Some(mocked_scheduler));
-        bank.schedule_transaction_executions([(&tx0, &0)].into_iter());
+        let result = bank.schedule_transaction_executions([(&tx0, &0)].into_iter());
+        if should_succeed {
+            assert_matches!(result, Ok(()));
+        } else {
+            assert_matches!(result, Err(TransactionError::InsufficientFundsForFee));
+        }
+    }
+
+    #[test]
+    fn test_schedule_execution_success() {
+        do_test_schedule_execution(true);
+    }
+
+    #[test]
+    fn test_schedule_execution_failure() {
+        do_test_schedule_execution(false);
     }
 }

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -135,7 +135,7 @@ pub trait InstalledScheduler: Send + Sync + Debug + 'static {
     /// Return the error which caused the scheduler to abort.
     ///
     /// Note that this must not be called until it's observed that `schedule_execution()` has
-    /// returned `Err(SchedulerAborted)`. Violating this will `panic!()`.
+    /// returned `Err(SchedulerAborted)`. Violating this should `panic!()`.
     ///
     /// That said, calling this multiple times is completely acceptable after the error observation
     /// from `schedule_execution()`. While it's not guaranteed, the same `.clone()`-ed errors of

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -25,6 +25,7 @@ solana-vote = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+lazy_static = { workspace = true }
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -174,7 +174,7 @@ where
             }
         };
 
-        // No need to join; the spanwed main loop will gracefully exit.
+        // No need to join; the spawned main loop will gracefully exit.
         thread::Builder::new()
             .name("solScCleaner".to_owned())
             .spawn(cleaner_main_loop())

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -555,7 +555,7 @@ where
     fn drop(&mut self) {
         trace!("ThreadManager::drop() is called...");
 
-        if self.is_threads_joined() {
+        if self.are_threads_joined() {
             return;
         }
         // If on-stack ThreadManager is being dropped abruptly while panicking, it's likely
@@ -592,7 +592,7 @@ where
     }
 
     fn is_trashed(&self) -> bool {
-        self.thread_manager.is_threads_joined()
+        self.thread_manager.are_threads_joined()
     }
 }
 
@@ -1065,7 +1065,7 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
             .unwrap_err()
     }
 
-    fn is_threads_joined(&self) -> bool {
+    fn are_threads_joined(&self) -> bool {
         if self.scheduler_thread.is_none() {
             assert!(self.handler_threads.is_empty());
             true
@@ -1075,7 +1075,7 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
     }
 
     fn end_session(&mut self) {
-        if self.is_threads_joined() {
+        if self.are_threads_joined() {
             assert!(self.session_result_with_timings.is_some());
             debug!("end_session(): skipping; already joined the aborted threads..");
             return;

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -143,7 +143,7 @@ where
             _phantom: PhantomData,
         });
 
-        let cleaner_main_loop = || {
+        let cleaner_main_loop = {
             let weak_scheduler_pool = Arc::downgrade(&scheduler_pool);
 
             move || loop {
@@ -177,7 +177,7 @@ where
         // No need to join; the spawned main loop will gracefully exit.
         thread::Builder::new()
             .name("solScCleaner".to_owned())
-            .spawn(cleaner_main_loop())
+            .spawn(cleaner_main_loop)
             .unwrap();
 
         scheduler_pool

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -56,6 +56,8 @@ use {
 mod sleepless_testing;
 use crate::sleepless_testing::BuilderTracked;
 
+// dead_code is false positive; these tuple fields are used via Debug.
+#[allow(dead_code)]
 #[derive(Debug)]
 enum CheckPoint {
     NewTask(usize),

--- a/unified-scheduler-pool/src/sleepless_testing.rs
+++ b/unified-scheduler-pool/src/sleepless_testing.rs
@@ -3,6 +3,7 @@ use std::{
     thread::{JoinHandle, Scope, ScopedJoinHandle},
 };
 
+#[allow(dead_code)]
 pub(crate) trait ScopeTracked<'scope>: Sized {
     fn spawn_tracked<T: Send + 'scope>(
         &'scope self,
@@ -16,6 +17,7 @@ pub(crate) trait BuilderTracked: Sized {
         f: impl FnOnce() -> T + Send + 'static,
     ) -> io::Result<JoinHandle<T>>;
 
+    #[allow(dead_code)]
     fn spawn_scoped_tracked<'scope, 'env, T: Send + 'scope>(
         self,
         scope: &'scope Scope<'scope, 'env>,

--- a/unified-scheduler-pool/src/sleepless_testing.rs
+++ b/unified-scheduler-pool/src/sleepless_testing.rs
@@ -1,0 +1,350 @@
+use std::{
+    io,
+    thread::{JoinHandle, Scope, ScopedJoinHandle},
+};
+
+pub(crate) trait ScopeTracked<'scope>: Sized {
+    fn spawn_tracked<T: Send + 'scope>(
+        &'scope self,
+        f: impl FnOnce() -> T + Send + 'scope,
+    ) -> ScopedJoinHandle<'scope, T>;
+}
+
+pub(crate) trait BuilderTracked: Sized {
+    fn spawn_tracked<T: Send + 'static>(
+        self,
+        f: impl FnOnce() -> T + Send + 'static,
+    ) -> io::Result<JoinHandle<T>>;
+
+    fn spawn_scoped_tracked<'scope, 'env, T: Send + 'scope>(
+        self,
+        scope: &'scope Scope<'scope, 'env>,
+        f: impl FnOnce() -> T + Send + 'scope,
+    ) -> io::Result<ScopedJoinHandle<'scope, T>>;
+}
+
+#[cfg(not(test))]
+pub(crate) use sleepless_testing_dummy::*;
+#[cfg(test)]
+pub(crate) use sleepless_testing_real::*;
+
+#[cfg(test)]
+mod sleepless_testing_real {
+    use {
+        lazy_static::lazy_static,
+        std::{
+            cmp::Ordering::{Equal, Greater, Less},
+            collections::{HashMap, HashSet},
+            fmt::Debug,
+            sync::{Arc, Condvar, Mutex},
+            thread::{current, JoinHandle, ThreadId},
+        },
+    };
+
+    #[derive(Debug)]
+    struct Progress {
+        _name: String,
+        check_points: Vec<String>,
+        current_check_point: Mutex<String>,
+        condvar: Condvar,
+    }
+
+    #[derive(Debug)]
+    struct JustCreated;
+
+    impl Progress {
+        fn new(check_points: impl Iterator<Item = String>, name: String) -> Self {
+            let initial_check_point = format!("{JustCreated:?}");
+            let check_points = [initial_check_point.clone()]
+                .into_iter()
+                .chain(check_points)
+                .collect::<Vec<_>>();
+            let check_points_set = check_points.iter().collect::<HashSet<_>>();
+            assert_eq!(check_points.len(), check_points_set.len());
+
+            Self {
+                _name: name,
+                check_points,
+                current_check_point: Mutex::new(initial_check_point),
+                condvar: Condvar::new(),
+            }
+        }
+
+        fn change_current_check_point(&self, anchored_check_point: String) {
+            let Some(anchored_index) = self
+                .check_points
+                .iter()
+                .position(|check_point| check_point == &anchored_check_point)
+            else {
+                // Ignore unrecognizable checkpoints...
+                return;
+            };
+
+            let mut current_check_point = self.current_check_point.lock().unwrap();
+
+            let should_change =
+                match anchored_index.cmp(&self.expected_next_index(&current_check_point)) {
+                    Equal => true,
+                    Greater => {
+                        // anchor is one of future check points; block the current thread until
+                        // that happens
+                        current_check_point = self
+                            .condvar
+                            .wait_while(current_check_point, |current_check_point| {
+                                anchored_index != self.expected_next_index(current_check_point)
+                            })
+                            .unwrap();
+                        true
+                    }
+                    // anchor is already observed.
+                    Less => false,
+                };
+
+            if should_change {
+                *current_check_point = anchored_check_point;
+                self.condvar.notify_all();
+            }
+        }
+
+        fn expected_next_index(&self, current_check_point: &String) -> usize {
+            let current_index = self
+                .check_points
+                .iter()
+                .position(|check_point| check_point == current_check_point)
+                .unwrap();
+            current_index.checked_add(1).unwrap()
+        }
+    }
+
+    lazy_static! {
+        static ref THREAD_REGISTRY: Mutex<HashMap<ThreadId, Arc<Progress>>> =
+            Mutex::new(HashMap::new());
+    }
+
+    #[must_use]
+    pub(crate) struct ActiveProgress(Arc<Progress>, ThreadId);
+
+    impl ActiveProgress {
+        fn new(progress: Arc<Progress>) -> Self {
+            let active_progress = Self(progress, current().id());
+            active_progress.activate();
+            active_progress
+        }
+
+        fn activate(&self) {
+            assert!(THREAD_REGISTRY
+                .lock()
+                .unwrap()
+                .insert(self.1, self.0.clone())
+                .is_none());
+        }
+
+        fn deactivate(&self) {
+            assert_eq!(
+                *self.0.check_points.last().unwrap(),
+                *self.0.current_check_point.lock().unwrap(),
+                "unfinished progress"
+            );
+            THREAD_REGISTRY.lock().unwrap().remove(&self.1).unwrap();
+        }
+    }
+
+    impl Drop for ActiveProgress {
+        fn drop(&mut self) {
+            self.deactivate();
+        }
+    }
+
+    /// Enable sleepless_testing with given check points being monitored, until the returned value
+    /// is dropped. This guarantees the check points are linearized in the exact order as
+    /// specified, among all of tracked threads.
+    pub(crate) fn setup(check_points: &[&dyn Debug]) -> ActiveProgress {
+        let progress = Arc::new(Progress::new(
+            check_points
+                .iter()
+                .map(|check_point| format!("{check_point:?}")),
+            current().name().unwrap_or_default().to_string(),
+        ));
+        ActiveProgress::new(progress)
+    }
+
+    /// Signal about the passage of the given check point. If sleepless_testing is enabled with the
+    /// check point monitored, this may block the current thread, not to violate the enforced order
+    /// of monitored check points.
+    pub(crate) fn at<T: Debug>(check_point: T) {
+        let mut registry = THREAD_REGISTRY.lock().unwrap();
+        if let Some(progress) = registry.get_mut(&current().id()).cloned() {
+            drop(registry);
+            progress.change_current_check_point(format!("{check_point:?}"));
+        } else if current().name().unwrap_or_default().starts_with("test_") {
+            panic!("seems setup() isn't called yet?");
+        }
+    }
+
+    pub(crate) mod thread {
+        pub(crate) use crate::sleepless_testing::{BuilderTracked, ScopeTracked};
+        use {
+            super::*,
+            std::{
+                io,
+                thread::{current, spawn, Builder, Scope, ScopedJoinHandle},
+            },
+        };
+
+        struct SpawningThreadTracker(Arc<(Mutex<bool>, Condvar)>);
+        struct SpawnedThreadTracker(Arc<(Mutex<bool>, Condvar)>, ThreadId, bool);
+
+        impl SpawningThreadTracker {
+            fn ensure_spawned_tracked(self) {
+                let (lock, cvar) = &*self.0;
+                let lock = lock.lock().unwrap();
+                assert!(cvar.wait_while(lock, |&mut tracked| !tracked).is_ok());
+            }
+        }
+
+        impl SpawnedThreadTracker {
+            fn do_track(&mut self) {
+                self.2 = {
+                    let mut registry = THREAD_REGISTRY.lock().unwrap();
+                    if let Some(progress) = registry.get(&self.1).cloned() {
+                        assert!(registry.insert(current().id(), progress).is_none());
+                        true
+                    } else {
+                        false
+                    }
+                };
+                let (lock, cvar) = &*self.0;
+                *lock.lock().unwrap() = true;
+                cvar.notify_one();
+            }
+
+            fn do_untrack(self) {
+                if self.2 {
+                    let mut registry = THREAD_REGISTRY.lock().unwrap();
+                    registry.remove(&current().id()).unwrap();
+                }
+            }
+
+            fn with_tracked<T: Send>(mut self, f: impl FnOnce() -> T + Send) -> T {
+                self.do_track();
+                let returned = f();
+                self.do_untrack();
+                returned
+            }
+        }
+
+        fn prepare_tracking() -> (SpawningThreadTracker, SpawnedThreadTracker) {
+            let lock_and_condvar1 = Arc::new((Mutex::new(false), Condvar::new()));
+            let lock_and_condvar2 = lock_and_condvar1.clone();
+            let spawning_thread_tracker = SpawningThreadTracker(lock_and_condvar1);
+            let spawning_thread_id = current().id();
+            let spawned_thread_tracker =
+                SpawnedThreadTracker(lock_and_condvar2, spawning_thread_id, false);
+            (spawning_thread_tracker, spawned_thread_tracker)
+        }
+
+        #[allow(dead_code)]
+        pub(crate) fn spawn_tracked<T: Send + 'static>(
+            f: impl FnOnce() -> T + Send + 'static,
+        ) -> JoinHandle<T> {
+            let (spawning_thread_tracker, spawned_thread_tracker) = prepare_tracking();
+            let spawned_thread = spawn(move || spawned_thread_tracker.with_tracked(f));
+            spawning_thread_tracker.ensure_spawned_tracked();
+            spawned_thread
+        }
+
+        impl<'scope, 'env> ScopeTracked<'scope> for Scope<'scope, 'env> {
+            fn spawn_tracked<T: Send + 'scope>(
+                &'scope self,
+                f: impl FnOnce() -> T + Send + 'scope,
+            ) -> ScopedJoinHandle<'scope, T> {
+                let (spawning_thread_tracker, spawned_thread_tracker) = prepare_tracking();
+                let spawned_thread = self.spawn(move || spawned_thread_tracker.with_tracked(f));
+                spawning_thread_tracker.ensure_spawned_tracked();
+                spawned_thread
+            }
+        }
+
+        impl BuilderTracked for Builder {
+            fn spawn_tracked<T: Send + 'static>(
+                self,
+                f: impl FnOnce() -> T + Send + 'static,
+            ) -> io::Result<JoinHandle<T>> {
+                let (spawning_thread_tracker, spawned_thread_tracker) = prepare_tracking();
+                let spawned_thread_result =
+                    self.spawn(move || spawned_thread_tracker.with_tracked(f));
+                if spawned_thread_result.is_ok() {
+                    spawning_thread_tracker.ensure_spawned_tracked();
+                }
+                spawned_thread_result
+            }
+
+            fn spawn_scoped_tracked<'scope, 'env, T: Send + 'scope>(
+                self,
+                scope: &'scope Scope<'scope, 'env>,
+                f: impl FnOnce() -> T + Send + 'scope,
+            ) -> io::Result<ScopedJoinHandle<'scope, T>> {
+                let (spawning_thread_tracker, spawned_thread_tracker) = prepare_tracking();
+                let spawned_thread_result =
+                    self.spawn_scoped(scope, move || spawned_thread_tracker.with_tracked(f));
+                if spawned_thread_result.is_ok() {
+                    spawning_thread_tracker.ensure_spawned_tracked();
+                }
+                spawned_thread_result
+            }
+        }
+    }
+}
+
+#[cfg(not(test))]
+mod sleepless_testing_dummy {
+    use std::fmt::Debug;
+
+    #[inline]
+    pub(crate) fn at<T: Debug>(_check_point: T) {}
+
+    pub(crate) mod thread {
+        pub(crate) use crate::sleepless_testing::{BuilderTracked, ScopeTracked};
+        use std::{
+            io,
+            thread::{spawn, Builder, JoinHandle, Scope, ScopedJoinHandle},
+        };
+
+        #[inline]
+        #[allow(dead_code)]
+        pub(crate) fn spawn_tracked<T: Send + 'static>(
+            f: impl FnOnce() -> T + Send + 'static,
+        ) -> JoinHandle<T> {
+            spawn(f)
+        }
+
+        impl<'scope, 'env> ScopeTracked<'scope> for Scope<'scope, 'env> {
+            #[inline]
+            fn spawn_tracked<T: Send + 'scope>(
+                &'scope self,
+                f: impl FnOnce() -> T + Send + 'scope,
+            ) -> ScopedJoinHandle<'scope, T> {
+                self.spawn(f)
+            }
+        }
+
+        impl BuilderTracked for Builder {
+            #[inline]
+            fn spawn_tracked<T: Send + 'static>(
+                self,
+                f: impl FnOnce() -> T + Send + 'static,
+            ) -> io::Result<JoinHandle<T>> {
+                self.spawn(f)
+            }
+
+            #[inline]
+            fn spawn_scoped_tracked<'scope, 'env, T: Send + 'scope>(
+                self,
+                scope: &'scope Scope<'scope, 'env>,
+                f: impl FnOnce() -> T + Send + 'scope,
+            ) -> io::Result<ScopedJoinHandle<'scope, T>> {
+                self.spawn_scoped(scope, f)
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Problem

As a quick background, the unified scheduler currently doesn't terminate at all. In other words, it leaks shamelessly. :p It means its memory usage is unbounded and indeed causes the process to be reaped by the out-of-memory killer after a while (like a week), even while it's pooled for reuse.

Let alone the memory issue, it needs proper shutdown mechanism for other reasons as well. Specifically, there are following several termination conditions which it must handle respectively:

1. Unified scheduler encounters on transaction errors while running. And it needs to abort immediately:
    - https://github.com/anza-xyz/agave/pull/1211
2. One of the handler threads could panic for extreme situations due to newly discovered LoA-like bugs. In that case, unified scheduler should propagate `panic!` promptly to terminate the whole process. This is an edge case variant of 1. (note: I'm against resuming normal operation after panic):
    - https://github.com/anza-xyz/agave/pull/1574
3. A unified scheduler can be idling in the scheduler pool for very long time. And it needs to be disposed of:
    - https://github.com/anza-xyz/agave/pull/1575
4. Because `UsageQueueLoader` doesn't never evict unused entries. it can become too big with many entries. Its design relies on some external mechanism to mitigate the unbounded growth. Thus, the unified scheduler needs to drop the scheduler itself depending on the size of `UsageQueueLoader`:
    - https://github.com/anza-xyz/agave/pull/1672
5. There could be many active (= taken-out-of-the-pool) unified schedulers under very forky network conditions for extended duration of lack of rooting. In that case, many native os threads will be created just to sit idling collectively because each unified scheduler instance separately creates and manages its own set of threads individually (for perf reasons). So, idling scheduler should be returned back to the pool. Then, eventually those pooled-back schedulers will be retired according to the (3) after the forky situation is resolved:
    - https://github.com/anza-xyz/agave/pull/1690

As for the (1), there's currently also no way for the unified scheduler to propagate errors back to the callers (the replay stage) until the bank freezing. So, the dead-block marking by the replay stage could be delayed by maliciously-crafted blocks even if the unified scheduler immediately aborts internally.

#### Summary of Changes

This pr specifically addresses `(1)`.

To that end, this pr makes the new task code-path return `Result`s to abruptly propagate previously-scheduled transaction error when unrelated new tasks are about to be submitted to the unified scheduler, in order to notify the replay stage earlier than reaching block boundaries.

After that, this pr introduces crossbeam-channel disconnection based cross-thread coordination for graceful termination of the unified scheduler instance itself. In this way, there's almost no runtime overhead other than bunch of additional `if`s. Also, this means there's no new potential bottleneck and synchronization. On the other hand, this incurs code complexities.

Lastly, a pool-owned (i.e. singleton) auxiliary background thread is introduced to actually drop the aborted scheduler.

Other termination conditions will be addressed in upcoming prs.

context: extracted from #1122 