### PR TITLE
remove unused syn features

### DIFF
--- a/frozen-abi/macro/Cargo.toml
+++ b/frozen-abi/macro/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true, features = ["full", "extra-traits", "visit-mut"] }
+syn = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/frozen-abi/macro/Cargo.toml
+++ b/frozen-abi/macro/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true }
+syn = { workspace = true, features = ["full", "extra-traits"] }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/sdk/macro/Cargo.toml
+++ b/sdk/macro/Cargo.toml
@@ -17,7 +17,7 @@ bs58 = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 rustversion = { workspace = true }
-syn = { workspace = true, features = ["full", "extra-traits"] }
+syn = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/macro/Cargo.toml
+++ b/sdk/macro/Cargo.toml
@@ -17,7 +17,7 @@ bs58 = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 rustversion = { workspace = true }
-syn = { workspace = true }
+syn = { workspace = true, features = ["full"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
We'll see what CI says but `cargo check --tests` passes if I remove these features, and based on what the syn docs say the code should just fail to compile if these features are needed

