### PR TITLE
Removes dead code

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -312,7 +312,7 @@ pub struct BankRc {
     pub(crate) parent: RwLock<Option<Arc<Bank>>>,
 
     /// Current slot
-    pub(crate) slot: Slot,
+    pub(crate) _slot: Slot,
 
     pub(crate) bank_id_generator: Arc<AtomicU64>,
 }
@@ -328,7 +328,7 @@ impl AbiExample for BankRc {
             parent: RwLock::new(None),
             // AbiExample for Accounts is specially implemented to contain a storage example
             accounts: AbiExample::example(),
-            slot: AbiExample::example(),
+            _slot: AbiExample::example(),
             bank_id_generator: Arc::new(AtomicU64::new(0)),
         }
     }
@@ -339,7 +339,7 @@ impl BankRc {
         Self {
             accounts: Arc::new(accounts),
             parent: RwLock::new(None),
-            slot,
+            _slot: slot,
             bank_id_generator: Arc::new(AtomicU64::new(0)),
         }
     }
@@ -1140,7 +1140,7 @@ impl Bank {
             BankRc {
                 accounts: Arc::new(Accounts::new(accounts_db)),
                 parent: RwLock::new(Some(Arc::clone(&parent))),
-                slot,
+                _slot: slot,
                 bank_id_generator: Arc::clone(&parent.rc.bank_id_generator),
             }
         });

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -714,11 +714,13 @@ pub fn reserialize_bank_with_new_accounts_hash(
     found
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 struct SerializableBankAndStorage<'a> {
     bank: &'a Bank,
     snapshot_storages: &'a [Vec<Arc<AccountStorageEntry>>],
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 impl<'a> Serialize for SerializableBankAndStorage<'a> {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -726,13 +726,14 @@ impl<'a> Serialize for SerializableBankAndStorage<'a> {
     where
         S: serde::ser::Serializer,
     {
+        let slot = self.bank.slot();
         let fields = self.bank.get_fields_to_serialize();
         let lamports_per_signature = fields.fee_rate_governor.lamports_per_signature;
         let bank_fields_to_serialize = (
             SerializableVersionedBank::from(fields),
             SerializableAccountsDb::<'_> {
                 accounts_db: &self.bank.rc.accounts.accounts_db,
-                slot: self.bank.rc.slot,
+                slot,
                 account_storage_entries: self.snapshot_storages,
             },
             // Additional fields, we manually store the lamps per signature here so that
@@ -776,12 +777,13 @@ impl<'a> Serialize for SerializableBankAndStorageNoExtra<'a> {
     where
         S: serde::ser::Serializer,
     {
+        let slot = self.bank.slot();
         let fields = self.bank.get_fields_to_serialize();
         (
             SerializableVersionedBank::from(fields),
             SerializableAccountsDb::<'_> {
                 accounts_db: &self.bank.rc.accounts.accounts_db,
-                slot: self.bank.rc.slot,
+                slot,
                 account_storage_entries: self.snapshot_storages,
             },
         )


### PR DESCRIPTION
#### Problem

The build is broken. See https://buildkite.com/anza/agave/builds/5158#018fc4c1-519e-463c-9faa-28e527975289.

```
error: field `slot` is never read
   --> runtime/src/bank.rs:315:16
    |
307 | pub struct BankRc {
    |            ------ field in this struct
...
315 |     pub(crate) slot: Slot,
    |                ^^^^
    |
    = note: `BankRc` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`
error: struct `SerializableBankAndStorage` is never constructed
   --> runtime/src/serde_snapshot.rs:717:8
    |
717 | struct SerializableBankAndStorage<'a> {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
```


#### Summary of Changes

* Removes slot field from BankRc
* Annotates SerializableBankAndStorage with DCOU