### PR TITLE
Format strings in solana-ledger crate

### DIFF
--- a/ledger/benches/blockstore_processor.rs
+++ b/ledger/benches/blockstore_processor.rs
@@ -117,9 +117,8 @@ fn bench_execute_batch(
     assert_eq!(
         TRANSACTIONS_PER_ITERATION % batch_size,
         0,
-        "batch_size must be a factor of \
-        `TRANSACTIONS_PER_ITERATION` ({TRANSACTIONS_PER_ITERATION}) \
-        so that bench results are easily comparable"
+        "batch_size must be a factor of `TRANSACTIONS_PER_ITERATION` \
+         ({TRANSACTIONS_PER_ITERATION}) so that bench results are easily comparable"
     );
     let batches_per_iteration = TRANSACTIONS_PER_ITERATION / batch_size;
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -40,7 +40,7 @@ pub enum BankForksUtilsError {
 
     #[error(
         "failed to load bank: {source}, full snapshot archive: {full_snapshot_archive}, \
-        incremental snapshot archive: {incremental_snapshot_archive}"
+         incremental snapshot archive: {incremental_snapshot_archive}"
     )]
     BankFromSnapshotsArchive {
         source: snapshot_utils::SnapshotError,
@@ -49,8 +49,8 @@ pub enum BankForksUtilsError {
     },
 
     #[error(
-        "there is no local state to startup from. \
-        Ensure --{flag} is NOT set to \"{value}\" and restart"
+        "there is no local state to startup from. Ensure --{flag} is NOT set to \"{value}\" and \
+         restart"
     )]
     NoBankSnapshotDirectory { flag: String, value: String },
 
@@ -262,9 +262,9 @@ fn bank_forks_from_snapshot(
             // higher than the local state we will load.  Did the user intend for this?
             if bank_snapshot.slot < latest_snapshot_archive_slot {
                 warn!(
-                    "Starting up from local state at slot {}, which is *older* than \
-                    the latest snapshot archive at slot {}. If this is not desired, \
-                    change the --{} CLI option to *not* \"{}\" and restart.",
+                    "Starting up from local state at slot {}, which is *older* than the latest \
+                     snapshot archive at slot {}. If this is not desired, change the --{} CLI \
+                     option to *not* \"{}\" and restart.",
                     bank_snapshot.slot,
                     latest_snapshot_archive_slot,
                     use_snapshot_archives_at_startup::cli::LONG_ARG,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1438,10 +1438,9 @@ impl Blockstore {
                     ));
                 } else {
                     error!(
-                        "Unable to find the conflicting coding shred that set {erasure_meta:?}.
-                        This should only happen in extreme cases where blockstore cleanup has \
-                         caught up to the root.
-                        Skipping the erasure meta duplicate shred check"
+                        "Unable to find the conflicting coding shred that set {erasure_meta:?}. \
+                         This should only happen in extreme cases where blockstore cleanup has \
+                         caught up to the root. Skipping the erasure meta duplicate shred check"
                     );
                 }
             }
