### PR TITLE
cli: Corrects help for --incremental-snapshot-archive-path

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -350,8 +350,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("DIR")
                 .takes_value(true)
                 .help(
-                    "Use DIR as separate location for incremental snapshot archives \
-                     [default: --snapshots value]",
+                    "Use DIR as incremental snapshot archives location [default: --ledger value]"
                 ),
         )
         .arg(


### PR DESCRIPTION
#### Problem

The validator help for `--incremental-snapshot-archive-path` is wrong about the default value.

Here's the code:
https://github.com/anza-xyz/agave/blob/fbc75a754433aeb430d3969ccfe2c70639f8d364/validator/src/main.rs#L1592-L1624


#### Summary of Changes

Correct it.