### PR TITLE
accounts-db/write-cache/refactor: move `remove_slots_le` to test context

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -262,20 +262,6 @@ impl AccountsCache {
         self.cache.iter().any(|e| e.key() <= &max_slot_inclusive)
     }
 
-    // Removes slots less than or equal to `max_root`. Only safe to pass in a rooted slot,
-    // otherwise the slot removed could still be undergoing replay!
-    pub fn remove_slots_le(&self, max_root: Slot) -> Vec<(Slot, SlotCache)> {
-        let mut removed_slots = vec![];
-        self.cache.retain(|slot, slot_cache| {
-            let should_remove = *slot <= max_root;
-            if should_remove {
-                removed_slots.push((*slot, slot_cache.clone()))
-            }
-            !should_remove
-        });
-        removed_slots
-    }
-
     pub fn cached_frozen_slots(&self) -> Vec<Slot> {
         let mut slots: Vec<_> = self
             .cache
@@ -313,6 +299,22 @@ impl AccountsCache {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+
+    impl AccountsCache {
+        // Removes slots less than or equal to `max_root`. Only safe to pass in a rooted slot,
+        // otherwise the slot removed could still be undergoing replay!
+        pub fn remove_slots_le(&self, max_root: Slot) -> Vec<(Slot, SlotCache)> {
+            let mut removed_slots = vec![];
+            self.cache.retain(|slot, slot_cache| {
+                let should_remove = *slot <= max_root;
+                if should_remove {
+                    removed_slots.push((*slot, slot_cache.clone()))
+                }
+                !should_remove
+            });
+            removed_slots
+        }
+    }
 
     #[test]
     fn test_remove_slots_le() {


### PR DESCRIPTION
#### Problem

`remove_slots_le` can be moved to test context.


#### Summary of Changes

move `remove_slots_le` to test context.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
