### PR TITLE
ci: Re-enable downstream SPL CLI tests and check

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -58,7 +58,6 @@ jobs:
           cargo check
 
   test:
-    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -71,6 +70,7 @@ jobs:
                   "token/program",
                   "token/program-2022",
                   "associated-token-account/program",
+                  "instruction-padding/program",
                 ],
             },
             {

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -37,7 +37,6 @@ env:
 
 jobs:
   check:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,9 +51,8 @@ jobs:
 
       - shell: bash
         run: |
-          source .github/scripts/downstream-project-spl-common.sh
           source .github/scripts/downstream-project-spl-install-deps.sh
-
+          source .github/scripts/downstream-project-spl-common.sh
           cargo check
 
   test:
@@ -101,8 +99,8 @@ jobs:
 
       - shell: bash
         run: |
-          source .github/scripts/downstream-project-spl-common.sh
           source .github/scripts/downstream-project-spl-install-deps.sh
+          source .github/scripts/downstream-project-spl-common.sh
 
           programStr="${{ tojson(matrix.arrays.required_programs) }}"
           IFS=', ' read -ra programs <<<"${programStr//[\[\]$'\n'$'\r' ]/}"


### PR DESCRIPTION
#### Problem

Breaking changes in #1185 were not detected due to the lack of downstream testing for CLIs.

#### Summary of Changes

There are already tests, but they're disabled for some reason. I couldn't remember why, and it worked locally, so let's enable them!

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
