### PR TITLE
Cleanup - Removes unused documentation URL and package.metadata.docs.rs from SBPF tests

### DIFF
--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -165,9 +165,6 @@ members = [
     "rust/upgraded",
 ]
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
 [patch.crates-io]
 # We include the following crates as our dependencies from crates.io:
 #

--- a/programs/sbf/rust/128bit/Cargo.toml
+++ b/programs/sbf/rust/128bit/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-128bit"
-documentation = "https://docs.rs/solana-sbf-rust-128bit"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -15,6 +14,3 @@ solana-sbf-rust-128bit-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/128bit_dep/Cargo.toml
+++ b/programs/sbf/rust/128bit_dep/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-128bit-dep"
-documentation = "https://docs.rs/solana-sbf-rust-128bit-dep"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -11,6 +10,3 @@ edition = { workspace = true }
 
 [dependencies]
 solana-program = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/alloc/Cargo.toml
+++ b/programs/sbf/rust/alloc/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-alloc"
-documentation = "https://docs.rs/solana-sbf-rust-alloc"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/alt_bn128/Cargo.toml
+++ b/programs/sbf/rust/alt_bn128/Cargo.toml
@@ -14,6 +14,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/alt_bn128_compression/Cargo.toml
+++ b/programs/sbf/rust/alt_bn128_compression/Cargo.toml
@@ -14,6 +14,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/big_mod_exp/Cargo.toml
+++ b/programs/sbf/rust/big_mod_exp/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-bpf-rust-big-mod-exp"
-documentation = "https://docs.rs/solana-bpf-rust-big-mod-exp"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -18,6 +17,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/call_depth/Cargo.toml
+++ b/programs/sbf/rust/call_depth/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-call-depth"
-documentation = "https://docs.rs/solana-sbf-rust-call-depth"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/caller_access/Cargo.toml
+++ b/programs/sbf/rust/caller_access/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-caller-access"
-documentation = "https://docs.rs/solana-sbf-rust-caller-access"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/curve25519/Cargo.toml
+++ b/programs/sbf/rust/curve25519/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-curve25519"
-documentation = "https://docs.rs/solana-sbf-rust-zktoken_crypto"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -15,6 +14,3 @@ solana-zk-token-sdk = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/custom_heap/Cargo.toml
+++ b/programs/sbf/rust/custom_heap/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-custom-heap"
-documentation = "https://docs.rs/solana-sbf-rust-custom-heap"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -18,6 +17,3 @@ custom-heap = []
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/dep_crate/Cargo.toml
+++ b/programs/sbf/rust/dep_crate/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-dep-crate"
-documentation = "https://docs.rs/solana-sbf-rust-dep-crate"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -11,11 +10,7 @@ edition = { workspace = true }
 
 [dependencies]
 byteorder = { workspace = true }
-# list of crates which must be buildable for bpf programs
 solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/deprecated_loader/Cargo.toml
