### PR TITLE
Program-Test: Add BPF program accounts to genesis

### DIFF
--- a/program-test/tests/bpf.rs
+++ b/program-test/tests/bpf.rs
@@ -1,0 +1,43 @@
+use {
+    solana_program_test::ProgramTest,
+    solana_sdk::{
+        bpf_loader_upgradeable, instruction::Instruction, pubkey::Pubkey, signature::Signer,
+        transaction::Transaction,
+    },
+};
+
+#[tokio::test]
+async fn test_bpf_program() {
+    let program_id = Pubkey::new_unique();
+
+    std::env::set_var("SBF_OUT_DIR", "../programs/bpf_loader/test_elfs/out");
+
+    let mut program_test = ProgramTest::default();
+    program_test.prefer_bpf(true);
+    program_test.add_program("noop_aligned", program_id, None);
+
+    let mut context = program_test.start_with_context().await;
+
+    // Assert the program is a BPF Loader 2 program.
+    let program_account = context
+        .banks_client
+        .get_account(program_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(program_account.owner, bpf_loader_upgradeable::id());
+
+    // Invoke the program.
+    let instruction = Instruction::new_with_bytes(program_id, &[], Vec::new());
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
#### Problem
Now that the runtime supports migrating builtin programs to Core BPF, we need a 
way to use `solana-program-test` to test the BPF versions of any given builtin 
programs.

Currently, if you provide a BPF program with the same program ID as a default 
builtin program - even if you set `prefer_bpf` to `true` - it will be 
overwritten during Bank setup by the original builtin version.

Program-test should allow developers to provide a BPF program, with `prefer_bpf` 
set to `true` and a program ID matching that of a default builtin, and ensure 
the builtin version is _not_ added, in favor of the provided BPF ELF.

#### Summary of Changes
Simply add any BPF program accounts to the test context's genesis config.

More notably, use Loader V3 for BPF programs.

In the case of any BPF programs whose address matches that of a default builtin
(Core BPF), the bank setup step will add the accounts _before_ Bank internally runs
`finish_init`, thus it will recognize the active feature for a Core BPF migration, as well
as the presence of BPF program accounts.
