### PR TITLE
program: remove unnecessary activation of serde feature of curve25519-dalek

### DIFF
--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -53,7 +53,7 @@ ark-ff = { workspace = true }
 ark-serialize = { workspace = true }
 base64 = { workspace = true, features = ["alloc", "std"] }
 bitflags = { workspace = true }
-curve25519-dalek = { workspace = true, features = ["serde"] }
+curve25519-dalek = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true, features = ["extra_traits"] }
 libsecp256k1 = { workspace = true }

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -24,7 +24,7 @@ tiny-bip39 = { workspace = true }
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 aes-gcm-siv = { workspace = true }
 bincode = { workspace = true }
-curve25519-dalek = { workspace = true }
+curve25519-dalek = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 rand = { version = "0.7" }

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -24,7 +24,7 @@ tiny-bip39 = { workspace = true }
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 aes-gcm-siv = { workspace = true }
 bincode = { workspace = true }
-curve25519-dalek = { workspace = true, features = ["serde"] }
+curve25519-dalek = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 rand = { version = "0.7" }


### PR DESCRIPTION
~~Both solana-program and solana-zk-sdk currently activate the `serde` feature of `curve25519-dalek` unnecessarily.~~

`solana-program`  currently activates the `serde` feature of `curve25519-dalek` unnecessarily. 
Fixing this improves compile time by allowing `curve25519-dalek` to be built earlier in the pipeline
