### PR TITLE
Fix intermittent test failure in test_deny_executable_write

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4451,7 +4451,7 @@ fn test_deny_executable_write() {
         ];
 
         let mut instruction_data = vec![TEST_WRITE_ACCOUNT, 2];
-        instruction_data.extend_from_slice(4usize.to_le_bytes().as_ref());
+        instruction_data.extend_from_slice(3usize.to_le_bytes().as_ref());
         instruction_data.push(42);
         let instruction = Instruction::new_with_bytes(
             invoke_program_id,


### PR DESCRIPTION
The test was writing 42 to offset 4 of the program account. The program is upgradable, so offset 4 is first byte of the account which holds the actual elf program.

There was a chance that the first byte of the account is 42, in which case the test passes, because with the non-direct mapping case, you can write to read only accounts as long as the contents does not change.