### PR TITLE
replay: do not recheck duplicate confirmation if already confirmed

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -508,7 +508,8 @@ impl Tower {
         }
     }
 
-    pub(crate) fn is_slot_confirmed(
+    #[cfg(test)]
+    fn is_slot_confirmed(
         &self,
         slot: Slot,
         voted_stakes: &VotedStakes,

--- a/core/src/consensus/progress_map.rs
+++ b/core/src/consensus/progress_map.rs
@@ -187,6 +187,7 @@ pub struct ForkStats {
     pub is_locked_out: bool,
     pub voted_stakes: VotedStakes,
     pub is_supermajority_confirmed: bool,
+    pub is_duplicate_confirmed: bool,
     pub computed: bool,
     pub lockout_intervals: LockoutIntervals,
     pub bank_hash: Option<Hash>,
@@ -377,6 +378,17 @@ impl ProgressMap {
         self.progress_map
             .get(&slot)
             .map(|s| s.fork_stats.is_supermajority_confirmed)
+    }
+
+    pub fn set_duplicate_confirmed_slot(&mut self, slot: Slot) {
+        let slot_progress = self.get_mut(&slot).unwrap();
+        slot_progress.fork_stats.is_duplicate_confirmed = true;
+    }
+
+    pub fn is_duplicate_confirmed(&self, slot: Slot) -> Option<bool> {
+        self.progress_map
+            .get(&slot)
+            .map(|s| s.fork_stats.is_duplicate_confirmed)
     }
 
     pub fn get_bank_prev_leader_slot(&self, bank: &Bank) -> Option<Slot> {

--- a/core/src/consensus/progress_map.rs
+++ b/core/src/consensus/progress_map.rs
@@ -186,8 +186,7 @@ pub struct ForkStats {
     pub vote_threshold: Vec<ThresholdDecision>,
     pub is_locked_out: bool,
     pub voted_stakes: VotedStakes,
-    pub is_supermajority_confirmed: bool,
-    pub is_duplicate_confirmed: bool,
+    pub duplicate_confirmed_hash: Option<Hash>,
     pub computed: bool,
     pub lockout_intervals: LockoutIntervals,
     pub bank_hash: Option<Hash>,
@@ -369,26 +368,15 @@ impl ProgressMap {
             .and_then(|s| s.fork_stats.my_latest_landed_vote)
     }
 
-    pub fn set_supermajority_confirmed_slot(&mut self, slot: Slot) {
+    pub fn set_duplicate_confirmed_hash(&mut self, slot: Slot, hash: Hash) {
         let slot_progress = self.get_mut(&slot).unwrap();
-        slot_progress.fork_stats.is_supermajority_confirmed = true;
-    }
-
-    pub fn is_supermajority_confirmed(&self, slot: Slot) -> Option<bool> {
-        self.progress_map
-            .get(&slot)
-            .map(|s| s.fork_stats.is_supermajority_confirmed)
-    }
-
-    pub fn set_duplicate_confirmed_slot(&mut self, slot: Slot) {
-        let slot_progress = self.get_mut(&slot).unwrap();
-        slot_progress.fork_stats.is_duplicate_confirmed = true;
+        slot_progress.fork_stats.duplicate_confirmed_hash = Some(hash);
     }
 
     pub fn is_duplicate_confirmed(&self, slot: Slot) -> Option<bool> {
         self.progress_map
             .get(&slot)
-            .map(|s| s.fork_stats.is_duplicate_confirmed)
+            .map(|s| s.fork_stats.duplicate_confirmed_hash.is_some())
     }
 
     pub fn get_bank_prev_leader_slot(&self, bank: &Bank) -> Option<Slot> {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4150,6 +4150,14 @@ impl ReplayStage {
                 }
             }
 
+            if progress.is_duplicate_confirmed(*slot).unwrap_or(false) {
+                // Already duplicate confirmed, nothing left to do
+                continue;
+            }
+
+            progress.set_duplicate_confirmed_slot(*slot);
+            assert!(*frozen_hash != Hash::default());
+
             if *slot <= root_slot {
                 continue;
             }
@@ -4215,7 +4223,8 @@ impl ReplayStage {
                     datapoint_info!("validator-confirmation", ("duration_ms", duration, i64));
                     confirmed_forks
                         .push(ConfirmedSlot::new_supermajority_voted(*slot, bank.hash()));
-                } else if bank.is_frozen()
+                } else if !prog.fork_stats.is_duplicate_confirmed
+                    && bank.is_frozen()
                     && tower.is_slot_duplicate_confirmed(*slot, voted_stakes, total_stake)
                 {
                     info!(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -126,12 +126,6 @@ enum ForkReplayMode {
     Parallel(ThreadPool),
 }
 
-#[derive(PartialEq, Eq, Debug)]
-enum ConfirmationType {
-    SupermajorityVoted,
-    DuplicateConfirmed,
-}
-
 enum GenerateVoteTxResult {
     // non voting validator, not eligible for refresh
     NonVoting,
@@ -143,31 +137,6 @@ enum GenerateVoteTxResult {
 impl GenerateVoteTxResult {
     fn is_non_voting(&self) -> bool {
         matches!(self, Self::NonVoting)
-    }
-}
-
-#[derive(PartialEq, Eq, Debug)]
-struct ConfirmedSlot {
-    slot: Slot,
-    frozen_hash: Hash,
-    confirmation_type: ConfirmationType,
-}
-
-impl ConfirmedSlot {
-    fn new_supermajority_voted(slot: Slot, frozen_hash: Hash) -> Self {
-        Self {
-            slot,
-            frozen_hash,
-            confirmation_type: ConfirmationType::SupermajorityVoted,
-        }
-    }
-
-    fn new_duplicate_confirmed_slot(slot: Slot, frozen_hash: Hash) -> Self {
-        Self {
-            slot,
-            frozen_hash,
-            confirmation_type: ConfirmationType::DuplicateConfirmed,
-        }
     }
 }
 
@@ -4118,7 +4087,7 @@ impl ReplayStage {
 
     #[allow(clippy::too_many_arguments)]
     fn mark_slots_confirmed(
-        confirmed_slots: &[ConfirmedSlot],
+        confirmed_slots: &[(Slot, Hash)],
         blockstore: &Blockstore,
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
@@ -4131,44 +4100,14 @@ impl ReplayStage {
         duplicate_confirmed_slots: &mut DuplicateConfirmedSlots,
     ) {
         let root_slot = bank_forks.read().unwrap().root();
-        for ConfirmedSlot {
-            slot,
-            frozen_hash,
-            confirmation_type,
-        } in confirmed_slots.iter()
-        {
-            if *confirmation_type == ConfirmationType::SupermajorityVoted {
-                // This case should be guaranteed as false by confirm_forks()
-                if let Some(false) = progress.is_supermajority_confirmed(*slot) {
-                    // Because supermajority confirmation will iterate through and update the
-                    // subtree in fork choice, only incur this cost if the slot wasn't already
-                    // confirmed
-                    progress.set_supermajority_confirmed_slot(*slot);
-                    // If the slot was confirmed, then it must be frozen. Otherwise, we couldn't
-                    // have replayed any of its descendants and figured out it was confirmed.
-                    assert!(*frozen_hash != Hash::default());
-                }
-            }
-
-            if progress.is_duplicate_confirmed(*slot).unwrap_or(false) {
-                // Already duplicate confirmed, nothing left to do
-                continue;
-            }
-
-            progress.set_duplicate_confirmed_slot(*slot);
+        for (slot, frozen_hash) in confirmed_slots.iter() {
             assert!(*frozen_hash != Hash::default());
 
             if *slot <= root_slot {
                 continue;
             }
 
-            match confirmation_type {
-                ConfirmationType::SupermajorityVoted => (),
-                ConfirmationType::DuplicateConfirmed => (),
-                #[allow(unreachable_patterns)]
-                _ => panic!("programmer error"),
-            }
-
+            progress.set_duplicate_confirmed_hash(*slot, *frozen_hash);
             if let Some(prev_hash) = duplicate_confirmed_slots.insert(*slot, *frozen_hash) {
                 assert_eq!(prev_hash, *frozen_hash);
                 // Already processed this signal
@@ -4201,52 +4140,44 @@ impl ReplayStage {
         total_stake: Stake,
         progress: &ProgressMap,
         bank_forks: &RwLock<BankForks>,
-    ) -> Vec<ConfirmedSlot> {
+    ) -> Vec<(Slot, Hash)> {
         let mut confirmed_forks = vec![];
         for (slot, prog) in progress.iter() {
-            if !prog.fork_stats.is_supermajority_confirmed {
-                let bank = bank_forks
-                    .read()
-                    .unwrap()
-                    .get(*slot)
-                    .expect("bank in progress must exist in BankForks")
-                    .clone();
-                let duration = prog
-                    .replay_stats
-                    .read()
-                    .unwrap()
-                    .started
-                    .elapsed()
-                    .as_millis();
-                if bank.is_frozen() && tower.is_slot_confirmed(*slot, voted_stakes, total_stake) {
-                    info!("validator fork confirmed {} {}ms", *slot, duration);
-                    datapoint_info!("validator-confirmation", ("duration_ms", duration, i64));
-                    confirmed_forks
-                        .push(ConfirmedSlot::new_supermajority_voted(*slot, bank.hash()));
-                } else if !prog.fork_stats.is_duplicate_confirmed
-                    && bank.is_frozen()
-                    && tower.is_slot_duplicate_confirmed(*slot, voted_stakes, total_stake)
-                {
-                    info!(
-                        "validator fork duplicate confirmed {} {}ms",
-                        *slot, duration
-                    );
-                    datapoint_info!(
-                        "validator-duplicate-confirmation",
-                        ("duration_ms", duration, i64)
-                    );
-                    confirmed_forks.push(ConfirmedSlot::new_duplicate_confirmed_slot(
-                        *slot,
-                        bank.hash(),
-                    ));
-                } else {
-                    debug!(
-                        "validator fork not confirmed {} {}ms {:?}",
-                        *slot,
-                        duration,
-                        voted_stakes.get(slot)
-                    );
-                }
+            if prog.fork_stats.duplicate_confirmed_hash.is_some() {
+                continue;
+            }
+            let bank = bank_forks
+                .read()
+                .unwrap()
+                .get(*slot)
+                .expect("bank in progress must exist in BankForks");
+            let duration = prog
+                .replay_stats
+                .read()
+                .unwrap()
+                .started
+                .elapsed()
+                .as_millis();
+            if !bank.is_frozen() {
+                continue;
+            }
+            if tower.is_slot_duplicate_confirmed(*slot, voted_stakes, total_stake) {
+                info!(
+                    "validator fork duplicate confirmed {} {}ms",
+                    *slot, duration
+                );
+                datapoint_info!(
+                    "validator-duplicate-confirmation",
+                    ("duration_ms", duration, i64)
+                );
+                confirmed_forks.push((*slot, bank.hash()));
+            } else {
+                debug!(
+                    "validator fork not confirmed {} {}ms {:?}",
+                    *slot,
+                    duration,
+                    voted_stakes.get(slot)
+                );
             }
         }
         confirmed_forks
@@ -5619,10 +5550,7 @@ pub(crate) mod tests {
                 &bank_forks,
             );
             // No new stats should have been computed
-            assert_eq!(
-                confirmed_forks,
-                vec![ConfirmedSlot::new_supermajority_voted(0, bank0.hash())]
-            );
+            assert_eq!(confirmed_forks, vec![(0, bank0.hash())]);
         }
 
         let ancestors = bank_forks.read().unwrap().ancestors();


### PR DESCRIPTION
#### Problem
We perform the replay duplicate confirmed check as long as the slot is not *supermajority* confirmed.
This can lead to the same slot being checked multiple times, notifying state machine multiple times, and the log / metric being spammed as well.

#### Summary of Changes
Separately track the duplicate confirmed status and only check slots that are not duplicate confirmed.

Fixes #1236 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
