### PR TITLE
refactor: `validate_fee_payer`

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -758,9 +758,8 @@ impl Consumer {
         validate_fee_payer(
             fee_payer,
             &mut fee_payer_account,
-            0,
             error_counters,
-            bank.rent_collector(),
+            &bank.rent_collector().rent,
             fee,
         )
     }


### PR DESCRIPTION
#### Problem
`validate_fee_payer` function has some parameters that can be simplified. This came up during a deeper refactoring around fee payer validation but breaking it out in a separate change for easier review.

#### Summary of Changes
- The `payer_index` param in `validate_fee_payer` is always `0` so stop passing it
- Only the `rent` field in the `RentCollector` param is used, so pass that instead

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
