### PR TITLE
clippy: allow dead_code for GraphVoteAccountModeError, DroppableTask and SubscriptionToken

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -172,8 +172,7 @@ impl Default for GraphVoteAccountMode {
     }
 }
 
-#[allow(dead_code)]
-struct GraphVoteAccountModeError(String);
+struct GraphVoteAccountModeError;
 
 impl FromStr for GraphVoteAccountMode {
     type Err = GraphVoteAccountModeError;
@@ -182,7 +181,7 @@ impl FromStr for GraphVoteAccountMode {
             Self::DISABLED => Ok(Self::Disabled),
             Self::LAST_ONLY => Ok(Self::LastOnly),
             Self::WITH_HISTORY => Ok(Self::WithHistory),
-            _ => Err(GraphVoteAccountModeError(s.to_string())),
+            _ => Err(GraphVoteAccountModeError),
         }
     }
 }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -172,6 +172,7 @@ impl Default for GraphVoteAccountMode {
     }
 }
 
+#[allow(dead_code)]
 struct GraphVoteAccountModeError(String);
 
 impl FromStr for GraphVoteAccountMode {

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1007,7 +1007,14 @@ struct DroppableTask<T>(Arc<AtomicBool>, JoinHandle<T>);
 impl<T> Drop for DroppableTask<T> {
     fn drop(&mut self) {
         self.0.store(true, Ordering::Relaxed);
-        self.1.abort();
+        trace!(
+            "stopping task, which is currently {}",
+            if self.1.is_finished() {
+                "finished"
+            } else {
+                "running"
+            }
+        );
     }
 }
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1002,6 +1002,7 @@ impl ProgramTestBanksClientExt for BanksClient {
     }
 }
 
+#[allow(dead_code)]
 struct DroppableTask<T>(Arc<AtomicBool>, JoinHandle<T>);
 
 impl<T> Drop for DroppableTask<T> {

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1002,12 +1002,12 @@ impl ProgramTestBanksClientExt for BanksClient {
     }
 }
 
-#[allow(dead_code)]
 struct DroppableTask<T>(Arc<AtomicBool>, JoinHandle<T>);
 
 impl<T> Drop for DroppableTask<T> {
     fn drop(&mut self) {
         self.0.store(true, Ordering::Relaxed);
+        self.1.abort();
     }
 }
 

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -575,6 +575,8 @@ impl Drop for SubscriptionTokenInner {
     }
 }
 
+// allowing dead code here to appease clippy, but unsure if/how the CounterToken is actually used.
+// further investigation would be necessary before removing
 #[allow(dead_code)]
 #[derive(Clone)]
 pub struct SubscriptionToken(Arc<SubscriptionTokenInner>, CounterToken);

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -575,6 +575,7 @@ impl Drop for SubscriptionTokenInner {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct SubscriptionToken(Arc<SubscriptionTokenInner>, CounterToken);
 


### PR DESCRIPTION
#### Problem

clippy changes for Rust v1.78.0 (#1309)

`GraphVoteAccountModeError`

![Screenshot 2024-05-08 at 15 56 27](https://github.com/anza-xyz/agave/assets/8209234/8d0adce8-286d-4023-b45b-e1ee63f059fa)

---

`DroppableTask`

![Screenshot 2024-05-08 at 15 57 39](https://github.com/anza-xyz/agave/assets/8209234/0098674f-b577-453f-815c-4d5016632e0d)

---

`SubscriptionToken`

![Screenshot 2024-05-08 at 15 57 28](https://github.com/anza-xyz/agave/assets/8209234/a30f5f1a-0293-4ae4-ab3f-c3db0064403d)


#### Summary of Changes

allow dead_code for them. we can create some issues to track/refactor later 💪 