### PR TITLE
deactivate serde feature of bitflags where not needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ atty = "0.2.11"
 backoff = "0.4.0"
 base64 = "0.22.0"
 bincode = "1.3.3"
-bitflags = { version = "2.4.2", features = ["serde"] }
+bitflags = { version = "2.4.2" }
 blake3 = "1.5.1"
 block-buffer = "0.10.4"
 borsh = { version = "1.5.0", features = ["derive", "unstable__schema"] }

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -25,7 +25,7 @@ im = { workspace = true, features = ["rayon", "serde"] }
 memmap2 = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
-bitflags = { workspace = true }
+bitflags = { workspace = true, features = ["serde"] }
 serde_bytes = { workspace = true }
 solana-logger = { workspace = true }
 

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -12,7 +12,7 @@ edition = { workspace = true }
 [dependencies]
 assert_matches = { workspace = true }
 bincode = { workspace = true }
-bitflags = { workspace = true }
+bitflags = { workspace = true, features = ["serde"] }
 byteorder = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
 chrono-humanize = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -40,7 +40,7 @@ dev-context-only-utils = [
 [dependencies]
 base64 = { workspace = true }
 bincode = { workspace = true }
-bitflags = { workspace = true }
+bitflags = { workspace = true, features = ["serde"] }
 borsh = { workspace = true }
 bs58 = { workspace = true }
 bytemuck = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
#### Problem
The serde feature of bitflags is only needed in solana-sdk but the workspace Cargo.toml activates it everywhere

#### Summary of Changes
~Move `features = ["serde"]` from ./Cargo.toml to sdk/Cargo.toml~
Remove `features = ["serde"]`  from bitflags in ./Cargo.toml, and add it to solana-sdk, solana-ledger and the dev-dependencies of solana-frozen-abi
