### PR TITLE
remove superfluous conditional

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1174,18 +1174,16 @@ impl Tower {
             fork_stake,
             total_stake
         );
-        if threshold_vote.confirmation_count() as usize > threshold_depth {
-            for old_vote in &vote_state_before_applying_vote.votes {
-                if old_vote.slot() == threshold_vote.slot()
-                    && old_vote.confirmation_count() == threshold_vote.confirmation_count()
-                {
-                    // If you bounce back to voting on the main fork after not
-                    // voting for a while, your latest vote N on the main fork
-                    // might pop off a lot of the stake of votes in the tower.
-                    // This stake would have rolled up to earlier votes in the
-                    // tower, so skip the stake check.
-                    return ThresholdDecision::PassedThreshold;
-                }
+        for old_vote in &vote_state_before_applying_vote.votes {
+            if old_vote.slot() == threshold_vote.slot()
+                && old_vote.confirmation_count() == threshold_vote.confirmation_count()
+            {
+                // If you bounce back to voting on the main fork after not
+                // voting for a while, your latest vote N on the main fork
+                // might pop off a lot of the stake of votes in the tower.
+                // This stake would have rolled up to earlier votes in the
+                // tower, so skip the stake check.
+                return ThresholdDecision::PassedThreshold;
             }
         }
         if lockout > threshold_size {


### PR DESCRIPTION
The if statement removed always evaluates to true by the following lemma:

**Lemma 1:**
The confirmation count of the N-th recent lockout (zero-index) is greater than N.

Proof by contradiction: If the Nth recent lockout has a confirmation count less than or equal to N, then, due to the monotonicity of confirmation counts, the (N-1)th most recent lockout must be less than or equal to (N-1). Applying induction, the first most recent lockout (index = 0) must have a confirmation count less less than or equal to 0. However, it is impossible for a vote to have a confirmation count of 0. So there is a contradiction.