### PR TITLE
Make solana-frozen-abi optional in all remaining crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5460,8 +5460,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rustc_version 0.4.0",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-program",
  "solana-program-runtime",
  "solana-sdk",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -80,8 +80,19 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustc_version = { workspace = true }
 
 [features]
-dev-context-only-utils = ["dep:qualifier_attr", "dep:solana-stake-program", "dep:solana-vote-program"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+dev-context-only-utils = [
+    "dep:qualifier_attr",
+    "dep:solana-stake-program",
+    "dep:solana-vote-program",
+]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-program-runtime/frozen-abi",
+    "solana-sdk/frozen-abi",
+    "solana-svm/frozen-abi",
+    "solana-vote-program/frozen-abi",
+]
 
 [[bench]]
 name = "bench_accounts_file"

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -80,11 +80,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustc_version = { workspace = true }
 
 [features]
-dev-context-only-utils = [
-    "dep:qualifier_attr",
-    "dep:solana-stake-program",
-    "dep:solana-vote-program",
-]
+dev-context-only-utils = ["dep:qualifier_attr", "dep:solana-stake-program", "dep:solana-vote-program"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -35,8 +35,8 @@ serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
 smallvec = { workspace = true, features = ["const_generics"] }
 solana-bucket-map = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-inline-spl = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
@@ -81,6 +81,7 @@ rustc_version = { workspace = true }
 
 [features]
 dev-context-only-utils = ["dep:qualifier_attr", "dep:solana-stake-program", "dep:solana-vote-program"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [[bench]]
 name = "bench_accounts_file"

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -261,7 +261,8 @@ impl<'a> ShrinkInProgress<'a> {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize, Serialize, AbiExample, AbiEnumVisitor)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize, Serialize)]
 pub enum AccountStorageStatus {
     Available = 0,
     Full = 1,

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -46,7 +46,8 @@ use {
 
 pub type PubkeyAccountSlot = (Pubkey, AccountSharedData, Slot);
 
-#[derive(Debug, Default, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Default)]
 pub struct AccountLocks {
     write_locks: HashSet<Pubkey>,
     readonly_locks: HashMap<Pubkey, u64>,
@@ -99,7 +100,8 @@ impl AccountLocks {
 }
 
 /// This structure handles synchronization for db
-#[derive(Debug, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug)]
 pub struct Accounts {
     /// Single global AccountsDb
     pub accounts_db: Arc<AccountsDb>,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2232,7 +2232,7 @@ pub fn make_min_priority_thread_pool() -> ThreadPool {
         .unwrap()
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl solana_frozen_abi::abi_example::AbiExample for AccountsDb {
     fn example() -> Self {
         let accounts_db = AccountsDb::new_single_for_tests();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1273,7 +1273,8 @@ pub fn get_temp_accounts_paths(count: u32) -> IoResult<(Vec<TempDir>, Vec<PathBu
     Ok((temp_dirs, paths))
 }
 
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BankHashStats {
     pub num_updated_accounts: u64,
     pub num_removed_accounts: u64,

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1228,7 +1228,8 @@ pub enum ZeroLamportAccounts {
 
 /// Hash of an account
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Pod, Zeroable, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Pod, Zeroable)]
 pub struct AccountHash(pub Hash);
 
 // Ensure the newtype wrapper never changes size from the underlying Hash
@@ -1273,7 +1274,8 @@ pub struct IncrementalAccountsHash(pub Hash);
 pub struct AccountsDeltaHash(pub Hash);
 
 /// Snapshot serde-safe accounts delta hash
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SerdeAccountsDeltaHash(pub Hash);
 
 impl From<SerdeAccountsDeltaHash> for AccountsDeltaHash {
@@ -1288,7 +1290,8 @@ impl From<AccountsDeltaHash> for SerdeAccountsDeltaHash {
 }
 
 /// Snapshot serde-safe accounts hash
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SerdeAccountsHash(pub Hash);
 
 impl From<SerdeAccountsHash> for AccountsHash {
@@ -1303,7 +1306,8 @@ impl From<AccountsHash> for SerdeAccountsHash {
 }
 
 /// Snapshot serde-safe incremental accounts hash
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SerdeIncrementalAccountsHash(pub Hash);
 
 impl From<SerdeIncrementalAccountsHash> for IncrementalAccountsHash {

--- a/accounts-db/src/ancestors.rs
+++ b/accounts-db/src/ancestors.rs
@@ -7,7 +7,8 @@ use {
 
 pub type AncestorsForSerialization = HashMap<Slot, usize>;
 
-#[derive(Clone, PartialEq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, PartialEq)]
 pub struct Ancestors {
     ancestors: RollingBitField,
 }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -209,7 +209,8 @@ enum InternalFileOrMmap<'a> {
     Mmap(&'a MmapMut),
 }
 
-#[derive(Debug, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug)]
 enum AppendVecFileBacking {
     /// A file-backed block of memory that is used to store the data for each appended item.
     MmapOnly(MmapMut),

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -228,7 +228,8 @@ impl AppendVecFileBacking {
 /// are serialized such that only one thread updates the internal `append_lock` at a time. No
 /// restrictions are placed on reading. That is, one may read items from one thread while another
 /// is appending new items.
-#[derive(Debug, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug)]
 pub struct AppendVec {
     /// The file path where the data is stored.
     path: PathBuf,

--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -17,8 +17,7 @@ struct HashAge {
 }
 
 /// Low memory overhead, so can be cloned for every checkpoint
-#[frozen_abi(digest = "8upYCMG37Awf4FGQ5kKtZARHP1QfD2GMpQCPnwCCsxhu")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "8upYCMG37Awf4FGQ5kKtZARHP1QfD2GMpQCPnwCCsxhu"))]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockhashQueue {
     /// index of last hash to be registered

--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -17,7 +17,11 @@ struct HashAge {
 }
 
 /// Low memory overhead, so can be cloned for every checkpoint
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "8upYCMG37Awf4FGQ5kKtZARHP1QfD2GMpQCPnwCCsxhu"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "8upYCMG37Awf4FGQ5kKtZARHP1QfD2GMpQCPnwCCsxhu")
+)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockhashQueue {
     /// index of last hash to be registered

--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -8,7 +8,8 @@ use {
     std::collections::HashMap,
 };
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 struct HashAge {
     fee_calculator: FeeCalculator,
     hash_index: u64,
@@ -17,7 +18,8 @@ struct HashAge {
 
 /// Low memory overhead, so can be cloned for every checkpoint
 #[frozen_abi(digest = "8upYCMG37Awf4FGQ5kKtZARHP1QfD2GMpQCPnwCCsxhu")]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockhashQueue {
     /// index of last hash to be registered
     last_hash_index: u64,

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -46,5 +46,6 @@ extern crate solana_metrics;
 #[macro_use]
 extern crate serde_derive;
 
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;

--- a/accounts-db/src/rolling_bit_field.rs
+++ b/accounts-db/src/rolling_bit_field.rs
@@ -8,7 +8,8 @@ use {
     solana_sdk::clock::Slot,
 };
 
-#[derive(Debug, AbiExample, Clone)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Clone)]
 pub struct RollingBitField {
     max_width: u64,
     min: u64,

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -7,7 +7,8 @@ use {
     },
 };
 
-#[derive(AbiExample, Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct StakeReward {
     pub stake_pubkey: Pubkey,
     pub stake_reward_info: RewardInfo,

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -7,7 +7,7 @@ use {
     },
 };
 
-#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct StakeReward {
     pub stake_pubkey: Pubkey,

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -32,4 +32,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustc_version = { workspace = true }
 
 [features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-sdk/frozen-abi",
+]

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -17,8 +17,8 @@ rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-sdk = { workspace = true }
 
 [lib]
@@ -30,3 +30,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
 rustc_version = { workspace = true }
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/bloom/src/bloom.rs
+++ b/bloom/src/bloom.rs
@@ -24,7 +24,8 @@ pub trait BloomHashIndex {
     fn hash_at_index(&self, hash_index: u64) -> u64;
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
 pub struct Bloom<T: BloomHashIndex> {
     pub keys: Vec<u64>,
     pub bits: BitVec<u64>,

--- a/bloom/src/lib.rs
+++ b/bloom/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 pub mod bloom;
 
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -95,9 +95,7 @@ solana-program-runtime = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 solana-stake-program = { workspace = true }
-solana-unified-scheduler-pool = { workspace = true, features = [
-    "dev-context-only-utils",
-] }
+solana-unified-scheduler-pool = { workspace = true, features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 systemstat = { workspace = true }
 test-case = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -95,7 +95,9 @@ solana-program-runtime = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 solana-stake-program = { workspace = true }
-solana-unified-scheduler-pool = { workspace = true, features = ["dev-context-only-utils"] }
+solana-unified-scheduler-pool = { workspace = true, features = [
+    "dev-context-only-utils",
+] }
 static_assertions = { workspace = true }
 systemstat = { workspace = true }
 test-case = { workspace = true }
@@ -108,7 +110,22 @@ rustc_version = { workspace = true }
 
 [features]
 dev-context-only-utils = []
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-accounts-db/frozen-abi",
+    "solana-bloom/frozen-abi",
+    "solana-cost-model/frozen-abi",
+    "solana-gossip/frozen-abi",
+    "solana-ledger/frozen-abi",
+    "solana-perf/frozen-abi",
+    "solana-program-runtime/frozen-abi",
+    "solana-runtime/frozen-abi",
+    "solana-sdk/frozen-abi",
+    "solana-svm/frozen-abi",
+    "solana-vote/frozen-abi",
+    "solana-vote-program/frozen-abi",
+]
 
 [[bench]]
 name = "banking_stage"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -46,8 +46,8 @@ solana-bloom = { workspace = true }
 solana-client = { workspace = true }
 solana-cost-model = { workspace = true }
 solana-entry = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-geyser-plugin-manager = { workspace = true }
 solana-gossip = { workspace = true }
 solana-ledger = { workspace = true }
@@ -108,6 +108,7 @@ rustc_version = { workspace = true }
 
 [features]
 dev-context-only-utils = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [[bench]]
 name = "banking_stage"

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -67,13 +67,15 @@ pub struct BankingTracer {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TimedTracedEvent(pub std::time::SystemTime, pub TracedEvent);
 
-#[derive(Serialize, Deserialize, Debug, AbiExample, AbiEnumVisitor)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Serialize, Deserialize, Debug)]
 pub enum TracedEvent {
     PacketBatch(ChannelLabel, BankingPacketBatch),
     BlockAndBankHash(Slot, Hash, Hash),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, AbiExample, AbiEnumVisitor)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum ChannelLabel {
     NonVote,
     TpuVote,

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -63,7 +63,8 @@ pub struct BankingTracer {
 }
 
 #[frozen_abi(digest = "Eq6YrAFtTbtPrCEvh6Et1mZZDCARUg1gcK2qiZdqyjUz")]
-#[derive(Serialize, Deserialize, Debug, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct TimedTracedEvent(pub std::time::SystemTime, pub TracedEvent);
 
 #[derive(Serialize, Deserialize, Debug, AbiExample, AbiEnumVisitor)]

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -62,7 +62,11 @@ pub struct BankingTracer {
     active_tracer: Option<ActiveTracer>,
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "Eq6YrAFtTbtPrCEvh6Et1mZZDCARUg1gcK2qiZdqyjUz"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "Eq6YrAFtTbtPrCEvh6Et1mZZDCARUg1gcK2qiZdqyjUz")
+)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TimedTracedEvent(pub std::time::SystemTime, pub TracedEvent);
 

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -62,8 +62,7 @@ pub struct BankingTracer {
     active_tracer: Option<ActiveTracer>,
 }
 
-#[frozen_abi(digest = "Eq6YrAFtTbtPrCEvh6Et1mZZDCARUg1gcK2qiZdqyjUz")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "Eq6YrAFtTbtPrCEvh6Et1mZZDCARUg1gcK2qiZdqyjUz"))]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TimedTracedEvent(pub std::time::SystemTime, pub TracedEvent);
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -234,8 +234,7 @@ pub(crate) enum BlockhashStatus {
     Blockhash(Hash),
 }
 
-#[frozen_abi(digest = "679XkZ4upGc389SwqAsjs5tr2qB4wisqjbwtei7fGhxC")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "679XkZ4upGc389SwqAsjs5tr2qB4wisqjbwtei7fGhxC"))]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower {
     pub node_pubkey: Pubkey,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -63,7 +63,8 @@ impl ThresholdDecision {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum SwitchForkDecision {
     SwitchProof(Hash),
     SameFork,
@@ -221,7 +222,8 @@ impl TowerVersions {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Default, Clone, Copy, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(PartialEq, Eq, Debug, Default, Clone, Copy)]
 pub(crate) enum BlockhashStatus {
     /// No vote since restart
     #[default]
@@ -233,7 +235,8 @@ pub(crate) enum BlockhashStatus {
 }
 
 #[frozen_abi(digest = "679XkZ4upGc389SwqAsjs5tr2qB4wisqjbwtei7fGhxC")]
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower {
     pub node_pubkey: Pubkey,
     threshold_depth: usize,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -234,7 +234,11 @@ pub(crate) enum BlockhashStatus {
     Blockhash(Hash),
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "679XkZ4upGc389SwqAsjs5tr2qB4wisqjbwtei7fGhxC"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "679XkZ4upGc389SwqAsjs5tr2qB4wisqjbwtei7fGhxC")
+)]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower {
     pub node_pubkey: Pubkey,

--- a/core/src/consensus/tower1_14_11.rs
+++ b/core/src/consensus/tower1_14_11.rs
@@ -6,7 +6,11 @@ use {
     },
 };
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "4LayQwoKrE2jPhbNtg3TSpKrtEtjcPiwsVPJN7aCavri"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "4LayQwoKrE2jPhbNtg3TSpKrtEtjcPiwsVPJN7aCavri")
+)]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower1_14_11 {
     pub(crate) node_pubkey: Pubkey,

--- a/core/src/consensus/tower1_14_11.rs
+++ b/core/src/consensus/tower1_14_11.rs
@@ -6,8 +6,7 @@ use {
     },
 };
 
-#[frozen_abi(digest = "4LayQwoKrE2jPhbNtg3TSpKrtEtjcPiwsVPJN7aCavri")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "4LayQwoKrE2jPhbNtg3TSpKrtEtjcPiwsVPJN7aCavri"))]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower1_14_11 {
     pub(crate) node_pubkey: Pubkey,

--- a/core/src/consensus/tower1_14_11.rs
+++ b/core/src/consensus/tower1_14_11.rs
@@ -7,7 +7,8 @@ use {
 };
 
 #[frozen_abi(digest = "4LayQwoKrE2jPhbNtg3TSpKrtEtjcPiwsVPJN7aCavri")]
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower1_14_11 {
     pub(crate) node_pubkey: Pubkey,
     pub(crate) threshold_depth: usize,

--- a/core/src/consensus/tower1_7_14.rs
+++ b/core/src/consensus/tower1_7_14.rs
@@ -8,8 +8,7 @@ use {
     solana_vote_program::vote_state::{vote_state_1_14_11::VoteState1_14_11, BlockTimestamp, Vote},
 };
 
-#[frozen_abi(digest = "9Kc3Cpak93xdL8bCnEwMWA8ZLGCBNfqh9PLo1o5RiPyT")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "9Kc3Cpak93xdL8bCnEwMWA8ZLGCBNfqh9PLo1o5RiPyT"))]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower1_7_14 {
     pub(crate) node_pubkey: Pubkey,
@@ -36,8 +35,7 @@ pub struct Tower1_7_14 {
     pub(crate) last_switch_threshold_check: Option<(Slot, SwitchForkDecision)>,
 }
 
-#[frozen_abi(digest = "CxwFFxKfn6ez6wifDKr5WYr3eu2PsWUKdMYp3LX8Xj52")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "CxwFFxKfn6ez6wifDKr5WYr3eu2PsWUKdMYp3LX8Xj52"))]
 #[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SavedTower1_7_14 {
     pub(crate) signature: Signature,

--- a/core/src/consensus/tower1_7_14.rs
+++ b/core/src/consensus/tower1_7_14.rs
@@ -9,7 +9,8 @@ use {
 };
 
 #[frozen_abi(digest = "9Kc3Cpak93xdL8bCnEwMWA8ZLGCBNfqh9PLo1o5RiPyT")]
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower1_7_14 {
     pub(crate) node_pubkey: Pubkey,
     pub(crate) threshold_depth: usize,
@@ -36,7 +37,8 @@ pub struct Tower1_7_14 {
 }
 
 #[frozen_abi(digest = "CxwFFxKfn6ez6wifDKr5WYr3eu2PsWUKdMYp3LX8Xj52")]
-#[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SavedTower1_7_14 {
     pub(crate) signature: Signature,
     pub(crate) data: Vec<u8>,

--- a/core/src/consensus/tower1_7_14.rs
+++ b/core/src/consensus/tower1_7_14.rs
@@ -8,7 +8,11 @@ use {
     solana_vote_program::vote_state::{vote_state_1_14_11::VoteState1_14_11, BlockTimestamp, Vote},
 };
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "9Kc3Cpak93xdL8bCnEwMWA8ZLGCBNfqh9PLo1o5RiPyT"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "9Kc3Cpak93xdL8bCnEwMWA8ZLGCBNfqh9PLo1o5RiPyT")
+)]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower1_7_14 {
     pub(crate) node_pubkey: Pubkey,
@@ -35,7 +39,11 @@ pub struct Tower1_7_14 {
     pub(crate) last_switch_threshold_check: Option<(Slot, SwitchForkDecision)>,
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "CxwFFxKfn6ez6wifDKr5WYr3eu2PsWUKdMYp3LX8Xj52"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "CxwFFxKfn6ez6wifDKr5WYr3eu2PsWUKdMYp3LX8Xj52")
+)]
 #[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SavedTower1_7_14 {
     pub(crate) signature: Signature,

--- a/core/src/consensus/tower_storage.rs
+++ b/core/src/consensus/tower_storage.rs
@@ -76,7 +76,11 @@ impl From<SavedTower1_7_14> for SavedTowerVersions {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "Gaxfwvx5MArn52mKZQgzHmDCyn5YfCuTHvp5Et3rFfpp"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "Gaxfwvx5MArn52mKZQgzHmDCyn5YfCuTHvp5Et3rFfpp")
+)]
 #[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SavedTower {
     signature: Signature,

--- a/core/src/consensus/tower_storage.rs
+++ b/core/src/consensus/tower_storage.rs
@@ -14,7 +14,8 @@ use {
     },
 };
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum SavedTowerVersions {
     V1_17_14(SavedTower1_7_14),
     Current(SavedTower),
@@ -76,7 +77,8 @@ impl From<SavedTower1_7_14> for SavedTowerVersions {
 }
 
 #[frozen_abi(digest = "Gaxfwvx5MArn52mKZQgzHmDCyn5YfCuTHvp5Et3rFfpp")]
-#[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SavedTower {
     signature: Signature,
     data: Vec<u8>,

--- a/core/src/consensus/tower_storage.rs
+++ b/core/src/consensus/tower_storage.rs
@@ -76,8 +76,7 @@ impl From<SavedTower1_7_14> for SavedTowerVersions {
     }
 }
 
-#[frozen_abi(digest = "Gaxfwvx5MArn52mKZQgzHmDCyn5YfCuTHvp5Et3rFfpp")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "Gaxfwvx5MArn52mKZQgzHmDCyn5YfCuTHvp5Et3rFfpp"))]
 #[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SavedTower {
     signature: Signature,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -59,7 +59,8 @@ extern crate serde_derive;
 #[macro_use]
 extern crate solana_metrics;
 
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
 
 #[cfg(test)]

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -140,7 +140,8 @@ impl AncestorHashesRepairType {
     }
 }
 
-#[derive(Debug, AbiEnumVisitor, AbiExample, Deserialize, Serialize)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample))]
+#[derive(Debug, Deserialize, Serialize)]
 #[frozen_abi(digest = "AKpurCovzn6rsji4aQrP3hUdEHxjtXUfT7AatZXN7Rpz")]
 pub enum AncestorHashesResponse {
     Hashes(Vec<(Slot, Hash)>),
@@ -216,7 +217,8 @@ impl RepairRequestHeader {
 pub(crate) type Ping = ping_pong::Ping<[u8; REPAIR_PING_TOKEN_SIZE]>;
 
 /// Window protocol messages
-#[derive(Debug, AbiEnumVisitor, AbiExample, Deserialize, Serialize)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample))]
+#[derive(Debug, Deserialize, Serialize)]
 #[frozen_abi(digest = "5cmSdmXMgkpUH5ZCmYYjxUVQfULe9iJqCqqfrADfsEmK")]
 pub enum RepairProtocol {
     LegacyWindowIndex,
@@ -260,7 +262,8 @@ fn discard_malformed_repair_requests(
     requests.len()
 }
 
-#[derive(Debug, AbiEnumVisitor, AbiExample, Deserialize, Serialize)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample))]
+#[derive(Debug, Deserialize, Serialize)]
 #[frozen_abi(digest = "CkffjyMPCwuJgk9NiCMELXLCecAnTPZqpKEnUCb3VyVf")]
 pub(crate) enum RepairResponse {
     Ping(Ping),

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -140,7 +140,11 @@ impl AncestorHashesRepairType {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample), frozen_abi(digest = "AKpurCovzn6rsji4aQrP3hUdEHxjtXUfT7AatZXN7Rpz"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiEnumVisitor, AbiExample),
+    frozen_abi(digest = "AKpurCovzn6rsji4aQrP3hUdEHxjtXUfT7AatZXN7Rpz")
+)]
 #[derive(Debug, Deserialize, Serialize)]
 pub enum AncestorHashesResponse {
     Hashes(Vec<(Slot, Hash)>),
@@ -217,7 +221,11 @@ impl RepairRequestHeader {
 pub(crate) type Ping = ping_pong::Ping<[u8; REPAIR_PING_TOKEN_SIZE]>;
 
 /// Window protocol messages
-#[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample), frozen_abi(digest = "5cmSdmXMgkpUH5ZCmYYjxUVQfULe9iJqCqqfrADfsEmK"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiEnumVisitor, AbiExample),
+    frozen_abi(digest = "5cmSdmXMgkpUH5ZCmYYjxUVQfULe9iJqCqqfrADfsEmK")
+)]
 #[derive(Debug, Deserialize, Serialize)]
 pub enum RepairProtocol {
     LegacyWindowIndex,
@@ -261,7 +269,11 @@ fn discard_malformed_repair_requests(
     requests.len()
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample), frozen_abi(digest = "5cmSdmXMgkpUH5ZCmYYjxUVQfULe9iJqCqqfrADfsEmK"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiEnumVisitor, AbiExample),
+    frozen_abi(digest = "5cmSdmXMgkpUH5ZCmYYjxUVQfULe9iJqCqqfrADfsEmK")
+)]
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) enum RepairResponse {
     Ping(Ping),

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -140,9 +140,8 @@ impl AncestorHashesRepairType {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample), frozen_abi(digest = "AKpurCovzn6rsji4aQrP3hUdEHxjtXUfT7AatZXN7Rpz"))]
 #[derive(Debug, Deserialize, Serialize)]
-#[frozen_abi(digest = "AKpurCovzn6rsji4aQrP3hUdEHxjtXUfT7AatZXN7Rpz")]
 pub enum AncestorHashesResponse {
     Hashes(Vec<(Slot, Hash)>),
     Ping(Ping),
@@ -218,9 +217,8 @@ impl RepairRequestHeader {
 pub(crate) type Ping = ping_pong::Ping<[u8; REPAIR_PING_TOKEN_SIZE]>;
 
 /// Window protocol messages
-#[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample), frozen_abi(digest = "5cmSdmXMgkpUH5ZCmYYjxUVQfULe9iJqCqqfrADfsEmK"))]
 #[derive(Debug, Deserialize, Serialize)]
-#[frozen_abi(digest = "5cmSdmXMgkpUH5ZCmYYjxUVQfULe9iJqCqqfrADfsEmK")]
 pub enum RepairProtocol {
     LegacyWindowIndex,
     LegacyHighestWindowIndex,
@@ -263,9 +261,8 @@ fn discard_malformed_repair_requests(
     requests.len()
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample), frozen_abi(digest = "5cmSdmXMgkpUH5ZCmYYjxUVQfULe9iJqCqqfrADfsEmK"))]
 #[derive(Debug, Deserialize, Serialize)]
-#[frozen_abi(digest = "CkffjyMPCwuJgk9NiCMELXLCecAnTPZqpKEnUCb3VyVf")]
 pub(crate) enum RepairResponse {
     Ping(Ping),
 }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -272,7 +272,7 @@ fn discard_malformed_repair_requests(
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiEnumVisitor, AbiExample),
-    frozen_abi(digest = "5cmSdmXMgkpUH5ZCmYYjxUVQfULe9iJqCqqfrADfsEmK")
+    frozen_abi(digest = "CkffjyMPCwuJgk9NiCMELXLCecAnTPZqpKEnUCb3VyVf")
 )]
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) enum RepairResponse {

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -193,7 +193,8 @@ struct ServeRepairStats {
     err_id_mismatch: usize,
 }
 
-#[derive(Debug, AbiExample, Deserialize, Serialize)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct RepairRequestHeader {
     signature: Signature,
     sender: Pubkey,

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -16,7 +16,8 @@ use {
     solana_sdk::{packet::Packet, saturating_add_assign},
 };
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SigverifyTracerPacketStats {
     pub total_removed_before_sigverify_stage: usize,
     pub total_tracer_packets_received_in_sigverify_stage: usize,

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -48,7 +48,6 @@ rustc_version = { workspace = true }
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
-    "solana-address-lookup-table-program/frozen-abi",
     "solana-program-runtime/frozen-abi",
     "solana-sdk/frozen-abi",
     "solana-vote-program/frozen-abi",

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -17,8 +17,8 @@ solana-address-lookup-table-program = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
 solana-compute-budget-program = { workspace = true }
 solana-config-program = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-loader-v4-program = { workspace = true }
 solana-metrics = { workspace = true }
 solana-program-runtime = { workspace = true }
@@ -43,6 +43,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
 rustc_version = { workspace = true }
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [[bench]]
 name = "cost_tracker"

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -45,7 +45,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustc_version = { workspace = true }
 
 [features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-address-lookup-table-program/frozen-abi",
+    "solana-program-runtime/frozen-abi",
+    "solana-sdk/frozen-abi",
+    "solana-vote-program/frozen-abi",
+]
 
 [[bench]]
 name = "cost_tracker"

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -57,7 +57,7 @@ pub struct UpdatedCosts {
     pub updated_costliest_account_cost: u64,
 }
 
-#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug)]
 pub struct CostTracker {
     account_cost_limit: u64,

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -57,7 +57,8 @@ pub struct UpdatedCosts {
     pub updated_costliest_account_cost: u64,
 }
 
-#[derive(AbiExample, Debug)]
+#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug)]
 pub struct CostTracker {
     account_cost_limit: u64,
     block_cost_limit: u64,

--- a/cost-model/src/lib.rs
+++ b/cost-model/src/lib.rs
@@ -6,5 +6,6 @@ pub mod cost_model;
 pub mod cost_tracker;
 pub mod transaction_cost;
 
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -33,8 +33,8 @@ solana-clap-utils = { workspace = true }
 solana-client = { workspace = true }
 solana-connection-cache = { workspace = true }
 solana-entry = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-ledger = { workspace = true }
 solana-logger = { workspace = true }
 solana-measure = { workspace = true }
@@ -60,6 +60,9 @@ test-case = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [[bench]]
 name = "crds"

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -62,7 +62,18 @@ test-case = { workspace = true }
 rustc_version = { workspace = true }
 
 [features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-bloom/frozen-abi",
+    "solana-ledger/frozen-abi",
+    "solana-perf/frozen-abi",
+    "solana-runtime/frozen-abi",
+    "solana-sdk/frozen-abi",
+    "solana-version/frozen-abi",
+    "solana-vote/frozen-abi",
+    "solana-vote-program/frozen-abi",
+]
 
 [[bench]]
 name = "crds"

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -270,7 +270,11 @@ struct PullData {
 pub(crate) type Ping = ping_pong::Ping<[u8; GOSSIP_PING_TOKEN_SIZE]>;
 
 // TODO These messages should go through the gpu pipeline for spam filtering
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor), frozen_abi(digest = "ogEqvffeEkPpojAaSiUbCv2HdJcdXDQ1ykgYyvKvLo2"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor),
+    frozen_abi(digest = "ogEqvffeEkPpojAaSiUbCv2HdJcdXDQ1ykgYyvKvLo2")
+)]
 #[derive(Serialize, Deserialize, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Protocol {

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -270,8 +270,7 @@ struct PullData {
 pub(crate) type Ping = ping_pong::Ping<[u8; GOSSIP_PING_TOKEN_SIZE]>;
 
 // TODO These messages should go through the gpu pipeline for spam filtering
-#[frozen_abi(digest = "ogEqvffeEkPpojAaSiUbCv2HdJcdXDQ1ykgYyvKvLo2")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor), frozen_abi(digest = "ogEqvffeEkPpojAaSiUbCv2HdJcdXDQ1ykgYyvKvLo2"))]
 #[derive(Serialize, Deserialize, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Protocol {

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -185,7 +185,8 @@ pub struct ClusterInfo {
     socket_addr_space: SocketAddrSpace,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub(crate) struct PruneData {
     /// Pubkey of the node that sent this prune data
     pubkey: Pubkey,
@@ -270,7 +271,8 @@ pub(crate) type Ping = ping_pong::Ping<[u8; GOSSIP_PING_TOKEN_SIZE]>;
 
 // TODO These messages should go through the gpu pipeline for spam filtering
 #[frozen_abi(digest = "ogEqvffeEkPpojAaSiUbCv2HdJcdXDQ1ykgYyvKvLo2")]
-#[derive(Serialize, Deserialize, Debug, AbiEnumVisitor, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Debug, AbiEnumVisitor)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Protocol {
     /// Gossip protocol messages

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -271,8 +271,8 @@ pub(crate) type Ping = ping_pong::Ping<[u8; GOSSIP_PING_TOKEN_SIZE]>;
 
 // TODO These messages should go through the gpu pipeline for spam filtering
 #[frozen_abi(digest = "ogEqvffeEkPpojAaSiUbCv2HdJcdXDQ1ykgYyvKvLo2")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, Debug, AbiEnumVisitor)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Serialize, Deserialize, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Protocol {
     /// Gossip protocol messages

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -593,7 +593,7 @@ pub(crate) fn get_quic_socket(socket: &SocketAddr) -> Result<SocketAddr, Error> 
     ))
 }
 
-#[cfg(all(test, RUSTC_WITH_SPECIALIZATION))]
+#[cfg(all(test, RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl solana_frozen_abi::abi_example::AbiExample for ContactInfo {
     fn example() -> Self {
         Self {

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -86,7 +86,8 @@ pub struct ContactInfo {
     cache: [SocketAddr; SOCKET_CACHE_SIZE],
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, AbiExample, Deserialize, Serialize)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 struct SocketEntry {
     key: u8,   // Protocol identifier, e.g. tvu, tpu, etc
     index: u8, // IpAddr index in the accompanying addrs vector.

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -55,7 +55,8 @@ const FAILED_INSERTS_RETENTION_MS: u64 = 20_000;
 pub const FALSE_RATE: f64 = 0.1f64;
 pub const KEYS: f64 = 8f64;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct CrdsFilter {
     pub filter: Bloom<Hash>,
     mask: u64,

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -41,7 +41,8 @@ pub type EpochSlotsIndex = u8;
 pub const MAX_EPOCH_SLOTS: EpochSlotsIndex = 255;
 
 /// CrdsValue that is replicated across the cluster
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct CrdsValue {
     pub signature: Signature,
     pub data: CrdsData,
@@ -175,7 +176,8 @@ impl CrdsData {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct AccountsHashes {
     pub from: Pubkey,
     pub hashes: Vec<(Slot, Hash)>,
@@ -223,7 +225,8 @@ impl AccountsHashes {
 
 type LegacySnapshotHashes = AccountsHashes;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct SnapshotHashes {
     pub from: Pubkey,
     pub full: (Slot, Hash),
@@ -249,7 +252,8 @@ impl Sanitize for SnapshotHashes {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct LowestSlot {
     pub from: Pubkey,
     root: Slot, //deprecated
@@ -370,7 +374,8 @@ impl<'de> Deserialize<'de> for Vote {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct LegacyVersion {
     pub from: Pubkey,
     pub wallclock: u64,
@@ -385,7 +390,8 @@ impl Sanitize for LegacyVersion {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Version {
     pub from: Pubkey,
     pub wallclock: u64,

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -308,7 +308,8 @@ impl Sanitize for LowestSlot {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, AbiExample, Serialize)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Vote {
     pub(crate) from: Pubkey,
     transaction: Transaction,
@@ -432,7 +433,8 @@ impl Version {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, AbiExample, Deserialize, Serialize)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct NodeInstance {
     from: Pubkey,
     wallclock: u64,

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -82,7 +82,8 @@ impl Signable for CrdsValue {
 /// * Merge Strategy - Latest wallclock is picked
 /// * LowestSlot index is deprecated
 #[allow(clippy::large_enum_variant)]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample, AbiEnumVisitor)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum CrdsData {
     #[allow(private_interfaces)]
     LegacyContactInfo(LegacyContactInfo),

--- a/gossip/src/deprecated.rs
+++ b/gossip/src/deprecated.rs
@@ -13,7 +13,8 @@ impl Default for CompressionType {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct EpochIncompleteSlots {
     first: Slot,
     compression: CompressionType,

--- a/gossip/src/deprecated.rs
+++ b/gossip/src/deprecated.rs
@@ -1,6 +1,7 @@
 use solana_sdk::clock::Slot;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample, AbiEnumVisitor)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 enum CompressionType {
     Uncompressed,
     GZip,

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -24,7 +24,8 @@ const DUPLICATE_SHRED_HEADER_SIZE: usize = 63;
 pub(crate) type DuplicateShredIndex = u16;
 pub(crate) const MAX_DUPLICATE_SHREDS: DuplicateShredIndex = 512;
 
-#[derive(Clone, Debug, PartialEq, Eq, AbiExample, Deserialize, Serialize)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DuplicateShred {
     pub(crate) from: Pubkey,
     pub(crate) wallclock: u64,

--- a/gossip/src/epoch_slots.rs
+++ b/gossip/src/epoch_slots.rs
@@ -158,7 +158,8 @@ impl Uncompressed {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample, AbiEnumVisitor)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum CompressedSlots {
     Flate2(Flate2),
     Uncompressed(Uncompressed),

--- a/gossip/src/epoch_slots.rs
+++ b/gossip/src/epoch_slots.rs
@@ -14,7 +14,8 @@ use {
 };
 
 pub const MAX_SLOTS_PER_ENTRY: usize = 2048 * 8;
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Uncompressed {
     pub first_slot: Slot,
     pub num: usize,
@@ -42,7 +43,8 @@ impl Sanitize for Uncompressed {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Flate2 {
     pub first_slot: Slot,
     pub num: usize,
@@ -224,7 +226,8 @@ impl CompressedSlots {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
 pub struct EpochSlots {
     pub from: Pubkey,
     pub slots: Vec<CompressedSlots>,

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -16,7 +16,8 @@ use {
 };
 
 /// Structure representing a node on the network
-#[derive(Clone, Debug, Eq, PartialEq, AbiExample, Deserialize, Serialize)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub(crate) struct LegacyContactInfo {
     id: Pubkey,
     /// gossip address

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -37,7 +37,8 @@ extern crate assert_matches;
 #[macro_use]
 extern crate serde_derive;
 
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
 
 #[macro_use]

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -18,7 +18,7 @@ use {
 
 const PING_PONG_HASH_PREFIX: &[u8] = "SOLANA_PING_PONG".as_bytes();
 
-#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Ping<T> {
     from: Pubkey,
@@ -26,7 +26,7 @@ pub struct Ping<T> {
     signature: Signature,
 }
 
-#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Pong {
     from: Pubkey,

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -18,14 +18,16 @@ use {
 
 const PING_PONG_HASH_PREFIX: &[u8] = "SOLANA_PING_PONG".as_bytes();
 
-#[derive(AbiExample, Debug, Deserialize, Serialize)]
+#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Ping<T> {
     from: Pubkey,
     token: T,
     signature: Signature,
 }
 
-#[derive(AbiExample, Debug, Deserialize, Serialize)]
+#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Pong {
     from: Pubkey,
     hash: Hash, // Hash of received ping token.

--- a/gossip/src/restart_crds_values.rs
+++ b/gossip/src/restart_crds_values.rs
@@ -39,7 +39,8 @@ pub struct RestartHeaviestFork {
     pub shred_version: u16,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample, AbiEnumVisitor)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 enum SlotsOffsets {
     RunLengthEncoding(RunLengthEncoding),
     RawOffsets(RawOffsets),

--- a/gossip/src/restart_crds_values.rs
+++ b/gossip/src/restart_crds_values.rs
@@ -13,7 +13,8 @@ use {
     thiserror::Error,
 };
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, AbiExample, Debug)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct RestartLastVotedForkSlots {
     pub from: Pubkey,
     pub wallclock: u64,
@@ -29,7 +30,8 @@ pub enum RestartLastVotedForkSlotsError {
     LastVotedForkEmpty,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, AbiExample, Debug)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct RestartHeaviestFork {
     pub from: Pubkey,
     pub wallclock: u64,

--- a/gossip/src/restart_crds_values.rs
+++ b/gossip/src/restart_crds_values.rs
@@ -45,15 +45,18 @@ enum SlotsOffsets {
     RawOffsets(RawOffsets),
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 struct U16(#[serde(with = "serde_varint")] u16);
 
 // The vector always starts with 1. Encode number of 1's and 0's consecutively.
 // For example, 110000111 is [2, 4, 3].
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 struct RunLengthEncoding(Vec<U16>);
 
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 struct RawOffsets(BitVec<u8>);
 
 impl Sanitize for RestartLastVotedForkSlots {

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -44,8 +44,8 @@ solana-accounts-db = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
 solana-cost-model = { workspace = true }
 solana-entry = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-perf = { workspace = true }
@@ -91,6 +91,7 @@ rustc_version = { workspace = true }
 
 [features]
 dev-context-only-utils = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [lib]
 crate-type = ["lib"]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -91,7 +91,11 @@ rustc_version = { workspace = true }
 
 [features]
 dev-context-only-utils = []
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-runtime/frozen-abi",
+]
 
 [lib]
 crate-type = ["lib"]

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -43,5 +43,6 @@ extern crate solana_metrics;
 #[macro_use]
 extern crate log;
 
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -170,6 +170,7 @@ pub enum Error {
 }
 
 #[repr(u8)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
 #[derive(
     Clone,
     Copy,
@@ -177,8 +178,6 @@ pub enum Error {
     Eq,
     Hash,
     PartialEq,
-    AbiEnumVisitor,
-    AbiExample,
     Deserialize,
     IntoPrimitive,
     Serialize,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -172,16 +172,7 @@ pub enum Error {
 #[repr(u8)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
 #[derive(
-    Clone,
-    Copy,
-    Debug,
-    Eq,
-    Hash,
-    PartialEq,
-    Deserialize,
-    IntoPrimitive,
-    Serialize,
-    TryFromPrimitive,
+    Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, IntoPrimitive, Serialize, TryFromPrimitive,
 )]
 #[serde(into = "u8", try_from = "u8")]
 pub enum ShredType {

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -46,7 +46,12 @@ test-case = { workspace = true }
 rustc_version = { workspace = true }
 
 [features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-sdk/frozen-abi",
+    "solana-vote-program/frozen-abi",
+]
 
 [[bench]]
 name = "sigverify"

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -21,8 +21,8 @@ log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-metrics = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-sdk = { workspace = true }
@@ -44,6 +44,9 @@ test-case = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [[bench]]
 name = "sigverify"

--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -54,7 +54,8 @@ fn unpin<T>(mem: *mut T) {
 // A vector wrapper where the underlying memory can be
 // page-pinned. Controlled by flags in case user only wants
 // to pin in certain circumstances.
-#[derive(Debug, Default, Serialize, Deserialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct PinnedVec<T: Default + Clone + Sized> {
     x: Vec<T>,
     pinned: bool,

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -24,7 +24,8 @@ extern crate assert_matches;
 #[macro_use]
 extern crate solana_metrics;
 
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
 
 fn is_rosetta_emulated() -> bool {

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -18,7 +18,8 @@ pub const NUM_PACKETS: usize = 1024 * 8;
 pub const PACKETS_PER_BATCH: usize = 64;
 pub const NUM_RCVMMSGS: usize = 64;
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct PacketBatch {
     packets: PinnedVec<Packet>,
 }

--- a/perf/src/recycler.rs
+++ b/perf/src/recycler.rs
@@ -57,7 +57,7 @@ impl<T: Default> Default for RecyclerX<T> {
     }
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl solana_frozen_abi::abi_example::AbiExample
     for RecyclerX<crate::cuda_runtime::PinnedVec<solana_sdk::packet::Packet>>
 {

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -47,4 +47,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustc_version = { workspace = true }
 
 [features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-sdk/frozen-abi",
+]

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -22,8 +22,8 @@ num-traits = { workspace = true }
 percentage = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-sdk = { workspace = true }
@@ -45,3 +45,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
 rustc_version = { workspace = true }
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -3,7 +3,7 @@ use {
     solana_sdk::{instruction::CompiledInstruction, pubkey::Pubkey, transaction::Result},
 };
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl ::solana_frozen_abi::abi_example::AbiExample for ComputeBudget {
     fn example() -> Self {
         // ComputeBudget is not Serialize so just rely on Default.

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1330,7 +1330,7 @@ impl solana_frozen_abi::abi_example::AbiExample for ProgramCacheEntry {
     }
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl<FG: ForkGraph> solana_frozen_abi::abi_example::AbiExample for ProgramCache<FG> {
     fn example() -> Self {
         // ProgramCache isn't serializable by definition.

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1322,7 +1322,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     }
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl solana_frozen_abi::abi_example::AbiExample for ProgramCacheEntry {
     fn example() -> Self {
         // ProgramCacheEntry isn't serializable by definition.

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -16,7 +16,7 @@ use {
     std::sync::Arc,
 };
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl ::solana_frozen_abi::abi_example::AbiExample for SysvarCache {
     fn example() -> Self {
         // SysvarCache is not Serialize so just rely on Default.

--- a/programs/address-lookup-table/Cargo.toml
+++ b/programs/address-lookup-table/Cargo.toml
@@ -15,8 +15,6 @@ bytemuck = { workspace = true }
 log = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true }
-solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-program = { workspace = true }
 thiserror = { workspace = true }
 
@@ -33,12 +31,3 @@ name = "solana_address_lookup_table_program"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-program/frozen-abi",
-    "solana-program-runtime/frozen-abi",
-    "solana-sdk/frozen-abi",
-]

--- a/programs/address-lookup-table/Cargo.toml
+++ b/programs/address-lookup-table/Cargo.toml
@@ -15,8 +15,8 @@ bytemuck = { workspace = true }
 log = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-program = { workspace = true }
 thiserror = { workspace = true }
 
@@ -33,3 +33,6 @@ name = "solana_address_lookup_table_program"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/programs/address-lookup-table/Cargo.toml
+++ b/programs/address-lookup-table/Cargo.toml
@@ -35,4 +35,10 @@ name = "solana_address_lookup_table_program"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-program/frozen-abi",
+    "solana-program-runtime/frozen-abi",
+    "solana-sdk/frozen-abi",
+]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4660,8 +4660,6 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "solana-bucket-map",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-inline-spl",
  "solana-measure",
  "solana-metrics",
@@ -4686,8 +4684,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rustc_version",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-program",
  "solana-program-runtime",
  "solana-sdk",
@@ -4749,8 +4745,6 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-sdk",
 ]
 
@@ -4959,8 +4953,6 @@ dependencies = [
  "solana-client",
  "solana-cost-model",
  "solana-entry",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-ledger",
@@ -5009,8 +5001,6 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
  "solana-config-program",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-loader-v4-program",
  "solana-metrics",
  "solana-program-runtime",
@@ -5072,34 +5062,6 @@ dependencies = [
  "spl-memo",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "solana-frozen-abi"
-version = "2.0.0"
-dependencies = [
- "bs58",
- "bv",
- "generic-array 0.14.7",
- "im",
- "log",
- "memmap2",
- "rustc_version",
- "serde",
- "serde_derive",
- "sha2 0.10.8",
- "solana-frozen-abi-macro",
- "thiserror",
-]
-
-[[package]]
-name = "solana-frozen-abi-macro"
-version = "2.0.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.58",
 ]
 
 [[package]]
@@ -5166,8 +5128,6 @@ dependencies = [
  "solana-client",
  "solana-connection-cache",
  "solana-entry",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-ledger",
  "solana-logger",
  "solana-measure",
@@ -5235,8 +5195,6 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-cost-model",
  "solana-entry",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-measure",
  "solana-metrics",
  "solana-perf",
@@ -5358,8 +5316,6 @@ dependencies = [
  "rayon",
  "rustc_version",
  "serde",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-metrics",
  "solana-rayon-threadlimit",
  "solana-sdk",
@@ -5446,8 +5402,6 @@ dependencies = [
  "rand 0.8.5",
  "rustc_version",
  "serde",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
@@ -5719,8 +5673,6 @@ dependencies = [
  "solana-compute-budget-program",
  "solana-config-program",
  "solana-cost-model",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-inline-spl",
  "solana-loader-v4-program",
  "solana-measure",
@@ -6210,8 +6162,6 @@ dependencies = [
  "sha2 0.10.8",
  "sha3 0.10.8",
  "siphasher",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-program",
  "solana-sdk-macro",
  "thiserror",
@@ -6353,8 +6303,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-bpf-loader-program",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-loader-v4-program",
  "solana-measure",
  "solana-metrics",
@@ -6562,8 +6510,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-sdk",
 ]
 
@@ -6577,8 +6523,6 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-sdk",
  "thiserror",
 ]
@@ -6594,8 +6538,6 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-metrics",
  "solana-program",
  "solana-program-runtime",

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -16,8 +16,8 @@ num-derive = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-metrics = { workspace = true }
 solana-program = { workspace = true }
 solana-program-runtime = { workspace = true }
@@ -38,3 +38,6 @@ name = "solana_vote_program"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -40,4 +40,10 @@ name = "solana_vote_program"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-program/frozen-abi",
+    "solana-program-runtime/frozen-abi",
+    "solana-sdk/frozen-abi",
+]

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -7,7 +7,8 @@ pub mod vote_transaction;
 #[macro_use]
 extern crate solana_metrics;
 
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
 
 pub use solana_sdk::vote::{

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -28,8 +28,7 @@ use {
     },
 };
 
-#[frozen_abi(digest = "EcS3xgfomytEAQ1eVd8R76ZejwyHp2Ed8dHqQWh6zi5v")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor), frozen_abi(digest = "EcS3xgfomytEAQ1eVd8R76ZejwyHp2Ed8dHqQWh6zi5v"))]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum VoteTransaction {
     Vote(Vote),

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -28,7 +28,11 @@ use {
     },
 };
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor), frozen_abi(digest = "EcS3xgfomytEAQ1eVd8R76ZejwyHp2Ed8dHqQWh6zi5v"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor),
+    frozen_abi(digest = "EcS3xgfomytEAQ1eVd8R76ZejwyHp2Ed8dHqQWh6zi5v")
+)]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum VoteTransaction {
     Vote(Vote),

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -29,8 +29,8 @@ use {
 };
 
 #[frozen_abi(digest = "EcS3xgfomytEAQ1eVd8R76ZejwyHp2Ed8dHqQWh6zi5v")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, AbiEnumVisitor)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum VoteTransaction {
     Vote(Vote),
     VoteStateUpdate(VoteStateUpdate),

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -29,7 +29,8 @@ use {
 };
 
 #[frozen_abi(digest = "EcS3xgfomytEAQ1eVd8R76ZejwyHp2Ed8dHqQWh6zi5v")]
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, AbiEnumVisitor, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, AbiEnumVisitor)]
 pub enum VoteTransaction {
     Vote(Vote),
     VoteStateUpdate(VoteStateUpdate),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -53,8 +53,8 @@ solana-bucket-map = { workspace = true }
 solana-compute-budget-program = { workspace = true }
 solana-config-program = { workspace = true }
 solana-cost-model = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-inline-spl = { workspace = true }
 solana-loader-v4-program = { workspace = true }
 solana-measure = { workspace = true }
@@ -106,6 +106,7 @@ rustc_version = { workspace = true }
 
 [features]
 dev-context-only-utils = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [[bench]]
 name = "prioritization_fee_cache"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -106,7 +106,20 @@ rustc_version = { workspace = true }
 
 [features]
 dev-context-only-utils = []
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-accounts-db/frozen-abi",
+    "solana-address-lookup-table-program/frozen-abi",
+    "solana-cost-model/frozen-abi",
+    "solana-perf/frozen-abi",
+    "solana-program-runtime/frozen-abi",
+    "solana-sdk/frozen-abi",
+    "solana-svm/frozen-abi",
+    "solana-version/frozen-abi",
+    "solana-vote/frozen-abi",
+    "solana-vote-program/frozen-abi",
+]
 
 [[bench]]
 name = "prioritization_fee_cache"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -110,7 +110,6 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-accounts-db/frozen-abi",
-    "solana-address-lookup-table-program/frozen-abi",
     "solana-cost-model/frozen-abi",
     "solana-perf/frozen-abi",
     "solana-program-runtime/frozen-abi",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -243,7 +243,7 @@ struct RentMetrics {
 }
 
 pub type BankStatusCache = StatusCache<Result<()>>;
-#[frozen_abi(digest = "9Pf3NTGr1AEzB4nKaVBY24uNwoQR4aJi8vc96W6kGvNk")]
+#[cfg_attr(feature = "frozen-abi", frozen_abi(digest = "9Pf3NTGr1AEzB4nKaVBY24uNwoQR4aJi8vc96W6kGvNk"))]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -266,7 +266,8 @@ impl AddAssign for SquashTiming {
     }
 }
 
-#[derive(AbiExample, Debug, Default, PartialEq)]
+#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Default, PartialEq)]
 pub(crate) struct CollectorFeeDetails {
     transaction_fee: u64,
     priority_fee: u64,
@@ -394,13 +395,15 @@ impl Default for TransactionLogCollectorFilter {
     }
 }
 
-#[derive(AbiExample, Debug, Default)]
+#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Default)]
 pub struct TransactionLogCollectorConfig {
     pub mentioned_addresses: HashSet<Pubkey>,
     pub filter: TransactionLogCollectorFilter,
 }
 
-#[derive(AbiExample, Clone, Debug, PartialEq, Eq)]
+#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransactionLogInfo {
     pub signature: Signature,
     pub result: Result<()>,
@@ -408,7 +411,8 @@ pub struct TransactionLogInfo {
     pub log_messages: TransactionLogMessages,
 }
 
-#[derive(AbiExample, Default, Debug)]
+#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Default, Debug)]
 pub struct TransactionLogCollector {
     // All the logs collected for from this Bank.  Exact contents depend on the
     // active `TransactionLogCollectorFilter`
@@ -659,7 +663,8 @@ impl AbiExample for OptionalDropCallback {
 /// Manager for the state of all accounts and programs after processing its entries.
 /// AbiExample is needed even without Serialize/Deserialize; actual (de-)serialization
 /// are implemented elsewhere for versioning
-#[derive(AbiExample, Debug)]
+#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug)]
 pub struct Bank {
     /// References to accounts, parent and signature status
     pub rc: BankRc,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -311,10 +311,10 @@ pub struct BankRc {
     pub(crate) bank_id_generator: Arc<AtomicU64>,
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 use solana_frozen_abi::abi_example::AbiExample;
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl AbiExample for BankRc {
     fn example() -> Self {
         BankRc {
@@ -653,7 +653,7 @@ pub trait DropCallback: fmt::Debug {
 #[derive(Debug, Default)]
 pub struct OptionalDropCallback(Option<Box<dyn DropCallback + Send + Sync>>);
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl AbiExample for OptionalDropCallback {
     fn example() -> Self {
         Self(None)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -243,7 +243,10 @@ struct RentMetrics {
 }
 
 pub type BankStatusCache = StatusCache<Result<()>>;
-#[cfg_attr(feature = "frozen-abi", frozen_abi(digest = "9Pf3NTGr1AEzB4nKaVBY24uNwoQR4aJi8vc96W6kGvNk"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    frozen_abi(digest = "9Pf3NTGr1AEzB4nKaVBY24uNwoQR4aJi8vc96W6kGvNk")
+)]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -266,7 +266,7 @@ impl AddAssign for SquashTiming {
     }
 }
 
-#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Default, PartialEq)]
 pub(crate) struct CollectorFeeDetails {
     transaction_fee: u64,
@@ -395,14 +395,14 @@ impl Default for TransactionLogCollectorFilter {
     }
 }
 
-#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Default)]
 pub struct TransactionLogCollectorConfig {
     pub mentioned_addresses: HashSet<Pubkey>,
     pub filter: TransactionLogCollectorFilter,
 }
 
-#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransactionLogInfo {
     pub signature: Signature,
@@ -411,7 +411,7 @@ pub struct TransactionLogInfo {
     pub log_messages: TransactionLogMessages,
 }
 
-#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Default, Debug)]
 pub struct TransactionLogCollector {
     // All the logs collected for from this Bank.  Exact contents depend on the
@@ -663,7 +663,7 @@ impl AbiExample for OptionalDropCallback {
 /// Manager for the state of all accounts and programs after processing its entries.
 /// AbiExample is needed even without Serialize/Deserialize; actual (de-)serialization
 /// are implemented elsewhere for versioning
-#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug)]
 pub struct Bank {
     /// References to accounts, parent and signature status

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -379,7 +379,8 @@ impl TransactionBalancesSet {
 }
 pub type TransactionBalances = Vec<Vec<u64>>;
 
-#[derive(Serialize, Deserialize, AbiExample, AbiEnumVisitor, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum TransactionLogCollectorFilter {
     All,
     AllWithVotes,

--- a/runtime/src/bank/builtins/prototypes.rs
+++ b/runtime/src/bank/builtins/prototypes.rs
@@ -23,7 +23,7 @@ impl std::fmt::Debug for BuiltinPrototype {
     }
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl solana_frozen_abi::abi_example::AbiExample for BuiltinPrototype {
     fn example() -> Self {
         // BuiltinPrototype isn't serializable by definition.

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -26,7 +26,7 @@ use {
 /// Distributing rewards to stake accounts begins AFTER this many blocks.
 const REWARD_CALCULATION_NUM_BLOCKS: u64 = 1;
 
-#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub(crate) struct PartitionedStakeReward {
     /// Stake account address
@@ -55,7 +55,7 @@ impl PartitionedStakeReward {
 
 type PartitionedStakeRewards = Vec<PartitionedStakeReward>;
 
-#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct StartBlockHeightAndRewards {
     /// the block height of the slot at which rewards distribution began

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -26,7 +26,8 @@ use {
 /// Distributing rewards to stake accounts begins AFTER this many blocks.
 const REWARD_CALCULATION_NUM_BLOCKS: u64 = 1;
 
-#[derive(AbiExample, Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub(crate) struct PartitionedStakeReward {
     /// Stake account address
     pub stake_pubkey: Pubkey,
@@ -54,7 +55,8 @@ impl PartitionedStakeReward {
 
 type PartitionedStakeRewards = Vec<PartitionedStakeReward>;
 
-#[derive(AbiExample, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct StartBlockHeightAndRewards {
     /// the block height of the slot at which rewards distribution began
     pub(crate) distribution_starting_block_height: u64,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -63,7 +63,8 @@ pub(crate) struct StartBlockHeightAndRewards {
 }
 
 /// Represent whether bank is in the reward phase or not.
-#[derive(AbiExample, AbiEnumVisitor, Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub(crate) enum EpochRewardStatus {
     /// this bank is in the reward phase.
     /// Contents are the start point for epoch reward calculation,

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -550,7 +550,8 @@ mod tests {
         // This some what long test harness is required to freeze the ABI of
         // Bank's serialization due to versioned nature
         #[frozen_abi(digest = "7Cze6NqwQMsqcEjtkMSQhLPykCW8dYffwkHpNuysjwTN")]
-        #[derive(Serialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+        #[derive(Serialize)]
         pub struct BankAbiTestWrapperNewer {
             #[serde(serialize_with = "wrapper")]
             bank: Bank,

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -549,7 +549,11 @@ mod tests {
 
         // This some what long test harness is required to freeze the ABI of
         // Bank's serialization due to versioned nature
-        #[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "7Cze6NqwQMsqcEjtkMSQhLPykCW8dYffwkHpNuysjwTN"))]
+        #[cfg_attr(
+            feature = "frozen-abi",
+            derive(AbiExample),
+            frozen_abi(digest = "7Cze6NqwQMsqcEjtkMSQhLPykCW8dYffwkHpNuysjwTN")
+        )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapperNewer {
             #[serde(serialize_with = "wrapper")]

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -549,8 +549,7 @@ mod tests {
 
         // This some what long test harness is required to freeze the ABI of
         // Bank's serialization due to versioned nature
-        #[frozen_abi(digest = "7Cze6NqwQMsqcEjtkMSQhLPykCW8dYffwkHpNuysjwTN")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+        #[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "7Cze6NqwQMsqcEjtkMSQhLPykCW8dYffwkHpNuysjwTN"))]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapperNewer {
             #[serde(serialize_with = "wrapper")]

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -16,7 +16,8 @@ pub struct NodeVoteAccounts {
     pub total_stake: u64,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, AbiExample, PartialEq)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct EpochStakes {
     #[serde(with = "crate::stakes::serde_stakes_enum_compat")]
     stakes: Arc<StakesEnum>,

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -9,7 +9,8 @@ use {
 pub type NodeIdToVoteAccounts = HashMap<Pubkey, NodeVoteAccounts>;
 pub type EpochAuthorizedVoters = HashMap<Pubkey, Pubkey>;
 
-#[derive(Clone, Serialize, Debug, Deserialize, Default, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Serialize, Debug, Deserialize, Default, PartialEq, Eq)]
 pub struct NodeVoteAccounts {
     pub vote_accounts: Vec<Pubkey>,
     pub total_stake: u64,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -40,7 +40,8 @@ extern crate solana_metrics;
 #[macro_use]
 extern crate serde_derive;
 
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
 
 // Don't make crates import the SVM if all they need is this module.

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -832,7 +832,7 @@ impl<'a> Serialize for SerializableAccountsDb<'a> {
 }
 
 #[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
-impl<'a, C> solana_frozen_abi::abi_example::IgnoreAsHelper for SerializableAccountsDb<'a, C> {}
+impl<'a> solana_frozen_abi::abi_example::IgnoreAsHelper for SerializableAccountsDb<'a> {}
 
 #[allow(clippy::too_many_arguments)]
 fn reconstruct_bank_from_fields<E>(

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -107,14 +107,16 @@ pub struct BankIncrementalSnapshotPersistence {
     pub incremental_capitalization: u64,
 }
 
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct BankHashInfo {
     accounts_delta_hash: SerdeAccountsDeltaHash,
     accounts_hash: SerdeAccountsHash,
     stats: BankHashStats,
 }
 
-#[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 struct UnusedAccounts {
     unused1: HashSet<Pubkey>,
     unused2: HashSet<Pubkey>,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -283,7 +283,7 @@ impl<'a> From<crate::bank::BankFieldsToSerialize<'a>> for SerializableVersionedB
     }
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl<'a> solana_frozen_abi::abi_example::IgnoreAsHelper for SerializableVersionedBank<'a> {}
 
 /// Helper type to wrap BufReader streams when deserializing and reconstructing from either just a
@@ -831,8 +831,8 @@ impl<'a> Serialize for SerializableAccountsDb<'a> {
     }
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
-impl<'a> solana_frozen_abi::abi_example::IgnoreAsHelper for SerializableAccountsDb<'a> {}
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
+impl<'a, C> solana_frozen_abi::abi_example::IgnoreAsHelper for SerializableAccountsDb<'a, C> {}
 
 #[allow(clippy::too_many_arguments)]
 fn reconstruct_bank_from_fields<E>(

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -71,7 +71,8 @@ pub(crate) use {
 
 const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;
 
-#[derive(Clone, Debug, Deserialize, Serialize, AbiExample, PartialEq, Eq)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct AccountsDbFields<T>(
     HashMap<Slot, Vec<T>>,
     StoredMetaWriteVersion,
@@ -93,7 +94,8 @@ pub struct AccountsDbFields<T>(
 /// NOT be consistent with the bank's capitalization. It is not feasible to
 /// calculate a capitalization delta that is correct given just incremental
 /// slots account data and the full snapshot's capitalization.
-#[derive(Serialize, Deserialize, AbiExample, Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct BankIncrementalSnapshotPersistence {
     /// slot of full snapshot
     pub full_slot: Slot,

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -36,5 +36,5 @@ impl From<&AccountStorageEntry> for SerializableAccountStorageEntry {
     }
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl solana_frozen_abi::abi_example::IgnoreAsHelper for SerializableAccountStorageEntry {}

--- a/runtime/src/serde_snapshot/utils.rs
+++ b/runtime/src/serde_snapshot/utils.rs
@@ -2,7 +2,7 @@ use serde::{
     ser::{SerializeSeq, SerializeTuple},
     Serialize, Serializer,
 };
-#[cfg(all(test, RUSTC_WITH_SPECIALIZATION))]
+#[cfg(all(test, RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 use solana_frozen_abi::abi_example::IgnoreAsHelper;
 
 // consumes an iterator and returns an object that will serialize as a serde seq
@@ -17,7 +17,7 @@ where
         iter: std::cell::RefCell<Option<I>>,
     }
 
-    #[cfg(all(test, RUSTC_WITH_SPECIALIZATION))]
+    #[cfg(all(test, RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
     impl<I> IgnoreAsHelper for SerializableSequencedIterator<I> {}
 
     impl<I> Serialize for SerializableSequencedIterator<I>
@@ -56,7 +56,7 @@ where
         iter: std::cell::RefCell<Option<I>>,
     }
 
-    #[cfg(all(test, RUSTC_WITH_SPECIALIZATION))]
+    #[cfg(all(test, RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
     impl<I> IgnoreAsHelper for SerializableSequencedIterator<I> {}
 
     impl<I> Serialize for SerializableSequencedIterator<I>
@@ -95,7 +95,7 @@ where
         iter: std::cell::RefCell<Option<I>>,
     }
 
-    #[cfg(all(test, RUSTC_WITH_SPECIALIZATION))]
+    #[cfg(all(test, RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
     impl<I> IgnoreAsHelper for SerializableMappedIterator<I> {}
 
     impl<K, V, I> Serialize for SerializableMappedIterator<I>

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -1,4 +1,4 @@
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 use solana_frozen_abi::abi_example::AbiExample;
 use {
     solana_sdk::{
@@ -91,7 +91,7 @@ impl<S, T> PartialEq<StakeAccount<S>> for StakeAccount<T> {
     }
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl AbiExample for StakeAccount<Delegation> {
     fn example() -> Self {
         use solana_sdk::{

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 /// The SDK's stake history with clone-on-write semantics
-#[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct StakeHistory(Arc<StakeHistoryInner>);
 
 impl Deref for StakeHistory {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -50,7 +50,8 @@ pub enum InvalidCacheEntryReason {
 
 type StakeAccount = stake_account::StakeAccount<Delegation>;
 
-#[derive(Default, Debug, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Default, Debug)]
 pub(crate) struct StakesCache(RwLock<Stakes<StakeAccount>>);
 
 impl StakesCache {
@@ -179,7 +180,8 @@ impl StakesCache {
 /// account and StakeStateV2 deserialized from the account. Doing so, will remove
 /// the need to load the stake account from accounts-db when working with
 /// stake-delegations.
-#[derive(Default, Clone, PartialEq, Debug, Deserialize, Serialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Default, Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct Stakes<T: Clone> {
     /// vote accounts
     vote_accounts: VoteAccounts,
@@ -204,7 +206,8 @@ pub struct Stakes<T: Clone> {
 // Below type allows EpochStakes to include either a Stakes<StakeAccount> or
 // Stakes<Delegation> and so bypass the conversion cost between the two at the
 // epoch boundary.
-#[derive(Debug, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug)]
 pub enum StakesEnum {
     Accounts(Stakes<StakeAccount>),
     Delegations(Stakes<Delegation>),

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -34,7 +34,8 @@ type SlotDeltaMap<T> = HashMap<Slot, Status<T>>;
 // construct a new one. Usually derived from a status cache's `SlotDeltaMap`
 pub type SlotDelta<T> = (Slot, bool, Status<T>);
 
-#[derive(Clone, Debug, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug)]
 pub struct StatusCache<T: Serialize + Clone> {
     cache: KeyStatusMap<T>,
     roots: HashSet<Slot>,

--- a/scripts/coverage-in-disk.sh
+++ b/scripts/coverage-in-disk.sh
@@ -72,8 +72,8 @@ fi
 #shellcheck source=ci/common/limit-threads.sh
 source ci/common/limit-threads.sh
 
-RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov --no-run "${packages[@]}"
-if RUST_LOG=solana=trace _ "$cargo" nightly test --jobs "$JOBS" --target-dir target/cov "${packages[@]}" 2> target/cov/coverage-stderr.log; then
+RUST_LOG=solana=trace _ "$cargo" nightly test --features frozen-abi --jobs "$JOBS" --target-dir target/cov --no-run "${packages[@]}"
+if RUST_LOG=solana=trace _ "$cargo" nightly test --features frozen-abi --jobs "$JOBS" --target-dir target/cov "${packages[@]}" 2> target/cov/coverage-stderr.log; then
   test_status=0
 else
   test_status=$?

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -57,7 +57,7 @@ TEST_ARGS=(
 # redirecting the stderr altogether on CI, where all tests are run unlike
 # developing.
 RUST_LOG="solana=trace,agave=trace,$RUST_LOG" INTERCEPT_OUTPUT=/dev/null "$here/../ci/intercept.sh" \
-  cargo +"$rust_nightly" test --target-dir "$here/../target/cov" "${PACKAGES[@]}" -- "${TEST_ARGS[@]}"
+  cargo +"$rust_nightly" test --features frozen-abi --target-dir "$here/../target/cov" "${PACKAGES[@]}" -- "${TEST_ARGS[@]}"
 
 # Generate test reports
 echo "--- grcov"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -17,26 +17,28 @@ edition = { workspace = true }
 program = []
 
 default = [
-  "full" # functionality that is not compatible or needed for on-chain programs
+  "full", # functionality that is not compatible or needed for on-chain programs
 ]
 full = [
-    "byteorder",
-    "chrono",
-    "generic-array",
-    "memmap2",
-    "rand",
-    "rand0-7",
-    "serde_json",
-    "ed25519-dalek",
-    "ed25519-dalek-bip32",
-    "libsecp256k1",
-    "sha3",
-    "digest",
+  "byteorder",
+  "chrono",
+  "generic-array",
+  "memmap2",
+  "rand",
+  "rand0-7",
+  "serde_json",
+  "ed25519-dalek",
+  "ed25519-dalek-bip32",
+  "libsecp256k1",
+  "sha3",
+  "digest",
 ]
-dev-context-only-utils = [
-  "qualifier_attr"
+dev-context-only-utils = ["qualifier_attr"]
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-program/frozen-abi",
 ]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [dependencies]
 bincode = { workspace = true }
@@ -51,9 +53,12 @@ derivation-path = { workspace = true }
 digest = { workspace = true, optional = true }
 ed25519-dalek = { workspace = true, optional = true }
 ed25519-dalek-bip32 = { workspace = true, optional = true }
-generic-array = { workspace = true, features = ["serde", "more_lengths"], optional = true }
+generic-array = { workspace = true, features = [
+  "serde",
+  "more_lengths",
+], optional = true }
 hmac = { workspace = true }
-itertools =  { workspace = true }
+itertools = { workspace = true }
 lazy_static = { workspace = true }
 libsecp256k1 = { workspace = true, optional = true, features = ["hmac"] }
 log = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -36,6 +36,7 @@ full = [
 dev-context-only-utils = [
   "qualifier_attr"
 ]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [dependencies]
 bincode = { workspace = true }
@@ -72,8 +73,8 @@ serde_with = { workspace = true, features = ["macros"] }
 sha2 = { workspace = true }
 sha3 = { workspace = true, optional = true }
 siphasher = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-program = { workspace = true }
 solana-sdk-macro = { workspace = true }
 thiserror = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -96,7 +96,6 @@ assert_matches = { workspace = true }
 curve25519-dalek = { workspace = true }
 hex = { workspace = true }
 solana-logger = { workspace = true }
-solana-program = { workspace = true, features = ["frozen-abi"] }
 solana-sdk = { path = ".", features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 tiny-bip39 = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -17,23 +17,25 @@ edition = { workspace = true }
 program = []
 
 default = [
-  "full", # functionality that is not compatible or needed for on-chain programs
+  "full" # functionality that is not compatible or needed for on-chain programs
 ]
 full = [
-  "byteorder",
-  "chrono",
-  "generic-array",
-  "memmap2",
-  "rand",
-  "rand0-7",
-  "serde_json",
-  "ed25519-dalek",
-  "ed25519-dalek-bip32",
-  "libsecp256k1",
-  "sha3",
-  "digest",
+    "byteorder",
+    "chrono",
+    "generic-array",
+    "memmap2",
+    "rand",
+    "rand0-7",
+    "serde_json",
+    "ed25519-dalek",
+    "ed25519-dalek-bip32",
+    "libsecp256k1",
+    "sha3",
+    "digest",
 ]
-dev-context-only-utils = ["qualifier_attr"]
+dev-context-only-utils = [
+  "qualifier_attr"
+]
 frozen-abi = [
   "dep:solana-frozen-abi",
   "dep:solana-frozen-abi-macro",
@@ -53,12 +55,9 @@ derivation-path = { workspace = true }
 digest = { workspace = true, optional = true }
 ed25519-dalek = { workspace = true, optional = true }
 ed25519-dalek-bip32 = { workspace = true, optional = true }
-generic-array = { workspace = true, features = [
-  "serde",
-  "more_lengths",
-], optional = true }
+generic-array = { workspace = true, features = ["serde", "more_lengths"], optional = true }
 hmac = { workspace = true }
-itertools = { workspace = true }
+itertools =  { workspace = true }
 lazy_static = { workspace = true }
 libsecp256k1 = { workspace = true, optional = true, features = ["hmac"] }
 log = { workspace = true }

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -27,8 +27,7 @@ use {
 
 /// An Account with data that is stored on chain
 #[repr(C)]
-#[frozen_abi(digest = "HawRVHh7t4d3H3bitWHFt25WhhoDmbJMCfWdESQQoYEy")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "HawRVHh7t4d3H3bitWHFt25WhhoDmbJMCfWdESQQoYEy"))]
 #[derive(Deserialize, PartialEq, Eq, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Account {
@@ -52,8 +51,7 @@ mod account_serialize {
         serde::{ser::Serializer, Serialize},
     };
     #[repr(C)]
-    #[frozen_abi(digest = "HawRVHh7t4d3H3bitWHFt25WhhoDmbJMCfWdESQQoYEy")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+    #[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "HawRVHh7t4d3H3bitWHFt25WhhoDmbJMCfWdESQQoYEy"))]
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
     struct Account<'a> {

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -28,7 +28,8 @@ use {
 /// An Account with data that is stored on chain
 #[repr(C)]
 #[frozen_abi(digest = "HawRVHh7t4d3H3bitWHFt25WhhoDmbJMCfWdESQQoYEy")]
-#[derive(Deserialize, PartialEq, Eq, Clone, Default, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Deserialize, PartialEq, Eq, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Account {
     /// lamports in the account
@@ -52,7 +53,8 @@ mod account_serialize {
     };
     #[repr(C)]
     #[frozen_abi(digest = "HawRVHh7t4d3H3bitWHFt25WhhoDmbJMCfWdESQQoYEy")]
-    #[derive(Serialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+    #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
     struct Account<'a> {
         lamports: u64,

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -106,7 +106,8 @@ impl Serialize for AccountSharedData {
 /// An Account with data that is stored on chain
 /// This will be the in-memory representation of the 'Account' struct data.
 /// The existing 'Account' structure cannot easily change due to downstream projects.
-#[derive(PartialEq, Eq, Clone, Default, AbiExample, Deserialize)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(PartialEq, Eq, Clone, Default, Deserialize)]
 #[serde(from = "Account")]
 pub struct AccountSharedData {
     /// lamports in the account

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -27,7 +27,11 @@ use {
 
 /// An Account with data that is stored on chain
 #[repr(C)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "HawRVHh7t4d3H3bitWHFt25WhhoDmbJMCfWdESQQoYEy"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "HawRVHh7t4d3H3bitWHFt25WhhoDmbJMCfWdESQQoYEy")
+)]
 #[derive(Deserialize, PartialEq, Eq, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Account {
@@ -51,7 +55,11 @@ mod account_serialize {
         serde::{ser::Serializer, Serialize},
     };
     #[repr(C)]
-    #[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "HawRVHh7t4d3H3bitWHFt25WhhoDmbJMCfWdESQQoYEy"))]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(AbiExample),
+        frozen_abi(digest = "HawRVHh7t4d3H3bitWHFt25WhhoDmbJMCfWdESQQoYEy")
+    )]
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
     struct Account<'a> {

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -11,16 +11,7 @@ crate::declare_id!("ComputeBudget111111111111111111111111111111");
 
 /// Compute Budget Instructions
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
-#[derive(
-    BorshDeserialize,
-    BorshSerialize,
-    Clone,
-    Debug,
-    Deserialize,
-    PartialEq,
-    Eq,
-    Serialize,
-)]
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub enum ComputeBudgetInstruction {
     Unused, // deprecated variant, reserved value.
     /// Request a specific transaction-wide program heap region size in bytes.

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -10,9 +10,8 @@ use {
 crate::declare_id!("ComputeBudget111111111111111111111111111111");
 
 /// Compute Budget Instructions
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
 #[derive(
-    AbiExample,
-    AbiEnumVisitor,
     BorshDeserialize,
     BorshSerialize,
     Clone,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -1034,7 +1034,7 @@ lazy_static! {
 }
 
 /// `FeatureSet` holds the set of currently active/inactive runtime features
-#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FeatureSet {
     pub active: HashMap<Pubkey, Slot>,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -1034,7 +1034,8 @@ lazy_static! {
 }
 
 /// `FeatureSet` holds the set of currently active/inactive runtime features
-#[derive(AbiExample, Debug, Clone, Eq, PartialEq)]
+#[cfg(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FeatureSet {
     pub active: HashMap<Pubkey, Slot>,
     pub inactive: HashSet<Pubkey>,

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -192,7 +192,7 @@ impl Default for FeeStructure {
     }
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl ::solana_frozen_abi::abi_example::AbiExample for FeeStructure {
     fn example() -> Self {
         FeeStructure::default()

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -41,7 +41,8 @@ pub const DEFAULT_GENESIS_DOWNLOAD_PATH: &str = "/genesis.tar.bz2";
 pub const UNUSED_DEFAULT: u64 = 1024;
 
 // The order can't align with release lifecycle only to remain ABI-compatible...
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, AbiEnumVisitor, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, AbiEnumVisitor)]
 pub enum ClusterType {
     Testnet,
     MainnetBeta,

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -41,8 +41,8 @@ pub const DEFAULT_GENESIS_DOWNLOAD_PATH: &str = "/genesis.tar.bz2";
 pub const UNUSED_DEFAULT: u64 = 1024;
 
 // The order can't align with release lifecycle only to remain ABI-compatible...
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, AbiEnumVisitor)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClusterType {
     Testnet,
     MainnetBeta,

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -84,8 +84,7 @@ impl FromStr for ClusterType {
     }
 }
 
-#[frozen_abi(digest = "3V3ZVRyzNhRfe8RJwDeGpeTP8xBWGGFBEbwTkvKKVjEa")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "3V3ZVRyzNhRfe8RJwDeGpeTP8xBWGGFBEbwTkvKKVjEa"))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct GenesisConfig {
     /// when the network (bootstrap validator) was started relative to the UNIX Epoch

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -84,7 +84,11 @@ impl FromStr for ClusterType {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "3V3ZVRyzNhRfe8RJwDeGpeTP8xBWGGFBEbwTkvKKVjEa"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "3V3ZVRyzNhRfe8RJwDeGpeTP8xBWGGFBEbwTkvKKVjEa")
+)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct GenesisConfig {
     /// when the network (bootstrap validator) was started relative to the UNIX Epoch

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -85,7 +85,8 @@ impl FromStr for ClusterType {
 }
 
 #[frozen_abi(digest = "3V3ZVRyzNhRfe8RJwDeGpeTP8xBWGGFBEbwTkvKKVjEa")]
-#[derive(Serialize, Deserialize, Debug, Clone, AbiExample, PartialEq)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct GenesisConfig {
     /// when the network (bootstrap validator) was started relative to the UNIX Epoch
     pub creation_time: UnixTimestamp,

--- a/sdk/src/hard_forks.rs
+++ b/sdk/src/hard_forks.rs
@@ -8,7 +8,8 @@ use {
     solana_sdk::clock::Slot,
 };
 
-#[derive(Default, Clone, Debug, Deserialize, Serialize, AbiExample, PartialEq, Eq)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Default, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct HardForks {
     hard_forks: Vec<(Slot, usize)>,
 }

--- a/sdk/src/inflation.rs
+++ b/sdk/src/inflation.rs
@@ -1,6 +1,7 @@
 //! configuration for network inflation
 
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Copy, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Copy)]
 #[serde(rename_all = "camelCase")]
 pub struct Inflation {
     /// Initial inflation percentage, from time=0

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -178,7 +178,8 @@ extern crate serde_derive;
 pub extern crate bs58;
 extern crate log as logger;
 
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
 
 #[cfg(test)]

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -57,10 +57,10 @@ impl ::solana_frozen_abi::abi_example::AbiExample for PacketFlags {
     }
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl ::solana_frozen_abi::abi_example::IgnoreAsHelper for PacketFlags {}
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl ::solana_frozen_abi::abi_example::EvenAsOpaque for PacketFlags {
     const TYPE_NAME_MATCHER: &'static str = "::_::InternalBitFlags";
 }

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -40,7 +40,8 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(C)]
 pub struct Meta {
     pub size: usize,
@@ -90,7 +91,8 @@ impl ::solana_frozen_abi::abi_example::EvenAsOpaque for PacketFlags {
 // ryoqun's dirty experiments:
 //   https://github.com/ryoqun/serde-array-comparisons
 #[serde_as]
-#[derive(Clone, Eq, Serialize, Deserialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Eq, Serialize, Deserialize)]
 #[repr(C)]
 pub struct Packet {
     // Bytes past Packet.meta.size are not valid to read from.

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -50,7 +50,7 @@ pub struct Meta {
     pub flags: PacketFlags,
 }
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl ::solana_frozen_abi::abi_example::AbiExample for PacketFlags {
     fn example() -> Self {
         Self::empty()

--- a/sdk/src/poh_config.rs
+++ b/sdk/src/poh_config.rs
@@ -5,7 +5,8 @@ use {
     std::time::Duration,
 };
 
-#[derive(Serialize, Deserialize, Clone, Debug, AbiExample, Eq, PartialEq)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct PohConfig {
     /// The target tick rate of the cluster.
     pub target_tick_duration: Duration,

--- a/sdk/src/rent_collector.rs
+++ b/sdk/src/rent_collector.rs
@@ -11,7 +11,8 @@ use solana_sdk::{
     rent::{Rent, RentDue},
 };
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct RentCollector {
     pub epoch: Epoch,
     pub epoch_schedule: EpochSchedule,

--- a/sdk/src/reserved_account_keys.rs
+++ b/sdk/src/reserved_account_keys.rs
@@ -24,7 +24,7 @@ mod zk_token_proof_program {
 
 // ReservedAccountKeys is not serialized into or deserialized from bank
 // snapshots but the bank requires this trait to be implemented anyways.
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl ::solana_frozen_abi::abi_example::AbiExample for ReservedAccountKeys {
     fn example() -> Self {
         // ReservedAccountKeys is not Serialize so just rely on Default.

--- a/sdk/src/reward_info.rs
+++ b/sdk/src/reward_info.rs
@@ -1,6 +1,7 @@
 use crate::reward_type::RewardType;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, AbiExample, Clone, Copy)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
 pub struct RewardInfo {
     pub reward_type: RewardType,
     /// Reward amount

--- a/sdk/src/reward_type.rs
+++ b/sdk/src/reward_type.rs
@@ -2,7 +2,8 @@
 
 use std::fmt;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, AbiExample, AbiEnumVisitor, Clone, Copy)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
 pub enum RewardType {
     Fee,
     Rent,

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -21,8 +21,9 @@ pub const SIGNATURE_BYTES: usize = 64;
 const MAX_BASE58_SIGNATURE_LEN: usize = 88;
 
 #[repr(transparent)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(
-    Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash, AbiExample,
+    Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash
 )]
 pub struct Signature(GenericArray<u8, U64>);
 

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -22,9 +22,7 @@ const MAX_BASE58_SIGNATURE_LEN: usize = 88;
 
 #[repr(transparent)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(
-    Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash
-)]
+#[derive(Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Signature(GenericArray<u8, U64>);
 
 impl crate::sanitize::Sanitize for Signature {}

--- a/sdk/src/transaction/error.rs
+++ b/sdk/src/transaction/error.rs
@@ -10,9 +10,7 @@ use {
 
 /// Reasons a transaction might be rejected.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
-#[derive(
-    Error, Serialize, Deserialize, Debug, PartialEq, Eq, Clone
-)]
+#[derive(Error, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum TransactionError {
     /// An account is already being processed in another transaction in a way
     /// that does not support parallelism

--- a/sdk/src/transaction/error.rs
+++ b/sdk/src/transaction/error.rs
@@ -9,8 +9,9 @@ use {
 };
 
 /// Reasons a transaction might be rejected.
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
 #[derive(
-    Error, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, AbiExample, AbiEnumVisitor,
+    Error, Serialize, Deserialize, Debug, PartialEq, Eq, Clone
 )]
 pub enum TransactionError {
     /// An account is already being processed in another transaction in a way

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -169,7 +169,8 @@ pub type Result<T> = result::Result<T, TransactionError>;
 /// redundantly specifying the fee-payer is not strictly required.
 #[wasm_bindgen]
 #[frozen_abi(digest = "FZtncnS1Xk8ghHfKiXE5oGiUbw2wJhmfXQuNgQR3K6Mc")]
-#[derive(Debug, PartialEq, Default, Eq, Clone, Serialize, Deserialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, PartialEq, Default, Eq, Clone, Serialize, Deserialize)]
 pub struct Transaction {
     /// A set of signatures of a serialized [`Message`], signed by the first
     /// keys of the `Message`'s [`account_keys`], where the number of signatures

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -168,7 +168,11 @@ pub type Result<T> = result::Result<T, TransactionError>;
 /// transaction's `Message` is both a signer and the expected fee-payer, then
 /// redundantly specifying the fee-payer is not strictly required.
 #[wasm_bindgen]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "FZtncnS1Xk8ghHfKiXE5oGiUbw2wJhmfXQuNgQR3K6Mc"))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "FZtncnS1Xk8ghHfKiXE5oGiUbw2wJhmfXQuNgQR3K6Mc")
+)]
 #[derive(Debug, PartialEq, Default, Eq, Clone, Serialize, Deserialize)]
 pub struct Transaction {
     /// A set of signatures of a serialized [`Message`], signed by the first

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -168,8 +168,7 @@ pub type Result<T> = result::Result<T, TransactionError>;
 /// transaction's `Message` is both a signer and the expected fee-payer, then
 /// redundantly specifying the fee-payer is not strictly required.
 #[wasm_bindgen]
-#[frozen_abi(digest = "FZtncnS1Xk8ghHfKiXE5oGiUbw2wJhmfXQuNgQR3K6Mc")]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample), frozen_abi(digest = "FZtncnS1Xk8ghHfKiXE5oGiUbw2wJhmfXQuNgQR3K6Mc"))]
 #[derive(Debug, PartialEq, Default, Eq, Clone, Serialize, Deserialize)]
 pub struct Transaction {
     /// A set of signatures of a serialized [`Message`], signed by the first

--- a/sdk/src/transaction/versioned/mod.rs
+++ b/sdk/src/transaction/versioned/mod.rs
@@ -47,7 +47,8 @@ impl TransactionVersion {
 
 // NOTE: Serialization-related changes must be paired with the direct read at sigverify.
 /// An atomic transaction
-#[derive(Debug, PartialEq, Default, Eq, Clone, Serialize, Deserialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, PartialEq, Default, Eq, Clone, Serialize, Deserialize)]
 pub struct VersionedTransaction {
     /// List of signatures
     #[serde(with = "short_vec")]

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -45,4 +45,9 @@ rustc_version = { workspace = true }
 
 [features]
 dev-context-only-utils = []
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-program-runtime/frozen-abi",
+    "solana-sdk/frozen-abi",
+]

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -16,8 +16,8 @@ percentage = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-loader-v4-program = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
@@ -45,3 +45,4 @@ rustc_version = { workspace = true }
 
 [features]
 dev-context-only-utils = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/svm/src/lib.rs
+++ b/svm/src/lib.rs
@@ -17,5 +17,6 @@ pub mod transaction_results;
 #[macro_use]
 extern crate solana_metrics;
 
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -18,7 +18,7 @@ use {
 #[derive(Debug, Default, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
 pub struct MessageProcessor {}
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl ::solana_frozen_abi::abi_example::AbiExample for MessageProcessor {
     fn example() -> Self {
         // MessageProcessor's fields are #[serde(skip)]-ed and not Serialize

--- a/svm/src/runtime_config.rs
+++ b/svm/src/runtime_config.rs
@@ -1,6 +1,6 @@
 use solana_program_runtime::compute_budget::ComputeBudget;
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
+#[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl ::solana_frozen_abi::abi_example::AbiExample for RuntimeConfig {
     fn example() -> Self {
         // RuntimeConfig is not Serialize so just rely on Default.

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -84,7 +84,7 @@ impl ExecutionRecordingConfig {
     }
 }
 
-#[derive(AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub struct TransactionBatchProcessor<FG: ForkGraph> {
     /// Bank slot (i.e. block)
     slot: Slot,

--- a/test-abi.sh
+++ b/test-abi.sh
@@ -5,4 +5,4 @@
 
 here=$(dirname "$0")
 set -x
-exec "${here}/cargo" nightly test --lib -- test_abi_ --nocapture
+exec "${here}/cargo" nightly test --features frozen-abi --lib -- test_abi_ --nocapture

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -20,7 +20,11 @@ solana-sdk = { workspace = true }
 
 [features]
 dummy-for-ci-check = []
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-sdk/frozen-abi",
+]
 
 [lib]
 name = "solana_version"

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -14,12 +14,13 @@ log = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-sdk = { workspace = true }
 
 [features]
 dummy-for-ci-check = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [lib]
 name = "solana_version"

--- a/version/src/legacy.rs
+++ b/version/src/legacy.rs
@@ -6,7 +6,8 @@ use {
 };
 
 // Older version structure used earlier 1.3.x releases
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct LegacyVersion1 {
     major: u16,
     minor: u16,
@@ -16,7 +17,8 @@ pub struct LegacyVersion1 {
 
 impl Sanitize for LegacyVersion1 {}
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct LegacyVersion2 {
     pub major: u16,
     pub minor: u16,

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -7,7 +7,8 @@ use {
     solana_sdk::{sanitize::Sanitize, serde_varint},
     std::{convert::TryInto, fmt},
 };
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
 
 mod legacy;

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -22,7 +22,8 @@ enum ClientId {
     Unknown(u16),
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Version {
     #[serde(with = "serde_varint")]
     pub major: u16,

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -15,8 +15,8 @@ itertools = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
-solana-frozen-abi = { workspace = true }
-solana-frozen-abi-macro = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-sdk = { workspace = true }
 thiserror = { workspace = true }
 
@@ -36,3 +36,4 @@ rustc_version = { workspace = true }
 
 [features]
 dev-context-only-utils = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -36,4 +36,8 @@ rustc_version = { workspace = true }
 
 [features]
 dev-context-only-utils = []
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-sdk/frozen-abi",
+]

--- a/vote/src/lib.rs
+++ b/vote/src/lib.rs
@@ -9,5 +9,6 @@ pub mod vote_transaction;
 #[macro_use]
 extern crate serde_derive;
 
-#[macro_use]
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -16,7 +16,8 @@ use {
     thiserror::Error,
 };
 
-#[derive(Clone, Debug, PartialEq, AbiExample, Deserialize)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
 #[serde(try_from = "AccountSharedData")]
 pub struct VoteAccount(Arc<VoteAccountInner>);
 

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -28,7 +28,8 @@ pub enum Error {
     InvalidOwner(/*owner:*/ Pubkey),
 }
 
-#[derive(Debug, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug)]
 struct VoteAccountInner {
     account: AccountSharedData,
     vote_state: OnceLock<Result<VoteState, Error>>,
@@ -36,7 +37,8 @@ struct VoteAccountInner {
 
 pub type VoteAccountsHashMap = HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>;
 
-#[derive(Clone, Debug, Deserialize, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(from = "Arc<VoteAccountsHashMap>")]
 pub struct VoteAccounts {
     vote_accounts: Arc<VoteAccountsHashMap>,


### PR DESCRIPTION
#### Summary of Changes
This could have been multiple extremely repetitive PRs but I think it's more efficient this way. It certainly would have taken me much longer to do the same find+replace over and over. 

Aside from the cfg and cfg_attr stuff, this PR also:
- Activates the `frozen-abi` feature in the scripts that are supposed to include ABI tests
- For any crate that has a frozen-abi feature, activates the frozen-abi feature on any relevant dependencies if it's activated in the crate itself
- Changes the dev-dependencies of solana-sdk to no longer activate frozen-abi in solana-program by default. This was added in #1222 

Fixes #1096 
