### PR TITLE
Fixup StartBlockHeightAndRewards::start_block_height

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1127,13 +1127,16 @@ mod tests {
 
         bank.recalculate_partitioned_rewards(null_tracer(), &thread_pool);
         let EpochRewardStatus::Active(StartBlockHeightAndRewards {
-            start_block_height,
+            distribution_starting_block_height,
             stake_rewards_by_partition: ref recalculated_rewards,
         }) = bank.epoch_reward_status
         else {
             panic!("{:?} not active", bank.epoch_reward_status);
         };
-        assert_eq!(expected_starting_block_height, start_block_height);
+        assert_eq!(
+            expected_starting_block_height,
+            distribution_starting_block_height
+        );
         assert_eq!(expected_stake_rewards.len(), recalculated_rewards.len());
         compare_stake_rewards(&expected_stake_rewards, recalculated_rewards);
 
@@ -1143,13 +1146,16 @@ mod tests {
 
         bank.recalculate_partitioned_rewards(null_tracer(), &thread_pool);
         let EpochRewardStatus::Active(StartBlockHeightAndRewards {
-            start_block_height,
+            distribution_starting_block_height,
             stake_rewards_by_partition: ref recalculated_rewards,
         }) = bank.epoch_reward_status
         else {
             panic!("{:?} not active", bank.epoch_reward_status);
         };
-        assert_eq!(expected_starting_block_height, start_block_height);
+        assert_eq!(
+            expected_starting_block_height,
+            distribution_starting_block_height
+        );
         assert_eq!(expected_stake_rewards.len(), recalculated_rewards.len());
         // First partition has already been distributed, so recalculation
         // returns 0 rewards

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -59,18 +59,22 @@ impl Bank {
         );
 
         let slot = self.slot();
-        let credit_start = self.block_height() + self.get_reward_calculation_num_blocks();
+        let distribution_starting_block_height =
+            self.block_height() + self.get_reward_calculation_num_blocks();
 
         let num_partitions = stake_rewards_by_partition.len() as u64;
 
-        self.set_epoch_reward_status_active(credit_start, stake_rewards_by_partition);
+        self.set_epoch_reward_status_active(
+            distribution_starting_block_height,
+            stake_rewards_by_partition,
+        );
 
         // create EpochRewards sysvar that holds the balance of undistributed rewards with
-        // (total_rewards, distributed_rewards, credit_start), total capital will increase by (total_rewards - distributed_rewards)
+        // (total_rewards, distributed_rewards, distribution_starting_block_height), total capital will increase by (total_rewards - distributed_rewards)
         self.create_epoch_rewards_sysvar(
             total_rewards,
             distributed_rewards,
-            credit_start,
+            distribution_starting_block_height,
             num_partitions,
             total_points,
         );
@@ -78,7 +82,7 @@ impl Bank {
         datapoint_info!(
             "epoch-rewards-status-update",
             ("start_slot", slot, i64),
-            ("start_block_height", self.block_height(), i64),
+            ("calculation_block_height", self.block_height(), i64),
             ("active", 1, i64),
             ("parent_slot", parent_slot, i64),
             ("parent_block_height", parent_block_height, i64),

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -63,7 +63,7 @@ impl Bank {
 
         let num_partitions = stake_rewards_by_partition.len() as u64;
 
-        self.set_epoch_reward_status_active(self.block_height(), stake_rewards_by_partition);
+        self.set_epoch_reward_status_active(credit_start, stake_rewards_by_partition);
 
         // create EpochRewards sysvar that holds the balance of undistributed rewards with
         // (total_rewards, distributed_rewards, credit_start), total capital will increase by (total_rewards - distributed_rewards)
@@ -530,10 +530,10 @@ impl Bank {
                 reward_calc_tracer,
                 thread_pool,
             );
-            let start_block_height = epoch_rewards_sysvar
-                .distribution_starting_block_height
-                .saturating_sub(self.get_reward_calculation_num_blocks());
-            self.set_epoch_reward_status_active(start_block_height, stake_rewards_by_partition);
+            self.set_epoch_reward_status_active(
+                epoch_rewards_sysvar.distribution_starting_block_height,
+                stake_rewards_by_partition,
+            );
         }
     }
 
@@ -1107,7 +1107,7 @@ mod tests {
         // mutable Bank methods require the bank not be Arc-wrapped.
         let new_slot = bank.slot() + 1;
         let mut bank = Bank::new_from_parent(bank, &Pubkey::default(), new_slot);
-        let expected_starting_block_height = bank.block_height();
+        let expected_starting_block_height = bank.block_height() + 1;
 
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let mut rewards_metrics = RewardsMetrics::default();

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -69,8 +69,6 @@ impl Bank {
             stake_rewards_by_partition,
         );
 
-        // create EpochRewards sysvar that holds the balance of undistributed rewards with
-        // (total_rewards, distributed_rewards, distribution_starting_block_height), total capital will increase by (total_rewards - distributed_rewards)
         self.create_epoch_rewards_sysvar(
             total_rewards,
             distributed_rewards,

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -45,7 +45,7 @@ impl Bank {
         };
 
         let height = self.block_height();
-        let credit_start = status.start_block_height;
+        let credit_start = status.distribution_starting_block_height;
         let credit_end_exclusive = credit_start + status.stake_rewards_by_partition.len() as u64;
         assert!(
             self.epoch_schedule.get_slots_in_epoch(self.epoch)
@@ -289,7 +289,7 @@ mod tests {
             bank.epoch_schedule().slots_per_epoch as usize + 1,
         );
 
-        bank.set_epoch_reward_status_active(bank.block_height(), stake_rewards);
+        bank.set_epoch_reward_status_active(bank.block_height() + 1, stake_rewards);
 
         bank.distribute_partitioned_epoch_rewards();
     }
@@ -299,7 +299,7 @@ mod tests {
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
         let mut bank = Bank::new_for_tests(&genesis_config);
 
-        bank.set_epoch_reward_status_active(bank.block_height(), vec![]);
+        bank.set_epoch_reward_status_active(bank.block_height() + 1, vec![]);
 
         bank.distribute_partitioned_epoch_rewards();
     }
@@ -405,7 +405,7 @@ mod tests {
 
         let stake_rewards_bucket =
             hash_rewards_into_partitions(stake_rewards, &Hash::new(&[1; 32]), 100);
-        bank.set_epoch_reward_status_active(bank.block_height(), stake_rewards_bucket.clone());
+        bank.set_epoch_reward_status_active(bank.block_height() + 1, stake_rewards_bucket.clone());
 
         // Test partitioned stores
         let mut total_rewards = 0;

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -45,8 +45,7 @@ impl Bank {
         };
 
         let height = self.block_height();
-        let start_block_height = status.start_block_height;
-        let credit_start = start_block_height + self.get_reward_calculation_num_blocks();
+        let credit_start = status.start_block_height;
         let credit_end_exclusive = credit_start + status.stake_rewards_by_partition.len() as u64;
         assert!(
             self.epoch_schedule.get_slots_in_epoch(self.epoch)
@@ -67,7 +66,7 @@ impl Bank {
                 ("slot", self.slot(), i64),
                 ("block_height", height, i64),
                 ("active", 0, i64),
-                ("start_block_height", start_block_height, i64),
+                ("start_block_height", credit_start, i64),
             );
 
             assert!(matches!(
@@ -267,7 +266,7 @@ mod tests {
 
         let stake_rewards = hash_rewards_into_partitions(stake_rewards, &Hash::new(&[1; 32]), 2);
 
-        bank.set_epoch_reward_status_active(bank.block_height(), stake_rewards);
+        bank.set_epoch_reward_status_active(bank.block_height() + 1, stake_rewards);
 
         bank.distribute_partitioned_epoch_rewards();
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -293,7 +293,7 @@ mod tests {
             .map(|_| StakeReward::new_random())
             .collect::<Vec<_>>();
 
-        bank.set_epoch_reward_status_active(bank.block_height(), vec![stake_rewards]);
+        bank.set_epoch_reward_status_active(bank.block_height() + 1, vec![stake_rewards]);
         assert!(bank.get_reward_interval() == RewardInterval::InsideInterval);
 
         bank.force_reward_interval_end_for_tests();

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -54,7 +54,7 @@ type PartitionedStakeRewards = Vec<PartitionedStakeReward>;
 #[derive(AbiExample, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct StartBlockHeightAndRewards {
     /// the block height of the slot at which rewards distribution began
-    pub(crate) start_block_height: u64,
+    pub(crate) distribution_starting_block_height: u64,
     /// calculated epoch rewards pending distribution, outer Vec is by partition (one partition per block)
     pub(crate) stake_rewards_by_partition: Arc<Vec<StakeRewards>>,
 }
@@ -152,11 +152,11 @@ impl Bank {
 
     pub(crate) fn set_epoch_reward_status_active(
         &mut self,
-        start_block_height: u64,
+        distribution_starting_block_height: u64,
         stake_rewards_by_partition: Vec<StakeRewards>,
     ) {
         self.epoch_reward_status = EpochRewardStatus::Active(StartBlockHeightAndRewards {
-            start_block_height,
+            distribution_starting_block_height,
             stake_rewards_by_partition: Arc::new(stake_rewards_by_partition),
         });
     }

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -544,7 +544,7 @@ mod tests {
 
         // This some what long test harness is required to freeze the ABI of
         // Bank's serialization due to versioned nature
-        #[frozen_abi(digest = "8BVfyLYrPt1ranknjF4sLePjZaZjpKXXrHt4wKf47g3W")]
+        #[frozen_abi(digest = "ENUEoDA5CYu9NLLCuaj23qpfKBZzCvxK3T5VsUFA9sti")]
         #[derive(Serialize, AbiExample)]
         pub struct BankAbiTestWrapperNewer {
             #[serde(serialize_with = "wrapper_newer")]


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/pull/1159#discussion_r1589853891
`StartBlockHeightAndRewards::start_block_height` currently stores the calculation block height, even though the code comment says "the block height of the slot at which rewards distribution began". This makes the field confusing and easy to misuse.

#### Summary of Changes
Populate the field with the correct data, ie. the block height at which distribution is starting.
Rename the field and some variables to make it clear that it is the `distribution_starting_block_height`

✅ ~~Needs rebase on #1159 because the field is used in recalculation methods~~
