### PR TITLE
clippy: move BumpAllocator under target_os = 'solana'

### DIFF
--- a/programs/sbf/rust/custom_heap/src/lib.rs
+++ b/programs/sbf/rust/custom_heap/src/lib.rs
@@ -19,6 +19,7 @@ use {
 /// Developers can implement their own heap by defining their own
 /// `#[global_allocator]`.  The following implements a dummy for test purposes
 /// but can be flushed out with whatever the developer sees fit.
+#[allow(dead_code)]
 struct BumpAllocator;
 unsafe impl std::alloc::GlobalAlloc for BumpAllocator {
     #[inline]

--- a/programs/sbf/rust/custom_heap/src/lib.rs
+++ b/programs/sbf/rust/custom_heap/src/lib.rs
@@ -2,25 +2,25 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 
+#[cfg(target_os = "solana")]
 use {
-    solana_program::{
-        account_info::AccountInfo,
-        entrypoint::{ProgramResult, HEAP_LENGTH, HEAP_START_ADDRESS},
-        msg,
-        pubkey::Pubkey,
-    },
+    solana_program::entrypoint::{HEAP_LENGTH, HEAP_START_ADDRESS},
+    std::{mem::size_of, ptr::null_mut},
+};
+use {
+    solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey},
     std::{
         alloc::{alloc, Layout},
-        mem::{align_of, size_of},
-        ptr::null_mut,
+        mem::align_of,
     },
 };
 
 /// Developers can implement their own heap by defining their own
 /// `#[global_allocator]`.  The following implements a dummy for test purposes
 /// but can be flushed out with whatever the developer sees fit.
-#[allow(dead_code)]
+#[cfg(target_os = "solana")]
 struct BumpAllocator;
+#[cfg(target_os = "solana")]
 unsafe impl std::alloc::GlobalAlloc for BumpAllocator {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -51,7 +51,7 @@ unsafe impl std::alloc::GlobalAlloc for BumpAllocator {
         // I'm a bump allocator, I don't free
     }
 }
-#[cfg(not(test))]
+#[cfg(all(not(test), target_os = "solana"))]
 #[global_allocator]
 static A: BumpAllocator = BumpAllocator;
 

--- a/programs/sbf/rust/custom_heap/src/lib.rs
+++ b/programs/sbf/rust/custom_heap/src/lib.rs
@@ -51,7 +51,7 @@ unsafe impl std::alloc::GlobalAlloc for BumpAllocator {
         // I'm a bump allocator, I don't free
     }
 }
-#[cfg(all(not(test), target_os = "solana"))]
+#[cfg(target_os = "solana")]
 #[global_allocator]
 static A: BumpAllocator = BumpAllocator;
 


### PR DESCRIPTION
#### Problem

some changes for bumping Rust version: https://github.com/anza-xyz/agave/pull/1309

![Screenshot 2024-05-13 at 20 04 34](https://github.com/anza-xyz/agave/assets/8209234/43ca1108-a16b-4510-a2cb-9944139775fc)

#### Summary of Changes

it's 4-year-old code but looks still useful 🤔  allow dead code as a stopgap.