### PR TITLE
clippy: allow dead code for TestTupleStruct

### DIFF
--- a/frozen-abi/src/abi_digester.rs
+++ b/frozen-abi/src/abi_digester.rs
@@ -689,6 +689,7 @@ mod tests {
     mod skip_should_be_same {
         #[frozen_abi(digest = "4LbuvQLX78XPbm4hqqZcHFHpseDJcw4qZL9EUZXSi2Ss")]
         #[derive(Serialize, AbiExample)]
+        #[allow(dead_code)]
         struct TestTupleStruct(i8, i8, #[serde(skip)] i8);
 
         #[frozen_abi(digest = "Hk7BYjZ71upWQJAx2PqoNcapggobPmFbMJd34xVdvRso")]


### PR DESCRIPTION
#### Problem

some changes for bumping Rust version: https://github.com/anza-xyz/agave/pull/1309

![Screenshot 2024-05-13 at 20 00 03](https://github.com/anza-xyz/agave/assets/8209234/6ea171ce-a233-4866-98e0-e4dac7642612)

#### Summary of Changes

not sure do we still want to keep it. add `#[allow(dead_code)]` as a stopgap.