### PR TITLE
Program Runtime: Unify transaction batch program caches

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -193,7 +193,7 @@ pub struct InvokeContext<'a> {
     /// Information about the currently executing transaction.
     pub transaction_context: &'a mut TransactionContext,
     /// The local program cache for the transaction batch.
-    pub program_cache_for_tx_batch: &'a ProgramCacheForTxBatch,
+    pub program_cache_for_tx_batch: &'a mut ProgramCacheForTxBatch,
     /// Runtime configurations used to provision the invocation environment.
     pub environment_config: EnvironmentConfig<'a>,
     /// The compute budget for the current invocation.
@@ -214,7 +214,7 @@ impl<'a> InvokeContext<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         transaction_context: &'a mut TransactionContext,
-        program_cache_for_tx_batch: &'a ProgramCacheForTxBatch,
+        program_cache_for_tx_batch: &'a mut ProgramCacheForTxBatch,
         environment_config: EnvironmentConfig<'a>,
         log_collector: Option<Rc<RefCell<LogCollector>>>,
         compute_budget: ComputeBudget,
@@ -733,11 +733,11 @@ macro_rules! with_mock_invoke_context {
             0,
             &sysvar_cache,
         );
-        let program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let mut $invoke_context = InvokeContext::new(
             &mut $transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             Some(LogCollector::new_ref()),
             compute_budget,
@@ -802,7 +802,7 @@ pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut Invo
         *loader_id,
         Arc::new(ProgramCacheEntry::new_builtin(0, 0, builtin_function)),
     );
