### PR TITLE
clippy: remove the unused field, elapsed, from SampleStats

### DIFF
--- a/bench-tps/src/perf_utils.rs
+++ b/bench-tps/src/perf_utils.rs
@@ -12,6 +12,7 @@ use {
     },
 };
 
+#[allow(dead_code)]
 #[derive(Default)]
 pub struct SampleStats {
     /// Maximum TPS reported by this node

--- a/bench-tps/src/perf_utils.rs
+++ b/bench-tps/src/perf_utils.rs
@@ -12,7 +12,6 @@ use {
     },
 };
 
-#[allow(dead_code)]
 #[derive(Default)]
 pub struct SampleStats {
     /// Maximum TPS reported by this node

--- a/bench-tps/src/perf_utils.rs
+++ b/bench-tps/src/perf_utils.rs
@@ -17,8 +17,6 @@ use {
 pub struct SampleStats {
     /// Maximum TPS reported by this node
     pub tps: f32,
-    /// Total time taken for those txs
-    pub elapsed: Duration,
     /// Total transactions reported by this node
     pub txs: u64,
 }
@@ -79,7 +77,6 @@ pub fn sample_txs<T>(
         if exit_signal.load(Ordering::Relaxed) {
             let stats = SampleStats {
                 tps: max_tps,
-                elapsed: total_elapsed,
                 txs: total_txs,
             };
             sample_stats.write().unwrap().push((client.addr(), stats));


### PR DESCRIPTION
#### Problem

some changes for bumping Rust version: https://github.com/anza-xyz/agave/pull/1309

![Screenshot 2024-05-14 at 20 20 25](https://github.com/anza-xyz/agave/assets/8209234/a0f116b9-1cb5-4a1c-9db6-d29d1ef008ed)


#### Summary of Changes

allow it as a stopgap 🫠 