### PR TITLE
Simd 118: update Bank::epoch_reward_status to store Stakes

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -426,14 +426,13 @@ impl Bank {
 
                         let post_balance = stake_account.lamports();
                         total_stake_rewards.fetch_add(stakers_reward, Relaxed);
-                        let assert_msg = "solana_stake_program::rewards::redeem_rewards output \
-                                          is_ok only when a stake account has state \
-                                          StakeStateV2::Stake";
-                        let StakeStateV2::Stake(_meta, stake, _stake_flags) =
-                            stake_account.state().expect(assert_msg)
-                        else {
-                            panic!("{assert_msg}");
-                        };
+
+                        // Safe to unwrap on the following lines because all
+                        // stake_delegations are type StakeAccount<Delegation>,
+                        // which will always only wrap a `StakeStateV2::Stake`
+                        // variant.
+                        let updated_stake_state: StakeStateV2 = stake_account.state().unwrap();
+                        let stake = updated_stake_state.stake().unwrap();
                         return Some(PartitionedStakeReward {
                             stake_pubkey,
                             stake_reward_info: RewardInfo {

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -984,8 +984,8 @@ mod tests {
     }
 
     fn compare_stake_rewards(
-        expected_stake_rewards: &[StakeRewards],
-        received_stake_rewards: &[StakeRewards],
+        expected_stake_rewards: &[PartitionedStakeRewards],
+        received_stake_rewards: &[PartitionedStakeRewards],
     ) {
         for (i, partition) in received_stake_rewards.iter().enumerate() {
             let expected_partition = &expected_stake_rewards[i];

--- a/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
@@ -1,13 +1,13 @@
 use {
-    crate::bank::partitioned_epoch_rewards::StakeRewards,
+    crate::bank::partitioned_epoch_rewards::PartitionedStakeRewards,
     solana_sdk::{epoch_rewards_hasher::EpochRewardsHasher, hash::Hash},
 };
 
 pub(in crate::bank::partitioned_epoch_rewards) fn hash_rewards_into_partitions(
-    stake_rewards: StakeRewards,
+    stake_rewards: PartitionedStakeRewards,
     parent_blockhash: &Hash,
     num_partitions: usize,
-) -> Vec<StakeRewards> {
+) -> Vec<PartitionedStakeRewards> {
     let hasher = EpochRewardsHasher::new(num_partitions, parent_blockhash);
     let mut result = vec![vec![]; num_partitions];
 

--- a/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
@@ -28,10 +28,10 @@ mod tests {
     use {
         super::*,
         crate::bank::{
-            partitioned_epoch_rewards::REWARD_CALCULATION_NUM_BLOCKS, tests::create_genesis_config,
+            partitioned_epoch_rewards::{PartitionedStakeReward, REWARD_CALCULATION_NUM_BLOCKS},
+            tests::create_genesis_config,
             Bank,
         },
-        solana_accounts_db::stake_rewards::StakeReward,
         solana_sdk::{epoch_schedule::EpochSchedule, native_token::LAMPORTS_PER_SOL},
         std::collections::HashMap,
     };
@@ -42,7 +42,7 @@ mod tests {
         let expected_num = 12345;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| StakeReward::new_random())
+            .map(|_| PartitionedStakeReward::new_random())
             .collect::<Vec<_>>();
 
         let total = stake_rewards
@@ -106,7 +106,7 @@ mod tests {
         // simulate 40K - 1 rewards, the expected num of credit blocks should be 10.
         let expected_num = 40959;
         let stake_rewards = (0..expected_num)
-            .map(|_| StakeReward::new_random())
+            .map(|_| PartitionedStakeReward::new_random())
             .collect::<Vec<_>>();
 
         let stake_rewards_bucket =
@@ -121,7 +121,7 @@ mod tests {
         let _range = &stake_rewards_bucket[15];
     }
 
-    fn compare(a: &StakeRewards, b: &StakeRewards) {
+    fn compare(a: &PartitionedStakeRewards, b: &PartitionedStakeRewards) {
         let mut a = a
             .iter()
             .map(|stake_reward| (stake_reward.stake_pubkey, stake_reward.clone()))

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -59,7 +59,7 @@ pub(crate) struct StartBlockHeightAndRewards {
     /// the block height of the slot at which rewards distribution began
     pub(crate) distribution_starting_block_height: u64,
     /// calculated epoch rewards pending distribution, outer Vec is by partition (one partition per block)
-    pub(crate) stake_rewards_by_partition: Arc<Vec<StakeRewards>>,
+    pub(crate) stake_rewards_by_partition: Arc<Vec<PartitionedStakeRewards>>,
 }
 
 /// Represent whether bank is in the reward phase or not.
@@ -156,7 +156,7 @@ impl Bank {
     pub(crate) fn set_epoch_reward_status_active(
         &mut self,
         distribution_starting_block_height: u64,
-        stake_rewards_by_partition: Vec<StakeRewards>,
+        stake_rewards_by_partition: Vec<PartitionedStakeRewards>,
     ) {
         self.epoch_reward_status = EpochRewardStatus::Active(StartBlockHeightAndRewards {
             distribution_starting_block_height,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -90,7 +90,7 @@ pub(super) struct VoteRewardsAccounts {
 /// result of calculating the stake rewards at end of epoch
 struct StakeRewardCalculation {
     /// each individual stake account to reward
-    stake_rewards: StakeRewards,
+    stake_rewards: PartitionedStakeRewards,
     /// total lamports across all `stake_rewards`
     total_stake_rewards_lamports: u64,
 }
@@ -127,7 +127,7 @@ pub(super) struct PartitionedRewardsCalculation {
 /// result of calculating the stake rewards at beginning of new epoch
 pub(super) struct StakeRewardCalculationPartitioned {
     /// each individual stake account to reward, grouped by partition
-    pub(super) stake_rewards_by_partition: Vec<StakeRewards>,
+    pub(super) stake_rewards_by_partition: Vec<PartitionedStakeRewards>,
     /// total lamports across all `stake_rewards`
     pub(super) total_stake_rewards_lamports: u64,
 }
@@ -142,7 +142,7 @@ pub(super) struct CalculateRewardsAndDistributeVoteRewardsResult {
     /// delegations
     pub(super) total_points: u128,
     /// stake rewards that still need to be distributed, grouped by partition
-    pub(super) stake_rewards_by_partition: Vec<StakeRewards>,
+    pub(super) stake_rewards_by_partition: Vec<PartitionedStakeRewards>,
 }
 
 pub(crate) type StakeRewards = Vec<StakeReward>;
@@ -179,7 +179,10 @@ impl Bank {
     }
 
     /// Calculate the number of blocks required to distribute rewards to all stake accounts.
-    pub(super) fn get_reward_distribution_num_blocks(&self, rewards: &StakeRewards) -> u64 {
+    pub(super) fn get_reward_distribution_num_blocks(
+        &self,
+        rewards: &PartitionedStakeRewards,
+    ) -> u64 {
         let total_stake_accounts = rewards.len();
         if self.epoch_schedule.warmup && self.epoch < self.first_normal_epoch() {
             1

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -255,6 +255,21 @@ mod tests {
         solana_vote_program::{vote_state, vote_transaction},
     };
 
+    impl PartitionedStakeReward {
+        pub fn new_random() -> Self {
+            Self::maybe_from(&StakeReward::new_random()).unwrap()
+        }
+    }
+
+    pub fn convert_rewards(
+        stake_rewards: impl IntoIterator<Item = StakeReward>,
+    ) -> PartitionedStakeRewards {
+        stake_rewards
+            .into_iter()
+            .map(|stake_reward| PartitionedStakeReward::maybe_from(&stake_reward).unwrap())
+            .collect()
+    }
+
     #[derive(Debug, PartialEq, Eq, Copy, Clone)]
     enum RewardInterval {
         /// the slot within the epoch is INSIDE the reward distribution interval
@@ -282,7 +297,7 @@ mod tests {
         let expected_num = 100;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| StakeReward::new_random())
+            .map(|_| PartitionedStakeReward::new_random())
             .collect::<Vec<_>>();
 
         bank.set_epoch_reward_status_active(
@@ -343,7 +358,7 @@ mod tests {
             |num_stakes: u64, expected_num_reward_distribution_blocks: u64| {
                 // Given the short epoch, i.e. 32 slots, we should cap the number of reward distribution blocks to 32/10 = 3.
                 let stake_rewards = (0..num_stakes)
-                    .map(|_| StakeReward::new_random())
+                    .map(|_| PartitionedStakeReward::new_random())
                     .collect::<Vec<_>>();
 
                 assert_eq!(
@@ -381,7 +396,7 @@ mod tests {
         // Given 8k rewards, it will take 2 blocks to credit all the rewards
         let expected_num = 8192;
         let stake_rewards = (0..expected_num)
-            .map(|_| StakeReward::new_random())
+            .map(|_| PartitionedStakeReward::new_random())
             .collect::<Vec<_>>();
 
         assert_eq!(bank.get_reward_distribution_num_blocks(&stake_rewards), 2);

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -27,7 +27,7 @@ use {
 const REWARD_CALCULATION_NUM_BLOCKS: u64 = 1;
 
 #[derive(AbiExample, Debug, Serialize, Deserialize, Clone, PartialEq)]
-struct PartitionedStakeReward {
+pub(crate) struct PartitionedStakeReward {
     /// Stake account address
     pub stake_pubkey: Pubkey,
     /// `Stake` state to be stored in account


### PR DESCRIPTION
#### Problem
Since stake accounts must be loaded in partitioned epoch rewards distribution (see https://github.com/anza-xyz/agave/pull/845), there is no reason to store the full stake accounts in the Bank after calculation.

#### Summary of Changes
Replace `StakeRewards` with `PartitionedStakeRewards` in `Bank::epoch_reward_status`
Update other calculation return types accordingly

✅ ~~Needs rebase on https://github.com/anza-xyz/agave/pull/1251~~
