### PR TITLE
fix multinode-demo stake script

### DIFF
--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -124,4 +124,4 @@ $solana_cli "${common_args[@]}" \
   create-stake-account "$stake_account" "$stake_sol"
 $solana_cli "${common_args[@]}" \
   delegate-stake $maybe_force "$stake_account" "$vote_account"
-$solana_cli "${common_args[@]}" stakes "$stake_account"
+$solana_cli "${common_args[@]}" stake-account "$stake_account"


### PR DESCRIPTION
#### Problem

we're using `solana stakes`  for a stake account 😢 (but which need a vote account or validator identity)

#### Summary of Changes

use `solana stake-account` instead
