### PR TITLE
Simd 118: replace calculation-blocks config value with constant

### DIFF
--- a/accounts-db/src/partitioned_rewards.rs
+++ b/accounts-db/src/partitioned_rewards.rs
@@ -6,11 +6,6 @@ use solana_sdk::clock::Slot;
 /// Configuration options for partitioned epoch rewards.
 /// This struct allows various forms of testing, especially prior to feature activation.
 pub struct PartitionedEpochRewardsConfig {
-    /// Number of blocks for reward calculation and storing vote accounts.
-    /// Distributing rewards to stake accounts begins AFTER this many blocks.
-    /// Normally, this will be 1.
-    /// if force_one_slot_partitioned_rewards, this will be 0 (ie. we take 0 blocks just for reward calculation)
-    pub reward_calculation_num_blocks: Slot,
     /// number of stake accounts to store in one block during partitioned reward interval
     /// normally, this is a number tuned for reasonable performance, such as 4096 accounts/block
     /// if force_one_slot_partitioned_rewards, this will usually be u64::MAX so that all stake accounts are written in the first block
@@ -26,9 +21,6 @@ pub struct PartitionedEpochRewardsConfig {
 impl Default for PartitionedEpochRewardsConfig {
     fn default() -> Self {
         Self {
-            // reward calculation happens synchronously during the first block of the epoch boundary.
-            // So, # blocks for reward calculation is 1.
-            reward_calculation_num_blocks: 1,
             // # stake accounts to store in one block during partitioned reward interval
             // Target to store 64 rewards per entry/tick in a block. A block has a minimum of 64
             // entries/tick. This gives 4096 total rewards to store in one block.
@@ -47,7 +39,6 @@ pub enum TestPartitionedEpochRewards {
     CompareResults,
     ForcePartitionedEpochRewardsInOneBlock,
     PartitionedEpochRewardsConfigRewardBlocks {
-        reward_calculation_num_blocks: u64,
         stake_account_stores_per_block: u64,
     },
 }
@@ -63,12 +54,12 @@ impl PartitionedEpochRewardsConfig {
                 Self::set_test_enable_partitioned_rewards()
             }
             TestPartitionedEpochRewards::PartitionedEpochRewardsConfigRewardBlocks {
-                    reward_calculation_num_blocks, stake_account_stores_per_block } => {
-                   Self::set_test_enable_partitioned_rewards_with_custom_number_of_stake_accounts_per_block(
-                    reward_calculation_num_blocks,
-                    stake_account_stores_per_block)
-                }
-
+                    stake_account_stores_per_block,
+            } => {
+                Self::set_test_enable_partitioned_rewards_with_custom_number_of_stake_accounts_per_block(
+                    stake_account_stores_per_block
+                )
+            }
         }
     }
 
@@ -77,7 +68,6 @@ impl PartitionedEpochRewardsConfig {
     /// code.
     fn set_test_enable_partitioned_rewards() -> Self {
         Self {
-            reward_calculation_num_blocks: 0,
             stake_account_stores_per_block: u64::MAX,
             test_enable_partitioned_rewards: true,
             // irrelevant if we are not running old code path
@@ -98,11 +88,9 @@ impl PartitionedEpochRewardsConfig {
     /// A method that configures how many reward reward calculation blocks and how many stake
     /// accounts to store per reward block.
     fn set_test_enable_partitioned_rewards_with_custom_number_of_stake_accounts_per_block(
-        reward_calculation_num_blocks: u64,
         stake_account_stores_per_block: u64,
     ) -> Self {
         Self {
-            reward_calculation_num_blocks,
             stake_account_stores_per_block,
             test_enable_partitioned_rewards: true,
             // irrelevant if we are not running old code path

--- a/accounts-db/src/partitioned_rewards.rs
+++ b/accounts-db/src/partitioned_rewards.rs
@@ -1,6 +1,4 @@
 //! Code related to partitioned rewards distribution
-//!
-use solana_sdk::clock::Slot;
 
 #[derive(Debug)]
 /// Configuration options for partitioned epoch rewards.
@@ -9,7 +7,7 @@ pub struct PartitionedEpochRewardsConfig {
     /// number of stake accounts to store in one block during partitioned reward interval
     /// normally, this is a number tuned for reasonable performance, such as 4096 accounts/block
     /// if force_one_slot_partitioned_rewards, this will usually be u64::MAX so that all stake accounts are written in the first block
-    pub stake_account_stores_per_block: Slot,
+    pub stake_account_stores_per_block: u64,
     /// if true, end of epoch bank rewards will force using partitioned rewards distribution.
     /// see `set_test_enable_partitioned_rewards`
     pub test_enable_partitioned_rewards: bool,

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -664,7 +664,6 @@ mod tests {
         let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING.clone();
         accounts_db_config.test_partitioned_epoch_rewards =
             TestPartitionedEpochRewards::PartitionedEpochRewardsConfigRewardBlocks {
-                reward_calculation_num_blocks: 1,
                 stake_account_stores_per_block,
             };
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -4,6 +4,7 @@ use {
         CalculateRewardsAndDistributeVoteRewardsResult, CalculateValidatorRewardsResult,
         EpochRewardCalculateParamInfo, PartitionedRewardsCalculation, StakeRewardCalculation,
         StakeRewardCalculationPartitioned, StakeRewards, VoteRewardsAccounts,
+        REWARD_CALCULATION_NUM_BLOCKS,
     },
     crate::{
         bank::{
@@ -60,7 +61,7 @@ impl Bank {
 
         let slot = self.slot();
         let distribution_starting_block_height =
-            self.block_height() + self.get_reward_calculation_num_blocks();
+            self.block_height() + REWARD_CALCULATION_NUM_BLOCKS;
 
         let num_partitions = stake_rewards_by_partition.len() as u64;
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -61,7 +61,12 @@ impl Bank {
 
         let slot = self.slot();
         let distribution_starting_block_height =
-            self.block_height() + REWARD_CALCULATION_NUM_BLOCKS;
+            // For live-cluster testing pre-activation
+            if self.force_partition_rewards_in_first_block_of_epoch() {
+                self.block_height()
+            } else {
+                self.block_height() + REWARD_CALCULATION_NUM_BLOCKS
+            };
 
         let num_partitions = stake_rewards_by_partition.len() as u64;
 

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -234,7 +234,9 @@ mod tests {
     use {
         super::*,
         crate::bank::{
-            partitioned_epoch_rewards::epoch_rewards_hasher::hash_rewards_into_partitions,
+            partitioned_epoch_rewards::{
+                epoch_rewards_hasher::hash_rewards_into_partitions, REWARD_CALCULATION_NUM_BLOCKS,
+            },
             tests::create_genesis_config,
         },
         rand::Rng,
@@ -271,7 +273,10 @@ mod tests {
 
         let stake_rewards = hash_rewards_into_partitions(stake_rewards, &Hash::new(&[1; 32]), 2);
 
-        bank.set_epoch_reward_status_active(bank.block_height() + 1, stake_rewards);
+        bank.set_epoch_reward_status_active(
+            bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
+            stake_rewards,
+        );
 
         bank.distribute_partitioned_epoch_rewards();
     }
@@ -294,7 +299,10 @@ mod tests {
             bank.epoch_schedule().slots_per_epoch as usize + 1,
         );
 
-        bank.set_epoch_reward_status_active(bank.block_height() + 1, stake_rewards);
+        bank.set_epoch_reward_status_active(
+            bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
+            stake_rewards,
+        );
 
         bank.distribute_partitioned_epoch_rewards();
     }
@@ -304,7 +312,10 @@ mod tests {
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
         let mut bank = Bank::new_for_tests(&genesis_config);
 
-        bank.set_epoch_reward_status_active(bank.block_height() + 1, vec![]);
+        bank.set_epoch_reward_status_active(
+            bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
+            vec![],
+        );
 
         bank.distribute_partitioned_epoch_rewards();
     }
@@ -410,7 +421,10 @@ mod tests {
 
         let stake_rewards_bucket =
             hash_rewards_into_partitions(stake_rewards, &Hash::new(&[1; 32]), 100);
-        bank.set_epoch_reward_status_active(bank.block_height() + 1, stake_rewards_bucket.clone());
+        bank.set_epoch_reward_status_active(
+            bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
+            stake_rewards_bucket.clone(),
+        );
 
         // Test partitioned stores
         let mut total_rewards = 0;

--- a/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
@@ -27,7 +27,10 @@ pub(in crate::bank::partitioned_epoch_rewards) fn hash_rewards_into_partitions(
 mod tests {
     use {
         super::*,
-        crate::bank::{tests::create_genesis_config, Bank},
+        crate::bank::{
+            partitioned_epoch_rewards::REWARD_CALCULATION_NUM_BLOCKS, tests::create_genesis_config,
+            Bank,
+        },
         solana_accounts_db::stake_rewards::StakeReward,
         solana_sdk::{epoch_schedule::EpochSchedule, native_token::LAMPORTS_PER_SOL},
         std::collections::HashMap,
@@ -109,7 +112,10 @@ mod tests {
         let stake_rewards_bucket =
             hash_rewards_into_partitions(stake_rewards, &Hash::new(&[1; 32]), 10);
 
-        bank.set_epoch_reward_status_active(bank.block_height(), stake_rewards_bucket.clone());
+        bank.set_epoch_reward_status_active(
+            bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
+            stake_rewards_bucket.clone(),
+        );
 
         // This call should panic, i.e. 15 is out of the num_credit_blocks
         let _range = &stake_rewards_bucket[15];

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -287,7 +287,10 @@ mod tests {
             .map(|_| StakeReward::new_random())
             .collect::<Vec<_>>();
 
-        bank.set_epoch_reward_status_active(bank.block_height() + 1, vec![stake_rewards]);
+        bank.set_epoch_reward_status_active(
+            bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
+            vec![stake_rewards],
+        );
         assert!(bank.get_reward_interval() == RewardInterval::InsideInterval);
 
         bank.force_reward_interval_end_for_tests();

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -23,6 +23,10 @@ use {
     std::sync::Arc,
 };
 
+/// Number of blocks for reward calculation and storing vote accounts.
+/// Distributing rewards to stake accounts begins AFTER this many blocks.
+const REWARD_CALCULATION_NUM_BLOCKS: u64 = 1;
+
 #[derive(AbiExample, Debug, Serialize, Deserialize, Clone, PartialEq)]
 struct PartitionedStakeReward {
     /// Stake account address

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -271,7 +271,7 @@ mod tests {
         }
 
         /// Return the total number of blocks in reward interval (including both calculation and crediting).
-        pub(in crate::bank) fn get_reward_total_num_blocks(&self, rewards: &StakeRewards) -> u64 {
+        fn get_reward_total_num_blocks(&self, rewards: &StakeRewards) -> u64 {
             REWARD_CALCULATION_NUM_BLOCKS + self.get_reward_distribution_num_blocks(rewards)
         }
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -316,7 +316,6 @@ mod tests {
         let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING.clone();
         accounts_db_config.test_partitioned_epoch_rewards =
             TestPartitionedEpochRewards::PartitionedEpochRewardsConfigRewardBlocks {
-                reward_calculation_num_blocks: 1,
                 stake_account_stores_per_block: 10,
             };
 
@@ -560,7 +559,6 @@ mod tests {
         let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING.clone();
         accounts_db_config.test_partitioned_epoch_rewards =
             TestPartitionedEpochRewards::PartitionedEpochRewardsConfigRewardBlocks {
-                reward_calculation_num_blocks: 1,
                 stake_account_stores_per_block: 50,
             };
 


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/pull/1159#discussion_r1591793159
[SIMD-0118](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0118-partitioned-epoch-reward-distribution.md) specifies that rewards calculation be done in one block (the first block of the epoch). But there is configuration plumbing in the code for >1 calculation blocks. Since any changes to calculation duration would need to be proposed in a new SIMD first, this is a potential footgun.

#### Summary of Changes
- Replace `PartitionedEpochRewardsConfig::reward_calculation_num_blocks` with a constant and use in `partitioned_epoch_rewards` module
- Add logic to preserve `force_partition_rewards_in_first_block_of_epoch`, which was manhandling the `reward_calculation_num_blocks` field
- Also fix an incorrect use of the `Slot` type alias nearby
