### PR TITLE
ci: update crate owner pipeline

### DIFF
--- a/.github/workflows/crate-check.yml
+++ b/.github/workflows/crate-check.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "**/Cargo.toml"
       - ".github/workflows/crate-check.yml"
+      - "./ci/check-crates.sh"
 
 jobs:
   check:

--- a/ci/check-crates.sh
+++ b/ci/check-crates.sh
@@ -21,7 +21,7 @@ declare skip_patterns=(
 )
 
 declare -A verified_crate_owners=(
-  ["chidobot"]=1
+  ["anza-team"]=1
 )
 
 # get Cargo.toml from git diff

--- a/ci/check-crates.sh
+++ b/ci/check-crates.sh
@@ -21,7 +21,7 @@ declare skip_patterns=(
 )
 
 declare -A verified_crate_owners=(
-  ["solana-grimes"]=1
+  ["chidobot"]=1
 )
 
 # get Cargo.toml from git diff

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -8,7 +8,6 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-# fake update
 
 [dependencies]
 assert_matches = { workspace = true }

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -8,7 +8,6 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-# trigger pipeline
 
 [dependencies]
 assert_matches = { workspace = true }

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+# fake update
 
 [dependencies]
 assert_matches = { workspace = true }

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+# trigger pipeline
 
 [dependencies]
 assert_matches = { workspace = true }


### PR DESCRIPTION
#### Summary of Changes

migrated ~all crates~ `solana-*` and `agave-*` crates from solana-grimes to anza-team 😭  

(I stopped the pipeline temporally)

---

after merge:

- [x] announce this one in devops channel
- [x] resume https://github.com/anza-xyz/agave/actions/workflows/crate-check.yml

