### PR TITLE
Use tls-zeroed-aligned-memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7791,7 +7791,7 @@ dependencies = [
 [[package]]
 name = "solana_rbpf"
 version = "0.8.0"
-source = "git+https://github.com/ryoqun/rbpf?rev=7347d279be0b3d6f7030eb6b434882e6ff53affe#7347d279be0b3d6f7030eb6b434882e6ff53affe"
+source = "git+https://github.com/ryoqun/rbpf?rev=28b63fe631aca9ecd5893290ea29a48f86837cdc#28b63fe631aca9ecd5893290ea29a48f86837cdc"
 dependencies = [
  "byteorder",
  "combine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7791,7 +7791,7 @@ dependencies = [
 [[package]]
 name = "solana_rbpf"
 version = "0.8.0"
-source = "git+https://github.com/ryoqun/rbpf?rev=28b63fe631aca9ecd5893290ea29a48f86837cdc#28b63fe631aca9ecd5893290ea29a48f86837cdc"
+source = "git+https://github.com/ryoqun/rbpf?rev=3107f6b77c435fd76837538e309f0e5870119a88#3107f6b77c435fd76837538e309f0e5870119a88"
 dependencies = [
  "byteorder",
  "combine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7791,8 +7791,7 @@ dependencies = [
 [[package]]
 name = "solana_rbpf"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d457cc2ba742c120492a64b7fa60e22c575e891f6b55039f4d736568fb112a3"
+source = "git+https://github.com/ryoqun/rbpf?rev=7347d279be0b3d6f7030eb6b434882e6ff53affe#7347d279be0b3d6f7030eb6b434882e6ff53affe"
 dependencies = [
  "byteorder",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -447,7 +447,7 @@ zstd = "0.11.2"
 # for details, see https://github.com/solana-labs/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
 
-solana_rbpf = { git = "https://github.com/ryoqun/rbpf", rev = "28b63fe631aca9ecd5893290ea29a48f86837cdc" }
+solana_rbpf = { git = "https://github.com/ryoqun/rbpf", rev = "3107f6b77c435fd76837538e309f0e5870119a88" }
 
 # We include the following crates as our dependencies above from crates.io:
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -447,6 +447,8 @@ zstd = "0.11.2"
 # for details, see https://github.com/solana-labs/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
 
+solana_rbpf = { git = "https://github.com/ryoqun/rbpf", rev = "7347d279be0b3d6f7030eb6b434882e6ff53affe" }
+
 # We include the following crates as our dependencies above from crates.io:
 #
 #  * spl-associated-token-account

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -447,7 +447,7 @@ zstd = "0.11.2"
 # for details, see https://github.com/solana-labs/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
 
-solana_rbpf = { git = "https://github.com/ryoqun/rbpf", rev = "7347d279be0b3d6f7030eb6b434882e6ff53affe" }
+solana_rbpf = { git = "https://github.com/ryoqun/rbpf", rev = "28b63fe631aca9ecd5893290ea29a48f86837cdc" }
 
 # We include the following crates as our dependencies above from crates.io:
 #


### PR DESCRIPTION
as part of eval of mimalloc (#1250 )

#### Problem

#### Perf result

all cases are measured with `--block-verification-method=blockstore-processor`

jemalloc

```
ledger processed in 24 seconds, 848 ms
ledger processed in 24 seconds, 842 ms
ledger processed in 24 seconds, 801 ms
```

mimalloc

```
ledger processed in 25 seconds, 666 ms
ledger processed in 25 seconds, 174 ms
ledger processed in 25 seconds, 77 ms
```

glibc

```
ledger processed in 24 seconds, 908 ms
ledger processed in 24 seconds, 827 ms
ledger processed in 24 seconds, 974 ms
```

rpmalloc

```
ledger processed in 24 seconds, 783 ms
ledger processed in 24 seconds, 977 ms
ledger processed in 25 seconds, 256 ms
```

... so, the conclusion is that all allocators are similar in terms of replay speed...

#### Summary of Changes

xref: https://github.com/solana-labs/rbpf/pull/565

Fixes https://github.com/solana-labs/solana/issues/27275
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
