### PR TITLE
Runtime: Core BPF Migration: Explicit upgrade authority checks in migration

### DIFF
--- a/runtime/src/bank/builtin_programs.rs
+++ b/runtime/src/bank/builtin_programs.rs
@@ -147,7 +147,7 @@ mod tests_core_bpf_migration {
         let (builtin_id, config) = prototype.deconstruct();
         let feature_id = &config.feature_id;
         let source_buffer_address = &config.source_buffer_address;
-        let upgrade_authority_address = Some(Pubkey::new_unique());
+        let upgrade_authority_address = config.upgrade_authority_address;
 
         // Add the feature to the bank's inactive feature set.
         // Note this will add the feature ID if it doesn't exist.

--- a/runtime/src/bank/builtins/core_bpf_migration/error.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/error.rs
@@ -32,5 +32,5 @@ pub enum CoreBpfMigrationError {
     ArithmeticOverflow,
     /// Upgrade authority mismatch
     #[error("Upgrade authority mismatch. Expected: {0:?}, Got: {1:?}")]
-    UpgradeAuthorityMismatch(Pubkey, Pubkey),
+    UpgradeAuthorityMismatch(Pubkey, Option<Pubkey>),
 }

--- a/runtime/src/bank/builtins/core_bpf_migration/error.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/error.rs
@@ -30,4 +30,7 @@ pub enum CoreBpfMigrationError {
     /// Arithmetic overflow
     #[error("Arithmetic overflow")]
     ArithmeticOverflow,
+    /// Upgrade authority mismatch
+    #[error("Upgrade authority mismatch. Expected: {0:?}, Got: {1:?}")]
+    UpgradeAuthorityMismatch(Pubkey, Pubkey),
 }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -42,6 +42,13 @@ pub(crate) struct CoreBpfMigrationConfig {
     /// The address of the source buffer account to be used to replace the
     /// builtin.
     pub source_buffer_address: Pubkey,
+    /// The authority to be used as the BPF program's upgrade authority.
+    ///
+    /// Note: If this value is set to `None`, then the migration will ignore
+    /// the source buffer account's authority. If it's set to any `Some(..)`
+    /// value, then the migration will perform a sanity check to ensure the
+    /// source buffer account's authority matches the provided value.
+    pub upgrade_authority_address: Option<Pubkey>,
     /// The feature gate to trigger the migration to Core BPF.
     /// Note: This feature gate should never be the same as any builtin's
     /// `enable_feature_id`. It should always be a feature gate that will be
@@ -513,6 +520,7 @@ pub(crate) mod tests {
 
         let core_bpf_migration_config = CoreBpfMigrationConfig {
             source_buffer_address,
+            upgrade_authority_address,
             feature_id: Pubkey::new_unique(),
             migration_target: CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "test_migrate_builtin",
@@ -571,6 +579,7 @@ pub(crate) mod tests {
 
         let core_bpf_migration_config = CoreBpfMigrationConfig {
             source_buffer_address,
+            upgrade_authority_address,
             feature_id: Pubkey::new_unique(),
             migration_target: CoreBpfMigrationTargetType::Stateless,
             datapoint_name: "test_migrate_stateless_builtin",

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -733,12 +733,14 @@ pub(crate) mod tests {
 
         let program_data_address = get_program_data_address(&builtin_id);
         let program_data_account = bank.get_account(&program_data_address).unwrap();
-        match program_data_account.state().unwrap() {
+        let program_data_account_state: UpgradeableLoaderState =
+            program_data_account.state().unwrap();
+        assert_eq!(
+            program_data_account_state,
             UpgradeableLoaderState::ProgramData {
-                upgrade_authority_address,
-                ..
-            } => assert_eq!(upgrade_authority_address, None),
-            _ => panic!("Unexpected state"),
-        }
+                upgrade_authority_address: None,
+                slot: bank.slot(),
+            },
+        );
     }
 }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -111,19 +111,14 @@ impl Bank {
             authority_address: buffer_authority,
         } = bincode::deserialize(&source.buffer_account.data()[..buffer_metadata_size])?
         {
-            let target_upgrade_authority_address =
-                match (upgrade_authority_address, buffer_authority) {
-                    (Some(provided_authority), Some(buffer_authority)) => {
-                        if provided_authority != buffer_authority {
-                            return Err(CoreBpfMigrationError::UpgradeAuthorityMismatch(
-                                provided_authority,
-                                buffer_authority,
-                            ));
-                        }
-                        Some(provided_authority)
-                    }
-                    _ => None,
-                };
+            if let Some(provided_authority) = upgrade_authority_address {
+                if upgrade_authority_address != buffer_authority {
+                    return Err(CoreBpfMigrationError::UpgradeAuthorityMismatch(
+                        provided_authority,
+                        buffer_authority,
+                    ));
+                }
+            }
 
             let elf = &source.buffer_account.data()[buffer_metadata_size..];
 
@@ -134,7 +129,7 @@ impl Bank {
 
             let programdata_metadata = UpgradeableLoaderState::ProgramData {
                 slot: self.slot,
-                upgrade_authority_address: target_upgrade_authority_address,
+                upgrade_authority_address,
             };
 
             let mut account = AccountSharedData::new_data_with_space(

--- a/runtime/src/bank/builtins/mod.rs
+++ b/runtime/src/bank/builtins/mod.rs
@@ -55,6 +55,7 @@ pub static BUILTINS: &[BuiltinPrototype] = &[
     BuiltinPrototype {
         core_bpf_migration_config: Some(CoreBpfMigrationConfig {
             source_buffer_address: buffer_accounts::config_program::id(),
+            upgrade_authority_address: None,
             feature_id: solana_sdk::feature_set::migrate_config_program_to_core_bpf::id(),
             migration_target: core_bpf_migration::CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_config_program",
@@ -118,6 +119,7 @@ pub static BUILTINS: &[BuiltinPrototype] = &[
 pub static STATELESS_BUILTINS: &[StatelessBuiltinPrototype] = &[StatelessBuiltinPrototype {
     core_bpf_migration_config: Some(CoreBpfMigrationConfig {
         source_buffer_address: buffer_accounts::feature_gate_program::id(),
+        upgrade_authority_address: None,
         feature_id: solana_sdk::feature_set::migrate_feature_gate_program_to_core_bpf::id(),
         migration_target: core_bpf_migration::CoreBpfMigrationTargetType::Stateless,
         datapoint_name: "migrate_stateless_to_core_bpf_feature_gate_program",
@@ -153,8 +155,12 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("EDEhzg1Jk79Wrk4mwpRa7txjgRxcE6igXwd6egFDVhuz");
         }
+        pub mod upgrade_authority {
+            solana_sdk::declare_id!("4d14UK2o1FKKoecEBWhVDZrBBbRuhug75G1j9XYCawC2");
+        }
         pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
+            upgrade_authority_address: Some(upgrade_authority::id()),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_system_program",
@@ -168,8 +174,12 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("6T9s4PTcHnpq2AVAqoCbJd4FuHsdD99MjSUEbS7qb1tT");
         }
+        pub mod upgrade_authority {
+            solana_sdk::declare_id!("2N4JfyYub6cWUP9R4JrsFHv6FYKT7JnoRX8GQUH9MdT3");
+        }
         pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
+            upgrade_authority_address: Some(upgrade_authority::id()),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_vote_program",
@@ -183,8 +193,12 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("2a3XnUr4Xfxd8hBST8wd4D3Qbiu339XKessYsDwabCED");
         }
+        pub mod upgrade_authority {
+            solana_sdk::declare_id!("F7K7ADSDzReQAgXYL1KE3u1UBjBtytxQ8bke7BF1Uegg");
+        }
         pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
+            upgrade_authority_address: Some(upgrade_authority::id()),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_stake_program",
@@ -198,8 +212,12 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("DveUYB5m9G3ce4zpV3fxg9pCNkvH1wDsyd8XberZ47JL");
         }
+        pub mod upgrade_authority {
+            solana_sdk::declare_id!("8Y5VTHdadnz4rZZWdUA4Qq2m2zWoCwwtb38spPZCXuGU");
+        }
         pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
+            upgrade_authority_address: Some(upgrade_authority::id()),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_bpf_loader_deprecated_program",
@@ -213,8 +231,12 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("2EWMYGJPuGLW4TexLLEMeXP2BkB1PXEKBFb698yw6LhT");
         }
+        pub mod upgrade_authority {
+            solana_sdk::declare_id!("3sQ9VZ1Lvuvs6NpFXFV3ByFAf52ajPPdXwuhYERJR3iJ");
+        }
         pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
+            upgrade_authority_address: Some(upgrade_authority::id()),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_bpf_loader_program",
@@ -228,8 +250,12 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("6bTmA9iefD57GDoQ9wUjG8SeYkSpRw3EkKzxZCbhkavq");
         }
+        pub mod upgrade_authority {
+            solana_sdk::declare_id!("CuJvJY1K2wx82oLrQGSSWtw4AF7nVifEHupzSC2KEcq5");
+        }
         pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
+            upgrade_authority_address: Some(upgrade_authority::id()),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_bpf_loader_upgradeable_program",
@@ -243,8 +269,12 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("KfX1oLpFC5CwmFeSgXrNcXaouKjFkPuSJ4UsKb3zKMX");
         }
+        pub mod upgrade_authority {
+            solana_sdk::declare_id!("HGTbQhaCXNTbpgpLb2KNjqWSwpJyb2dqDB66Lc3Ph4aN");
+        }
         pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
+            upgrade_authority_address: Some(upgrade_authority::id()),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_compute_budget_program",
@@ -258,8 +288,12 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("DQshE9LTac8eXjZTi8ApeuZJYH67UxTMUxaEGstC6mqJ");
         }
+        pub mod upgrade_authority {
+            solana_sdk::declare_id!("EPKzhEZxiwQ9n6bCj1pgdcN3nhtecCxjWqUcPGMT3wYK");
+        }
         pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
+            upgrade_authority_address: Some(upgrade_authority::id()),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_address_lookup_table_program",
@@ -273,8 +307,12 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("Ffe9gL8vXraBkiv3HqbLvBqY7i9V4qtZxjH83jYYDe1V");
         }
+        pub mod upgrade_authority {
+            solana_sdk::declare_id!("6zkXWHR8YeCvfMqHwyiz2n7g6hMUKCFhrVccZZTDk4ei");
+        }
         pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
+            upgrade_authority_address: Some(upgrade_authority::id()),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_zk_token_proof_program",
@@ -288,8 +326,12 @@ mod test_only {
         pub mod source_buffer {
             solana_sdk::declare_id!("EH45pKy1kzjifB93wEJi91js3S4HETdsteywR7ZCNPn5");
         }
+        pub mod upgrade_authority {
+            solana_sdk::declare_id!("AWbiYRbFts9GVX5uwUkwV46hTFP85PxCAM8e8ir8Hqtq");
+        }
         pub const CONFIG: super::CoreBpfMigrationConfig = super::CoreBpfMigrationConfig {
             source_buffer_address: source_buffer::id(),
+            upgrade_authority_address: Some(upgrade_authority::id()),
             feature_id: feature::id(),
             migration_target: super::CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_loader_v4_program",


### PR DESCRIPTION
#### Problem
Authority for buffer accounts is not optional (cannot be `None`). This means a builtin
that should have no upgrade authority once it becomes Core BPF must first be migrated
then manually have its authority revoked.

Additionally, there can be more explicit sanity checks to ensure the resulting upgrade
authority results in the expected value.

#### Summary of Changes
Require the upgrade authority to be explicitly specified on the migration configuration.

If the authority is specified as `None`, the migration will create the BPF version of the program
with `None` for upgrade authority, removing the manual step.

If `Some(..)` authority is specified, the migration will perform a sanity check to ensure the
provided authority matches the source buffer account's authority.