### PR TITLE
 add `reopen_storage_as_readonly_shrinking_in_progress_ok`

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -82,6 +82,18 @@ impl AccountStorage {
         self.get_slot_storage_entry_shrinking_in_progress_ok(slot)
     }
 
+    pub(crate) fn replace_storage_with_equivalent(
+        &self,
+        slot: Slot,
+        storage: Arc<AccountStorageEntry>,
+    ) {
+        assert_eq!(storage.slot(), slot);
+        if let Some(mut existing_storage) = self.map.get_mut(&slot) {
+            assert_eq!(slot, existing_storage.value().storage.slot());
+            existing_storage.value_mut().storage = storage;
+        }
+    }
+
     /// return the append vec for 'slot' if it exists
     pub(crate) fn get_slot_storage_entry_shrinking_in_progress_ok(
         &self,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1111,6 +1111,19 @@ impl AccountStorageEntry {
         }
     }
 
+    /// open a new instance of the storage that is readonly
+    fn reopen_as_readonly(&self) -> Option<Self> {
+        let count_and_status = self.count_and_status.lock_write();
+        self.accounts.reopen_as_readonly().map(|accounts| Self {
+            id: self.id,
+            slot: self.slot,
+            count_and_status: SeqLock::new(*count_and_status),
+            approx_store_count: AtomicUsize::new(self.approx_stored_count()),
+            alive_bytes: AtomicUsize::new(self.alive_bytes()),
+            accounts,
+        })
+    }
+
     pub fn new_existing(
         slot: Slot,
         id: AccountsFileId,
@@ -3991,6 +4004,8 @@ impl AccountsDb {
         let (_, drop_storage_entries_elapsed) = measure_us!(drop(dead_storages));
         time.stop();
 
+        self.reopen_storage_as_readonly_shrinking_in_progress_ok(shrink_collect.slot);
+
         self.stats
             .dropped_stores
             .fetch_add(dead_storages_len as u64, Ordering::Relaxed);
@@ -4180,6 +4195,26 @@ impl AccountsDb {
         }
 
         dead_storages
+    }
+
+    /// we are done writing to the storage at `slot`. It can be re-opened as read-only if that would help
+    /// system performance.
+    pub(crate) fn reopen_storage_as_readonly_shrinking_in_progress_ok(&self, slot: Slot) {
+        if let Some(storage) = self
+            .storage
+            .get_slot_storage_entry_shrinking_in_progress_ok(slot)
+        {
+            if let Some(new_storage) = storage.reopen_as_readonly() {
+                // consider here the race condition of tx processing having looked up something in the index,
+                // which could return (slot, append vec id). We want the lookup for the storage to get a storage
+                // that works whether the lookup occurs before or after the replace call here.
+                // So, the two storages have to be exactly equivalent wrt offsets, counts, len, id, etc.
+                assert_eq!(storage.append_vec_id(), new_storage.append_vec_id());
+                assert_eq!(storage.accounts.len(), new_storage.accounts.len());
+                self.storage
+                    .replace_storage_with_equivalent(slot, Arc::new(new_storage));
+            }
+        }
     }
 
     /// return a store that can contain 'aligned_total' bytes
@@ -4592,6 +4627,9 @@ impl AccountsDb {
             // Assert: it cannot be the case that we already had an ancient append vec at this slot and
             // yet that ancient append vec does not have room for the accounts stored at this slot currently
             assert_ne!(slot, current_ancient.slot());
+
+            // we filled one up
+            self.reopen_storage_as_readonly_shrinking_in_progress_ok(current_ancient.slot());
 
             // Now we create an ancient append vec at `slot` to store the overflows.
             let (shrink_in_progress_overflow, time_us) = measure_us!(current_ancient
@@ -6393,6 +6431,7 @@ impl AccountsDb {
             // If the above sizing function is correct, just one AppendVec is enough to hold
             // all the data for the slot
             assert!(self.storage.get_slot_storage_entry(slot).is_some());
+            self.reopen_storage_as_readonly_shrinking_in_progress_ok(slot);
         }
 
         // Remove this slot from the cache, which will to AccountsDb's new readers should look like an

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -89,6 +89,14 @@ impl AccountsFile {
         }
     }
 
+    /// if storage is not readonly, reopen another instance that is read only
+    pub(crate) fn reopen_as_readonly(&self) -> Option<Self> {
+        match self {
+            Self::AppendVec(av) => av.reopen_as_readonly().map(Self::AppendVec),
+            Self::TieredStorage(_) => None,
+        }
+    }
+
     pub fn flush(&self) -> Result<()> {
         match self {
             Self::AppendVec(av) => av.flush(),

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -591,6 +591,8 @@ impl AccountsDb {
             let shrink_in_progress = write_ancient_accounts.shrinks_in_progress.remove(&slot);
             if shrink_in_progress.is_none() {
                 dropped_roots.push(slot);
+            } else {
+                self.reopen_storage_as_readonly_shrinking_in_progress_ok(slot);
             }
             self.remove_old_stores_shrink(
                 &shrink_collect,

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -354,6 +354,13 @@ impl AppendVec {
         self.current_len.store(0, Ordering::Release);
     }
 
+    /// when we can use file i/o as opposed to mmap, this is the trigger to tell us
+    /// that no more appending will occur and we can close the initial mmap.
+    pub(crate) fn reopen_as_readonly(&self) -> Option<Self> {
+        // this is a no-op when we are already a mmap
+        None
+    }
+
     /// how many more bytes can be stored in this append vec
     pub fn remaining_bytes(&self) -> u64 {
         self.capacity()


### PR DESCRIPTION
#### Problem
Goal is to stop mmapping append vecs.
When we are done shrinking, ancient comining, etc., we can re-open a appendable storage as readonly.

#### Summary of Changes
Add a method to reopen a storage as readonly after these operations.
This allows us to keep the runtime path fast, avoiding any kind of lock on the file or map.
Note that the append vec does not implement reopen right now, so nothing is ever replaced in the validator today. That's coming next. This has no meaning until we can use file i/o on a storage.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
