### PR TITLE
Simplify signature of Bank::load_and_execute_transactions

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -33,7 +33,7 @@ use {
     solana_svm::{
         account_loader::{validate_fee_payer, TransactionCheckResult},
         transaction_error_metrics::TransactionErrorMetrics,
-        transaction_processor::ExecutionRecordingConfig,
+        transaction_processor::{ExecutionRecordingConfig, TransactionProcessingConfig},
     },
     std::{
         sync::{atomic::Ordering, Arc},
@@ -603,11 +603,15 @@ impl Consumer {
             .load_and_execute_transactions(
                 batch,
                 MAX_PROCESSING_AGE,
-                ExecutionRecordingConfig::new_single_setting(transaction_status_sender_enabled),
                 &mut execute_and_commit_timings.execute_timings,
-                None, // account_overrides
-                self.log_messages_bytes_limit,
-                true,
+                TransactionProcessingConfig {
+                    account_overrides: None,
+                    log_messages_bytes_limit: self.log_messages_bytes_limit,
+                    limit_to_load_programs: true,
+                    recording_config: ExecutionRecordingConfig::new_single_setting(
+                        transaction_status_sender_enabled
+                    ),
+                }
             ));
         execute_and_commit_timings.load_execute_us = load_execute_us;
 


### PR DESCRIPTION
Simplified the signature of `Bank::load_and_execute_transactions` in order to remove `#[allow(clippy::too_many_arguments, clippy::type_complexity)]` by using `TransactionProcessingConfig` introduced in #1475.