### PR TITLE
Don't panic the vote program

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -300,7 +300,9 @@ fn check_and_filter_proposed_vote_state(
                 if slot_hashes_index == slot_hashes.len() {
                     // The vote slot does not exist in the SlotHashes history because it's too old,
                     // i.e. older than the oldest slot in the history.
-                    assert!(proposed_vote_slot < earliest_slot_hash_in_history);
+                    if proposed_vote_slot >= earliest_slot_hash_in_history {
+                        return Err(VoteError::AssertionFailed);
+                    }
                     if !vote_state.contains_slot(proposed_vote_slot) && root_to_check.is_none() {
                         // If the vote slot is both:
                         // 1) Too old
@@ -317,7 +319,9 @@ fn check_and_filter_proposed_vote_state(
                         // 2. We know from the assert earlier in the function that
                         // `proposed_vote_slot < earliest_slot_hash_in_history`,
                         // so from 1. we know that `new_proposed_root < earliest_slot_hash_in_history`.
-                        assert!(new_proposed_root < earliest_slot_hash_in_history);
+                        if new_proposed_root >= earliest_slot_hash_in_history {
+                            return Err(VoteError::AssertionFailed);
+                        }
                         root_to_check = None;
                     } else {
                         proposed_lockouts_index = proposed_lockouts_index.checked_add(1).expect(

--- a/sdk/program/src/vote/error.rs
+++ b/sdk/program/src/vote/error.rs
@@ -69,6 +69,9 @@ pub enum VoteError {
 
     #[error("Cannot update commission at this point in the epoch")]
     CommissionUpdateTooLate,
+
+    #[error("Assertion failed")]
+    AssertionFailed,
 }
 
 impl<E> DecodeError<E> for VoteError {


### PR DESCRIPTION
#### Problem

If the vote state corrupts the vote program can panic the validator.
This behavior is unique to the vote program. All other native programs and user deployed programs can only cause a transaction failure but not crash the whole validator.

Note that this is not a security bug. The crash can never happen on mainnet but may happen in fuzz runs, etc. 

#### Summary of Changes

This commit introduces a new vote program custom error type (AssertionFailed) and changes some assertions so that they return this error type instead of crashing the entire validator.

Relates to https://github.com/anza-xyz/agave/pull/730
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
