### PR TITLE
[zk-sdk] Add batched range proof instructions

### DIFF
--- a/zk-sdk/src/elgamal_program/instruction.rs
+++ b/zk-sdk/src/elgamal_program/instruction.rs
@@ -141,6 +141,66 @@ pub enum ProofInstruction {
     ///   ii. `u32` byte offset if proof is provided as an account
     ///
     VerifyPercentageWithCap,
+
+    /// Verify a 64-bit batched range proof.
+    ///
+    /// A batched range proof is defined with respect to a sequence of Pedersen commitments `[C_1,
+    /// ..., C_N]` and bit-lengths `[n_1, ..., n_N]`. It certifies that each commitment `C_i` is a
+    /// commitment to a positive number of bit-length `n_i`. Batch verifying range proofs is more
+    /// efficient than verifying independent range proofs on commitments `C_1, ..., C_N`
+    /// separately.
+    ///
+    /// The bit-length of a batched range proof specifies the sum of the individual bit-lengths
+    /// `n_1, ..., n_N`. For example, this instruction can be used to certify that two commitments
+    /// `C_1` and `C_2` each hold positive 32-bit numbers.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[]` (Optional) Account to read the proof from
+    ///   1. `[writable]` (Optional) The proof context account
+    ///   2. `[]` (Optional) The proof context account owner
+    ///
+    /// The instruction expects either:
+    ///   i. `BatchedRangeProofU64Data` if proof is provided as instruction data
+    ///   ii. `u32` byte offset if proof is provided as an account
+    ///
+    VerifyBatchedRangeProofU64,
+
+    /// Verify 128-bit batched range proof.
+    ///
+    /// The bit-length of a batched range proof specifies the sum of the individual bit-lengths
+    /// `n_1, ..., n_N`. For example, this instruction can be used to certify that two commitments
+    /// `C_1` and `C_2` each hold positive 64-bit numbers.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[]` (Optional) Account to read the proof from
+    ///   1. `[writable]` (Optional) The proof context account
+    ///   2. `[]` (Optional) The proof context account owner
+    ///
+    /// The instruction expects either:
+    ///   i. `BatchedRangeProofU128Data` if proof is provided as instruction data
+    ///   ii. `u32` byte offset if proof is provided as an account
+    ///
+    VerifyBatchedRangeProofU128,
+
+    /// Verify 256-bit batched range proof.
+    ///
+    /// The bit-length of a batched range proof specifies the sum of the individual bit-lengths
+    /// `n_1, ..., n_N`. For example, this instruction can be used to certify that four commitments
+    /// `[C_1, C_2, C_3, C_4]` each hold positive 64-bit numbers.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[]` (Optional) Account to read the proof from
+    ///   1. `[writable]` (Optional) The proof context account
+    ///   2. `[]` (Optional) The proof context account owner
+    ///
+    /// The instruction expects either:
+    ///   i. `BatchedRangeProofU256Data` if proof is provided as instruction data
+    ///   ii. `u32` byte offset if proof is provided as an account
+    ///
+    VerifyBatchedRangeProofU256,
 }
 
 /// Pubkeys associated with a context state account to be used as parameters to functions.

