### PR TITLE
SVM: change modified programs result to hash map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5423,7 +5423,6 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-nohash-hasher",
- "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-stake-program",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -41,7 +41,6 @@ solana-inline-spl = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-nohash-hasher = { workspace = true }
-solana-program-runtime = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-sdk = { workspace = true }
 solana-stake-program = { workspace = true, optional = true }
@@ -84,7 +83,6 @@ dev-context-only-utils = ["dep:qualifier_attr", "dep:solana-stake-program", "dep
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
-    "solana-program-runtime/frozen-abi",
     "solana-sdk/frozen-abi",
     "solana-svm/frozen-abi",
     "solana-vote-program/frozen-abi",

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -826,7 +826,6 @@ mod tests {
     use {
         super::*,
         assert_matches::assert_matches,
-        solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
         solana_sdk::{
             account::{AccountSharedData, WritableAccount},
             address_lookup_table::state::LookupTableMeta,
@@ -878,7 +877,7 @@ mod tests {
                 executed_units: 0,
                 accounts_data_len_delta: 0,
             },
-            programs_modified_by_tx: Box::<ProgramCacheForTxBatch>::default(),
+            programs_modified_by_tx: HashMap::new(),
         }
     }
 

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -720,6 +720,10 @@ impl ProgramCacheForTxBatch {
         &self.entries
     }
 
+    pub fn take_entries(&mut self) -> HashMap<Pubkey, Arc<ProgramCacheEntry>> {
+        std::mem::take(&mut self.entries)
+    }
+
     /// Returns the current environments depending on the given epoch
     pub fn get_environments_for_epoch(&self, epoch: Epoch) -> &ProgramRuntimeEnvironments {
         if epoch != self.latest_root_epoch {

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -716,6 +716,10 @@ impl ProgramCacheForTxBatch {
         }
     }
 
+    pub fn entries(&self) -> &HashMap<Pubkey, Arc<ProgramCacheEntry>> {
+        &self.entries
+    }
+
     /// Returns the current environments depending on the given epoch
     pub fn get_environments_for_epoch(&self, epoch: Epoch) -> &ProgramRuntimeEnvironments {
         if epoch != self.latest_root_epoch {
@@ -764,8 +768,8 @@ impl ProgramCacheForTxBatch {
         self.slot = slot;
     }
 
-    pub fn merge(&mut self, other: &Self) {
-        other.entries.iter().for_each(|(key, entry)| {
+    pub fn merge(&mut self, modified_entries: &HashMap<Pubkey, Arc<ProgramCacheEntry>>) {
+        modified_entries.iter().for_each(|(key, entry)| {
             self.merged_modified = true;
             self.replenish(*key, entry.clone());
         })
@@ -1156,8 +1160,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         }
     }
 
-    pub fn merge(&mut self, tx_batch_cache: &ProgramCacheForTxBatch) {
-        tx_batch_cache.entries.iter().for_each(|(key, entry)| {
+    pub fn merge(&mut self, modified_entries: &HashMap<Pubkey, Arc<ProgramCacheEntry>>) {
+        modified_entries.iter().for_each(|(key, entry)| {
             self.assign_program(*key, entry.clone());
         })
     }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4583,7 +4583,6 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-nohash-hasher",
- "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-svm",

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -232,7 +232,7 @@ impl Bank {
             .program_cache
             .write()
             .unwrap()
-            .merge(&programs_modified);
+            .merge(programs_modified.entries());
 
         Ok(())
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -43,7 +43,7 @@ use {
     solana_logger,
     solana_program_runtime::{
         declare_process_instruction,
-        loaded_programs::{ProgramCacheEntry, ProgramCacheEntryType, ProgramCacheForTxBatch},
+        loaded_programs::{ProgramCacheEntry, ProgramCacheEntryType},
         timings::ExecuteTimings,
     },
     solana_sdk::{
@@ -247,7 +247,7 @@ fn new_execution_result(
             executed_units: 0,
             accounts_data_len_delta: 0,
         },
-        programs_modified_by_tx: Box::<ProgramCacheForTxBatch>::default(),
+        programs_modified_by_tx: HashMap::new(),
     }
 }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -868,7 +868,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 executed_units,
                 accounts_data_len_delta,
             },
-            programs_modified_by_tx: programs_modified_by_tx.entries().clone(),
+            programs_modified_by_tx: programs_modified_by_tx.take_entries(),
         }
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -868,7 +868,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 executed_units,
                 accounts_data_len_delta,
             },
-            programs_modified_by_tx: Box::new(programs_modified_by_tx),
+            programs_modified_by_tx: programs_modified_by_tx.entries().clone(),
         }
     }
 

--- a/svm/src/transaction_results.rs
+++ b/svm/src/transaction_results.rs
@@ -6,13 +6,15 @@
 pub use solana_sdk::inner_instruction::{InnerInstruction, InnerInstructionsList};
 use {
     serde::{Deserialize, Serialize},
-    solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
+    solana_program_runtime::loaded_programs::ProgramCacheEntry,
     solana_sdk::{
         fee::FeeDetails,
+        pubkey::Pubkey,
         rent_debits::RentDebits,
         transaction::{self, TransactionError},
         transaction_context::TransactionReturnData,
     },
+    std::{collections::HashMap, sync::Arc},
 };
 
 pub struct TransactionResults {
@@ -42,7 +44,7 @@ pub struct TransactionLoadedAccountsStats {
 pub enum TransactionExecutionResult {
     Executed {
         details: TransactionExecutionDetails,
-        programs_modified_by_tx: Box<ProgramCacheForTxBatch>,
+        programs_modified_by_tx: HashMap<Pubkey, Arc<ProgramCacheEntry>>,
     },
     NotExecuted(TransactionError),
 }


### PR DESCRIPTION
#### Problem
Currently, the SVM's `TransactionResult` requires a full local program cache
instance to return the programs modified by the transaction batch. This can
be done more elegantly with a hash map.

Furthermore, other crates who must mock out SVM transaction results can
now simply use `HashMap::new()`, and forego having to drag in types from
`solana-program-runtime`. This even removes the dependency from AccountsDB
altogether.

#### Summary of Changes
Change `programs_modified_by_tx` in the SVM's `TransactionResult` to be a
`HashMap<Pubkey, Arc<ProgramCacheEntry>>`.
