### PR TITLE
Simd 118: always pass epoch reward status to snapshot as None

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6659,13 +6659,6 @@ impl Bank {
         Some(epoch_accounts_hash)
     }
 
-    /// Return the epoch_reward_status field on the bank to serialize
-    /// Returns none if we are NOT in the reward interval.
-    pub(crate) fn get_epoch_reward_status_to_serialize(&self) -> Option<&EpochRewardStatus> {
-        matches!(self.epoch_reward_status, EpochRewardStatus::Active(_))
-            .then_some(&self.epoch_reward_status)
-    }
-
     /// Convenience fn to get the Epoch Accounts Hash
     pub fn epoch_accounts_hash(&self) -> Option<EpochAccountsHash> {
         self.rc

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -544,7 +544,7 @@ mod tests {
 
         // This some what long test harness is required to freeze the ABI of
         // Bank's serialization due to versioned nature
-        #[frozen_abi(digest = "ENUEoDA5CYu9NLLCuaj23qpfKBZzCvxK3T5VsUFA9sti")]
+        #[frozen_abi(digest = "8pZwgyMdvxExLgN9GMKnCdofb5CQJgsZ8Dt88hfVd9bf")]
         #[derive(Serialize, AbiExample)]
         pub struct BankAbiTestWrapperNewer {
             #[serde(serialize_with = "wrapper_newer")]

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -531,11 +531,9 @@ mod tests {
         // Defaults to 0
         assert_eq!(0, dbank.fee_rate_governor.lamports_per_signature);
 
-        // epoch_reward status should default to `Inactive`
-        let epoch_reward_status = dbank
-            .get_epoch_reward_status_to_serialize()
-            .unwrap_or(&EpochRewardStatus::Inactive);
-        assert_matches!(epoch_reward_status, EpochRewardStatus::Inactive);
+        // The snapshot epoch_reward_status always equals `None`, so the bank
+        // field should default to `Inactive`
+        assert_eq!(dbank.epoch_reward_status, EpochRewardStatus::Inactive);
     }
 
     #[cfg(RUSTC_WITH_SPECIALIZATION)]

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -18,7 +18,6 @@ mod tests {
             },
             status_cache::StatusCache,
         },
-        assert_matches::assert_matches,
         solana_accounts_db::{
             account_storage::{AccountStorageMap, AccountStorageReference},
             accounts_db::{


### PR DESCRIPTION
#### Problem
As of https://github.com/anza-xyz/agave/pull/1159, `Bank::epoch_reward_status` is always populated from recalculation during the rewards period; the snapshot data is never used. Therefore, there is no need to pass a populated `epoch_reward_status` to snapshot serialization.

#### Summary of Changes
Always pass `epoch_reward_status` to snapshot serialization as None. There are several other pieces of snapshot logic that can now be removed, but I wanted to take this slowly and carefully.

Side note: I was surprised that the frozen_abi hash needed to be updated on this change, since the `Some` variant is still available in the snapshot format. However, it was a useful opportunity to learn more about the frozen_abi process. Structs tagged with `AbiExample` are initialized with minimally populated values, not defaults. So a print statement for `Bank::epoch_reward_status` added to the test [here](https://github.com/anza-xyz/agave/blob/2bc026d092db26e5dfc481b68a95288784549d51/runtime/src/bank/serde_snapshot.rs#L554) shows `EpochRewardStatus::Active(_)` containing one reward (with default values), and this is what was being used in serialization to determine the frozen_abi hash. Since this PR always uses `None` in serialization, the frozen_abi hash changes.

On the plus side, I would expect the frozen_abi hash to *not* change again when the actual `epoch_reward_status` field is removed from the snapshot.
