### PR TITLE
Deny warns to catch dcou compilation failures

### DIFF
--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -148,7 +148,12 @@ fi
 # 2. Check implicit usage of `dev-context-only-utils`-gated code in dev (=
 # test/benches) code by building in isolation from other crates, which might
 # happen to enable `dev-context-only-utils`
-export RUSTFLAGS="-Z threads=8 $RUSTFLAGS"
+
+# dcou tends to newly trigger `unused_imports` and `dead_code` lints.
+# We could selectively deny (= `-D`) them here, however, deny all warnings for
+# consistency with other CI steps and for the possibility of new similar lints.
+export RUSTFLAGS="-D warnings -Z threads=8 $RUSTFLAGS"
+
 if [[ $mode = "check-bins" || $mode = "full" ]]; then
   _ cargo "+${rust_nightly}" hack check --bins
 fi


### PR DESCRIPTION
#### Problem

dcou-related compilation errors isn't detected until the very last step of our buildkite ci pipeline (from `stable-sbf`: https://buildkite.com/anza/agave/builds/5112#018fc10c-e68e-4545-81dc-425cbf646df8):

```
   Compiling solana-config-program v2.0.0 (/solana/programs/config)
   Compiling solana-compute-budget-program v2.0.0 (/solana/programs/compute-budget)
   Compiling solana-bpf-loader-program v2.0.0 (/solana/programs/bpf_loader)
   Compiling solana-zk-token-proof-program v2.0.0 (/solana/programs/zk-token-proof)
error: unused imports: `AddBankSnapshotError`, `BankSnapshotKind`, `BufWriter`, `bank_to_stream`, `fs`, `get_bank_snapshot_dir`, `get_snapshot_file_name`, `get_storages_to_serialize`, `hard_link_storages_to_snapshot`
  --> runtime/src/snapshot_bank_utils.rs:7:32
   |
7  |             bank_from_streams, bank_to_stream, fields_from_streams,
   |                                ^^^^^^^^^^^^^^
...
18 |             get_bank_snapshot_dir, get_highest_bank_snapshot_post,
   |             ^^^^^^^^^^^^^^^^^^^^^
19 |             get_highest_full_snapshot_archive_info, get_highest_incremental_snapshot_archive_info,
20 |             get_snapshot_file_name, get_storages_to_serialize, hard_link_storages_to_snapshot,
   |             ^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
23 |             AddBankSnapshotError, ArchiveFormat, BankSnapshotInfo, BankSnapshotKind, SnapshotError,
   |             ^^^^^^^^^^^^^^^^^^^^                                   ^^^^^^^^^^^^^^^^
...
50 |         fs,
   |         ^^
51 |         io::{BufWriter, Write},
   |              ^^^^^^^^^
   |
   = note: `-D unused-imports` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_imports)]`
error: unused import: `Write`
  --> runtime/src/snapshot_bank_utils.rs:51:25
   |
51 |         io::{BufWriter, Write},
   |                         ^^^^^
error: function `bank_to_stream` is never used
   --> runtime/src/serde_snapshot.rs:547:15
    |
547 | pub(crate) fn bank_to_stream<W>(
    |               ^^^^^^^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`
error: could not compile `solana-runtime` (lib) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
```

ref: https://discord.com/channels/428295358100013066/560503042458517505/1245185433340612751

#### Summary of Changes

it turns out these warnings are already emitted in the checks ci step.... So, just deny them like other ci step is doing with `RUSTFLAGS=-D warnings`.

you can see correct _failing_ ci results here: #1511

cc: @brooksprumo 