### PR TITLE
After tx execution, store all writable accounts even if they are "loader" accounts

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -726,9 +726,8 @@ impl Accounts {
 
             let message = tx.message();
             let loaded_transaction = tx_load_result.as_mut().unwrap();
-            for (i, (address, account)) in (0..message.account_keys().len())
-                .zip(loaded_transaction.accounts.iter_mut())
-                .filter(|(i, _)| message.is_non_loader_key(*i))
+            for (i, (address, account)) in
+                (0..message.account_keys().len()).zip(loaded_transaction.accounts.iter_mut())
             {
                 if message.is_writable(i) {
                     let is_fee_payer = i == 0;


### PR DESCRIPTION
#### Problem
After tx execution, account storage explicitly filters out all "loader" keys when determining which accounts should be updated in accounts db. This code is pretty much redundant because inside `message.is_writable`, we demote write-locks for invoked programs to read-only (unless the upgradeable loader key is present).

Also, I'm on a mission to deprecate the `is_non_loader_key` method because I find its name and function to be very unclear. Currently, a "non-loader key" is a transaction account which is either not invoked or if invoked, is passed as an instruction account to some program.

#### Summary of Changes
Slight change in behavior when deciding to store accounts. My understanding is that an extra call to store an account that didn't change in a transaction is not a consensus breaking change.

**Before:**
We never attempt to store any account which is invoked and not passed to a program

**After:**
We could possibly store an invoked account which is not passed to a program if it's marked as writable and the upgradeable loader key is present in the transaction accounts list. Since this invoked account is not passed to a program, it couldn't have possible been mutated so this is a no-op.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
