### PR TITLE
accounts-db/write-cache/refactor: decorate test_util with dev-context attr

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9619,6 +9619,7 @@ impl<'a> VerifyAccountsHashAndLamportsConfig<'a> {
 }
 
 /// A set of utility functions used for testing and benchmarking
+#[cfg(feature = "dev-context-only-utils")]
 pub mod test_utils {
     use {
         super::*,


### PR DESCRIPTION
#### Problem

test_util can be decorated in dev-context.


#### Summary of Changes

Decorate test_util with dev-context attribute.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
