### PR TITLE
refactor: consolidate fee deduction for failed transactions

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -67,6 +67,7 @@ serde_bytes = { workspace = true }
 solana-accounts-db = { path = ".", features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
+solana-svm = { workspace = true, features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -330,7 +330,6 @@ pub(crate) mod tests {
             log_messages: None,
             inner_instructions: None,
             fee_details: FeeDetails::default(),
-            is_nonce: true,
             return_data: None,
             executed_units: 0,
             accounts_data_len_delta: 0,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -104,7 +104,7 @@ use {
         transaction_context::TransactionAccount,
     },
     solana_stake_program::stake_state::{self, StakeStateV2},
-    solana_svm::nonce_info::NonceFull,
+    solana_svm::nonce_info::NoncePartial,
     solana_vote_program::{
         vote_instruction,
         vote_state::{
@@ -233,7 +233,7 @@ fn test_race_register_tick_freeze() {
 
 fn new_execution_result(
     status: Result<()>,
-    nonce: Option<&NonceFull>,
+    nonce: Option<&NoncePartial>,
     fee_details: FeeDetails,
 ) -> TransactionExecutionResult {
     TransactionExecutionResult::Executed {
@@ -2867,28 +2867,11 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
 #[test]
 fn test_filter_program_errors_and_collect_fee() {
     let leader = solana_sdk::pubkey::new_rand();
-    let GenesisConfigInfo {
-        genesis_config,
-        mint_keypair,
-        ..
-    } = create_genesis_config_with_leader(100_000, &leader, 3);
+    let GenesisConfigInfo { genesis_config, .. } =
+        create_genesis_config_with_leader(100_000, &leader, 3);
     let mut bank = Bank::new_for_tests(&genesis_config);
     // this test is only for when `feature_set::reward_full_priority_fee` inactivated
     bank.deactivate_feature(&feature_set::reward_full_priority_fee::id());
-
-    let key = solana_sdk::pubkey::new_rand();
-    let tx1 = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
-        &mint_keypair,
-        &key,
-        2,
-        genesis_config.hash(),
-    ));
-    let tx2 = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
-        &mint_keypair,
-        &key,
-        5,
-        genesis_config.hash(),
-    ));
 
     let tx_fee = 42;
     let fee_details = FeeDetails::new_for_tests(tx_fee, 0, false);
@@ -2905,7 +2888,7 @@ fn test_filter_program_errors_and_collect_fee() {
     ];
     let initial_balance = bank.get_balance(&leader);
 
-    let results = bank.filter_program_errors_and_collect_fee(&[tx1, tx2], &results);
+    let results = bank.filter_program_errors_and_collect_fee(&results);
     bank.freeze();
     assert_eq!(
         bank.get_balance(&leader),
@@ -2918,28 +2901,11 @@ fn test_filter_program_errors_and_collect_fee() {
 #[test]
 fn test_filter_program_errors_and_collect_priority_fee() {
     let leader = solana_sdk::pubkey::new_rand();
-    let GenesisConfigInfo {
-        genesis_config,
-        mint_keypair,
-        ..
-    } = create_genesis_config_with_leader(1000000, &leader, 3);
+    let GenesisConfigInfo { genesis_config, .. } =
+        create_genesis_config_with_leader(1000000, &leader, 3);
     let mut bank = Bank::new_for_tests(&genesis_config);
     // this test is only for when `feature_set::reward_full_priority_fee` inactivated
     bank.deactivate_feature(&feature_set::reward_full_priority_fee::id());
-
-    let key = solana_sdk::pubkey::new_rand();
-    let tx1 = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
-        &mint_keypair,
-        &key,
-        2,
-        genesis_config.hash(),
-    ));
-    let tx2 = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
-        &mint_keypair,
-        &key,
-        5,
-        genesis_config.hash(),
-    ));
 
     let priority_fee = 42;
     let fee_details: FeeDetails = FeeDetails::new_for_tests(0, priority_fee, false);
@@ -2956,7 +2922,7 @@ fn test_filter_program_errors_and_collect_priority_fee() {
     ];
     let initial_balance = bank.get_balance(&leader);
 
-    let results = bank.filter_program_errors_and_collect_fee(&[tx1, tx2], &results);
+    let results = bank.filter_program_errors_and_collect_fee(&results);
     bank.freeze();
     assert_eq!(
         bank.get_balance(&leader),
@@ -12935,18 +12901,15 @@ fn test_failed_simulation_compute_units() {
 
 #[test]
 fn test_filter_program_errors_and_collect_fee_details() {
-    // TX  | EXECUTION RESULT            | is nonce | COLLECT            | ADDITIONAL          | COLLECT
-    //     |                             |          | (TX_FEE, PRIO_FEE) | WITHDRAW FROM PAYER | RESULT
-    // ------------------------------------------------------------------------------------------------------
-    // tx1 | not executed                | n/a      | (0    , 0)         | 0                   | Original Err
-    // tx2 | executed and no error       | n/a      | (5_000, 1_000)     | 0                   | Ok
-    // tx3 | executed has error          | true     | (5_000, 1_000)     | 0                   | Ok
-    // tx4 | executed has error          | false    | (5_000, 1_000)     | 6_000               | Ok
-    // tx5 | executed error,
-    //         payer insufficient fund   | false    | (0    , 0)         | 0                   | InsufficientFundsForFee
+    // TX  | EXECUTION RESULT            | is nonce | COLLECT            | COLLECT
+    //     |                             |          | (TX_FEE, PRIO_FEE) | RESULT
+    // ---------------------------------------------------------------------------------
+    // tx1 | not executed                | n/a      | (0    , 0)         | Original Err
+    // tx2 | executed and no error       | n/a      | (5_000, 1_000)     | Ok
+    // tx3 | executed has error          | true     | (5_000, 1_000)     | Ok
+    // tx4 | executed has error          | false    | (5_000, 1_000)     | Ok
     //
     let initial_payer_balance = 7_000;
-    let additional_payer_withdraw = 6_000;
     let tx_fee = 5000;
     let priority_fee = 1000;
     let tx_fee_details = FeeDetails::new_for_tests(tx_fee, priority_fee, false);
@@ -12960,7 +12923,6 @@ fn test_filter_program_errors_and_collect_fee_details() {
         Ok(()),
         Ok(()),
         Ok(()),
-        Err(TransactionError::InsufficientFundsForFee),
     ];
 
     let GenesisConfigInfo {
@@ -12970,18 +12932,6 @@ fn test_filter_program_errors_and_collect_fee_details() {
     } = create_genesis_config_with_leader(initial_payer_balance, &Pubkey::new_unique(), 3);
     let bank = Bank::new_for_tests(&genesis_config);
 
-    let tx = SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
-        &[system_instruction::transfer(
-            &mint_keypair.pubkey(),
-            &Pubkey::new_unique(),
-            2,
-        )],
-        Some(&mint_keypair.pubkey()),
-        &[&mint_keypair],
-        genesis_config.hash(),
-    ));
-    let txs = vec![tx.clone(), tx.clone(), tx.clone(), tx.clone(), tx];
-
     let results = vec![
         TransactionExecutionResult::NotExecuted(TransactionError::AccountNotFound),
         new_execution_result(Ok(()), None, tx_fee_details),
@@ -12990,10 +12940,9 @@ fn test_filter_program_errors_and_collect_fee_details() {
                 0,
                 SystemError::ResultWithNegativeLamports.into(),
             )),
-            Some(&NonceFull::new(
+            Some(&NoncePartial::new(
                 Pubkey::new_unique(),
                 AccountSharedData::default(),
-                None,
             )),
             tx_fee_details,
         ),
@@ -13005,71 +12954,21 @@ fn test_filter_program_errors_and_collect_fee_details() {
             None,
             tx_fee_details,
         ),
-        new_execution_result(Err(TransactionError::AccountNotFound), None, tx_fee_details),
     ];
 
-    let results = bank.filter_program_errors_and_collect_fee_details(&txs, &results);
+    let results = bank.filter_program_errors_and_collect_fee_details(&results);
 
     assert_eq!(
         expected_collected_fee_details,
         *bank.collector_fee_details.read().unwrap()
     );
     assert_eq!(
-        initial_payer_balance - additional_payer_withdraw,
+        initial_payer_balance,
         bank.get_balance(&mint_keypair.pubkey())
     );
     assert_eq!(expected_collect_results, results);
 }
 
-#[test]
-fn test_check_execution_status_and_charge_fee() {
-    let fee = 5000;
-    let initial_balance = fee - 1000;
-    let tx_error =
-        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature);
-    let GenesisConfigInfo {
-        mut genesis_config,
-        mint_keypair,
-        ..
-    } = create_genesis_config_with_leader(initial_balance, &Pubkey::new_unique(), 3);
-    genesis_config.fee_rate_governor = FeeRateGovernor::new(5000, 0);
-    let bank = Bank::new_for_tests(&genesis_config);
-    let message = new_sanitized_message(Message::new(
-        &[system_instruction::transfer(
-            &mint_keypair.pubkey(),
-            &Pubkey::new_unique(),
-            1,
-        )],
-        Some(&mint_keypair.pubkey()),
-    ));
-
-    [Ok(()), Err(tx_error)]
-        .iter()
-        .flat_map(|result| [true, false].iter().map(move |is_nonce| (result, is_nonce)))
-        .for_each(|(result, is_nonce)| {
-            if result.is_err() && !is_nonce {
-                assert_eq!(
-                    Err(TransactionError::InsufficientFundsForFee),
-                    bank.check_execution_status_and_charge_fee(&message, result, *is_nonce, fee)
-                );
-                assert_eq!(initial_balance, bank.get_balance(&mint_keypair.pubkey()));
-
-                let small_fee = 1;
-                assert!(bank
-                    .check_execution_status_and_charge_fee(&message, result, *is_nonce, small_fee)
-                    .is_ok());
-                assert_eq!(
-                    initial_balance - small_fee,
-                    bank.get_balance(&mint_keypair.pubkey())
-                );
-            } else {
-                assert!(bank
-                    .check_execution_status_and_charge_fee(&message, result, *is_nonce, fee)
-                    .is_ok());
-                assert_eq!(initial_balance, bank.get_balance(&mint_keypair.pubkey()));
-            }
-        });
-}
 #[test]
 fn test_deploy_last_epoch_slot() {
     solana_logger::setup();

--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -277,11 +277,10 @@ Steps of `load_and_execute_sanitized_transactions`
             - Validate the fee payer and the loaded accounts
             - Validate the programs accounts that have been loaded and checks if they are builtin programs.
             - Return `struct LoadedTransaction` containing the accounts (pubkey and data),
-              indices to the excutabe accounts in `TransactionContext` (or `InstructionContext`),
+              indices to the executable accounts in `TransactionContext` (or `InstructionContext`),
               the transaction rent, and the `struct RentDebit`.
-            - Generate a `NonceFull` struct (holds fee subtracted nonce info) when possible, `None` otherwise.
-    - Returns `TransactionLoadedResult`, a tuple containing the `LoadTransaction` we obtained from `loaded_transaction_accounts`,
-      and a `Option<NonceFull>`.
+            - Generate a `RollbackAccounts` struct which holds fee-subtracted fee payer account and pre-execution nonce state used for rolling back account state on execution failure.
+    - Returns `TransactionLoadedResult`, containing the `LoadTransaction` we obtained from `loaded_transaction_accounts`
 
 3. Execute each loaded transactions
    1. Compute the sum of transaction accounts' balances. This sum is

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -432,7 +432,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            nonce_info::NonceFull, transaction_account_state_info::TransactionAccountStateInfo,
+            transaction_account_state_info::TransactionAccountStateInfo,
             transaction_processing_callback::TransactionProcessingCallback,
         },
         nonce::state::Versions as NonceVersions,
@@ -1108,6 +1108,70 @@ mod tests {
     }
 
     #[test]
+    fn test_load_transaction_accounts_fee_payer() {
+        let fee_payer_address = Pubkey::new_unique();
+        let message = Message {
+            account_keys: vec![fee_payer_address],
+            header: MessageHeader::default(),
+            instructions: vec![],
+            recent_blockhash: Hash::default(),
+        };
+
+        let sanitized_message = new_unchecked_sanitized_message(message);
+        let mut mock_bank = TestCallbacks::default();
+
+        let fee_payer_balance = 200;
+        let mut fee_payer_account_data = AccountSharedData::default();
+        fee_payer_account_data.set_lamports(fee_payer_balance);
+        mock_bank
+            .accounts_map
+            .insert(fee_payer_address, fee_payer_account_data.clone());
+        let fee_payer_rent_debit = 42;
+
+        let mut error_metrics = TransactionErrorMetrics::default();
+        let loaded_programs = ProgramCacheForTxBatch::default();
+
+        let sanitized_transaction = SanitizedTransaction::new_for_tests(
+            sanitized_message,
+            vec![Signature::new_unique()],
+            false,
+        );
+        let result = load_transaction_accounts(
+            &mock_bank,
+            sanitized_transaction.message(),
+            ValidatedTransactionDetails {
+                rollback_accounts: RollbackAccounts::default(),
+                fee_details: FeeDetails::default(),
+                fee_payer_account: fee_payer_account_data.clone(),
+                fee_payer_rent_debit,
+            },
+            &mut error_metrics,
+            None,
+            &FeatureSet::default(),
+            &RentCollector::default(),
+            &loaded_programs,
+        );
+
+        let expected_rent_debits = {
+            let mut rent_debits = RentDebits::default();
+            rent_debits.insert(&fee_payer_address, fee_payer_rent_debit, fee_payer_balance);
+            rent_debits
+        };
+        assert_eq!(
+            result.unwrap(),
+            LoadedTransaction {
+                accounts: vec![(fee_payer_address, fee_payer_account_data),],
+                program_indices: vec![],
+                fee_details: FeeDetails::default(),
+                rollback_accounts: RollbackAccounts::default(),
+                rent: fee_payer_rent_debit,
+                rent_debits: expected_rent_debits,
+                loaded_accounts_data_size: 0,
+            }
+        );
+    }
+
+    #[test]
     fn test_load_transaction_accounts_native_loader() {
         let key1 = Keypair::new();
         let message = Message {
@@ -1140,14 +1204,13 @@ mod tests {
             vec![Signature::new_unique()],
             false,
         );
-        let fee_details = FeeDetails::new_for_tests(32, 0, false);
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
             ValidatedTransactionDetails {
-                nonce: None,
-                fee_details,
-                fee_payer_account: fee_payer_account_data,
+                rollback_accounts: RollbackAccounts::default(),
+                fee_details: FeeDetails::default(),
+                fee_payer_account: fee_payer_account_data.clone(),
                 fee_payer_rent_debit: 0,
             },
             &mut error_metrics,
@@ -1161,18 +1224,15 @@ mod tests {
             result.unwrap(),
             LoadedTransaction {
                 accounts: vec![
-                    (
-                        key1.pubkey(),
-                        mock_bank.accounts_map[&key1.pubkey()].clone()
-                    ),
+                    (key1.pubkey(), fee_payer_account_data),
                     (
                         native_loader::id(),
                         mock_bank.accounts_map[&native_loader::id()].clone()
                     )
                 ],
                 program_indices: vec![vec![]],
-                nonce: None,
-                fee_details,
+                fee_details: FeeDetails::default(),
+                rollback_accounts: RollbackAccounts::default(),
                 rent: 0,
                 rent_debits: RentDebits::default(),
                 loaded_accounts_data_size: 0,
@@ -1352,14 +1412,13 @@ mod tests {
             vec![Signature::new_unique()],
             false,
         );
-        let fee_details = FeeDetails::new_for_tests(32, 0, false);
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
             ValidatedTransactionDetails {
-                nonce: None,
-                fee_details,
-                fee_payer_account: fee_payer_account_data,
+                rollback_accounts: RollbackAccounts::default(),
+                fee_details: FeeDetails::default(),
+                fee_payer_account: fee_payer_account_data.clone(),
                 fee_payer_rent_debit: 0,
             },
             &mut error_metrics,
@@ -1373,17 +1432,14 @@ mod tests {
             result.unwrap(),
             LoadedTransaction {
                 accounts: vec![
-                    (
-                        key2.pubkey(),
-                        mock_bank.accounts_map[&key2.pubkey()].clone()
-                    ),
+                    (key2.pubkey(), fee_payer_account_data),
                     (
                         key1.pubkey(),
                         mock_bank.accounts_map[&key1.pubkey()].clone()
                     ),
                 ],
-                nonce: None,
-                fee_details,
+                fee_details: FeeDetails::default(),
+                rollback_accounts: RollbackAccounts::default(),
                 program_indices: vec![vec![1]],
                 rent: 0,
                 rent_debits: RentDebits::default(),
@@ -1538,14 +1594,13 @@ mod tests {
             vec![Signature::new_unique()],
             false,
         );
-        let fee_details = FeeDetails::new_for_tests(32, 0, false);
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
             ValidatedTransactionDetails {
-                nonce: None,
-                fee_details,
-                fee_payer_account: fee_payer_account_data,
+                rollback_accounts: RollbackAccounts::default(),
+                fee_details: FeeDetails::default(),
+                fee_payer_account: fee_payer_account_data.clone(),
                 fee_payer_rent_debit: 0,
             },
             &mut error_metrics,
@@ -1559,10 +1614,7 @@ mod tests {
             result.unwrap(),
             LoadedTransaction {
                 accounts: vec![
-                    (
-                        key2.pubkey(),
-                        mock_bank.accounts_map[&key2.pubkey()].clone()
-                    ),
+                    (key2.pubkey(), fee_payer_account_data),
                     (
                         key1.pubkey(),
                         mock_bank.accounts_map[&key1.pubkey()].clone()
@@ -1573,8 +1625,8 @@ mod tests {
                     ),
                 ],
                 program_indices: vec![vec![2, 1]],
-                nonce: None,
-                fee_details,
+                fee_details: FeeDetails::default(),
+                rollback_accounts: RollbackAccounts::default(),
                 rent: 0,
                 rent_debits: RentDebits::default(),
                 loaded_accounts_data_size: 0,
@@ -1633,14 +1685,13 @@ mod tests {
             vec![Signature::new_unique()],
             false,
         );
-        let fee_details = FeeDetails::new_for_tests(32, 0, false);
         let result = load_transaction_accounts(
             &mock_bank,
             sanitized_transaction.message(),
             ValidatedTransactionDetails {
-                nonce: None,
-                fee_details,
-                fee_payer_account: fee_payer_account_data,
+                rollback_accounts: RollbackAccounts::default(),
+                fee_details: FeeDetails::default(),
+                fee_payer_account: fee_payer_account_data.clone(),
                 fee_payer_rent_debit: 0,
             },
             &mut error_metrics,
@@ -1656,10 +1707,7 @@ mod tests {
             result.unwrap(),
             LoadedTransaction {
                 accounts: vec![
-                    (
-                        key2.pubkey(),
-                        mock_bank.accounts_map[&key2.pubkey()].clone()
-                    ),
+                    (key2.pubkey(), fee_payer_account_data),
                     (
                         key1.pubkey(),
                         mock_bank.accounts_map[&key1.pubkey()].clone()
@@ -1671,8 +1719,8 @@ mod tests {
                     ),
                 ],
                 program_indices: vec![vec![3, 1], vec![3, 1]],
-                nonce: None,
-                fee_details,
+                fee_details: FeeDetails::default(),
+                rollback_accounts: RollbackAccounts::default(),
                 rent: 0,
                 rent_debits: RentDebits::default(),
                 loaded_accounts_data_size: 0,
@@ -1793,7 +1841,7 @@ mod tests {
             false,
         );
         let validation_result = Ok(ValidatedTransactionDetails {
-            nonce: None,
+            rollback_accounts: RollbackAccounts::default(),
             fee_details: FeeDetails::default(),
             fee_payer_account: fee_payer_account_data,
             fee_payer_rent_debit: 0,
@@ -1834,8 +1882,8 @@ mod tests {
                     ),
                 ],
                 program_indices: vec![vec![3, 1], vec![3, 1]],
-                nonce: None,
                 fee_details: FeeDetails::default(),
+                rollback_accounts: RollbackAccounts::default(),
                 rent: 0,
                 rent_debits: RentDebits::default(),
                 loaded_accounts_data_size: 0,
@@ -1868,7 +1916,7 @@ mod tests {
         );
 
         let validation_result = Ok(ValidatedTransactionDetails {
-            nonce: Some(NonceFull::default()),
+            rollback_accounts: RollbackAccounts::default(),
             fee_details: FeeDetails::default(),
             fee_payer_account: AccountSharedData::default(),
             fee_payer_rent_debit: 0,

--- a/svm/src/lib.rs
+++ b/svm/src/lib.rs
@@ -7,6 +7,7 @@ pub mod account_rent_state;
 pub mod message_processor;
 pub mod nonce_info;
 pub mod program_loader;
+pub mod rollback_accounts;
 pub mod runtime_config;
 pub mod transaction_account_state_info;
 pub mod transaction_error_metrics;

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -41,40 +41,21 @@ mod tests {
         super::*,
         solana_sdk::{
             hash::Hash,
-            instruction::Instruction,
-            message::{Message, SanitizedMessage},
-            nonce::{self, state::DurableNonce},
-            reserved_account_keys::ReservedAccountKeys,
-            signature::{keypair_from_seed, Signer},
-            system_instruction, system_program,
+            nonce::state::{
+                Data as NonceData, DurableNonce, State as NonceState, Versions as NonceVersions,
+            },
+            system_program,
         },
     };
 
-    fn new_sanitized_message(
-        instructions: &[Instruction],
-        payer: Option<&Pubkey>,
-    ) -> SanitizedMessage {
-        SanitizedMessage::try_from_legacy_message(
-            Message::new(instructions, payer),
-            &ReservedAccountKeys::empty_key_set(),
-        )
-        .unwrap()
-    }
-
     #[test]
     fn test_nonce_info() {
-        let lamports_per_signature = 42;
-
-        let nonce_authority = keypair_from_seed(&[0; 32]).unwrap();
-        let nonce_address = nonce_authority.pubkey();
-        let from = keypair_from_seed(&[1; 32]).unwrap();
-        let from_address = from.pubkey();
-        let to_address = Pubkey::new_unique();
-
+        let nonce_address = Pubkey::new_unique();
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
+        let lamports_per_signature = 42;
         let nonce_account = AccountSharedData::new_data(
             43,
-            &nonce::state::Versions::new(nonce::State::Initialized(nonce::state::Data::new(
+            &NonceVersions::new(NonceState::Initialized(NonceData::new(
                 Pubkey::default(),
                 durable_nonce,
                 lamports_per_signature,
@@ -82,71 +63,15 @@ mod tests {
             &system_program::id(),
         )
         .unwrap();
-        let from_account = AccountSharedData::new(44, 0, &Pubkey::default());
-
-        const TEST_RENT_DEBIT: u64 = 1;
-        let rent_collected_nonce_account = {
-            let mut account = nonce_account.clone();
-            account.set_lamports(nonce_account.lamports() - TEST_RENT_DEBIT);
-            account
-        };
-        let rent_collected_from_account = {
-            let mut account = from_account.clone();
-            account.set_lamports(from_account.lamports() - TEST_RENT_DEBIT);
-            account
-        };
-
-        let instructions = vec![
-            system_instruction::advance_nonce_account(&nonce_address, &nonce_authority.pubkey()),
-            system_instruction::transfer(&from_address, &to_address, 42),
-        ];
 
         // NoncePartial create + NonceInfo impl
-        let partial = NoncePartial::new(nonce_address, rent_collected_nonce_account.clone());
+        let partial = NoncePartial::new(nonce_address, nonce_account.clone());
         assert_eq!(*partial.address(), nonce_address);
-        assert_eq!(*partial.account(), rent_collected_nonce_account);
+        assert_eq!(*partial.account(), nonce_account);
         assert_eq!(
             partial.lamports_per_signature(),
             Some(lamports_per_signature)
         );
         assert_eq!(partial.fee_payer_account(), None);
-
-        // NonceFull create + NonceInfo impl
-        {
-            let message = new_sanitized_message(&instructions, Some(&from_address));
-            let fee_payer_address = message.account_keys().get(0).unwrap();
-            let fee_payer_account = rent_collected_from_account.clone();
-            let full = NonceFull::from_partial(
-                partial.clone(),
-                fee_payer_address,
-                fee_payer_account,
-                TEST_RENT_DEBIT,
-            );
-            assert_eq!(*full.address(), nonce_address);
-            assert_eq!(*full.account(), rent_collected_nonce_account);
-            assert_eq!(full.lamports_per_signature(), Some(lamports_per_signature));
-            assert_eq!(
-                full.fee_payer_account(),
-                Some(&from_account),
-                "rent debit should be refunded in captured fee account"
-            );
-        }
-
-        // Nonce account is fee-payer
-        {
-            let message = new_sanitized_message(&instructions, Some(&nonce_address));
-            let fee_payer_address = message.account_keys().get(0).unwrap();
-            let fee_payer_account = rent_collected_nonce_account;
-            let full = NonceFull::from_partial(
-                partial,
-                fee_payer_address,
-                fee_payer_account,
-                TEST_RENT_DEBIT,
-            );
-            assert_eq!(*full.address(), nonce_address);
-            assert_eq!(*full.account(), nonce_account);
-            assert_eq!(full.lamports_per_signature(), Some(lamports_per_signature));
-            assert_eq!(full.fee_payer_account(), None);
-        }
     }
 }

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -1,8 +1,4 @@
-use solana_sdk::{
-    account::{AccountSharedData, ReadableAccount, WritableAccount},
-    nonce_account,
-    pubkey::Pubkey,
-};
+use solana_sdk::{account::AccountSharedData, nonce_account, pubkey::Pubkey};
 
 pub trait NonceInfo {
     fn address(&self) -> &Pubkey;
@@ -36,67 +32,6 @@ impl NonceInfo for NoncePartial {
     }
     fn fee_payer_account(&self) -> Option<&AccountSharedData> {
         None
-    }
-}
-
-/// Holds fee subtracted nonce info
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct NonceFull {
-    address: Pubkey,
-    account: AccountSharedData,
-    fee_payer_account: Option<AccountSharedData>,
-}
-
-impl NonceFull {
-    pub fn new(
-        address: Pubkey,
-        account: AccountSharedData,
-        fee_payer_account: Option<AccountSharedData>,
-    ) -> Self {
-        Self {
-            address,
-            account,
-            fee_payer_account,
-        }
-    }
-
-    pub fn from_partial(
-        partial: NoncePartial,
-        fee_payer_address: &Pubkey,
-        mut fee_payer_account: AccountSharedData,
-        fee_payer_rent_debit: u64,
-    ) -> Self {
-        fee_payer_account.set_lamports(
-            fee_payer_account
-                .lamports()
-                .saturating_add(fee_payer_rent_debit),
-        );
-
-        let NoncePartial {
-            address: nonce_address,
-            account: nonce_account,
-        } = partial;
-
-        if *fee_payer_address == nonce_address {
-            Self::new(nonce_address, fee_payer_account, None)
-        } else {
-            Self::new(nonce_address, nonce_account, Some(fee_payer_account))
-        }
-    }
-}
-
-impl NonceInfo for NonceFull {
-    fn address(&self) -> &Pubkey {
-        &self.address
-    }
-    fn account(&self) -> &AccountSharedData {
-        &self.account
-    }
-    fn lamports_per_signature(&self) -> Option<u64> {
-        nonce_account::lamports_per_signature_of(&self.account)
-    }
-    fn fee_payer_account(&self) -> Option<&AccountSharedData> {
-        self.fee_payer_account.as_ref()
     }
 }
 

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -1,0 +1,92 @@
+use {
+    crate::nonce_info::{NonceInfo, NoncePartial},
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount, WritableAccount},
+        pubkey::Pubkey,
+    },
+};
+
+/// Captured account state used to rollback account state for nonce and fee
+/// payer accounts after a failed executed transaction.
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum RollbackAccounts {
+    FeePayerOnly {
+        fee_payer_account: AccountSharedData,
+    },
+    SameNonceAndFeePayer {
+        nonce: NoncePartial,
+    },
+    SeparateNonceAndFeePayer {
+        nonce: NoncePartial,
+        fee_payer_account: AccountSharedData,
+    },
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl Default for RollbackAccounts {
+    fn default() -> Self {
+        Self::FeePayerOnly {
+            fee_payer_account: AccountSharedData::default(),
+        }
+    }
+}
+
+impl RollbackAccounts {
+    pub fn new(
+        nonce: Option<NoncePartial>,
+        fee_payer_address: Pubkey,
+        mut fee_payer_account: AccountSharedData,
+        fee_payer_rent_debit: u64,
+        fee_payer_loaded_rent_epoch: u64,
+    ) -> Self {
+        // When the fee payer account is rolled back due to transaction failure,
+        // rent should not be charged so credit the previously debited rent
+        // amount.
+        fee_payer_account.set_lamports(
+            fee_payer_account
+                .lamports()
+                .saturating_add(fee_payer_rent_debit),
+        );
+
+        if let Some(nonce) = nonce {
+            if &fee_payer_address == nonce.address() {
+                RollbackAccounts::SameNonceAndFeePayer {
+                    nonce: NoncePartial::new(fee_payer_address, fee_payer_account),
+                }
+            } else {
+                RollbackAccounts::SeparateNonceAndFeePayer {
+                    nonce,
+                    fee_payer_account,
+                }
+            }
+        } else {
+            // When rolling back failed transactions which don't use nonces, the
+            // runtime should not update the fee payer's rent epoch so reset the
+            // rollback fee payer acocunt's rent epoch to its originally loaded
+            // rent epoch value. In the future, a feature gate could be used to
+            // alter this behavior such that rent epoch updates are handled the
+            // same for both nonce and non-nonce failed transactions.
+            fee_payer_account.set_rent_epoch(fee_payer_loaded_rent_epoch);
+            RollbackAccounts::FeePayerOnly { fee_payer_account }
+        }
+    }
+
+    pub fn nonce(&self) -> Option<&NoncePartial> {
+        match self {
+            Self::FeePayerOnly { .. } => None,
+            Self::SameNonceAndFeePayer { nonce } | Self::SeparateNonceAndFeePayer { nonce, .. } => {
+                Some(nonce)
+            }
+        }
+    }
+
+    pub fn fee_payer_account(&self) -> &AccountSharedData {
+        match self {
+            Self::FeePayerOnly { fee_payer_account }
+            | Self::SeparateNonceAndFeePayer {
+                fee_payer_account, ..
+            } => fee_payer_account,
+            Self::SameNonceAndFeePayer { nonce } => nonce.account(),
+        }
+    }
+}

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -2,6 +2,7 @@ use {
     crate::nonce_info::{NonceInfo, NoncePartial},
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
+        clock::Epoch,
         pubkey::Pubkey,
     },
 };
@@ -37,7 +38,7 @@ impl RollbackAccounts {
         fee_payer_address: Pubkey,
         mut fee_payer_account: AccountSharedData,
         fee_payer_rent_debit: u64,
-        fee_payer_loaded_rent_epoch: u64,
+        fee_payer_loaded_rent_epoch: Epoch,
     ) -> Self {
         // When the fee payer account is rolled back due to transaction failure,
         // rent should not be charged so credit the previously debited rent

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -90,3 +90,139 @@ impl RollbackAccounts {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_sdk::{
+            account::{ReadableAccount, WritableAccount},
+            hash::Hash,
+            nonce::state::{
+                Data as NonceData, DurableNonce, State as NonceState, Versions as NonceVersions,
+            },
+            system_program,
+        },
+    };
+
+    #[test]
+    fn test_new_fee_payer_only() {
+        let fee_payer_address = Pubkey::new_unique();
+        let fee_payer_account = AccountSharedData::new(100, 0, &Pubkey::default());
+        let fee_payer_rent_epoch = fee_payer_account.rent_epoch();
+
+        const TEST_RENT_DEBIT: u64 = 1;
+        let rent_collected_fee_payer_account = {
+            let mut account = fee_payer_account.clone();
+            account.set_lamports(fee_payer_account.lamports() - TEST_RENT_DEBIT);
+            account.set_rent_epoch(fee_payer_rent_epoch + 1);
+            account
+        };
+
+        let rollback_accounts = RollbackAccounts::new(
+            None,
+            fee_payer_address,
+            rent_collected_fee_payer_account,
+            TEST_RENT_DEBIT,
+            fee_payer_rent_epoch,
+        );
+
+        let expected_fee_payer_account = fee_payer_account;
+        match rollback_accounts {
+            RollbackAccounts::FeePayerOnly { fee_payer_account } => {
+                assert_eq!(expected_fee_payer_account, fee_payer_account);
+            }
+            _ => panic!("Expected FeePayerOnly variant"),
+        }
+    }
+
+    #[test]
+    fn test_new_same_nonce_and_fee_payer() {
+        let nonce_address = Pubkey::new_unique();
+        let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
+        let lamports_per_signature = 42;
+        let nonce_account = AccountSharedData::new_data(
+            43,
+            &NonceVersions::new(NonceState::Initialized(NonceData::new(
+                Pubkey::default(),
+                durable_nonce,
+                lamports_per_signature,
+            ))),
+            &system_program::id(),
+        )
+        .unwrap();
+
+        const TEST_RENT_DEBIT: u64 = 1;
+        let rent_collected_nonce_account = {
+            let mut account = nonce_account.clone();
+            account.set_lamports(nonce_account.lamports() - TEST_RENT_DEBIT);
+            account
+        };
+
+        let nonce = NoncePartial::new(nonce_address, rent_collected_nonce_account.clone());
+        let rollback_accounts = RollbackAccounts::new(
+            Some(nonce),
+            nonce_address,
+            rent_collected_nonce_account,
+            TEST_RENT_DEBIT,
+            u64::MAX, // ignored
+        );
+
+        match rollback_accounts {
+            RollbackAccounts::SameNonceAndFeePayer { nonce } => {
+                assert_eq!(nonce.address(), &nonce_address);
+                assert_eq!(nonce.account(), &nonce_account);
+            }
+            _ => panic!("Expected SameNonceAndFeePayer variant"),
+        }
+    }
+
+    #[test]
+    fn test_separate_nonce_and_fee_payer() {
+        let nonce_address = Pubkey::new_unique();
+        let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
+        let lamports_per_signature = 42;
+        let nonce_account = AccountSharedData::new_data(
+            43,
+            &NonceVersions::new(NonceState::Initialized(NonceData::new(
+                Pubkey::default(),
+                durable_nonce,
+                lamports_per_signature,
+            ))),
+            &system_program::id(),
+        )
+        .unwrap();
+
+        let fee_payer_address = Pubkey::new_unique();
+        let fee_payer_account = AccountSharedData::new(44, 0, &Pubkey::default());
+
+        const TEST_RENT_DEBIT: u64 = 1;
+        let rent_collected_fee_payer_account = {
+            let mut account = fee_payer_account.clone();
+            account.set_lamports(fee_payer_account.lamports() - TEST_RENT_DEBIT);
+            account
+        };
+
+        let nonce = NoncePartial::new(nonce_address, nonce_account.clone());
+        let rollback_accounts = RollbackAccounts::new(
+            Some(nonce),
+            fee_payer_address,
+            rent_collected_fee_payer_account.clone(),
+            TEST_RENT_DEBIT,
+            u64::MAX, // ignored
+        );
+
+        let expected_fee_payer_account = fee_payer_account;
+        match rollback_accounts {
+            RollbackAccounts::SeparateNonceAndFeePayer {
+                nonce,
+                fee_payer_account,
+            } => {
+                assert_eq!(nonce.address(), &nonce_address);
+                assert_eq!(nonce.account(), &nonce_account);
+                assert_eq!(expected_fee_payer_account, fee_payer_account);
+            }
+            _ => panic!("Expected SeparateNonceAndFeePayer variant"),
+        }
+    }
+}

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -484,7 +484,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         // to rollback to if transaction execution fails.
         let rollback_accounts = RollbackAccounts::new(
             nonce,
-            *message.fee_payer(),
+            *fee_payer_address,
             fee_payer_account.clone(),
             fee_payer_rent_debit,
             fee_payer_loaded_rent_epoch,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -465,7 +465,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         lamports_per_signature: u64,
         rent_collector: &RentCollector,
         error_counters: &mut TransactionErrorMetrics,
-    ) -> transaction::Result<(FeeDetails, AccountSharedData, u64, u64)> {
+    ) -> transaction::Result<(FeeDetails, AccountSharedData, u64, Epoch)> {
         let fee_payer_address = message.fee_payer();
         let Some(mut fee_payer_account) = callbacks.get_account_shared_data(fee_payer_address)
         else {
@@ -894,7 +894,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 log_messages,
                 inner_instructions,
                 fee_details: loaded_transaction.fee_details,
-                is_nonce: loaded_transaction.rollback_accounts.nonce().is_some(),
                 return_data,
                 executed_units,
                 accounts_data_len_delta,

--- a/svm/src/transaction_results.rs
+++ b/svm/src/transaction_results.rs
@@ -85,7 +85,6 @@ pub struct TransactionExecutionDetails {
     pub log_messages: Option<Vec<String>>,
     pub inner_instructions: Option<InnerInstructionsList>,
     pub fee_details: FeeDetails,
-    pub is_nonce: bool,
     pub return_data: Option<TransactionReturnData>,
     pub executed_units: u64,
     /// The change in accounts data len for this transaction.


### PR DESCRIPTION
#### Problem
Fee deduction for failed transactions is done in two different places depending on whether the transaction uses a durable nonce or not. Having a single code path is preferable and easier to understand.

#### Summary of Changes
Before, only when processing nonce transactions would we capture the fee deducted state of the fee payer account, but now we always capture this state for rollback. And now rollback is always done for failed transactions, regardless of whether they use durable nonces.

- Replaced `NonceFull` with `RollbackAccounts` for tracking account state that will be used for rolling back failed transactions
- Fee collection for non-nonce transactions is now effectively done in `Accounts::collect_accounts_to_store` instead of in `Bank::filter_program_errors_and_collect_fee`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
