### PR TITLE
Gets accounts-db fields for snapshots sooner

### DIFF
--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -111,12 +111,18 @@ mod serde_snapshot_tests {
     where
         W: Write,
     {
+        let bank_hash_stats = accounts_db.get_bank_hash_stats(slot).unwrap();
+        let accounts_delta_hash = accounts_db.get_accounts_delta_hash(slot).unwrap();
+        let accounts_hash = accounts_db.get_accounts_hash(slot).unwrap().0;
         serialize_into(
             stream,
             &SerializableAccountsDb {
                 accounts_db,
                 slot,
                 account_storage_entries,
+                bank_hash_stats,
+                accounts_delta_hash,
+                accounts_hash,
             },
         )
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -22,8 +22,9 @@ use {
     regex::Regex,
     solana_accounts_db::{
         account_storage::AccountStorageMap,
-        accounts_db::{AccountStorageEntry, AccountsDb, AtomicAccountsFileId},
+        accounts_db::{AccountStorageEntry, AccountsDb, AtomicAccountsFileId, BankHashStats},
         accounts_file::{AccountsFile, AccountsFileError, InternalsForArchive, StorageAccess},
+        accounts_hash::{AccountsDeltaHash, AccountsHash},
         epoch_accounts_hash::EpochAccountsHash,
         hardened_unpack::{self, ParallelSelector, UnpackError},
         shared_buffer_reader::{SharedBuffer, SharedBufferReader},
@@ -747,6 +748,9 @@ pub fn serialize_and_archive_snapshot_package(
         mut snapshot_storages,
         status_cache_slot_deltas,
         bank_fields_to_serialize,
+        bank_hash_stats,
+        accounts_delta_hash,
+        accounts_hash,
         epoch_accounts_hash,
         bank_incremental_snapshot_persistence,
         accounts,
@@ -760,6 +764,9 @@ pub fn serialize_and_archive_snapshot_package(
         snapshot_storages.as_slice(),
         status_cache_slot_deltas.as_slice(),
         bank_fields_to_serialize,
+        bank_hash_stats,
+        accounts_delta_hash,
+        accounts_hash,
         epoch_accounts_hash,
         bank_incremental_snapshot_persistence.as_ref(),
     )?;
@@ -811,6 +818,7 @@ pub fn serialize_and_archive_snapshot_package(
 }
 
 /// Serializes a snapshot into `bank_snapshots_dir`
+#[allow(clippy::too_many_arguments)]
 fn serialize_snapshot(
     bank_snapshots_dir: impl AsRef<Path>,
     snapshot_version: SnapshotVersion,
@@ -818,6 +826,9 @@ fn serialize_snapshot(
     snapshot_storages: &[Arc<AccountStorageEntry>],
     slot_deltas: &[BankSlotDelta],
     bank_fields: BankFieldsToSerialize,
+    bank_hash_stats: BankHashStats,
+    accounts_delta_hash: AccountsDeltaHash,
+    accounts_hash: AccountsHash,
     epoch_accounts_hash: Option<EpochAccountsHash>,
     bank_incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
 ) -> Result<BankSnapshotInfo> {
@@ -866,6 +877,9 @@ fn serialize_snapshot(
             serde_snapshot::serialize_bank_snapshot_into(
                 stream,
                 bank_fields,
+                bank_hash_stats,
+                accounts_delta_hash,
+                accounts_hash,
                 accounts_db,
                 &get_storages_to_serialize(snapshot_storages),
                 bank_incremental_snapshot_persistence,


### PR DESCRIPTION
#### Problem

There is a race condition in the snapshot pipeline that is causing the validator to panic.

Now that the reserialization has been removed from AccountsHashVerifier, we wait until SnapshotPackagerService to serialize the bank snapshot. During this serialization, we ask AccountsDb for some fields at this bank's slot. One of them is the Accounts Delta Hash.

It is possible that by the time SPS runs and asks AccountsDb for the accounts delta hash, that the bank itself has been cleaned up. When that happens its accounts delta hash will be removed from AccountsDb (can happen in `flush` or `clean`). Thus SPS will not be able to query AccountsDb for the slot's accounts delta hash. Sadness ensues.


#### Summary of Changes

Get the accounts-db fields earlier in the snapshot pipeline (in ABS), and pass them through the AccountsPackage and SnapshotPackage to be serialized.

Fixes #1559 