### PR TITLE
ci: add llvm-tools-preview

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -70,6 +70,7 @@ RUN \
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y && \
   rustup component add rustfmt && \
   rustup component add clippy && \
+  rustup component add llvm-tools-preview && \
   rustup install $RUST_NIGHTLY_VERSION && \
   rustup component add clippy --toolchain=$RUST_NIGHTLY_VERSION && \
   rustup component add rustfmt --toolchain=$RUST_NIGHTLY_VERSION && \


### PR DESCRIPTION
#### Problem

this one has landed to our docker image. it's used by https://github.com/anza-xyz/agave/pull/1260

#### Summary of Changes

add `llvm-tools-preview`