### PR TITLE
SVM: move program cache construction inside SVM

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -996,10 +996,7 @@ impl Bank {
             bank.epoch,
             bank.epoch_schedule.clone(),
             Arc::new(RuntimeConfig::default()),
-            Arc::new(RwLock::new(ProgramCache::new(
-                Slot::default(),
-                Epoch::default(),
-            ))),
+            Arc::new(RwLock::new(ProgramCache::new(bank.slot, bank.epoch))),
             HashSet::default(),
         );
 
@@ -1630,7 +1627,7 @@ impl Bank {
             bank.epoch,
             bank.epoch_schedule.clone(),
             runtime_config,
-            Arc::new(RwLock::new(ProgramCache::new(fields.slot, fields.epoch))),
+            Arc::new(RwLock::new(ProgramCache::new(bank.slot, bank.epoch))),
             HashSet::default(),
         );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -97,7 +97,7 @@ use {
     solana_program_runtime::{
         invoke_context::BuiltinFunctionWithContext,
         loaded_programs::{
-            ProgramCache, ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
+            ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
             ProgramCacheMatchCriteria,
         },
         timings::{ExecuteTimingType, ExecuteTimings},
@@ -996,7 +996,6 @@ impl Bank {
             bank.epoch,
             bank.epoch_schedule.clone(),
             Arc::new(RuntimeConfig::default()),
-            Arc::new(RwLock::new(ProgramCache::new(bank.slot, bank.epoch))),
             HashSet::default(),
         );
 
@@ -1627,7 +1626,6 @@ impl Bank {
             bank.epoch,
             bank.epoch_schedule.clone(),
             runtime_config,
-            Arc::new(RwLock::new(ProgramCache::new(bank.slot, bank.epoch))),
             HashSet::default(),
         );
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -164,7 +164,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         epoch: Epoch,
         epoch_schedule: EpochSchedule,
         runtime_config: Arc<RuntimeConfig>,
-        program_cache: Arc<RwLock<ProgramCache<FG>>>,
         builtin_program_ids: HashSet<Pubkey>,
     ) -> Self {
         Self {
@@ -174,7 +173,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             fee_structure: FeeStructure::default(),
             runtime_config,
             sysvar_cache: RwLock::<SysvarCache>::default(),
-            program_cache,
+            program_cache: Arc::new(RwLock::new(ProgramCache::new(slot, epoch))),
             builtin_program_ids: RwLock::new(builtin_program_ids),
         }
     }
@@ -1711,7 +1710,6 @@ mod tests {
             5,
             EpochSchedule::default(),
             Arc::new(RuntimeConfig::default()),
-            Arc::new(RwLock::new(ProgramCache::new(5, 5))),
             HashSet::new(),
         );
         batch_processor.program_cache.write().unwrap().fork_graph =

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1711,7 +1711,7 @@ mod tests {
             5,
             EpochSchedule::default(),
             Arc::new(RuntimeConfig::default()),
-            Arc::new(RwLock::new(ProgramCache::new(0, 0))),
+            Arc::new(RwLock::new(ProgramCache::new(5, 5))),
             HashSet::new(),
         );
         batch_processor.program_cache.write().unwrap().fork_graph =
@@ -1733,13 +1733,10 @@ mod tests {
             let ths: Vec<_> = (0..4)
                 .map(|_| {
                     let local_bank = mock_bank.clone();
-                    let processor = TransactionBatchProcessor::new(
+                    let processor = TransactionBatchProcessor::new_from(
+                        &batch_processor,
                         batch_processor.slot,
                         batch_processor.epoch,
-                        batch_processor.epoch_schedule.clone(),
-                        batch_processor.runtime_config.clone(),
-                        batch_processor.program_cache.clone(),
-                        HashSet::new(),
                     );
                     let maps = account_maps.clone();
                     let programs = programs.clone();

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -244,7 +244,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
     let v1_environment =
         create_program_runtime_environment_v1(&feature_set, &compute_budget, false, false).unwrap();
 
-    let mut program_cache = ProgramCache::<MockForkGraph>::new(0, 20);
+    let mut program_cache = ProgramCache::<MockForkGraph>::new(42, 2);
     program_cache.environments = ProgramRuntimeEnvironments {
         program_runtime_v1: Arc::new(v1_environment),
         program_runtime_v2: Arc::new(BuiltinProgram::new_loader(

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -10,9 +10,7 @@ use {
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_program_runtime::{
         invoke_context::{EnvironmentConfig, InvokeContext},
-        loaded_programs::{
-            ProgramCache, ProgramCacheEntry, ProgramCacheForTxBatch, ProgramRuntimeEnvironments,
-        },
+        loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch, ProgramRuntimeEnvironments},
         log_collector::LogCollector,
         solana_rbpf::{
             program::{BuiltinProgram, FunctionRegistry},
@@ -244,26 +242,26 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
     let v1_environment =
         create_program_runtime_environment_v1(&feature_set, &compute_budget, false, false).unwrap();
 
-    let mut program_cache = ProgramCache::<MockForkGraph>::new(42, 2);
-    program_cache.environments = ProgramRuntimeEnvironments {
-        program_runtime_v1: Arc::new(v1_environment),
-        program_runtime_v2: Arc::new(BuiltinProgram::new_loader(
-            Config::default(),
-            FunctionRegistry::default(),
-        )),
-    };
-    program_cache.fork_graph = Some(Arc::new(RwLock::new(MockForkGraph {})));
-
-    let program_cache = Arc::new(RwLock::new(program_cache));
     mock_bank.override_feature_set(feature_set);
     let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(
         42,
         2,
         EpochSchedule::default(),
         Arc::new(RuntimeConfig::default()),
-        program_cache.clone(),
         HashSet::new(),
     );
+
+    {
+        let mut program_cache = batch_processor.program_cache.write().unwrap();
+        program_cache.environments = ProgramRuntimeEnvironments {
+            program_runtime_v1: Arc::new(v1_environment),
+            program_runtime_v2: Arc::new(BuiltinProgram::new_loader(
+                Config::default(),
+                FunctionRegistry::default(),
+            )),
+        };
+        program_cache.fork_graph = Some(Arc::new(RwLock::new(MockForkGraph {})));
+    }
 
     batch_processor.fill_missing_sysvar_cache_entries(&mock_bank);
     register_builtins(&batch_processor, &mock_bank);

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -133,7 +133,7 @@ fn create_custom_environment<'a>() -> BuiltinProgram<InvokeContext<'a>> {
 }
 
 fn create_executable_environment(mock_bank: &mut MockBankCallback) -> ProgramCache<MockForkGraph> {
-    let mut program_cache = ProgramCache::<MockForkGraph>::new(0, 20);
+    let mut program_cache = ProgramCache::<MockForkGraph>::new(EXECUTION_SLOT, EXECUTION_EPOCH);
 
     program_cache.environments = ProgramRuntimeEnvironments {
         program_runtime_v1: Arc::new(create_custom_environment()),

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -132,9 +132,10 @@ fn create_custom_environment<'a>() -> BuiltinProgram<InvokeContext<'a>> {
     BuiltinProgram::new_loader(vm_config, function_registry)
 }
 
-fn create_executable_environment(mock_bank: &mut MockBankCallback) -> ProgramCache<MockForkGraph> {
-    let mut program_cache = ProgramCache::<MockForkGraph>::new(EXECUTION_SLOT, EXECUTION_EPOCH);
-
+fn create_executable_environment(
+    mock_bank: &mut MockBankCallback,
+    program_cache: &mut ProgramCache<MockForkGraph>,
+) {
     program_cache.environments = ProgramRuntimeEnvironments {
         program_runtime_v1: Arc::new(create_custom_environment()),
         // We are not using program runtime v2
@@ -165,8 +166,6 @@ fn create_executable_environment(mock_bank: &mut MockBankCallback) -> ProgramCac
         .account_shared_data
         .borrow_mut()
         .insert(Clock::id(), account_data);
-
-    program_cache
 }
 
 fn load_program(name: String) -> Vec<u8> {
@@ -445,15 +444,17 @@ fn prepare_transactions(
 fn svm_integration() {
     let mut mock_bank = MockBankCallback::default();
     let (transactions, mut check_results) = prepare_transactions(&mut mock_bank);
-    let program_cache = create_executable_environment(&mut mock_bank);
-    let program_cache = Arc::new(RwLock::new(program_cache));
     let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(
         EXECUTION_SLOT,
         EXECUTION_EPOCH,
         EpochSchedule::default(),
         Arc::new(RuntimeConfig::default()),
-        program_cache.clone(),
-        HashSet::default(),
+        HashSet::new(),
+    );
+
+    create_executable_environment(
+        &mut mock_bank,
+        &mut batch_processor.program_cache.write().unwrap(),
     );
 
     // The sysvars must be put in the cache


### PR DESCRIPTION
#### Problem
The program cache is overly exposed to users of SVM.

#### Summary of Changes
This PR moves the construction of the cache inside SVM. This is the first step in containing the cache within SVM bounds.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
