### PR TITLE
ledger-tool: Get shreds from BigTable blocks

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -22,11 +22,14 @@ use {
         display::println_transaction, CliBlock, CliTransaction, CliTransactionConfirmation,
         OutputFormat,
     },
+    solana_entry::entry::Entry,
     solana_ledger::{
-        bigtable_upload::ConfirmedBlockUploadConfig, blockstore::Blockstore,
+        bigtable_upload::ConfirmedBlockUploadConfig,
+        blockstore::Blockstore,
         blockstore_options::AccessType,
+        shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
     },
-    solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature},
+    solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature, signer::keypair::Keypair},
     solana_storage_bigtable::CredentialType,
     solana_transaction_status::{ConfirmedBlock, UiTransactionEncoding, VersionedConfirmedBlock},
     std::{
@@ -161,6 +164,63 @@ async fn entries(
         slot,
     };
     println!("{}", output_format.formatted_string(&cli_entries));
+    Ok(())
+}
+
+async fn shreds(
+    blockstore: Arc<Blockstore>,
+    starting_slot: Slot,
+    ending_slot: Slot,
+    config: solana_storage_bigtable::LedgerStorageConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let bigtable = solana_storage_bigtable::LedgerStorage::new_with_config(config)
+        .await
+        .map_err(|err| format!("Failed to connect to storage: {err:?}"))?;
+
+    // Make the range inclusive of both starting and ending slot
+    let limit = (ending_slot - starting_slot + 1) as usize;
+    let mut slots = bigtable.get_confirmed_blocks(starting_slot, limit).await?;
+    slots.retain(|&slot| slot <= ending_slot);
+
+    let keypair = Keypair::from_bytes(&[0; 64]).unwrap();
+    // TODO: parse this / allow command line flag ?
+    let shred_version = 0;
+
+    for slot in slots.iter() {
+        let block = bigtable.get_confirmed_block(*slot).await?;
+        let entry_summaries = bigtable.get_entries(*slot).await?;
+        let entries: Vec<_> = entry_summaries
+            .map(|entry_summary| {
+                let num_hashes = entry_summary.num_hashes;
+                let hash = entry_summary.hash;
+                let transactions = block.transactions[entry_summary.starting_transaction_index
+                    ..entry_summary.starting_transaction_index
+                        + entry_summary.num_transactions as usize]
+                    .iter()
+                    .map(|tx_with_meta| tx_with_meta.get_transaction())
+                    .collect();
+                Entry {
+                    num_hashes,
+                    hash,
+                    transactions,
+                }
+            })
+            .collect();
+
+        let shredder = Shredder::new(*slot, block.parent_slot, 0, shred_version)?;
+        let (data_shreds, _coding_shreds) = shredder.entries_to_shreds(
+            &keypair,
+            &entries,
+            true,  // last_in_slot
+            None,  // chained_merkle_root
+            0,     // next_shred_index
+            0,     // next_code_index
+            false, // merkle_variant
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        );
+        blockstore.insert_shreds(data_shreds, None, false)?;
+    }
     Ok(())
 }
 
