### PR TITLE
cli: Fixes snapshot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Release channels have their own copy of this changelog:
   * RPC's `simulateTransaction` now returns an extra `replacementBlockhash` field in the response
     when the `replaceRecentBlockhash` config param is `true` (#380)
   * SDK: `cargo test-sbf` accepts `--tools-version`, just like `build-sbf` (#1359)
+  * CLI: Can specify `--full-snapshot-archive-path` (#1631)
 
 ## [1.18.0]
 * Changes

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -808,6 +808,7 @@ fn main() {
             Arg::with_name("snapshots")
                 .long("snapshots")
                 .alias("snapshot-archive-path")
+                .alias("full-snapshot-archive-path")
                 .value_name("DIR")
                 .takes_value(true)
                 .global(true)

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -332,7 +332,11 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("snapshots")
                 .value_name("DIR")
                 .takes_value(true)
-                .help("Use DIR as snapshot location [default: <LEDGER>/snapshots]"),
+                .help(
+                    "Use DIR as the base location for snapshots. \
+                     A subdirectory named \"snapshots\" will be created. \
+                     [default: --ledger value]",
+                 ),
         )
         .arg(
             Arg::with_name(use_snapshot_archives_at_startup::cli::NAME)

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -344,13 +344,23 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long_help(use_snapshot_archives_at_startup::cli::LONG_HELP),
         )
         .arg(
+            Arg::with_name("full_snapshot_archive_path")
+                .long("full-snapshot-archive-path")
+                .value_name("DIR")
+                .takes_value(true)
+                .help(
+                    "Use DIR as full snapshot archives location \
+                     [default: --snapshots value]",
+                 ),
+        )
+        .arg(
             Arg::with_name("incremental_snapshot_archive_path")
                 .long("incremental-snapshot-archive-path")
                 .conflicts_with("no-incremental-snapshots")
                 .value_name("DIR")
                 .takes_value(true)
                 .help(
-                    "Use DIR as separate location for incremental snapshot archives \
+                    "Use DIR as incremental snapshot archives location \
                      [default: --snapshots value]",
                 ),
         )


### PR DESCRIPTION
#### Problem

The CLI snapshot paths for the validator are wonky. This results in issues like #1563: if a validator wants to put the incremental snapshot *archives* into their own path, it'll also put the bank snapshots there too. This can be especially bad if the operator is trying to put only the incremental snapshot archives in a ram-backed file system.

There should be a way to intuitively and distinctly specify all three snapshot paths: bank snapshots, full snapshot archives, and incremental snapshot archives.

Example:
Operator sets `--snapshots snap --incremental-snapshot-archive-path incr`

Here's what currently happens vs what's expected:

| directory | expected | actual |
|--------|--------|--------|
| full snapshot archives | snap | snap |
| incremental snapshot archives | incr | incr | 
| bank snapshots | snap/snapshots | incr/snapshots |


#### Summary of Changes

* Add a CLI arg for the full snapshot archives dir
* Fix the logic such that all three snapshot paths are distinct
* Update the help text for --snapshots

Fixes #1563 