### PR TITLE
snapshot/don't flush accounts file when taking snapshots

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,6 +1,7 @@
 mod snapshot_gossip_manager;
 use {
     crossbeam_channel::{Receiver, Sender},
+    itertools::Itertools,
     snapshot_gossip_manager::SnapshotGossipManager,
     solana_accounts_db::accounts_db::AccountStorageEntry,
     solana_gossip::cluster_info::ClusterInfo,
@@ -9,7 +10,7 @@ use {
     solana_runtime::{
         snapshot_config::SnapshotConfig,
         snapshot_hash::StartingSnapshotHashes,
-        snapshot_package::{self, SnapshotKind, SnapshotPackage},
+        snapshot_package::{self, SnapshotPackage},
         snapshot_utils,
     },
     std::{
@@ -46,16 +47,18 @@ impl SnapshotPackagerService {
                 renice_this_thread(snapshot_config.packager_thread_niceness_adj).unwrap();
                 let mut snapshot_gossip_manager = enable_gossip_push
                     .then(|| SnapshotGossipManager::new(cluster_info, starting_snapshot_hashes));
-                let mut last_snapshot_storages: Vec<Arc<AccountStorageEntry>> = vec![];
+                let mut last_snapshot_storages: Option<Vec<Arc<AccountStorageEntry>>> = None;
                 loop {
                     if exit.load(Ordering::Relaxed) {
                         info!("SnapshotPackagerService exiting, flushing last snapshot storages ... ");
                         let (_, measure_flush) = measure_us!({
-                            for storage in last_snapshot_storages {
-                                if let Err(e) = storage.flush() {
-                                    error!("error flushing {:?} {}", storage.path().to_path_buf(), e);
+                            if let Some(last_snapshot_storages) = last_snapshot_storages {
+                                for storage in last_snapshot_storages {
+                                    if let Err(e) = storage.flush() {
+                                        error!("error flushing {:?} {}", storage.path().to_path_buf(), e);
+                                    }
                                 }
-                            }
+                        }
                         });
                         info!("Done flushing snapshot storages - {}us. SnapshotPackagerService exit.", measure_flush);
                         break;
@@ -80,13 +83,7 @@ impl SnapshotPackagerService {
                     let snapshot_kind = snapshot_package.snapshot_kind;
                     let snapshot_slot = snapshot_package.slot;
                     let snapshot_hash = snapshot_package.hash;
-
-                    if matches!(snapshot_kind, SnapshotKind::FullSnapshot) {
-                        last_snapshot_storages.clear();
-                    }
-                    for storage in snapshot_package.snapshot_storages.iter().cloned() {
-                        last_snapshot_storages.push(storage);
-                    }
+                    last_snapshot_storages = Some(snapshot_package.snapshot_storages.iter().cloned().collect_vec());
                     // Archiving the snapshot package is not allowed to fail.
                     // AccountsBackgroundService calls `clean_accounts()` with a value for
                     // last_full_snapshot_slot that requires this archive call to succeed.

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,7 +1,9 @@
 mod snapshot_gossip_manager;
 use {
     crossbeam_channel::{Receiver, Sender},
+    itertools::Itertools,
     snapshot_gossip_manager::SnapshotGossipManager,
+    solana_accounts_db::accounts_db::AccountStorageEntry,
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::{measure::Measure, measure_us},
     solana_perf::thread::renice_this_thread,
@@ -45,9 +47,20 @@ impl SnapshotPackagerService {
                 renice_this_thread(snapshot_config.packager_thread_niceness_adj).unwrap();
                 let mut snapshot_gossip_manager = enable_gossip_push
                     .then(|| SnapshotGossipManager::new(cluster_info, starting_snapshot_hashes));
-
+                let mut last_snapshot_storages: Option<Vec<Arc<AccountStorageEntry>>> = None;
                 loop {
                     if exit.load(Ordering::Relaxed) {
+                        info!("SnapshotPackagerService exiting, flushing last snapshot storages ... ");
+                        let (_, measure_flush) = measure_us!({
+                            if let Some(last_snapshot_storages) = last_snapshot_storages {
+                                for storage in last_snapshot_storages {
+                                    if let Err(e) = storage.flush() {
+                                        error!("error flushing {:?} {}", storage.path().to_path_buf(), e);
+                                    }
+                                }
+                        }
+                        });
+                        info!("Done flushing snapshot storages - {}us. SnapshotPackagerService exit.", measure_flush);
                         break;
                     }
 
@@ -70,7 +83,7 @@ impl SnapshotPackagerService {
                     let snapshot_kind = snapshot_package.snapshot_kind;
                     let snapshot_slot = snapshot_package.slot;
                     let snapshot_hash = snapshot_package.hash;
-
+                    last_snapshot_storages = Some(snapshot_package.snapshot_storages.iter().cloned().collect_vec());
                     // Archiving the snapshot package is not allowed to fail.
                     // AccountsBackgroundService calls `clean_accounts()` with a value for
                     // last_full_snapshot_slot that requires this archive call to succeed.

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,9 +1,7 @@
 mod snapshot_gossip_manager;
 use {
     crossbeam_channel::{Receiver, Sender},
-    itertools::Itertools,
     snapshot_gossip_manager::SnapshotGossipManager,
-    solana_accounts_db::accounts_db::AccountStorageEntry,
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::{measure::Measure, measure_us},
     solana_perf::thread::renice_this_thread,
@@ -47,20 +45,9 @@ impl SnapshotPackagerService {
                 renice_this_thread(snapshot_config.packager_thread_niceness_adj).unwrap();
                 let mut snapshot_gossip_manager = enable_gossip_push
                     .then(|| SnapshotGossipManager::new(cluster_info, starting_snapshot_hashes));
-                let mut last_snapshot_storages: Option<Vec<Arc<AccountStorageEntry>>> = None;
+
                 loop {
                     if exit.load(Ordering::Relaxed) {
-                        info!("SnapshotPackagerService exiting, flushing last snapshot storages ... ");
-                        let (_, measure_flush) = measure_us!({
-                            if let Some(last_snapshot_storages) = last_snapshot_storages {
-                                for storage in last_snapshot_storages {
-                                    if let Err(e) = storage.flush() {
-                                        error!("error flushing {:?} {}", storage.path().to_path_buf(), e);
-                                    }
-                                }
-                        }
-                        });
-                        info!("Done flushing snapshot storages - {}us. SnapshotPackagerService exit.", measure_flush);
                         break;
                     }
 
@@ -83,7 +70,7 @@ impl SnapshotPackagerService {
                     let snapshot_kind = snapshot_package.snapshot_kind;
                     let snapshot_slot = snapshot_package.slot;
                     let snapshot_hash = snapshot_package.hash;
-                    last_snapshot_storages = Some(snapshot_package.snapshot_storages.iter().cloned().collect_vec());
+
                     // Archiving the snapshot package is not allowed to fail.
                     // AccountsBackgroundService calls `clean_accounts()` with a value for
                     // last_full_snapshot_slot that requires this archive call to succeed.

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -10,12 +10,10 @@ use {
     solana_runtime::{
         snapshot_config::SnapshotConfig,
         snapshot_hash::StartingSnapshotHashes,
-        snapshot_package::{self, SnapshotPackage},
+        snapshot_package::{self, SnapshotKind, SnapshotPackage},
         snapshot_utils,
     },
     std::{
-        fs,
-        path::PathBuf,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc,
@@ -49,31 +47,22 @@ impl SnapshotPackagerService {
                 renice_this_thread(snapshot_config.packager_thread_niceness_adj).unwrap();
                 let mut snapshot_gossip_manager = enable_gossip_push
                     .then(|| SnapshotGossipManager::new(cluster_info, starting_snapshot_hashes));
-                let mut snapshot_errored = false;
-                let mut last_snapshot_storages: Vec<Arc<AccountStorageEntry>> = vec![];
-                let mut last_bank_snapshot_dir: PathBuf = PathBuf::default();
+                let mut last_full_snapshot_storages: Vec<Arc<AccountStorageEntry>> = vec![];
+                let mut last_incremental_snapshot_storages: Vec<Arc<AccountStorageEntry>> = vec![];
                 loop {
                     if exit.load(Ordering::Relaxed) {
-                        // When last snapshot archive fails, skip flushing and don't mark the 'complete' for the bad archive.
-                        if snapshot_errored {
-                            break;
-                        }
                         info!("SnapshotPackagerService exiting, flushing last snapshot storages ... ");
                         let (_, measure_flush) = measure_us!({
-                            for storage in last_snapshot_storages {
+                            for storage in itertools::chain(last_full_snapshot_storages, last_incremental_snapshot_storages) {
                                 if let Err(e) = storage.flush() {
                                     error!("error flushing {:?} {}", storage.path().to_path_buf(), e);
                                 }
                             }
                         });
-                        // Mark this directory complete so it can be used.  Check this flag first before selecting for deserialization.
-                        let state_complete_path = last_bank_snapshot_dir.join(snapshot_utils::SNAPSHOT_STATE_COMPLETE_FILENAME);
-                        if let Err(e) = fs::File::create(&state_complete_path) {
-                            error!("error creating snapshot state complete file {:?} {}", state_complete_path, e);
-                        }
                         info!("Done flushing snapshot storages - {}us. SnapshotPackagerService exit.", measure_flush);
                         break;
                     }
+
                     let Some((
                         snapshot_package,
                         num_outstanding_snapshot_packages,
@@ -93,9 +82,14 @@ impl SnapshotPackagerService {
                     let snapshot_kind = snapshot_package.snapshot_kind;
                     let snapshot_slot = snapshot_package.slot;
                     let snapshot_hash = snapshot_package.hash;
-
-                    last_bank_snapshot_dir.clone_from(&snapshot_config.bank_snapshots_dir);
-                    last_snapshot_storages = snapshot_package.snapshot_storages.iter().cloned().collect_vec();
+                    match snapshot_kind {
+                        SnapshotKind::FullSnapshot => {
+                            last_full_snapshot_storages = snapshot_package.snapshot_storages.iter().cloned().collect_vec();
+                        }
+                        SnapshotKind::IncrementalSnapshot(_) => {
+                            last_incremental_snapshot_storages = snapshot_package.snapshot_storages.iter().cloned().collect_vec();
+                        }
+                    }
                     // Archiving the snapshot package is not allowed to fail.
                     // AccountsBackgroundService calls `clean_accounts()` with a value for
                     // last_full_snapshot_slot that requires this archive call to succeed.
@@ -103,14 +97,13 @@ impl SnapshotPackagerService {
                         snapshot_package,
                         &snapshot_config,
                     ));
-
-                    #[allow(unused_assignments)]
                     if let Err(err) = archive_result {
-                        snapshot_errored = true;
                         error!("Stopping SnapshotPackagerService! Fatal error while archiving snapshot package: {err}");
                         exit.store(true, Ordering::Relaxed);
                         break;
                     }
+
+
                     if let Some(snapshot_gossip_manager) = snapshot_gossip_manager.as_mut() {
                         snapshot_gossip_manager.push_snapshot_hash(snapshot_kind, (snapshot_slot, snapshot_hash));
                     }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,7 +1,6 @@
 mod snapshot_gossip_manager;
 use {
     crossbeam_channel::{Receiver, Sender},
-    itertools::Itertools,
     snapshot_gossip_manager::SnapshotGossipManager,
     solana_accounts_db::accounts_db::AccountStorageEntry,
     solana_gossip::cluster_info::ClusterInfo,
@@ -47,13 +46,12 @@ impl SnapshotPackagerService {
                 renice_this_thread(snapshot_config.packager_thread_niceness_adj).unwrap();
                 let mut snapshot_gossip_manager = enable_gossip_push
                     .then(|| SnapshotGossipManager::new(cluster_info, starting_snapshot_hashes));
-                let mut last_full_snapshot_storages: Vec<Arc<AccountStorageEntry>> = vec![];
-                let mut last_incremental_snapshot_storages: Vec<Arc<AccountStorageEntry>> = vec![];
+                let mut last_snapshot_storages: Vec<Arc<AccountStorageEntry>> = vec![];
                 loop {
                     if exit.load(Ordering::Relaxed) {
                         info!("SnapshotPackagerService exiting, flushing last snapshot storages ... ");
                         let (_, measure_flush) = measure_us!({
-                            for storage in itertools::chain(last_full_snapshot_storages, last_incremental_snapshot_storages) {
+                            for storage in last_snapshot_storages {
                                 if let Err(e) = storage.flush() {
                                     error!("error flushing {:?} {}", storage.path().to_path_buf(), e);
                                 }
@@ -82,13 +80,12 @@ impl SnapshotPackagerService {
                     let snapshot_kind = snapshot_package.snapshot_kind;
                     let snapshot_slot = snapshot_package.slot;
                     let snapshot_hash = snapshot_package.hash;
-                    match snapshot_kind {
-                        SnapshotKind::FullSnapshot => {
-                            last_full_snapshot_storages = snapshot_package.snapshot_storages.iter().cloned().collect_vec();
-                        }
-                        SnapshotKind::IncrementalSnapshot(_) => {
-                            last_incremental_snapshot_storages = snapshot_package.snapshot_storages.iter().cloned().collect_vec();
-                        }
+
+                    if matches!(snapshot_kind, SnapshotKind::FullSnapshot) {
+                        last_snapshot_storages.clear();
+                    }
+                    for storage in snapshot_package.snapshot_storages.iter().cloned() {
+                        last_snapshot_storages.push(storage);
                     }
                     // Archiving the snapshot package is not allowed to fail.
                     // AccountsBackgroundService calls `clean_accounts()` with a value for

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -855,14 +855,6 @@ fn serialize_snapshot(
             bank_snapshot_path.display(),
         );
 
-        let (_, measure_flush) = measure!({
-            for storage in snapshot_storages {
-                storage.flush().map_err(|err| {
-                    AddBankSnapshotError::FlushStorage(err, storage.path().to_path_buf())
-                })?;
-            }
-        });
-
         // We are constructing the snapshot directory to contain the full snapshot state information to allow
         // constructing a bank from this directory.  It acts like an archive to include the full state.
         // The set of the account storages files is the necessary part of this snapshot state.  Hard-link them
@@ -921,7 +913,6 @@ fn serialize_snapshot(
             ("slot", slot, i64),
             ("bank_size", bank_snapshot_consumed_size, i64),
             ("status_cache_size", status_cache_consumed_size, i64),
-            ("flush_storages_us", measure_flush.as_us(), i64),
             ("hard_link_storages_us", measure_hard_linking.as_us(), i64),
             ("bank_serialize_us", bank_serialize.as_us(), i64),
             (

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -440,9 +440,6 @@ pub enum AddBankSnapshotError {
     #[error("failed to create snapshot dir '{1}': {0}")]
     CreateSnapshotDir(#[source] IoError, PathBuf),
 
-    #[error("failed to flush storage '{1}': {0}")]
-    FlushStorage(#[source] AccountsFileError, PathBuf),
-
     #[error("failed to hard link storages: {0}")]
     HardLinkStorages(#[source] HardLinkStoragesToSnapshotError),
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -451,6 +451,9 @@ pub enum AddBankSnapshotError {
 
     #[error("failed to write snapshot version file '{1}': {0}")]
     WriteSnapshotVersionFile(#[source] IoError, PathBuf),
+
+    #[error("failed to mark snapshot as 'complete': failed to create file '{1}': {0}")]
+    CreateStateCompleteFile(#[source] IoError, PathBuf),
 }
 
 /// Errors that can happen in `archive_snapshot_package()`
@@ -892,6 +895,13 @@ fn serialize_snapshot(
         )
         .map_err(|err| AddBankSnapshotError::WriteSnapshotVersionFile(err, version_path))?);
 
+        // Mark this directory complete so it can be used.  Check this flag first before selecting for deserialization.
+        let state_complete_path = bank_snapshot_dir.join(SNAPSHOT_STATE_COMPLETE_FILENAME);
+        let (_, measure_write_state_complete_file) =
+            measure!(fs::File::create(&state_complete_path).map_err(|err| {
+                AddBankSnapshotError::CreateStateCompleteFile(err, state_complete_path)
+            })?);
+
         measure_everything.stop();
 
         // Monitor sizes because they're capped to MAX_SNAPSHOT_DATA_FILE_SIZE
@@ -910,6 +920,11 @@ fn serialize_snapshot(
             (
                 "write_version_file_us",
                 measure_write_version_file.as_us(),
+                i64
+            ),
+            (
+                "write_state_complete_file_us",
+                measure_write_state_complete_file.as_us(),
                 i64
             ),
             ("total_us", measure_everything.as_us(), i64),


### PR DESCRIPTION
#### Problem

In https://github.com/anza-xyz/agave/pull/1430, we found that mmap flush caused
larger accounts files on disk (due to alignment padding). This results in
larger snapshot files. 

Since we have switched to archive mmap direct from in-memory representation.
There is no longer a need to flush the mmap.

![image](https://github.com/anza-xyz/agave/assets/219428/9231d1ba-0b12-4f6c-a369-7c7a557f529b)

By removing flush, we could reduce the snapshot timing by 2-7s.



#### Summary of Changes

- don't flush mmap when taking snapshots


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
