### PR TITLE
Adhoc concurrent test for program cache

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -452,10 +452,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 // Once a task completes we'll wake up and try to load the
                 // missing programs inside the tx batch again.
                 let _new_cookie = task_waiter.wait(task_cookie);
-
-                // This branch is not tested in the SVM because it requires concurrent threads.
-                // In addition, one of them must be holding the mutex while the other must be
-                // trying to lock it.
             }
         }
 
@@ -753,6 +749,7 @@ mod tests {
         solana_sdk::{
             account::{create_account_shared_data_for_test, WritableAccount},
             bpf_loader,
+            bpf_loader_upgradeable::{self, UpgradeableLoaderState},
             feature_set::FeatureSet,
             fee_calculator::FeeCalculator,
             hash::Hash,
@@ -764,6 +761,12 @@ mod tests {
             sysvar::{self, rent::Rent},
             transaction::{SanitizedTransaction, Transaction, TransactionError},
             transaction_context::TransactionContext,
+        },
+        std::{
+            env,
+            fs::{self, File},
+            io::Read,
+            thread,
         },
     };
 
@@ -786,12 +789,12 @@ mod tests {
     pub struct MockBankCallback {
         rent_collector: RentCollector,
         feature_set: Arc<FeatureSet>,
-        pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
+        pub account_shared_data: Arc<RwLock<HashMap<Pubkey, AccountSharedData>>>,
     }
 
     impl TransactionProcessingCallback for MockBankCallback {
         fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {
-            if let Some(data) = self.account_shared_data.borrow().get(account) {
+            if let Some(data) = self.account_shared_data.read().unwrap().get(account) {
                 if data.lamports() == 0 {
                     None
                 } else {
@@ -803,7 +806,11 @@ mod tests {
         }
 
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
-            self.account_shared_data.borrow().get(pubkey).cloned()
+            self.account_shared_data
+                .read()
+                .unwrap()
+                .get(pubkey)
+                .cloned()
         }
 
         fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64) {
@@ -822,7 +829,8 @@ mod tests {
             let mut account_data = AccountSharedData::default();
             account_data.set_data(name.as_bytes().to_vec());
             self.account_shared_data
-                .borrow_mut()
+                .write()
+                .unwrap()
                 .insert(*program_id, account_data);
         }
     }
@@ -1084,7 +1092,8 @@ mod tests {
         account_data.set_owner(bpf_loader::id());
         mock_bank
             .account_shared_data
-            .borrow_mut()
+            .write()
+            .unwrap()
             .insert(key, account_data);
 
         let mut account_maps: HashMap<Pubkey, u64> = HashMap::new();
@@ -1116,7 +1125,8 @@ mod tests {
         data.set_lamports(93);
         mock_bank
             .account_shared_data
-            .borrow_mut()
+            .write()
+            .unwrap()
             .insert(key1, data);
 
         let message = Message {
@@ -1146,7 +1156,8 @@ mod tests {
         account_data.set_lamports(90);
         mock_bank
             .account_shared_data
-            .borrow_mut()
+            .write()
+            .unwrap()
             .insert(key2, account_data);
 
         let message = Message {
@@ -1215,35 +1226,35 @@ mod tests {
         let account5_pubkey = Pubkey::new_unique();
 
         let bank = MockBankCallback::default();
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             non_program_pubkey1,
             AccountSharedData::new(1, 10, &account5_pubkey),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             non_program_pubkey2,
             AccountSharedData::new(1, 10, &account5_pubkey),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             program1_pubkey,
             AccountSharedData::new(40, 1, &account5_pubkey),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             program2_pubkey,
             AccountSharedData::new(40, 1, &account5_pubkey),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             account1_pubkey,
             AccountSharedData::new(1, 10, &non_program_pubkey1),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             account2_pubkey,
             AccountSharedData::new(1, 10, &non_program_pubkey2),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             account3_pubkey,
             AccountSharedData::new(40, 1, &program1_pubkey),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             account4_pubkey,
             AccountSharedData::new(40, 1, &program2_pubkey),
         );
@@ -1308,35 +1319,35 @@ mod tests {
         let account5_pubkey = Pubkey::new_unique();
 
         let bank = MockBankCallback::default();
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             non_program_pubkey1,
             AccountSharedData::new(1, 10, &account5_pubkey),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             non_program_pubkey2,
             AccountSharedData::new(1, 10, &account5_pubkey),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             program1_pubkey,
             AccountSharedData::new(40, 1, &account5_pubkey),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             program2_pubkey,
             AccountSharedData::new(40, 1, &account5_pubkey),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             account1_pubkey,
             AccountSharedData::new(1, 10, &non_program_pubkey1),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             account2_pubkey,
             AccountSharedData::new(1, 10, &non_program_pubkey2),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             account3_pubkey,
             AccountSharedData::new(40, 1, &program1_pubkey),
         );
-        bank.account_shared_data.borrow_mut().insert(
+        bank.account_shared_data.write().unwrap().insert(
             account4_pubkey,
             AccountSharedData::new(40, 1, &program2_pubkey),
         );
@@ -1396,14 +1407,16 @@ mod tests {
         let clock_account = create_account_shared_data_for_test(&clock);
         mock_bank
             .account_shared_data
-            .borrow_mut()
+            .write()
+            .unwrap()
             .insert(sysvar::clock::id(), clock_account);
 
         let epoch_schedule = EpochSchedule::custom(64, 2, true);
         let epoch_schedule_account = create_account_shared_data_for_test(&epoch_schedule);
         mock_bank
             .account_shared_data
-            .borrow_mut()
+            .write()
+            .unwrap()
             .insert(sysvar::epoch_schedule::id(), epoch_schedule_account);
 
         let fees = sysvar::fees::Fees {
@@ -1414,14 +1427,16 @@ mod tests {
         let fees_account = create_account_shared_data_for_test(&fees);
         mock_bank
             .account_shared_data
-            .borrow_mut()
+            .write()
+            .unwrap()
             .insert(sysvar::fees::id(), fees_account);
 
         let rent = Rent::with_slots_per_epoch(2048);
         let rent_account = create_account_shared_data_for_test(&rent);
         mock_bank
             .account_shared_data
-            .borrow_mut()
+            .write()
+            .unwrap()
             .insert(sysvar::rent::id(), rent_account);
 
         let transaction_processor = TransactionBatchProcessor::<TestForkGraph>::default();
@@ -1468,14 +1483,16 @@ mod tests {
         let clock_account = create_account_shared_data_for_test(&clock);
         mock_bank
             .account_shared_data
-            .borrow_mut()
+            .write()
+            .unwrap()
             .insert(sysvar::clock::id(), clock_account);
 
         let epoch_schedule = EpochSchedule::custom(64, 2, true);
         let epoch_schedule_account = create_account_shared_data_for_test(&epoch_schedule);
         mock_bank
             .account_shared_data
-            .borrow_mut()
+            .write()
+            .unwrap()
             .insert(sysvar::epoch_schedule::id(), epoch_schedule_account);
 
         let fees = sysvar::fees::Fees {
@@ -1486,14 +1503,16 @@ mod tests {
         let fees_account = create_account_shared_data_for_test(&fees);
         mock_bank
             .account_shared_data
-            .borrow_mut()
+            .write()
+            .unwrap()
             .insert(sysvar::fees::id(), fees_account);
 
         let rent = Rent::with_slots_per_epoch(2048);
         let rent_account = create_account_shared_data_for_test(&rent);
         mock_bank
             .account_shared_data
-            .borrow_mut()
+            .write()
+            .unwrap()
             .insert(sysvar::rent::id(), rent_account);
 
         let transaction_processor = TransactionBatchProcessor::<TestForkGraph>::default();
@@ -1560,7 +1579,7 @@ mod tests {
         batch_processor.add_builtin(&mock_bank, key, name, program);
 
         assert_eq!(
-            mock_bank.account_shared_data.borrow()[&key].data(),
+            mock_bank.account_shared_data.read().unwrap()[&key].data(),
             name.as_bytes()
         );
 
@@ -1583,5 +1602,129 @@ mod tests {
             |_invoke_context, _param0, _param1, _param2, _param3, _param4| {},
         );
         assert_eq!(entry, Arc::new(program));
+    }
+
+    #[test]
+    fn fast_concur_test() {
+        let mut mock_bank = MockBankCallback::default();
+        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::new(
+            5,
+            5,
+            EpochSchedule::default(),
+            Arc::new(RuntimeConfig::default()),
+            Arc::new(RwLock::new(ProgramCache::new(0, 0))),
+            HashSet::new(),
+        );
+        batch_processor.program_cache.write().unwrap().fork_graph =
+            Some(Arc::new(RwLock::new(TestForkGraph {})));
+
+        let hello_program = deploy_program("hello-solana".to_string(), &mut mock_bank);
+        let transfer_program = deploy_program("simple-transfer".to_string(), &mut mock_bank);
+        let clock_program = deploy_program("clock-sysvar".to_string(), &mut mock_bank);
+
+        let mut account_maps: HashMap<Pubkey, u64> = HashMap::new();
+        account_maps.insert(clock_program, 2);
+        account_maps.insert(transfer_program, 1);
+        account_maps.insert(hello_program, 0);
+
+        for _ in 0..10 {
+            let ths: Vec<_> = (0..4)
+                .map(|_| {
+                    let local_bank = mock_bank.clone();
+                    let processor = TransactionBatchProcessor::new(
+                        batch_processor.slot,
+                        batch_processor.epoch,
+                        batch_processor.epoch_schedule.clone(),
+                        batch_processor.runtime_config.clone(),
+                        batch_processor.program_cache.clone(),
+                        HashSet::new(),
+                    );
+                    let maps = account_maps.clone();
+                    thread::spawn(move || {
+                        let result = processor.replenish_program_cache(&local_bank, &maps, true);
+                        let clock = result.find(&clock_program);
+                        assert!(matches!(
+                            clock.unwrap().program,
+                            ProgramCacheEntryType::Loaded(_)
+                        ));
+                        let transfer = result.find(&transfer_program);
+                        assert!(matches!(
+                            transfer.unwrap().program,
+                            ProgramCacheEntryType::Loaded(_)
+                        ));
+                        let hello = result.find(&transfer_program);
+                        assert!(matches!(
+                            hello.unwrap().program,
+                            ProgramCacheEntryType::Loaded(_)
+                        ));
+                        let entries = processor
+                            .program_cache
+                            .read()
+                            .unwrap()
+                            .get_flattened_entries(true, true);
+                        assert_eq!(entries.len(), 3);
+                    })
+                })
+                .collect();
+
+            for th in ths {
+                th.join().unwrap();
+            }
+        }
+    }
+
+    fn deploy_program(name: String, mock_bank: &mut MockBankCallback) -> Pubkey {
+        let program_account = Pubkey::new_unique();
+        let program_data_account = Pubkey::new_unique();
+        let state = UpgradeableLoaderState::Program {
+            programdata_address: program_data_account,
+        };
+
+        // The program account must have funds and hold the executable binary
+        let mut account_data = AccountSharedData::default();
+        account_data.set_data(bincode::serialize(&state).unwrap());
+        account_data.set_lamports(25);
+        account_data.set_owner(bpf_loader_upgradeable::id());
+        mock_bank
+            .account_shared_data
+            .write()
+            .unwrap()
+            .insert(program_account, account_data);
+
+        let mut account_data = AccountSharedData::default();
+        let state = UpgradeableLoaderState::ProgramData {
+            slot: 0,
+            upgrade_authority_address: None,
+        };
+        let mut header = bincode::serialize(&state).unwrap();
+        let mut complement = vec![
+            0;
+            std::cmp::max(
+                0,
+                UpgradeableLoaderState::size_of_programdata_metadata().saturating_sub(header.len())
+            )
+        ];
+
+        let mut dir = env::current_dir().unwrap();
+        dir.push("tests");
+        dir.push("example-programs");
+        dir.push(name.as_str());
+        let name = name.replace('-', "_");
+        dir.push(name + "_program.so");
+        let mut file = File::open(dir.clone()).expect("file not found");
+        let metadata = fs::metadata(dir).expect("Unable to read metadata");
+        let mut buffer = vec![0; metadata.len() as usize];
+        file.read_exact(&mut buffer).expect("Buffer overflow");
+
+        header.append(&mut complement);
+        header.append(&mut buffer);
+        account_data.set_data(header);
+        mock_bank
+            .account_shared_data
+            .write()
+            .unwrap()
+            .insert(program_data_account, account_data);
+
+        program_account
     }
 }


### PR DESCRIPTION
#### Problem

There are no concurrent tests for the program cache. We cover most lines in our testing, but the line that stops a thread on a condition variable has no testing coverage.

I noticed that this is the only place where there is an explicit wait/notify condition. In all other places in the program cache, we use mutexes and RWLocks, which are already covered in basic unit tests. Adding concurrent tests for them would only mean covering their blocking functionality.

#### Summary of Changes

I included an impromptu test to cover the cookie line in `replenish_program_cache`. The test is adhoc and is only a stop gap until I configure the repository to receive [shuttle](https://github.com/awslabs/shuttle), which provides with mechanisms to manipulate thread scheduling and ensure correct multithreaded tests.
