### PR TITLE
[zk-sdk] Clean up `(target_os = "solana")`

### DIFF
--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 [dependencies]
 base64 = { workspace = true }
 bytemuck = { workspace = true }
+merlin = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 solana-program = { workspace = true }
@@ -26,7 +27,6 @@ bincode = { workspace = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
-merlin = { workspace = true }
 rand = { version = "0.7" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -3,7 +3,10 @@
 //! This module is a simple wrapper of the `Aes128GcmSiv` implementation specialized for SPL
 //! token-2022 where the plaintext is always `u64`.
 use {
-    crate::errors::AuthenticatedEncryptionError,
+    crate::{
+        encryption::{AE_CIPHERTEXT_LEN, AE_KEY_LEN},
+        errors::AuthenticatedEncryptionError,
+    },
     aes_gcm_siv::{
         aead::{Aead, NewAead},
         Aes128GcmSiv,
@@ -28,18 +31,11 @@ use {
     zeroize::Zeroize,
 };
 
-/// Byte length of an authenticated encryption secret key
-pub const AE_KEY_LEN: usize = 16;
-
 /// Byte length of an authenticated encryption nonce component
 const NONCE_LEN: usize = 12;
 
 /// Byte lenth of an authenticated encryption ciphertext component
 const CIPHERTEXT_LEN: usize = 24;
-
-/// Byte length of a complete authenticated encryption ciphertext component that includes the
-/// ciphertext and nonce components
-const AE_CIPHERTEXT_LEN: usize = 36;
 
 struct AuthenticatedEncryption;
 impl AuthenticatedEncryption {

--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -4,7 +4,12 @@
 //! token-2022 where the plaintext is always `u64`.
 use {
     crate::errors::AuthenticatedEncryptionError,
+    aes_gcm_siv::{
+        aead::{Aead, NewAead},
+        Aes128GcmSiv,
+    },
     base64::{prelude::BASE64_STANDARD, Engine},
+    rand::{rngs::OsRng, Rng},
     sha3::{Digest, Sha3_512},
     solana_sdk::{
         derivation_path::DerivationPath,
@@ -21,14 +26,6 @@ use {
     },
     subtle::ConstantTimeEq,
     zeroize::Zeroize,
-};
-#[cfg(not(target_os = "solana"))]
-use {
-    aes_gcm_siv::{
-        aead::{Aead, NewAead},
-        Aes128GcmSiv,
-    },
-    rand::{rngs::OsRng, Rng},
 };
 
 /// Byte length of an authenticated encryption secret key
@@ -49,14 +46,12 @@ impl AuthenticatedEncryption {
     /// Generates an authenticated encryption key.
     ///
     /// This function is randomized. It internally samples a 128-bit key using `OsRng`.
-    #[cfg(not(target_os = "solana"))]
     fn keygen() -> AeKey {
         AeKey(OsRng.gen::<[u8; AE_KEY_LEN]>())
     }
 
     /// On input of an authenticated encryption key and an amount, the function returns a
     /// corresponding authenticated encryption ciphertext.
-    #[cfg(not(target_os = "solana"))]
     fn encrypt(key: &AeKey, balance: u64) -> AeCiphertext {
         let mut plaintext = balance.to_le_bytes();
         let nonce: Nonce = OsRng.gen::<[u8; NONCE_LEN]>();
@@ -76,7 +71,6 @@ impl AuthenticatedEncryption {
 
     /// On input of an authenticated encryption key and a ciphertext, the function returns the
     /// originally encrypted amount.
-    #[cfg(not(target_os = "solana"))]
     fn decrypt(key: &AeKey, ciphertext: &AeCiphertext) -> Option<u64> {
         let plaintext = Aes128GcmSiv::new(&key.0.into())
             .decrypt(&ciphertext.nonce.into(), ciphertext.ciphertext.as_ref());

--- a/zk-sdk/src/encryption/discrete_log.rs
+++ b/zk-sdk/src/encryption/discrete_log.rs
@@ -14,8 +14,6 @@
 //! information on a discrete log solution depending on the execution time of the implementation.
 //!
 
-#![cfg(not(target_os = "solana"))]
-
 #[cfg(not(target_arch = "wasm32"))]
 use std::thread;
 use {

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -17,12 +17,11 @@ use {
     crate::{
         encryption::{
             discrete_log::DiscreteLog,
-            pedersen::{
-                Pedersen, PedersenCommitment, PedersenOpening, G, H, PEDERSEN_COMMITMENT_LEN,
-            },
+            pedersen::{Pedersen, PedersenCommitment, PedersenOpening, G, H},
+            DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN, ELGAMAL_KEYPAIR_LEN, ELGAMAL_PUBKEY_LEN,
+            ELGAMAL_SECRET_KEY_LEN, PEDERSEN_COMMITMENT_LEN,
         },
         errors::ElGamalError,
-        RISTRETTO_POINT_LEN, SCALAR_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
     core::ops::{Add, Mul, Sub},
@@ -51,21 +50,6 @@ use {
     subtle::{Choice, ConstantTimeEq},
     zeroize::Zeroize,
 };
-
-/// Byte length of a decrypt handle
-const DECRYPT_HANDLE_LEN: usize = RISTRETTO_POINT_LEN;
-
-/// Byte length of an ElGamal ciphertext
-const ELGAMAL_CIPHERTEXT_LEN: usize = PEDERSEN_COMMITMENT_LEN + DECRYPT_HANDLE_LEN;
-
-/// Byte length of an ElGamal public key
-const ELGAMAL_PUBKEY_LEN: usize = RISTRETTO_POINT_LEN;
-
-/// Byte length of an ElGamal secret key
-const ELGAMAL_SECRET_KEY_LEN: usize = SCALAR_LEN;
-
-/// Byte length of an ElGamal keypair
-pub const ELGAMAL_KEYPAIR_LEN: usize = ELGAMAL_PUBKEY_LEN + ELGAMAL_SECRET_KEY_LEN;
 
 /// Algorithm handle for the twisted ElGamal encryption scheme
 pub struct ElGamal;

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -31,7 +31,9 @@ use {
         scalar::Scalar,
         traits::Identity,
     },
+    rand::rngs::OsRng,
     serde::{Deserialize, Serialize},
+    sha3::{Digest, Sha3_512},
     solana_sdk::{
         derivation_path::DerivationPath,
         signature::Signature,
@@ -41,18 +43,13 @@ use {
         },
     },
     std::convert::TryInto,
-    subtle::{Choice, ConstantTimeEq},
-    zeroize::Zeroize,
-};
-#[cfg(not(target_os = "solana"))]
-use {
-    rand::rngs::OsRng,
-    sha3::{Digest, Sha3_512},
     std::{
         error, fmt,
         io::{Read, Write},
         path::Path,
     },
+    subtle::{Choice, ConstantTimeEq},
+    zeroize::Zeroize,
 };
 
 /// Byte length of a decrypt handle
@@ -76,7 +73,6 @@ impl ElGamal {
     /// Generates an ElGamal keypair.
     ///
     /// This function is randomized. It internally samples a scalar element using `OsRng`.
-    #[cfg(not(target_os = "solana"))]
     #[allow(non_snake_case)]
     fn keygen() -> ElGamalKeypair {
         // secret scalar should be non-zero except with negligible probability
@@ -90,7 +86,6 @@ impl ElGamal {
     /// Generates an ElGamal keypair from a scalar input that determines the ElGamal private key.
     ///
     /// This function panics if the input scalar is zero, which is not a valid key.
-    #[cfg(not(target_os = "solana"))]
     #[allow(non_snake_case)]
     fn keygen_with_scalar(s: &Scalar) -> ElGamalKeypair {
         let secret = ElGamalSecretKey(*s);
@@ -103,7 +98,6 @@ impl ElGamal {
     /// corresponding ElGamal ciphertext.
     ///
     /// This function is randomized. It internally samples a scalar element using `OsRng`.
-    #[cfg(not(target_os = "solana"))]
     fn encrypt<T: Into<Scalar>>(public: &ElGamalPubkey, amount: T) -> ElGamalCiphertext {
         let (commitment, opening) = Pedersen::new(amount);
         let handle = public.decrypt_handle(&opening);
@@ -113,7 +107,6 @@ impl ElGamal {
 
     /// On input a public key, amount, and Pedersen opening, the function returns the corresponding
     /// ElGamal ciphertext.
-    #[cfg(not(target_os = "solana"))]
     fn encrypt_with<T: Into<Scalar>>(
         amount: T,
         public: &ElGamalPubkey,
@@ -128,7 +121,6 @@ impl ElGamal {
     /// On input an amount, the function returns a twisted ElGamal ciphertext where the associated
     /// Pedersen opening is always zero. Since the opening is zero, any twisted ElGamal ciphertext
     /// of this form is a valid ciphertext under any ElGamal public key.
-    #[cfg(not(target_os = "solana"))]
     pub fn encode<T: Into<Scalar>>(amount: T) -> ElGamalCiphertext {
         let commitment = Pedersen::encode(amount);
         let handle = DecryptHandle(RistrettoPoint::identity());
@@ -141,7 +133,6 @@ impl ElGamal {
     ///
     /// The output of this function is of type `DiscreteLog`. To recover, the originally encrypted
     /// amount, use `DiscreteLog::decode`.
-    #[cfg(not(target_os = "solana"))]
     fn decrypt(secret: &ElGamalSecretKey, ciphertext: &ElGamalCiphertext) -> DiscreteLog {
         DiscreteLog::new(
             *G,
@@ -154,7 +145,6 @@ impl ElGamal {
     ///
     /// If the originally encrypted amount is not a positive 32-bit number, then the function
     /// returns `None`.
-    #[cfg(not(target_os = "solana"))]
     fn decrypt_u32(secret: &ElGamalSecretKey, ciphertext: &ElGamalCiphertext) -> Option<u64> {
         let discrete_log_instance = Self::decrypt(secret, ciphertext);
         discrete_log_instance.decode_u32()
@@ -194,7 +184,6 @@ impl ElGamalKeypair {
     /// wallets, the signing key is not exposed in the API. Therefore, this function uses a signer
     /// to sign a public seed and the resulting signature is then hashed to derive an ElGamal
     /// keypair.
-    #[cfg(not(target_os = "solana"))]
     #[allow(non_snake_case)]
     pub fn new_from_signer(
         signer: &dyn Signer,
@@ -208,7 +197,6 @@ impl ElGamalKeypair {
     /// Generates the public and secret keys for ElGamal encryption.
     ///
     /// This function is randomized. It internally samples a scalar element using `OsRng`.
-    #[cfg(not(target_os = "solana"))]
     pub fn new_rand() -> Self {
         ElGamal::keygen()
     }
@@ -348,7 +336,6 @@ impl ElGamalPubkey {
     /// Encrypts an amount under the public key.
     ///
     /// This function is randomized. It internally samples a scalar element using `OsRng`.
-    #[cfg(not(target_os = "solana"))]
     pub fn encrypt<T: Into<Scalar>>(&self, amount: T) -> ElGamalCiphertext {
         ElGamal::encrypt(self, amount)
     }

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -41,8 +41,8 @@ use {
             SeedDerivable, Signer, SignerError,
         },
     },
-    std::convert::TryInto,
     std::{
+        convert::TryInto,
         error, fmt,
         io::{Read, Write},
         path::Path,

--- a/zk-sdk/src/encryption/mod.rs
+++ b/zk-sdk/src/encryption/mod.rs
@@ -10,10 +10,16 @@
 //! - Basic type-wrapper around the AES-GCM-SIV symmetric authenticated encryption scheme
 //! implemented by [aes-gcm-siv](https://docs.rs/aes-gcm-siv/latest/aes_gcm_siv/) crate.
 
+#[cfg(not(target_os = "solana"))]
 #[macro_use]
 pub(crate) mod macros;
+#[cfg(not(target_os = "solana"))]
 pub mod auth_encryption;
+#[cfg(not(target_os = "solana"))]
 pub mod discrete_log;
+#[cfg(not(target_os = "solana"))]
 pub mod elgamal;
+#[cfg(not(target_os = "solana"))]
 pub mod grouped_elgamal;
+#[cfg(not(target_os = "solana"))]
 pub mod pedersen;

--- a/zk-sdk/src/encryption/mod.rs
+++ b/zk-sdk/src/encryption/mod.rs
@@ -10,6 +10,8 @@
 //! - Basic type-wrapper around the AES-GCM-SIV symmetric authenticated encryption scheme
 //! implemented by [aes-gcm-siv](https://docs.rs/aes-gcm-siv/latest/aes_gcm_siv/) crate.
 
+use crate::{RISTRETTO_POINT_LEN, SCALAR_LEN};
+
 #[cfg(not(target_os = "solana"))]
 #[macro_use]
 pub(crate) mod macros;
@@ -23,3 +25,31 @@ pub mod elgamal;
 pub mod grouped_elgamal;
 #[cfg(not(target_os = "solana"))]
 pub mod pedersen;
+
+/// Byte length of an authenticated encryption secret key
+pub const AE_KEY_LEN: usize = 16;
+
+/// Byte length of a complete authenticated encryption ciphertext component that includes the
+/// ciphertext and nonce components
+pub const AE_CIPHERTEXT_LEN: usize = 36;
+
+/// Byte length of a decrypt handle
+pub const DECRYPT_HANDLE_LEN: usize = RISTRETTO_POINT_LEN;
+
+/// Byte length of an ElGamal ciphertext
+pub const ELGAMAL_CIPHERTEXT_LEN: usize = PEDERSEN_COMMITMENT_LEN + DECRYPT_HANDLE_LEN;
+
+/// Byte length of an ElGamal public key
+pub const ELGAMAL_PUBKEY_LEN: usize = RISTRETTO_POINT_LEN;
+
+/// Byte length of an ElGamal secret key
+pub const ELGAMAL_SECRET_KEY_LEN: usize = SCALAR_LEN;
+
+/// Byte length of an ElGamal keypair
+pub const ELGAMAL_KEYPAIR_LEN: usize = ELGAMAL_PUBKEY_LEN + ELGAMAL_SECRET_KEY_LEN;
+
+/// Byte length of a Pedersen opening.
+pub const PEDERSEN_OPENING_LEN: usize = SCALAR_LEN;
+
+/// Byte length of a Pedersen commitment.
+pub const PEDERSEN_COMMITMENT_LEN: usize = RISTRETTO_POINT_LEN;

--- a/zk-sdk/src/encryption/pedersen.rs
+++ b/zk-sdk/src/encryption/pedersen.rs
@@ -1,7 +1,5 @@
 //! Pedersen commitment implementation using the Ristretto prime-order group.
 
-#[cfg(not(target_os = "solana"))]
-use rand::rngs::OsRng;
 use {
     crate::{RISTRETTO_POINT_LEN, SCALAR_LEN},
     core::ops::{Add, Mul, Sub},
@@ -11,6 +9,7 @@ use {
         scalar::Scalar,
         traits::MultiscalarMul,
     },
+    rand::rngs::OsRng,
     serde::{Deserialize, Serialize},
     sha3::Sha3_512,
     std::convert::TryInto,
@@ -39,7 +38,6 @@ impl Pedersen {
     /// message and the corresponding opening.
     ///
     /// This function is randomized. It internally samples a Pedersen opening using `OsRng`.
-    #[cfg(not(target_os = "solana"))]
     #[allow(clippy::new_ret_no_self)]
     pub fn new<T: Into<Scalar>>(amount: T) -> (PedersenCommitment, PedersenOpening) {
         let opening = PedersenOpening::new_rand();
@@ -84,7 +82,6 @@ impl PedersenOpening {
         &self.0
     }
 
-    #[cfg(not(target_os = "solana"))]
     pub fn new_rand() -> Self {
         PedersenOpening(Scalar::random(&mut OsRng))
     }

--- a/zk-sdk/src/encryption/pedersen.rs
+++ b/zk-sdk/src/encryption/pedersen.rs
@@ -1,7 +1,7 @@
 //! Pedersen commitment implementation using the Ristretto prime-order group.
 
 use {
-    crate::{RISTRETTO_POINT_LEN, SCALAR_LEN},
+    crate::encryption::{PEDERSEN_COMMITMENT_LEN, PEDERSEN_OPENING_LEN},
     core::ops::{Add, Mul, Sub},
     curve25519_dalek::{
         constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT},
@@ -16,12 +16,6 @@ use {
     subtle::{Choice, ConstantTimeEq},
     zeroize::Zeroize,
 };
-
-/// Byte length of a Pedersen opening.
-const PEDERSEN_OPENING_LEN: usize = SCALAR_LEN;
-
-/// Byte length of a Pedersen commitment.
-pub(crate) const PEDERSEN_COMMITMENT_LEN: usize = RISTRETTO_POINT_LEN;
 
 lazy_static::lazy_static! {
     /// Pedersen base point for encoding messages to be committed.

--- a/zk-sdk/src/lib.rs
+++ b/zk-sdk/src/lib.rs
@@ -24,7 +24,6 @@ pub mod encryption;
 pub mod errors;
 mod range_proof;
 mod sigma_proofs;
-#[cfg(not(target_os = "solana"))]
 mod transcript;
 
 /// Byte length of a compressed Ristretto point or scalar in Curve255519

--- a/zk-sdk/src/lib.rs
+++ b/zk-sdk/src/lib.rs
@@ -23,7 +23,6 @@ pub mod elgamal_program;
 pub mod encryption;
 pub mod errors;
 mod range_proof;
-#[cfg(not(target_os = "solana"))]
 mod sigma_proofs;
 #[cfg(not(target_os = "solana"))]
 mod transcript;

--- a/zk-sdk/src/lib.rs
+++ b/zk-sdk/src/lib.rs
@@ -20,7 +20,6 @@
 #![allow(clippy::arithmetic_side_effects, clippy::op_ref)]
 
 pub mod elgamal_program;
-#[cfg(not(target_os = "solana"))]
 pub mod encryption;
 pub mod errors;
 mod range_proof;

--- a/zk-sdk/src/sigma_proofs/mod.rs
+++ b/zk-sdk/src/sigma_proofs/mod.rs
@@ -9,14 +9,22 @@
 
 pub mod errors;
 
+#[cfg(not(target_os = "solana"))]
 pub mod batched_grouped_ciphertext_validity;
+#[cfg(not(target_os = "solana"))]
 pub mod ciphertext_ciphertext_equality;
+#[cfg(not(target_os = "solana"))]
 pub mod ciphertext_commitment_equality;
+#[cfg(not(target_os = "solana"))]
 pub mod grouped_ciphertext_validity;
+#[cfg(not(target_os = "solana"))]
 pub mod percentage_with_cap;
+#[cfg(not(target_os = "solana"))]
 pub mod pubkey;
+#[cfg(not(target_os = "solana"))]
 pub mod zero_ciphertext;
 
+#[cfg(not(target_os = "solana"))]
 use {
     crate::{sigma_proofs::errors::SigmaProofVerificationError, RISTRETTO_POINT_LEN, SCALAR_LEN},
     curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},

--- a/zk-sdk/src/transcript.rs
+++ b/zk-sdk/src/transcript.rs
@@ -1,18 +1,22 @@
+use merlin::Transcript;
+#[cfg(not(target_os = "solana"))]
 use {
     crate::errors::TranscriptError,
     curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar, traits::IsIdentity},
-    merlin::Transcript,
 };
 
 pub trait TranscriptProtocol {
     /// Append a `scalar` with the given `label`.
+    #[cfg(not(target_os = "solana"))]
     fn append_scalar(&mut self, label: &'static [u8], scalar: &Scalar);
 
     /// Append a `point` with the given `label`.
+    #[cfg(not(target_os = "solana"))]
     fn append_point(&mut self, label: &'static [u8], point: &CompressedRistretto);
 
     /// Check that a point is not the identity, then append it to the
     /// transcript.  Otherwise, return an error.
+    #[cfg(not(target_os = "solana"))]
     fn validate_and_append_point(
         &mut self,
         label: &'static [u8],
@@ -47,18 +51,22 @@ pub trait TranscriptProtocol {
     fn pubkey_proof_domain_separator(&mut self);
 
     /// Compute a `label`ed challenge variable.
+    #[cfg(not(target_os = "solana"))]
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar;
 }
 
 impl TranscriptProtocol for Transcript {
+    #[cfg(not(target_os = "solana"))]
     fn append_scalar(&mut self, label: &'static [u8], scalar: &Scalar) {
         self.append_message(label, scalar.as_bytes());
     }
 
+    #[cfg(not(target_os = "solana"))]
     fn append_point(&mut self, label: &'static [u8], point: &CompressedRistretto) {
         self.append_message(label, point.as_bytes());
     }
 
+    #[cfg(not(target_os = "solana"))]
     fn validate_and_append_point(
         &mut self,
         label: &'static [u8],
@@ -112,6 +120,7 @@ impl TranscriptProtocol for Transcript {
         self.append_message(b"dom-sep", b"pubkey-proof")
     }
 
+    #[cfg(not(target_os = "solana"))]
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar {
         let mut buf = [0u8; 64];
         self.challenge_bytes(label, &mut buf);


### PR DESCRIPTION
#### Problem
I thought I fixed this in the range proof module, but the `target_os = "solana"` is uselessly throughout the `encryption` and `sigma` modules. Although the entire `encryption` and `sigma` modules are not targeted for the solana vm, the specific functions inside have `cfg(not(taget_os = "solana"))`.

#### Summary of Changes
This is another embarrassing PR, but there must be a fix anyhow... I went through the entire zk-sdk module and cleaned up the use of `cfg(not(taget_os = "solana"))`. The determining factor for whether we use `cfg(not(taget_os = "solana"))` or not is whether the logic depends on the `curve25519-dalek` crate since this crate cannot be compiled to for solana target very well.
- For the `encryption` module, I added `cfg(not(taget_os = "solana"))` to all the submodules and then pulled out the constants into `mod.rs` so that the pod types (https://github.com/anza-xyz/agave/pull/1169) can access them.
- For the` sigma` module, I added `cfg(not(taget_os = "solana"))` to all the submodules except for the `errors` module like in the range proof module.
- I cleaned up `cfg(not(taget_os = "solana"))` in the `transcript` module as well.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
