### PR TITLE
store-tool: Reuses Pubkey::to_string()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7266,7 +7266,6 @@ dependencies = [
 name = "solana-store-tool"
 version = "2.0.0"
 dependencies = [
- "bs58",
  "clap 2.33.3",
  "solana-accounts-db",
  "solana-sdk",

--- a/accounts-db/store-tool/Cargo.toml
+++ b/accounts-db/store-tool/Cargo.toml
@@ -10,7 +10,6 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-bs58 = { workspace = true }
 clap = { workspace = true }
 solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true }

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -38,8 +38,8 @@ fn main() {
         println!(
             "{:#0offset_width$x}: {:44}, owner: {:44}, data size: {:data_size_width$}, lamports: {}",
             account.offset(),
-            bs58::encode(account.pubkey()).into_string(),
-            bs58::encode(account.owner()).into_string(),
+            account.pubkey().to_string(),
+            account.owner().to_string(),
             account.data_len(),
             account.lamports(),
         );


### PR DESCRIPTION
#### Problem

The store-tool copies code from Pubkey's Display so that it can pretty-print the pubkeys. This is unnecessary. Since Pubkey implements Display, that means it also automatically implements ToString. That can be used here instead.


#### Summary of Changes

Use Pubkey::to_string() instead.

Note, we cannot just use Pubkey's Display directly, as it will not respect the formatting directives (specifically here, the widths).