### PR TITLE
program: remove unused libc dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6673,7 +6673,6 @@ dependencies = [
  "itertools",
  "js-sys",
  "lazy_static",
- "libc",
  "libsecp256k1",
  "light-poseidon",
  "log",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5420,7 +5420,6 @@ dependencies = [
  "itertools",
  "js-sys",
  "lazy_static",
- "libc",
  "libsecp256k1 0.6.0",
  "light-poseidon",
  "log",

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -55,7 +55,6 @@ base64 = { workspace = true, features = ["alloc", "std"] }
 bitflags = { workspace = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-libc = { workspace = true, features = ["extra_traits"] }
 libsecp256k1 = { workspace = true }
 light-poseidon = { workspace = true }
 num-bigint = { workspace = true }


### PR DESCRIPTION
#### Problem

libc is not directly used by solana-program


#### Summary of Changes

Remove it from Cargo.toml and update lock files
