### PR TITLE
clippy: allow dead_code for zk transcript

### DIFF
--- a/zk-token-sdk/src/transcript.rs
+++ b/zk-token-sdk/src/transcript.rs
@@ -4,6 +4,7 @@ use {
     merlin::Transcript,
 };
 
+#[allow(dead_code)]
 pub trait TranscriptProtocol {
     /// Append a domain separator for an `n`-bit rangeproof for ElGamalKeypair
     /// ciphertext using a decryption key


### PR DESCRIPTION
#### Problem

some clippy changes for Rust v1.78.0. (#1309)

there is a clippy error from TranscriptProtocol

![Screenshot 2024-05-08 at 15 29 24](https://github.com/anza-xyz/agave/assets/8209234/6b7753ee-66b7-443e-8262-c46795c9c254)

I think we can add some unit tests here to avoid this error. let's allow it first and fix later 🙈 

#### Summary of Changes

allow dead code