### PR TITLE
accounts-db/read-cache: don't populate read cache for withdraw, deposit, fee_distribution and store_capital update

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5206,7 +5206,7 @@ impl Bank {
     fn load_account_with(
         &self,
         pubkey: &Pubkey,
-        callback: impl for<'a> Fn(&'a AccountSharedData) -> bool,
+        callback: impl for<'local> Fn(&'local AccountSharedData) -> bool,
     ) -> Option<(AccountSharedData, Slot)> {
         self.rc
             .accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5027,7 +5027,7 @@ impl Bank {
         new_account: &AccountSharedData,
     ) {
         let old_account_data_size =
-            if let Some(old_account) = self.get_account_with_fixed_root(pubkey) {
+            if let Some(old_account) = self.get_account_with_fixed_root_no_cache(pubkey) {
                 match new_account.lamports().cmp(&old_account.lamports()) {
                     std::cmp::Ordering::Greater => {
                         let increased = new_account.lamports() - old_account.lamports();
@@ -5069,7 +5069,7 @@ impl Bank {
     }
 
     fn withdraw(&self, pubkey: &Pubkey, lamports: u64) -> Result<()> {
-        match self.get_account_with_fixed_root(pubkey) {
+        match self.get_account_with_fixed_root_no_cache(pubkey) {
             Some(mut account) => {
                 let min_balance = match get_system_account_kind(&account) {
                     Some(SystemAccountKind::Nonce) => self
@@ -5193,6 +5193,25 @@ impl Bank {
                 .unwrap()
                 .register(new_hard_fork_slot);
         }
+    }
+
+    pub fn get_account_with_fixed_root_no_cache(
+        &self,
+        pubkey: &Pubkey,
+    ) -> Option<AccountSharedData> {
+        self.load_account_with(pubkey, |_| false)
+            .map(|(acc, _slot)| acc)
+    }
+
+    fn load_account_with(
+        &self,
+        pubkey: &Pubkey,
+        callback: impl for<'a> Fn(&'a AccountSharedData) -> bool,
+    ) -> Option<(AccountSharedData, Slot)> {
+        self.rc
+            .accounts
+            .accounts_db
+            .load_account_with(&self.ancestors, pubkey, callback)
     }
 
     // Hi! leaky abstraction here....
@@ -7307,7 +7326,9 @@ pub mod test_utils {
     ) -> std::result::Result<u64, LamportsError> {
         // This doesn't collect rents intentionally.
         // Rents should only be applied to actual TXes
-        let mut account = bank.get_account_with_fixed_root(pubkey).unwrap_or_default();
+        let mut account = bank
+            .get_account_with_fixed_root_no_cache(pubkey)
+            .unwrap_or_default();
         account.checked_add_lamports(lamports)?;
         bank.store_account(pubkey, &account);
         Ok(account.lamports())

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -168,7 +168,9 @@ impl Bank {
         fees: u64,
         options: DepositFeeOptions,
     ) -> Result<u64, DepositFeeError> {
-        let mut account = self.get_account_with_fixed_root(pubkey).unwrap_or_default();
+        let mut account = self
+            .get_account_with_fixed_root_no_cache(pubkey)
+            .unwrap_or_default();
 
         if options.check_account_owner && !system_program::check_id(account.owner()) {
             return Err(DepositFeeError::InvalidAccountOwner);


### PR DESCRIPTION
#### Problem

When performing withdraw, deposit, fee_distribution, and store_capital_update, we do load, update and store. We put the old account into read cache after loading. This is not needed and can lead to inefficient use of read cache. 


#### Summary of Changes

- expose `load_with` API from accounts-db to bank
- create a helper method `get_account_with_fixed_root_no_cache`
- use `get_account_with_fixed_root_no_cache` to avoid putting stale account
  into read cache.

#### Performance comparison

![image](https://github.com/anza-xyz/agave/assets/219428/eb480a54-40de-43e9-8728-a5c49f5d778d)

blue: base 
red: this PR

It shows better `load_us` and `prog_cache_us`. `prog_cache_us` includes filtering which load accounts and checks owners. Both of this operations benefits from more efficient use of read-only caches.  



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
