### PR TITLE
ledger-tool: Remove duplicate slot output code

### DIFF
--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -36,7 +36,7 @@ solana-cost-model = { workspace = true }
 solana-entry = { workspace = true }
 solana-geyser-plugin-manager = { workspace = true }
 solana-gossip = { workspace = true }
-solana-ledger = { workspace = true }
+solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-program-runtime = { workspace = true }

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -1019,6 +1019,8 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
         ("slot", Some(arg_matches)) => {
             let slots = values_t_or_exit!(arg_matches, "slots", Slot);
             let allow_dead_slots = arg_matches.is_present("allow_dead_slots");
+            let output_format = OutputFormat::from_matches(arg_matches, "output_format", false);
+
             let blockstore =
                 crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
             for slot in slots {
@@ -1027,7 +1029,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                     &blockstore,
                     slot,
                     allow_dead_slots,
-                    &OutputFormat::Display,
+                    &output_format,
                     verbose_level,
                     &mut HashMap::new(),
                 )?;

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -848,7 +848,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 num_slots,
                 verbose_level,
                 only_rooted,
-            );
+            )?;
         }
         ("print-file-metadata", Some(arg_matches)) => {
             let blockstore =
@@ -1023,16 +1023,14 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
             for slot in slots {
                 println!("Slot {slot}");
-                if let Err(err) = output_slot(
+                output_slot(
                     &blockstore,
                     slot,
                     allow_dead_slots,
                     &OutputFormat::Display,
                     verbose_level,
                     &mut HashMap::new(),
-                ) {
-                    eprintln!("{err}");
-                }
+                )?;
             }
         }
         _ => unreachable!(),

