### PR TITLE
Refactor - Adds `StableVec::len()`

### DIFF
--- a/sdk/program/src/stable_layout/stable_vec.rs
+++ b/sdk/program/src/stable_layout/stable_vec.rs
@@ -30,19 +30,27 @@ pub struct StableVec<T> {
     _marker: PhantomData<T>,
 }
 
+// We shadow these slice methods of the same name to avoid going through
+// `deref`, which creates an intermediate reference.
 impl<T> StableVec<T> {
     #[inline]
     pub fn as_ptr(&self) -> *const T {
-        // We shadow the slice method of the same name to avoid going through
-        // `deref`, which creates an intermediate reference.
         self.ptr.as_ptr()
     }
 
     #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut T {
-        // We shadow the slice method of the same name to avoid going through
-        // `deref_mut`, which creates an intermediate reference.
         self.ptr.as_ptr()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
     }
 }
 


### PR DESCRIPTION
#### Problem
Accessing the `.len()` of a `StableVec` currently constructs the entire slice and then immediately discards it again.

#### Summary of Changes
Adds a direct `StableVec::len()` and `StableVec::is_empty()`, similar to the existing `StableVec::as_ptr()`.