--- a/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
@@ -1,0 +1,195 @@
+//! The 128-bit batched range proof instruction.
+
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{
+        encryption::pedersen::{PedersenCommitment, PedersenOpening},
+        errors::{ProofGenerationError, ProofVerificationError},
+        instruction::batched_range_proof::MAX_COMMITMENTS,
+        range_proof::RangeProof,
+    },
+    std::convert::TryInto,
+};
+use {
+    crate::{
+        instruction::{batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData},
+        zk_token_elgamal::pod,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+
+/// The instruction data that is needed for the
+/// `ProofInstruction::VerifyBatchedRangeProofU128` instruction.
+///
+/// It includes the cryptographic proof as well as the context data information needed to verify
+/// the proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct BatchedRangeProofU128Data {
+    /// The context data for a batched range proof
+    pub context: BatchedRangeProofContext,
+
+    /// The batched range proof
+    pub proof: pod::RangeProofU128,
+}
+
+#[cfg(not(target_os = "solana"))]
+impl BatchedRangeProofU128Data {
+    pub fn new(
+        commitments: Vec<&PedersenCommitment>,
+        amounts: Vec<u64>,
+        bit_lengths: Vec<usize>,
+        openings: Vec<&PedersenOpening>,
+    ) -> Result<Self, ProofGenerationError> {
+        // the sum of the bit lengths must be 128
+        let batched_bit_length = bit_lengths
+            .iter()
+            .try_fold(0_usize, |acc, &x| acc.checked_add(x))
+            .ok_or(ProofGenerationError::IllegalAmountBitLength)?;
+
+        // `u128::BITS` is 128, which fits in a single byte and should not overflow to `usize` for
+        // an overwhelming number of platforms. However, to be extra cautious, use `try_from` and
+        // `unwrap` here. A simple case `u128::BITS as usize` can silently overflow.
+        let expected_bit_length = usize::try_from(u128::BITS).unwrap();
+        if batched_bit_length != expected_bit_length {
+            return Err(ProofGenerationError::IllegalAmountBitLength);
+        }
+
+        let context =
+            BatchedRangeProofContext::new(&commitments, &amounts, &bit_lengths, &openings)?;
+
+        let mut transcript = context.new_transcript();
+        let proof: pod::RangeProofU128 =
+            RangeProof::new(amounts, bit_lengths, openings, &mut transcript)?
+                .try_into()
+                .map_err(|_| ProofGenerationError::ProofLength)?;
+
+        Ok(Self { context, proof })
+    }
+}
+
+impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU128Data {
+    const PROOF_TYPE: ProofType = ProofType::BatchedRangeProofU128;
+
+    fn context_data(&self) -> &BatchedRangeProofContext {
+        &self.context
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
+        let (commitments, bit_lengths) = self.context.try_into()?;
+        let num_commitments = commitments.len();
+
+        if num_commitments > MAX_COMMITMENTS || num_commitments != bit_lengths.len() {
+            return Err(ProofVerificationError::IllegalCommitmentLength);
+        }
+
+        let mut transcript = self.context_data().new_transcript();
+        let proof: RangeProof = self.proof.try_into()?;
+
+        proof
+            .verify(commitments.iter().collect(), bit_lengths, &mut transcript)
+            .map_err(|e| e.into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::{
+            encryption::pedersen::Pedersen, errors::ProofVerificationError,
+            range_proof::errors::RangeProofVerificationError,
+        },
+    };
+
+    #[test]
+    fn test_batched_range_proof_u128_instruction_correctness() {
+        let amount_1 = 65535_u64;
+        let amount_2 = 77_u64;
+        let amount_3 = 99_u64;
+        let amount_4 = 99_u64;
+        let amount_5 = 11_u64;
+        let amount_6 = 33_u64;
+        let amount_7 = 99_u64;
+        let amount_8 = 99_u64;
+
+        let (commitment_1, opening_1) = Pedersen::new(amount_1);
+        let (commitment_2, opening_2) = Pedersen::new(amount_2);
+        let (commitment_3, opening_3) = Pedersen::new(amount_3);
+        let (commitment_4, opening_4) = Pedersen::new(amount_4);
+        let (commitment_5, opening_5) = Pedersen::new(amount_5);
+        let (commitment_6, opening_6) = Pedersen::new(amount_6);
+        let (commitment_7, opening_7) = Pedersen::new(amount_7);
+        let (commitment_8, opening_8) = Pedersen::new(amount_8);
+
+        let proof_data = BatchedRangeProofU128Data::new(
+            vec![
+                &commitment_1,
+                &commitment_2,
+                &commitment_3,
+                &commitment_4,
+                &commitment_5,
+                &commitment_6,
+                &commitment_7,
+                &commitment_8,
+            ],
+            vec![
+                amount_1, amount_2, amount_3, amount_4, amount_5, amount_6, amount_7, amount_8,
+            ],
+            vec![16, 16, 16, 16, 16, 16, 16, 16],
+            vec![
+                &opening_1, &opening_2, &opening_3, &opening_4, &opening_5, &opening_6, &opening_7,
+                &opening_8,
+            ],
+        )
+        .unwrap();
+
+        assert!(proof_data.verify_proof().is_ok());
+
+        let amount_1 = 65536_u64; // not representable as an 8-bit number
+        let amount_2 = 77_u64;
+        let amount_3 = 99_u64;
+        let amount_4 = 99_u64;
+        let amount_5 = 11_u64;
+        let amount_6 = 33_u64;
+        let amount_7 = 99_u64;
+        let amount_8 = 99_u64;
+
+        let (commitment_1, opening_1) = Pedersen::new(amount_1);
+        let (commitment_2, opening_2) = Pedersen::new(amount_2);
+        let (commitment_3, opening_3) = Pedersen::new(amount_3);
+        let (commitment_4, opening_4) = Pedersen::new(amount_4);
+        let (commitment_5, opening_5) = Pedersen::new(amount_5);
+        let (commitment_6, opening_6) = Pedersen::new(amount_6);
+        let (commitment_7, opening_7) = Pedersen::new(amount_7);
+        let (commitment_8, opening_8) = Pedersen::new(amount_8);
+
+        let proof_data = BatchedRangeProofU128Data::new(
+            vec![
+                &commitment_1,
+                &commitment_2,
+                &commitment_3,
+                &commitment_4,
+                &commitment_5,
+                &commitment_6,
+                &commitment_7,
+                &commitment_8,
+            ],
+            vec![
+                amount_1, amount_2, amount_3, amount_4, amount_5, amount_6, amount_7, amount_8,
+            ],
+            vec![16, 16, 16, 16, 16, 16, 16, 16],
+            vec![
+                &opening_1, &opening_2, &opening_3, &opening_4, &opening_5, &opening_6, &opening_7,
+                &opening_8,
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            proof_data.verify_proof().unwrap_err(),
+            ProofVerificationError::RangeProof(RangeProofVerificationError::AlgebraicRelation),
+        );
+    }
+}

--- a/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
@@ -151,7 +151,7 @@ mod test {
 
         assert!(proof_data.verify_proof().is_ok());
 
-        let amount_1 = 65536_u64; // not representable as an 8-bit number
+        let amount_1 = 65536_u64; // not representable as a 16-bit number
         let amount_2 = 77_u64;
         let amount_3 = 99_u64;
         let amount_4 = 99_u64;

--- a/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
@@ -1,21 +1,25 @@
 //! The 128-bit batched range proof instruction.
 
+use {
+    crate::{
+        elgamal_program::proof_data::{
+            batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData,
+        },
+        range_proof::pod::PodRangeProofU128,
+    },
+    bytemuck::{Pod, Zeroable},
+};
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{
+        elgamal_program::{
+            errors::{ProofGenerationError, ProofVerificationError},
+            proof_data::batched_range_proof::MAX_COMMITMENTS,
+        },
         encryption::pedersen::{PedersenCommitment, PedersenOpening},
-        errors::{ProofGenerationError, ProofVerificationError},
-        instruction::batched_range_proof::MAX_COMMITMENTS,
         range_proof::RangeProof,
     },
     std::convert::TryInto,
-};
-use {
-    crate::{
-        instruction::{batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData},
-        zk_token_elgamal::pod,
-    },
-    bytemuck::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the
@@ -30,7 +34,7 @@ pub struct BatchedRangeProofU128Data {
     pub context: BatchedRangeProofContext,
 
     /// The batched range proof
-    pub proof: pod::RangeProofU128,
+    pub proof: PodRangeProofU128,
 }
 
 #[cfg(not(target_os = "solana"))]
@@ -59,7 +63,7 @@ impl BatchedRangeProofU128Data {
             BatchedRangeProofContext::new(&commitments, &amounts, &bit_lengths, &openings)?;
 
         let mut transcript = context.new_transcript();
-        let proof: pod::RangeProofU128 =
+        let proof: PodRangeProofU128 =
             RangeProof::new(amounts, bit_lengths, openings, &mut transcript)?
                 .try_into()
                 .map_err(|_| ProofGenerationError::ProofLength)?;
@@ -98,7 +102,7 @@ mod test {
     use {
         super::*,
         crate::{
-            encryption::pedersen::Pedersen, errors::ProofVerificationError,
+            elgamal_program::errors::ProofVerificationError, encryption::pedersen::Pedersen,
             range_proof::errors::RangeProofVerificationError,
         },
     };

--- a/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u256.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u256.rs
@@ -1,0 +1,207 @@
+//! The 256-bit batched range proof instruction.
+
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{
+        encryption::pedersen::{PedersenCommitment, PedersenOpening},
+        errors::{ProofGenerationError, ProofVerificationError},
+        instruction::batched_range_proof::{MAX_COMMITMENTS, MAX_SINGLE_BIT_LENGTH},
+        range_proof::RangeProof,
+    },
+    std::convert::TryInto,
+};
+use {
+    crate::{
+        instruction::{batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData},
+        zk_token_elgamal::pod,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+
+#[cfg(not(target_os = "solana"))]
+const BATCHED_RANGE_PROOF_U256_BIT_LENGTH: usize = 256;
+
+/// The instruction data that is needed for the
+/// `ProofInstruction::BatchedRangeProofU256Data` instruction.
+///
+/// It includes the cryptographic proof as well as the context data information needed to verify
+/// the proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct BatchedRangeProofU256Data {
+    /// The context data for a batched range proof
+    pub context: BatchedRangeProofContext,
+
+    /// The batched range proof
+    pub proof: pod::RangeProofU256,
+}
+
+#[cfg(not(target_os = "solana"))]
+impl BatchedRangeProofU256Data {
+    pub fn new(
+        commitments: Vec<&PedersenCommitment>,
+        amounts: Vec<u64>,
+        bit_lengths: Vec<usize>,
+        openings: Vec<&PedersenOpening>,
+    ) -> Result<Self, ProofGenerationError> {
+        // each bit length must be at most 128
+        if bit_lengths
+            .iter()
+            .any(|length| *length > MAX_SINGLE_BIT_LENGTH)
+        {
+            return Err(ProofGenerationError::IllegalCommitmentLength);
+        }
+
+        // the sum of the bit lengths must be 256
+        let batched_bit_length = bit_lengths
+            .iter()
+            .try_fold(0_usize, |acc, &x| acc.checked_add(x))
+            .ok_or(ProofGenerationError::IllegalAmountBitLength)?;
+        if batched_bit_length != BATCHED_RANGE_PROOF_U256_BIT_LENGTH {
+            return Err(ProofGenerationError::IllegalAmountBitLength);
+        }
+
+        let context =
+            BatchedRangeProofContext::new(&commitments, &amounts, &bit_lengths, &openings)?;
+
+        let mut transcript = context.new_transcript();
+        let proof = RangeProof::new(amounts, bit_lengths, openings, &mut transcript)?
+            .try_into()
+            .map_err(|_| ProofGenerationError::ProofLength)?;
+
+        Ok(Self { context, proof })
+    }
+}
+
+impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU256Data {
+    const PROOF_TYPE: ProofType = ProofType::BatchedRangeProofU256;
+
+    fn context_data(&self) -> &BatchedRangeProofContext {
+        &self.context
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
+        let (commitments, bit_lengths) = self.context.try_into()?;
+        let num_commitments = commitments.len();
+
+        if bit_lengths
+            .iter()
+            .any(|length| *length > MAX_SINGLE_BIT_LENGTH)
+        {
+            return Err(ProofVerificationError::IllegalCommitmentLength);
+        }
+
+        if num_commitments > MAX_COMMITMENTS || num_commitments != bit_lengths.len() {
+            return Err(ProofVerificationError::IllegalCommitmentLength);
+        }
+
+        let mut transcript = self.context_data().new_transcript();
+        let proof: RangeProof = self.proof.try_into()?;
+
+        proof
+            .verify(commitments.iter().collect(), bit_lengths, &mut transcript)
+            .map_err(|e| e.into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::{
+            encryption::pedersen::Pedersen, errors::ProofVerificationError,
+            range_proof::errors::RangeProofVerificationError,
+        },
+    };
+
+    #[test]
+    fn test_batched_range_proof_256_instruction_correctness() {
+        let amount_1 = 4294967295_u64;
+        let amount_2 = 77_u64;
+        let amount_3 = 99_u64;
+        let amount_4 = 99_u64;
+        let amount_5 = 11_u64;
+        let amount_6 = 33_u64;
+        let amount_7 = 99_u64;
+        let amount_8 = 99_u64;
+
+        let (commitment_1, opening_1) = Pedersen::new(amount_1);
+        let (commitment_2, opening_2) = Pedersen::new(amount_2);
+        let (commitment_3, opening_3) = Pedersen::new(amount_3);
+        let (commitment_4, opening_4) = Pedersen::new(amount_4);
+        let (commitment_5, opening_5) = Pedersen::new(amount_5);
+        let (commitment_6, opening_6) = Pedersen::new(amount_6);
+        let (commitment_7, opening_7) = Pedersen::new(amount_7);
+        let (commitment_8, opening_8) = Pedersen::new(amount_8);
+
+        let proof_data = BatchedRangeProofU256Data::new(
+            vec![
+                &commitment_1,
+                &commitment_2,
+                &commitment_3,
+                &commitment_4,
+                &commitment_5,
+                &commitment_6,
+                &commitment_7,
+                &commitment_8,
+            ],
+            vec![
+                amount_1, amount_2, amount_3, amount_4, amount_5, amount_6, amount_7, amount_8,
+            ],
+            vec![32, 32, 32, 32, 32, 32, 32, 32],
+            vec![
+                &opening_1, &opening_2, &opening_3, &opening_4, &opening_5, &opening_6, &opening_7,
+                &opening_8,
+            ],
+        )
+        .unwrap();
+
+        assert!(proof_data.verify_proof().is_ok());
+
+        let amount_1 = 4294967296_u64; // not representable as an 8-bit number
+        let amount_2 = 77_u64;
+        let amount_3 = 99_u64;
+        let amount_4 = 99_u64;
+        let amount_5 = 11_u64;
+        let amount_6 = 33_u64;
+        let amount_7 = 99_u64;
+        let amount_8 = 99_u64;
+
+        let (commitment_1, opening_1) = Pedersen::new(amount_1);
+        let (commitment_2, opening_2) = Pedersen::new(amount_2);
+        let (commitment_3, opening_3) = Pedersen::new(amount_3);
+        let (commitment_4, opening_4) = Pedersen::new(amount_4);
+        let (commitment_5, opening_5) = Pedersen::new(amount_5);
+        let (commitment_6, opening_6) = Pedersen::new(amount_6);
+        let (commitment_7, opening_7) = Pedersen::new(amount_7);
+        let (commitment_8, opening_8) = Pedersen::new(amount_8);
+
+        let proof_data = BatchedRangeProofU256Data::new(
+            vec![
+                &commitment_1,
+                &commitment_2,
+                &commitment_3,
+                &commitment_4,
+                &commitment_5,
+                &commitment_6,
+                &commitment_7,
+                &commitment_8,
+            ],
+            vec![
+                amount_1, amount_2, amount_3, amount_4, amount_5, amount_6, amount_7, amount_8,
+            ],
+            vec![32, 32, 32, 32, 32, 32, 32, 32],
+            vec![
+                &opening_1, &opening_2, &opening_3, &opening_4, &opening_5, &opening_6, &opening_7,
+                &opening_8,
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            proof_data.verify_proof().unwrap_err(),
+            ProofVerificationError::RangeProof(RangeProofVerificationError::AlgebraicRelation),
+        );
+    }
+}

--- a/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u256.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u256.rs
@@ -165,7 +165,7 @@ mod test {
 
         assert!(proof_data.verify_proof().is_ok());
 
-        let amount_1 = 4294967296_u64; // not representable as an 8-bit number
+        let amount_1 = 4294967296_u64; // not representable as a 32-bit number
         let amount_2 = 77_u64;
         let amount_3 = 99_u64;
         let amount_4 = 99_u64;

--- a/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u64.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u64.rs
@@ -1,0 +1,194 @@
+//! The 64-bit batched range proof instruction.
+
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{
+        encryption::pedersen::{PedersenCommitment, PedersenOpening},
+        errors::{ProofGenerationError, ProofVerificationError},
+        instruction::batched_range_proof::MAX_COMMITMENTS,
+        range_proof::RangeProof,
+    },
+    std::convert::TryInto,
+};
+use {
+    crate::{
+        instruction::{batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData},
+        zk_token_elgamal::pod,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+
+/// The instruction data that is needed for the
+/// `ProofInstruction::VerifyBatchedRangeProofU64` instruction.
+///
+/// It includes the cryptographic proof as well as the context data information needed to verify
+/// the proof.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct BatchedRangeProofU64Data {
+    /// The context data for a batched range proof
+    pub context: BatchedRangeProofContext,
+
+    /// The batched range proof
+    pub proof: pod::RangeProofU64,
+}
+
+#[cfg(not(target_os = "solana"))]
+impl BatchedRangeProofU64Data {
+    pub fn new(
+        commitments: Vec<&PedersenCommitment>,
+        amounts: Vec<u64>,
+        bit_lengths: Vec<usize>,
+        openings: Vec<&PedersenOpening>,
+    ) -> Result<Self, ProofGenerationError> {
+        // the sum of the bit lengths must be 64
+        let batched_bit_length = bit_lengths
+            .iter()
+            .try_fold(0_usize, |acc, &x| acc.checked_add(x))
+            .ok_or(ProofGenerationError::IllegalAmountBitLength)?;
+
+        // `u64::BITS` is 64, which fits in a single byte and should not overflow to `usize` for an
+        // overwhelming number of platforms. However, to be extra cautious, use `try_from` and
+        // `unwrap` here. A simple case `u64::BITS as usize` can silently overflow.
+        let expected_bit_length = usize::try_from(u64::BITS).unwrap();
+        if batched_bit_length != expected_bit_length {
+            return Err(ProofGenerationError::IllegalAmountBitLength);
+        }
+
+        let context =
+            BatchedRangeProofContext::new(&commitments, &amounts, &bit_lengths, &openings)?;
+
+        let mut transcript = context.new_transcript();
+        let proof = RangeProof::new(amounts, bit_lengths, openings, &mut transcript)?
+            .try_into()
+            .map_err(|_| ProofGenerationError::ProofLength)?;
+
+        Ok(Self { context, proof })
+    }
+}
+
+impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU64Data {
+    const PROOF_TYPE: ProofType = ProofType::BatchedRangeProofU64;
+
+    fn context_data(&self) -> &BatchedRangeProofContext {
+        &self.context
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
+        let (commitments, bit_lengths) = self.context.try_into()?;
+        let num_commitments = commitments.len();
+
+        if num_commitments > MAX_COMMITMENTS || num_commitments != bit_lengths.len() {
+            return Err(ProofVerificationError::IllegalCommitmentLength);
+        }
+
+        let mut transcript = self.context_data().new_transcript();
+        let proof: RangeProof = self.proof.try_into()?;
+
+        proof
+            .verify(commitments.iter().collect(), bit_lengths, &mut transcript)
+            .map_err(|e| e.into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::{
+            encryption::pedersen::Pedersen, errors::ProofVerificationError,
+            range_proof::errors::RangeProofVerificationError,
+        },
+    };
+
+    #[test]
+    fn test_batched_range_proof_u64_instruction_correctness() {
+        let amount_1 = 255_u64;
+        let amount_2 = 77_u64;
+        let amount_3 = 99_u64;
+        let amount_4 = 99_u64;
+        let amount_5 = 11_u64;
+        let amount_6 = 33_u64;
+        let amount_7 = 99_u64;
+        let amount_8 = 99_u64;
+
+        let (commitment_1, opening_1) = Pedersen::new(amount_1);
+        let (commitment_2, opening_2) = Pedersen::new(amount_2);
+        let (commitment_3, opening_3) = Pedersen::new(amount_3);
+        let (commitment_4, opening_4) = Pedersen::new(amount_4);
+        let (commitment_5, opening_5) = Pedersen::new(amount_5);
+        let (commitment_6, opening_6) = Pedersen::new(amount_6);
+        let (commitment_7, opening_7) = Pedersen::new(amount_7);
+        let (commitment_8, opening_8) = Pedersen::new(amount_8);
+
+        let proof_data = BatchedRangeProofU64Data::new(
+            vec![
+                &commitment_1,
+                &commitment_2,
+                &commitment_3,
+                &commitment_4,
+                &commitment_5,
+                &commitment_6,
+                &commitment_7,
+                &commitment_8,
+            ],
+            vec![
+                amount_1, amount_2, amount_3, amount_4, amount_5, amount_6, amount_7, amount_8,
+            ],
+            vec![8, 8, 8, 8, 8, 8, 8, 8],
+            vec![
+                &opening_1, &opening_2, &opening_3, &opening_4, &opening_5, &opening_6, &opening_7,
+                &opening_8,
+            ],
+        )
+        .unwrap();
+
+        assert!(proof_data.verify_proof().is_ok());
+
+        let amount_1 = 256_u64; // not representable as an 8-bit number
+        let amount_2 = 77_u64;
+        let amount_3 = 99_u64;
+        let amount_4 = 99_u64;
+        let amount_5 = 11_u64;
+        let amount_6 = 33_u64;
+        let amount_7 = 99_u64;
+        let amount_8 = 99_u64;
+
+        let (commitment_1, opening_1) = Pedersen::new(amount_1);
+        let (commitment_2, opening_2) = Pedersen::new(amount_2);
+        let (commitment_3, opening_3) = Pedersen::new(amount_3);
+        let (commitment_4, opening_4) = Pedersen::new(amount_4);
+        let (commitment_5, opening_5) = Pedersen::new(amount_5);
+        let (commitment_6, opening_6) = Pedersen::new(amount_6);
+        let (commitment_7, opening_7) = Pedersen::new(amount_7);
+        let (commitment_8, opening_8) = Pedersen::new(amount_8);
+
+        let proof_data = BatchedRangeProofU64Data::new(
+            vec![
+                &commitment_1,
+                &commitment_2,
+                &commitment_3,
+                &commitment_4,
+                &commitment_5,
+                &commitment_6,
+                &commitment_7,
+                &commitment_8,
+            ],
+            vec![
+                amount_1, amount_2, amount_3, amount_4, amount_5, amount_6, amount_7, amount_8,
+            ],
+            vec![8, 8, 8, 8, 8, 8, 8, 8],
+            vec![
+                &opening_1, &opening_2, &opening_3, &opening_4, &opening_5, &opening_6, &opening_7,
+                &opening_8,
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            proof_data.verify_proof().unwrap_err(),
+            ProofVerificationError::RangeProof(RangeProofVerificationError::AlgebraicRelation),
+        );
+    }
+}

--- a/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u64.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/batched_range_proof_u64.rs
@@ -1,21 +1,25 @@
 //! The 64-bit batched range proof instruction.
 
+use {
+    crate::{
+        elgamal_program::proof_data::{
+            batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData,
+        },
+        range_proof::pod::PodRangeProofU64,
+    },
+    bytemuck::{Pod, Zeroable},
+};
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{
+        elgamal_program::{
+            errors::{ProofGenerationError, ProofVerificationError},
+            proof_data::batched_range_proof::MAX_COMMITMENTS,
+        },
         encryption::pedersen::{PedersenCommitment, PedersenOpening},
-        errors::{ProofGenerationError, ProofVerificationError},
-        instruction::batched_range_proof::MAX_COMMITMENTS,
         range_proof::RangeProof,
     },
     std::convert::TryInto,
-};
-use {
-    crate::{
-        instruction::{batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData},
-        zk_token_elgamal::pod,
-    },
-    bytemuck::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the
@@ -30,7 +34,7 @@ pub struct BatchedRangeProofU64Data {
     pub context: BatchedRangeProofContext,
 
     /// The batched range proof
-    pub proof: pod::RangeProofU64,
+    pub proof: PodRangeProofU64,
 }
 
 #[cfg(not(target_os = "solana"))]
@@ -97,7 +101,7 @@ mod test {
     use {
         super::*,
         crate::{
-            encryption::pedersen::Pedersen, errors::ProofVerificationError,
+            elgamal_program::errors::ProofVerificationError, encryption::pedersen::Pedersen,
             range_proof::errors::RangeProofVerificationError,
         },
     };

--- a/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/mod.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/mod.rs
@@ -1,0 +1,129 @@
+//! The batched range proof instructions.
+//!
+//! A batched range proof is defined with respect to a sequence of commitments `[C_1, ..., C_N]`
+//! and bit-lengths `[n_1, ..., n_N]`. It certifies that each `C_i` is a commitment to a number of
+//! bit-length `n_i`.
+//!
+//! There are three batched range proof instructions: `VerifyBatchedRangeProof64`,
+//! `VerifyBatchedRangeProof128`, and `VerifyBatchedRangeProof256`. The value `N` in
+//! `VerifyBatchedRangeProof{N}` specifies the sum of the bit-lengths that the proof is certifying
+//! for a sequence of commitments.
+//!
+//! For example to generate a batched range proof on a sequence of commitments `[C_1, C_2, C_3]` on
+//! a sequence of bit-lengths `[32, 32, 64]`, one must use `VerifyBatchedRangeProof128` as 128 is
+//! the sum of all bit-lengths.
+//!
+//! The maximum number of commitments is fixed at 8. Each bit-length in `[n_1, ..., n_N]` must be a
+//! power-of-two positive integer less than 128.
+
+pub mod batched_range_proof_u128;
+pub mod batched_range_proof_u256;
+pub mod batched_range_proof_u64;
+
+use {
+    crate::zk_token_elgamal::pod,
+    bytemuck::{Pod, Zeroable},
+};
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::{
+        encryption::pedersen::{PedersenCommitment, PedersenOpening},
+        errors::{ProofGenerationError, ProofVerificationError},
+    },
+    bytemuck::bytes_of,
+    curve25519_dalek::traits::IsIdentity,
+    merlin::Transcript,
+    std::convert::TryInto,
+};
+
+const MAX_COMMITMENTS: usize = 8;
+
+/// A bit length in a batched range proof must be at most 128.
+///
+/// A 256-bit range proof on a single Pedersen commitment is meaningless and hence enforce an upper
+/// bound as the largest power-of-two number less than 256.
+#[cfg(not(target_os = "solana"))]
+const MAX_SINGLE_BIT_LENGTH: usize = 128;
+
+/// The context data needed to verify a range-proof for a Pedersen committed value.
+///
+/// The context data is shared by all `VerifyBatchedRangeProof{N}` instructions.
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct BatchedRangeProofContext {
+    pub commitments: [pod::PedersenCommitment; MAX_COMMITMENTS],
+    pub bit_lengths: [u8; MAX_COMMITMENTS],
+}
+
+#[allow(non_snake_case)]
+#[cfg(not(target_os = "solana"))]
+impl BatchedRangeProofContext {
+    fn new_transcript(&self) -> Transcript {
+        let mut transcript = Transcript::new(b"BatchedRangeProof");
+        transcript.append_message(b"commitments", bytes_of(&self.commitments));
+        transcript.append_message(b"bit-lengths", bytes_of(&self.bit_lengths));
+        transcript
+    }
+
+    fn new(
+        commitments: &[&PedersenCommitment],
+        amounts: &[u64],
+        bit_lengths: &[usize],
+        openings: &[&PedersenOpening],
+    ) -> Result<Self, ProofGenerationError> {
+        // the number of commitments is capped at 8
+        let num_commitments = commitments.len();
+        if num_commitments > MAX_COMMITMENTS
+            || num_commitments != amounts.len()
+            || num_commitments != bit_lengths.len()
+            || num_commitments != openings.len()
+        {
+            return Err(ProofGenerationError::IllegalCommitmentLength);
+        }
+
+        let mut pod_commitments = [pod::PedersenCommitment::zeroed(); MAX_COMMITMENTS];
+        for (i, commitment) in commitments.iter().enumerate() {
+            // all-zero commitment is invalid
+            if commitment.get_point().is_identity() {
+                return Err(ProofGenerationError::InvalidCommitment);
+            }
+            pod_commitments[i] = pod::PedersenCommitment(commitment.to_bytes());
+        }
+
+        let mut pod_bit_lengths = [0; MAX_COMMITMENTS];
+        for (i, bit_length) in bit_lengths.iter().enumerate() {
+            pod_bit_lengths[i] = (*bit_length)
+                .try_into()
+                .map_err(|_| ProofGenerationError::IllegalAmountBitLength)?;
+        }
+
+        Ok(BatchedRangeProofContext {
+            commitments: pod_commitments,
+            bit_lengths: pod_bit_lengths,
+        })
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+impl TryInto<(Vec<PedersenCommitment>, Vec<usize>)> for BatchedRangeProofContext {
+    type Error = ProofVerificationError;
+
+    fn try_into(self) -> Result<(Vec<PedersenCommitment>, Vec<usize>), Self::Error> {
+        let commitments = self
+            .commitments
+            .into_iter()
+            .take_while(|commitment| *commitment != pod::PedersenCommitment::zeroed())
+            .map(|commitment| commitment.try_into())
+            .collect::<Result<Vec<PedersenCommitment>, _>>()
+            .map_err(|_| ProofVerificationError::ProofContext)?;
+
+        let bit_lengths: Vec<_> = self
+            .bit_lengths
+            .into_iter()
+            .take(commitments.len())
+            .map(|bit_length| bit_length as usize)
+            .collect();
+
+        Ok((commitments, bit_lengths))
+    }
+}

--- a/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/mod.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/batched_range_proof/mod.rs
@@ -14,7 +14,7 @@
 //! the sum of all bit-lengths.
 //!
 //! The maximum number of commitments is fixed at 8. Each bit-length in `[n_1, ..., n_N]` must be a
-//! power-of-two positive integer less than 128.
+//! power-of-two positive integer less than or equal to 128.
 
 pub mod batched_range_proof_u128;
 pub mod batched_range_proof_u256;

--- a/zk-sdk/src/elgamal_program/proof_data/mod.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/mod.rs
@@ -5,6 +5,7 @@ use {
     num_derive::{FromPrimitive, ToPrimitive},
 };
 
+pub mod batched_range_proof;
 pub mod ciphertext_ciphertext_equality;
 pub mod ciphertext_commitment_equality;
 pub mod errors;
@@ -23,6 +24,9 @@ pub enum ProofType {
     CiphertextCommitmentEquality,
     PubkeyValidity,
     PercentageWithCap,
+    BatchedRangeProofU64,
+    BatchedRangeProofU128,
+    BatchedRangeProofU256,
 }
 
 pub trait ZkProofData<T: Pod> {


### PR DESCRIPTION
#### Problem
The batched range proof instructions have yet to be added to the elgamal proof program.

#### Summary of Changes
Add the batched range proof instructions. I think all the changes should be pretty straightforward. I think the regular (non-batched) range proof instruction can be subsumed by the batched range proof instructions, so I don't think we need to add it.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
