### PR TITLE
clippy: ignore false map_clone warning

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -501,6 +501,7 @@ impl<O: BucketOccupied> BucketStorage<O> {
     }
 
     /// allocate a new bucket, copying data from 'bucket'
+    #[allow(clippy::map_clone)] // https://github.com/rust-lang/rust-clippy/issues/12560
     pub fn new_resized(
         drives: &Arc<Vec<PathBuf>>,
         max_search: MaxSearch,

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -501,7 +501,6 @@ impl<O: BucketOccupied> BucketStorage<O> {
     }
 
     /// allocate a new bucket, copying data from 'bucket'
-    #[allow(clippy::map_clone)] // https://github.com/rust-lang/rust-clippy/issues/12560
     pub fn new_resized(
         drives: &Arc<Vec<PathBuf>>,
         max_search: MaxSearch,
@@ -518,6 +517,7 @@ impl<O: BucketOccupied> BucketStorage<O> {
             capacity,
             max_search,
             Arc::clone(stats),
+            #[allow(clippy::map_clone)] // https://github.com/rust-lang/rust-clippy/issues/12560
             bucket
                 .map(|bucket| Arc::clone(&bucket.count))
                 .unwrap_or_default(),


### PR DESCRIPTION
#### Problem

some clippy changes for Rust v1.78.0. (#1309)

it complains about this line but which is an arc clone.
https://github.com/anza-xyz/agave/blob/718101183271a0b75f307d86bde48721051ca5e9/bucket_map/src/bucket_storage.rs#L521

#### Summary of Changes

ignore false map_clone warning.
