### PR TITLE
CI: Add Anchor v0.30.0 as a downstream target

### DIFF
--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["v0.29.0"]
+        version: ["v0.29.0", "v0.30.0"]
     steps:
       - uses: actions/checkout@v4
 

--- a/scripts/patch-spl-crates-for-anchor.sh
+++ b/scripts/patch-spl-crates-for-anchor.sh
@@ -1,5 +1,6 @@
 spl_associated_token_account_version=
 spl_memo_version=
+spl_pod_version=
 spl_token_version=
 spl_token_2022_version=
 spl_token_group_interface_version=
@@ -12,6 +13,7 @@ get_spl_versions() {
     declare spl_dir="$1"
     spl_associated_token_account_version=$(readCargoVariable version "$spl_dir/associated-token-account/program/Cargo.toml")
     spl_memo_version=$(readCargoVariable version "$spl_dir/memo/program/Cargo.toml")
+    spl_pod_version=$(readCargoVariable version "$spl_dir/libraries/pod/Cargo.toml")
     spl_token_version=$(readCargoVariable version "$spl_dir/token/program/Cargo.toml")
     spl_token_2022_version=$(readCargoVariable version "$spl_dir/token/program-2022/Cargo.toml"| head -c1) # only use the major version for convenience
     spl_token_group_interface_version=$(readCargoVariable version "$spl_dir/token-group/interface/Cargo.toml")
@@ -38,6 +40,8 @@ update_spl_dependencies() {
     sed -i -e "s#\(spl-associated-token-account = { version = \"\)[^\"]*\(\"\)#\1$spl_associated_token_account_version\2#g" "${tomls[@]}" || return $?
     sed -i -e "s#\(spl-memo = \"\)[^\"]*\(\"\)#\1$spl_memo_version\2#g" "${tomls[@]}" || return $?
     sed -i -e "s#\(spl-memo = { version = \"\)[^\"]*\(\"\)#\1$spl_memo_version\2#g" "${tomls[@]}" || return $?
+    sed -i -e "s#\(spl-pod = \"\)[^\"]*\(\"\)#\1$spl_pod_version\2#g" "${tomls[@]}" || return $?
+    sed -i -e "s#\(spl-pod = { version = \"\)[^\"]*\(\"\)#\1$spl_pod_version\2#g" "${tomls[@]}" || return $?
     sed -i -e "s#\(spl-token = \"\)[^\"]*\(\"\)#\1$spl_token_version\2#g" "${tomls[@]}" || return $?
     sed -i -e "s#\(spl-token = { version = \"\)[^\"]*\(\"\)#\1$spl_token_version\2#g" "${tomls[@]}" || return $?
     sed -i -e "s#\(spl-token-2022 = \"\).*\(\"\)#\1$spl_token_2022_version\2#g" "${tomls[@]}" || return $?
@@ -64,6 +68,7 @@ patch_crates_io() {
     cat >> "$Cargo_toml" <<EOF
     spl-associated-token-account = { path = "$spl_dir/associated-token-account/program" }
     spl-memo = { path = "$spl_dir/memo/program" }
+    spl-pod = { path = "$spl_dir/libraries/pod" }
     spl-token = { path = "$spl_dir/token/program" }
     spl-token-2022 = { path = "$spl_dir/token/program-2022" }
     spl-token-group-interface = { path = "$spl_dir/token-group/interface" }


### PR DESCRIPTION
#### Problem

Anchor version 0.30.0 has been out for some time, but the CI downstream jobs only test against 0.29.0.

#### Summary of Changes

Add 0.30.0 as another downstream target -- this requires an additional patch for the spl-pod crate, but no other changes are required.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
