### PR TITLE
sdk: remove unused num-derive and num-traits deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7123,8 +7123,6 @@ dependencies = [
  "libsecp256k1",
  "log",
  "memmap2",
- "num-derive",
- "num-traits",
  "num_enum",
  "pbkdf2 0.11.0",
  "qstring",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6209,8 +6209,6 @@ dependencies = [
  "libsecp256k1 0.6.0",
  "log",
  "memmap2",
- "num-derive 0.4.2",
- "num-traits",
  "num_enum",
  "pbkdf2 0.11.0",
  "qstring",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -58,8 +58,6 @@ lazy_static = { workspace = true }
 libsecp256k1 = { workspace = true, optional = true, features = ["hmac"] }
 log = { workspace = true }
 memmap2 = { workspace = true, optional = true }
-num-derive = { workspace = true }
-num-traits = { workspace = true }
 num_enum = { workspace = true }
 pbkdf2 = { workspace = true }
 qstring = { workspace = true }


### PR DESCRIPTION
#### Problem
num-derive and num-traits are not directly used by solana-sdk

#### Summary of Changes
Remove them from Cargo.toml and update lock files