### PR TITLE
Adds CLI arg for accounts db storage access method

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1465,6 +1465,10 @@ pub struct AccountsDb {
     /// storage format to use for new storages
     accounts_file_provider: AccountsFileProvider,
 
+    /// method to use for accessing storages
+    #[allow(dead_code)]
+    storage_access: StorageAccess,
+
     /// this will live here until the feature for partitioned epoch rewards is activated.
     /// At that point, this and other code can be deleted.
     pub partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig,
@@ -2446,6 +2450,7 @@ impl AccountsDb {
             log_dead_slots: AtomicBool::new(true),
             exhaustively_verify_refcounts: false,
             accounts_file_provider: AccountsFileProvider::default(),
+            storage_access: StorageAccess::default(),
             partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig::default(),
             epoch_accounts_hash_manager: EpochAccountsHashManager::new_invalid(),
             test_skip_rewrites_but_include_in_bank_hash: false,
@@ -2546,6 +2551,11 @@ impl AccountsDb {
                 Self::DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_HI,
             ));
 
+        let storage_access = accounts_db_config
+            .as_ref()
+            .map(|config| config.storage_access)
+            .unwrap_or_default();
+
         let paths_is_empty = paths.is_empty();
         let mut new = Self {
             paths,
@@ -2567,6 +2577,7 @@ impl AccountsDb {
             partitioned_epoch_rewards_config,
             exhaustively_verify_refcounts,
             test_skip_rewrites_but_include_in_bank_hash,
+            storage_access,
             ..Self::default_with_accounts_index(
                 accounts_index,
                 base_working_path,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1299,6 +1299,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .hidden(hidden_unless_forced()),
         )
         .arg(
+            Arg::with_name("accounts_db_access_storages_method")
+                .long("accounts-db-access-storages-method")
+                .value_name("METHOD")
+                .takes_value(true)
+                .possible_values(&["mmap", "file"])
+                .help("Access account storage using this method")
+                .hidden(hidden_unless_forced()),
+        )
+        .arg(
             Arg::with_name("accounts_db_ancient_append_vecs")
                 .long("accounts-db-ancient-append-vecs")
                 .value_name("SLOT-OFFSET")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -18,6 +18,7 @@ use {
     rand::{seq::SliceRandom, thread_rng},
     solana_accounts_db::{
         accounts_db::{AccountShrinkThreshold, AccountsDb, AccountsDbConfig, CreateAncientStorage},
+        accounts_file::StorageAccess,
         accounts_index::{
             AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude,
             AccountsIndexConfig, IndexLimitMb,
@@ -1261,6 +1262,17 @@ pub fn main() {
             }
         })
         .unwrap_or_default();
+    let storage_access = matches
+        .value_of("accounts_db_access_storages_method")
+        .map(|method| match method {
+            "mmap" => StorageAccess::Mmap,
+            "file" => unimplemented!(),
+            _ => {
+                // clap will enforce one of the above values is given
+                unreachable!("invalid value given to accounts-db-access-storages-method")
+            }
+        })
+        .unwrap_or_default();
 
     let accounts_db_config = AccountsDbConfig {
         index: Some(accounts_index_config),
@@ -1277,6 +1289,7 @@ pub fn main() {
         test_partitioned_epoch_rewards,
         test_skip_rewrites_but_include_in_bank_hash: matches
             .is_present("accounts_db_test_skip_rewrites"),
+        storage_access,
         ..AccountsDbConfig::default()
     };
 


### PR DESCRIPTION
#### Problem

There's not a way to select how to access account storages.


#### Summary of Changes

Add a hidden CLI arg.