### PR TITLE
clippy: unnecessary_get_then_check

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1252,13 +1252,12 @@ mod tests {
         );
 
         // Check that read-only lock with zero references is deleted
-        assert!(accounts
+        assert!(!accounts
             .account_locks
             .lock()
             .unwrap()
             .readonly_locks
-            .get(&keypair1.pubkey())
-            .is_none());
+            .contains_key(&keypair1.pubkey()));
     }
 
     #[test]
@@ -1495,13 +1494,12 @@ mod tests {
             2
         );
         // verify that keypair2 (for tx1) is not write-locked
-        assert!(accounts
+        assert!(!accounts
             .account_locks
             .lock()
             .unwrap()
             .write_locks
-            .get(&keypair2.pubkey())
-            .is_none());
+            .contains(&keypair2.pubkey()));
 
         accounts.unlock_accounts(txs.iter().zip(&results));
 

--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -60,7 +60,7 @@ impl BlockhashQueue {
     /// Check if the age of the hash is within the queue's max age
     #[deprecated(since = "2.0.0", note = "Please use `is_hash_valid_for_age` instead")]
     pub fn is_hash_valid(&self, hash: &Hash) -> bool {
-        self.ages.get(hash).is_some()
+        self.ages.contains_key(hash)
     }
 
     /// Check if the age of the hash is within the specified age

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -492,7 +492,7 @@ mod tests {
                 expected.increase_confirmation_stake(1, 50);
                 assert_eq!(*commitment.get(&a).unwrap(), expected);
             } else {
-                assert!(commitment.get(&a).is_none());
+                assert!(!commitment.contains_key(&a));
             }
         }
         assert_eq!(rooted_stake.len(), 2);

--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -416,7 +416,7 @@ impl HeaviestSubtreeForkChoice {
 
     pub fn add_root_parent(&mut self, root_parent: SlotHashKey) {
         assert!(root_parent.0 < self.tree_root.0);
-        assert!(self.fork_infos.get(&root_parent).is_none());
+        assert!(!self.fork_infos.contains_key(&root_parent));
         let root_info = self
             .fork_infos
             .get_mut(&self.tree_root)

--- a/core/src/consensus/latest_validator_votes_for_frozen_banks.rs
+++ b/core/src/consensus/latest_validator_votes_for_frozen_banks.rs
@@ -184,10 +184,9 @@ mod tests {
                     (vote_slot, vec![frozen_hash])
                 );
             } else {
-                assert!(latest_validator_votes_for_frozen_banks
+                assert!(!latest_validator_votes_for_frozen_banks
                     .fork_choice_dirty_set
-                    .get(&vote_pubkey)
-                    .is_none());
+                    .contains_key(&vote_pubkey));
             }
         }
 
@@ -218,10 +217,9 @@ mod tests {
                 (vote_slot, all_frozen_hashes.clone())
             );
         } else {
-            assert!(latest_validator_votes_for_frozen_banks
+            assert!(!latest_validator_votes_for_frozen_banks
                 .fork_choice_dirty_set
-                .get(&vote_pubkey)
-                .is_none());
+                .contains_key(&vote_pubkey));
         }
 
         // Case 4: Adding duplicate vote that is not frozen should not update the state
@@ -250,10 +248,9 @@ mod tests {
                 (vote_slot, all_frozen_hashes.clone())
             );
         } else {
-            assert!(latest_validator_votes_for_frozen_banks
+            assert!(!latest_validator_votes_for_frozen_banks
                 .fork_choice_dirty_set
-                .get(&vote_pubkey)
-                .is_none());
+                .contains_key(&vote_pubkey));
         }
 
         // Case 5: Adding a vote for a new higher slot that is not yet frozen
@@ -285,10 +282,9 @@ mod tests {
                 (old_vote_slot, all_frozen_hashes)
             );
         } else {
-            assert!(latest_validator_votes_for_frozen_banks
+            assert!(!latest_validator_votes_for_frozen_banks
                 .fork_choice_dirty_set
-                .get(&vote_pubkey)
-                .is_none());
+                .contains_key(&vote_pubkey));
         }
 
         // Case 6: Adding a vote for a new higher slot that *is* frozen
@@ -318,10 +314,9 @@ mod tests {
                 (vote_slot, vec![frozen_hash])
             );
         } else {
-            assert!(latest_validator_votes_for_frozen_banks
+            assert!(!latest_validator_votes_for_frozen_banks
                 .fork_choice_dirty_set
-                .get(&vote_pubkey)
-                .is_none());
+                .contains_key(&vote_pubkey));
         }
 
         // Case 7: Adding a vote for a new pubkey should also update the state
@@ -352,10 +347,9 @@ mod tests {
                 (vote_slot, vec![frozen_hash])
             );
         } else {
-            assert!(latest_validator_votes_for_frozen_banks
+            assert!(!latest_validator_votes_for_frozen_banks
                 .fork_choice_dirty_set
-                .get(&vote_pubkey)
-                .is_none());
+                .contains_key(&vote_pubkey));
         }
     }
 

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1497,7 +1497,7 @@ mod test {
             .unwrap()
             .repair_pubkey_and_addr
             .is_none());
-        assert!(duplicate_slot_repair_statuses.get(&dead_slot).is_some());
+        assert!(duplicate_slot_repair_statuses.contains_key(&dead_slot));
 
         // Give the slot a repair address
         duplicate_slot_repair_statuses
@@ -1519,7 +1519,7 @@ mod test {
             &identity_keypair,
         );
         assert_eq!(duplicate_slot_repair_statuses.len(), 1);
