### PR TITLE
Deprecate `is_non_loader_key` message methods

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -15,7 +15,10 @@ use {
         account_utils::StateMut,
         address_lookup_table::{self, error::AddressLookupError, state::AddressLookupTable},
         clock::{BankId, Slot},
-        message::v0::{LoadedAddresses, MessageAddressTableLookup},
+        message::{
+            v0::{LoadedAddresses, MessageAddressTableLookup},
+            SanitizedMessage,
+        },
         nonce::{
             state::{DurableNonce, Versions as NonceVersions},
             State as NonceState,
@@ -31,10 +34,7 @@ use {
     },
     std::{
         cmp::Reverse,
-        collections::{
-            hash_map::{self},
-            BinaryHeap, HashMap, HashSet,
-        },
+        collections::{hash_map, BinaryHeap, HashMap, HashSet},
         ops::RangeBounds,
         sync::{
             atomic::{AtomicUsize, Ordering},
@@ -724,11 +724,27 @@ impl Accounts {
                 }
             };
 
+            // Accounts that are invoked and also not passed to a program don't
+            // need to be stored because it's assumed to be impossible for a
+            // committable transaction to modify an invoked account if said
+            // account isn't passed to some program.
+            //
+            // Note that this assumption might not hold in the future after
+            // SIMD-0082 is implemented because we may decide to commit
+            // transactions that incorrectly attempt to invoke a fee payer or
+            // durable nonce account. If that happens, we would NOT want to use
+            // this filter because we always NEED to store those accounts even
+            // if they aren't passed to any programs (because they are mutated
+            // outside of the VM).
+            let is_storable_account = |message: &SanitizedMessage, key_index: usize| -> bool {
+                !message.is_invoked(key_index) || message.is_key_passed_to_program(key_index)
+            };
+
             let message = tx.message();
             let loaded_transaction = tx_load_result.as_mut().unwrap();
             for (i, (address, account)) in (0..message.account_keys().len())
                 .zip(loaded_transaction.accounts.iter_mut())
-                .filter(|(i, _)| message.is_non_loader_key(*i))
+                .filter(|(i, _)| is_storable_account(message, *i))
             {
                 if message.is_writable(i) {
                     let is_fee_payer = i == 0;

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -543,6 +543,10 @@ impl Message {
         }
     }
 
+    #[deprecated(
+        since = "2.0.0",
+        note = "Please use `is_key_called_as_program` and `is_key_passed_to_program` directly"
+    )]
     pub fn is_non_loader_key(&self, key_index: usize) -> bool {
         !self.is_key_called_as_program(key_index) || self.is_key_passed_to_program(key_index)
     }
@@ -934,6 +938,7 @@ mod tests {
 
     #[test]
     fn test_is_non_loader_key() {
+        #![allow(deprecated)]
         let key0 = Pubkey::new_unique();
         let key1 = Pubkey::new_unique();
         let loader2 = Pubkey::new_unique();

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -222,7 +222,7 @@ impl SanitizedMessage {
 
     /// Returns true if the account at the specified index is an input to some
     /// program instruction in this message.
-    fn is_key_passed_to_program(&self, key_index: usize) -> bool {
+    pub fn is_key_passed_to_program(&self, key_index: usize) -> bool {
         if let Ok(key_index) = u8::try_from(key_index) {
             self.instructions()
                 .iter()
@@ -243,6 +243,10 @@ impl SanitizedMessage {
 
     /// Returns true if the account at the specified index is not invoked as a
     /// program or, if invoked, is passed to a program.
+    #[deprecated(
+        since = "2.0.0",
+        note = "Please use `is_invoked` and `is_key_passed_to_program` instead"
+    )]
     pub fn is_non_loader_key(&self, key_index: usize) -> bool {
         !self.is_invoked(key_index) || self.is_key_passed_to_program(key_index)
     }
@@ -457,6 +461,7 @@ mod tests {
 
     #[test]
     fn test_is_non_loader_key() {
+        #![allow(deprecated)]
         let key0 = Pubkey::new_unique();
         let key1 = Pubkey::new_unique();
         let loader_key = Pubkey::new_unique();


### PR DESCRIPTION
#### Problem
I personally find the `is_non_loader_key` message methods to be very confusingly named and unclear in what they are actually checking. Currently, a "non-loader key" is any account key which is either not invoked as a program OR if invoked, is passed to some program.

#### Summary of Changes
- Deprecate `is_non_loader_key` in `Message` and `SanitizedMessage`
- Replace the last usage of `is_non_loader_key` with explicit inline checks and add heavy documentation for the assumptions of those checks

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
