### PR TITLE
v1.18 - Add detailed metrics reporting for packet filtering

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -68,6 +68,7 @@ mod latest_unprocessed_votes;
 mod leader_slot_timing_metrics;
 mod multi_iterator_scanner;
 mod packet_deserializer;
+mod packet_filter;
 mod packet_receiver;
 mod read_write_account_set;
 #[allow(dead_code)]

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -1,5 +1,5 @@
 use {
-    solana_cost_model::block_cost_limits::BUILT_IN_INSTRUCTION_COSTS,
+    super::packet_filter::PacketFilterFailure,
     solana_perf::packet::Packet,
     solana_runtime::transaction_priority_details::{
         GetTransactionPriorityDetails, TransactionPriorityDetails,
@@ -9,7 +9,6 @@ use {
         hash::Hash,
         message::Message,
         sanitize::SanitizeError,
-        saturating_add_assign,
         short_vec::decode_shortu16_len,
         signature::Signature,
         transaction::{
@@ -36,6 +35,8 @@ pub enum DeserializedPacketError {
     PrioritizationFailure,
     #[error("vote transaction failure")]
     VoteTransactionError,
+    #[error("Packet filter failure: {0}")]
+    FailedFilter(#[from] PacketFilterFailure),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -100,22 +101,6 @@ impl ImmutableDeserializedPacket {
 
     pub fn priority_details(&self) -> TransactionPriorityDetails {
         self.priority_details.clone()
-    }
-
-    /// Returns true if the transaction's compute unit limit is at least as
-    /// large as the sum of the static builtins' costs.
-    /// This is a simple sanity check so the leader can discard transactions
-    /// which are statically known to exceed the compute budget, and will
-    /// result in no useful state-change.
-    pub fn compute_unit_limit_above_static_builtins(&self) -> bool {
-        let mut static_builtin_cost_sum: u64 = 0;
-        for (program_id, _) in self.transaction.get_message().program_instructions_iter() {
-            if let Some(ix_cost) = BUILT_IN_INSTRUCTION_COSTS.get(program_id) {
-                saturating_add_assign!(static_builtin_cost_sum, *ix_cost);
-            }
-        }
-
-        self.compute_unit_limit() >= static_builtin_cost_sum
     }
 
     // This function deserializes packets into transactions, computes the blake3 hash of transaction
@@ -196,7 +181,11 @@ mod tests {
         // 1. compute_unit_limit under static builtins
         // 2. compute_unit_limit equal to static builtins
         // 3. compute_unit_limit above static builtins
-        for (cu_limit, expectation) in [(250, false), (300, true), (350, true)] {
+        for (cu_limit, expectation) in [
+            (250, Err(PacketFilterFailure::InsufficientComputeLimit)),
+            (300, Ok(())),
+            (350, Ok(())),
+        ] {
             let keypair = Keypair::new();
             let bpf_program_id = Pubkey::new_unique();
             let ixs = vec![
@@ -213,7 +202,7 @@ mod tests {
             let packet = Packet::from_data(None, tx).unwrap();
             let deserialized_packet = ImmutableDeserializedPacket::new(packet).unwrap();
             assert_eq!(
-                deserialized_packet.compute_unit_limit_above_static_builtins(),
+                deserialized_packet.check_insufficent_compute_unit_limit(),
                 expectation
             );
         }

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -1,7 +1,14 @@
 use {
     super::{
         leader_slot_timing_metrics::{LeaderExecuteAndCommitTimings, LeaderSlotTimingMetrics},
+<<<<<<< HEAD
         unprocessed_transaction_storage::InsertPacketBatchSummary,
+=======
+        packet_deserializer::PacketReceiverStats,
+        unprocessed_transaction_storage::{
+            InsertPacketBatchSummary, UnprocessedTransactionStorage,
+        },
+>>>>>>> 0ebabfea63 (Add detailed metrics reporting for packet filtering)
     },
     solana_accounts_db::transaction_error_metrics::*,
     solana_poh::poh_recorder::BankStart,
@@ -63,6 +70,21 @@ struct LeaderSlotPacketCountMetrics {
 
     // total number of packets TPU received from sigverify that failed signature verification.
     newly_failed_sigverify_count: u64,
+
+    // total number of packets filtered due to sanitization failures during receiving from sigverify
+    failed_sanitization_count: u64,
+
+    // total number of packets filtered due to prioritization failures during receiving from sigverify
+    failed_prioritization_count: u64,
+
+    // total number of packets filtered due to insufficient compute limits during receiving from sigverify
+    insufficient_compute_limit_count: u64,
+
+    // total number of packets filtered due to excessive precompile signatures during receiving from sigverify
+    excessive_precompile_count: u64,
+
+    // total number of invalid vote packets filtered out during receiving from sigverify
+    invalid_votes_count: u64,
 
     // total number of dropped packet due to the thread's buffered packets capacity being reached.
     exceeded_buffer_limit_dropped_packets_count: u64,
@@ -148,113 +170,156 @@ impl LeaderSlotPacketCountMetrics {
     fn report(&self, id: u32, slot: Slot) {
         datapoint_info!(
             "banking_stage-leader_slot_packet_counts",
+<<<<<<< HEAD
             ("id", id as i64, i64),
             ("slot", slot as i64, i64),
+=======
+            "id" => id,
+            ("slot", slot, i64),
+>>>>>>> 0ebabfea63 (Add detailed metrics reporting for packet filtering)
             (
                 "total_new_valid_packets",
-                self.total_new_valid_packets as i64,
+                self.total_new_valid_packets,
                 i64
             ),
             (
                 "newly_failed_sigverify_count",
-                self.newly_failed_sigverify_count as i64,
+                self.newly_failed_sigverify_count,
+                i64
+            ),
+            (
+                "failed_sanitization_count",
+                self.failed_sanitization_count,
+                i64
+            ),
+            (
+                "failed_prioritization_count",
+                self.failed_prioritization_count,
+                i64
+            ),
+            (
+                "insufficient_compute_limit_count",
+                self.insufficient_compute_limit_count,
+                i64
+            ),
+            (
+                "excessive_precompile_count",
+                self.excessive_precompile_count,
+                i64
+            ),
+            (
+                "invalid_votes_count",
+                self.invalid_votes_count,
                 i64
             ),
             (
                 "exceeded_buffer_limit_dropped_packets_count",
-                self.exceeded_buffer_limit_dropped_packets_count as i64,
+                self.exceeded_buffer_limit_dropped_packets_count,
                 i64
             ),
             (
                 "newly_buffered_packets_count",
-                self.newly_buffered_packets_count as i64,
+                self.newly_buffered_packets_count,
                 i64
             ),
             (
                 "retryable_packets_filtered_count",
-                self.retryable_packets_filtered_count as i64,
+                self.retryable_packets_filtered_count,
                 i64
             ),
             (
                 "transactions_attempted_execution_count",
-                self.transactions_attempted_execution_count as i64,
+                self.transactions_attempted_execution_count,
                 i64
             ),
             (
                 "committed_transactions_count",
-                self.committed_transactions_count as i64,
+                self.committed_transactions_count,
                 i64
             ),
             (
                 "committed_transactions_with_successful_result_count",
-                self.committed_transactions_with_successful_result_count as i64,
+                self.committed_transactions_with_successful_result_count,
                 i64
             ),
             (
                 "retryable_errored_transaction_count",
-                self.retryable_errored_transaction_count as i64,
+                self.retryable_errored_transaction_count,
                 i64
             ),
             (
                 "retryable_packets_count",
-                self.retryable_packets_count as i64,
+                self.retryable_packets_count,
                 i64
             ),
             (
                 "nonretryable_errored_transactions_count",
-                self.nonretryable_errored_transactions_count as i64,
+                self.nonretryable_errored_transactions_count,
                 i64
             ),
             (
                 "executed_transactions_failed_commit_count",
-                self.executed_transactions_failed_commit_count as i64,
+                self.executed_transactions_failed_commit_count,
                 i64
             ),
             (
                 "account_lock_throttled_transactions_count",
-                self.account_lock_throttled_transactions_count as i64,
+                self.account_lock_throttled_transactions_count,
                 i64
             ),
             (
                 "account_locks_limit_throttled_transactions_count",
-                self.account_locks_limit_throttled_transactions_count as i64,
+                self.account_locks_limit_throttled_transactions_count,
                 i64
             ),
             (
                 "cost_model_throttled_transactions_count",
-                self.cost_model_throttled_transactions_count as i64,
+                self.cost_model_throttled_transactions_count,
                 i64
             ),
             (
                 "failed_forwarded_packets_count",
-                self.failed_forwarded_packets_count as i64,
+                self.failed_forwarded_packets_count,
                 i64
             ),
             (
                 "successful_forwarded_packets_count",
-                self.successful_forwarded_packets_count as i64,
+                self.successful_forwarded_packets_count,
                 i64
             ),
             (
                 "packet_batch_forward_failure_count",
-                self.packet_batch_forward_failure_count as i64,
+                self.packet_batch_forward_failure_count,
                 i64
             ),
             (
                 "cleared_from_buffer_after_forward_count",
-                self.cleared_from_buffer_after_forward_count as i64,
+                self.cleared_from_buffer_after_forward_count,
                 i64
             ),
             (
                 "forwardable_batches_count",
-                self.forwardable_batches_count as i64,
+                self.forwardable_batches_count,
                 i64
             ),
             (
                 "end_of_slot_unprocessed_buffer_len",
-                self.end_of_slot_unprocessed_buffer_len as i64,
+                self.end_of_slot_unprocessed_buffer_len,
                 i64
             ),
+<<<<<<< HEAD
+=======
+            (
+                "min_prioritization_fees",
+                self.min_prioritization_fees,
+                i64
+            ),
+            (
+                "max_prioritization_fees",
+                self.max_prioritization_fees,
+                i64
+            ),
+>>>>>>> 0ebabfea63 (Add detailed metrics reporting for packet filtering)
         );
     }
 }
@@ -559,24 +624,34 @@ impl LeaderSlotMetricsTracker {
     }
 
     // Packet inflow/outflow/processing metrics
-    pub(crate) fn increment_total_new_valid_packets(&mut self, count: u64) {
+    pub(crate) fn increment_received_packet_counts(&mut self, stats: PacketReceiverStats) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .total_new_valid_packets,
-                count
-            );
-        }
-    }
+            let metrics = &mut leader_slot_metrics.packet_count_metrics;
+            let PacketReceiverStats {
+                passed_sigverify_count,
+                failed_sigverify_count,
+                invalid_vote_count,
+                failed_prioritization_count,
+                failed_sanitization_count,
+                excessive_precompile_count,
+                insufficient_compute_limit_count,
+            } = stats;
 
-    pub(crate) fn increment_newly_failed_sigverify_count(&mut self, count: u64) {
-        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
+            saturating_add_assign!(metrics.total_new_valid_packets, passed_sigverify_count);
+            saturating_add_assign!(metrics.newly_failed_sigverify_count, failed_sigverify_count);
+            saturating_add_assign!(metrics.invalid_votes_count, invalid_vote_count);
             saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .newly_failed_sigverify_count,
-                count
+                metrics.failed_prioritization_count,
+                failed_prioritization_count
+            );
+            saturating_add_assign!(metrics.failed_sanitization_count, failed_sanitization_count);
+            saturating_add_assign!(
+                metrics.excessive_precompile_count,
+                excessive_precompile_count
+            );
+            saturating_add_assign!(
+                metrics.insufficient_compute_limit_count,
+                insufficient_compute_limit_count
             );
         }
     }

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -1,14 +1,8 @@
 use {
     super::{
         leader_slot_timing_metrics::{LeaderExecuteAndCommitTimings, LeaderSlotTimingMetrics},
-<<<<<<< HEAD
-        unprocessed_transaction_storage::InsertPacketBatchSummary,
-=======
         packet_deserializer::PacketReceiverStats,
-        unprocessed_transaction_storage::{
-            InsertPacketBatchSummary, UnprocessedTransactionStorage,
-        },
->>>>>>> 0ebabfea63 (Add detailed metrics reporting for packet filtering)
+        unprocessed_transaction_storage::InsertPacketBatchSummary,
     },
     solana_accounts_db::transaction_error_metrics::*,
     solana_poh::poh_recorder::BankStart,
@@ -170,18 +164,9 @@ impl LeaderSlotPacketCountMetrics {
     fn report(&self, id: u32, slot: Slot) {
         datapoint_info!(
             "banking_stage-leader_slot_packet_counts",
-<<<<<<< HEAD
-            ("id", id as i64, i64),
-            ("slot", slot as i64, i64),
-=======
-            "id" => id,
+            ("id", id, i64),
             ("slot", slot, i64),
->>>>>>> 0ebabfea63 (Add detailed metrics reporting for packet filtering)
-            (
-                "total_new_valid_packets",
-                self.total_new_valid_packets,
-                i64
-            ),
+            ("total_new_valid_packets", self.total_new_valid_packets, i64),
             (
                 "newly_failed_sigverify_count",
                 self.newly_failed_sigverify_count,
@@ -207,11 +192,7 @@ impl LeaderSlotPacketCountMetrics {
                 self.excessive_precompile_count,
                 i64
             ),
-            (
-                "invalid_votes_count",
-                self.invalid_votes_count,
-                i64
-            ),
+            ("invalid_votes_count", self.invalid_votes_count, i64),
             (
                 "exceeded_buffer_limit_dropped_packets_count",
                 self.exceeded_buffer_limit_dropped_packets_count,
@@ -247,11 +228,7 @@ impl LeaderSlotPacketCountMetrics {
                 self.retryable_errored_transaction_count,
                 i64
             ),
-            (
-                "retryable_packets_count",
-                self.retryable_packets_count,
-                i64
-            ),
+            ("retryable_packets_count", self.retryable_packets_count, i64),
             (
                 "nonretryable_errored_transactions_count",
                 self.nonretryable_errored_transactions_count,
@@ -307,19 +284,6 @@ impl LeaderSlotPacketCountMetrics {
                 self.end_of_slot_unprocessed_buffer_len,
                 i64
             ),
-<<<<<<< HEAD
-=======
-            (
-                "min_prioritization_fees",
-                self.min_prioritization_fees,
-                i64
-            ),
-            (
-                "max_prioritization_fees",
-                self.max_prioritization_fees,
-                i64
-            ),
->>>>>>> 0ebabfea63 (Add detailed metrics reporting for packet filtering)
         );
     }
 }

--- a/core/src/banking_stage/packet_filter.rs
+++ b/core/src/banking_stage/packet_filter.rs
@@ -1,0 +1,55 @@
+use {
+    super::immutable_deserialized_packet::ImmutableDeserializedPacket,
+    solana_cost_model::block_cost_limits::BUILT_IN_INSTRUCTION_COSTS,
+    solana_sdk::{ed25519_program, saturating_add_assign, secp256k1_program},
+    thiserror::Error,
+};
+
+#[derive(Debug, Error, PartialEq)]
+pub enum PacketFilterFailure {
+    #[error("Insufficient compute unit limit")]
+    InsufficientComputeLimit,
+    #[error("Excessive precompile usage")]
+    ExcessivePrecompiles,
+}
+
+impl ImmutableDeserializedPacket {
+    /// Returns ok if the transaction's compute unit limit is at least as
+    /// large as the sum of the static builtins' costs.
+    /// This is a simple sanity check so the leader can discard transactions
+    /// which are statically known to exceed the compute budget, and will
+    /// result in no useful state-change.
+    pub fn check_insufficent_compute_unit_limit(&self) -> Result<(), PacketFilterFailure> {
+        let mut static_builtin_cost_sum: u64 = 0;
+        for (program_id, _) in self.transaction().get_message().program_instructions_iter() {
+            if let Some(ix_cost) = BUILT_IN_INSTRUCTION_COSTS.get(program_id) {
+                saturating_add_assign!(static_builtin_cost_sum, *ix_cost);
+            }
+        }
+
+        if self.compute_unit_limit() >= static_builtin_cost_sum {
+            Ok(())
+        } else {
+            Err(PacketFilterFailure::InsufficientComputeLimit)
+        }
+    }
+
+    /// Returns ok if the number of precompile signature verifications
+    /// performed by the transaction is not excessive.
+    pub fn check_excessive_precompiles(&self) -> Result<(), PacketFilterFailure> {
+        let mut num_precompile_signatures: u64 = 0;
+        for (program_id, ix) in self.transaction().get_message().program_instructions_iter() {
+            if secp256k1_program::check_id(program_id) || ed25519_program::check_id(program_id) {
+                let num_signatures = ix.data.first().map_or(0, |byte| u64::from(*byte));
+                saturating_add_assign!(num_precompile_signatures, num_signatures);
+            }
+        }
+
+        const MAX_ALLOWED_PRECOMPILE_SIGNATURES: u64 = 8;
+        if num_precompile_signatures <= MAX_ALLOWED_PRECOMPILE_SIGNATURES {
+            Ok(())
+        } else {
+            Err(PacketFilterFailure::ExcessivePrecompiles)
+        }
+    }
+}

--- a/core/src/banking_stage/packet_receiver.rs
+++ b/core/src/banking_stage/packet_receiver.rs
@@ -49,7 +49,11 @@ impl PacketReceiver {
                 .receive_packets(
                     recv_timeout,
                     unprocessed_transaction_storage.max_receive_size(),
-                    |packet| packet.compute_unit_limit_above_static_builtins(),
+                    |packet| {
+                        packet.check_insufficent_compute_unit_limit()?;
+                        packet.check_excessive_precompiles()?;
+                        Ok(packet)
+                    },
                 )
                 // Consumes results if Ok, otherwise we keep the Err
                 .map(|receive_packet_results| {
@@ -95,8 +99,7 @@ impl PacketReceiver {
         ReceivePacketResults {
             deserialized_packets,
             new_tracer_stats_option,
-            passed_sigverify_count,
-            failed_sigverify_count,
+            packet_stats,
         }: ReceivePacketResults,
         unprocessed_transaction_storage: &mut UnprocessedTransactionStorage,
         banking_stage_stats: &mut BankingStageStats,
@@ -106,13 +109,10 @@ impl PacketReceiver {
         let packet_count = deserialized_packets.len();
         debug!("@{:?} txs: {} id: {}", timestamp(), packet_count, self.id);
 
+        slot_metrics_tracker.increment_received_packet_counts(packet_stats);
         if let Some(new_sigverify_stats) = &new_tracer_stats_option {
             tracer_packet_stats.aggregate_sigverify_tracer_packet_stats(new_sigverify_stats);
         }
-
-        // Track all the packets incoming from sigverify, both valid and invalid
-        slot_metrics_tracker.increment_total_new_valid_packets(passed_sigverify_count);
-        slot_metrics_tracker.increment_newly_failed_sigverify_count(failed_sigverify_count);
 
         let mut dropped_packets_count = 0;
         let mut newly_buffered_packets_count = 0;

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -272,8 +272,19 @@ impl SchedulerController {
 
         let (received_packet_results, receive_time_us) = measure_us!(self
             .packet_receiver
+<<<<<<< HEAD
             .receive_packets(recv_timeout, remaining_queue_capacity, |_| true));
         saturating_add_assign!(self.timing_metrics.receive_time_us, receive_time_us);
+=======
+            .receive_packets(recv_timeout, remaining_queue_capacity, |packet| {
+                packet.check_excessive_precompiles()?;
+                Ok(packet)
+            }));
+
+        self.timing_metrics.update(|timing_metrics| {
+            saturating_add_assign!(timing_metrics.receive_time_us, receive_time_us);
+        });
+>>>>>>> 0ebabfea63 (Add detailed metrics reporting for packet filtering)
 
         match received_packet_results {
             Ok(receive_packet_results) => {

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -272,19 +272,11 @@ impl SchedulerController {
 
         let (received_packet_results, receive_time_us) = measure_us!(self
             .packet_receiver
-<<<<<<< HEAD
-            .receive_packets(recv_timeout, remaining_queue_capacity, |_| true));
-        saturating_add_assign!(self.timing_metrics.receive_time_us, receive_time_us);
-=======
             .receive_packets(recv_timeout, remaining_queue_capacity, |packet| {
                 packet.check_excessive_precompiles()?;
                 Ok(packet)
             }));
-
-        self.timing_metrics.update(|timing_metrics| {
-            saturating_add_assign!(timing_metrics.receive_time_us, receive_time_us);
-        });
->>>>>>> 0ebabfea63 (Add detailed metrics reporting for packet filtering)
+        saturating_add_assign!(self.timing_metrics.receive_time_us, receive_time_us);
 
         match received_packet_results {
             Ok(receive_packet_results) => {


### PR DESCRIPTION
#### Problem
We don't report metrics on how many packets are filtered out in banking stage for various reasons like sanitization failures, invalid compute, etc.

#### Summary of Changes
Report more metrics for different types of filtered packets

Manual backport of https://github.com/anza-xyz/agave/pull/1421

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
