### PR TITLE
Make borsh optional in sdk and program crates

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -17,6 +17,7 @@ edition = { workspace = true }
 program = []
 
 default = [
+  "borsh",
   "full" # functionality that is not compatible or needed for on-chain programs
 ]
 full = [
@@ -33,7 +34,9 @@ full = [
     "sha3",
     "digest",
 ]
+borsh = ["dep:borsh", "solana-program/borsh"]
 dev-context-only-utils = [
+  "borsh",
   "qualifier_attr"
 ]
 frozen-abi = [
@@ -45,7 +48,7 @@ frozen-abi = [
 [dependencies]
 bincode = { workspace = true }
 bitflags = { workspace = true, features = ["serde"] }
-borsh = { workspace = true }
+borsh = { workspace = true, optional = true }
 bs58 = { workspace = true }
 bytemuck = { workspace = true, features = ["derive"] }
 byteorder = { workspace = true, optional = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -36,7 +36,6 @@ full = [
 ]
 borsh = ["dep:borsh", "solana-program/borsh"]
 dev-context-only-utils = [
-  "borsh",
   "qualifier_attr"
 ]
 frozen-abi = [

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -14,8 +14,8 @@ rust-version = "1.75.0" # solana platform-tools rust version
 [dependencies]
 bincode = { workspace = true }
 blake3 = { workspace = true, features = ["digest", "traits-preview"] }
-borsh = { workspace = true }
-borsh0-10 = { package = "borsh", version = "0.10.3" }
+borsh = { workspace = true, optional = true }
+borsh0-10 = { package = "borsh", version = "0.10.3", optional = true }
 bs58 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true, features = ["derive"] }
@@ -92,5 +92,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = []
+default = ["borsh"]
+borsh = ["dep:borsh", "dep:borsh0-10"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/sdk/program/src/blake3.rs
+++ b/sdk/program/src/blake3.rs
@@ -2,9 +2,10 @@
 //!
 //! [blake3]: https://github.com/BLAKE3-team/BLAKE3
 
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use {
     crate::sanitize::Sanitize,
-    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     std::{convert::TryFrom, fmt, mem, str::FromStr},
     thiserror::Error,
 };
@@ -16,22 +17,12 @@ const MAX_BASE58_LEN: usize = 44;
 
 /// A blake3 hash.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(
-    Serialize,
-    Deserialize,
-    BorshSerialize,
-    BorshDeserialize,
-    BorshSchema,
-    Clone,
-    Copy,
-    Default,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
 )]
-#[borsh(crate = "borsh")]
+#[derive(Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct Hash(pub [u8; HASH_BYTES]);
 

--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -5,12 +5,13 @@
 
 use {
     crate::{sanitize::Sanitize, wasm_bindgen},
-    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     bytemuck::{Pod, Zeroable},
     sha2::{Digest, Sha256},
     std::{convert::TryFrom, fmt, mem, str::FromStr},
     thiserror::Error,
 };
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 /// Size of a hash in bytes.
 pub const HASH_BYTES: usize = 32;
@@ -29,12 +30,14 @@ const MAX_BASE58_LEN: usize = 44;
 /// [`Message::hash`]: crate::message::Message::hash
 #[wasm_bindgen]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
+)]
 #[derive(
     Serialize,
     Deserialize,
-    BorshSerialize,
-    BorshDeserialize,
-    BorshSchema,
     Clone,
     Copy,
     Default,
@@ -46,7 +49,6 @@ const MAX_BASE58_LEN: usize = 44;
     Pod,
     Zeroable,
 )]
-#[borsh(crate = "borsh")]
 #[repr(transparent)]
 pub struct Hash(pub(crate) [u8; HASH_BYTES]);
 

