### PR TITLE
sdk: Add macro to get Cargo.toml package metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7104,6 +7104,7 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.58",
+ "toml 0.8.10",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -3550,7 +3550,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -3559,7 +3559,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -4280,6 +4280,15 @@ checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+dependencies = [
  "serde",
 ]
 
@@ -6123,6 +6132,7 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.58",
+ "toml 0.8.12",
 ]
 
 [[package]]
@@ -7292,10 +7302,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.12",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -7305,7 +7330,20 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.2.5",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.25",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap 2.2.5",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.8",
 ]
 
 [[package]]
@@ -7948,6 +7986,15 @@ name = "winnow"
 version = "0.5.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e87b8dfbe3baffbe687eef2e164e32286eff31a5ee16463ce03d991643ec94"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
 dependencies = [
  "memchr",
 ]

--- a/sdk/macro/Cargo.toml
+++ b/sdk/macro/Cargo.toml
@@ -18,6 +18,7 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 rustversion = { workspace = true }
 syn = { workspace = true, features = ["full"] }
+toml = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -469,7 +469,7 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
 /// use solana_sdk_macro::package_metadata;
 ///
 /// pub fn main() {
-///     println!("{}", package_metadata!("copyright"));
+///     let copyright = package_metadata!("copyright");
 /// }
 /// ```
 ///

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -8,6 +8,7 @@ use {
     proc_macro::TokenStream,
     proc_macro2::{Delimiter, Span, TokenTree},
     quote::{quote, ToTokens},
+    std::{env, fs},
     syn::{
         bracketed,
         parse::{Parse, ParseStream, Result},
@@ -16,6 +17,7 @@ use {
         token::Bracket,
         Expr, Ident, LitByte, LitStr, Path, Token,
     },
+    toml::value::{Array, Value},
 };
 
 fn parse_id(
@@ -444,4 +446,267 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
         _ => unimplemented!(),
     }
     .into()
+}
+
+/// Macro for accessing data from the `package.metadata` section of the Cargo manifest
+///
+/// # Arguments
+/// * `key` - A string slice of a dot-separated path to the TOML key of interest
+///
+/// # Example
+/// Given the following `Cargo.toml`:
+/// ```ignore
+/// [package]
+/// name = "MyApp"
+/// version = "0.1.0"
+///
+/// [package.metadata]
+/// copyright = "Copyright (c) 2024 ACME Inc."
+/// ```
+///
+/// And the following `lib.rs`:
+/// ```ignore
+/// use solana_sdk_macro::package_metadata;
+///
+/// pub fn main() {
+///     println!("{}", package_metadata!("copyright"));
+/// }
+/// ```
+///
+/// Invoking `cargo run` will produce:
+/// ```ignore
+/// Copyright (c) 2024 ACME Inc.
+/// ```
+///
+/// ## TOML Support
+/// This macro only supports static data:
+/// * Strings
+/// * Integers
+/// * Floating-point numbers
+/// * Booleans
+/// * Datetimes
+/// * Arrays
+///
+/// ## Array Example
+/// Given the following Cargo manifest:
+/// ```ignore
+/// [package.metadata.arrays]
+/// some_array = [ 1, 2, 3 ]
+/// ```
+///
+/// This is legal:
+/// ```ignore
+/// static ARR: [i64; 3] = package_metadata!("arrays.some_array");
+/// ```
+///
+/// It does *not* currently support accessing TOML array elements directly.
+/// TOML tables are not supported.
+#[proc_macro]
+pub fn package_metadata(input: TokenStream) -> TokenStream {
+    let key = parse_macro_input!(input as syn::LitStr);
+    let full_key = &key.value();
+    let path = format!("{}/Cargo.toml", env::var("CARGO_MANIFEST_DIR").unwrap());
+    let manifest = load_manifest(&path);
+    let value = package_metadata_value(&manifest, full_key);
+    toml_value_codegen(value).into()
+}
+
+fn package_metadata_value<'a>(manifest: &'a Value, full_key: &str) -> &'a Value {
+    let error_message =
+        format!("Key `package.metadata.{full_key}` must be present in the Cargo manifest");
+    manifest
+        .get("package")
+        .and_then(|package| package.get("metadata"))
+        .and_then(|metadata| {
+            let mut table = metadata
+                .as_table()
+                .expect("TOML property `package.metadata` must be a table");
+            let mut value = None;
+            for key in full_key.split('.') {
+                match table.get(key).expect(&error_message) {
+                    Value::Table(t) => {
+                        table = t;
+                    }
+                    v => {
+                        value = Some(v);
+                    }
+                }
+            }
+            value
+        })
+        .expect(&error_message)
+}
+
+fn toml_value_codegen(value: &Value) -> proc_macro2::TokenStream {
+    match value {
+        Value::String(s) => quote! {{ #s }},
+        Value::Integer(i) => quote! {{ #i }},
+        Value::Float(f) => quote! {{ #f }},
+        Value::Boolean(b) => quote! {{ #b }},
+        Value::Array(a) => toml_array_codegen(a),
+        Value::Datetime(d) => {
+            let date_str = toml::ser::to_string(d).unwrap();
+            quote! {{
+                #date_str
+            }}
+        }
+        Value::Table(_) => {
+            panic!("Tables are not supported");
+        }
+    }
+}
+
+fn toml_array_codegen(array: &Array) -> proc_macro2::TokenStream {
+    let statements = array
+        .iter()
+        .flat_map(|val| {
+            let val = toml_value_codegen(val);
+            quote! {
+                #val,
+            }
+        })
+        .collect::<proc_macro2::TokenStream>();
+    quote! {{
+        [
+            #statements
+        ]
+    }}
+}
+
+fn load_manifest(path: &str) -> Value {
+    let contents = fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("error occurred reading Cargo manifest {path}: {err}"));
+    toml::from_str(&contents)
+        .unwrap_or_else(|err| panic!("error occurred parsing Cargo manifest {path}: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::str::FromStr};
+
+    #[test]
+    fn package_metadata_string() {
+        let copyright = "Copyright (c) 2024 ACME Inc.";
+        let manifest = toml::from_str(&format!(
+            r#"
+            [package.metadata]
+            copyright = "{copyright}"
+        "#
+        ))
+        .unwrap();
+        assert_eq!(
+            package_metadata_value(&manifest, "copyright")
+                .as_str()
+                .unwrap(),
+            copyright
+        );
+    }
+
+    #[test]
+    fn package_metadata_nested() {
+        let program_id = "11111111111111111111111111111111";
+        let manifest = toml::from_str(&format!(
+            r#"
+            [package.metadata.solana]
+            program-id = "{program_id}"
+        "#
+        ))
+        .unwrap();
+        assert_eq!(
+            package_metadata_value(&manifest, "solana.program-id")
+                .as_str()
+                .unwrap(),
+            program_id
+        );
+    }
+
+    #[test]
+    fn package_metadata_bool() {
+        let manifest = toml::from_str(
+            r#"
+            [package.metadata]
+            is-ok = true
+        "#,
+        )
+        .unwrap();
+        assert!(package_metadata_value(&manifest, "is-ok")
+            .as_bool()
+            .unwrap());
+    }
+
+    #[test]
+    fn package_metadata_int() {
+        let number = 123;
+        let manifest = toml::from_str(&format!(
+            r#"
+            [package.metadata]
+            number = {number}
+        "#
+        ))
+        .unwrap();
+        assert_eq!(
+            package_metadata_value(&manifest, "number")
+                .as_integer()
+                .unwrap(),
+            number
+        );
+    }
+
+    #[test]
+    fn package_metadata_float() {
+        let float = 123.456;
+        let manifest = toml::from_str(&format!(
+            r#"
+            [package.metadata]
+            float = {float}
+        "#
+        ))
+        .unwrap();
+        assert_eq!(
+            package_metadata_value(&manifest, "float")
+                .as_float()
+                .unwrap(),
+            float
+        );
+    }
+
+    #[test]
+    fn package_metadata_array() {
+        let array = ["1", "2", "3"];
+        let manifest = toml::from_str(&format!(
+            r#"
+            [package.metadata]
+            array = {array:?}
+        "#
+        ))
+        .unwrap();
+        assert_eq!(
+            package_metadata_value(&manifest, "array")
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|x| x.as_str().unwrap())
+                .collect::<Vec<_>>(),
+            array
+        );
+    }
+
+    #[test]
+    fn package_metadata_datetime() {
+        let datetime = "1979-05-27T07:32:00Z";
+        let manifest = toml::from_str(&format!(
+            r#"
+            [package.metadata]
+            datetime = {datetime}
+        "#
+        ))
+        .unwrap();
+        let toml_datetime = toml::value::Datetime::from_str(datetime).unwrap();
+        assert_eq!(
+            package_metadata_value(&manifest, "datetime")
+                .as_datetime()
+                .unwrap(),
+            &toml_datetime
+        );
+    }
 }

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -464,18 +464,14 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
 /// copyright = "Copyright (c) 2024 ACME Inc."
 /// ```
 ///
-/// And the following `lib.rs`:
+/// You can fetch the copyright with the following:
 /// ```ignore
 /// use solana_sdk_macro::package_metadata;
 ///
 /// pub fn main() {
 ///     let copyright = package_metadata!("copyright");
+///     assert_eq!(copyright, "Copyright (c) 2024 ACME Inc.");
 /// }
-/// ```
-///
-/// Invoking `cargo run` will produce:
-/// ```ignore
-/// Copyright (c) 2024 ACME Inc.
 /// ```
 ///
 /// ## TOML Support


### PR DESCRIPTION
#### Problem

As part of the new format for solana programs, we want to use the `[package.metadata]` section in Cargo.toml to store Solana-specific information, such as the program id, as in https://github.com/solana-program/config/blob/396c398b558abb0b57c9c03e11f766417ce1fc94/program/Cargo.toml#L11-L12

Unfortunately, we need to specify this in two places since it isn't possible to just get the data from the Cargo.toml's metadata directly, ie https://github.com/solana-program/config/blob/396c398b558abb0b57c9c03e11f766417ce1fc94/program/src/lib.rs#L11

#### Summary of Changes

Following the implementation at https://gitlab.com/shanepearlman/cargo_meta, add a macro that extracts the data from `Cargo.toml` directly.

This is the first step, next we need to add a macro to generate a const pubkey that we can use with `declare_id`, ie. something like:

```
macro_rules! declare_pubkey {
    ($pk:expr) => {{
        let id_array = bs58::decode($pk.as_bytes())
            .with_alphabet(bs58::Alphabet::RIPPLE)
            .into_array_const_unwrap::<PUBKEY_BYTES>();
        Pubkey::new_from_array(id_array)
    }};
}

declare_id!(declare_pubkey!(package_metadata!("solana.program-id")));
```

cc @lorisleiva

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
