### PR TITLE
Deprecate `is_key_passed_to_program` in favor of `is_instruction_account`

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -729,10 +729,10 @@ impl Accounts {
                 }
             };
 
-            // Accounts that are invoked and also not passed to a program don't
-            // need to be stored because it's assumed to be impossible for a
-            // committable transaction to modify an invoked account if said
-            // account isn't passed to some program.
+            // Accounts that are invoked and also not passed as an instruction
+            // account to a program don't need to be stored because it's assumed
+            // to be impossible for a committable transaction to modify an
+            // invoked account if said account isn't passed to some program.
             //
             // Note that this assumption might not hold in the future after
             // SIMD-0082 is implemented because we may decide to commit
@@ -742,7 +742,7 @@ impl Accounts {
             // if they aren't passed to any programs (because they are mutated
             // outside of the VM).
             let is_storable_account = |message: &SanitizedMessage, key_index: usize| -> bool {
-                !message.is_invoked(key_index) || message.is_key_passed_to_program(key_index)
+                !message.is_invoked(key_index) || message.is_instruction_account(key_index)
             };
 
             let message = tx.message();

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -527,7 +527,14 @@ impl Message {
             .collect()
     }
 
+    #[deprecated(since = "2.0.0", note = "Please use `is_instruction_account` instead")]
     pub fn is_key_passed_to_program(&self, key_index: usize) -> bool {
+        self.is_instruction_account(key_index)
+    }
+
+    /// Returns true if the account at the specified index is an account input
+    /// to some program instruction in this message.
+    pub fn is_instruction_account(&self, key_index: usize) -> bool {
         if let Ok(key_index) = u8::try_from(key_index) {
             self.instructions
                 .iter()
@@ -549,10 +556,10 @@ impl Message {
 
     #[deprecated(
         since = "2.0.0",
-        note = "Please use `is_key_called_as_program` and `is_key_passed_to_program` directly"
+        note = "Please use `is_key_called_as_program` and `is_instruction_account` directly"
     )]
     pub fn is_non_loader_key(&self, key_index: usize) -> bool {
-        !self.is_key_called_as_program(key_index) || self.is_key_passed_to_program(key_index)
+        !self.is_key_called_as_program(key_index) || self.is_instruction_account(key_index)
     }
 
     pub fn program_position(&self, index: usize) -> Option<usize> {
@@ -921,7 +928,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_key_passed_to_program() {
+    fn test_is_instruction_account() {
         let key0 = Pubkey::new_unique();
         let key1 = Pubkey::new_unique();
         let loader2 = Pubkey::new_unique();
@@ -935,9 +942,9 @@ mod tests {
             instructions,
         );
 
-        assert!(message.is_key_passed_to_program(0));
-        assert!(message.is_key_passed_to_program(1));
-        assert!(!message.is_key_passed_to_program(2));
+        assert!(message.is_instruction_account(0));
+        assert!(message.is_instruction_account(1));
+        assert!(!message.is_instruction_account(2));
     }
 
     #[test]

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -222,7 +222,14 @@ impl SanitizedMessage {
 
     /// Returns true if the account at the specified index is an input to some
     /// program instruction in this message.
+    #[deprecated(since = "2.0.0", note = "Please use `is_instruction_account` instead")]
     pub fn is_key_passed_to_program(&self, key_index: usize) -> bool {
+        self.is_instruction_account(key_index)
+    }
+
+    /// Returns true if the account at the specified index is an input to some
+    /// program instruction in this message.
+    pub fn is_instruction_account(&self, key_index: usize) -> bool {
         if let Ok(key_index) = u8::try_from(key_index) {
             self.instructions()
                 .iter()
@@ -245,10 +252,10 @@ impl SanitizedMessage {
     /// program or, if invoked, is passed to a program.
     #[deprecated(
         since = "2.0.0",
-        note = "Please use `is_invoked` and `is_key_passed_to_program` instead"
+        note = "Please use `is_invoked` and `is_instruction_account` instead"
     )]
     pub fn is_non_loader_key(&self, key_index: usize) -> bool {
-        !self.is_invoked(key_index) || self.is_key_passed_to_program(key_index)
+        !self.is_invoked(key_index) || self.is_instruction_account(key_index)
     }
 
     /// Returns true if the account at the specified index is writable by the

--- a/sdk/program/src/message/versions/mod.rs
+++ b/sdk/program/src/message/versions/mod.rs
@@ -92,9 +92,14 @@ impl VersionedMessage {
         }
     }
 
+    #[deprecated(since = "2.0.0", note = "Please use `is_instruction_account` instead")]
+    pub fn is_key_passed_to_program(&self, key_index: usize) -> bool {
+        self.is_instruction_account(key_index)
+    }
+
     /// Returns true if the account at the specified index is an input to some
     /// program instruction in this message.
-    fn is_key_passed_to_program(&self, key_index: usize) -> bool {
+    fn is_instruction_account(&self, key_index: usize) -> bool {
         if let Ok(key_index) = u8::try_from(key_index) {
             self.instructions()
                 .iter()
@@ -114,7 +119,7 @@ impl VersionedMessage {
     /// Returns true if the account at the specified index is not invoked as a
     /// program or, if invoked, is passed to a program.
     pub fn is_non_loader_key(&self, key_index: usize) -> bool {
-        !self.is_invoked(key_index) || self.is_key_passed_to_program(key_index)
+        !self.is_invoked(key_index) || self.is_instruction_account(key_index)
     }
 
     pub fn recent_blockhash(&self) -> &Hash {


### PR DESCRIPTION
#### Context

`is_key_passed_to_program()` should also go or be renamed `is_instruction_account()`, that is what we call it in transaction loading now: https://github.com/anza-xyz/agave/blob/718101183271a0b75f307d86bde48721051ca5e9/svm/src/account_loader.rs#L216C21-L216C40

_Originally posted by @Lichtso in https://github.com/anza-xyz/agave/issues/1219#issuecomment-2100276729_
            