### PR TITLE
ancient pack retries with simpler after failure

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1487,6 +1487,9 @@ pub struct AccountsDb {
     /// At that point, this and other code can be deleted.
     pub partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig,
 
+    /// true if the last time ancient pack ran it failed, so pack more conservatively the next time to make progress
+    pub(crate) previous_ancient_pack_failed: AtomicBool,
+
     /// the full accounts hash calculation as of a predetermined block height 'N'
     /// to be included in the bank hash at a predetermined block height 'M'
     /// The cadence is once per epoch, all nodes calculate a full accounts hash as of a known slot calculated using 'N'
@@ -2407,6 +2410,7 @@ impl AccountsDb {
         const ACCOUNTS_STACK_SIZE: usize = 8 * 1024 * 1024;
 
         AccountsDb {
+            previous_ancient_pack_failed: AtomicBool::default(),
             create_ancient_storage: CreateAncientStorage::default(),
             verify_accounts_hash_in_bg: VerifyAccountsHashInBackground::default(),
             active_stats: ActiveStats::default(),


### PR DESCRIPTION
#### Problem
when ancient packing runs, it can encounter a pubkey that is alive in an ancient slot, but is also present in an older slot (alive or dead). This means the older entry needs to be shrunk/packed/dropped before this found entry will be the ONLY entry for this pubkey. We don't know where the older entry is. So, packing can only move this alive entry to a slot that is >= the current slot. Otherwise, we might pack this account behind a dead version of this account. However, if we have one of these accounts to move but we can't guarantee its new slot will be high enough, we currently abort the pack. If this occurs repeatedly, we don't make progress and we accumulate old slots. This is fatal.

#### Summary of Changes
When ancient pack fails for this reason, remember it. Next time ancient pack runs, skip all slots that contain multi ref accounts. The hope is we'll pack/drop enough accounts that this will no longer be an issue later. Also, the particular problem of THIS slot not being packed to a new enough slot will be solved because there will be newer ancient slots next time we run. This allows the algorithm to make progress.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
