### PR TITLE
Add option to build v0 message in SVM

### DIFF
--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -268,7 +268,7 @@ fn prepare_transactions(
     transaction_builder.create_instruction(hello_program, Vec::new(), HashMap::new(), Vec::new());
 
     let sanitized_transaction =
-        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()));
+        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), false);
 
     all_transactions.push(sanitized_transaction);
     transaction_checks.push((Ok(()), None, Some(20)));
@@ -312,7 +312,7 @@ fn prepare_transactions(
     );
 
     let sanitized_transaction =
-        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()));
+        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), true);
     all_transactions.push(sanitized_transaction);
     transaction_checks.push((Ok(()), None, Some(20)));
 
@@ -350,7 +350,7 @@ fn prepare_transactions(
     transaction_builder.create_instruction(program_account, Vec::new(), HashMap::new(), Vec::new());
 
     let sanitized_transaction =
-        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()));
+        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), false);
 
     all_transactions.push(sanitized_transaction);
     transaction_checks.push((Ok(()), None, Some(20)));
@@ -392,7 +392,7 @@ fn prepare_transactions(
     );
 
     let sanitized_transaction =
-        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()));
+        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), true);
     all_transactions.push(sanitized_transaction.clone());
     transaction_checks.push((Ok(()), None, Some(20)));
 


### PR DESCRIPTION
#### Problem

The transaction builder in the SVM tests only builds legacy messages. If we want comprehensive tests with firedancer test-vectors we should also build V0 messages.

#### Summary of Changes

The `build` function now has a boolean allowing us to choose which version we want to build.

