### PR TITLE
clippy: missing_transmute_annotations

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -90,8 +90,9 @@ thread_local! {
     static INVOKE_CONTEXT: RefCell<Option<usize>> = const { RefCell::new(None) };
 }
 fn set_invoke_context(new: &mut InvokeContext) {
-    INVOKE_CONTEXT
-        .with(|invoke_context| unsafe { invoke_context.replace(Some(transmute::<_, usize>(new))) });
+    INVOKE_CONTEXT.with(|invoke_context| unsafe {
+        invoke_context.replace(Some(transmute::<&mut InvokeContext, usize>(new)))
+    });
 }
 fn get_invoke_context<'a, 'b>() -> &'a mut InvokeContext<'b> {
     let ptr = INVOKE_CONTEXT.with(|invoke_context| match *invoke_context.borrow() {

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -90,8 +90,12 @@ thread_local! {
     static INVOKE_CONTEXT: RefCell<Option<usize>> = const { RefCell::new(None) };
 }
 fn set_invoke_context(new: &mut InvokeContext) {
-    INVOKE_CONTEXT
-        .with(|invoke_context| unsafe { invoke_context.replace(Some(transmute::<_, usize>(new))) });
+    INVOKE_CONTEXT.with(|invoke_context| unsafe {
+        invoke_context.replace(Some(transmute::<
+            &mut solana_program_runtime::invoke_context::InvokeContext<'_>,
+            usize,
+        >(new)))
+    });
 }
 fn get_invoke_context<'a, 'b>() -> &'a mut InvokeContext<'b> {
     let ptr = INVOKE_CONTEXT.with(|invoke_context| match *invoke_context.borrow() {

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -90,12 +90,8 @@ thread_local! {
     static INVOKE_CONTEXT: RefCell<Option<usize>> = const { RefCell::new(None) };
 }
 fn set_invoke_context(new: &mut InvokeContext) {
-    INVOKE_CONTEXT.with(|invoke_context| unsafe {
-        invoke_context.replace(Some(transmute::<
-            &mut solana_program_runtime::invoke_context::InvokeContext<'_>,
-            usize,
-        >(new)))
-    });
+    INVOKE_CONTEXT
+        .with(|invoke_context| unsafe { invoke_context.replace(Some(transmute::<_, usize>(new))) });
 }
 fn get_invoke_context<'a, 'b>() -> &'a mut InvokeContext<'b> {
     let ptr = INVOKE_CONTEXT.with(|invoke_context| match *invoke_context.borrow() {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1335,16 +1335,7 @@ fn execute<'a, 'b: 'a>(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // We dropped the lifetime tracking in the Executor by setting it to 'static,
     // thus we need to reintroduce the correct lifetime of InvokeContext here again.
-    let executable = unsafe {
-        mem::transmute::<
-            &solana_rbpf::elf::Executable<
-                solana_program_runtime::invoke_context::InvokeContext<'_>,
-            >,
-            &solana_rbpf::elf::Executable<
-                solana_program_runtime::invoke_context::InvokeContext<'_>,
-            >,
-        >(executable)
-    };
+    let executable = unsafe { mem::transmute::<_, &'a Executable<InvokeContext<'b>>>(executable) };
     let log_collector = invoke_context.get_log_collector();
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1336,7 +1336,7 @@ fn execute<'a, 'b: 'a>(
     // We dropped the lifetime tracking in the Executor by setting it to 'static,
     // thus we need to reintroduce the correct lifetime of InvokeContext here again.
     let executable = unsafe {
-        mem::transmute::<&'a Executable<InvokeContext<'static>>, &'a Executable<InvokeContext<'b>>>(
+        mem::transmute::<&Executable<InvokeContext<'static>>, &'a Executable<InvokeContext<'b>>>(
             executable,
         )
     };

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1335,7 +1335,11 @@ fn execute<'a, 'b: 'a>(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // We dropped the lifetime tracking in the Executor by setting it to 'static,
     // thus we need to reintroduce the correct lifetime of InvokeContext here again.
-    let executable = unsafe { mem::transmute::<_, &'a Executable<InvokeContext<'b>>>(executable) };
+    let executable = unsafe {
+        mem::transmute::<&'a Executable<InvokeContext<'static>>, &'a Executable<InvokeContext<'b>>>(
+            executable,
+        )
+    };
     let log_collector = invoke_context.get_log_collector();
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1335,7 +1335,16 @@ fn execute<'a, 'b: 'a>(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // We dropped the lifetime tracking in the Executor by setting it to 'static,
     // thus we need to reintroduce the correct lifetime of InvokeContext here again.
-    let executable = unsafe { mem::transmute::<_, &'a Executable<InvokeContext<'b>>>(executable) };
+    let executable = unsafe {
+        mem::transmute::<
+            &solana_rbpf::elf::Executable<
+                solana_program_runtime::invoke_context::InvokeContext<'_>,
+            >,
+            &solana_rbpf::elf::Executable<
+                solana_program_runtime::invoke_context::InvokeContext<'_>,
+            >,
+        >(executable)
+    };
     let log_collector = invoke_context.get_log_collector();
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1336,7 +1336,7 @@ fn execute<'a, 'b: 'a>(
     // We dropped the lifetime tracking in the Executor by setting it to 'static,
     // thus we need to reintroduce the correct lifetime of InvokeContext here again.
     let executable = unsafe {
-        mem::transmute::<&Executable<InvokeContext<'static>>, &'a Executable<InvokeContext<'b>>>(
+        mem::transmute::<&'a Executable<InvokeContext<'static>>, &'a Executable<InvokeContext<'b>>>(
             executable,
         )
     };

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -146,8 +146,12 @@ fn execute<'a, 'b: 'a>(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // We dropped the lifetime tracking in the Executor by setting it to 'static,
     // thus we need to reintroduce the correct lifetime of InvokeContext here again.
-    let executable =
-        unsafe { std::mem::transmute::<_, &'a Executable<InvokeContext<'b>>>(executable) };
+    let executable = unsafe {
+        std::mem::transmute::<
+            &'a Executable<InvokeContext<'static>>,
+            &'a Executable<InvokeContext<'b>>,
+        >(executable)
+    };
     let log_collector = invoke_context.get_log_collector();
     let stack_height = invoke_context.get_stack_height();
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -146,8 +146,16 @@ fn execute<'a, 'b: 'a>(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // We dropped the lifetime tracking in the Executor by setting it to 'static,
     // thus we need to reintroduce the correct lifetime of InvokeContext here again.
-    let executable =
-        unsafe { std::mem::transmute::<_, &'a Executable<InvokeContext<'b>>>(executable) };
+    let executable = unsafe {
+        std::mem::transmute::<
+            &solana_rbpf::elf::Executable<
+                solana_program_runtime::invoke_context::InvokeContext<'_>,
+            >,
+            &solana_rbpf::elf::Executable<
+                solana_program_runtime::invoke_context::InvokeContext<'_>,
+            >,
+        >(executable)
+    };
     let log_collector = invoke_context.get_log_collector();
     let stack_height = invoke_context.get_stack_height();
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -146,16 +146,8 @@ fn execute<'a, 'b: 'a>(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // We dropped the lifetime tracking in the Executor by setting it to 'static,
     // thus we need to reintroduce the correct lifetime of InvokeContext here again.
-    let executable = unsafe {
-        std::mem::transmute::<
-            &solana_rbpf::elf::Executable<
-                solana_program_runtime::invoke_context::InvokeContext<'_>,
-            >,
-            &solana_rbpf::elf::Executable<
-                solana_program_runtime::invoke_context::InvokeContext<'_>,
-            >,
-        >(executable)
-    };
+    let executable =
+        unsafe { std::mem::transmute::<_, &'a Executable<InvokeContext<'b>>>(executable) };
     let log_collector = invoke_context.get_log_collector();
     let stack_height = invoke_context.get_stack_height();
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/sbf/rust/invoke/src/processor.rs
+++ b/programs/sbf/rust/invoke/src/processor.rs
@@ -1158,7 +1158,7 @@ fn process_instruction(
             let mut lamports = account.lamports();
             account
                 .lamports
-                .replace(unsafe { mem::transmute::<&mut u64, &mut u64>(&mut lamports) });
+                .replace(unsafe { mem::transmute(&mut lamports) });
             let callee_program_id = accounts[CALLEE_PROGRAM_INDEX].key;
 
             invoke(

--- a/programs/sbf/rust/invoke/src/processor.rs
+++ b/programs/sbf/rust/invoke/src/processor.rs
@@ -1158,7 +1158,7 @@ fn process_instruction(
             let mut lamports = account.lamports();
             account
                 .lamports
-                .replace(unsafe { mem::transmute(&mut lamports) });
+                .replace(unsafe { mem::transmute::<&mut u64, &mut u64>(&mut lamports) });
             let callee_program_id = accounts[CALLEE_PROGRAM_INDEX].key;
 
             invoke(

--- a/programs/sbf/rust/invoke/src/processor.rs
+++ b/programs/sbf/rust/invoke/src/processor.rs
@@ -67,9 +67,9 @@ fn do_nested_invokes(num_nested_invokes: u64, accounts: &[AccountInfo]) -> Progr
 }
 
 solana_program::entrypoint!(process_instruction);
-fn process_instruction(
+fn process_instruction<'a>(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'a>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("invoke Rust program");
@@ -1158,7 +1158,7 @@ fn process_instruction(
             let mut lamports = account.lamports();
             account
                 .lamports
-                .replace(unsafe { mem::transmute::<&mut u64, &mut u64>(&mut lamports) });
+                .replace(unsafe { mem::transmute::<&'_ mut u64, &'a mut u64>(&mut lamports) });
             let callee_program_id = accounts[CALLEE_PROGRAM_INDEX].key;
 
             invoke(

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -316,8 +316,8 @@ mod utils {
         #[cfg_attr(miri, ignore)]
         fn test_ub_illegally_created_multiple_tokens() {
             // Unauthorized token minting!
-            let mut token1 = unsafe { mem::transmute(()) };
-            let mut token2 = unsafe { mem::transmute(()) };
+            let mut token1 = unsafe { mem::transmute::<(), Token<FakeQueue>>(()) };
+            let mut token2 = unsafe { mem::transmute::<(), Token<FakeQueue>>(()) };
 
             let queue = TokenCell::new(FakeQueue {
                 v: Vec::with_capacity(20),

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -316,12 +316,8 @@ mod utils {
         #[cfg_attr(miri, ignore)]
         fn test_ub_illegally_created_multiple_tokens() {
             // Unauthorized token minting!
-            let mut token1 = unsafe {
-                mem::transmute::<(), crate::utils::Token<crate::utils::tests::FakeQueue>>(())
-            };
-            let mut token2 = unsafe {
-                mem::transmute::<(), crate::utils::Token<crate::utils::tests::FakeQueue>>(())
-            };
+            let mut token1 = unsafe { mem::transmute(()) };
+            let mut token2 = unsafe { mem::transmute(()) };
 
             let queue = TokenCell::new(FakeQueue {
                 v: Vec::with_capacity(20),

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -316,8 +316,12 @@ mod utils {
         #[cfg_attr(miri, ignore)]
         fn test_ub_illegally_created_multiple_tokens() {
             // Unauthorized token minting!
-            let mut token1 = unsafe { mem::transmute(()) };
-            let mut token2 = unsafe { mem::transmute(()) };
+            let mut token1 = unsafe {
+                mem::transmute::<(), crate::utils::Token<crate::utils::tests::FakeQueue>>(())
+            };
+            let mut token2 = unsafe {
+                mem::transmute::<(), crate::utils::Token<crate::utils::tests::FakeQueue>>(())
+            };
 
             let queue = TokenCell::new(FakeQueue {
                 v: Vec::with_capacity(20),


### PR DESCRIPTION
#### Problem

some changes for bumping Rust version: https://github.com/anza-xyz/agave/pull/1309

![Screenshot 2024-05-14 at 19 55 24](https://github.com/anza-xyz/agave/assets/8209234/9e550e5c-f7bf-41f5-a409-cc90f3074d74)

https://rust-lang.github.io/rust-clippy/master/index.html#/missing_transmute_annotations

#### Summary of Changes

add the missing types!