### PR TITLE
Adds CLI arg for setting accounts read cache size limits

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1356,6 +1356,25 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 ),
         )
         .arg(
+            Arg::with_name("accounts_db_read_cache_limit_mb")
+                .long("accounts-db-read-cache-limit-mb")
+                .value_name("MAX | LOW,HIGH")
+                .takes_value(true)
+                .min_values(1)
+                .max_values(2)
+                .multiple(false)
+                .require_delimiter(true)
+                .help("How large the read cache for account data can become, in mebibytes")
+                .long_help(
+                    "How large the read cache for account data can become, in mebibytes. \
+                     If given a single value, it will be the maximum size for the cache. \
+                     If given a pair of values, they will be the low and high watermarks \
+                     for the cache. When the cache exceeds the high watermark, entries will \
+                     be evicted until the size reaches the low watermark."
+                )
+                .hidden(hidden_unless_forced()),
+        )
+        .arg(
             Arg::with_name("accounts_index_scan_results_limit_mb")
                 .long("accounts-index-scan-results-limit-mb")
                 .value_name("MEGABYTES")


### PR DESCRIPTION
#### Problem

Spinning up validators to test out different sizes for the accounts read cache is slowed down because the size is a hard coded literal. So we have to edit the source code and recompile each time. This also makes it harder to track which machine is running which size/configuration. It would be helpful to have a CLI arg for setting the size.


#### Summary of Changes

Add `--accounts-db-read-cache-limit-mb` as a *hidden* CLI arg to the validator.