### PR TITLE
v1.18 - Adds error log for replacements in ProgramCache::assign_program().

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -766,6 +766,10 @@ impl<FG: ForkGraph> LoadedPrograms<FG> {
                     false
                 } else {
                     // Something is wrong, I can feel it ...
+                    error!(
+                        "ProgramCache::assign_program() failed key={:?} existing={:?} entry={:?}",
+                        key, slot_versions, entry
+                    );
                     self.stats.replacements.fetch_add(1, Ordering::Relaxed);
                     true
                 }
@@ -1036,6 +1040,7 @@ impl<FG: ForkGraph> LoadedPrograms<FG> {
             self.stats.lost_insertions.fetch_add(1, Ordering::Relaxed);
         }
         let was_occupied = self.assign_program(key, loaded_program);
+        debug_assert!(!was_occupied, "Unexpected replacement of an entry");
         self.loading_task_waiter.notify();
         was_occupied
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5144,6 +5144,7 @@ impl Bank {
         ));
 
         if programs_loaded_for_tx_batch.borrow().hit_max_limit {
+            error!("Discarding TX batch {:#?}", batch.sanitized_transactions());
             return LoadAndExecuteTransactionsOutput {
                 loaded_transactions: vec![],
                 execution_results: vec![],


### PR DESCRIPTION
#### Problem
These only exist on master and were not backported so far.

#### Summary of Changes
Adds error log for replacements in `ProgramCache::assign_program()`.
