### PR TITLE
gossip: process duplicate proofs for chained merkle root conflicts

### DIFF
--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -338,7 +338,7 @@ impl SlotMeta {
 }
 
 impl ErasureMeta {
-    pub(crate) fn from_coding_shred(shred: &Shred) -> Option<Self> {
+    pub fn from_coding_shred(shred: &Shred) -> Option<Self> {
         match shred.shred_type() {
             ShredType::Data => None,
             ShredType::Code => {
@@ -396,7 +396,7 @@ impl ErasureMeta {
         u32::try_from(self.first_received_coding_index).ok()
     }
 
-    pub(crate) fn next_fec_set_index(&self) -> Option<u32> {
+    pub fn next_fec_set_index(&self) -> Option<u32> {
         let num_data = u64::try_from(self.config.num_data).ok()?;
         self.fec_set_index
             .checked_add(num_data)

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -348,7 +348,7 @@ impl Shred {
     dispatch!(fn set_signature(&mut self, signature: Signature));
     dispatch!(fn signed_data(&self) -> Result<SignedData, Error>);
 
-    dispatch!(pub(crate) fn chained_merkle_root(&self) -> Result<Hash, Error>);
+    dispatch!(pub fn chained_merkle_root(&self) -> Result<Hash, Error>);
     // Returns the portion of the shred's payload which is erasure coded.
     dispatch!(pub(crate) fn erasure_shard(self) -> Result<Vec<u8>, Error>);
     // Like Shred::erasure_shard but returning a slice.


### PR DESCRIPTION
#### Problem
With the addition of chained merkle shreds, there is a new class of duplicate proofs available to be gossiped

#### Summary of Changes
Add a check for chained merkle root conflict proofs:
* Lower fec set shred must be a coding shred
* Fec sets are adjacent
* Merkle root of the lower fec set must not equal the chained merkle root of the higher fec set

Fixes https://github.com/solana-labs/solana/issues/34897