### PR TITLE
CHANGELOG: Add entry for `test-sbf --tools-version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Release channels have their own copy of this changelog:
   * CLI: Can specify `--with-compute-unit-price`, `--max-sign-attempts`, and `--use-rpc` during program deployment
   * RPC's `simulateTransaction` now returns an extra `replacementBlockhash` field in the response
     when the `replaceRecentBlockhash` config param is `true` (#380)
+  * SDK: `cargo test-sbf` accepts `--tools-version`, just like `build-sbf` (#1359)
 
 ## [1.18.0]
 * Changes


### PR DESCRIPTION
#### Problem

#1359 added the ability to specify `--tools-version`, but it's not in the changelog.

#### Summary of Changes

People have a hard enough time finding out about the flag, so let's add an entry about it to the changelog.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
