### PR TITLE
[runtime] Fix build with musl

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -907,7 +907,7 @@ pub(crate) fn remap_append_vec_file(
         let remapped_file_name = AccountsFile::file_name(slot, remapped_append_vec_id);
         remapped_append_vec_path = append_vec_path.parent().unwrap().join(remapped_file_name);
 
-        #[cfg(target_os = "linux")]
+        #[cfg(all(target_os = "linux", target_env = "gnu"))]
         {
             let remapped_append_vec_path_cstr = cstring_from_path(&remapped_append_vec_path)?;
 
@@ -923,7 +923,10 @@ pub(crate) fn remap_append_vec_file(
             }
         }
 
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(any(
+            not(target_os = "linux"),
+            all(target_os = "linux", not(target_env = "gnu"))
+        ))]
         if std::fs::metadata(&remapped_append_vec_path).is_err() {
             break (remapped_append_vec_id, remapped_append_vec_path);
         }
@@ -935,7 +938,10 @@ pub(crate) fn remap_append_vec_file(
 
     // Only rename the file if the new ID is actually different from the original. In the target_os
     // = linux case, we have already renamed if necessary.
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(any(
+        not(target_os = "linux"),
+        all(target_os = "linux", not(target_env = "gnu"))
+    ))]
     if old_append_vec_id != remapped_append_vec_id as SerializedAccountsFileId {
         std::fs::rename(append_vec_path, &remapped_append_vec_path)?;
     }
@@ -1206,7 +1212,7 @@ where
 }
 
 // Rename `src` to `dest` only if `dest` doesn't already exist.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 fn rename_no_replace(src: &CStr, dest: &CStr) -> io::Result<()> {
     let ret = unsafe {
         libc::renameat2(


### PR DESCRIPTION
#### Problem

The current version of musl libc doesn't define a separate `renameat2` function. It uses `renameat2` syscall insice `renameat` when it's avaialble, but it doesn't allow to provide flags[0].

There is a patchset introducing a separate function, which also allows to define flags, but it's not included in any release yet[1].

[0] https://git.musl-libc.org/cgit/musl/tree/src/unistd/renameat.c
[1] https://www.openwall.com/lists/musl/2024/05/07/7

#### Summary of Changes

Guard the `renameat2` call with `target_env = "gnu"`, include the combination of `target_os = "linux"` and `target_env = "musl"` in the fallback which manually renames without replacing.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
