### PR TITLE
accounts-db/write-cache: fix memory consistence ordering for max_flush_root

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -306,7 +306,7 @@ impl AccountsCache {
     }
 
     pub fn set_max_flush_root(&self, root: Slot) {
-        self.max_flushed_root.fetch_max(root, Ordering::AcqRel);
+        self.max_flushed_root.fetch_max(root, Ordering::Release);
     }
 }
 

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -302,11 +302,11 @@ impl AccountsCache {
     }
 
     pub fn fetch_max_flush_root(&self) -> Slot {
-        self.max_flushed_root.load(Ordering::Relaxed)
+        self.max_flushed_root.load(Ordering::Acquire)
     }
 
     pub fn set_max_flush_root(&self, root: Slot) {
-        self.max_flushed_root.fetch_max(root, Ordering::Relaxed);
+        self.max_flushed_root.fetch_max(root, Ordering::AcqRel);
     }
 }
 


### PR DESCRIPTION
#### Problem

Atomic max_flush_root should honor acquire release memeory consistency.


#### Summary of Changes

use acquire/release memory consistency for atomic max_flush_root for write
cache.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
