### PR TITLE
SVM: Move nonce_info from SDK to SVM

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -20,14 +20,15 @@ use {
             state::{DurableNonce, Versions as NonceVersions},
             State as NonceState,
         },
-        nonce_info::{NonceFull, NonceInfo},
         pubkey::Pubkey,
         slot_hashes::SlotHashes,
         transaction::{Result, SanitizedTransaction, TransactionAccountLocks, TransactionError},
         transaction_context::TransactionAccount,
     },
     solana_svm::{
-        account_loader::TransactionLoadResult, transaction_results::TransactionExecutionResult,
+        account_loader::TransactionLoadResult,
+        nonce_info::{NonceFull, NonceInfo},
+        transaction_results::TransactionExecutionResult,
     },
     std::{
         cmp::Reverse,

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -222,7 +222,6 @@ pub(crate) mod tests {
             message::{LegacyMessage, Message, MessageHeader, SanitizedMessage},
             nonce::{self, state::DurableNonce},
             nonce_account,
-            nonce_info::{NonceFull, NoncePartial},
             pubkey::Pubkey,
             rent_debits::RentDebits,
             reserved_account_keys::ReservedAccountKeys,
@@ -233,6 +232,7 @@ pub(crate) mod tests {
                 VersionedTransaction,
             },
         },
+        solana_svm::nonce_info::{NonceFull, NoncePartial},
         solana_transaction_status::{
             token_balances::TransactionTokenBalancesSet, TransactionStatusMeta,
             TransactionTokenBalance,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -137,7 +137,6 @@ use {
         native_token::LAMPORTS_PER_SOL,
         nonce::{self, state::DurableNonce, NONCED_TX_MARKER_IX_INDEX},
         nonce_account,
-        nonce_info::{NonceInfo, NoncePartial},
         packet::PACKET_DATA_SIZE,
         precompiles::get_precompiles,
         pubkey::Pubkey,
@@ -167,6 +166,7 @@ use {
     solana_svm::{
         account_loader::{TransactionCheckResult, TransactionLoadResult},
         account_overrides::AccountOverrides,
+        nonce_info::{NonceInfo, NoncePartial},
         program_loader::load_program_with_pubkey,
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_processing_callback::TransactionProcessingCallback,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -75,7 +75,6 @@ use {
         native_loader,
         native_token::{sol_to_lamports, LAMPORTS_PER_SOL},
         nonce::{self, state::DurableNonce},
-        nonce_info::NonceFull,
         packet::PACKET_DATA_SIZE,
         poh_config::PohConfig,
         program::MAX_RETURN_DATA,
@@ -102,7 +101,7 @@ use {
         transaction_context::TransactionAccount,
     },
     solana_stake_program::stake_state::{self, StakeStateV2},
-    solana_svm::transaction_results::DurableNonceFee,
+    solana_svm::{nonce_info::NonceFull, transaction_results::DurableNonceFee},
     solana_vote_program::{
         vote_instruction,
         vote_state::{

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -83,7 +83,6 @@ pub mod log;
 pub mod native_loader;
 pub mod net;
 pub mod nonce_account;
-pub mod nonce_info;
 pub mod offchain_message;
 pub mod packet;
 pub mod poh_config;

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1,6 +1,8 @@
 use {
     crate::{
-        account_overrides::AccountOverrides, account_rent_state::RentState,
+        account_overrides::AccountOverrides,
+        account_rent_state::RentState,
+        nonce_info::{NonceFull, NoncePartial},
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_processing_callback::TransactionProcessingCallback,
     },
@@ -19,7 +21,6 @@ use {
         message::SanitizedMessage,
         native_loader,
         nonce::State as NonceState,
-        nonce_info::{NonceFull, NoncePartial},
         pubkey::Pubkey,
         rent::RentDue,
         rent_collector::{RentCollector, RENT_EXEMPT_RENT_EPOCH},
@@ -449,6 +450,7 @@ mod tests {
     use {
         super::*,
         crate::{
+            nonce_info::{NonceFull, NoncePartial},
             transaction_account_state_info::TransactionAccountStateInfo,
             transaction_processing_callback::TransactionProcessingCallback,
         },
@@ -475,7 +477,6 @@ mod tests {
             native_loader,
             native_token::sol_to_lamports,
             nonce,
-            nonce_info::{NonceFull, NoncePartial},
             pubkey::Pubkey,
             rent::Rent,
             rent_collector::{RentCollector, RENT_EXEMPT_RENT_EPOCH},

--- a/svm/src/lib.rs
+++ b/svm/src/lib.rs
@@ -5,6 +5,7 @@ pub mod account_loader;
 pub mod account_overrides;
 pub mod account_rent_state;
 pub mod message_processor;
+pub mod nonce_info;
 pub mod program_loader;
 pub mod runtime_config;
 pub mod transaction_account_state_info;

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -1,5 +1,4 @@
-#![cfg(feature = "full")]
-use crate::{
+use solana_sdk::{
     account::{AccountSharedData, ReadableAccount, WritableAccount},
     message::SanitizedMessage,
     nonce_account,
@@ -109,7 +108,7 @@ impl NonceInfo for NonceFull {
 mod tests {
     use {
         super::*,
-        crate::{
+        solana_sdk::{
             hash::Hash,
             instruction::Instruction,
             message::Message,

--- a/svm/src/transaction_results.rs
+++ b/svm/src/transaction_results.rs
@@ -5,9 +5,9 @@
 )]
 pub use solana_sdk::inner_instruction::{InnerInstruction, InnerInstructionsList};
 use {
+    crate::nonce_info::{NonceFull, NonceInfo},
     solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
     solana_sdk::{
-        nonce_info::{NonceFull, NonceInfo},
         rent_debits::RentDebits,
         transaction::{self, TransactionError},
         transaction_context::TransactionReturnData,


### PR DESCRIPTION
because it's not something we want to be subjected to the backwards compatibility policy.

follow up https://github.com/solana-labs/solana/pull/35138