### PR TITLE
Disable CompletedDataSetsService when unused

### DIFF
--- a/core/src/completed_data_sets_service.rs
+++ b/core/src/completed_data_sets_service.rs
@@ -37,7 +37,9 @@ impl CompletedDataSetsService {
     ) -> Self {
         let thread_hdl = Builder::new()
             .name("solComplDataSet".to_string())
-            .spawn(move || loop {
+            .spawn(move || {
+                info!("CompletedDataSetsService has started");
+                loop {
                 if exit.load(Ordering::Relaxed) {
                     break;
                 }
@@ -49,6 +51,8 @@ impl CompletedDataSetsService {
                 ) {
                     break;
                 }
+            }
+            info!("CompletedDataSetsService has stopped");
             })
             .unwrap();
         Self { thread_hdl }

--- a/core/src/completed_data_sets_service.rs
+++ b/core/src/completed_data_sets_service.rs
@@ -40,19 +40,19 @@ impl CompletedDataSetsService {
             .spawn(move || {
                 info!("CompletedDataSetsService has started");
                 loop {
-                if exit.load(Ordering::Relaxed) {
-                    break;
+                    if exit.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    if let Err(RecvTimeoutError::Disconnected) = Self::recv_completed_data_sets(
+                        &completed_sets_receiver,
+                        &blockstore,
+                        &rpc_subscriptions,
+                        &max_slots,
+                    ) {
+                        break;
+                    }
                 }
-                if let Err(RecvTimeoutError::Disconnected) = Self::recv_completed_data_sets(
-                    &completed_sets_receiver,
-                    &blockstore,
-                    &rpc_subscriptions,
-                    &max_slots,
-                ) {
-                    break;
-                }
-            }
-            info!("CompletedDataSetsService has stopped");
+                info!("CompletedDataSetsService has stopped");
             })
             .unwrap();
         Self { thread_hdl }

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -141,7 +141,7 @@ impl Tvu {
         gossip_verified_vote_hash_receiver: GossipVerifiedVoteHashReceiver,
         verified_vote_receiver: VerifiedVoteReceiver,
         replay_vote_sender: ReplayVoteSender,
-        completed_data_sets_sender: CompletedDataSetsSender,
+        completed_data_sets_sender: Option<CompletedDataSetsSender>,
         bank_notification_sender: Option<BankNotificationSenderConfig>,
         duplicate_confirmed_slots_receiver: DuplicateConfirmedSlotsReceiver,
         tvu_config: TvuConfig,
@@ -457,7 +457,6 @@ pub mod tests {
         let (_gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = unbounded();
         let (_verified_vote_sender, verified_vote_receiver) = unbounded();
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-        let (completed_data_sets_sender, _completed_data_sets_receiver) = unbounded();
         let (_, gossip_confirmed_slots_receiver) = unbounded();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
@@ -503,7 +502,7 @@ pub mod tests {
             gossip_verified_vote_hash_receiver,
             verified_vote_receiver,
             replay_vote_sender,
-            completed_data_sets_sender,
+            /*completed_data_sets_sender:*/ None,
             None,
             gossip_confirmed_slots_receiver,
             TvuConfig::default(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1033,23 +1033,23 @@ impl Validator {
                 prioritization_fee_cache.clone(),
             )?;
 
-                let pubsub_service = if !config.rpc_config.full_api {
-                    None
-                } else {
-                    let (trigger, pubsub_service) = PubSubService::new(
-                        config.pubsub_config.clone(),
-                        &rpc_subscriptions,
-                        rpc_pubsub_addr,
-                    );
-                    config
-                        .validator_exit
-                        .write()
-                        .unwrap()
-                        .register_exit(Box::new(move || trigger.cancel()));
+            let pubsub_service = if !config.rpc_config.full_api {
+                None
+            } else {
+                let (trigger, pubsub_service) = PubSubService::new(
+                    config.pubsub_config.clone(),
+                    &rpc_subscriptions,
+                    rpc_pubsub_addr,
+                );
+                config
+                    .validator_exit
+                    .write()
+                    .unwrap()
+                    .register_exit(Box::new(move || trigger.cancel()));
 
-                    Some(pubsub_service)
-                };
-                let optimistically_confirmed_bank_tracker =
+                Some(pubsub_service)
+            };
+            let optimistically_confirmed_bank_tracker =
                 Some(OptimisticallyConfirmedBankTracker::new(
                     bank_notification_receiver,
                     exit.clone(),
@@ -1059,15 +1059,15 @@ impl Validator {
                     confirmed_bank_subscribers,
                     prioritization_fee_cache.clone(),
                 ));
-                let bank_notification_sender_config = Some(BankNotificationSenderConfig {
-                    sender: bank_notification_sender,
-                    should_send_parents: geyser_plugin_service.is_some(),
-                });
+            let bank_notification_sender_config = Some(BankNotificationSenderConfig {
+                sender: bank_notification_sender,
+                should_send_parents: geyser_plugin_service.is_some(),
+            });
             (
                 Some(json_rpc_service),
                 pubsub_service,
                 optimistically_confirmed_bank_tracker,
-                bank_notification_sender_config
+                bank_notification_sender_config,
             )
         } else {
             (None, None, None, None)

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -471,7 +471,7 @@ pub struct Validator {
     stats_reporter_service: StatsReporterService,
     gossip_service: GossipService,
     serve_repair_service: ServeRepairService,
-    completed_data_sets_service: CompletedDataSetsService,
+    completed_data_sets_service: Option<CompletedDataSetsService>,
     snapshot_packager_service: Option<SnapshotPackagerService>,
     poh_recorder: Arc<RwLock<PohRecorder>>,
     poh_service: PohService,
@@ -927,15 +927,6 @@ impl Validator {
         ));
 
         let max_slots = Arc::new(MaxSlots::default());
-        let (completed_data_sets_sender, completed_data_sets_receiver) =
-            bounded(MAX_COMPLETED_DATA_SETS_IN_CHANNEL);
-        let completed_data_sets_service = CompletedDataSetsService::new(
-            completed_data_sets_receiver,
-            blockstore.clone(),
-            rpc_subscriptions.clone(),
-            exit.clone(),
-            max_slots.clone(),
-        );
 
         let startup_verification_complete;
         let (poh_recorder, entry_receiver, record_receiver) = {
@@ -988,6 +979,8 @@ impl Validator {
         let (
             json_rpc_service,
             pubsub_service,
+            completed_data_sets_sender,
+            completed_data_sets_service,
             optimistically_confirmed_bank_tracker,
             bank_notification_sender,
         ) = if let Some((rpc_addr, rpc_pubsub_addr)) = config.rpc_addrs {
@@ -1049,6 +1042,26 @@ impl Validator {
 
                 Some(pubsub_service)
             };
+
+            let (completed_data_sets_sender, completed_data_sets_service) =
+                if !config.rpc_config.full_api {
+                    (None, None)
+                } else {
+                    let (completed_data_sets_sender, completed_data_sets_receiver) =
+                        bounded(MAX_COMPLETED_DATA_SETS_IN_CHANNEL);
+                    let completed_data_sets_service = CompletedDataSetsService::new(
+                        completed_data_sets_receiver,
+                        blockstore.clone(),
+                        rpc_subscriptions.clone(),
+                        exit.clone(),
+                        max_slots.clone(),
+                    );
+                    (
+                        Some(completed_data_sets_sender),
+                        Some(completed_data_sets_service),
+                    )
+                };
+
             let optimistically_confirmed_bank_tracker =
                 Some(OptimisticallyConfirmedBankTracker::new(
                     bank_notification_receiver,
@@ -1066,11 +1079,13 @@ impl Validator {
             (
                 Some(json_rpc_service),
                 pubsub_service,
+                completed_data_sets_sender,
+                completed_data_sets_service,
                 optimistically_confirmed_bank_tracker,
                 bank_notification_sender_config,
             )
         } else {
-            (None, None, None, None)
+            (None, None, None, None, None, None)
         };
 
         if config.halt_at_slot.is_some() {
@@ -1614,9 +1629,11 @@ impl Validator {
                 .transpose()
                 .unwrap();
         }
-        self.completed_data_sets_service
-            .join()
-            .expect("completed_data_sets_service");
+        if let Some(completed_data_sets_service) = self.completed_data_sets_service {
+            completed_data_sets_service
+                .join()
+                .expect("completed_data_sets_service");
+        }
         if let Some(ip_echo_server) = self.ip_echo_server {
             ip_echo_server.shutdown_background();
         }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1033,9 +1033,7 @@ impl Validator {
                 prioritization_fee_cache.clone(),
             )?;
 
-            (
-                Some(json_rpc_service),
-                if !config.rpc_config.full_api {
+                let pubsub_service = if !config.rpc_config.full_api {
                     None
                 } else {
                     let (trigger, pubsub_service) = PubSubService::new(
@@ -1050,7 +1048,8 @@ impl Validator {
                         .register_exit(Box::new(move || trigger.cancel()));
 
                     Some(pubsub_service)
-                },
+                };
+                let optimistically_confirmed_bank_tracker =
                 Some(OptimisticallyConfirmedBankTracker::new(
                     bank_notification_receiver,
                     exit.clone(),
@@ -1059,11 +1058,16 @@ impl Validator {
                     rpc_subscriptions.clone(),
                     confirmed_bank_subscribers,
                     prioritization_fee_cache.clone(),
-                )),
-                Some(BankNotificationSenderConfig {
+                ));
+                let bank_notification_sender_config = Some(BankNotificationSenderConfig {
                     sender: bank_notification_sender,
                     should_send_parents: geyser_plugin_service.is_some(),
-                }),
+                });
+            (
+                Some(json_rpc_service),
+                pubsub_service,
+                optimistically_confirmed_bank_tracker,
+                bank_notification_sender_config
             )
         } else {
             (None, None, None, None)


### PR DESCRIPTION
#### Problem
The `CompletedDataSetsService` service is used as a helper service for RPC pub sub. Namely, this service:
1. Receives shred indices that correspond to complete data blocks (group of shred to deserialize into `Vec<Entry>`)
2. Read and deserializes those shreds into `Vec<Entry>`
3. Parses the transactions in entries, and sends the signatures to another pub sub service if pub sub is enabled.

However, the items in 1. and 2. occur even if pub sub is disabled. This means all validators with RPC disabled expend resources to do the work in 1. and 2. for nothing.

#### Summary of Changes
Adjust `CompletedDataSetsService` to only be created if RPC pub sub is enabled. This is broken out from https://github.com/anza-xyz/agave/pull/1358

I ran a quick manual test and ensured the threads were still present with `--full-rpc-api` and not present without that flag