### PR TITLE
chore: remove log-analyzer from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ target/
 *.log
 log-*.txt
 log-*/
+!log-analyzer/*
 
 # intellij files
 .idea/


### PR DESCRIPTION
#### Problem

the `log-*/` in `.gitignore` is affecting our `log-analyzer` directory.

btw, there is a short message for it 1y ago 🙈 https://discord.com/channels/428295358100013066/560503042458517505/1103358742503903283

#### Summary of Changes

I think we should get it back to git.