### PR TITLE
SVM: Dissolve `RuntimeConfig`

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -612,6 +612,7 @@ impl Consumer {
                     recording_config: ExecutionRecordingConfig::new_single_setting(
                         transaction_status_sender_enabled
                     ),
+                    transaction_account_lock_limit: Some(bank.get_transaction_account_lock_limit()),
                 }
             ));
         execute_and_commit_timings.load_execute_us = load_execute_us;

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -606,6 +606,7 @@ impl Consumer {
                 &mut execute_and_commit_timings.execute_timings,
                 TransactionProcessingConfig {
                     account_overrides: None,
+                    compute_budget: bank.compute_budget(),
                     log_messages_bytes_limit: self.log_messages_bytes_limit,
                     limit_to_load_programs: true,
                     recording_config: ExecutionRecordingConfig::new_single_setting(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -89,7 +89,10 @@ use {
         storable_accounts::StorableAccounts,
     },
     solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
-    solana_compute_budget::compute_budget_processor::process_compute_budget_instructions,
+    solana_compute_budget::{
+        compute_budget::ComputeBudget,
+        compute_budget_processor::process_compute_budget_instructions,
+    },
     solana_cost_model::cost_tracker::CostTracker,
     solana_loader_v4_program::create_program_runtime_environment_v2,
     solana_measure::{measure, measure::Measure, measure_us},
@@ -3389,6 +3392,7 @@ impl Bank {
             &mut timings,
             TransactionProcessingConfig {
                 account_overrides: Some(&account_overrides),
+                compute_budget: self.compute_budget(),
                 log_messages_bytes_limit: None,
                 limit_to_load_programs: true,
                 recording_config: ExecutionRecordingConfig {
@@ -4814,6 +4818,7 @@ impl Bank {
             timings,
             TransactionProcessingConfig {
                 account_overrides: None,
+                compute_budget: self.compute_budget(),
                 log_messages_bytes_limit,
                 limit_to_load_programs: false,
                 recording_config,
@@ -6769,6 +6774,10 @@ impl Bank {
 
     pub fn runtime_config(&self) -> &RuntimeConfig {
         &self.transaction_processor.runtime_config
+    }
+
+    pub fn compute_budget(&self) -> Option<ComputeBudget> {
+        self.transaction_processor.runtime_config.compute_budget
     }
 
     pub fn add_builtin(&self, program_id: Pubkey, name: &str, builtin: ProgramCacheEntry) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1008,7 +1008,6 @@ impl Bank {
             bank.slot,
             bank.epoch,
             bank.epoch_schedule.clone(),
-            Arc::new(RuntimeConfig::default()),
             HashSet::default(),
         );
 
@@ -1048,7 +1047,6 @@ impl Bank {
         bank.compute_budget = runtime_config.compute_budget;
         bank.transaction_account_lock_limit = runtime_config.transaction_account_lock_limit;
         bank.transaction_debug_keys = debug_keys;
-        bank.transaction_processor.runtime_config = runtime_config;
         bank.cluster_type = Some(genesis_config.cluster_type);
 
         #[cfg(not(feature = "dev-context-only-utils"))]
@@ -1645,7 +1643,6 @@ impl Bank {
             bank.slot,
             bank.epoch,
             bank.epoch_schedule.clone(),
-            runtime_config,
             HashSet::default(),
         );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1287,7 +1287,8 @@ impl Bank {
             .transaction_processor
             .prepare_program_cache_for_upcoming_feature_set(
                 &new,
-                &new.compute_active_feature_set(true).0
+                &new.compute_active_feature_set(true).0,
+                &new.compute_budget.unwrap_or_default(),
             ));
 
         // Update sysvars before processing transactions

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3408,6 +3408,7 @@ impl Bank {
                     enable_log_recording: true,
                     enable_return_data_recording: true,
                 },
+                transaction_account_lock_limit: Some(self.get_transaction_account_lock_limit()),
             },
         );
 
@@ -4830,6 +4831,7 @@ impl Bank {
                 log_messages_bytes_limit,
                 limit_to_load_programs: false,
                 recording_config,
+                transaction_account_lock_limit: Some(self.get_transaction_account_lock_limit()),
             },
         );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5161,7 +5161,7 @@ impl Bank {
         program_cache.environments.program_runtime_v1 = Arc::new(
             create_program_runtime_environment_v1(
                 &self.feature_set,
-                &self.runtime_config().compute_budget.unwrap_or_default(),
+                &self.compute_budget().unwrap_or_default(),
                 false, /* deployment */
                 false, /* debugging_features */
             )
@@ -5169,7 +5169,7 @@ impl Bank {
         );
         program_cache.environments.program_runtime_v2 =
             Arc::new(create_program_runtime_environment_v2(
-                &self.runtime_config().compute_budget.unwrap_or_default(),
+                &self.compute_budget().unwrap_or_default(),
                 false, /* debugging_features */
             ));
     }
@@ -6786,10 +6786,6 @@ impl Bank {
 
     pub fn fee_structure(&self) -> &FeeStructure {
         &self.transaction_processor.fee_structure
-    }
-
-    pub fn runtime_config(&self) -> &RuntimeConfig {
-        &self.transaction_processor.runtime_config
     }
 
     pub fn compute_budget(&self) -> Option<ComputeBudget> {

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -185,7 +185,7 @@ impl Bank {
         // environment, as well as the two `ProgramCacheForTxBatch`
         // instances configured above, then invoke the loader.
         {
-            let compute_budget = self.runtime_config().compute_budget.unwrap_or_default();
+            let compute_budget = self.compute_budget().unwrap_or_default();
             let mut sysvar_cache = SysvarCache::default();
             sysvar_cache.fill_missing_entries(|pubkey, set_sysvar| {
                 if let Some(account) = self.get_account(pubkey) {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -104,6 +104,8 @@ pub struct TransactionProcessingConfig<'a> {
     pub limit_to_load_programs: bool,
     /// Recording capabilities for transaction execution.
     pub recording_config: ExecutionRecordingConfig,
+    /// The max number of accounts that a transaction may lock.
+    pub transaction_account_lock_limit: Option<usize>,
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -95,6 +95,8 @@ pub struct TransactionProcessingConfig<'a> {
     /// Encapsulates overridden accounts, typically used for transaction
     /// simulation.
     pub account_overrides: Option<&'a AccountOverrides>,
+    /// The compute budget to use for transaction execution.
+    pub compute_budget: Option<ComputeBudget>,
     /// The maximum number of bytes that log messages can consume.
     pub log_messages_bytes_limit: Option<usize>,
     /// Whether to limit the number of programs loaded for the transaction

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -492,6 +492,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         &self,
         callbacks: &CB,
         upcoming_feature_set: &FeatureSet,
+        compute_budget: &ComputeBudget,
     ) {
         // Recompile loaded programs one at a time before the next epoch hits
         let (_epoch, slot_index) = self.epoch_schedule.get_epoch_and_slot_index(self.slot);
@@ -533,13 +534,13 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             let mut program_cache = self.program_cache.write().unwrap();
             let program_runtime_environment_v1 = create_program_runtime_environment_v1(
                 upcoming_feature_set,
-                &self.runtime_config.compute_budget.unwrap_or_default(),
+                compute_budget,
                 false, /* deployment */
                 false, /* debugging_features */
             )
             .unwrap();
             let program_runtime_environment_v2 = create_program_runtime_environment_v2(
-                &self.runtime_config.compute_budget.unwrap_or_default(),
+                compute_budget,
                 false, /* debugging_features */
             );
             let mut upcoming_environments = program_cache.environments.clone();

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -38,7 +38,6 @@ use {
     solana_svm::{
         account_loader::CheckedTransactionDetails,
         program_loader,
-        runtime_config::RuntimeConfig,
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processor::{
             ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingConfig,
@@ -251,7 +250,6 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
         42,
         2,
         EpochSchedule::default(),
-        Arc::new(RuntimeConfig::default()),
         HashSet::new(),
     );
 

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -295,6 +295,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
         log_messages_bytes_limit: None,
         limit_to_load_programs: true,
         recording_config,
+        transaction_account_lock_limit: None,
     };
 
     if execute_as_instr {

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -291,6 +291,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
     };
     let processor_config = TransactionProcessingConfig {
         account_overrides: None,
+        compute_budget: None,
         log_messages_bytes_limit: None,
         limit_to_load_programs: true,
         recording_config,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -31,7 +31,6 @@ use {
     },
     solana_svm::{
         account_loader::{CheckedTransactionDetails, TransactionCheckResult},
-        runtime_config::RuntimeConfig,
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processor::{
             ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingConfig,
@@ -446,7 +445,6 @@ fn svm_integration() {
         EXECUTION_SLOT,
         EXECUTION_EPOCH,
         EpochSchedule::default(),
-        Arc::new(RuntimeConfig::default()),
         HashSet::new(),
     );
 


### PR DESCRIPTION
#### Problem
The transaction batch processor requires a global configuration for `RuntimeConfig` -
a small configuration object for transaction processing behavior.

Since the batch processor already uses a `TransactionProcessingConfig` for adjusting
runtime behavior, it's redundant to also include some configurations in the batch
processor itself globally.

The `log_messages_byte_limit` config in `RuntimeConfig` is also not used, since it's
also provided in `TransactionProcessingConfig`.

#### Summary of Changes
First refactor `Bank` to store `compute_budget` and `transaction_account_lock_limit`
outside of SVM.

Then, add `compute_budget` and `transaction_account_lock_limit` to the batch
processor's `TransactionProcessingConfig`.

Finally, drop `RuntimeConfig` from the batch processor's global configurations.
