### PR TITLE
Do not purge old snapshot archives in bank_to_snapshot_archive()

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2118,12 +2118,6 @@ fn maybe_warp_slot(
             &config.snapshot_config.full_snapshot_archives_dir,
             &config.snapshot_config.incremental_snapshot_archives_dir,
             config.snapshot_config.archive_format,
-            config
-                .snapshot_config
-                .maximum_full_snapshot_archives_to_retain,
-            config
-                .snapshot_config
-                .maximum_incremental_snapshot_archives_to_retain,
         ) {
             Ok(archive_info) => archive_info,
             Err(e) => return Err(format!("Unable to create snapshot: {e}")),

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -87,7 +87,6 @@ use {
         fs,
         io::Read,
         iter,
-        num::NonZeroUsize,
         path::Path,
         sync::{
             atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -2222,8 +2221,6 @@ fn create_snapshot_to_hard_fork(
         ledger_path,
         ledger_path,
         snapshot_config.archive_format,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
     )
     .unwrap();
     info!(

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -38,7 +38,6 @@ mod tests {
         },
         std::{
             io::{Cursor, Read, Write},
-            num::NonZeroUsize,
             ops::RangeFull,
             path::Path,
             sync::{Arc, RwLock},
@@ -429,8 +428,6 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             ArchiveFormat::Tar,
-            NonZeroUsize::new(1).unwrap(),
-            NonZeroUsize::new(1).unwrap(),
         )
         .unwrap();
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12786,8 +12786,6 @@ fn test_rebuild_skipped_rewrites() {
         full_snapshot_archives_dir.path(),
         incremental_snapshot_archives_dir.path(),
         snapshot_utils::ArchiveFormat::Tar,
-        snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     )
     .unwrap();
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1025,8 +1025,6 @@ pub fn bank_to_full_snapshot_archive(
     full_snapshot_archives_dir: impl AsRef<Path>,
     incremental_snapshot_archives_dir: impl AsRef<Path>,
     archive_format: ArchiveFormat,
-    maximum_full_snapshot_archives_to_retain: NonZeroUsize,
-    maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
 ) -> snapshot_utils::Result<FullSnapshotArchiveInfo> {
     let snapshot_version = snapshot_version.unwrap_or_default();
 
@@ -1056,8 +1054,10 @@ pub fn bank_to_full_snapshot_archive(
         snapshot_storages,
         archive_format,
         snapshot_version,
-        maximum_full_snapshot_archives_to_retain,
-        maximum_incremental_snapshot_archives_to_retain,
+        // Since bank_to_snapshot_archive() is not called as part of normal validator operation,
+        // do *not* purge any snapshot archives; leave that up to the node operator.
+        NonZeroUsize::MAX,
+        NonZeroUsize::MAX,
     )
 }
 
@@ -1076,8 +1076,6 @@ pub fn bank_to_incremental_snapshot_archive(
     full_snapshot_archives_dir: impl AsRef<Path>,
     incremental_snapshot_archives_dir: impl AsRef<Path>,
     archive_format: ArchiveFormat,
-    maximum_full_snapshot_archives_to_retain: NonZeroUsize,
-    maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
 ) -> snapshot_utils::Result<IncrementalSnapshotArchiveInfo> {
     let snapshot_version = snapshot_version.unwrap_or_default();
 
@@ -1116,8 +1114,10 @@ pub fn bank_to_incremental_snapshot_archive(
         snapshot_storages,
         archive_format,
         snapshot_version,
-        maximum_full_snapshot_archives_to_retain,
-        maximum_incremental_snapshot_archives_to_retain,
+        // Since bank_to_snapshot_archive() is not called as part of normal validator operation,
+        // do *not* purge any snapshot archives; leave that up to the node operator.
+        NonZeroUsize::MAX,
+        NonZeroUsize::MAX,
     )
 }
 
@@ -1382,8 +1382,6 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
 
@@ -1498,8 +1496,6 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
 
@@ -1591,8 +1587,6 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
 
@@ -1634,8 +1628,6 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
 
@@ -1717,8 +1709,6 @@ mod tests {
             &full_snapshot_archives_dir,
             &incremental_snapshot_archives_dir,
             snapshot_archive_format,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
 
@@ -1760,8 +1750,6 @@ mod tests {
             &full_snapshot_archives_dir,
             &incremental_snapshot_archives_dir,
             snapshot_archive_format,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
 
@@ -1862,8 +1850,6 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
 
@@ -1904,8 +1890,6 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
         let (deserialized_bank, _) = bank_from_snapshot_archives(
@@ -1971,8 +1955,6 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
 
@@ -2039,8 +2021,6 @@ mod tests {
             &all_snapshots_dir,
             &all_snapshots_dir,
             snapshot_archive_format,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
 
@@ -2062,8 +2042,6 @@ mod tests {
             &all_snapshots_dir,
             &all_snapshots_dir,
             snapshot_archive_format,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
 
@@ -2278,8 +2256,6 @@ mod tests {
             &full_snapshot_archives_dir,
             &incremental_snapshot_archives_dir,
             ArchiveFormat::Tar,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
         let full_accounts_hash = bank
@@ -2310,8 +2286,6 @@ mod tests {
             &full_snapshot_archives_dir,
             &incremental_snapshot_archives_dir,
             ArchiveFormat::Tar,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
         let incremental_accounts_hash = bank


### PR DESCRIPTION
#### Problem

When creating a new snapshot archive with `bank_to_snapshot_archive()`, there are parameters for how total archives to keep; older ones are purged. There's not really a good use-case for having this function purge old archives though, and leaving the parameter in is a foot-gun for new code. In fact, wen-restart is adding the step to generate a snapshot, and it almost put in a value to purge older snapshot archives. We likely never want to remove older snapshots in this restart scenario until we are 100% sure the new ones are correct. `leger-tool` already correctly defaults to *not* purging any older archives. This should not be an option anymore.


#### Summary of Changes

Remove the parameters from `bank_to_snapshot_archive()` and have it never purge older snapshot archives.