### PR TITLE
program-runtime: invoke context: rename `programs_loaded_for_tx` to `program_cache_for_tx_batch`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -536,17 +536,17 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
 
     // Adding `DELAY_VISIBILITY_SLOT_OFFSET` to slots to accommodate for delay visibility of the program
-    let mut loaded_programs =
+    let mut program_cache_for_tx_batch =
         bank.new_program_cache_for_tx_batch_for_slot(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
     for key in cached_account_keys {
-        loaded_programs.replenish(
+        program_cache_for_tx_batch.replenish(
             key,
             bank.load_program(&key, false, bank.epoch())
                 .expect("Couldn't find program account"),
         );
         debug!("Loaded program {}", key);
     }
-    invoke_context.programs_loaded_for_tx_batch = &loaded_programs;
+    invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 
     invoke_context
         .transaction_context

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -185,13 +185,14 @@ pub struct SerializedAccountMetadata {
 pub struct InvokeContext<'a> {
     /// Information about the currently executing transaction.
     pub transaction_context: &'a mut TransactionContext,
+    /// The local program cache for the transaction batch.
+    pub program_cache_for_tx_batch: &'a ProgramCacheForTxBatch,
     /// Runtime configurations used to provision the invocation environment.
     pub environment_config: EnvironmentConfig<'a>,
     log_collector: Option<Rc<RefCell<LogCollector>>>,
     compute_budget: ComputeBudget,
     current_compute_budget: ComputeBudget,
     compute_meter: RefCell<u64>,
-    pub programs_loaded_for_tx_batch: &'a ProgramCacheForTxBatch,
     pub programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
     pub timings: ExecuteDetailsTimings,
     pub syscall_context: Vec<Option<SyscallContext>>,
@@ -202,20 +203,20 @@ impl<'a> InvokeContext<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         transaction_context: &'a mut TransactionContext,
+        program_cache_for_tx_batch: &'a ProgramCacheForTxBatch,
         environment_config: EnvironmentConfig<'a>,
         log_collector: Option<Rc<RefCell<LogCollector>>>,
         compute_budget: ComputeBudget,
-        programs_loaded_for_tx_batch: &'a ProgramCacheForTxBatch,
         programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
     ) -> Self {
         Self {
             transaction_context,
+            program_cache_for_tx_batch,
             environment_config,
             log_collector,
             current_compute_budget: compute_budget,
             compute_budget,
             compute_meter: RefCell::new(compute_budget.compute_unit_limit),
-            programs_loaded_for_tx_batch,
             programs_modified_by_tx,
             timings: ExecuteDetailsTimings::default(),
             syscall_context: Vec::new(),
@@ -228,7 +229,7 @@ impl<'a> InvokeContext<'a> {
         // the cache of the cache of the programs that are loaded for the transaction batch.
         self.programs_modified_by_tx
             .find(pubkey)
-            .or_else(|| self.programs_loaded_for_tx_batch.find(pubkey))
+            .or_else(|| self.program_cache_for_tx_batch.find(pubkey))
     }
 
     pub fn get_environments_for_slot(
@@ -238,7 +239,7 @@ impl<'a> InvokeContext<'a> {
         let epoch_schedule = self.environment_config.sysvar_cache.get_epoch_schedule()?;
         let epoch = epoch_schedule.get_epoch(effective_slot);
         Ok(self
-            .programs_loaded_for_tx_batch
+            .program_cache_for_tx_batch
             .get_environments_for_epoch(epoch))
     }
 
@@ -491,7 +492,7 @@ impl<'a> InvokeContext<'a> {
         // The Murmur3 hash value (used by RBPF) of the string "entrypoint"
         const ENTRYPOINT_KEY: u32 = 0x71E3CF81;
         let entry = self
-            .programs_loaded_for_tx_batch
+            .program_cache_for_tx_batch
             .find(&builtin_id)
             .ok_or(InstructionError::UnsupportedProgramId)?;
         let function = match &entry.program {
@@ -517,7 +518,7 @@ impl<'a> InvokeContext<'a> {
         let empty_memory_mapping =
             MemoryMapping::new(Vec::new(), &mock_config, &SBPFVersion::V1).unwrap();
         let mut vm = EbpfVm::new(
-            self.programs_loaded_for_tx_batch
+            self.program_cache_for_tx_batch
                 .environments
                 .program_runtime_v2
                 .clone(),
@@ -711,14 +712,14 @@ macro_rules! with_mock_invoke_context {
             0,
             &sysvar_cache,
         );
-        let programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
+        let program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let mut $invoke_context = InvokeContext::new(
             &mut $transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             Some(LogCollector::new_ref()),
             compute_budget,
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
     };
@@ -775,12 +776,12 @@ pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut Invo
         false
     };
     with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
-    let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
-    programs_loaded_for_tx_batch.replenish(
+    let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+    program_cache_for_tx_batch.replenish(
         *loader_id,
         Arc::new(ProgramCacheEntry::new_builtin(0, 0, builtin_function)),
     );
-    invoke_context.programs_loaded_for_tx_batch = &programs_loaded_for_tx_batch;
+    invoke_context.program_cache_for_tx_batch = &program_cache_for_tx_batch;
     pre_adjustments(&mut invoke_context);
     let result = invoke_context.process_instruction(
         instruction_data,
@@ -1032,12 +1033,12 @@ mod tests {
             })
             .collect::<Vec<_>>();
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
-        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        program_cache_for_tx_batch.replenish(
             callee_program_id,
             Arc::new(ProgramCacheEntry::new_builtin(0, 1, MockBuiltin::vm)),
         );
-        invoke_context.programs_loaded_for_tx_batch = &programs_loaded_for_tx_batch;
+        invoke_context.program_cache_for_tx_batch = &program_cache_for_tx_batch;
 
         // Account modification tests
         let cases = vec![
@@ -1181,12 +1182,12 @@ mod tests {
             },
         ];
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
-        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        program_cache_for_tx_batch.replenish(
             program_key,
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
-        invoke_context.programs_loaded_for_tx_batch = &programs_loaded_for_tx_batch;
+        invoke_context.program_cache_for_tx_batch = &program_cache_for_tx_batch;
 
         // Test: Resize the account to *the same size*, so not consuming any additional size; this must succeed
         {

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -129,9 +129,8 @@ impl Bank {
     /// cache.
     ///
     /// Invoking the loader's `direct_deploy_program` function will update the
-    /// program cache in the currently executing context (ie. `programs_loaded`
-    /// and `programs_modified`), but the runtime must also propagate those
-    /// updates to the currently active cache.
+    /// program cache in the currently executing context, but the runtime must
+    /// also propagate those updates to the currently active cache.
     fn directly_invoke_loader_v3_deploy(
         &self,
         builtin_program_id: &Pubkey,
@@ -142,16 +141,16 @@ impl Bank {
         let elf = &programdata[progradata_metadata_size..];
         // Set up the two `LoadedProgramsForTxBatch` instances, as if
         // processing a new transaction batch.
-        let programs_loaded = ProgramCacheForTxBatch::new_from_cache(
+        let program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
             self.slot,
             self.epoch,
             &self.transaction_processor.program_cache.read().unwrap(),
         );
         let mut programs_modified = ProgramCacheForTxBatch::new(
             self.slot,
-            programs_loaded.environments.clone(),
-            programs_loaded.upcoming_environments.clone(),
-            programs_loaded.latest_root_epoch,
+            program_cache_for_tx_batch.environments.clone(),
+            program_cache_for_tx_batch.upcoming_environments.clone(),
+            program_cache_for_tx_batch.latest_root_epoch,
         );
 
         // Configure a dummy `InvokeContext` from the runtime's current
@@ -175,10 +174,10 @@ impl Bank {
 
             let mut dummy_invoke_context = InvokeContext::new(
                 &mut dummy_transaction_context,
+                &program_cache_for_tx_batch,
                 EnvironmentConfig::new(Hash::default(), self.feature_set.clone(), 0, &sysvar_cache),
                 None,
                 compute_budget,
-                &programs_loaded,
                 &mut programs_modified,
             );
 

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -240,8 +240,8 @@ mod tests {
         ];
         let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3);
         let program_indices = vec![vec![2]];
-        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        program_cache_for_tx_batch.replenish(
             mock_system_program_id,
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
@@ -281,10 +281,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
@@ -335,10 +335,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
@@ -379,10 +379,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
@@ -475,8 +475,8 @@ mod tests {
         ];
         let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3);
         let program_indices = vec![vec![2]];
-        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        program_cache_for_tx_batch.replenish(
             mock_program_id,
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
@@ -514,10 +514,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
@@ -553,10 +553,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
@@ -589,10 +589,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
@@ -672,8 +672,8 @@ mod tests {
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
         let sysvar_cache = SysvarCache::default();
-        let mut programs_loaded_for_tx_batch = ProgramCacheForTxBatch::default();
-        programs_loaded_for_tx_batch.replenish(
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        program_cache_for_tx_batch.replenish(
             mock_program_id,
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
@@ -686,10 +686,10 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            &program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
-            &programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -198,13 +198,13 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             program_accounts_map.insert(*builtin_program, 0);
         }
 
-        let programs_loaded_for_tx_batch = Rc::new(RefCell::new(self.replenish_program_cache(
+        let program_cache_for_tx_batch = Rc::new(RefCell::new(self.replenish_program_cache(
             callbacks,
             &program_accounts_map,
             limit_to_load_programs,
         )));
 
-        if programs_loaded_for_tx_batch.borrow().hit_max_limit {
+        if program_cache_for_tx_batch.borrow().hit_max_limit {
             const ERROR: TransactionError = TransactionError::ProgramCacheHitMaxLimit;
             let loaded_transactions = vec![(Err(ERROR), None); sanitized_txs.len()];
             let execution_results =
@@ -224,7 +224,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             error_counters,
             &self.fee_structure,
             account_overrides,
-            &programs_loaded_for_tx_batch.borrow(),
+            &program_cache_for_tx_batch.borrow(),
         );
         load_time.stop();
 
@@ -268,7 +268,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         timings,
                         error_counters,
                         log_messages_bytes_limit,
-                        &programs_loaded_for_tx_batch.borrow(),
+                        &program_cache_for_tx_batch.borrow(),
                     );
 
                     if let TransactionExecutionResult::Executed {
@@ -279,7 +279,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         // Update batch specific cache of the loaded programs with the modifications
                         // made by the transaction, if it executed successfully.
                         if details.status.is_ok() {
-                            programs_loaded_for_tx_batch
+                            program_cache_for_tx_batch
                                 .borrow_mut()
                                 .merge(programs_modified_by_tx);
                         }
@@ -296,8 +296,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         // ProgramCache entries. Note that loaded_missing is deliberately defined, so that there's
         // still at least one other batch, which will evict the program cache, even after the
         // occurrences of cooperative loading.
-        if programs_loaded_for_tx_batch.borrow().loaded_missing
-            || programs_loaded_for_tx_batch.borrow().merged_modified
+        if program_cache_for_tx_batch.borrow().loaded_missing
+            || program_cache_for_tx_batch.borrow().merged_modified
         {
             const SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE: u8 = 90;
             self.program_cache
@@ -476,7 +476,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         timings: &mut ExecuteTimings,
         error_counters: &mut TransactionErrorMetrics,
         log_messages_bytes_limit: Option<usize>,
-        programs_loaded_for_tx_batch: &ProgramCacheForTxBatch,
+        program_cache_for_tx_batch: &ProgramCacheForTxBatch,
     ) -> TransactionExecutionResult {
         let transaction_accounts = std::mem::take(&mut loaded_transaction.accounts);
 
@@ -527,14 +527,15 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let mut executed_units = 0u64;
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::new(
             self.slot,
-            programs_loaded_for_tx_batch.environments.clone(),
-            programs_loaded_for_tx_batch.upcoming_environments.clone(),
-            programs_loaded_for_tx_batch.latest_root_epoch,
+            program_cache_for_tx_batch.environments.clone(),
+            program_cache_for_tx_batch.upcoming_environments.clone(),
+            program_cache_for_tx_batch.latest_root_epoch,
         );
         let sysvar_cache = &self.sysvar_cache.read().unwrap();
 
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
+            program_cache_for_tx_batch,
             EnvironmentConfig::new(
                 blockhash,
                 callback.get_feature_set(),
@@ -543,7 +544,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             ),
             log_collector.clone(),
             compute_budget,
-            programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
         );
 
@@ -892,7 +892,7 @@ mod tests {
         };
 
         let sanitized_message = new_unchecked_sanitized_message(message);
-        let loaded_programs = ProgramCacheForTxBatch::default();
+        let program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         let mock_bank = MockBankCallback::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
@@ -925,7 +925,7 @@ mod tests {
             &mut ExecuteTimings::default(),
             &mut TransactionErrorMetrics::default(),
             None,
-            &loaded_programs,
+            &program_cache_for_tx_batch,
         );
 
         let TransactionExecutionResult::Executed {
@@ -947,7 +947,7 @@ mod tests {
             &mut ExecuteTimings::default(),
             &mut TransactionErrorMetrics::default(),
             Some(2),
-            &loaded_programs,
+            &program_cache_for_tx_batch,
         );
 
         let TransactionExecutionResult::Executed {
@@ -978,7 +978,7 @@ mod tests {
             &mut ExecuteTimings::default(),
             &mut TransactionErrorMetrics::default(),
             None,
-            &loaded_programs,
+            &program_cache_for_tx_batch,
         );
 
         let TransactionExecutionResult::Executed {
@@ -1016,7 +1016,7 @@ mod tests {
         };
 
         let sanitized_message = new_unchecked_sanitized_message(message);
-        let loaded_programs = ProgramCacheForTxBatch::default();
+        let program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         let mock_bank = MockBankCallback::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
@@ -1051,7 +1051,7 @@ mod tests {
             &mut ExecuteTimings::default(),
             &mut error_metrics,
             None,
-            &loaded_programs,
+            &program_cache_for_tx_batch,
         );
 
         assert_eq!(error_metrics.instruction_error, 1);


### PR DESCRIPTION
#### Problem
The `InvokeContext` makes use of two local program cache instances to manage:

- The program cache for the current transaction batch, which is what the
   transaction batch will load from.
- Another, smaller, program cache instance for tracking _only_ programs modified
   by the transaction batch.

It's not immediately clear which one is the source of truth for programs the
transaction batch should use.

Additionally, as we increment closer to unifying these local cache instances, a more
unified name could be useful.

#### Summary of Changes
In the `InvokeContext`, _and_ the SVM's `TransactionBatchProcessor`, rename
`programs_loaded_for_tx` to `program_cache_for_tx_batch`.
