### PR TITLE
sdk: Remove support for borsh 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,16 +932,6 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
-dependencies = [
- "borsh-derive 0.9.3",
- "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "borsh"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
@@ -962,25 +952,12 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
-dependencies = [
- "borsh-derive-internal 0.9.3",
- "borsh-schema-derive-internal 0.9.3",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
 dependencies = [
- "borsh-derive-internal 0.10.3",
- "borsh-schema-derive-internal 0.10.3",
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
@@ -1002,31 +979,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2539,15 +2494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.8",
 ]
 
 [[package]]
@@ -6661,7 +6607,6 @@ dependencies = [
  "bitflags 2.5.0",
  "blake3",
  "borsh 0.10.3",
- "borsh 0.9.3",
  "borsh 1.5.0",
  "bs58",
  "bv",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -742,16 +742,6 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
-dependencies = [
- "borsh-derive 0.9.3",
- "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "borsh"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
@@ -772,25 +762,12 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
-dependencies = [
- "borsh-derive-internal 0.9.3",
- "borsh-schema-derive-internal 0.9.3",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
 dependencies = [
- "borsh-derive-internal 0.10.3",
- "borsh-schema-derive-internal 0.10.3",
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
@@ -812,31 +789,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2030,15 +1985,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder 1.5.0",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.8",
 ]
 
 [[package]]
@@ -5351,7 +5297,6 @@ dependencies = [
  "bitflags 2.5.0",
  "blake3",
  "borsh 0.10.3",
- "borsh 0.9.3",
  "borsh 1.5.0",
  "bs58",
  "bv",

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -16,7 +16,6 @@ bincode = { workspace = true }
 blake3 = { workspace = true, features = ["digest", "traits-preview"] }
 borsh = { workspace = true }
 borsh0-10 = { package = "borsh", version = "0.10.3" }
-borsh0-9 = { package = "borsh", version = "0.9.3" }
 bs58 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true, features = ["derive"] }

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -477,7 +477,6 @@ pub mod big_mod_exp;
 pub mod blake3;
 pub mod borsh;
 pub mod borsh0_10;
-pub mod borsh0_9;
 pub mod borsh1;
 pub mod bpf_loader;
 pub mod bpf_loader_deprecated;

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -684,11 +684,6 @@ impl borsh0_10::de::BorshDeserialize for Pubkey {
         )?))
     }
 }
-impl borsh0_9::de::BorshDeserialize for Pubkey {
-    fn deserialize(buf: &mut &[u8]) -> ::core::result::Result<Self, borsh0_9::maybestd::io::Error> {
-        Ok(Self(borsh0_9::BorshDeserialize::deserialize(buf)?))
-    }
-}
 
 macro_rules! impl_borsh_schema {
     ($borsh:ident) => {
@@ -722,7 +717,6 @@ macro_rules! impl_borsh_schema {
     };
 }
 impl_borsh_schema!(borsh0_10);
-impl_borsh_schema!(borsh0_9);
 
 macro_rules! impl_borsh_serialize {
     ($borsh:ident) => {
@@ -738,7 +732,6 @@ macro_rules! impl_borsh_serialize {
     };
 }
 impl_borsh_serialize!(borsh0_10);
-impl_borsh_serialize!(borsh0_9);
 
 #[cfg(test)]
 mod tests {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -42,17 +42,16 @@ pub use solana_program::program_stubs;
 // These solana_program imports could be *-imported, but that causes a bunch of
 // confusing duplication in the docs due to a rustdoc bug. #26211
 pub use solana_program::{
-    account_info, address_lookup_table, alt_bn128, big_mod_exp, blake3, borsh, borsh0_10, borsh0_9,
-    borsh1, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, clock, config,
-    custom_heap_default, custom_panic_default, debug_account_data, declare_deprecated_sysvar_id,
-    declare_sysvar_id, decode_error, ed25519_program, epoch_rewards, epoch_schedule,
-    fee_calculator, impl_sysvar_get, incinerator, instruction, keccak, lamports,
-    loader_instruction, loader_upgradeable_instruction, loader_v4, loader_v4_instruction, message,
-    msg, native_token, nonce, poseidon, program, program_error, program_memory, program_option,
-    program_pack, rent, sanitize, secp256k1_program, secp256k1_recover, serde_varint,
-    serialize_utils, short_vec, slot_hashes, slot_history, stable_layout, stake, stake_history,
-    syscalls, system_instruction, system_program, sysvar, unchecked_div_by_const, vote,
-    wasm_bindgen,
+    account_info, address_lookup_table, alt_bn128, big_mod_exp, blake3, borsh, borsh0_10, borsh1,
+    bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, clock, config, custom_heap_default,
+    custom_panic_default, debug_account_data, declare_deprecated_sysvar_id, declare_sysvar_id,
+    decode_error, ed25519_program, epoch_rewards, epoch_schedule, fee_calculator, impl_sysvar_get,
+    incinerator, instruction, keccak, lamports, loader_instruction, loader_upgradeable_instruction,
+    loader_v4, loader_v4_instruction, message, msg, native_token, nonce, poseidon, program,
+    program_error, program_memory, program_option, program_pack, rent, sanitize, secp256k1_program,
+    secp256k1_recover, serde_varint, serialize_utils, short_vec, slot_hashes, slot_history,
+    stable_layout, stake, stake_history, syscalls, system_instruction, system_program, sysvar,
+    unchecked_div_by_const, vote, wasm_bindgen,
 };
 #[allow(deprecated)]
 pub use solana_program::{address_lookup_table_account, sdk_ids};


### PR DESCRIPTION
#### Problem

Borsh 0.9 has been deprecated from the SDK since 1.16, see https://github.com/solana-labs/solana/pull/32511

#### Summary of Changes

Since it's been deprecated for some time, remove all support for borsh 0.9.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
