### PR TITLE
Flushes tiered storage files explicitly after writing

### DIFF
--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -77,6 +77,9 @@ fn bench_write_accounts_file(c: &mut Criterion) {
                     let res = hot_storage.write_accounts(&storable_accounts, 0).unwrap();
                     let accounts_written_count = res.offsets.len();
                     assert_eq!(accounts_written_count, accounts_count);
+                    // Purposely do not call hot_storage.flush() here, since it will impact the
+                    // bench.  Flushing will be handled by Drop, which is *not* timed (and that's
+                    // what we want).
                 },
                 BatchSize::SmallInput,
             );

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -118,9 +118,11 @@ impl TieredStorage {
         }
 
         if format == &HOT_FORMAT {
-            let result = {
+            let stored_accounts_info = {
                 let mut writer = HotStorageWriter::new(&self.path)?;
-                writer.write_accounts(accounts, skip)
+                let stored_accounts_info = writer.write_accounts(accounts, skip)?;
+                writer.flush()?;
+                stored_accounts_info
             };
 
             // panic here if self.reader.get() is not None as self.reader can only be
@@ -131,7 +133,7 @@ impl TieredStorage {
                 .set(TieredStorageReader::new_from_path(&self.path)?)
                 .unwrap();
 
-            result
+            Ok(stored_accounts_info)
         } else {
             Err(TieredStorageError::UnknownFormat(self.path.to_path_buf()))
         }

--- a/accounts-db/src/tiered_storage/error.rs
+++ b/accounts-db/src/tiered_storage/error.rs
@@ -31,4 +31,7 @@ pub enum TieredStorageError {
 
     #[error("OffsetAlignmentError: offset {0} must be multiple of {1}")]
     OffsetAlignmentError(usize, usize),
+
+    #[error("failed to flush hot storage writer: {0}")]
+    FlushHotWriter(#[source] std::io::Error),
 }


### PR DESCRIPTION
#### Problem

After writing to a tiered storage file, if we do not flush the internal BufWriter explicitly, it will be flushed on drop. However, that internal flush will swallow errors[^1], as to not panic during drop.

If flushing to disk fails, that means the storage file could be corrupt. This is not something we can silently ignore. 

[^1]: https://doc.rust-lang.org/src/std/io/buffered/bufwriter.rs.html#672-677


#### Summary of Changes

* Explicitly flush the BufWriter after we are done writing to the hot storage file. This way we can/will catch any errors.
* If for some reason we don't call flush explicitly, call flush on drop of TieredWritableFile, and panic on any errors.