### PR TITLE
Flushes append vec mmaps only if dirty

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -54,7 +54,10 @@ use {
         ancient_append_vecs::{
             get_ancient_append_vec_capacity, is_ancient, AccountsToStore, StorageSelector,
         },
-        append_vec::{aligned_stored_size, APPEND_VEC_MMAPPED_FILES_OPEN, STORE_META_OVERHEAD},
+        append_vec::{
+            aligned_stored_size, APPEND_VEC_MMAPPED_FILES_DIRTY, APPEND_VEC_MMAPPED_FILES_OPEN,
+            STORE_META_OVERHEAD,
+        },
         cache_hash_data::{
             CacheHashData, CacheHashDataFileReference, DeletionPolicy as CacheHashDeletionPolicy,
         },
@@ -1904,6 +1907,11 @@ impl LatestAccountsIndexRootsStats {
             (
                 "append_vecs_open",
                 APPEND_VEC_MMAPPED_FILES_OPEN.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "append_vecs_dirty",
+                APPEND_VEC_MMAPPED_FILES_DIRTY.load(Ordering::Relaxed),
                 i64
             )
         );

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -34,7 +34,7 @@ use {
         path::{Path, PathBuf},
         ptr,
         sync::{
-            atomic::{AtomicU64, AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
             Mutex,
         },
     },
@@ -212,7 +212,19 @@ struct AccountOffsets {
 #[derive(Debug)]
 enum AppendVecFileBacking {
     /// A file-backed block of memory that is used to store the data for each appended item.
-    MmapOnly(MmapMut),
+    MmapOnly(MmapOnly),
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug)]
+struct MmapOnly {
+    mmap: MmapMut,
+    /// Flags if the mmap is dirty or not.
+    /// Since fastboot requires that all mmaps are flushed to disk, be smart about it.
+    /// AppendVecs are (almost) always write-once.  The common case is that an AppendVec
+    /// will only need to be flushed once.  This avoids unnecessary syscalls/kernel work
+    /// when nothing in the AppendVec has changed.
+    is_dirty: AtomicBool,
 }
 
 /// A thread-safe, file-backed block of memory used to store `Account` instances. Append operations
@@ -303,7 +315,10 @@ impl AppendVec {
 
         AppendVec {
             path: file,
-            backing: AppendVecFileBacking::MmapOnly(mmap),
+            backing: AppendVecFileBacking::MmapOnly(MmapOnly {
+                mmap,
+                is_dirty: AtomicBool::new(false),
+            }),
             // This mutex forces append to be single threaded, but concurrent with reads
             // See UNSAFE usage in `append_ptr`
             append_lock: Mutex::new(()),
@@ -335,7 +350,14 @@ impl AppendVec {
 
     pub fn flush(&self) -> Result<()> {
         match &self.backing {
-            AppendVecFileBacking::MmapOnly(mmap) => Ok(mmap.flush()?),
+            AppendVecFileBacking::MmapOnly(mmap_only) => {
+                // Check to see if the mmap is actually dirty before flushing.
+                if mmap_only.is_dirty.load(Ordering::Acquire) {
+                    mmap_only.mmap.flush()?;
+                    mmap_only.is_dirty.store(false, Ordering::Release)
+                }
+                Ok(())
+            }
         }
     }
 
@@ -419,7 +441,10 @@ impl AppendVec {
 
         Ok(AppendVec {
             path,
-            backing: AppendVecFileBacking::MmapOnly(mmap),
+            backing: AppendVecFileBacking::MmapOnly(MmapOnly {
+                mmap,
+                is_dirty: AtomicBool::new(false),
+            }),
             append_lock: Mutex::new(()),
             current_len: AtomicUsize::new(current_len),
             file_size,
@@ -484,8 +509,8 @@ impl AppendVec {
     fn append_ptr(&self, offset: &mut usize, src: *const u8, len: usize) {
         let pos = u64_align!(*offset);
         match &self.backing {
-            AppendVecFileBacking::MmapOnly(mmap) => {
-                let data = &mmap[pos..(pos + len)];
+            AppendVecFileBacking::MmapOnly(mmap_only) => {
+                let data = &mmap_only.mmap[pos..(pos + len)];
                 //UNSAFE: This mut append is safe because only 1 thread can append at a time
                 //Mutex<()> guarantees exclusive write access to the memory occupied in
                 //the range.
@@ -547,7 +572,7 @@ impl AppendVec {
         mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>) -> Ret,
     ) -> Option<Ret> {
         match &self.backing {
-            AppendVecFileBacking::MmapOnly(mmap) => {
+            AppendVecFileBacking::MmapOnly(MmapOnly { mmap, .. }) => {
                 let slice = self.get_valid_slice_from_mmap(mmap);
                 let (meta, next): (&StoredMeta, _) = Self::get_type(slice, offset)?;
                 let (account_meta, next): (&AccountMeta, _) = Self::get_type(slice, next)?;
@@ -647,7 +672,7 @@ impl AppendVec {
     pub(crate) fn scan_index(&self, mut callback: impl FnMut(IndexInfo)) {
         let mut offset = 0;
         match &self.backing {
-            AppendVecFileBacking::MmapOnly(mmap) => {
+            AppendVecFileBacking::MmapOnly(MmapOnly { mmap, .. }) => {
                 let slice = self.get_valid_slice_from_mmap(mmap);
                 loop {
                     let Some((stored_meta, next)) = Self::get_type::<StoredMeta>(slice, offset)
@@ -710,7 +735,7 @@ impl AppendVec {
     pub(crate) fn get_account_sizes(&self, sorted_offsets: &[usize]) -> Vec<usize> {
         let mut result = Vec::with_capacity(sorted_offsets.len());
         match &self.backing {
-            AppendVecFileBacking::MmapOnly(mmap) => {
+            AppendVecFileBacking::MmapOnly(MmapOnly { mmap, .. }) => {
                 let slice = self.get_valid_slice_from_mmap(mmap);
                 for &offset in sorted_offsets {
                     let Some((stored_meta, _)) = Self::get_type::<StoredMeta>(slice, offset) else {
@@ -736,7 +761,7 @@ impl AppendVec {
     pub(crate) fn scan_pubkeys(&self, mut callback: impl FnMut(&Pubkey)) {
         let mut offset = 0;
         match &self.backing {
-            AppendVecFileBacking::MmapOnly(mmap) => {
+            AppendVecFileBacking::MmapOnly(MmapOnly { mmap, .. }) => {
                 let slice = self.get_valid_slice_from_mmap(mmap);
                 loop {
                     let Some((stored_meta, _)) = Self::get_type::<StoredMeta>(slice, offset) else {
@@ -813,6 +838,16 @@ impl AppendVec {
             });
         }
 
+        if !offsets.is_empty() {
+            match &self.backing {
+                AppendVecFileBacking::MmapOnly(mmap_only) => {
+                    // If we've actually written to the AppendVec, make sure we mark it as dirty.
+                    // This ensures we properly flush it later.
+                    mmap_only.is_dirty.store(true, Ordering::Release)
+                }
+            }
+        }
+
         (!offsets.is_empty()).then(|| {
             // The last entry in the offsets needs to be the u64 aligned `offset`, because that's
             // where the *next* entry will begin to be stored.
@@ -836,7 +871,9 @@ impl AppendVec {
     pub(crate) fn internals_for_archive(&self) -> InternalsForArchive {
         match &self.backing {
             // note this returns the entire mmap slice, even bytes that we consider invalid
-            AppendVecFileBacking::MmapOnly(mmap) => InternalsForArchive::Mmap(mmap),
+            AppendVecFileBacking::MmapOnly(MmapOnly { mmap, .. }) => {
+                InternalsForArchive::Mmap(mmap)
+            }
         }
     }
 }


### PR DESCRIPTION
#### Problem

We flush append vecs *a lot*. Too much, some might say[^1]. 

Some observations: the common case is append-vecs are write-once, yet we call `flush()` on every append vec for every snapshot. The default is every 100 slots. So we are doing a lot of unnecessary work asking the OS/kernel to re-flush something that doesn't need to be flushed again.

[^1]: @alessandrod 


#### Summary of Changes

Track if an AppendVec's internal mmap is dirty or not. If it has been written to, then it is dirty. If it's dirty, then we flush. Otherwise, no need.


#### Results

On the left half of the graph is my node running regular master. On the right half I restarted the node with this PR.

Before, flushing took about 1 second. Afterwards, flushing takes about 20 milliseconds.

![Screenshot 2024-06-10 at 7 27 12 PM](https://github.com/anza-xyz/agave/assets/840349/47ffc8e5-0c37-4a41-b243-4f71219f0da1)

In addition to these speedups, we should also see improvements to the system as-a-whole, due to stress reduction of not asking the kernel to flush 432,000 files every 100 slots.