### PR TITLE
refactor: transaction check result cleanup

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -872,6 +872,7 @@ mod tests {
             system_instruction, system_program, system_transaction,
             transaction::{MessageHash, Transaction, VersionedTransaction},
         },
+        solana_svm::account_loader::CheckedTransactionDetails,
         solana_transaction_status::{TransactionStatusMeta, VersionedTransactionWithStatusMeta},
         std::{
             borrow::Cow,
@@ -2511,24 +2512,45 @@ mod tests {
     fn test_bank_filter_valid_transaction_indexes() {
         assert_eq!(
             Consumer::filter_valid_transaction_indexes(&[
-                (Err(TransactionError::BlockhashNotFound), None, None),
-                (Err(TransactionError::BlockhashNotFound), None, None),
-                (Ok(()), None, None),
-                (Err(TransactionError::BlockhashNotFound), None, None),
-                (Ok(()), None, None),
-                (Ok(()), None, None),
+                Err(TransactionError::BlockhashNotFound),
+                Err(TransactionError::BlockhashNotFound),
+                Ok(CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature: None
+                }),
+                Err(TransactionError::BlockhashNotFound),
+                Ok(CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature: None
+                }),
+                Ok(CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature: None
+                }),
             ]),
             [2, 4, 5]
         );
 
         assert_eq!(
             Consumer::filter_valid_transaction_indexes(&[
-                (Ok(()), None, None),
-                (Err(TransactionError::BlockhashNotFound), None, None),
-                (Err(TransactionError::BlockhashNotFound), None, None),
-                (Ok(()), None, None),
-                (Ok(()), None, None),
-                (Ok(()), None, None),
+                Ok(CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature: None
+                }),
+                Err(TransactionError::BlockhashNotFound),
+                Err(TransactionError::BlockhashNotFound),
+                Ok(CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature: None
+                }),
+                Ok(CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature: None
+                }),
+                Ok(CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature: None
+                }),
             ]),
             [0, 3, 4, 5]
         );

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -413,9 +413,7 @@ impl Consumer {
         let pre_results = vec![Ok(()); txs.len()];
         let check_results =
             bank.check_transactions(txs, &pre_results, MAX_PROCESSING_AGE, &mut error_counters);
-        let check_results = check_results
-            .into_iter()
-            .map(|(result, _nonce, _lamports)| result);
+        let check_results = check_results.into_iter().map(|result| result.map(|_| ()));
         let mut output = self.process_and_record_transactions_with_pre_results(
             bank,
             txs,
@@ -819,7 +817,7 @@ impl Consumer {
         valid_txs
             .iter()
             .enumerate()
-            .filter_map(|(index, (x, _h, _lamports))| if x.is_ok() { Some(index) } else { None })
+            .filter_map(|(index, res)| res.as_ref().ok().map(|_| index))
             .collect_vec()
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -216,7 +216,7 @@ impl SchedulerController {
         let fee_check_results: Vec<_> = check_results
             .into_iter()
             .zip(transactions)
-            .map(|((result, _nonce, _lamports), tx)| {
+            .map(|(result, tx)| {
                 result?; // if there's already error do nothing
                 Consumer::check_fee_payer_unlocked(bank, tx.message(), &mut error_counters)
             })
@@ -381,7 +381,7 @@ impl SchedulerController {
                 &mut error_counters,
             );
 
-            for ((result, _nonce, _lamports), id) in check_results.into_iter().zip(chunk.iter()) {
+            for (result, id) in check_results.into_iter().zip(chunk.iter()) {
                 if result.is_err() {
                     saturating_add_assign!(num_dropped_on_age_and_status, 1);
                     self.container.remove_by_id(&id.id);
@@ -535,7 +535,7 @@ impl SchedulerController {
                 .zip(transactions)
                 .zip(fee_budget_limits_vec)
                 .zip(check_results)
-                .filter(|(_, check_result)| check_result.0.is_ok())
+                .filter(|(_, check_result)| check_result.is_ok())
             {
                 saturating_add_assign!(post_transaction_check_count, 1);
                 let transaction_id = self.transaction_id_generator.next();

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -809,9 +809,7 @@ impl ThreadLocalUnprocessedPackets {
         results
             .iter()
             .enumerate()
-            .filter_map(
-                |(tx_index, (result, _, _))| if result.is_ok() { Some(tx_index) } else { None },
-            )
+            .filter_map(|(tx_index, result)| result.as_ref().ok().map(|_| tx_index))
             .collect_vec()
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -164,7 +164,9 @@ use {
         stake_state::StakeStateV2,
     },
     solana_svm::{
-        account_loader::{TransactionCheckResult, TransactionLoadResult},
+        account_loader::{
+            CheckedTransactionDetails, TransactionCheckResult, TransactionLoadResult,
+        },
         account_overrides::AccountOverrides,
         nonce_info::{NonceInfo, NoncePartial},
         program_loader::load_program_with_pubkey,
@@ -3476,7 +3478,7 @@ impl Bank {
                     &hash_queue,
                     error_counters,
                 ),
-                Err(e) => (Err(e.clone()), None, None),
+                Err(e) => Err(e.clone()),
             })
             .collect()
     }
@@ -3491,20 +3493,23 @@ impl Bank {
     ) -> TransactionCheckResult {
         let recent_blockhash = tx.message().recent_blockhash();
         if hash_queue.is_hash_valid_for_age(recent_blockhash, max_age) {
-            (
-                Ok(()),
-                None,
-                hash_queue.get_lamports_per_signature(tx.message().recent_blockhash()),
-            )
+            Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: hash_queue
+                    .get_lamports_per_signature(tx.message().recent_blockhash()),
+            })
         } else if let Some((address, account)) =
             self.check_transaction_for_nonce(tx, next_durable_nonce)
         {
             let nonce = NoncePartial::new(address, account);
             let lamports_per_signature = nonce.lamports_per_signature();
-            (Ok(()), Some(nonce), lamports_per_signature)
+            Ok(CheckedTransactionDetails {
+                nonce: Some(nonce),
+                lamports_per_signature,
+            })
         } else {
             error_counters.blockhash_not_found += 1;
-            (Err(TransactionError::BlockhashNotFound), None, None)
+            Err(TransactionError::BlockhashNotFound)
         }
     }
 
@@ -3530,16 +3535,16 @@ impl Bank {
         sanitized_txs
             .iter()
             .zip(lock_results)
-            .map(|(sanitized_tx, (lock_result, nonce, lamports))| {
+            .map(|(sanitized_tx, lock_result)| {
                 let sanitized_tx = sanitized_tx.borrow();
                 if lock_result.is_ok()
                     && self.is_transaction_already_processed(sanitized_tx, &rcache)
                 {
                     error_counters.already_processed += 1;
-                    return (Err(TransactionError::AlreadyProcessed), None, None);
+                    return Err(TransactionError::AlreadyProcessed);
                 }
 
-                (lock_result, nonce, lamports)
+                lock_result
             })
             .collect()
     }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -555,7 +555,10 @@ mod tests {
         load_accounts(
             &callbacks,
             &[sanitized_tx],
-            &[(Ok(()), None, Some(lamports_per_signature))],
+            &[Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: Some(lamports_per_signature),
+            })],
             error_counters,
             fee_structure,
             None,
@@ -1040,7 +1043,10 @@ mod tests {
         load_accounts(
             &callbacks,
             &[tx],
-            &[(Ok(()), None, Some(10))],
+            &[Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: Some(10),
+            })],
             &mut error_counters,
             &FeeStructure::default(),
             account_overrides,
@@ -2041,7 +2047,10 @@ mod tests {
         let loaded_txs = load_accounts(
             &bank,
             &[sanitized_tx.clone()],
-            &[(Ok(()), None, Some(0))],
+            &[Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: Some(0),
+            })],
             &mut error_counters,
             &FeeStructure::default(),
             None,
@@ -2118,8 +2127,10 @@ mod tests {
             vec![Signature::new_unique()],
             false,
         );
-        let check_result =
-            (Ok(()), Some(NoncePartial::default()), Some(20u64)) as TransactionCheckResult;
+        let check_result = Ok(CheckedTransactionDetails {
+            nonce: Some(NoncePartial::default()),
+            lamports_per_signature: Some(20),
+        });
 
         let results = load_accounts(
             &mock_bank,
@@ -2187,7 +2198,10 @@ mod tests {
             false,
         );
 
-        let check_result = (Ok(()), Some(NoncePartial::default()), None) as TransactionCheckResult;
+        let check_result = Ok(CheckedTransactionDetails {
+            nonce: Some(NoncePartial::default()),
+            lamports_per_signature: None,
+        });
         let fee_structure = FeeStructure::default();
 
         let result = load_accounts(
@@ -2202,8 +2216,10 @@ mod tests {
 
         assert_eq!(result, vec![Err(TransactionError::BlockhashNotFound)]);
 
-        let check_result =
-            (Ok(()), Some(NoncePartial::default()), Some(20u64)) as TransactionCheckResult;
+        let check_result = Ok(CheckedTransactionDetails {
+            nonce: Some(NoncePartial::default()),
+            lamports_per_signature: Some(20),
+        });
 
         let result = load_accounts(
             &mock_bank,
@@ -2217,11 +2233,7 @@ mod tests {
 
         assert_eq!(result, vec![Err(TransactionError::AccountNotFound)]);
 
-        let check_result = (
-            Err(TransactionError::InvalidWritableAccount),
-            Some(NoncePartial::default()),
-            Some(20u64),
-        ) as TransactionCheckResult;
+        let check_result = Err(TransactionError::InvalidWritableAccount);
 
         let result = load_accounts(
             &mock_bank,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -830,6 +830,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 mod tests {
     use {
         super::*,
+        crate::account_loader::CheckedTransactionDetails,
         solana_program_runtime::loaded_programs::{BlockRelation, ProgramCacheEntryType},
         solana_sdk::{
             account::{create_account_shared_data_for_test, WritableAccount},
@@ -1254,10 +1255,19 @@ mod tests {
             sanitized_transaction_1,
         ];
         let mut lock_results = vec![
-            (Ok(()), None, Some(25)),
-            (Ok(()), None, Some(25)),
-            (Ok(()), None, None),
-            (Err(TransactionError::ProgramAccountNotFound), None, None),
+            Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: Some(25),
+            }),
+            Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: Some(25),
+            }),
+            Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: None,
+            }),
+            Err(TransactionError::ProgramAccountNotFound),
         ];
         let owners = vec![owner1, owner2];
 
@@ -1268,10 +1278,7 @@ mod tests {
             &owners,
         );
 
-        assert_eq!(
-            lock_results[2],
-            (Err(TransactionError::BlockhashNotFound), None, None)
-        );
+        assert_eq!(lock_results[2], Err(TransactionError::BlockhashNotFound));
         assert_eq!(result.len(), 2);
         assert_eq!(result[&key1], 2);
         assert_eq!(result[&key2], 1);
@@ -1350,7 +1357,16 @@ mod tests {
             TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
                 &bank,
                 &[sanitized_tx1, sanitized_tx2],
-                &mut [(Ok(()), None, Some(0)), (Ok(()), None, Some(0))],
+                &mut [
+                    Ok(CheckedTransactionDetails {
+                        nonce: None,
+                        lamports_per_signature: Some(0),
+                    }),
+                    Ok(CheckedTransactionDetails {
+                        nonce: None,
+                        lamports_per_signature: Some(0),
+                    }),
+                ],
                 owners,
             );
 
@@ -1440,7 +1456,16 @@ mod tests {
         let sanitized_tx2 = SanitizedTransaction::from_transaction_for_tests(tx2);
 
         let owners = &[program1_pubkey, program2_pubkey];
-        let mut lock_results = vec![(Ok(()), None, Some(0)), (Ok(()), None, None)];
+        let mut lock_results = vec![
+            Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: Some(0),
+            }),
+            Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: None,
+            }),
+        ];
         let programs =
             TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
                 &bank,
@@ -1457,7 +1482,7 @@ mod tests {
                 .expect("failed to find the program account"),
             &1
         );
-        assert_eq!(lock_results[1].0, Err(TransactionError::BlockhashNotFound));
+        assert_eq!(lock_results[1], Err(TransactionError::BlockhashNotFound));
     }
 
     #[test]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -344,8 +344,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     ) -> HashMap<Pubkey, u64> {
         let mut result: HashMap<Pubkey, u64> = HashMap::new();
         check_results.iter_mut().zip(txs).for_each(|etx| {
-            if let ((Ok(()), _nonce, lamports_per_signature), tx) = etx {
-                if lamports_per_signature.is_some() {
+            if let (Ok(checked_details), tx) = etx {
+                if checked_details.lamports_per_signature.is_some() {
                     tx.message()
                         .account_keys()
                         .iter()
@@ -367,7 +367,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     // If the transaction's nonce account was not valid, and blockhash is not found,
                     // the transaction will fail to process. Let's not load any programs from the
                     // transaction, and update the status of the transaction.
-                    *etx.0 = (Err(TransactionError::BlockhashNotFound), None, None);
+                    *etx.0 = Err(TransactionError::BlockhashNotFound);
                 }
             }
         });

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -31,7 +31,7 @@ use {
         transaction::{SanitizedTransaction, TransactionError},
     },
     solana_svm::{
-        account_loader::TransactionCheckResult,
+        account_loader::{CheckedTransactionDetails, TransactionCheckResult},
         runtime_config::RuntimeConfig,
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_processing_callback::TransactionProcessingCallback,
@@ -271,7 +271,10 @@ fn prepare_transactions(
         transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), false);
 
     all_transactions.push(sanitized_transaction);
-    transaction_checks.push((Ok(()), None, Some(20)));
+    transaction_checks.push(Ok(CheckedTransactionDetails {
+        nonce: None,
+        lamports_per_signature: Some(20),
+    }));
 
     // The transaction fee payer must have enough funds
     let mut account_data = AccountSharedData::default();
@@ -314,7 +317,10 @@ fn prepare_transactions(
     let sanitized_transaction =
         transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), true);
     all_transactions.push(sanitized_transaction);
-    transaction_checks.push((Ok(()), None, Some(20)));
+    transaction_checks.push(Ok(CheckedTransactionDetails {
+        nonce: None,
+        lamports_per_signature: Some(20),
+    }));
 
     // Setting up the accounts for the transfer
 
@@ -353,7 +359,10 @@ fn prepare_transactions(
         transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), false);
 
     all_transactions.push(sanitized_transaction);
-    transaction_checks.push((Ok(()), None, Some(20)));
+    transaction_checks.push(Ok(CheckedTransactionDetails {
+        nonce: None,
+        lamports_per_signature: Some(20),
+    }));
 
     let mut account_data = AccountSharedData::default();
     account_data.set_lamports(80000);
@@ -394,7 +403,10 @@ fn prepare_transactions(
     let sanitized_transaction =
         transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), true);
     all_transactions.push(sanitized_transaction.clone());
-    transaction_checks.push((Ok(()), None, Some(20)));
+    transaction_checks.push(Ok(CheckedTransactionDetails {
+        nonce: None,
+        lamports_per_signature: Some(20),
+    }));
 
     // fee payer
     let mut account_data = AccountSharedData::default();
@@ -422,7 +434,7 @@ fn prepare_transactions(
 
     // A transaction whose verification has already failed
     all_transactions.push(sanitized_transaction);
-    transaction_checks.push((Err(TransactionError::BlockhashNotFound), None, Some(20)));
+    transaction_checks.push(Err(TransactionError::BlockhashNotFound));
 
     (all_transactions, transaction_checks)
 }


### PR DESCRIPTION
#### Problem
`TransactionCheckResult` uses a tuple of `(transaction::Result<()>, Option<NoncePartial>, Option<u64>)` to track the check result, nonce info, and lamports per signature value for each transaction. But the nonce and lamports per signature values are _always_ `None` when the check result is an error. This leads to overly verbose error handling.

#### Summary of Changes
Introduce new struct `CheckedTransactionDetails` which encapsulates nonce info and lamports per signature inside the check result

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
