### PR TITLE
[programs] Add `zk-elgamal-proof` program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7710,6 +7710,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-zk-elgamal-proof-program"
+version = "2.0.0"
+dependencies = [
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-program-runtime",
+ "solana-sdk",
+ "solana-zk-token-sdk",
+]
+
+[[package]]
 name = "solana-zk-keygen"
 version = "2.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7718,7 +7718,7 @@ dependencies = [
  "num-traits",
  "solana-program-runtime",
  "solana-sdk",
- "solana-zk-token-sdk",
+ "solana-zk-sdk",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ members = [
     "programs/stake",
     "programs/system",
     "programs/vote",
+    "programs/zk-elgamal-proof",
     "programs/zk-token-proof",
     "programs/zk-token-proof-tests",
     "pubsub-client",
@@ -396,6 +397,7 @@ solana-version = { path = "version", version = "=2.0.0" }
 solana-vote = { path = "vote", version = "=2.0.0" }
 solana-vote-program = { path = "programs/vote", version = "=2.0.0" }
 solana-wen-restart = { path = "wen-restart", version = "=2.0.0" }
+solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=2.0.0" }
 solana-zk-keygen = { path = "zk-keygen", version = "=2.0.0" }
 solana-zk-sdk = { path = "zk-sdk", version = "=2.0.0" }
 solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=2.0.0" }

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -7,9 +7,9 @@ cargo="$(readlink -f "./cargo")"
 source ci/_
 
 annotate() {
-	${BUILDKITE:-false} && {
-		buildkite-agent annotate "$@"
-	}
+  ${BUILDKITE:-false} && {
+    buildkite-agent annotate "$@"
+  }
 }
 
 # Run the appropriate test based on entrypoint
@@ -33,136 +33,136 @@ source ci/common/shared-functions.sh
 echo "Executing $testName"
 case $testName in
 test-stable)
-	_ ci/intercept.sh cargo test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
-	;;
+  _ ci/intercept.sh cargo test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
+  ;;
 test-stable-sbf)
-	# Clear the C dependency files, if dependency moves these files are not regenerated
-	test -d target/debug/sbf && find target/debug/sbf -name '*.d' -delete
-	test -d target/release/sbf && find target/release/sbf -name '*.d' -delete
+  # Clear the C dependency files, if dependency moves these files are not regenerated
+  test -d target/debug/sbf && find target/debug/sbf -name '*.d' -delete
+  test -d target/release/sbf && find target/release/sbf -name '*.d' -delete
 
-	# rustfilt required for dumping SBF assembly listings
-	"$cargo" install rustfilt
+  # rustfilt required for dumping SBF assembly listings
+  "$cargo" install rustfilt
 
-	# solana-keygen required when building C programs
-	_ "$cargo" build --manifest-path=keygen/Cargo.toml
+  # solana-keygen required when building C programs
+  _ "$cargo" build --manifest-path=keygen/Cargo.toml
 
-	export PATH="$PWD/target/debug":$PATH
-	cargo_build_sbf="$(realpath ./cargo-build-sbf)"
-	cargo_test_sbf="$(realpath ./cargo-test-sbf)"
+  export PATH="$PWD/target/debug":$PATH
+  cargo_build_sbf="$(realpath ./cargo-build-sbf)"
+  cargo_test_sbf="$(realpath ./cargo-test-sbf)"
 
-	# SBF solana-sdk legacy compile test
-	"$cargo_build_sbf" --manifest-path sdk/Cargo.toml
+  # SBF solana-sdk legacy compile test
+  "$cargo_build_sbf" --manifest-path sdk/Cargo.toml
 
-	# Ensure the minimum supported "rust-version" matches platform tools to fail
-	# quickly if users try to build with an older platform tools install
-	cargo_toml=sdk/program/Cargo.toml
-	source "scripts/read-cargo-variable.sh"
-	crate_rust_version=$(readCargoVariable rust-version $cargo_toml)
-	platform_tools_rust_version=$("$cargo_build_sbf" --version | grep rustc)
-	platform_tools_rust_version=$(echo "$platform_tools_rust_version" | cut -d\  -f2) # Remove "rustc " prefix from a string like "rustc 1.68.0-dev"
-	platform_tools_rust_version=$(echo "$platform_tools_rust_version" | cut -d- -f1)  # Remove "-dev" suffix from a string like "1.68.0-dev"
+  # Ensure the minimum supported "rust-version" matches platform tools to fail
+  # quickly if users try to build with an older platform tools install
+  cargo_toml=sdk/program/Cargo.toml
+  source "scripts/read-cargo-variable.sh"
+  crate_rust_version=$(readCargoVariable rust-version $cargo_toml)
+  platform_tools_rust_version=$("$cargo_build_sbf" --version | grep rustc)
+  platform_tools_rust_version=$(echo "$platform_tools_rust_version" | cut -d\  -f2) # Remove "rustc " prefix from a string like "rustc 1.68.0-dev"
+  platform_tools_rust_version=$(echo "$platform_tools_rust_version" | cut -d- -f1)  # Remove "-dev" suffix from a string like "1.68.0-dev"
 
-	if [[ $crate_rust_version != "$platform_tools_rust_version" ]]; then
-		echo "Error: Update 'rust-version' field in '$cargo_toml' from $crate_rust_version to $platform_tools_rust_version"
-		exit 1
-	fi
+  if [[ $crate_rust_version != "$platform_tools_rust_version" ]]; then
+    echo "Error: Update 'rust-version' field in '$cargo_toml' from $crate_rust_version to $platform_tools_rust_version"
+    exit 1
+  fi
 
