### PR TITLE
program: remove unused zeroize dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6698,7 +6698,6 @@ dependencies = [
  "static_assertions",
  "thiserror",
  "wasm-bindgen",
- "zeroize",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5440,7 +5440,6 @@ dependencies = [
  "solana-sdk-macro",
  "thiserror",
  "wasm-bindgen",
- "zeroize",
 ]
 
 [[package]]

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -61,7 +61,6 @@ light-poseidon = { workspace = true }
 num-bigint = { workspace = true }
 rand = { workspace = true }
 wasm-bindgen = { workspace = true }
-zeroize = { workspace = true, features = ["default", "zeroize_derive"] }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 arbitrary = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
#### Problem
zeroize is not directly used by solana-program


#### Summary of Changes
Remove it from Cargo.toml and update lock files
