### PR TITLE
Renames solana-store-tool to agave-store-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-store-tool"
+version = "2.0.0"
+dependencies = [
+ "clap 2.33.3",
+ "solana-accounts-db",
+ "solana-sdk",
+ "solana-version",
+]
+
+[[package]]
 name = "agave-validator"
 version = "2.0.0"
 dependencies = [
@@ -7260,16 +7270,6 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "tonic-build",
-]
-
-[[package]]
-name = "solana-store-tool"
-version = "2.0.0"
-dependencies = [
- "clap 2.33.3",
- "solana-accounts-db",
- "solana-sdk",
- "solana-version",
 ]
 
 [[package]]

--- a/accounts-db/store-tool/Cargo.toml
+++ b/accounts-db/store-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "solana-store-tool"
-description = "Tool to inspect append vecs"
+name = "agave-store-tool"
+description = "Tool to inspect account storage files"
 publish = false
 version = { workspace = true }
 authors = { workspace = true }

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -33,7 +33,7 @@ declare tainted_packages=(
   solana-banking-bench
   agave-ledger-tool
   solana-bench-tps
-  solana-store-tool
+  agave-store-tool
 )
 
 # convert to comma separeted (ref: https://stackoverflow.com/a/53839433)


### PR DESCRIPTION
#### Problem

The store-tool is meant to only inspect account storage files created by the Agave client. To be consistent with agave-validator and agave-ledger-tool, the store-tool should also be called agave-store-tool (and not solana-store-tool, which is its current name).


#### Summary of Changes

Rename