### PR TITLE
ff cleanup: index_erasure_conflict_duplicate_proofs

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -159,11 +159,6 @@ fn run_check_duplicate(
             root_bank = bank_forks.read().unwrap().root_bank();
         }
         let shred_slot = shred.slot();
-        let send_index_and_erasure_conflicts = cluster_nodes::check_feature_activation(
-            &feature_set::index_erasure_conflict_duplicate_proofs::id(),
-            shred_slot,
-            &root_bank,
-        );
         let merkle_conflict_duplicate_proofs = cluster_nodes::check_feature_activation(
             &feature_set::merkle_conflict_duplicate_proofs::id(),
             shred_slot,
@@ -176,13 +171,7 @@ fn run_check_duplicate(
         );
         let (shred1, shred2) = match shred {
             PossibleDuplicateShred::LastIndexConflict(shred, conflict)
-            | PossibleDuplicateShred::ErasureConflict(shred, conflict) => {
-                if send_index_and_erasure_conflicts {
-                    (shred, conflict)
-                } else {
-                    return Ok(());
-                }
-            }
+            | PossibleDuplicateShred::ErasureConflict(shred, conflict) => (shred, conflict),
             PossibleDuplicateShred::MerkleRootConflict(shred, conflict) => {
                 if merkle_conflict_duplicate_proofs {
                     // Although this proof can be immediately stored on detection, we wait until


### PR DESCRIPTION
This feature has been activated on all clusters:
```
Feature                                      | Status                  | Activation Slot | Description
dupPajaLy2SSn8ko42aZz4mHANDNrLe8Nw8VQgFecLa  | active since epoch 603  | 260496000       | generate duplicate proofs for index and erasure conflicts #34360
```
Fixes https://github.com/solana-labs/solana/issues/34543