### PR TITLE
refactor: move nonce info into `LoadedTransaction`

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1574,25 +1574,21 @@ mod tests {
         ];
         let tx1 = new_sanitized_tx(&[&keypair1], message, Hash::default());
 
-        let loaded0 = (
-            Ok(LoadedTransaction {
-                accounts: transaction_accounts0,
-                program_indices: vec![],
-                rent: 0,
-                rent_debits: RentDebits::default(),
-            }),
-            None,
-        );
+        let loaded0 = Ok(LoadedTransaction {
+            accounts: transaction_accounts0,
+            program_indices: vec![],
+            nonce: None,
+            rent: 0,
+            rent_debits: RentDebits::default(),
+        });
 
-        let loaded1 = (
-            Ok(LoadedTransaction {
-                accounts: transaction_accounts1,
-                program_indices: vec![],
-                rent: 0,
-                rent_debits: RentDebits::default(),
-            }),
-            None,
-        );
+        let loaded1 = Ok(LoadedTransaction {
+            accounts: transaction_accounts1,
+            program_indices: vec![],
+            nonce: None,
+            rent: 0,
+            rent_debits: RentDebits::default(),
+        });
 
         let mut loaded = vec![loaded0, loaded1];
 
@@ -1962,15 +1958,13 @@ mod tests {
             Some(from_account_pre.clone()),
         ));
 
-        let loaded = (
-            Ok(LoadedTransaction {
-                accounts: transaction_accounts,
-                program_indices: vec![],
-                rent: 0,
-                rent_debits: RentDebits::default(),
-            }),
-            nonce.clone(),
-        );
+        let loaded = Ok(LoadedTransaction {
+            accounts: transaction_accounts,
+            program_indices: vec![],
+            nonce: nonce.clone(),
+            rent: 0,
+            rent_debits: RentDebits::default(),
+        });
 
         let mut loaded = vec![loaded];
 
@@ -2068,15 +2062,13 @@ mod tests {
             None,
         ));
 
