### PR TITLE
Use num_partitions to find specific stake rewards in partitions

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -632,8 +632,7 @@ impl JsonRpcRequestProcessor {
             .map(|slot| slot <= first_confirmed_block_in_epoch)
             .unwrap_or(false);
 
-        // Collect rewards from first block in the epoch if partitioned epoch
-        // rewards not enabled, or address is a vote account
+        // Get first block in the epoch
         let Ok(Some(epoch_boundary_block)) = self
             .get_block(
                 first_confirmed_block_in_epoch,
@@ -647,6 +646,8 @@ impl JsonRpcRequestProcessor {
             .into());
         };
 
+        // Collect rewards from first block in the epoch if partitioned epoch
+        // rewards not enabled, or address is a vote account
         let mut reward_map: HashMap<String, (Reward, Slot)> = {
             let addresses: Vec<String> =
                 addresses.iter().map(|pubkey| pubkey.to_string()).collect();
@@ -661,6 +662,8 @@ impl JsonRpcRequestProcessor {
             )
         };
 
+        // Append stake account rewards from partitions if partitions epoch
+        // rewards is enabled
         if partitioned_epoch_reward_enabled {
             let num_partitions = epoch_boundary_block.num_reward_partitions.expect(
                 "epoch-boundary block should have num_reward_partitions after partitioned epoch \

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -621,6 +621,16 @@ impl JsonRpcRequestProcessor {
                 slot: first_slot_in_epoch,
             })?;
 
+        // Determine if partitioned epoch rewards were enabled for the desired
+        // epoch
+        let bank = self.get_bank_with_config(context_config)?;
+        let partitioned_epoch_reward_enabled_slot = bank
+            .feature_set
+            .activated_slot(&feature_set::enable_partitioned_epoch_reward::id());
+        let partitioned_epoch_reward_enabled = partitioned_epoch_reward_enabled_slot
+            .map(|slot| slot <= first_confirmed_block_in_epoch)
+            .unwrap_or(false);
+
         let Ok(Some(first_confirmed_block)) = self
             .get_block(
                 first_confirmed_block_in_epoch,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -625,6 +625,10 @@ impl JsonRpcRequestProcessor {
         // Determine if partitioned epoch rewards were enabled for the desired
         // epoch
         let bank = self.get_bank_with_config(context_config)?;
+
+        // DO NOT CLEAN UP with feature_set::enable_partitioned_epoch_reward
+        // This logic needs to be retained indefinitely to support historical
+        // rewards before and after feature activation.
         let partitioned_epoch_reward_enabled_slot = bank
             .feature_set
             .activated_slot(&feature_set::enable_partitioned_epoch_reward::id());

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -719,12 +719,10 @@ impl JsonRpcRequestProcessor {
                             "every block after partitioned_epoch_reward_enabled should have a \
                              populated block_height",
                         );
-                    {
-                        RpcCustomError::EpochRewardsPeriodActive {
-                            slot: bank.slot(),
-                            current_block_height: bank.block_height(),
-                            rewards_complete_block_height,
-                        }
+                    RpcCustomError::EpochRewardsPeriodActive {
+                        slot: bank.slot(),
+                        current_block_height: bank.block_height(),
+                        rewards_complete_block_height,
                     }
                 })?;
 

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -23,7 +23,6 @@ use {
         account::AccountSharedData,
         clock::Slot,
         epoch_schedule::EpochSchedule,
-        feature_set,
         native_token::sol_to_lamports,
         pubkey::Pubkey,
         rent::Rent,
@@ -352,9 +351,7 @@ fn main() {
         exit(1);
     });
 
-    let mut features_to_deactivate = pubkeys_of(&matches, "deactivate_feature").unwrap_or_default();
-    // Remove this when client support is ready for the enable_partitioned_epoch_reward feature
-    features_to_deactivate.push(feature_set::enable_partitioned_epoch_reward::id());
+    let features_to_deactivate = pubkeys_of(&matches, "deactivate_feature").unwrap_or_default();
 
     if TestValidatorGenesis::ledger_exists(&ledger_path) {
         for (name, long) in &[


### PR DESCRIPTION
#### Problem
See #1601 : no existing way for RPC or clients to find partitioned stake rewards

#### Summary of Changes
Use `num_partitions`, added to block metadata in Blockstore and Bigtable in #1601 , to construct an EpochRewardsHasher to find rewards for any particular stake account

- [x] Needs rebase on #1601 