### PR TITLE
replay: do not hold bank forks lock during mark_dead_slot

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2979,10 +2979,11 @@ impl ReplayStage {
                 match replay_result {
                     Ok(replay_tx_count) => tx_count += replay_tx_count,
                     Err(err) => {
+                        let root = bank_forks.read().unwrap().root();
                         Self::mark_dead_slot(
                             blockstore,
                             bank,
-                            bank_forks.read().unwrap().root(),
+                            root,
                             err,
                             rpc_subscriptions,
                             duplicate_slots_tracker,
@@ -3022,10 +3023,11 @@ impl ReplayStage {
                         .accumulate(metrics);
 
                     if let Err(err) = result {
+                        let root = bank_forks.read().unwrap().root();
                         Self::mark_dead_slot(
                             blockstore,
                             bank,
-                            bank_forks.read().unwrap().root(),
+                            root,
                             &BlockstoreProcessorError::InvalidTransaction(err),
                             rpc_subscriptions,
                             duplicate_slots_tracker,


### PR DESCRIPTION
#### Problem
In order to access the root, we hold the `bank_forks` lock for the entirety of `mark_dead_slot`. However it does not seem this function needs to acquire the lock.

#### Summary of Changes
Copy the root out, so the lock is not held.

See original discussion here 
https://github.com/anza-xyz/agave/pull/1002#discussion_r1598990662