### PR TITLE
RuntimeMessage: interface for MessageProcessor

### DIFF
--- a/svm/src/lib.rs
+++ b/svm/src/lib.rs
@@ -8,6 +8,7 @@ pub mod message_processor;
 pub mod nonce_info;
 pub mod program_loader;
 pub mod runtime_config;
+pub mod runtime_message;
 pub mod transaction_account_state_info;
 pub mod transaction_error_metrics;
 pub mod transaction_processing_callback;

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -1,4 +1,5 @@
 use {
+    crate::runtime_message::RuntimeMessage,
     serde::{Deserialize, Serialize},
     solana_measure::measure::Measure,
     solana_program_runtime::{
@@ -7,7 +8,6 @@ use {
     },
     solana_sdk::{
         account::WritableAccount,
-        message::SanitizedMessage,
         precompiles::is_precompile,
         saturating_add_assign,
         sysvar::instructions,
@@ -35,13 +35,13 @@ impl MessageProcessor {
     /// the call does not violate the bank's accounting rules.
     /// The accounts are committed back to the bank only if every instruction succeeds.
     pub fn process_message(
-        message: &SanitizedMessage,
+        message: &impl RuntimeMessage,
         program_indices: &[Vec<IndexOfAccount>],
         invoke_context: &mut InvokeContext,
         timings: &mut ExecuteTimings,
         accumulated_consumed_units: &mut u64,
     ) -> Result<(), TransactionError> {
-        debug_assert_eq!(program_indices.len(), message.instructions().len());
+        debug_assert_eq!(program_indices.len(), message.num_instructions());
         for (instruction_index, ((program_id, instruction), program_indices)) in message
             .program_instructions_iter()
             .zip(program_indices.iter())
@@ -98,7 +98,7 @@ impl MessageProcessor {
                         instruction_context.configure(
                             program_indices,
                             &instruction_accounts,
-                            &instruction.data,
+                            instruction.data,
                         );
                     })
                     .and_then(|_| {
@@ -109,7 +109,7 @@ impl MessageProcessor {
                 let time = Measure::start("execute_instruction");
                 let mut compute_units_consumed = 0;
                 let result = invoke_context.process_instruction(
-                    &instruction.data,
+                    instruction.data,
                     &instruction_accounts,
                     program_indices,
                     &mut compute_units_consumed,
@@ -158,7 +158,7 @@ mod tests {
             feature_set::FeatureSet,
             hash::Hash,
             instruction::{AccountMeta, Instruction, InstructionError},
-            message::{AccountKeys, Message},
+            message::{AccountKeys, Message, SanitizedMessage},
             native_loader::{self, create_loadable_account_for_test},
             pubkey::Pubkey,
             rent::Rent,

--- a/svm/src/runtime_message.rs
+++ b/svm/src/runtime_message.rs
@@ -1,0 +1,68 @@
+use solana_sdk::{message::SanitizedMessage, pubkey::Pubkey};
+
+pub trait RuntimeMessage {
+    /// Return the number of instructions in the message.
+    fn num_instructions(&self) -> usize;
+
+    /// Return an iterator over the instructions in the message.
+    fn instructions_iter(&self) -> impl Iterator<Item = Instruction>;
+
+    /// Return an iterator over the instructions in the message, paired with
+    /// the pubkey of the program.
+    fn program_instructions_iter(&self) -> impl Iterator<Item = (&Pubkey, Instruction)>;
+
+    /// Returns `true` if the account at `index` is writable.
+    fn is_writable(&self, index: usize) -> bool;
+
+    /// Returns `true` if the account at `index` is signer.
+    fn is_signer(&self, index: usize) -> bool;
+}
+
+/// A non-owning version of [`CompiledInstruction`] that references
+/// slices of account indexes and data
+///
+/// [`Message`]: crate::message::Message
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Instruction<'a> {
+    /// Index into the transaction keys array indicating the program account that executes this instruction.
+    pub program_id_index: u8,
+    /// Ordered indices into the transaction keys array indicating which accounts to pass to the program.
+    pub accounts: &'a [u8],
+    /// The program input data.
+    pub data: &'a [u8],
+}
+
+// Implement for the "reference" `SanitizedMessage` type.
+impl RuntimeMessage for SanitizedMessage {
+    fn num_instructions(&self) -> usize {
+        self.instructions().len()
+    }
+
+    fn instructions_iter(&self) -> impl Iterator<Item = Instruction> {
+        self.instructions()
+            .iter()
+            .map(|compiled_instruction| Instruction {
+                program_id_index: compiled_instruction.program_id_index,
+                accounts: &compiled_instruction.accounts,
+                data: &compiled_instruction.data,
+            })
+    }
+
+    fn program_instructions_iter(&self) -> impl Iterator<Item = (&Pubkey, Instruction)> {
+        self.instructions_iter().map(|instruction| {
+            let program_id = self
+                .account_keys()
+                .get(instruction.program_id_index as usize)
+                .expect("message is sanitized");
+            (program_id, instruction)
+        })
+    }
+
+    fn is_writable(&self, index: usize) -> bool {
+        SanitizedMessage::is_writable(self, index)
+    }
+
+    fn is_signer(&self, index: usize) -> bool {
+        SanitizedMessage::is_signer(self, index)
+    }
+}


### PR DESCRIPTION
### Experimental PR

#### Problem
- Want to abstract message and transaction types in SVM so we can introduce and use a new transaction/message format.

#### Summary of Changes

- Create minimum interface for `MessageProcessor` to process a message
- Implement interface for the reference type `SanitizedMessage` from SDK

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
