### PR TITLE
sdk: Remove borsh usage from Pubkey test

### DIFF
--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -971,7 +971,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "borsh")]
     fn pubkey_from_seed_by_marker(marker: &[u8]) -> Result<Pubkey, PubkeyError> {
         let key = Pubkey::new_unique();
         let owner = Pubkey::default();
@@ -980,12 +979,11 @@ mod tests {
         to_fake.extend_from_slice(marker);
 
         let seed = &String::from_utf8(to_fake[..to_fake.len() - 32].to_vec()).expect("not utf8");
-        let base = &Pubkey::try_from_slice(&to_fake[to_fake.len() - 32..]).unwrap();
+        let base = &Pubkey::try_from(&to_fake[to_fake.len() - 32..]).unwrap();
 
         Pubkey::create_with_seed(&key, seed, base)
     }
 
-    #[cfg(feature = "borsh")]
     #[test]
     fn test_create_with_seed_rejects_illegal_owner() {
         assert_eq!(


### PR DESCRIPTION
#### Problem

While reviewing #1576, I noticed a pubkey test that used borsh, but totally didn't need to.

#### Summary of Changes

Use `TryFrom::<&[u8]>` instead of `BorshDeserialize::try_from_slice` in the test

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
