### PR TITLE
ff cleanup: consume_blockstore_duplicate_proofs

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1400,9 +1400,7 @@ impl ReplayStage {
                 .unwrap();
             let duplicate_slot_hashes = duplicate_slots.filter_map(|slot| {
                 let bank = bank_forks.get(slot)?;
-                bank.feature_set
-                    .is_active(&feature_set::consume_blockstore_duplicate_proofs::id())
-                    .then_some((slot, bank.hash()))
+                Some((slot, bank.hash()))
             });
             (
                 bank_forks.root_bank(),
@@ -2283,11 +2281,7 @@ impl ReplayStage {
         );
 
         // If we previously marked this slot as duplicate in blockstore, let the state machine know
-        if bank
-            .feature_set
-            .is_active(&feature_set::consume_blockstore_duplicate_proofs::id())
-            && !duplicate_slots_tracker.contains(&slot)
-            && blockstore.get_duplicate_slot(slot).is_some()
+        if !duplicate_slots_tracker.contains(&slot) && blockstore.get_duplicate_slot(slot).is_some()
         {
             let duplicate_state = DuplicateState::new_from_state(
                 slot,
@@ -3111,10 +3105,7 @@ impl ReplayStage {
                     SlotStateUpdate::BankFrozen(bank_frozen_state),
                 );
                 // If we previously marked this slot as duplicate in blockstore, let the state machine know
-                if bank
-                    .feature_set
-                    .is_active(&feature_set::consume_blockstore_duplicate_proofs::id())
-                    && !duplicate_slots_tracker.contains(&bank.slot())
+                if !duplicate_slots_tracker.contains(&bank.slot())
                     && blockstore.get_duplicate_slot(bank.slot()).is_some()
                 {
                     let duplicate_state = DuplicateState::new_from_state(


### PR DESCRIPTION
This feature has been activated on all clusters:
```
Feature                                      | Status                  | Activation Slot | Description
6YsBCejwK96GZCkJ6mkZ4b68oP63z2PLoQmWjC7ggTqZ | active since epoch 602  | 260064000       | consume duplicate proofs from blockstore in consensus #34372
```
Fixes https://github.com/solana-labs/solana/issues/34532