### PR TITLE
Allow `cargo-test-sbf` accept `--tools-version`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5715,6 +5715,7 @@ dependencies = [
  "clap 3.2.23",
  "itertools",
  "log",
+ "regex",
  "solana-logger",
 ]
 

--- a/sdk/cargo-test-sbf/Cargo.toml
+++ b/sdk/cargo-test-sbf/Cargo.toml
@@ -14,6 +14,7 @@ cargo_metadata = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo"] }
 itertools = { workspace = true }
 log = { workspace = true, features = ["std"] }
+regex = { workspace = true }
 solana-logger = { workspace = true }
 
 [[bin]]


### PR DESCRIPTION
#### Problem

I need to use newer `platform-tools`, when build the program, I can use for example `cargo-build-sbf --tools-version v1.41`,
but `cargo-test-sbf` can't specify it, so it will fail

```
$ cargo-test-sbf
error: package `solana-program v1.18.12` cannot be built because it requires rustc 1.75.0 or newer, while the currently active rustc version is 1.68.0-dev
Either upgrade to rustc 1.75.0 or newer, or use
cargo update -p solana-program@1.18.12 --precise ver
where `ver` is the latest version of `solana-program` supporting rustc 1.68.0-dev
```

#### Summary of Changes

Allow `cargo-test-sbf` accept `--tools-version`