### PR TITLE
accounts-db/write-cache: add stats to track write cache hits/misses

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -315,11 +315,11 @@ impl AccountsCache {
     }
 
     pub fn fetch_max_flush_root(&self) -> Slot {
-        self.max_flushed_root.load(Ordering::Relaxed)
+        self.max_flushed_root.load(Ordering::Acquire)
     }
 
     pub fn set_max_flush_root(&self, root: Slot) {
-        self.max_flushed_root.fetch_max(root, Ordering::Relaxed);
+        self.max_flushed_root.fetch_max(root, Ordering::AcqRel);
     }
 }
 

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -24,6 +24,7 @@ pub struct SlotCacheInner {
     cache: DashMap<Pubkey, CachedAccount>,
     same_account_writes: AtomicU64,
     same_account_writes_size: AtomicU64,
+    unique_account_writes: AtomicU64,
     unique_account_writes_size: AtomicU64,
     size: AtomicU64,
     total_size: Arc<AtomicU64>,
@@ -50,6 +51,11 @@ impl SlotCacheInner {
             (
                 "same_account_writes_size",
                 self.same_account_writes_size.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "unique_account_writes",
+                self.unique_account_writes.load(Ordering::Relaxed),
                 i64
             ),
             (
@@ -94,6 +100,7 @@ impl SlotCacheInner {
             self.total_size.fetch_add(data_len, Ordering::Relaxed);
             self.unique_account_writes_size
                 .fetch_add(data_len, Ordering::Relaxed);
+            self.unique_account_writes.fetch_add(1, Ordering::Relaxed);
         }
         item
     }
@@ -183,6 +190,7 @@ impl AccountsCache {
             cache: DashMap::default(),
             same_account_writes: AtomicU64::default(),
             same_account_writes_size: AtomicU64::default(),
+            unique_account_writes: AtomicU64::default(),
             unique_account_writes_size: AtomicU64::default(),
             size: AtomicU64::default(),
             total_size: Arc::clone(&self.total_size),

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -289,20 +289,6 @@ impl AccountsCache {
         self.cache.iter().any(|e| e.key() <= &max_slot_inclusive)
     }
 
-    // Removes slots less than or equal to `max_root`. Only safe to pass in a rooted slot,
-    // otherwise the slot removed could still be undergoing replay!
-    pub fn remove_slots_le(&self, max_root: Slot) -> Vec<(Slot, SlotCache)> {
-        let mut removed_slots = vec![];
-        self.cache.retain(|slot, slot_cache| {
-            let should_remove = *slot <= max_root;
-            if should_remove {
-                removed_slots.push((*slot, slot_cache.clone()))
-            }
-            !should_remove
-        });
-        removed_slots
-    }
-
     pub fn cached_frozen_slots(&self) -> Vec<Slot> {
         let mut slots: Vec<_> = self
             .cache
@@ -340,6 +326,22 @@ impl AccountsCache {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+
+    impl AccountsCache {
+        // Removes slots less than or equal to `max_root`. Only safe to pass in a rooted slot,
+        // otherwise the slot removed could still be undergoing replay!
+        pub fn remove_slots_le(&self, max_root: Slot) -> Vec<(Slot, SlotCache)> {
+            let mut removed_slots = vec![];
+            self.cache.retain(|slot, slot_cache| {
+                let should_remove = *slot <= max_root;
+                if should_remove {
+                    removed_slots.push((*slot, slot_cache.clone()))
+                }
+                !should_remove
+            });
+            removed_slots
+        }
+    }
 
     #[test]
     fn test_remove_slots_le() {

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -211,6 +211,19 @@ impl AccountsCache {
     pub fn size(&self) -> u64 {
         self.total_size.load(Ordering::Relaxed)
     }
+
+    fn total_num_accounts(&self) -> u64 {
+        let total = self
+            .cache
+            .iter()
+            .map(|item| {
+                let slot_cache = item.value();
+                slot_cache.len()
+            })
+            .sum::<usize>();
+        total as u64
+    }
+
     pub fn report_size(&self) {
         datapoint_info!(
             "accounts_cache_size",
@@ -225,6 +238,7 @@ impl AccountsCache {
                 self.unique_account_writes_size(),
                 i64
             ),
+            ("total_num_accounts", self.total_num_accounts(), i64),
             ("total_size", self.size(), i64),
         );
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9622,6 +9622,7 @@ impl<'a> VerifyAccountsHashAndLamportsConfig<'a> {
 }
 
 /// A set of utility functions used for testing and benchmarking
+#[cfg(feature = "dev-context-only-utils")]
 pub mod test_utils {
     use {
         super::*,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8385,6 +8385,7 @@ impl AccountsDb {
     fn report_store_timings(&self) {
         if self.stats.last_store_report.should_update(1000) {
             let read_cache_stats = self.read_only_accounts_cache.get_and_reset_stats();
+            let write_cache_stats = self.accounts_cache.get_and_reset_stats();
             datapoint_info!(
                 "accounts_db_store_timings",
                 (
@@ -8475,6 +8476,8 @@ impl AccountsDb {
                     read_cache_stats.evictor_wakeup_count_productive,
                     i64
                 ),
+                ("write_cache_hits", write_cache_stats.hits, i64),
+                ("write_cache_misses", write_cache_stats.misses, i64),
                 (
                     "calc_stored_meta_us",
                     self.stats.calc_stored_meta.swap(0, Ordering::Relaxed),


### PR DESCRIPTION
#### Problem

We want to track how many accounts loads that hit write cache.


#### Summary of Changes

- add stats to track account write cache hits/misses

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
