### PR TITLE
Refactor - `SyscallInvokeSignedRust::translate_instruction()`

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -442,11 +442,11 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
         )?
         .to_vec();
 
-        check_instruction_size(accounts.len(), data.len(), invoke_context)?;
+        check_instruction_size(account_metas.len(), data.len(), invoke_context)?;
 
-        let mut accounts = Vec::with_capacity(accounts.len());
+        let mut accounts = Vec::with_capacity(account_metas.len());
         #[allow(clippy::needless_range_loop)]
-        for account_index in 0..ix.accounts.len() {
+        for account_index in 0..account_metas.len() {
             #[allow(clippy::indexing_slicing)]
             let account_meta = &account_metas[account_index];
             if unsafe {
@@ -459,14 +459,13 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
             accounts.push(account_meta.clone());
         }
 
-        let ix_data_len = ix.data.len() as u64;
         if invoke_context
             .get_feature_set()
             .is_active(&feature_set::loosen_cpi_size_restriction::id())
         {
             consume_compute_meter(
                 invoke_context,
-                (ix_data_len)
+                (data.len() as u64)
                     .checked_div(invoke_context.get_compute_budget().cpi_bytes_per_unit)
                     .unwrap_or(u64::MAX),
             )?;

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -428,16 +428,23 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
             addr,
             invoke_context.get_check_aligned(),
         )?;
-
-        check_instruction_size(ix.accounts.len(), ix.data.len(), invoke_context)?;
-
         let account_metas = translate_slice::<AccountMeta>(
             memory_mapping,
             ix.accounts.as_ptr() as u64,
             ix.accounts.len() as u64,
             invoke_context.get_check_aligned(),
         )?;
-        let mut accounts = Vec::with_capacity(ix.accounts.len());
+        let data = translate_slice::<u8>(
+            memory_mapping,
+            ix.data.as_ptr() as u64,
+            ix.data.len() as u64,
+            invoke_context.get_check_aligned(),
+        )?
+        .to_vec();
+
+        check_instruction_size(accounts.len(), data.len(), invoke_context)?;
+
+        let mut accounts = Vec::with_capacity(accounts.len());
         #[allow(clippy::needless_range_loop)]
         for account_index in 0..ix.accounts.len() {
             #[allow(clippy::indexing_slicing)]
@@ -464,14 +471,6 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
                     .unwrap_or(u64::MAX),
             )?;
         }
-
-        let data = translate_slice::<u8>(
-            memory_mapping,
-            ix.data.as_ptr() as u64,
-            ix_data_len,
-            invoke_context.get_check_aligned(),
-        )?
-        .to_vec();
 
         Ok(StableInstruction {
             accounts: accounts.into(),


### PR DESCRIPTION
#### Problem
Even though the guest `len` and the host `len` are numerically the same (not changed by translation) we should be using the host one for consistency.

#### Summary of Changes
- Reorders all `translate_slice()` to the beginning of the method.
- Uses the host slice length instead of the guest one.
- Reorders `consume_compute_meter()` (which is gated by an inactive feature) to happen before heap allocation.