### PR TITLE
Program-Test: Add support for Core BPF programs

### DIFF
--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -25,7 +25,7 @@ solana-bpf-loader-program = { workspace = true }
 solana-inline-spl = { workspace = true }
 solana-logger = { workspace = true }
 solana-program-runtime = { workspace = true }
-solana-runtime = { workspace = true }
+solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true }
 solana-svm = { workspace = true }
 solana-vote-program = { workspace = true }

--- a/program-test/tests/bpf.rs
+++ b/program-test/tests/bpf.rs
@@ -1,0 +1,43 @@
+use {
+    solana_program_test::ProgramTest,
+    solana_sdk::{
+        bpf_loader, instruction::Instruction, pubkey::Pubkey, signature::Signer,
+        transaction::Transaction,
+    },
+};
+
+#[tokio::test]
+async fn core_bpf_program() {
+    let program_id = Pubkey::new_unique();
+
+    std::env::set_var("SBF_OUT_DIR", "../programs/bpf_loader/test_elfs/out");
+
+    let mut program_test = ProgramTest::default();
+    program_test.prefer_bpf(true);
+    program_test.add_program("noop_aligned", program_id, None);
+
+    let mut context = program_test.start_with_context().await;
+
+    // Assert the program is a BPF Loader 2 program.
+    let program_account = context
+        .banks_client
+        .get_account(program_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(program_account.owner, bpf_loader::id());
+
+    // Invoke the program.
+    let instruction = Instruction::new_with_bytes(program_id, &[], Vec::new());
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}

--- a/program-test/tests/core_bpf.rs
+++ b/program-test/tests/core_bpf.rs
@@ -1,0 +1,69 @@
+use {
+    solana_program_test::ProgramTest,
+    solana_sdk::{
+        bpf_loader_upgradeable, feature, instruction::Instruction, signature::Signer,
+        transaction::Transaction,
+    },
+};
+
+#[tokio::test]
+async fn core_bpf_program() {
+    let program_id = solana_sdk::config::program::id();
+    let feature_id = solana_runtime::bank::builtins::test_only::config_program::feature::id();
+    let buffer_address =
+        solana_runtime::bank::builtins::test_only::config_program::source_buffer::id();
+
+    std::env::set_var("SBF_OUT_DIR", "../programs/bpf_loader/test_elfs/out");
+
+    let mut program_test = ProgramTest::default();
+    program_test.prefer_bpf(true);
+    program_test.add_program("noop_aligned", program_id, None);
+
+    let mut context = program_test.start_with_context().await;
+
+    // Assert the feature is active.
+    let feature_account = context
+        .banks_client
+        .get_account(feature_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let feature_account_state = feature::from_account(&feature_account).unwrap();
+    assert_eq!(
+        feature_account_state,
+        feature::Feature {
+            activated_at: Some(0)
+        }
+    );
+
+    // Assert the source buffer does not exist.
+    let buffer_account = context
+        .banks_client
+        .get_account(buffer_address)
+        .await
+        .unwrap();
+    assert!(buffer_account.is_none());
+
+    // Assert the program is an upgradeable BPF program.
+    let program_account = context
+        .banks_client
+        .get_account(program_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(program_account.owner, bpf_loader_upgradeable::id());
+
+    // Invoke the program.
+    let instruction = Instruction::new_with_bytes(program_id, &[], Vec::new());
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7142,6 +7142,14 @@ impl Bank {
     pub fn set_fee_structure(&mut self, fee_structure: &FeeStructure) {
         self.transaction_processor.fee_structure = fee_structure.clone();
     }
+
+    pub fn apply_builtin_program_feature_transitions_for_tests(
+        &mut self,
+        feature_ids: &HashSet<Pubkey>,
+    ) {
+        self.apply_builtin_program_feature_transitions(true, feature_ids);
+        feature_ids.iter().for_each(|f| self.activate_feature(f));
+    }
 }
 
 /// Compute how much an account has changed size.  This function is useful when the data size delta

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -38,7 +38,7 @@ pub(crate) enum CoreBpfMigrationTargetType {
 
 /// Configuration for migrating a built-in program to Core BPF.
 #[derive(Debug, PartialEq)]
-pub(crate) struct CoreBpfMigrationConfig {
+pub struct CoreBpfMigrationConfig {
     /// The address of the source buffer account to be used to replace the
     /// builtin.
     pub source_buffer_address: Pubkey,
@@ -48,12 +48,12 @@ pub(crate) struct CoreBpfMigrationConfig {
     /// activated after the builtin is already enabled.
     pub feature_id: Pubkey,
     /// The type of target to replace.
-    pub migration_target: CoreBpfMigrationTargetType,
+    pub(crate) migration_target: CoreBpfMigrationTargetType,
     /// Static message used to emit datapoint logging.
     /// This is used to identify the migration in the logs.
     /// Should be unique to the migration, ie:
     /// "migrate_{builtin/stateless}_to_core_bpf_{program_name}".
-    pub datapoint_name: &'static str,
+    pub(crate) datapoint_name: &'static str,
 }
 
 fn checked_add<T: CheckedAdd>(a: T, b: T) -> Result<T, CoreBpfMigrationError> {

--- a/runtime/src/bank/builtins/mod.rs
+++ b/runtime/src/bank/builtins/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod core_bpf_migration;
+pub mod core_bpf_migration;
 pub mod prototypes;
 
 pub use prototypes::{BuiltinPrototype, StatelessBuiltinPrototype};
@@ -12,11 +12,11 @@ macro_rules! testable_prototype {
     }) => {
         $prototype {
             core_bpf_migration_config: {
-                #[cfg(not(test))]
+                #[cfg(not(any(test, feature = "dev-context-only-utils")))]
                 {
                     $core_bpf_migration_config
                 }
-                #[cfg(test)]
+                #[cfg(any(test, feature = "dev-context-only-utils"))]
                 {
                     Some( test_only::$name::CONFIG )
                 }
@@ -121,8 +121,8 @@ pub static STATELESS_BUILTINS: &[StatelessBuiltinPrototype] =
 // into the builtins list for both the feature ID and the source program ID.
 // These arbitrary IDs can then be used to configure feature-activation runtime
 // tests.
-#[cfg(test)]
-mod test_only {
+#[cfg(any(test, feature = "dev-context-only-utils"))]
+pub mod test_only {
     use super::core_bpf_migration::{CoreBpfMigrationConfig, CoreBpfMigrationTargetType};
     pub mod system_program {
         pub mod feature {
@@ -131,7 +131,7 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("EDEhzg1Jk79Wrk4mwpRa7txjgRxcE6igXwd6egFDVhuz");
         }
-        pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
+        pub(crate) const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
@@ -146,7 +146,7 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("6T9s4PTcHnpq2AVAqoCbJd4FuHsdD99MjSUEbS7qb1tT");
         }
-        pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
+        pub(crate) const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
@@ -161,7 +161,7 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("2a3XnUr4Xfxd8hBST8wd4D3Qbiu339XKessYsDwabCED");
         }
-        pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
+        pub(crate) const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
@@ -176,7 +176,7 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("73ALcNtVqyM3q7XsvB2xkVECvggu4CcLX5J2XKmpjdBU");
         }
-        pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
+        pub(crate) const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
@@ -191,7 +191,7 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("DveUYB5m9G3ce4zpV3fxg9pCNkvH1wDsyd8XberZ47JL");
         }
-        pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
+        pub(crate) const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
@@ -206,7 +206,7 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("2EWMYGJPuGLW4TexLLEMeXP2BkB1PXEKBFb698yw6LhT");
         }
-        pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
+        pub(crate) const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
@@ -221,7 +221,7 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("6bTmA9iefD57GDoQ9wUjG8SeYkSpRw3EkKzxZCbhkavq");
         }
-        pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
+        pub(crate) const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
@@ -236,7 +236,7 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("KfX1oLpFC5CwmFeSgXrNcXaouKjFkPuSJ4UsKb3zKMX");
         }
-        pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
+        pub(crate) const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
@@ -251,7 +251,7 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("DQshE9LTac8eXjZTi8ApeuZJYH67UxTMUxaEGstC6mqJ");
         }
-        pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
+        pub(crate) const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
@@ -266,7 +266,7 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("Ffe9gL8vXraBkiv3HqbLvBqY7i9V4qtZxjH83jYYDe1V");
         }
-        pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
+        pub(crate) const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
@@ -281,7 +281,7 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("EH45pKy1kzjifB93wEJi91js3S4HETdsteywR7ZCNPn5");
         }
-        pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
+        pub(crate) const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
@@ -296,7 +296,7 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("CWioXdq2ctv8Z4XdhmzJzgpU5i97ZHZZJVSJUmndV3mk");
         }
-        pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
+        pub(crate) const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Stateless,

--- a/runtime/src/bank/builtins/prototypes.rs
+++ b/runtime/src/bank/builtins/prototypes.rs
@@ -5,7 +5,7 @@ use {
 
 /// Transitions of built-in programs at epoch boundaries when features are activated.
 pub struct BuiltinPrototype {
-    pub(crate) core_bpf_migration_config: Option<CoreBpfMigrationConfig>,
+    pub core_bpf_migration_config: Option<CoreBpfMigrationConfig>,
     pub enable_feature_id: Option<Pubkey>,
     pub program_id: Pubkey,
     pub name: &'static str,

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -33,6 +33,7 @@ declare tainted_packages=(
   solana-banking-bench
   agave-ledger-tool
   solana-bench-tps
+  solana-program-test
 )
 
 # convert to comma separeted (ref: https://stackoverflow.com/a/53839433)


### PR DESCRIPTION
#### Problem
Now that the runtime supports migrating builtin programs to Core BPF, we need a 
way to use `solana-program-test` to test the BPF versions of any given builtin 
programs.

Currently, if you provide a BPF program with the same program ID as a default 
builtin program - even if you set `prefer_bpf` to `true` - it will be 
overwritten during Bank setup by the original builtin version.

Program-test should allow developers to provide a BPF program, with `prefer_bpf` 
set to `true` and a program ID matching that of a default builtin, and ensure 
the builtin version is _not_ added, in favor of the provided BPF ELF.

#### Summary of Changes
First, expose the test-only feature gates for migrating builtin program to BPF 
under the runtime's `dev-context-only-utils` feature flag.

Additionally, under `dev-context-only-utils`, expose a test-only function to 
force builtin program feature transitions.

Finally, add support to program-test's `add_program` function for handling Core 
BPF programs correctly, with tests!
