### PR TITLE
refactor: get hash info for tx

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3492,11 +3492,10 @@ impl Bank {
         error_counters: &mut TransactionErrorMetrics,
     ) -> TransactionCheckResult {
         let recent_blockhash = tx.message().recent_blockhash();
-        if hash_queue.is_hash_valid_for_age(recent_blockhash, max_age) {
+        if let Some(hash_info) = hash_queue.get_hash_info_if_valid(recent_blockhash, max_age) {
             Ok(CheckedTransactionDetails {
                 nonce: None,
-                lamports_per_signature: hash_queue
-                    .get_lamports_per_signature(tx.message().recent_blockhash()),
+                lamports_per_signature: Some(hash_info.lamports_per_signature()),
             })
         } else if let Some((address, account)) =
             self.check_transaction_for_nonce(tx, next_durable_nonce)

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -577,7 +577,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "E2yBALNrNC7xwrRaXknqjSDsPzWFGsQnK8RHE8niKTds")
+            frozen_abi(digest = "7K1xfUkoCwhxssszgoSpbeMCcX3KEyjycGyLXrpFaJNe")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapperNewer {


### PR DESCRIPTION
#### Problem
When creating `CheckedTransactionDetails` for transactions, the `lamports_per_signature` value is an `Option` but actually can never be `None`. Using an `Option` rather than directly using the value makes error handling needlessly complex downstream.

#### Summary of Changes
- Add a new method to `BlockhashQueue` to get the info for a particular hash if it's valid
- Rename `HashAge` to `HashInfo` and add a method to get the lamports per signature value

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
