### PR TITLE
sdk: Add macro to define program id from Cargo.toml

### DIFF
--- a/programs/sbf/rust/simulation/Cargo.toml
+++ b/programs/sbf/rust/simulation/Cargo.toml
@@ -26,3 +26,6 @@ crate-type = ["cdylib", "lib"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[package.metadata.solana]
+program-id = "Sim1jD5C35odT8mzctm8BWnjic8xW5xgeb5MbcbErTo"

--- a/programs/sbf/rust/simulation/src/lib.rs
+++ b/programs/sbf/rust/simulation/src/lib.rs
@@ -4,7 +4,7 @@ use {
     solana_program::{
         account_info::{next_account_info, AccountInfo},
         clock::Clock,
-        declare_program_id_with_package_metadata,
+        declare_id_with_package_metadata,
         entrypoint::ProgramResult,
         msg,
         pubkey::Pubkey,
@@ -13,7 +13,7 @@ use {
     std::convert::TryInto,
 };
 
-declare_program_id_with_package_metadata!("solana.program-id");
+declare_id_with_package_metadata!("solana.program-id");
 
 solana_program::entrypoint!(process_instruction);
 

--- a/programs/sbf/rust/simulation/src/lib.rs
+++ b/programs/sbf/rust/simulation/src/lib.rs
@@ -4,7 +4,7 @@ use {
     solana_program::{
         account_info::{next_account_info, AccountInfo},
         clock::Clock,
-        declare_id,
+        declare_program_id_with_package_metadata,
         entrypoint::ProgramResult,
         msg,
         pubkey::Pubkey,
@@ -13,7 +13,7 @@ use {
     std::convert::TryInto,
 };
 
-declare_id!("Sim1jD5C35odT8mzctm8BWnjic8xW5xgeb5MbcbErTo");
+declare_program_id_with_package_metadata!("solana.program-id");
 
 solana_program::entrypoint!(process_instruction);
 

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -448,55 +448,6 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
     .into()
 }
 
-/// Macro for accessing data from the `package.metadata` section of the Cargo manifest
-///
-/// # Arguments
-/// * `key` - A string slice of a dot-separated path to the TOML key of interest
-///
-/// # Example
-/// Given the following `Cargo.toml`:
-/// ```ignore
-/// [package]
-/// name = "MyApp"
-/// version = "0.1.0"
-///
-/// [package.metadata]
-/// copyright = "Copyright (c) 2024 ACME Inc."
-/// ```
-///
-/// You can fetch the copyright with the following:
-/// ```ignore
-/// use solana_sdk_macro::package_metadata;
-///
-/// pub fn main() {
-///     let copyright = package_metadata!("copyright");
-///     assert_eq!(copyright, "Copyright (c) 2024 ACME Inc.");
-/// }
-/// ```
-///
-/// ## TOML Support
-/// This macro only supports static data:
-/// * Strings
-/// * Integers
-/// * Floating-point numbers
-/// * Booleans
-/// * Datetimes
-/// * Arrays
-///
-/// ## Array Example
-/// Given the following Cargo manifest:
-/// ```ignore
-/// [package.metadata.arrays]
-/// some_array = [ 1, 2, 3 ]
-/// ```
-///
-/// This is legal:
-/// ```ignore
-/// static ARR: [i64; 3] = package_metadata!("arrays.some_array");
-/// ```
-///
-/// It does *not* currently support accessing TOML array elements directly.
-/// TOML tables are not supported.
 #[proc_macro]
 pub fn package_metadata(input: TokenStream) -> TokenStream {
     let key = parse_macro_input!(input as syn::LitStr);

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -712,7 +712,7 @@ pub use solana_sdk_macro::program_pubkey as pubkey;
 /// id in code:
 ///
 /// ```ignore
-/// declare_program_id_with_package_metadata!("solana.program-id");
+/// declare_id_with_package_metadata!("solana.program-id");
 /// ```
 ///
 /// This program id behaves exactly as if the developer had written:
@@ -724,7 +724,7 @@ pub use solana_sdk_macro::program_pubkey as pubkey;
 /// Meaning that it's possible to refer to the program id using `crate::id()`,
 /// without needing to specify the program id in multiple places.
 #[macro_export]
-macro_rules! declare_program_id_with_package_metadata {
+macro_rules! declare_id_with_package_metadata {
     ($key:literal) => {
         solana_program::declare_id!(solana_program::pubkey::Pubkey::from_str_const(
             solana_program::package_metadata!($key)

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -718,7 +718,7 @@ pub use solana_sdk_macro::program_pubkey as pubkey;
 /// This program id behaves exactly as if the developer had written:
 ///
 /// ```
-/// declare_id!("MyProgram1111111111111111111111111111111111");
+/// solana_program::declare_id!("MyProgram1111111111111111111111111111111111");
 /// ```
 ///
 /// Meaning that it's possible to refer to the program id using `crate::id()`,

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -601,6 +601,56 @@ pub mod sdk_ids {
     }
 }
 
+/// Macro for accessing data from the `package.metadata` section of the Cargo manifest
+///
+/// # Arguments
+/// * `key` - A string slice of a dot-separated path to the TOML key of interest
+///
+/// # Example
+/// Given the following `Cargo.toml`:
+/// ```ignore
+/// [package]
+/// name = "MyApp"
+/// version = "0.1.0"
+///
+/// [package.metadata]
+/// copyright = "Copyright (c) 2024 ACME Inc."
+/// ```
+///
+/// You can fetch the copyright with the following:
+/// ```ignore
+/// use solana_sdk_macro::package_metadata;
+///
+/// pub fn main() {
+///     let copyright = package_metadata!("copyright");
+///     assert_eq!(copyright, "Copyright (c) 2024 ACME Inc.");
+/// }
+/// ```
+///
+/// ## TOML Support
+/// This macro only supports static data:
+/// * Strings
+/// * Integers
+/// * Floating-point numbers
+/// * Booleans
+/// * Datetimes
+/// * Arrays
+///
+/// ## Array Example
+/// Given the following Cargo manifest:
+/// ```ignore
+/// [package.metadata.arrays]
+/// some_array = [ 1, 2, 3 ]
+/// ```
+///
+/// This is legal:
+/// ```ignore
+/// static ARR: [i64; 3] = package_metadata!("arrays.some_array");
+/// ```
+///
+/// It does *not* currently support accessing TOML array elements directly.
+/// TOML tables are not supported.
+pub use solana_sdk_macro::package_metadata;
 /// Same as [`declare_id`] except that it reports that this ID has been deprecated.
 pub use solana_sdk_macro::program_declare_deprecated_id as declare_deprecated_id;
 /// Convenience macro to declare a static public key and functions to interact with it.
@@ -641,6 +691,46 @@ pub use solana_sdk_macro::program_declare_id as declare_id;
 /// assert_eq!(ID, my_id);
 /// ```
 pub use solana_sdk_macro::program_pubkey as pubkey;
+
+/// Convenience macro for declaring a program id from Cargo.toml package metadata.
+///
+/// # Arguments
+/// * `key` - A string slice of a dot-separated path to the TOML key of interest
+///
+/// # Example
+/// Given the following `Cargo.toml`:
+/// ```ignore
+/// [package]
+/// name = "my-solana-program"
+/// version = "0.1.0"
+///
+/// [package.metadata.solana]
+/// program-id = "MyProgram1111111111111111111111111111111111"
+/// ```
+///
+/// A program can use the program id declared in its `Cargo.toml` as the program
+/// id in code:
+///
+/// ```ignore
+/// declare_program_id_with_package_metadata!("solana.program-id");
+/// ```
+///
+/// This program id behaves exactly as if the developer had written:
+///
+/// ```
+/// declare_id!("MyProgram1111111111111111111111111111111111");
+/// ```
+///
+/// Meaning that it's possible to refer to the program id using `crate::id()`,
+/// without needing to specify the program id in multiple places.
+#[macro_export]
+macro_rules! declare_program_id_with_package_metadata {
+    ($key:literal) => {
+        solana_program::declare_id!(solana_program::pubkey::Pubkey::from_str_const(
+            solana_program::package_metadata!($key)
+        ));
+    };
+}
 
 #[macro_use]
 extern crate serde_derive;

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -188,6 +188,16 @@ impl Pubkey {
         Self(pubkey_array)
     }
 
+    /// Decode a string into a Pubkey, usable in a const context
+    ///
+    /// Note: Until https://github.com/Nullus157/bs58-rs/pull/120 lands, this
+    /// function does not include a check that the output decodes to exactly 32
+    /// bytes.
+    pub const fn from_str_const(s: &str) -> Self {
+        let id_array = bs58::decode(s.as_bytes()).into_array_const_unwrap::<PUBKEY_BYTES>();
+        Pubkey::new_from_array(id_array)
+    }
+
     #[deprecated(since = "1.3.9", note = "Please use 'Pubkey::new_unique' instead")]
     #[cfg(not(target_os = "solana"))]
     pub fn new_rand() -> Self {


### PR DESCRIPTION
#### Problem

We've added in the preliminary scaffolding in #1464 and #1465, but we still don't have the last bit to declare the program id in Cargo.toml.

#### Summary of Changes

Add the macro. As part of this, we have a few additions:

* Move the documentation for the macro and re-export in solana-program. This seems to be how we do all the other macros
* Add `Pubkey::from_str_const`
* Add a little extra helper macro to combine everything
* Changed one of the test programs to show the new way to declare the program id.

As noted in `Pubkey::from_str_const`, it's currently impossible to do a length check, which isn't great. We'll see if the upstream PR get accepted. I can keep this in draft until that goes through. I can also move that to a separate PR.

cc @lorisleiva
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
