### PR TITLE
Unignore `test_local_cluster_signature_subscribe` and remove `test_spend_and_verify_all_nodes_env_num_nodes`

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -199,7 +199,6 @@ fn test_spend_and_verify_all_nodes_3() {
 
 #[test]
 #[serial]
-#[ignore]
 fn test_local_cluster_signature_subscribe() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     let num_nodes = 2;

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -278,31 +278,6 @@ fn test_local_cluster_signature_subscribe() {
 }
 
 #[test]
-#[allow(unused_attributes)]
-#[ignore]
-fn test_spend_and_verify_all_nodes_env_num_nodes() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
-    let num_nodes: usize = std::env::var("NUM_NODES")
-        .expect("please set environment variable NUM_NODES")
-        .parse()
-        .expect("could not parse NUM_NODES as a number");
-    let local = LocalCluster::new_with_equal_stakes(
-        num_nodes,
-        DEFAULT_CLUSTER_LAMPORTS,
-        DEFAULT_NODE_STAKE,
-        SocketAddrSpace::Unspecified,
-    );
-    cluster_tests::spend_and_verify_all_nodes(
-        &local.entry_point_info,
-        &local.funding_keypair,
-        num_nodes,
-        HashSet::new(),
-        SocketAddrSpace::Unspecified,
-        &local.connection_cache,
-    );
-}
-
-#[test]
 #[serial]
 fn test_two_unbalanced_stakes() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);


### PR DESCRIPTION
#### Problem
`test_local_cluster_signature_subscribe` passed 100 times without failure
`test_spend_and_verify_all_nodes_env_num_nodes` should already be covered by `test_spend_and_verify_all_nodes_1`, `test_spend_and_verify_all_nodes_2`, and `test_spend_and_verify_all_nodes_3`

#### Summary of Changes
Unignore `test_local_cluster_signature_subscribe` and remove `test_spend_and_verify_all_nodes_env_num_nodes`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