-    invoke_context.program_cache_for_tx_batch = &program_cache_for_tx_batch;
+    invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
     pre_adjustments(&mut invoke_context);
     let result = invoke_context.process_instruction(
         instruction_data,
@@ -1059,7 +1059,7 @@ mod tests {
             callee_program_id,
             Arc::new(ProgramCacheEntry::new_builtin(0, 1, MockBuiltin::vm)),
         );
-        invoke_context.program_cache_for_tx_batch = &program_cache_for_tx_batch;
+        invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 
         // Account modification tests
         let cases = vec![
@@ -1208,7 +1208,7 @@ mod tests {
             program_key,
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
-        invoke_context.program_cache_for_tx_batch = &program_cache_for_tx_batch;
+        invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 
         // Test: Resize the account to *the same size*, so not consuming any additional size; this must succeed
         {

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -232,10 +232,6 @@ impl<'a> InvokeContext<'a> {
         }
     }
 
-    pub fn find_program_in_cache(&self, pubkey: &Pubkey) -> Option<Arc<ProgramCacheEntry>> {
-        self.program_cache_for_tx_batch.find(pubkey)
-    }
-
     pub fn get_environments_for_slot(
         &self,
         effective_slot: Slot,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -720,14 +720,6 @@ impl ProgramCacheForTxBatch {
         }
     }
 
-    pub fn entries(&self) -> &HashMap<Pubkey, Arc<ProgramCacheEntry>> {
-        &self.entries
-    }
-
-    pub fn take_entries(&mut self) -> HashMap<Pubkey, Arc<ProgramCacheEntry>> {
-        std::mem::take(&mut self.entries)
-    }
-
     /// Returns the current environments depending on the given epoch
     pub fn get_environments_for_epoch(&self, epoch: Epoch) -> &ProgramRuntimeEnvironments {
         if epoch != self.latest_root_epoch {

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -663,6 +663,8 @@ pub struct ProgramCacheForTxBatch {
     /// Pubkey is the address of a program.
     /// ProgramCacheEntry is the corresponding program entry valid for the slot in which a transaction is being executed.
     entries: HashMap<Pubkey, Arc<ProgramCacheEntry>>,
+    /// Program entries modified during the transaction batch.
+    modified_entries: HashMap<Pubkey, Arc<ProgramCacheEntry>>,
     slot: Slot,
     pub environments: ProgramRuntimeEnvironments,
     /// Anticipated replacement for `environments` at the next epoch.
@@ -689,6 +691,7 @@ impl ProgramCacheForTxBatch {
     ) -> Self {
         Self {
             entries: HashMap::new(),
+            modified_entries: HashMap::new(),
             slot,
             environments,
             upcoming_environments,
@@ -706,6 +709,7 @@ impl ProgramCacheForTxBatch {
     ) -> Self {
         Self {
             entries: HashMap::new(),
+            modified_entries: HashMap::new(),
             slot,
             environments: cache.get_environments_for_epoch(epoch),
             upcoming_environments: cache.get_upcoming_environments_for_epoch(epoch),
@@ -747,21 +751,39 @@ impl ProgramCacheForTxBatch {
         (self.entries.insert(key, entry.clone()).is_some(), entry)
     }
 
+    /// Store an entry in `modified_entries` for a program modified during the
+    /// transaction batch.
+    pub fn store_modified_entry(&mut self, key: Pubkey, entry: Arc<ProgramCacheEntry>) {
+        self.modified_entries.insert(key, entry);
+    }
+
+    /// Drain the program cache's modified entries, returning the owned
+    /// collection.
+    pub fn drain_modified_entries(&mut self) -> HashMap<Pubkey, Arc<ProgramCacheEntry>> {
+        std::mem::take(&mut self.modified_entries)
+    }
+
     pub fn find(&self, key: &Pubkey) -> Option<Arc<ProgramCacheEntry>> {
-        self.entries.get(key).map(|entry| {
-            if entry.is_implicit_delay_visibility_tombstone(self.slot) {
-                // Found a program entry on the current fork, but it's not effective
-                // yet. It indicates that the program has delayed visibility. Return
-                // the tombstone to reflect that.
-                Arc::new(ProgramCacheEntry::new_tombstone(
-                    entry.deployment_slot,
-                    entry.account_owner,
-                    ProgramCacheEntryType::DelayVisibility,
-                ))
-            } else {
-                entry.clone()
-            }
-        })
+        // First lookup the cache of the programs modified by the current
+        // transaction. If not found, lookup the cache of the cache of the
+        // programs that are loaded for the transaction batch.
+        self.modified_entries
+            .get(key)
+            .or(self.entries.get(key))
+            .map(|entry| {
+                if entry.is_implicit_delay_visibility_tombstone(self.slot) {
+                    // Found a program entry on the current fork, but it's not effective
+                    // yet. It indicates that the program has delayed visibility. Return
+                    // the tombstone to reflect that.
+                    Arc::new(ProgramCacheEntry::new_tombstone(
+                        entry.deployment_slot,
+                        entry.account_owner,
+                        ProgramCacheEntryType::DelayVisibility,
+                    ))
+                } else {
+                    entry.clone()
+                }
+            })
     }
 
     pub fn slot(&self) -> Slot {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -152,7 +152,7 @@ macro_rules! deploy_program {
             environments.program_runtime_v1.clone(),
             true,
         )?;
-        if let Some(old_entry) = $invoke_context.find_program_in_cache(&$program_id) {
+        if let Some(old_entry) = $invoke_context.program_cache_for_tx_batch.find(&$program_id) {
             executor.tx_usage_counter.store(
                 old_entry.tx_usage_counter.load(Ordering::Relaxed),
                 Ordering::Relaxed
@@ -437,7 +437,8 @@ pub fn process_instruction_inner(
 
     let mut get_or_create_executor_time = Measure::start("get_or_create_executor_time");
     let executor = invoke_context
-        .find_program_in_cache(program_account.get_key())
+        .program_cache_for_tx_batch
+        .find(program_account.get_key())
         .ok_or_else(|| {
             ic_logger_msg!(log_collector, "Program is not cached");
             InstructionError::InvalidAccountData

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -165,7 +165,7 @@ macro_rules! deploy_program {
         $drop
         load_program_metrics.program_id = $program_id.to_string();
         load_program_metrics.submit_datapoint(&mut $invoke_context.timings);
-        $invoke_context.programs_modified_by_tx.replenish($program_id, Arc::new(executor));
+        $invoke_context.programs_modified_by_tx.store_modified_entry($program_id, Arc::new(executor));
     }};
 }
 
@@ -1109,7 +1109,7 @@ fn process_loader_upgradeable_instruction(
                                 &log_collector,
                             )?;
                             let clock = invoke_context.get_sysvar_cache().get_clock()?;
-                            invoke_context.programs_modified_by_tx.replenish(
+                            invoke_context.programs_modified_by_tx.store_modified_entry(
                                 program_key,
                                 Arc::new(ProgramCacheEntry::new_tombstone(
                                     clock.slot,
@@ -1547,7 +1547,7 @@ pub mod test_utils {
                         .set_slot_for_tests(DELAY_VISIBILITY_SLOT_OFFSET);
                     invoke_context
                         .programs_modified_by_tx
-                        .replenish(*pubkey, Arc::new(loaded_program));
+                        .store_modified_entry(*pubkey, Arc::new(loaded_program));
                 }
             }
         }

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -460,7 +460,7 @@ pub fn process_instruction_deploy(
         );
     }
     invoke_context
-        .programs_modified_by_tx
+        .program_cache_for_tx_batch
         .store_modified_entry(*program.get_key(), Arc::new(executor));
     Ok(())
 }
@@ -661,7 +661,7 @@ mod tests {
                     if let Ok(loaded_program) = ProgramCacheEntry::new(
                         &loader_v4::id(),
                         invoke_context
-                            .programs_modified_by_tx
+                            .program_cache_for_tx_batch
                             .environments
                             .program_runtime_v2
                             .clone(),
@@ -671,9 +671,11 @@ mod tests {
                         account.data().len(),
                         &mut load_program_metrics,
                     ) {
-                        invoke_context.programs_modified_by_tx.set_slot_for_tests(0);
                         invoke_context
-                            .programs_modified_by_tx
+                            .program_cache_for_tx_batch
+                            .set_slot_for_tests(0);
+                        invoke_context
+                            .program_cache_for_tx_batch
                             .store_modified_entry(*pubkey, Arc::new(loaded_program));
                     }
                 }
@@ -708,7 +710,7 @@ mod tests {
             Entrypoint::vm,
             |invoke_context| {
                 invoke_context
-                    .programs_modified_by_tx
+                    .program_cache_for_tx_batch
                     .environments
                     .program_runtime_v2 = Arc::new(create_program_runtime_environment_v2(
                     &ComputeBudget::default(),

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -461,7 +461,7 @@ pub fn process_instruction_deploy(
     }
     invoke_context
         .programs_modified_by_tx
-        .replenish(*program.get_key(), Arc::new(executor));
+        .store_modified_entry(*program.get_key(), Arc::new(executor));
     Ok(())
 }
 
@@ -674,7 +674,7 @@ mod tests {
                         invoke_context.programs_modified_by_tx.set_slot_for_tests(0);
                         invoke_context
                             .programs_modified_by_tx
-                            .replenish(*pubkey, Arc::new(loaded_program));
+                            .store_modified_entry(*pubkey, Arc::new(loaded_program));
                     }
                 }
             }

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -449,7 +449,10 @@ pub fn process_instruction_deploy(
     state.slot = current_slot;
     state.status = LoaderV4Status::Deployed;
 
-    if let Some(old_entry) = invoke_context.find_program_in_cache(program.get_key()) {
+    if let Some(old_entry) = invoke_context
+        .program_cache_for_tx_batch
+        .find(program.get_key())
+    {
         executor.tx_usage_counter.store(
             old_entry.tx_usage_counter.load(Ordering::Relaxed),
             Ordering::Relaxed,
@@ -592,7 +595,8 @@ pub fn process_instruction_inner(
         }
         let mut get_or_create_executor_time = Measure::start("get_or_create_executor_time");
         let loaded_program = invoke_context
-            .find_program_in_cache(program.get_key())
+            .program_cache_for_tx_batch
+            .find(program.get_key())
             .ok_or_else(|| {
                 ic_logger_msg!(log_collector, "Program is not cached");
                 InstructionError::InvalidAccountData

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -169,7 +169,7 @@ impl Bank {
         let elf = &programdata[progradata_metadata_size..];
         // Set up the two `LoadedProgramsForTxBatch` instances, as if
         // processing a new transaction batch.
-        let program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
             self.slot,
             self.epoch,
             &self.transaction_processor.program_cache.read().unwrap(),
@@ -202,7 +202,7 @@ impl Bank {
 
             let mut dummy_invoke_context = InvokeContext::new(
                 &mut dummy_transaction_context,
-                &program_cache_for_tx_batch,
+                &mut program_cache_for_tx_batch,
                 EnvironmentConfig::new(
                     Hash::default(),
                     None,

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -174,12 +174,6 @@ impl Bank {
             self.epoch,
             &self.transaction_processor.program_cache.read().unwrap(),
         );
-        let mut programs_modified = ProgramCacheForTxBatch::new(
-            self.slot,
-            program_cache_for_tx_batch.environments.clone(),
-            program_cache_for_tx_batch.upcoming_environments.clone(),
-            program_cache_for_tx_batch.latest_root_epoch,
-        );
 
         // Configure a dummy `InvokeContext` from the runtime's current
         // environment, as well as the two `ProgramCacheForTxBatch`
@@ -213,7 +207,6 @@ impl Bank {
                 ),
                 None,
                 compute_budget,
-                &mut programs_modified,
             );
 
             solana_bpf_loader_program::direct_deploy_program(
@@ -232,7 +225,7 @@ impl Bank {
             .program_cache
             .write()
             .unwrap()
-            .merge(&programs_modified.drain_modified_entries());
+            .merge(&program_cache_for_tx_batch.drain_modified_entries());
 
         Ok(())
     }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -232,7 +232,7 @@ impl Bank {
             .program_cache
             .write()
             .unwrap()
-            .merge(programs_modified.entries());
+            .merge(&programs_modified.drain_modified_entries());
 
         Ok(())
     }

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -286,7 +286,7 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
@@ -342,7 +342,7 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
@@ -388,7 +388,7 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
@@ -525,7 +525,7 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
@@ -566,7 +566,7 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
@@ -604,7 +604,7 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),
@@ -703,7 +703,7 @@ mod tests {
         );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             environment_config,
             None,
             ComputeBudget::default(),

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -275,7 +275,6 @@ mod tests {
             ]),
         ));
         let sysvar_cache = SysvarCache::default();
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             None,
@@ -290,7 +289,6 @@ mod tests {
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -331,7 +329,6 @@ mod tests {
                 ),
             ]),
         ));
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             None,
@@ -346,7 +343,6 @@ mod tests {
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -377,7 +373,6 @@ mod tests {
                 ),
             ]),
         ));
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             None,
@@ -392,7 +387,6 @@ mod tests {
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -514,7 +508,6 @@ mod tests {
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
         let sysvar_cache = SysvarCache::default();
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             None,
@@ -529,7 +522,6 @@ mod tests {
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -555,7 +547,6 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             None,
@@ -570,7 +561,6 @@ mod tests {
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -593,7 +583,6 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             None,
@@ -608,7 +597,6 @@ mod tests {
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,
@@ -692,7 +680,6 @@ mod tests {
             mock_program_id,
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             None,
@@ -707,7 +694,6 @@ mod tests {
             environment_config,
             None,
             ComputeBudget::default(),
-            &mut programs_modified_by_tx,
         );
         let result = MessageProcessor::process_message(
             &message,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -775,12 +775,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let lamports_per_signature = environment.lamports_per_signature;
 
         let mut executed_units = 0u64;
-        let mut programs_modified_by_tx = ProgramCacheForTxBatch::new(
-            self.slot,
-            program_cache_for_tx_batch.environments.clone(),
-            program_cache_for_tx_batch.upcoming_environments.clone(),
-            program_cache_for_tx_batch.latest_root_epoch,
-        );
         let sysvar_cache = &self.sysvar_cache.read().unwrap();
 
         let mut invoke_context = InvokeContext::new(
@@ -796,7 +790,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             ),
             log_collector.clone(),
             compute_budget,
-            &mut programs_modified_by_tx,
         );
 
         let mut process_message_time = Measure::start("process_message_time");
@@ -903,7 +896,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 executed_units,
                 accounts_data_len_delta,
             },
-            programs_modified_by_tx: programs_modified_by_tx.drain_modified_entries(),
+            programs_modified_by_tx: program_cache_for_tx_batch.drain_modified_entries(),
         }
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -903,7 +903,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 executed_units,
                 accounts_data_len_delta,
             },
-            programs_modified_by_tx: programs_modified_by_tx.take_entries(),
+            programs_modified_by_tx: programs_modified_by_tx.drain_modified_entries(),
         }
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -339,7 +339,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         compute_budget,
                         &mut execute_timings,
                         &mut error_metrics,
-                        &program_cache_for_tx_batch.borrow(),
+                        &mut program_cache_for_tx_batch.borrow_mut(),
                         environment,
                         config,
                     );
@@ -722,7 +722,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         compute_budget: ComputeBudget,
         execute_timings: &mut ExecuteTimings,
         error_metrics: &mut TransactionErrorMetrics,
-        program_cache_for_tx_batch: &ProgramCacheForTxBatch,
+        program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
         environment: &TransactionProcessingEnvironment,
         config: &TransactionProcessingConfig,
     ) -> TransactionExecutionResult {
@@ -1149,7 +1149,7 @@ mod tests {
         };
 
         let sanitized_message = new_unchecked_sanitized_message(message);
-        let program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
@@ -1179,7 +1179,7 @@ mod tests {
             ComputeBudget::default(),
             &mut ExecuteTimings::default(),
             &mut TransactionErrorMetrics::default(),
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             &processing_environment,
             &processing_config,
         );
@@ -1201,7 +1201,7 @@ mod tests {
             ComputeBudget::default(),
             &mut ExecuteTimings::default(),
             &mut TransactionErrorMetrics::default(),
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             &processing_environment,
             &processing_config,
         );
@@ -1231,7 +1231,7 @@ mod tests {
             ComputeBudget::default(),
             &mut ExecuteTimings::default(),
             &mut TransactionErrorMetrics::default(),
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             &processing_environment,
             &processing_config,
         );
@@ -1271,7 +1271,7 @@ mod tests {
         };
 
         let sanitized_message = new_unchecked_sanitized_message(message);
-        let program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
@@ -1307,7 +1307,7 @@ mod tests {
             ComputeBudget::default(),
             &mut ExecuteTimings::default(),
             &mut error_metrics,
-            &program_cache_for_tx_batch,
+            &mut program_cache_for_tx_batch,
             &TransactionProcessingEnvironment::default(),
             &processing_config,
         );

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -460,7 +460,6 @@ fn execute_fixture_as_instr(
         )),
     );
 
-    let mut programs_modified_by_tx = ProgramCacheForTxBatch::default();
     let log_collector = LogCollector::new_ref();
 
     let sysvar_cache = &batch_processor.sysvar_cache.read().unwrap();
@@ -479,7 +478,6 @@ fn execute_fixture_as_instr(
         env_config,
         Some(log_collector.clone()),
         compute_budget,
-        &mut programs_modified_by_tx,
     );
 
     let mut instruction_accounts: Vec<InstructionAccount> =

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -475,7 +475,7 @@ fn execute_fixture_as_instr(
 
     let mut invoke_context = InvokeContext::new(
         &mut transaction_context,
-        &loaded_programs,
+        &mut loaded_programs,
         env_config,
         Some(log_collector.clone()),
         compute_budget,


### PR DESCRIPTION
#### Problem

The `InvokeContext` makes use of two local program cache instances - 
`program_cache_for_tx_batch` and `programs_modified_by_tx` - in order to track 
programs that may have been modified by a transaction, such as via 
deployment/upgrade or closure.

The use of two instances of a local cache in tandem is overkill, since all the 
upstream caller (SVM, runtime) cares about is the entries added to 
`programs_modified_by_tx`. Additionally, setup configurations are confusing when 
working with `InvokeContext`, and can be simplified by unifying these cache 
instances.

#### Summary of Changes

Introduce a `modified_entries` field to the local program cache 
(`ProgramCacheForTxBatch`), and use it to track entries modified by a 
transaction.

Then, use this new field when cascading changed program entries up to 
SVM/runtime, effectively unifying the two cache methods.