### PR TITLE
Removes references from BankFieldsToSerialize

### DIFF
--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -552,7 +552,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "7Cze6NqwQMsqcEjtkMSQhLPykCW8dYffwkHpNuysjwTN")
+            frozen_abi(digest = "E2yBALNrNC7xwrRaXknqjSDsPzWFGsQnK8RHE8niKTds")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapperNewer {


### PR DESCRIPTION
#### Problem

Serializing the bank involves creating a BankFieldsToSerialize struct, which then gets passed into the serde snapshot code. This struct has references into the Bank. This means if we hold onto this struct longer, it'll keep the Bank alive longer.

We'd like to remove reserializing the bank in AccountsHashVerifier. To do this, we'll wait to serialize the bank until after we've calculated the accounts hash. We don't want to keep the Bank alive longer though. So that means we need to get rid of the reference fields on BankFieldsToSerialize.

The concerns would be that we're now copying lots of data. Here's info about each of those fields:

* BlockHashQueue: this is a map of hash to hash age. That's about 56 bytes. There are a max of 300 items. So 16 KB. I think this is minimal, given the benefit of removing reserialization.
* HardForks: this is a vec of the hard forks slots (and a count). There's single digit entries today. This field is marginal.
* Stakes/EpochStakes: these are large structs for the stakes info. Luckily, they are im-hashmaps, so there is no real data copying here. It is similar to cloning an Rc or Arc.


#### Summary of Changes

Replace the reference types with value types in BankFieldsToSerialize