### PR TITLE
Logs handling snapshot request with info!()

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -298,10 +298,7 @@ impl SnapshotRequestHandler {
         accounts_package_kind: AccountsPackageKind,
         exit: &AtomicBool,
     ) -> Result<u64, SnapshotError> {
-        debug!(
-            "handling snapshot request: {:?}, {:?}",
-            snapshot_request, accounts_package_kind
-        );
+        info!("handling snapshot request: {snapshot_request:?}, {accounts_package_kind:?}");
         let mut total_time = Measure::start("snapshot_request_receiver_total_time");
         let SnapshotRequest {
             snapshot_root_bank,


### PR DESCRIPTION
#### Problem

When the background services begin handling a request they log a message indicating such.

AccountsBackgroundService:
https://github.com/anza-xyz/agave/blob/9830fb6761067b3aaf69c363a5f1094a699b44b3/runtime/src/accounts_background_service.rs#L301-L304

AccountsHashVerifier:
https://github.com/anza-xyz/agave/blob/9830fb6761067b3aaf69c363a5f1094a699b44b3/core/src/accounts_hash_verifier.rs#L69

SnapshotPackagerService:
https://github.com/anza-xyz/agave/blob/9830fb6761067b3aaf69c363a5f1094a699b44b3/core/src/snapshot_packager_service.rs#L66

As you can see, AHV and SPS both log with `info!`, whereas ABS logs with `debug!`. I've run into situations where having this log line be `info!`, like AHV and SPS, would be beneficial.


#### Summary of Changes

Promote the log to `info!`.
