### PR TITLE
remove superfluous usage of allow(dead_code)

### DIFF
--- a/cargo-registry/src/crate_handler.rs
+++ b/cargo-registry/src/crate_handler.rs
@@ -43,7 +43,6 @@ pub(crate) enum DependencyType {
     Normal,
 }
 
-#[allow(dead_code)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct Dependency {
     pub name: String,

--- a/core/src/banking_stage/transaction_scheduler/in_flight_tracker.rs
+++ b/core/src/banking_stage/transaction_scheduler/in_flight_tracker.rs
@@ -34,7 +34,6 @@ impl InFlightTracker {
     }
 
     /// Returns the number of cus that are in flight for each thread.
-    #[allow(dead_code)]
     pub fn cus_in_flight_per_thread(&self) -> &[u64] {
         &self.cus_in_flight_per_thread
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -590,7 +590,6 @@ impl Blockstore {
         }))
     }
 
-    #[allow(dead_code)]
     pub fn live_slots_iterator(&self, root: Slot) -> impl Iterator<Item = (Slot, SlotMeta)> + '_ {
         let root_forks = NextSlotsIterator::new(root, self);
 

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -548,7 +548,6 @@ pub mod test_mocks {
         pub points_written: Arc<Mutex<Vec<DataPoint>>>,
     }
     impl MockMetricsWriter {
-        #[allow(dead_code)]
         pub fn new() -> Self {
             MockMetricsWriter {
                 points_written: Arc::new(Mutex::new(Vec::new())),

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -590,9 +590,7 @@ struct SolAccountInfo {
     data_addr: u64,
     owner_addr: u64,
     rent_epoch: u64,
-    #[allow(dead_code)]
     is_signer: bool,
-    #[allow(dead_code)]
     is_writable: bool,
     executable: bool,
 }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -681,7 +681,6 @@ fn test_return_data_and_log_data_syscall() {
 fn test_program_sbf_invoke_sanity() {
     solana_logger::setup();
 
-    #[allow(dead_code)]
     #[derive(Debug)]
     enum Languages {
         C,

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -252,7 +252,6 @@ pub trait RemoteWallet<T> {
 /// `RemoteWallet` device
 #[derive(Debug)]
 pub struct Device {
-    #[allow(dead_code)]
     pub(crate) path: String,
     pub(crate) info: RemoteWalletInfo,
     pub wallet_type: RemoteWalletType,

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -114,7 +114,6 @@ impl RpcRequestMiddleware {
             .unwrap()
     }
 
-    #[allow(dead_code)]
     fn internal_server_error() -> hyper::Response<hyper::Body> {
         hyper::Response::builder()
             .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -182,7 +182,6 @@ impl ToTokens for ProgramSdkIdDeprecated {
     }
 }
 
-#[allow(dead_code)] // `respan` may be compiled out
 struct RespanInput {
     to_respan: Path,
     respan_using: Span,

--- a/sdk/program/src/log.rs
+++ b/sdk/program/src/log.rs
@@ -124,7 +124,6 @@ pub fn sol_log_data(data: &[&[u8]]) {
 }
 
 /// Print the hexadecimal representation of a slice.
-#[allow(dead_code)]
 pub fn sol_log_slice(slice: &[u8]) {
     for (i, s) in slice.iter().enumerate() {
         sol_log_64(0, 0, 0, i as u64, *s as u64);
@@ -135,7 +134,6 @@ pub fn sol_log_slice(slice: &[u8]) {
 ///
 /// - `accounts` - A slice of [`AccountInfo`].
 /// - `data` - The instruction data.
-#[allow(dead_code)]
 pub fn sol_log_params(accounts: &[AccountInfo], data: &[u8]) {
     for (i, account) in accounts.iter().enumerate() {
         msg!("AccountInfo");


### PR DESCRIPTION
There are some places where removing `#[allow(dead_code)]` doesn't break any lint checks
