### PR TITLE
Don't pass in extra ancestors param to Bank::get_fields_to_serialize()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -491,7 +491,7 @@ pub struct BankFieldsToDeserialize {
 #[derive(Debug)]
 pub(crate) struct BankFieldsToSerialize<'a> {
     pub(crate) blockhash_queue: &'a RwLock<BlockhashQueue>,
-    pub(crate) ancestors: &'a AncestorsForSerialization,
+    pub(crate) ancestors: AncestorsForSerialization,
     pub(crate) hash: Hash,
     pub(crate) parent_hash: Hash,
     pub(crate) parent_slot: Slot,
@@ -1716,13 +1716,10 @@ impl Bank {
     }
 
     /// Return subset of bank fields representing serializable state
-    pub(crate) fn get_fields_to_serialize<'a>(
-        &'a self,
-        ancestors: &'a HashMap<Slot, usize>,
-    ) -> BankFieldsToSerialize<'a> {
+    pub(crate) fn get_fields_to_serialize(&self) -> BankFieldsToSerialize {
         BankFieldsToSerialize {
             blockhash_queue: &self.blockhash_queue,
-            ancestors,
+            ancestors: AncestorsForSerialization::from(&self.ancestors),
             hash: *self.hash.read().unwrap(),
             parent_hash: self.parent_hash,
             parent_slot: self.parent_slot,

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -105,7 +105,7 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
 #[derive(Serialize)]
 struct SerializableVersionedBank<'a> {
     blockhash_queue: &'a RwLock<BlockhashQueue>,
-    ancestors: &'a AncestorsForSerialization,
+    ancestors: AncestorsForSerialization,
     hash: Hash,
     parent_hash: Hash,
     parent_slot: Slot,
@@ -194,8 +194,7 @@ impl<'a> TypeContext<'a> for Context {
     where
         Self: std::marker::Sized,
     {
-        let ancestors = HashMap::from(&serializable_bank.bank.ancestors);
-        let fields = serializable_bank.bank.get_fields_to_serialize(&ancestors);
+        let fields = serializable_bank.bank.get_fields_to_serialize();
         let lamports_per_signature = fields.fee_rate_governor.lamports_per_signature;
         let bank_fields_to_serialize = (
             SerializableVersionedBank::from(fields),
@@ -226,8 +225,7 @@ impl<'a> TypeContext<'a> for Context {
     where
         Self: std::marker::Sized,
     {
-        let ancestors = HashMap::from(&serializable_bank.bank.ancestors);
-        let fields = serializable_bank.bank.get_fields_to_serialize(&ancestors);
+        let fields = serializable_bank.bank.get_fields_to_serialize();
         (
             SerializableVersionedBank::from(fields),
             SerializableAccountsDb::<'a, Self> {
@@ -370,7 +368,7 @@ impl<'a> TypeContext<'a> for Context {
 
         let bank = SerializableVersionedBank {
             blockhash_queue: &blockhash_queue,
-            ancestors: &rhs.ancestors,
+            ancestors: rhs.ancestors,
             hash: rhs.hash,
             parent_hash: rhs.parent_hash,
             parent_slot: rhs.parent_slot,


### PR DESCRIPTION
#### Problem

`Bank::get_fields_to_serialize()` has an `ancestors` parameter because we need a way to get a reference to the ancestors fields as per the fields definition in `BankFieldsToSerialize`.

```rust
pub(crate) struct BankFieldsToSerialize<'a> {
    [..]
    pub(crate) ancestors: &'a AncestorsForSerialization,
```

But the callers of `get_fields_to_serialize()` make a copy of ancestors before calling the function, and then pass in the reference.

So there's no benefit for having `BankFieldsToSerialize::ancestors` be a reference. It just makes all users a bit harder. (And future changes that move bank serialization will need the `ancestors` field to be a non-reference anyway.)


#### Summary of Changes

* Make the ancestors field a value, not a reference
* Remove the ancestors param from `get_fields_to_serialize()`