### PR TITLE
Add default value for loaded-accounts-data-size

### DIFF
--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -17,6 +17,7 @@ solana-sdk = { workspace = true }
 rustc_version = { workspace = true }
 
 [features]
+dev-context-only-utils = []
 frozen-abi = [
     "dep:solana-frozen-abi",
     "solana-sdk/frozen-abi",

--- a/compute-budget/src/compute_budget_processor.rs
+++ b/compute-budget/src/compute_budget_processor.rs
@@ -22,6 +22,9 @@ pub const MIN_HEAP_FRAME_BYTES: u32 = HEAP_LENGTH as u32;
 /// The total accounts data a transaction can load is limited to 64MiB to not break
 /// anyone in Mainnet-beta today. It can be set by set_loaded_accounts_data_size_limit instruction
 pub const MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES: u32 = 64 * 1024 * 1024;
+/// The default accounts data size a transaction can load if sender didn't set specific
+/// value via set_loaded_accounts_data_size_limit
+pub const DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_BYTES: u32 = 32 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ComputeBudgetLimits {
@@ -37,7 +40,7 @@ impl Default for ComputeBudgetLimits {
             updated_heap_bytes: MIN_HEAP_FRAME_BYTES,
             compute_unit_limit: MAX_COMPUTE_UNIT_LIMIT,
             compute_unit_price: 0,
-            loaded_accounts_bytes: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
+            loaded_accounts_bytes: DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
         }
     }
 }
@@ -136,7 +139,7 @@ pub fn process_compute_budget_instructions<'a>(
     let compute_unit_price = updated_compute_unit_price.unwrap_or(0);
 
     let loaded_accounts_bytes = updated_loaded_accounts_data_size_limit
