### PR TITLE
refactor: clean up geyser-plugin-manager

### DIFF
--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -52,9 +52,8 @@ impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
             100000
         );
 
-        if let Some(account_info) = account {
-            self.notify_plugins_of_account_update(account_info, slot, true);
-        }
+        self.notify_plugins_of_account_update(account, slot, true);
+
         measure_all.stop();
 
         inc_new_counter_debug!(
@@ -124,7 +123,7 @@ impl AccountsUpdateNotifierImpl {
     fn accountinfo_from_stored_account_meta<'a>(
         &self,
         stored_account_meta: &'a StoredAccountMeta,
-    ) -> Option<ReplicaAccountInfoV3<'a>> {
+    ) -> ReplicaAccountInfoV3<'a> {
         // We do not need to rely on the specific write_version read from the append vec.
         // So, overwrite the write_version with something that works.
         // There is already only entry per pubkey.
@@ -132,7 +131,7 @@ impl AccountsUpdateNotifierImpl {
         // so it doesn't matter what value it gets here.
         // Passing 0 for everyone's write_version is sufficiently correct.
         let write_version = 0;
-        Some(ReplicaAccountInfoV3 {
+        ReplicaAccountInfoV3 {
             pubkey: stored_account_meta.pubkey().as_ref(),
             lamports: stored_account_meta.lamports(),
             owner: stored_account_meta.owner().as_ref(),
@@ -141,7 +140,7 @@ impl AccountsUpdateNotifierImpl {
             data: stored_account_meta.data(),
             write_version,
             txn: None,
-        })
+        }
     }
 
     fn notify_plugins_of_account_update(

--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -33,11 +33,9 @@ impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
         pubkey: &Pubkey,
         write_version: u64,
     ) {
-        if let Some(account_info) =
-            self.accountinfo_from_shared_account_data(account, txn, pubkey, write_version)
-        {
-            self.notify_plugins_of_account_update(account_info, slot, false);
-        }
+        let account_info =
+            self.accountinfo_from_shared_account_data(account, txn, pubkey, write_version);
+        self.notify_plugins_of_account_update(account_info, slot, false);
     }
 
     fn notify_account_restore_from_snapshot(&self, slot: Slot, account: &StoredAccountMeta) {
@@ -110,8 +108,8 @@ impl AccountsUpdateNotifierImpl {
         txn: &'a Option<&'a SanitizedTransaction>,
         pubkey: &'a Pubkey,
         write_version: u64,
-    ) -> Option<ReplicaAccountInfoV3<'a>> {
-        Some(ReplicaAccountInfoV3 {
+    ) -> ReplicaAccountInfoV3<'a> {
+        ReplicaAccountInfoV3 {
             pubkey: pubkey.as_ref(),
             lamports: account.lamports(),
             owner: account.owner().as_ref(),
@@ -120,7 +118,7 @@ impl AccountsUpdateNotifierImpl {
             data: account.data(),
             write_version,
             txn: *txn,
-        })
+        }
     }
 
     fn accountinfo_from_stored_account_meta<'a>(


### PR DESCRIPTION
#### Problem
Some methods returned redundant `Option<T>` wrapper types. Also, building `ReplicaTransactionInfoV2` can be simplified, since the signature field can be initialised from the `SanitizedTransaction` value too.

#### Summary of Changes
Simplified the code.
