### PR TITLE
Use try_read() in get_environments_for_epoch() to prevent recursive read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7331,6 +7331,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "qualifier_attr",
  "rand 0.8.5",
  "rustc_version 0.4.0",
  "serde",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6311,6 +6311,7 @@ dependencies = [
  "log",
  "percentage",
  "prost-build",
+ "qualifier_attr",
  "rustc_version",
  "serde",
  "serde_derive",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -96,6 +96,7 @@ solana-logger = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-runtime = { path = ".", features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
+solana-svm = { workspace = true, features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6749,25 +6749,6 @@ impl Bank {
         self.check_program_modification_slot = true;
     }
 
-    pub fn load_program(
-        &self,
-        pubkey: &Pubkey,
-        reload: bool,
-        effective_epoch: Epoch,
-    ) -> Option<Arc<ProgramCacheEntry>> {
-        let environments = self
-            .transaction_processor
-            .get_environments_for_epoch(effective_epoch)?;
-        load_program_with_pubkey(
-            self,
-            &environments,
-            pubkey,
-            self.slot(),
-            self.epoch_schedule(),
-            reload,
-        )
-    }
-
     pub fn fee_structure(&self) -> &FeeStructure {
         &self.transaction_processor.fee_structure
     }
@@ -7112,6 +7093,25 @@ impl Bank {
 
     pub fn set_fee_structure(&mut self, fee_structure: &FeeStructure) {
         self.transaction_processor.fee_structure = fee_structure.clone();
+    }
+
+    pub fn load_program(
+        &self,
+        pubkey: &Pubkey,
+        reload: bool,
+        effective_epoch: Epoch,
+    ) -> Option<Arc<ProgramCacheEntry>> {
+        let environments = self
+            .transaction_processor
+            .get_environments_for_epoch(effective_epoch)?;
+        load_program_with_pubkey(
+            self,
+            &environments,
+            pubkey,
+            self.slot(),
+            self.epoch_schedule(),
+            reload,
+        )
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -169,7 +169,6 @@ use {
         },
         account_overrides::AccountOverrides,
         nonce_info::NoncePartial,
-        program_loader::load_program_with_pubkey,
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processor::{
@@ -209,6 +208,7 @@ use {
         ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
     },
     solana_program_runtime::{loaded_programs::ProgramCacheForTxBatch, sysvar_cache::SysvarCache},
+    solana_svm::program_loader::load_program_with_pubkey,
 };
 
 /// params to `verify_accounts_hash`

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6757,7 +6757,7 @@ impl Bank {
     ) -> Option<Arc<ProgramCacheEntry>> {
         let environments = self
             .transaction_processor
-            .get_environments_for_epoch(effective_epoch);
+            .get_environments_for_epoch(effective_epoch)?;
         load_program_with_pubkey(
             self,
             &environments,

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 percentage = { workspace = true }
+qualifier_attr = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
 solana-bpf-loader-program = { workspace = true }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -517,7 +517,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(50),
+            &batch_processor.get_environments_for_epoch(50).unwrap(),
             &key,
             500,
             &batch_processor.epoch_schedule,
@@ -540,7 +540,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20),
+            &batch_processor.get_environments_for_epoch(20).unwrap(),
             &key,
             0, // Slot 0
             &batch_processor.epoch_schedule,
@@ -553,6 +553,7 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
                     .get_environments_for_epoch(20)
+                    .unwrap()
                     .program_runtime_v1,
             ),
         );
@@ -574,7 +575,7 @@ mod tests {
         // This should return an error
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20),
+            &batch_processor.get_environments_for_epoch(20).unwrap(),
             &key,
             200,
             &batch_processor.epoch_schedule,
@@ -586,6 +587,7 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
                     .get_environments_for_epoch(20)
+                    .unwrap()
                     .program_runtime_v1,
             ),
         );
@@ -601,7 +603,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20),
+            &batch_processor.get_environments_for_epoch(20).unwrap(),
             &key,
             200,
             &batch_processor.epoch_schedule,
@@ -655,7 +657,7 @@ mod tests {
         // This should return an error
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(0),
+            &batch_processor.get_environments_for_epoch(0).unwrap(),
             &key1,
             0,
             &batch_processor.epoch_schedule,
@@ -667,6 +669,7 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
                     .get_environments_for_epoch(0)
+                    .unwrap()
                     .program_runtime_v1,
             ),
         );
