### PR TITLE
Remove recursive read locking of program cache

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -433,7 +433,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     // Load, verify and compile one program.
                     let program = load_program_with_pubkey(
                         callback,
-                        &self.get_environments_for_epoch(self.epoch),
+                        &program_cache.get_environments_for_epoch(self.epoch),
                         &key,
                         self.slot,
                         &self.epoch_schedule,


### PR DESCRIPTION
#### Problem
The transaction processor is read locking program cache recursively.

#### Summary of Changes
Use the existing read locked program cache instance, instead of locking it again.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