-        let loaded = (
-            Ok(LoadedTransaction {
-                accounts: transaction_accounts,
-                program_indices: vec![],
-                rent: 0,
-                rent_debits: RentDebits::default(),
-            }),
-            nonce.clone(),
-        );
+        let loaded = Ok(LoadedTransaction {
+            accounts: transaction_accounts,
+            program_indices: vec![],
+            nonce: nonce.clone(),
+            rent: 0,
+            rent_debits: RentDebits::default(),
+        });
 
         let mut loaded = vec![loaded];
 

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -707,11 +707,11 @@ impl Accounts {
     ) {
         let mut accounts = Vec::with_capacity(load_results.len());
         let mut transactions = Vec::with_capacity(load_results.len());
-        for (i, ((tx_load_result, nonce), tx)) in load_results.iter_mut().zip(txs).enumerate() {
-            if tx_load_result.is_err() {
+        for (i, (tx_load_result, tx)) in load_results.iter_mut().zip(txs).enumerate() {
+            let Ok(loaded_transaction) = tx_load_result else {
                 // Don't store any accounts if tx failed to load
                 continue;
-            }
+            };
 
             let execution_status = match &execution_results[i] {
                 TransactionExecutionResult::Executed { details, .. } => &details.status,
@@ -719,7 +719,7 @@ impl Accounts {
                 TransactionExecutionResult::NotExecuted(_) => continue,
             };
 
-            let maybe_nonce = match (execution_status, &*nonce) {
+            let maybe_nonce = match (execution_status, &loaded_transaction.nonce) {
                 (Ok(_), _) => None, // Success, don't do any additional nonce processing
                 (Err(_), Some(nonce)) => {
                     Some((nonce, true /* rollback */))
@@ -748,7 +748,6 @@ impl Accounts {
             };
 
             let message = tx.message();
-            let loaded_transaction = tx_load_result.as_mut().unwrap();
             for (i, (address, account)) in (0..message.account_keys().len())
                 .zip(loaded_transaction.accounts.iter_mut())
                 .filter(|(i, _)| is_storable_account(message, *i))

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3371,7 +3371,7 @@ impl Bank {
         let post_simulation_accounts = loaded_transactions
             .into_iter()
             .next()
-            .and_then(|(loaded_transactions_res, _)| loaded_transactions_res.ok())
+            .and_then(|loaded_transactions_res| loaded_transactions_res.ok())
             .map(|loaded_transaction| {
                 loaded_transaction
                     .accounts
@@ -4160,7 +4160,7 @@ impl Bank {
         let rent_debits: Vec<_> = loaded_txs
             .iter_mut()
             .zip(execution_results)
-            .map(|((load_result, _nonce), execution_result)| {
+            .map(|(load_result, execution_result)| {
                 if let (Ok(loaded_transaction), true) =
                     (load_result, execution_result.was_executed_successfully())
                 {
@@ -6100,7 +6100,7 @@ impl Bank {
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
         izip!(txs, execution_results, loaded_txs)
             .filter(|(_, execution_result, _)| execution_result.was_executed_successfully())
-            .flat_map(|(tx, _, (load_result, _))| {
+            .flat_map(|(tx, _, load_result)| {
                 load_result.iter().flat_map(|loaded_transaction| {
                     let num_account_keys = tx.message().account_keys().len();
                     loaded_transaction.accounts.iter().take(num_account_keys)

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -631,10 +631,7 @@ mod tests {
 
         assert_eq!(error_counters.account_not_found, 1);
         assert_eq!(loaded_accounts.len(), 1);
-        assert_eq!(
-            loaded_accounts[0],
-            (Err(TransactionError::AccountNotFound), None,),
-        );
+        assert_eq!(loaded_accounts[0], Err(TransactionError::AccountNotFound));
     }
 
     #[test]
@@ -667,7 +664,7 @@ mod tests {
         assert_eq!(loaded_accounts.len(), 1);
         assert_eq!(
             loaded_accounts[0],
-            (Err(TransactionError::ProgramAccountNotFound), None,)
+            Err(TransactionError::ProgramAccountNotFound)
         );
     }
 
@@ -716,7 +713,7 @@ mod tests {
         assert_eq!(loaded_accounts.len(), 1);
         assert_eq!(
             loaded_accounts[0].clone(),
-            (Err(TransactionError::InsufficientFundsForFee), None,),
+            Err(TransactionError::InsufficientFundsForFee)
         );
     }
 
@@ -746,7 +743,7 @@ mod tests {
         assert_eq!(loaded_accounts.len(), 1);
         assert_eq!(
             loaded_accounts[0],
-            (Err(TransactionError::InvalidAccountForFee), None,),
+            Err(TransactionError::InvalidAccountForFee)
         );
     }
 
@@ -794,7 +791,7 @@ mod tests {
             &FeeStructure::default(),
         );
         assert_eq!(loaded_accounts.len(), 1);
-        let (load_res, _nonce) = &loaded_accounts[0];
+        let load_res = &loaded_accounts[0];
         let loaded_transaction = load_res.as_ref().unwrap();
         assert_eq!(loaded_transaction.accounts[0].1.lamports(), min_balance);
 
@@ -810,7 +807,7 @@ mod tests {
             &FeeStructure::default(),
         );
         assert_eq!(loaded_accounts.len(), 1);
-        let (load_res, _nonce) = &loaded_accounts[0];
+        let load_res = &loaded_accounts[0];
         assert_eq!(*load_res, Err(TransactionError::InsufficientFundsForFee));
 
         // Fee leaves non-zero, but sub-min_balance balance fails
@@ -827,7 +824,7 @@ mod tests {
             &FeeStructure::default(),
         );
         assert_eq!(loaded_accounts.len(), 1);
-        let (load_res, _nonce) = &loaded_accounts[0];
+        let load_res = &loaded_accounts[0];
         assert_eq!(*load_res, Err(TransactionError::InsufficientFundsForFee));
     }
 
@@ -863,13 +860,13 @@ mod tests {
         assert_eq!(error_counters.account_not_found, 0);
         assert_eq!(loaded_accounts.len(), 1);
         match &loaded_accounts[0] {
-            (Ok(loaded_transaction), _nonce) => {
+            Ok(loaded_transaction) => {
                 assert_eq!(loaded_transaction.accounts.len(), 3);
                 assert_eq!(loaded_transaction.accounts[0].1, accounts[0].1);
                 assert_eq!(loaded_transaction.program_indices.len(), 1);
                 assert_eq!(loaded_transaction.program_indices[0].len(), 0);
             }
-            (Err(e), _nonce) => panic!("{e}"),
+            Err(e) => panic!("{e}"),
         }
     }
 
@@ -905,7 +902,7 @@ mod tests {
         assert_eq!(loaded_accounts.len(), 1);
         assert_eq!(
             loaded_accounts[0],
-            (Err(TransactionError::ProgramAccountNotFound), None,)
+            Err(TransactionError::ProgramAccountNotFound)
         );
     }
 
@@ -939,7 +936,7 @@ mod tests {
         assert_eq!(loaded_accounts.len(), 1);
         assert_eq!(
             loaded_accounts[0],
-            (Err(TransactionError::InvalidProgramForExecution), None,)
+            Err(TransactionError::InvalidProgramForExecution)
         );
     }
 
@@ -987,7 +984,7 @@ mod tests {
         assert_eq!(error_counters.account_not_found, 0);
         assert_eq!(loaded_accounts.len(), 1);
         match &loaded_accounts[0] {
-            (Ok(loaded_transaction), _nonce) => {
+            Ok(loaded_transaction) => {
                 assert_eq!(loaded_transaction.accounts.len(), 4);
                 assert_eq!(loaded_transaction.accounts[0].1, accounts[0].1);
                 assert_eq!(loaded_transaction.program_indices.len(), 2);
@@ -1007,7 +1004,7 @@ mod tests {
                     }
                 }
             }
-            (Err(e), _nonce) => panic!("{e}"),
+            Err(e) => panic!("{e}"),
         }
     }
 
@@ -1055,7 +1052,7 @@ mod tests {
 
         let loaded_accounts = load_accounts_no_store(&[], tx, None);
         assert_eq!(loaded_accounts.len(), 1);
-        assert!(loaded_accounts[0].0.is_err());
+        assert!(loaded_accounts[0].is_err());
     }
 
     #[test]
@@ -1081,7 +1078,7 @@ mod tests {
         let loaded_accounts =
             load_accounts_no_store(&[(keypair.pubkey(), account)], tx, Some(&account_overrides));
         assert_eq!(loaded_accounts.len(), 1);
-        let loaded_transaction = loaded_accounts[0].0.as_ref().unwrap();
+        let loaded_transaction = loaded_accounts[0].as_ref().unwrap();
         assert_eq!(loaded_transaction.accounts[0].0, keypair.pubkey());
         assert_eq!(loaded_transaction.accounts[1].0, slot_history_id);
         assert_eq!(loaded_transaction.accounts[1].1.lamports(), 42);
@@ -1246,7 +1243,7 @@ mod tests {
         assert_eq!(loaded_accounts.len(), 1);
         assert_eq!(
             loaded_accounts[0].clone(),
-            (Err(TransactionError::InsufficientFundsForFee), None),
+            Err(TransactionError::InsufficientFundsForFee)
         );
     }
 
@@ -1436,6 +1433,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
+            None,
             32,
             &mut error_counter,
             None,
@@ -1479,6 +1477,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
+            None,
             32,
             &mut error_counter,
             None,
@@ -1504,6 +1503,7 @@ mod tests {
                     )
                 ],
                 program_indices: vec![vec![]],
+                nonce: None,
                 rent: 0,
                 rent_debits: RentDebits::default()
             }
@@ -1544,6 +1544,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
+            None,
             32,
             &mut error_counter,
             None,
@@ -1586,6 +1587,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
+            None,
             32,
             &mut error_counter,
             None,
@@ -1628,6 +1630,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
+            None,
             32,
             &mut error_counter,
             None,
@@ -1677,6 +1680,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
+            None,
             32,
             &mut error_counter,
             None,
@@ -1701,6 +1705,7 @@ mod tests {
                         mock_bank.accounts_map[&key1.pubkey()].clone()
                     ),
                 ],
+                nonce: None,
                 program_indices: vec![vec![1]],
                 rent: 0,
                 rent_debits: RentDebits::default()
@@ -1744,6 +1749,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
+            None,
             32,
             &mut error_counter,
             None,
@@ -1800,6 +1806,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
+            None,
             32,
             &mut error_counter,
             None,
@@ -1861,6 +1868,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
+            None,
             32,
             &mut error_counter,
             None,
@@ -1890,6 +1898,7 @@ mod tests {
                     ),
                 ],
                 program_indices: vec![vec![2, 1]],
+                nonce: None,
                 rent: 0,
                 rent_debits: RentDebits::default()
             }
@@ -1948,6 +1957,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
+            None,
             32,
             &mut error_counter,
             None,
@@ -1980,6 +1990,7 @@ mod tests {
                     ),
                 ],
                 program_indices: vec![vec![3, 1], vec![3, 1]],
+                nonce: None,
                 rent: 0,
                 rent_debits: RentDebits::default()
             }
@@ -2029,7 +2040,7 @@ mod tests {
             compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
         ));
         let transaction_context = TransactionContext::new(
-            loaded_txs[0].0.as_ref().unwrap().accounts.clone(),
+            loaded_txs[0].as_ref().unwrap().accounts.clone(),
             Rent::default(),
             compute_budget.max_invoke_stack_height,
             compute_budget.max_instruction_trace_length,
@@ -2112,7 +2123,7 @@ mod tests {
         account_data.set_rent_epoch(RENT_EXEMPT_RENT_EPOCH);
 
         assert_eq!(results.len(), 1);
-        let (loaded_result, nonce) = results[0].clone();
+        let loaded_result = results[0].clone();
         assert_eq!(
             loaded_result.unwrap(),
             LoadedTransaction {
@@ -2132,18 +2143,14 @@ mod tests {
                     ),
                 ],
                 program_indices: vec![vec![3, 1], vec![3, 1]],
+                nonce: Some(NonceFull::new(
+                    Pubkey::from([0; 32]),
+                    AccountSharedData::default(),
+                    Some(mock_bank.accounts_map[&key2.pubkey()].clone())
+                )),
                 rent: 0,
                 rent_debits: RentDebits::default()
             }
-        );
-
-        assert_eq!(
-            nonce.unwrap(),
-            NonceFull::new(
-                Pubkey::from([0; 32]),
-                AccountSharedData::default(),
-                Some(mock_bank.accounts_map[&key2.pubkey()].clone())
-            )
         );
     }
 
@@ -2181,10 +2188,7 @@ mod tests {
             &ProgramCacheForTxBatch::default(),
         );
 
-        assert_eq!(
-            result,
-            vec![(Err(TransactionError::BlockhashNotFound), None)]
-        );
+        assert_eq!(result, vec![Err(TransactionError::BlockhashNotFound)]);
 
         let check_result =
             (Ok(()), Some(NoncePartial::default()), Some(20u64)) as TransactionCheckResult;
@@ -2199,7 +2203,7 @@ mod tests {
             &ProgramCacheForTxBatch::default(),
         );
 
-        assert_eq!(result, vec![(Err(TransactionError::AccountNotFound), None)]);
+        assert_eq!(result, vec![Err(TransactionError::AccountNotFound)]);
 
         let check_result = (
             Err(TransactionError::InvalidWritableAccount),
@@ -2217,9 +2221,6 @@ mod tests {
             &ProgramCacheForTxBatch::default(),
         );
 
-        assert_eq!(
-            result,
-            vec![(Err(TransactionError::InvalidWritableAccount), None)]
-        );
+        assert_eq!(result, vec![Err(TransactionError::InvalidWritableAccount)]);
     }
 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -986,6 +986,7 @@ mod tests {
         let mut loaded_transaction = LoadedTransaction {
             accounts: vec![(Pubkey::new_unique(), AccountSharedData::default())],
             program_indices: vec![vec![0]],
+            nonce: None,
             rent: 0,
             rent_debits: RentDebits::default(),
         };
@@ -1001,7 +1002,6 @@ mod tests {
             &sanitized_transaction,
             &mut loaded_transaction,
             ComputeBudget::default(),
-            None,
             record_config,
             &mut ExecuteTimings::default(),
             &mut TransactionErrorMetrics::default(),
@@ -1023,7 +1023,6 @@ mod tests {
             &sanitized_transaction,
             &mut loaded_transaction,
             ComputeBudget::default(),
-            None,
             record_config,
             &mut ExecuteTimings::default(),
             &mut TransactionErrorMetrics::default(),
@@ -1054,7 +1053,6 @@ mod tests {
             &sanitized_transaction,
             &mut loaded_transaction,
             ComputeBudget::default(),
-            None,
             record_config,
             &mut ExecuteTimings::default(),
             &mut TransactionErrorMetrics::default(),
@@ -1115,6 +1113,7 @@ mod tests {
                 (key2, AccountSharedData::default()),
             ],
             program_indices: vec![vec![0]],
+            nonce: None,
             rent: 0,
             rent_debits: RentDebits::default(),
         };
@@ -1127,7 +1126,6 @@ mod tests {
             &sanitized_transaction,
             &mut loaded_transaction,
             ComputeBudget::default(),
-            None,
             record_config,
             &mut ExecuteTimings::default(),
             &mut error_metrics,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -489,7 +489,6 @@ fn svm_integration() {
     // The SVM does not commit the account changes in MockBank
     let recipient_key = transactions[1].message().account_keys()[2];
     let recipient_data = result.loaded_transactions[1]
-        .0
         .as_ref()
         .unwrap()
         .accounts


### PR DESCRIPTION
#### Problem
While working on prototyping partial transaction loading (ie only load fee payer and nonce for a transaction) for [SIMD-0082](https://github.com/solana-foundation/solana-improvement-documents/pull/82), it was difficult to keep track of important nonce info for loaded transactions due to the current implementation separating the nonce info from `LoadedTransaction`. I think it makes more sense to keep this info in the loaded transaction than in a tuple.

#### Summary of Changes
Refactor code so that rather than using a tuple `(Result<LoadedTransaction>, Option<NonceFull>)` to track nonce info, move `Option<NonceFull>` into the `LoadedTransaction` struct.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
