### PR TITLE
Reduce to single blockstore inserter thread in BroadcastStage

### DIFF
--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -279,7 +279,7 @@ impl BroadcastStage {
         blockstore: Arc<Blockstore>,
         bank_forks: Arc<RwLock<BankForks>>,
         quic_endpoint_sender: AsyncSender<(SocketAddr, Bytes)>,
-        broadcast_stage_run: impl BroadcastRun + Send + 'static + Clone,
+        mut broadcast_stage_run: impl BroadcastRun + Send + 'static + Clone,
     ) -> Self {
         let (socket_sender, socket_receiver) = unbounded();
         let (blockstore_sender, blockstore_receiver) = unbounded();
@@ -333,11 +333,9 @@ impl BroadcastStage {
         // Blockstore::insert_threads() obtains and holds a write lock for the entire function.
         // Until this changes, only a single inserter thread is necessary.
         thread_hdls.push({
-            let blockstore_receiver = blockstore_receiver.clone();
-            let mut bs_record = broadcast_stage_run.clone();
-            let btree = blockstore.clone();
+            let blockstore = blockstore.clone();
             let run_record = move || loop {
-                let res = bs_record.record(&blockstore_receiver, &btree);
+                let res = broadcast_stage_run.record(&blockstore_receiver, &blockstore);
                 let res = Self::handle_error(res, "solana-broadcaster-record");
                 if let Some(res) = res {
                     return res;

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -33,7 +33,6 @@ use {
     },
     std::{
         collections::{HashMap, HashSet},
-        iter::repeat_with,
         net::{SocketAddr, UdpSocket},
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -56,9 +55,6 @@ mod standard_broadcast_run;
 const CLUSTER_NODES_CACHE_NUM_EPOCH_CAP: usize = 8;
 const CLUSTER_NODES_CACHE_TTL: Duration = Duration::from_secs(5);
 
-// Blockstore::insert_threads() obtains and holds a write lock for the entire function. Until
-// this changes, there is no point in having more than one blockstore inserter thread.
-pub(crate) const NUM_INSERT_THREADS: usize = 1;
 pub(crate) type RecordReceiver = Receiver<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>;
 pub(crate) type TransmitReceiver = Receiver<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>;
 
@@ -333,25 +329,26 @@ impl BroadcastStage {
                 .spawn(run_transmit)
                 .unwrap()
         }));
-        thread_hdls.extend(
-            repeat_with(|| {
-                let blockstore_receiver = blockstore_receiver.clone();
-                let mut bs_record = broadcast_stage_run.clone();
-                let btree = blockstore.clone();
-                let run_record = move || loop {
-                    let res = bs_record.record(&blockstore_receiver, &btree);
-                    let res = Self::handle_error(res, "solana-broadcaster-record");
-                    if let Some(res) = res {
-                        return res;
-                    }
-                };
-                Builder::new()
-                    .name("solBroadcastRec".to_string())
-                    .spawn(run_record)
-                    .unwrap()
-            })
-            .take(NUM_INSERT_THREADS),
-        );
+
+        // Blockstore::insert_threads() obtains and holds a write lock for the entire function.
+        // Until this changes, only a single inserter thread is necessary.
+        thread_hdls.push({
+            let blockstore_receiver = blockstore_receiver.clone();
+            let mut bs_record = broadcast_stage_run.clone();
+            let btree = blockstore.clone();
+            let run_record = move || loop {
+                let res = bs_record.record(&blockstore_receiver, &btree);
+                let res = Self::handle_error(res, "solana-broadcaster-record");
+                if let Some(res) = res {
+                    return res;
+                }
+            };
+            Builder::new()
+                .name("solBroadcastRec".to_string())
+                .spawn(run_record)
+                .unwrap()
+        });
+
         let retransmit_thread = Builder::new()
             .name("solBroadcastRtx".to_string())
             .spawn(move || loop {

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -56,7 +56,9 @@ mod standard_broadcast_run;
 const CLUSTER_NODES_CACHE_NUM_EPOCH_CAP: usize = 8;
 const CLUSTER_NODES_CACHE_TTL: Duration = Duration::from_secs(5);
 
-pub(crate) const NUM_INSERT_THREADS: usize = 2;
+// Blockstore::insert_threads() obtains and holds a write lock for the entire function. Until
+// this changes, there is no point in having more than one blockstore inserter thread.
+pub(crate) const NUM_INSERT_THREADS: usize = 1;
 pub(crate) type RecordReceiver = Receiver<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>;
 pub(crate) type TransmitReceiver = Receiver<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>;
 


### PR DESCRIPTION
#### Problem
The implementation of Blockstore::insert_shreds() holds a write lock for the entirety of the function. Thus, there is no point in having more than one thread in BroadcastStage insert shreds. Namely, this lock:
https://github.com/anza-xyz/agave/blob/1eaa5cf1aa8a8713db9ea76c4c99fb37c71cd89c/ledger/src/blockstore.rs#L941

#### Summary of Changes
Reduce the constant to have **one** thread instead of **two**

Kudos to the Firedancer team (not sure who exactly first observed this) for bringing this to our attention