### PR TITLE
refactor: `Bank::check_transaction_for_nonce`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -168,7 +168,7 @@ use {
             CheckedTransactionDetails, TransactionCheckResult, TransactionLoadResult,
         },
         account_overrides::AccountOverrides,
-        nonce_info::{NonceInfo, NoncePartial},
+        nonce_info::NoncePartial,
         program_loader::load_program_with_pubkey,
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_processing_callback::TransactionProcessingCallback,
@@ -3039,10 +3039,8 @@ impl Bank {
             blockhash_queue.get_lamports_per_signature(message.recent_blockhash())
         }
         .or_else(|| {
-            self.check_message_for_nonce(message)
-                .and_then(|(address, account)| {
-                    NoncePartial::new(address, account).lamports_per_signature()
-                })
+            self.load_message_nonce_account(message)
+                .map(|(_nonce, nonce_data)| nonce_data.get_lamports_per_signature())
         })?;
         Some(self.get_fee_for_message_with_lamports_per_signature(message, lamports_per_signature))
     }
@@ -3498,14 +3496,12 @@ impl Bank {
                 lamports_per_signature: hash_queue
                     .get_lamports_per_signature(tx.message().recent_blockhash()),
             })
-        } else if let Some((address, account)) =
-            self.check_transaction_for_nonce(tx, next_durable_nonce)
+        } else if let Some((nonce, nonce_data)) =
+            self.check_and_load_message_nonce_account(tx.message(), next_durable_nonce)
         {
-            let nonce = NoncePartial::new(address, account);
-            let lamports_per_signature = nonce.lamports_per_signature();
             Ok(CheckedTransactionDetails {
                 nonce: Some(nonce),
-                lamports_per_signature,
+                lamports_per_signature: Some(nonce_data.get_lamports_per_signature()),
             })
         } else {
             error_counters.blockhash_not_found += 1;
@@ -3560,7 +3556,10 @@ impl Bank {
             .is_hash_valid_for_age(hash, max_age)
     }
 
-    fn check_message_for_nonce(&self, message: &SanitizedMessage) -> Option<TransactionAccount> {
+    fn load_message_nonce_account(
+        &self,
+        message: &SanitizedMessage,
+    ) -> Option<(NoncePartial, nonce::state::Data)> {
         let nonce_address = message.get_durable_nonce()?;
         let nonce_account = self.get_account_with_fixed_root(nonce_address)?;
         let nonce_data =
@@ -3573,17 +3572,17 @@ impl Bank {
             return None;
         }
 
-        Some((*nonce_address, nonce_account))
+        Some((NoncePartial::new(*nonce_address, nonce_account), nonce_data))
     }
 
-    fn check_transaction_for_nonce(
+    fn check_and_load_message_nonce_account(
         &self,
-        tx: &SanitizedTransaction,
+        message: &SanitizedMessage,
         next_durable_nonce: &DurableNonce,
-    ) -> Option<TransactionAccount> {
-        let nonce_is_advanceable = tx.message().recent_blockhash() != next_durable_nonce.as_hash();
+    ) -> Option<(NoncePartial, nonce::state::Data)> {
+        let nonce_is_advanceable = message.recent_blockhash() != next_durable_nonce.as_hash();
         if nonce_is_advanceable {
-            self.check_message_for_nonce(tx.message())
+            self.load_message_nonce_account(message)
         } else {
             None
         }


### PR DESCRIPTION
#### Problem
When creating `CheckedTransactionDetails` for nonce transactions, the `lamports_per_signature` value is an `Option` but actually can never be `None`. Using an `Option` rather than directly using the value makes error handling needlessly complex downstream.

#### Summary of Changes
- Renamed a few functions so that it's more clear that they are loading an account
  -  `Bank::check_message_for_nonce` -> `Bank::load_message_nonce_account`
  - `Bank::check_transaction_for_nonce` -> `Bank::check_and_load_message_nonce_account`
- Directly return nonce data from these methods so that `lamports_per_signature` can be retrieved directly

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
