### PR TITLE
clippy: unused_enumerate_index

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -6730,10 +6730,7 @@ pub mod tests {
             let (mut shred, entry) =
                 make_slot_entries(slot, parent_slot, 1, /*merkle_variant:*/ false);
             num_shreds_per_slot = shred.len() as u64;
-            shred
-                .iter_mut()
-                .enumerate()
-                .for_each(|(_, shred)| shred.set_index(0));
+            shred.iter_mut().for_each(|shred| shred.set_index(0));
             shreds.extend(shred);
             entries.extend(entry);
         }


### PR DESCRIPTION
#### Problem

some changes for bumping Rust version: https://github.com/anza-xyz/agave/pull/1309

https://rust-lang.github.io/rust-clippy/master/index.html#/enumerate

#### Summary of Changes

fix it!