### PR TITLE
ledger-tool: Make joining AccountsBackgroundService optional

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -54,7 +54,7 @@ use {
     thiserror::Error,
 };
 
-pub(crate) struct LoadAndProcessLedgerOutput {
+pub struct LoadAndProcessLedgerOutput {
     pub bank_forks: Arc<RwLock<BankForks>>,
     pub starting_snapshot_hashes: Option<StartingSnapshotHashes>,
     // Typically, we would want to join all threads before returning. However,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1439,13 +1439,14 @@ fn main() {
                         arg_matches,
                         get_access_type(&process_options),
                     );
-                    let (bank_forks, _) = load_and_process_ledger_or_exit(
-                        arg_matches,
-                        &genesis_config,
-                        Arc::new(blockstore),
-                        process_options,
-                        None,
-                    );
+                    let LoadAndProcessLedgerOutput { bank_forks, .. } =
+                        load_and_process_ledger_or_exit(
+                            arg_matches,
+                            &genesis_config,
+                            Arc::new(blockstore),
+                            process_options,
+                            None,
+                        );
 
                     println!(
                         "{}",
@@ -1629,13 +1630,14 @@ fn main() {
                         arg_matches,
                         get_access_type(&process_options),
                     );
-                    let (bank_forks, _) = load_and_process_ledger_or_exit(
-                        arg_matches,
-                        &genesis_config,
-                        Arc::new(blockstore),
-                        process_options,
-                        transaction_status_sender,
-                    );
+                    let LoadAndProcessLedgerOutput { bank_forks, .. } =
+                        load_and_process_ledger_or_exit(
+                            arg_matches,
+                            &genesis_config,
+                            Arc::new(blockstore),
+                            process_options,
+                            transaction_status_sender,
+                        );
 
                     let working_bank = bank_forks.read().unwrap().working_bank();
                     if print_accounts_stats {
@@ -1695,13 +1697,14 @@ fn main() {
                         arg_matches,
                         get_access_type(&process_options),
                     );
-                    let (bank_forks, _) = load_and_process_ledger_or_exit(
-                        arg_matches,
-                        &genesis_config,
-                        Arc::new(blockstore),
-                        process_options,
-                        None,
-                    );
+                    let LoadAndProcessLedgerOutput { bank_forks, .. } =
+                        load_and_process_ledger_or_exit(
+                            arg_matches,
+                            &genesis_config,
+                            Arc::new(blockstore),
+                            process_options,
+                            None,
+                        );
 
                     let dot = graph_forks(&bank_forks.read().unwrap(), &graph_config);
                     let extension = Path::new(&output_file).extension();
@@ -1864,7 +1867,10 @@ fn main() {
                         output_directory.display()
                     );
 
-                    let (bank_forks, starting_snapshot_hashes) = load_and_process_ledger_or_exit(
+                    let LoadAndProcessLedgerOutput {
+                        bank_forks,
+                        starting_snapshot_hashes,
+                    } = load_and_process_ledger_or_exit(
                         arg_matches,
                         &genesis_config,
                         blockstore.clone(),
@@ -2252,13 +2258,14 @@ fn main() {
                         arg_matches,
                         get_access_type(&process_options),
                     );
-                    let (bank_forks, _) = load_and_process_ledger_or_exit(
-                        arg_matches,
-                        &genesis_config,
-                        Arc::new(blockstore),
-                        process_options,
-                        None,
-                    );
+                    let LoadAndProcessLedgerOutput { bank_forks, .. } =
+                        load_and_process_ledger_or_exit(
+                            arg_matches,
+                            &genesis_config,
+                            Arc::new(blockstore),
+                            process_options,
+                            None,
+                        );
                     let bank = bank_forks.read().unwrap().working_bank();
 
                     let include_sysvars = arg_matches.is_present("include_sysvars");
@@ -2303,13 +2310,14 @@ fn main() {
                         arg_matches,
                         get_access_type(&process_options),
                     );
-                    let (bank_forks, _) = load_and_process_ledger_or_exit(
-                        arg_matches,
-                        &genesis_config,
-                        Arc::new(blockstore),
-                        process_options,
-                        None,
-                    );
+                    let LoadAndProcessLedgerOutput { bank_forks, .. } =
+                        load_and_process_ledger_or_exit(
+                            arg_matches,
+                            &genesis_config,
+                            Arc::new(blockstore),
+                            process_options,
+                            None,
+                        );
                     let bank_forks = bank_forks.read().unwrap();
                     let slot = bank_forks.working_bank().slot();
                     let bank = bank_forks.get(slot).unwrap_or_else(|| {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1870,6 +1870,7 @@ fn main() {
                     let LoadAndProcessLedgerOutput {
                         bank_forks,
                         starting_snapshot_hashes,
+                        accounts_background_service,
                     } = load_and_process_ledger_or_exit(
                         arg_matches,
                         &genesis_config,
@@ -1877,6 +1878,12 @@ fn main() {
                         process_options,
                         None,
                     );
+                    // Snapshot creation will implicitly perform AccountsDb
+                    // flush and clean operations. These operations cannot be
+                    // run concurrently, so ensure ABS is stopped to avoid that
+                    // possibility.
+                    accounts_background_service.join().unwrap();
+
                     let mut bank = bank_forks
                         .read()
                         .unwrap()

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -79,7 +79,7 @@ fn load_blockstore(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -> Arc<Bank
     let genesis_config = open_genesis_config_by(ledger_path, arg_matches);
     info!("genesis hash: {}", genesis_config.hash());
     let blockstore = open_blockstore(ledger_path, arg_matches, AccessType::Secondary);
-    let (bank_forks, ..) = load_and_process_ledger_or_exit(
+    let LoadAndProcessLedgerOutput { bank_forks, .. } = load_and_process_ledger_or_exit(
         arg_matches,
         &genesis_config,
         Arc::new(blockstore),


### PR DESCRIPTION
#### Problem
    AccountsBackgroundService performs several operations that can take a
    long time to complete and do not check the exit flag mid-operation.
    Thus, ledger-tool can get hung up for a while waiting for ABS to finish.
    
    The majority of the ledger-tool commands that process a ledger do not
    need to wait for ABS to finish in order to perform the desired work.

#### Summary of Changes
    So, return a handle to the ABS thread and allow the caller to decide whether
    to join ABS or not.
    
    As of right now, create-snapshot is the only command that requires ABS
    to have finished


Kudos to @alessandrod for coming up with a simpler solution than what I proposed in https://github.com/anza-xyz/agave/issues/346.

Fixes https://github.com/anza-xyz/agave/issues/346

#### Testing
<details>
<summary>Manual testing details</summary>

#### Testing (Tip of master)
I ran the change on a ledger that previously been showing the "hangup". Previously, the we would see a large time span for clean, such as this (with ledger-tool returning almost immediately after clean finished):
```
[2024-05-29T17:15:02.872115558Z INFO  solana_metrics::metrics] datapoint: accounts_db_active clean=1i
...
[2024-05-29T17:17:23.121183654Z INFO  solana_ledger::blockstore_processor] ledger processed in 2 minutes, 20 seconds, ...
// 10.5 minutes after clean started
[2024-05-29T17:25:31.015283032Z INFO  solana_metrics::metrics] datapoint: accounts_db_active clean=0i
[2024-05-29T17:25:31.133567169Z INFO  solana_runtime::accounts_background_service] AccountsBackgroundService has stopped
[2024-05-29T17:25:32.335459921Z INFO  agave_ledger_tool] ledger tool took 1071.7s
```
#### Testing (This branch)
With this branch, I see the log that clean started, but I see things bail out without waiting for ABS to finish.
```
[2024-06-17T21:00:46.723451144Z INFO  solana_metrics::metrics] datapoint: accounts_db_active clean=1i
...
[2024-06-17T21:00:48.777768779Z INFO  solana_ledger::blockstore_processor] ledger processed in 2 seconds, ...
[2024-06-17T21:00:49.123788763Z INFO  solana_core::accounts_hash_verifier] AccountsHashVerifier has stopped
[2024-06-17T21:00:49.972443381Z INFO  agave_ledger_tool] ledger tool took 424.1s
```
While these were different ledger, note that the "before" run spent 140 seconds processing ledger. The "after" run only spent 2; when accounting for this difference, the "after" run finished more than 8 minutes earlier. And most importantly, the log lines for clean finishing and ABS exiting are absent (the whole point of this PR)  

</details>
