### PR TITLE
CHANGELOG: Add breaking change for Borsh 0.9 removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Release channels have their own copy of this changelog:
 
 <a name="edge-channel"></a>
 ## [2.0.0] - Unreleased
+* Breaking
+  * SDK: Support for Borsh v0.9 removed, please use v1 or v0.10 (#1440)
 * Changes
   * `central-scheduler` as default option for `--block-production-method` (#34891)
   * `solana-rpc-client-api`: `RpcFilterError` depends on `base64` version 0.22, so users may need to upgrade to `base64` version 0.22


### PR DESCRIPTION
#### Problem

The borsh v0.9 removal in #1440 is a breaking change, but not called out  in the Changelog.

#### Summary of Changes

Add a section for breaking changes, and add the borsh v0.9 removal to it.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
