### PR TITLE
clippy: allow non_local_definitions

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -330,6 +330,7 @@ fn test_bank_block_height() {
 
 #[test]
 fn test_bank_update_epoch_stakes() {
+    #[allow(non_local_definitions)]
     impl Bank {
         fn epoch_stake_keys(&self) -> Vec<Epoch> {
             let mut keys: Vec<Epoch> = self.epoch_stakes.keys().copied().collect();

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -1002,6 +1002,7 @@ pub(crate) mod tests {
     #[test]
     fn test_vote_balance_and_staked_normal() {
         let stakes_cache = StakesCache::default();
+        #[allow(non_local_definitions)]
         impl Stakes<StakeAccount> {
             fn vote_balance_and_warmed_staked(&self) -> u64 {
                 let vote_balance: u64 = self

--- a/sdk/program/src/poseidon.rs
+++ b/sdk/program/src/poseidon.rs
@@ -217,6 +217,7 @@ pub fn hashv(
             light_poseidon::{Poseidon, PoseidonBytesHasher, PoseidonError},
         };
 
+        #[allow(non_local_definitions)]
         impl From<PoseidonError> for PoseidonSyscallError {
             fn from(error: PoseidonError) -> Self {
                 match error {


### PR DESCRIPTION
#### Problem

some changes for bumping Rust version: https://github.com/anza-xyz/agave/pull/1309

![Screenshot 2024-05-13 at 20 18 03](https://github.com/anza-xyz/agave/assets/8209234/92bf2314-c748-4496-8ed3-7e9f3df7732a)

```
error: non-local `impl` definition, they should be avoided as they go against expectation
   --> sdk/program/src/poseidon.rs:220:9
    |
220 | /         impl From<PoseidonError> for PoseidonSyscallError {
221 | |             fn from(error: PoseidonError) -> Self {
222 | |                 match error {
223 | |                     PoseidonError::InvalidNumberOfInputs { .. } => {
...   |
243 | |             }
244 | |         }
    | |_________^
    |
    = help: move this `impl` block outside the of the current function `hashv`
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `-D non-local-definitions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(non_local_definitions)]`
```
#### Summary of Changes

seems this behavior get our code blocks look more elegant. I think maybe we can keep them 🤔 
