### PR TITLE
chore: bump rust stable to v1.78.0, nightly to 2024-05-02

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2024-01-05
+  nightly_version=2024-05-02
 fi
 
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -330,6 +330,7 @@ fn test_bank_block_height() {
 
 #[test]
 fn test_bank_update_epoch_stakes() {
+    #[allow(non_local_definitions)]
     impl Bank {
         fn epoch_stake_keys(&self) -> Vec<Epoch> {
             let mut keys: Vec<Epoch> = self.epoch_stakes.keys().copied().collect();

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -1036,6 +1036,7 @@ pub(crate) mod tests {
     #[test]
     fn test_vote_balance_and_staked_normal() {
         let stakes_cache = StakesCache::default();
+        #[allow(non_local_definitions)]
         impl Stakes<StakeAccount> {
             fn vote_balance_and_warmed_staked(&self) -> u64 {
                 let vote_balance: u64 = self

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.78.0"

--- a/sdk/program/src/poseidon.rs
+++ b/sdk/program/src/poseidon.rs
@@ -217,6 +217,7 @@ pub fn hashv(
             light_poseidon::{Poseidon, PoseidonBytesHasher, PoseidonError},
         };
 
+        #[allow(non_local_definitions)]
         impl From<PoseidonError> for PoseidonSyscallError {
             fn from(error: PoseidonError) -> Self {
                 match error {


### PR DESCRIPTION
#### Summary of Changes

bump Rust version
