### PR TITLE
store-tool: Opens file without needing len

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7265,10 +7265,9 @@ dependencies = [
 name = "solana-store-tool"
 version = "2.0.0"
 dependencies = [
+ "bs58",
  "clap 2.33.3",
- "log",
  "solana-accounts-db",
- "solana-logger",
  "solana-sdk",
  "solana-version",
 ]

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -426,6 +426,14 @@ impl AppendVec {
         })
     }
 
+    /// Opens the AppendVec at `path` for use by `store-tool`
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn new_for_store_tool(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        let file_size = std::fs::metadata(&path)?.len();
+        Self::new_from_file_unchecked(path, file_size as usize, StorageAccess::default())
+    }
+
     fn sanitize_layout_and_length(&self) -> (bool, usize) {
         // This discards allocated accounts immediately after check at each loop iteration.
         //

--- a/accounts-db/store-tool/Cargo.toml
+++ b/accounts-db/store-tool/Cargo.toml
@@ -10,12 +10,11 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bs58 = { workspace = true }
 clap = { workspace = true }
-log = { workspace = true }
-solana-accounts-db = { workspace = true }
-solana-logger = { workspace = true }
+solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true }
 solana-version = { workspace = true }
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+[features]
+dev-context-only-utils = []

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -1,80 +1,56 @@
 use {
-    clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg},
-    log::*,
-    solana_accounts_db::{
-        account_storage::meta::StoredAccountMeta, accounts_hash::AccountHash, append_vec::AppendVec,
-    },
-    solana_sdk::{
-        account::{AccountSharedData, ReadableAccount},
-        hash::Hash,
-        pubkey::Pubkey,
-    },
-    std::mem::ManuallyDrop,
+    clap::{crate_description, crate_name, value_t_or_exit, App, Arg},
+    solana_accounts_db::append_vec::AppendVec,
+    solana_sdk::{account::ReadableAccount, system_instruction::MAX_PERMITTED_DATA_LENGTH},
+    std::{mem::ManuallyDrop, num::Saturating},
 };
 
 fn main() {
-    solana_logger::setup_with_default_filter();
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())
         .arg(
             Arg::with_name("file")
-                .long("file")
+                .index(1)
                 .takes_value(true)
-                .value_name("<PATH>")
-                .help("store to open"),
-        )
-        .arg(
-            Arg::with_name("len")
-                .long("len")
-                .takes_value(true)
-                .value_name("LEN")
-                .help("len of store to open"),
+                .value_name("PATH")
+                .help("account storage file to open"),
         )
         .get_matches();
 
     let file = value_t_or_exit!(matches, "file", String);
