### PR TITLE
v1.17 - Adds error log for replacements in ProgramCache::assign_program().

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -677,8 +677,13 @@ impl<FG: ForkGraph> LoadedPrograms<FG> {
                     (false, entry)
                 } else {
                     // Something is wrong, I can feel it ...
+                    let existing = existing.clone();
+                    error!(
+                        "ProgramCache::assign_program() failed key={:?} existing={:?} entry={:?}",
+                        key, slot_versions, entry
+                    );
                     self.stats.replacements.fetch_add(1, Ordering::Relaxed);
-                    (true, existing.clone())
+                    (true, existing)
                 }
             }
             Err(index) => {
@@ -699,7 +704,7 @@ impl<FG: ForkGraph> LoadedPrograms<FG> {
         entry: Arc<LoadedProgram>,
     ) -> (bool, Arc<LoadedProgram>) {
         let (was_occupied, entry) = self.replenish(key, entry);
-        debug_assert!(!was_occupied);
+        debug_assert!(!was_occupied, "Unexpected replacement of an entry");
         (was_occupied, entry)
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5223,6 +5223,7 @@ impl Bank {
         ));
 
         if programs_loaded_for_tx_batch.borrow().hit_max_limit {
+            error!("Discarding TX batch {:#?}", batch.sanitized_transactions());
             return LoadAndExecuteTransactionsOutput {
                 loaded_transactions: vec![],
                 execution_results: vec![],


### PR DESCRIPTION
#### Problem
These only exist on master and were not backported so far.

#### Summary of Changes
Adds error log for replacements in `ProgramCache::assign_program()`.