### PR TITLE
[zk-sdk] Remove `source`, `destination`, and `auditor` variable names

### DIFF
--- a/zk-sdk/src/elgamal_program/proof_data/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/batched_grouped_ciphertext_validity/handles_3.rs
@@ -45,11 +45,11 @@ pub struct BatchedGroupedCiphertext3HandlesValidityProofData {
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct BatchedGroupedCiphertext3HandlesValidityProofContext {
-    pub source_pubkey: PodElGamalPubkey, // 32 bytes
+    pub first_pubkey: PodElGamalPubkey, // 32 bytes
 
-    pub destination_pubkey: PodElGamalPubkey, // 32 bytes
+    pub second_pubkey: PodElGamalPubkey, // 32 bytes
 
-    pub auditor_pubkey: PodElGamalPubkey, // 32 bytes
+    pub third_pubkey: PodElGamalPubkey, // 32 bytes
 
     pub grouped_ciphertext_lo: PodGroupedElGamalCiphertext3Handles, // 128 bytes
 
@@ -59,9 +59,9 @@ pub struct BatchedGroupedCiphertext3HandlesValidityProofContext {
 #[cfg(not(target_os = "solana"))]
 impl BatchedGroupedCiphertext3HandlesValidityProofData {
     pub fn new(
-        source_pubkey: &ElGamalPubkey,
-        destination_pubkey: &ElGamalPubkey,
-        auditor_pubkey: &ElGamalPubkey,
+        first_pubkey: &ElGamalPubkey,
+        second_pubkey: &ElGamalPubkey,
+        third_pubkey: &ElGamalPubkey,
         grouped_ciphertext_lo: &GroupedElGamalCiphertext<3>,
         grouped_ciphertext_hi: &GroupedElGamalCiphertext<3>,
         amount_lo: u64,
@@ -69,16 +69,16 @@ impl BatchedGroupedCiphertext3HandlesValidityProofData {
         opening_lo: &PedersenOpening,
         opening_hi: &PedersenOpening,
     ) -> Result<Self, ProofGenerationError> {
-        let pod_source_pubkey = PodElGamalPubkey(source_pubkey.into());
-        let pod_destination_pubkey = PodElGamalPubkey(destination_pubkey.into());
-        let pod_auditor_pubkey = PodElGamalPubkey(auditor_pubkey.into());
+        let pod_first_pubkey = PodElGamalPubkey(first_pubkey.into());
+        let pod_second_pubkey = PodElGamalPubkey(second_pubkey.into());
+        let pod_third_pubkey = PodElGamalPubkey(third_pubkey.into());
         let pod_grouped_ciphertext_lo = (*grouped_ciphertext_lo).into();
         let pod_grouped_ciphertext_hi = (*grouped_ciphertext_hi).into();
 
         let context = BatchedGroupedCiphertext3HandlesValidityProofContext {
-            source_pubkey: pod_source_pubkey,
-            destination_pubkey: pod_destination_pubkey,
-            auditor_pubkey: pod_auditor_pubkey,
+            first_pubkey: pod_first_pubkey,
+            second_pubkey: pod_second_pubkey,
+            third_pubkey: pod_third_pubkey,
             grouped_ciphertext_lo: pod_grouped_ciphertext_lo,
             grouped_ciphertext_hi: pod_grouped_ciphertext_hi,
         };
@@ -86,9 +86,9 @@ impl BatchedGroupedCiphertext3HandlesValidityProofData {
         let mut transcript = context.new_transcript();
 
         let proof = BatchedGroupedCiphertext3HandlesValidityProof::new(
-            source_pubkey,
-            destination_pubkey,
-            auditor_pubkey,
+            first_pubkey,
+            second_pubkey,
+            third_pubkey,
             amount_lo,
             amount_hi,
             opening_lo,
@@ -114,37 +114,37 @@ impl ZkProofData<BatchedGroupedCiphertext3HandlesValidityProofContext>
     fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let mut transcript = self.context.new_transcript();
 
-        let source_pubkey = self.context.source_pubkey.try_into()?;
-        let destination_pubkey = self.context.destination_pubkey.try_into()?;
-        let auditor_pubkey = self.context.auditor_pubkey.try_into()?;
+        let first_pubkey = self.context.first_pubkey.try_into()?;
+        let second_pubkey = self.context.second_pubkey.try_into()?;
+        let third_pubkey = self.context.third_pubkey.try_into()?;
         let grouped_ciphertext_lo: GroupedElGamalCiphertext<3> =
             self.context.grouped_ciphertext_lo.try_into()?;
         let grouped_ciphertext_hi: GroupedElGamalCiphertext<3> =
             self.context.grouped_ciphertext_hi.try_into()?;
 
-        let source_handle_lo = grouped_ciphertext_lo.handles.first().unwrap();
-        let destination_handle_lo = grouped_ciphertext_lo.handles.get(1).unwrap();
-        let auditor_handle_lo = grouped_ciphertext_lo.handles.get(2).unwrap();
+        let first_handle_lo = grouped_ciphertext_lo.handles.first().unwrap();
+        let second_handle_lo = grouped_ciphertext_lo.handles.get(1).unwrap();
+        let third_handle_lo = grouped_ciphertext_lo.handles.get(2).unwrap();
 
-        let source_handle_hi = grouped_ciphertext_hi.handles.first().unwrap();
-        let destination_handle_hi = grouped_ciphertext_hi.handles.get(1).unwrap();
-        let auditor_handle_hi = grouped_ciphertext_hi.handles.get(2).unwrap();
+        let first_handle_hi = grouped_ciphertext_hi.handles.first().unwrap();
+        let second_handle_hi = grouped_ciphertext_hi.handles.get(1).unwrap();
+        let third_handle_hi = grouped_ciphertext_hi.handles.get(2).unwrap();
 
         let proof: BatchedGroupedCiphertext3HandlesValidityProof = self.proof.try_into()?;
 
         proof
             .verify(
-                &source_pubkey,
-                &destination_pubkey,
-                &auditor_pubkey,
+                &first_pubkey,
+                &second_pubkey,
+                &third_pubkey,
                 &grouped_ciphertext_lo.commitment,
                 &grouped_ciphertext_hi.commitment,
-                source_handle_lo,
-                source_handle_hi,
-                destination_handle_lo,
-                destination_handle_hi,
-                auditor_handle_lo,
-                auditor_handle_hi,
+                first_handle_lo,
+                first_handle_hi,
+                second_handle_lo,
+                second_handle_hi,
+                third_handle_lo,
+                third_handle_hi,
                 &mut transcript,
             )
             .map_err(|e| e.into())
@@ -157,9 +157,9 @@ impl BatchedGroupedCiphertext3HandlesValidityProofContext {
         let mut transcript =
             Transcript::new(b"batched-grouped-ciphertext-validity-3-handles-instruction");
 
-        transcript.append_message(b"source-pubkey", bytes_of(&self.source_pubkey));
-        transcript.append_message(b"destination-pubkey", bytes_of(&self.destination_pubkey));
-        transcript.append_message(b"auditor-pubkey", bytes_of(&self.auditor_pubkey));
+        transcript.append_message(b"first-pubkey", bytes_of(&self.first_pubkey));
+        transcript.append_message(b"second-pubkey", bytes_of(&self.second_pubkey));
+        transcript.append_message(b"third-pubkey", bytes_of(&self.third_pubkey));
         transcript.append_message(
             b"grouped-ciphertext-lo",
             bytes_of(&self.grouped_ciphertext_lo),
@@ -182,14 +182,14 @@ mod test {
 
     #[test]
     fn test_ciphertext_validity_proof_instruction_correctness() {
-        let source_keypair = ElGamalKeypair::new_rand();
-        let source_pubkey = source_keypair.pubkey();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let first_pubkey = first_keypair.pubkey();
 
-        let destination_keypair = ElGamalKeypair::new_rand();
-        let destination_pubkey = destination_keypair.pubkey();
+        let second_keypair = ElGamalKeypair::new_rand();
+        let second_pubkey = second_keypair.pubkey();
 
-        let auditor_keypair = ElGamalKeypair::new_rand();
-        let auditor_pubkey = auditor_keypair.pubkey();
+        let third_keypair = ElGamalKeypair::new_rand();
+        let third_pubkey = third_keypair.pubkey();
 
         let amount_lo: u64 = 11;
         let amount_hi: u64 = 22;
@@ -198,21 +198,21 @@ mod test {
         let opening_hi = PedersenOpening::new_rand();
 
         let grouped_ciphertext_lo = GroupedElGamal::encrypt_with(
-            [source_pubkey, destination_pubkey, auditor_pubkey],
+            [first_pubkey, second_pubkey, third_pubkey],
             amount_lo,
             &opening_lo,
         );
 
         let grouped_ciphertext_hi = GroupedElGamal::encrypt_with(
-            [source_pubkey, destination_pubkey, auditor_pubkey],
+            [first_pubkey, second_pubkey, third_pubkey],
             amount_hi,
             &opening_hi,
         );
 
         let proof_data = BatchedGroupedCiphertext3HandlesValidityProofData::new(
-            source_pubkey,
-            destination_pubkey,
-            auditor_pubkey,
+            first_pubkey,
+            second_pubkey,
+            third_pubkey,
             &grouped_ciphertext_lo,
             &grouped_ciphertext_hi,
             amount_lo,

--- a/zk-sdk/src/elgamal_program/proof_data/ciphertext_ciphertext_equality.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/ciphertext_ciphertext_equality.rs
@@ -4,9 +4,6 @@
 //! ciphertexts. The proof certifies that the two ciphertexts encrypt the same message. To generate
 //! the proof, a prover must provide the decryption key for the first ciphertext and the randomness
 //! used to generate the second ciphertext.
-//!
-//! The first ciphertext associated with the proof is referred to as the "source" ciphertext. The
-//! second ciphertext associated with the proof is referred to as the "destination" ciphertext.
 
 #[cfg(not(target_os = "solana"))]
 use {
@@ -48,44 +45,44 @@ pub struct CiphertextCiphertextEqualityProofData {
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct CiphertextCiphertextEqualityProofContext {
-    pub source_pubkey: PodElGamalPubkey, // 32 bytes
+    pub first_pubkey: PodElGamalPubkey, // 32 bytes
 
-    pub destination_pubkey: PodElGamalPubkey, // 32 bytes
+    pub second_pubkey: PodElGamalPubkey, // 32 bytes
 
-    pub source_ciphertext: PodElGamalCiphertext, // 64 bytes
+    pub first_ciphertext: PodElGamalCiphertext, // 64 bytes
 
-    pub destination_ciphertext: PodElGamalCiphertext, // 64 bytes
+    pub second_ciphertext: PodElGamalCiphertext, // 64 bytes
 }
 
 #[cfg(not(target_os = "solana"))]
 impl CiphertextCiphertextEqualityProofData {
     pub fn new(
-        source_keypair: &ElGamalKeypair,
-        destination_pubkey: &ElGamalPubkey,
-        source_ciphertext: &ElGamalCiphertext,
-        destination_ciphertext: &ElGamalCiphertext,
-        destination_opening: &PedersenOpening,
+        first_keypair: &ElGamalKeypair,
+        second_pubkey: &ElGamalPubkey,
+        first_ciphertext: &ElGamalCiphertext,
+        second_ciphertext: &ElGamalCiphertext,
+        second_opening: &PedersenOpening,
         amount: u64,
     ) -> Result<Self, ProofGenerationError> {
-        let pod_source_pubkey = PodElGamalPubkey(source_keypair.pubkey().into());
-        let pod_destination_pubkey = PodElGamalPubkey(destination_pubkey.into());
-        let pod_source_ciphertext = PodElGamalCiphertext(source_ciphertext.to_bytes());
-        let pod_destination_ciphertext = PodElGamalCiphertext(destination_ciphertext.to_bytes());
+        let pod_first_pubkey = PodElGamalPubkey(first_keypair.pubkey().into());
+        let pod_second_pubkey = PodElGamalPubkey(second_pubkey.into());
+        let pod_first_ciphertext = PodElGamalCiphertext(first_ciphertext.to_bytes());
+        let pod_second_ciphertext = PodElGamalCiphertext(second_ciphertext.to_bytes());
 
         let context = CiphertextCiphertextEqualityProofContext {
-            source_pubkey: pod_source_pubkey,
-            destination_pubkey: pod_destination_pubkey,
-            source_ciphertext: pod_source_ciphertext,
-            destination_ciphertext: pod_destination_ciphertext,
+            first_pubkey: pod_first_pubkey,
+            second_pubkey: pod_second_pubkey,
+            first_ciphertext: pod_first_ciphertext,
+            second_ciphertext: pod_second_ciphertext,
         };
 
         let mut transcript = context.new_transcript();
 
         let proof = CiphertextCiphertextEqualityProof::new(
-            source_keypair,
-            destination_pubkey,
-            source_ciphertext,
-            destination_opening,
+            first_keypair,
+            second_pubkey,
+            first_ciphertext,
+            second_opening,
             amount,
             &mut transcript,
         )
@@ -108,18 +105,18 @@ impl ZkProofData<CiphertextCiphertextEqualityProofContext>
     fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let mut transcript = self.context.new_transcript();
 
-        let source_pubkey = self.context.source_pubkey.try_into()?;
-        let destination_pubkey = self.context.destination_pubkey.try_into()?;
-        let source_ciphertext = self.context.source_ciphertext.try_into()?;
-        let destination_ciphertext = self.context.destination_ciphertext.try_into()?;
+        let first_pubkey = self.context.first_pubkey.try_into()?;
+        let second_pubkey = self.context.second_pubkey.try_into()?;
+        let first_ciphertext = self.context.first_ciphertext.try_into()?;
+        let second_ciphertext = self.context.second_ciphertext.try_into()?;
         let proof: CiphertextCiphertextEqualityProof = self.proof.try_into()?;
 
         proof
             .verify(
-                &source_pubkey,
-                &destination_pubkey,
-                &source_ciphertext,
-                &destination_ciphertext,
+                &first_pubkey,
+                &second_pubkey,
+                &first_ciphertext,
+                &second_ciphertext,
                 &mut transcript,
             )
             .map_err(|e| e.into())
@@ -132,13 +129,10 @@ impl CiphertextCiphertextEqualityProofContext {
     fn new_transcript(&self) -> Transcript {
         let mut transcript = Transcript::new(b"ciphertext-ciphertext-equality-instruction");
 
-        transcript.append_message(b"source-pubkey", bytes_of(&self.source_pubkey));
-        transcript.append_message(b"destination-pubkey", bytes_of(&self.destination_pubkey));
-        transcript.append_message(b"source-ciphertext", bytes_of(&self.source_ciphertext));
-        transcript.append_message(
-            b"destination-ciphertext",
-            bytes_of(&self.destination_ciphertext),
-        );
+        transcript.append_message(b"first-pubkey", bytes_of(&self.first_pubkey));
+        transcript.append_message(b"second-pubkey", bytes_of(&self.second_pubkey));
+        transcript.append_message(b"first-ciphertext", bytes_of(&self.first_ciphertext));
+        transcript.append_message(b"second-ciphertext", bytes_of(&self.second_ciphertext));
 
         transcript
     }
@@ -150,23 +144,23 @@ mod test {
 
     #[test]
     fn test_ciphertext_ciphertext_instruction_correctness() {
-        let source_keypair = ElGamalKeypair::new_rand();
-        let destination_keypair = ElGamalKeypair::new_rand();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let second_keypair = ElGamalKeypair::new_rand();
 
         let amount: u64 = 0;
-        let source_ciphertext = source_keypair.pubkey().encrypt(amount);
+        let first_ciphertext = first_keypair.pubkey().encrypt(amount);
 
-        let destination_opening = PedersenOpening::new_rand();
-        let destination_ciphertext = destination_keypair
+        let second_opening = PedersenOpening::new_rand();
+        let second_ciphertext = second_keypair
             .pubkey()
-            .encrypt_with(amount, &destination_opening);
+            .encrypt_with(amount, &second_opening);
 
         let proof_data = CiphertextCiphertextEqualityProofData::new(
-            &source_keypair,
-            destination_keypair.pubkey(),
-            &source_ciphertext,
-            &destination_ciphertext,
-            &destination_opening,
+            &first_keypair,
+            second_keypair.pubkey(),
+            &first_ciphertext,
+            &second_ciphertext,
+            &second_opening,
             amount,
         )
         .unwrap();
@@ -174,19 +168,19 @@ mod test {
         assert!(proof_data.verify_proof().is_ok());
 
         let amount: u64 = 55;
-        let source_ciphertext = source_keypair.pubkey().encrypt(amount);
+        let first_ciphertext = first_keypair.pubkey().encrypt(amount);
 
-        let destination_opening = PedersenOpening::new_rand();
-        let destination_ciphertext = destination_keypair
+        let second_opening = PedersenOpening::new_rand();
+        let second_ciphertext = second_keypair
             .pubkey()
-            .encrypt_with(amount, &destination_opening);
+            .encrypt_with(amount, &second_opening);
 
         let proof_data = CiphertextCiphertextEqualityProofData::new(
-            &source_keypair,
-            destination_keypair.pubkey(),
-            &source_ciphertext,
-            &destination_ciphertext,
-            &destination_opening,
+            &first_keypair,
+            second_keypair.pubkey(),
+            &first_ciphertext,
+            &second_ciphertext,
+            &second_opening,
             amount,
         )
         .unwrap();
@@ -194,19 +188,19 @@ mod test {
         assert!(proof_data.verify_proof().is_ok());
 
         let amount = u64::MAX;
-        let source_ciphertext = source_keypair.pubkey().encrypt(amount);
+        let first_ciphertext = first_keypair.pubkey().encrypt(amount);
 
-        let destination_opening = PedersenOpening::new_rand();
-        let destination_ciphertext = destination_keypair
+        let second_opening = PedersenOpening::new_rand();
+        let second_ciphertext = second_keypair
             .pubkey()
-            .encrypt_with(amount, &destination_opening);
+            .encrypt_with(amount, &second_opening);
 
         let proof_data = CiphertextCiphertextEqualityProofData::new(
-            &source_keypair,
-            destination_keypair.pubkey(),
-            &source_ciphertext,
-            &destination_ciphertext,
-            &destination_opening,
+            &first_keypair,
+            second_keypair.pubkey(),
+            &first_ciphertext,
+            &second_ciphertext,
+            &second_opening,
             amount,
         )
         .unwrap();

--- a/zk-sdk/src/elgamal_program/proof_data/grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/grouped_ciphertext_validity/handles_3.rs
@@ -45,11 +45,11 @@ pub struct GroupedCiphertext3HandlesValidityProofData {
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct GroupedCiphertext3HandlesValidityProofContext {
-    pub source_pubkey: PodElGamalPubkey, // 32 bytes
+    pub first_pubkey: PodElGamalPubkey, // 32 bytes
 
-    pub destination_pubkey: PodElGamalPubkey, // 32 bytes
+    pub second_pubkey: PodElGamalPubkey, // 32 bytes
 
-    pub auditor_pubkey: PodElGamalPubkey, // 32 bytes
+    pub third_pubkey: PodElGamalPubkey, // 32 bytes
 
     pub grouped_ciphertext: PodGroupedElGamalCiphertext3Handles, // 128 bytes
 }
@@ -57,31 +57,31 @@ pub struct GroupedCiphertext3HandlesValidityProofContext {
 #[cfg(not(target_os = "solana"))]
 impl GroupedCiphertext3HandlesValidityProofData {
     pub fn new(
-        source_pubkey: &ElGamalPubkey,
-        destination_pubkey: &ElGamalPubkey,
-        auditor_pubkey: &ElGamalPubkey,
+        first_pubkey: &ElGamalPubkey,
+        second_pubkey: &ElGamalPubkey,
+        third_pubkey: &ElGamalPubkey,
         grouped_ciphertext: &GroupedElGamalCiphertext<3>,
         amount: u64,
         opening: &PedersenOpening,
     ) -> Result<Self, ProofGenerationError> {
-        let pod_source_pubkey = PodElGamalPubkey(source_pubkey.into());
-        let pod_destination_pubkey = PodElGamalPubkey(destination_pubkey.into());
-        let pod_auditor_pubkey = PodElGamalPubkey(auditor_pubkey.into());
+        let pod_first_pubkey = PodElGamalPubkey(first_pubkey.into());
+        let pod_second_pubkey = PodElGamalPubkey(second_pubkey.into());
+        let pod_third_pubkey = PodElGamalPubkey(third_pubkey.into());
         let pod_grouped_ciphertext = (*grouped_ciphertext).into();
 
         let context = GroupedCiphertext3HandlesValidityProofContext {
-            source_pubkey: pod_source_pubkey,
-            destination_pubkey: pod_destination_pubkey,
-            auditor_pubkey: pod_auditor_pubkey,
+            first_pubkey: pod_first_pubkey,
+            second_pubkey: pod_second_pubkey,
+            third_pubkey: pod_third_pubkey,
             grouped_ciphertext: pod_grouped_ciphertext,
         };
 
         let mut transcript = context.new_transcript();
 
         let proof = GroupedCiphertext3HandlesValidityProof::new(
-            source_pubkey,
-            destination_pubkey,
-            auditor_pubkey,
+            first_pubkey,
+            second_pubkey,
+            third_pubkey,
             amount,
             opening,
             &mut transcript,
@@ -105,27 +105,27 @@ impl ZkProofData<GroupedCiphertext3HandlesValidityProofContext>
     fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let mut transcript = self.context.new_transcript();
 
-        let source_pubkey = self.context.source_pubkey.try_into()?;
-        let destination_pubkey = self.context.destination_pubkey.try_into()?;
-        let auditor_pubkey = self.context.auditor_pubkey.try_into()?;
+        let first_pubkey = self.context.first_pubkey.try_into()?;
+        let second_pubkey = self.context.second_pubkey.try_into()?;
+        let third_pubkey = self.context.third_pubkey.try_into()?;
         let grouped_ciphertext: GroupedElGamalCiphertext<3> =
             self.context.grouped_ciphertext.try_into()?;
 
-        let source_handle = grouped_ciphertext.handles.first().unwrap();
-        let destination_handle = grouped_ciphertext.handles.get(1).unwrap();
-        let auditor_handle = grouped_ciphertext.handles.get(2).unwrap();
+        let first_handle = grouped_ciphertext.handles.first().unwrap();
+        let second_handle = grouped_ciphertext.handles.get(1).unwrap();
+        let third_handle = grouped_ciphertext.handles.get(2).unwrap();
 
         let proof: GroupedCiphertext3HandlesValidityProof = self.proof.try_into()?;
 
         proof
             .verify(
                 &grouped_ciphertext.commitment,
-                &source_pubkey,
-                &destination_pubkey,
-                &auditor_pubkey,
-                source_handle,
-                destination_handle,
-                auditor_handle,
+                &first_pubkey,
+                &second_pubkey,
+                &third_pubkey,
+                first_handle,
+                second_handle,
+                third_handle,
                 &mut transcript,
             )
             .map_err(|e| e.into())
@@ -137,9 +137,9 @@ impl GroupedCiphertext3HandlesValidityProofContext {
     fn new_transcript(&self) -> Transcript {
         let mut transcript = Transcript::new(b"grouped-ciphertext-validity-3-handles-instruction");
 
-        transcript.append_message(b"source-pubkey", bytes_of(&self.source_pubkey));
-        transcript.append_message(b"destination-pubkey", bytes_of(&self.destination_pubkey));
-        transcript.append_message(b"auditor-pubkey", bytes_of(&self.auditor_pubkey));
+        transcript.append_message(b"first-pubkey", bytes_of(&self.first_pubkey));
+        transcript.append_message(b"second-pubkey", bytes_of(&self.second_pubkey));
+        transcript.append_message(b"third-pubkey", bytes_of(&self.third_pubkey));
         transcript.append_message(b"grouped-ciphertext", bytes_of(&self.grouped_ciphertext));
 
         transcript
@@ -155,27 +155,27 @@ mod test {
 
     #[test]
     fn test_ciphertext_validity_proof_instruction_correctness() {
-        let source_keypair = ElGamalKeypair::new_rand();
-        let source_pubkey = source_keypair.pubkey();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let first_pubkey = first_keypair.pubkey();
 
-        let destination_keypair = ElGamalKeypair::new_rand();
-        let destination_pubkey = destination_keypair.pubkey();
+        let second_keypair = ElGamalKeypair::new_rand();
+        let second_pubkey = second_keypair.pubkey();
 
-        let auditor_keypair = ElGamalKeypair::new_rand();
-        let auditor_pubkey = auditor_keypair.pubkey();
+        let third_keypair = ElGamalKeypair::new_rand();
+        let third_pubkey = third_keypair.pubkey();
 
         let amount: u64 = 55;
         let opening = PedersenOpening::new_rand();
         let grouped_ciphertext = GroupedElGamal::encrypt_with(
-            [source_pubkey, destination_pubkey, auditor_pubkey],
+            [first_pubkey, second_pubkey, third_pubkey],
             amount,
             &opening,
         );
 
         let proof_data = GroupedCiphertext3HandlesValidityProofData::new(
-            source_pubkey,
-            destination_pubkey,
-            auditor_pubkey,
+            first_pubkey,
+            second_pubkey,
+            third_pubkey,
             &grouped_ciphertext,
             amount,
             &opening,

--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
@@ -3,10 +3,10 @@
 //! A batched grouped ciphertext validity proof certifies the validity of two instances of a
 //! standard grouped ciphertext validity proof. An instance of a standard grouped ciphertext
 //! with 3 handles validity proof consists of one ciphertext and three decryption handles:
-//! `(commitment, source_handle, destination_handle, auditor_handle)`. An instance of a batched
+//! `(commitment, first_handle, second_handle, third_handle)`. An instance of a batched
 //! grouped ciphertext with 3 handles validity proof consist of a pair of `(commitment_0,
-//! source_handle_0, destination_handle_0, auditor_handle_0)` and `(commitment_1, source_handle_1,
-//! destination_handle_1, auditor_handle_1)`. The proof certifies the anagolous decryptable
+//! first_handle_0, second_handle_0, third_handle_0)` and `(commitment_1, first_handle_1,
+//! second_handle_1, third_handle_1)`. The proof certifies the anagolous decryptable
 //! properties for each one of these pairs of commitment and decryption handles.
 //!
 //! The protocol guarantees computational soundness (by the hardness of discrete log) and perfect
@@ -48,9 +48,9 @@ impl BatchedGroupedCiphertext3HandlesValidityProof {
     /// The function simply batches the input openings and invokes the standard grouped ciphertext
     /// validity proof constructor.
     pub fn new<T: Into<Scalar>>(
-        source_pubkey: &ElGamalPubkey,
-        destination_pubkey: &ElGamalPubkey,
-        auditor_pubkey: &ElGamalPubkey,
+        first_pubkey: &ElGamalPubkey,
+        second_pubkey: &ElGamalPubkey,
+        third_pubkey: &ElGamalPubkey,
         amount_lo: T,
         amount_hi: T,
         opening_lo: &PedersenOpening,
@@ -65,9 +65,9 @@ impl BatchedGroupedCiphertext3HandlesValidityProof {
         let batched_opening = opening_lo + &(opening_hi * &t);
 
         BatchedGroupedCiphertext3HandlesValidityProof(GroupedCiphertext3HandlesValidityProof::new(
-            source_pubkey,
-            destination_pubkey,
-            auditor_pubkey,
+            first_pubkey,
+            second_pubkey,
+            third_pubkey,
             batched_message,
             &batched_opening,
             transcript,
@@ -84,17 +84,17 @@ impl BatchedGroupedCiphertext3HandlesValidityProof {
     #[allow(clippy::too_many_arguments)]
     pub fn verify(
         self,
-        source_pubkey: &ElGamalPubkey,
-        destination_pubkey: &ElGamalPubkey,
-        auditor_pubkey: &ElGamalPubkey,
+        first_pubkey: &ElGamalPubkey,
+        second_pubkey: &ElGamalPubkey,
+        third_pubkey: &ElGamalPubkey,
         commitment_lo: &PedersenCommitment,
         commitment_hi: &PedersenCommitment,
-        source_handle_lo: &DecryptHandle,
-        source_handle_hi: &DecryptHandle,
-        destination_handle_lo: &DecryptHandle,
-        destination_handle_hi: &DecryptHandle,
-        auditor_handle_lo: &DecryptHandle,
-        auditor_handle_hi: &DecryptHandle,
+        first_handle_lo: &DecryptHandle,
+        first_handle_hi: &DecryptHandle,
+        second_handle_lo: &DecryptHandle,
+        second_handle_hi: &DecryptHandle,
+        third_handle_lo: &DecryptHandle,
+        third_handle_hi: &DecryptHandle,
         transcript: &mut Transcript,
     ) -> Result<(), ValidityProofVerificationError> {
         transcript.batched_grouped_ciphertext_validity_proof_domain_separator(3);
@@ -102,20 +102,20 @@ impl BatchedGroupedCiphertext3HandlesValidityProof {
         let t = transcript.challenge_scalar(b"t");
 
         let batched_commitment = commitment_lo + commitment_hi * t;
-        let source_batched_handle = source_handle_lo + source_handle_hi * t;
-        let destination_batched_handle = destination_handle_lo + destination_handle_hi * t;
-        let auditor_batched_handle = auditor_handle_lo + auditor_handle_hi * t;
+        let first_batched_handle = first_handle_lo + first_handle_hi * t;
+        let second_batched_handle = second_handle_lo + second_handle_hi * t;
+        let third_batched_handle = third_handle_lo + third_handle_hi * t;
 
         let BatchedGroupedCiphertext3HandlesValidityProof(validity_proof) = self;
 
         validity_proof.verify(
             &batched_commitment,
-            source_pubkey,
-            destination_pubkey,
-            auditor_pubkey,
-            &source_batched_handle,
-            &destination_batched_handle,
-            &auditor_batched_handle,
+            first_pubkey,
+            second_pubkey,
+            third_pubkey,
+            &first_batched_handle,
+            &second_batched_handle,
+            &third_batched_handle,
             transcript,
         )
     }
@@ -138,14 +138,14 @@ mod test {
 
     #[test]
     fn test_batched_grouped_ciphertext_validity_proof() {
-        let source_keypair = ElGamalKeypair::new_rand();
-        let source_pubkey = source_keypair.pubkey();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let first_pubkey = first_keypair.pubkey();
 
-        let destination_keypair = ElGamalKeypair::new_rand();
-        let destination_pubkey = destination_keypair.pubkey();
+        let second_keyapir = ElGamalKeypair::new_rand();
+        let second_pubkey = second_keyapir.pubkey();
 
-        let auditor_keypair = ElGamalKeypair::new_rand();
-        let auditor_pubkey = auditor_keypair.pubkey();
+        let third_keypair = ElGamalKeypair::new_rand();
+        let third_pubkey = third_keypair.pubkey();
 
         let amount_lo: u64 = 55;
         let amount_hi: u64 = 77;
@@ -153,22 +153,22 @@ mod test {
         let (commitment_lo, open_lo) = Pedersen::new(amount_lo);
         let (commitment_hi, open_hi) = Pedersen::new(amount_hi);
 
-        let source_handle_lo = source_pubkey.decrypt_handle(&open_lo);
-        let source_handle_hi = source_pubkey.decrypt_handle(&open_hi);
+        let first_handle_lo = first_pubkey.decrypt_handle(&open_lo);
+        let first_handle_hi = first_pubkey.decrypt_handle(&open_hi);
 
-        let destination_handle_lo = destination_pubkey.decrypt_handle(&open_lo);
-        let destination_handle_hi = destination_pubkey.decrypt_handle(&open_hi);
+        let second_handle_lo = second_pubkey.decrypt_handle(&open_lo);
+        let second_handle_hi = second_pubkey.decrypt_handle(&open_hi);
 
-        let auditor_handle_lo = auditor_pubkey.decrypt_handle(&open_lo);
-        let auditor_handle_hi = auditor_pubkey.decrypt_handle(&open_hi);
+        let third_handle_lo = third_pubkey.decrypt_handle(&open_lo);
+        let third_handle_hi = third_pubkey.decrypt_handle(&open_hi);
 
         let mut prover_transcript = Transcript::new(b"Test");
         let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = BatchedGroupedCiphertext3HandlesValidityProof::new(
-            source_pubkey,
-            destination_pubkey,
-            auditor_pubkey,
+            first_pubkey,
+            second_pubkey,
+            third_pubkey,
             amount_lo,
             amount_hi,
             &open_lo,
@@ -178,17 +178,17 @@ mod test {
 
         assert!(proof
             .verify(
-                source_pubkey,
-                destination_pubkey,
-                auditor_pubkey,
+                first_pubkey,
+                second_pubkey,
+                third_pubkey,
                 &commitment_lo,
                 &commitment_hi,
-                &source_handle_lo,
-                &source_handle_hi,
-                &destination_handle_lo,
-                &destination_handle_hi,
-                &auditor_handle_lo,
-                &auditor_handle_hi,
+                &first_handle_lo,
+                &first_handle_hi,
+                &second_handle_lo,
+                &second_handle_hi,
+                &third_handle_lo,
+                &third_handle_hi,
                 &mut verifier_transcript,
             )
             .is_ok());

--- a/zk-sdk/src/sigma_proofs/zero_ciphertext.rs
+++ b/zk-sdk/src/sigma_proofs/zero_ciphertext.rs
@@ -188,30 +188,28 @@ mod test {
 
     #[test]
     fn test_zero_cipehrtext_proof_correctness() {
-        let source_keypair = ElGamalKeypair::new_rand();
+        let keypair = ElGamalKeypair::new_rand();
 
         let mut prover_transcript = Transcript::new(b"test");
         let mut verifier_transcript = Transcript::new(b"test");
 
         // general case: encryption of 0
-        let elgamal_ciphertext = source_keypair.pubkey().encrypt(0_u64);
-        let proof =
-            ZeroCiphertextProof::new(&source_keypair, &elgamal_ciphertext, &mut prover_transcript);
+        let elgamal_ciphertext = keypair.pubkey().encrypt(0_u64);
+        let proof = ZeroCiphertextProof::new(&keypair, &elgamal_ciphertext, &mut prover_transcript);
         assert!(proof
             .verify(
-                source_keypair.pubkey(),
+                keypair.pubkey(),
                 &elgamal_ciphertext,
                 &mut verifier_transcript
             )
             .is_ok());
 
         // general case: encryption of > 0
-        let elgamal_ciphertext = source_keypair.pubkey().encrypt(1_u64);
-        let proof =
-            ZeroCiphertextProof::new(&source_keypair, &elgamal_ciphertext, &mut prover_transcript);
+        let elgamal_ciphertext = keypair.pubkey().encrypt(1_u64);
+        let proof = ZeroCiphertextProof::new(&keypair, &elgamal_ciphertext, &mut prover_transcript);
         assert!(proof
             .verify(
-                source_keypair.pubkey(),
+                keypair.pubkey(),
                 &elgamal_ciphertext,
                 &mut verifier_transcript
             )
@@ -220,7 +218,7 @@ mod test {
 
     #[test]
     fn test_zero_ciphertext_proof_edge_cases() {
-        let source_keypair = ElGamalKeypair::new_rand();
+        let keypair = ElGamalKeypair::new_rand();
 
         let mut prover_transcript = Transcript::new(b"test");
         let mut verifier_transcript = Transcript::new(b"test");
@@ -228,14 +226,10 @@ mod test {
         // all zero ciphertext should always be a valid encryption of 0
         let ciphertext = ElGamalCiphertext::from_bytes(&[0u8; 64]).unwrap();
 
-        let proof = ZeroCiphertextProof::new(&source_keypair, &ciphertext, &mut prover_transcript);
+        let proof = ZeroCiphertextProof::new(&keypair, &ciphertext, &mut prover_transcript);
 
         assert!(proof
-            .verify(
-                source_keypair.pubkey(),
-                &ciphertext,
-                &mut verifier_transcript
-            )
+            .verify(keypair.pubkey(), &ciphertext, &mut verifier_transcript)
             .is_ok());
 
         // if only either commitment or handle is zero, the ciphertext is always invalid and proof
@@ -244,7 +238,7 @@ mod test {
         let mut verifier_transcript = Transcript::new(b"test");
 
         let zeroed_commitment = PedersenCommitment::from_bytes(&[0u8; 32]).unwrap();
-        let handle = source_keypair
+        let handle = keypair
             .pubkey()
             .decrypt_handle(&PedersenOpening::new_rand());
 
@@ -253,14 +247,10 @@ mod test {
             handle,
         };
 
-        let proof = ZeroCiphertextProof::new(&source_keypair, &ciphertext, &mut prover_transcript);
+        let proof = ZeroCiphertextProof::new(&keypair, &ciphertext, &mut prover_transcript);
 
         assert!(proof
-            .verify(
-                source_keypair.pubkey(),
-                &ciphertext,
-                &mut verifier_transcript
-            )
+            .verify(keypair.pubkey(), &ciphertext, &mut verifier_transcript)
             .is_err());
 
         let mut prover_transcript = Transcript::new(b"test");
@@ -272,14 +262,10 @@ mod test {
             handle: DecryptHandle::from_bytes(&[0u8; 32]).unwrap(),
         };
 
-        let proof = ZeroCiphertextProof::new(&source_keypair, &ciphertext, &mut prover_transcript);
+        let proof = ZeroCiphertextProof::new(&keypair, &ciphertext, &mut prover_transcript);
 
         assert!(proof
-            .verify(
-                source_keypair.pubkey(),
-                &ciphertext,
-                &mut verifier_transcript
-            )
+            .verify(keypair.pubkey(), &ciphertext, &mut verifier_transcript)
             .is_err());
 
         // if public key is always zero, then the proof should always reject
@@ -289,14 +275,10 @@ mod test {
         let public = ElGamalPubkey::try_from([0u8; 32].as_slice()).unwrap();
         let ciphertext = public.encrypt(0_u64);
 
-        let proof = ZeroCiphertextProof::new(&source_keypair, &ciphertext, &mut prover_transcript);
+        let proof = ZeroCiphertextProof::new(&keypair, &ciphertext, &mut prover_transcript);
 
         assert!(proof
-            .verify(
-                source_keypair.pubkey(),
-                &ciphertext,
-                &mut verifier_transcript
-            )
+            .verify(keypair.pubkey(), &ciphertext, &mut verifier_transcript)
             .is_err());
     }
 }


### PR DESCRIPTION
#### Problem
As part of https://github.com/anza-xyz/agave/issues/671, we want to make the zk-sdk independent of spl token as much as possible. However, throughout the crate, there are variables that are referred to as the `source`, `destination`, or `auditor`.

#### Summary of Changes
Rename these variables.
- For ciphertext-commitment equality proofs, there is only one keypair, ciphertext, commitment, and openings, so I just removed the prefixes.
- For the other proofs, I thought a bit about alternative ways to rename the variables and just ended up with `first`, `second`, and `third` prefixes for simplicity.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
