### PR TITLE
add loaded-account-data-size-cost to qos metric

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -285,6 +285,7 @@ pub struct BatchedTransactionCostDetails {
     pub batched_signature_cost: u64,
     pub batched_write_lock_cost: u64,
     pub batched_data_bytes_cost: u64,
+    pub batched_loaded_accounts_data_size_cost: u64,
     pub batched_programs_execute_cost: u64,
 }
 

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -245,6 +245,15 @@ impl QosService {
             batched_transaction_details.costs.batched_data_bytes_cost,
             Ordering::Relaxed,
         );
+        self.metrics
+            .stats
+            .estimated_loaded_accounts_data_size_cu
+            .fetch_add(
+                batched_transaction_details
+                    .costs
+                    .batched_loaded_accounts_data_size_cost,
+                Ordering::Relaxed,
+            );
         self.metrics.stats.estimated_programs_execute_cu.fetch_add(
             batched_transaction_details
                 .costs
@@ -332,6 +341,12 @@ impl QosService {
                 saturating_add_assign!(
                     batched_transaction_details.costs.batched_data_bytes_cost,
                     cost.data_bytes_cost()
+                );
+                saturating_add_assign!(
+                    batched_transaction_details
+                        .costs
+                        .batched_loaded_accounts_data_size_cost,
+                    cost.loaded_accounts_data_size_cost()
                 );
                 saturating_add_assign!(
                     batched_transaction_details
@@ -428,6 +443,9 @@ struct QosServiceMetricsStats {
     /// accumulated estimated instruction data Compute Units to be packed into block
     estimated_data_bytes_cu: AtomicU64,
 
+    /// accumulated estimated loaded accounts data size cost to be packed into block
+    estimated_loaded_accounts_data_size_cu: AtomicU64,
+
     /// accumulated estimated program Compute Units to be packed into block
     estimated_programs_execute_cu: AtomicU64,
 
@@ -509,6 +527,13 @@ impl QosServiceMetrics {
                     "estimated_data_bytes_cu",
                     self.stats
                         .estimated_data_bytes_cu
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "estimated_loaded_accounts_data_size_cu",
+                    self.stats
+                        .estimated_loaded_accounts_data_size_cu
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),


### PR DESCRIPTION
#### Problem

`loaded_accounts_data_size_cost` are not reported to metric.

#### Summary of Changes
- add it to qos metric table

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
