### PR TITLE
remove respan macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Release channels have their own copy of this changelog:
 <a name="edge-channel"></a>
 ## [2.1.0] - Unreleased
 
+* Changes
+  * SDK: removed the `respan` macro. This was marked as "internal use only" and was no longer used internally.
+
 ## [2.0.0]
 * Breaking
   * SDK: Support for Borsh v0.9 removed, please use v1 or v0.10 (#1440)

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -154,8 +154,6 @@ pub use solana_sdk_macro::declare_id;
 pub use solana_sdk_macro::pubkey;
 /// Convenience macro to define multiple static public keys.
 pub use solana_sdk_macro::pubkeys;
-#[rustversion::since(1.46.0)]
-pub use solana_sdk_macro::respan;
 
 // Unused `solana_sdk::program_stubs!()` macro retained for source backwards compatibility with older programs
 #[macro_export]


### PR DESCRIPTION
This isn't used anywhere in this repo or solana-program-library, and I can't imagine it's used anywhere else. Thoughts?
