### PR TITLE
Validate transaction fee payer earlier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7325,6 +7325,7 @@ dependencies = [
  "serde_derive",
  "solana-bpf-loader-program",
  "solana-compute-budget",
+ "solana-compute-budget-program",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-loader-v4-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7333,6 +7333,7 @@ dependencies = [
  "solana-metrics",
  "solana-program-runtime",
  "solana-sdk",
+ "solana-svm",
  "solana-system-program",
 ]
 

--- a/program-runtime/src/timings.rs
+++ b/program-runtime/src/timings.rs
@@ -43,6 +43,7 @@ impl ProgramTiming {
 #[derive(Debug, Sequence)]
 pub enum ExecuteTimingType {
     CheckUs,
+    ValidateFeesUs,
     LoadUs,
     ExecuteUs,
     StoreUs,
@@ -93,6 +94,13 @@ eager_macro_rules! { $eager_1
                 *$self
                     .metrics
                     .index(ExecuteTimingType::CheckUs),
+                i64
+            ),
+            (
+                "validate_fees_us",
+                *$self
+                    .metrics
+                    .index(ExecuteTimingType::ValidateFeesUs),
                 i64
             ),
             (

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3687,7 +3687,7 @@ impl Bank {
             .collect();
 
         let mut check_time = Measure::start("check_transactions");
-        let mut check_results = self.check_transactions(
+        let check_results = self.check_transactions(
             sanitized_txs,
             batch.lock_results(),
             max_age,
@@ -3702,7 +3702,7 @@ impl Bank {
             .load_and_execute_sanitized_transactions(
                 self,
                 sanitized_txs,
-                &mut check_results,
+                check_results,
                 &processing_config,
             );
 

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -38,6 +38,7 @@ prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
+solana-compute-budget-program = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 # See order-crates-for-publishing.py for using this unusual `path = "."`

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -40,6 +40,8 @@ rand = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
+# See order-crates-for-publishing.py for using this unusual `path = "."`
+solana-svm = { path = ".", features = ["dev-context-only-utils"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -43,6 +43,7 @@ pub struct CheckedTransactionDetails {
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
+#[cfg_attr(feature = "dev-context-only-utils", derive(Default))]
 pub struct ValidatedTransactionDetails {
     pub nonce: Option<NonceFull>,
     pub fee_details: FeeDetails,
@@ -435,24 +436,17 @@ mod tests {
     use {
         super::*,
         crate::{
-            nonce_info::{NonceFull, NoncePartial},
-            transaction_account_state_info::TransactionAccountStateInfo,
+            nonce_info::NonceFull, transaction_account_state_info::TransactionAccountStateInfo,
             transaction_processing_callback::TransactionProcessingCallback,
         },
         nonce::state::Versions as NonceVersions,
-        solana_compute_budget::{
-            compute_budget::ComputeBudget,
-            compute_budget_processor,
-            prioritization_fee::{PrioritizationFeeDetails, PrioritizationFeeType},
-        },
+        solana_compute_budget::{compute_budget::ComputeBudget, compute_budget_processor},
         solana_program_runtime::loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
         solana_sdk::{
             account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
             bpf_loader_upgradeable,
-            compute_budget::ComputeBudgetInstruction,
             epoch_schedule::EpochSchedule,
             feature_set::FeatureSet,
-            fee::FeeStructure,
             hash::Hash,
             instruction::CompiledInstruction,
             message::{
@@ -504,17 +498,16 @@ mod tests {
         }
     }
 
-    fn load_accounts_with_fee_and_rent(
+    fn load_accounts_with_features_and_rent(
         tx: Transaction,
         ka: &[TransactionAccount],
-        lamports_per_signature: u64,
         rent_collector: &RentCollector,
         error_metrics: &mut TransactionErrorMetrics,
         feature_set: &mut FeatureSet,
-        fee_structure: &FeeStructure,
     ) -> Vec<TransactionLoadResult> {
         feature_set.deactivate(&feature_set::disable_rent_fees_collection::id());
         let sanitized_tx = SanitizedTransaction::from_transaction_for_tests(tx);
+        let fee_payer_account = ka[0].1.clone();
         let mut accounts_map = HashMap::new();
         for (pubkey, account) in ka {
             accounts_map.insert(*pubkey, account.clone());
@@ -527,12 +520,11 @@ mod tests {
         load_accounts(
             &callbacks,
             &[sanitized_tx],
-            &[Ok(CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature,
+            vec![Ok(ValidatedTransactionDetails {
+                fee_payer_account,
+                ..ValidatedTransactionDetails::default()
             })],
             error_metrics,
-            fee_structure,
             None,
             &ProgramCacheForTxBatch::default(),
         )
@@ -548,11 +540,6 @@ mod tests {
         features
     }
 
-    fn new_sanitized_message(message: Message) -> SanitizedMessage {
-        SanitizedMessage::try_from_legacy_message(message, &ReservedAccountKeys::empty_key_set())
-            .unwrap()
-    }
-
     fn new_unchecked_sanitized_message(message: Message) -> SanitizedMessage {
         SanitizedMessage::Legacy(LegacyMessage::new(
             message,
@@ -560,33 +547,18 @@ mod tests {
         ))
     }
 
-    fn load_accounts_with_fee(
-        tx: Transaction,
-        ka: &[TransactionAccount],
-        lamports_per_signature: u64,
-        error_metrics: &mut TransactionErrorMetrics,
-        exclude_features: Option<&[Pubkey]>,
-    ) -> Vec<TransactionLoadResult> {
-        load_accounts_with_fee_and_rent(
-            tx,
-            ka,
-            lamports_per_signature,
-            &RentCollector::default(),
-            error_metrics,
-            &mut all_features_except(exclude_features),
-            &FeeStructure {
-                lamports_per_signature,
-                ..FeeStructure::default()
-            },
-        )
-    }
-
     fn load_accounts_aux_test(
         tx: Transaction,
         ka: &[TransactionAccount],
         error_metrics: &mut TransactionErrorMetrics,
     ) -> Vec<TransactionLoadResult> {
-        load_accounts_with_fee(tx, ka, 0, error_metrics, None)
+        load_accounts_with_features_and_rent(
+            tx,
+            ka,
+            &RentCollector::default(),
+            error_metrics,
+            &mut FeatureSet::all_enabled(),
+        )
     }
 
     fn load_accounts_with_excluded_features(
@@ -595,30 +567,13 @@ mod tests {
         error_metrics: &mut TransactionErrorMetrics,
         exclude_features: Option<&[Pubkey]>,
     ) -> Vec<TransactionLoadResult> {
-        load_accounts_with_fee(tx, ka, 0, error_metrics, exclude_features)
-    }
-
-    #[test]
-    fn test_load_accounts_no_account_0_exists() {
-        let accounts: Vec<TransactionAccount> = Vec::new();
-        let mut error_metrics = TransactionErrorMetrics::default();
-
-        let keypair = Keypair::new();
-
-        let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
-        let tx = Transaction::new_with_compiled_instructions(
-            &[&keypair],
-            &[],
-            Hash::default(),
-            vec![native_loader::id()],
-            instructions,
-        );
-
-        let loaded_accounts = load_accounts_aux_test(tx, &accounts, &mut error_metrics);
-
-        assert_eq!(error_metrics.account_not_found, 1);
-        assert_eq!(loaded_accounts.len(), 1);
-        assert_eq!(loaded_accounts[0], Err(TransactionError::AccountNotFound));
+        load_accounts_with_features_and_rent(
+            tx,
+            ka,
+            &RentCollector::default(),
+            error_metrics,
+            &mut all_features_except(exclude_features),
+        )
     }
 
     #[test]
@@ -653,166 +608,6 @@ mod tests {
             loaded_accounts[0],
             Err(TransactionError::ProgramAccountNotFound)
         );
-    }
-
-    #[test]
-    fn test_load_accounts_insufficient_funds() {
-        let lamports_per_signature = 5000;
-        let mut accounts: Vec<TransactionAccount> = Vec::new();
-        let mut error_metrics = TransactionErrorMetrics::default();
-
-        let keypair = Keypair::new();
-        let key0 = keypair.pubkey();
-
-        let account = AccountSharedData::new(1, 0, &Pubkey::default());
-        accounts.push((key0, account));
-
-        let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
-        let tx = Transaction::new_with_compiled_instructions(
-            &[&keypair],
-            &[],
-            Hash::default(),
-            vec![native_loader::id()],
-            instructions,
-        );
-
-        let message = new_sanitized_message(tx.message().clone());
-        let fee = FeeStructure::default().calculate_fee(
-            &message,
-            lamports_per_signature,
-            &process_compute_budget_instructions(message.program_instructions_iter())
-                .unwrap_or_default()
-                .into(),
-            false,
-            true,
-        );
-        assert_eq!(fee, lamports_per_signature);
-
-        let loaded_accounts = load_accounts_with_fee(
-            tx,
-            &accounts,
-            lamports_per_signature,
-            &mut error_metrics,
-            None,
-        );
-
-        assert_eq!(error_metrics.insufficient_funds, 1);
-        assert_eq!(loaded_accounts.len(), 1);
-        assert_eq!(
-            loaded_accounts[0].clone(),
-            Err(TransactionError::InsufficientFundsForFee)
-        );
-    }
-
-    #[test]
-    fn test_load_accounts_invalid_account_for_fee() {
-        let mut accounts: Vec<TransactionAccount> = Vec::new();
-        let mut error_metrics = TransactionErrorMetrics::default();
-
-        let keypair = Keypair::new();
-        let key0 = keypair.pubkey();
-
-        let account = AccountSharedData::new(1, 1, &solana_sdk::pubkey::new_rand()); // <-- owner is not the system program
-        accounts.push((key0, account));
-
-        let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
-        let tx = Transaction::new_with_compiled_instructions(
-            &[&keypair],
-            &[],
-            Hash::default(),
-            vec![native_loader::id()],
-            instructions,
-        );
-
-        let loaded_accounts = load_accounts_aux_test(tx, &accounts, &mut error_metrics);
-
-        assert_eq!(error_metrics.invalid_account_for_fee, 1);
-        assert_eq!(loaded_accounts.len(), 1);
-        assert_eq!(
-            loaded_accounts[0],
-            Err(TransactionError::InvalidAccountForFee)
-        );
-    }
-
-    #[test]
-    fn test_load_accounts_fee_payer_is_nonce() {
-        let lamports_per_signature = 5000;
-        let mut error_metrics = TransactionErrorMetrics::default();
-        let rent_collector = RentCollector::new(
-            0,
-            EpochSchedule::default(),
-            500_000.0,
-            Rent {
-                lamports_per_byte_year: 42,
-                ..Rent::default()
-            },
-        );
-        let min_balance = rent_collector.rent.minimum_balance(NonceState::size());
-        let nonce = Keypair::new();
-        let mut accounts = vec![(
-            nonce.pubkey(),
-            AccountSharedData::new_data(
-                min_balance + lamports_per_signature,
-                &NonceVersions::new(NonceState::Initialized(nonce::state::Data::default())),
-                &system_program::id(),
-            )
-            .unwrap(),
-        )];
-        let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
-        let tx = Transaction::new_with_compiled_instructions(
-            &[&nonce],
-            &[],
-            Hash::default(),
-            vec![native_loader::id()],
-            instructions,
-        );
-
-        // Fee leaves min_balance balance succeeds
-        let loaded_accounts = load_accounts_with_fee_and_rent(
-            tx.clone(),
-            &accounts,
-            lamports_per_signature,
-            &rent_collector,
-            &mut error_metrics,
-            &mut all_features_except(None),
-            &FeeStructure::default(),
-        );
-        assert_eq!(loaded_accounts.len(), 1);
-        let load_res = &loaded_accounts[0];
-        let loaded_transaction = load_res.as_ref().unwrap();
-        assert_eq!(loaded_transaction.accounts[0].1.lamports(), min_balance);
-
-        // Fee leaves zero balance fails
-        accounts[0].1.set_lamports(lamports_per_signature);
-        let loaded_accounts = load_accounts_with_fee_and_rent(
-            tx.clone(),
-            &accounts,
-            lamports_per_signature,
-            &rent_collector,
-            &mut error_metrics,
-            &mut FeatureSet::all_enabled(),
-            &FeeStructure::default(),
-        );
-        assert_eq!(loaded_accounts.len(), 1);
-        let load_res = &loaded_accounts[0];
-        assert_eq!(*load_res, Err(TransactionError::InsufficientFundsForFee));
-
-        // Fee leaves non-zero, but sub-min_balance balance fails
-        accounts[0]
-            .1
-            .set_lamports(lamports_per_signature + min_balance / 2);
-        let loaded_accounts = load_accounts_with_fee_and_rent(
-            tx,
-            &accounts,
-            lamports_per_signature,
-            &rent_collector,
-            &mut error_metrics,
-            &mut FeatureSet::all_enabled(),
-            &FeeStructure::default(),
-        );
-        assert_eq!(loaded_accounts.len(), 1);
-        let load_res = &loaded_accounts[0];
-        assert_eq!(*load_res, Err(TransactionError::InsufficientFundsForFee));
     }
 
     #[test]
@@ -1015,12 +810,8 @@ mod tests {
         load_accounts(
             &callbacks,
             &[tx],
-            &[Ok(CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature: 10,
-            })],
+            vec![Ok(ValidatedTransactionDetails::default())],
             &mut error_metrics,
-            &FeeStructure::default(),
             account_overrides,
             &ProgramCacheForTxBatch::default(),
         )
@@ -1176,65 +967,6 @@ mod tests {
         test(tx_not_set_limit, &result_default_limit);
         test(tx_set_limit_99, &result_requested_limit);
         test(tx_set_limit_0, &result_invalid_limit);
-    }
-
-    #[test]
-    fn test_load_accounts_too_high_prioritization_fee() {
-        solana_logger::setup();
-        let lamports_per_signature = 5000_u64;
-        let request_units = 1_000_000_u32;
-        let request_unit_price = 2_000_000_000_u64;
-        let prioritization_fee_details = PrioritizationFeeDetails::new(
-            PrioritizationFeeType::ComputeUnitPrice(request_unit_price),
-            request_units as u64,
-        );
-        let prioritization_fee = prioritization_fee_details.get_fee();
-
-        let keypair = Keypair::new();
-        let key0 = keypair.pubkey();
-        // set up account with balance of `prioritization_fee`
-        let account = AccountSharedData::new(prioritization_fee, 0, &Pubkey::default());
-        let accounts = vec![(key0, account)];
-
-        let instructions = &[
-            ComputeBudgetInstruction::set_compute_unit_limit(request_units),
-            ComputeBudgetInstruction::set_compute_unit_price(request_unit_price),
-        ];
-        let tx = Transaction::new(
-            &[&keypair],
-            Message::new(instructions, Some(&key0)),
-            Hash::default(),
-        );
-
-        let message = new_sanitized_message(tx.message().clone());
-        let fee = FeeStructure::default().calculate_fee(
-            &message,
-            lamports_per_signature,
-            &process_compute_budget_instructions(message.program_instructions_iter())
-                .unwrap_or_default()
-                .into(),
-            false,
-            true,
-        );
-        assert_eq!(fee, lamports_per_signature + prioritization_fee);
-
-        // assert fail to load account with 2B lamport balance for transaction asking for 2B
-        // lamports as prioritization fee.
-        let mut error_metrics = TransactionErrorMetrics::default();
-        let loaded_accounts = load_accounts_with_fee(
-            tx,
-            &accounts,
-            lamports_per_signature,
-            &mut error_metrics,
-            None,
-        );
-
-        assert_eq!(error_metrics.insufficient_funds, 1);
-        assert_eq!(loaded_accounts.len(), 1);
-        assert_eq!(
-            loaded_accounts[0].clone(),
-            Err(TransactionError::InsufficientFundsForFee)
-        );
     }
 
     struct ValidateFeePayerTestParameter {
@@ -1398,42 +1130,6 @@ mod tests {
     }
 
     #[test]
-    fn test_load_transaction_accounts_fail_to_validate_fee_payer() {
-        let message = Message {
-            account_keys: vec![Pubkey::new_from_array([0; 32])],
-            header: MessageHeader::default(),
-            instructions: vec![CompiledInstruction {
-                program_id_index: 0,
-                accounts: vec![],
-                data: vec![],
-            }],
-            recent_blockhash: Hash::default(),
-        };
-
-        let sanitized_message = new_unchecked_sanitized_message(message);
-        let mock_bank = TestCallbacks::default();
-        let mut error_metrics = TransactionErrorMetrics::default();
-        let loaded_programs = ProgramCacheForTxBatch::default();
-
-        let sanitized_transaction = SanitizedTransaction::new_for_tests(
-            sanitized_message,
-            vec![Signature::new_unique()],
-            false,
-        );
-        let result = load_transaction_accounts(
-            &mock_bank,
-            sanitized_transaction.message(),
-            None,
-            FeeDetails::default(),
-            &mut error_metrics,
-            None,
-            &loaded_programs,
-        );
-
-        assert_eq!(result.err(), Some(TransactionError::AccountNotFound));
-    }
-
-    #[test]
     fn test_load_transaction_accounts_native_loader() {
         let key1 = Keypair::new();
         let message = Message {
@@ -1452,9 +1148,11 @@ mod tests {
         mock_bank
             .accounts_map
             .insert(native_loader::id(), AccountSharedData::default());
-        let mut account_data = AccountSharedData::default();
-        account_data.set_lamports(200);
-        mock_bank.accounts_map.insert(key1.pubkey(), account_data);
+        let mut fee_payer_account_data = AccountSharedData::default();
+        fee_payer_account_data.set_lamports(200);
+        mock_bank
+            .accounts_map
+            .insert(key1.pubkey(), fee_payer_account_data.clone());
 
         let mut error_metrics = TransactionErrorMetrics::default();
         let loaded_programs = ProgramCacheForTxBatch::default();
@@ -1468,17 +1166,16 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
-            None,
-            fee_details,
+            ValidatedTransactionDetails {
+                nonce: None,
+                fee_details,
+                fee_payer_account: fee_payer_account_data,
+                fee_payer_rent_debit: 0,
+            },
             &mut error_metrics,
             None,
             &loaded_programs,
         );
-        mock_bank
-            .accounts_map
-            .get_mut(&key1.pubkey())
-            .unwrap()
-            .set_lamports(200 - 32);
 
         assert_eq!(
             result.unwrap(),
@@ -1537,8 +1234,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
-            None,
-            FeeDetails::default(),
+            ValidatedTransactionDetails::default(),
             &mut error_metrics,
             None,
             &loaded_programs,
@@ -1580,8 +1276,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
-            None,
-            FeeDetails::default(),
+            ValidatedTransactionDetails::default(),
             &mut error_metrics,
             None,
             &loaded_programs,
@@ -1623,8 +1318,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
-            None,
-            FeeDetails::default(),
+            ValidatedTransactionDetails::default(),
             &mut error_metrics,
             None,
             &loaded_programs,
@@ -1659,9 +1353,11 @@ mod tests {
         account_data.set_executable(true);
         mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
-        let mut account_data = AccountSharedData::default();
-        account_data.set_lamports(200);
-        mock_bank.accounts_map.insert(key2.pubkey(), account_data);
+        let mut fee_payer_account_data = AccountSharedData::default();
+        fee_payer_account_data.set_lamports(200);
+        mock_bank
+            .accounts_map
+            .insert(key2.pubkey(), fee_payer_account_data.clone());
         let mut error_metrics = TransactionErrorMetrics::default();
         let loaded_programs = ProgramCacheForTxBatch::default();
 
@@ -1674,17 +1370,16 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
-            None,
-            fee_details,
+            ValidatedTransactionDetails {
+                nonce: None,
+                fee_details,
+                fee_payer_account: fee_payer_account_data,
+                fee_payer_rent_debit: 0,
+            },
             &mut error_metrics,
             None,
             &loaded_programs,
         );
-        mock_bank
-            .accounts_map
-            .get_mut(&key2.pubkey())
-            .unwrap()
-            .set_lamports(200 - 32);
 
         assert_eq!(
             result.unwrap(),
@@ -1745,8 +1440,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
-            None,
-            FeeDetails::default(),
+            ValidatedTransactionDetails::default(),
             &mut error_metrics,
             None,
             &loaded_programs,
@@ -1797,8 +1491,7 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
-            None,
-            FeeDetails::default(),
+            ValidatedTransactionDetails::default(),
             &mut error_metrics,
             None,
             &loaded_programs,
@@ -1834,9 +1527,11 @@ mod tests {
         account_data.set_owner(key3.pubkey());
         mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
-        let mut account_data = AccountSharedData::default();
-        account_data.set_lamports(200);
-        mock_bank.accounts_map.insert(key2.pubkey(), account_data);
+        let mut fee_payer_account_data = AccountSharedData::default();
+        fee_payer_account_data.set_lamports(200);
+        mock_bank
+            .accounts_map
+            .insert(key2.pubkey(), fee_payer_account_data.clone());
 
         let mut account_data = AccountSharedData::default();
         account_data.set_executable(true);
@@ -1855,17 +1550,16 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
-            None,
-            fee_details,
+            ValidatedTransactionDetails {
+                nonce: None,
+                fee_details,
+                fee_payer_account: fee_payer_account_data,
+                fee_payer_rent_debit: 0,
+            },
             &mut error_metrics,
             None,
             &loaded_programs,
         );
-        mock_bank
-            .accounts_map
-            .get_mut(&key2.pubkey())
-            .unwrap()
-            .set_lamports(200 - 32);
 
         assert_eq!(
             result.unwrap(),
@@ -1926,9 +1620,11 @@ mod tests {
         account_data.set_owner(key3.pubkey());
         mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
-        let mut account_data = AccountSharedData::default();
-        account_data.set_lamports(200);
-        mock_bank.accounts_map.insert(key2.pubkey(), account_data);
+        let mut fee_payer_account_data = AccountSharedData::default();
+        fee_payer_account_data.set_lamports(200);
+        mock_bank
+            .accounts_map
+            .insert(key2.pubkey(), fee_payer_account_data.clone());
 
         let mut account_data = AccountSharedData::default();
         account_data.set_executable(true);
@@ -1947,17 +1643,16 @@ mod tests {
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
-            None,
-            fee_details,
+            ValidatedTransactionDetails {
+                nonce: None,
+                fee_details,
+                fee_payer_account: fee_payer_account_data,
+                fee_payer_rent_debit: 0,
+            },
             &mut error_metrics,
             None,
             &loaded_programs,
         );
-        mock_bank
-            .accounts_map
-            .get_mut(&key2.pubkey())
-            .unwrap()
-            .set_lamports(200 - 32);
 
         let mut account_data = AccountSharedData::default();
         account_data.set_rent_epoch(RENT_EXEMPT_RENT_EPOCH);
@@ -2021,12 +1716,8 @@ mod tests {
         let loaded_txs = load_accounts(
             &bank,
             &[sanitized_tx.clone()],
-            &[Ok(CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature: 0,
-            })],
+            vec![Ok(ValidatedTransactionDetails::default())],
             &mut error_metrics,
-            &FeeStructure::default(),
             None,
             &ProgramCacheForTxBatch::default(),
         );
@@ -2084,9 +1775,11 @@ mod tests {
         account_data.set_owner(key3.pubkey());
         mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
-        let mut account_data = AccountSharedData::default();
-        account_data.set_lamports(200);
-        mock_bank.accounts_map.insert(key2.pubkey(), account_data);
+        let mut fee_payer_account_data = AccountSharedData::default();
+        fee_payer_account_data.set_lamports(200);
+        mock_bank
+            .accounts_map
+            .insert(key2.pubkey(), fee_payer_account_data.clone());
 
         let mut account_data = AccountSharedData::default();
         account_data.set_executable(true);
@@ -2101,17 +1794,18 @@ mod tests {
             vec![Signature::new_unique()],
             false,
         );
-        let check_result = Ok(CheckedTransactionDetails {
-            nonce: Some(NoncePartial::default()),
-            lamports_per_signature: 20,
+        let validation_result = Ok(ValidatedTransactionDetails {
+            nonce: None,
+            fee_details: FeeDetails::default(),
+            fee_payer_account: fee_payer_account_data,
+            fee_payer_rent_debit: 0,
         });
 
         let results = load_accounts(
             &mock_bank,
             &[sanitized_transaction],
-            &[check_result],
+            vec![validation_result],
             &mut error_metrics,
-            &FeeStructure::default(),
             None,
             &loaded_programs,
         );
@@ -2140,11 +1834,7 @@ mod tests {
                     ),
                 ],
                 program_indices: vec![vec![3, 1], vec![3, 1]],
-                nonce: Some(NonceFull::new(
-                    Pubkey::from([0; 32]),
-                    AccountSharedData::default(),
-                    Some(mock_bank.accounts_map[&key2.pubkey()].clone())
-                )),
+                nonce: None,
                 fee_details: FeeDetails::default(),
                 rent: 0,
                 rent_debits: RentDebits::default(),
@@ -2174,32 +1864,34 @@ mod tests {
             false,
         );
 
-        let fee_structure = FeeStructure::default();
-        let check_result = Ok(CheckedTransactionDetails {
-            nonce: Some(NoncePartial::default()),
-            lamports_per_signature: 20,
+        let validation_result = Ok(ValidatedTransactionDetails {
+            nonce: Some(NonceFull::default()),
+            fee_details: FeeDetails::default(),
+            fee_payer_account: AccountSharedData::default(),
+            fee_payer_rent_debit: 0,
         });
 
         let result = load_accounts(
             &mock_bank,
             &[sanitized_transaction.clone()],
-            &[check_result.clone()],
+            vec![validation_result.clone()],
             &mut TransactionErrorMetrics::default(),
-            &fee_structure,
             None,
             &ProgramCacheForTxBatch::default(),
         );
 
-        assert_eq!(result, vec![Err(TransactionError::AccountNotFound)]);
+        assert_eq!(
+            result,
+            vec![Err(TransactionError::InvalidProgramForExecution)]
+        );
 
-        let check_result = Err(TransactionError::InvalidWritableAccount);
+        let validation_result = Err(TransactionError::InvalidWritableAccount);
 
         let result = load_accounts(
             &mock_bank,
             &[sanitized_transaction.clone()],
-            &[check_result],
+            vec![validation_result],
             &mut TransactionErrorMetrics::default(),
-            &fee_structure,
             None,
             &ProgramCacheForTxBatch::default(),
         );

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -176,29 +176,16 @@ mod tests {
         );
         assert_eq!(partial.fee_payer_account(), None);
 
-        // Add rent debits to ensure the rollback captures accounts without rent fees
-        let mut rent_debits = RentDebits::default();
-        rent_debits.insert(
-            &from_address,
-            TEST_RENT_DEBIT,
-            rent_collected_from_account.lamports(),
-        );
-        rent_debits.insert(
-            &nonce_address,
-            TEST_RENT_DEBIT,
-            rent_collected_nonce_account.lamports(),
-        );
-
         // NonceFull create + NonceInfo impl
         {
             let message = new_sanitized_message(&instructions, Some(&from_address));
             let fee_payer_address = message.account_keys().get(0).unwrap();
             let fee_payer_account = rent_collected_from_account.clone();
             let full = NonceFull::from_partial(
-                &partial,
+                partial.clone(),
                 fee_payer_address,
                 fee_payer_account,
-                &rent_debits,
+                TEST_RENT_DEBIT,
             );
             assert_eq!(*full.address(), nonce_address);
             assert_eq!(*full.account(), rent_collected_nonce_account);
@@ -216,10 +203,10 @@ mod tests {
             let fee_payer_address = message.account_keys().get(0).unwrap();
             let fee_payer_account = rent_collected_nonce_account;
             let full = NonceFull::from_partial(
-                &partial,
+                partial,
                 fee_payer_address,
                 fee_payer_account,
-                &rent_debits,
+                TEST_RENT_DEBIT,
             );
             assert_eq!(*full.address(), nonce_address);
             assert_eq!(*full.account(), nonce_account);

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -965,7 +965,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 mod tests {
     use {
         super::*,
-        crate::account_loader::CheckedTransactionDetails,
+        crate::account_loader::ValidatedTransactionDetails,
         solana_program_runtime::loaded_programs::{BlockRelation, ProgramCacheEntryType},
         solana_sdk::{
             account::{create_account_shared_data_for_test, WritableAccount},
@@ -1407,15 +1407,9 @@ mod tests {
             sanitized_transaction_2.clone(),
             sanitized_transaction_1,
         ];
-        let mut lock_results = vec![
-            Ok(CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature: 25,
-            }),
-            Ok(CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature: 25,
-            }),
+        let validation_results = vec![
+            Ok(ValidatedTransactionDetails::default()),
+            Ok(ValidatedTransactionDetails::default()),
             Err(TransactionError::ProgramAccountNotFound),
         ];
         let owners = vec![owner1, owner2];
@@ -1423,7 +1417,7 @@ mod tests {
         let result = TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
             &mock_bank,
             &transactions,
-            lock_results.as_mut_slice(),
+            &validation_results,
             &owners,
         );
 
@@ -1505,15 +1499,9 @@ mod tests {
             TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
                 &bank,
                 &[sanitized_tx1, sanitized_tx2],
-                &mut [
-                    Ok(CheckedTransactionDetails {
-                        nonce: None,
-                        lamports_per_signature: 0,
-                    }),
-                    Ok(CheckedTransactionDetails {
-                        nonce: None,
-                        lamports_per_signature: 0,
-                    }),
+                &[
+                    Ok(ValidatedTransactionDetails::default()),
+                    Ok(ValidatedTransactionDetails::default()),
                 ],
                 owners,
             );
@@ -1604,18 +1592,15 @@ mod tests {
         let sanitized_tx2 = SanitizedTransaction::from_transaction_for_tests(tx2);
 
         let owners = &[program1_pubkey, program2_pubkey];
-        let mut lock_results = vec![
-            Ok(CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature: 0,
-            }),
+        let validation_results = vec![
+            Ok(ValidatedTransactionDetails::default()),
             Err(TransactionError::BlockhashNotFound),
         ];
         let programs =
             TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
                 &bank,
                 &[sanitized_tx1, sanitized_tx2],
-                &mut lock_results,
+                &validation_results,
                 owners,
             );
 

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -233,7 +233,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
     };
 
     let transactions = vec![transaction];
-    let mut transaction_check = vec![Ok(CheckedTransactionDetails {
+    let transaction_check = vec![Ok(CheckedTransactionDetails {
         nonce: None,
         lamports_per_signature: 30,
     })];
@@ -312,7 +312,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
     let result = batch_processor.load_and_execute_sanitized_transactions(
         &mock_bank,
         &transactions,
-        transaction_check.as_mut_slice(),
+        transaction_check,
         &processor_config,
     );
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -441,7 +441,7 @@ fn prepare_transactions(
 #[test]
 fn svm_integration() {
     let mut mock_bank = MockBankCallback::default();
-    let (transactions, mut check_results) = prepare_transactions(&mut mock_bank);
+    let (transactions, check_results) = prepare_transactions(&mut mock_bank);
     let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(
         EXECUTION_SLOT,
         EXECUTION_EPOCH,
@@ -471,7 +471,7 @@ fn svm_integration() {
     let result = batch_processor.load_and_execute_sanitized_transactions(
         &mock_bank,
         &transactions,
-        check_results.as_mut_slice(),
+        check_results,
         &processing_config,
     );
 


### PR DESCRIPTION
#### Problem
In order to charge fees for additional types of failed but committed transactions in [SIMD-0082](https://github.com/solana-foundation/solana-improvement-documents/pull/82), transaction fee payer validation failures need to be identified separately from other transaction loading failures like invalid invoked programs so that a leader can decide to commit only the transactions that can be charged fees successfully.

Transaction fee payer errors should also be detected as early as possible to avoid doing unnecessary work. Note that both the new and old banking stage schedulers already have preliminary fee payer checks for transactions that help avoid doing any work for transactions with invalid fee payers but are not a complete solution since they do not operate over locked accounts, meaning that a checked fee payer in one transaction could be modified in another scheduled transaction.

#### Summary of Changes
New tx processor methods:
- `TransactionBatchProcessor::validate_fees` which validates the fee payers for a batch of transactions by calling `validate_transaction_fee_payer`
- `TransactionBatchProcessor::validate_transaction_fee_payer` which loads the fee payer account, validates it, and deducts fees

`validate_fees` is now called first inside the `load_and_execute_sanitized_transactions` function before updating the programs cache and loading other accounts.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
