### PR TITLE
compute budget: add frozen-abi build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5897,6 +5897,7 @@ dependencies = [
 name = "solana-compute-budget"
 version = "2.0.0"
 dependencies = [
+ "rustc_version 0.4.0",
  "solana-frozen-abi",
  "solana-sdk",
 ]

--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -13,6 +13,9 @@ edition = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-sdk = { workspace = true }
 
+[build-dependencies]
+rustc_version = { workspace = true }
+
 [features]
 frozen-abi = [
     "dep:solana-frozen-abi",

--- a/compute-budget/build.rs
+++ b/compute-budget/build.rs
@@ -1,0 +1,1 @@
+../frozen-abi/build.rs

--- a/compute-budget/src/lib.rs
+++ b/compute-budget/src/lib.rs
@@ -1,4 +1,5 @@
 //! Solana compute budget types and default configurations.
+#![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 
 pub mod compute_budget;
 pub mod compute_budget_processor;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4858,6 +4858,7 @@ dependencies = [
 name = "solana-compute-budget"
 version = "2.0.0"
 dependencies = [
+ "rustc_version",
  "solana-sdk",
 ]
 


### PR DESCRIPTION
#### Problem
Continuing the work on #1606, the `solana-compute-budget` crate requires the
specialization build script in order for `RUSTC_WITH_SPECIALIZATION` and the
feature flag `frozen-abi` to work properly.

#### Summary of Changes
Add the build script!