### PR TITLE
Bumps solana_rbpf to v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7736,9 +7736,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d457cc2ba742c120492a64b7fa60e22c575e891f6b55039f4d736568fb112a3"
+checksum = "06beab07f4104d6ad70d47baa67ad1bcd501a2345a983e20c389bade7c72305e"
 dependencies = [
  "byteorder",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -397,7 +397,7 @@ solana-zk-keygen = { path = "zk-keygen", version = "=2.0.0" }
 solana-zk-sdk = { path = "zk-sdk", version = "=2.0.0" }
 solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=2.0.0" }
 solana-zk-token-sdk = { path = "zk-token-sdk", version = "=2.0.0" }
-solana_rbpf = "=0.8.0"
+solana_rbpf = "=0.8.1"
 spl-associated-token-account = "=3.0.2"
 spl-instruction-padding = "0.1"
 spl-memo = "=4.0.1"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6568,9 +6568,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d457cc2ba742c120492a64b7fa60e22c575e891f6b55039f4d736568fb112a3"
+checksum = "06beab07f4104d6ad70d47baa67ad1bcd501a2345a983e20c389bade7c72305e"
 dependencies = [
  "byteorder 1.5.0",
  "combine",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -50,7 +50,7 @@ solana-svm = { path = "../../svm", version = "=2.0.0" }
 solana-transaction-status = { path = "../../transaction-status", version = "=2.0.0" }
 agave-validator = { path = "../../validator", version = "=2.0.0" }
 solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=2.0.0" }
-solana_rbpf = "=0.8.0"
+solana_rbpf = "=0.8.1"
 static_assertions = "1.1.0"
 thiserror = "1.0"
 


### PR DESCRIPTION
#### Problem
[solana_rbpf v0.8.1](https://github.com/solana-labs/rbpf/releases/tag/v0.8.1) was released.

#### Summary of Changes
Pure version bump, no interfaces changed.
