### PR TITLE
Vote: hoist vote sender types up to runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7616,7 +7616,6 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "solana-unified-scheduler-logic",
- "solana-vote",
 ]
 
 [[package]]
@@ -7646,7 +7645,6 @@ name = "solana-vote"
 version = "2.0.0"
 dependencies = [
  "bincode",
- "crossbeam-channel",
  "itertools",
  "log",
  "rand 0.8.5",

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -36,9 +36,11 @@ use {
     solana_measure::{measure, measure_us},
     solana_perf::{data_budget::DataBudget, packet::PACKETS_PER_BATCH},
     solana_poh::poh_recorder::{PohRecorder, TransactionRecorder},
-    solana_runtime::{bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache},
+    solana_runtime::{
+        bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
+        vote_sender_types::ReplayVoteSender,
+    },
     solana_sdk::timing::AtomicInterval,
-    solana_vote::vote_sender_types::ReplayVoteSender,
     std::{
         cmp, env,
         sync::{

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -10,6 +10,7 @@ use {
         bank_utils,
         prioritization_fee_cache::PrioritizationFeeCache,
         transaction_batch::TransactionBatch,
+        vote_sender_types::ReplayVoteSender,
     },
     solana_sdk::{hash::Hash, pubkey::Pubkey, saturating_add_assign},
     solana_svm::{
@@ -19,7 +20,6 @@ use {
     solana_transaction_status::{
         token_balances::TransactionTokenBalancesSet, TransactionTokenBalance,
     },
-    solana_vote::vote_sender_types::ReplayVoteSender,
     std::{collections::HashMap, sync::Arc},
 };
 

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -698,12 +698,13 @@ mod tests {
             get_tmp_ledger_path_auto_delete, leader_schedule_cache::LeaderScheduleCache,
         },
         solana_poh::poh_recorder::{PohRecorder, WorkingBankEntry},
-        solana_runtime::prioritization_fee_cache::PrioritizationFeeCache,
+        solana_runtime::{
+            prioritization_fee_cache::PrioritizationFeeCache, vote_sender_types::ReplayVoteReceiver,
+        },
         solana_sdk::{
             genesis_config::GenesisConfig, poh_config::PohConfig, pubkey::Pubkey,
             signature::Keypair, system_transaction,
         },
-        solana_vote::vote_sender_types::ReplayVoteReceiver,
         std::{
             sync::{atomic::AtomicBool, RwLock},
             thread::JoinHandle,

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -27,7 +27,7 @@ use {
     },
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, commitment::VOTE_THRESHOLD_SIZE,
-        epoch_stakes::EpochStakes,
+        epoch_stakes::EpochStakes, vote_sender_types::ReplayVoteReceiver,
     },
     solana_sdk::{
         clock::{Slot, DEFAULT_MS_PER_SLOT, DEFAULT_TICKS_PER_SLOT},
@@ -40,7 +40,6 @@ use {
     },
     solana_vote::{
         vote_parser::{self, ParsedVote},
-        vote_sender_types::ReplayVoteReceiver,
         vote_transaction::VoteTransaction,
     },
     std::{
@@ -907,13 +906,13 @@ mod tests {
             genesis_utils::{
                 self, create_genesis_config, GenesisConfigInfo, ValidatorVoteKeypairs,
             },
+            vote_sender_types::ReplayVoteSender,
         },
         solana_sdk::{
             hash::Hash,
             pubkey::Pubkey,
             signature::{Keypair, Signature, Signer},
         },
-        solana_vote::vote_sender_types::ReplayVoteSender,
         solana_vote_program::{
             vote_state::{TowerSync, Vote},
             vote_transaction,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -63,6 +63,7 @@ use {
         commitment::BlockCommitmentCache,
         installed_scheduler_pool::BankWithScheduler,
         prioritization_fee_cache::PrioritizationFeeCache,
+        vote_sender_types::ReplayVoteSender,
     },
     solana_sdk::{
         clock::{BankId, Slot, MAX_PROCESSING_AGE, NUM_CONSECUTIVE_LEADER_SLOTS},
@@ -75,7 +76,6 @@ use {
         timing::timestamp,
         transaction::Transaction,
     },
-    solana_vote::vote_sender_types::ReplayVoteSender,
     solana_vote_program::vote_state::VoteTransaction,
     std::{
         collections::{HashMap, HashSet},

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -30,7 +30,11 @@ use {
         optimistically_confirmed_bank_tracker::BankNotificationSender,
         rpc_subscriptions::RpcSubscriptions,
     },
-    solana_runtime::{bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache},
+    solana_runtime::{
+        bank_forks::BankForks,
+        prioritization_fee_cache::PrioritizationFeeCache,
+        vote_sender_types::{ReplayVoteReceiver, ReplayVoteSender},
+    },
     solana_sdk::{clock::Slot, pubkey::Pubkey, quic::NotifyKeyUpdate, signature::Keypair},
     solana_streamer::{
         nonblocking::quic::{DEFAULT_MAX_STREAMS_PER_MS, DEFAULT_WAIT_FOR_CHUNK_TIMEOUT},
@@ -38,7 +42,6 @@ use {
         streamer::StakedNodes,
     },
     solana_turbine::broadcast_stage::{BroadcastStage, BroadcastStageType},
-    solana_vote::vote_sender_types::{ReplayVoteReceiver, ReplayVoteSender},
     std::{
         collections::HashMap,
         net::{SocketAddr, UdpSocket},

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -46,10 +46,10 @@ use {
     solana_runtime::{
         accounts_background_service::AbsRequestSender, bank_forks::BankForks,
         commitment::BlockCommitmentCache, prioritization_fee_cache::PrioritizationFeeCache,
+        vote_sender_types::ReplayVoteSender,
     },
     solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Keypair},
     solana_turbine::retransmit_stage::RetransmitStage,
-    solana_vote::vote_sender_types::ReplayVoteSender,
     std::{
         collections::HashSet,
         net::{SocketAddr, UdpSocket},

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -42,6 +42,7 @@ use {
         prioritization_fee_cache::PrioritizationFeeCache,
         runtime_config::RuntimeConfig,
         transaction_batch::TransactionBatch,
+        vote_sender_types::ReplayVoteSender,
     },
     solana_sdk::{
         clock::{Slot, MAX_PROCESSING_AGE},
@@ -65,7 +66,7 @@ use {
         },
     },
     solana_transaction_status::token_balances::TransactionTokenBalancesSet,
-    solana_vote::{vote_account::VoteAccountsHashMap, vote_sender_types::ReplayVoteSender},
+    solana_vote::vote_account::VoteAccountsHashMap,
     std::{
         borrow::Cow,
         collections::{HashMap, HashSet},

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6500,7 +6500,6 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "solana-unified-scheduler-logic",
- "solana-vote",
 ]
 
 [[package]]
@@ -6519,7 +6518,6 @@ dependencies = [
 name = "solana-vote"
 version = "2.0.0"
 dependencies = [
- "crossbeam-channel",
  "itertools",
  "log",
  "rustc_version",

--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -1,3 +1,7 @@
+use {
+    crate::vote_sender_types::ReplayVoteSender, solana_sdk::transaction::SanitizedTransaction,
+    solana_svm::transaction_results::TransactionResults, solana_vote::vote_parser,
+};
 #[cfg(feature = "dev-context-only-utils")]
 use {
     crate::{
@@ -5,11 +9,6 @@ use {
         genesis_utils::{self, GenesisConfigInfo, ValidatorVoteKeypairs},
     },
     solana_sdk::{pubkey::Pubkey, signature::Signer},
-};
-use {
-    solana_sdk::transaction::SanitizedTransaction,
-    solana_svm::transaction_results::TransactionResults,
-    solana_vote::{vote_parser, vote_sender_types::ReplayVoteSender},
 };
 
 #[cfg(feature = "dev-context-only-utils")]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,6 +34,7 @@ pub mod stakes;
 pub mod static_ids;
 pub mod status_cache;
 pub mod transaction_batch;
+pub mod vote_sender_types;
 
 #[macro_use]
 extern crate solana_metrics;

--- a/runtime/src/vote_sender_types.rs
+++ b/runtime/src/vote_sender_types.rs
@@ -1,6 +1,6 @@
 use {
-    crate::vote_parser::ParsedVote,
     crossbeam_channel::{Receiver, Sender},
+    solana_vote::vote_parser::ParsedVote,
 };
 
 pub type ReplayVoteSender = Sender<ParsedVote>;

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -21,7 +21,6 @@ solana-program-runtime = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 solana-unified-scheduler-logic = { workspace = true }
-solana-vote = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -33,13 +33,13 @@ use {
             SchedulerId, SchedulingContext, UninstalledScheduler, UninstalledSchedulerBox,
         },
         prioritization_fee_cache::PrioritizationFeeCache,
+        vote_sender_types::ReplayVoteSender,
     },
     solana_sdk::{
         pubkey::Pubkey,
         transaction::{Result, SanitizedTransaction, TransactionError},
     },
     solana_unified_scheduler_logic::{SchedulingStateMachine, Task, UsageQueue},
-    solana_vote::vote_sender_types::ReplayVoteSender,
     std::{
         fmt::Debug,
         marker::PhantomData,

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -10,7 +10,6 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-crossbeam-channel = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, features = ["rc"] }

--- a/vote/src/lib.rs
+++ b/vote/src/lib.rs
@@ -3,7 +3,6 @@
 
 pub mod vote_account;
 pub mod vote_parser;
-pub mod vote_sender_types;
 pub mod vote_transaction;
 
 #[macro_use]


### PR DESCRIPTION
#### Problem
Crates who wish to depend on `solana-vote` as a lightweight dependency for various
Vote types are forced to bring `crossbeam-channel` into their dependency tree as
well, as a result of the vote sender types `ReplayVoteSender` and `ReplayVoteReceiver`.

#### Summary of Changes
Hoist these up to `solana-runtime`, which all crates that use these types already
depend on.
