### PR TITLE
clippy: allow dead_code for ParsedFilename

### DIFF
--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -382,6 +382,7 @@ impl CacheHashData {
 }
 
 /// The values of each part of a cache hash data filename
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct ParsedFilename {
     pub slot_range_start: Slot,

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -382,14 +382,13 @@ impl CacheHashData {
 }
 
 /// The values of each part of a cache hash data filename
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct ParsedFilename {
     pub slot_range_start: Slot,
-    pub slot_range_end: Slot,
-    pub bin_range_start: u64,
-    pub bin_range_end: u64,
-    pub hash: u64,
+    pub _slot_range_end: Slot,
+    pub _bin_range_start: u64,
+    pub _bin_range_end: u64,
+    pub _hash: u64,
 }
 
 /// Parses a cache hash data filename into its parts
@@ -408,10 +407,10 @@ fn parse_filename(cache_filename: impl AsRef<Path>) -> Option<ParsedFilename> {
     let hash = u64::from_str_radix(parts.get(4)?, 16).ok()?; // the hash is in hex
     Some(ParsedFilename {
         slot_range_start,
-        slot_range_end,
-        bin_range_start,
-        bin_range_end,
-        hash,
+        _slot_range_end: slot_range_end,
+        _bin_range_start: bin_range_start,
+        _bin_range_end: bin_range_end,
+        _hash: hash,
     })
 }
 
@@ -588,14 +587,15 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::used_underscore_binding)]
     fn test_parse_filename() {
         let good_filename = "123.456.0.65536.537d65697d9b2baa";
         let parsed_filename = parse_filename(good_filename).unwrap();
         assert_eq!(parsed_filename.slot_range_start, 123);
-        assert_eq!(parsed_filename.slot_range_end, 456);
-        assert_eq!(parsed_filename.bin_range_start, 0);
-        assert_eq!(parsed_filename.bin_range_end, 65536);
-        assert_eq!(parsed_filename.hash, 0x537d65697d9b2baa);
+        assert_eq!(parsed_filename._slot_range_end, 456);
+        assert_eq!(parsed_filename._bin_range_start, 0);
+        assert_eq!(parsed_filename._bin_range_end, 65536);
+        assert_eq!(parsed_filename._hash, 0x537d65697d9b2baa);
 
         let bad_filenames = [
             // bad separator


### PR DESCRIPTION
#### Problem

some changes for bumping Rust version: https://github.com/anza-xyz/agave/pull/1309

![Screenshot 2024-05-14 at 20 13 46](https://github.com/anza-xyz/agave/assets/8209234/41203139-d972-409d-ae56-2c5c61bea679)

#### Summary of Changes

allow them as a stopgap