-        assert!(duplicate_slot_repair_statuses.get(&dead_slot).is_some());
+        assert!(duplicate_slot_repair_statuses.contains_key(&dead_slot));
 
         // Insert rest of shreds. Slot is full, should get filtered from
         // `duplicate_slot_repair_statuses`

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4242,7 +4242,7 @@ impl ReplayStage {
                 .get(&parent_slot)
                 .expect("missing parent in bank forks");
             for child_slot in children {
-                if forks.get(child_slot).is_some() || new_banks.get(&child_slot).is_some() {
+                if forks.get(child_slot).is_some() || new_banks.contains_key(&child_slot) {
                     trace!("child already active or frozen {}", child_slot);
                     continue;
                 }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -526,7 +526,7 @@ impl Rocks {
             .chain(std::iter::once(DEFAULT_COLUMN_NAME.to_string()))
             .collect();
         detected_cfs.iter().for_each(|cf_name| {
-            if known_cfs.get(cf_name.as_str()).is_none() {
+            if !known_cfs.contains(cf_name.as_str()) {
                 info!("Detected unknown column {cf_name}, opening column with basic options");
                 // This version of the software was unaware of the column, so
                 // it is fair to assume that we will not attempt to read or

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -2474,7 +2474,7 @@ mod tests {
         let program_id = Pubkey::new_unique();
         cache.assign_program(program_id, entry.clone());
         cache.unload_program_entry(&program_id, &entry);
-        assert!(cache.stats.evictions.get(&program_id).is_some());
+        assert!(cache.stats.evictions.contains_key(&program_id));
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2009,7 +2009,7 @@ impl Bank {
         // update epoch_stakes cache
         //  if my parent didn't populate for this staker's epoch, we've
         //  crossed a boundary
-        if self.epoch_stakes.get(&leader_schedule_epoch).is_none() {
+        if !self.epoch_stakes.contains_key(&leader_schedule_epoch) {
             self.epoch_stakes.retain(|&epoch, _| {
                 epoch >= leader_schedule_epoch.saturating_sub(MAX_LEADER_SCHEDULE_STAKES)
             });

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -810,8 +810,8 @@ mod tests {
         let bank0 = bank_forks[0].clone();
         let child_bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.insert(child_bank);
-        assert!(bank_forks.frozen_banks().get(&0).is_some());
-        assert!(bank_forks.frozen_banks().get(&1).is_none());
+        assert!(bank_forks.frozen_banks().contains_key(&0));
+        assert!(!bank_forks.frozen_banks().contains_key(&1));
     }
 
     #[test]

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -133,7 +133,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
         if let Some(stored_forks) = keymap.get(key_slice) {
             let res = stored_forks
                 .iter()
-                .find(|(f, _)| ancestors.contains_key(f) || self.roots.get(f).is_some())
+                .find(|(f, _)| ancestors.contains_key(f) || self.roots.contains(f))
                 .cloned();
             if res.is_some() {
                 return res;
@@ -442,7 +442,7 @@ mod tests {
             status_cache.add_root(i as u64);
         }
         assert_eq!(status_cache.slot_deltas.len(), 1);
-        assert!(status_cache.slot_deltas.get(&1).is_some());
+        assert!(status_cache.slot_deltas.contains_key(&1));
         let slot_deltas = status_cache.root_slot_deltas();
         let cache = StatusCache::from_slot_deltas(&slot_deltas);
         assert_eq!(cache, status_cache);
@@ -486,8 +486,8 @@ mod tests {
 
         // Check that the slot delta for slot 0 is gone, but slot 1 still
         // exists
-        assert!(status_cache.slot_deltas.get(&0).is_none());
-        assert!(status_cache.slot_deltas.get(&1).is_some());
+        assert!(!status_cache.slot_deltas.contains_key(&0));
+        assert!(status_cache.slot_deltas.contains_key(&1));
 
         // Clear slot 1 related data
         status_cache.clear_slot_entries(1);

--- a/sdk/program/src/vote/authorized_voters.rs
+++ b/sdk/program/src/vote/authorized_voters.rs
@@ -77,7 +77,7 @@ impl AuthorizedVoters {
     }
 
     pub fn contains(&self, epoch: Epoch) -> bool {
-        self.authorized_voters.get(&epoch).is_some()
+        self.authorized_voters.contains_key(&epoch)
     }
 
     pub fn iter(&self) -> std::collections::btree_map::Iter<Epoch, Pubkey> {

--- a/turbine/src/broadcast_stage/broadcast_metrics.rs
+++ b/turbine/src/broadcast_stage/broadcast_metrics.rs
@@ -294,7 +294,7 @@ mod test {
             }),
         );
 
-        assert!(slot_broadcast_stats.0.get(&0).is_none());
+        assert!(!slot_broadcast_stats.0.contains_key(&0));
     }
 
     #[test]
@@ -335,7 +335,7 @@ mod test {
                 t.join().unwrap();
             }
 
-            assert!(slot_broadcast_stats.lock().unwrap().0.get(&slot).is_none());
+            assert!(!slot_broadcast_stats.lock().unwrap().0.contains_key(&slot));
             let (returned_count, returned_slot, _returned_instant) = receiver.recv().unwrap();
             assert_eq!(returned_count, num_threads);
             assert_eq!(returned_slot, slot);


### PR DESCRIPTION
#### Problem

some clippy changes for Rust v1.78.0. (#1309)

https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check

#### Summary of Changes

```diff
- foo.get(xxx).is_some()
+ foo.contains(xxx)
```

```diff
- foo.get(xxx).is_none()
+ !foo.contains(xxx)
```