### PR TITLE
refactor addref_accounts_failed_to_shrink_ancient

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -365,7 +365,7 @@ impl AccountsDb {
                 accounts_to_combine.target_slots_sorted.last(),
                 many_refs_newest.last().map(|accounts| accounts.slot)
             );
-            self.addref_accounts_failed_to_shrink_ancient(accounts_to_combine);
+            self.addref_accounts_failed_to_shrink_ancient(accounts_to_combine.accounts_to_combine);
             return;
         }
 
@@ -385,7 +385,7 @@ impl AccountsDb {
             // Not enough slots to contain the accounts we are trying to pack.
             // `shrink_collect` previously unref'd some accounts. We need to addref them
             // to restore the correct state since we failed to combine anything.
-            self.addref_accounts_failed_to_shrink_ancient(accounts_to_combine);
+            self.addref_accounts_failed_to_shrink_ancient(accounts_to_combine.accounts_to_combine);
             return;
         }
 
@@ -399,24 +399,24 @@ impl AccountsDb {
     }
 
     /// for each account in `unrefed_pubkeys`, in each `accounts_to_combine`, addref
-    fn addref_accounts_failed_to_shrink_ancient(&self, accounts_to_combine: AccountsToCombine) {
+    fn addref_accounts_failed_to_shrink_ancient<'a>(
+        &self,
+        accounts_to_combine: Vec<ShrinkCollect<'a, ShrinkCollectAliveSeparatedByRefs<'a>>>,
+    ) {
         self.thread_pool_clean.install(|| {
-            accounts_to_combine
-                .accounts_to_combine
-                .into_par_iter()
-                .for_each(|combine| {
-                    self.accounts_index.scan(
-                        combine.unrefed_pubkeys.into_iter(),
-                        |_pubkey, _slots_refs, entry| {
-                            if let Some(entry) = entry {
-                                entry.addref();
-                            }
-                            AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
-                        },
-                        None,
-                        true,
-                    );
-                });
+            accounts_to_combine.into_par_iter().for_each(|combine| {
+                self.accounts_index.scan(
+                    combine.unrefed_pubkeys.into_iter(),
+                    |_pubkey, _slots_refs, entry| {
+                        if let Some(entry) = entry {
+                            entry.addref();
+                        }
+                        AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
+                    },
+                    None,
+                    true,
+                );
+            });
         });
     }
 
@@ -3413,7 +3413,7 @@ pub mod tests {
                 target_slots_sorted: Vec::default(),
                 unpackable_slots_count: 0,
             };
-            db.addref_accounts_failed_to_shrink_ancient(accounts_to_combine);
+            db.addref_accounts_failed_to_shrink_ancient(accounts_to_combine.accounts_to_combine);
             db.accounts_index.scan(
                 unrefed_pubkeys.iter(),
                 |k, slot_refs, _entry| {


### PR DESCRIPTION
#### Problem
when ancient packing runs, it can encounter a pubkey that is alive in an ancient slot, but is also present in an older slot (alive or dead). This means the older entry needs to be shrunk/packed/dropped before this found entry will be the ONLY entry for this pubkey. We don't know where the older entry is. So, packing can only move this alive entry to a slot that is >= the current slot. Otherwise, we might pack this account behind a dead version of this account. However, if we have one of these accounts to move but we can't guarantee its new slot will be high enough, we currently abort the pack. If this occurs repeatedly, we don't make progress and we accumulate old slots. This is fatal.

#### Summary of Changes
There are several potential solutions to this problem. Both involve addrefing accounts that were unref'd. Refactoring `addref_accounts_failed_to_shrink_ancient` makes these other prs easier at no cost.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
