### PR TITLE
SVM: Group transaction processing environment

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6889,10 +6889,6 @@ impl TransactionProcessingCallback for Bank {
             .map(|(acc, _)| acc)
     }
 
-    fn get_rent_collector(&self) -> &RentCollector {
-        &self.rent_collector
-    }
-
     fn get_feature_set(&self) -> Arc<FeatureSet> {
         self.feature_set.clone()
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6889,10 +6889,6 @@ impl TransactionProcessingCallback for Bank {
             .map(|(acc, _)| acc)
     }
 
-    fn get_feature_set(&self) -> Arc<FeatureSet> {
-        self.feature_set.clone()
-    }
-
     fn get_epoch_total_stake(&self) -> Option<u64> {
         self.epoch_total_stake(self.epoch())
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6889,10 +6889,6 @@ impl TransactionProcessingCallback for Bank {
             .map(|(acc, _)| acc)
     }
 
-    fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64) {
-        self.last_blockhash_and_lamports_per_signature()
-    }
-
     fn get_rent_collector(&self) -> &RentCollector {
         &self.rent_collector
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6889,14 +6889,6 @@ impl TransactionProcessingCallback for Bank {
             .map(|(acc, _)| acc)
     }
 
-    fn get_epoch_total_stake(&self) -> Option<u64> {
-        self.epoch_total_stake(self.epoch())
-    }
-
-    fn get_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
-        self.epoch_vote_accounts(self.epoch())
-    }
-
     fn get_program_match_criteria(&self, program: &Pubkey) -> ProgramCacheMatchCriteria {
         if self.check_program_modification_slot {
             self.program_modification_slot(program)

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -486,10 +486,6 @@ mod tests {
             self.accounts_map.get(pubkey).cloned()
         }
 
-        fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64) {
-            (Hash::new_unique(), 0)
-        }
-
         fn get_rent_collector(&self) -> &RentCollector {
             &self.rent_collector
         }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -469,7 +469,6 @@ mod tests {
             transaction::{Result, SanitizedTransaction, Transaction, TransactionError},
             transaction_context::{TransactionAccount, TransactionContext},
         },
-        solana_vote::vote_account::VoteAccountsHashMap,
         std::{borrow::Cow, collections::HashMap, convert::TryFrom, sync::Arc},
     };
 
@@ -485,14 +484,6 @@ mod tests {
 
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
             self.accounts_map.get(pubkey).cloned()
-        }
-
-        fn get_epoch_total_stake(&self) -> Option<u64> {
-            None
-        }
-
-        fn get_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
-            None
         }
     }
 

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -230,7 +230,6 @@ mod tests {
         },
         solana_sdk::{
             account::WritableAccount, bpf_loader, bpf_loader_upgradeable, feature_set::FeatureSet,
-            rent_collector::RentCollector,
         },
         solana_vote::vote_account::VoteAccountsHashMap,
         std::{
@@ -252,7 +251,6 @@ mod tests {
 
     #[derive(Default, Clone)]
     pub struct MockBankCallback {
-        rent_collector: RentCollector,
         feature_set: Arc<FeatureSet>,
         pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
     }
@@ -272,10 +270,6 @@ mod tests {
 
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
             self.account_shared_data.borrow().get(pubkey).cloned()
-        }
-
-        fn get_rent_collector(&self) -> &RentCollector {
-            &self.rent_collector
         }
 
         fn get_feature_set(&self) -> Arc<FeatureSet> {

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -230,7 +230,7 @@ mod tests {
         },
         solana_sdk::{
             account::WritableAccount, bpf_loader, bpf_loader_upgradeable, feature_set::FeatureSet,
-            hash::Hash, rent_collector::RentCollector,
+            rent_collector::RentCollector,
         },
         solana_vote::vote_account::VoteAccountsHashMap,
         std::{
@@ -272,10 +272,6 @@ mod tests {
 
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
             self.account_shared_data.borrow().get(pubkey).cloned()
-        }
-
-        fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64) {
-            (Hash::new_unique(), 2)
         }
 
         fn get_rent_collector(&self) -> &RentCollector {

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -229,7 +229,6 @@ mod tests {
             solana_rbpf::program::BuiltinProgram,
         },
         solana_sdk::{account::WritableAccount, bpf_loader, bpf_loader_upgradeable},
-        solana_vote::vote_account::VoteAccountsHashMap,
         std::{
             cell::RefCell,
             collections::HashMap,
@@ -267,14 +266,6 @@ mod tests {
 
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
             self.account_shared_data.borrow().get(pubkey).cloned()
-        }
-
-        fn get_epoch_total_stake(&self) -> Option<u64> {
-            None
-        }
-
-        fn get_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
-            None
         }
 
         fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -228,9 +228,7 @@ mod tests {
             loaded_programs::{BlockRelation, ForkGraph, ProgramRuntimeEnvironments},
             solana_rbpf::program::BuiltinProgram,
         },
-        solana_sdk::{
-            account::WritableAccount, bpf_loader, bpf_loader_upgradeable, feature_set::FeatureSet,
-        },
+        solana_sdk::{account::WritableAccount, bpf_loader, bpf_loader_upgradeable},
         solana_vote::vote_account::VoteAccountsHashMap,
         std::{
             cell::RefCell,
@@ -251,7 +249,6 @@ mod tests {
 
     #[derive(Default, Clone)]
     pub struct MockBankCallback {
-        feature_set: Arc<FeatureSet>,
         pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
     }
 
@@ -270,10 +267,6 @@ mod tests {
 
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
             self.account_shared_data.borrow().get(pubkey).cloned()
-        }
-
-        fn get_feature_set(&self) -> Arc<FeatureSet> {
-            self.feature_set.clone()
         }
 
         fn get_epoch_total_stake(&self) -> Option<u64> {

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,7 +1,7 @@
 use {
     solana_program_runtime::loaded_programs::ProgramCacheMatchCriteria,
     solana_sdk::{
-        account::AccountSharedData, feature_set::FeatureSet, hash::Hash, pubkey::Pubkey,
+        account::AccountSharedData, feature_set::FeatureSet, pubkey::Pubkey,
         rent_collector::RentCollector,
     },
     solana_vote::vote_account::VoteAccountsHashMap,
@@ -13,8 +13,6 @@ pub trait TransactionProcessingCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize>;
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
-
-    fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64);
 
     fn get_rent_collector(&self) -> &RentCollector;
 

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,7 +1,6 @@
 use {
     solana_program_runtime::loaded_programs::ProgramCacheMatchCriteria,
     solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
-    solana_vote::vote_account::VoteAccountsHashMap,
 };
 
 /// Runtime callbacks for transaction processing.
@@ -9,10 +8,6 @@ pub trait TransactionProcessingCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize>;
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
-
-    fn get_epoch_total_stake(&self) -> Option<u64>;
-
-    fn get_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap>;
 
     fn get_program_match_criteria(&self, _program: &Pubkey) -> ProgramCacheMatchCriteria {
         ProgramCacheMatchCriteria::NoCriteria

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,8 +1,7 @@
 use {
     solana_program_runtime::loaded_programs::ProgramCacheMatchCriteria,
-    solana_sdk::{account::AccountSharedData, feature_set::FeatureSet, pubkey::Pubkey},
+    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
     solana_vote::vote_account::VoteAccountsHashMap,
-    std::sync::Arc,
 };
 
 /// Runtime callbacks for transaction processing.
@@ -10,8 +9,6 @@ pub trait TransactionProcessingCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize>;
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
-
-    fn get_feature_set(&self) -> Arc<FeatureSet>;
 
     fn get_epoch_total_stake(&self) -> Option<u64>;
 

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,9 +1,6 @@
 use {
     solana_program_runtime::loaded_programs::ProgramCacheMatchCriteria,
-    solana_sdk::{
-        account::AccountSharedData, feature_set::FeatureSet, pubkey::Pubkey,
-        rent_collector::RentCollector,
-    },
+    solana_sdk::{account::AccountSharedData, feature_set::FeatureSet, pubkey::Pubkey},
     solana_vote::vote_account::VoteAccountsHashMap,
     std::sync::Arc,
 };
@@ -13,8 +10,6 @@ pub trait TransactionProcessingCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize>;
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
-
-    fn get_rent_collector(&self) -> &RentCollector;
 
     fn get_feature_set(&self) -> Arc<FeatureSet>;
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -711,7 +711,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         execute_timings: &mut ExecuteTimings,
         error_metrics: &mut TransactionErrorMetrics,
         program_cache_for_tx_batch: &ProgramCacheForTxBatch,
-        _environment: &TransactionProcessingEnvironment,
+        environment: &TransactionProcessingEnvironment,
         config: &TransactionProcessingConfig,
     ) -> TransactionExecutionResult {
         let transaction_accounts = std::mem::take(&mut loaded_transaction.accounts);
@@ -757,8 +757,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             None
         };
 
-        let (blockhash, lamports_per_signature) =
-            callback.get_last_blockhash_and_lamports_per_signature();
+        let blockhash = environment.blockhash;
+        let lamports_per_signature = environment.lamports_per_signature;
 
         let mut executed_units = 0u64;
         let mut programs_modified_by_tx = ProgramCacheForTxBatch::new(
@@ -1064,10 +1064,6 @@ mod tests {
                 .unwrap()
                 .get(pubkey)
                 .cloned()
-        }
-
-        fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64) {
-            (Hash::new_unique(), 2)
         }
 
         fn get_rent_collector(&self) -> &RentCollector {

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -280,9 +280,6 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
         .map(|x| (x.blockhash, x.fee_calculator.lamports_per_signature))
         .unwrap_or_default();
 
-    mock_bank.lamports_per_sginature = lamports_per_signature;
-    mock_bank.blockhash = blockhash;
-
     let recording_config = ExecutionRecordingConfig {
         enable_log_recording: true,
         enable_return_data_recording: true,
@@ -468,11 +465,11 @@ fn execute_fixture_as_instr(
 
     let sysvar_cache = &batch_processor.sysvar_cache.read().unwrap();
     let env_config = EnvironmentConfig::new(
-        mock_bank.blockhash,
+        Hash::default(),
         None,
         None,
         mock_bank.feature_set.clone(),
-        mock_bank.lamports_per_sginature,
+        0,
         sysvar_cache,
     );
 

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -41,6 +41,7 @@ use {
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processor::{
             ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingConfig,
+            TransactionProcessingEnvironment,
         },
     },
     std::{
@@ -313,6 +314,11 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
         &mock_bank,
         &transactions,
         transaction_check,
+        &TransactionProcessingEnvironment {
+            blockhash,
+            lamports_per_signature,
+            ..Default::default()
+        },
         &processor_config,
     );
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -34,6 +34,7 @@ use {
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processor::{
             ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingConfig,
+            TransactionProcessingEnvironment,
         },
         transaction_results::TransactionExecutionResult,
     },
@@ -470,6 +471,7 @@ fn svm_integration() {
         &mock_bank,
         &transactions,
         check_results,
+        &TransactionProcessingEnvironment::default(),
         &processing_config,
     );
 

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -9,7 +9,6 @@ use {
         slot_hashes::Slot,
     },
     solana_svm::transaction_processing_callback::TransactionProcessingCallback,
-    solana_vote::vote_account::VoteAccountsHashMap,
     std::{cell::RefCell, cmp::Ordering, collections::HashMap, sync::Arc},
 };
 
@@ -50,14 +49,6 @@ impl TransactionProcessingCallback for MockBankCallback {
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         self.account_shared_data.borrow().get(pubkey).cloned()
-    }
-
-    fn get_epoch_total_stake(&self) -> Option<u64> {
-        None
-    }
-
-    fn get_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
-        None
     }
 
     fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -4,7 +4,6 @@ use {
         account::{AccountSharedData, ReadableAccount},
         clock::Epoch,
         feature_set::FeatureSet,
-        hash::Hash,
         native_loader,
         pubkey::Pubkey,
         rent_collector::RentCollector,
@@ -35,8 +34,6 @@ impl ForkGraph for MockForkGraph {
 pub struct MockBankCallback {
     rent_collector: RentCollector,
     pub feature_set: Arc<FeatureSet>,
-    pub blockhash: Hash,
-    pub lamports_per_sginature: u64,
     pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
 }
 
@@ -55,11 +52,6 @@ impl TransactionProcessingCallback for MockBankCallback {
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         self.account_shared_data.borrow().get(pubkey).cloned()
-    }
-
-    fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64) {
-        // Mock a hash and a value
-        (self.blockhash, self.lamports_per_sginature)
     }
 
     fn get_rent_collector(&self) -> &RentCollector {

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -6,7 +6,6 @@ use {
         feature_set::FeatureSet,
         native_loader,
         pubkey::Pubkey,
-        rent_collector::RentCollector,
         slot_hashes::Slot,
     },
     solana_svm::transaction_processing_callback::TransactionProcessingCallback,
@@ -32,7 +31,6 @@ impl ForkGraph for MockForkGraph {
 
 #[derive(Default)]
 pub struct MockBankCallback {
-    rent_collector: RentCollector,
     pub feature_set: Arc<FeatureSet>,
     pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
 }
@@ -52,10 +50,6 @@ impl TransactionProcessingCallback for MockBankCallback {
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         self.account_shared_data.borrow().get(pubkey).cloned()
-    }
-
-    fn get_rent_collector(&self) -> &RentCollector {
-        &self.rent_collector
     }
 
     fn get_feature_set(&self) -> Arc<FeatureSet> {

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -52,10 +52,6 @@ impl TransactionProcessingCallback for MockBankCallback {
         self.account_shared_data.borrow().get(pubkey).cloned()
     }
 
-    fn get_feature_set(&self) -> Arc<FeatureSet> {
-        self.feature_set.clone()
-    }
-
     fn get_epoch_total_stake(&self) -> Option<u64> {
         None
     }


### PR DESCRIPTION
#### Problem
The `TransactionBatchProcessorCallbacks` trait is required for callers who wish 
to use the `TransactionBatchProcessor`. It provides the batch processor with a 
means for loading accounts, as well as retrieving information about the runtime 
environment.

The `TransactionBatchProcessor` already requires a handful of runtime 
configurations in its global config, as well as as inputs to 
`load_and_execute_sanitized_transactions`.

It would be easier for downstream users of the transaction batch processor if we
coalesced runtime environment configurations.

#### Summary of Changes

First introduce the `TransactionProcessingEnvironment` as a required input to
the transaction batch processor.

Then, remove environment-related callbacks from
`TransactionBatchProcessorCallbacks` in favor of the provided environment
object.