### PR TITLE
[zk-sdk] Add equality, pubkey validity, and percentage-with-cap instruction data

### DIFF
--- a/zk-sdk/src/elgamal_program/errors.rs
+++ b/zk-sdk/src/elgamal_program/errors.rs
@@ -1,7 +1,8 @@
+#[cfg(not(target_os = "solana"))]
+use crate::range_proof::errors::RangeProofGenerationError;
 use {
     crate::{
-        errors::ElGamalError,
-        range_proof::errors::{RangeProofGenerationError, RangeProofVerificationError},
+        errors::ElGamalError, range_proof::errors::RangeProofVerificationError,
         sigma_proofs::errors::*,
     },
     thiserror::Error,
@@ -41,10 +42,17 @@ pub enum ProofVerificationError {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SigmaProofType {
     ZeroCiphertext,
+    CiphertextCiphertextEquality,
 }
 
 impl From<ZeroCiphertextProofVerificationError> for ProofVerificationError {
     fn from(err: ZeroCiphertextProofVerificationError) -> Self {
         Self::SigmaProof(SigmaProofType::ZeroCiphertext, err.0)
+    }
+}
+
+impl From<EqualityProofVerificationError> for ProofVerificationError {
+    fn from(err: EqualityProofVerificationError) -> Self {
+        Self::SigmaProof(SigmaProofType::CiphertextCiphertextEquality, err.0)
     }
 }

--- a/zk-sdk/src/elgamal_program/errors.rs
+++ b/zk-sdk/src/elgamal_program/errors.rs
@@ -42,7 +42,7 @@ pub enum ProofVerificationError {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SigmaProofType {
     ZeroCiphertext,
-    CiphertextCiphertextEquality,
+    Equality,
 }
 
 impl From<ZeroCiphertextProofVerificationError> for ProofVerificationError {
@@ -53,6 +53,6 @@ impl From<ZeroCiphertextProofVerificationError> for ProofVerificationError {
 
 impl From<EqualityProofVerificationError> for ProofVerificationError {
     fn from(err: EqualityProofVerificationError) -> Self {
-        Self::SigmaProof(SigmaProofType::CiphertextCiphertextEquality, err.0)
+        Self::SigmaProof(SigmaProofType::Equality, err.0)
     }
 }

--- a/zk-sdk/src/elgamal_program/errors.rs
+++ b/zk-sdk/src/elgamal_program/errors.rs
@@ -44,6 +44,7 @@ pub enum SigmaProofType {
     ZeroCiphertext,
     Equality,
     PubkeyValidity,
+    PercentageWithCap,
 }
 
 impl From<ZeroCiphertextProofVerificationError> for ProofVerificationError {
@@ -61,5 +62,11 @@ impl From<EqualityProofVerificationError> for ProofVerificationError {
 impl From<PubkeyValidityProofVerificationError> for ProofVerificationError {
     fn from(err: PubkeyValidityProofVerificationError) -> Self {
         Self::SigmaProof(SigmaProofType::PubkeyValidity, err.0)
+    }
+}
+
+impl From<PercentageWithCapProofVerificationError> for ProofVerificationError {
+    fn from(err: PercentageWithCapProofVerificationError) -> Self {
+        Self::SigmaProof(SigmaProofType::PercentageWithCap, err.0)
     }
 }

--- a/zk-sdk/src/elgamal_program/errors.rs
+++ b/zk-sdk/src/elgamal_program/errors.rs
@@ -43,6 +43,7 @@ pub enum ProofVerificationError {
 pub enum SigmaProofType {
     ZeroCiphertext,
     Equality,
+    PubkeyValidity,
 }
 
 impl From<ZeroCiphertextProofVerificationError> for ProofVerificationError {
@@ -54,5 +55,11 @@ impl From<ZeroCiphertextProofVerificationError> for ProofVerificationError {
 impl From<EqualityProofVerificationError> for ProofVerificationError {
     fn from(err: EqualityProofVerificationError) -> Self {
         Self::SigmaProof(SigmaProofType::Equality, err.0)
+    }
+}
+
+impl From<PubkeyValidityProofVerificationError> for ProofVerificationError {
+    fn from(err: PubkeyValidityProofVerificationError) -> Self {
+        Self::SigmaProof(SigmaProofType::PubkeyValidity, err.0)
     }
 }

--- a/zk-sdk/src/elgamal_program/instruction.rs
+++ b/zk-sdk/src/elgamal_program/instruction.rs
@@ -124,6 +124,23 @@ pub enum ProofInstruction {
     ///   ii. `u32` byte offset if proof is provided as an account
     ///
     VerifyPubkeyValidity,
+
+    /// Verify a percentage-with-cap proof.
+    ///
+    /// A percentage-with-cap proof certifies that a tuple of Pedersen commitments satisfy a
+    /// percentage relation.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[]` (Optional) Account to read the proof from
+    ///   1. `[writable]` (Optional) The proof context account
+    ///   2. `[]` (Optional) The proof context account owner
+    ///
+    /// The instruction expects either:
+    ///   i. `PercentageWithCapProofData` if proof is provided as instruction data
+    ///   ii. `u32` byte offset if proof is provided as an account
+    ///
+    VerifyPercentageWithCap,
 }
 
 /// Pubkeys associated with a context state account to be used as parameters to functions.

--- a/zk-sdk/src/elgamal_program/instruction.rs
+++ b/zk-sdk/src/elgamal_program/instruction.rs
@@ -107,6 +107,23 @@ pub enum ProofInstruction {
     ///   ii. `u32` byte offset if proof is provided as an account
     ///
     VerifyCiphertextCommitmentEquality,
+
+    /// Verify a public key validity zero-knowledge proof.
+    ///
+    /// A public key validity proof certifies that an ElGamal public key is well-formed and the
+    /// prover knows the corresponding secret key.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[]` (Optional) Account to read the proof from
+    ///   1. `[writable]` (Optional) The proof context account
+    ///   2. `[]` (Optional) The proof context account owner
+    ///
+    /// The instruction expects either:
+    ///   i. `PubkeyValidityData` if proof is provided as instruction data
+    ///   ii. `u32` byte offset if proof is provided as an account
+    ///
+    VerifyPubkeyValidity,
 }
 
 /// Pubkeys associated with a context state account to be used as parameters to functions.

--- a/zk-sdk/src/elgamal_program/instruction.rs
+++ b/zk-sdk/src/elgamal_program/instruction.rs
@@ -73,6 +73,23 @@ pub enum ProofInstruction {
     ///   ii. `u32` byte offset if proof is provided as an account
     ///
     VerifyZeroCiphertext,
+
+    /// Verify a ciphertext-ciphertext equality proof.
+    ///
+    /// A ciphertext-ciphertext equality proof certifies that two ElGamal ciphertexts encrypt the
+    /// same message.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[]` (Optional) Account to read the proof from
+    ///   1. `[writable]` (Optional) The proof context account
+    ///   2. `[]` (Optional) The proof context account owner
+    ///
+    /// The instruction expects either:
+    ///   i. `CiphertextCiphertextEqualityProofData` if proof is provided as instruction data
+    ///   ii. `u32` byte offset if proof is provided as an account
+    ///
+    VerifyCiphertextCiphertextEquality,
 }
 
 /// Pubkeys associated with a context state account to be used as parameters to functions.

--- a/zk-sdk/src/elgamal_program/instruction.rs
+++ b/zk-sdk/src/elgamal_program/instruction.rs
@@ -90,6 +90,23 @@ pub enum ProofInstruction {
     ///   ii. `u32` byte offset if proof is provided as an account
     ///
     VerifyCiphertextCiphertextEquality,
+
+    /// Verify a ciphertext-commitment equality proof.
+    ///
+    /// A ciphertext-commitment equality proof certifies that an ElGamal ciphertext and a Pedersen
+    /// commitment encrypt/encode the same message.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[]` (Optional) Account to read the proof from
+    ///   1. `[writable]` (Optional) The proof context account
+    ///   2. `[]` (Optional) The proof context account owner
+    ///
+    /// The instruction expects either:
+    ///   i. `CiphertextCommitmentEqualityProofData` if proof is provided as instruction data
+    ///   ii. `u32` byte offset if proof is provided as an account
+    ///
+    VerifyCiphertextCommitmentEquality,
 }
 
 /// Pubkeys associated with a context state account to be used as parameters to functions.

--- a/zk-sdk/src/elgamal_program/proof_data/ciphertext_ciphertext_equality.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/ciphertext_ciphertext_equality.rs
@@ -1,0 +1,213 @@
+//! The ciphertext-ciphertext equality proof instruction.
+//!
+//! A ciphertext-ciphertext equality proof is defined with respect to two twisted ElGamal
+//! ciphertexts. The proof certifies that the two ciphertexts encrypt the same message. To generate
+//! the proof, a prover must provide the decryption key for the first ciphertext and the randomness
+//! used to generate the second ciphertext.
+//!
+//! The first ciphertext associated with the proof is referred to as the "source" ciphertext. The
+//! second ciphertext associated with the proof is referred to as the "destination" ciphertext.
+
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{
+        encryption::{
+            elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
+            pedersen::PedersenOpening,
+        },
+        errors::{ProofGenerationError, ProofVerificationError},
+        sigma_proofs::ciphertext_ciphertext_equality_proof::CiphertextCiphertextEqualityProof,
+        transcript::TranscriptProtocol,
+    },
+    merlin::Transcript,
+    std::convert::TryInto,
+};
+use {
+    crate::{
+        instruction::{ProofType, ZkProofData},
+        zk_token_elgamal::pod,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+
+/// The instruction data that is needed for the
+/// `ProofInstruction::VerifyCiphertextCiphertextEquality` instruction.
+///
+/// It includes the cryptographic proof as well as the context data information needed to verify
+/// the proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct CiphertextCiphertextEqualityProofData {
+    pub context: CiphertextCiphertextEqualityProofContext,
+
+    pub proof: pod::CiphertextCiphertextEqualityProof,
+}
+
+/// The context data needed to verify a ciphertext-ciphertext equality proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct CiphertextCiphertextEqualityProofContext {
+    pub source_pubkey: pod::ElGamalPubkey, // 32 bytes
+
+    pub destination_pubkey: pod::ElGamalPubkey, // 32 bytes
+
+    pub source_ciphertext: pod::ElGamalCiphertext, // 64 bytes
+
+    pub destination_ciphertext: pod::ElGamalCiphertext, // 64 bytes
+}
+
+#[cfg(not(target_os = "solana"))]
+impl CiphertextCiphertextEqualityProofData {
+    pub fn new(
+        source_keypair: &ElGamalKeypair,
+        destination_pubkey: &ElGamalPubkey,
+        source_ciphertext: &ElGamalCiphertext,
+        destination_ciphertext: &ElGamalCiphertext,
+        destination_opening: &PedersenOpening,
+        amount: u64,
+    ) -> Result<Self, ProofGenerationError> {
+        let pod_source_pubkey = pod::ElGamalPubkey(source_keypair.pubkey().into());
+        let pod_destination_pubkey = pod::ElGamalPubkey(destination_pubkey.into());
+        let pod_source_ciphertext = pod::ElGamalCiphertext(source_ciphertext.to_bytes());
+        let pod_destination_ciphertext = pod::ElGamalCiphertext(destination_ciphertext.to_bytes());
+
+        let context = CiphertextCiphertextEqualityProofContext {
+            source_pubkey: pod_source_pubkey,
+            destination_pubkey: pod_destination_pubkey,
+            source_ciphertext: pod_source_ciphertext,
+            destination_ciphertext: pod_destination_ciphertext,
+        };
+
+        let mut transcript = context.new_transcript();
+
+        let proof = CiphertextCiphertextEqualityProof::new(
+            source_keypair,
+            destination_pubkey,
+            source_ciphertext,
+            destination_opening,
+            amount,
+            &mut transcript,
+        )
+        .into();
+
+        Ok(Self { context, proof })
+    }
+}
+
+impl ZkProofData<CiphertextCiphertextEqualityProofContext>
+    for CiphertextCiphertextEqualityProofData
+{
+    const PROOF_TYPE: ProofType = ProofType::CiphertextCiphertextEquality;
+
+    fn context_data(&self) -> &CiphertextCiphertextEqualityProofContext {
+        &self.context
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
+        let mut transcript = self.context.new_transcript();
+
+        let source_pubkey = self.context.source_pubkey.try_into()?;
+        let destination_pubkey = self.context.destination_pubkey.try_into()?;
+        let source_ciphertext = self.context.source_ciphertext.try_into()?;
+        let destination_ciphertext = self.context.destination_ciphertext.try_into()?;
+        let proof: CiphertextCiphertextEqualityProof = self.proof.try_into()?;
+
+        proof
+            .verify(
+                &source_pubkey,
+                &destination_pubkey,
+                &source_ciphertext,
+                &destination_ciphertext,
+                &mut transcript,
+            )
+            .map_err(|e| e.into())
+    }
+}
+
+#[allow(non_snake_case)]
+#[cfg(not(target_os = "solana"))]
+impl CiphertextCiphertextEqualityProofContext {
+    fn new_transcript(&self) -> Transcript {
+        let mut transcript = Transcript::new(b"CiphertextCiphertextEqualityProof");
+
+        transcript.append_pubkey(b"source-pubkey", &self.source_pubkey);
+        transcript.append_pubkey(b"destination-pubkey", &self.destination_pubkey);
+
+        transcript.append_ciphertext(b"source-ciphertext", &self.source_ciphertext);
+        transcript.append_ciphertext(b"destination-ciphertext", &self.destination_ciphertext);
+
+        transcript
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_ciphertext_ciphertext_instruction_correctness() {
+        let source_keypair = ElGamalKeypair::new_rand();
+        let destination_keypair = ElGamalKeypair::new_rand();
+
+        let amount: u64 = 0;
+        let source_ciphertext = source_keypair.pubkey().encrypt(amount);
+
+        let destination_opening = PedersenOpening::new_rand();
+        let destination_ciphertext = destination_keypair
+            .pubkey()
+            .encrypt_with(amount, &destination_opening);
+
+        let proof_data = CiphertextCiphertextEqualityProofData::new(
+            &source_keypair,
+            destination_keypair.pubkey(),
+            &source_ciphertext,
+            &destination_ciphertext,
+            &destination_opening,
+            amount,
+        )
+        .unwrap();
+
+        assert!(proof_data.verify_proof().is_ok());
+
+        let amount: u64 = 55;
+        let source_ciphertext = source_keypair.pubkey().encrypt(amount);
+
+        let destination_opening = PedersenOpening::new_rand();
+        let destination_ciphertext = destination_keypair
+            .pubkey()
+            .encrypt_with(amount, &destination_opening);
+
+        let proof_data = CiphertextCiphertextEqualityProofData::new(
+            &source_keypair,
+            destination_keypair.pubkey(),
+            &source_ciphertext,
+            &destination_ciphertext,
+            &destination_opening,
+            amount,
+        )
+        .unwrap();
+
+        assert!(proof_data.verify_proof().is_ok());
+
+        let amount = u64::MAX;
+        let source_ciphertext = source_keypair.pubkey().encrypt(amount);
+
+        let destination_opening = PedersenOpening::new_rand();
+        let destination_ciphertext = destination_keypair
+            .pubkey()
+            .encrypt_with(amount, &destination_opening);
+
+        let proof_data = CiphertextCiphertextEqualityProofData::new(
+            &source_keypair,
+            destination_keypair.pubkey(),
+            &source_ciphertext,
+            &destination_ciphertext,
+            &destination_opening,
+            amount,
+        )
+        .unwrap();
+
+        assert!(proof_data.verify_proof().is_ok());
+    }
+}

--- a/zk-sdk/src/elgamal_program/proof_data/ciphertext_commitment_equality.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/ciphertext_commitment_equality.rs
@@ -1,0 +1,145 @@
+//! The ciphertext-commitment equality proof instruction.
+//!
+//! A ciphertext-commitment equality proof is defined with respect to a twisted ElGamal ciphertext
+//! and a Pedersen commitment. The proof certifies that a given ciphertext and a commitment pair
+//! encrypts/encodes the same message. To generate the proof, a prover must provide the decryption
+//! key for the first ciphertext and the Pedersen opening for the commitment.
+
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{
+        encryption::{
+            elgamal::{ElGamalCiphertext, ElGamalKeypair},
+            pedersen::{PedersenCommitment, PedersenOpening},
+        },
+        errors::{ProofGenerationError, ProofVerificationError},
+        sigma_proofs::ciphertext_commitment_equality_proof::CiphertextCommitmentEqualityProof,
+        transcript::TranscriptProtocol,
+    },
+    merlin::Transcript,
+    std::convert::TryInto,
+};
+use {
+    crate::{
+        instruction::{ProofType, ZkProofData},
+        zk_token_elgamal::pod,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+/// The instruction data that is needed for the
+/// `ProofInstruction::VerifyCiphertextCommitmentEquality` instruction.
+///
+/// It includes the cryptographic proof as well as the context data information needed to verify
+/// the proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct CiphertextCommitmentEqualityProofData {
+    pub context: CiphertextCommitmentEqualityProofContext,
+    pub proof: pod::CiphertextCommitmentEqualityProof,
+}
+
+/// The context data needed to verify a ciphertext-commitment equality proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct CiphertextCommitmentEqualityProofContext {
+    /// The ElGamal pubkey
+    pub pubkey: pod::ElGamalPubkey, // 32 bytes
+
+    /// The ciphertext encrypted under the ElGamal pubkey
+    pub ciphertext: pod::ElGamalCiphertext, // 64 bytes
+
+    /// The Pedersen commitment
+    pub commitment: pod::PedersenCommitment, // 32 bytes
+}
+
+#[cfg(not(target_os = "solana"))]
+impl CiphertextCommitmentEqualityProofData {
+    pub fn new(
+        keypair: &ElGamalKeypair,
+        ciphertext: &ElGamalCiphertext,
+        commitment: &PedersenCommitment,
+        opening: &PedersenOpening,
+        amount: u64,
+    ) -> Result<Self, ProofGenerationError> {
+        let context = CiphertextCommitmentEqualityProofContext {
+            pubkey: pod::ElGamalPubkey(keypair.pubkey().into()),
+            ciphertext: pod::ElGamalCiphertext(ciphertext.to_bytes()),
+            commitment: pod::PedersenCommitment(commitment.to_bytes()),
+        };
+        let mut transcript = context.new_transcript();
+        let proof = CiphertextCommitmentEqualityProof::new(
+            keypair,
+            ciphertext,
+            opening,
+            amount,
+            &mut transcript,
+        );
+        Ok(CiphertextCommitmentEqualityProofData {
+            context,
+            proof: proof.into(),
+        })
+    }
+}
+
+impl ZkProofData<CiphertextCommitmentEqualityProofContext>
+    for CiphertextCommitmentEqualityProofData
+{
+    const PROOF_TYPE: ProofType = ProofType::CiphertextCommitmentEquality;
+
+    fn context_data(&self) -> &CiphertextCommitmentEqualityProofContext {
+        &self.context
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
+        let mut transcript = self.context.new_transcript();
+
+        let pubkey = self.context.pubkey.try_into()?;
+        let ciphertext = self.context.ciphertext.try_into()?;
+        let commitment = self.context.commitment.try_into()?;
+        let proof: CiphertextCommitmentEqualityProof = self.proof.try_into()?;
+
+        proof
+            .verify(&pubkey, &ciphertext, &commitment, &mut transcript)
+            .map_err(|e| e.into())
+    }
+}
+
+#[allow(non_snake_case)]
+#[cfg(not(target_os = "solana"))]
+impl CiphertextCommitmentEqualityProofContext {
+    fn new_transcript(&self) -> Transcript {
+        let mut transcript = Transcript::new(b"CtxtCommEqualityProof");
+        transcript.append_pubkey(b"pubkey", &self.pubkey);
+        transcript.append_ciphertext(b"ciphertext", &self.ciphertext);
+        transcript.append_commitment(b"commitment", &self.commitment);
+        transcript
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::encryption::{elgamal::ElGamalKeypair, pedersen::Pedersen},
+    };
+
+    #[test]
+    fn test_ctxt_comm_equality_proof_correctness() {
+        let keypair = ElGamalKeypair::new_rand();
+        let amount: u64 = 55;
+        let ciphertext = keypair.pubkey().encrypt(amount);
+        let (commitment, opening) = Pedersen::new(amount);
+
+        let proof_data = CiphertextCommitmentEqualityProofData::new(
+            &keypair,
+            &ciphertext,
+            &commitment,
+            &opening,
+            amount,
+        )
+        .unwrap();
+
+        assert!(proof_data.verify_proof().is_ok());
+    }
+}

--- a/zk-sdk/src/elgamal_program/proof_data/mod.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/mod.rs
@@ -9,6 +9,7 @@ pub mod ciphertext_ciphertext_equality;
 pub mod ciphertext_commitment_equality;
 pub mod errors;
 pub mod pod;
+pub mod pubkey;
 pub mod zero_ciphertext;
 
 #[derive(Clone, Copy, Debug, FromPrimitive, ToPrimitive, PartialEq, Eq)]
@@ -19,6 +20,7 @@ pub enum ProofType {
     ZeroCiphertext,
     CiphertextCiphertextEquality,
     CiphertextCommitmentEquality,
+    PubkeyValidity,
 }
 
 pub trait ZkProofData<T: Pod> {

--- a/zk-sdk/src/elgamal_program/proof_data/mod.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/mod.rs
@@ -6,6 +6,7 @@ use {
 };
 
 pub mod ciphertext_ciphertext_equality;
+pub mod ciphertext_commitment_equality;
 pub mod errors;
 pub mod pod;
 pub mod zero_ciphertext;
@@ -17,6 +18,7 @@ pub enum ProofType {
     Uninitialized,
     ZeroCiphertext,
     CiphertextCiphertextEquality,
+    CiphertextCommitmentEquality,
 }
 
 pub trait ZkProofData<T: Pod> {

--- a/zk-sdk/src/elgamal_program/proof_data/mod.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/mod.rs
@@ -1,9 +1,11 @@
+#[cfg(not(target_os = "solana"))]
+use crate::elgamal_program::errors::ProofVerificationError;
 use {
-    crate::elgamal_program::errors::ProofVerificationError,
     bytemuck::Pod,
     num_derive::{FromPrimitive, ToPrimitive},
 };
 
+pub mod ciphertext_ciphertext_equality;
 pub mod errors;
 pub mod pod;
 pub mod zero_ciphertext;
@@ -14,6 +16,7 @@ pub enum ProofType {
     /// Empty proof type used to distinguish if a proof context account is initialized
     Uninitialized,
     ZeroCiphertext,
+    CiphertextCiphertextEquality,
 }
 
 pub trait ZkProofData<T: Pod> {

--- a/zk-sdk/src/elgamal_program/proof_data/mod.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/mod.rs
@@ -8,6 +8,7 @@ use {
 pub mod ciphertext_ciphertext_equality;
 pub mod ciphertext_commitment_equality;
 pub mod errors;
+pub mod percentage_with_cap;
 pub mod pod;
 pub mod pubkey;
 pub mod zero_ciphertext;
@@ -21,6 +22,7 @@ pub enum ProofType {
     CiphertextCiphertextEquality,
     CiphertextCommitmentEquality,
     PubkeyValidity,
+    PercentageWithCap,
 }
 
 pub trait ZkProofData<T: Pod> {

--- a/zk-sdk/src/elgamal_program/proof_data/percentage_with_cap.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/percentage_with_cap.rs
@@ -1,0 +1,217 @@
+//! The fee sigma proof instruction.
+//!
+//! A fee sigma proof certifies that a Pedersen commitment to a transfer fee for SPL Token 2022 is
+//! well-formed.
+//!
+//! A formal documentation of how transfer fees and fee sigma proof are computed can be found in
+//! the [`ZK Token proof`] program documentation.
+//!
+//! [`ZK Token proof`]: https://docs.solanalabs.com/runtime/zk-token-proof
+
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{
+        encryption::pedersen::{PedersenCommitment, PedersenOpening},
+        errors::{ProofGenerationError, ProofVerificationError},
+        sigma_proofs::fee_proof::FeeSigmaProof,
+        transcript::TranscriptProtocol,
+    },
+    merlin::Transcript,
+    std::convert::TryInto,
+};
+use {
+    crate::{
+        instruction::{ProofType, ZkProofData},
+        zk_token_elgamal::pod,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+
+/// The instruction data that is needed for the `ProofInstruction::VerifyFeeSigma` instruction.
+///
+/// It includes the cryptographic proof as well as the context data information needed to verify
+/// the proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct FeeSigmaProofData {
+    pub context: FeeSigmaProofContext,
+
+    pub proof: pod::FeeSigmaProof,
+}
+
+/// The context data needed to verify a pubkey validity proof.
+///
+/// We refer to [`ZK Token proof`] for the formal details on how the fee sigma proof is computed.
+///
+/// [`ZK Token proof`]: https://docs.solanalabs.com/runtime/zk-token-proof
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct FeeSigmaProofContext {
+    /// The Pedersen commitment to the transfer fee
+    pub fee_commitment: pod::PedersenCommitment,
+
+    /// The Pedersen commitment to the real delta fee.
+    pub delta_commitment: pod::PedersenCommitment,
+
+    /// The Pedersen commitment to the claimed delta fee.
+    pub claimed_commitment: pod::PedersenCommitment,
+
+    /// The maximum cap for a transfer fee
+    pub max_fee: pod::PodU64,
+}
+
+#[cfg(not(target_os = "solana"))]
+impl FeeSigmaProofData {
+    pub fn new(
+        fee_commitment: &PedersenCommitment,
+        delta_commitment: &PedersenCommitment,
+        claimed_commitment: &PedersenCommitment,
+        fee_opening: &PedersenOpening,
+        delta_opening: &PedersenOpening,
+        claimed_opening: &PedersenOpening,
+        fee_amount: u64,
+        delta_fee: u64,
+        max_fee: u64,
+    ) -> Result<Self, ProofGenerationError> {
+        let pod_fee_commitment = pod::PedersenCommitment(fee_commitment.to_bytes());
+        let pod_delta_commitment = pod::PedersenCommitment(delta_commitment.to_bytes());
+        let pod_claimed_commitment = pod::PedersenCommitment(claimed_commitment.to_bytes());
+        let pod_max_fee = max_fee.into();
+
+        let context = FeeSigmaProofContext {
+            fee_commitment: pod_fee_commitment,
+            delta_commitment: pod_delta_commitment,
+            claimed_commitment: pod_claimed_commitment,
+            max_fee: pod_max_fee,
+        };
+
+        let mut transcript = context.new_transcript();
+
+        let proof = FeeSigmaProof::new(
+            (fee_amount, fee_commitment, fee_opening),
+            (delta_fee, delta_commitment, delta_opening),
+            (claimed_commitment, claimed_opening),
+            max_fee,
+            &mut transcript,
+        )
+        .into();
+
+        Ok(Self { context, proof })
+    }
+}
+
+impl ZkProofData<FeeSigmaProofContext> for FeeSigmaProofData {
+    const PROOF_TYPE: ProofType = ProofType::FeeSigma;
+
+    fn context_data(&self) -> &FeeSigmaProofContext {
+        &self.context
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
+        let mut transcript = self.context.new_transcript();
+
+        let fee_commitment = self.context.fee_commitment.try_into()?;
+        let delta_commitment = self.context.delta_commitment.try_into()?;
+        let claimed_commitment = self.context.claimed_commitment.try_into()?;
+        let max_fee = self.context.max_fee.into();
+        let proof: FeeSigmaProof = self.proof.try_into()?;
+
+        proof
+            .verify(
+                &fee_commitment,
+                &delta_commitment,
+                &claimed_commitment,
+                max_fee,
+                &mut transcript,
+            )
+            .map_err(|e| e.into())
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl FeeSigmaProofContext {
+    fn new_transcript(&self) -> Transcript {
+        let mut transcript = Transcript::new(b"FeeSigmaProof");
+        transcript.append_commitment(b"fee-commitment", &self.fee_commitment);
+        transcript.append_commitment(b"delta-commitment", &self.fee_commitment);
+        transcript.append_commitment(b"claimed-commitment", &self.fee_commitment);
+        transcript.append_u64(b"max-fee", self.max_fee.into());
+        transcript
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {super::*, crate::encryption::pedersen::Pedersen, curve25519_dalek::scalar::Scalar};
+
+    #[test]
+    fn test_fee_sigma_instruction_correctness() {
+        // transfer fee amount is below max fee
+        let transfer_amount: u64 = 1;
+        let max_fee: u64 = 3;
+
+        let fee_rate: u16 = 400;
+        let fee_amount: u64 = 1;
+        let delta_fee: u64 = 9600;
+
+        let (transfer_commitment, transfer_opening) = Pedersen::new(transfer_amount);
+        let (fee_commitment, fee_opening) = Pedersen::new(fee_amount);
+
+        let scalar_rate = Scalar::from(fee_rate);
+        let delta_commitment =
+            &fee_commitment * Scalar::from(10_000_u64) - &transfer_commitment * &scalar_rate;
+        let delta_opening =
+            &fee_opening * &Scalar::from(10_000_u64) - &transfer_opening * &scalar_rate;
+
+        let (claimed_commitment, claimed_opening) = Pedersen::new(delta_fee);
+
+        let proof_data = FeeSigmaProofData::new(
+            &fee_commitment,
+            &delta_commitment,
+            &claimed_commitment,
+            &fee_opening,
+            &delta_opening,
+            &claimed_opening,
+            fee_amount,
+            delta_fee,
+            max_fee,
+        )
+        .unwrap();
+
+        assert!(proof_data.verify_proof().is_ok());
+
+        // transfer fee amount is equal to max fee
+        let transfer_amount: u64 = 55;
+        let max_fee: u64 = 3;
+
+        let fee_rate: u16 = 555;
+        let fee_amount: u64 = 4;
+
+        let (transfer_commitment, transfer_opening) = Pedersen::new(transfer_amount);
+        let (fee_commitment, fee_opening) = Pedersen::new(max_fee);
+
+        let scalar_rate = Scalar::from(fee_rate);
+        let delta_commitment =
+            &fee_commitment * &Scalar::from(10000_u64) - &transfer_commitment * &scalar_rate;
+        let delta_opening =
+            &fee_opening * &Scalar::from(10000_u64) - &transfer_opening * &scalar_rate;
+
+        let (claimed_commitment, claimed_opening) = Pedersen::new(0_u64);
+
+        let proof_data = FeeSigmaProofData::new(
+            &fee_commitment,
+            &delta_commitment,
+            &claimed_commitment,
+            &fee_opening,
+            &delta_opening,
+            &claimed_opening,
+            fee_amount,
+            delta_fee,
+            max_fee,
+        )
+        .unwrap();
+
+        assert!(proof_data.verify_proof().is_ok());
+    }
+}

--- a/zk-sdk/src/elgamal_program/proof_data/percentage_with_cap.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/percentage_with_cap.rs
@@ -1,97 +1,104 @@
-//! The fee sigma proof instruction.
+//! The percentage-with-cap proof instruction.
 //!
-//! A fee sigma proof certifies that a Pedersen commitment to a transfer fee for SPL Token 2022 is
-//! well-formed.
-//!
-//! A formal documentation of how transfer fees and fee sigma proof are computed can be found in
-//! the [`ZK Token proof`] program documentation.
-//!
-//! [`ZK Token proof`]: https://docs.solanalabs.com/runtime/zk-token-proof
+//! The percentage-with-cap proof is defined with respect to three Pedersen commitments that
+//! encodes values referred to as a `percentage`, `delta`, and `claimed` amounts. The proof
+//! certifies that either
+//! - the `percentage` amount is equal to a constant (referred to as the `max_value`)
+//! - the `delta` and `claimed` amounts are equal
 
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{
+        elgamal_program::errors::{ProofGenerationError, ProofVerificationError},
         encryption::pedersen::{PedersenCommitment, PedersenOpening},
-        errors::{ProofGenerationError, ProofVerificationError},
-        sigma_proofs::fee_proof::FeeSigmaProof,
-        transcript::TranscriptProtocol,
+        sigma_proofs::percentage_with_cap::PercentageWithCapProof,
     },
+    bytemuck::bytes_of,
     merlin::Transcript,
     std::convert::TryInto,
 };
 use {
     crate::{
-        instruction::{ProofType, ZkProofData},
-        zk_token_elgamal::pod,
+        elgamal_program::proof_data::{ProofType, ZkProofData},
+        encryption::pod::pedersen::PodPedersenCommitment,
+        pod::PodU64,
+        sigma_proofs::pod::PodPercentageWithCapProof,
     },
     bytemuck::{Pod, Zeroable},
 };
 
-/// The instruction data that is needed for the `ProofInstruction::VerifyFeeSigma` instruction.
+/// The instruction data that is needed for the `ProofInstruction::VerifyPercentageWithCap`
+/// instruction.
 ///
 /// It includes the cryptographic proof as well as the context data information needed to verify
 /// the proof.
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
-pub struct FeeSigmaProofData {
-    pub context: FeeSigmaProofContext,
+pub struct PercentageWithCapProofData {
+    pub context: PercentageWithCapProofContext,
 
-    pub proof: pod::FeeSigmaProof,
+    pub proof: PodPercentageWithCapProof,
 }
 
-/// The context data needed to verify a pubkey validity proof.
+/// The context data needed to verify a percentage-with-cap proof.
 ///
-/// We refer to [`ZK Token proof`] for the formal details on how the fee sigma proof is computed.
+/// We refer to [`ZK ElGamal proof`] for the formal details on how the percentage-with-cap proof is
+/// computed.
 ///
-/// [`ZK Token proof`]: https://docs.solanalabs.com/runtime/zk-token-proof
+/// [`ZK ElGamal proof`]: https://docs.solanalabs.com/runtime/zk-token-proof
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
-pub struct FeeSigmaProofContext {
-    /// The Pedersen commitment to the transfer fee
-    pub fee_commitment: pod::PedersenCommitment,
+pub struct PercentageWithCapProofContext {
+    /// The Pedersen commitment to the percentage amount.
+    pub percentage_commitment: PodPedersenCommitment,
 
-    /// The Pedersen commitment to the real delta fee.
-    pub delta_commitment: pod::PedersenCommitment,
+    /// The Pedersen commitment to the delta amount.
+    pub delta_commitment: PodPedersenCommitment,
 
-    /// The Pedersen commitment to the claimed delta fee.
-    pub claimed_commitment: pod::PedersenCommitment,
+    /// The Pedersen commitment to the claimed amount.
+    pub claimed_commitment: PodPedersenCommitment,
 
-    /// The maximum cap for a transfer fee
-    pub max_fee: pod::PodU64,
+    /// The maximum cap bound.
+    pub max_value: PodU64,
 }
 
 #[cfg(not(target_os = "solana"))]
-impl FeeSigmaProofData {
+impl PercentageWithCapProofData {
     pub fn new(
-        fee_commitment: &PedersenCommitment,
+        percentage_commitment: &PedersenCommitment,
+        percentage_opening: &PedersenOpening,
+        percentage_amount: u64,
         delta_commitment: &PedersenCommitment,
-        claimed_commitment: &PedersenCommitment,
-        fee_opening: &PedersenOpening,
         delta_opening: &PedersenOpening,
+        delta_amount: u64,
+        claimed_commitment: &PedersenCommitment,
         claimed_opening: &PedersenOpening,
-        fee_amount: u64,
-        delta_fee: u64,
-        max_fee: u64,
+        max_value: u64,
     ) -> Result<Self, ProofGenerationError> {
-        let pod_fee_commitment = pod::PedersenCommitment(fee_commitment.to_bytes());
-        let pod_delta_commitment = pod::PedersenCommitment(delta_commitment.to_bytes());
-        let pod_claimed_commitment = pod::PedersenCommitment(claimed_commitment.to_bytes());
-        let pod_max_fee = max_fee.into();
+        let pod_percentage_commitment = PodPedersenCommitment(percentage_commitment.to_bytes());
+        let pod_delta_commitment = PodPedersenCommitment(delta_commitment.to_bytes());
+        let pod_claimed_commitment = PodPedersenCommitment(claimed_commitment.to_bytes());
+        let pod_max_value = max_value.into();
 
-        let context = FeeSigmaProofContext {
-            fee_commitment: pod_fee_commitment,
+        let context = PercentageWithCapProofContext {
+            percentage_commitment: pod_percentage_commitment,
             delta_commitment: pod_delta_commitment,
             claimed_commitment: pod_claimed_commitment,
-            max_fee: pod_max_fee,
+            max_value: pod_max_value,
         };
 
         let mut transcript = context.new_transcript();
 
-        let proof = FeeSigmaProof::new(
-            (fee_amount, fee_commitment, fee_opening),
-            (delta_fee, delta_commitment, delta_opening),
-            (claimed_commitment, claimed_opening),
-            max_fee,
+        let proof = PercentageWithCapProof::new(
+            percentage_commitment,
+            percentage_opening,
+            percentage_amount,
+            delta_commitment,
+            delta_opening,
+            delta_amount,
+            claimed_commitment,
+            claimed_opening,
+            max_value,
             &mut transcript,
         )
         .into();
@@ -100,10 +107,10 @@ impl FeeSigmaProofData {
     }
 }
 
-impl ZkProofData<FeeSigmaProofContext> for FeeSigmaProofData {
-    const PROOF_TYPE: ProofType = ProofType::FeeSigma;
+impl ZkProofData<PercentageWithCapProofContext> for PercentageWithCapProofData {
+    const PROOF_TYPE: ProofType = ProofType::PercentageWithCap;
 
-    fn context_data(&self) -> &FeeSigmaProofContext {
+    fn context_data(&self) -> &PercentageWithCapProofContext {
         &self.context
     }
 
@@ -111,18 +118,18 @@ impl ZkProofData<FeeSigmaProofContext> for FeeSigmaProofData {
     fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let mut transcript = self.context.new_transcript();
 
-        let fee_commitment = self.context.fee_commitment.try_into()?;
+        let percentage_commitment = self.context.percentage_commitment.try_into()?;
         let delta_commitment = self.context.delta_commitment.try_into()?;
         let claimed_commitment = self.context.claimed_commitment.try_into()?;
-        let max_fee = self.context.max_fee.into();
-        let proof: FeeSigmaProof = self.proof.try_into()?;
+        let max_value = self.context.max_value.into();
+        let proof: PercentageWithCapProof = self.proof.try_into()?;
 
         proof
             .verify(
-                &fee_commitment,
+                &percentage_commitment,
                 &delta_commitment,
                 &claimed_commitment,
-                max_fee,
+                max_value,
                 &mut transcript,
             )
             .map_err(|e| e.into())
@@ -130,13 +137,16 @@ impl ZkProofData<FeeSigmaProofContext> for FeeSigmaProofData {
 }
 
 #[cfg(not(target_os = "solana"))]
-impl FeeSigmaProofContext {
+impl PercentageWithCapProofContext {
     fn new_transcript(&self) -> Transcript {
-        let mut transcript = Transcript::new(b"FeeSigmaProof");
-        transcript.append_commitment(b"fee-commitment", &self.fee_commitment);
-        transcript.append_commitment(b"delta-commitment", &self.fee_commitment);
-        transcript.append_commitment(b"claimed-commitment", &self.fee_commitment);
-        transcript.append_u64(b"max-fee", self.max_fee.into());
+        let mut transcript = Transcript::new(b"percentage-with-cap-instruction");
+        transcript.append_message(
+            b"percentage-commitment",
+            bytes_of(&self.percentage_commitment),
+        );
+        transcript.append_message(b"delta-commitment", bytes_of(&self.delta_commitment));
+        transcript.append_message(b"claimed-commitment", bytes_of(&self.claimed_commitment));
+        transcript.append_u64(b"max-value", self.max_value.into());
         transcript
     }
 }
@@ -146,69 +156,69 @@ mod test {
     use {super::*, crate::encryption::pedersen::Pedersen, curve25519_dalek::scalar::Scalar};
 
     #[test]
-    fn test_fee_sigma_instruction_correctness() {
-        // transfer fee amount is below max fee
-        let transfer_amount: u64 = 1;
-        let max_fee: u64 = 3;
+    fn test_percentage_with_cap_instruction_correctness() {
+        // base amount is below max value
+        let base_amount: u64 = 1;
+        let max_value: u64 = 3;
 
-        let fee_rate: u16 = 400;
-        let fee_amount: u64 = 1;
-        let delta_fee: u64 = 9600;
+        let percentage_rate: u16 = 400;
+        let percentage_amount: u64 = 1;
+        let delta_amount: u64 = 9600;
 
-        let (transfer_commitment, transfer_opening) = Pedersen::new(transfer_amount);
-        let (fee_commitment, fee_opening) = Pedersen::new(fee_amount);
+        let (base_commitment, base_opening) = Pedersen::new(base_amount);
+        let (percentage_commitment, percentage_opening) = Pedersen::new(percentage_amount);
 
-        let scalar_rate = Scalar::from(fee_rate);
+        let scalar_rate = Scalar::from(percentage_rate);
         let delta_commitment =
-            &fee_commitment * Scalar::from(10_000_u64) - &transfer_commitment * &scalar_rate;
+            &percentage_commitment * Scalar::from(10_000_u64) - &base_commitment * &scalar_rate;
         let delta_opening =
-            &fee_opening * &Scalar::from(10_000_u64) - &transfer_opening * &scalar_rate;
+            &percentage_opening * &Scalar::from(10_000_u64) - &base_opening * &scalar_rate;
 
-        let (claimed_commitment, claimed_opening) = Pedersen::new(delta_fee);
+        let (claimed_commitment, claimed_opening) = Pedersen::new(delta_amount);
 
-        let proof_data = FeeSigmaProofData::new(
-            &fee_commitment,
+        let proof_data = PercentageWithCapProofData::new(
+            &percentage_commitment,
+            &percentage_opening,
+            percentage_amount,
             &delta_commitment,
-            &claimed_commitment,
-            &fee_opening,
             &delta_opening,
+            delta_amount,
+            &claimed_commitment,
             &claimed_opening,
-            fee_amount,
-            delta_fee,
-            max_fee,
+            max_value,
         )
         .unwrap();
 
         assert!(proof_data.verify_proof().is_ok());
 
-        // transfer fee amount is equal to max fee
-        let transfer_amount: u64 = 55;
-        let max_fee: u64 = 3;
+        // base amount is equal to max value
+        let base_amount: u64 = 55;
+        let max_value: u64 = 3;
 
-        let fee_rate: u16 = 555;
-        let fee_amount: u64 = 4;
+        let percentage_rate: u16 = 555;
+        let percentage_amount: u64 = 4;
 
-        let (transfer_commitment, transfer_opening) = Pedersen::new(transfer_amount);
-        let (fee_commitment, fee_opening) = Pedersen::new(max_fee);
+        let (transfer_commitment, transfer_opening) = Pedersen::new(base_amount);
+        let (percentage_commitment, percentage_opening) = Pedersen::new(max_value);
 
-        let scalar_rate = Scalar::from(fee_rate);
+        let scalar_rate = Scalar::from(percentage_rate);
         let delta_commitment =
-            &fee_commitment * &Scalar::from(10000_u64) - &transfer_commitment * &scalar_rate;
+            &percentage_commitment * &Scalar::from(10000_u64) - &transfer_commitment * &scalar_rate;
         let delta_opening =
-            &fee_opening * &Scalar::from(10000_u64) - &transfer_opening * &scalar_rate;
+            &percentage_opening * &Scalar::from(10000_u64) - &transfer_opening * &scalar_rate;
 
         let (claimed_commitment, claimed_opening) = Pedersen::new(0_u64);
 
-        let proof_data = FeeSigmaProofData::new(
-            &fee_commitment,
+        let proof_data = PercentageWithCapProofData::new(
+            &percentage_commitment,
+            &percentage_opening,
+            percentage_amount,
             &delta_commitment,
-            &claimed_commitment,
-            &fee_opening,
             &delta_opening,
+            delta_amount,
+            &claimed_commitment,
             &claimed_opening,
-            fee_amount,
-            delta_fee,
-            max_fee,
+            max_value,
         )
         .unwrap();
 

--- a/zk-sdk/src/elgamal_program/proof_data/pubkey.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/pubkey.rs
@@ -1,0 +1,101 @@
+//! The public-key validity proof instruction.
+//!
+//! A public-key validity proof system is defined with respect to an ElGamal public key. The proof
+//! certifies that a given public key is a valid ElGamal public key (i.e. the prover knows a
+//! corresponding secret key). To generate the proof, a prover must provide the secret key for the
+//! public key.
+
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{
+        encryption::elgamal::ElGamalKeypair,
+        errors::{ProofGenerationError, ProofVerificationError},
+        sigma_proofs::pubkey_proof::PubkeyValidityProof,
+        transcript::TranscriptProtocol,
+    },
+    merlin::Transcript,
+    std::convert::TryInto,
+};
+use {
+    crate::{
+        instruction::{ProofType, ZkProofData},
+        zk_token_elgamal::pod,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+
+/// The instruction data that is needed for the `ProofInstruction::VerifyPubkeyValidity`
+/// instruction.
+///
+/// It includes the cryptographic proof as well as the context data information needed to verify
+/// the proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct PubkeyValidityData {
+    /// The context data for the public key validity proof
+    pub context: PubkeyValidityProofContext, // 32 bytes
+
+    /// Proof that the public key is well-formed
+    pub proof: pod::PubkeyValidityProof, // 64 bytes
+}
+
+/// The context data needed to verify a pubkey validity proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct PubkeyValidityProofContext {
+    /// The public key to be proved
+    pub pubkey: pod::ElGamalPubkey, // 32 bytes
+}
+
+#[cfg(not(target_os = "solana"))]
+impl PubkeyValidityData {
+    pub fn new(keypair: &ElGamalKeypair) -> Result<Self, ProofGenerationError> {
+        let pod_pubkey = pod::ElGamalPubkey(keypair.pubkey().into());
+
+        let context = PubkeyValidityProofContext { pubkey: pod_pubkey };
+
+        let mut transcript = context.new_transcript();
+        let proof = PubkeyValidityProof::new(keypair, &mut transcript).into();
+
+        Ok(PubkeyValidityData { context, proof })
+    }
+}
+
+impl ZkProofData<PubkeyValidityProofContext> for PubkeyValidityData {
+    const PROOF_TYPE: ProofType = ProofType::PubkeyValidity;
+
+    fn context_data(&self) -> &PubkeyValidityProofContext {
+        &self.context
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
+        let mut transcript = self.context.new_transcript();
+        let pubkey = self.context.pubkey.try_into()?;
+        let proof: PubkeyValidityProof = self.proof.try_into()?;
+        proof.verify(&pubkey, &mut transcript).map_err(|e| e.into())
+    }
+}
+
+#[allow(non_snake_case)]
+#[cfg(not(target_os = "solana"))]
+impl PubkeyValidityProofContext {
+    fn new_transcript(&self) -> Transcript {
+        let mut transcript = Transcript::new(b"PubkeyProof");
+        transcript.append_pubkey(b"pubkey", &self.pubkey);
+        transcript
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_pubkey_validity_instruction_correctness() {
+        let keypair = ElGamalKeypair::new_rand();
+
+        let pubkey_validity_data = PubkeyValidityData::new(&keypair).unwrap();
+        assert!(pubkey_validity_data.verify_proof().is_ok());
+    }
+}

--- a/zk-sdk/src/elgamal_program/proof_data/zero_ciphertext.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/zero_ciphertext.rs
@@ -4,25 +4,24 @@
 //! certifies that a given ciphertext encrypts the message 0 in the field (`Scalar::zero()`). To
 //! generate the proof, a prover must provide the decryption key for the ciphertext.
 
-use {
-    crate::{
-        elgamal_program::{
-            errors::{ProofGenerationError, ProofVerificationError},
-            proof_data::{ProofType, ZkProofData},
-        },
-        encryption::pod::elgamal::{PodElGamalCiphertext, PodElGamalPubkey},
-        sigma_proofs::pod::PodZeroCiphertextProof,
-    },
-    bytemuck::{bytes_of, Pod, Zeroable},
-};
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{
+        elgamal_program::errors::{ProofGenerationError, ProofVerificationError},
         encryption::elgamal::{ElGamalCiphertext, ElGamalKeypair},
         sigma_proofs::zero_ciphertext::ZeroCiphertextProof,
     },
+    bytemuck::bytes_of,
     merlin::Transcript,
     std::convert::TryInto,
+};
+use {
+    crate::{
+        elgamal_program::proof_data::{ProofType, ZkProofData},
+        encryption::pod::elgamal::{PodElGamalCiphertext, PodElGamalPubkey},
+        sigma_proofs::pod::PodZeroCiphertextProof,
+    },
+    bytemuck::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the `ProofInstruction::ZeroCiphertext` instruction.


### PR DESCRIPTION
#### Problem
The equality, pubkey validity, and percentage-with-cap proof instruction data have yet to be added to the new elgamal proof program.

#### Summary of Changes
Added the instructions listed above. I think the commits should be pretty straightforward. The main difference should be updating `FeeSigmaProof...` to `PercentageWithCapProof...`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
