### PR TITLE
Include loaded accounts data size in TransactionResults

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1580,6 +1580,7 @@ mod tests {
             nonce: None,
             rent: 0,
             rent_debits: RentDebits::default(),
+            loaded_accounts_data_size: 0,
         });
 
         let loaded1 = Ok(LoadedTransaction {
@@ -1588,6 +1589,7 @@ mod tests {
             nonce: None,
             rent: 0,
             rent_debits: RentDebits::default(),
+            loaded_accounts_data_size: 0,
         });
 
         let mut loaded = vec![loaded0, loaded1];
@@ -1964,6 +1966,7 @@ mod tests {
             nonce: nonce.clone(),
             rent: 0,
             rent_debits: RentDebits::default(),
+            loaded_accounts_data_size: 0,
         });
 
         let mut loaded = vec![loaded];
@@ -2068,6 +2071,7 @@ mod tests {
             nonce: nonce.clone(),
             rent: 0,
             rent_debits: RentDebits::default(),
+            loaded_accounts_data_size: 0,
         });
 
         let mut loaded = vec![loaded];

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -177,7 +177,8 @@ use {
             TransactionProcessingConfig,
         },
         transaction_results::{
-            TransactionExecutionDetails, TransactionExecutionResult, TransactionResults,
+            TransactionExecutionDetails, TransactionExecutionResult,
+            TransactionLoadedAccountsStats, TransactionResults,
         },
     },
     solana_system_program::{get_system_account_kind, SystemAccountKind},
@@ -4193,11 +4194,34 @@ impl Bank {
             update_transaction_statuses_time.as_us(),
         );
 
+        let loaded_accounts_stats = Self::collect_loaded_accounts_stats(loaded_txs);
+        assert_eq!(
+            loaded_accounts_stats.len(),
+            execution_results.len(),
+            "loaded_account_stats and execution_results are not the same size"
+        );
+
         TransactionResults {
             fee_collection_results,
+            loaded_accounts_stats,
             execution_results,
             rent_debits,
         }
+    }
+
+    fn collect_loaded_accounts_stats(
+        loaded_txs: &[TransactionLoadResult],
+    ) -> Vec<Result<TransactionLoadedAccountsStats>> {
+        loaded_txs
+            .iter()
+            .map(|load_result| match load_result {
+                Ok(loaded_tx) => Ok(TransactionLoadedAccountsStats {
+                    loaded_accounts_data_size: loaded_tx.loaded_accounts_data_size,
+                    loaded_accounts_count: loaded_tx.accounts.len(),
+                }),
+                Err(err) => Err(err.clone()),
+            })
+            .collect()
     }
 
     fn collect_rent(

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -53,6 +53,7 @@ pub struct LoadedTransaction {
     pub nonce: Option<NonceFull>,
     pub rent: TransactionRent,
     pub rent_debits: RentDebits,
+    pub loaded_accounts_data_size: usize,
 }
 
 impl LoadedTransaction {
@@ -388,6 +389,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
         nonce,
         rent: tx_rent,
         rent_debits,
+        loaded_accounts_data_size: accumulated_accounts_data_size,
     })
 }
 
@@ -1519,7 +1521,8 @@ mod tests {
                 program_indices: vec![vec![]],
                 nonce: None,
                 rent: 0,
-                rent_debits: RentDebits::default()
+                rent_debits: RentDebits::default(),
+                loaded_accounts_data_size: 0,
             }
         );
     }
@@ -1722,7 +1725,8 @@ mod tests {
                 nonce: None,
                 program_indices: vec![vec![1]],
                 rent: 0,
-                rent_debits: RentDebits::default()
+                rent_debits: RentDebits::default(),
+                loaded_accounts_data_size: 0,
             }
         );
     }
@@ -1914,7 +1918,8 @@ mod tests {
                 program_indices: vec![vec![2, 1]],
                 nonce: None,
                 rent: 0,
-                rent_debits: RentDebits::default()
+                rent_debits: RentDebits::default(),
+                loaded_accounts_data_size: 0,
             }
         );
     }
@@ -2006,7 +2011,8 @@ mod tests {
                 program_indices: vec![vec![3, 1], vec![3, 1]],
                 nonce: None,
                 rent: 0,
-                rent_debits: RentDebits::default()
+                rent_debits: RentDebits::default(),
+                loaded_accounts_data_size: 0,
             }
         );
     }
@@ -2168,7 +2174,8 @@ mod tests {
                     Some(mock_bank.accounts_map[&key2.pubkey()].clone())
                 )),
                 rent: 0,
-                rent_debits: RentDebits::default()
+                rent_debits: RentDebits::default(),
+                loaded_accounts_data_size: 0,
             }
         );
     }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1000,6 +1000,7 @@ mod tests {
             nonce: None,
             rent: 0,
             rent_debits: RentDebits::default(),
+            loaded_accounts_data_size: 32,
         };
 
         let mut processing_config = TransactionProcessingConfig::default();
@@ -1124,6 +1125,7 @@ mod tests {
             nonce: None,
             rent: 0,
             rent_debits: RentDebits::default(),
+            loaded_accounts_data_size: 0,
         };
 
         let processing_config = TransactionProcessingConfig {

--- a/svm/src/transaction_results.rs
+++ b/svm/src/transaction_results.rs
@@ -16,8 +16,15 @@ use {
 
 pub struct TransactionResults {
     pub fee_collection_results: Vec<transaction::Result<()>>,
+    pub loaded_accounts_stats: Vec<transaction::Result<TransactionLoadedAccountsStats>>,
     pub execution_results: Vec<TransactionExecutionResult>,
     pub rent_debits: Vec<RentDebits>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct TransactionLoadedAccountsStats {
+    pub loaded_accounts_data_size: usize,
+    pub loaded_accounts_count: usize,
 }
 
 /// Type safe representation of a transaction execution attempt which


### PR DESCRIPTION
#### Problem

Total loaded-accounts-data-size for successfully loaded transaction is accumulated during `load_transaction_accounts()`. It is useful information, could be included in `TransactionResults` that is returned from `load_execute_and_commit_transactions()`, so call sites can access stats of loaded accounts of sanitized transactions. 

For now, such stats includes the actual loaded-accounts-data-size, count of loaded accounts.

The use of this information is planned for: 
1. `cost_tracker` uses it to adjust reserved block space for transaction, in the same fashion as it adjust for estimated/actual execution cost. (note: loaded accounts data size contributes to transaction cost in term of CU, #1356 )
2. `replay_stage` uses it to report histogram of loaded accounts data size per transaction.

#### Summary of Changes
- add `pub struct TransactionLoadedAccountsStats` 
- include it into `TransactionResults`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
