### PR TITLE
ci: use macos-latest for macos clippy

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest-large
+          - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest-large
+          - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
#### Problem

we upgraded our macos runner in https://github.com/solana-labs/solana/pull/34725. the main reason for this upgrade is that our macos nightly clippy became flaky.
fortunately, we have bumped our nightly version to a new one. it should be a good time to revert this one and see how it goes!

#### Summary of Changes

use normal macos runner for clippy