### PR TITLE
remove all rustversion usage because it is redundant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6391,7 +6391,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "rustc_version 0.4.0",
- "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -6821,7 +6820,6 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand 0.8.5",
  "rustc_version 0.4.0",
- "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -7274,7 +7272,6 @@ dependencies = [
  "rand 0.7.3",
  "rand 0.8.5",
  "rustc_version 0.4.0",
- "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -7303,7 +7300,6 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.68",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,7 +299,6 @@ rolling-file = "0.2.0"
 rpassword = "7.3"
 rustc_version = "0.4"
 rustls = { version = "0.21.12", default-features = false, features = ["quic"] }
-rustversion = "1.0.17"
 scopeguard = "1.2.0"
 semver = "1.0.23"
 seqlock = "0.2.0"

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -24,7 +24,6 @@ num-traits = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
-rustversion = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_derive = { workspace = true }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2076,7 +2076,7 @@ impl ClusterInfo {
     //
     // allow lint false positive trait bound requirement (`CryptoRng` only
     // implemented on `&'a mut T`
-    #[rustversion::attr(since(1.73), allow(clippy::needless_pass_by_ref_mut))]
+    #[allow(clippy::needless_pass_by_ref_mut)]
     fn check_pull_request<'a, R>(
         &'a self,
         now: Instant,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5043,7 +5043,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "rustc_version",
- "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -5306,7 +5305,6 @@ dependencies = [
  "parking_lot 0.12.2",
  "rand 0.8.5",
  "rustc_version",
- "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -5822,7 +5820,6 @@ dependencies = [
 name = "solana-sbf-rust-invoke"
 version = "2.1.0"
 dependencies = [
- "rustversion",
  "solana-program",
  "solana-sbf-rust-invoke-dep",
  "solana-sbf-rust-invoked-dep",
@@ -6128,7 +6125,6 @@ dependencies = [
  "rand 0.7.3",
  "rand 0.8.5",
  "rustc_version",
- "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -6151,7 +6147,6 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.58",
 ]
 

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -22,7 +22,6 @@ net2 = "0.2.37"
 num-derive = "0.4.2"
 num-traits = "0.2"
 rand = "0.8"
-rustversion = "1.0.14"
 serde = "1.0.112" # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_derive = "1.0.112" # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_json = "1.0.56"

--- a/programs/sbf/rust/invoke/Cargo.toml
+++ b/programs/sbf/rust/invoke/Cargo.toml
@@ -9,7 +9,6 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-rustversion = { workspace = true }
 solana-program = { workspace = true }
 solana-sbf-rust-invoke-dep = { workspace = true }
 solana-sbf-rust-invoked-dep = { workspace = true }

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -1127,7 +1127,7 @@ fn process_instruction<'a>(
             let account = &accounts[ARGUMENT_INDEX];
             let key = *account.key;
             let key = &key as *const _ as usize;
-            #[rustversion::attr(since(1.72), allow(invalid_reference_casting))]
+            #[allow(invalid_reference_casting)]
             fn overwrite_account_key(account: &AccountInfo, key: *const Pubkey) {
                 unsafe {
                     let ptr = mem::transmute::<_, *mut *const Pubkey>(&account.key);
@@ -1178,7 +1178,7 @@ fn process_instruction<'a>(
             const CALLEE_PROGRAM_INDEX: usize = 2;
             let account = &accounts[ARGUMENT_INDEX];
             let owner = account.owner as *const _ as usize + 1;
-            #[rustversion::attr(since(1.72), allow(invalid_reference_casting))]
+            #[allow(invalid_reference_casting)]
             fn overwrite_account_owner(account: &AccountInfo, owner: *const Pubkey) {
                 unsafe {
                     let ptr = mem::transmute::<_, *mut *const Pubkey>(&account.owner);
@@ -1457,7 +1457,7 @@ struct RcBox<T> {
     value: T,
 }
 
-#[rustversion::attr(since(1.72), allow(invalid_reference_casting))]
+#[allow(invalid_reference_casting)]
 unsafe fn overwrite_account_data(account: &AccountInfo, data: Rc<RefCell<&mut [u8]>>) {
     std::ptr::write_volatile(
         &account.data as *const _ as usize as *mut Rc<RefCell<&mut [u8]>>,

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -71,7 +71,6 @@ qstring = { workspace = true }
 qualifier_attr = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 rand0-7 = { package = "rand", version = "0.7", optional = true }
-rustversion = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_derive = { workspace = true }

--- a/sdk/macro/Cargo.toml
+++ b/sdk/macro/Cargo.toml
@@ -16,7 +16,6 @@ proc-macro = true
 bs58 = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-rustversion = { workspace = true }
 syn = { workspace = true, features = ["full"] }
 
 [package.metadata.docs.rs]

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -25,7 +25,6 @@ log = { workspace = true }
 memoffset = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true, features = ["i128"] }
-rustversion = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_derive = { workspace = true }

--- a/sdk/program/src/account_info.rs
+++ b/sdk/program/src/account_info.rs
@@ -182,7 +182,7 @@ impl<'a> AccountInfo<'a> {
         Ok(())
     }
 
-    #[rustversion::attr(since(1.72), allow(invalid_reference_casting))]
+    #[allow(invalid_reference_casting)]
     pub fn assign(&self, new_owner: &Pubkey) {
         // Set the non-mut owner field
         unsafe {

--- a/sdk/program/src/program_option.rs
+++ b/sdk/program/src/program_option.rs
@@ -950,7 +950,6 @@ impl<T> From<Option<T>> for COption<T> {
     }
 }
 
-#[rustversion::since(1.49.0)]
 impl<T> From<COption<T>> for Option<T> {
     fn from(coption: COption<T>) -> Self {
         match coption {


### PR DESCRIPTION
#### Problem
Everywhere the rustversion crate is used in this repo, it is calling `since` with a version older than 1.75. But solana-program's Cargo.toml specifies `rust-version = "1.75.0"`, and all crates in this repo that use rustversion depend on solana-program, so rustversion is doing nothing.

#### Summary of Changes
Remove all rustversion usage

