### PR TITLE
solana-program: `StakeHistorySyscall` and `get_entry`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6830,6 +6830,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
+ "serial_test",
  "sha2 0.10.8",
  "sha3 0.10.8",
  "solana-frozen-abi",

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -30,7 +30,7 @@ use {
             instruction::LockupArgs,
             state::{Delegation, Lockup, StakeActivationStatus, StakeAuthorize, StakeStateV2},
         },
-        sysvar::stake_history,
+        sysvar::stake_history::{self, StakeHistory},
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_test_validator::{TestValidator, TestValidatorGenesis},
@@ -167,7 +167,8 @@ fn test_stake_redelegation() {
                                    expected_state: StakeActivationState,
                                    expected_active_stake: u64| {
         let stake_history_account = rpc_client.get_account(&stake_history::id()).unwrap();
-        let stake_history = solana_sdk::account::from_account(&stake_history_account).unwrap();
+        let stake_history: StakeHistory =
+            solana_sdk::account::from_account(&stake_history_account).unwrap();
         let current_epoch = rpc_client.get_epoch_info().unwrap().epoch;
         let StakeActivationStatus {
             effective,

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -76,7 +76,7 @@ fn get_stake_status(
     let stake_history = invoke_context.get_sysvar_cache().get_stake_history()?;
     Ok(stake.delegation.stake_activating_and_deactivating(
         clock.epoch,
-        &stake_history,
+        stake_history.as_ref(),
         new_warmup_cooldown_rate_epoch(invoke_context),
     ))
 }
@@ -310,7 +310,7 @@ fn deactivate_stake(
             // deactivation is only permitted when the stake delegation activating amount is zero.
             let status = stake.delegation.stake_activating_and_deactivating(
                 epoch,
-                &stake_history,
+                stake_history.as_ref(),
                 new_warmup_cooldown_rate_epoch(invoke_context),
             );
             if status.activating != 0 {

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -1,8 +1,12 @@
 //! This module implements clone-on-write semantics for the SDK's `StakeHistory` to reduce
 //! unnecessary cloning of the underlying vector.
-use std::{
-    ops::{Deref, DerefMut},
-    sync::Arc,
+pub use solana_sdk::stake_history::StakeHistoryGetEntry;
+use {
+    solana_sdk::{clock::Epoch, stake_history::StakeHistoryEntry},
+    std::{
+        ops::{Deref, DerefMut},
+        sync::Arc,
+    },
 };
 
 /// The SDK's stake history with clone-on-write semantics
@@ -25,6 +29,12 @@ impl DerefMut for StakeHistory {
 
 /// The inner type, which is the SDK's stake history
 type StakeHistoryInner = solana_sdk::stake_history::StakeHistory;
+
+impl StakeHistoryGetEntry for StakeHistory {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        self.0.get_entry(epoch)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -77,6 +77,7 @@ array-bytes = { workspace = true }
 assert_matches = { workspace = true }
 itertools = { workspace = true }
 serde_json = { workspace = true }
+serial_test = { workspace = true }
 static_assertions = { workspace = true }
 
 [build-dependencies]

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -7,7 +7,7 @@
 //! [`sysvar::stake_history`]: crate::sysvar::stake_history
 
 pub use crate::clock::Epoch;
-use std::{ops::Deref, sync::Arc};
+use std::ops::Deref;
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 
@@ -93,13 +93,6 @@ impl StakeHistoryGetEntry for StakeHistory {
         self.binary_search_by(|probe| epoch.cmp(&probe.0))
             .ok()
             .map(|index| self[index].1.clone())
-    }
-}
-
-// required for SysvarCache
-impl StakeHistoryGetEntry for Arc<StakeHistory> {
-    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
-        self.deref().get_entry(epoch)
     }
 }
 

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -7,7 +7,7 @@
 //! [`sysvar::stake_history`]: crate::sysvar::stake_history
 
 pub use crate::clock::Epoch;
-use std::ops::Deref;
+use std::{ops::Deref, sync::Arc};
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 
@@ -81,6 +81,25 @@ impl Deref for StakeHistory {
     type Target = Vec<(Epoch, StakeHistoryEntry)>;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+pub trait StakeHistoryGetEntry {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry>;
+}
+
+impl StakeHistoryGetEntry for StakeHistory {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        self.binary_search_by(|probe| epoch.cmp(&probe.0))
+            .ok()
+            .map(|index| self[index].1.clone())
+    }
+}
+
+// required for SysvarCache
+impl StakeHistoryGetEntry for Arc<StakeHistory> {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        self.deref().get_entry(epoch)
     }
 }
 

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -46,7 +46,12 @@
 //! ```
 
 pub use crate::stake_history::StakeHistory;
-use crate::sysvar::Sysvar;
+use crate::{
+    clock::Epoch,
+    program_error::ProgramError,
+    stake_history::{StakeHistoryEntry, StakeHistoryGetEntry, MAX_ENTRIES},
+    sysvar::{get_sysvar, Sysvar, SysvarId},
+};
 
 crate::declare_sysvar_id!("SysvarStakeHistory1111111111111111111111111", StakeHistory);
 
@@ -55,6 +60,71 @@ impl Sysvar for StakeHistory {
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty
         16392 // golden, update if MAX_ENTRIES changes
+    }
+}
+
+// we do not provide Default because this requires the real current epoch
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct StakeHistorySysvar(Epoch);
+
+impl StakeHistorySysvar {
+    pub fn new(current_epoch: Epoch) -> Result<Self, ProgramError> {
+        if current_epoch > 0 {
+            Ok(Self(current_epoch))
+        } else {
+            Err(ProgramError::InvalidAccountData)
+        }
+    }
+}
+
+// precompute so we can statically allocate buffer
+const EPOCH_AND_ENTRY_SERIALIZED_SIZE: u64 = 32;
+
+impl StakeHistoryGetEntry for StakeHistorySysvar {
+    fn get_entry(&self, target_epoch: Epoch) -> Option<StakeHistoryEntry> {
+        let current_epoch = self.0;
+        let newest_historical_epoch = current_epoch.checked_sub(1)?;
+        let oldest_historical_epoch = newest_historical_epoch.saturating_sub(MAX_ENTRIES as u64);
+
+        // target epoch is before the beginning of time; this is a user error
+        if target_epoch == 0 {
+            return None;
+        }
+
+        // target epoch is old enough to have fallen off history; presume fully active/deactive
+        if target_epoch < oldest_historical_epoch {
+            return None;
+        }
+
+        // epoch delta is how many epoch-entries we offset in the stake history vector, which may be zero
+        // None means target epoch is current or in the future; this is a user error
+        let epoch_delta = newest_historical_epoch.checked_sub(target_epoch)?;
+
+        // offset is the number of bytes to our desired entry, including eight for vector length
+        let offset = epoch_delta
+            .checked_mul(EPOCH_AND_ENTRY_SERIALIZED_SIZE)?
+            .checked_add(std::mem::size_of::<u64>() as u64)?;
+
+        let mut entry_buf = [0; EPOCH_AND_ENTRY_SERIALIZED_SIZE as usize];
+        let result = get_sysvar(
+            &mut entry_buf,
+            &StakeHistory::id(),
+            offset,
+            EPOCH_AND_ENTRY_SERIALIZED_SIZE,
+        );
+
+        match result {
+            Ok(()) => {
+                let (entry_epoch, entry) =
+                    bincode::deserialize::<(Epoch, StakeHistoryEntry)>(&entry_buf).ok()?;
+
+                // this would only fail if stake history skipped an epoch or the binary format of the sysvar changed
+                assert_eq!(entry_epoch, target_epoch);
+
+                Some(entry)
+            }
+            _ => None,
+        }
     }
 }
 
@@ -78,6 +148,27 @@ mod tests {
         assert_eq!(
             bincode::serialized_size(&stake_history).unwrap() as usize,
             StakeHistory::size_of()
+        );
+    }
+
+    #[test]
+    fn test_precompute_entry_size() {
+        let mut stake_history = StakeHistory::default();
+        stake_history.add(
+            1,
+            StakeHistoryEntry {
+                activating: 1,
+                ..StakeHistoryEntry::default()
+            },
+        );
+
+        let stake_history_inner: Vec<(Epoch, StakeHistoryEntry)> =
+            bincode::deserialize(&bincode::serialize(&stake_history).unwrap()).unwrap();
+        let epoch_entry = stake_history_inner.into_iter().next().unwrap();
+
+        assert_eq!(
+            bincode::serialized_size(&epoch_entry).unwrap(),
+            EPOCH_AND_ENTRY_SERIALIZED_SIZE
         );
     }
 


### PR DESCRIPTION
#### Problem
to support the native to bpf conversion of the stake program, we need a way to get stake history in instructions that dont pass in the account data, to replace the usage of `SysvarCache` from `InvokeContext` for that purpose

#### Summary of Changes
in #560 and #1307 we implemented a syscall to get the necessary sysvar data. this pr provides an interface over that syscall usable by bpf programs

an object `StakeHistorySysvar` is constructed with the current `Clock.epoch`, which allows it to calculate offsets to retrieve arbitrary stake history entries in O(1), which is does via the `sol_get_sysvar` syscall. we also introduce a trait, `StakeHistoryGetEntry`, which provides the method `get_entry`, and change important functions on `Stake` and `Delegation` to use implementers of this trait interchangebly, so that all existing callers of the relevant functions remain unchanged

after we convert the native programs, there will be very few remaining callers of `get` and we can deprecate it in favor of `get_entry`