### PR TITLE
Replaces Accounts with WriteVersion in SnapshotPackage

### DIFF
--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -114,15 +114,16 @@ mod serde_snapshot_tests {
         let bank_hash_stats = accounts_db.get_bank_hash_stats(slot).unwrap();
         let accounts_delta_hash = accounts_db.get_accounts_delta_hash(slot).unwrap();
         let accounts_hash = accounts_db.get_accounts_hash(slot).unwrap().0;
+        let write_version = accounts_db.write_version.load(Ordering::Acquire);
         serialize_into(
             stream,
             &SerializableAccountsDb {
-                accounts_db,
                 slot,
                 account_storage_entries,
                 bank_hash_stats,
                 accounts_delta_hash,
                 accounts_hash,
+                write_version,
             },
         )
     }


### PR DESCRIPTION
#### Problem

We pass an `Accounts` object all the way through the snapshot pipeline, but SnapshotPackagerService only uses this to get the write version. We can pass that into the snapshot package and remove the Accounts field entirely.


#### Summary of Changes

Replace Accounts with WriteVersion in SnapshotPackage