### PR TITLE
upgrade to rust 1.78.0 🎉

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.78.0"


### PR DESCRIPTION
Upgrades rust toolchain to use the new 1.78 release 🎉 

https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html
