### PR TITLE
Integrate test-vectors bpf-loader in SVM

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -150,6 +150,7 @@ jobs:
 
       - shell: bash
         run: |
+          source .github/scripts/downstream-project-spl-install-deps.sh
           source .github/scripts/downstream-project-spl-common.sh
 
           programStr="${{ tojson(matrix.programs) }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7264,9 +7264,13 @@ version = "2.0.0"
 dependencies = [
  "bincode",
  "itertools",
+ "lazy_static",
  "libsecp256k1",
  "log",
  "percentage",
+ "prost",
+ "prost-build",
+ "prost-types",
  "rand 0.8.5",
  "rustc_version 0.4.0",
  "serde",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6257,6 +6257,7 @@ dependencies = [
  "itertools",
  "log",
  "percentage",
+ "prost-build",
  "rustc_version",
  "serde",
  "serde_derive",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -31,7 +31,10 @@ name = "solana_svm"
 
 [dev-dependencies]
 bincode = { workspace = true }
+lazy_static = { workspace = true }
 libsecp256k1 = { workspace = true }
+prost = { workspace = true }
+prost-types = { workspace = true }
 rand = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
 solana-logger = { workspace = true }
@@ -41,6 +44,7 @@ solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
+prost-build = { workspace = true }
 rustc_version = { workspace = true }
 
 [features]

--- a/svm/build.rs
+++ b/svm/build.rs
@@ -1,1 +1,36 @@
-../frozen-abi/build.rs
+extern crate rustc_version;
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    // Copied and adapted from
+    // https://github.com/Kimundi/rustc-version-rs/blob/1d692a965f4e48a8cb72e82cda953107c0d22f47/README.md#example
+    // Licensed under Apache-2.0 + MIT
+    match version_meta().unwrap().channel {
+        Channel::Stable => {
+            println!("cargo:rustc-cfg=RUSTC_WITHOUT_SPECIALIZATION");
+        }
+        Channel::Beta => {
+            println!("cargo:rustc-cfg=RUSTC_WITHOUT_SPECIALIZATION");
+        }
+        Channel::Nightly => {
+            println!("cargo:rustc-cfg=RUSTC_WITH_SPECIALIZATION");
+        }
+        Channel::Dev => {
+            println!("cargo:rustc-cfg=RUSTC_WITH_SPECIALIZATION");
+        }
+    }
+
+    let proto_base_path = std::path::PathBuf::from("proto");
+    let protos = ["context.proto", "invoke.proto", "sysvar.proto", "txn.proto"];
+    let protos_path: Vec<_> = protos
+        .iter()
+        .map(|name| proto_base_path.join(name))
+        .collect();
+
+    protos_path
+        .iter()
+        .for_each(|proto| println!("cargo:rerun-if-changed={}", proto.display()));
+
+    prost_build::compile_protos(protos_path.as_ref(), &[proto_base_path])
+        .expect("Failed to compile protobuf files");
+}

--- a/svm/proto/context.proto
+++ b/svm/proto/context.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+package org.solana.sealevel.v1;
+
+import "sysvar.proto";
+
+// A set of feature flags.
+message FeatureSet {
+  // Every item in this list marks an enabled feature.  The value of
+  // each item is the first 8 bytes of the feature ID as a little-
+  // endian integer.
+  repeated fixed64 features = 1;
+}
+
+// A seed address.  This is not a PDA.
+message SeedAddress {
+  // The seed address base.  (32 bytes)
+  bytes base = 1;
+
+  // The seed path  (<= 32 bytes)
+  bytes seed = 2;
+
+  // The seed address owner.  (32 bytes)
+  bytes owner = 3;
+}
+
+// The complete state of an account excluding its public key.
+message AcctState {
+  // The account address.  (32 bytes)
+  bytes address = 1;
+
+  uint64 lamports = 2;
+
+  // Account data is limited to 10 MiB on Solana mainnet as of 2024-Feb.
+  bytes data = 3;
+
+  bool executable = 4;
+
+  // The rent epoch is deprecated on Solana mainnet as of 2024-Feb.
+  // If ommitted, implies a value of UINT64_MAX.
+  uint64 rent_epoch = 5;
+
+  // Address of the program that owns this account.  (32 bytes)
+  bytes owner = 6;
+
+  // The account address, but derived as a seed address.  Overrides
+  // `address` if present.
+  // TODO: This is a solfuzz specific extension and is not compliant
+  // with the org.solana.sealevel.v1 API.
+  SeedAddress seed_addr = 7;
+}
+
+// EpochContext includes context scoped to an epoch.
+// On "real" ledgers, it is created during the epoch boundary.
+message EpochContext {
+  FeatureSet features = 1;
+}
+
+
+// SlotContext includes context scoped to a block.
+// On "real" ledgers, it is created during the slot boundary.
+message SlotContext {
+  repeated bytes recent_block_hashes = 1;
+  // public key for the leader
+  bytes leader = 2;
+  // Slot number
+  fixed64 slot = 3;
+  SysvarCache sysvar_cache = 4;
+}

--- a/svm/proto/invoke.proto
+++ b/svm/proto/invoke.proto
@@ -1,0 +1,65 @@
+syntax = "proto3";
+package org.solana.sealevel.v1;
+
+import "context.proto";
+import "txn.proto";
+
+message InstrAcct {
+  // Selects an account in an external list
+  uint32 index = 1;
+  bool is_writable = 2;
+  bool is_signer = 3;
+}
+
+// The execution context of a program invocation (aka instruction).
+// Contains all required information to independently replay an instruction.
+// Also includes partial transaction context.
+message InstrContext {
+  // The address of the program invoked.  (32 bytes)
+  bytes program_id = 1;
+
+  // Account state accessed by the instruction.  This may include
+  // indirect accesses like sysvars.
+  repeated AcctState accounts = 3;
+
+  // Account access list for this instruction (refers to above accounts list)
+  repeated InstrAcct instr_accounts = 4;
+
+  // The input data passed to program execution.
+  bytes data = 5;
+
+  uint64 cu_avail = 6;
+
+  TxnContext txn_context = 7;
+  SlotContext slot_context = 8;
+  EpochContext epoch_context = 9;
+}
+
+// The results of executing an InstrContext.
+message InstrEffects {
+  // result is zero if the instruction executed succesfully.
+  // Otherwise, a non-zero error code.  Error codes are not relevant to
+  // consensus.
+  int32 result = 1;
+
+  // Some error cases additionally have a custom error code.  Unlike
+  // the expected_result, this is stable across clients.
+  uint32 custom_err = 2;
+
+  // Copies of accounts that were changed.  May be in an arbitrary
+  // order.  The pubkey of each account is unique in this list.  Each
+  // account address modified here must also be in the
+  // InstrContext.
+  repeated AcctState modified_accounts = 3;
+
+  uint64 cu_avail = 4;
+
+  // Instruction return data.
+  bytes return_data = 5;
+}
+
+// An instruction processing test fixture.
+message InstrFixture {
+  InstrContext input = 1;
+  InstrEffects output = 2;
+}

--- a/svm/proto/sysvar.proto
+++ b/svm/proto/sysvar.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+package org.solana.sealevel.v1;
+
+// The clock account data
+message Clock {
+  uint64 slot = 1;
+  uint64 epoch_start_timestamp = 2;
+  uint64 epoch = 3;
+  uint64 leader_schedule_epoch = 4;
+  uint64 unix_timestamp = 5;
+}
+
+// The data for the Rent account
+message Rent {
+  uint64 lamports_per_byte_year = 1;
+  double exemption_threshold = 2;
+  uint64 burn_percent = 3;
+}
+
+// The recent slot hash vector contents
+message SlotHash {
+  uint64 slot = 1;
+  bytes hash = 2;
+}
+
+// The sysvar cache for a transaction execution
+message SysvarCache {
+  Clock clock = 1;
+  Rent rent = 2;
+  // Slot hashes sysvar: SysvarS1otHashes111111111111111111111111111
+  repeated SlotHash slot_hash = 3;
+}

--- a/svm/proto/txn.proto
+++ b/svm/proto/txn.proto
@@ -1,0 +1,115 @@
+syntax = "proto3";
+package org.solana.sealevel.v1;
+
+import "context.proto";
+
+// Message header contains the counts of required readonly and signatures
+message MessageHeader {
+  uint32 num_required_signatures = 1;
+  uint32 num_readonly_signed_accounts = 2;
+  uint32 num_readonly_unsigned_accounts = 3;
+}
+
+
+// The instruction a transaction executes
+message CompiledInstruction {
+  // Index into the message pubkey array
+  uint32 program_id_index = 1;
+  // Indexes into the message pubkey array
+  repeated uint32 accounts = 2;
+  bytes data = 3;
+}
+
+// List of address table lookups used to load additional accounts for a transaction
+message MessageAddressTableLookup {
+  bytes account_key = 1;
+  repeated uint32 writable_indexes = 2;
+  repeated uint32 readonly_indexes = 3;
+}
+
+// Addresses loaded with on-chain lookup tables
+message LoadedAddresses {
+  repeated bytes writable = 1;
+  repeated bytes readonly = 2;
+}
+
+// Message contains the transaction data
+message TransactionMessage {
+  // Whether this is a legacy message or not
+  bool is_legacy = 1;
+
+  MessageHeader header = 2;
+  // Vector of pubkeys
+  repeated bytes account_keys = 3;
+  // Data associated with the accounts referred above. Not all accounts need to be here.
+  repeated AcctState account_shared_data = 4;
+  // The block hash contains 32-bytes
+  bytes recent_blockhash = 5;
+  // The instructions this transaction executes
+  repeated CompiledInstruction instructions = 6;
+
+  // Not available in legacy message
+  repeated MessageAddressTableLookup address_table_lookups = 7;
+  // Not available in legacy messages
+  LoadedAddresses loaded_addresses = 8;
+}
+
+// A valid verified transaction
+message SanitizedTransaction {
+  // The transaction information
+  TransactionMessage message = 1;
+  // The message hash
+  bytes message_hash = 2;
+  // Is this a voting transaction?
+  bool is_simple_vote_tx = 3;
+  // The signatures needed in the transaction
+  repeated bytes signatures = 4;
+}
+
+// This Transaction context be used to fuzz either `load_execute_and_commit_transactions`,
+// `load_and_execute_transactions` in `bank.rs` or `load_and_execute_sanitized_transactions`
+// in `svm/transaction_processor.rs`
+message TxnContext {
+  // The transaction data
+  SanitizedTransaction tx = 1;
+  // The maximum age allowed for this transaction
+  uint64 max_age = 2;
+  // The limit of bytes allowed for this transaction to load
+  uint64 log_messages_byte_limit = 3;
+
+  EpochContext epoch_ctx = 4;
+  SlotContext slot_ctx = 5;
+}
+
+// The resulting state of an account after a transaction
+message ResultingState {
+  AcctState state = 1;
+  uint64 transaction_rent = 2;
+  RentDebits rent_debit = 3;
+}
+
+// The rent state for an account after a transaction
+message RentDebits {
+  uint64 rent_collected = 1;
+  uint64 post_balance = 2;
+}
+
+// The execution results for a transaction
+message TxnResult {
+  // Whether this transaction was executed
+  bool executed = 1;
+  // The state of each account after the transaction
+  repeated ResultingState states = 2;
+  uint64 rent = 3;
+
+  // If an executed transaction has no error
+  bool is_ok = 4;
+  // The transaction status (error code)
+  uint32 status = 5;
+  // The return data from this transaction, if any
+  bytes return_data = 6;
+  // Number of executed compute units
+  uint64 executed_units = 7;
+  // The change in accounts data len for this transaction
+  uint64 accounts_data_len_delta = 8;
+}

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -1,0 +1,355 @@
+use {
+    crate::{
+        mock_bank::{MockBankCallback, MockForkGraph},
+        proto::InstrFixture,
+        transaction_builder::SanitizedTransactionBuilder,
+    },
+    lazy_static::lazy_static,
+    prost::Message,
+    solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
+    solana_program_runtime::{
+        compute_budget::ComputeBudget,
+        loaded_programs::{ProgramCache, ProgramCacheEntry, ProgramRuntimeEnvironments},
+        solana_rbpf::{
+            program::{BuiltinProgram, FunctionRegistry},
+            vm::Config,
+        },
+        timings::ExecuteTimings,
+    },
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount, WritableAccount},
+        bpf_loader_upgradeable,
+        epoch_schedule::EpochSchedule,
+        feature_set::{FeatureSet, FEATURE_NAMES},
+        hash::Hash,
+        instruction::AccountMeta,
+        pubkey::Pubkey,
+        signature::Signature,
+    },
+    solana_svm::{
+        runtime_config::RuntimeConfig,
+        transaction_error_metrics::TransactionErrorMetrics,
+        transaction_processor::{ExecutionRecordingConfig, TransactionBatchProcessor},
+    },
+    std::{
+        collections::{HashMap, HashSet},
+        env,
+        ffi::OsString,
+        fs::{self, File},
+        io::Read,
+        path::PathBuf,
+        process::Command,
+        sync::{Arc, RwLock},
+    },
+};
+
+mod proto {
+    include!(concat!(env!("OUT_DIR"), "/org.solana.sealevel.v1.rs"));
+}
+mod mock_bank;
+mod transaction_builder;
+
+const fn feature_u64(feature: &Pubkey) -> u64 {
+    let feature_id = feature.to_bytes();
+    feature_id[0] as u64
+        | (feature_id[1] as u64) << 8
+        | (feature_id[2] as u64) << 16
+        | (feature_id[3] as u64) << 24
+        | (feature_id[4] as u64) << 32
+        | (feature_id[5] as u64) << 40
+        | (feature_id[6] as u64) << 48
+        | (feature_id[7] as u64) << 56
+}
+
+lazy_static! {
+    static ref INDEXED_FEATURES: HashMap<u64, Pubkey> = {
+        FEATURE_NAMES
+            .iter()
+            .map(|(pubkey, _)| (feature_u64(pubkey), *pubkey))
+            .collect()
+    };
+}
+
+fn setup() -> PathBuf {
+    let mut dir = env::current_dir().unwrap();
+    dir.push("test-vectors");
+    if !dir.exists() {
+        std::println!("Cloning test-vectors ...");
+        Command::new("git")
+            .args([
+                "clone",
+                "https://github.com/firedancer-io/test-vectors",
+                dir.as_os_str().to_str().unwrap(),
+            ])
+            .status()
+            .expect("Failed to download test-vectors");
+
+        std::println!("Checking out commit e94f22066cb2e98f8fe5f05a6797b8111ad78265");
+        Command::new("git")
+            .current_dir(&dir)
+            .args(["checkout", "e94f22066cb2e98f8fe5f05a6797b8111ad78265"])
+            .status()
+            .expect("Failed to checkout to proper test-vector commit");
+
+        std::println!("Setup done!");
+    }
+
+    dir
+}
+
+fn cleanup() {
+    let mut dir = env::current_dir().unwrap();
+    dir.push("test-vectors");
+
+    if dir.exists() {
+        fs::remove_dir_all(dir).expect("Failed to delete test-vectors repository");
+    }
+}
+
+#[test]
+fn execute_fixtures() {
+    let mut base_dir = setup();
+    base_dir.push("instr");
+    base_dir.push("fixtures");
+
+    // bpf-loader tests
+    base_dir.push("bpf-loader");
+    for path in std::fs::read_dir(base_dir).unwrap() {
+        let filename = path.as_ref().unwrap().file_name();
+        let mut file = File::open(path.as_ref().unwrap().path()).expect("file not found");
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer).expect("Failed to read file");
+
+        let fixture = proto::InstrFixture::decode(buffer.as_slice()).unwrap();
+        std::println!("Testing case: {:?}", filename);
+        run_fixture(fixture, filename);
+    }
+
+    cleanup();
+}
+
+fn run_fixture(fixture: InstrFixture, filename: OsString) {
+    let input = fixture.input.unwrap();
+    let output = fixture.output.unwrap();
+
+    let mut transaction_builder = SanitizedTransactionBuilder::default();
+    let program_id = Pubkey::new_from_array(input.program_id.try_into().unwrap());
+    let mut accounts: Vec<AccountMeta> = Vec::with_capacity(input.instr_accounts.len());
+    let mut signatures: HashMap<Pubkey, Signature> =
+        HashMap::with_capacity(input.instr_accounts.len());
+
+    for item in input.instr_accounts {
+        let pubkey = Pubkey::new_from_array(
+            input.accounts[item.index as usize]
+                .address
+                .clone()
+                .try_into()
+                .unwrap(),
+        );
+        accounts.push(AccountMeta {
+            pubkey,
+            is_signer: item.is_signer,
+            is_writable: item.is_writable,
+        });
+
+        if item.is_signer {
+            signatures.insert(pubkey, Signature::new_unique());
+        }
+    }
+
+    transaction_builder.create_instruction(program_id, accounts, signatures, input.data);
+
+    let mut feature_set = FeatureSet::default();
+    if let Some(features) = &input.epoch_context.as_ref().unwrap().features {
+        for id in &features.features {
+            if let Some(pubkey) = INDEXED_FEATURES.get(id) {
+                feature_set.activate(pubkey, 0);
+            }
+        }
+    }
+
+    let fee_payer = Pubkey::new_unique();
+    let Ok(transaction) =
+        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), false)
+    else {
+        // If we can't build a sanitized transaction,
+        // the output must be a failed instruction as well
+        assert_ne!(output.result, 0);
+        return;
+    };
+
+    let transactions = vec![transaction];
+    let mut transaction_check = vec![(Ok(()), None, Some(30))];
+
+    let mut mock_bank = MockBankCallback::default();
+    {
+        let mut account_data_map = mock_bank.account_shared_data.borrow_mut();
+        for item in input.accounts {
+            let pubkey = Pubkey::new_from_array(item.address.try_into().unwrap());
+            let mut account_data = AccountSharedData::default();
+            account_data.set_lamports(item.lamports);
+            account_data.set_data(item.data);
+            account_data.set_owner(Pubkey::new_from_array(item.owner.try_into().unwrap()));
+            account_data.set_executable(item.executable);
+            account_data.set_rent_epoch(item.rent_epoch);
+
+            account_data_map.insert(pubkey, account_data);
+        }
+        let mut account_data = AccountSharedData::default();
+        account_data.set_lamports(800000);
+        account_data_map.insert(fee_payer, account_data);
+    }
+
+    let compute_budget = ComputeBudget {
+        compute_unit_limit: input.cu_avail,
+        ..ComputeBudget::default()
+    };
+
+    let v1_environment =
+        create_program_runtime_environment_v1(&feature_set, &compute_budget, false, false).unwrap();
+
+    let mut program_cache = ProgramCache::<MockForkGraph>::new(0, 20);
+    program_cache.environments = ProgramRuntimeEnvironments {
+        program_runtime_v1: Arc::new(v1_environment),
+        program_runtime_v2: Arc::new(BuiltinProgram::new_loader(
+            Config::default(),
+            FunctionRegistry::default(),
+        )),
+    };
+    program_cache.fork_graph = Some(Arc::new(RwLock::new(MockForkGraph {})));
+
+    let program_cache = Arc::new(RwLock::new(program_cache));
+    mock_bank.override_feature_set(feature_set);
+    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(
+        42,
+        2,
+        EpochSchedule::default(),
+        Arc::new(RuntimeConfig::default()),
+        program_cache.clone(),
+        HashSet::new(),
+    );
+
+    batch_processor.fill_missing_sysvar_cache_entries(&mock_bank);
+    register_builtins(&batch_processor, &mock_bank);
+
+    let mut error_counter = TransactionErrorMetrics::default();
+    let recording_config = ExecutionRecordingConfig {
+        enable_log_recording: true,
+        enable_return_data_recording: true,
+        enable_cpi_recording: false,
+    };
+    let mut timings = ExecuteTimings::default();
+
+    let result = batch_processor.load_and_execute_sanitized_transactions(
+        &mock_bank,
+        &transactions,
+        transaction_check.as_mut_slice(),
+        &mut error_counter,
+        recording_config,
+        &mut timings,
+        None,
+        None,
+        true,
+    );
+
+    // Assert that the transaction has worked without errors.
+    if !result.execution_results[0].was_executed()
+        || result.execution_results[0]
+            .details()
+            .unwrap()
+            .status
+            .is_err()
+    {
+        assert_ne!(
+            output.result, 0,
+            "Transaction was not successful, but should have been: file {:?}",
+            filename
+        );
+        return;
+    }
+
+    // Check modified accounts
+    let idx_map: HashMap<Pubkey, usize> = result.loaded_transactions[0]
+        .0
+        .as_ref()
+        .unwrap()
+        .accounts
+        .iter()
+        .enumerate()
+        .map(|(idx, item)| (item.0, idx))
+        .collect();
+
+    for item in &output.modified_accounts {
+        let pubkey = Pubkey::new_from_array(item.address.clone().try_into().unwrap());
+        let index = *idx_map
+            .get(&pubkey)
+            .expect("Account not in expected results");
+        let received_data = &result.loaded_transactions[0].0.as_ref().unwrap().accounts[index].1;
+
+        assert_eq!(
+            received_data.lamports(),
+            item.lamports,
+            "Lamports differ in case: {:?}",
+            filename
+        );
+        assert_eq!(
+            received_data.data(),
+            item.data.as_slice(),
+            "Account data differs in case: {:?}",
+            filename
+        );
+        assert_eq!(
+            received_data.owner(),
+            &Pubkey::new_from_array(item.owner.clone().try_into().unwrap()),
+            "Account owner differs in case: {:?}",
+            filename
+        );
+        assert_eq!(
+            received_data.executable(),
+            item.executable,
+            "Executable boolean differs in case: {:?}",
+            filename
+        );
+
+        // u64::MAX means we are not considering the epoch
+        if item.rent_epoch != u64::MAX && received_data.rent_epoch() != u64::MAX {
+            assert_eq!(
+                received_data.rent_epoch(),
+                item.rent_epoch,
+                "Rent epoch differs in case: {:?}",
+                filename
+            );
+        }
+    }
+
+    let execution_details = result.execution_results[0].details().unwrap();
+    assert_eq!(
+        execution_details.executed_units,
+        input.cu_avail.saturating_sub(output.cu_avail),
+        "Execution units differs in case: {:?}",
+        filename
+    );
+
+    if let Some(return_data) = &execution_details.return_data {
+        assert_eq!(return_data.data, output.return_data);
+    } else {
+        assert_eq!(output.return_data.len(), 0);
+    }
+}
+
+fn register_builtins(
+    batch_processor: &TransactionBatchProcessor<MockForkGraph>,
+    mock_bank: &MockBankCallback,
+) {
+    let bpf_loader = "solana_bpf_loader_upgradeable_program";
+    batch_processor.add_builtin(
+        mock_bank,
+        bpf_loader_upgradeable::id(),
+        bpf_loader,
+        ProgramCacheEntry::new_builtin(
+            0,
+            bpf_loader.len(),
+            solana_bpf_loader_program::Entrypoint::vm,
+        ),
+    );
+}

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -272,7 +272,7 @@ fn prepare_transactions(
     let sanitized_transaction =
         transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), false);
 
