### PR TITLE
Bank::unix_timestamp_from_genesis use saturating math

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1813,7 +1813,11 @@ impl Bank {
 
     /// computed unix_timestamp at this slot height
     pub fn unix_timestamp_from_genesis(&self) -> i64 {
-        self.genesis_creation_time + ((self.slot as u128 * self.ns_per_slot) / 1_000_000_000) as i64
+        self.genesis_creation_time.saturating_add(
+            (self.slot as u128)
+                .saturating_mul(self.ns_per_slot)
+                .saturating_div(1_000_000_000) as i64,
+        )
     }
 
     fn update_sysvar_account<F>(&self, pubkey: &Pubkey, updater: F)


### PR DESCRIPTION
#### Problem

- `unix_timestamp_from_genesis` will panic if the multiplication overflows
- In many tests we use `new_no_wallclock_throttle_for_tests` which will set `ns_per_tick = u128::MAX`
- In all these tests, the multiplication will overflow if the function is called
- This was found in #1260 when logs were enabled in the `test_write_persist_loaded_addresses` test

#### Summary of Changes

- Make `unix_timestamp_from_genesis` use saturating math to avoid overflows
- For real values of `ns_per_tick` we should be unlikely to ever hit the overflow; on mnb:
```
ns_per_slot = 400000000
u128::MAX / ns_per_slot = 8.507059173023461586584365185794205286375 × 10^29
```
so if agave's still around well after the sun has died we'll have to come up with a better fix

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
