### PR TITLE
Sets default accounts read cache watermarks to 400-410 MiB

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2346,8 +2346,8 @@ impl AccountsDb {
 
     // The default high and low watermark sizes for the accounts read cache.
     // If the cache size exceeds MAX_SIZE_HI, it'll evict entries until the size is <= MAX_SIZE_LO.
-    const DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_LO: usize = 400_000_000;
-    const DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_HI: usize = 400_000_000;
+    const DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_LO: usize = 400 * 1024 * 1024;
+    const DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_HI: usize = 410 * 1024 * 1024;
 
     pub fn default_for_tests() -> Self {
         Self::default_with_accounts_index(AccountInfoAccountsIndex::default_for_tests(), None, None)


### PR DESCRIPTION
### Problem

The accounts read cache had a background thread that handles evictions. It is woken up when the cache size exceeds a high watermark, and then it evicts entries until it reaches a low watermark.

Currently, the low and high watermarks are both set to 400 MB. 

This means when the evictor wakes up, it doesn't do a lot of work. And thus is woken up often. Wakeups are not free, so it is in the interest of the overall system to reduce them when possible.


### Summary of Changes

Sets the defaults for the accounts read cache's watermarks to 400 MiB (low) and 410 MiB (high).


### Results

This extra 10 MiB makes a *big* difference on wakeups. I spun up two nodes to test. One had lo-hi at 400-400, and the other had 400-410. I then swapped the configs to ensure it wasn't just a fluke on the one machine.

Below are graphs from the two nodes, and how the number of wakeups changes. It'll be obvious where the change/restart occurs. Each node has two graphs: one is the number of *all* the wakeups, and the second is the number of *spurious* wakeups. Spurious wakeups are ones where the node wakeups and realizes there is no actual work to do (aka the cache size is already at-or-below the low watermark).

Other things to note: No impacts to replay was observed. There now a 10 MiB increase in memory usage though. This seems like a good trade-off though.


#### Node A

All wakeups:
![node a, all](https://github.com/anza-xyz/agave/assets/840349/6d3b7559-1675-4d8b-8e39-6a3092e9ca35)

Spurious wakeups:
![node a, spurious](https://github.com/anza-xyz/agave/assets/840349/b4e70840-96cd-4ec4-903e-26484ba6bae2)


#### Node B

All wakeups:
![node b, all](https://github.com/anza-xyz/agave/assets/840349/5616e75f-6e5c-49ab-b191-a17842988474)

Spurious wakeups:
![node b, spurious](https://github.com/anza-xyz/agave/assets/840349/4de88dce-63f4-4cfe-b009-3fedc55a0d1a)