--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -3,6 +3,8 @@
 //! [SHA-256]: https://en.wikipedia.org/wiki/SHA-2
 //! [`Hash`]: struct@Hash
 
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use {
     crate::{sanitize::Sanitize, wasm_bindgen},
     bytemuck::{Pod, Zeroable},
@@ -10,8 +12,6 @@ use {
     std::{convert::TryFrom, fmt, mem, str::FromStr},
     thiserror::Error,
 };
-#[cfg(feature = "borsh")]
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 /// Size of a hash in bytes.
 pub const HASH_BYTES: usize = 32;

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -16,10 +16,11 @@
 use {
     crate::{pubkey::Pubkey, sanitize::Sanitize, short_vec, wasm_bindgen},
     bincode::serialize,
-    borsh::BorshSerialize,
     serde::Serialize,
     thiserror::Error,
 };
+#[cfg(feature = "borsh")]
+use borsh::BorshSerialize;
 
 /// Reasons the runtime might have rejected an instruction.
 ///
@@ -339,6 +340,7 @@ pub struct Instruction {
 }
 
 impl Instruction {
+    #[cfg(feature = "borsh")]
     /// Create a new instruction from a value, encoded with [`borsh`].
     ///
     /// [`borsh`]: https://docs.rs/borsh/latest/borsh/

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -13,14 +13,14 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 
+#[cfg(feature = "borsh")]
+use borsh::BorshSerialize;
 use {
     crate::{pubkey::Pubkey, sanitize::Sanitize, short_vec, wasm_bindgen},
     bincode::serialize,
     serde::Serialize,
     thiserror::Error,
 };
-#[cfg(feature = "borsh")]
-use borsh::BorshSerialize;
 
 /// Reasons the runtime might have rejected an instruction.
 ///

--- a/sdk/program/src/keccak.rs
+++ b/sdk/program/src/keccak.rs
@@ -2,14 +2,14 @@
 //!
 //! [keccak]: https://keccak.team/keccak.html
 
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use {
     crate::sanitize::Sanitize,
     sha3::{Digest, Keccak256},
     std::{convert::TryFrom, fmt, mem, str::FromStr},
     thiserror::Error,
 };
-#[cfg(feature = "borsh")]
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 pub const HASH_BYTES: usize = 32;
 /// Maximum string length of a base58 encoded hash
@@ -20,18 +20,7 @@ const MAX_BASE58_LEN: usize = 44;
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
     borsh(crate = "borsh")
 )]
-#[derive(
-    Serialize,
-    Deserialize,
-    Clone,
-    Copy,
-    Default,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-)]
+#[derive(Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct Hash(pub [u8; HASH_BYTES]);
 

--- a/sdk/program/src/keccak.rs
+++ b/sdk/program/src/keccak.rs
@@ -4,22 +4,25 @@
 
 use {
     crate::sanitize::Sanitize,
-    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     sha3::{Digest, Keccak256},
     std::{convert::TryFrom, fmt, mem, str::FromStr},
     thiserror::Error,
 };
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 pub const HASH_BYTES: usize = 32;
 /// Maximum string length of a base58 encoded hash
 const MAX_BASE58_LEN: usize = 44;
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
+)]
 #[derive(
     Serialize,
     Deserialize,
-    BorshSerialize,
-    BorshDeserialize,
-    BorshSchema,
     Clone,
     Copy,
     Default,
@@ -29,7 +32,6 @@ const MAX_BASE58_LEN: usize = 44;
     PartialOrd,
     Hash,
 )]
-#[borsh(crate = "borsh")]
 #[repr(transparent)]
 pub struct Hash(pub [u8; HASH_BYTES]);
 

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -475,8 +475,11 @@ pub mod alt_bn128;
 pub(crate) mod atomic_u64;
 pub mod big_mod_exp;
 pub mod blake3;
+#[cfg(feature = "borsh")]
 pub mod borsh;
+#[cfg(feature = "borsh")]
 pub mod borsh0_10;
+#[cfg(feature = "borsh")]
 pub mod borsh1;
 pub mod bpf_loader;
 pub mod bpf_loader_deprecated;

--- a/sdk/program/src/program_error.rs
+++ b/sdk/program/src/program_error.rs
@@ -3,11 +3,12 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
     crate::{decode_error::DecodeError, instruction::InstructionError, msg, pubkey::PubkeyError},
-    borsh::io::Error as BorshIoError,
     num_traits::{FromPrimitive, ToPrimitive},
     std::convert::TryFrom,
     thiserror::Error,
 };
+#[cfg(feature = "borsh")]
+use borsh::io::Error as BorshIoError;
 
 /// Reasons the program may fail
 #[derive(Clone, Debug, Deserialize, Eq, Error, PartialEq, Serialize)]
@@ -343,6 +344,7 @@ impl From<PubkeyError> for ProgramError {
     }
 }
 
