### PR TITLE
clippy: multiple_bound_locations

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -126,12 +126,9 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
     });
 }
 
-fn store_accounts_with_possible_contention<F: 'static>(
-    bench_name: &str,
-    bencher: &mut Bencher,
-    reader_f: F,
-) where
-    F: Fn(&Accounts, &[Pubkey]) + Send + Copy,
+fn store_accounts_with_possible_contention<F>(bench_name: &str, bencher: &mut Bencher, reader_f: F)
+where
+    F: Fn(&Accounts, &[Pubkey]) + Send + Copy + 'static,
 {
     let num_readers = 5;
     let accounts_db = new_accounts_db(vec![PathBuf::from(


### PR DESCRIPTION
#### Problem

some changes for bumping Rust version: https://github.com/anza-xyz/agave/pull/1309

https://rust-lang.github.io/rust-clippy/master/index.html#/multiple_bound_locations

#### Summary of Changes

fix it!

```diff
- fn store_accounts_with_possible_contention<F: 'static>(
+ fn store_accounts_with_possible_contention<F>(
    bench_name: &str,
    bencher: &mut Bencher,
    reader_f: F,
) where
-    F: Fn(&Accounts, &[Pubkey]) + Send + Copy,
+    F: Fn(&Accounts, &[Pubkey]) + Send + Copy + 'static,
```