+++ b/programs/sbf/rust/deprecated_loader/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-deprecated-loader"
-documentation = "https://docs.rs/solana-sbf-rust-deprecated-loader"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/dup_accounts/Cargo.toml
+++ b/programs/sbf/rust/dup_accounts/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-dup-accounts"
-documentation = "https://docs.rs/solana-sbf-rust-dup-accounts"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/error_handling/Cargo.toml
+++ b/programs/sbf/rust/error_handling/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-error-handling"
-documentation = "https://docs.rs/solana-sbf-rust-error-handling"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -17,6 +16,3 @@ thiserror = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/external_spend/Cargo.toml
+++ b/programs/sbf/rust/external_spend/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-external-spend"
-documentation = "https://docs.rs/solana-sbf-rust-external-spend"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/finalize/Cargo.toml
+++ b/programs/sbf/rust/finalize/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-finalize"
-documentation = "https://docs.rs/solana-sbf-rust-finalize"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/get_minimum_delegation/Cargo.toml
+++ b/programs/sbf/rust/get_minimum_delegation/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-get-minimum-delegation"
-documentation = "https://docs.rs/solana-sbf-rust-get-minimum-delegation"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/inner_instruction_alignment_check/Cargo.toml
+++ b/programs/sbf/rust/inner_instruction_alignment_check/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-inner_instruction_alignment_check"
-documentation = "https://docs.rs/solana-sbf-rust-inner_instruction_alignment_check"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/instruction_introspection/Cargo.toml
+++ b/programs/sbf/rust/instruction_introspection/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-instruction-introspection"
-documentation = "https://docs.rs/solana-sbf-rust-instruction-introspection"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/invoke/Cargo.toml
+++ b/programs/sbf/rust/invoke/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-invoke"
-documentation = "https://docs.rs/solana-sbf-rust-invoke"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -21,6 +20,3 @@ solana-sbf-rust-realloc = { workspace = true }
 
 [lib]
 crate-type = ["lib", "cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/invoke_and_error/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_error/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-invoke-and-error"
-documentation = "https://docs.rs/solana-sbf-rust-invoke-and-error"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/invoke_and_ok/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_ok/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-invoke-and-ok"
-documentation = "https://docs.rs/solana-sbf-rust-invoke-and-ok"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/invoke_and_return/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_return/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-invoke-and-return"
-documentation = "https://docs.rs/solana-sbf-rust-invoke-and-return"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/invoked/Cargo.toml
+++ b/programs/sbf/rust/invoked/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-invoked"
-documentation = "https://docs.rs/solana-sbf-rust-invoked"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -18,6 +17,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["lib", "cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/iter/Cargo.toml
+++ b/programs/sbf/rust/iter/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-iter"
-documentation = "https://docs.rs/solana-sbf-rust-iter"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/log_data/Cargo.toml
+++ b/programs/sbf/rust/log_data/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-log-data"
-documentation = "https://docs.rs/solana-sbf-rust-log-data"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -18,6 +17,3 @@ program = []
 
 [lib]
 crate-type = ["lib", "cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/many_args/Cargo.toml
+++ b/programs/sbf/rust/many_args/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-many-args"
-documentation = "https://docs.rs/solana-sbf-rust-many-args"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -15,6 +14,3 @@ solana-sbf-rust-many-args-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/many_args_dep/Cargo.toml
+++ b/programs/sbf/rust/many_args_dep/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-many-args-dep"
-documentation = "https://docs.rs/solana-sbf-rust-many-args-dep"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -11,6 +10,3 @@ edition = { workspace = true }
 
 [dependencies]
 solana-program = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/mem/Cargo.toml
+++ b/programs/sbf/rust/mem/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-mem"
-documentation = "https://docs.rs/solana-sbf-rust-mem"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -24,6 +23,3 @@ solana-sdk = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "lib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/membuiltins/Cargo.toml
+++ b/programs/sbf/rust/membuiltins/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-membuiltins"
-documentation = "https://docs.rs/solana-sbf-rust-mem"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -15,6 +14,3 @@ solana-sbf-rust-mem = { workspace = true, features = ["no-entrypoint"] }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/noop/Cargo.toml
+++ b/programs/sbf/rust/noop/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-noop"
-documentation = "https://docs.rs/solana-sbf-rust-noop"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/panic/Cargo.toml
+++ b/programs/sbf/rust/panic/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-panic"
-documentation = "https://docs.rs/solana-sbf-rust-panic"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -18,6 +17,3 @@ custom-panic = []
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/param_passing/Cargo.toml
+++ b/programs/sbf/rust/param_passing/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-param-passing"
-documentation = "https://docs.rs/solana-sbf-rust-param-passing"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -15,6 +14,3 @@ solana-sbf-rust-param-passing-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/param_passing_dep/Cargo.toml
+++ b/programs/sbf/rust/param_passing_dep/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "solana-sbf-rust-param-passing-dep"
-description = "Solana SBF program written in Rust"
-documentation = "https://docs.rs/solana-sbf-rust-param-passing-dep"
 version = { workspace = true }
+description = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
@@ -11,6 +10,3 @@ edition = { workspace = true }
 
 [dependencies]
 solana-program = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/poseidon/Cargo.toml
+++ b/programs/sbf/rust/poseidon/Cargo.toml
@@ -15,6 +15,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/rand/Cargo.toml
+++ b/programs/sbf/rust/rand/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-rand"
-documentation = "https://docs.rs/solana-sbf-rust-rand"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -16,6 +15,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/realloc/Cargo.toml
+++ b/programs/sbf/rust/realloc/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-realloc"
-documentation = "https://docs.rs/solana-sbf-rust-realloc"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -18,6 +17,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["lib", "cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/realloc_invoke/Cargo.toml
+++ b/programs/sbf/rust/realloc_invoke/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-realloc-invoke"
-documentation = "https://docs.rs/solana-sbf-rust-realloc-invoke"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -19,6 +18,3 @@ solana-sbf-rust-realloc = { workspace = true }
 
 [lib]
 crate-type = ["lib", "cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/remaining_compute_units/Cargo.toml
+++ b/programs/sbf/rust/remaining_compute_units/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-remaining-compute-units"
-documentation = "https://docs.rs/solana-sbf-rust-remaining-compute-units"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -24,6 +23,3 @@ solana-sdk = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "lib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/ro_account_modify/Cargo.toml
+++ b/programs/sbf/rust/ro_account_modify/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-ro-account_modify"
-documentation = "https://docs.rs/solana-sbf-rust-ro-modify"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/ro_modify/Cargo.toml
+++ b/programs/sbf/rust/ro_modify/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-ro-modify"
-documentation = "https://docs.rs/solana-sbf-rust-ro-modify"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/sanity/Cargo.toml
+++ b/programs/sbf/rust/sanity/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-sanity"
-documentation = "https://docs.rs/solana-sbf-rust-sanity"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -23,6 +22,3 @@ solana-sdk = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "lib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/secp256k1_recover/Cargo.toml
+++ b/programs/sbf/rust/secp256k1_recover/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-secp256k1-recover"
-documentation = "https://docs.rs/solana-sbf-rust-secp256k1-recover"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -15,6 +14,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/sha/Cargo.toml
+++ b/programs/sbf/rust/sha/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-sha"
-documentation = "https://docs.rs/solana-sbf-rust-sha"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -15,6 +14,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/sibling_inner_instruction/Cargo.toml
+++ b/programs/sbf/rust/sibling_inner_instruction/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-sibling_inner-instructions"
-documentation = "https://docs.rs/solana-sbf-rust-log-data"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -18,6 +17,3 @@ program = []
 
 [lib]
 crate-type = ["lib", "cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/sibling_instruction/Cargo.toml
+++ b/programs/sbf/rust/sibling_instruction/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-sibling-instructions"
-documentation = "https://docs.rs/solana-sbf-rust-log-data"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -18,6 +17,3 @@ program = []
 
 [lib]
 crate-type = ["lib", "cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/simulation/Cargo.toml
+++ b/programs/sbf/rust/simulation/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "solana-sbf-rust-simulation"
 description = "Solana SBF Program Simulation Differences"
-documentation = "https://docs.rs/solana-sbf-rust-simulation"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
@@ -23,6 +22,3 @@ solana-sdk = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "lib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/spoof1/Cargo.toml
+++ b/programs/sbf/rust/spoof1/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-spoof1"
-documentation = "https://docs.rs/solana-sbf-rust-spoof1"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/spoof1_system/Cargo.toml
+++ b/programs/sbf/rust/spoof1_system/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-spoof1-system"
-documentation = "https://docs.rs/solana-sbf-rust-spoof1-system"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -14,6 +13,3 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/sysvar/Cargo.toml
+++ b/programs/sbf/rust/sysvar/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-sysvar"
-documentation = "https://docs.rs/solana-sbf-rust-sysvar"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -23,6 +22,3 @@ solana-sdk = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "lib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/upgradeable/Cargo.toml
+++ b/programs/sbf/rust/upgradeable/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-upgradeable"
-documentation = "https://docs.rs/solana-sbf-rust-upgradeable"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -15,6 +14,3 @@ solana-program = { workspace = true }
 [lib]
 name = "solana_sbf_rust_upgradeable"
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/sbf/rust/upgraded/Cargo.toml
+++ b/programs/sbf/rust/upgraded/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-sbf-rust-upgraded"
-documentation = "https://docs.rs/solana-sbf-rust-upgraded"
 version = { workspace = true }
 description = { workspace = true }
 authors = { workspace = true }
@@ -15,6 +14,3 @@ solana-program = { workspace = true }
 [lib]
 name = "solana_sbf_rust_upgraded"
 crate-type = ["cdylib"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
This PR is split off from #1581.

#### Problem
There are no docs for the SBPF tests, thus their doc links are misleading.
Also, `package.metadata.docs.rs.targets` stands in the way of removing the need to build the test programs for the host architecture.

#### Summary of Changes
From all SBPF test program crates removes:
- `package.documentation`
- `package.metadata.docs.rs.targets`