### PR TITLE
Do not purge old snapshot archives inside of archive_snapshot_package()

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -858,8 +858,6 @@ fn make_full_snapshot_archive(
         bank.get_snapshot_storages(None),
         snapshot_config.archive_format,
         snapshot_config.snapshot_version,
-        snapshot_config.maximum_full_snapshot_archives_to_retain,
-        snapshot_config.maximum_incremental_snapshot_archives_to_retain,
     )?;
 
     Ok(())
@@ -897,8 +895,6 @@ fn make_incremental_snapshot_archive(
         storages,
         snapshot_config.archive_format,
         snapshot_config.snapshot_version,
-        snapshot_config.maximum_full_snapshot_archives_to_retain,
-        snapshot_config.maximum_incremental_snapshot_archives_to_retain,
     )?;
 
     Ok(())

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -275,14 +275,7 @@ fn run_bank_forks_snapshot_n<F>(
         None,
     );
     let snapshot_package = SnapshotPackage::new(accounts_package, accounts_hash.into());
-    snapshot_utils::archive_snapshot_package(
-        &snapshot_package,
-        &snapshot_config.full_snapshot_archives_dir,
-        &snapshot_config.incremental_snapshot_archives_dir,
-        snapshot_config.maximum_full_snapshot_archives_to_retain,
-        snapshot_config.maximum_incremental_snapshot_archives_to_retain,
-    )
-    .unwrap();
+    snapshot_utils::archive_snapshot_package(&snapshot_package).unwrap();
 
     // Restore bank from snapshot
     let (_tmp_dir, temporary_accounts_dir) = create_tmp_accounts_dir_for_tests();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1155,13 +1155,7 @@ fn package_and_archive_full_snapshot(
     );
 
     let snapshot_package = SnapshotPackage::new(accounts_package, accounts_hash.into());
-    archive_snapshot_package(
-        &snapshot_package,
-        full_snapshot_archives_dir,
-        incremental_snapshot_archives_dir,
-        maximum_full_snapshot_archives_to_retain,
-        maximum_incremental_snapshot_archives_to_retain,
-    )?;
+    archive_snapshot_package(&snapshot_package)?;
 
     Ok(FullSnapshotArchiveInfo::new(
         snapshot_package.snapshot_archive_info,
@@ -1224,13 +1218,7 @@ fn package_and_archive_incremental_snapshot(
     );
 
     let snapshot_package = SnapshotPackage::new(accounts_package, incremental_accounts_hash.into());
-    archive_snapshot_package(
-        &snapshot_package,
-        full_snapshot_archives_dir,
-        incremental_snapshot_archives_dir,
-        maximum_full_snapshot_archives_to_retain,
-        maximum_incremental_snapshot_archives_to_retain,
-    )?;
+    archive_snapshot_package(&snapshot_package)?;
 
     Ok(IncrementalSnapshotArchiveInfo::new(
         incremental_snapshot_base_slot,

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -52,7 +52,6 @@ use {
         collections::{HashMap, HashSet},
         fs,
         io::{BufWriter, Write},
-        num::NonZeroUsize,
         ops::RangeInclusive,
         path::{Path, PathBuf},
         sync::{atomic::AtomicBool, Arc},
@@ -1058,10 +1057,6 @@ pub fn bank_to_full_snapshot_archive(
         snapshot_storages,
         archive_format,
         snapshot_version,
-        // Since bank_to_snapshot_archive() is not called as part of normal validator operation,
-        // do *not* purge any snapshot archives; leave that up to the node operator.
-        NonZeroUsize::MAX,
-        NonZeroUsize::MAX,
     )
 }
 
@@ -1111,10 +1106,6 @@ pub fn bank_to_incremental_snapshot_archive(
         snapshot_storages,
         archive_format,
         snapshot_version,
-        // Since bank_to_snapshot_archive() is not called as part of normal validator operation,
-        // do *not* purge any snapshot archives; leave that up to the node operator.
-        NonZeroUsize::MAX,
-        NonZeroUsize::MAX,
     )
 }
 
@@ -1129,8 +1120,6 @@ fn package_and_archive_full_snapshot(
     snapshot_storages: Vec<Arc<AccountStorageEntry>>,
     archive_format: ArchiveFormat,
     snapshot_version: SnapshotVersion,
-    maximum_full_snapshot_archives_to_retain: NonZeroUsize,
-    maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
 ) -> snapshot_utils::Result<FullSnapshotArchiveInfo> {
     let accounts_package = AccountsPackage::new_for_snapshot(
         AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
@@ -1174,8 +1163,6 @@ fn package_and_archive_incremental_snapshot(
     snapshot_storages: Vec<Arc<AccountStorageEntry>>,
     archive_format: ArchiveFormat,
     snapshot_version: SnapshotVersion,
-    maximum_full_snapshot_archives_to_retain: NonZeroUsize,
-    maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
 ) -> snapshot_utils::Result<IncrementalSnapshotArchiveInfo> {
     let accounts_package = AccountsPackage::new_for_snapshot(
         AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(
@@ -2761,8 +2748,6 @@ mod tests {
                 snapshot_storages,
                 snapshot_config.archive_format,
                 snapshot_config.snapshot_version,
-                snapshot_config.maximum_full_snapshot_archives_to_retain,
-                snapshot_config.maximum_incremental_snapshot_archives_to_retain,
             )
             .unwrap();
         }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -730,13 +730,7 @@ pub fn remove_tmp_snapshot_archives(snapshot_archives_dir: impl AsRef<Path>) {
 }
 
 /// Make a snapshot archive out of the snapshot package
-pub fn archive_snapshot_package(
-    snapshot_package: &SnapshotPackage,
-    full_snapshot_archives_dir: impl AsRef<Path>,
-    incremental_snapshot_archives_dir: impl AsRef<Path>,
-    maximum_full_snapshot_archives_to_retain: NonZeroUsize,
-    maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
-) -> Result<()> {
+pub fn archive_snapshot_package(snapshot_package: &SnapshotPackage) -> Result<()> {
     use ArchiveSnapshotPackageError as E;
     const SNAPSHOTS_DIR: &str = "snapshots";
     const ACCOUNTS_DIR: &str = "accounts";
@@ -883,13 +877,6 @@ pub fn archive_snapshot_package(
         .map_err(|err| E::QueryArchiveMetadata(err, archive_path.clone()))?;
     fs::rename(&archive_path, snapshot_package.path())
         .map_err(|err| E::MoveArchive(err, archive_path, snapshot_package.path().clone()))?;
-
-    purge_old_snapshot_archives(
-        full_snapshot_archives_dir,
-        incremental_snapshot_archives_dir,
-        maximum_full_snapshot_archives_to_retain,
-        maximum_incremental_snapshot_archives_to_retain,
-    );
 
     timer.stop();
     info!(


### PR DESCRIPTION
#### Problem

Old snapshot archives are purged inside of `archive_snapshot_package()`. I find this surprising. This also causes the function (and all its callers) to pass in four extra parameters. I'd argue that purging should be done explicitly. Additionally, I'm working on removing the reserialization of bank snapshots, and part of that will be removing unnecessary fields from the AccountsPackage/SnapshotPackage. That will include the snapshot archive dirs, which are duplicates of the SnapshotConfig that AccountsHashVerifier and SnapshotPackagerService already have a copy of.


#### Summary of Changes

Do not purge old snapshot archives inside of archive_snapshot_package(). Instead, `purge` explicitly, after archiving.

Note: Ignoring whitespace in the diff may make it easier.