### PR TITLE
sdk: remove unused base64 dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7100,7 +7100,6 @@ version = "2.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "base64 0.22.0",
  "bincode",
  "bitflags 2.4.2",
  "borsh 1.5.0",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6188,7 +6188,6 @@ dependencies = [
 name = "solana-sdk"
 version = "2.0.0"
 dependencies = [
- "base64 0.22.0",
  "bincode",
  "bitflags 2.4.2",
  "borsh 1.5.0",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -38,7 +38,6 @@ dev-context-only-utils = [
 ]
 
 [dependencies]
-base64 = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true, features = ["serde"] }
 borsh = { workspace = true }


### PR DESCRIPTION
#### Problem
base64 is not directly used by solana-sdk

#### Summary of Changes

Remove it from Cargo.toml and update lock files