@@ -692,7 +695,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20),
+            &batch_processor.get_environments_for_epoch(20).unwrap(),
             &key1,
             200,
             &batch_processor.epoch_schedule,
@@ -742,7 +745,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(0),
+            &batch_processor.get_environments_for_epoch(0).unwrap(),
             &key,
             0,
             &batch_processor.epoch_schedule,
@@ -754,6 +757,7 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
                     .get_environments_for_epoch(0)
+                    .unwrap()
                     .program_runtime_v1,
             ),
         );
@@ -775,7 +779,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20),
+            &batch_processor.get_environments_for_epoch(20).unwrap(),
             &key,
             200,
             &batch_processor.epoch_schedule,
@@ -824,7 +828,9 @@ mod tests {
         for is_upcoming_env in [false, true] {
             let result = load_program_with_pubkey(
                 &mock_bank,
-                &batch_processor.get_environments_for_epoch(is_upcoming_env as u64),
+                &batch_processor
+                    .get_environments_for_epoch(is_upcoming_env as u64)
+                    .unwrap(),
                 &key,
                 200,
                 &batch_processor.epoch_schedule,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -208,11 +208,12 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     }
 
     /// Returns the current environments depending on the given epoch
-    pub fn get_environments_for_epoch(&self, epoch: Epoch) -> ProgramRuntimeEnvironments {
+    /// Returns None if the call could result in a deadlock
+    pub fn get_environments_for_epoch(&self, epoch: Epoch) -> Option<ProgramRuntimeEnvironments> {
         self.program_cache
-            .read()
-            .unwrap()
-            .get_environments_for_epoch(epoch)
+            .try_read()
+            .ok()
+            .map(|cache| cache.get_environments_for_epoch(epoch))
     }
 
     /// Main entrypoint to the SVM.
@@ -620,14 +621,16 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             if let Some((key, program_to_recompile)) = program_cache.programs_to_recompile.pop() {
                 let effective_epoch = program_cache.latest_root_epoch.saturating_add(1);
                 drop(program_cache);
+                let program_cache_read = self.program_cache.read().unwrap();
                 if let Some(recompiled) = load_program_with_pubkey(
                     callbacks,
-                    &self.get_environments_for_epoch(effective_epoch),
+                    &program_cache_read.get_environments_for_epoch(effective_epoch),
                     &key,
                     self.slot,
                     &self.epoch_schedule,
                     false,
                 ) {
+                    drop(program_cache_read);
                     recompiled
                         .tx_usage_counter
                         .fetch_add(program_to_recompile.tx_usage_counter.load(Relaxed), Relaxed);

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     crate::{
         account_loader::{
@@ -209,6 +211,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
     /// Returns the current environments depending on the given epoch
     /// Returns None if the call could result in a deadlock
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub fn get_environments_for_epoch(&self, epoch: Epoch) -> Option<ProgramRuntimeEnvironments> {
         self.program_cache
             .try_read()

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -439,7 +439,7 @@ fn execute_fixture_as_instr(
 
     let loaded_program = program_loader::load_program_with_pubkey(
         mock_bank,
-        &batch_processor.get_environments_for_epoch(2),
+        &batch_processor.get_environments_for_epoch(2).unwrap(),
         &program_id,
         42,
         &batch_processor.epoch_schedule,


### PR DESCRIPTION
#### Problem
Recursive read locks on program cache can cause deadlocks in multithreaded environment, where write locks are taken intermittently.

#### Summary of Changes
Replaced read() with try_read().

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
