### PR TITLE
ci: patching spl project before anchor project uses it

### DIFF
--- a/scripts/build-downstream-anchor-projects.sh
+++ b/scripts/build-downstream-anchor-projects.sh
@@ -48,6 +48,7 @@ anchor() {
   rm -rf spl
   git clone https://github.com/solana-labs/solana-program-library.git spl
   cd spl || exit 1
+  ./patch.crates-io.sh "$solana_dir"
   spl_dir=$PWD
   get_spl_versions "$spl_dir"
   cd ..


### PR DESCRIPTION
#### Problem

Anchor downstream tests start failing 😢 

<img width="1176" alt="Screenshot 2024-05-31 at 21 34 28" src="https://github.com/anza-xyz/agave/assets/8209234/726a2ae4-1086-40c8-b062-5460e9f4a2ec">

the error message:

```
error[E0308]: mismatched types
   --> /home/runner/work/agave/agave/target/downstream-projects-anchor/spl/token/program-2022/src/extension/confidential_transfer/instruction.rs:784:27
    |
784 |         instructions.push(verify_pubkey_validity(None, proof_data));
    |                      ---- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Instruction`, found a different `Instruction`
    |                      |
    |                      arguments to this method are incorrect
    |
    = note: `Instruction` and `Instruction` have similar names, but are actually distinct types
note: `Instruction` is defined in crate `solana_program`
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/solana-program-1.18.15/src/instruction.rs:329:1

(... omit)
```

it looks like we're compiling a wrong version crate.

#### Summary of Changes

I checked our anchor downstream tests steps. we will patch spl and solana for anchor. I guess we should also patch solana for spl so that we can ensure the deps consistency 🤔 


