### PR TITLE
refactor: checked transaction lps is never none

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -2516,16 +2516,16 @@ mod tests {
                 Err(TransactionError::BlockhashNotFound),
                 Ok(CheckedTransactionDetails {
                     nonce: None,
-                    lamports_per_signature: None
+                    lamports_per_signature: 0
                 }),
                 Err(TransactionError::BlockhashNotFound),
                 Ok(CheckedTransactionDetails {
                     nonce: None,
-                    lamports_per_signature: None
+                    lamports_per_signature: 0
                 }),
                 Ok(CheckedTransactionDetails {
                     nonce: None,
-                    lamports_per_signature: None
+                    lamports_per_signature: 0
                 }),
             ]),
             [2, 4, 5]
@@ -2535,21 +2535,21 @@ mod tests {
             Consumer::filter_valid_transaction_indexes(&[
                 Ok(CheckedTransactionDetails {
                     nonce: None,
-                    lamports_per_signature: None
+                    lamports_per_signature: 0,
                 }),
                 Err(TransactionError::BlockhashNotFound),
                 Err(TransactionError::BlockhashNotFound),
                 Ok(CheckedTransactionDetails {
                     nonce: None,
-                    lamports_per_signature: None
+                    lamports_per_signature: 0,
                 }),
                 Ok(CheckedTransactionDetails {
                     nonce: None,
-                    lamports_per_signature: None
+                    lamports_per_signature: 0,
                 }),
                 Ok(CheckedTransactionDetails {
                     nonce: None,
-                    lamports_per_signature: None
+                    lamports_per_signature: 0,
                 }),
             ]),
             [0, 3, 4, 5]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3493,14 +3493,14 @@ impl Bank {
         if let Some(hash_info) = hash_queue.get_hash_info_if_valid(recent_blockhash, max_age) {
             Ok(CheckedTransactionDetails {
                 nonce: None,
-                lamports_per_signature: Some(hash_info.lamports_per_signature()),
+                lamports_per_signature: hash_info.lamports_per_signature(),
             })
         } else if let Some((nonce, nonce_data)) =
             self.check_and_load_message_nonce_account(tx.message(), next_durable_nonce)
         {
             Ok(CheckedTransactionDetails {
                 nonce: Some(nonce),
-                lamports_per_signature: Some(nonce_data.get_lamports_per_signature()),
+                lamports_per_signature: nonce_data.get_lamports_per_signature(),
             })
         } else {
             error_counters.blockhash_not_found += 1;

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1041,7 +1041,7 @@ mod tests {
             &[tx],
             &[Ok(CheckedTransactionDetails {
                 nonce: None,
-                lamports_per_signature: Some(10),
+                lamports_per_signature: 10,
             })],
             &mut error_counters,
             &FeeStructure::default(),
@@ -2045,7 +2045,7 @@ mod tests {
             &[sanitized_tx.clone()],
             &[Ok(CheckedTransactionDetails {
                 nonce: None,
-                lamports_per_signature: Some(0),
+                lamports_per_signature: 0,
             })],
             &mut error_counters,
             &FeeStructure::default(),
@@ -2125,7 +2125,7 @@ mod tests {
         );
         let check_result = Ok(CheckedTransactionDetails {
             nonce: Some(NoncePartial::default()),
-            lamports_per_signature: Some(20),
+            lamports_per_signature: 20,
         });
 
         let results = load_accounts(
@@ -2194,27 +2194,10 @@ mod tests {
             false,
         );
 
-        let check_result = Ok(CheckedTransactionDetails {
-            nonce: Some(NoncePartial::default()),
-            lamports_per_signature: None,
-        });
         let fee_structure = FeeStructure::default();
-
-        let result = load_accounts(
-            &mock_bank,
-            &[sanitized_transaction.clone()],
-            &[check_result],
-            &mut TransactionErrorMetrics::default(),
-            &fee_structure,
-            None,
-            &ProgramCacheForTxBatch::default(),
-        );
-
-        assert_eq!(result, vec![Err(TransactionError::BlockhashNotFound)]);
-
         let check_result = Ok(CheckedTransactionDetails {
             nonce: Some(NoncePartial::default()),
-            lamports_per_signature: Some(20),
+            lamports_per_signature: 20,
         });
 
         let result = load_accounts(

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -43,7 +43,7 @@ pub type TransactionLoadResult = Result<LoadedTransaction>;
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CheckedTransactionDetails {
     pub nonce: Option<NoncePartial>,
-    pub lamports_per_signature: Option<u64>,
+    pub lamports_per_signature: u64,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -141,20 +141,16 @@ pub(crate) fn load_accounts<CB: TransactionProcessingCallback>(
                 }),
             ) => {
                 let message = tx.message();
-                let fee = if let Some(lamports_per_signature) = lamports_per_signature {
-                    fee_structure.calculate_fee(
-                        message,
-                        *lamports_per_signature,
-                        &process_compute_budget_instructions(message.program_instructions_iter())
-                            .unwrap_or_default()
-                            .into(),
-                        feature_set
-                            .is_active(&include_loaded_accounts_data_size_in_fee_calculation::id()),
-                        feature_set.is_active(&remove_rounding_in_fee_calculation::id()),
-                    )
-                } else {
-                    return Err(TransactionError::BlockhashNotFound);
-                };
+                let fee = fee_structure.calculate_fee(
+                    message,
+                    *lamports_per_signature,
+                    &process_compute_budget_instructions(message.program_instructions_iter())
+                        .unwrap_or_default()
+                        .into(),
+                    feature_set
+                        .is_active(&include_loaded_accounts_data_size_in_fee_calculation::id()),
+                    feature_set.is_active(&remove_rounding_in_fee_calculation::id()),
+                );
 
                 // load transactions
                 load_transaction_accounts(
@@ -557,7 +553,7 @@ mod tests {
             &[sanitized_tx],
             &[Ok(CheckedTransactionDetails {
                 nonce: None,
-                lamports_per_signature: Some(lamports_per_signature),
+                lamports_per_signature,
             })],
             error_counters,
             fee_structure,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1244,21 +1244,16 @@ mod tests {
         let transactions = vec![
             sanitized_transaction_1.clone(),
             sanitized_transaction_2.clone(),
-            sanitized_transaction_2,
             sanitized_transaction_1,
         ];
         let mut lock_results = vec![
             Ok(CheckedTransactionDetails {
                 nonce: None,
-                lamports_per_signature: Some(25),
+                lamports_per_signature: 25,
             }),
             Ok(CheckedTransactionDetails {
                 nonce: None,
-                lamports_per_signature: Some(25),
-            }),
-            Ok(CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature: None,
+                lamports_per_signature: 25,
             }),
             Err(TransactionError::ProgramAccountNotFound),
         ];
@@ -1271,7 +1266,6 @@ mod tests {
             &owners,
         );
 
-        assert_eq!(lock_results[2], Err(TransactionError::BlockhashNotFound));
         assert_eq!(result.len(), 2);
         assert_eq!(result[&key1], 2);
         assert_eq!(result[&key2], 1);
@@ -1353,11 +1347,11 @@ mod tests {
                 &mut [
                     Ok(CheckedTransactionDetails {
                         nonce: None,
-                        lamports_per_signature: Some(0),
+                        lamports_per_signature: 0,
                     }),
                     Ok(CheckedTransactionDetails {
                         nonce: None,
-                        lamports_per_signature: Some(0),
+                        lamports_per_signature: 0,
                     }),
                 ],
                 owners,
@@ -1452,12 +1446,9 @@ mod tests {
         let mut lock_results = vec![
             Ok(CheckedTransactionDetails {
                 nonce: None,
-                lamports_per_signature: Some(0),
+                lamports_per_signature: 0,
             }),
-            Ok(CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature: None,
-            }),
+            Err(TransactionError::BlockhashNotFound),
         ];
         let programs =
             TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
@@ -1475,7 +1466,6 @@ mod tests {
                 .expect("failed to find the program account"),
             &1
         );
-        assert_eq!(lock_results[1], Err(TransactionError::BlockhashNotFound));
     }
 
     #[test]

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -273,7 +273,7 @@ fn prepare_transactions(
     all_transactions.push(sanitized_transaction);
     transaction_checks.push(Ok(CheckedTransactionDetails {
         nonce: None,
-        lamports_per_signature: Some(20),
+        lamports_per_signature: 20,
     }));
 
     // The transaction fee payer must have enough funds
@@ -319,7 +319,7 @@ fn prepare_transactions(
     all_transactions.push(sanitized_transaction);
     transaction_checks.push(Ok(CheckedTransactionDetails {
         nonce: None,
-        lamports_per_signature: Some(20),
+        lamports_per_signature: 20,
     }));
 
     // Setting up the accounts for the transfer
@@ -361,7 +361,7 @@ fn prepare_transactions(
     all_transactions.push(sanitized_transaction);
     transaction_checks.push(Ok(CheckedTransactionDetails {
         nonce: None,
-        lamports_per_signature: Some(20),
+        lamports_per_signature: 20,
     }));
 
     let mut account_data = AccountSharedData::default();
@@ -405,7 +405,7 @@ fn prepare_transactions(
     all_transactions.push(sanitized_transaction.clone());
     transaction_checks.push(Ok(CheckedTransactionDetails {
         nonce: None,
-        lamports_per_signature: Some(20),
+        lamports_per_signature: 20,
     }));
 
     // fee payer


### PR DESCRIPTION
#### Problem
The `lamports_per_signature` field is `Option` wrapped but can never actually be `None`

#### Summary of Changes
Remove `Option`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
