### PR TITLE
ThreadAwareAccountLocks: use AHashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5956,6 +5956,7 @@ dependencies = [
 name = "solana-core"
 version = "2.0.0"
 dependencies = [
+ "ahash 0.8.10",
  "assert_matches",
  "base64 0.22.0",
  "bincode",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ edition = { workspace = true }
 codecov = { repository = "solana-labs/solana", branch = "master", service = "github" }
 
 [dependencies]
+ahash = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
 bs58 = { workspace = true }
@@ -95,7 +96,9 @@ solana-program-runtime = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 solana-stake-program = { workspace = true }
-solana-unified-scheduler-pool = { workspace = true, features = ["dev-context-only-utils"] }
+solana-unified-scheduler-pool = { workspace = true, features = [
+    "dev-context-only-utils",
+] }
 static_assertions = { workspace = true }
 systemstat = { workspace = true }
 test-case = { workspace = true }

--- a/core/src/banking_stage/transaction_scheduler/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/transaction_scheduler/thread_aware_account_locks.rs
@@ -1,7 +1,8 @@
 use {
+    ahash::AHashMap,
     solana_sdk::pubkey::Pubkey,
     std::{
-        collections::{hash_map::Entry, HashMap},
+        collections::hash_map::Entry,
         fmt::{Debug, Display},
         ops::{BitAnd, BitAndAssign, Sub},
     },
@@ -48,7 +49,7 @@ pub(crate) struct ThreadAwareAccountLocks {
     num_threads: usize, // 0..MAX_THREADS
     /// Locks for each account. An account should only have an entry if there
     /// is at least one lock.
-    locks: HashMap<Pubkey, AccountLocks>,
+    locks: AHashMap<Pubkey, AccountLocks>,
 }
 
 impl ThreadAwareAccountLocks {
@@ -62,7 +63,7 @@ impl ThreadAwareAccountLocks {
 
         Self {
             num_threads,
-            locks: HashMap::new(),
+            locks: AHashMap::new(),
         }
     }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4938,6 +4938,7 @@ dependencies = [
 name = "solana-core"
 version = "2.0.0"
 dependencies = [
+ "ahash 0.8.10",
  "base64 0.22.0",
  "bincode",
  "bs58",


### PR DESCRIPTION
#### Problem

- Default hash is slow for `Pubkey`

#### Summary of Changes

- Use `ahash::AHashMap` to use the `ahash` hasher which is faster (see #1252)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