@@ -849,6 +909,31 @@ impl BigTableSubCommand for App<'_, '_> {
                         ),
                 )
                 .subcommand(
+                    SubCommand::with_name("shreds")
+                        .about(
+                            "Get confirmed blocks, shred them and insert the shreds into the \
+                            local Blockstore",
+                        )
+                        .arg(
+                            Arg::with_name("starting_slot")
+                                .long("starting-slot")
+                                .validator(is_slot)
+                                .value_name("SLOT")
+                                .takes_value(true)
+                                .required(true)
+                                .help("Reconstruct starting from this slot (inclusive)"),
+                        )
+                        .arg(
+                            Arg::with_name("ending_slot")
+                                .long("ending-slot")
+                                .validator(is_slot)
+                                .value_name("SLOT")
+                                .takes_value(true)
+                                .required(true)
+                                .help("Reconstruct ending with this slot (inclusive)"),
+                        ),
+                )
+                .subcommand(
                     SubCommand::with_name("confirm")
                         .about("Confirm transaction by signature")
                         .arg(
@@ -1141,6 +1226,23 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
             runtime.block_on(entries(slot, output_format, config))
+        }
+        ("shreds", Some(arg_matches)) => {
+            let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
+            let ending_slot = value_t_or_exit!(arg_matches, "ending_slot", Slot);
+            let blockstore = Arc::new(crate::open_blockstore(
+                &canonicalize_ledger_path(ledger_path),
+                arg_matches,
+                AccessType::Primary,
+            ));
+
+            let config = solana_storage_bigtable::LedgerStorageConfig {
+                read_only: true,
+                instance_name,
+                app_profile_id,
+                ..solana_storage_bigtable::LedgerStorageConfig::default()
+            };
+            runtime.block_on(shreds(blockstore, starting_slot, ending_slot, config))
         }
         ("blocks", Some(arg_matches)) => {
             let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -195,6 +195,14 @@ async fn shreds(
     let mut slots = bigtable.get_confirmed_blocks(starting_slot, limit).await?;
     slots.retain(|&slot| slot <= ending_slot);
 
+    // Create a "dummy" keypair to sign the shreds that will later be created.
+    //
+    // The validator shred ingestion path sigverifies shreds from the network
+    // using the known leader for any given slot. It is unlikely that a user of
+    // this tool will have access to these leader identity keypairs. However,
+    // shred sigverify occurs prior to Blockstore::insert_shreds(). Thus, the
+    // shreds being signed with the "dummy" keyapir can still be inserted and
+    // later read/replayed/etc
     let keypair = Keypair::from_bytes(&[0; 64])?;
     let ShredConfig {
         shred_version,

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -1,6 +1,7 @@
 //! The `bigtable` subcommand
 use {
     crate::{
+        args::snapshot_args,
         ledger_path::canonicalize_ledger_path,
         load_and_process_ledger_or_exit, open_genesis_config_by,
         output::{
@@ -40,7 +41,7 @@ use {
     std::{
         cmp::min,
         collections::HashSet,
-        path::{Path, PathBuf},
+        path::Path,
         process::exit,
         result::Result,
         str::FromStr,
@@ -1027,6 +1028,7 @@ impl BigTableSubCommand for App<'_, '_> {
                             and entries, shred the block and then insert the shredded blocks into \
                             the local Blockstore",
                         )
+                        .args(&snapshot_args())
                         .arg(
                             Arg::with_name("starting_slot")
                                 .long("starting-slot")
@@ -1272,13 +1274,6 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
 
     let verbose = matches.is_present("verbose");
     let output_format = OutputFormat::from_matches(matches, "output_format", verbose);
-    let snapshot_archive_path = value_t!(matches, "snapshots", String)
-        .ok()
-        .map(PathBuf::from);
-    let incremental_snapshot_archive_path =
-        value_t!(matches, "incremental_snapshot_archive_path", String)
-            .ok()
-            .map(PathBuf::from);
 
     let (subcommand, sub_matches) = matches.subcommand();
     let instance_name = get_global_subcommand_arg(
@@ -1383,8 +1378,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 &genesis_config,
                 blockstore.clone(),
                 process_options,
-                snapshot_archive_path,
-                incremental_snapshot_archive_path,
+                None,
             );
 
             let bank = bank_forks.read().unwrap().working_bank();

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -34,7 +34,7 @@ use {
     },
     solana_sdk::{
         clock::Slot, hash::Hash, pubkey::Pubkey, shred_version::compute_shred_version,
-        signature::Signature, signer::keypair::Keypair,
+        signature::Signature, signer::keypair::keypair_from_seed,
     },
     solana_storage_bigtable::CredentialType,
     solana_transaction_status::{ConfirmedBlock, UiTransactionEncoding, VersionedConfirmedBlock},
@@ -204,7 +204,7 @@ async fn shreds(
     // shred sigverify occurs prior to Blockstore::insert_shreds(). Thus, the
     // shreds being signed with the "dummy" keyapir can still be inserted and
     // later read/replayed/etc
-    let keypair = Keypair::from_bytes(&[0; 64])?;
+    let keypair = keypair_from_seed(&[0; 64])?;
     let ShredConfig {
         shred_version,
         num_hashes_per_tick,

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -1,14 +1,14 @@
 //! The `bigtable` subcommand
 use {
     crate::{
-        args::snapshot_args,
+        args::{load_genesis_arg, snapshot_args},
         ledger_path::canonicalize_ledger_path,
         load_and_process_ledger_or_exit, open_genesis_config_by,
         output::{
             encode_confirmed_block, CliBlockWithEntries, CliEntries,
             EncodedConfirmedBlockWithEntries,
         },
-        parse_process_options,
+        parse_process_options, LoadAndProcessLedgerOutput,
     },
     clap::{
         value_t, value_t_or_exit, values_t_or_exit, App, AppSettings, Arg, ArgMatches, SubCommand,
@@ -1028,6 +1028,7 @@ impl BigTableSubCommand for App<'_, '_> {
                             and entries, shred the block and then insert the shredded blocks into \
                             the local Blockstore",
                         )
+                        .arg(load_genesis_arg())
                         .args(&snapshot_args())
                         .arg(
                             Arg::with_name("starting_slot")
@@ -1373,7 +1374,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 arg_matches,
                 AccessType::Primary,
             ));
-            let (bank_forks, _) = load_and_process_ledger_or_exit(
+            let LoadAndProcessLedgerOutput { bank_forks, .. } = load_and_process_ledger_or_exit(
                 arg_matches,
                 &genesis_config,
                 blockstore.clone(),

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -12,7 +12,7 @@ use {
     },
     crossbeam_channel::unbounded,
     futures::stream::FuturesUnordered,
-    log::{debug, error, info},
+    log::{debug, error, info, warn},
     serde_json::json,
     solana_clap_utils::{
         input_parsers::pubkey_of,
@@ -22,14 +22,16 @@ use {
         display::println_transaction, CliBlock, CliTransaction, CliTransactionConfirmation,
         OutputFormat,
     },
-    solana_entry::entry::Entry,
+    solana_entry::entry::{create_ticks, Entry},
     solana_ledger::{
         bigtable_upload::ConfirmedBlockUploadConfig,
         blockstore::Blockstore,
         blockstore_options::AccessType,
         shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
     },
-    solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature, signer::keypair::Keypair},
+    solana_sdk::{
+        clock::Slot, hash::Hash, pubkey::Pubkey, signature::Signature, signer::keypair::Keypair,
+    },
     solana_storage_bigtable::CredentialType,
     solana_transaction_status::{ConfirmedBlock, UiTransactionEncoding, VersionedConfirmedBlock},
     std::{
@@ -171,6 +173,7 @@ async fn shreds(
     blockstore: Arc<Blockstore>,
     starting_slot: Slot,
     ending_slot: Slot,
+    allow_dummy_poh: bool,
     config: solana_storage_bigtable::LedgerStorageConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bigtable = solana_storage_bigtable::LedgerStorage::new_with_config(config)
@@ -182,30 +185,107 @@ async fn shreds(
     let mut slots = bigtable.get_confirmed_blocks(starting_slot, limit).await?;
     slots.retain(|&slot| slot <= ending_slot);
 
-    let keypair = Keypair::from_bytes(&[0; 64]).unwrap();
-    // TODO: parse this / allow command line flag ?
+    let keypair = Keypair::from_bytes(&[0; 64])?;
+    // TODO: parse this from CLI ?
     let shred_version = 0;
+    // TODO: parse from CLI OR extract from genesis
+    let num_ticks_per_slot = 64;
+    // TODO: parse from CLI OR extract from Bank; tick rate changed recently
+    let num_hashes_per_tick = 12500;
 
     for slot in slots.iter() {
         let block = bigtable.get_confirmed_block(*slot).await?;
-        let entry_summaries = bigtable.get_entries(*slot).await?;
-        let entries: Vec<_> = entry_summaries
-            .map(|entry_summary| {
-                let num_hashes = entry_summary.num_hashes;
-                let hash = entry_summary.hash;
-                let transactions = block.transactions[entry_summary.starting_transaction_index
-                    ..entry_summary.starting_transaction_index
-                        + entry_summary.num_transactions as usize]
-                    .iter()
-                    .map(|tx_with_meta| tx_with_meta.get_transaction())
-                    .collect();
-                Entry {
-                    num_hashes,
-                    hash,
-                    transactions,
+        let entry_summaries = match bigtable.get_entries(*slot).await {
+            Ok(summaries) => Some(summaries),
+            Err(err) => {
+                let err_msg = format!("Failed to get PoH entry data for {slot}: {err}");
+
+                if allow_dummy_poh {
+                    warn!("{err_msg}. Will create dummy PoH data instead.");
+                } else {
+                    return Err(format!(
+                        "{err_msg}. Try passing --allow-dummy-poh to allow \
+                        creation of shreds with dummy PoH data"
+                    ))?;
                 }
-            })
-            .collect();
+                None
+            }
+        };
+
+        let entries = match entry_summaries {
+            Some(entry_summaries) => entry_summaries
+                .map(|entry_summary| {
+                    let num_hashes = entry_summary.num_hashes;
+                    let hash = entry_summary.hash;
+                    let transactions = block.transactions[entry_summary.starting_transaction_index
+                        ..entry_summary.starting_transaction_index
+                            + entry_summary.num_transactions as usize]
+                        .iter()
+                        .map(|tx_with_meta| tx_with_meta.get_transaction())
+                        .collect();
+                    Entry {
+                        num_hashes,
+                        hash,
+                        transactions,
+                    }
+                })
+                .collect(),
+            None => {
+                let num_total_ticks = ((slot - block.parent_slot) * num_ticks_per_slot) as usize;
+                let num_total_entries = num_total_ticks + block.transactions.len();
+                let mut entries = Vec::with_capacity(num_total_entries);
+
+                // Create virtual tick entries for any skipped slots
+                //
+                // These ticks are necessary so that the tick height is
+                // advanced to the proper value when this block is processed.
+                //
+                // Additionally, a blockhash will still be inserted into the
+                // recent blockhashes sysvar for skipped slots. So, these
+                // virtual ticks will have the proper PoH
+                let num_skipped_slots = slot - block.parent_slot - 1;
+                if num_skipped_slots > 0 {
+                    let num_virtual_ticks = num_skipped_slots * num_ticks_per_slot;
+                    let parent_blockhash = Hash::from_str(&block.previous_blockhash)?;
+                    let virtual_ticks_entries =
+                        create_ticks(num_virtual_ticks, num_hashes_per_tick, parent_blockhash);
+                    entries.extend(virtual_ticks_entries.into_iter());
+                }
+
+                // Create transaction entries
+                //
+                // Keep it simple and just do one transaction per Entry
+                let transaction_entries = block.transactions.iter().map(|tx_with_meta| Entry {
+                    num_hashes: 0,
+                    hash: Hash::default(),
+                    transactions: vec![tx_with_meta.get_transaction()],
+                });
+                entries.extend(transaction_entries.into_iter());
+
+                // Create the tick entries for this slot
+                //
+                // We do not know the intermediate hashes, so just use default
+                // hash for all ticks. The exception is the final tick; the
+                // final tick determines the blockhash so set it the known
+                // blockhash from the bigtable block
+                let blockhash = Hash::from_str(&block.blockhash)?;
+                let tick_entries = (0..num_ticks_per_slot).map(|idx| {
+                    let hash = if idx == num_ticks_per_slot - 1 {
+                        blockhash
+                    } else {
+                        Hash::default()
+                    };
+                    Entry {
+                        num_hashes: 0,
+                        hash,
+                        transactions: vec![],
+                    }
+                });
+                entries.extend(tick_entries.into_iter());
+
+                entries
+            }
+        };
 
         let shredder = Shredder::new(*slot, block.parent_slot, 0, shred_version)?;
         let (data_shreds, _coding_shreds) = shredder.entries_to_shreds(
@@ -1242,7 +1322,13 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 app_profile_id,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
-            runtime.block_on(shreds(blockstore, starting_slot, ending_slot, config))
+            runtime.block_on(shreds(
+                blockstore,
+                starting_slot,
+                ending_slot,
+                false,
+                config,
+            ))
         }
         ("blocks", Some(arg_matches)) => {
             let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -173,7 +173,7 @@ async fn shreds(
     blockstore: Arc<Blockstore>,
     starting_slot: Slot,
     ending_slot: Slot,
-    allow_dummy_poh: bool,
+    allow_mock_poh: bool,
     config: solana_storage_bigtable::LedgerStorageConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bigtable = solana_storage_bigtable::LedgerStorage::new_with_config(config)
@@ -198,14 +198,14 @@ async fn shreds(
         let entry_summaries = match bigtable.get_entries(*slot).await {
             Ok(summaries) => Some(summaries),
             Err(err) => {
-                let err_msg = format!("Failed to get PoH entry data for {slot}: {err}");
+                let err_msg = format!("Failed to get PoH entries for {slot}: {err}");
 
-                if allow_dummy_poh {
-                    warn!("{err_msg}. Will create dummy PoH data instead.");
+                if allow_mock_poh {
+                    warn!("{err_msg}. Will create mock PoH entries instead.");
                 } else {
                     return Err(format!(
-                        "{err_msg}. Try passing --allow-dummy-poh to allow \
-                        creation of shreds with dummy PoH data"
+                        "{err_msg}. Try passing --allow-mock-poh to allow \
+                        creation of shreds with mocked PoH entries"
                     ))?;
                 }
                 None
@@ -991,8 +991,9 @@ impl BigTableSubCommand for App<'_, '_> {
                 .subcommand(
                     SubCommand::with_name("shreds")
                         .about(
-                            "Get confirmed blocks, shred them and insert the shreds into the \
-                            local Blockstore",
+                            "Get confirmed blocks from BigTable, reassemble the transactions \
+                            and entries, shred the block and then insert the shredded blocks into \
+                            the local Blockstore",
                         )
                         .arg(
                             Arg::with_name("starting_slot")
@@ -1001,7 +1002,7 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .value_name("SLOT")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Reconstruct starting from this slot (inclusive)"),
+                                .help("Start shred creation at this slot (inclusive)"),
                         )
                         .arg(
                             Arg::with_name("ending_slot")
@@ -1010,7 +1011,18 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .value_name("SLOT")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Reconstruct ending with this slot (inclusive)"),
+                                .help("Stop shred creation at this slot (inclusive)"),
+                        )
+                        .arg(
+                            Arg::with_name("allow_mock_poh")
+                                .long("allow-mock-poh")
+                                .takes_value(false)
+                                .help(
+                                    "For slots where PoH entries are unavailable, allow the \
+                                    generation of mock PoH entries. The mock PoH entries enable \
+                                    the shredded block(s) to be replayable if PoH verification is \
+                                    disabled.",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -1310,6 +1322,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
         ("shreds", Some(arg_matches)) => {
             let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
             let ending_slot = value_t_or_exit!(arg_matches, "ending_slot", Slot);
+            let allow_mock_poh = arg_matches.is_present("allow_mock_poh");
             let blockstore = Arc::new(crate::open_blockstore(
                 &canonicalize_ledger_path(ledger_path),
                 arg_matches,
@@ -1326,7 +1339,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 blockstore,
                 starting_slot,
                 ending_slot,
-                false,
+                allow_mock_poh,
                 config,
             ))
         }

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -247,7 +247,7 @@ async fn shreds(
                         return Err(format!(
                             "Entry summary {i} for slot {slot} with starting_transaction_index \
                              {starting_transaction_index} and num_transactions {num_transactions} \
-                             is in conflict with the block has {num_block_transactions} \
+                             is in conflict with the block, which has {num_block_transactions} \
                              transactions"
                         ));
                     };


### PR DESCRIPTION
Picked up from https://github.com/solana-labs/solana/pull/35090

#### Problem
There is often a desire to examine/replay/etc blocks. If the blocks are
very recent, they can often be pulled from an actively running node.
Otherwise, the blocks must be pulled down from the warehouse node
archives. These archives are uploaded on a per-epoch basis so they are
quite large (100's of GB's). Even with a good download speed and
capable machine, it can take several hours before having access to the
block. And, 100's of GB's must be downloaded and expanded even if
access to only a single block is desired.

#### Summary of Changes
With the addition of Entry data to BigTable, blocks, in the form that
solana-validator and solana-ledger-tool operate with, can be recreated
from BigTable. This change add a new BigTable command that does just
that; fetch BigTable block data, parse it, and then insert the block
as shreds into a local Blockstore.

Several important callouts:
- Shreds for some slot S will not have valid shred signatures; instead,
shreds will signed with a dummy keypair. This does not inhibit the
utility of these shreds by other solana-ledger-tool commands.
- Entry PoH data does not go back to genesis in BigTable. While this
data could be extracted and uploaded from existing rocksdb archives,
I'm not sure if that work is planned. So, this change adds a flag that
generates mock PoH entries for such blocks. These blocks are replayable
by passing --skip-poh-verify to solana-ledger-tool commands.

As written, a snapshot from the same epoch must be present to extract
the correct PoH values like hashes per tick. This is technically only
necessary if `--allow-mock-poh` is True. If not, a user could supply a
valid shred version and avoid the overhead of unpacking a snapshot.
This seems like it'd be useful, but at the moment, I think this can be
done in a subsequent PR.