### PR TITLE
chore: remove unused clippy attributes, float_cmp

### DIFF
--- a/genesis/src/unlocks.rs
+++ b/genesis/src/unlocks.rs
@@ -130,7 +130,6 @@ pub struct Unlock {
 
 impl Unlock {
     /// the number of lamports unlocked at this event
-    #[allow(clippy::float_cmp)]
     pub fn amount(&self, total: u64) -> u64 {
         if self.fraction == 1.0 {
             total - (self.prev_fraction * total as f64) as u64
@@ -145,7 +144,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[allow(clippy::float_cmp)]
     fn test_make_lockups() {
         // this number just a random val
         let total_lamports: u64 = 1_725_987_234_408_923;

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -1304,7 +1304,6 @@ pub(crate) mod tests {
         assert_eq!(node_crds.num_purged(), 0);
     }
     #[test]
-    #[allow(clippy::float_cmp)]
     fn test_crds_filter_mask() {
         let filter = CrdsFilter::new_rand(1, 128);
         assert_eq!(filter.mask, !0x0);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1494,7 +1494,6 @@ impl Bank {
     }
 
     /// Create a bank from explicit arguments and deserialized fields from snapshot
-    #[allow(clippy::float_cmp)]
     pub(crate) fn new_from_fields(
         bank_rc: BankRc,
         genesis_config: &GenesisConfig,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -273,7 +273,6 @@ fn test_bank_unix_timestamp_from_genesis() {
 }
 
 #[test]
-#[allow(clippy::float_cmp)]
 fn test_bank_new() {
     let dummy_leader_pubkey = solana_sdk::pubkey::new_rand();
     let dummy_leader_stake_lamports = bootstrap_validator_stake_lamports();

--- a/sdk/src/inflation.rs
+++ b/sdk/src/inflation.rs
@@ -113,7 +113,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[allow(clippy::float_cmp)]
     fn test_inflation_basic() {
         let inflation = Inflation::default();
 
@@ -133,7 +132,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::float_cmp)]
     fn test_inflation_fixed() {
         let inflation = Inflation::new_fixed(0.001);
         for year in &[0.1, 0.5, 1.0, DEFAULT_FOUNDATION_TERM, 100.0] {

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -127,7 +127,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::float_cmp)]
     fn test_years_as_slots() {
         let tick_duration = Duration::from_micros(1000 * 1000 / 160);
 


### PR DESCRIPTION
#### Summary of Changes

this clippy attribute is no longer needed. remove it!