### PR TITLE
Moves bank snapshot serialization to SnapshotPackagerService

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -383,23 +383,15 @@ impl SnapshotRequestHandler {
         let accounts_package = match request_kind {
             SnapshotRequestKind::Snapshot => match &accounts_package_kind {
                 AccountsPackageKind::Snapshot(_) => {
-                    let bank_snapshot_info = snapshot_bank_utils::add_bank_snapshot(
-                        &self.snapshot_config.bank_snapshots_dir,
-                        &snapshot_root_bank,
-                        &snapshot_storages,
-                        self.snapshot_config.snapshot_version,
-                        status_cache_slot_deltas,
-                    )?;
                     AccountsPackage::new_for_snapshot(
                         accounts_package_kind,
                         &snapshot_root_bank,
-                        &bank_snapshot_info,
                         snapshot_storages,
+                        status_cache_slot_deltas,
                         accounts_hash_for_testing,
                     )
                 }
                 AccountsPackageKind::AccountsHashVerifier => {
-                    // skip the bank snapshot, just make an accounts package to send to AHV
                     AccountsPackage::new_for_accounts_hash_verifier(
                         accounts_package_kind,
                         &snapshot_root_bank,
@@ -410,7 +402,6 @@ impl SnapshotRequestHandler {
                 AccountsPackageKind::EpochAccountsHash => panic!("Illegal account package type: EpochAccountsHash packages must be from an EpochAccountsHash request!"),
             },
             SnapshotRequestKind::EpochAccountsHash => {
-                // skip the bank snapshot, just make an accounts package to send to AHV
                 AccountsPackage::new_for_epoch_accounts_hash(
                     accounts_package_kind,
                     &snapshot_root_bank,
@@ -430,7 +421,7 @@ impl SnapshotRequestHandler {
         }
         snapshot_time.stop();
         info!(
-            "Took bank snapshot. accounts package kind: {:?}, slot: {}, bank hash: {}",
+            "Handled snapshot request. accounts package kind: {:?}, slot: {}, bank hash: {}",
             accounts_package_kind,
             snapshot_root_bank.slot(),
             snapshot_root_bank.hash(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -500,38 +500,38 @@ pub struct BankFieldsToDeserialize {
 /// new fields can be optionally serialized and optionally deserialized. At some point, the serialization and
 /// deserialization will use a new mechanism or otherwise be in sync more clearly.
 #[derive(Debug)]
-pub(crate) struct BankFieldsToSerialize {
-    pub(crate) blockhash_queue: BlockhashQueue,
-    pub(crate) ancestors: AncestorsForSerialization,
-    pub(crate) hash: Hash,
-    pub(crate) parent_hash: Hash,
-    pub(crate) parent_slot: Slot,
-    pub(crate) hard_forks: HardForks,
-    pub(crate) transaction_count: u64,
-    pub(crate) tick_height: u64,
-    pub(crate) signature_count: u64,
-    pub(crate) capitalization: u64,
-    pub(crate) max_tick_height: u64,
-    pub(crate) hashes_per_tick: Option<u64>,
-    pub(crate) ticks_per_slot: u64,
-    pub(crate) ns_per_slot: u128,
-    pub(crate) genesis_creation_time: UnixTimestamp,
-    pub(crate) slots_per_year: f64,
-    pub(crate) slot: Slot,
-    pub(crate) epoch: Epoch,
-    pub(crate) block_height: u64,
-    pub(crate) collector_id: Pubkey,
-    pub(crate) collector_fees: u64,
-    pub(crate) fee_calculator: FeeCalculator,
-    pub(crate) fee_rate_governor: FeeRateGovernor,
-    pub(crate) collected_rent: u64,
-    pub(crate) rent_collector: RentCollector,
-    pub(crate) epoch_schedule: EpochSchedule,
-    pub(crate) inflation: Inflation,
-    pub(crate) stakes: StakesEnum,
-    pub(crate) epoch_stakes: HashMap<Epoch, EpochStakes>,
-    pub(crate) is_delta: bool,
-    pub(crate) accounts_data_len: u64,
+pub struct BankFieldsToSerialize {
+    pub blockhash_queue: BlockhashQueue,
+    pub ancestors: AncestorsForSerialization,
+    pub hash: Hash,
+    pub parent_hash: Hash,
+    pub parent_slot: Slot,
+    pub hard_forks: HardForks,
+    pub transaction_count: u64,
+    pub tick_height: u64,
+    pub signature_count: u64,
+    pub capitalization: u64,
+    pub max_tick_height: u64,
+    pub hashes_per_tick: Option<u64>,
+    pub ticks_per_slot: u64,
+    pub ns_per_slot: u128,
+    pub genesis_creation_time: UnixTimestamp,
+    pub slots_per_year: f64,
+    pub slot: Slot,
+    pub epoch: Epoch,
+    pub block_height: u64,
+    pub collector_id: Pubkey,
+    pub collector_fees: u64,
+    pub fee_calculator: FeeCalculator,
+    pub fee_rate_governor: FeeRateGovernor,
+    pub collected_rent: u64,
+    pub rent_collector: RentCollector,
+    pub epoch_schedule: EpochSchedule,
+    pub inflation: Inflation,
+    pub stakes: StakesEnum,
+    pub epoch_stakes: HashMap<Epoch, EpochStakes>,
+    pub is_delta: bool,
+    pub accounts_data_len: u64,
 }
 
 // Can't derive PartialEq because RwLock doesn't implement PartialEq
@@ -634,6 +634,47 @@ impl PartialEq for Bank {
             && *stakes_cache.stakes() == *other.stakes_cache.stakes()
             && epoch_stakes == &other.epoch_stakes
             && is_delta.load(Relaxed) == other.is_delta.load(Relaxed)
+    }
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl BankFieldsToSerialize {
+    /// Create a new BankFieldsToSerialize where basically every field is defaulted.
+    /// Only use for tests; many of the fields are invalid!
+    pub fn default_for_tests() -> Self {
+        Self {
+            blockhash_queue: BlockhashQueue::default(),
+            ancestors: AncestorsForSerialization::default(),
+            hash: Hash::default(),
+            parent_hash: Hash::default(),
+            parent_slot: Slot::default(),
+            hard_forks: HardForks::default(),
+            transaction_count: u64::default(),
+            tick_height: u64::default(),
+            signature_count: u64::default(),
+            capitalization: u64::default(),
+            max_tick_height: u64::default(),
+            hashes_per_tick: Option::default(),
+            ticks_per_slot: u64::default(),
+            ns_per_slot: u128::default(),
+            genesis_creation_time: UnixTimestamp::default(),
+            slots_per_year: f64::default(),
+            slot: Slot::default(),
+            epoch: Epoch::default(),
+            block_height: u64::default(),
+            collector_id: Pubkey::default(),
+            collector_fees: u64::default(),
+            fee_calculator: FeeCalculator::default(),
+            fee_rate_governor: FeeRateGovernor::default(),
+            collected_rent: u64::default(),
+            rent_collector: RentCollector::default(),
+            epoch_schedule: EpochSchedule::default(),
+            inflation: Inflation::default(),
+            stakes: Stakes::<Delegation>::default().into(),
+            epoch_stakes: HashMap::default(),
+            is_delta: bool::default(),
+            accounts_data_len: u64::default(),
+        }
     }
 }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -579,6 +579,38 @@ where
     )
 }
 
+/// Serializes bank snapshot into `stream`
+pub fn serialize_bank_snapshot<W>(
+    stream: &mut BufWriter<W>,
+    bank_fields: BankFieldsToSerialize,
+    accounts_db: &AccountsDb,
+    account_storage_entries: &[Vec<Arc<AccountStorageEntry>>],
+    incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
+    epoch_accounts_hash: Option<EpochAccountsHash>,
+) -> Result<(), Error>
+where
+    W: Write,
+{
+    let slot = bank_fields.slot;
+    let lamports_per_signature = bank_fields.fee_rate_governor.lamports_per_signature;
+    let serializable_bank = SerializableVersionedBank::from(bank_fields);
+    let serializable_accounts_db = SerializableAccountsDb::<'_> {
+        accounts_db,
+        slot,
+        account_storage_entries,
+    };
+    bincode::serialize_into(
+        stream,
+        &(
+            serializable_bank,
+            serializable_accounts_db,
+            lamports_per_signature,
+            incremental_snapshot_persistence,
+            epoch_accounts_hash,
+        ),
+    )
+}
+
 /// deserialize the bank from 'stream_reader'
 /// modify the accounts_hash
 /// reserialize the bank to 'stream_writer'
@@ -800,10 +832,9 @@ impl<'a> Serialize for SerializableAccountsDb<'a> {
             .get_accounts_delta_hash(slot)
             .map(Into::into)
             .unwrap_or_else(|| panic!("Missing accounts delta hash entry for slot {slot}"));
-        // NOTE: The accounts hash is calculated in AHV, which is *after* a bank snapshot is taken
-        // (and serialized here).  Thus it is expected that an accounts hash is *not* found for
-        // this slot, and a placeholder value will be used instead.  The real accounts hash will be
-        // set by `reserialize_bank_with_new_accounts_hash` from AHV.
+        // NOTE: This accounts hash is only needed when serializing a full snapshot.
+        // When serializing an incremental snapshot, there will not be a full accounts hash
+        // at `slot`.  In that case, use the default, because it doesn't actually get used.
         let accounts_hash = self
             .accounts_db
             .get_accounts_hash(slot)

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -544,6 +544,7 @@ where
     )
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 pub(crate) fn bank_to_stream<W>(
     stream: &mut BufWriter<W>,
     bank: &Bank,

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "dev-context-only-utils")]
-use qualifier_attr::qualifiers;
 use {
     crate::{
         bank::{builtins::BuiltinPrototype, Bank, BankFieldsToDeserialize, BankSlotDelta},
@@ -16,8 +14,8 @@ use {
         snapshot_hash::SnapshotHash,
         snapshot_package::{AccountsPackage, AccountsPackageKind, SnapshotKind, SnapshotPackage},
         snapshot_utils::{
-            self, archive_snapshot_package, deserialize_snapshot_data_file,
-            deserialize_snapshot_data_files, get_bank_snapshot_dir, get_highest_bank_snapshot_post,
+            self, deserialize_snapshot_data_file, deserialize_snapshot_data_files,
+            get_bank_snapshot_dir, get_highest_bank_snapshot_post,
             get_highest_full_snapshot_archive_info, get_highest_incremental_snapshot_archive_info,
             get_snapshot_file_name, get_storages_to_serialize, hard_link_storages_to_snapshot,
             rebuild_storages_from_snapshot_dir, serialize_snapshot_data_file,
@@ -36,7 +34,6 @@ use {
             CalcAccountsHashDataSource,
         },
         accounts_file::StorageAccess,
-        accounts_hash::AccountsHash,
         accounts_index::AccountSecondaryIndexes,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         utils::delete_contents_of_path,
@@ -45,7 +42,6 @@ use {
     solana_sdk::{
         clock::{Epoch, Slot},
         genesis_config::GenesisConfig,
-        hash::Hash,
         pubkey::Pubkey,
         slot_history::{Check, SlotHistory},
     },
@@ -65,11 +61,7 @@ pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: Slot = 100;
 pub const DISABLED_SNAPSHOT_ARCHIVE_INTERVAL: Slot = Slot::MAX;
 
 /// Serialize a bank to a snapshot
-///
-/// **DEVELOPER NOTE** Any error that is returned from this function may bring down the node!  This
-/// function is called from AccountsBackgroundService to handle snapshot requests.  Since taking a
-/// snapshot is not permitted to fail, any errors returned here will trigger the node to shutdown.
-/// So, be careful whenever adding new code that may return errors.
+#[cfg(feature = "dev-context-only-utils")]
 pub fn add_bank_snapshot(
     bank_snapshots_dir: impl AsRef<Path>,
     bank: &Bank,
@@ -202,7 +194,7 @@ pub fn add_bank_snapshot(
     do_add_bank_snapshot().map_err(|err| SnapshotError::AddBankSnapshot(err, bank.slot()))
 }
 
-fn serialize_status_cache(
+pub fn serialize_status_cache(
     slot_deltas: &[BankSlotDelta],
     status_cache_path: &Path,
 ) -> snapshot_utils::Result<u64> {
@@ -1029,34 +1021,65 @@ pub fn bank_to_full_snapshot_archive(
     archive_format: ArchiveFormat,
 ) -> snapshot_utils::Result<FullSnapshotArchiveInfo> {
     let snapshot_version = snapshot_version.unwrap_or_default();
-
-    assert!(bank.is_complete());
-    bank.squash(); // Bank may not be a root
-    bank.force_flush_accounts_cache();
-    bank.clean_accounts(Some(bank.slot()));
-    bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
-    bank.rehash(); // Bank accounts may have been manually modified by the caller
-
-    let temp_dir = tempfile::tempdir_in(bank_snapshots_dir)?;
-    let snapshot_storages = bank.get_snapshot_storages(None);
-    let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
-    let bank_snapshot_info = add_bank_snapshot(
-        &temp_dir,
+    let temp_bank_snapshots_dir = tempfile::tempdir_in(bank_snapshots_dir)?;
+    bank_to_full_snapshot_archive_with(
+        &temp_bank_snapshots_dir,
         bank,
-        &snapshot_storages,
         snapshot_version,
-        slot_deltas,
-    )?;
-
-    package_and_archive_full_snapshot(
-        bank,
-        &bank_snapshot_info,
         full_snapshot_archives_dir,
         incremental_snapshot_archives_dir,
+        archive_format,
+    )
+}
+
+/// See bank_to_full_snapshot_archive() for documentation
+///
+/// This fn does *not* create a tmpdir inside `bank_snapshots_dir`
+/// (which is needed by a test)
+fn bank_to_full_snapshot_archive_with(
+    bank_snapshots_dir: impl AsRef<Path>,
+    bank: &Bank,
+    snapshot_version: SnapshotVersion,
+    full_snapshot_archives_dir: impl AsRef<Path>,
+    incremental_snapshot_archives_dir: impl AsRef<Path>,
+    archive_format: ArchiveFormat,
+) -> snapshot_utils::Result<FullSnapshotArchiveInfo> {
+    assert!(bank.is_complete());
+    bank.squash(); // Bank may not be a root
+    bank.rehash(); // Bank accounts may have been manually modified by the caller
+    bank.force_flush_accounts_cache();
+    bank.clean_accounts(Some(bank.slot()));
+    let calculated_accounts_hash =
+        bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
+
+    let snapshot_storages = bank.get_snapshot_storages(None);
+    let status_cache_slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
+    let accounts_package = AccountsPackage::new_for_snapshot(
+        AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
+        bank,
         snapshot_storages,
+        status_cache_slot_deltas,
+        None,
+    );
+
+    let accounts_hash = bank
+        .get_accounts_hash()
+        .expect("accounts hash is required for snapshot");
+    assert_eq!(accounts_hash, calculated_accounts_hash);
+    let snapshot_package = SnapshotPackage::new(accounts_package, accounts_hash.into(), None);
+
+    let snapshot_config = SnapshotConfig {
+        full_snapshot_archives_dir: full_snapshot_archives_dir.as_ref().to_path_buf(),
+        incremental_snapshot_archives_dir: incremental_snapshot_archives_dir.as_ref().to_path_buf(),
+        bank_snapshots_dir: bank_snapshots_dir.as_ref().to_path_buf(),
         archive_format,
         snapshot_version,
-    )
+        ..Default::default()
+    };
+    let snapshot_archive_info =
+        snapshot_utils::serialize_and_archive_snapshot_package(snapshot_package, &snapshot_config)?;
+
+    Ok(FullSnapshotArchiveInfo::new(snapshot_archive_info))
 }
 
 /// Convenience function to create an incremental snapshot archive out of any Bank, regardless of
@@ -1080,108 +1103,27 @@ pub fn bank_to_incremental_snapshot_archive(
     assert!(bank.is_complete());
     assert!(bank.slot() > full_snapshot_slot);
     bank.squash(); // Bank may not be a root
+    bank.rehash(); // Bank accounts may have been manually modified by the caller
     bank.force_flush_accounts_cache();
     bank.clean_accounts(Some(full_snapshot_slot));
-    bank.update_incremental_accounts_hash(full_snapshot_slot);
-    bank.rehash(); // Bank accounts may have been manually modified by the caller
+    let calculated_incremental_accounts_hash =
+        bank.update_incremental_accounts_hash(full_snapshot_slot);
 
-    let temp_dir = tempfile::tempdir_in(bank_snapshots_dir)?;
     let snapshot_storages = bank.get_snapshot_storages(Some(full_snapshot_slot));
-    let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
-    let bank_snapshot_info = add_bank_snapshot(
-        &temp_dir,
-        bank,
-        &snapshot_storages,
-        snapshot_version,
-        slot_deltas,
-    )?;
-
-    package_and_archive_incremental_snapshot(
-        bank,
-        full_snapshot_slot,
-        &bank_snapshot_info,
-        full_snapshot_archives_dir,
-        incremental_snapshot_archives_dir,
-        snapshot_storages,
-        archive_format,
-        snapshot_version,
-    )
-}
-
-/// Helper function to hold shared code to package, process, and archive full snapshots
-#[allow(clippy::too_many_arguments)]
-#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-fn package_and_archive_full_snapshot(
-    bank: &Bank,
-    bank_snapshot_info: &BankSnapshotInfo,
-    full_snapshot_archives_dir: impl AsRef<Path>,
-    incremental_snapshot_archives_dir: impl AsRef<Path>,
-    snapshot_storages: Vec<Arc<AccountStorageEntry>>,
-    archive_format: ArchiveFormat,
-    snapshot_version: SnapshotVersion,
-) -> snapshot_utils::Result<FullSnapshotArchiveInfo> {
+    let status_cache_slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
     let accounts_package = AccountsPackage::new_for_snapshot(
-        AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
+        AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(full_snapshot_slot)),
         bank,
-        bank_snapshot_info,
         snapshot_storages,
+        status_cache_slot_deltas,
         None,
     );
 
-    let accounts_hash = bank
-        .get_accounts_hash()
-        .expect("accounts hash is required for snapshot");
-    crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
-        accounts_package.bank_snapshot_dir(),
-        accounts_package.slot,
-        &accounts_hash,
-        None,
-    );
-
-    let snapshot_config = SnapshotConfig {
-        full_snapshot_archives_dir: full_snapshot_archives_dir.as_ref().to_path_buf(),
-        incremental_snapshot_archives_dir: incremental_snapshot_archives_dir.as_ref().to_path_buf(),
-        archive_format,
-        snapshot_version,
-        ..Default::default()
-    };
-    let snapshot_package =
-        SnapshotPackage::new(accounts_package, accounts_hash.into(), &snapshot_config);
-    archive_snapshot_package(&snapshot_package)?;
-
-    Ok(FullSnapshotArchiveInfo::new(
-        snapshot_package.snapshot_archive_info,
-    ))
-}
-
-/// Helper function to hold shared code to package, process, and archive incremental snapshots
-#[allow(clippy::too_many_arguments)]
-#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-fn package_and_archive_incremental_snapshot(
-    bank: &Bank,
-    incremental_snapshot_base_slot: Slot,
-    bank_snapshot_info: &BankSnapshotInfo,
-    full_snapshot_archives_dir: impl AsRef<Path>,
-    incremental_snapshot_archives_dir: impl AsRef<Path>,
-    snapshot_storages: Vec<Arc<AccountStorageEntry>>,
-    archive_format: ArchiveFormat,
-    snapshot_version: SnapshotVersion,
-) -> snapshot_utils::Result<IncrementalSnapshotArchiveInfo> {
-    let accounts_package = AccountsPackage::new_for_snapshot(
-        AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(
-            incremental_snapshot_base_slot,
-        )),
-        bank,
-        bank_snapshot_info,
-        snapshot_storages,
-        None,
-    );
-
-    let (base_accounts_hash, base_capitalization) = bank
+    let (full_accounts_hash, full_capitalization) = bank
         .rc
         .accounts
         .accounts_db
-        .get_accounts_hash(incremental_snapshot_base_slot)
+        .get_accounts_hash(full_snapshot_slot)
         .expect("base accounts hash is required for incremental snapshot");
     let (incremental_accounts_hash, incremental_capitalization) = bank
         .rc
@@ -1189,37 +1131,41 @@ fn package_and_archive_incremental_snapshot(
         .accounts_db
         .get_incremental_accounts_hash(bank.slot())
         .expect("incremental accounts hash is required for incremental snapshot");
-    let bank_incremental_snapshot_persistence = Some(BankIncrementalSnapshotPersistence {
-        full_slot: incremental_snapshot_base_slot,
-        full_hash: base_accounts_hash.into(),
-        full_capitalization: base_capitalization,
+    assert_eq!(
+        incremental_accounts_hash,
+        calculated_incremental_accounts_hash,
+    );
+    let bank_incremental_snapshot_persistence = BankIncrementalSnapshotPersistence {
+        full_slot: full_snapshot_slot,
+        full_hash: full_accounts_hash.into(),
+        full_capitalization,
         incremental_hash: incremental_accounts_hash.into(),
         incremental_capitalization,
-    });
-    crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
-        accounts_package.bank_snapshot_dir(),
-        accounts_package.slot,
-        &AccountsHash(Hash::default()), // value does not matter; not used for incremental snapshots
-        bank_incremental_snapshot_persistence.as_ref(),
-    );
-
-    let snapshot_config = SnapshotConfig {
-        full_snapshot_archives_dir: full_snapshot_archives_dir.as_ref().to_path_buf(),
-        incremental_snapshot_archives_dir: incremental_snapshot_archives_dir.as_ref().to_path_buf(),
-        archive_format,
-        snapshot_version,
-        ..Default::default()
     };
     let snapshot_package = SnapshotPackage::new(
         accounts_package,
         incremental_accounts_hash.into(),
-        &snapshot_config,
+        Some(bank_incremental_snapshot_persistence),
     );
-    archive_snapshot_package(&snapshot_package)?;
+
+    // Note: Since the snapshot_storages above are *only* the incremental storages,
+    // this bank snapshot *cannot* be used by fastboot.
+    // Putting the snapshot in a tempdir effectively enforces that.
+    let temp_bank_snapshots_dir = tempfile::tempdir_in(bank_snapshots_dir)?;
+    let snapshot_config = SnapshotConfig {
+        full_snapshot_archives_dir: full_snapshot_archives_dir.as_ref().to_path_buf(),
+        incremental_snapshot_archives_dir: incremental_snapshot_archives_dir.as_ref().to_path_buf(),
+        bank_snapshots_dir: temp_bank_snapshots_dir.path().to_path_buf(),
+        archive_format,
+        snapshot_version,
+        ..Default::default()
+    };
+    let snapshot_archive_info =
+        snapshot_utils::serialize_and_archive_snapshot_package(snapshot_package, &snapshot_config)?;
 
     Ok(IncrementalSnapshotArchiveInfo::new(
-        incremental_snapshot_base_slot,
-        snapshot_package.snapshot_archive_info,
+        full_snapshot_slot,
+        snapshot_archive_info,
     ))
 }
 
@@ -1239,8 +1185,8 @@ mod tests {
                 get_highest_loadable_bank_snapshot, purge_all_bank_snapshots, purge_bank_snapshot,
                 purge_bank_snapshots_older_than_slot, purge_incomplete_bank_snapshots,
                 purge_old_bank_snapshots, purge_old_bank_snapshots_at_startup,
-                snapshot_storage_rebuilder::get_slot_and_append_vec_id,
-                write_full_snapshot_slot_file, ArchiveFormat, SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME,
+                snapshot_storage_rebuilder::get_slot_and_append_vec_id, ArchiveFormat,
+                SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME,
             },
             status_cache::Status,
         },
@@ -2730,36 +2676,13 @@ mod tests {
             let slot = bank.slot() + 1;
             bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
             bank.fill_bank_with_ticks_for_tests();
-            bank.squash();
-            bank.force_flush_accounts_cache();
-            bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
-            let snapshot_storages = bank.get_snapshot_storages(None);
-            let slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
-            let bank_snapshot_info = add_bank_snapshot(
-                &bank_snapshots_dir,
+            bank_to_full_snapshot_archive_with(
+                &snapshot_config.bank_snapshots_dir,
                 &bank,
-                &snapshot_storages,
                 snapshot_config.snapshot_version,
-                slot_deltas,
-            )
-            .unwrap();
-            assert!(
-                crate::serde_snapshot::reserialize_bank_with_new_accounts_hash(
-                    &bank_snapshot_info.snapshot_dir,
-                    bank.slot(),
-                    &bank.get_accounts_hash().unwrap(),
-                    None,
-                )
-            );
-            write_full_snapshot_slot_file(&bank_snapshot_info.snapshot_dir, slot).unwrap();
-            package_and_archive_full_snapshot(
-                &bank,
-                &bank_snapshot_info,
-                &full_snapshot_archives_dir,
-                &incremental_snapshot_archives_dir,
-                snapshot_storages,
+                &snapshot_config.full_snapshot_archives_dir,
+                &snapshot_config.incremental_snapshot_archives_dir,
                 snapshot_config.archive_format,
-                snapshot_config.snapshot_version,
             )
             .unwrap();
         }

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -4,8 +4,7 @@ use {
         epoch_stakes::EpochStakes,
         runtime_config::RuntimeConfig,
         serde_snapshot::{
-            bank_from_streams, bank_to_stream, fields_from_streams,
-            BankIncrementalSnapshotPersistence,
+            bank_from_streams, fields_from_streams, BankIncrementalSnapshotPersistence,
         },
         snapshot_archive_info::{
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
@@ -15,13 +14,11 @@ use {
         snapshot_package::{AccountsPackage, AccountsPackageKind, SnapshotKind, SnapshotPackage},
         snapshot_utils::{
             self, deserialize_snapshot_data_file, deserialize_snapshot_data_files,
-            get_bank_snapshot_dir, get_highest_bank_snapshot_post,
-            get_highest_full_snapshot_archive_info, get_highest_incremental_snapshot_archive_info,
-            get_snapshot_file_name, get_storages_to_serialize, hard_link_storages_to_snapshot,
-            rebuild_storages_from_snapshot_dir, serialize_snapshot_data_file,
-            verify_and_unarchive_snapshots, verify_unpacked_snapshots_dir_and_version,
-            AddBankSnapshotError, ArchiveFormat, BankSnapshotInfo, BankSnapshotKind, SnapshotError,
-            SnapshotRootPaths, SnapshotVersion, StorageAndNextAccountsFileId,
+            get_highest_bank_snapshot_post, get_highest_full_snapshot_archive_info,
+            get_highest_incremental_snapshot_archive_info, rebuild_storages_from_snapshot_dir,
+            serialize_snapshot_data_file, verify_and_unarchive_snapshots,
+            verify_unpacked_snapshots_dir_and_version, ArchiveFormat, BankSnapshotInfo,
+            SnapshotError, SnapshotRootPaths, SnapshotVersion, StorageAndNextAccountsFileId,
             UnpackedSnapshotsDirAndVersion, VerifyEpochStakesError, VerifySlotDeltasError,
         },
         status_cache,
@@ -47,8 +44,6 @@ use {
     },
     std::{
         collections::{HashMap, HashSet},
-        fs,
-        io::{BufWriter, Write},
         ops::RangeInclusive,
         path::{Path, PathBuf},
         sync::{atomic::AtomicBool, Arc},
@@ -69,6 +64,20 @@ pub fn add_bank_snapshot(
     snapshot_version: SnapshotVersion,
     slot_deltas: Vec<BankSlotDelta>,
 ) -> snapshot_utils::Result<BankSnapshotInfo> {
+    use {
+        crate::{
+            serde_snapshot::bank_to_stream,
+            snapshot_utils::{
+                get_bank_snapshot_dir, get_snapshot_file_name, get_storages_to_serialize,
+                hard_link_storages_to_snapshot, AddBankSnapshotError, BankSnapshotKind,
+            },
+        },
+        std::{
+            fs,
+            io::{BufWriter, Write},
+        },
+    };
+
     // this lambda function is to facilitate converting between
     // the AddBankSnapshotError and SnapshotError types
     let do_add_bank_snapshot = || {
@@ -1180,13 +1189,13 @@ mod tests {
             snapshot_config::SnapshotConfig,
             snapshot_utils::{
                 clean_orphaned_account_snapshot_dirs, create_tmp_accounts_dir_for_tests,
-                get_bank_snapshots, get_bank_snapshots_post, get_bank_snapshots_pre,
-                get_highest_bank_snapshot, get_highest_bank_snapshot_pre,
+                get_bank_snapshot_dir, get_bank_snapshots, get_bank_snapshots_post,
+                get_bank_snapshots_pre, get_highest_bank_snapshot, get_highest_bank_snapshot_pre,
                 get_highest_loadable_bank_snapshot, purge_all_bank_snapshots, purge_bank_snapshot,
                 purge_bank_snapshots_older_than_slot, purge_incomplete_bank_snapshots,
                 purge_old_bank_snapshots, purge_old_bank_snapshots_at_startup,
                 snapshot_storage_rebuilder::get_slot_and_append_vec_id, ArchiveFormat,
-                SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME,
+                BankSnapshotKind, SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME,
             },
             status_cache::Status,
         },
@@ -1202,7 +1211,10 @@ mod tests {
             system_transaction,
             transaction::SanitizedTransaction,
         },
-        std::sync::{atomic::Ordering, Arc, RwLock},
+        std::{
+            fs,
+            sync::{atomic::Ordering, Arc, RwLock},
+        },
         test_case::test_case,
     };
 

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -1,10 +1,8 @@
 use {
     crate::{
-        bank::Bank,
-        snapshot_archive_info::{SnapshotArchiveInfo, SnapshotArchiveInfoGetter},
-        snapshot_config::SnapshotConfig,
+        bank::{Bank, BankFieldsToSerialize, BankSlotDelta},
+        serde_snapshot::BankIncrementalSnapshotPersistence,
         snapshot_hash::SnapshotHash,
-        snapshot_utils::{self, BankSnapshotInfo},
     },
     log::*,
     solana_accounts_db::{
@@ -16,11 +14,7 @@ use {
     solana_sdk::{
         clock::Slot, rent_collector::RentCollector, sysvar::epoch_schedule::EpochSchedule,
     },
-    std::{
-        path::{Path, PathBuf},
-        sync::Arc,
-        time::Instant,
-    },
+    std::{sync::Arc, time::Instant},
 };
 
 mod compare;
@@ -51,8 +45,8 @@ impl AccountsPackage {
     pub fn new_for_snapshot(
         package_kind: AccountsPackageKind,
         bank: &Bank,
-        bank_snapshot_info: &BankSnapshotInfo,
         snapshot_storages: Vec<Arc<AccountStorageEntry>>,
+        status_cache_slot_deltas: Vec<BankSlotDelta>,
         accounts_hash_for_testing: Option<AccountsHash>,
     ) -> Self {
         if let AccountsPackageKind::Snapshot(snapshot_kind) = package_kind {
@@ -72,7 +66,8 @@ impl AccountsPackage {
         }
 
         let snapshot_info = SupplementalSnapshotInfo {
-            bank_snapshot_dir: bank_snapshot_info.snapshot_dir.clone(),
+            status_cache_slot_deltas,
+            bank_fields_to_serialize: bank.get_fields_to_serialize(),
             epoch_accounts_hash: bank.get_epoch_accounts_hash_to_serialize(),
         };
         Self::_new(
@@ -160,27 +155,11 @@ impl AccountsPackage {
             epoch_schedule: EpochSchedule::default(),
             rent_collector: RentCollector::default(),
             snapshot_info: Some(SupplementalSnapshotInfo {
-                bank_snapshot_dir: PathBuf::default(),
+                status_cache_slot_deltas: Vec::default(),
+                bank_fields_to_serialize: BankFieldsToSerialize::default_for_tests(),
                 epoch_accounts_hash: Option::default(),
             }),
             enqueued: Instant::now(),
-        }
-    }
-
-    /// Returns the path to the snapshot dir
-    ///
-    /// NOTE: This fn will panic if the AccountsPackage is of type EpochAccountsHash.
-    pub fn bank_snapshot_dir(&self) -> &Path {
-        match self.package_kind {
-            AccountsPackageKind::AccountsHashVerifier | AccountsPackageKind::Snapshot(..) => self
-                .snapshot_info
-                .as_ref()
-                .unwrap()
-                .bank_snapshot_dir
-                .as_path(),
-            AccountsPackageKind::EpochAccountsHash => {
-                panic!("EAH accounts packages do not contain snapshot information")
-            }
         }
     }
 }
@@ -197,7 +176,8 @@ impl std::fmt::Debug for AccountsPackage {
 
 /// Supplemental information needed for snapshots
 pub struct SupplementalSnapshotInfo {
-    pub bank_snapshot_dir: PathBuf,
+    pub status_cache_slot_deltas: Vec<BankSlotDelta>,
+    pub bank_fields_to_serialize: BankFieldsToSerialize,
     pub epoch_accounts_hash: Option<EpochAccountsHash>,
 }
 
@@ -213,11 +193,16 @@ pub enum AccountsPackageKind {
 
 /// This struct packages up fields to send from AccountsHashVerifier to SnapshotPackagerService
 pub struct SnapshotPackage {
-    pub snapshot_archive_info: SnapshotArchiveInfo,
-    pub block_height: Slot,
-    pub bank_snapshot_dir: PathBuf,
-    pub snapshot_storages: Vec<Arc<AccountStorageEntry>>,
     pub snapshot_kind: SnapshotKind,
+    pub slot: Slot,
+    pub block_height: Slot,
+    pub hash: SnapshotHash,
+    pub snapshot_storages: Vec<Arc<AccountStorageEntry>>,
+    pub status_cache_slot_deltas: Vec<BankSlotDelta>,
+    pub bank_fields_to_serialize: BankFieldsToSerialize,
+    pub epoch_accounts_hash: Option<EpochAccountsHash>,
+    pub bank_incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
+    pub accounts: Arc<Accounts>,
 
     /// The instant this snapshot package was sent to the queue.
     /// Used to track how long snapshot packages wait before handling.
@@ -228,9 +213,9 @@ impl SnapshotPackage {
     pub fn new(
         accounts_package: AccountsPackage,
         accounts_hash: AccountsHashKind,
-        snapshot_config: &SnapshotConfig,
+        bank_incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
     ) -> Self {
-        let AccountsPackageKind::Snapshot(snapshot_kind) = accounts_package.package_kind else {
+        let AccountsPackageKind::Snapshot(kind) = accounts_package.package_kind else {
             panic!(
                 "The AccountsPackage must be of kind Snapshot in order to make a SnapshotPackage!"
             );
@@ -240,43 +225,40 @@ impl SnapshotPackage {
                 "The AccountsPackage must have snapshot info in order to make a SnapshotPackage!"
             );
         };
-        let snapshot_hash =
-            SnapshotHash::new(&accounts_hash, snapshot_info.epoch_accounts_hash.as_ref());
-        let mut snapshot_storages = accounts_package.snapshot_storages;
-        let snapshot_archive_path = match snapshot_kind {
-            SnapshotKind::FullSnapshot => snapshot_utils::build_full_snapshot_archive_path(
-                &snapshot_config.full_snapshot_archives_dir,
-                accounts_package.slot,
-                &snapshot_hash,
-                snapshot_config.archive_format,
-            ),
-            SnapshotKind::IncrementalSnapshot(incremental_snapshot_base_slot) => {
-                snapshot_storages.retain(|storage| storage.slot() > incremental_snapshot_base_slot);
-                assert!(
-                    snapshot_storages.iter().all(|storage| storage.slot() > incremental_snapshot_base_slot),
-                    "Incremental snapshot package must only contain storage entries where slot > incremental snapshot base slot (i.e. full snapshot slot)!"
-                );
-                snapshot_utils::build_incremental_snapshot_archive_path(
-                    &snapshot_config.incremental_snapshot_archives_dir,
-                    incremental_snapshot_base_slot,
-                    accounts_package.slot,
-                    &snapshot_hash,
-                    snapshot_config.archive_format,
-                )
-            }
-        };
 
         Self {
-            snapshot_archive_info: SnapshotArchiveInfo {
-                path: snapshot_archive_path,
-                slot: accounts_package.slot,
-                hash: snapshot_hash,
-                archive_format: snapshot_config.archive_format,
-            },
+            snapshot_kind: kind,
+            slot: accounts_package.slot,
             block_height: accounts_package.block_height,
-            bank_snapshot_dir: snapshot_info.bank_snapshot_dir,
-            snapshot_storages,
-            snapshot_kind,
+            hash: SnapshotHash::new(&accounts_hash, snapshot_info.epoch_accounts_hash.as_ref()),
+            snapshot_storages: accounts_package.snapshot_storages,
+            status_cache_slot_deltas: snapshot_info.status_cache_slot_deltas,
+            bank_fields_to_serialize: snapshot_info.bank_fields_to_serialize,
+            epoch_accounts_hash: snapshot_info.epoch_accounts_hash,
+            bank_incremental_snapshot_persistence,
+            accounts: accounts_package.accounts,
+            enqueued: Instant::now(),
+        }
+    }
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl SnapshotPackage {
+    /// Create a new SnapshotPackage where basically every field is defaulted.
+    /// Only use for tests; many of the fields are invalid!
+    pub fn default_for_tests() -> Self {
+        use {solana_accounts_db::accounts_db::AccountsDb, solana_sdk::hash::Hash};
+        Self {
+            snapshot_kind: SnapshotKind::FullSnapshot,
+            slot: Slot::default(),
+            block_height: Slot::default(),
+            hash: SnapshotHash(Hash::default()),
+            snapshot_storages: Vec::default(),
+            status_cache_slot_deltas: Vec::default(),
+            bank_fields_to_serialize: BankFieldsToSerialize::default_for_tests(),
+            epoch_accounts_hash: None,
+            bank_incremental_snapshot_persistence: None,
+            accounts: Accounts::new(AccountsDb::default_for_tests().into()).into(),
             enqueued: Instant::now(),
         }
     }
@@ -285,16 +267,10 @@ impl SnapshotPackage {
 impl std::fmt::Debug for SnapshotPackage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SnapshotPackage")
-            .field("type", &self.snapshot_kind)
-            .field("slot", &self.slot())
+            .field("kind", &self.snapshot_kind)
+            .field("slot", &self.slot)
             .field("block_height", &self.block_height)
             .finish_non_exhaustive()
-    }
-}
-
-impl SnapshotArchiveInfoGetter for SnapshotPackage {
-    fn snapshot_archive_info(&self) -> &SnapshotArchiveInfo {
-        &self.snapshot_archive_info
     }
 }
 

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -1,15 +1,12 @@
 use {
-    super::{
-        AccountsPackage, AccountsPackageKind, SnapshotArchiveInfoGetter, SnapshotKind,
-        SnapshotPackage,
-    },
+    super::{AccountsPackage, AccountsPackageKind, SnapshotKind, SnapshotPackage},
     std::cmp::Ordering::{self, Equal, Greater, Less},
 };
 
 /// Compare snapshot packages by priority; first by type, then by slot
 #[must_use]
 pub fn cmp_snapshot_packages_by_priority(a: &SnapshotPackage, b: &SnapshotPackage) -> Ordering {
-    cmp_snapshot_kinds_by_priority(&a.snapshot_kind, &b.snapshot_kind).then(a.slot().cmp(&b.slot()))
+    cmp_snapshot_kinds_by_priority(&a.snapshot_kind, &b.snapshot_kind).then(a.slot.cmp(&b.slot))
 }
 
 /// Compare accounts packages by priority; first by type, then by slot
@@ -71,31 +68,16 @@ pub fn cmp_snapshot_kinds_by_priority(a: &SnapshotKind, b: &SnapshotKind) -> Ord
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        crate::{
-            snapshot_archive_info::SnapshotArchiveInfo, snapshot_hash::SnapshotHash,
-            snapshot_utils::ArchiveFormat,
-        },
-        solana_sdk::{clock::Slot, hash::Hash},
-        std::{path::PathBuf, time::Instant},
-    };
+    use {super::*, solana_sdk::clock::Slot};
 
     #[test]
     fn test_cmp_snapshot_packages_by_priority() {
         fn new(snapshot_kind: SnapshotKind, slot: Slot) -> SnapshotPackage {
             SnapshotPackage {
-                snapshot_archive_info: SnapshotArchiveInfo {
-                    path: PathBuf::default(),
-                    slot,
-                    hash: SnapshotHash(Hash::default()),
-                    archive_format: ArchiveFormat::Tar,
-                },
-                block_height: slot,
-                bank_snapshot_dir: PathBuf::default(),
-                snapshot_storages: Vec::default(),
                 snapshot_kind,
-                enqueued: Instant::now(),
+                slot,
+                block_height: slot,
+                ..SnapshotPackage::default_for_tests()
             }
         }
 


### PR DESCRIPTION
#### Problem

In the snapshot pipeline, we currently serialize the bank snapshot in AccountsBackgroundService _without an Accounts Hash_, then calculate the accounts hash in AccountsHashVerifier and reserialize the bank snapshot with correct accounts hash. This has many performance issues that @alessandrod has discovered through profiling. One being the many many allocations that deserialization does. It is beneficial to the whole system if we can remove allocations. And reserialization is a big offender.


#### Summary of Changes

Serialize the bank snapshot in SnapshotPackagerService. Currently we serialize in ABS and reserialize in AHV. Now do it just once in SPS.

This has many knock-on effects:
* The ABS snapshot request handling loop is now much faster. Since serialization takes 10-15 seconds, we no longer have to block `flush`/`clean`/`shrink` while serializing.
* AHV is now faster since we don't have to deserialize and then serialize the snapshot again.
* More/most snapshot code is now in a single place, SPS.
* We can also remove reserialization from `snapshot_utils::bank_to_snapshot_archive()`, which is used by `ledger-tool create-snapshot`.

Other code-related changes:
* By moving `serialize` to SPS, we had to change the fields that are in `AccountsPackage` and `SnapshotPackage`.
* The `reserialize()` functions are *not* removed in this PR. That'll come next, as this PR is already very big.

Results:
* Profiling from @alessandrod shows significant improvements. See Discord for more details: https://discord.com/channels/428295358100013066/838890116386521088/1245191509230223430