### PR TITLE
ci: update dependabot pipeline

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -33,7 +33,8 @@ jobs:
           echo "crate_name: $crate_name, old_version: $old_version, new_version: $new_version"
 
           ./scripts/cargo-for-all-lock-files.sh -- update -p $crate_name:$old_version --precise $new_version || \
-          ./scripts/cargo-for-all-lock-files.sh -- update -p $crate_name --precise $new_version
+          ./scripts/cargo-for-all-lock-files.sh -- update -p $crate_name --precise $new_version || \
+          ./scripts/cargo-for-all-lock-files.sh -- tree
 
       - name: push
         run: |


### PR DESCRIPTION
#### Problem

there is an issue for the relaxed rule https://github.com/anza-xyz/agave/pull/1455
<img width="870" alt="Screenshot 2024-05-28 at 00 56 43" src="https://github.com/anza-xyz/agave/assets/8209234/b4b31c84-454f-4b43-acc0-c4adc5fa00c8">

#### Summary of Changes

we will parse `from` and `to` version from the PR title. I guess using `tree` command to update lock files will be more suitable for the relaxed rule.