### PR TITLE
accounts-db: parallel insersion

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8917,7 +8917,9 @@ impl AccountsDb {
             let mut populate_duplicate_keys_us = 0;
             // outer vec is accounts index bin (determined by pubkey value)
             // inner vec is the pubkeys within that bin that are present in > 1 slot
-            let unique_pubkeys_by_bin = Mutex::new(Vec::<Vec<Pubkey>>::default());
+            //let unique_pubkeys_by_bin = Mutex::new(Vec::<Vec<Pubkey>>::default());
+            let unique_pubkeys_by_bin = DashMap::new(); //Mutex::new(Vec::<Vec<Pubkey>>::default());
+
             if pass == 0 {
                 // tell accounts index we are done adding the initial accounts at startup
                 let mut m = Measure::start("accounts_index_idle_us");
@@ -8929,26 +8931,32 @@ impl AccountsDb {
                     // this has to happen before visit_duplicate_pubkeys_during_startup below
                     // get duplicate keys from acct idx. We have to wait until we've finished flushing.
                     self.accounts_index
-                        .populate_and_retrieve_duplicate_keys_from_startup(|slot_keys| {
-                            total_duplicate_slot_keys
-                                .fetch_add(slot_keys.len() as u64, Ordering::Relaxed);
-                            let unique_keys =
-                                HashSet::<Pubkey>::from_iter(slot_keys.iter().map(|(_, key)| *key));
-                            for (slot, key) in slot_keys {
-                                self.uncleaned_pubkeys.entry(slot).or_default().push(key);
-                            }
-                            let unique_pubkeys_by_bin_inner =
-                                unique_keys.into_iter().collect::<Vec<_>>();
-                            // does not matter that this is not ordered by slot
-                            unique_pubkeys_by_bin
-                                .lock()
-                                .unwrap()
-                                .push(unique_pubkeys_by_bin_inner);
-                        });
+                        .populate_and_retrieve_duplicate_keys_from_startup2(
+                            |(pubkey_bin, slot_keys)| {
+                                total_duplicate_slot_keys
+                                    .fetch_add(slot_keys.len() as u64, Ordering::Relaxed);
+                                let unique_keys = HashSet::<Pubkey>::from_iter(
+                                    slot_keys.iter().map(|(_, key)| *key),
+                                );
+                                for (slot, key) in slot_keys {
+                                    self.uncleaned_pubkeys.entry(slot).or_default().push(key);
+                                }
+                                let unique_pubkeys_by_bin_inner =
+                                    unique_keys.into_iter().collect::<Vec<_>>();
+                                unique_pubkeys_by_bin
+                                    .insert(pubkey_bin, unique_pubkeys_by_bin_inner);
+                                // does not matter that this is not ordered by slot
+                                // unique_pubkeys_by_bin
+                                //     .lock()
+                                //     .unwrap()
+                                //     .push(unique_pubkeys_by_bin_inner);
+                            },
+                        );
                 })
                 .1;
             }
