### PR TITLE
Forwarder to own forward_packet_batches_by_accounts batches

### DIFF
--- a/core/benches/forwarder.rs
+++ b/core/benches/forwarder.rs
@@ -128,7 +128,7 @@ fn bench_forwarder_handle_forwading_contentious_transaction(bencher: &mut Benche
     let BenchSetup {
         exit,
         poh_service,
-        forwarder,
+        mut forwarder,
         mut unprocessed_packet_batches,
         mut tracker,
         stats,
@@ -165,7 +165,7 @@ fn bench_forwarder_handle_forwading_parallel_transactions(bencher: &mut Bencher)
     let BenchSetup {
         exit,
         poh_service,
-        forwarder,
+        mut forwarder,
         mut unprocessed_packet_batches,
         mut tracker,
         stats,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -626,7 +626,7 @@ impl BankingStage {
         committer: Committer,
         transaction_recorder: TransactionRecorder,
         log_messages_bytes_limit: Option<usize>,
-        forwarder: Forwarder,
+        mut forwarder: Forwarder,
         unprocessed_transaction_storage: UnprocessedTransactionStorage,
     ) -> JoinHandle<()> {
         let mut packet_receiver = PacketReceiver::new(id, packet_receiver, bank_forks);
@@ -643,7 +643,7 @@ impl BankingStage {
                 Self::process_loop(
                     &mut packet_receiver,
                     &decision_maker,
-                    &forwarder,
+                    &mut forwarder,
                     &consumer,
                     id,
                     unprocessed_transaction_storage,
@@ -655,7 +655,7 @@ impl BankingStage {
     #[allow(clippy::too_many_arguments)]
     fn process_buffered_packets(
         decision_maker: &DecisionMaker,
-        forwarder: &Forwarder,
+        forwarder: &mut Forwarder,
         consumer: &Consumer,
         unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
         banking_stage_stats: &BankingStageStats,
@@ -724,7 +724,7 @@ impl BankingStage {
     fn process_loop(
         packet_receiver: &mut PacketReceiver,
         decision_maker: &DecisionMaker,
-        forwarder: &Forwarder,
+        forwarder: &mut Forwarder,
         consumer: &Consumer,
         id: u32,
         mut unprocessed_transaction_storage: UnprocessedTransactionStorage,

--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -102,8 +102,6 @@ impl Forwarder {
         // load all accounts from address loader;
         let current_bank = self.bank_forks.read().unwrap().working_bank();
 
-        self.clear_batches();
-
         // sanitize and filter packets that are no longer valid (could be too old, a duplicate of something
         // already processed), then add to forwarding buffer.
         let filter_forwarding_result = unprocessed_transaction_storage
@@ -165,6 +163,7 @@ impl Forwarder {
                     );
                 }
             });
+        self.clear_batches();
 
         if !hold {
             slot_metrics_tracker.increment_cleared_from_buffer_after_forward_count(

--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -6,6 +6,7 @@ use {
         ForwardOption,
     },
     crate::{
+        banking_stage::immutable_deserialized_packet::ImmutableDeserializedPacket,
         next_leader::{next_leader, next_leader_tpu_vote},
         tracer_packet_stats::TracerPacketStats,
     },
@@ -15,7 +16,10 @@ use {
     solana_perf::{data_budget::DataBudget, packet::Packet},
     solana_poh::poh_recorder::PohRecorder,
     solana_runtime::bank_forks::BankForks,
-    solana_sdk::{pubkey::Pubkey, transport::TransportError},
+    solana_sdk::{
+        feature_set::FeatureSet, pubkey::Pubkey, transaction::SanitizedTransaction,
+        transport::TransportError,
+    },
     solana_streamer::sendmmsg::batch_send,
     std::{
         iter::repeat,
@@ -31,6 +35,7 @@ pub struct Forwarder {
     cluster_info: Arc<ClusterInfo>,
     connection_cache: Arc<ConnectionCache>,
     data_budget: Arc<DataBudget>,
+    forward_packet_batches_by_accounts: ForwardPacketBatchesByAccounts,
 }
 
 impl Forwarder {
@@ -48,11 +53,43 @@ impl Forwarder {
             cluster_info,
             connection_cache,
             data_budget,
+            forward_packet_batches_by_accounts:
+                ForwardPacketBatchesByAccounts::new_with_default_batch_limits(),
         }
     }
 
+    pub fn clear_batches(&mut self) {
+        self.forward_packet_batches_by_accounts.reset();
+    }
+
+    pub fn try_add_packet(
+        &mut self,
+        sanitized_transaction: &SanitizedTransaction,
+        immutable_packet: Arc<ImmutableDeserializedPacket>,
+        feature_set: &FeatureSet,
+    ) -> bool {
+        self.forward_packet_batches_by_accounts.try_add_packet(
+            sanitized_transaction,
+            immutable_packet,
+            feature_set,
+        )
+    }
+
+    pub fn forward_batched_packets(&self, forward_option: &ForwardOption) {
+        self.forward_packet_batches_by_accounts
+            .iter_batches()
+            .filter(|&batch| !batch.is_empty())
+            .for_each(|forwardable_batch| {
+                let _ = self
+                    .forward_packets(forward_option, forwardable_batch.get_forwardable_packets());
+            });
+    }
+
+    /// This function is exclusively used by multi-iterator banking threads to handle forwarding
+    /// logic per thread. Central scheduler Controller uses try_add_packet() ... forward_batched_packets()
+    /// to handle forwarding slight differently.
     pub fn handle_forwarding(
-        &self,
+        &mut self,
         unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
         hold: bool,
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
@@ -65,15 +102,14 @@ impl Forwarder {
         // load all accounts from address loader;
         let current_bank = self.bank_forks.read().unwrap().working_bank();
 
-        let mut forward_packet_batches_by_accounts =
-            ForwardPacketBatchesByAccounts::new_with_default_batch_limits();
+        self.clear_batches();
 
         // sanitize and filter packets that are no longer valid (could be too old, a duplicate of something
         // already processed), then add to forwarding buffer.
         let filter_forwarding_result = unprocessed_transaction_storage
             .filter_forwardable_packets_and_add_batches(
                 current_bank,
-                &mut forward_packet_batches_by_accounts,
+                &mut self.forward_packet_batches_by_accounts,
             );
         slot_metrics_tracker.increment_transactions_from_packets_us(
             filter_forwarding_result.total_packet_conversion_us,
@@ -93,7 +129,7 @@ impl Forwarder {
             Ordering::Relaxed,
         );
 
-        forward_packet_batches_by_accounts
+        self.forward_packet_batches_by_accounts
             .iter_batches()
             .filter(|&batch| !batch.is_empty())
             .for_each(|forward_batch| {
@@ -367,7 +403,7 @@ mod tests {
             ("budget-available", DataBudget::default(), 1),
         ];
         for (name, data_budget, expected_num_forwarded) in test_cases {
-            let forwarder = Forwarder::new(
+            let mut forwarder = Forwarder::new(
                 poh_recorder.clone(),
                 bank_forks.clone(),
                 cluster_info.clone(),
@@ -451,7 +487,7 @@ mod tests {
             ("fwd-no-hold", false, vec![], 0),
         ];
 
-        let forwarder = Forwarder::new(
+        let mut forwarder = Forwarder::new(
             poh_recorder,
             bank_forks,
             cluster_info,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -233,7 +233,6 @@ impl SchedulerController {
         let start = Instant::now();
         let bank = self.bank_forks.read().unwrap().working_bank();
         let feature_set = &bank.feature_set;
-        self.forwarder.clear_batches();
 
         // Pop from the container in chunks, filter using bank checks, then attempt to forward.
         // This doubles as a way to clean the queue as well as forwarding transactions.
@@ -302,6 +301,7 @@ impl SchedulerController {
         // Forward each batch of transactions
         self.forwarder
             .forward_batched_packets(&ForwardOption::ForwardTransaction);
+        self.forwarder.clear_batches();
 
         // If we hit the time limit. Drop everything that was not checked/processed.
         // If we cannot run these simple checks in time, then we cannot run them during

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -16,7 +16,6 @@ use {
         consume_worker::ConsumeWorkerMetrics,
         consumer::Consumer,
         decision_maker::{BufferedPacketsDecision, DecisionMaker},
-        forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
         forwarder::Forwarder,
         immutable_deserialized_packet::ImmutableDeserializedPacket,
         packet_deserializer::PacketDeserializer,
@@ -234,8 +233,7 @@ impl SchedulerController {
         let start = Instant::now();
         let bank = self.bank_forks.read().unwrap().working_bank();
         let feature_set = &bank.feature_set;
-        let mut forwardable_packets =
-            ForwardPacketBatchesByAccounts::new_with_default_batch_limits();
+        self.forwarder.clear_batches();
 
         // Pop from the container in chunks, filter using bank checks, then attempt to forward.
         // This doubles as a way to clean the queue as well as forwarding transactions.
@@ -284,7 +282,7 @@ impl SchedulerController {
 
                 // If not already forwarded and can be forwarded, add to forwardable packets.
                 if state.should_forward()
-                    && forwardable_packets.try_add_packet(
+                    && self.forwarder.try_add_packet(
                         sanitized_transaction,
                         immutable_packet,
                         feature_set,
@@ -302,12 +300,8 @@ impl SchedulerController {
         }
 
         // Forward each batch of transactions
-        for batch in forwardable_packets.iter_batches() {
-            let _ = self.forwarder.forward_packets(
-                &ForwardOption::ForwardTransaction,
-                batch.get_forwardable_packets(),
-            );
-        }
+        self.forwarder
+            .forward_batched_packets(&ForwardOption::ForwardTransaction);
 
         // If we hit the time limit. Drop everything that was not checked/processed.
         // If we cannot run these simple checks in time, then we cannot run them during

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -102,6 +102,18 @@ impl Default for CostTracker {
 }
 
 impl CostTracker {
+    pub fn reset(&mut self) {
+        self.cost_by_writable_accounts.clear();
+        self.block_cost = 0;
+        self.vote_cost = 0;
+        self.transaction_count = 0;
+        self.account_data_size = 0;
+        self.transaction_signature_count = 0;
+        self.secp256k1_instruction_signature_count = 0;
+        self.ed25519_instruction_signature_count = 0;
+        self.in_flight_transaction_count = 0;
+    }
+
     /// allows to adjust limits initiated during construction
     pub fn set_limits(
         &mut self,


### PR DESCRIPTION
#### Problem

Follow-up of https://github.com/anza-xyz/agave/pull/1156, instead of allocating ForwardPacketBatchesByAccounts every time forwarding is called, can let `Forwarder` owns and shares it between calls. This way, can further reduce memory (re)allocation. 

#### Summary of Changes
- `Forwarder` to own a instance of `ForwardPacketBatchesByAccounts`, which is reset and shared between forwarding calls
- clear HashMaps and Vectors when `ForwardPacketBatchesByAccounts` is reset.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
