### PR TITLE
Decorates AccountsPackage::default_for_tests() with DCOU

### DIFF
--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -8,7 +8,7 @@ use {
     log::*,
     solana_accounts_db::{
         accounts::Accounts,
-        accounts_db::{AccountStorageEntry, AccountsDb},
+        accounts_db::AccountStorageEntry,
         accounts_hash::{AccountsHash, AccountsHashKind},
         epoch_accounts_hash::EpochAccountsHash,
     },
@@ -162,6 +162,7 @@ impl AccountsPackage {
     /// Only use for tests; many of the fields are invalid!
     #[cfg(feature = "dev-context-only-utils")]
     pub fn default_for_tests() -> Self {
+        use solana_accounts_db::accounts_db::AccountsDb;
         let accounts_db = AccountsDb::default_for_tests();
         let accounts = Accounts::new(Arc::new(accounts_db));
         Self {

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -160,6 +160,7 @@ impl AccountsPackage {
 
     /// Create a new Accounts Package where basically every field is defaulted.
     /// Only use for tests; many of the fields are invalid!
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn default_for_tests() -> Self {
         let accounts_db = AccountsDb::default_for_tests();
         let accounts = Accounts::new(Arc::new(accounts_db));


### PR DESCRIPTION
#### Problem

`AccountsPackage::default_for_tests()` is only called from tests. I want to enforce that non-tests cannot call this function, as I intend to add more fields to this type that I definitely do not want called from non-tests.


#### Summary of Changes

Decorate with DCOU.
