### PR TITLE
bump socket2 from 0.5.6 to 0.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,7 +2682,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -4295,7 +4295,7 @@ checksum = "6df19e284d93757a9fb91d63672f7741b129246a669db09d1c0063071debc0c0"
 dependencies = [
  "bytes",
  "libc",
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "tracing",
  "windows-sys 0.48.0",
 ]
@@ -5243,9 +5243,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -6496,7 +6496,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_derive",
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "solana-logger",
  "solana-sdk",
  "solana-version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ signal-hook = "0.3.17"
 siphasher = "0.3.11"
 smallvec = "1.13.2"
 smpl_jwt = "0.7.1"
-socket2 = "0.5.6"
+socket2 = "0.5.7"
 soketto = "0.7"
 solana-account-decoder = { path = "account-decoder", version = "=2.0.0" }
 solana-accounts-db = { path = "accounts-db", version = "=2.0.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2154,7 +2154,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -3721,7 +3721,7 @@ checksum = "6df19e284d93757a9fb91d63672f7741b129246a669db09d1c0063071debc0c0"
 dependencies = [
  "bytes",
  "libc",
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "tracing",
  "windows-sys 0.48.0",
 ]
@@ -4531,9 +4531,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -5228,7 +5228,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_derive",
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "solana-logger",
  "solana-sdk",
  "solana-version",


### PR DESCRIPTION
#### Summary of Changes

bump socket2 from 0.5.6 to 0.5.7

(I haven't checked why `ci/dependabot-pr.sh` isn't working. use this one for unblocking the process)