### PR TITLE
sdk: fix replace_signatures for variable signer ordering

### DIFF
--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -1060,13 +1060,18 @@ impl Transaction {
             return Err(TransactionError::InvalidAccountIndex);
         }
 
-        signers
-            .iter()
-            .enumerate()
-            .for_each(|(i, (pubkey, signature))| {
-                self.signatures[i] = *signature;
-                self.message.account_keys[i] = *pubkey;
-            });
+        let indices = signers.iter().map(|(pubkey, _signature)| {
+            self.message
+                .account_keys
+                .iter()
+                .position(|key| key == pubkey)
+                .filter(|index| index < &num_required_signatures)
+                .ok_or(TransactionError::InvalidAccountIndex)
+        });
+        for ((_pubkey, signature), index) in signers.iter().zip(indices) {
+            let index = index?;
+            self.signatures[index] = *signature
+        }
 
         self.verify()
     }


### PR DESCRIPTION
#### Problem
`Transaction::replace_signatures()` assumes that the new signers/signatures being passed as input are ordered the same as has been previously specified in the transaction, which is not necessarily the case

#### Summary of Changes
Look up the new signers' key index in `Message::account_keys` rather than assuming correct input ordering

Closes #395
