### PR TITLE
introduce enums for non-mmap based append vecs

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -203,6 +203,27 @@ struct AccountOffsets {
     stored_size_aligned: usize,
 }
 
+#[derive(Debug)]
+enum InternalFileOrMMap<'a> {
+    /// A file-backed block of memory that is used to store the data for each appended item.
+    Map(&'a MmapMut),
+}
+
+impl AppendVecFileBacking {
+    /// access the backing
+    fn get<T>(&self, mut callback: impl for<'local> FnMut(InternalFileOrMMap<'local>) -> T) -> T {
+        match self {
+            AppendVecFileBacking::MapOnly(map) => callback(InternalFileOrMMap::Map(map)),
+        }
+    }
+}
+
+#[derive(Debug, AbiExample)]
+enum AppendVecFileBacking {
+    /// A file-backed block of memory that is used to store the data for each appended item.
+    MapOnly(MmapMut),
+}
+
 /// A thread-safe, file-backed block of memory used to store `Account` instances. Append operations
 /// are serialized such that only one thread updates the internal `append_lock` at a time. No
 /// restrictions are placed on reading. That is, one may read items from one thread while another
@@ -212,8 +233,8 @@ pub struct AppendVec {
     /// The file path where the data is stored.
     path: PathBuf,
 
-    /// A file-backed block of memory that is used to store the data for each appended item.
-    map: MmapMut,
+    /// access the file data
+    backing: AppendVecFileBacking,
 
     /// A lock used to serialize append operations.
     append_lock: Mutex<()>,
@@ -290,7 +311,7 @@ impl AppendVec {
 
         AppendVec {
             path: file,
-            map,
+            backing: AppendVecFileBacking::MapOnly(map),
             // This mutex forces append to be single threaded, but concurrent with reads
             // See UNSAFE usage in `append_ptr`
             append_lock: Mutex::new(()),
@@ -321,8 +342,9 @@ impl AppendVec {
     }
 
     pub fn flush(&self) -> Result<()> {
-        self.map.flush()?;
-        Ok(())
+        self.backing.get(|file_or_map| match file_or_map {
+            InternalFileOrMMap::Map(map) => Ok(map.flush()?),
+        })
     }
 
     pub fn reset(&self) {
@@ -390,7 +412,7 @@ impl AppendVec {
 
         Ok(AppendVec {
             path,
-            map,
+            backing: AppendVecFileBacking::MapOnly(map),
             append_lock: Mutex::new(()),
             current_len: AtomicUsize::new(current_len),
             file_size,
@@ -431,30 +453,40 @@ impl AppendVec {
         if overflow || next > self.len() {
             return None;
         }
-        let data = &self.map[offset..next];
-        let next = u64_align!(next);
+        self.backing.get(|file_or_map| {
+            match file_or_map {
+                InternalFileOrMMap::Map(map) => {
+                    let data = &map[offset..next];
+                    let next = u64_align!(next);
 
-        Some((
-            //UNSAFE: This unsafe creates a slice that represents a chunk of self.map memory
-            //The lifetime of this slice is tied to &self, since it points to self.map memory
-            unsafe { std::slice::from_raw_parts(data.as_ptr(), size) },
-            next,
-        ))
+                    Some((
+                        //UNSAFE: This unsafe creates a slice that represents a chunk of self.map memory
+                        //The lifetime of this slice is tied to &self, since it points to self.map memory
+                        unsafe { std::slice::from_raw_parts(data.as_ptr(), size) },
+                        next,
+                    ))
+                }
+            }
+        })
     }
 
     /// Copy `len` bytes from `src` to the first 64-byte boundary after position `offset` of
     /// the internal buffer. Then update `offset` to the first byte after the copied data.
     fn append_ptr(&self, offset: &mut usize, src: *const u8, len: usize) {
         let pos = u64_align!(*offset);
-        let data = &self.map[pos..(pos + len)];
-        //UNSAFE: This mut append is safe because only 1 thread can append at a time
-        //Mutex<()> guarantees exclusive write access to the memory occupied in
-        //the range.
-        unsafe {
-            let dst = data.as_ptr() as *mut _;
-            ptr::copy(src, dst, len);
-        };
-        *offset = pos + len;
+        self.backing.get(|file_or_map| match file_or_map {
+            InternalFileOrMMap::Map(map) => {
+                let data = &map[pos..(pos + len)];
+                //UNSAFE: This mut append is safe because only 1 thread can append at a time
+                //Mutex<()> guarantees exclusive write access to the memory occupied in
+                //the range.
+                unsafe {
+                    let dst = data.as_ptr() as *mut _;
+                    ptr::copy(src, dst, len);
+                };
+                *offset = pos + len;
+            }
+        })
     }
 
     /// Copy each value in `vals`, in order, to the first 64-byte boundary after position `offset`.
@@ -791,7 +823,9 @@ impl AppendVec {
 
     /// Returns a slice suitable for use when archiving append vecs
     pub fn data_for_archive(&self) -> &[u8] {
-        self.map.as_ref()
+        match &self.backing {
+            AppendVecFileBacking::MapOnly(map) => map.as_ref(),
+        }
     }
 }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -342,7 +342,7 @@ impl AppendVec {
     }
 
     pub fn flush(&self) -> Result<()> {
-        self.backing.get(|file_or_map| match file_or_map {
+        self.backing.get(|file_or_mmap| match file_or_mmap {
             InternalFileOrMmap::Mmap(mmap) => Ok(mmap.flush()?),
         })
     }
@@ -453,8 +453,8 @@ impl AppendVec {
         if overflow || next > self.len() {
             return None;
         }
-        self.backing.get(|file_or_map| {
-            match file_or_map {
+        self.backing.get(|file_or_mmap| {
+            match file_or_mmap {
                 InternalFileOrMmap::Mmap(mmap) => {
                     let data = &mmap[offset..next];
                     let next = u64_align!(next);
@@ -474,7 +474,7 @@ impl AppendVec {
     /// the internal buffer. Then update `offset` to the first byte after the copied data.
     fn append_ptr(&self, offset: &mut usize, src: *const u8, len: usize) {
         let pos = u64_align!(*offset);
-        self.backing.get(|file_or_map| match file_or_map {
+        self.backing.get(|file_or_mmap| match file_or_mmap {
             InternalFileOrMmap::Mmap(mmap) => {
                 let data = &mmap[pos..(pos + len)];
                 //UNSAFE: This mut append is safe because only 1 thread can append at a time


### PR DESCRIPTION
#### Problem
Goal is to stop mmapping append vecs.

#### Summary of Changes
Introduce an enum that allows an append vec to be accessed later by file. Appending requires mmap. There will be several enum values to support file and a map that can be closed and re-opened as a file.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
