### PR TITLE
Fix - `ExecuteDetailsTimings::execute_us`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -196,6 +196,8 @@ pub struct InvokeContext<'a> {
     compute_meter: RefCell<u64>,
     log_collector: Option<Rc<RefCell<LogCollector>>>,
     pub programs_modified_by_tx: &'a mut ProgramCacheForTxBatch,
+    /// Latest measurement not yet accumulated in [ExecuteDetailsTimings::execute_us]
+    pub execute_time: Option<Measure>,
     pub timings: ExecuteDetailsTimings,
     pub syscall_context: Vec<Option<SyscallContext>>,
     traces: Vec<Vec<[u64; 12]>>,
@@ -219,6 +221,7 @@ impl<'a> InvokeContext<'a> {
             compute_budget,
             compute_meter: RefCell::new(compute_budget.compute_unit_limit),
             programs_modified_by_tx,
+            execute_time: None,
             timings: ExecuteDetailsTimings::default(),
             syscall_context: Vec::new(),
             traces: Vec::new(),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1385,10 +1385,9 @@ fn execute<'a, 'b: 'a>(
         .collect::<Vec<_>>();
 
     let mut create_vm_time = Measure::start("create_vm");
-    let mut execute_time;
     let execution_result = {
         let compute_meter_prev = invoke_context.get_remaining();
-        create_vm!(vm, executable, regions, accounts_metadata, invoke_context,);
+        create_vm!(vm, executable, regions, accounts_metadata, invoke_context);
         let mut vm = match vm {
             Ok(info) => info,
             Err(e) => {
@@ -1398,9 +1397,14 @@ fn execute<'a, 'b: 'a>(
         };
         create_vm_time.stop();
 
-        execute_time = Measure::start("execute");
+        vm.context_object_pointer.execute_time = Some(Measure::start("execute"));
         let (compute_units_consumed, result) = vm.execute_program(executable, !use_jit);
         drop(vm);
+        if let Some(execute_time) = invoke_context.execute_time.as_mut() {
+            execute_time.stop();
+            saturating_add_assign!(invoke_context.timings.execute_us, execute_time.as_us());
+        }
+
         ic_logger_msg!(
             log_collector,
             "Program {} consumed {} of {} compute units",
@@ -1463,7 +1467,6 @@ fn execute<'a, 'b: 'a>(
             _ => Ok(()),
         }
     };
-    execute_time.stop();
 
     fn deserialize_parameters(
         invoke_context: &mut InvokeContext,
@@ -1489,13 +1492,12 @@ fn execute<'a, 'b: 'a>(
     deserialize_time.stop();
 
     // Update the timings
-    let timings = &mut invoke_context.timings;
-    timings.serialize_us = timings.serialize_us.saturating_add(serialize_time.as_us());
-    timings.create_vm_us = timings.create_vm_us.saturating_add(create_vm_time.as_us());
-    timings.execute_us = timings.execute_us.saturating_add(execute_time.as_us());
-    timings.deserialize_us = timings
-        .deserialize_us
-        .saturating_add(deserialize_time.as_us());
+    saturating_add_assign!(invoke_context.timings.serialize_us, serialize_time.as_us());
+    saturating_add_assign!(invoke_context.timings.create_vm_us, create_vm_time.as_us());
+    saturating_add_assign!(
+        invoke_context.timings.deserialize_us,
+        deserialize_time.as_us()
+    );
 
     execute_or_deserialize_result
 }


### PR DESCRIPTION
#### Problem
`ExecuteDetailsTimings::execute_us` currently over-counts (ca. +120%) because its measurement recursively overlaps with itself during CPI and includes other measurements as well.

#### Summary of Changes
- Adds `InvokeContext::execute_time`
- Explicitly stops and restarts the measurement in the CPI syscall
- Uses `saturating_add_assign()` for the other `ExecuteDetailsTimings` as well