### PR TITLE
rpc-client: Print transaction logs in preflight error

### DIFF
--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -860,7 +860,7 @@ fn test_cli_program_upgrade_auto_extend() {
          RPC response error -32002: \
          Transaction simulation failed: \
          Error processing Instruction 0: \
-         account data too small for instruction 3 log messages:\n  \
+         account data too small for instruction; 3 log messages:\n  \
          Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [1]\n  \
          ProgramData account not large enough\n  \
          Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n",
@@ -1150,7 +1150,7 @@ fn test_cli_program_extend_program() {
          RPC response error -32002: \
          Transaction simulation failed: \
          Error processing Instruction 0: \
-         account data too small for instruction 3 log messages:\n  \
+         account data too small for instruction; 3 log messages:\n  \
          Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [1]\n  \
          ProgramData account not large enough\n  \
          Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n",

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -860,7 +860,10 @@ fn test_cli_program_upgrade_auto_extend() {
          RPC response error -32002: \
          Transaction simulation failed: \
          Error processing Instruction 0: \
-         account data too small for instruction [3 log messages]",
+         account data too small for instruction 3 log messages:\n  \
+         Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [1]\n  \
+         ProgramData account not large enough\n  \
+         Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n",
     );
 
     // Attempt to upgrade the program with a larger program, this time without
@@ -1147,7 +1150,10 @@ fn test_cli_program_extend_program() {
          RPC response error -32002: \
          Transaction simulation failed: \
          Error processing Instruction 0: \
-         account data too small for instruction [3 log messages]",
+         account data too small for instruction 3 log messages:\n  \
+         Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [1]\n  \
+         ProgramData account not large enough\n  \
+         Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n",
     );
 
     // Wait one slot to avoid "Program was deployed in this block already" error

--- a/rpc-client-api/src/request.rs
+++ b/rpc-client-api/src/request.rs
@@ -243,8 +243,7 @@ impl fmt::Display for RpcResponseErrorData {
                 if logs.is_empty() {
                     Ok(())
                 } else {
-                    // Give the user a hint that there is more useful logging information available...
-                    write!(f, "[{} log messages]", logs.len())
+                    write!(f, "[{} log messages: {logs:?}]", logs.len())
                 }
             }
             _ => Ok(()),

--- a/rpc-client-api/src/request.rs
+++ b/rpc-client-api/src/request.rs
@@ -259,7 +259,7 @@ impl fmt::Display for RpcResponseErrorData {
 pub enum RpcError {
     #[error("RPC request error: {0}")]
     RpcRequestError(String),
-    #[error("RPC response error {code}: {message} {data}")]
+    #[error("RPC response error {code}: {message}; {data}")]
     RpcResponseError {
         code: i64,
         message: String,

--- a/rpc-client-api/src/request.rs
+++ b/rpc-client-api/src/request.rs
@@ -243,7 +243,11 @@ impl fmt::Display for RpcResponseErrorData {
                 if logs.is_empty() {
                     Ok(())
                 } else {
-                    write!(f, "[{} log messages: {logs:?}]", logs.len())
+                    writeln!(f, "{} log messages:", logs.len())?;
+                    for log in logs {
+                        writeln!(f, "  {log}")?;
+                    }
+                    Ok(())
                 }
             }
             _ => Ok(()),


### PR DESCRIPTION
#### Problem

When using many of the CLI tools, if there's a preflight error, users are given an error message such as this one during a program deployment:

```
Error: Deploying program failed: RPC response error -32002: Transaction simulation failed: Error processing Instruction 1: invalid account data for instruction [7 log messages]
```

And often, they can't figure out what went wrong or debug any further, since the transaction has no signature to query separately. In the past, I've used things like a `--dry-run` flag to simulate the transaction and print out the full error, like at https://github.com/solana-labs/solana-program-library/blob/3178de622635d3d39d686325b0b6a9aa78e1dcb0/stake-pool/cli/src/main.rs#L198

But most tools don't have a `--dry-run` option, and in other situations, it might take a very long time to recreate the error condition. In the example of a program deployment, a user might try to land ~1000 transactions again before getting the same error.

#### Summary of Changes

This may be contentious, since it will create much longer logs for users, but I think it'll help more than harm. In the last example, the program used a syscall that wasn't enabled on the target cluster. With this change, the error message becomes:

```
Error: Deploying program failed: RPC response error -32002: Transaction simulation failed: Error processing Instruction 1: invalid account data for instruction [7 log messages: ["Program 11111111111111111111111111111111 invoke [1]", "Program 11111111111111111111111111111111 success", "Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [1]", "Program 11111111111111111111111111111111 invoke [2]", "Program 11111111111111111111111111111111 success", "Unresolved symbol (sol_blake3) at instruction #53 (ELF file offset 0x1a8)", "Program BPFLoaderUpgradeab1e11111111111111111111111 failed: invalid account data for instruction"]]
```

Let me know what you think! I'm certainly open to other options, and might be missing negative downstream consequences of this change.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->