### PR TITLE
Disable RpcCompletedSlotsService when unused

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -54,8 +54,8 @@ use {
     solana_ledger::{
         bank_forks_utils,
         blockstore::{
-            Blockstore, BlockstoreError, CompletedSlotsReceiver, PurgeType,
-            MAX_COMPLETED_SLOTS_IN_CHANNEL, MAX_REPLAY_WAKE_UP_SIGNALS,
+            Blockstore, BlockstoreError, PurgeType, MAX_COMPLETED_SLOTS_IN_CHANNEL,
+            MAX_REPLAY_WAKE_UP_SIGNALS,
         },
         blockstore_metric_report_service::BlockstoreMetricReportService,
         blockstore_options::{BlockstoreOptions, BlockstoreRecoveryMode, LedgerColumnOptions},
@@ -702,7 +702,6 @@ impl Validator {
             blockstore,
             original_blockstore_root,
             ledger_signal_receiver,
-            completed_slots_receiver,
             leader_schedule_cache,
             starting_snapshot_hashes,
             TransactionHistoryServices {
@@ -982,6 +981,7 @@ impl Validator {
             pubsub_service,
             completed_data_sets_sender,
             completed_data_sets_service,
+            rpc_completed_slots_service,
             optimistically_confirmed_bank_tracker,
             bank_notification_sender,
         ) = if let Some((rpc_addr, rpc_pubsub_addr)) = config.rpc_addrs {
@@ -1063,6 +1063,20 @@ impl Validator {
                     )
                 };
 
+            let rpc_completed_slots_service = if !config.rpc_config.full_api {
+                None
+            } else {
+                let (completed_slots_sender, completed_slots_receiver) =
+                    bounded(MAX_COMPLETED_SLOTS_IN_CHANNEL);
+                blockstore.add_completed_slots_signal(completed_slots_sender);
+
+                Some(RpcCompletedSlotsService::spawn(
+                    completed_slots_receiver,
+                    rpc_subscriptions.clone(),
+                    exit.clone(),
+                ))
+            };
+
             let optimistically_confirmed_bank_tracker =
                 Some(OptimisticallyConfirmedBankTracker::new(
                     bank_notification_receiver,
@@ -1082,11 +1096,12 @@ impl Validator {
                 pubsub_service,
                 completed_data_sets_sender,
                 completed_data_sets_service,
+                rpc_completed_slots_service,
                 optimistically_confirmed_bank_tracker,
                 bank_notification_sender_config,
             )
         } else {
-            (None, None, None, None, None, None)
+            (None, None, None, None, None, None, None)
         };
 
         if config.halt_at_slot.is_some() {
@@ -1181,12 +1196,6 @@ impl Validator {
         let (verified_vote_sender, verified_vote_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = unbounded();
         let (duplicate_confirmed_slot_sender, duplicate_confirmed_slots_receiver) = unbounded();
-
-        let rpc_completed_slots_service = Some(RpcCompletedSlotsService::spawn(
-            completed_slots_receiver,
-            rpc_subscriptions.clone(),
-            exit.clone(),
-        ));
 
         let (banking_tracer, tracer_thread) =
             BankingTracer::new((config.banking_trace_dir_byte_limit > 0).then_some((
@@ -1810,7 +1819,6 @@ fn load_blockstore(
         Arc<Blockstore>,
         Slot,
         Receiver<bool>,
-        CompletedSlotsReceiver,
         LeaderScheduleCache,
         Option<StartingSnapshotHashes>,
         TransactionHistoryServices,
@@ -1854,10 +1862,6 @@ fn load_blockstore(
 
     let (ledger_signal_sender, ledger_signal_receiver) = bounded(MAX_REPLAY_WAKE_UP_SIGNALS);
     blockstore.add_new_shred_signal(ledger_signal_sender);
-
-    let (completed_slots_sender, completed_slots_receiver) =
-        bounded(MAX_COMPLETED_SLOTS_IN_CHANNEL);
-    blockstore.add_completed_slots_signal(completed_slots_sender);
 
     blockstore.shred_timing_point_sender = poh_timing_point_sender;
     // following boot sequence (esp BankForks) could set root. so stash the original value
@@ -1944,7 +1948,6 @@ fn load_blockstore(
         blockstore,
         original_blockstore_root,
         ledger_signal_receiver,
-        completed_slots_receiver,
         leader_schedule_cache,
         starting_snapshot_hashes,
         transaction_history_services,


### PR DESCRIPTION
#### Problem
The `RpcCompletedSlotsService` service is a helper for RPC pub sub. Namely, this service:
1. Receives slots that have been completed from `Blockstore`
2. Reads the slots sent from `Blockstore` and translates to an RPC pub sub type

Overall, this service isn't too expensive. But, we can still disable if we know nothing on the other side will be receiving

#### Summary of Changes
Adjust `RpcCompletedSlotsService` to only be created if `--full-rpc-api` is passed in.

Subsequent cleanup will make it such that we only enable this service (and `CompletedDataSetsService`) if `--full-rpc-api` is passed AND pub sub is explicitly enabled.

Ran a quick sanity check with and without RPC flags and ensured the service is running (thread is present) when it should be