+#[cfg(feature = "borsh")]
 impl From<BorshIoError> for ProgramError {
     fn from(error: BorshIoError) -> Self {
         Self::BorshIoError(format!("{error}"))

--- a/sdk/program/src/program_error.rs
+++ b/sdk/program/src/program_error.rs
@@ -1,14 +1,14 @@
 //! The [`ProgramError`] type and related definitions.
 
 #![allow(clippy::arithmetic_side_effects)]
+#[cfg(feature = "borsh")]
+use borsh::io::Error as BorshIoError;
 use {
     crate::{decode_error::DecodeError, instruction::InstructionError, msg, pubkey::PubkeyError},
     num_traits::{FromPrimitive, ToPrimitive},
     std::convert::TryFrom,
     thiserror::Error,
 };
-#[cfg(feature = "borsh")]
-use borsh::io::Error as BorshIoError;
 
 /// Reasons the program may fail
 #[derive(Clone, Debug, Deserialize, Eq, Error, PartialEq, Serialize)]

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -4,6 +4,8 @@
 
 #[cfg(test)]
 use arbitrary::Arbitrary;
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use {
     crate::{decode_error::DecodeError, hash::hashv, wasm_bindgen},
     bytemuck::{Pod, Zeroable},
@@ -15,8 +17,6 @@ use {
     },
     thiserror::Error,
 };
-#[cfg(feature = "borsh")]
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 /// Number of bytes in a pubkey
 pub const PUBKEY_BYTES: usize = 32;

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -6,7 +6,6 @@
 use arbitrary::Arbitrary;
 use {
     crate::{decode_error::DecodeError, hash::hashv, wasm_bindgen},
-    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     bytemuck::{Pod, Zeroable},
     num_derive::{FromPrimitive, ToPrimitive},
     std::{
@@ -16,6 +15,8 @@ use {
     },
     thiserror::Error,
 };
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 /// Number of bytes in a pubkey
 pub const PUBKEY_BYTES: usize = 32;
@@ -70,10 +71,12 @@ impl From<u64> for PubkeyError {
 #[wasm_bindgen]
 #[repr(transparent)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
+)]
 #[derive(
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
     Clone,
     Copy,
     Default,
@@ -87,7 +90,6 @@ impl From<u64> for PubkeyError {
     Serialize,
     Zeroable,
 )]
-#[borsh(crate = "borsh")]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct Pubkey(pub(crate) [u8; 32]);
 
@@ -675,6 +677,7 @@ impl fmt::Display for Pubkey {
     }
 }
 
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for Pubkey {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -685,6 +688,7 @@ impl borsh0_10::de::BorshDeserialize for Pubkey {
     }
 }
 
+#[cfg(feature = "borsh")]
 macro_rules! impl_borsh_schema {
     ($borsh:ident) => {
         impl $borsh::BorshSchema for Pubkey
@@ -716,8 +720,10 @@ macro_rules! impl_borsh_schema {
         }
     };
 }
+#[cfg(feature = "borsh")]
 impl_borsh_schema!(borsh0_10);
 
+#[cfg(feature = "borsh")]
 macro_rules! impl_borsh_serialize {
     ($borsh:ident) => {
         impl $borsh::ser::BorshSerialize for Pubkey {
@@ -731,6 +737,7 @@ macro_rules! impl_borsh_serialize {
         }
     };
 }
+#[cfg(feature = "borsh")]
 impl_borsh_serialize!(borsh0_10);
 
 #[cfg(test)]
@@ -964,6 +971,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "borsh")]
     fn pubkey_from_seed_by_marker(marker: &[u8]) -> Result<Pubkey, PubkeyError> {
         let key = Pubkey::new_unique();
         let owner = Pubkey::default();
@@ -977,6 +985,7 @@ mod tests {
         Pubkey::create_with_seed(&key, seed, base)
     }
 
+    #[cfg(feature = "borsh")]
     #[test]
     fn test_create_with_seed_rejects_illegal_owner() {
         assert_eq!(

--- a/sdk/program/src/secp256k1_recover.rs
+++ b/sdk/program/src/secp256k1_recover.rs
@@ -25,10 +25,11 @@
 //! [`ecrecover`]: https://docs.soliditylang.org/en/v0.8.14/units-and-global-variables.html?highlight=ecrecover#mathematical-and-cryptographic-functions
 
 use {
-    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     core::convert::TryFrom,
     thiserror::Error,
 };
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum Secp256k1RecoverError {
@@ -66,10 +67,14 @@ pub const SECP256K1_PUBLIC_KEY_LENGTH: usize = 64;
 
 #[repr(transparent)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(
-    BorshSerialize, BorshDeserialize, BorshSchema, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash,
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
 )]
-#[borsh(crate = "borsh")]
+#[derive(
+    Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash,
+)]
 pub struct Secp256k1Pubkey(pub [u8; SECP256K1_PUBLIC_KEY_LENGTH]);
 
 impl Secp256k1Pubkey {

--- a/sdk/program/src/secp256k1_recover.rs
+++ b/sdk/program/src/secp256k1_recover.rs
@@ -24,12 +24,9 @@
 //! [sp]: crate::secp256k1_program
 //! [`ecrecover`]: https://docs.soliditylang.org/en/v0.8.14/units-and-global-variables.html?highlight=ecrecover#mathematical-and-cryptographic-functions
 
-use {
-    core::convert::TryFrom,
-    thiserror::Error,
-};
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use {core::convert::TryFrom, thiserror::Error};
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum Secp256k1RecoverError {
@@ -72,9 +69,7 @@ pub const SECP256K1_PUBLIC_KEY_LENGTH: usize = 64;
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
     borsh(crate = "borsh")
 )]
