### PR TITLE
solana-program: stake to program error

### DIFF
--- a/sdk/program/src/stake/instruction.rs
+++ b/sdk/program/src/stake/instruction.rs
@@ -5,6 +5,7 @@ use {
         clock::{Epoch, UnixTimestamp},
         decode_error::DecodeError,
         instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
         pubkey::Pubkey,
         stake::{
             program::id,
@@ -77,6 +78,12 @@ pub enum StakeError {
 
     #[error("stake action is not permitted while the epoch rewards period is active")]
     EpochRewardsActive,
+}
+
+impl From<StakeError> for ProgramError {
+    fn from(e: StakeError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
 }
 
 impl<E> DecodeError<E> for StakeError {


### PR DESCRIPTION
#### Problem
not being able to `.into()` a `StakeError` in tests has been a minor annoyance that i want to fix now that im putting new stake program tests in monorepo

before:
```rust
assert_eq!(e, ProgramError::Custom(10));
```

after:
```rust
assert_eq!(e, StakeError::VoteAddressMismatch.into());
```

this will also be used in the bpf stake program because im changing from `InstructionError` to `ProgramError`

#### Summary of Changes
`impl From<StakeError> for ProgramError`