### PR TITLE
Updates frozen abi test for bank snapshot serialization

### DIFF
--- a/accounts-db/src/epoch_accounts_hash.rs
+++ b/accounts-db/src/epoch_accounts_hash.rs
@@ -13,6 +13,7 @@ mod manager;
 pub use manager::Manager as EpochAccountsHashManager;
 
 /// The EpochAccountsHash holds the result after calculating the accounts hash once per epoch
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Serialize, Deserialize, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct EpochAccountsHash(Hash);
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -863,7 +863,7 @@ fn serialize_snapshot(
             );
 
         let bank_snapshot_serializer = move |stream: &mut BufWriter<fs::File>| -> Result<()> {
-            serde_snapshot::serialize_bank_snapshot(
+            serde_snapshot::serialize_bank_snapshot_into(
                 stream,
                 bank_fields,
                 accounts_db,


### PR DESCRIPTION
#### Problem

The frozen abi test that we have for the bank serialization is not accurate/up to date with what we actually are serializing!


#### Summary of Changes

Update the test to use the same serializing function that real snapshotting uses.

<details><summary>Updated frozen abi digest details</summary>
<p>

The frozen abi digest for the test changed. This is expected, as we weren't testing the same thing as what is actually used by a real validator. 

Here's the diff of the changes.

1. The name of the wrapper type changed. We no longer have the concept of "newer" and "older", so I removed that here.
2. The old test-only serialization used a raw `Hash` for the epoch accounts hash, but real validators use `EpochAccountsHash`. So now the test correctly reflects that.

```diff
❯ diff -u bank__serde_snapshot__tests__test_bank_serialize__BankAbiTestWrapperNewer_frozen_abi__test_abi_digest_7K1xfUkoCwhxssszgoSpbeMCcX3KEyjycGyLXrpFaJNe bank__serde_snapshot__tests__test_bank_serialize__BankAbiTestWrapper_frozen_abi__test_abi_digest_6riNuebfnAUpS2e3GYb5G8udH5PoEtep48ULchLjRDCB
--- bank__serde_snapshot__tests__test_bank_serialize__BankAbiTestWrapperNewer_frozen_abi__test_abi_digest_7K1xfUkoCwhxssszgoSpbeMCcX3KEyjycGyLXrpFaJNe	2024-05-30 11:28:12
+++ bank__serde_snapshot__tests__test_bank_serialize__BankAbiTestWrapper_frozen_abi__test_abi_digest_6riNuebfnAUpS2e3GYb5G8udH5PoEtep48ULchLjRDCB	2024-05-30 11:56:46
@@ -1,4 +1,4 @@
-struct BankAbiTestWrapperNewer (fields = 1)
+struct BankAbiTestWrapper (fields = 1)
     field bank: __SerializeWith
         tuple (elements = 5)
             element solana_runtime::serde_snapshot::SerializableVersionedBank
@@ -2009,73 +2009,74 @@
                                                 primitive u8
                             field incremental_capitalization: u64
                                 primitive u64
-            element core::option::Option<solana_program::hash::Hash>
+            element core::option::Option<solana_accounts_db::epoch_accounts_hash::EpochAccountsHash>
                 enum Option (variants = 2)
                     variant(0) None (unit)
-                    variant(1) Some(solana_program::hash::Hash) (newtype)
-                        struct Hash([u8; 32]) (newtype)
-                            tuple (elements = 32)
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
-                                element u8
-                                    primitive u8
+                    variant(1) Some(solana_accounts_db::epoch_accounts_hash::EpochAccountsHash) (newtype)
+                        struct EpochAccountsHash(solana_program::hash::Hash) (newtype)
+                            struct Hash([u8; 32]) (newtype)
+                                tuple (elements = 32)
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
+                                    element u8
+                                        primitive u8
```

</p>
</details> 