### PR TITLE
StandardBroadcastRun::entries_to_shreds(): Remove `Result`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7520,7 +7520,6 @@ dependencies = [
 name = "solana-turbine"
 version = "2.0.0"
 dependencies = [
- "assert_matches",
  "bincode",
  "bytes",
  "crossbeam-channel",

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -40,7 +40,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
-assert_matches = { workspace = true }
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 test-case = { workspace = true }

--- a/turbine/src/lib.rs
+++ b/turbine/src/lib.rs
@@ -11,7 +11,3 @@ extern crate log;
 
 #[macro_use]
 extern crate solana_metrics;
-
-#[cfg(test)]
-#[macro_use]
-extern crate assert_matches;


### PR DESCRIPTION
The only error that `entries_to_shreds()` can currently return is the data or the code shred index going out of bounds.  The only caller, `process_receive_results()` just calls `unwrap()` with no special processing.

And `Shredder` is also checking the produced shred indices.  So it seems simpler to move panics from `process_receive_results()` into `entries_to_shreds()`, removing two arguments from `entries_to_shreds()` and simplifying the return value type.
