### PR TITLE
Compute Budget: add `frozen-abi` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5883,6 +5883,7 @@ dependencies = [
 name = "solana-compute-budget"
 version = "2.0.0"
 dependencies = [
+ "solana-frozen-abi",
  "solana-sdk",
 ]
 

--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -10,4 +10,11 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+solana-frozen-abi = { workspace = true, optional = true }
 solana-sdk = { workspace = true }
+
+[features]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "solana-sdk/frozen-abi",
+]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -117,6 +117,7 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "solana-accounts-db/frozen-abi",
     "solana-bloom/frozen-abi",
+    "solana-compute-budget/frozen-abi",
     "solana-cost-model/frozen-abi",
     "solana-gossip/frozen-abi",
     "solana-ledger/frozen-abi",

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -48,6 +48,7 @@ rustc_version = { workspace = true }
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
+    "solana-compute-budget/frozen-abi",
     "solana-sdk/frozen-abi",
     "solana-vote-program/frozen-abi",
 ]

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -51,5 +51,6 @@ rustc_version = { workspace = true }
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
+    "solana-compute-budget/frozen-abi",
     "solana-sdk/frozen-abi",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -111,6 +111,7 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-accounts-db/frozen-abi",
+    "solana-compute-budget/frozen-abi",
     "solana-cost-model/frozen-abi",
     "solana-perf/frozen-abi",
     "solana-program-runtime/frozen-abi",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -53,6 +53,7 @@ dev-context-only-utils = []
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
+    "solana-compute-budget/frozen-abi",
     "solana-program-runtime/frozen-abi",
     "solana-sdk/frozen-abi",
 ]


### PR DESCRIPTION
#### Problem
After #1278, `solana-frozen-abi` is now optional across all crates, meaning it must be
added with a feature flag (`frozen-abi`).

The new `solana-compute-budget` crate is missing this feature flag, but it implements
`solana_frozen_abi::AbiExample` on the `ComputeBudget` type.

#### Summary of Changes
Add the missing `frozen-abi` feature flag and conditionally enable the flag in all crates
that depend on `solana-compute-budget`.
