### PR TITLE
Remove explicit assert in Blockstore::get_slot_entries_in_block()

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3515,10 +3515,12 @@ impl Blockstore {
         completed_ranges: CompletedRanges,
         slot_meta: Option<&SlotMeta>,
     ) -> Result<Vec<Entry>> {
-        assert!(!completed_ranges.is_empty());
-
-        let (all_ranges_start_index, _) = *completed_ranges.first().unwrap();
-        let (_, all_ranges_end_index) = *completed_ranges.last().unwrap();
+        let Some((all_ranges_start_index, _)) = completed_ranges.first().copied() else {
+            return Ok(vec![]);
+        };
+        let Some((_, all_ranges_end_index)) = completed_ranges.last().copied() else {
+            return Ok(vec![]);
+        };
         let keys =
             (all_ranges_start_index..=all_ranges_end_index).map(|index| (slot, u64::from(index)));
 


### PR DESCRIPTION
#### Problem
This is a private function and the callers should NOT be calling with an empty completed range vector. Regardless, it is safer to just return an empty Entry vector should an empty CompletedRanges be provided as input.

I was initially worried about something downstream not handling an empty `Vec<Entry>` gracefully. However, I found the concern to invalid for the two current callers of `get_slot_entries_in_block()`:

https://github.com/anza-xyz/agave/blob/8a55087d8edd51e4fa44ffc7318521ed7a73ba75/ledger/src/blockstore.rs#L3597-L3605
- The sole consumer of `Blockstore::get_entries_in_block()` iterates over the the entries, so no concerns with empty `Vec`

https://github.com/anza-xyz/agave/blob/8a55087d8edd51e4fa44ffc7318521ed7a73ba75/ledger/src/blockstore.rs#L3371-L3397
- `Blockstore::get_slot_entries_with_shred_info()` checks if `completed_ranges` is empty before calling `Blockstore::get_slot_entries_in_block()`

This is (long overdue) followup to this comment: https://github.com/solana-labs/solana/pull/34768#discussion_r1505331754