### PR TITLE
Move `PartialEq` impls behind DCOU feature

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -450,7 +450,8 @@ impl TransactionLogCollector {
 /// Since it is difficult to insert fields to serialize/deserialize against existing code already deployed,
 /// new fields can be optionally serialized and optionally deserialized. At some point, the serialization and
 /// deserialization will use a new mechanism or otherwise be in sync more clearly.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct BankFieldsToDeserialize {
     pub(crate) blockhash_queue: BlockhashQueue,
     pub(crate) ancestors: AncestorsForSerialization,
@@ -531,6 +532,7 @@ pub(crate) struct BankFieldsToSerialize<'a> {
 }
 
 // Can't derive PartialEq because RwLock doesn't implement PartialEq
+#[cfg(feature = "dev-context-only-utils")]
 impl PartialEq for Bank {
     fn eq(&self, other: &Self) -> bool {
         if std::ptr::eq(self, other) {

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -16,8 +16,9 @@ pub struct NodeVoteAccounts {
     pub total_stake: u64,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct EpochStakes {
     #[serde(with = "crate::stakes::serde_stakes_enum_compat")]
     stakes: Arc<StakesEnum>,

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -528,6 +528,7 @@ impl From<Stakes<Delegation>> for StakesEnum {
 // Therefore, if one side is Stakes<StakeAccount> and the other is a
 // Stakes<Delegation> we convert the former one to Stakes<Delegation> before
 // comparing for equality.
+#[cfg(feature = "dev-context-only-utils")]
 impl PartialEq<StakesEnum> for StakesEnum {
     fn eq(&self, other: &StakesEnum) -> bool {
         match (self, other) {


### PR DESCRIPTION
#### Problem
Implementing `PartialEq` for epoch stakes is quite expensive but it's not clear that it's actually okay-ish for it to be that way since equality is only ever checked in tests. For context, this issue came up here: https://github.com/anza-xyz/agave/pull/1146/files#r1594226939

#### Summary of Changes
Move some `PartialEq` impl's behind the `"dev-context-only-utils"` feature

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
