### PR TITLE
add `can_append`

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4454,8 +4454,12 @@ impl AccountsDb {
                     .fetch_add(1, Ordering::Relaxed);
                 return true;
             }
-            // this slot is ancient and can become the 'current' ancient for other slots to be squashed into
-            *current_ancient = CurrentAncientAccountsFile::new(slot, Arc::clone(storage));
+            if storage.accounts.can_append() {
+                // this slot is ancient and can become the 'current' ancient for other slots to be squashed into
+                *current_ancient = CurrentAncientAccountsFile::new(slot, Arc::clone(storage));
+            } else {
+                *current_ancient = CurrentAncientAccountsFile::default();
+            }
             return false; // we're done with this slot - this slot IS the ancient append vec
         }
 

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -69,6 +69,15 @@ impl AccountsFile {
         Ok((Self::AppendVec(av), num_accounts))
     }
 
+    /// true if this storage can possibly be appended to (independent of capacity check)
+    pub(crate) fn can_append(&self) -> bool {
+        match self {
+            Self::AppendVec(av) => av.can_append(),
+            // once created, tiered storages cannot be appended to
+            Self::TieredStorage(_) => false,
+        }
+    }
+
     pub fn flush(&self) -> Result<()> {
         match self {
             Self::AppendVec(av) => av.flush(),

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -821,6 +821,12 @@ impl AppendVec {
         })
     }
 
+    /// true if this storage can possibly be appended to (independent of capacity check)
+    pub(crate) fn can_append(&self) -> bool {
+        // always can append to a mmapped append vec
+        true
+    }
+
     /// Returns a slice suitable for use when archiving append vecs
     pub fn data_for_archive(&self) -> &[u8] {
         match &self.backing {


### PR DESCRIPTION
#### Problem
Goal is to stop mmapping append vecs. Soon we will introduce a file i/o based read only access to append vecs. We need to know that it is not possible to append to one of these file i/o append vecs.

#### Summary of Changes
Add `can_append` to keep algorithms like ancient append vec append from trying to illegally append to a read only append vec.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
