### PR TITLE
Supports archiving account storage files that are backed by Mmap or File

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -11,6 +11,7 @@ use {
     },
     solana_sdk::{account::AccountSharedData, clock::Slot, pubkey::Pubkey},
     std::{
+        fs,
         io::Read,
         mem,
         path::{Path, PathBuf},
@@ -289,6 +290,18 @@ impl AccountsFile {
                 .data_for_archive(),
         }
     }
+
+    /// brooks TODO: doc
+    pub fn internals_for_archive(&self) -> InternalsForArchive {
+        match self {
+            Self::AppendVec(av) => InternalsForArchive::Mmap(av.data_for_archive()),
+            Self::TieredStorage(ts) => InternalsForArchive::Mmap(
+                ts.reader()
+                    .expect("must be a reader when archiving")
+                    .data_for_archive(),
+            ),
+        }
+    }
 }
 
 /// An enum that creates AccountsFile instance with the specified format.
@@ -308,6 +321,13 @@ impl AccountsFileProvider {
             Self::HotStorage => AccountsFile::TieredStorage(TieredStorage::new_writable(path)),
         }
     }
+}
+
+/// brooks TODO: doc
+#[derive(Debug)]
+pub enum InternalsForArchive<'a> {
+    Mmap(&'a [u8]),
+    File(fs::File),
 }
 
 /// Information after storing accounts

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -831,18 +831,13 @@ pub fn archive_snapshot_package(
                         })?;
                         header.set_size(storage.capacity());
                         header.set_cksum();
-                        archive.append(&header, data).map_err(|err| {
-                            E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
-                        })?;
+                        archive.append(&header, data)
                     }
                     InternalsForArchive::FileIo(path) => {
-                        archive
-                            .append_path_with_name(path, path_in_archive)
-                            .map_err(|err| {
-                                E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
-                            })?;
+                        archive.append_path_with_name(path, path_in_archive)
                     }
                 }
+                .map_err(|err| E::ArchiveAccountStorageFile(err, storage.path().to_path_buf()))?;
             }
 
             archive.into_inner().map_err(E::FinishArchive)?;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -20,7 +20,7 @@ use {
     solana_accounts_db::{
         account_storage::AccountStorageMap,
         accounts_db::{AccountStorageEntry, AtomicAccountsFileId},
-        accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
+        accounts_file::{AccountsFile, AccountsFileError, InternalsForArchive, StorageAccess},
         hardened_unpack::{self, ParallelSelector, UnpackError},
         shared_buffer_reader::{SharedBuffer, SharedBufferReader},
         utils::{move_and_async_delete_path, ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR},
@@ -823,17 +823,26 @@ pub fn archive_snapshot_package(
                     storage.slot(),
                     storage.append_vec_id(),
                 ));
-                let mut header = tar::Header::new_gnu();
-                header.set_path(path_in_archive).map_err(|err| {
-                    E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
-                })?;
-                header.set_size(storage.capacity());
-                header.set_cksum();
-                archive
-                    .append(&header, storage.accounts.data_for_archive())
-                    .map_err(|err| {
-                        E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
-                    })?;
+                match storage.accounts.internals_for_archive() {
+                    InternalsForArchive::Mmap(data) => {
+                        let mut header = tar::Header::new_gnu();
+                        header.set_path(path_in_archive).map_err(|err| {
+                            E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
+                        })?;
+                        header.set_size(storage.capacity());
+                        header.set_cksum();
+                        archive.append(&header, data).map_err(|err| {
+                            E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
+                        })?;
+                    }
+                    InternalsForArchive::File(mut file) => {
+                        archive
+                            .append_file(path_in_archive, &mut file)
+                            .map_err(|err| {
+                                E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
+                            })?;
+                    }
+                }
             }
 
             archive.into_inner().map_err(E::FinishArchive)?;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -835,9 +835,9 @@ pub fn archive_snapshot_package(
                             E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
                         })?;
                     }
-                    InternalsForArchive::File(mut file) => {
+                    InternalsForArchive::FileIo(path) => {
                         archive
-                            .append_file(path_in_archive, &mut file)
+                            .append_path_with_name(path, path_in_archive)
                             .map_err(|err| {
                                 E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
                             })?;


### PR DESCRIPTION
#### Problem

When archiving a snapshot we need to archive the account storages. Right now we assume we can get a byte slice to that data. This is possible since we Mmap all the account storage files into memory.

We are adding support to access account storages with File I/O. In that scenario we cannot get a byte slice to the storage. We need another way to archive the storages.


#### Summary of Changes

Add a method to AccountsFile that returns an enum whether the backing/access of the file is Mmap or File I/O.
Use the new method when archiving to determine which impl to use for adding the storage to the archive.

I also tested by setting `can_append()` to `false`, thus forcing the archive code to use the File I/O variant. I successfully ran-and-passed all the accounts-db tests, and all the snapshot tests in runtime.