-            let unique_pubkeys_by_bin = unique_pubkeys_by_bin.into_inner().unwrap();
+            //let unique_pubkeys_by_bin = unique_pubkeys_by_bin.into_inner().unwrap();
+            //let unique_pubkeys_by_bin = unique_pubkeys_by_bin.
 
             let mut timings = GenerateIndexTimings {
                 index_flush_us,
@@ -9002,6 +9010,7 @@ impl AccountsDb {
                         DuplicatePubkeysVisitedInfo::default,
                         |accum, pubkeys_by_bin| {
                             let intermediate = pubkeys_by_bin
+                                .value()
                                 .par_chunks(4096)
                                 .fold(DuplicatePubkeysVisitedInfo::default, |accum, pubkeys| {
                                     let (accounts_data_len_from_duplicates, uncleaned_roots) = self

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9002,8 +9002,9 @@ impl AccountsDb {
                         DuplicatePubkeysVisitedInfo::default,
                         |accum, pubkeys_by_bin| {
                             let intermediate = pubkeys_by_bin
-                                .par_chunks(4096)
-                                .fold(DuplicatePubkeysVisitedInfo::default, |accum, pubkeys| {
+                                //.par_chunks(4096)
+                                .chunks(4096)
+                                .fold(DuplicatePubkeysVisitedInfo::default(), |accum, pubkeys| {
                                     let (accounts_data_len_from_duplicates, uncleaned_roots) = self
                                         .visit_duplicate_pubkeys_during_startup(
                                             pubkeys,
@@ -9015,11 +9016,11 @@ impl AccountsDb {
                                         uncleaned_roots,
                                     };
                                     DuplicatePubkeysVisitedInfo::reduce(accum, intermediate)
-                                })
-                                .reduce(
-                                    DuplicatePubkeysVisitedInfo::default,
-                                    DuplicatePubkeysVisitedInfo::reduce,
-                                );
+                                });
+                            // .reduce(
+                            //     DuplicatePubkeysVisitedInfo::default,
+                            //     DuplicatePubkeysVisitedInfo::reduce,
+                            // );
                             DuplicatePubkeysVisitedInfo::reduce(accum, intermediate)
                         },
                     )

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -28,7 +28,8 @@ use {
         collections::{btree_map::BTreeMap, HashSet},
         fmt::Debug,
         ops::{
-            Bound::{self, Excluded, Included, Unbounded},
+            Bound,
+            Bound::{Excluded, Included, Unbounded},
             Range, RangeBounds,
         },
         path::PathBuf,
@@ -1646,8 +1647,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         let mut binned = (0..bins)
             .map(|_| Vec::with_capacity(expected_items_per_bin))
             .collect::<Vec<_>>();
-        let count = AtomicUsize::new(0);
-        let dirty_pubkeys = items
+        let mut count = 0;
+        let mut dirty_pubkeys = items
             .filter_map(|(pubkey, account_info)| {
                 let pubkey_bin = self.bin_calculator.bin_from_pubkey(&pubkey);
                 // this value is equivalent to what update() below would have created if we inserted a new item
@@ -1659,30 +1660,29 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             })
             .collect::<Vec<_>>();
 
-        let binned = Mutex::new(binned);
-        let dirty_pubkeys = Mutex::new(dirty_pubkeys);
-        let mut insert_time = Measure::start("insert_into_primary_index");
+        let insertion_time = AtomicU64::new(0);
+
         // offset bin processing in the 'binned' array by a random amount.
         // This results in calls to insert_new_entry_if_missing_with_lock from different threads starting at different bins to avoid
         // lock contention.
         let random_offset = thread_rng().gen_range(0..bins);
-        let duplicates = Mutex::new(Vec::default());
-        (0..bins).into_par_iter().for_each(|pubkey_bin| {
+        let mut duplicates = Vec::default();
+        (0..bins).for_each(|pubkey_bin| {
             let pubkey_bin = (pubkey_bin + random_offset) % bins;
-            let mut items: Vec<_> = std::mem::take(binned.lock().unwrap()[pubkey_bin].as_mut());
+            let mut items = std::mem::take(&mut binned[pubkey_bin]);
             if items.is_empty() {
                 return;
             }
 
             let these_duplicates = Self::remove_older_duplicate_pubkeys(&mut items);
             if let Some(mut these_duplicates) = these_duplicates {
-                duplicates.lock().unwrap().append(&mut these_duplicates);
+                duplicates.append(&mut these_duplicates);
             }
 
             let r_account_maps = &self.account_maps[pubkey_bin];
-
+            let mut insert_time = Measure::start("insert_into_primary_index");
             // count only considers non-duplicate accounts
-            count.fetch_add(items.len(), Ordering::SeqCst);
+            count += items.len();
             if use_disk {
                 r_account_maps.startup_insert_only(items.into_iter());
             } else {
@@ -1703,27 +1703,21 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                             InsertNewEntryResults::DidNotExist => {}
                             InsertNewEntryResults::ExistedNewEntryZeroLamports => {}
                             InsertNewEntryResults::ExistedNewEntryNonZeroLamports => {
-                                dirty_pubkeys.lock().unwrap().push(pubkey);
+                                dirty_pubkeys.push(pubkey);
                             }
                         }
                     });
             }
+            insert_time.stop();
+            insertion_time.fetch_add(insert_time.as_us(), Ordering::Relaxed);
         });
-        insert_time.stop();
 
-        let mut dups_inner = duplicates.lock().unwrap();
-        let dups = if dups_inner.is_empty() {
-            None
-        } else {
-            Some(std::mem::take(dups_inner.as_mut()))
-        };
-        let dirty_pubkeys = std::mem::take(dirty_pubkeys.lock().unwrap().as_mut());
         (
             dirty_pubkeys,
-            insert_time.as_us(),
+            insertion_time.load(Ordering::Relaxed),
             GenerateIndexResult {
-                count: count.load(Ordering::SeqCst),
-                duplicates: dups,
+                count,
+                duplicates: (!duplicates.is_empty()).then_some(duplicates),
             },
         )
     }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1736,23 +1736,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             .for_each(f);
     }
 
-    /// use Vec<> because the internal vecs are already allocated per bin
-    pub(crate) fn populate_and_retrieve_duplicate_keys_from_startup2(
-        &self,
-        f: impl Fn((usize, Vec<(Slot, Pubkey)>)) + Sync + Send,
-    ) {
-        (0..self.bins())
-            .into_par_iter()
-            .map(|pubkey_bin| {
-                let r_account_maps = &self.account_maps[pubkey_bin];
-                (
-                    pubkey_bin,
-                    r_account_maps.populate_and_retrieve_duplicate_keys_from_startup(),
-                )
-            })
-            .for_each(f);
-    }
-
     /// Updates the given pubkey at the given slot with the new account information.
     /// on return, the index's previous account info may be returned in 'reclaims' depending on 'previous_slot_entry_was_cached'
     pub fn upsert(

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1736,6 +1736,23 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             .for_each(f);
     }
 
+    /// use Vec<> because the internal vecs are already allocated per bin
+    pub(crate) fn populate_and_retrieve_duplicate_keys_from_startup2(
+        &self,
+        f: impl Fn((usize, Vec<(Slot, Pubkey)>)) + Sync + Send,
+    ) {
+        (0..self.bins())
+            .into_par_iter()
+            .map(|pubkey_bin| {
+                let r_account_maps = &self.account_maps[pubkey_bin];
+                (
+                    pubkey_bin,
+                    r_account_maps.populate_and_retrieve_duplicate_keys_from_startup(),
+                )
+            })
+            .for_each(f);
+    }
+
     /// Updates the given pubkey at the given slot with the new account information.
     /// on return, the index's previous account info may be returned in 'reclaims' depending on 'previous_slot_entry_was_cached'
     pub fn upsert(


### PR DESCRIPTION
#### Problem

wip

turns out parallel insersion is slower.

We have already parallelized the outer insertion, i.e. slot. Parallel within a slot make it slower. 

1. remove hashset to vec in populate_dup_keys [no difference]
2. parallel insersion within a slot [slower]
3. change Mutx<Vec<..>> into DashMap [no difference]
4. remove inner par_chunk parallel for account_data_len_dup [no difference]

#### Summary of Changes



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
