### PR TITLE
test: remove some useless cases in the test

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1409,13 +1409,6 @@ pub mod tests {
                     // Depending on use, *executable_bool can be truthy or falsy due to direct memory manipulation
                     // assert_eq! thinks *executable_bool is equal to false but the if condition thinks it's not, contradictorily.
                     assert!(!*executable_bool);
-                    #[cfg(not(target_arch = "aarch64"))]
-                    {
-                        const FALSE: bool = false; // keep clippy happy
-                        if *executable_bool == FALSE {
-                            panic!("This didn't occur if this test passed.");
-                        }
-                    }
                     assert_eq!(*account.ref_executable_byte(), crafted_executable);
                 }
 


### PR DESCRIPTION
#### Problem

some changes for bumping Rust version: https://github.com/anza-xyz/agave/pull/1309

`test_new_from_file_crafted_executable` is failed on `nightly-2024-05-02` (run on linux). I have bisected it. it looks like everything works fine before `nightly-2024-03-27`.

the reproducible command is:
```
RUST_BACKTRACE=all cargo +nightly-2024-05-02 test --package solana-accounts-db --lib -- append_vec::tests::test_new_from_file_crafted_executable::storageaccess_mmap_expects --exact --show-output
```

the error I got:
```
thread 'append_vec::tests::test_new_from_file_crafted_executable::storageaccess_mmap_expects' panicked at accounts-db/src/append_vec.rs:1416:29:
This didn't occur if this test passed.
stack backtrace:
   0: rust_begin_unwind
             at /rustc/c987ad527540e8f1565f57c31204bde33f63df76/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_fmt
             at /rustc/c987ad527540e8f1565f57c31204bde33f63df76/library/core/src/panicking.rs:72:14
   2: solana_accounts_db::append_vec::tests::test_new_from_file_crafted_executable::{{closure}}
             at ./src/append_vec.rs:1416:29
   3: solana_accounts_db::append_vec::AppendVec::get_stored_account_meta_callback
             at ./src/append_vec.rs:549:22
   4: solana_accounts_db::append_vec::tests::test_new_from_file_crafted_executable
             at ./src/append_vec.rs:1398:13
   5: solana_accounts_db::append_vec::tests::test_new_from_file_crafted_executable::storageaccess_mmap_expects
             at ./src/append_vec.rs:1366:5
   6: solana_accounts_db::append_vec::tests::test_new_from_file_crafted_executable::storageaccess_mmap_expects::{{closure}}
             at ./src/append_vec.rs:1366:38
   7: core::ops::function::FnOnce::call_once
             at /rustc/c987ad527540e8f1565f57c31204bde33f63df76/library/core/src/ops/function.rs:250:5
   8: core::ops::function::FnOnce::call_once
             at /rustc/c987ad527540e8f1565f57c31204bde33f63df76/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

#### Summary of Changes

if I understand correctly, we tried to convert a byte to bool here. I think `assert!(!account.sanitize_executable());` has already covered the case and catch it. do we want to keep those undefined behaviors checking? I lean to remove them if we don't have similar use cases in the real world. (or maybe get them like a doc and don't need to run them)


(thanks @brooksprumo for sharing the original issue https://github.com/solana-labs/solana/pull/26009)