### PR TITLE
feat(rpc): return the replacement blockhash used in `simulate_transaction`

### DIFF
--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -424,6 +424,7 @@ pub struct RpcSimulateTransactionResult {
     pub units_consumed: Option<u64>,
     pub return_data: Option<UiTransactionReturnData>,
     pub inner_instructions: Option<Vec<UiInnerInstructions>>,
+    pub replacement_blockhash: Option<RpcBlockhash>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -351,6 +351,7 @@ impl RpcSender for MockSender {
                     units_consumed: None,
                     return_data: None,
                     inner_instructions: None,
+                    replacement_blockhash: None,
                 },
             })?,
             "getMinimumBalanceForRentExemption" => json![20],


### PR DESCRIPTION
#### Problem

Presently, to ‘prepare’ a transaction for submission there are several things that a developer has to do, including:

* give the transaction a lifetime (eg. by fetching a recent blockhash from the network)
* decide on a compute unit limit (ie. to increase the chance that a validator will include their transaction in a block)

One idea is that there should be a single RPC call that answers both of these questions. Right now `simulateTransaction` comes _close_ but it's missing one thing – it does not return a recent blockhash, even if you call it with `replaceRecentBlockhash`.

#### Summary of Changes

In this PR, we return the replacement blockhash in the RPC response if the simulation was called with `replace_recent_blockhash: true`. This in combination with `unitsConsumed` is enough to answer the questions above with one RPC call.

We will later add an API to `@solana/web3.js` that makes use of this value to ‘prepare’ transactions using a single call to `simulateTransaction`.