### PR TITLE
Bugfix: clean_queue pushes valid transactions back into queue

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -385,6 +385,8 @@ impl SchedulerController {
                 if result.is_err() {
                     saturating_add_assign!(num_dropped_on_age_and_status, 1);
                     self.container.remove_by_id(&id.id);
+                } else {
+                    self.container.push_id_into_queue(*id);
                 }
             }
         }


### PR DESCRIPTION
#### Problem

- `clean_queue` pops ids from the queue
- Checks if transactions are valid or not
- Removes invalid ones
- It does not push the valid ones back into the queue

#### Summary of Changes

- Push valid ids back into the queue

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
