### PR TITLE
use StorageAccess from config

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -10,9 +10,7 @@ use {
         use_snapshot_archives_at_startup::{self, UseSnapshotArchivesAtStartup},
     },
     log::*,
-    solana_accounts_db::{
-        accounts_file::StorageAccess, accounts_update_notifier_interface::AccountsUpdateNotifier,
-    },
+    solana_accounts_db::accounts_update_notifier_interface::AccountsUpdateNotifier,
     solana_runtime::{
         accounts_background_service::AbsRequestSender,
         bank_forks::BankForks,
@@ -294,7 +292,6 @@ fn bank_forks_from_snapshot(
             process_options.accounts_db_config.clone(),
             accounts_update_notifier,
             exit,
-            StorageAccess::default(),
         )
         .map_err(|err| BankForksUtilsError::BankFromSnapshotsDirectory {
             source: err,


### PR DESCRIPTION
#### Problem
working on getting rid of mmaps for append vecs

#### Summary of Changes
Config contains the `StorageAccess` to use. Plumb that through to snapshot loading.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
