### PR TITLE
deactivate hmac feature of libsecp256k1 where not needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,7 +242,10 @@ lazy-lru = "0.1.2"
 lazy_static = "1.4.0"
 libc = "0.2.153"
 libloading = "0.7.4"
-libsecp256k1 = "0.6.0"
+libsecp256k1 = { version = "0.6.0", default-features = false, features = [
+    "std",
+    "static-context",
+] }
 light-poseidon = "0.2.0"
 log = "0.4.21"
 lru = "0.7.7"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -55,7 +55,7 @@ generic-array = { workspace = true, features = ["serde", "more_lengths"], option
 hmac = { workspace = true }
 itertools =  { workspace = true }
 lazy_static = { workspace = true }
-libsecp256k1 = { workspace = true, optional = true }
+libsecp256k1 = { workspace = true, optional = true, features = ["hmac"] }
 log = { workspace = true }
 memmap2 = { workspace = true, optional = true }
 num-derive = { workspace = true }


### PR DESCRIPTION
#### Problem
The workspace Cargo.toml activates the hmac feature of libsecp256k1 which brings in a hmac dependency that is not used outside of solana-sdk.

#### Summary of Changes
- Sets default-features to false in the workspace Cargo.toml but explicitly keeps the non-hmac features that were previously being activated as default features.
- Activates the hmac feature in solana-sdk where it actually is needed

libsecp256k1 0.6.0 default features are here:
https://github.com/paritytech/libsecp256k1/blob/e5095a8930de6f2ae2003c164eba9bfb7ce2f628/Cargo.toml#L34


