### PR TITLE
SVM: Group transaction processing configs

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -174,6 +174,7 @@ use {
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processor::{
             ExecutionRecordingConfig, TransactionBatchProcessor, TransactionLogMessages,
+            TransactionProcessingConfig,
         },
         transaction_results::{
             TransactionExecutionDetails, TransactionExecutionResult, TransactionResults,
@@ -3674,6 +3675,13 @@ impl Bank {
         debug!("check: {}us", check_time.as_us());
         timings.saturating_add_in_place(ExecuteTimingType::CheckUs, check_time.as_us());
 
+        let processing_config = TransactionProcessingConfig {
+            account_overrides,
+            limit_to_load_programs,
+            log_messages_bytes_limit,
+            recording_config,
+        };
+
         let sanitized_output = self
             .transaction_processor
             .load_and_execute_sanitized_transactions(
@@ -3681,11 +3689,8 @@ impl Bank {
                 sanitized_txs,
                 &mut check_results,
                 &mut error_counters,
-                recording_config,
                 timings,
-                account_overrides,
-                log_messages_bytes_limit,
-                limit_to_load_programs,
+                &processing_config,
             );
 
         let mut signature_count = 0;

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -35,7 +35,9 @@ use {
         runtime_config::RuntimeConfig,
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_processing_callback::TransactionProcessingCallback,
-        transaction_processor::{ExecutionRecordingConfig, TransactionBatchProcessor},
+        transaction_processor::{
+            ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingConfig,
+        },
         transaction_results::TransactionExecutionResult,
     },
     std::{
@@ -459,10 +461,13 @@ fn svm_integration() {
     register_builtins(&mock_bank, &batch_processor);
 
     let mut error_counter = TransactionErrorMetrics::default();
-    let recording_config = ExecutionRecordingConfig {
-        enable_log_recording: true,
-        enable_return_data_recording: true,
-        enable_cpi_recording: false,
+    let processing_config = TransactionProcessingConfig {
+        recording_config: ExecutionRecordingConfig {
+            enable_log_recording: true,
+            enable_return_data_recording: true,
+            enable_cpi_recording: false,
+        },
+        ..Default::default()
     };
     let mut timings = ExecuteTimings::default();
 
@@ -471,11 +476,8 @@ fn svm_integration() {
         &transactions,
         check_results.as_mut_slice(),
         &mut error_counter,
-        recording_config,
         &mut timings,
-        None,
-        None,
-        false,
+        &processing_config,
     );
 
     assert_eq!(result.execution_results.len(), 5);


### PR DESCRIPTION
#### Problem
The SVM's transaction processing functions - `load_and_execute_sanitized_transactions`
and `execute_loaded_transaction` - are quickly becoming overloaded with inputs.

Since many of these inputs are optional configurations to customize transaction
processing behavior, it makes sense to group these together, in a type that implements
`Default`, and require only a reference to said type to process transactions.

This would make integrating the transaction processor's API with a set of configs much
more idiomatic.

#### Summary of Changes
Group all optional configurations for processing transactions into a new configuration
object: `TransactionProcessingConfig` and require a reference to this object in the
SVM API.

Adiós `#[allow(clippy::too_many_arguments)]`!
