### PR TITLE
Trims fields from snapshot package

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -542,7 +542,8 @@ impl AccountsHashVerifier {
             return;
         };
 
-        let snapshot_package = SnapshotPackage::new(accounts_package, accounts_hash);
+        let snapshot_package =
+            SnapshotPackage::new(accounts_package, accounts_hash, snapshot_config);
         let send_result = snapshot_package_sender.send(snapshot_package);
         if let Err(err) = send_result {
             // Sending the snapshot package should never fail *unless* we're shutting down.

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -206,7 +206,7 @@ mod tests {
             snapshot_archive_info::SnapshotArchiveInfo,
             snapshot_hash::SnapshotHash,
             snapshot_package::{SnapshotKind, SnapshotPackage},
-            snapshot_utils::{ArchiveFormat, SnapshotVersion},
+            snapshot_utils::ArchiveFormat,
         },
         solana_sdk::{clock::Slot, hash::Hash},
         std::{path::PathBuf, time::Instant},
@@ -230,7 +230,6 @@ mod tests {
                 block_height: slot,
                 bank_snapshot_dir: PathBuf::default(),
                 snapshot_storages: Vec::default(),
-                snapshot_version: SnapshotVersion::default(),
                 snapshot_kind,
                 enqueued: Instant::now(),
             }

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -394,11 +394,7 @@ impl SnapshotRequestHandler {
                         accounts_package_kind,
                         &snapshot_root_bank,
                         &bank_snapshot_info,
-                        &self.snapshot_config.full_snapshot_archives_dir,
-                        &self.snapshot_config.incremental_snapshot_archives_dir,
                         snapshot_storages,
-                        self.snapshot_config.archive_format,
-                        self.snapshot_config.snapshot_version,
                         accounts_hash_for_testing,
                     )
                 }

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -12,6 +12,7 @@ use {
         snapshot_archive_info::{
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
         },
+        snapshot_config::SnapshotConfig,
         snapshot_hash::SnapshotHash,
         snapshot_package::{AccountsPackage, AccountsPackageKind, SnapshotKind, SnapshotPackage},
         snapshot_utils::{
@@ -1123,11 +1124,7 @@ fn package_and_archive_full_snapshot(
         AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
         bank,
         bank_snapshot_info,
-        full_snapshot_archives_dir.as_ref(),
-        incremental_snapshot_archives_dir.as_ref(),
         snapshot_storages,
-        archive_format,
-        snapshot_version,
         None,
     );
 
@@ -1141,7 +1138,15 @@ fn package_and_archive_full_snapshot(
         None,
     );
 
-    let snapshot_package = SnapshotPackage::new(accounts_package, accounts_hash.into());
+    let snapshot_config = SnapshotConfig {
+        full_snapshot_archives_dir: full_snapshot_archives_dir.as_ref().to_path_buf(),
+        incremental_snapshot_archives_dir: incremental_snapshot_archives_dir.as_ref().to_path_buf(),
+        archive_format,
+        snapshot_version,
+        ..Default::default()
+    };
+    let snapshot_package =
+        SnapshotPackage::new(accounts_package, accounts_hash.into(), &snapshot_config);
     archive_snapshot_package(&snapshot_package)?;
 
     Ok(FullSnapshotArchiveInfo::new(
@@ -1168,11 +1173,7 @@ fn package_and_archive_incremental_snapshot(
         )),
         bank,
         bank_snapshot_info,
-        full_snapshot_archives_dir.as_ref(),
-        incremental_snapshot_archives_dir.as_ref(),
         snapshot_storages,
-        archive_format,
-        snapshot_version,
         None,
     );
 
@@ -1202,7 +1203,18 @@ fn package_and_archive_incremental_snapshot(
         bank_incremental_snapshot_persistence.as_ref(),
     );
 
-    let snapshot_package = SnapshotPackage::new(accounts_package, incremental_accounts_hash.into());
+    let snapshot_config = SnapshotConfig {
+        full_snapshot_archives_dir: full_snapshot_archives_dir.as_ref().to_path_buf(),
+        incremental_snapshot_archives_dir: incremental_snapshot_archives_dir.as_ref().to_path_buf(),
+        archive_format,
+        snapshot_version,
+        ..Default::default()
+    };
+    let snapshot_package = SnapshotPackage::new(
+        accounts_package,
+        incremental_accounts_hash.into(),
+        &snapshot_config,
+    );
     archive_snapshot_package(&snapshot_package)?;
 
     Ok(IncrementalSnapshotArchiveInfo::new(

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -74,9 +74,8 @@ mod tests {
     use {
         super::*,
         crate::{
-            snapshot_archive_info::SnapshotArchiveInfo,
-            snapshot_hash::SnapshotHash,
-            snapshot_utils::{ArchiveFormat, SnapshotVersion},
+            snapshot_archive_info::SnapshotArchiveInfo, snapshot_hash::SnapshotHash,
+            snapshot_utils::ArchiveFormat,
         },
         solana_sdk::{clock::Slot, hash::Hash},
         std::{path::PathBuf, time::Instant},
@@ -95,7 +94,6 @@ mod tests {
                 block_height: slot,
                 bank_snapshot_dir: PathBuf::default(),
                 snapshot_storages: Vec::default(),
-                snapshot_version: SnapshotVersion::default(),
                 snapshot_kind,
                 enqueued: Instant::now(),
             }


### PR DESCRIPTION
#### Problem

Some fields in the snapshot packages (AccountsPackage and SnapshotPackage) are duplicates of what's in SnapshotConfig. Originally, not all the background threads had a copy of SnapshotConfig, so these fields were needed. Now, the background threads *do* have a copy of SnapshotConfig, and we can remove the duplicate fields in the snapshot packages.

This means we don't need to allocate strings/etc every 100 slots for incremental snapshots. And it furthers the goal of remove the reserialization of bank snapshots.


#### Summary of Changes

Removes fields from AccountsPackage and SnapshotPackage that are duplicates of what's in SnapshotConfig