-#[derive(
-    Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash,
-)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Secp256k1Pubkey(pub [u8; SECP256K1_PUBLIC_KEY_LENGTH]);
 
 impl Secp256k1Pubkey {

--- a/sdk/program/src/serialize_utils/cursor.rs
+++ b/sdk/program/src/serialize_utils/cursor.rs
@@ -70,6 +70,7 @@ pub(crate) fn read_bool<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<bool, 
     }
 }
 
+#[cfg(feature = "borsh")]
 #[cfg(test)]
 mod test {
     use {super::*, rand::Rng, std::fmt::Debug};

--- a/sdk/program/src/stake/stake_flags.rs
+++ b/sdk/program/src/stake/stake_flags.rs
@@ -1,13 +1,16 @@
+#[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 /// Additional flags for stake state.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
+)]
 #[derive(
     Serialize,
     Deserialize,
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
     Copy,
     PartialEq,
     Eq,
@@ -17,10 +20,11 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
     Hash,
     Debug,
 )]
-#[borsh(crate = "borsh")]
 pub struct StakeFlags {
     bits: u8,
 }
+
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for StakeFlags {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -30,6 +34,8 @@ impl borsh0_10::de::BorshDeserialize for StakeFlags {
         })
     }
 }
+
+#[cfg(feature = "borsh")]
 impl borsh0_10::BorshSchema for StakeFlags {
     fn declaration() -> borsh0_10::schema::Declaration {
         "StakeFlags".to_string()
@@ -55,6 +61,8 @@ impl borsh0_10::BorshSchema for StakeFlags {
         <u8 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+
+#[cfg(feature = "borsh")]
 impl borsh0_10::ser::BorshSerialize for StakeFlags {
     fn serialize<W: borsh0_10::maybestd::io::Write>(
         &self,

--- a/sdk/program/src/stake/stake_flags.rs
+++ b/sdk/program/src/stake/stake_flags.rs
@@ -8,18 +8,7 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
     borsh(crate = "borsh")
 )]
-#[derive(
-    Serialize,
-    Deserialize,
-    Copy,
-    PartialEq,
-    Eq,
-    Clone,
-    PartialOrd,
-    Ord,
-    Hash,
-    Debug,
-)]
+#[derive(Serialize, Deserialize, Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
 pub struct StakeFlags {
     bits: u8,
 }

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -14,9 +14,10 @@ use {
         },
         stake_history::{StakeHistory, StakeHistoryEntry},
     },
-    borsh::{io, BorshDeserialize, BorshSchema, BorshSerialize},
     std::collections::HashSet,
 };
+#[cfg(feature = "borsh")]
+use borsh::{io, BorshDeserialize, BorshSchema, BorshSerialize};
 
 pub type StakeActivationStatus = StakeHistoryEntry;
 
@@ -34,6 +35,7 @@ pub fn warmup_cooldown_rate(current_epoch: Epoch, new_rate_activation_epoch: Opt
     }
 }
 
