### PR TITLE
SVM: remove usage of program cache from load_program_with_pubkey()

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -704,7 +704,7 @@ impl ProgramCacheForTxBatch {
         Self {
             entries: HashMap::new(),
             slot,
-            environments: cache.get_environments_for_epoch(epoch).clone(),
+            environments: cache.get_environments_for_epoch(epoch),
             upcoming_environments: cache.get_upcoming_environments_for_epoch(epoch),
             latest_root_epoch: cache.latest_root_epoch,
             hit_max_limit: false,
@@ -802,13 +802,13 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     }
 
     /// Returns the current environments depending on the given epoch
-    pub fn get_environments_for_epoch(&self, epoch: Epoch) -> &ProgramRuntimeEnvironments {
+    pub fn get_environments_for_epoch(&self, epoch: Epoch) -> ProgramRuntimeEnvironments {
         if epoch != self.latest_root_epoch {
             if let Some(upcoming_environments) = self.upcoming_environments.as_ref() {
-                return upcoming_environments;
+                return upcoming_environments.clone();
             }
         }
-        &self.environments
+        self.environments.clone()
     }
 
     /// Returns the upcoming environments depending on the given epoch

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6746,13 +6746,14 @@ impl Bank {
         reload: bool,
         effective_epoch: Epoch,
     ) -> Option<Arc<ProgramCacheEntry>> {
-        let program_cache = self.transaction_processor.program_cache.read().unwrap();
+        let environments = self
+            .transaction_processor
+            .get_environments_for_epoch(effective_epoch);
         load_program_with_pubkey(
             self,
-            &program_cache,
+            &environments,
             pubkey,
             self.slot(),
-            effective_epoch,
             self.epoch_schedule(),
             reload,
         )

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12006,16 +12006,14 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase() {
         .read()
         .unwrap()
         .get_environments_for_epoch(0)
-        .program_runtime_v1
-        .clone();
+        .program_runtime_v1;
     let upcoming_env = bank
         .transaction_processor
         .program_cache
         .read()
         .unwrap()
         .get_environments_for_epoch(1)
-        .program_runtime_v1
-        .clone();
+        .program_runtime_v1;
 
     // Advance the bank to recompile the program.
     {

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -2,8 +2,8 @@ use {
     crate::transaction_processing_callback::TransactionProcessingCallback,
     solana_program_runtime::{
         loaded_programs::{
-            ForkGraph, LoadProgramMetrics, ProgramCache, ProgramCacheEntry, ProgramCacheEntryOwner,
-            ProgramCacheEntryType, ProgramRuntimeEnvironment, DELAY_VISIBILITY_SLOT_OFFSET,
+            LoadProgramMetrics, ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
+            ProgramRuntimeEnvironment, ProgramRuntimeEnvironments, DELAY_VISIBILITY_SLOT_OFFSET,
         },
         timings::ExecuteDetailsTimings,
     },
@@ -12,7 +12,7 @@ use {
         account_utils::StateMut,
         bpf_loader, bpf_loader_deprecated,
         bpf_loader_upgradeable::UpgradeableLoaderState,
-        clock::{Epoch, Slot},
+        clock::Slot,
         epoch_schedule::EpochSchedule,
         instruction::InstructionError,
         loader_v4::{self, LoaderV4State, LoaderV4Status},
@@ -121,16 +121,14 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
 /// If the account doesn't exist it returns `None`. If the account does exist, it must be a program
 /// account (belong to one of the program loaders). Returns `Some(InvalidAccountData)` if the program
 /// account is `Closed`, contains invalid data or any of the programdata accounts are invalid.
-pub fn load_program_with_pubkey<CB: TransactionProcessingCallback, FG: ForkGraph>(
+pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     callbacks: &CB,
-    program_cache: &ProgramCache<FG>,
+    environments: &ProgramRuntimeEnvironments,
     pubkey: &Pubkey,
     slot: Slot,
-    effective_epoch: Epoch,
     _epoch_schedule: &EpochSchedule,
     reload: bool,
 ) -> Option<Arc<ProgramCacheEntry>> {
-    let environments = program_cache.get_environments_for_epoch(effective_epoch);
     let mut load_program_metrics = LoadProgramMetrics {
         program_id: pubkey.to_string(),
         ..LoadProgramMetrics::default()
@@ -227,7 +225,7 @@ mod tests {
         super::*,
         crate::transaction_processor::TransactionBatchProcessor,
         solana_program_runtime::{
-            loaded_programs::{BlockRelation, ProgramRuntimeEnvironments},
+            loaded_programs::{BlockRelation, ForkGraph, ProgramRuntimeEnvironments},
             solana_rbpf::program::BuiltinProgram,
         },
         solana_sdk::{
@@ -507,14 +505,12 @@ mod tests {
         let mock_bank = MockBankCallback::default();
         let key = Pubkey::new_unique();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let program_cache = batch_processor.program_cache.read().unwrap();
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &program_cache,
+            &batch_processor.get_environments_for_epoch(50),
             &key,
             500,
-            50,
             &batch_processor.epoch_schedule,
             false,
         );
@@ -533,14 +529,11 @@ mod tests {
             .borrow_mut()
             .insert(key, account_data.clone());
 
-        let program_cache = batch_processor.program_cache.read().unwrap();
-
         let result = load_program_with_pubkey(
             &mock_bank,
-            &program_cache,
+            &batch_processor.get_environments_for_epoch(20),
             &key,
             0, // Slot 0
-            20,
             &batch_processor.epoch_schedule,
             false,
         );
@@ -573,15 +566,12 @@ mod tests {
             .borrow_mut()
             .insert(key, account_data.clone());
 
-        let program_cache = batch_processor.program_cache.read().unwrap();
-
         // This should return an error
         let result = load_program_with_pubkey(
             &mock_bank,
-            &program_cache,
+            &batch_processor.get_environments_for_epoch(20),
             &key,
             200,
-            20,
             &batch_processor.epoch_schedule,
             false,
         );
@@ -610,10 +600,9 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &program_cache,
+            &batch_processor.get_environments_for_epoch(20),
             &key,
             200,
-            20,
             &batch_processor.epoch_schedule,
             false,
         );
@@ -638,7 +627,6 @@ mod tests {
         let key2 = Pubkey::new_unique();
         let mock_bank = MockBankCallback::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let program_cache = batch_processor.program_cache.read().unwrap();
 
         let mut account_data = AccountSharedData::default();
         account_data.set_owner(bpf_loader_upgradeable::id());
@@ -666,9 +654,8 @@ mod tests {
         // This should return an error
         let result = load_program_with_pubkey(
             &mock_bank,
-            &program_cache,
+            &batch_processor.get_environments_for_epoch(0),
             &key1,
-            0,
             0,
             &batch_processor.epoch_schedule,
             false,
@@ -708,10 +695,9 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &program_cache,
+            &batch_processor.get_environments_for_epoch(20),
             &key1,
             200,
-            20,
             &batch_processor.epoch_schedule,
             false,
         );
@@ -740,7 +726,6 @@ mod tests {
         let mut account_data = AccountSharedData::default();
         account_data.set_owner(loader_v4::id());
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let program_cache = batch_processor.program_cache.read().unwrap();
 
         let loader_data = LoaderV4State {
             slot: 0,
@@ -760,9 +745,8 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &program_cache,
+            &batch_processor.get_environments_for_epoch(0),
             &key,
-            0,
             0,
             &batch_processor.epoch_schedule,
             false,
@@ -798,10 +782,9 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &program_cache,
+            &batch_processor.get_environments_for_epoch(20),
             &key,
             200,
-            20,
             &batch_processor.epoch_schedule,
             false,
         );
@@ -845,15 +828,12 @@ mod tests {
             .borrow_mut()
             .insert(key, account_data.clone());
 
-        let program_cache = batch_processor.program_cache.read().unwrap();
-
         for is_upcoming_env in [false, true] {
             let result = load_program_with_pubkey(
                 &mock_bank,
-                &program_cache,
+                &batch_processor.get_environments_for_epoch(is_upcoming_env as u64),
                 &key,
                 200,
-                is_upcoming_env as u64,
                 &batch_processor.epoch_schedule,
                 false,
             )

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -543,11 +543,7 @@ mod tests {
             ProgramCacheEntryOwner::LoaderV4,
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
-                    .program_cache
-                    .read()
-                    .unwrap()
                     .get_environments_for_epoch(20)
-                    .clone()
                     .program_runtime_v1,
             ),
         );
@@ -580,11 +576,7 @@ mod tests {
             ProgramCacheEntryOwner::LoaderV2,
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
-                    .program_cache
-                    .read()
-                    .unwrap()
                     .get_environments_for_epoch(20)
-                    .clone()
                     .program_runtime_v1,
             ),
         );
@@ -665,11 +657,7 @@ mod tests {
             ProgramCacheEntryOwner::LoaderV3,
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
-                    .program_cache
-                    .read()
-                    .unwrap()
                     .get_environments_for_epoch(0)
-                    .clone()
                     .program_runtime_v1,
             ),
         );
@@ -756,11 +744,7 @@ mod tests {
             ProgramCacheEntryOwner::LoaderV4,
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
-                    .program_cache
-                    .read()
-                    .unwrap()
                     .get_environments_for_epoch(0)
-                    .clone()
                     .program_runtime_v1,
             ),
         );

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -197,7 +197,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .read()
             .unwrap()
             .get_environments_for_epoch(epoch)
-            .clone()
     }
 
     /// Main entrypoint to the SVM.

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -22,7 +22,7 @@ use {
         invoke_context::{EnvironmentConfig, InvokeContext},
         loaded_programs::{
             ForkGraph, ProgramCache, ProgramCacheEntry, ProgramCacheForTxBatch,
-            ProgramCacheMatchCriteria,
+            ProgramCacheMatchCriteria, ProgramRuntimeEnvironments,
         },
         log_collector::LogCollector,
         sysvar_cache::SysvarCache,
@@ -189,6 +189,15 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             program_cache: self.program_cache.clone(),
             builtin_program_ids: RwLock::new(self.builtin_program_ids.read().unwrap().clone()),
         }
+    }
+
+    /// Returns the current environments depending on the given epoch
+    pub fn get_environments_for_epoch(&self, epoch: Epoch) -> ProgramRuntimeEnvironments {
+        self.program_cache
+            .read()
+            .unwrap()
+            .get_environments_for_epoch(epoch)
+            .clone()
     }
 
     /// Main entrypoint to the SVM.
@@ -416,10 +425,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     // Load, verify and compile one program.
                     let program = load_program_with_pubkey(
                         callback,
-                        &program_cache,
+                        &self.get_environments_for_epoch(self.epoch),
                         &key,
                         self.slot,
-                        self.epoch,
                         &self.epoch_schedule,
                         false,
                     )
@@ -481,17 +489,14 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             if let Some((key, program_to_recompile)) = program_cache.programs_to_recompile.pop() {
                 let effective_epoch = program_cache.latest_root_epoch.saturating_add(1);
                 drop(program_cache);
-                let program_cache_read = self.program_cache.read().unwrap();
                 if let Some(recompiled) = load_program_with_pubkey(
                     callbacks,
-                    &program_cache_read,
+                    &self.get_environments_for_epoch(effective_epoch),
                     &key,
                     self.slot,
-                    effective_epoch,
                     &self.epoch_schedule,
                     false,
                 ) {
-                    drop(program_cache_read);
                     recompiled
                         .tx_usage_counter
                         .fetch_add(program_to_recompile.tx_usage_counter.load(Relaxed), Relaxed);

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -439,10 +439,9 @@ fn execute_fixture_as_instr(
 
     let loaded_program = program_loader::load_program_with_pubkey(
         mock_bank,
-        &batch_processor.program_cache.read().unwrap(),
+        &batch_processor.get_environments_for_epoch(2),
         &program_id,
         42,
-        2,
         &batch_processor.epoch_schedule,
         false,
     )


### PR DESCRIPTION
#### Problem
Use of  `ProgramCache` in `load_program_with_pubkey()` can be removed. It's mainly used to get the instance of `RuntimeEnvironments`. That can instead be supplied by the caller. Relaxing this dependency will reduce call sites outsize SVM where `ProgramCache` is being referenced.

#### Summary of Changes

- Add accessor in `TransactionBatchProcessor` to get the `RuntimeEnvironments` for a given epoch
- Pass the environments to `load_program_with_pubkey()`, removing the need for `ProgramCache`
- Update unit tests

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