-	# # SBF C program system tests
-	# _ make -C programs/sbf/c tests
-	# _ cargo test \
-	#   --manifest-path programs/sbf/Cargo.toml \
-	#   --no-default-features --features=sbf_c,sbf_rust -- --nocapture
+  # SBF C program system tests
+  _ make -C programs/sbf/c tests
+  _ cargo test \
+    --manifest-path programs/sbf/Cargo.toml \
+    --no-default-features --features=sbf_c,sbf_rust -- --nocapture
 
-	# SBF Rust program unit tests
-	for sbf_test in programs/sbf/rust/*; do
-		if pushd "$sbf_test"; then
-			"$cargo" test
-			"$cargo_build_sbf" --sbf-sdk ../../../../sdk/sbf --dump
-			"$cargo_test_sbf" --sbf-sdk ../../../../sdk/sbf
-			popd
-		fi
-	done |& tee cargo.log
-	# Save the output of cargo building the sbf tests so we can analyze
-	# the number of redundant rebuilds of dependency crates. The
-	# expected number of solana-program crate compilations is 4. There
-	# should be 3 builds of solana-program while 128bit crate is
-	# built. These compilations are not redundant because the crate is
-	# built for different target each time. An additional compilation of
-	# solana-program is performed when simulation crate is built. This
-	# last compiled solana-program is of different version, normally the
-	# latest mainbeta release version.
-	solana_program_count=$(grep -c 'solana-program v' cargo.log)
-	# rm -f cargo.log
-	if ((solana_program_count > 20)); then
-		echo "Regression of build redundancy ${solana_program_count}."
-		echo "Review dependency features that trigger redundant rebuilds of solana-program."
-		exit 1
-	fi
+  # SBF Rust program unit tests
+  for sbf_test in programs/sbf/rust/*; do
+    if pushd "$sbf_test"; then
+      "$cargo" test
+      "$cargo_build_sbf" --sbf-sdk ../../../../sdk/sbf --dump
+      "$cargo_test_sbf" --sbf-sdk ../../../../sdk/sbf
+      popd
+    fi
+  done |& tee cargo.log
+  # Save the output of cargo building the sbf tests so we can analyze
+  # the number of redundant rebuilds of dependency crates. The
+  # expected number of solana-program crate compilations is 4. There
+  # should be 3 builds of solana-program while 128bit crate is
+  # built. These compilations are not redundant because the crate is
+  # built for different target each time. An additional compilation of
+  # solana-program is performed when simulation crate is built. This
+  # last compiled solana-program is of different version, normally the
+  # latest mainbeta release version.
+  solana_program_count=$(grep -c 'solana-program v' cargo.log)
+  rm -f cargo.log
+  if ((solana_program_count > 20)); then
+      echo "Regression of build redundancy ${solana_program_count}."
+      echo "Review dependency features that trigger redundant rebuilds of solana-program."
+      exit 1
+  fi
 
-	# platform-tools version
-	"$cargo_build_sbf" -V
+  # platform-tools version
+  "$cargo_build_sbf" -V
 
-	# SBF program instruction count assertion
-	sbf_target_path=programs/sbf/target
-	_ cargo test \
-		--manifest-path programs/sbf/Cargo.toml \
-		--no-default-features --features=sbf_c,sbf_rust assert_instruction_count \
-		-- --nocapture &>"${sbf_target_path}"/deploy/instruction_counts.txt
+  # SBF program instruction count assertion
+  sbf_target_path=programs/sbf/target
+  _ cargo test \
+    --manifest-path programs/sbf/Cargo.toml \
+    --no-default-features --features=sbf_c,sbf_rust assert_instruction_count \
+    -- --nocapture &> "${sbf_target_path}"/deploy/instruction_counts.txt
 
-	sbf_dump_archive="sbf-dumps.tar.bz2"
-	rm -f "$sbf_dump_archive"
-	tar cjvf "$sbf_dump_archive" "${sbf_target_path}"/{deploy/*.txt,sbf-solana-solana/release/*.so}
-	exit 0
-	;;
+  sbf_dump_archive="sbf-dumps.tar.bz2"
+  rm -f "$sbf_dump_archive"
+  tar cjvf "$sbf_dump_archive" "${sbf_target_path}"/{deploy/*.txt,sbf-solana-solana/release/*.so}
+  exit 0
+  ;;
 test-stable-perf)
-	if [[ $(uname) = Linux ]]; then
-		# Enable persistence mode to keep the CUDA kernel driver loaded, avoiding a
-		# lengthy and unexpected delay the first time CUDA is involved when the driver
-		# is not yet loaded.
-		sudo --non-interactive ./net/scripts/enable-nvidia-persistence-mode.sh || true
+  if [[ $(uname) = Linux ]]; then
+    # Enable persistence mode to keep the CUDA kernel driver loaded, avoiding a
+    # lengthy and unexpected delay the first time CUDA is involved when the driver
+    # is not yet loaded.
+    sudo --non-interactive ./net/scripts/enable-nvidia-persistence-mode.sh || true
 
-		rm -rf target/perf-libs
-		./fetch-perf-libs.sh
+    rm -rf target/perf-libs
+    ./fetch-perf-libs.sh
 
-		# Force CUDA for solana-core unit tests
-		export TEST_PERF_LIBS_CUDA=1
+    # Force CUDA for solana-core unit tests
+    export TEST_PERF_LIBS_CUDA=1
 
-		# Force CUDA in ci/localnet-sanity.sh
-		export SOLANA_CUDA=1
-	fi
+    # Force CUDA in ci/localnet-sanity.sh
+    export SOLANA_CUDA=1
+  fi
 
-	_ cargo build --bins ${V:+--verbose}
-	_ cargo test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
-	_ cargo run --manifest-path poh-bench/Cargo.toml ${V:+--verbose} -- --hashes-per-tick 10
-	;;
+  _ cargo build --bins ${V:+--verbose}
+  _ cargo test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
+  _ cargo run --manifest-path poh-bench/Cargo.toml ${V:+--verbose} -- --hashes-per-tick 10
+  ;;
 test-wasm)
-	_ node --version
-	_ npm --version
-	for dir in sdk/{program,}; do
-		if [[ -r "$dir"/package.json ]]; then
-			pushd "$dir"
-			_ npm install
-			_ npm test
-			popd
-		fi
-	done
-	exit 0
-	;;
+  _ node --version
+  _ npm --version
+  for dir in sdk/{program,}; do
+    if [[ -r "$dir"/package.json ]]; then
+      pushd "$dir"
+      _ npm install
+      _ npm test
+      popd
+    fi
+  done
+  exit 0
+  ;;
 test-docs)
-	_ cargo test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
-	exit 0
-	;;
+  _ cargo test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
+  exit 0
+  ;;
 *)
-	echo "Error: Unknown test: $testName"
-	;;
+  echo "Error: Unknown test: $testName"
+  ;;
 esac
 
 (
-	export CARGO_TOOLCHAIN=+"$rust_stable"
-	export RUST_LOG="solana_metrics=warn,info,$RUST_LOG"
-	echo --- ci/localnet-sanity.sh
-	ci/localnet-sanity.sh -x
+  export CARGO_TOOLCHAIN=+"$rust_stable"
+  export RUST_LOG="solana_metrics=warn,info,$RUST_LOG"
+  echo --- ci/localnet-sanity.sh
+  ci/localnet-sanity.sh -x
 
-	echo --- ci/run-sanity.sh
-	ci/run-sanity.sh -x
+  echo --- ci/run-sanity.sh
+  ci/run-sanity.sh -x
 )

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -7,9 +7,9 @@ cargo="$(readlink -f "./cargo")"
 source ci/_
 
 annotate() {
-  ${BUILDKITE:-false} && {
-    buildkite-agent annotate "$@"
-  }
+	${BUILDKITE:-false} && {
+		buildkite-agent annotate "$@"
+	}
 }
 
 # Run the appropriate test based on entrypoint
@@ -33,136 +33,136 @@ source ci/common/shared-functions.sh
 echo "Executing $testName"
 case $testName in
 test-stable)
-  _ ci/intercept.sh cargo test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
-  ;;
+	_ ci/intercept.sh cargo test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
+	;;
 test-stable-sbf)
-  # Clear the C dependency files, if dependency moves these files are not regenerated
-  test -d target/debug/sbf && find target/debug/sbf -name '*.d' -delete
-  test -d target/release/sbf && find target/release/sbf -name '*.d' -delete
+	# Clear the C dependency files, if dependency moves these files are not regenerated
+	test -d target/debug/sbf && find target/debug/sbf -name '*.d' -delete
+	test -d target/release/sbf && find target/release/sbf -name '*.d' -delete
 
-  # rustfilt required for dumping SBF assembly listings
-  "$cargo" install rustfilt
+	# rustfilt required for dumping SBF assembly listings
+	"$cargo" install rustfilt
 
-  # solana-keygen required when building C programs
-  _ "$cargo" build --manifest-path=keygen/Cargo.toml
+	# solana-keygen required when building C programs
+	_ "$cargo" build --manifest-path=keygen/Cargo.toml
 
-  export PATH="$PWD/target/debug":$PATH
-  cargo_build_sbf="$(realpath ./cargo-build-sbf)"
-  cargo_test_sbf="$(realpath ./cargo-test-sbf)"
+	export PATH="$PWD/target/debug":$PATH
+	cargo_build_sbf="$(realpath ./cargo-build-sbf)"
+	cargo_test_sbf="$(realpath ./cargo-test-sbf)"
 
-  # SBF solana-sdk legacy compile test
-  "$cargo_build_sbf" --manifest-path sdk/Cargo.toml
+	# SBF solana-sdk legacy compile test
+	"$cargo_build_sbf" --manifest-path sdk/Cargo.toml
 
-  # Ensure the minimum supported "rust-version" matches platform tools to fail
-  # quickly if users try to build with an older platform tools install
-  cargo_toml=sdk/program/Cargo.toml
-  source "scripts/read-cargo-variable.sh"
-  crate_rust_version=$(readCargoVariable rust-version $cargo_toml)
-  platform_tools_rust_version=$("$cargo_build_sbf" --version | grep rustc)
-  platform_tools_rust_version=$(echo "$platform_tools_rust_version" | cut -d\  -f2) # Remove "rustc " prefix from a string like "rustc 1.68.0-dev"
-  platform_tools_rust_version=$(echo "$platform_tools_rust_version" | cut -d- -f1)  # Remove "-dev" suffix from a string like "1.68.0-dev"
+	# Ensure the minimum supported "rust-version" matches platform tools to fail
+	# quickly if users try to build with an older platform tools install
+	cargo_toml=sdk/program/Cargo.toml
+	source "scripts/read-cargo-variable.sh"
+	crate_rust_version=$(readCargoVariable rust-version $cargo_toml)
+	platform_tools_rust_version=$("$cargo_build_sbf" --version | grep rustc)
+	platform_tools_rust_version=$(echo "$platform_tools_rust_version" | cut -d\  -f2) # Remove "rustc " prefix from a string like "rustc 1.68.0-dev"
+	platform_tools_rust_version=$(echo "$platform_tools_rust_version" | cut -d- -f1)  # Remove "-dev" suffix from a string like "1.68.0-dev"
 
-  if [[ $crate_rust_version != "$platform_tools_rust_version" ]]; then
-    echo "Error: Update 'rust-version' field in '$cargo_toml' from $crate_rust_version to $platform_tools_rust_version"
-    exit 1
-  fi
+	if [[ $crate_rust_version != "$platform_tools_rust_version" ]]; then
+		echo "Error: Update 'rust-version' field in '$cargo_toml' from $crate_rust_version to $platform_tools_rust_version"
+		exit 1
+	fi
 
-  # SBF C program system tests
-  _ make -C programs/sbf/c tests
-  _ cargo test \
-    --manifest-path programs/sbf/Cargo.toml \
-    --no-default-features --features=sbf_c,sbf_rust -- --nocapture
+	# # SBF C program system tests
+	# _ make -C programs/sbf/c tests
+	# _ cargo test \
+	#   --manifest-path programs/sbf/Cargo.toml \
+	#   --no-default-features --features=sbf_c,sbf_rust -- --nocapture
 
-  # SBF Rust program unit tests
-  for sbf_test in programs/sbf/rust/*; do
-    if pushd "$sbf_test"; then
-      "$cargo" test
-      "$cargo_build_sbf" --sbf-sdk ../../../../sdk/sbf --dump
-      "$cargo_test_sbf" --sbf-sdk ../../../../sdk/sbf
-      popd
-    fi
-  done |& tee cargo.log
-  # Save the output of cargo building the sbf tests so we can analyze
-  # the number of redundant rebuilds of dependency crates. The
-  # expected number of solana-program crate compilations is 4. There
-  # should be 3 builds of solana-program while 128bit crate is
-  # built. These compilations are not redundant because the crate is
-  # built for different target each time. An additional compilation of
-  # solana-program is performed when simulation crate is built. This
-  # last compiled solana-program is of different version, normally the
-  # latest mainbeta release version.
-  solana_program_count=$(grep -c 'solana-program v' cargo.log)
-  rm -f cargo.log
-  if ((solana_program_count > 20)); then
-      echo "Regression of build redundancy ${solana_program_count}."
-      echo "Review dependency features that trigger redundant rebuilds of solana-program."
-      exit 1
-  fi
+	# SBF Rust program unit tests
+	for sbf_test in programs/sbf/rust/*; do
+		if pushd "$sbf_test"; then
+			"$cargo" test
+			"$cargo_build_sbf" --sbf-sdk ../../../../sdk/sbf --dump
+			"$cargo_test_sbf" --sbf-sdk ../../../../sdk/sbf
+			popd
+		fi
+	done |& tee cargo.log
+	# Save the output of cargo building the sbf tests so we can analyze
+	# the number of redundant rebuilds of dependency crates. The
+	# expected number of solana-program crate compilations is 4. There
+	# should be 3 builds of solana-program while 128bit crate is
+	# built. These compilations are not redundant because the crate is
+	# built for different target each time. An additional compilation of
+	# solana-program is performed when simulation crate is built. This
+	# last compiled solana-program is of different version, normally the
+	# latest mainbeta release version.
+	solana_program_count=$(grep -c 'solana-program v' cargo.log)
+	# rm -f cargo.log
+	if ((solana_program_count > 20)); then
+		echo "Regression of build redundancy ${solana_program_count}."
+		echo "Review dependency features that trigger redundant rebuilds of solana-program."
+		exit 1
+	fi
 
-  # platform-tools version
-  "$cargo_build_sbf" -V
+	# platform-tools version
+	"$cargo_build_sbf" -V
 
-  # SBF program instruction count assertion
-  sbf_target_path=programs/sbf/target
-  _ cargo test \
-    --manifest-path programs/sbf/Cargo.toml \
-    --no-default-features --features=sbf_c,sbf_rust assert_instruction_count \
-    -- --nocapture &> "${sbf_target_path}"/deploy/instruction_counts.txt
+	# SBF program instruction count assertion
+	sbf_target_path=programs/sbf/target
+	_ cargo test \
+		--manifest-path programs/sbf/Cargo.toml \
+		--no-default-features --features=sbf_c,sbf_rust assert_instruction_count \
+		-- --nocapture &>"${sbf_target_path}"/deploy/instruction_counts.txt
 
-  sbf_dump_archive="sbf-dumps.tar.bz2"
-  rm -f "$sbf_dump_archive"
-  tar cjvf "$sbf_dump_archive" "${sbf_target_path}"/{deploy/*.txt,sbf-solana-solana/release/*.so}
-  exit 0
-  ;;
+	sbf_dump_archive="sbf-dumps.tar.bz2"
+	rm -f "$sbf_dump_archive"
+	tar cjvf "$sbf_dump_archive" "${sbf_target_path}"/{deploy/*.txt,sbf-solana-solana/release/*.so}
+	exit 0
+	;;
 test-stable-perf)
-  if [[ $(uname) = Linux ]]; then
-    # Enable persistence mode to keep the CUDA kernel driver loaded, avoiding a
-    # lengthy and unexpected delay the first time CUDA is involved when the driver
-    # is not yet loaded.
-    sudo --non-interactive ./net/scripts/enable-nvidia-persistence-mode.sh || true
+	if [[ $(uname) = Linux ]]; then
+		# Enable persistence mode to keep the CUDA kernel driver loaded, avoiding a
+		# lengthy and unexpected delay the first time CUDA is involved when the driver
+		# is not yet loaded.
+		sudo --non-interactive ./net/scripts/enable-nvidia-persistence-mode.sh || true
 
-    rm -rf target/perf-libs
-    ./fetch-perf-libs.sh
+		rm -rf target/perf-libs
+		./fetch-perf-libs.sh
 
-    # Force CUDA for solana-core unit tests
-    export TEST_PERF_LIBS_CUDA=1
+		# Force CUDA for solana-core unit tests
+		export TEST_PERF_LIBS_CUDA=1
 
-    # Force CUDA in ci/localnet-sanity.sh
-    export SOLANA_CUDA=1
-  fi
+		# Force CUDA in ci/localnet-sanity.sh
+		export SOLANA_CUDA=1
+	fi
 
-  _ cargo build --bins ${V:+--verbose}
-  _ cargo test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
-  _ cargo run --manifest-path poh-bench/Cargo.toml ${V:+--verbose} -- --hashes-per-tick 10
-  ;;
+	_ cargo build --bins ${V:+--verbose}
+	_ cargo test --package solana-perf --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
+	_ cargo run --manifest-path poh-bench/Cargo.toml ${V:+--verbose} -- --hashes-per-tick 10
+	;;
 test-wasm)
-  _ node --version
-  _ npm --version
-  for dir in sdk/{program,}; do
-    if [[ -r "$dir"/package.json ]]; then
-      pushd "$dir"
-      _ npm install
-      _ npm test
-      popd
-    fi
-  done
-  exit 0
-  ;;
+	_ node --version
+	_ npm --version
+	for dir in sdk/{program,}; do
+		if [[ -r "$dir"/package.json ]]; then
+			pushd "$dir"
+			_ npm install
+			_ npm test
+			popd
+		fi
+	done
+	exit 0
+	;;
 test-docs)
-  _ cargo test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
-  exit 0
-  ;;
+	_ cargo test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
+	exit 0
+	;;
 *)
-  echo "Error: Unknown test: $testName"
-  ;;
+	echo "Error: Unknown test: $testName"
+	;;
 esac
 
 (
-  export CARGO_TOOLCHAIN=+"$rust_stable"
-  export RUST_LOG="solana_metrics=warn,info,$RUST_LOG"
-  echo --- ci/localnet-sanity.sh
-  ci/localnet-sanity.sh -x
+	export CARGO_TOOLCHAIN=+"$rust_stable"
+	export RUST_LOG="solana_metrics=warn,info,$RUST_LOG"
+	echo --- ci/localnet-sanity.sh
+	ci/localnet-sanity.sh -x
 
-  echo --- ci/run-sanity.sh
-  ci/run-sanity.sh -x
+	echo --- ci/run-sanity.sh
+	ci/run-sanity.sh -x
 )

--- a/programs/zk-elgamal-proof/Cargo.toml
+++ b/programs/zk-elgamal-proof/Cargo.toml
@@ -7,3 +7,11 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+
+[dependencies]
+bytemuck = { workspace = true, features = ["derive"] }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
+solana-program-runtime = { workspace = true }
+solana-sdk = { workspace = true }
+solana-zk-sdk = { workspace = true }

--- a/programs/zk-elgamal-proof/Cargo.toml
+++ b/programs/zk-elgamal-proof/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "solana-zk-elgamal-proof-program"
+description = "Solana Zk ElGamal Proof Program"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }

--- a/programs/zk-elgamal-proof/src/lib.rs
+++ b/programs/zk-elgamal-proof/src/lib.rs
@@ -1,0 +1,369 @@
+#![forbid(unsafe_code)]
+
+use {
+    bytemuck::Pod,
+    solana_program_runtime::{declare_process_instruction, ic_msg, invoke_context::InvokeContext},
+    solana_sdk::{
+        feature_set,
+        instruction::{InstructionError, TRANSACTION_LEVEL_STACK_HEIGHT},
+        system_program,
+    },
+    solana_zk_token_sdk::{
+        zk_token_proof_instruction::*,
+        zk_token_proof_program::id,
+        zk_token_proof_state::{ProofContextState, ProofContextStateMeta},
+    },
+    std::result::Result,
+};
+
+pub const CLOSE_CONTEXT_STATE_COMPUTE_UNITS: u64 = 3_300;
+pub const VERIFY_ZERO_BALANCE_COMPUTE_UNITS: u64 = 6_000;
+pub const VERIFY_WITHDRAW_COMPUTE_UNITS: u64 = 110_000;
+pub const VERIFY_CIPHERTEXT_CIPHERTEXT_EQUALITY_COMPUTE_UNITS: u64 = 8_000;
+pub const VERIFY_TRANSFER_COMPUTE_UNITS: u64 = 219_000;
+pub const VERIFY_TRANSFER_WITH_FEE_COMPUTE_UNITS: u64 = 407_000;
+pub const VERIFY_PUBKEY_VALIDITY_COMPUTE_UNITS: u64 = 2_600;
+pub const VERIFY_RANGE_PROOF_U64_COMPUTE_UNITS: u64 = 105_000;
+pub const VERIFY_BATCHED_RANGE_PROOF_U64_COMPUTE_UNITS: u64 = 111_000;
+pub const VERIFY_BATCHED_RANGE_PROOF_U128_COMPUTE_UNITS: u64 = 200_000;
+pub const VERIFY_BATCHED_RANGE_PROOF_U256_COMPUTE_UNITS: u64 = 368_000;
+pub const VERIFY_CIPHERTEXT_COMMITMENT_EQUALITY_COMPUTE_UNITS: u64 = 6_400;
+pub const VERIFY_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_COMPUTE_UNITS: u64 = 6_400;
+pub const VERIFY_BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_COMPUTE_UNITS: u64 = 13_000;
+pub const VERIFY_FEE_SIGMA_COMPUTE_UNITS: u64 = 6_500;
+pub const VERIFY_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_COMPUTE_UNITS: u64 = 8_100;
+pub const VERIFY_BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_COMPUTE_UNITS: u64 = 16_400;
+
+const INSTRUCTION_DATA_LENGTH_WITH_PROOF_ACCOUNT: usize = 5;
+
+fn process_verify_proof<T, U>(invoke_context: &mut InvokeContext) -> Result<(), InstructionError>
+where
+    T: Pod + ZkProofData<U>,
+    U: Pod,
+{
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let instruction_data = instruction_context.get_instruction_data();
+
+    // number of accessed accounts so far
+    let mut accessed_accounts = 0_u16;
+
+    // if instruction data is exactly 5 bytes, then read proof from an account
+    let context_data = if instruction_data.len() == INSTRUCTION_DATA_LENGTH_WITH_PROOF_ACCOUNT {
+        if !invoke_context
+            .get_feature_set()
+            .is_active(&feature_set::enable_zk_proof_from_account::id())
+        {
+            return Err(InstructionError::InvalidInstructionData);
+        }
+
+        let proof_data_account = instruction_context
+            .try_borrow_instruction_account(transaction_context, accessed_accounts)?;
+        accessed_accounts = accessed_accounts.checked_add(1).unwrap();
+
+        let proof_data_offset = u32::from_le_bytes(
+            // the first byte is the instruction discriminator
+            instruction_data[1..INSTRUCTION_DATA_LENGTH_WITH_PROOF_ACCOUNT]
+                .try_into()
+                .map_err(|_| InstructionError::InvalidInstructionData)?,
+        );
+        let proof_data_start: usize = proof_data_offset
+            .try_into()
+            .map_err(|_| InstructionError::InvalidInstructionData)?;
+        let proof_data_end = proof_data_start
+            .checked_add(std::mem::size_of::<T>())
+            .ok_or(InstructionError::InvalidInstructionData)?;
+        let proof_data_raw = proof_data_account
+            .get_data()
+            .get(proof_data_start..proof_data_end)
+            .ok_or(InstructionError::InvalidAccountData)?;
+
+        let proof_data = bytemuck::try_from_bytes::<T>(proof_data_raw).map_err(|_| {
+            ic_msg!(invoke_context, "invalid proof data");
+            InstructionError::InvalidInstructionData
+        })?;
+        proof_data.verify_proof().map_err(|err| {
+            ic_msg!(invoke_context, "proof verification failed: {:?}", err);
+            InstructionError::InvalidInstructionData
+        })?;
+
+        *proof_data.context_data()
+    } else {
+        let proof_data =
+            ProofInstruction::proof_data::<T, U>(instruction_data).ok_or_else(|| {
+                ic_msg!(invoke_context, "invalid proof data");
+                InstructionError::InvalidInstructionData
+            })?;
+        proof_data.verify_proof().map_err(|err| {
+            ic_msg!(invoke_context, "proof_verification failed: {:?}", err);
+            InstructionError::InvalidInstructionData
+        })?;
+
+        *proof_data.context_data()
+    };
+
+    // create context state if additional accounts are provided with the instruction
+    if instruction_context.get_number_of_instruction_accounts() > accessed_accounts {
+        let context_state_authority = *instruction_context
+            .try_borrow_instruction_account(
+                transaction_context,
+                accessed_accounts.checked_add(1).unwrap(),
+            )?
+            .get_key();
+
+        let mut proof_context_account = instruction_context
+            .try_borrow_instruction_account(transaction_context, accessed_accounts)?;
+
+        if *proof_context_account.get_owner() != id() {
+            return Err(InstructionError::InvalidAccountOwner);
+        }
+
+        let proof_context_state_meta =
+            ProofContextStateMeta::try_from_bytes(proof_context_account.get_data())?;
+
+        if proof_context_state_meta.proof_type != ProofType::Uninitialized.into() {
+            return Err(InstructionError::AccountAlreadyInitialized);
+        }
+
+        let context_state_data =
+            ProofContextState::encode(&context_state_authority, T::PROOF_TYPE, &context_data);
+
+        if proof_context_account.get_data().len() != context_state_data.len() {
+            return Err(InstructionError::InvalidAccountData);
+        }
+
+        proof_context_account.set_data_from_slice(&context_state_data)?;
+    }
+
+    Ok(())
+}
+
+fn process_close_proof_context(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+
+    let owner_pubkey = {
+        let owner_account =
+            instruction_context.try_borrow_instruction_account(transaction_context, 2)?;
+
+        if !owner_account.is_signer() {
+            return Err(InstructionError::MissingRequiredSignature);
+        }
+        *owner_account.get_key()
+    }; // done with `owner_account`, so drop it to prevent a potential double borrow
+
+    let proof_context_account_pubkey = *instruction_context
+        .try_borrow_instruction_account(transaction_context, 0)?
+        .get_key();
+    let destination_account_pubkey = *instruction_context
+        .try_borrow_instruction_account(transaction_context, 1)?
+        .get_key();
+    if proof_context_account_pubkey == destination_account_pubkey {
+        return Err(InstructionError::InvalidInstructionData);
+    }
+
+    let mut proof_context_account =
+        instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
+    let proof_context_state_meta =
+        ProofContextStateMeta::try_from_bytes(proof_context_account.get_data())?;
+    let expected_owner_pubkey = proof_context_state_meta.context_state_authority;
+
+    if owner_pubkey != expected_owner_pubkey {
+        return Err(InstructionError::InvalidAccountOwner);
+    }
+
+    let mut destination_account =
+        instruction_context.try_borrow_instruction_account(transaction_context, 1)?;
+    destination_account.checked_add_lamports(proof_context_account.get_lamports())?;
+    proof_context_account.set_lamports(0)?;
+    proof_context_account.set_data_length(0)?;
+    proof_context_account.set_owner(system_program::id().as_ref())?;
+
+    Ok(())
+}
+
+declare_process_instruction!(Entrypoint, 0, |invoke_context| {
+    let enable_zk_transfer_with_fee = invoke_context
+        .get_feature_set()
+        .is_active(&feature_set::enable_zk_transfer_with_fee::id());
+
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let instruction_data = instruction_context.get_instruction_data();
+    let instruction = ProofInstruction::instruction_type(instruction_data)
+        .ok_or(InstructionError::InvalidInstructionData)?;
+
+    if invoke_context.get_stack_height() != TRANSACTION_LEVEL_STACK_HEIGHT
+        && instruction != ProofInstruction::CloseContextState
+    {
+        // Proof verification instructions are not supported as an inner instruction
+        return Err(InstructionError::UnsupportedProgramId);
+    }
+
+    match instruction {
+        ProofInstruction::CloseContextState => {
+            invoke_context
+                .consume_checked(CLOSE_CONTEXT_STATE_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "CloseContextState");
+            process_close_proof_context(invoke_context)
+        }
+        ProofInstruction::VerifyZeroBalance => {
+            invoke_context
+                .consume_checked(VERIFY_ZERO_BALANCE_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyZeroBalance");
+            process_verify_proof::<ZeroBalanceProofData, ZeroBalanceProofContext>(invoke_context)
+        }
+        ProofInstruction::VerifyWithdraw => {
+            invoke_context
+                .consume_checked(VERIFY_WITHDRAW_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyWithdraw");
+            process_verify_proof::<WithdrawData, WithdrawProofContext>(invoke_context)
+        }
+        ProofInstruction::VerifyCiphertextCiphertextEquality => {
+            invoke_context
+                .consume_checked(VERIFY_CIPHERTEXT_CIPHERTEXT_EQUALITY_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyCiphertextCiphertextEquality");
+            process_verify_proof::<
+                CiphertextCiphertextEqualityProofData,
+                CiphertextCiphertextEqualityProofContext,
+            >(invoke_context)
+        }
+        ProofInstruction::VerifyTransfer => {
+            invoke_context
+                .consume_checked(VERIFY_TRANSFER_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyTransfer");
+            process_verify_proof::<TransferData, TransferProofContext>(invoke_context)
+        }
+        ProofInstruction::VerifyTransferWithFee => {
+            // transfer with fee related proofs are not enabled
+            if !enable_zk_transfer_with_fee {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+
+            invoke_context
+                .consume_checked(VERIFY_TRANSFER_WITH_FEE_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyTransferWithFee");
+            process_verify_proof::<TransferWithFeeData, TransferWithFeeProofContext>(invoke_context)
+        }
+        ProofInstruction::VerifyPubkeyValidity => {
+            invoke_context
+                .consume_checked(VERIFY_PUBKEY_VALIDITY_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyPubkeyValidity");
+            process_verify_proof::<PubkeyValidityData, PubkeyValidityProofContext>(invoke_context)
+        }
+        ProofInstruction::VerifyRangeProofU64 => {
+            invoke_context
+                .consume_checked(VERIFY_RANGE_PROOF_U64_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyRangeProof");
+            process_verify_proof::<RangeProofU64Data, RangeProofContext>(invoke_context)
+        }
+        ProofInstruction::VerifyBatchedRangeProofU64 => {
+            invoke_context
+                .consume_checked(VERIFY_BATCHED_RANGE_PROOF_U64_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyBatchedRangeProof64");
+            process_verify_proof::<BatchedRangeProofU64Data, BatchedRangeProofContext>(
+                invoke_context,
+            )
+        }
+        ProofInstruction::VerifyBatchedRangeProofU128 => {
+            invoke_context
+                .consume_checked(VERIFY_BATCHED_RANGE_PROOF_U128_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyBatchedRangeProof128");
+            process_verify_proof::<BatchedRangeProofU128Data, BatchedRangeProofContext>(
+                invoke_context,
+            )
+        }
+        ProofInstruction::VerifyBatchedRangeProofU256 => {
+            // transfer with fee related proofs are not enabled
+            if !enable_zk_transfer_with_fee {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+
+            invoke_context
+                .consume_checked(VERIFY_BATCHED_RANGE_PROOF_U256_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyBatchedRangeProof256");
+            process_verify_proof::<BatchedRangeProofU256Data, BatchedRangeProofContext>(
+                invoke_context,
+            )
+        }
+        ProofInstruction::VerifyCiphertextCommitmentEquality => {
+            invoke_context
+                .consume_checked(VERIFY_CIPHERTEXT_COMMITMENT_EQUALITY_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyCiphertextCommitmentEquality");
+            process_verify_proof::<
+                CiphertextCommitmentEqualityProofData,
+                CiphertextCommitmentEqualityProofContext,
+            >(invoke_context)
+        }
+        ProofInstruction::VerifyGroupedCiphertext2HandlesValidity => {
+            invoke_context
+                .consume_checked(VERIFY_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyGroupedCiphertext2HandlesValidity");
+            process_verify_proof::<
+                GroupedCiphertext2HandlesValidityProofData,
+                GroupedCiphertext2HandlesValidityProofContext,
+            >(invoke_context)
+        }
+        ProofInstruction::VerifyBatchedGroupedCiphertext2HandlesValidity => {
+            invoke_context
+                .consume_checked(VERIFY_BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(
+                invoke_context,
+                "VerifyBatchedGroupedCiphertext2HandlesValidity"
+            );
+            process_verify_proof::<
+                BatchedGroupedCiphertext2HandlesValidityProofData,
+                BatchedGroupedCiphertext2HandlesValidityProofContext,
+            >(invoke_context)
+        }
+        ProofInstruction::VerifyFeeSigma => {
+            // transfer with fee related proofs are not enabled
+            if !enable_zk_transfer_with_fee {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+
+            invoke_context
+                .consume_checked(VERIFY_FEE_SIGMA_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyFeeSigma");
+            process_verify_proof::<FeeSigmaProofData, FeeSigmaProofContext>(invoke_context)
+        }
+        ProofInstruction::VerifyGroupedCiphertext3HandlesValidity => {
+            invoke_context
+                .consume_checked(VERIFY_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(invoke_context, "VerifyGroupedCiphertext3HandlesValidity");
+            process_verify_proof::<
+                GroupedCiphertext3HandlesValidityProofData,
+                GroupedCiphertext3HandlesValidityProofContext,
+            >(invoke_context)
+        }
+        ProofInstruction::VerifyBatchedGroupedCiphertext3HandlesValidity => {
+            invoke_context
+                .consume_checked(VERIFY_BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_COMPUTE_UNITS)
+                .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
+            ic_msg!(
+                invoke_context,
+                "VerifyBatchedGroupedCiphertext3HandlesValidity"
+            );
+            process_verify_proof::<
+                BatchedGroupedCiphertext3HandlesValidityProofData,
+                BatchedGroupedCiphertext3HandlesValidityProofContext,
+            >(invoke_context)
+        }
+    }
+});

--- a/programs/zk-elgamal-proof/src/lib.rs
+++ b/programs/zk-elgamal-proof/src/lib.rs
@@ -244,7 +244,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
             invoke_context
                 .consume_checked(VERIFY_BATCHED_RANGE_PROOF_U64_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
-            ic_msg!(invoke_context, "VerifyBatchedRangeProof64");
+            ic_msg!(invoke_context, "VerifyBatchedRangeProofU64");
             process_verify_proof::<BatchedRangeProofU64Data, BatchedRangeProofContext>(
                 invoke_context,
             )
@@ -253,7 +253,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
             invoke_context
                 .consume_checked(VERIFY_BATCHED_RANGE_PROOF_U128_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
-            ic_msg!(invoke_context, "VerifyBatchedRangeProof128");
+            ic_msg!(invoke_context, "VerifyBatchedRangeProofU128");
             process_verify_proof::<BatchedRangeProofU128Data, BatchedRangeProofContext>(
                 invoke_context,
             )
@@ -262,7 +262,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
             invoke_context
                 .consume_checked(VERIFY_BATCHED_RANGE_PROOF_U256_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
-            ic_msg!(invoke_context, "VerifyBatchedRangeProof256");
+            ic_msg!(invoke_context, "VerifyBatchedRangeProofU256");
             process_verify_proof::<BatchedRangeProofU256Data, BatchedRangeProofContext>(
                 invoke_context,
             )

--- a/programs/zk-elgamal-proof/src/lib.rs
+++ b/programs/zk-elgamal-proof/src/lib.rs
@@ -10,7 +10,7 @@ use {
     solana_zk_sdk::elgamal_program::{
         id,
         instruction::ProofInstruction,
-        proof_data::{grouped_ciphertext_validity::*, *},
+        proof_data::*,
         state::{ProofContextState, ProofContextStateMeta},
     },
     std::result::Result,


### PR DESCRIPTION
#### Problem
The new `zk-elgamal-proof` logic is not yet added.

#### Summary of Changes
Added the main `zk-elgamal-proof` logic. This is the same as the `zk-token-proof` logic except that:
- the `Withdraw`, `Transfer`, and `TransferWithFee` related instructions have been removed
- the `VerifyFeeSigma` and `VerifyZeroBalance` instructions have been renamed
- the feature gates have been removed

The program id and feature gate have not yet been added to the list of built-in programs. I will do that in a separate PR.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
