### PR TITLE
Remove `ThinClient` from `LocalCluster`

### DIFF
--- a/local-cluster/src/cluster.rs
+++ b/local-cluster/src/cluster.rs
@@ -1,5 +1,4 @@
 use {
-    solana_client::thin_client::ThinClient,
     solana_core::validator::{Validator, ValidatorConfig},
     solana_gossip::{cluster_info::Node, contact_info::ContactInfo},
     solana_ledger::shred::Shred,
@@ -41,7 +40,7 @@ impl ClusterValidatorInfo {
 
 pub trait Cluster {
     fn get_node_pubkeys(&self) -> Vec<Pubkey>;
-    fn get_validator_client(&self, pubkey: &Pubkey) -> Option<ThinClient>;
+    fn get_validator_client(&self, pubkey: &Pubkey) -> Option<QuicTpuClient>;
     fn build_tpu_quic_client(&self) -> Result<QuicTpuClient>;
     fn build_tpu_quic_client_with_commitment(
         &self,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -8,9 +8,7 @@ use {
     itertools::izip,
     log::*,
     solana_accounts_db::utils::create_accounts_run_and_snapshot_dirs,
-    solana_client::{
-        connection_cache::ConnectionCache, rpc_client::RpcClient, thin_client::ThinClient,
-    },
+    solana_client::{connection_cache::ConnectionCache, rpc_client::RpcClient},
     solana_core::{
         consensus::tower_storage::FileTowerStorage,
         validator::{Validator, ValidatorConfig, ValidatorStartProgress},
@@ -30,7 +28,6 @@ use {
     },
     solana_sdk::{
         account::{Account, AccountSharedData},
-        client::SyncClient,
         clock::{Slot, DEFAULT_DEV_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT},
         commitment_config::CommitmentConfig,
         epoch_schedule::EpochSchedule,
@@ -481,11 +478,7 @@ impl LocalCluster {
         mut voting_keypair: Option<Arc<Keypair>>,
         socket_addr_space: SocketAddrSpace,
     ) -> Pubkey {
-        let (rpc, tpu) = cluster_tests::get_client_facing_addr(
-            self.connection_cache.protocol(),
-            &self.entry_point_info,
-        );
-        let client = ThinClient::new(rpc, tpu, self.connection_cache.clone());
+        let client = self.build_tpu_quic_client().expect("tpu_client");
 
         // Must have enough tokens to fund vote account and set delegate
         let should_create_vote_pubkey = voting_keypair.is_none();
@@ -577,11 +570,7 @@ impl LocalCluster {
     }
 
     pub fn transfer(&self, source_keypair: &Keypair, dest_pubkey: &Pubkey, lamports: u64) -> u64 {
-        let (rpc, tpu) = cluster_tests::get_client_facing_addr(
-            self.connection_cache.protocol(),
-            &self.entry_point_info,
-        );
-        let client = ThinClient::new(rpc, tpu, self.connection_cache.clone());
+        let client = self.build_tpu_quic_client().expect("new tpu quic client");
         Self::transfer_with_client(&client, source_keypair, dest_pubkey, lamports)
     }
 
@@ -675,13 +664,14 @@ impl LocalCluster {
     }
 
     fn transfer_with_client(
-        client: &ThinClient,
+        client: &QuicTpuClient,
         source_keypair: &Keypair,
         dest_pubkey: &Pubkey,
         lamports: u64,
     ) -> u64 {
         trace!("getting leader blockhash");
         let (blockhash, _) = client
+            .rpc_client()
             .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
             .unwrap();
         let mut tx = system_transaction::transfer(source_keypair, dest_pubkey, lamports, blockhash);
@@ -692,19 +682,20 @@ impl LocalCluster {
             *dest_pubkey
         );
         client
-            .retry_transfer(source_keypair, &mut tx, 10)
-            .expect("client transfer");
+            .send_and_confirm_transaction_with_retries(&[source_keypair], &mut tx, 10, 0)
+            .expect("client transfer should succeed");
         client
+            .rpc_client()
             .wait_for_balance_with_commitment(
                 dest_pubkey,
                 Some(lamports),
                 CommitmentConfig::processed(),
             )
-            .expect("get balance")
+            .expect("get balance should succeed")
     }
 
     fn setup_vote_and_stake_accounts(
-        client: &ThinClient,
+        client: &QuicTpuClient,
         vote_account: &Keypair,
         from_account: &Arc<Keypair>,
         amount: u64,
@@ -720,6 +711,7 @@ impl LocalCluster {
 
         // Create the vote account if necessary
         if client
+            .rpc_client()
             .poll_get_balance_with_commitment(&vote_account_pubkey, CommitmentConfig::processed())
             .unwrap_or(0)
             == 0
@@ -729,6 +721,7 @@ impl LocalCluster {
             // as the cluster is already running, and using the wrong account size will cause the
             // InitializeAccount tx to fail
             let use_current_vote_state = client
+                .rpc_client()
                 .poll_get_balance_with_commitment(
                     &feature_set::vote_state_add_vote_latency::id(),
                     CommitmentConfig::processed(),
@@ -757,14 +750,16 @@ impl LocalCluster {
                 &[from_account.as_ref(), vote_account],
                 message,
                 client
+                    .rpc_client()
                     .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
                     .unwrap()
                     .0,
             );
             client
-                .retry_transfer(from_account, &mut transaction, 10)
+                .send_and_confirm_transaction_with_retries(&[from_account], &mut transaction, 10, 0)
                 .expect("fund vote");
             client
+                .rpc_client()
                 .wait_for_balance_with_commitment(
                     &vote_account_pubkey,
                     Some(amount),
@@ -785,13 +780,14 @@ impl LocalCluster {
                 &[from_account.as_ref(), &stake_account_keypair],
                 message,
                 client
+                    .rpc_client()
                     .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
                     .unwrap()
                     .0,
             );
 
             client
-                .send_and_confirm_transaction(
+                .send_and_confirm_transaction_with_retries(
                     &[from_account.as_ref(), &stake_account_keypair],
                     &mut transaction,
                     5,
@@ -799,6 +795,7 @@ impl LocalCluster {
                 )
                 .expect("delegate stake");
             client
+                .rpc_client()
                 .wait_for_balance_with_commitment(
                     &stake_account_pubkey,
                     Some(amount),
@@ -814,36 +811,58 @@ impl LocalCluster {
         info!("Checking for vote account registration of {}", node_pubkey);
         match (
             client
+                .rpc_client()
                 .get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::processed()),
-            client.get_account_with_commitment(&vote_account_pubkey, CommitmentConfig::processed()),
+            client
+                .rpc_client()
+                .get_account_with_commitment(&vote_account_pubkey, CommitmentConfig::processed()),
         ) {
-            (Ok(Some(stake_account)), Ok(Some(vote_account))) => {
-                match (
-                    stake_state::stake_from(&stake_account),
-                    vote_state::from(&vote_account),
-                ) {
-                    (Some(stake_state), Some(vote_state)) => {
-                        if stake_state.delegation.voter_pubkey != vote_account_pubkey
-                            || stake_state.delegation.stake != amount
-                        {
-                            Err(Error::new(ErrorKind::Other, "invalid stake account state"))
-                        } else if vote_state.node_pubkey != node_pubkey {
-                            Err(Error::new(ErrorKind::Other, "invalid vote account state"))
-                        } else {
-                            info!("node {} {:?} {:?}", node_pubkey, stake_state, vote_state);
+            (Ok(stake_account), Ok(vote_account)) => {
+                match (stake_account.value, vote_account.value) {
+                    (Some(stake_account), Some(vote_account)) => {
+                        match (
+                            stake_state::stake_from(&stake_account),
+                            vote_state::from(&vote_account),
+                        ) {
+                            (Some(stake_state), Some(vote_state)) => {
+                                if stake_state.delegation.voter_pubkey != vote_account_pubkey
+                                    || stake_state.delegation.stake != amount
+                                {
+                                    Err(Error::new(ErrorKind::Other, "invalid stake account state"))
+                                } else if vote_state.node_pubkey != node_pubkey {
+                                    Err(Error::new(ErrorKind::Other, "invalid vote account state"))
+                                } else {
+                                    info!(
+                                        "node {} {:?} {:?}",
+                                        node_pubkey, stake_state, vote_state
+                                    );
 
-                            Ok(())
+                                    return Ok(());
+                                }
+                            }
+                            (None, _) => {
+                                Err(Error::new(ErrorKind::Other, "invalid stake account data"))
+                            }
+                            (_, None) => {
+                                Err(Error::new(ErrorKind::Other, "invalid vote account data"))
+                            }
                         }
                     }
-                    (None, _) => Err(Error::new(ErrorKind::Other, "invalid stake account data")),
-                    (_, None) => Err(Error::new(ErrorKind::Other, "invalid vote account data")),
+                    (None, _) => Err(Error::new(
+                        ErrorKind::Other,
+                        "unable to retrieve stake account data",
+                    )),
+                    (_, None) => Err(Error::new(
+                        ErrorKind::Other,
+                        "unable to retrieve vote account data",
+                    )),
                 }
             }
-            (Ok(None), _) | (Err(_), _) => Err(Error::new(
+            (Err(_), _) => Err(Error::new(
                 ErrorKind::Other,
                 "unable to retrieve stake account data",
             )),
-            (_, Ok(None)) | (_, Err(_)) => Err(Error::new(
+            (_, Err(_)) => Err(Error::new(
                 ErrorKind::Other,
                 "unable to retrieve vote account data",
             )),
@@ -895,13 +914,10 @@ impl Cluster for LocalCluster {
         self.validators.keys().cloned().collect()
     }
 
-    fn get_validator_client(&self, pubkey: &Pubkey) -> Option<ThinClient> {
-        self.validators.get(pubkey).map(|f| {
-            let (rpc, tpu) = cluster_tests::get_client_facing_addr(
-                self.connection_cache.protocol(),
-                &f.info.contact_info,
-            );
-            ThinClient::new(rpc, tpu, self.connection_cache.clone())
+    fn get_validator_client(&self, pubkey: &Pubkey) -> Option<QuicTpuClient> {
+        self.validators.get(pubkey).map(|_| {
+            self.build_tpu_quic_client()
+                .expect("should build tpu quic client")
         })
     }
 

--- a/local-cluster/src/local_cluster_snapshot_utils.rs
+++ b/local-cluster/src/local_cluster_snapshot_utils.rs
@@ -7,7 +7,7 @@ use {
         },
         snapshot_utils,
     },
-    solana_sdk::{client::SyncClient, commitment_config::CommitmentConfig},
+    solana_sdk::commitment_config::CommitmentConfig,
     std::{
         path::Path,
         thread::sleep,
@@ -76,6 +76,7 @@ impl LocalCluster {
             .get_validator_client(self.entry_point_info.pubkey())
             .unwrap();
         let last_slot = client
+            .rpc_client()
             .get_slot_with_commitment(CommitmentConfig::processed())
             .expect("Couldn't get slot");
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -9,7 +9,6 @@ use {
     solana_accounts_db::{
         hardened_unpack::open_genesis_config, utils::create_accounts_run_and_snapshot_dirs,
     },
-    solana_client::thin_client::ThinClient,
     solana_core::{
         consensus::{
             tower_storage::FileTowerStorage, Tower, SWITCH_FORK_THRESHOLD, VOTE_THRESHOLD_DEPTH,
@@ -31,7 +30,7 @@ use {
         use_snapshot_archives_at_startup::UseSnapshotArchivesAtStartup,
     },
     solana_local_cluster::{
-        cluster::{Cluster, ClusterValidatorInfo},
+        cluster::{Cluster, ClusterValidatorInfo, QuicTpuClient},
         cluster_tests,
         integration_tests::{
             copy_blocks, create_custom_leader_schedule,
@@ -62,7 +61,7 @@ use {
     },
     solana_sdk::{
         account::AccountSharedData,
-        client::{AsyncClient, SyncClient},
+        client::AsyncClient,
         clock::{self, Slot, DEFAULT_TICKS_PER_SLOT, MAX_PROCESSING_AGE},
         commitment_config::CommitmentConfig,
         epoch_schedule::{DEFAULT_SLOTS_PER_EPOCH, MINIMUM_SLOTS_PER_EPOCH},
@@ -216,13 +215,10 @@ fn test_local_cluster_signature_subscribe() {
         .unwrap();
     let non_bootstrap_info = cluster.get_contact_info(&non_bootstrap_id).unwrap();
 
-    let (rpc, tpu) = cluster_tests::get_client_facing_addr(
-        cluster.connection_cache.protocol(),
-        non_bootstrap_info,
-    );
-    let tx_client = ThinClient::new(rpc, tpu, cluster.connection_cache.clone());
+    let tx_client = cluster.build_tpu_quic_client().unwrap();
 
     let (blockhash, _) = tx_client
+        .rpc_client()
         .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
         .unwrap();
 
@@ -244,7 +240,12 @@ fn test_local_cluster_signature_subscribe() {
     .unwrap();
 
     tx_client
-        .retry_transfer(&cluster.funding_keypair, &mut transaction, 5)
+        .send_and_confirm_transaction_with_retries(
+            &[&cluster.funding_keypair],
+            &mut transaction,
+            5,
+            0,
+        )
         .unwrap();
 
     let mut got_received_notification = false;
@@ -371,6 +372,7 @@ fn test_restart_node() {
             ticks_per_slot,
             slots_per_epoch,
             stakers_slot_offset: slots_per_epoch,
+            skip_warmup_slots: true,
             ..ClusterConfig::default()
         },
         SocketAddrSpace::Unspecified,
@@ -422,11 +424,7 @@ fn test_mainnet_beta_cluster_type() {
     .unwrap();
     assert_eq!(cluster_nodes.len(), 1);
 
-    let (rpc, tpu) = cluster_tests::get_client_facing_addr(
-        cluster.connection_cache.protocol(),
-        &cluster.entry_point_info,
-    );
-    let client = ThinClient::new(rpc, tpu, cluster.connection_cache.clone());
+    let client = cluster.build_tpu_quic_client().unwrap();
 
     // Programs that are available at epoch 0
     for program_id in [
@@ -444,8 +442,10 @@ fn test_mainnet_beta_cluster_type() {
             (
                 program_id,
                 client
+                    .rpc_client()
                     .get_account_with_commitment(program_id, CommitmentConfig::processed())
                     .unwrap()
+                    .value
             ),
             (_program_id, Some(_))
         );
@@ -457,8 +457,10 @@ fn test_mainnet_beta_cluster_type() {
             (
                 program_id,
                 client
+                    .rpc_client()
                     .get_account_with_commitment(program_id, CommitmentConfig::processed())
                     .unwrap()
+                    .value
             ),
             (program_id, None)
         );
@@ -995,6 +997,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
         let validator_current_slot = cluster
             .get_validator_client(&validator_identity.pubkey())
             .unwrap()
+            .rpc_client()
             .get_slot_with_commitment(CommitmentConfig::finalized())
             .unwrap();
         trace!("validator current slot: {validator_current_slot}");
@@ -1230,6 +1233,7 @@ fn test_snapshot_restart_tower() {
             safe_clone_config(&leader_snapshot_test_config.validator_config),
             safe_clone_config(&validator_snapshot_test_config.validator_config),
         ],
+        skip_warmup_slots: true,
         ..ClusterConfig::default()
     };
 
@@ -1373,7 +1377,10 @@ fn test_snapshots_blockstore_floor() {
     let target_slot = slot_floor + 40;
     while current_slot <= target_slot {
         trace!("current_slot: {}", current_slot);
-        if let Ok(slot) = validator_client.get_slot_with_commitment(CommitmentConfig::processed()) {
+        if let Ok(slot) = validator_client
+            .rpc_client()
+            .get_slot_with_commitment(CommitmentConfig::processed())
+        {
             current_slot = slot;
         } else {
             continue;
@@ -1565,6 +1572,7 @@ fn test_no_voting() {
         .unwrap();
     loop {
         let last_slot = client
+            .rpc_client()
             .get_slot_with_commitment(CommitmentConfig::processed())
             .expect("Couldn't get slot");
         if last_slot > 4 * VOTE_THRESHOLD_DEPTH as u64 {
@@ -1628,6 +1636,7 @@ fn test_optimistic_confirmation_violation_detection() {
     let mut prev_voted_slot = 0;
     loop {
         let last_voted_slot = client
+            .rpc_client()
             .get_slot_with_commitment(CommitmentConfig::processed())
             .unwrap();
         if last_voted_slot > 50 {
@@ -1681,6 +1690,7 @@ fn test_optimistic_confirmation_violation_detection() {
         let client = cluster.get_validator_client(&node_to_restart).unwrap();
         loop {
             let last_root = client
+                .rpc_client()
                 .get_slot_with_commitment(CommitmentConfig::finalized())
                 .unwrap();
             if last_root > prev_voted_slot {
@@ -1758,7 +1768,10 @@ fn test_validator_saves_tower() {
 
     // Wait for some votes to be generated
     loop {
-        if let Ok(slot) = validator_client.get_slot_with_commitment(CommitmentConfig::processed()) {
+        if let Ok(slot) = validator_client
+            .rpc_client()
+            .get_slot_with_commitment(CommitmentConfig::processed())
+        {
             trace!("current slot: {}", slot);
             if slot > 2 {
                 break;
@@ -1783,7 +1796,10 @@ fn test_validator_saves_tower() {
         #[allow(deprecated)]
         // This test depends on knowing the immediate root, without any delay from the commitment
         // service, so the deprecated CommitmentConfig::root() is retained
-        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::root()) {
+        if let Ok(root) = validator_client
+            .rpc_client()
+            .get_slot_with_commitment(CommitmentConfig::root())
+        {
             trace!("current root: {}", root);
             if root > 0 {
                 break root;
@@ -1812,7 +1828,10 @@ fn test_validator_saves_tower() {
         #[allow(deprecated)]
         // This test depends on knowing the immediate root, without any delay from the commitment
         // service, so the deprecated CommitmentConfig::root() is retained
-        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::root()) {
+        if let Ok(root) = validator_client
+            .rpc_client()
+            .get_slot_with_commitment(CommitmentConfig::root())
+        {
             trace!(
                 "current root: {}, last_replayed_root: {}",
                 root,
@@ -1845,7 +1864,10 @@ fn test_validator_saves_tower() {
         #[allow(deprecated)]
         // This test depends on knowing the immediate root, without any delay from the commitment
         // service, so the deprecated CommitmentConfig::root() is retained
-        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::root()) {
+        if let Ok(root) = validator_client
+            .rpc_client()
+            .get_slot_with_commitment(CommitmentConfig::root())
+        {
             trace!("current root: {}, last tower root: {}", root, tower3_root);
             if root > tower3_root {
                 break root;
@@ -2651,11 +2673,7 @@ fn test_oc_bad_signatures() {
     );
 
     // 3) Start up a spy to listen for and push votes to leader TPU
-    let (rpc, tpu) = cluster_tests::get_client_facing_addr(
-        cluster.connection_cache.protocol(),
-        &cluster.entry_point_info,
-    );
-    let client = ThinClient::new(rpc, tpu, cluster.connection_cache.clone());
+    let client = cluster.build_tpu_quic_client().unwrap();
     let cluster_funding_keypair = cluster.funding_keypair.insecure_clone();
     let voter_thread_sleep_ms: usize = 100;
     let num_votes_simulated = Arc::new(AtomicUsize::new(0));
@@ -2702,7 +2720,12 @@ fn test_oc_bad_signatures() {
                     None,
                 );
                 client
-                    .retry_transfer(&cluster_funding_keypair, &mut vote_tx, 5)
+                    .send_and_confirm_transaction_with_retries(
+                        &[&cluster_funding_keypair],
+                        &mut vote_tx,
+                        5,
+                        0,
+                    )
                     .unwrap();
 
                 num_votes_simulated.fetch_add(1, Ordering::Relaxed);
@@ -2856,8 +2879,8 @@ fn setup_transfer_scan_threads(
     num_starting_accounts: usize,
     exit: Arc<AtomicBool>,
     scan_commitment: CommitmentConfig,
-    update_client_receiver: Receiver<ThinClient>,
-    scan_client_receiver: Receiver<ThinClient>,
+    update_client_receiver: Receiver<QuicTpuClient>,
+    scan_client_receiver: Receiver<QuicTpuClient>,
 ) -> (
     JoinHandle<()>,
     JoinHandle<()>,
@@ -2895,6 +2918,7 @@ fn setup_transfer_scan_threads(
                     return;
                 }
                 let (blockhash, _) = client
+                    .rpc_client()
                     .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
                     .unwrap();
                 for i in 0..starting_keypairs_.len() {
@@ -2941,6 +2965,7 @@ fn setup_transfer_scan_threads(
                     return;
                 }
                 if let Some(total_scan_balance) = client
+                    .rpc_client()
                     .get_program_accounts_with_config(
                         &system_program::id(),
                         scan_commitment_config.clone(),

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -222,7 +222,7 @@ fn test_local_cluster_signature_subscribe() {
         .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
         .unwrap();
 
-    let mut transaction = system_transaction::transfer(
+    let transaction = system_transaction::transfer(
         &cluster.funding_keypair,
         &solana_sdk::pubkey::new_rand(),
         10,
@@ -240,12 +240,7 @@ fn test_local_cluster_signature_subscribe() {
     .unwrap();
 
     tx_client
-        .send_and_confirm_transaction_with_retries(
-            &[&cluster.funding_keypair],
-            &mut transaction,
-            5,
-            0,
-        )
+        .send_transaction_to_upcoming_leaders(&transaction)
         .unwrap();
 
     let mut got_received_notification = false;
@@ -2674,7 +2669,6 @@ fn test_oc_bad_signatures() {
 
     // 3) Start up a spy to listen for and push votes to leader TPU
     let client = cluster.build_tpu_quic_client().unwrap();
-    let cluster_funding_keypair = cluster.funding_keypair.insecure_clone();
     let voter_thread_sleep_ms: usize = 100;
     let num_votes_simulated = Arc::new(AtomicUsize::new(0));
     let gossip_voter = cluster_tests::start_gossip_voter(
@@ -2709,7 +2703,7 @@ fn test_oc_bad_signatures() {
                 let vote_slots: Vec<Slot> = vec![vote_slot];
 
                 let bad_authorized_signer_keypair = Keypair::new();
-                let mut vote_tx = vote_transaction::new_vote_transaction(
+                let vote_tx = vote_transaction::new_vote_transaction(
                     vote_slots,
                     vote_hash,
                     leader_vote_tx.message.recent_blockhash,
@@ -2720,12 +2714,7 @@ fn test_oc_bad_signatures() {
                     None,
                 );
                 client
-                    .send_and_confirm_transaction_with_retries(
-                        &[&cluster_funding_keypair],
-                        &mut vote_tx,
-                        5,
-                        0,
-                    )
+                    .send_transaction_to_upcoming_leaders(&vote_tx)
                     .unwrap();
 
                 num_votes_simulated.fetch_add(1, Ordering::Relaxed);

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -676,6 +676,23 @@ where
         self.exit.store(true, Ordering::Relaxed);
         self.leader_tpu_service.join().await;
     }
+
+    pub fn get_connection_cache(&self) -> &Arc<ConnectionCache<P, M, C>>
+    where
+        P: ConnectionPool<NewConnectionConfig = C>,
+        M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
+        C: NewConnectionConfig,
+    {
+        &self.connection_cache
+    }
+
+    pub fn get_leader_tpu_service(&self) -> &LeaderTpuService {
+        &self.leader_tpu_service
+    }
+
+    pub fn get_fanout_slots(&self) -> u64 {
+        self.fanout_slots
+    }
 }
 
 impl<P, M, C> Drop for TpuClient<P, M, C> {
@@ -752,7 +769,7 @@ impl LeaderTpuService {
         self.recent_slots.estimated_current_slot()
     }
 
-    fn leader_tpu_sockets(&self, fanout_slots: u64) -> Vec<SocketAddr> {
+    pub fn leader_tpu_sockets(&self, fanout_slots: u64) -> Vec<SocketAddr> {
         let current_slot = self.recent_slots.estimated_current_slot();
         self.leader_tpu_cache
             .read()

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -111,6 +111,10 @@ where
     /// Attempt to send and confirm tx "attempts" times
     /// Wait for signature confirmation before returning
     /// Return the transaction signature
+    /// NOTE: send_wire_transaction() and try_send_transaction() above both fail in a specific case when used in LocalCluster
+    /// They both invoke the nonblocking TPUClient and both fail when calling "transfer_with_client()" multiple times
+    /// I do not full understand WHY the nonblocking TPUClient fails in this specific case. But the method defined below
+    /// does work although it has only been tested in LocalCluster integration tests
     pub fn send_and_confirm_transaction_with_retries<T: Signers + ?Sized>(
         &self,
         keypairs: &T,

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -1,7 +1,6 @@
 pub use crate::nonblocking::tpu_client::TpuSenderError;
 use {
     crate::nonblocking::tpu_client::TpuClient as NonblockingTpuClient,
-    log::*,
     rayon::iter::{IntoParallelIterator, ParallelIterator},
     solana_connection_cache::{
         client_connection::ClientConnection,
@@ -12,7 +11,7 @@ use {
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{
         client::AsyncClient,
-        clock::{Slot, MAX_PROCESSING_AGE},
+        clock::Slot,
         signature::Signature,
         transaction::{Transaction, VersionedTransaction},
         transport::Result as TransportResult,
@@ -21,7 +20,6 @@ use {
         collections::VecDeque,
         net::UdpSocket,
         sync::{Arc, RwLock},
-        time::Instant,
     },
 };
 #[cfg(feature = "spinner")]
@@ -107,67 +105,29 @@ where
     }
 
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
-    /// size
-    /// Attempt to send and confirm tx "attempts" times
-    /// Wait for signature confirmation before returning
-    /// Return the transaction signature
     /// NOTE: send_wire_transaction() and try_send_transaction() above both fail in a specific case when used in LocalCluster
     /// They both invoke the nonblocking TPUClient and both fail when calling "transfer_with_client()" multiple times
     /// I do not full understand WHY the nonblocking TPUClient fails in this specific case. But the method defined below
     /// does work although it has only been tested in LocalCluster integration tests
-    pub fn send_and_confirm_transaction_with_retries<T: Signers + ?Sized>(
+    pub fn send_transaction_to_upcoming_leaders(
         &self,
-        keypairs: &T,
-        transaction: &mut Transaction,
-        attempts: usize,
-        pending_confirmations: usize,
-    ) -> TransportResult<Signature> {
-        for attempt in 0..attempts {
-            let now = Instant::now();
-            let mut num_confirmed = 0;
-            let mut wait_time = MAX_PROCESSING_AGE;
-            // resend the same transaction until the transaction has no chance of succeeding
-            let wire_transaction =
-                bincode::serialize(&transaction).expect("should serialize transaction");
+        transaction: &Transaction,
+    ) -> TransportResult<()> {
+        let wire_transaction =
+            bincode::serialize(&transaction).expect("should serialize transaction");
 
-            while now.elapsed().as_secs() < wait_time as u64 {
-                let leaders = self
-                    .tpu_client
-                    .get_leader_tpu_service()
-                    .leader_tpu_sockets(self.tpu_client.get_fanout_slots());
-                if num_confirmed == 0 {
-                    for tpu_address in &leaders {
-                        let cache = self.tpu_client.get_connection_cache();
-                        let conn = cache.get_connection(tpu_address);
-                        conn.send_data_async(wire_transaction.clone())?;
-                    }
-                }
+        let leaders = self
+            .tpu_client
+            .get_leader_tpu_service()
+            .leader_tpu_sockets(self.tpu_client.get_fanout_slots());
 
-                if let Ok(confirmed_blocks) = self.rpc_client().poll_for_signature_confirmation(
-                    &transaction.signatures[0],
-                    pending_confirmations,
-                ) {
-                    num_confirmed = confirmed_blocks;
-                    if confirmed_blocks >= pending_confirmations {
-                        return Ok(transaction.signatures[0]);
-                    }
-                    // Since network has seen the transaction, wait longer to receive
-                    // all pending confirmations. Resending the transaction could result into
-                    // extra transaction fees
-                    wait_time = wait_time.max(
-                        MAX_PROCESSING_AGE * pending_confirmations.saturating_sub(num_confirmed),
-                    );
-                }
-            }
-            info!("{attempt} tries failed transfer");
-            let blockhash = self.rpc_client().get_latest_blockhash()?;
-            transaction.sign(keypairs, blockhash);
+        for tpu_address in &leaders {
+            let cache = self.tpu_client.get_connection_cache();
+            let conn = cache.get_connection(tpu_address);
+            conn.send_data_async(wire_transaction.clone())?;
         }
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "failed to confirm transaction".to_string(),
-        )
-        .into())
+
+        Ok(())
     }
 
     /// Serialize and send a batch of transactions to the current and upcoming leader TPUs according


### PR DESCRIPTION
A Followup PR to: https://github.com/anza-xyz/agave/pull/258.
This is the 10th PR on the way to remove ThinClient completely.

#### Problem
`ThinClient` is deprecated. Replacing with `TpuClient`

#### Summary of Changes
Replace `ThinClient` with `TpuClient` in `LocalCluster`
Specifically, we use a Quic TpuClient, not a UDP TpuClient

#### Notes
This works but I can't say for sure why it works. 
I had initially replaced all of `ThinClient` within `LocalCluster` with the nonblocking version of `TpuClient`. I had made the switch such that `transfer_with_client()` calls `TpuClient.try_send_transaction()` which calls `send_wire_transaction_to_addr()`. `send_wire_transaction_to_addr()` uses a non-blocking connection from the connection_cache to send the transaction. 

However, using the changes above, I consistently ran into an issue with any test that called `add_validator()` more than once. Under the hood, `add_validator()` calls `transfer_with_client()`. `transfer_with_client()` transfers some amount of lamports to a destination account (aka the account associated with the validator we are trying to add). However in the `LocalCluster` tests, `transfer_with_client()` would consistently fail when adding the second validator with `add_validator()`. It would always fail with: `transport custom error: "ConnectError(EndpointStopping)`. 

I noticed that `ThinClient` used a blocking connection when sending transactions with `retry_transfer()` (which was used to send a transaction within `transfer_with_client()`. So, I switched over to using the blocking `TpuClient` and that seems to work well. I had to make a few changes to expose the leader schedule, connection cache, and fanout slots from the `nonblocking/tpu_client` up to the blocking `tpu_client`. 

I am still working on investigating. But thinks its probably a good idea to get some eyes on this since it does work as expected now.