### PR TITLE
clippy: readonly_write_lock

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -10979,7 +10979,10 @@ pub mod tests {
                             let slot = shreds[0].slot();
                             // Grab this lock to block `get_slot_entries` before it fetches completed datasets
                             // and then mark the slot as dead, but full, by inserting carefully crafted shreds.
-                            #[allow(clippy::readonly_write_lock)] // Possible clippy bug, the lock is unused so clippy lint shouldn't care about read vs. write lock
+
+                            #[allow(clippy::readonly_write_lock)]
+                            // Possible clippy bug, the lock is unused so clippy shouldn't care
+                            // about read vs. write lock
                             let _lowest_cleanup_slot =
                                 blockstore.lowest_cleanup_slot.write().unwrap();
                             blockstore.insert_shreds(shreds, None, false).unwrap();

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -10979,6 +10979,7 @@ pub mod tests {
                             let slot = shreds[0].slot();
                             // Grab this lock to block `get_slot_entries` before it fetches completed datasets
                             // and then mark the slot as dead, but full, by inserting carefully crafted shreds.
+                            #[allow(clippy::readonly_write_lock)]
                             let _lowest_cleanup_slot =
                                 blockstore.lowest_cleanup_slot.write().unwrap();
                             blockstore.insert_shreds(shreds, None, false).unwrap();

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -10979,7 +10979,7 @@ pub mod tests {
                             let slot = shreds[0].slot();
                             // Grab this lock to block `get_slot_entries` before it fetches completed datasets
                             // and then mark the slot as dead, but full, by inserting carefully crafted shreds.
-                            #[allow(clippy::readonly_write_lock)]
+                            #[allow(clippy::readonly_write_lock)] // Possible clippy bug, the lock is unused so clippy lint shouldn't care about read vs. write lock
                             let _lowest_cleanup_slot =
                                 blockstore.lowest_cleanup_slot.write().unwrap();
                             blockstore.insert_shreds(shreds, None, false).unwrap();


### PR DESCRIPTION
#### Problem

some changes for bumping Rust version: https://github.com/anza-xyz/agave/pull/1309

![Screenshot 2024-05-14 at 15 03 58](https://github.com/anza-xyz/agave/assets/8209234/644a1d25-3981-4c1c-942d-edd70b79858d)

but looks like we fetching this lock intentionally. 

#### Summary of Changes

keep it!