### PR TITLE
Adds CLI arg for accounts db squash storages method

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1327,9 +1327,12 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .conflicts_with("accounts_db_skip_shrink"),
         )
         .arg(
-            Arg::with_name("accounts_db_create_ancient_storage_packed")
-                .long("accounts-db-create-ancient-storage-packed")
-                .help("Create ancient storages in one shot instead of appending.")
+            Arg::with_name("accounts_db_squash_storages_method")
+                .long("accounts-db-squash-storages-method")
+                .value_name("METHOD")
+                .takes_value(true)
+                .possible_values(&["pack", "append"])
+                .help("Squash multiple account storage files together using this method")
                 .hidden(hidden_unless_forced()),
         )
         .arg(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1248,6 +1248,17 @@ pub fn main() {
                 }
             }
         });
+    let create_ancient_storage = matches
+        .value_of("accounts_db_squash_storages_method")
+        .map(|method| match method {
+            "pack" => CreateAncientStorage::Pack,
+            "append" => CreateAncientStorage::Append,
+            _ => {
+                // clap will enforce one of the above values is given
+                unreachable!("invalid value given to accounts-db-squash-storages-method")
+            }
+        })
+        .unwrap_or_default();
 
     let accounts_db_config = AccountsDbConfig {
         index: Some(accounts_index_config),
@@ -1260,10 +1271,7 @@ pub fn main() {
             .map(|mb| mb * MB as u64),
         ancient_append_vec_offset: value_t!(matches, "accounts_db_ancient_append_vecs", i64).ok(),
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
-        create_ancient_storage: matches
-            .is_present("accounts_db_create_ancient_storage_packed")
-            .then_some(CreateAncientStorage::Pack)
-            .unwrap_or_default(),
+        create_ancient_storage,
         test_partitioned_epoch_rewards,
         test_skip_rewrites_but_include_in_bank_hash: matches
             .is_present("accounts_db_test_skip_rewrites"),


### PR DESCRIPTION
#### Problem

There's not a CLI arg to specify what method to use for squashing ancient storage files together. The existing CLI arg lets you opt into using 'pack', but now that pack is the default, there's not a way to use 'append'.


#### Summary of Changes

* Adds *hidden* CLI arg `--accounts-db-squash-storages-method` to specify which squash method to use.
* Removes the old CLI arg, `--accounts-db-create-ancient-storage-packed`