### PR TITLE
Mark unified scheduler as ready as opt-in for block verification

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -150,8 +150,8 @@ const WAIT_FOR_WEN_RESTART_SUPERMAJORITY_THRESHOLD_PERCENT: u64 =
 #[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
 #[strum(serialize_all = "kebab-case")]
 pub enum BlockVerificationMethod {
-    BlockstoreProcessor,
     #[default]
+    BlockstoreProcessor,
     UnifiedScheduler,
 }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -150,8 +150,8 @@ const WAIT_FOR_WEN_RESTART_SUPERMAJORITY_THRESHOLD_PERCENT: u64 =
 #[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
 #[strum(serialize_all = "kebab-case")]
 pub enum BlockVerificationMethod {
-    #[default]
     BlockstoreProcessor,
+    #[default]
     UnifiedScheduler,
 }
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -720,7 +720,6 @@ fn main() {
                 .takes_value(true)
                 .possible_values(BlockVerificationMethod::cli_names())
                 .global(true)
-                .hidden(hidden_unless_forced())
                 .help(BlockVerificationMethod::cli_message()),
         )
         .arg(
@@ -730,7 +729,6 @@ fn main() {
                 .takes_value(true)
                 .validator(|s| is_within_range(s, 1..))
                 .global(true)
-                .hidden(hidden_unless_forced())
                 .help(DefaultSchedulerPool::cli_message()),
         )
         .arg(

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -1,8 +1,3 @@
-//! NOTE: While the unified scheduler is fully functional and moderately performant even with
-//! mainnet-beta, it has known resource-exhaustion related security issues for replaying
-//! specially-crafted blocks produced by malicious leaders. Thus, this experimental and
-//! nondefault functionality is exempt from the bug bounty program for now.
-//!
 //! Transaction scheduling code.
 //!
 //! This crate implements 3 solana-runtime traits (`InstalledScheduler`, `UninstalledScheduler` and

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1522,7 +1522,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .arg(
             Arg::with_name("block_verification_method")
                 .long("block-verification-method")
-                .hidden(hidden_unless_forced())
                 .value_name("METHOD")
                 .takes_value(true)
                 .possible_values(BlockVerificationMethod::cli_names())
@@ -1539,7 +1538,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .arg(
             Arg::with_name("unified_scheduler_handler_threads")
                 .long("unified-scheduler-handler-threads")
-                .hidden(hidden_unless_forced())
                 .value_name("COUNT")
                 .takes_value(true)
                 .validator(|s| is_within_range(s, 1..))


### PR DESCRIPTION
#### Problem

time has come.

#### Summary of Changes

soak the unified scheduler.

After some discussion, i decided that unified scheduler doesn't go straight to mb at v2.0 by enabling it by default.

OLD:

> after some thought, i think we can be aggressive here by enabling unified scheduler by default:
> 
> - replay stage's job is deterministic by nature, so there should be less variability of general performance. i.e. unlike banking stage, replay stage don't affect block composition.
> - this is just changing cli default. we can always revert back to the old default (blockstore-processor). 
> 
> ~(note that there's still release-blocker prs to be merged prior to this pr; thus this pr is draft)~ (all blocking prs got merged)