### PR TITLE
Re-export curve25519-dalek from solana-zk-token-sdk

### DIFF
--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -35,6 +35,9 @@ pub mod zk_token_proof_instruction;
 pub mod zk_token_proof_program;
 pub mod zk_token_proof_state;
 
+#[cfg(not(target_os = "solana"))]
+pub use curve25519_dalek;
+
 /// Byte length of a compressed Ristretto point or scalar in Curve255519
 const UNIT_LEN: usize = 32;
 /// Byte length of a compressed Ristretto point in Curve25519


### PR DESCRIPTION
#### Problem
The [`spl-token-client`](https://crates.io/crates/spl-token-client/0.10.0/dependencies) crate from [solana-program-library](https://github.com/solana-labs/solana-program-library) repository started depending directly on [curve-25519-dalek v3.2.1](https://crates.io/crates/curve25519-dalek/3.2.1) since https://github.com/solana-labs/solana-program-library/pull/5258. This blocks #513 which tries to update `curve-25519-dalek` to a newer version.


#### Summary of Changes
Re-exported `curve25519-dalek` crate from `solana-zk-token-sdk` crate in order to remove specifying an explicit version (in `Cargo.toml`) for `curve-25519-dalek` in `solana-program-library` repository.

@samkim-crypto 