### PR TITLE
Program-Test: Spport adding genesis accounts

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -464,6 +464,7 @@ pub fn read_file<P: AsRef<Path>>(path: P) -> Vec<u8> {
 
 pub struct ProgramTest {
     accounts: Vec<(Pubkey, AccountSharedData)>,
+    genesis_accounts: Vec<(Pubkey, AccountSharedData)>,
     builtin_programs: Vec<(Pubkey, &'static str, ProgramCacheEntry)>,
     compute_max_units: Option<u64>,
     prefer_bpf: bool,
@@ -496,6 +497,7 @@ impl Default for ProgramTest {
 
         Self {
             accounts: vec![],
+            genesis_accounts: vec![],
             builtin_programs: vec![],
             compute_max_units: None,
             prefer_bpf,
@@ -547,6 +549,12 @@ impl ProgramTest {
     #[deprecated(since = "1.8.0", note = "please use `set_compute_max_units` instead")]
     pub fn set_bpf_compute_max_units(&mut self, bpf_compute_max_units: u64) {
         self.set_compute_max_units(bpf_compute_max_units);
+    }
+
+    /// Add an account to the test environment's genesis config.
+    pub fn add_genesis_account(&mut self, address: Pubkey, account: Account) {
+        self.genesis_accounts
+            .push((address, AccountSharedData::from(account)));
     }
 
     /// Add an account to the test environment
@@ -781,7 +789,7 @@ impl ProgramTest {
             fee_rate_governor,
             rent,
             ClusterType::Development,
-            vec![],
+            std::mem::take(&mut self.genesis_accounts),
         );
 
         // Remove features tagged to deactivate

--- a/program-test/tests/genesis_accounts.rs
+++ b/program-test/tests/genesis_accounts.rs
@@ -1,0 +1,45 @@
+use {
+    solana_program_test::ProgramTest,
+    solana_sdk::{account::Account, pubkey::Pubkey},
+};
+
+#[tokio::test]
+async fn genesis_accounts() {
+    let my_genesis_accounts = [
+        (
+            Pubkey::new_unique(),
+            Account::new(1, 0, &solana_sdk::system_program::id()),
+        ),
+        (
+            Pubkey::new_unique(),
+            Account::new(1, 0, &solana_sdk::config::program::id()),
+        ),
+        (
+            Pubkey::new_unique(),
+            Account::new(1, 0, &solana_sdk::feature::id()),
+        ),
+        (
+            Pubkey::new_unique(),
+            Account::new(1, 0, &solana_sdk::stake::program::id()),
+        ),
+    ];
+
+    let mut program_test = ProgramTest::default();
+
+    for (pubkey, account) in my_genesis_accounts.iter() {
+        program_test.add_genesis_account(*pubkey, account.clone());
+    }
+
+    let mut context = program_test.start_with_context().await;
+
+    // Verify the accounts are present.
+    for (pubkey, account) in my_genesis_accounts.iter() {
+        let fetched_account = context
+            .banks_client
+            .get_account(*pubkey)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(fetched_account, *account);
+    }
+}


### PR DESCRIPTION
#### Problem
Program-test always serves an empty vector to its bank's genesis config.

It would be useful to be able to provide a list of genesis accounts to be used
when setting up the bank.

#### Summary of Changes
Add support for adding genesis accounts to program-test.
