### PR TITLE
refactor: remove feature gate from `total_fee` function

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3945,16 +3945,15 @@ impl Bank {
                             .into(),
                         self.feature_set
                             .is_active(&include_loaded_accounts_data_size_in_fee_calculation::id()),
+                        self.feature_set
+                            .is_active(&remove_rounding_in_fee_calculation::id()),
                     );
 
                     self.check_execution_status_and_charge_fee(
                         message,
                         execution_status,
                         is_nonce,
-                        fee_details.total_fee(
-                            self.feature_set
-                                .is_active(&remove_rounding_in_fee_calculation::id()),
-                        ),
+                        fee_details.total_fee(),
                     )?;
 
                     accumulated_fee_details.accumulate(&fee_details);


### PR DESCRIPTION
#### Problem
In PR https://github.com/anza-xyz/agave/pull/1462 I would like to calculate fees details once and reuse them downstream in places where the active feature set might not available. This makes calculating the `total_fee` for a transaction difficult because it requires a feature flag.

#### Summary of Changes
Minor refactor which stores the `remove_rounding_in_fee_calculation` feature gate value in `FeeDetails` so that it isn't required when calling `total_fee`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
