### PR TITLE
Simd 118: remove epoch_reward_status from BankFieldsToDeserialize

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -478,7 +478,6 @@ pub struct BankFieldsToDeserialize {
     pub(crate) accounts_data_len: u64,
     pub(crate) incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
     pub(crate) epoch_accounts_hash: Option<Hash>,
-    pub(crate) epoch_reward_status: EpochRewardStatus,
 }
 
 /// Bank's common fields shared by all supported snapshot versions for serialization.

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -4,10 +4,7 @@ use {
         utils::{serialize_iter_as_map, serialize_iter_as_seq},
         *,
     },
-    crate::{
-        bank::partitioned_epoch_rewards::EpochRewardStatus,
-        stakes::{serde_stakes_enum_compat, StakesEnum},
-    },
+    crate::stakes::{serde_stakes_enum_compat, StakesEnum},
     solana_accounts_db::{accounts_hash::AccountsHash, ancestors::AncestorsForSerialization},
     solana_measure::measure::Measure,
     solana_sdk::{deserialize_utils::ignore_eof_error, stake::state::Delegation},
@@ -99,7 +96,6 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             is_delta: dvb.is_delta,
             incremental_snapshot_persistence: None,
             epoch_accounts_hash: None,
-            epoch_reward_status: EpochRewardStatus::Inactive,
         }
     }
 }
@@ -337,9 +333,6 @@ impl<'a> TypeContext<'a> for Context {
 
         let epoch_accounts_hash = ignore_eof_error(deserialize_from(&mut stream))?;
         bank_fields.epoch_accounts_hash = epoch_accounts_hash;
-
-        let epoch_reward_status = ignore_eof_error(deserialize_from(&mut stream))?;
-        bank_fields.epoch_reward_status = epoch_reward_status;
 
         Ok((bank_fields, accounts_db_fields))
     }


### PR DESCRIPTION
#### Problem
`epoch_reward_status` is never populated in snapshots. Therefore, there is no need to support deserializing it.

#### Summary of Changes
Remove `BankFieldsToDeserialize::epoch_reward_status` field