--- a/ledger-tool/src/error.rs
+++ b/ledger-tool/src/error.rs
@@ -11,7 +11,13 @@ pub enum LedgerToolError {
     SerdeJson(#[from] serde_json::Error),
 
     #[error("{0}")]
+    TransactionEncode(#[from] solana_transaction_status::EncodeError),
+
+    #[error("{0}")]
     Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Generic(String),
 
     #[error("{0}")]
     BadArgument(String),

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -381,6 +381,8 @@ pub fn output_slot(
 
     if verbose_level == 0 {
         if *output_format == OutputFormat::Display {
+            // Given that Blockstore::get_complete_block_with_entries() returning Ok(_), we know
+            // that we have a full block so meta.consumed is the number of shreds in the block
             println!(
                 "  num_shreds: {}, parent_slot: {:?}, next_slots: {:?}, num_entries: {}, \
                  is_full: {}",

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -327,9 +327,9 @@ impl EncodedConfirmedBlockWithEntries {
     }
 }
 
-pub fn output_slot_rewards(blockstore: &Blockstore, slot: Slot, method: &OutputFormat) {
+pub fn output_slot_rewards(blockstore: &Blockstore, slot: Slot, output_format: &OutputFormat) {
     // Note: rewards are not output in JSON yet
-    if *method == OutputFormat::Display {
+    if *output_format == OutputFormat::Display {
         if let Ok(Some(rewards)) = blockstore.read_rewards(slot) {
             if !rewards.is_empty() {
                 println!("  Rewards:");
@@ -364,12 +364,12 @@ pub fn output_slot_rewards(blockstore: &Blockstore, slot: Slot, method: &OutputF
 
 pub fn output_entry(
     blockstore: &Blockstore,
-    method: &OutputFormat,
+    output_format: &OutputFormat,
     slot: Slot,
     entry_index: usize,
     entry: Entry,
 ) {
-    match method {
+    match output_format {
         OutputFormat::Display => {
             println!(
                 "  Entry {} - num_hashes: {}, hash: {}, transactions: {}",
@@ -414,13 +414,13 @@ pub fn output_slot(
     blockstore: &Blockstore,
     slot: Slot,
     allow_dead_slots: bool,
-    method: &OutputFormat,
+    output_format: &OutputFormat,
     verbose_level: u64,
     all_program_ids: &mut HashMap<Pubkey, u64>,
 ) -> Result<()> {
     if blockstore.is_dead(slot) {
         if allow_dead_slots {
-            if *method == OutputFormat::Display {
+            if *output_format == OutputFormat::Display {
                 println!(" Slot is dead");
             }
         } else {
@@ -431,7 +431,7 @@ pub fn output_slot(
     let (entries, num_shreds, is_full) =
         blockstore.get_slot_entries_with_shred_info(slot, 0, allow_dead_slots)?;
 
-    if *method == OutputFormat::Display {
+    if *output_format == OutputFormat::Display {
         if let Some(meta) = blockstore.meta(slot)? {
             if verbose_level >= 1 {
                 println!("  {meta:?} is_full: {is_full}");
@@ -451,10 +451,10 @@ pub fn output_slot(
 
     if verbose_level >= 2 {
         for (entry_index, entry) in entries.into_iter().enumerate() {
-            output_entry(blockstore, method, slot, entry_index, entry);
+            output_entry(blockstore, output_format, slot, entry_index, entry);
         }
 
-        output_slot_rewards(blockstore, slot, method);
+        output_slot_rewards(blockstore, slot, output_format);
     } else if verbose_level >= 1 {
         let mut transactions = 0;
         let mut num_hashes = 0;
@@ -490,14 +490,14 @@ pub fn output_ledger(
     starting_slot: Slot,
     ending_slot: Slot,
     allow_dead_slots: bool,
-    method: OutputFormat,
+    output_format: OutputFormat,
     num_slots: Option<Slot>,
     verbose_level: u64,
     only_rooted: bool,
 ) -> Result<()> {
     let slot_iterator = blockstore.slot_meta_iterator(starting_slot)?;
 
-    if method == OutputFormat::Json {
+    if output_format == OutputFormat::Json {
         stdout().write_all(b"{\"ledger\":[\n")?;
     }
 
@@ -512,7 +512,7 @@ pub fn output_ledger(
             break;
         }
 
-        match method {
+        match output_format {
             OutputFormat::Display => {
                 println!("Slot {} root?: {}", slot, blockstore.is_root(slot))
             }
@@ -527,7 +527,7 @@ pub fn output_ledger(
             &blockstore,
             slot,
             allow_dead_slots,
-            &method,
+            &output_format,
             verbose_level,
             &mut all_program_ids,
         ) {
@@ -539,7 +539,7 @@ pub fn output_ledger(
         }
     }
 
-    if method == OutputFormat::Json {
+    if output_format == OutputFormat::Json {
         stdout().write_all(b"\n]}\n")?;
     } else {
         println!("Summary of Programs:");

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -381,7 +381,7 @@ pub fn output_slot(
 
     if verbose_level == 0 {
         if *output_format == OutputFormat::Display {
-            // Given that Blockstore::get_complete_block_with_entries() returning Ok(_), we know
+            // Given that Blockstore::get_complete_block_with_entries() returned Ok(_), we know
             // that we have a full block so meta.consumed is the number of shreds in the block
             println!(
                 "  num_shreds: {}, parent_slot: {:?}, next_slots: {:?}, num_entries: {}, \

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -28,7 +28,6 @@ use {
         fmt::{self, Display, Formatter},
         io::{stdout, Write},
         rc::Rc,
-        result::Result,
         sync::Arc,
     },
 };
@@ -292,7 +291,7 @@ impl EncodedConfirmedBlockWithEntries {
     pub fn try_from(
         block: EncodedConfirmedBlock,
         entries_iterator: impl Iterator<Item = EntrySummary>,
-    ) -> Result<Self, String> {
+    ) -> std::result::Result<Self, String> {
         let mut entries = vec![];
         for (i, entry) in entries_iterator.enumerate() {
             let ending_transaction_index = entry
@@ -415,7 +414,7 @@ pub fn output_slot(
     method: &OutputFormat,
     verbose_level: u64,
     all_program_ids: &mut HashMap<Pubkey, u64>,
-) -> Result<(), String> {
+) -> std::result::Result<(), String> {
     if blockstore.is_dead(slot) {
         if allow_dead_slots {
             if *method == OutputFormat::Display {
@@ -600,7 +599,7 @@ impl AccountsOutputStreamer {
         }
     }
 
-    pub fn output(&self) -> Result<(), String> {
+    pub fn output(&self) -> std::result::Result<(), String> {
         match self.output_format {
             OutputFormat::Json | OutputFormat::JsonCompact => {
                 let mut serializer = serde_json::Serializer::new(stdout());
@@ -741,7 +740,7 @@ impl AccountsScanner {
 }
 
 impl serde::Serialize for AccountsScanner {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
     {

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -1,12 +1,10 @@
 use {
     assert_cmd::prelude::*,
-    solana_entry::entry,
     solana_ledger::{
         blockstore, blockstore::Blockstore, blockstore_options::ShredStorageType,
         create_new_tmp_ledger, create_new_tmp_ledger_fifo, genesis_utils::create_genesis_config,
         get_tmp_ledger_path_auto_delete,
     },
-    solana_sdk::hash::Hash,
     std::{
         fs,
         path::Path,
@@ -77,13 +75,12 @@ fn nominal_fifo() {
 
 fn insert_test_shreds(ledger_path: &Path, ending_slot: u64) {
     let blockstore = Blockstore::open(ledger_path).unwrap();
-    for i in 1..ending_slot {
-        let entries = entry::create_ticks(1, 0, Hash::default());
-        let shreds = blockstore::entries_to_test_shreds(
-            &entries, i, 0, false, 0, /*merkle_variant:*/ true,
-        );
-        blockstore.insert_shreds(shreds, None, false).unwrap();
-    }
+    let (shreds, _) = blockstore::make_many_slot_entries(
+        /*start_slot:*/ 0,
+        ending_slot,
+        /*entries_per_slot:*/ 10,
+    );
+    blockstore.insert_shreds(shreds, None, false).unwrap();
 }
 
 fn ledger_tool_copy_test(src_shred_compaction: &str, dst_shred_compaction: &str) {

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -20,10 +20,6 @@ fn run_ledger_tool(args: &[&str]) -> Output {
         .unwrap()
 }
 
-fn count_newlines(chars: &[u8]) -> usize {
-    bytecount::count(chars, b'\n')
-}
-
 #[test]
 fn bad_arguments() {
     // At least a ledger path is required
@@ -35,42 +31,26 @@ fn bad_arguments() {
         .success());
 }
 
-fn nominal_test_helper(ledger_path: &str, ticks: usize) {
-    let meta_lines = 2;
-    let summary_lines = 1;
-
+fn nominal_test_helper(ledger_path: &str) {
     let output = run_ledger_tool(&["-l", ledger_path, "verify"]);
     assert!(output.status.success());
 
-    // Print everything
-    let output = run_ledger_tool(&["-l", ledger_path, "print", "-vvv"]);
+    let output = run_ledger_tool(&["-l", ledger_path, "print", "-vv"]);
     assert!(output.status.success());
-    assert_eq!(
-        count_newlines(&output.stdout)
-            .saturating_sub(meta_lines)
-            .saturating_sub(summary_lines),
-        ticks
-    );
 }
 
 #[test]
 fn nominal_default() {
     let genesis_config = create_genesis_config(100).genesis_config;
     let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
-    nominal_test_helper(
-        ledger_path.path().to_str().unwrap(),
-        genesis_config.ticks_per_slot as usize,
-    );
+    nominal_test_helper(ledger_path.path().to_str().unwrap());
 }
 
 #[test]
 fn nominal_fifo() {
     let genesis_config = create_genesis_config(100).genesis_config;
     let (ledger_path, _blockhash) = create_new_tmp_ledger_fifo_auto_delete!(&genesis_config);
-    nominal_test_helper(
-        ledger_path.path().to_str().unwrap(),
-        genesis_config.ticks_per_slot as usize,
-    );
+    nominal_test_helper(ledger_path.path().to_str().unwrap());
 }
 
 fn insert_test_shreds(ledger_path: &Path, ending_slot: u64) {

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -2,8 +2,8 @@ use {
     assert_cmd::prelude::*,
     solana_ledger::{
         blockstore, blockstore::Blockstore, blockstore_options::ShredStorageType,
-        create_new_tmp_ledger, create_new_tmp_ledger_fifo, genesis_utils::create_genesis_config,
-        get_tmp_ledger_path_auto_delete,
+        create_new_tmp_ledger_auto_delete, create_new_tmp_ledger_fifo_auto_delete,
+        genesis_utils::create_genesis_config, get_tmp_ledger_path_auto_delete,
     },
     std::{
         fs,
@@ -56,9 +56,9 @@ fn nominal_test_helper(ledger_path: &str, ticks: usize) {
 #[test]
 fn nominal_default() {
     let genesis_config = create_genesis_config(100).genesis_config;
-    let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
+    let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
     nominal_test_helper(
-        ledger_path.to_str().unwrap(),
+        ledger_path.path().to_str().unwrap(),
         genesis_config.ticks_per_slot as usize,
     );
 }
@@ -66,9 +66,9 @@ fn nominal_default() {
 #[test]
 fn nominal_fifo() {
     let genesis_config = create_genesis_config(100).genesis_config;
-    let (ledger_path, _blockhash) = create_new_tmp_ledger_fifo!(&genesis_config);
+    let (ledger_path, _blockhash) = create_new_tmp_ledger_fifo_auto_delete!(&genesis_config);
     nominal_test_helper(
-        ledger_path.to_str().unwrap(),
+        ledger_path.path().to_str().unwrap(),
         genesis_config.ticks_per_slot as usize,
     );
 }
@@ -87,13 +87,13 @@ fn ledger_tool_copy_test(src_shred_compaction: &str, dst_shred_compaction: &str)
     let genesis_config = create_genesis_config(100).genesis_config;
 
     let (ledger_path, _blockhash) = match src_shred_compaction {
-        "fifo" => create_new_tmp_ledger_fifo!(&genesis_config),
-        _ => create_new_tmp_ledger!(&genesis_config),
+        "fifo" => create_new_tmp_ledger_fifo_auto_delete!(&genesis_config),
+        _ => create_new_tmp_ledger_auto_delete!(&genesis_config),
     };
     const LEDGER_TOOL_COPY_TEST_SHRED_COUNT: u64 = 25;
     const LEDGER_TOOL_COPY_TEST_ENDING_SLOT: u64 = LEDGER_TOOL_COPY_TEST_SHRED_COUNT + 1;
-    insert_test_shreds(&ledger_path, LEDGER_TOOL_COPY_TEST_ENDING_SLOT);
-    let ledger_path = ledger_path.to_str().unwrap();
+    insert_test_shreds(ledger_path.path(), LEDGER_TOOL_COPY_TEST_ENDING_SLOT);
+    let ledger_path = ledger_path.path().to_str().unwrap();
 
     let target_ledger_path = get_tmp_ledger_path_auto_delete!();
     if dst_shred_compaction == "fifo" {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2559,8 +2559,13 @@ impl Blockstore {
         slot: Slot,
         require_previous_blockhash: bool,
     ) -> Result<VersionedConfirmedBlock> {
-        self.get_complete_block_with_entries(slot, require_previous_blockhash, false)
-            .map(|result| result.block)
+        self.do_get_complete_block_with_entries(
+            slot,
+            require_previous_blockhash,
+            false,
+            /*allow_dead_slots:*/ false,
+        )
+        .map(|result| result.block)
     }
 
     pub fn get_rooted_block_with_entries(
@@ -2574,23 +2579,49 @@ impl Blockstore {
         let _lock = self.check_lowest_cleanup_slot(slot)?;
 
         if self.is_root(slot) {
-            return self.get_complete_block_with_entries(slot, require_previous_blockhash, true);
+            return self.do_get_complete_block_with_entries(
+                slot,
+                require_previous_blockhash,
+                true,
+                /*allow_dead_slots:*/ false,
+            );
         }
         Err(BlockstoreError::SlotNotRooted)
     }
 
-    fn get_complete_block_with_entries(
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn get_complete_block_with_entries(
         &self,
         slot: Slot,
         require_previous_blockhash: bool,
         populate_entries: bool,
+        allow_dead_slots: bool,
+    ) -> Result<VersionedConfirmedBlockWithEntries> {
+        self.do_get_complete_block_with_entries(
+            slot,
+            require_previous_blockhash,
+            populate_entries,
+            allow_dead_slots,
+        )
+    }
+
+    fn do_get_complete_block_with_entries(
+        &self,
+        slot: Slot,
+        require_previous_blockhash: bool,
+        populate_entries: bool,
+        allow_dead_slots: bool,
     ) -> Result<VersionedConfirmedBlockWithEntries> {
         let Some(slot_meta) = self.meta_cf.get(slot)? else {
             info!("SlotMeta not found for slot {}", slot);
             return Err(BlockstoreError::SlotUnavailable);
         };
         if slot_meta.is_full() {
-            let slot_entries = self.get_slot_entries(slot, 0)?;
+            let (slot_entries, _, _) = self.get_slot_entries_with_shred_info(
+                slot,
+                /*shred_start_index:*/ 0,
+                allow_dead_slots,
+            )?;
             if !slot_entries.is_empty() {
                 let blockhash = slot_entries
                     .last()
@@ -2630,8 +2661,13 @@ impl Blockstore {
                 let parent_slot_entries = slot_meta
                     .parent_slot
                     .and_then(|parent_slot| {
-                        self.get_slot_entries(parent_slot, /*shred_start_index:*/ 0)
-                            .ok()
+                        self.get_slot_entries_with_shred_info(
+                            parent_slot,
+                            /*shred_start_index:*/ 0,
+                            allow_dead_slots,
+                        )
+                        .ok()
+                        .map(|(entries, _, _)| entries)
                     })
                     .unwrap_or_default();
                 if parent_slot_entries.is_empty() && require_previous_blockhash {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2613,7 +2613,7 @@ impl Blockstore {
         allow_dead_slots: bool,
     ) -> Result<VersionedConfirmedBlockWithEntries> {
         let Some(slot_meta) = self.meta_cf.get(slot)? else {
-            trace!("do_get_complete_block_with_entries() failing for {slot} (missing SlotMeta)");
+            trace!("do_get_complete_block_with_entries() failed for {slot} (missing SlotMeta)");
             return Err(BlockstoreError::SlotUnavailable);
         };
         if slot_meta.is_full() {
@@ -2706,7 +2706,7 @@ impl Blockstore {
                 return Ok(VersionedConfirmedBlockWithEntries { block, entries });
             }
         }
-        trace!("do_get_complete_block_with_entries() failing for {slot} (slot not full)");
+        trace!("do_get_complete_block_with_entries() failed for {slot} (slot not full)");
         Err(BlockstoreError::SlotUnavailable)
     }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2613,7 +2613,7 @@ impl Blockstore {
         allow_dead_slots: bool,
     ) -> Result<VersionedConfirmedBlockWithEntries> {
         let Some(slot_meta) = self.meta_cf.get(slot)? else {
-            info!("SlotMeta not found for slot {}", slot);
+            trace!("do_get_complete_block_with_entries() failing for {slot} (missing SlotMeta)");
             return Err(BlockstoreError::SlotUnavailable);
         };
         if slot_meta.is_full() {
@@ -2706,6 +2706,7 @@ impl Blockstore {
                 return Ok(VersionedConfirmedBlockWithEntries { block, entries });
             }
         }
+        trace!("do_get_complete_block_with_entries() failing for {slot} (slot not full)");
         Err(BlockstoreError::SlotUnavailable)
     }
 


### PR DESCRIPTION
#### Problem
Currently, `ledger-tool slot` has some duplicate implementation for outputting a block. Also, the `--output json` mode for the `slot` command is effectively broken / uselss.

#### Summary of Changes
This PR removes some of the duplicate implementation, and makes the outputs from `ledger-tool blockstore slot -vv` and `ledger-tool bigtable block` follow the same codepath. The bigtable command with `--show-entries` flag will result in identical output assuming the blockstore has the metadata fields (ie node was running with `--enable-rpc-transaction-history`)