@@ -1753,9 +1752,9 @@ impl Blockstore {
         }
 
         warn!(
-            "Received conflicting merkle roots for slot: {}, erasure_set: {:?}
-                original merkle root meta {:?} vs
-                conflicting merkle root {:?} shred index {} type {:?}. Reporting as duplicate",
+            "Received conflicting merkle roots for slot: {}, erasure_set: {:?} original merkle \
+             root meta {:?} vs conflicting merkle root {:?} shred index {} type {:?}. Reporting \
+             as duplicate",
             slot,
             shred.erasure_set(),
             merkle_root_meta,
@@ -1776,10 +1775,9 @@ impl Blockstore {
             else {
                 error!(
                     "Shred {shred_id:?} indiciated by merkle root meta {merkle_root_meta:?} is \
-                     missing from blockstore.
-                    This should only happen in extreme cases where blockstore cleanup has caught \
-                     up to the root.
-                    Skipping the merkle root consistency check"
+                     missing from blockstore. This should only happen in extreme cases where \
+                     blockstore cleanup has caught up to the root. Skipping the merkle root \
+                     consistency check"
                 );
                 return true;
             };
@@ -1842,10 +1840,9 @@ impl Blockstore {
         else {
             error!(
                 "Shred {next_shred_id:?} indicated by merkle root meta {next_merkle_root_meta:?} \
-                 is missing from blockstore.
-                 This should only happen in extreme cases where blockstore cleanup has caught up \
-                 to the root.
-                 Skipping the forward chained merkle root consistency check"
+                 is missing from blockstore. This should only happen in extreme cases where \
+                 blockstore cleanup has caught up to the root. Skipping the forward chained \
+                 merkle root consistency check"
             );
             return true;
         };
@@ -1854,11 +1851,10 @@ impl Blockstore {
 
         if !self.check_chaining(merkle_root, chained_merkle_root) {
             warn!(
-                "Received conflicting chained merkle roots for slot: {slot},
-                shred {erasure_set:?} type {:?} has merkle root {merkle_root:?}, however
-                next fec set shred {next_erasure_set:?} type {:?} chains to merkle root \
-                 {chained_merkle_root:?}.
-                Reporting as duplicate",
+                "Received conflicting chained merkle roots for slot: {slot}, shred \
+                 {erasure_set:?} type {:?} has merkle root {merkle_root:?}, however next fec set \
+                 shred {next_erasure_set:?} type {:?} chains to merkle root \
+                 {chained_merkle_root:?}. Reporting as duplicate",
                 shred.shred_type(),
                 next_merkle_root_meta.first_received_shred_type(),
             );
@@ -1929,9 +1925,8 @@ impl Blockstore {
         else {
             warn!(
                 "The merkle root meta for the previous erasure set {prev_erasure_set:?} does not \
-                 exist.
-                This should only happen if you have recently upgraded from a version < v1.18.13.
-                Skipping the backwards chained merkle root for {erasure_set:?}"
+                 exist. This should only happen if you have recently upgraded from a version < \
+                 v1.18.13. Skipping the backwards chained merkle root for {erasure_set:?}"
             );
             return true;
         };
@@ -1946,10 +1941,9 @@ impl Blockstore {
         else {
             error!(
                 "Shred {prev_shred_id:?} indicated by merkle root meta {prev_merkle_root_meta:?} \
-                 is missing from blockstore.
-                 This should only happen in extreme cases where blockstore cleanup has caught up \
-                 to the root.
-                 Skipping the backwards chained merkle root consistency check"
+                 is missing from blockstore. This should only happen in extreme cases where \
+                 blockstore cleanup has caught up to the root. Skipping the backwards chained \
+                 merkle root consistency check"
             );
             return true;
         };
@@ -1958,11 +1952,10 @@ impl Blockstore {
 
         if !self.check_chaining(merkle_root, chained_merkle_root) {
             warn!(
-                "Received conflicting chained merkle roots for slot: {slot},
-                    shred {:?} type {:?} chains to merkle root {chained_merkle_root:?}, however
-                    previous fec set shred {prev_erasure_set:?} type {:?} has merkle root \
-                 {merkle_root:?}.
-                    Reporting as duplicate",
+                "Received conflicting chained merkle roots for slot: {slot}, shred {:?} type {:?} \
+                 chains to merkle root {chained_merkle_root:?}, however previous fec set shred \
+                 {prev_erasure_set:?} type {:?} has merkle root {merkle_root:?}. Reporting as \
+                 duplicate",
                 shred.erasure_set(),
                 shred.shred_type(),
                 prev_merkle_root_meta.first_received_shred_type(),
@@ -2026,10 +2019,9 @@ impl Blockstore {
                 else {
                     error!(
                         "Last index data shred {shred_id:?} indiciated by slot meta {slot_meta:?} \
-                         is missing from blockstore.
-                        This should only happen in extreme cases where blockstore cleanup has \
-                         caught up to the root.
-                        Skipping data shred insertion"
+                         is missing from blockstore. This should only happen in extreme cases \
+                         where blockstore cleanup has caught up to the root. Skipping data shred \
+                         insertion"
                     );
                     return false;
                 };
@@ -2077,10 +2069,9 @@ impl Blockstore {
                 else {
                     error!(
                         "Last received data shred {shred_id:?} indiciated by slot meta \
-                         {slot_meta:?} is missing from blockstore.
-                        This should only happen in extreme cases where blockstore cleanup has \
-                         caught up to the root.
-                        Skipping data shred insertion"
+                         {slot_meta:?} is missing from blockstore. This should only happen in \
+                         extreme cases where blockstore cleanup has caught up to the root. \
+                         Skipping data shred insertion"
                     );
                     return false;
                 };

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1426,7 +1426,10 @@ impl Blockstore {
                         conflicting_shred.clone(),
                         shred.payload().clone(),
                     ) {
-                        warn!("Unable to store conflicting erasure meta duplicate proof for {slot} {erasure_set:?} {e}");
+                        warn!(
+                            "Unable to store conflicting erasure meta duplicate proof for {slot} \
+                             {erasure_set:?} {e}"
+                        );
                     }
 
                     duplicate_shreds.push(PossibleDuplicateShred::ErasureConflict(
@@ -1436,7 +1439,8 @@ impl Blockstore {
                 } else {
                     error!(
                         "Unable to find the conflicting coding shred that set {erasure_meta:?}.
-                        This should only happen in extreme cases where blockstore cleanup has caught up to the root.
+                        This should only happen in extreme cases where blockstore cleanup has \
+                         caught up to the root.
                         Skipping the erasure meta duplicate shred check"
                     );
                 }
@@ -1445,8 +1449,8 @@ impl Blockstore {
             // ToDo: This is a potential slashing condition
             warn!("Received multiple erasure configs for the same erasure set!!!");
             warn!(
-                "Slot: {}, shred index: {}, erasure_set: {:?}, \
-                is_duplicate: {}, stored config: {:#?}, new shred: {:#?}",
+                "Slot: {}, shred index: {}, erasure_set: {:?}, is_duplicate: {}, stored config: \
+                 {:#?}, new shred: {:#?}",
                 slot,
                 shred.index(),
                 erasure_set,
@@ -1615,7 +1619,11 @@ impl Blockstore {
                 // just purge all shreds > the new last index slot, but because replay may have already
                 // replayed entries past the newly detected "last" shred, then mark the slot as dead
                 // and wait for replay to dump and repair the correct version.
-                warn!("Received *last* shred index {} less than previous shred index {}, and slot {} is not full, marking slot dead", shred_index, slot_meta.received, slot);
+                warn!(
+                    "Received *last* shred index {} less than previous shred index {}, and slot \
+                     {} is not full, marking slot dead",
+                    shred_index, slot_meta.received, slot
+                );
                 write_batch.put::<cf::DeadSlots>(slot, &true).unwrap();
             }
 
@@ -1767,8 +1775,10 @@ impl Blockstore {
                 .map(Cow::into_owned)
             else {
                 error!(
-                    "Shred {shred_id:?} indiciated by merkle root meta {merkle_root_meta:?} is missing from blockstore.
-                    This should only happen in extreme cases where blockstore cleanup has caught up to the root.
+                    "Shred {shred_id:?} indiciated by merkle root meta {merkle_root_meta:?} is \
+                     missing from blockstore.
+                    This should only happen in extreme cases where blockstore cleanup has caught \
+                     up to the root.
                     Skipping the merkle root consistency check"
                 );
                 return true;
@@ -1831,8 +1841,10 @@ impl Blockstore {
                 .map(Cow::into_owned)
         else {
             error!(
-                "Shred {next_shred_id:?} indicated by merkle root meta {next_merkle_root_meta:?} is missing from blockstore.
-                 This should only happen in extreme cases where blockstore cleanup has caught up to the root.
+                "Shred {next_shred_id:?} indicated by merkle root meta {next_merkle_root_meta:?} \
+                 is missing from blockstore.
+                 This should only happen in extreme cases where blockstore cleanup has caught up \
+                 to the root.
                  Skipping the forward chained merkle root consistency check"
             );
             return true;
@@ -1844,7 +1856,8 @@ impl Blockstore {
             warn!(
                 "Received conflicting chained merkle roots for slot: {slot},
                 shred {erasure_set:?} type {:?} has merkle root {merkle_root:?}, however
-                next fec set shred {next_erasure_set:?} type {:?} chains to merkle root {chained_merkle_root:?}.
+                next fec set shred {next_erasure_set:?} type {:?} chains to merkle root \
+                 {chained_merkle_root:?}.
                 Reporting as duplicate",
                 shred.shred_type(),
                 next_merkle_root_meta.first_received_shred_type(),
@@ -1915,7 +1928,8 @@ impl Blockstore {
             })
         else {
             warn!(
-                "The merkle root meta for the previous erasure set {prev_erasure_set:?} does not exist.
+                "The merkle root meta for the previous erasure set {prev_erasure_set:?} does not \
+                 exist.
                 This should only happen if you have recently upgraded from a version < v1.18.13.
                 Skipping the backwards chained merkle root for {erasure_set:?}"
             );
@@ -1931,8 +1945,10 @@ impl Blockstore {
                 .map(Cow::into_owned)
         else {
             error!(
-                "Shred {prev_shred_id:?} indicated by merkle root meta {prev_merkle_root_meta:?} is missing from blockstore.
-                 This should only happen in extreme cases where blockstore cleanup has caught up to the root.
+                "Shred {prev_shred_id:?} indicated by merkle root meta {prev_merkle_root_meta:?} \
+                 is missing from blockstore.
+                 This should only happen in extreme cases where blockstore cleanup has caught up \
+                 to the root.
                  Skipping the backwards chained merkle root consistency check"
             );
             return true;
@@ -1942,14 +1958,15 @@ impl Blockstore {
 
         if !self.check_chaining(merkle_root, chained_merkle_root) {
             warn!(
-                    "Received conflicting chained merkle roots for slot: {slot},
+                "Received conflicting chained merkle roots for slot: {slot},
                     shred {:?} type {:?} chains to merkle root {chained_merkle_root:?}, however
-                    previous fec set shred {prev_erasure_set:?} type {:?} has merkle root {merkle_root:?}.
+                    previous fec set shred {prev_erasure_set:?} type {:?} has merkle root \
+                 {merkle_root:?}.
                     Reporting as duplicate",
-                    shred.erasure_set(),
-                    shred.shred_type(),
-                    prev_merkle_root_meta.first_received_shred_type(),
-                );
+                shred.erasure_set(),
+                shred.shred_type(),
+                prev_merkle_root_meta.first_received_shred_type(),
+            );
 
             if !self.has_duplicate_shreds_in_slot(shred.slot()) {
                 duplicate_shreds.push(PossibleDuplicateShred::ChainedMerkleRootConflict(
@@ -2008,8 +2025,10 @@ impl Blockstore {
                     .map(Cow::into_owned)
                 else {
                     error!(
-                        "Last index data shred {shred_id:?} indiciated by slot meta {slot_meta:?} is missing from blockstore.
-                        This should only happen in extreme cases where blockstore cleanup has caught up to the root.
+                        "Last index data shred {shred_id:?} indiciated by slot meta {slot_meta:?} \
+                         is missing from blockstore.
+                        This should only happen in extreme cases where blockstore cleanup has \
+                         caught up to the root.
                         Skipping data shred insertion"
                     );
                     return false;
@@ -2032,7 +2051,8 @@ impl Blockstore {
                 (
                     "error",
                     format!(
-                        "Leader {leader_pubkey:?}, slot {slot}: received index {shred_index} >= slot.last_index {last_index:?}, shred_source: {shred_source:?}"
+                        "Leader {leader_pubkey:?}, slot {slot}: received index {shred_index} >= \
+                         slot.last_index {last_index:?}, shred_source: {shred_source:?}"
                     ),
                     String
                 )
@@ -2056,8 +2076,10 @@ impl Blockstore {
                     .map(Cow::into_owned)
                 else {
                     error!(
-                        "Last received data shred {shred_id:?} indiciated by slot meta {slot_meta:?} is missing from blockstore.
-                        This should only happen in extreme cases where blockstore cleanup has caught up to the root.
+                        "Last received data shred {shred_id:?} indiciated by slot meta \
+                         {slot_meta:?} is missing from blockstore.
+                        This should only happen in extreme cases where blockstore cleanup has \
+                         caught up to the root.
                         Skipping data shred insertion"
                     );
                     return false;
@@ -2080,7 +2102,8 @@ impl Blockstore {
                 (
                     "error",
                     format!(
-                        "Leader {:?}, slot {}: received shred_index {} < slot.received {}, shred_source: {:?}",
+                        "Leader {:?}, slot {}: received shred_index {} < slot.received {}, \
+                         shred_source: {:?}",
                         leader_pubkey, slot, shred_index, slot_meta.received, shred_source
                     ),
                     String
@@ -2650,9 +2673,7 @@ impl Blockstore {
                     .map(|transaction| {
                         if let Err(err) = transaction.sanitize() {
                             warn!(
-                                "Blockstore::get_block sanitize failed: {:?}, \
-                                slot: {:?}, \
-                                {:?}",
+                                "Blockstore::get_block sanitize failed: {:?}, slot: {:?}, {:?}",
                                 err, slot, transaction,
                             );
                         }
@@ -3097,9 +3118,8 @@ impl Blockstore {
             .map(|transaction| {
                 if let Err(err) = transaction.sanitize() {
                     warn!(
-                        "Blockstore::find_transaction_in_slot sanitize failed: {:?}, \
-                        slot: {:?}, \
-                        {:?}",
+                        "Blockstore::find_transaction_in_slot sanitize failed: {:?}, slot: {:?}, \
+                         {:?}",
                         err, slot, transaction,
                     );
                 }
@@ -3605,39 +3625,38 @@ impl Blockstore {
             .into_iter()
             .collect();
         let data_shreds = data_shreds?;
-        let data_shreds: Result<Vec<Shred>> =
-            data_shreds
-                .into_iter()
-                .enumerate()
-                .map(|(idx, shred_bytes)| {
-                    if shred_bytes.is_none() {
-                        if let Some(slot_meta) = slot_meta {
-                            if slot > self.lowest_cleanup_slot() {
-                                panic!(
-                                    "Shred with slot: {}, index: {}, consumed: {}, completed_indexes: {:?} \
-                                    must exist if shred index was included in a range: {} {}",
-                                    slot,
-                                    idx,
-                                    slot_meta.consumed,
-                                    slot_meta.completed_data_indexes,
-                                    all_ranges_start_index,
-                                    all_ranges_end_index
-                                );
-                            }
+        let data_shreds: Result<Vec<Shred>> = data_shreds
+            .into_iter()
+            .enumerate()
+            .map(|(idx, shred_bytes)| {
+                if shred_bytes.is_none() {
+                    if let Some(slot_meta) = slot_meta {
+                        if slot > self.lowest_cleanup_slot() {
+                            panic!(
+                                "Shred with slot: {}, index: {}, consumed: {}, completed_indexes: \
+                                 {:?} must exist if shred index was included in a range: {} {}",
+                                slot,
+                                idx,
+                                slot_meta.consumed,
+                                slot_meta.completed_data_indexes,
+                                all_ranges_start_index,
+                                all_ranges_end_index
+                            );
                         }
-                        return Err(BlockstoreError::InvalidShredData(Box::new(
-                            bincode::ErrorKind::Custom(format!(
-                                "Missing shred for slot {slot}, index {idx}"
-                            )),
-                        )));
                     }
-                    Shred::new_from_serialized_shred(shred_bytes.unwrap()).map_err(|err| {
-                        BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
-                            format!("Could not reconstruct shred from shred payload: {err:?}"),
-                        )))
-                    })
+                    return Err(BlockstoreError::InvalidShredData(Box::new(
+                        bincode::ErrorKind::Custom(format!(
+                            "Missing shred for slot {slot}, index {idx}"
+                        )),
+                    )));
+                }
+                Shred::new_from_serialized_shred(shred_bytes.unwrap()).map_err(|err| {
+                    BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
+                        format!("Could not reconstruct shred from shred payload: {err:?}"),
+                    )))
                 })
-                .collect();
+            })
+            .collect();
         let data_shreds = data_shreds?;
 
         completed_ranges

--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -60,8 +60,8 @@ impl BlockstoreCleanupService {
             .name("solBstoreClean".to_string())
             .spawn(move || {
                 info!(
-                    "BlockstoreCleanupService has started with max \
-                    ledger shreds={max_ledger_shreds}",
+                    "BlockstoreCleanupService has started with max ledger \
+                     shreds={max_ledger_shreds}",
                 );
                 loop {
                     if exit.load(Ordering::Relaxed) {
@@ -142,8 +142,8 @@ impl BlockstoreCleanupService {
             .unwrap_or(lowest_slot);
         if highest_slot < lowest_slot {
             error!(
-                "Skipping Blockstore cleanup: \
-                highest slot {highest_slot} < lowest slot {lowest_slot}",
+                "Skipping Blockstore cleanup: highest slot {highest_slot} < lowest slot \
+                 {lowest_slot}",
             );
             return (false, 0, num_shreds);
         }
@@ -153,7 +153,7 @@ impl BlockstoreCleanupService {
         let mean_shreds_per_slot = num_shreds / num_slots;
         info!(
             "Blockstore has {num_shreds} alive shreds in slots [{lowest_slot}, {highest_slot}], \
-            mean of {mean_shreds_per_slot} shreds per slot",
+             mean of {mean_shreds_per_slot} shreds per slot",
         );
 
         if num_shreds <= max_ledger_shreds {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -431,9 +431,9 @@ impl Rocks {
             AccessType::Secondary => {
                 let secondary_path = path.join("solana-secondary");
                 info!(
-                    "Opening Rocks with secondary (read only) access at: {secondary_path:?}. \
-                    This secondary access could temporarily degrade other accesses, such as \
-                    by agave-validator"
+                    "Opening Rocks with secondary (read only) access at: {secondary_path:?}. This \
+                     secondary access could temporarily degrade other accesses, such as by \
+                     agave-validator"
                 );
                 DB::open_cf_descriptors_as_secondary(
                     &db_options,
@@ -2085,8 +2085,10 @@ fn new_cf_descriptor_fifo<C: 'static + Column + ColumnName>(
         )
     } else {
         panic!(
-            "{} cf_size must be greater than write buffer size {} when using ShredStorageType::RocksFifo.",
-            C::NAME, FIFO_WRITE_BUFFER_SIZE
+            "{} cf_size must be greater than write buffer size {} when using \
+             ShredStorageType::RocksFifo.",
+            C::NAME,
+            FIFO_WRITE_BUFFER_SIZE
         );
     }
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -625,7 +625,8 @@ fn process_entries(
                             (
                                 "error",
                                 format!(
-                                    "Lock accounts error, entry conflicts with itself, txs: {transactions:?}"
+                                    "Lock accounts error, entry conflicts with itself, txs: \
+                                     {transactions:?}"
                                 ),
                                 String
                             )
@@ -1428,8 +1429,8 @@ fn confirm_slot_entries(
         let tick_hash_count = &mut progress.tick_hash_count;
         verify_ticks(bank, &entries, slot_full, tick_hash_count).map_err(|err| {
             warn!(
-                "{:#?}, slot: {}, entry len: {}, tick_height: {}, last entry: {}, \
-                last_blockhash: {}, shred_index: {}, slot_full: {}",
+                "{:#?}, slot: {}, entry len: {}, tick_height: {}, last entry: {}, last_blockhash: \
+                 {}, shred_index: {}, slot_full: {}",
                 err,
                 slot,
                 num_entries,
@@ -1719,18 +1720,13 @@ fn load_frozen_forks(
                 let slots_per_sec = slots_processed as f32 / secs;
                 let txs_per_sec = txs as f32 / secs;
                 info!(
-                    "processing ledger: slot={slot}, \
-                    root_slot={root} \
-                    slots={slots_processed}, \
-                    slots/s={slots_per_sec}, \
-                    txs/s={txs_per_sec}"
+                    "processing ledger: slot={slot}, root_slot={root} slots={slots_processed}, \
+                     slots/s={slots_per_sec}, txs/s={txs_per_sec}"
                 );
                 debug!(
-                    "processing ledger timing: \
-                    set_root_us={set_root_us}, \
-                    root_retain_us={root_retain_us}, \
-                    process_single_slot_us:{process_single_slot_us}, \
-                    voting_us: {voting_us}"
+                    "processing ledger timing: set_root_us={set_root_us}, \
+                     root_retain_us={root_retain_us}, \
+                     process_single_slot_us:{process_single_slot_us}, voting_us: {voting_us}"
                 );
 
                 last_status_report = Instant::now();

--- a/ledger/src/use_snapshot_archives_at_startup.rs
+++ b/ledger/src/use_snapshot_archives_at_startup.rs
@@ -27,21 +27,17 @@ pub mod cli {
     pub const NAME: &str = "use_snapshot_archives_at_startup";
     pub const LONG_ARG: &str = "use-snapshot-archives-at-startup";
     pub const HELP: &str = "When should snapshot archives be used at startup?";
-    pub const LONG_HELP: &str = "At startup, when should snapshot archives be extracted \
-        versus using what is already on disk? \
-        \nSpecifying \"always\" will always startup by extracting snapshot archives \
-        and disregard any snapshot-related state already on disk. \
-        Note that starting up from snapshot archives will incur the runtime costs \
-        associated with extracting the archives and rebuilding the local state. \
-        \nSpecifying \"never\" will never startup from snapshot archives \
-        and will only use snapshot-related state already on disk. \
-        If there is no state already on disk, startup will fail. \
-        Note, this will use the latest state available, \
-        which may be newer than the latest snapshot archive. \
-        \nSpecifying \"when-newest\" will use snapshot-related state \
-        already on disk unless there are snapshot archives newer than it. \
-        This can happen if a new snapshot archive is downloaded \
-        while the node is stopped.";
+    pub const LONG_HELP: &str =
+        "At startup, when should snapshot archives be extracted versus using what is already on \
+         disk? \nSpecifying \"always\" will always startup by extracting snapshot archives and \
+         disregard any snapshot-related state already on disk. Note that starting up from \
+         snapshot archives will incur the runtime costs associated with extracting the archives \
+         and rebuilding the local state. \nSpecifying \"never\" will never startup from snapshot \
+         archives and will only use snapshot-related state already on disk. If there is no state \
+         already on disk, startup will fail. Note, this will use the latest state available, \
+         which may be newer than the latest snapshot archive. \nSpecifying \"when-newest\" will \
+         use snapshot-related state already on disk unless there are snapshot archives newer than \
+         it. This can happen if a new snapshot archive is downloaded while the node is stopped.";
 
     pub const POSSIBLE_VALUES: &[&str] = UseSnapshotArchivesAtStartup::VARIANTS;
 

--- a/ledger/src/use_snapshot_archives_at_startup.rs
+++ b/ledger/src/use_snapshot_archives_at_startup.rs
@@ -27,17 +27,21 @@ pub mod cli {
     pub const NAME: &str = "use_snapshot_archives_at_startup";
     pub const LONG_ARG: &str = "use-snapshot-archives-at-startup";
     pub const HELP: &str = "When should snapshot archives be used at startup?";
-    pub const LONG_HELP: &str =
-        "At startup, when should snapshot archives be extracted versus using what is already on \
-         disk? \nSpecifying \"always\" will always startup by extracting snapshot archives and \
-         disregard any snapshot-related state already on disk. Note that starting up from \
-         snapshot archives will incur the runtime costs associated with extracting the archives \
-         and rebuilding the local state. \nSpecifying \"never\" will never startup from snapshot \
-         archives and will only use snapshot-related state already on disk. If there is no state \
-         already on disk, startup will fail. Note, this will use the latest state available, \
-         which may be newer than the latest snapshot archive. \nSpecifying \"when-newest\" will \
-         use snapshot-related state already on disk unless there are snapshot archives newer than \
-         it. This can happen if a new snapshot archive is downloaded while the node is stopped.";
+    pub const LONG_HELP: &str = "At startup, when should snapshot archives be extracted \
+        versus using what is already on disk? \
+        \nSpecifying \"always\" will always startup by extracting snapshot archives \
+        and disregard any snapshot-related state already on disk. \
+        Note that starting up from snapshot archives will incur the runtime costs \
+        associated with extracting the archives and rebuilding the local state. \
+        \nSpecifying \"never\" will never startup from snapshot archives \
+        and will only use snapshot-related state already on disk. \
+        If there is no state already on disk, startup will fail. \
+        Note, this will use the latest state available, \
+        which may be newer than the latest snapshot archive. \
+        \nSpecifying \"when-newest\" will use snapshot-related state \
+        already on disk unless there are snapshot archives newer than it. \
+        This can happen if a new snapshot archive is downloaded \
+        while the node is stopped.";
 
     pub const POSSIBLE_VALUES: &[&str] = UseSnapshotArchivesAtStartup::VARIANTS;
 


### PR DESCRIPTION
#### Problem
Cleaning up some of the strings in `solana-ledger` crate, strings that are too long are known to inhibit clippy from working properly on entire files.

#### Summary of Changes
- Put `format_strings = true` in `rustfmt.toml`
- Run `../cargo nightly fmt` within `ledger` directory
- Manually tweak some strings after that