### PR TITLE
[banks-server] fix: Enable CPI tracking by default

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -195,7 +195,7 @@ fn simulate_transaction(
         units_consumed,
         return_data,
         inner_instructions,
-    } = bank.simulate_transaction_unchecked(&sanitized_transaction, false);
+    } = bank.simulate_transaction_unchecked(&sanitized_transaction, true);
 
     let simulation_details = TransactionSimulationDetails {
         logs,


### PR DESCRIPTION
#### Problem

Before this change, simulating a transaction from banks-client (with `BanksClient::simulate_transaction`) did not include inner instructions in `TransactionSimulationDetails`.

Not enabling it by default makes it impossible to test "compression" (logging events through noop program) in Rust tests (with solana-program-test), because there is no way to enable that feature through solana-program-test or solana-banks-client.

Enabling it makes such test cases possible[0]. It makes it easy to simulate a transaction, then fetch and serialize an associated event logged through noop program in Rust tests, without having to do it in JS/TS or relying on external indexers.

[0] https://github.com/Lightprotocol/light-protocol/blob/9e8c13e26c1e019f92b32025c580809ea04fd375/test-utils/src/lib.rs#L212-L232

#### Summary of Changes

Set the `enable_cpi_recording` argument in `simulate_transaction_unchecked` call inside banks-server to `true`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