+#[cfg(feature = "borsh")]
 macro_rules! impl_borsh_stake_state {
     ($borsh:ident) => {
         impl $borsh::BorshDeserialize for StakeState {
@@ -91,7 +93,9 @@ pub enum StakeState {
     Stake(Meta, Stake),
     RewardsPool,
 }
+#[cfg(feature = "borsh")]
 impl_borsh_stake_state!(borsh);
+#[cfg(feature = "borsh")]
 impl_borsh_stake_state!(borsh0_10);
 impl StakeState {
     /// The fixed number of bytes used to serialize each stake account
@@ -144,6 +148,7 @@ pub enum StakeStateV2 {
     Stake(Meta, Stake, StakeFlags),
     RewardsPool,
 }
+#[cfg(feature = "borsh")]
 macro_rules! impl_borsh_stake_state_v2 {
     ($borsh:ident) => {
         impl $borsh::BorshDeserialize for StakeStateV2 {
@@ -190,7 +195,9 @@ macro_rules! impl_borsh_stake_state_v2 {
         }
     };
 }
+#[cfg(feature = "borsh")]
 impl_borsh_stake_state_v2!(borsh);
+#[cfg(feature = "borsh")]
 impl_borsh_stake_state_v2!(borsh0_10);
 
 impl StakeStateV2 {
@@ -242,6 +249,11 @@ pub enum StakeAuthorize {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
+)]
 #[derive(
     Default,
     Debug,
@@ -251,11 +263,7 @@ pub enum StakeAuthorize {
     Eq,
     Clone,
     Copy,
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
 )]
-#[borsh(crate = "borsh")]
 pub struct Lockup {
     /// UnixTimestamp at which this stake will allow withdrawal, unless the
     ///   transaction is signed by the custodian
@@ -275,6 +283,7 @@ impl Lockup {
         self.unix_timestamp > clock.unix_timestamp || self.epoch > clock.epoch
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for Lockup {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -286,6 +295,7 @@ impl borsh0_10::de::BorshDeserialize for Lockup {
         })
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::BorshSchema for Lockup {
     fn declaration() -> borsh0_10::schema::Declaration {
         "Lockup".to_string()
@@ -323,6 +333,7 @@ impl borsh0_10::BorshSchema for Lockup {
         <Pubkey as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::ser::BorshSerialize for Lockup {
     fn serialize<W: borsh0_10::maybestd::io::Write>(
         &self,
@@ -336,6 +347,11 @@ impl borsh0_10::ser::BorshSerialize for Lockup {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
+)]
 #[derive(
     Default,
     Debug,
@@ -345,11 +361,7 @@ impl borsh0_10::ser::BorshSerialize for Lockup {
     Eq,
     Clone,
     Copy,
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
 )]
-#[borsh(crate = "borsh")]
 pub struct Authorized {
     pub staker: Pubkey,
     pub withdrawer: Pubkey,
@@ -415,6 +427,7 @@ impl Authorized {
         Ok(())
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for Authorized {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -425,6 +438,7 @@ impl borsh0_10::de::BorshDeserialize for Authorized {
         })
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::BorshSchema for Authorized {
     fn declaration() -> borsh0_10::schema::Declaration {
         "Authorized".to_string()
@@ -457,6 +471,7 @@ impl borsh0_10::BorshSchema for Authorized {
         <Pubkey as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::ser::BorshSerialize for Authorized {
     fn serialize<W: borsh0_10::maybestd::io::Write>(
         &self,
@@ -469,6 +484,11 @@ impl borsh0_10::ser::BorshSerialize for Authorized {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
+)]
 #[derive(
     Default,
     Debug,
@@ -478,11 +498,7 @@ impl borsh0_10::ser::BorshSerialize for Authorized {
     Eq,
     Clone,
     Copy,
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
 )]
-#[borsh(crate = "borsh")]
 pub struct Meta {
     pub rent_exempt_reserve: u64,
     pub authorized: Authorized,
@@ -525,6 +541,7 @@ impl Meta {
         }
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for Meta {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -536,6 +553,7 @@ impl borsh0_10::de::BorshDeserialize for Meta {
         })
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::BorshSchema for Meta {
     fn declaration() -> borsh0_10::schema::Declaration {
         "Meta".to_string()
@@ -573,6 +591,7 @@ impl borsh0_10::BorshSchema for Meta {
         <Lockup as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::ser::BorshSerialize for Meta {
     fn serialize<W: borsh0_10::maybestd::io::Write>(
         &self,
@@ -586,6 +605,11 @@ impl borsh0_10::ser::BorshSerialize for Meta {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
+)]
 #[derive(
     Debug,
     Serialize,
@@ -593,11 +617,7 @@ impl borsh0_10::ser::BorshSerialize for Meta {
     PartialEq,
     Clone,
     Copy,
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
 )]
-#[borsh(crate = "borsh")]
 pub struct Delegation {
     /// to whom the stake is delegated
     pub voter_pubkey: Pubkey,
@@ -825,6 +845,7 @@ impl Delegation {
         }
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for Delegation {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -838,6 +859,7 @@ impl borsh0_10::de::BorshDeserialize for Delegation {
         })
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::BorshSchema for Delegation {
     fn declaration() -> borsh0_10::schema::Declaration {
         "Delegation".to_string()
@@ -885,6 +907,7 @@ impl borsh0_10::BorshSchema for Delegation {
         <f64 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::ser::BorshSerialize for Delegation {
     fn serialize<W: borsh0_10::maybestd::io::Write>(
         &self,
@@ -900,6 +923,11 @@ impl borsh0_10::ser::BorshSerialize for Delegation {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
+)]
 #[derive(
     Debug,
     Default,
@@ -908,11 +936,7 @@ impl borsh0_10::ser::BorshSerialize for Delegation {
     PartialEq,
     Clone,
     Copy,
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
 )]
-#[borsh(crate = "borsh")]
 pub struct Stake {
     pub delegation: Delegation,
     /// credits observed is credits from vote account state when delegated or redeemed
@@ -958,6 +982,7 @@ impl Stake {
         }
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for Stake {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -968,6 +993,7 @@ impl borsh0_10::de::BorshDeserialize for Stake {
         })
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::BorshSchema for Stake {
     fn declaration() -> borsh0_10::schema::Declaration {
         "Stake".to_string()
@@ -1000,6 +1026,7 @@ impl borsh0_10::BorshSchema for Stake {
         <u64 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::ser::BorshSerialize for Stake {
     fn serialize<W: borsh0_10::maybestd::io::Write>(
         &self,
@@ -1014,27 +1041,33 @@ impl borsh0_10::ser::BorshSerialize for Stake {
 #[cfg(test)]
 mod test {
     use {
-        super::*, crate::borsh1::try_from_slice_unchecked, assert_matches::assert_matches,
+        super::*, assert_matches::assert_matches,
         bincode::serialize,
     };
+    #[cfg(feature = "borsh")]
+    use crate::borsh1::try_from_slice_unchecked;
 
+    #[cfg(feature = "borsh")]
     fn check_borsh_deserialization(stake: StakeStateV2) {
         let serialized = serialize(&stake).unwrap();
         let deserialized = StakeStateV2::try_from_slice(&serialized).unwrap();
         assert_eq!(stake, deserialized);
     }
 
+    #[cfg(feature = "borsh")]
     fn check_borsh_serialization(stake: StakeStateV2) {
         let bincode_serialized = serialize(&stake).unwrap();
         let borsh_serialized = borsh::to_vec(&stake).unwrap();
         assert_eq!(bincode_serialized, borsh_serialized);
     }
 
+    #[cfg(feature = "borsh")]
     #[test]
     fn test_size_of() {
         assert_eq!(StakeStateV2::size_of(), std::mem::size_of::<StakeStateV2>());
     }
 
+    #[cfg(feature = "borsh")]
     #[test]
     fn bincode_vs_borsh_deserialization() {
         check_borsh_deserialization(StakeStateV2::Uninitialized);
@@ -1070,6 +1103,7 @@ mod test {
         ));
     }
 
+    #[cfg(feature = "borsh")]
     #[test]
     fn bincode_vs_borsh_serialization() {
         check_borsh_serialization(StakeStateV2::Uninitialized);
@@ -1105,6 +1139,7 @@ mod test {
         ));
     }
 
+    #[cfg(feature = "borsh")]
     #[test]
     fn borsh_deserialization_live_data() {
         let data = [
@@ -1171,12 +1206,14 @@ mod test {
 
     mod deprecated {
         use super::*;
+        #[cfg(feature = "borsh")]
         fn check_borsh_deserialization(stake: StakeState) {
             let serialized = serialize(&stake).unwrap();
             let deserialized = StakeState::try_from_slice(&serialized).unwrap();
             assert_eq!(stake, deserialized);
         }
 
+        #[cfg(feature = "borsh")]
         fn check_borsh_serialization(stake: StakeState) {
             let bincode_serialized = serialize(&stake).unwrap();
             let borsh_serialized = borsh::to_vec(&stake).unwrap();
@@ -1188,6 +1225,7 @@ mod test {
             assert_eq!(StakeState::size_of(), std::mem::size_of::<StakeState>());
         }
 
+        #[cfg(feature = "borsh")]
         #[test]
         fn bincode_vs_borsh_deserialization() {
             check_borsh_deserialization(StakeState::Uninitialized);
@@ -1222,6 +1260,7 @@ mod test {
             ));
         }
 
+        #[cfg(feature = "borsh")]
         #[test]
         fn bincode_vs_borsh_serialization() {
             check_borsh_serialization(StakeState::Uninitialized);
@@ -1256,6 +1295,7 @@ mod test {
             ));
         }
 
+        #[cfg(feature = "borsh")]
         #[test]
         fn borsh_deserialization_live_data() {
             let data = [

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -3,6 +3,8 @@
 // warnings from uses of deprecated types during trait derivations.
 #![allow(deprecated)]
 
+#[cfg(feature = "borsh")]
+use borsh::{io, BorshDeserialize, BorshSchema, BorshSerialize};
 use {
     crate::{
         clock::{Clock, Epoch, UnixTimestamp},
@@ -16,8 +18,6 @@ use {
     },
     std::collections::HashSet,
 };
-#[cfg(feature = "borsh")]
-use borsh::{io, BorshDeserialize, BorshSchema, BorshSerialize};
 
 pub type StakeActivationStatus = StakeHistoryEntry;
 
@@ -254,16 +254,7 @@ pub enum StakeAuthorize {
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
     borsh(crate = "borsh")
 )]
-#[derive(
-    Default,
-    Debug,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Eq,
-    Clone,
-    Copy,
-)]
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub struct Lockup {
     /// UnixTimestamp at which this stake will allow withdrawal, unless the
     ///   transaction is signed by the custodian
@@ -352,16 +343,7 @@ impl borsh0_10::ser::BorshSerialize for Lockup {
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
     borsh(crate = "borsh")
 )]
-#[derive(
-    Default,
-    Debug,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Eq,
-    Clone,
-    Copy,
-)]
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub struct Authorized {
     pub staker: Pubkey,
     pub withdrawer: Pubkey,
@@ -489,16 +471,7 @@ impl borsh0_10::ser::BorshSerialize for Authorized {
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
     borsh(crate = "borsh")
 )]
-#[derive(
-    Default,
-    Debug,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Eq,
-    Clone,
-    Copy,
-)]
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub struct Meta {
     pub rent_exempt_reserve: u64,
     pub authorized: Authorized,
@@ -610,14 +583,7 @@ impl borsh0_10::ser::BorshSerialize for Meta {
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
     borsh(crate = "borsh")
 )]
-#[derive(
-    Debug,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Clone,
-    Copy,
-)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub struct Delegation {
     /// to whom the stake is delegated
     pub voter_pubkey: Pubkey,
@@ -928,15 +894,7 @@ impl borsh0_10::ser::BorshSerialize for Delegation {
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
     borsh(crate = "borsh")
 )]
-#[derive(
-    Debug,
-    Default,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Clone,
-    Copy,
-)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub struct Stake {
     pub delegation: Delegation,
     /// credits observed is credits from vote account state when delegated or redeemed
@@ -1040,12 +998,9 @@ impl borsh0_10::ser::BorshSerialize for Stake {
 
 #[cfg(test)]
 mod test {
-    use {
-        super::*, assert_matches::assert_matches,
-        bincode::serialize,
-    };
     #[cfg(feature = "borsh")]
     use crate::borsh1::try_from_slice_unchecked;
+    use {super::*, assert_matches::assert_matches, bincode::serialize};
 
     #[cfg(feature = "borsh")]
     fn check_borsh_deserialization(stake: StakeStateV2) {

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -2,6 +2,7 @@
 
 #![cfg(feature = "full")]
 
+#[cfg(feature = "borsh")]
 use {
     crate::instruction::Instruction,
     borsh::{BorshDeserialize, BorshSerialize},
@@ -29,16 +30,19 @@ pub enum ComputeBudgetInstruction {
 }
 
 impl ComputeBudgetInstruction {
+    #[cfg(feature = "borsh")]
     /// Create a `ComputeBudgetInstruction::RequestHeapFrame` `Instruction`
     pub fn request_heap_frame(bytes: u32) -> Instruction {
         Instruction::new_with_borsh(id(), &Self::RequestHeapFrame(bytes), vec![])
     }
 
+    #[cfg(feature = "borsh")]
     /// Create a `ComputeBudgetInstruction::SetComputeUnitLimit` `Instruction`
     pub fn set_compute_unit_limit(units: u32) -> Instruction {
         Instruction::new_with_borsh(id(), &Self::SetComputeUnitLimit(units), vec![])
     }
 
+    #[cfg(feature = "borsh")]
     /// Create a `ComputeBudgetInstruction::SetComputeUnitPrice` `Instruction`
     pub fn set_compute_unit_price(micro_lamports: u64) -> Instruction {
         Instruction::new_with_borsh(id(), &Self::SetComputeUnitPrice(micro_lamports), vec![])
@@ -51,6 +55,7 @@ impl ComputeBudgetInstruction {
         borsh::to_vec(&self)
     }
 
+    #[cfg(feature = "borsh")]
     /// Create a `ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit` `Instruction`
     pub fn set_loaded_accounts_data_size_limit(bytes: u32) -> Instruction {
         Instruction::new_with_borsh(id(), &Self::SetLoadedAccountsDataSizeLimit(bytes), vec![])

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -50,7 +50,7 @@ impl ComputeBudgetInstruction {
 
     /// Serialize Instruction using borsh, this is only used in runtime::cost_model::tests but compilation
     /// can't be restricted as it's used across packages
-    #[cfg(feature = "dev-context-only-utils")]
+    #[cfg(all(feature = "dev-context-only-utils", feature = "borsh"))]
     pub fn pack(self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(&self)
     }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -42,7 +42,7 @@ pub use solana_program::program_stubs;
 // These solana_program imports could be *-imported, but that causes a bunch of
 // confusing duplication in the docs due to a rustdoc bug. #26211
 pub use solana_program::{
-    account_info, address_lookup_table, alt_bn128, big_mod_exp, blake3, borsh, borsh0_10, borsh1,
+    account_info, address_lookup_table, alt_bn128, big_mod_exp, blake3,
     bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, clock, config, custom_heap_default,
     custom_panic_default, debug_account_data, declare_deprecated_sysvar_id, declare_sysvar_id,
     decode_error, ed25519_program, epoch_rewards, epoch_schedule, fee_calculator, impl_sysvar_get,
@@ -53,6 +53,8 @@ pub use solana_program::{
     stable_layout, stake, stake_history, syscalls, system_instruction, system_program, sysvar,
     unchecked_div_by_const, vote, wasm_bindgen,
 };
+#[cfg(feature = "borsh")]
+pub use solana_program::{borsh, borsh0_10, borsh1};
 #[allow(deprecated)]
 pub use solana_program::{address_lookup_table_account, sdk_ids};
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -42,8 +42,8 @@ pub use solana_program::program_stubs;
 // These solana_program imports could be *-imported, but that causes a bunch of
 // confusing duplication in the docs due to a rustdoc bug. #26211
 pub use solana_program::{
-    account_info, address_lookup_table, alt_bn128, big_mod_exp, blake3,
-    bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, clock, config, custom_heap_default,
+    account_info, address_lookup_table, alt_bn128, big_mod_exp, blake3, bpf_loader,
+    bpf_loader_deprecated, bpf_loader_upgradeable, clock, config, custom_heap_default,
     custom_panic_default, debug_account_data, declare_deprecated_sysvar_id, declare_sysvar_id,
     decode_error, ed25519_program, epoch_rewards, epoch_schedule, fee_calculator, impl_sysvar_get,
     incinerator, instruction, keccak, lamports, loader_instruction, loader_upgradeable_instruction,
@@ -53,10 +53,10 @@ pub use solana_program::{
     stable_layout, stake, stake_history, syscalls, system_instruction, system_program, sysvar,
     unchecked_div_by_const, vote, wasm_bindgen,
 };
-#[cfg(feature = "borsh")]
-pub use solana_program::{borsh, borsh0_10, borsh1};
 #[allow(deprecated)]
 pub use solana_program::{address_lookup_table_account, sdk_ids};
+#[cfg(feature = "borsh")]
+pub use solana_program::{borsh, borsh0_10, borsh1};
 
 pub mod account;
 pub mod account_utils;


### PR DESCRIPTION
#### Problem
Borsh is an annoying dependency and most parts of the sdk and program crates are still useful without it.

Note: new crates are usually preferable to new features, but most of the borsh usage is in `derive` attributes that can't go in a new crate


#### Summary of Changes
- Puts borsh stuff behind a `borsh` feature in solana-sdk and solana-program
- Adds the `borsh` feature to default-features
- Activates the `borsh` feature in solana-program when it is activated in solana-sdk