-    let len = value_t!(matches, "len", usize)
-        .unwrap_or_else(|_| std::fs::metadata(&file).unwrap().len() as usize);
-
-    // When the AppendVec is dropped, the backing file will be removed.  We do not want to remove
-    // the backing file here in the store-tool, so prevent dropping.
-    let store = ManuallyDrop::new(
-        AppendVec::new_from_file_unchecked(
-            file,
-            len,
-            solana_accounts_db::accounts_file::StorageAccess::default(),
-        )
-        .expect("new AppendVec from file"),
-    );
-    info!("store: len: {} capacity: {}", store.len(), store.capacity());
-    let mut num_accounts: usize = 0;
-    let mut stored_accounts_len: usize = 0;
-    let mut quit = false;
-    store.scan_accounts(|account| {
-        if is_account_zeroed(&account) || quit {
-            quit = true;
-            return;
-        }
-        info!(
-            "  account: {:?} lamports: {} data: {} hash: {:?}",
-            account.pubkey(),
-            account.lamports(),
-            account.data_len(),
-            account.hash()
-        );
-        num_accounts = num_accounts.saturating_add(1);
-        stored_accounts_len = stored_accounts_len.saturating_add(account.stored_size());
+    let store = AppendVec::new_for_store_tool(&file).unwrap_or_else(|err| {
+        eprintln!("failed to open storage file '{file}': {err}");
+        std::process::exit(1);
     });
-    info!(
-        "num_accounts: {} stored_accounts_len: {}",
-        num_accounts, stored_accounts_len
-    );
-}
+    // By default, when the AppendVec is dropped, the backing file will be removed.
+    // We do not want to remove the backing file here in the store-tool, so prevent dropping.
+    let store = ManuallyDrop::new(store);
 
-fn is_account_zeroed(account: &StoredAccountMeta) -> bool {
-    account.hash() == &AccountHash(Hash::default())
-        && account.data_len() == 0
-        && account.pubkey() == &Pubkey::default()
-        && account.to_account_shared_data() == AccountSharedData::default()
+    // max data size is 10 MiB (10,485,760 bytes)
+    // therefore, the max width is ceil(log(10485760))
+    let data_size_width = (MAX_PERMITTED_DATA_LENGTH as f64).log10().ceil() as usize;
+    let offset_width = (store.capacity() as f64).log(16.0).ceil() as usize;
+
+    let mut num_accounts = Saturating(0usize);
+    let mut stored_accounts_size = Saturating(0);
+    store.scan_accounts(|account| {
+        println!(
+            "{:#0offset_width$x}: {:44}, owner: {:44}, data size: {:data_size_width$}, lamports: {}",
+            account.offset(),
+            bs58::encode(account.pubkey()).into_string(),
+            bs58::encode(account.owner()).into_string(),
+            account.data_len(),
+            account.lamports(),
+        );
+        num_accounts += 1;
+        stored_accounts_size += account.stored_size();
+    });
+
+    println!(
+        "number of accounts: {}, stored accounts size: {}, file size: {}",
+        num_accounts,
+        stored_accounts_size,
+        store.capacity(),
+    );
 }

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -33,6 +33,7 @@ declare tainted_packages=(
   solana-banking-bench
   agave-ledger-tool
   solana-bench-tps
+  solana-store-tool
 )
 
 # convert to comma separeted (ref: https://stackoverflow.com/a/53839433)


### PR DESCRIPTION
#### Problem

While investigating why the snapshot archives on master are much smaller than those on v1.18, I wanted to use store-tool to inspect the storage files themselves for any differences. However, when using store-tool, you must pass in the len of the append vec. This is not easy to find out, and it is not even needed.


#### Summary of Changes

Remove the need to pass in the len

(also cleanup the output/printing and error handling)

<details><summary>Example Output</summary>
<p>

```
0x00000: SysvarC1ock11111111111111111111111111111111 , owner: Sysvar1111111111111111111111111111111111111 , data size:       40, lamports: 1169280
0x000b0: CqQ8NUMk4UPftj7Dy8VWpUvT6F2k6sUhfk6Dybmp8bfY, owner: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA , data size:      165, lamports: 2039280
0x001e0: 4B1xhw7fQSxqCCnuVSDeis68AKAcpgDeku64eJ6qntcw, owner: srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX , data size:     3228, lamports: 23357760
0x00f08: 87qMYyvUFmftsA9nkLcauN1PbxPJNfwY6N3xChssfWAx, owner: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA , data size:      165, lamports: 2039280
0x01038: 9G2N1tW9GPQEzQX4JAutudhwCSCJNNS2aMGNXXFunDsR, owner: 11111111111111111111111111111111            , data size:        0, lamports: 22295687649
0x010c0: CqQ92hECZi1h3eHNZofyq3syFRK5vtikSD8K1ukFL2RR, owner: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA , data size:      165, lamports: 2039280
0x011f0: CqQEGiwqnpvj3HkyXhgCiXHKb4y2WnjUmETSbMm1kVmu, owner: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s , data size:      679, lamports: 5616720
0x01520: CqQER2miDbxXJTDWhFZEo23XrxB3J3ZLGQemHmhy6SxH, owner: 4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7, data size:      104, lamports: 1614720
0x01610: 2n74puGYXh8j5cU7KBJzDZN2PL1xsrre9jUW4i99iCg2, owner: GDDMwNyyx8uB6zrqwBFHjLLG3TBYk2F8Az4yrQC5RzMp, data size:       48, lamports: 1224960
0x016c8: 4qvFxnUXYjBdcviCwVV7gKcGJMCENEBfS82hSLJUhyvu, owner: Vote111111111111111111111111111111111111111 , data size:     3762, lamports: 64879511276
0x02608: CqQFjTSeus44ABhnYBC8fpoX6LfhqAVYtHvbNhC4uck6, owner: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s , data size:      679, lamports: 5616720
0x02938: 92RWsU6jb7GfUs34G8xs7QLWda5MTs1ARDEh3LzkXiih, owner: 11111111111111111111111111111111            , data size:        0, lamports: 13930821814
0x029c0: sAESK3Gda4FqBXvbj1XfwLL3ZMzhuW8NikgXJvPYV88 , owner: Vote111111111111111111111111111111111111111 , data size:     3762, lamports: 19851317603
0x03900: Cx8eWxJAaCQAFVmv1mP7B2cVie2BnkR7opP8vUh23Wcr, owner: 2wT8Yq49kHgDzXuPxZSaeLaH1qbmGXtEyPy64bL7aD3c, data size:      911, lamports: 7231440
0x03d18: 4K8TQcYHjzKyHvReuoPT4pboENga8dYm3SwdgX3UkKVN, owner: 11111111111111111111111111111111            , data size:        0, lamports: 5804437525
0x03da0: D4v2YWUmB2bnccRzE8MBxxRJ2wkoUdFt4HNBGYtY8TRK, owner: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA , data size:      165, lamports: 2039280
0x03ed0: 46aWpTtjQaTRL81dWXg19H5V2Jf2rg1Cy3hzr76vJDSf, owner: Vote111111111111111111111111111111111111111 , data size:     3762, lamports: 6104294761
0x04e10: 66fsNu5A6iB1WUXGjuBMBXm2qYQrbtc385bcVYaVu7QD, owner: Vote111111111111111111111111111111111111111 , data size:     3762, lamports: 7435076975
0x05d50: CqQ9hPTT393UcgiXaFwSQ47FNAL83uVfjDjyKAhncfxS, owner: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s , data size:      241, lamports: 2568240
0x05ed0: fP5jRDEhW8GchEa2EXpgfZ3bSZAFE65vuWBeKN2aLqn , owner: srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX , data size:    65500, lamports: 456770880
0x15f38: HWtAyz5KQKrwQdqnBqt5DdR8zgw84Ge8NNists94vv5c, owner: ZETAxsqBRek56DhiGXrn75yj2NHU3aYUnxvHXpkf3aD , data size:     3517, lamports: 25369200
0x16d80: F3RWuto5gAUYCXrKAtcVdbDEXxNG6ApopT88N5B2zTmB, owner: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA , data size:      165, lamports: 669521444
0x16eb0: DCD3rKBxPpXQZiMg7foGKGSaad73UEZ1gQY48K4VV6h8, owner: ZETAxsqBRek56DhiGXrn75yj2NHU3aYUnxvHXpkf3aD , data size:     3517, lamports: 25369200
0x17cf8: Picanmgae1ZFueTPZLwLzPRhNG4Y7H1yQtrqxCqUZLe , owner: 11111111111111111111111111111111            , data size:        0, lamports: 8522044575
0x17d80: 6h2dCnWYaFTmJU55CsieJckM1zf5z5ZwnDF5oS8YXkDJ, owner: SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f , data size:      372, lamports: 3480000
0x17f80: CqQEM6q2jYTCefcXtdCk1LnJgPMXTGMVn6uAvzMzmWHe, owner: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA , data size:      165, lamports: 2039280
0x180b0: wowK1ivqmU9WhHnghiJQ4UUySndzvrUAJinjMUw54eX , owner: 11111111111111111111111111111111            , data size:        0, lamports: 13496300439
0x18138: 2Z2yiFrVhqMkLkaHceDgWreEgKdSPPX225V3zV6v7czA, owner: 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8, data size:     2208, lamports: 16258560
0x18a60: CrEA7jydDYM1kxLR3MoYXm3r7WJxmgR54MyjhF9FgbtW, owner: Vote111111111111111111111111111111111111111 , data size:     3762, lamports: 29725140926
0x199a0: EBoyo2DA2wQtnfGgVcGUCi48MguJFBNEdMt6V9dSns9r, owner: 11111111111111111111111111111111            , data size:        0, lamports: 41023504512
0x19a28: CqQDmwsxRdfhbwqrzT3oedNgkjz2dYw3xCFZyy3fzBbm, owner: meRjbQXFNf5En86FXT2YPz1dQzLj4Yb3xK8u1MVgqpb , data size:      104, lamports: 1614720
0x19b18: 58KprHKFNHgH1Cvo4QwxWkDeJNaSQVteCoAAFUWjtESn, owner: 11111111111111111111111111111111            , data size:        0, lamports: 1567525439230
0x19ba0: CqQAu3523wzYRZo9bgiUD7KQzyQ9qk3mbjQJzX3JiWa8, owner: 11111111111111111111111111111111            , data size:        0, lamports: 890880
0x19c28: 4gwDtAXtXaWJArFiPtjTYAHAgGcvM8W9oKXXZexwgVG4, owner: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA , data size:      165, lamports: 2039280
0x19d58: 4FezXvUkXv5GgYs9fFeWF8SNAc43bQxLXKv8PyNnKbPX, owner: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA , data size:      165, lamports: 2039280
```

</p>
</details> 