-        .unwrap_or(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES)
+        .unwrap_or(DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_BYTES)
         .min(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
 
     Ok(ComputeBudgetLimits {

--- a/compute-budget/src/compute_budget_processor.rs
+++ b/compute-budget/src/compute_budget_processor.rs
@@ -198,7 +198,7 @@ mod tests {
     };
 
     macro_rules! test {
-        ( $instructions: expr, $expected_result: expr, $use_default_loaded_accounts_data_szie: expr) => {
+        ( $instructions: expr, $expected_result: expr, $use_default_loaded_accounts_data_size: expr) => {
             let payer_keypair = Keypair::new();
             let tx = SanitizedTransaction::from_transaction_for_tests(Transaction::new(
                 &[&payer_keypair],
@@ -207,7 +207,7 @@ mod tests {
             ));
             let result = process_compute_budget_instructions(
                 tx.message().program_instructions_iter(),
-                $use_default_loaded_accounts_data_szie,
+                $use_default_loaded_accounts_data_size,
             );
             assert_eq!($expected_result, result);
         };

--- a/compute-budget/src/compute_budget_processor.rs
+++ b/compute-budget/src/compute_budget_processor.rs
@@ -34,6 +34,14 @@ pub struct ComputeBudgetLimits {
     pub loaded_accounts_bytes: u32,
 }
 
+// Default is only usable from dev context (ie. tests, benches etc)
+#[cfg(any(test, feature = "dev-context-only-utils"))]
+impl Default for ComputeBudgetLimits {
+    fn default() -> Self {
+        Self::new_with(false)
+    }
+}
+
 impl ComputeBudgetLimits {
     // default constructor with feature gate
     pub fn new_with(use_default_loaded_accounts_data_size: bool) -> Self {
@@ -188,17 +196,6 @@ mod tests {
             transaction::{SanitizedTransaction, Transaction},
         },
     };
-
-    impl Default for ComputeBudgetLimits {
-        fn default() -> Self {
-            ComputeBudgetLimits {
-                updated_heap_bytes: u32::try_from(MIN_HEAP_FRAME_BYTES).unwrap(),
-                compute_unit_limit: MAX_COMPUTE_UNIT_LIMIT,
-                compute_unit_price: 0,
-                loaded_accounts_bytes: DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
-            }
-        }
-    }
 
     macro_rules! test {
         ( $instructions: expr, $expected_result: expr, $use_default_loaded_accounts_data_szie: expr) => {

--- a/compute-budget/src/compute_budget_processor.rs
+++ b/compute-budget/src/compute_budget_processor.rs
@@ -443,7 +443,7 @@ mod tests {
         // budget is set to default data size
         let expected_result = Ok(ComputeBudgetLimits {
             compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
-            loaded_accounts_bytes: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
+            loaded_accounts_bytes: DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
             ..ComputeBudgetLimits::default()
         });
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -741,8 +741,12 @@ impl Consumer {
         error_counters: &mut TransactionErrorMetrics,
     ) -> Result<(), TransactionError> {
         let fee_payer = message.fee_payer();
-        let budget_limits =
-            process_compute_budget_instructions(message.program_instructions_iter())?.into();
+        let budget_limits = process_compute_budget_instructions(
+            message.program_instructions_iter(),
+            bank.feature_set
+                .is_active(&feature_set::default_loaded_accounts_data_size_limit::id()),
+        )?
+        .into();
         let fee = bank.fee_structure().calculate_fee(
             message,
             bank.get_lamports_per_signature(),

--- a/core/src/banking_stage/forward_packet_batches_by_accounts.rs
+++ b/core/src/banking_stage/forward_packet_batches_by_accounts.rs
@@ -187,6 +187,7 @@ mod tests {
         let transaction = Transaction::new_unsigned(Message::new(
             &[
                 ComputeBudgetInstruction::set_compute_unit_price(priority),
+                ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(64 * 1024 * 1024),
                 system_instruction::transfer(&from_account, write_to_account, 2),
             ],
             Some(&from_account),

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -281,6 +281,7 @@ impl CostModel {
 mod tests {
     use {
         super::*,
+        solana_compute_budget::compute_budget_processor::ComputeBudgetLimits,
         solana_sdk::{
             compute_budget::{self, ComputeBudgetInstruction},
             fee::ACCOUNT_DATA_COST_PAGE_SIZE,
@@ -617,8 +618,7 @@ mod tests {
             .unwrap();
         const DEFAULT_PAGE_COST: u64 = 8;
         let expected_loaded_accounts_data_size_cost =
-            solana_program_runtime::compute_budget_processor::DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_BYTES
-                as u64
+            ComputeBudgetLimits::get_default_loaded_accounts_data_size_bytes(true) as u64
                 / ACCOUNT_DATA_COST_PAGE_SIZE
                 * DEFAULT_PAGE_COST;
 

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -615,7 +615,7 @@ mod tests {
             .unwrap();
         const DEFAULT_PAGE_COST: u64 = 8;
         let expected_loaded_accounts_data_size_cost =
-            solana_compute_budget::compute_budget_processor::MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES
+            solana_program_runtime::compute_budget_processor::DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_BYTES
                 as u64
                 / ACCOUNT_DATA_COST_PAGE_SIZE
                 * DEFAULT_PAGE_COST;

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -173,8 +173,10 @@ impl CostModel {
 
         // if failed to process compute_budget instructions, the transaction will not be executed
         // by `bank`, therefore it should be considered as no execution cost by cost model.
-        match process_compute_budget_instructions(transaction.message().program_instructions_iter())
-        {
+        match process_compute_budget_instructions(
+            transaction.message().program_instructions_iter(),
+            feature_set.is_active(&feature_set::default_loaded_accounts_data_size_limit::id()),
+        ) {
             Ok(compute_budget_limits) => {
                 // if tx contained user-space instructions and a more accurate estimate available correct it,
                 // where "user-space instructions" must be specifically checked by

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -199,6 +199,7 @@ mod tests {
     use {
         super::*,
         crate::cost_model::CostModel,
+        solana_compute_budget::compute_budget_processor::ComputeBudgetLimits,
         solana_sdk::{
             feature_set::FeatureSet,
             fee::ACCOUNT_DATA_COST_PAGE_SIZE,
@@ -252,8 +253,7 @@ mod tests {
         // expected non-vote tx cost would include default loaded accounts size cost additionally
         const DEFAULT_PAGE_COST: u64 = 8;
         let expected_loaded_accounts_data_size_cost =
-            solana_program_runtime::compute_budget_processor::DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_BYTES
-                as u64
+            ComputeBudgetLimits::get_default_loaded_accounts_data_size_bytes(true) as u64
                 / ACCOUNT_DATA_COST_PAGE_SIZE
                 * DEFAULT_PAGE_COST;
         let min_none_vote_cost = SIMPLE_VOTE_USAGE_COST + expected_loaded_accounts_data_size_cost;

--- a/programs/bpf-loader-tests/tests/common.rs
+++ b/programs/bpf-loader-tests/tests/common.rs
@@ -6,6 +6,7 @@ use {
         account::AccountSharedData,
         account_utils::StateMut,
         bpf_loader_upgradeable::{id, UpgradeableLoaderState},
+        compute_budget::ComputeBudgetInstruction,
         instruction::{Instruction, InstructionError},
         pubkey::Pubkey,
         signature::{Keypair, Signer},
@@ -35,7 +36,10 @@ pub async fn assert_ix_error(
     }
 
     let transaction = Transaction::new_signed_with_payer(
-        &[ix],
+        &[
+            ix,
+            ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(64 * 1024 * 1024),
+        ],
         Some(&fee_payer.pubkey()),
         &signers,
         recent_blockhash,

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -139,6 +139,7 @@ mod tests {
         },
         solana_sdk::{
             compute_budget::ComputeBudgetInstruction,
+            feature_set::FeatureSet,
             instruction::Instruction,
             message::Message,
             reserved_account_keys::ReservedAccountKeys,
@@ -221,10 +222,15 @@ mod tests {
             svt: SanitizedVersionedTransaction,
             is_simple_vote: Option<bool>,
         ) -> bool {
-            RuntimeTransaction::<SanitizedVersionedMessage>::try_from(svt, None, is_simple_vote)
-                .unwrap()
-                .meta
-                .is_simple_vote_tx
+            RuntimeTransaction::<SanitizedVersionedMessage>::try_from(
+                svt,
+                None,
+                is_simple_vote,
+                &FeatureSet::default(),
+            )
+            .unwrap()
+            .meta
+            .is_simple_vote_tx
         }
 
         assert!(!get_is_simple_vote(
@@ -257,6 +263,7 @@ mod tests {
                 non_vote_sanitized_versioned_transaction(),
                 Some(hash),
                 None,
+                &FeatureSet::default(),
             )
             .unwrap();
 
@@ -291,6 +298,7 @@ mod tests {
                 .to_sanitized_versioned_transaction(),
             Some(hash),
             None,
+            &FeatureSet::default(),
         )
         .unwrap();
 

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -15,7 +15,7 @@ use {
         process_compute_budget_instructions, ComputeBudgetLimits,
     },
     solana_sdk::{
-        feature_set::{self, default_loaded_accounts_data_size_limit},
+        feature_set::{default_loaded_accounts_data_size_limit, FeatureSet},
         hash::Hash,
         message::{AddressLoader, SanitizedMessage, SanitizedVersionedMessage},
         pubkey::Pubkey,
@@ -72,7 +72,7 @@ impl RuntimeTransaction<SanitizedVersionedMessage> {
         sanitized_versioned_tx: SanitizedVersionedTransaction,
         message_hash: Option<Hash>,
         is_simple_vote_tx: Option<bool>,
-        feature_set: &feature_set::FeatureSet,
+        feature_set: &FeatureSet,
     ) -> Result<Self> {
         let mut meta = TransactionMeta::default();
         meta.set_is_simple_vote_tx(

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -15,6 +15,7 @@ use {
         process_compute_budget_instructions, ComputeBudgetLimits,
     },
     solana_sdk::{
+        feature_set::{self, default_loaded_accounts_data_size_limit},
         hash::Hash,
         message::{AddressLoader, SanitizedMessage, SanitizedVersionedMessage},
         pubkey::Pubkey,
@@ -71,6 +72,7 @@ impl RuntimeTransaction<SanitizedVersionedMessage> {
         sanitized_versioned_tx: SanitizedVersionedTransaction,
         message_hash: Option<Hash>,
         is_simple_vote_tx: Option<bool>,
+        feature_set: &feature_set::FeatureSet,
     ) -> Result<Self> {
         let mut meta = TransactionMeta::default();
         meta.set_is_simple_vote_tx(
@@ -86,7 +88,10 @@ impl RuntimeTransaction<SanitizedVersionedMessage> {
             compute_unit_price,
             loaded_accounts_bytes,
             ..
-        } = process_compute_budget_instructions(message.program_instructions_iter())?;
+        } = process_compute_budget_instructions(
+            message.program_instructions_iter(),
+            feature_set.is_active(&default_loaded_accounts_data_size_limit::id()),
+        )?;
         meta.set_compute_unit_limit(compute_unit_limit);
         meta.set_compute_unit_price(compute_unit_price);
         meta.set_loaded_accounts_bytes(loaded_accounts_bytes);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -97,7 +97,6 @@ use {
     solana_measure::{measure, measure::Measure, measure_us},
     solana_perf::perf_libs,
     solana_program_runtime::{
-        compute_budget_processor::{process_compute_budget_instructions, ComputeBudgetLimits},
         invoke_context::BuiltinFunctionWithContext,
         loaded_programs::ProgramCacheEntry,
         timings::{ExecuteTimingType, ExecuteTimings},

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -90,7 +90,7 @@ use {
     solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
     solana_compute_budget::{
         compute_budget::ComputeBudget,
-        compute_budget_processor::process_compute_budget_instructions,
+        compute_budget_processor::{process_compute_budget_instructions, ComputeBudgetLimits},
     },
     solana_cost_model::cost_tracker::CostTracker,
     solana_loader_v4_program::create_program_runtime_environment_v2,

--- a/runtime/src/compute_budget_details.rs
+++ b/runtime/src/compute_budget_details.rs
@@ -23,7 +23,14 @@ pub trait GetComputeBudgetDetails {
         instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
         _round_compute_unit_price_enabled: bool,
     ) -> Option<ComputeBudgetDetails> {
-        let compute_budget_limits = process_compute_budget_instructions(instructions).ok()?;
+        // ComputeBudgetDetails does not concern with loaded_accounts_data_size_limit, hence safe
+        // to hardcode its feature gate `default_loaded_accounts_data_size_limit` as activated
+        let use_default_loaded_accounts_data_size = true;
+        let compute_budget_limits = process_compute_budget_instructions(
+            instructions,
+            use_default_loaded_accounts_data_size,
+        )
+        .ok()?;
         Some(ComputeBudgetDetails {
             compute_unit_price: compute_budget_limits.compute_unit_price,
             compute_unit_limit: u64::from(compute_budget_limits.compute_unit_limit),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -832,6 +832,10 @@ pub mod verify_retransmitter_signature {
     solana_sdk::declare_id!("BZ5g4hRbu5hLQQBdPyo2z9icGyJ8Khiyj3QS6dhWijTb");
 }
 
+pub mod default_loaded_accounts_data_size_limit {
+    solana_sdk::declare_id!("CVvWw7NMVCn2Yp5RfxqrcTHXnaYyh91A2bGbkk88XXMM");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -1035,6 +1039,7 @@ lazy_static! {
         (migrate_address_lookup_table_program_to_core_bpf::id(), "Migrate Address Lookup Table program to Core BPF #1651"),
         (zk_elgamal_proof_program_enabled::id(), "Enable ZkElGamalProof program SIMD-0153"),
         (verify_retransmitter_signature::id(), "Verify retransmitter signature #1840"),
+        (default_loaded_accounts_data_size_limit::id(), "add default loaded_accounts_data_size_limit #1568"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -41,6 +41,7 @@ prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
+solana-compute-budget = { workspace = true, features = ["dev-context-only-utils"] }
 solana-compute-budget-program = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -904,7 +904,6 @@ mod tests {
 
     #[test]
     fn test_get_requested_loaded_accounts_data_size_limit() {
-        // an private helper function
         fn test(
             instructions: &[solana_sdk::instruction::Instruction],
             expected_result: &Result<Option<NonZeroUsize>>,

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -204,7 +204,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
 
     let requested_loaded_accounts_data_size_limit = get_requested_loaded_accounts_data_size_limit(
         message,
-        feature_set.is_active(&default_loaded_accounts_data_size_limit::id()),
+        feature_set.is_active(&feature_set::default_loaded_accounts_data_size_limit::id()),
     )?;
     let mut accumulated_accounts_data_size: usize = 0;
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -934,7 +934,7 @@ mod tests {
 
         let result_default_limit = Ok(Some(
             NonZeroUsize::new(
-                usize::try_from(compute_budget_processor::MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES)
+                usize::try_from(compute_budget_processor::DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_BYTES)
                     .unwrap(),
             )
             .unwrap(),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -422,6 +422,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     ) -> transaction::Result<ValidatedTransactionDetails> {
         let compute_budget_limits = process_compute_budget_instructions(
             message.program_instructions_iter(),
+            feature_set.is_active(&feature_set::default_loaded_accounts_data_size_limit::id()),
         )
         .map_err(|err| {
             error_counters.invalid_compute_budget += 1;

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -39,6 +39,7 @@ use {
         account::{AccountSharedData, ReadableAccount, PROGRAM_OWNERS},
         clock::{Epoch, Slot},
         feature_set::{
+            default_loaded_accounts_data_size_limit,
             include_loaded_accounts_data_size_in_fee_calculation,
             remove_rounding_in_fee_calculation, FeatureSet,
         },
@@ -422,7 +423,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     ) -> transaction::Result<ValidatedTransactionDetails> {
         let compute_budget_limits = process_compute_budget_instructions(
             message.program_instructions_iter(),
-            feature_set.is_active(&feature_set::default_loaded_accounts_data_size_limit::id()),
+            feature_set.is_active(&default_loaded_accounts_data_size_limit::id()),
         )
         .map_err(|err| {
             error_counters.invalid_compute_budget += 1;
@@ -1958,7 +1959,7 @@ mod tests {
             &Hash::new_unique(),
         ));
         let compute_budget_limits =
-            process_compute_budget_instructions(message.program_instructions_iter()).unwrap();
+            process_compute_budget_instructions(message.program_instructions_iter(), true).unwrap();
         let fee_payer_address = message.fee_payer();
         let current_epoch = 42;
         let rent_collector = RentCollector {
@@ -2038,7 +2039,7 @@ mod tests {
             &Hash::new_unique(),
         ));
         let compute_budget_limits =
-            process_compute_budget_instructions(message.program_instructions_iter()).unwrap();
+            process_compute_budget_instructions(message.program_instructions_iter(), true).unwrap();
         let fee_payer_address = message.fee_payer();
         let mut rent_collector = RentCollector::default();
         rent_collector.rent.lamports_per_byte_year = 1_000_000;
@@ -2275,7 +2276,7 @@ mod tests {
             &Hash::new_unique(),
         ));
         let compute_budget_limits =
-            process_compute_budget_instructions(message.program_instructions_iter()).unwrap();
+            process_compute_budget_instructions(message.program_instructions_iter(), true).unwrap();
         let fee_payer_address = message.fee_payer();
         let min_balance = Rent::default().minimum_balance(nonce::State::size());
         let transaction_fee = lamports_per_signature;


### PR DESCRIPTION
#### Problem

Compute budget instruction `set_loaded_accounts_data_size_limit` was introduced since v1.16, transaction sender can use it to set limits of accounts to load for transaction. It uses `MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES = 64MiB` as default value if `set_loaded_accounts_data_size_limit` is absent from transaction during initial rollout, so no known transactions in mnb would fail without adapting the new instruction. It should use a reasonable default value that is lesser than MAX, as users start to adapting this instruction.

#### Summary of Changes
- add and use `DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_BYTES` in absence of `set_loaded_accounts_data_size_limit`

Feature Gate Issue: #1568 
<!-- Don't forget to add the "feature-gate" label -->
