### PR TITLE
SVM: Return error metrics from API

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3703,10 +3703,12 @@ impl Bank {
                 self,
                 sanitized_txs,
                 &mut check_results,
-                &mut error_counters,
                 timings,
                 &processing_config,
             );
+
+        // Accumulate the errors returned by the batch processor.
+        error_counters.accumulate(&sanitized_output.error_metrics);
 
         let mut signature_count = 0;
 

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -39,7 +39,6 @@ use {
         account_loader::CheckedTransactionDetails,
         program_loader,
         runtime_config::RuntimeConfig,
-        transaction_error_metrics::TransactionErrorMetrics,
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processor::{
             ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingConfig,
@@ -280,7 +279,6 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
     mock_bank.lamports_per_sginature = lamports_per_signature;
     mock_bank.blockhash = blockhash;
 
-    let mut error_counter = TransactionErrorMetrics::default();
     let recording_config = ExecutionRecordingConfig {
         enable_log_recording: true,
         enable_return_data_recording: true,
@@ -311,7 +309,6 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
         &mock_bank,
         &transactions,
         transaction_check.as_mut_slice(),
-        &mut error_counter,
         &mut timings,
         &processor_config,
     );

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -33,7 +33,6 @@ use {
     solana_svm::{
         account_loader::{CheckedTransactionDetails, TransactionCheckResult},
         runtime_config::RuntimeConfig,
-        transaction_error_metrics::TransactionErrorMetrics,
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processor::{
             ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingConfig,
@@ -461,7 +460,6 @@ fn svm_integration() {
     batch_processor.fill_missing_sysvar_cache_entries(&mock_bank);
     register_builtins(&mock_bank, &batch_processor);
 
-    let mut error_counter = TransactionErrorMetrics::default();
     let processing_config = TransactionProcessingConfig {
         recording_config: ExecutionRecordingConfig {
             enable_log_recording: true,
@@ -476,7 +474,6 @@ fn svm_integration() {
         &mock_bank,
         &transactions,
         check_results.as_mut_slice(),
-        &mut error_counter,
         &mut timings,
         &processing_config,
     );


### PR DESCRIPTION
#### Problem
The transaction batch processor's main API - `load_and_execute_sanitized_transactions` -
requires a mutable `TransactionErrorMetrics` input, which it then plumbs all throughout the
transaction batch execution.

The API would be simplified if this object was instead returned. Callers who wish to ignore
this object could simply disregard the returned object, rather than having to provide a
default implementation, which they will then discard.

#### Summary of Changes
Move `error_metrics: TransactionErrorMetrics` to the return type of `load_and_execute_sanitized_transactions`, renaming all instances within SVM to `error_metrics` for consistency.

Note the `TransactionErrorMetrics` type already has an `accumulate` function, making this change trivial.
