### PR TITLE
sdk: Fix --no-default-features build in transaction_context.rs

### DIFF
--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -1,7 +1,7 @@
 //! Data shared between program runtime and built-in programs as well as SBF programs.
 #![deny(clippy::indexing_slicing)]
 
-#[cfg(all(not(target_os = "solana"), debug_assertions))]
+#[cfg(all(not(target_os = "solana"), feature = "full", debug_assertions))]
 use crate::signature::Signature;
 #[cfg(not(target_os = "solana"))]
 use {
@@ -145,7 +145,7 @@ pub struct TransactionContext {
     #[cfg(not(target_os = "solana"))]
     rent: Rent,
     /// Useful for debugging to filter by or to look it up on the explorer
-    #[cfg(all(not(target_os = "solana"), debug_assertions))]
+    #[cfg(all(not(target_os = "solana"), feature = "full", debug_assertions))]
     signature: Signature,
 }
 
@@ -172,7 +172,7 @@ impl TransactionContext {
             return_data: TransactionReturnData::default(),
             accounts_resize_delta: RefCell::new(0),
             rent,
-            #[cfg(all(not(target_os = "solana"), debug_assertions))]
+            #[cfg(all(not(target_os = "solana"), feature = "full", debug_assertions))]
             signature: Signature::default(),
         }
     }
@@ -195,13 +195,13 @@ impl TransactionContext {
     }
 
     /// Stores the signature of the current transaction
-    #[cfg(all(not(target_os = "solana"), debug_assertions))]
+    #[cfg(all(not(target_os = "solana"), feature = "full", debug_assertions))]
     pub fn set_signature(&mut self, signature: &Signature) {
         self.signature = *signature;
     }
 
     /// Returns the signature of the current transaction
-    #[cfg(all(not(target_os = "solana"), debug_assertions))]
+    #[cfg(all(not(target_os = "solana"), feature = "full", debug_assertions))]
     pub fn get_signature(&self) -> &Signature {
         &self.signature
     }


### PR DESCRIPTION
#### Problem

The `Signature` type is only provided on `feature = "full"`, but its usage in `transaction_context.rs` isn't gated on the feature, so building the sdk with --no-default-features doesn't work, as pointed out in #1339

#### Summary of Changes

All usage of `Signature` is already gated, so just include the requirement that the `"full"` feature must be enabled.

cc @kevinheavey -- thanks for reporting this!

Fixes #1339
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
