### PR TITLE
[zk-sdk] Add error types and zero ciphertext instruction

### DIFF
--- a/zk-sdk/src/elgamal_program/errors.rs
+++ b/zk-sdk/src/elgamal_program/errors.rs
@@ -12,8 +12,6 @@ use {
 pub enum ProofGenerationError {
     #[error("not enough funds in account")]
     NotEnoughFunds,
-    #[error("transfer fee calculation error")]
-    FeeCalculation,
     #[error("illegal number of commitments")]
     IllegalCommitmentLength,
     #[error("illegal amount bit length")]

--- a/zk-sdk/src/elgamal_program/errors.rs
+++ b/zk-sdk/src/elgamal_program/errors.rs
@@ -43,4 +43,12 @@ pub enum ProofVerificationError {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SigmaProofType;
+pub enum SigmaProofType {
+    ZeroCiphertext,
+}
+
+impl From<ZeroCiphertextProofVerificationError> for ProofVerificationError {
+    fn from(err: ZeroCiphertextProofVerificationError) -> Self {
+        Self::SigmaProof(SigmaProofType::ZeroCiphertext, err.0)
+    }
+}

--- a/zk-sdk/src/elgamal_program/errors.rs
+++ b/zk-sdk/src/elgamal_program/errors.rs
@@ -1,7 +1,46 @@
-use thiserror::Error;
+use {
+    crate::{
+        errors::ElGamalError,
+        range_proof::errors::{RangeProofGenerationError, RangeProofVerificationError},
+        sigma_proofs::errors::*,
+    },
+    thiserror::Error,
+};
+
+#[cfg(not(target_os = "solana"))]
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum ProofGenerationError {
+    #[error("not enough funds in account")]
+    NotEnoughFunds,
+    #[error("transfer fee calculation error")]
+    FeeCalculation,
+    #[error("illegal number of commitments")]
+    IllegalCommitmentLength,
+    #[error("illegal amount bit length")]
+    IllegalAmountBitLength,
+    #[error("invalid commitment")]
+    InvalidCommitment,
+    #[error("range proof generation failed")]
+    RangeProof(#[from] RangeProofGenerationError),
+    #[error("unexpected proof length")]
+    ProofLength,
+}
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ProofVerificationError {
+    #[error("range proof verification failed")]
+    RangeProof(#[from] RangeProofVerificationError),
+    #[error("sigma proof verification failed")]
+    SigmaProof(SigmaProofType, SigmaProofVerificationError),
+    #[error("ElGamal ciphertext or public key error")]
+    ElGamal(#[from] ElGamalError),
     #[error("Invalid proof context")]
     ProofContext,
+    #[error("illegal commitment length")]
+    IllegalCommitmentLength,
+    #[error("illegal amount bit length")]
+    IllegalAmountBitLength,
 }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SigmaProofType;

--- a/zk-sdk/src/elgamal_program/errors.rs
+++ b/zk-sdk/src/elgamal_program/errors.rs
@@ -10,8 +10,6 @@ use {
 #[cfg(not(target_os = "solana"))]
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ProofGenerationError {
-    #[error("not enough funds in account")]
-    NotEnoughFunds,
     #[error("illegal number of commitments")]
     IllegalCommitmentLength,
     #[error("illegal amount bit length")]

--- a/zk-sdk/src/elgamal_program/proof_data/mod.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/mod.rs
@@ -6,12 +6,14 @@ use {
 
 pub mod errors;
 pub mod pod;
+pub mod zero_ciphertext;
 
 #[derive(Clone, Copy, Debug, FromPrimitive, ToPrimitive, PartialEq, Eq)]
 #[repr(u8)]
 pub enum ProofType {
     /// Empty proof type used to distinguish if a proof context account is initialized
     Uninitialized,
+    ZeroCiphertext,
 }
 
 pub trait ZkProofData<T: Pod> {

--- a/zk-sdk/src/elgamal_program/proof_data/zero_ciphertext.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/zero_ciphertext.rs
@@ -1,0 +1,123 @@
+
+//! The zero-balance proof instruction.
+//!
+//! A zero-balance proof is defined with respect to a twisted ElGamal ciphertext. The proof
+//! certifies that a given ciphertext encrypts the message 0 in the field (`Scalar::zero()`). To
+//! generate the proof, a prover must provide the decryption key for the ciphertext.
+
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{
+        encryption::elgamal::{ElGamalCiphertext, ElGamalKeypair},
+        errors::{ProofGenerationError, ProofVerificationError},
+        sigma_proofs::zero_balance_proof::ZeroBalanceProof,
+        transcript::TranscriptProtocol,
+    },
+    merlin::Transcript,
+    std::convert::TryInto,
+};
+use {
+    crate::{
+        instruction::{ProofType, ZkProofData},
+        zk_token_elgamal::pod,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+
+/// The instruction data that is needed for the `ProofInstruction::ZeroBalance` instruction.
+///
+/// It includes the cryptographic proof as well as the context data information needed to verify
+/// the proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct ZeroBalanceProofData {
+    /// The context data for the zero-balance proof
+    pub context: ZeroBalanceProofContext, // 96 bytes
+
+    /// Proof that the source account available balance is zero
+    pub proof: pod::ZeroBalanceProof, // 96 bytes
+}
+
+/// The context data needed to verify a zero-balance proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct ZeroBalanceProofContext {
+    /// The source account ElGamal pubkey
+    pub pubkey: pod::ElGamalPubkey, // 32 bytes
+
+    /// The source account available balance in encrypted form
+    pub ciphertext: pod::ElGamalCiphertext, // 64 bytes
+}
+
+#[cfg(not(target_os = "solana"))]
+impl ZeroBalanceProofData {
+    pub fn new(
+        keypair: &ElGamalKeypair,
+        ciphertext: &ElGamalCiphertext,
+    ) -> Result<Self, ProofGenerationError> {
+        let pod_pubkey = pod::ElGamalPubkey(keypair.pubkey().into());
+        let pod_ciphertext = pod::ElGamalCiphertext(ciphertext.to_bytes());
+
+        let context = ZeroBalanceProofContext {
+            pubkey: pod_pubkey,
+            ciphertext: pod_ciphertext,
+        };
+
+        let mut transcript = context.new_transcript();
+        let proof = ZeroBalanceProof::new(keypair, ciphertext, &mut transcript).into();
+
+        Ok(ZeroBalanceProofData { context, proof })
+    }
+}
+
+impl ZkProofData<ZeroBalanceProofContext> for ZeroBalanceProofData {
+    const PROOF_TYPE: ProofType = ProofType::ZeroBalance;
+
+    fn context_data(&self) -> &ZeroBalanceProofContext {
+        &self.context
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
+        let mut transcript = self.context.new_transcript();
+        let pubkey = self.context.pubkey.try_into()?;
+        let ciphertext = self.context.ciphertext.try_into()?;
+        let proof: ZeroBalanceProof = self.proof.try_into()?;
+        proof
+            .verify(&pubkey, &ciphertext, &mut transcript)
+            .map_err(|e| e.into())
+    }
+}
+
+#[allow(non_snake_case)]
+#[cfg(not(target_os = "solana"))]
+impl ZeroBalanceProofContext {
+    fn new_transcript(&self) -> Transcript {
+        let mut transcript = Transcript::new(b"ZeroBalanceProof");
+
+        transcript.append_pubkey(b"pubkey", &self.pubkey);
+        transcript.append_ciphertext(b"ciphertext", &self.ciphertext);
+
+        transcript
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_zero_balance_proof_instruction_correctness() {
+        let keypair = ElGamalKeypair::new_rand();
+
+        // general case: encryption of 0
+        let ciphertext = keypair.pubkey().encrypt(0_u64);
+        let zero_balance_proof_data = ZeroBalanceProofData::new(&keypair, &ciphertext).unwrap();
+        assert!(zero_balance_proof_data.verify_proof().is_ok());
+
+        // general case: encryption of > 0
+        let ciphertext = keypair.pubkey().encrypt(1_u64);
+        let zero_balance_proof_data = ZeroBalanceProofData::new(&keypair, &ciphertext).unwrap();
+        assert!(zero_balance_proof_data.verify_proof().is_err());
+    }
+}

--- a/zk-sdk/src/elgamal_program/proof_data/zero_ciphertext.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/zero_ciphertext.rs
@@ -1,79 +1,80 @@
-
-//! The zero-balance proof instruction.
+//! The zero-ciphertext proof instruction.
 //!
-//! A zero-balance proof is defined with respect to a twisted ElGamal ciphertext. The proof
+//! A zero-ciphertext proof is defined with respect to a twisted ElGamal ciphertext. The proof
 //! certifies that a given ciphertext encrypts the message 0 in the field (`Scalar::zero()`). To
 //! generate the proof, a prover must provide the decryption key for the ciphertext.
 
+use {
+    crate::{
+        elgamal_program::{
+            errors::{ProofGenerationError, ProofVerificationError},
+            proof_data::{ProofType, ZkProofData},
+        },
+        encryption::pod::elgamal::{PodElGamalCiphertext, PodElGamalPubkey},
+        sigma_proofs::pod::PodZeroCiphertextProof,
+    },
+    bytemuck::{bytes_of, Pod, Zeroable},
+};
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{
         encryption::elgamal::{ElGamalCiphertext, ElGamalKeypair},
-        errors::{ProofGenerationError, ProofVerificationError},
-        sigma_proofs::zero_balance_proof::ZeroBalanceProof,
-        transcript::TranscriptProtocol,
+        sigma_proofs::zero_ciphertext::ZeroCiphertextProof,
     },
     merlin::Transcript,
     std::convert::TryInto,
 };
-use {
-    crate::{
-        instruction::{ProofType, ZkProofData},
-        zk_token_elgamal::pod,
-    },
-    bytemuck::{Pod, Zeroable},
-};
 
-/// The instruction data that is needed for the `ProofInstruction::ZeroBalance` instruction.
+/// The instruction data that is needed for the `ProofInstruction::ZeroCiphertext` instruction.
 ///
 /// It includes the cryptographic proof as well as the context data information needed to verify
 /// the proof.
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
-pub struct ZeroBalanceProofData {
-    /// The context data for the zero-balance proof
-    pub context: ZeroBalanceProofContext, // 96 bytes
+pub struct ZeroCiphertextProofData {
+    /// The context data for the zero-ciphertext proof
+    pub context: ZeroCiphertextProofContext, // 96 bytes
 
-    /// Proof that the source account available balance is zero
-    pub proof: pod::ZeroBalanceProof, // 96 bytes
+    /// Proof that the ciphertext is zero
+    pub proof: PodZeroCiphertextProof, // 96 bytes
 }
 
-/// The context data needed to verify a zero-balance proof.
+/// The context data needed to verify a zero-ciphertext proof.
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
-pub struct ZeroBalanceProofContext {
-    /// The source account ElGamal pubkey
-    pub pubkey: pod::ElGamalPubkey, // 32 bytes
+pub struct ZeroCiphertextProofContext {
+    /// The ElGamal pubkey associated with the ElGamal ciphertext
+    pub pubkey: PodElGamalPubkey, // 32 bytes
 
-    /// The source account available balance in encrypted form
-    pub ciphertext: pod::ElGamalCiphertext, // 64 bytes
+    /// The ElGamal ciphertext that encrypts zero
+    pub ciphertext: PodElGamalCiphertext, // 64 bytes
 }
 
 #[cfg(not(target_os = "solana"))]
-impl ZeroBalanceProofData {
+impl ZeroCiphertextProofData {
     pub fn new(
         keypair: &ElGamalKeypair,
         ciphertext: &ElGamalCiphertext,
     ) -> Result<Self, ProofGenerationError> {
-        let pod_pubkey = pod::ElGamalPubkey(keypair.pubkey().into());
-        let pod_ciphertext = pod::ElGamalCiphertext(ciphertext.to_bytes());
+        let pod_pubkey = PodElGamalPubkey(keypair.pubkey().into());
+        let pod_ciphertext = PodElGamalCiphertext(ciphertext.to_bytes());
 
-        let context = ZeroBalanceProofContext {
+        let context = ZeroCiphertextProofContext {
             pubkey: pod_pubkey,
             ciphertext: pod_ciphertext,
         };
 
         let mut transcript = context.new_transcript();
-        let proof = ZeroBalanceProof::new(keypair, ciphertext, &mut transcript).into();
+        let proof = ZeroCiphertextProof::new(keypair, ciphertext, &mut transcript).into();
 
-        Ok(ZeroBalanceProofData { context, proof })
+        Ok(ZeroCiphertextProofData { context, proof })
     }
 }
 
-impl ZkProofData<ZeroBalanceProofContext> for ZeroBalanceProofData {
-    const PROOF_TYPE: ProofType = ProofType::ZeroBalance;
+impl ZkProofData<ZeroCiphertextProofContext> for ZeroCiphertextProofData {
+    const PROOF_TYPE: ProofType = ProofType::ZeroCiphertext;
 
-    fn context_data(&self) -> &ZeroBalanceProofContext {
+    fn context_data(&self) -> &ZeroCiphertextProofContext {
         &self.context
     }
 
@@ -82,7 +83,7 @@ impl ZkProofData<ZeroBalanceProofContext> for ZeroBalanceProofData {
         let mut transcript = self.context.new_transcript();
         let pubkey = self.context.pubkey.try_into()?;
         let ciphertext = self.context.ciphertext.try_into()?;
-        let proof: ZeroBalanceProof = self.proof.try_into()?;
+        let proof: ZeroCiphertextProof = self.proof.try_into()?;
         proof
             .verify(&pubkey, &ciphertext, &mut transcript)
             .map_err(|e| e.into())
@@ -91,12 +92,12 @@ impl ZkProofData<ZeroBalanceProofContext> for ZeroBalanceProofData {
 
 #[allow(non_snake_case)]
 #[cfg(not(target_os = "solana"))]
-impl ZeroBalanceProofContext {
+impl ZeroCiphertextProofContext {
     fn new_transcript(&self) -> Transcript {
-        let mut transcript = Transcript::new(b"ZeroBalanceProof");
+        let mut transcript = Transcript::new(b"zero-ciphertext-instruction");
 
-        transcript.append_pubkey(b"pubkey", &self.pubkey);
-        transcript.append_ciphertext(b"ciphertext", &self.ciphertext);
+        transcript.append_message(b"pubkey", bytes_of(&self.pubkey));
+        transcript.append_message(b"ciphertext", bytes_of(&self.ciphertext));
 
         transcript
     }
@@ -107,17 +108,20 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_zero_balance_proof_instruction_correctness() {
+    fn test_zero_ciphertext_proof_instruction_correctness() {
         let keypair = ElGamalKeypair::new_rand();
 
         // general case: encryption of 0
         let ciphertext = keypair.pubkey().encrypt(0_u64);
-        let zero_balance_proof_data = ZeroBalanceProofData::new(&keypair, &ciphertext).unwrap();
-        assert!(zero_balance_proof_data.verify_proof().is_ok());
+        let zero_ciphertext_proof_data =
+            ZeroCiphertextProofData::new(&keypair, &ciphertext).unwrap();
+        assert!(zero_ciphertext_proof_data.verify_proof().is_ok());
 
         // general case: encryption of > 0
         let ciphertext = keypair.pubkey().encrypt(1_u64);
-        let zero_balance_proof_data = ZeroBalanceProofData::new(&keypair, &ciphertext).unwrap();
-        assert!(zero_balance_proof_data.verify_proof().is_err());
+        let zero_ciphertext_proof_data =
+            ZeroCiphertextProofData::new(&keypair, &ciphertext).unwrap();
+        assert!(zero_ciphertext_proof_data.verify_proof().is_err());
     }
 }
+

--- a/zk-sdk/src/elgamal_program/proof_data/zero_ciphertext.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/zero_ciphertext.rs
@@ -124,4 +124,3 @@ mod test {
         assert!(zero_ciphertext_proof_data.verify_proof().is_err());
     }
 }
-


### PR DESCRIPTION
#### Problem
The proof data and instructions for the new elgamal program in zk-sdk are not added yet.

#### Summary of Changes
I added the zero-ciphertext instruction to start. Once this PR is merged after some feedback, then I think I can add the rest of the proof data in slightly larger chunk PRs.

- [7c0e380](https://github.com/anza-xyz/agave/pull/1453/commits/7c0e38048af5b1d8155439ce7c948e8bb06b1f42): I added the `ProofGenerationError` and `ProofVerificationError`. These types remain largely the same as in zk-token-sdk and in particular, wraps `RangeProofError` and `SigmaProofError`.
- [d701214](https://github.com/anza-xyz/agave/pull/1453/commits/d70121472302650038442e13e2a6ba6da54e2d7a): I just copied the `zero_balance` instruction data module from zk-token-sdk verbatim to make the diffs in the next commit easier to view.
- [8468880](https://github.com/anza-xyz/agave/pull/1453/commits/846888072a69292ece9c423fa4b252287ec50c37): I updated the `zero_balance` instruction data. The changes are essentially updating `ZeroBalance...` to `ZeroCiphertext...` and re-organizing the imports.
- [25c3c88](https://github.com/anza-xyz/agave/pull/1453/commits/25c3c88b9d88840831f50b1b8f135522635b74eb): Added the `VerifyZeroCiphertext` instruction in the elgamal proof program.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
