### PR TITLE
[zk-sdk] Re-export grouped ciphertext validity proof data and context

### DIFF
--- a/zk-sdk/src/elgamal_program/proof_data/mod.rs
+++ b/zk-sdk/src/elgamal_program/proof_data/mod.rs
@@ -34,6 +34,10 @@ pub use {
     ciphertext_commitment_equality::{
         CiphertextCommitmentEqualityProofContext, CiphertextCommitmentEqualityProofData,
     },
+    grouped_ciphertext_validity::{
+        GroupedCiphertext2HandlesValidityProofContext, GroupedCiphertext2HandlesValidityProofData,
+        GroupedCiphertext3HandlesValidityProofContext, GroupedCiphertext3HandlesValidityProofData,
+    },
     percentage_with_cap::{PercentageWithCapProofContext, PercentageWithCapProofData},
     pubkey_validity::{PubkeyValidityProofContext, PubkeyValidityProofData},
     zero_ciphertext::{ZeroCiphertextProofContext, ZeroCiphertextProofData},


### PR DESCRIPTION
#### Problem
Sorry for the annoyance, but I missed re-exporting grouped ciphertext validity proof data in https://github.com/anza-xyz/agave/pull/1532.

#### Summary of Changes
Re-export grouped ciphertext validity proof data directly from the `proof_data` module.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
