### PR TITLE
ledger-tool: Add --enable-extended-tx-metadata-storage arg

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -377,7 +377,7 @@ pub fn load_and_process_ledger(
             enable_rpc_transaction_history,
             transaction_notifier,
             tss_blockstore,
-            false,
+            arg_matches.is_present("enable_extended_tx_metadata_storage"),
             exit.clone(),
         );
         (

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -988,6 +988,16 @@ fn main() {
                         .help("Store transaction info for processed slots into local ledger"),
                 )
                 .arg(
+                    Arg::with_name("enable_extended_tx_metadata_storage")
+                        .long("enable-extended-tx-metadata-storage")
+                        .requires("enable_rpc_transaction_history")
+                        .takes_value(false)
+                        .help(
+                            "Include CPI inner instructions, logs, and return data in the historical \
+                             transaction info stored",
+                        ),
+                )
+                .arg(
                     Arg::with_name("run_final_hash_calc")
                         .long("run-final-accounts-hash-calculation")
                         .takes_value(false)


### PR DESCRIPTION
#### Problem
`agave-ledger-tool verify` can be used to replay transactions with truncated logs (example [tx](https://solscan.io/tx/4QdDG3fjk4vLLHEpxrFYUMux49Eg4vVaynaiKA9fJR64ZSoEcBA4xPpSYAfnSxoB1p2GQAruh8fPoXsUgX5YdZsj) with `"Log truncated"`) in order to recover them and `agave-ledger-tool bigtable upload` can be used to re-upload those blocks having transactions with recovered logs. But currently the required argument `--enable-extended-tx-metadata-storage` is not supported by `agave-ledger-tool`.


#### Summary of Changes
Added `--enable-extended-tx-metadata-storage` argument to `agave-ledger-tool`.