### PR TITLE
exit early if buffer is empty

### DIFF
--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -293,6 +293,10 @@ impl PrioritizationFeeCache {
         bank_id: BankId,
         metrics: &PrioritizationFeeCacheMetrics,
     ) {
+        if unfinalized.is_empty() {
+            return;
+        }
+
         // prune cache by evicting write account entry from prioritization fee if its fee is less
         // or equal to block's minimum transaction fee, because they are irrelevant in calculating
         // block minimum fee.

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -307,7 +307,6 @@ impl PrioritizationFeeCache {
                     .split_off(&slot.checked_sub(MAX_UNFINALIZED_SLOTS).unwrap_or_default());
 
                 let Some(mut slot_prioritization_fee) = unfinalized.remove(&slot) else {
-                    warn!("Finalized slot {slot} not found");
                     return;
                 };
 


### PR DESCRIPTION
#### Problem

A `warn` of finalized slot isn't found in priority fee cache, is printed for empty slot. This `warn` is false negative, since empty slot will not have any prioritization fee info.

#### Summary of Changes
- exit early if `unfinalized` buffer is empty.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
