### PR TITLE
ledger::shred: Combine all branches in `dispatch!`

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -312,33 +312,15 @@ impl ErasureSetId {
 }
 
 macro_rules! dispatch {
-    ($vis:vis fn $name:ident(&self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
+    ($vis:vis fn $name:ident($self:ty $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
         #[inline]
-        $vis fn $name(&self $(, $arg:$ty)?) $(-> $out)? {
+        $vis fn $name($self $(, $arg:$ty)?) $(-> $out)? {
             match self {
                 Self::ShredCode(shred) => shred.$name($($arg, )?),
                 Self::ShredData(shred) => shred.$name($($arg, )?),
             }
         }
     };
-    ($vis:vis fn $name:ident(self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
-        #[inline]
-        $vis fn $name(self $(, $arg:$ty)?) $(-> $out)? {
-            match self {
-                Self::ShredCode(shred) => shred.$name($($arg, )?),
-                Self::ShredData(shred) => shred.$name($($arg, )?),
-            }
-        }
-    };
-    ($vis:vis fn $name:ident(&mut self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
-        #[inline]
-        $vis fn $name(&mut self $(, $arg:$ty)?) $(-> $out)? {
-            match self {
-                Self::ShredCode(shred) => shred.$name($($arg, )?),
-                Self::ShredData(shred) => shred.$name($($arg, )?),
-            }
-        }
-    }
 }
 
 use dispatch;


### PR DESCRIPTION
Using a single implementation makes the simple logic of `dispatch!` more obvious.
With 3 branches, the reader has to compare the branch texts to see if there are any differences.

`$self:ty` is more broad, compared to `self | &self | &mut self`, but it should not be an issue in practice.
An invalid type value (such as `u32`) would fail to compile.
And there are actually other types that can be used for `self`.