-    all_transactions.push(sanitized_transaction);
+    all_transactions.push(sanitized_transaction.unwrap());
     transaction_checks.push(Ok(CheckedTransactionDetails {
         nonce: None,
         lamports_per_signature: 20,
@@ -318,7 +318,7 @@ fn prepare_transactions(
 
     let sanitized_transaction =
         transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), true);
-    all_transactions.push(sanitized_transaction);
+    all_transactions.push(sanitized_transaction.unwrap());
     transaction_checks.push(Ok(CheckedTransactionDetails {
         nonce: None,
         lamports_per_signature: 20,
@@ -360,7 +360,7 @@ fn prepare_transactions(
     let sanitized_transaction =
         transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), false);
 
-    all_transactions.push(sanitized_transaction);
+    all_transactions.push(sanitized_transaction.unwrap());
     transaction_checks.push(Ok(CheckedTransactionDetails {
         nonce: None,
         lamports_per_signature: 20,
@@ -404,7 +404,7 @@ fn prepare_transactions(
 
     let sanitized_transaction =
         transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), true);
-    all_transactions.push(sanitized_transaction.clone());
+    all_transactions.push(sanitized_transaction.clone().unwrap());
     transaction_checks.push(Ok(CheckedTransactionDetails {
         nonce: None,
         lamports_per_signature: 20,
@@ -435,7 +435,7 @@ fn prepare_transactions(
         .insert(recipient, account_data);
 
     // A transaction whose verification has already failed
-    all_transactions.push(sanitized_transaction);
+    all_transactions.push(sanitized_transaction.unwrap());
     transaction_checks.push(Err(TransactionError::BlockhashNotFound));
 
     (all_transactions, transaction_checks)


### PR DESCRIPTION
#### Problem


The firedancer team has released the [test-vectors](https://github.com/firedancer-io/test-vectors) to ensure conformance between their validator and Agave. This means, we can include the tests in our CI to avoid any difference in transaction processing from future changes.

The vectors include tests for the following builtins:

1. BPF-loader
2. Stake program
3. System program
4. Vote program
5. Compute budget tests

#### Summary of Changes

This PR adds tests for the BPF-loader program. Further tests will be added in upcoming PRs.

I clone the test-vectors repository in Rust and delete it after the test.