### PR TITLE
fix test oddity

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -16881,8 +16881,8 @@ pub mod tests {
         let ideal_av_size = ancient_append_vecs::get_ancient_append_vec_capacity();
         let fat_account_size = (1.5 * ideal_av_size as f64) as u64;
 
-        // Prepare 4 appendvec to combine [small, big, small, small]
-        let account_data_sizes = vec![100, fat_account_size, 100, 100];
+        // Prepare 3 append vecs to combine [small, big, small]
+        let account_data_sizes = vec![100, fat_account_size, 100];
         let (db, slot1) = create_db_with_storages_and_index_with_customized_account_size_per_slot(
             true,
             num_normal_slots + 1,
@@ -16893,11 +16893,11 @@ pub mod tests {
 
         // Adjust alive_ratio for slot2 to test it is shrinkable and is a
         // candidate for squashing into the previous ancient append vec.
-        // However, due to the fact that this appendvec is `oversized`, it can't
+        // However, due to the fact that this append vec is `oversized`, it can't
         // be squashed into the ancient append vec at previous slot (exceeds the
-        // size limit). Therefore, a new "oversized" ancient append vec are
+        // size limit). Therefore, a new "oversized" ancient append vec is
         // created at slot2 as the overflow. This is where the "min_bytes" in
-        // `fn create_ancient_append_vec` used for.
+        // `fn create_ancient_append_vec` is used.
         let slot2 = slot1 + 1;
         let storage2 = db.storage.get_slot_storage_entry(slot2).unwrap();
         let original_cap_slot2 = storage2.accounts.capacity();
@@ -16905,7 +16905,7 @@ pub mod tests {
             .accounts
             .set_current_len_for_tests(original_cap_slot2 as usize);
 
-        // Combine appendvec into ancient append vec.
+        // Combine append vec into ancient append vec.
         let slots_to_combine: Vec<Slot> = (slot1..slot1 + (num_normal_slots + 1) as Slot).collect();
         db.combine_ancient_slots(slots_to_combine, CAN_RANDOMLY_SHRINK_FALSE);
 
@@ -16925,8 +16925,8 @@ pub mod tests {
         assert_eq!(created_accounts.stored_accounts.len(), 1);
         assert_eq!(after_stored_accounts.len(), 1);
 
-        // slot2, even after shrinking, it is still oversized. Therefore, there
-        // exists as an ancient append vec at slot2.
+        // slot2, even after shrinking, is still oversized. Therefore, slot 2
+        // exists as an ancient append vec.
         let storage2_after = db.storage.get_slot_storage_entry(slot2).unwrap();
         assert!(is_ancient(&storage2_after.accounts));
         assert!(storage2_after.capacity() > ideal_av_size);
@@ -17261,7 +17261,7 @@ pub mod tests {
         if num_slots == 0 {
             return;
         }
-        assert!(account_data_sizes.len() == num_slots + 1);
+        assert!(account_data_sizes.len() == num_slots);
         let local_tf = (tf.is_none()).then(|| {
             crate::append_vec::test_utils::get_append_vec_path("create_storages_and_update_index")
         });


### PR DESCRIPTION
#### Problem
some test code has an incorrect and confusing assert. We assert we have more elements in a vec than we use.

#### Summary of Changes
Fix the assert and the one caller.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
