### PR TITLE
ledger::shred: Document the `dispatch!` macro

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -311,6 +311,14 @@ impl ErasureSetId {
     }
 }
 
+/// To be used with the [`Shred`] enum.
+///
+/// Writes a function implementation that forwards the invocation to an identically defined function
+/// in one of the two enum branches.
+///
+/// Due to an inability of a macro to match on the `self` shorthand syntax, this macro has 3
+/// branches.  But they are only different in the `self` argument matching.  Make sure to keep the
+/// identical otherwise.
 macro_rules! dispatch {
     ($vis:vis fn $name:ident(&self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
         #[inline]


### PR DESCRIPTION
Using a single implementation makes the simple logic of `dispatch!` more obvious.  With 3 branches, the reader has to compare the branch texts to see if there are any differences.

We can also allow a single `dispatch!` invocation to accept multiple method declarations.

There is a downside of requiring a non-shorthand syntax for `self`.

---

Not sure if this is 100% better than what is already there, as it does not accept the shorthand `self` syntax.
But the fact that the macro has only one branch seems like a win to me.

Behzad, what do you think?