### PR TITLE
clippy: suspicious_open_options

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -922,8 +922,7 @@ pub mod tests {
         let _data = OpenOptions::new()
             .read(true)
             .write(true)
-            .create(true)
-            .truncate(false)
+            .create_new(true)
             .open(path)
             .expect("create a test file for mmap");
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -923,6 +923,7 @@ pub mod tests {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(path)
             .expect("create a test file for mmap");
 

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -179,6 +179,7 @@ impl CacheHashDataFile {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(file)?;
 
         // Theoretical performance optimization: write a zero to the end of

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -178,8 +178,7 @@ impl CacheHashDataFile {
         let mut data = OpenOptions::new()
             .read(true)
             .write(true)
-            .create(true)
-            .truncate(false)
+            .create_new(true)
             .open(file)?;
 
         // Theoretical performance optimization: write a zero to the end of

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -604,7 +604,7 @@ mod test {
                 .read(true)
                 .write(true)
                 .create(true)
-                .truncate(false)
+                .truncate(true)
                 .open(path.clone())
                 .unwrap();
             _ = file.write_all(&vec![1u8; len]);

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -604,6 +604,7 @@ mod test {
                 .read(true)
                 .write(true)
                 .create(true)
+                .truncate(false)
                 .open(path.clone())
                 .unwrap();
             _ = file.write_all(&vec![1u8; len]);

--- a/bucket_map/src/restart.rs
+++ b/bucket_map/src/restart.rs
@@ -242,6 +242,7 @@ impl Restart {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(file)?;
 
         if capacity > 0 {

--- a/bucket_map/src/restart.rs
+++ b/bucket_map/src/restart.rs
@@ -241,8 +241,7 @@ impl Restart {
         let mut data = OpenOptions::new()
             .read(true)
             .write(true)
-            .create(true)
-            .truncate(false)
+            .create_new(true)
             .open(file)?;
 
         if capacity > 0 {

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -1158,7 +1158,11 @@ pub fn init_or_update(config_file: &str, is_init: bool, check_only: bool) -> Res
     // Trigger an update to the modification time for `release_dir`
     {
         let path = &release_dir.join(".touch");
-        let _ = fs::OpenOptions::new().create(true).write(true).open(path);
+        let _ = fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(path);
         let _ = fs::remove_file(path);
     }
 

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -1159,8 +1159,7 @@ pub fn init_or_update(config_file: &str, is_init: bool, check_only: bool) -> Res
     {
         let path = &release_dir.join(".touch");
         let _ = fs::OpenOptions::new()
-            .create(true)
-            .truncate(false)
+            .create_new(true)
             .write(true)
             .open(path);
         let _ = fs::remove_file(path);

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -142,6 +142,7 @@ pub fn ledger_lockfile(ledger_path: &Path) -> RwLock<File> {
         OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(false)
             .open(lockfile)
             .unwrap(),
     )


### PR DESCRIPTION
#### Problem

some clippy changes for Rust v1.78.0. (#1309)

https://rust-lang.github.io/rust-clippy/master/index.html#/suspicious_open_options

#### Summary of Changes

truncate(false) is the default behavior. added it explicitly
