### PR TITLE
clippy: allow dead_code for SerializeAccount

### DIFF
--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -25,6 +25,7 @@ use {
 /// SBF VM.
 const MAX_INSTRUCTION_ACCOUNTS: u8 = NON_DUP_MARKER;
 
+#[allow(dead_code)]
 enum SerializeAccount<'a> {
     Account(IndexOfAccount, BorrowedAccount<'a>),
     Duplicate(IndexOfAccount),


### PR DESCRIPTION
#### Problem

clippy changes for Rust v1.78.0 (#1309)

![Screenshot 2024-05-08 at 16 02 50](https://github.com/anza-xyz/agave/assets/8209234/65b2f70d-d18c-44f4-bfe7-5e311fef2238)

#### Summary of Changes

it looks like this filed is quite useful 🤔 allow dead_code for it temporary and we can refactor later!