### PR TITLE
[zk-sdk] Add `pod` modules for sigma and range proofs

### DIFF
--- a/zk-sdk/src/range_proof/mod.rs
+++ b/zk-sdk/src/range_proof/mod.rs
@@ -12,11 +12,11 @@
 
 #![allow(dead_code)]
 
+use crate::{RISTRETTO_POINT_LEN, SCALAR_LEN};
 #[cfg(not(target_os = "solana"))]
 use {
-    crate::encryption::pedersen::{Pedersen, PedersenCommitment, PedersenOpening},
     crate::{
-        encryption::pedersen::{G, H},
+        encryption::pedersen::{Pedersen, PedersenCommitment, PedersenOpening, G, H},
         range_proof::{
             errors::{RangeProofGenerationError, RangeProofVerificationError},
             generators::RangeProofGens,
@@ -37,12 +37,39 @@ use {
 };
 
 pub mod errors;
+pub mod pod;
+
 #[cfg(not(target_os = "solana"))]
 pub mod generators;
 #[cfg(not(target_os = "solana"))]
 pub mod inner_product;
 #[cfg(not(target_os = "solana"))]
 pub mod util;
+
+/// Byte length of a range proof excluding the inner-product proof component
+pub const RANGE_PROOF_MODULO_INNER_PRODUCT_PROOF_LEN: usize =
+    5 * RISTRETTO_POINT_LEN + 2 * SCALAR_LEN;
+
+/// Byte length of an inner-product proof for a vector of length 64
+pub const INNER_PRODUCT_PROOF_U64_LEN: usize = 448;
+
+/// Byte length of a range proof for an unsigned 64-bit number
+pub const RANGE_PROOF_U64_LEN: usize =
+    INNER_PRODUCT_PROOF_U64_LEN + RANGE_PROOF_MODULO_INNER_PRODUCT_PROOF_LEN;
+
+/// Byte length of an inner-product proof for a vector of length 128
+pub const INNER_PRODUCT_PROOF_U128_LEN: usize = 512;
+
+/// Byte length of a range proof for an unsigned 128-bit number
+pub const RANGE_PROOF_U128_LEN: usize =
+    INNER_PRODUCT_PROOF_U128_LEN + RANGE_PROOF_MODULO_INNER_PRODUCT_PROOF_LEN;
+
+/// Byte length of an inner-product proof for a vector of length 256
+pub const INNER_PRODUCT_PROOF_U256_LEN: usize = 576;
+
+/// Byte length of a range proof for an unsigned 256-bit number
+pub const RANGE_PROOF_U256_LEN: usize =
+    INNER_PRODUCT_PROOF_U256_LEN + RANGE_PROOF_MODULO_INNER_PRODUCT_PROOF_LEN;
 
 #[allow(non_snake_case)]
 #[cfg(not(target_os = "solana"))]

--- a/zk-sdk/src/range_proof/pod.rs
+++ b/zk-sdk/src/range_proof/pod.rs
@@ -1,0 +1,158 @@
+//! Plain Old Data types for range proofs.
+
+#[cfg(not(target_os = "solana"))]
+use crate::{
+    range_proof::{self as decoded, errors::RangeProofVerificationError},
+    UNIT_LEN,
+};
+use crate::{
+    zk_token_elgamal::pod::{Pod, Zeroable},
+    RISTRETTO_POINT_LEN, SCALAR_LEN,
+};
+
+/// Byte length of a range proof excluding the inner-product proof component
+const RANGE_PROOF_MODULO_INNER_PRODUCT_PROOF_LEN: usize = 5 * RISTRETTO_POINT_LEN + 2 * SCALAR_LEN;
+
+/// Byte length of an inner-product proof for a vector of length 64
+const INNER_PRODUCT_PROOF_U64_LEN: usize = 448;
+
+/// Byte length of a range proof for an unsigned 64-bit number
+const RANGE_PROOF_U64_LEN: usize =
+    INNER_PRODUCT_PROOF_U64_LEN + RANGE_PROOF_MODULO_INNER_PRODUCT_PROOF_LEN;
+
+/// Byte length of an inner-product proof for a vector of length 128
+const INNER_PRODUCT_PROOF_U128_LEN: usize = 512;
+
+/// Byte length of a range proof for an unsigned 128-bit number
+const RANGE_PROOF_U128_LEN: usize =
+    INNER_PRODUCT_PROOF_U128_LEN + RANGE_PROOF_MODULO_INNER_PRODUCT_PROOF_LEN;
+
+/// Byte length of an inner-product proof for a vector of length 256
+const INNER_PRODUCT_PROOF_U256_LEN: usize = 576;
+
+/// Byte length of a range proof for an unsigned 256-bit number
+const RANGE_PROOF_U256_LEN: usize =
+    INNER_PRODUCT_PROOF_U256_LEN + RANGE_PROOF_MODULO_INNER_PRODUCT_PROOF_LEN;
+
+/// The `RangeProof` type as a `Pod` restricted to proofs on 64-bit numbers.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct RangeProofU64(pub [u8; RANGE_PROOF_U64_LEN]);
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<decoded::RangeProof> for RangeProofU64 {
+    type Error = RangeProofVerificationError;
+
+    fn try_from(decoded_proof: decoded::RangeProof) -> Result<Self, Self::Error> {
+        if decoded_proof.ipp_proof.serialized_size() != INNER_PRODUCT_PROOF_U64_LEN {
+            return Err(RangeProofVerificationError::Deserialization);
+        }
+
+        let mut buf = [0_u8; RANGE_PROOF_U64_LEN];
+        copy_range_proof_modulo_inner_product_proof(&decoded_proof, &mut buf);
+        buf[RANGE_PROOF_MODULO_INNER_PRODUCT_PROOF_LEN..RANGE_PROOF_U64_LEN]
+            .copy_from_slice(&decoded_proof.ipp_proof.to_bytes());
+        Ok(RangeProofU64(buf))
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<RangeProofU64> for decoded::RangeProof {
+    type Error = RangeProofVerificationError;
+
+    fn try_from(pod_proof: RangeProofU64) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_proof.0)
+    }
+}
+
+/// The `RangeProof` type as a `Pod` restricted to proofs on 128-bit numbers.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct RangeProofU128(pub [u8; RANGE_PROOF_U128_LEN]);
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<decoded::RangeProof> for RangeProofU128 {
+    type Error = RangeProofVerificationError;
+
+    fn try_from(decoded_proof: decoded::RangeProof) -> Result<Self, Self::Error> {
+        if decoded_proof.ipp_proof.serialized_size() != INNER_PRODUCT_PROOF_U128_LEN {
+            return Err(RangeProofVerificationError::Deserialization);
+        }
+
+        let mut buf = [0_u8; RANGE_PROOF_U128_LEN];
+        copy_range_proof_modulo_inner_product_proof(&decoded_proof, &mut buf);
+        buf[RANGE_PROOF_MODULO_INNER_PRODUCT_PROOF_LEN..RANGE_PROOF_U128_LEN]
+            .copy_from_slice(&decoded_proof.ipp_proof.to_bytes());
+        Ok(RangeProofU128(buf))
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<RangeProofU128> for decoded::RangeProof {
+    type Error = RangeProofVerificationError;
+
+    fn try_from(pod_proof: RangeProofU128) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_proof.0)
+    }
+}
+
+/// The `RangeProof` type as a `Pod` restricted to proofs on 256-bit numbers.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct RangeProofU256(pub [u8; RANGE_PROOF_U256_LEN]);
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<decoded::RangeProof> for RangeProofU256 {
+    type Error = RangeProofVerificationError;
+
+    fn try_from(decoded_proof: decoded::RangeProof) -> Result<Self, Self::Error> {
+        if decoded_proof.ipp_proof.serialized_size() != INNER_PRODUCT_PROOF_U256_LEN {
+            return Err(RangeProofVerificationError::Deserialization);
+        }
+
+        let mut buf = [0_u8; RANGE_PROOF_U256_LEN];
+        copy_range_proof_modulo_inner_product_proof(&decoded_proof, &mut buf);
+        buf[RANGE_PROOF_MODULO_INNER_PRODUCT_PROOF_LEN..RANGE_PROOF_U256_LEN]
+            .copy_from_slice(&decoded_proof.ipp_proof.to_bytes());
+        Ok(RangeProofU256(buf))
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<RangeProofU256> for decoded::RangeProof {
+    type Error = RangeProofVerificationError;
+
+    fn try_from(pod_proof: RangeProofU256) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_proof.0)
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+fn copy_range_proof_modulo_inner_product_proof(proof: &decoded::RangeProof, buf: &mut [u8]) {
+    let mut chunks = buf.chunks_mut(UNIT_LEN);
+    chunks.next().unwrap().copy_from_slice(proof.A.as_bytes());
+    chunks.next().unwrap().copy_from_slice(proof.S.as_bytes());
+    chunks.next().unwrap().copy_from_slice(proof.T_1.as_bytes());
+    chunks.next().unwrap().copy_from_slice(proof.T_2.as_bytes());
+    chunks.next().unwrap().copy_from_slice(proof.t_x.as_bytes());
+    chunks
+        .next()
+        .unwrap()
+        .copy_from_slice(proof.t_x_blinding.as_bytes());
+    chunks
+        .next()
+        .unwrap()
+        .copy_from_slice(proof.e_blinding.as_bytes());
+}
+
+// The range proof pod types are wrappers for byte arrays, which are both `Pod` and `Zeroable`. However,
+// the marker traits `bytemuck::Pod` and `bytemuck::Zeroable` can only be derived for power-of-two
+// length byte arrays. Directly implement these traits for the range proof pod types.
+unsafe impl Zeroable for RangeProofU64 {}
+unsafe impl Pod for RangeProofU64 {}
+
+unsafe impl Zeroable for RangeProofU128 {}
+unsafe impl Pod for RangeProofU128 {}
+
+unsafe impl Zeroable for RangeProofU256 {}
+unsafe impl Pod for RangeProofU256 {}

--- a/zk-sdk/src/sigma_proofs/mod.rs
+++ b/zk-sdk/src/sigma_proofs/mod.rs
@@ -8,6 +8,7 @@
 #![allow(dead_code, unused_imports)]
 
 pub mod errors;
+pub mod pod;
 
 #[cfg(not(target_os = "solana"))]
 pub mod batched_grouped_ciphertext_validity;
@@ -23,6 +24,33 @@ pub mod percentage_with_cap;
 pub mod pubkey;
 #[cfg(not(target_os = "solana"))]
 pub mod zero_ciphertext;
+
+/// Byte length of a ciphertext-commitment equality proof
+pub const CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_LEN: usize = 192;
+
+/// Byte length of a ciphertext-ciphertext equality proof
+pub const CIPHERTEXT_CIPHERTEXT_EQUALITY_PROOF_LEN: usize = 224;
+
+/// Byte length of a grouped ciphertext for 2 handles validity proof
+pub const GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN: usize = 160;
+
+/// Byte length of a grouped ciphertext for 3 handles validity proof
+pub const GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN: usize = 192;
+
+/// Byte length of a batched grouped ciphertext for 2 handles validity proof
+pub const BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN: usize = 160;
+
+/// Byte length of a batched grouped ciphertext for 3 handles validity proof
+pub const BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN: usize = 192;
+
+/// Byte length of a zero-balance proof
+pub const ZERO_BALANCE_PROOF_LEN: usize = 96;
+
+/// Byte length of a fee sigma proof
+pub const FEE_SIGMA_PROOF_LEN: usize = 256;
+
+/// Byte length of a public key validity proof
+pub const PUBKEY_VALIDITY_PROOF_LEN: usize = 64;
 
 #[cfg(not(target_os = "solana"))]
 use {

--- a/zk-sdk/src/sigma_proofs/mod.rs
+++ b/zk-sdk/src/sigma_proofs/mod.rs
@@ -43,11 +43,11 @@ pub const BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN: usize = 160;
 /// Byte length of a batched grouped ciphertext for 3 handles validity proof
 pub const BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN: usize = 192;
 
-/// Byte length of a zero-balance proof
-pub const ZERO_BALANCE_PROOF_LEN: usize = 96;
+/// Byte length of a zero-ciphertext proof
+pub const ZERO_CIPHERTEXT_PROOF_LEN: usize = 96;
 
-/// Byte length of a fee sigma proof
-pub const FEE_SIGMA_PROOF_LEN: usize = 256;
+/// Byte length of a percentage with cap proof
+pub const PERCENTAGE_WITH_CAP_PROOF_LEN: usize = 256;
 
 /// Byte length of a public key validity proof
 pub const PUBKEY_VALIDITY_PROOF_LEN: usize = 64;

--- a/zk-sdk/src/sigma_proofs/pod.rs
+++ b/zk-sdk/src/sigma_proofs/pod.rs
@@ -191,7 +191,7 @@ impl TryFrom<PodZeroCiphertextProof> for ZeroCiphertextProof {
     }
 }
 
-/// The `FeeSigmaProof` type as a `Pod`.
+/// The `PercentageWithCapProof` type as a `Pod`.
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(transparent)]
 pub struct PodPercentageWithCapProof(pub(crate) [u8; PERCENTAGE_WITH_CAP_PROOF_LEN]);

--- a/zk-sdk/src/sigma_proofs/pod.rs
+++ b/zk-sdk/src/sigma_proofs/pod.rs
@@ -170,7 +170,7 @@ impl TryFrom<PodBatchedGroupedCiphertext3HandlesValidityProof>
     }
 }
 
-/// The `ZeroBalanceProof` type as a `Pod`.
+/// The `ZeroCiphertextProof` type as a `Pod`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct PodZeroCiphertextProof(pub(crate) [u8; ZERO_CIPHERTEXT_PROOF_LEN]);

--- a/zk-sdk/src/sigma_proofs/pod.rs
+++ b/zk-sdk/src/sigma_proofs/pod.rs
@@ -173,7 +173,7 @@ impl TryFrom<PodBatchedGroupedCiphertext3HandlesValidityProof>
 /// The `ZeroBalanceProof` type as a `Pod`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct PodZeroCiphertextProof(pub(crate) [u8; ZERO_BALANCE_PROOF_LEN]);
+pub struct PodZeroCiphertextProof(pub(crate) [u8; ZERO_CIPHERTEXT_PROOF_LEN]);
 
 #[cfg(not(target_os = "solana"))]
 impl From<ZeroCiphertextProof> for PodZeroCiphertextProof {
@@ -194,7 +194,7 @@ impl TryFrom<PodZeroCiphertextProof> for ZeroCiphertextProof {
 /// The `FeeSigmaProof` type as a `Pod`.
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(transparent)]
-pub struct PodPercentageWithCapProof(pub(crate) [u8; FEE_SIGMA_PROOF_LEN]);
+pub struct PodPercentageWithCapProof(pub(crate) [u8; PERCENTAGE_WITH_CAP_PROOF_LEN]);
 
 #[cfg(not(target_os = "solana"))]
 impl From<PercentageWithCapProof> for PodPercentageWithCapProof {

--- a/zk-sdk/src/sigma_proofs/pod.rs
+++ b/zk-sdk/src/sigma_proofs/pod.rs
@@ -1,0 +1,283 @@
+//! Plain Old Data types for sigma proofs.
+
+#[cfg(not(target_os = "solana"))]
+use crate::sigma_proofs::{
+    batched_grouped_ciphertext_validity_proof::BatchedGroupedCiphertext2HandlesValidityProof as DecodedBatchedGroupedCiphertext2HandlesValidityProof,
+    batched_grouped_ciphertext_validity_proof::BatchedGroupedCiphertext3HandlesValidityProof as DecodedBatchedGroupedCiphertext3HandlesValidityProof,
+    ciphertext_ciphertext_equality_proof::CiphertextCiphertextEqualityProof as DecodedCiphertextCiphertextEqualityProof,
+    ciphertext_commitment_equality_proof::CiphertextCommitmentEqualityProof as DecodedCiphertextCommitmentEqualityProof,
+    errors::*, fee_proof::FeeSigmaProof as DecodedFeeSigmaProof,
+    grouped_ciphertext_validity_proof::GroupedCiphertext2HandlesValidityProof as DecodedGroupedCiphertext2HandlesValidityProof,
+    grouped_ciphertext_validity_proof::GroupedCiphertext3HandlesValidityProof as DecodedGroupedCiphertext3HandlesValidityProof,
+    pubkey_proof::PubkeyValidityProof as DecodedPubkeyValidityProof,
+    zero_balance_proof::ZeroBalanceProof as DecodedZeroBalanceProof,
+};
+use crate::zk_token_elgamal::pod::{Pod, Zeroable};
+
+/// Byte length of a ciphertext-commitment equality proof
+const CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_LEN: usize = 192;
+
+/// Byte length of a ciphertext-ciphertext equality proof
+const CIPHERTEXT_CIPHERTEXT_EQUALITY_PROOF_LEN: usize = 224;
+
+/// Byte length of a grouped ciphertext for 2 handles validity proof
+const GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN: usize = 160;
+
+/// Byte length of a grouped ciphertext for 3 handles validity proof
+const GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN: usize = 192;
+
+/// Byte length of a batched grouped ciphertext for 2 handles validity proof
+const BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN: usize = 160;
+
+/// Byte length of a batched grouped ciphertext for 3 handles validity proof
+const BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN: usize = 192;
+
+/// Byte length of a zero-balance proof
+const ZERO_BALANCE_PROOF_LEN: usize = 96;
+
+/// Byte length of a fee sigma proof
+const FEE_SIGMA_PROOF_LEN: usize = 256;
+
+/// Byte length of a public key validity proof
+const PUBKEY_VALIDITY_PROOF_LEN: usize = 64;
+
+/// The `CiphertextCommitmentEqualityProof` type as a `Pod`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct CiphertextCommitmentEqualityProof(pub [u8; CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_LEN]);
+
+#[cfg(not(target_os = "solana"))]
+impl From<DecodedCiphertextCommitmentEqualityProof> for CiphertextCommitmentEqualityProof {
+    fn from(decoded_proof: DecodedCiphertextCommitmentEqualityProof) -> Self {
+        Self(decoded_proof.to_bytes())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<CiphertextCommitmentEqualityProof> for DecodedCiphertextCommitmentEqualityProof {
+    type Error = EqualityProofVerificationError;
+
+    fn try_from(pod_proof: CiphertextCommitmentEqualityProof) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_proof.0)
+    }
+}
+
+/// The `CiphertextCiphertextEqualityProof` type as a `Pod`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct CiphertextCiphertextEqualityProof(pub [u8; CIPHERTEXT_CIPHERTEXT_EQUALITY_PROOF_LEN]);
+
+#[cfg(not(target_os = "solana"))]
+impl From<DecodedCiphertextCiphertextEqualityProof> for CiphertextCiphertextEqualityProof {
+    fn from(decoded_proof: DecodedCiphertextCiphertextEqualityProof) -> Self {
+        Self(decoded_proof.to_bytes())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<CiphertextCiphertextEqualityProof> for DecodedCiphertextCiphertextEqualityProof {
+    type Error = EqualityProofVerificationError;
+
+    fn try_from(pod_proof: CiphertextCiphertextEqualityProof) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_proof.0)
+    }
+}
+
+/// The `GroupedCiphertext2HandlesValidityProof` type as a `Pod`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct GroupedCiphertext2HandlesValidityProof(
+    pub [u8; GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN],
+);
+
+#[cfg(not(target_os = "solana"))]
+impl From<DecodedGroupedCiphertext2HandlesValidityProof>
+    for GroupedCiphertext2HandlesValidityProof
+{
+    fn from(decoded_proof: DecodedGroupedCiphertext2HandlesValidityProof) -> Self {
+        Self(decoded_proof.to_bytes())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<GroupedCiphertext2HandlesValidityProof>
+    for DecodedGroupedCiphertext2HandlesValidityProof
+{
+    type Error = ValidityProofVerificationError;
+
+    fn try_from(pod_proof: GroupedCiphertext2HandlesValidityProof) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_proof.0)
+    }
+}
+
+/// The `GroupedCiphertext3HandlesValidityProof` type as a `Pod`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct GroupedCiphertext3HandlesValidityProof(
+    pub [u8; GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN],
+);
+
+#[cfg(not(target_os = "solana"))]
+impl From<DecodedGroupedCiphertext3HandlesValidityProof>
+    for GroupedCiphertext3HandlesValidityProof
+{
+    fn from(decoded_proof: DecodedGroupedCiphertext3HandlesValidityProof) -> Self {
+        Self(decoded_proof.to_bytes())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<GroupedCiphertext3HandlesValidityProof>
+    for DecodedGroupedCiphertext3HandlesValidityProof
+{
+    type Error = ValidityProofVerificationError;
+
+    fn try_from(pod_proof: GroupedCiphertext3HandlesValidityProof) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_proof.0)
+    }
+}
+
+/// The `BatchedGroupedCiphertext2HandlesValidityProof` type as a `Pod`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct BatchedGroupedCiphertext2HandlesValidityProof(
+    pub [u8; BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN],
+);
+
+#[cfg(not(target_os = "solana"))]
+impl From<DecodedBatchedGroupedCiphertext2HandlesValidityProof>
+    for BatchedGroupedCiphertext2HandlesValidityProof
+{
+    fn from(decoded_proof: DecodedBatchedGroupedCiphertext2HandlesValidityProof) -> Self {
+        Self(decoded_proof.to_bytes())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<BatchedGroupedCiphertext2HandlesValidityProof>
+    for DecodedBatchedGroupedCiphertext2HandlesValidityProof
+{
+    type Error = ValidityProofVerificationError;
+
+    fn try_from(
+        pod_proof: BatchedGroupedCiphertext2HandlesValidityProof,
+    ) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_proof.0)
+    }
+}
+
+/// The `BatchedGroupedCiphertext3HandlesValidityProof` type as a `Pod`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct BatchedGroupedCiphertext3HandlesValidityProof(
+    pub [u8; BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN],
+);
+
+#[cfg(not(target_os = "solana"))]
+impl From<DecodedBatchedGroupedCiphertext3HandlesValidityProof>
+    for BatchedGroupedCiphertext3HandlesValidityProof
+{
+    fn from(decoded_proof: DecodedBatchedGroupedCiphertext3HandlesValidityProof) -> Self {
+        Self(decoded_proof.to_bytes())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<BatchedGroupedCiphertext3HandlesValidityProof>
+    for DecodedBatchedGroupedCiphertext3HandlesValidityProof
+{
+    type Error = ValidityProofVerificationError;
+
+    fn try_from(
+        pod_proof: BatchedGroupedCiphertext3HandlesValidityProof,
+    ) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_proof.0)
+    }
+}
+
+/// The `ZeroBalanceProof` type as a `Pod`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct ZeroBalanceProof(pub [u8; ZERO_BALANCE_PROOF_LEN]);
+
+#[cfg(not(target_os = "solana"))]
+impl From<DecodedZeroBalanceProof> for ZeroBalanceProof {
+    fn from(decoded_proof: DecodedZeroBalanceProof) -> Self {
+        Self(decoded_proof.to_bytes())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<ZeroBalanceProof> for DecodedZeroBalanceProof {
+    type Error = ZeroBalanceProofVerificationError;
+
+    fn try_from(pod_proof: ZeroBalanceProof) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_proof.0)
+    }
+}
+
+/// The `FeeSigmaProof` type as a `Pod`.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct FeeSigmaProof(pub [u8; FEE_SIGMA_PROOF_LEN]);
+
+#[cfg(not(target_os = "solana"))]
+impl From<DecodedFeeSigmaProof> for FeeSigmaProof {
+    fn from(decoded_proof: DecodedFeeSigmaProof) -> Self {
+        Self(decoded_proof.to_bytes())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<FeeSigmaProof> for DecodedFeeSigmaProof {
+    type Error = FeeSigmaProofVerificationError;
+
+    fn try_from(pod_proof: FeeSigmaProof) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_proof.0)
+    }
+}
+
+/// The `PubkeyValidityProof` type as a `Pod`.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PubkeyValidityProof(pub [u8; PUBKEY_VALIDITY_PROOF_LEN]);
+
+#[cfg(not(target_os = "solana"))]
+impl From<DecodedPubkeyValidityProof> for PubkeyValidityProof {
+    fn from(decoded_proof: DecodedPubkeyValidityProof) -> Self {
+        Self(decoded_proof.to_bytes())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryFrom<PubkeyValidityProof> for DecodedPubkeyValidityProof {
+    type Error = PubkeyValidityProofVerificationError;
+
+    fn try_from(pod_proof: PubkeyValidityProof) -> Result<Self, Self::Error> {
+        Self::from_bytes(&pod_proof.0)
+    }
+}
+
+// The sigma proof pod types are wrappers for byte arrays, which are both `Pod` and `Zeroable`. However,
+// the marker traits `bytemuck::Pod` and `bytemuck::Zeroable` can only be derived for power-of-two
+// length byte arrays. Directly implement these traits for the sigma proof pod types.
+unsafe impl Zeroable for CiphertextCommitmentEqualityProof {}
+unsafe impl Pod for CiphertextCommitmentEqualityProof {}
+
+unsafe impl Zeroable for CiphertextCiphertextEqualityProof {}
+unsafe impl Pod for CiphertextCiphertextEqualityProof {}
+
+unsafe impl Zeroable for GroupedCiphertext2HandlesValidityProof {}
+unsafe impl Pod for GroupedCiphertext2HandlesValidityProof {}
+
+unsafe impl Zeroable for GroupedCiphertext3HandlesValidityProof {}
+unsafe impl Pod for GroupedCiphertext3HandlesValidityProof {}
+
+unsafe impl Zeroable for BatchedGroupedCiphertext2HandlesValidityProof {}
+unsafe impl Pod for BatchedGroupedCiphertext2HandlesValidityProof {}
+
+unsafe impl Zeroable for BatchedGroupedCiphertext3HandlesValidityProof {}
+unsafe impl Pod for BatchedGroupedCiphertext3HandlesValidityProof {}
+
+unsafe impl Zeroable for ZeroBalanceProof {}
+unsafe impl Pod for ZeroBalanceProof {}

--- a/zk-sdk/src/sigma_proofs/pod.rs
+++ b/zk-sdk/src/sigma_proofs/pod.rs
@@ -2,62 +2,43 @@
 
 #[cfg(not(target_os = "solana"))]
 use crate::sigma_proofs::{
-    batched_grouped_ciphertext_validity_proof::BatchedGroupedCiphertext2HandlesValidityProof as DecodedBatchedGroupedCiphertext2HandlesValidityProof,
-    batched_grouped_ciphertext_validity_proof::BatchedGroupedCiphertext3HandlesValidityProof as DecodedBatchedGroupedCiphertext3HandlesValidityProof,
-    ciphertext_ciphertext_equality_proof::CiphertextCiphertextEqualityProof as DecodedCiphertextCiphertextEqualityProof,
-    ciphertext_commitment_equality_proof::CiphertextCommitmentEqualityProof as DecodedCiphertextCommitmentEqualityProof,
-    errors::*, fee_proof::FeeSigmaProof as DecodedFeeSigmaProof,
-    grouped_ciphertext_validity_proof::GroupedCiphertext2HandlesValidityProof as DecodedGroupedCiphertext2HandlesValidityProof,
-    grouped_ciphertext_validity_proof::GroupedCiphertext3HandlesValidityProof as DecodedGroupedCiphertext3HandlesValidityProof,
-    pubkey_proof::PubkeyValidityProof as DecodedPubkeyValidityProof,
-    zero_balance_proof::ZeroBalanceProof as DecodedZeroBalanceProof,
+    batched_grouped_ciphertext_validity::{
+        BatchedGroupedCiphertext2HandlesValidityProof,
+        BatchedGroupedCiphertext3HandlesValidityProof,
+    },
+    ciphertext_ciphertext_equality::CiphertextCiphertextEqualityProof,
+    ciphertext_commitment_equality::CiphertextCommitmentEqualityProof,
+    grouped_ciphertext_validity::{
+        GroupedCiphertext2HandlesValidityProof, GroupedCiphertext3HandlesValidityProof,
+    },
+    percentage_with_cap::PercentageWithCapProof,
+    pubkey::PubkeyValidityProof,
+    zero_ciphertext::ZeroCiphertextProof,
 };
-use crate::zk_token_elgamal::pod::{Pod, Zeroable};
-
-/// Byte length of a ciphertext-commitment equality proof
-const CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_LEN: usize = 192;
-
-/// Byte length of a ciphertext-ciphertext equality proof
-const CIPHERTEXT_CIPHERTEXT_EQUALITY_PROOF_LEN: usize = 224;
-
-/// Byte length of a grouped ciphertext for 2 handles validity proof
-const GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN: usize = 160;
-
-/// Byte length of a grouped ciphertext for 3 handles validity proof
-const GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN: usize = 192;
-
-/// Byte length of a batched grouped ciphertext for 2 handles validity proof
-const BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN: usize = 160;
-
-/// Byte length of a batched grouped ciphertext for 3 handles validity proof
-const BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN: usize = 192;
-
-/// Byte length of a zero-balance proof
-const ZERO_BALANCE_PROOF_LEN: usize = 96;
-
-/// Byte length of a fee sigma proof
-const FEE_SIGMA_PROOF_LEN: usize = 256;
-
-/// Byte length of a public key validity proof
-const PUBKEY_VALIDITY_PROOF_LEN: usize = 64;
+use {
+    crate::sigma_proofs::{errors::*, *},
+    bytemuck::{Pod, Zeroable},
+};
 
 /// The `CiphertextCommitmentEqualityProof` type as a `Pod`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct CiphertextCommitmentEqualityProof(pub [u8; CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_LEN]);
+pub struct PodCiphertextCommitmentEqualityProof(
+    pub(crate) [u8; CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_LEN],
+);
 
 #[cfg(not(target_os = "solana"))]
-impl From<DecodedCiphertextCommitmentEqualityProof> for CiphertextCommitmentEqualityProof {
-    fn from(decoded_proof: DecodedCiphertextCommitmentEqualityProof) -> Self {
+impl From<CiphertextCommitmentEqualityProof> for PodCiphertextCommitmentEqualityProof {
+    fn from(decoded_proof: CiphertextCommitmentEqualityProof) -> Self {
         Self(decoded_proof.to_bytes())
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<CiphertextCommitmentEqualityProof> for DecodedCiphertextCommitmentEqualityProof {
+impl TryFrom<PodCiphertextCommitmentEqualityProof> for CiphertextCommitmentEqualityProof {
     type Error = EqualityProofVerificationError;
 
-    fn try_from(pod_proof: CiphertextCommitmentEqualityProof) -> Result<Self, Self::Error> {
+    fn try_from(pod_proof: PodCiphertextCommitmentEqualityProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
     }
 }
@@ -65,20 +46,22 @@ impl TryFrom<CiphertextCommitmentEqualityProof> for DecodedCiphertextCommitmentE
 /// The `CiphertextCiphertextEqualityProof` type as a `Pod`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct CiphertextCiphertextEqualityProof(pub [u8; CIPHERTEXT_CIPHERTEXT_EQUALITY_PROOF_LEN]);
+pub struct PodCiphertextCiphertextEqualityProof(
+    pub(crate) [u8; CIPHERTEXT_CIPHERTEXT_EQUALITY_PROOF_LEN],
+);
 
 #[cfg(not(target_os = "solana"))]
-impl From<DecodedCiphertextCiphertextEqualityProof> for CiphertextCiphertextEqualityProof {
-    fn from(decoded_proof: DecodedCiphertextCiphertextEqualityProof) -> Self {
+impl From<CiphertextCiphertextEqualityProof> for PodCiphertextCiphertextEqualityProof {
+    fn from(decoded_proof: CiphertextCiphertextEqualityProof) -> Self {
         Self(decoded_proof.to_bytes())
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<CiphertextCiphertextEqualityProof> for DecodedCiphertextCiphertextEqualityProof {
+impl TryFrom<PodCiphertextCiphertextEqualityProof> for CiphertextCiphertextEqualityProof {
     type Error = EqualityProofVerificationError;
 
-    fn try_from(pod_proof: CiphertextCiphertextEqualityProof) -> Result<Self, Self::Error> {
+    fn try_from(pod_proof: PodCiphertextCiphertextEqualityProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
     }
 }
@@ -86,26 +69,22 @@ impl TryFrom<CiphertextCiphertextEqualityProof> for DecodedCiphertextCiphertextE
 /// The `GroupedCiphertext2HandlesValidityProof` type as a `Pod`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct GroupedCiphertext2HandlesValidityProof(
-    pub [u8; GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN],
+pub struct PodGroupedCiphertext2HandlesValidityProof(
+    pub(crate) [u8; GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN],
 );
 
 #[cfg(not(target_os = "solana"))]
-impl From<DecodedGroupedCiphertext2HandlesValidityProof>
-    for GroupedCiphertext2HandlesValidityProof
-{
-    fn from(decoded_proof: DecodedGroupedCiphertext2HandlesValidityProof) -> Self {
+impl From<GroupedCiphertext2HandlesValidityProof> for PodGroupedCiphertext2HandlesValidityProof {
+    fn from(decoded_proof: GroupedCiphertext2HandlesValidityProof) -> Self {
         Self(decoded_proof.to_bytes())
     }
 }
-
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<GroupedCiphertext2HandlesValidityProof>
-    for DecodedGroupedCiphertext2HandlesValidityProof
-{
+
+impl TryFrom<PodGroupedCiphertext2HandlesValidityProof> for GroupedCiphertext2HandlesValidityProof {
     type Error = ValidityProofVerificationError;
 
-    fn try_from(pod_proof: GroupedCiphertext2HandlesValidityProof) -> Result<Self, Self::Error> {
+    fn try_from(pod_proof: PodGroupedCiphertext2HandlesValidityProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
     }
 }
@@ -113,26 +92,22 @@ impl TryFrom<GroupedCiphertext2HandlesValidityProof>
 /// The `GroupedCiphertext3HandlesValidityProof` type as a `Pod`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct GroupedCiphertext3HandlesValidityProof(
-    pub [u8; GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN],
+pub struct PodGroupedCiphertext3HandlesValidityProof(
+    pub(crate) [u8; GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN],
 );
 
 #[cfg(not(target_os = "solana"))]
-impl From<DecodedGroupedCiphertext3HandlesValidityProof>
-    for GroupedCiphertext3HandlesValidityProof
-{
-    fn from(decoded_proof: DecodedGroupedCiphertext3HandlesValidityProof) -> Self {
+impl From<GroupedCiphertext3HandlesValidityProof> for PodGroupedCiphertext3HandlesValidityProof {
+    fn from(decoded_proof: GroupedCiphertext3HandlesValidityProof) -> Self {
         Self(decoded_proof.to_bytes())
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<GroupedCiphertext3HandlesValidityProof>
-    for DecodedGroupedCiphertext3HandlesValidityProof
-{
+impl TryFrom<PodGroupedCiphertext3HandlesValidityProof> for GroupedCiphertext3HandlesValidityProof {
     type Error = ValidityProofVerificationError;
 
-    fn try_from(pod_proof: GroupedCiphertext3HandlesValidityProof) -> Result<Self, Self::Error> {
+    fn try_from(pod_proof: PodGroupedCiphertext3HandlesValidityProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
     }
 }
@@ -140,27 +115,27 @@ impl TryFrom<GroupedCiphertext3HandlesValidityProof>
 /// The `BatchedGroupedCiphertext2HandlesValidityProof` type as a `Pod`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct BatchedGroupedCiphertext2HandlesValidityProof(
-    pub [u8; BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN],
+pub struct PodBatchedGroupedCiphertext2HandlesValidityProof(
+    pub(crate) [u8; BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN],
 );
 
 #[cfg(not(target_os = "solana"))]
-impl From<DecodedBatchedGroupedCiphertext2HandlesValidityProof>
-    for BatchedGroupedCiphertext2HandlesValidityProof
+impl From<BatchedGroupedCiphertext2HandlesValidityProof>
+    for PodBatchedGroupedCiphertext2HandlesValidityProof
 {
-    fn from(decoded_proof: DecodedBatchedGroupedCiphertext2HandlesValidityProof) -> Self {
+    fn from(decoded_proof: BatchedGroupedCiphertext2HandlesValidityProof) -> Self {
         Self(decoded_proof.to_bytes())
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<BatchedGroupedCiphertext2HandlesValidityProof>
-    for DecodedBatchedGroupedCiphertext2HandlesValidityProof
+impl TryFrom<PodBatchedGroupedCiphertext2HandlesValidityProof>
+    for BatchedGroupedCiphertext2HandlesValidityProof
 {
     type Error = ValidityProofVerificationError;
 
     fn try_from(
-        pod_proof: BatchedGroupedCiphertext2HandlesValidityProof,
+        pod_proof: PodBatchedGroupedCiphertext2HandlesValidityProof,
     ) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
     }
@@ -169,27 +144,27 @@ impl TryFrom<BatchedGroupedCiphertext2HandlesValidityProof>
 /// The `BatchedGroupedCiphertext3HandlesValidityProof` type as a `Pod`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct BatchedGroupedCiphertext3HandlesValidityProof(
-    pub [u8; BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN],
+pub struct PodBatchedGroupedCiphertext3HandlesValidityProof(
+    pub(crate) [u8; BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN],
 );
 
 #[cfg(not(target_os = "solana"))]
-impl From<DecodedBatchedGroupedCiphertext3HandlesValidityProof>
-    for BatchedGroupedCiphertext3HandlesValidityProof
+impl From<BatchedGroupedCiphertext3HandlesValidityProof>
+    for PodBatchedGroupedCiphertext3HandlesValidityProof
 {
-    fn from(decoded_proof: DecodedBatchedGroupedCiphertext3HandlesValidityProof) -> Self {
+    fn from(decoded_proof: BatchedGroupedCiphertext3HandlesValidityProof) -> Self {
         Self(decoded_proof.to_bytes())
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<BatchedGroupedCiphertext3HandlesValidityProof>
-    for DecodedBatchedGroupedCiphertext3HandlesValidityProof
+impl TryFrom<PodBatchedGroupedCiphertext3HandlesValidityProof>
+    for BatchedGroupedCiphertext3HandlesValidityProof
 {
     type Error = ValidityProofVerificationError;
 
     fn try_from(
-        pod_proof: BatchedGroupedCiphertext3HandlesValidityProof,
+        pod_proof: PodBatchedGroupedCiphertext3HandlesValidityProof,
     ) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
     }
@@ -198,20 +173,20 @@ impl TryFrom<BatchedGroupedCiphertext3HandlesValidityProof>
 /// The `ZeroBalanceProof` type as a `Pod`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct ZeroBalanceProof(pub [u8; ZERO_BALANCE_PROOF_LEN]);
+pub struct PodZeroCiphertextProof(pub(crate) [u8; ZERO_BALANCE_PROOF_LEN]);
 
 #[cfg(not(target_os = "solana"))]
-impl From<DecodedZeroBalanceProof> for ZeroBalanceProof {
-    fn from(decoded_proof: DecodedZeroBalanceProof) -> Self {
+impl From<ZeroCiphertextProof> for PodZeroCiphertextProof {
+    fn from(decoded_proof: ZeroCiphertextProof) -> Self {
         Self(decoded_proof.to_bytes())
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<ZeroBalanceProof> for DecodedZeroBalanceProof {
-    type Error = ZeroBalanceProofVerificationError;
+impl TryFrom<PodZeroCiphertextProof> for ZeroCiphertextProof {
+    type Error = ZeroCiphertextProofVerificationError;
 
-    fn try_from(pod_proof: ZeroBalanceProof) -> Result<Self, Self::Error> {
+    fn try_from(pod_proof: PodZeroCiphertextProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
     }
 }
@@ -219,20 +194,20 @@ impl TryFrom<ZeroBalanceProof> for DecodedZeroBalanceProof {
 /// The `FeeSigmaProof` type as a `Pod`.
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(transparent)]
-pub struct FeeSigmaProof(pub [u8; FEE_SIGMA_PROOF_LEN]);
+pub struct PodPercentageWithCapProof(pub(crate) [u8; FEE_SIGMA_PROOF_LEN]);
 
 #[cfg(not(target_os = "solana"))]
-impl From<DecodedFeeSigmaProof> for FeeSigmaProof {
-    fn from(decoded_proof: DecodedFeeSigmaProof) -> Self {
+impl From<PercentageWithCapProof> for PodPercentageWithCapProof {
+    fn from(decoded_proof: PercentageWithCapProof) -> Self {
         Self(decoded_proof.to_bytes())
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<FeeSigmaProof> for DecodedFeeSigmaProof {
-    type Error = FeeSigmaProofVerificationError;
+impl TryFrom<PodPercentageWithCapProof> for PercentageWithCapProof {
+    type Error = PercentageWithCapProofVerificationError;
 
-    fn try_from(pod_proof: FeeSigmaProof) -> Result<Self, Self::Error> {
+    fn try_from(pod_proof: PodPercentageWithCapProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
     }
 }
@@ -240,20 +215,20 @@ impl TryFrom<FeeSigmaProof> for DecodedFeeSigmaProof {
 /// The `PubkeyValidityProof` type as a `Pod`.
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(transparent)]
-pub struct PubkeyValidityProof(pub [u8; PUBKEY_VALIDITY_PROOF_LEN]);
+pub struct PodPubkeyValidityProof(pub(crate) [u8; PUBKEY_VALIDITY_PROOF_LEN]);
 
 #[cfg(not(target_os = "solana"))]
-impl From<DecodedPubkeyValidityProof> for PubkeyValidityProof {
-    fn from(decoded_proof: DecodedPubkeyValidityProof) -> Self {
+impl From<PubkeyValidityProof> for PodPubkeyValidityProof {
+    fn from(decoded_proof: PubkeyValidityProof) -> Self {
         Self(decoded_proof.to_bytes())
     }
 }
 
 #[cfg(not(target_os = "solana"))]
-impl TryFrom<PubkeyValidityProof> for DecodedPubkeyValidityProof {
+impl TryFrom<PodPubkeyValidityProof> for PubkeyValidityProof {
     type Error = PubkeyValidityProofVerificationError;
 
-    fn try_from(pod_proof: PubkeyValidityProof) -> Result<Self, Self::Error> {
+    fn try_from(pod_proof: PodPubkeyValidityProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
     }
 }
@@ -261,23 +236,23 @@ impl TryFrom<PubkeyValidityProof> for DecodedPubkeyValidityProof {
 // The sigma proof pod types are wrappers for byte arrays, which are both `Pod` and `Zeroable`. However,
 // the marker traits `bytemuck::Pod` and `bytemuck::Zeroable` can only be derived for power-of-two
 // length byte arrays. Directly implement these traits for the sigma proof pod types.
-unsafe impl Zeroable for CiphertextCommitmentEqualityProof {}
-unsafe impl Pod for CiphertextCommitmentEqualityProof {}
+unsafe impl Zeroable for PodCiphertextCommitmentEqualityProof {}
+unsafe impl Pod for PodCiphertextCommitmentEqualityProof {}
 
-unsafe impl Zeroable for CiphertextCiphertextEqualityProof {}
-unsafe impl Pod for CiphertextCiphertextEqualityProof {}
+unsafe impl Zeroable for PodCiphertextCiphertextEqualityProof {}
+unsafe impl Pod for PodCiphertextCiphertextEqualityProof {}
 
-unsafe impl Zeroable for GroupedCiphertext2HandlesValidityProof {}
-unsafe impl Pod for GroupedCiphertext2HandlesValidityProof {}
+unsafe impl Zeroable for PodGroupedCiphertext2HandlesValidityProof {}
+unsafe impl Pod for PodGroupedCiphertext2HandlesValidityProof {}
 
-unsafe impl Zeroable for GroupedCiphertext3HandlesValidityProof {}
-unsafe impl Pod for GroupedCiphertext3HandlesValidityProof {}
+unsafe impl Zeroable for PodGroupedCiphertext3HandlesValidityProof {}
+unsafe impl Pod for PodGroupedCiphertext3HandlesValidityProof {}
 
-unsafe impl Zeroable for BatchedGroupedCiphertext2HandlesValidityProof {}
-unsafe impl Pod for BatchedGroupedCiphertext2HandlesValidityProof {}
+unsafe impl Zeroable for PodBatchedGroupedCiphertext2HandlesValidityProof {}
+unsafe impl Pod for PodBatchedGroupedCiphertext2HandlesValidityProof {}
 
-unsafe impl Zeroable for BatchedGroupedCiphertext3HandlesValidityProof {}
-unsafe impl Pod for BatchedGroupedCiphertext3HandlesValidityProof {}
+unsafe impl Zeroable for PodBatchedGroupedCiphertext3HandlesValidityProof {}
+unsafe impl Pod for PodBatchedGroupedCiphertext3HandlesValidityProof {}
 
-unsafe impl Zeroable for ZeroBalanceProof {}
-unsafe impl Pod for ZeroBalanceProof {}
+unsafe impl Zeroable for PodZeroCiphertextProof {}
+unsafe impl Pod for PodZeroCiphertextProof {}


### PR DESCRIPTION
#### Problem
The `pod` modules have been added to the `encryption` module, but not yet for the sigma and range proof modules.

#### Summary of Changes
Add the `pod` modules for the sigma and range proof modules.

This is a follow-up to https://github.com/anza-xyz/agave/pull/1169 and it should be pretty similar.
- For each pod types, I added the `Pod` prefix (e.g. `PubkeyValidityProof` to `PodPubkeyValidityProof`)
- I made the inner bytes of the pod types to be `pub(crate)`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
