### PR TITLE
Return back stale out-of-pool scheduler by timeout

### DIFF
--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -232,7 +232,9 @@ impl BankForks {
         let bank = if let Some(scheduler_pool) = &self.scheduler_pool {
             let context = SchedulingContext::new(bank.clone());
             let scheduler = scheduler_pool.take_scheduler(context);
-            BankWithScheduler::new(bank, Some(scheduler))
+            let bank_with_scheduler = BankWithScheduler::new(bank, Some(scheduler));
+            scheduler_pool.register_timeout_listener(bank_with_scheduler.create_timeout_listener());
+            bank_with_scheduler
         } else {
             BankWithScheduler::new_without_scheduler(bank)
         };

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -294,7 +294,8 @@ pub enum SchedulerStatus {
     /// Note that transition to Unavailable from {Active, Stale} is one-way (i.e. one-time).
     Unavailable,
     /// Scheduler is installed into a bank; could be running or just be idling.
-    /// This will be transitioned to Stale after certain time has passed if its bank hasn't frozen.
+    /// This will be transitioned to Stale after certain time has passed if its bank hasn't been
+    /// frozen.
     Active(InstalledSchedulerBox),
     /// Scheduler is idling for long time, returning scheduler back to the pool.
     /// This will be immediately (i.e. transaparently) transitioned to Active as soon as there's
@@ -547,7 +548,7 @@ impl BankWithSchedulerInner {
                 let scheduler = self.scheduler.read().unwrap();
                 // Re-register a new timeout listener only after acquiring the read lock;
                 // Otherwise, the listener would again put scheduler into Stale before the read
-                // lock, causing panic below.
+                // lock under an extremely-rare race condition, causing panic below.
                 pool.register_timeout_listener(self.do_create_timeout_listener());
                 f(scheduler.active_scheduler())
             }

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -30,7 +30,8 @@ use {
         transaction::{Result, SanitizedTransaction, TransactionError},
     },
     std::{
-        fmt::Debug,
+        fmt::{self, Debug},
+        mem,
         ops::Deref,
         sync::{Arc, RwLock},
     },
@@ -38,13 +39,49 @@ use {
 #[cfg(feature = "dev-context-only-utils")]
 use {mockall::automock, qualifier_attr::qualifiers};
 
+pub fn initialized_result_with_timings() -> ResultWithTimings {
+    (Ok(()), ExecuteTimings::default())
+}
+
 pub trait InstalledSchedulerPool: Send + Sync + Debug {
-    fn take_scheduler(&self, context: SchedulingContext) -> InstalledSchedulerBox;
+    fn take_scheduler(&self, context: SchedulingContext) -> InstalledSchedulerBox {
+        self.take_resumed_scheduler(context, initialized_result_with_timings())
+    }
+
+    fn take_resumed_scheduler(
+        &self,
+        context: SchedulingContext,
+        result_with_timings: ResultWithTimings,
+    ) -> InstalledSchedulerBox;
+
+    fn register_timeout_listener(&self, timeout_listener: TimeoutListener);
 }
 
 #[derive(Debug)]
 pub struct SchedulerAborted;
 pub type ScheduleResult = std::result::Result<(), SchedulerAborted>;
+
+pub struct TimeoutListener {
+    callback: Box<dyn FnOnce(InstalledSchedulerPoolArc) + Sync + Send>,
+}
+
+impl TimeoutListener {
+    pub(crate) fn new(f: impl FnOnce(InstalledSchedulerPoolArc) + Sync + Send + 'static) -> Self {
+        Self {
+            callback: Box::new(f),
+        }
+    }
+
+    pub fn trigger(self, pool: InstalledSchedulerPoolArc) {
+        (self.callback)(pool);
+    }
+}
+
+impl Debug for TimeoutListener {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TimeoutListener({self:p})")
+    }
+}
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// Schedules, executes, and commits transactions under encapsulated implementation
@@ -250,6 +287,61 @@ impl WaitReason {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum SchedulerStatus {
+    Unavailable,
+    Active(InstalledSchedulerBox),
+    Stale(InstalledSchedulerPoolArc, ResultWithTimings),
+}
+
+impl SchedulerStatus {
+    fn new(scheduler: Option<InstalledSchedulerBox>) -> Self {
+        match scheduler {
+            Some(scheduler) => SchedulerStatus::Active(scheduler),
+            None => SchedulerStatus::Unavailable,
+        }
+    }
+
+    fn transition_from_stale_to_active(
+        &mut self,
+        f: impl FnOnce(InstalledSchedulerPoolArc, ResultWithTimings) -> InstalledSchedulerBox,
+    ) {
+        let Self::Stale(pool, result_with_timings) = mem::replace(self, Self::Unavailable) else {
+            panic!();
+        };
+        *self = Self::Active(f(pool, result_with_timings));
+    }
+
+    pub(crate) fn maybe_transition_from_active_to_stale(
+        &mut self,
+        f: impl FnOnce(InstalledSchedulerBox) -> (InstalledSchedulerPoolArc, ResultWithTimings),
+    ) {
+        if !matches!(self, Self::Active(_scheduler)) {
+            return;
+        }
+        let Self::Active(scheduler) = mem::replace(self, Self::Unavailable) else {
+            panic!();
+        };
+        let (pool, result_with_timings) = f(scheduler);
+        *self = Self::Stale(pool, result_with_timings);
+    }
+
+    pub(crate) fn transition_from_active_to_unavailable(&mut self) -> InstalledSchedulerBox {
+        let Self::Active(scheduler) = mem::replace(self, Self::Unavailable) else {
+            panic!();
+        };
+        scheduler
+    }
+
+    pub(crate) fn transition_from_stale_to_unavailable(&mut self) -> ResultWithTimings {
+        let Self::Stale(_pool, result_with_timings) = mem::replace(self, Self::Unavailable) else {
+            panic!();
+        };
+        result_with_timings
+    }
+}
+
 /// Very thin wrapper around Arc<Bank>
 ///
 /// It brings type-safety against accidental mixing of bank and scheduler with different slots,
@@ -277,7 +369,7 @@ pub struct BankWithSchedulerInner {
     bank: Arc<Bank>,
     scheduler: InstalledSchedulerRwLock,
 }
-pub type InstalledSchedulerRwLock = RwLock<Option<InstalledSchedulerBox>>;
+pub type InstalledSchedulerRwLock = RwLock<SchedulerStatus>;
 
 impl BankWithScheduler {
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
@@ -292,7 +384,7 @@ impl BankWithScheduler {
         Self {
             inner: Arc::new(BankWithSchedulerInner {
                 bank,
-                scheduler: RwLock::new(scheduler),
+                scheduler: RwLock::new(SchedulerStatus::new(scheduler)),
             }),
         }
     }
@@ -321,7 +413,10 @@ impl BankWithScheduler {
     }
 
     pub fn has_installed_scheduler(&self) -> bool {
-        self.inner.scheduler.read().unwrap().is_some()
+        !matches!(
+            &*self.inner.scheduler.read().unwrap(),
+            SchedulerStatus::Unavailable
+        )
     }
 
     /// Schedule the transaction as long as the scheduler hasn't been aborted.
@@ -338,29 +433,29 @@ impl BankWithScheduler {
             transactions_with_indexes.len()
         );
 
-        let scheduler_guard = self.inner.scheduler.read().unwrap();
-        let scheduler = scheduler_guard.as_ref().unwrap();
-
-        for (sanitized_transaction, &index) in transactions_with_indexes {
-            if scheduler
-                .schedule_execution(&(sanitized_transaction, index))
-                .is_err()
-            {
-                drop(scheduler_guard);
-                // This write lock isn't atomic with the above the read lock. So, another thread
-                // could have called .recover_error_after_abort() while we're literally stuck at
-                // the gaps of these locks (i.e. this comment in source code wise) under extreme
-                // race conditions. Thus, .recover_error_after_abort() is made idempotetnt for that
-                // consideration in mind.
-                //
-                // Lastly, this non-atomic nature is intentional for optimizing the fast code-path
-                let mut scheduler_guard = self.inner.scheduler.write().unwrap();
-                let scheduler = scheduler_guard.as_mut().unwrap();
-                return Err(scheduler.recover_error_after_abort());
+        let schedule_result: ScheduleResult = self.inner.with_active_scheduler(|scheduler| {
+            for (sanitized_transaction, &index) in transactions_with_indexes {
+                scheduler.schedule_execution(&(sanitized_transaction, index))?;
             }
+            Ok(())
+        });
+
+        if schedule_result.is_err() {
+            // This write lock isn't atomic with the above the read lock. So, another thread
+            // could have called .recover_error_after_abort() while we're literally stuck at
+            // the gaps of these locks (i.e. this comment in source code wise) under extreme
+            // race conditions. Thus, .recover_error_after_abort() is made idempotetnt for that
+            // consideration in mind.
+            //
+            // Lastly, this non-atomic nature is intentional for optimizing the fast code-path
+            return Err(self.inner.retrieve_error_after_schedule_failure());
         }
 
         Ok(())
+    }
+
+    pub(crate) fn create_timeout_listener(&self) -> TimeoutListener {
+        self.inner.do_create_timeout_listener()
     }
 
     // take needless &mut only to communicate its semantic mutability to humans...
@@ -391,11 +486,72 @@ impl BankWithScheduler {
     }
 
     pub const fn no_scheduler_available() -> InstalledSchedulerRwLock {
-        RwLock::new(None)
+        RwLock::new(SchedulerStatus::Unavailable)
     }
 }
 
 impl BankWithSchedulerInner {
+    fn with_active_scheduler(
+        self: &Arc<Self>,
+        f: impl FnOnce(&InstalledSchedulerBox) -> ScheduleResult,
+    ) -> ScheduleResult {
+        let scheduler = self.scheduler.read().unwrap();
+        match &*scheduler {
+            SchedulerStatus::Active(scheduler) => {
+                // This is the fast path, needing single read-lock most of time.
+                f(scheduler)
+            }
+            SchedulerStatus::Stale(_pool, (result, _timings)) if result.is_err() => {
+                Err(SchedulerAborted)
+            }
+            SchedulerStatus::Stale(_pool, _result_with_timings) => {
+                drop(scheduler);
+
+                let context = SchedulingContext::new(self.bank.clone());
+                let mut scheduler = self.scheduler.write().unwrap();
+                scheduler.transition_from_stale_to_active(|scheduler_pool, result_with_timings| {
+                    scheduler_pool.register_timeout_listener(self.do_create_timeout_listener());
+                    scheduler_pool.take_resumed_scheduler(context, result_with_timings)
+                });
+                drop(scheduler);
+
+                self.with_active_scheduler(f)
+            }
+            SchedulerStatus::Unavailable => panic!(),
+        }
+    }
+
+    fn do_create_timeout_listener(self: &Arc<Self>) -> TimeoutListener {
+        let weak_bank = Arc::downgrade(self);
+        TimeoutListener::new(move |scheduler_pool| {
+            let Some(bank) = weak_bank.upgrade() else {
+                return;
+            };
+
+            let Ok(mut scheduler) = bank.scheduler.write() else {
+                return;
+            };
+
+            scheduler.maybe_transition_from_active_to_stale(|scheduler| {
+                let (result_with_timings, uninstalled_scheduler) =
+                    scheduler.wait_for_termination(false);
+                uninstalled_scheduler.return_to_pool();
+                (scheduler_pool, result_with_timings)
+            })
+        })
+    }
+
+    fn retrieve_error_after_schedule_failure(&self) -> TransactionError {
+        let mut scheduler = self.scheduler.write().unwrap();
+        match &mut *scheduler {
+            SchedulerStatus::Active(scheduler) => scheduler.recover_error_after_abort(),
+            SchedulerStatus::Stale(_pool, (result, _timings)) if result.is_err() => {
+                result.clone().unwrap_err()
+            }
+            _ => panic!(),
+        }
+    }
+
     #[must_use]
     fn wait_for_completed_scheduler_from_drop(&self) -> Option<ResultWithTimings> {
         Self::wait_for_scheduler_termination(
@@ -419,18 +575,24 @@ impl BankWithSchedulerInner {
         );
 
         let mut scheduler = scheduler.write().unwrap();
-        let (was_noop, result_with_timings) =
-            if let Some(scheduler) = scheduler.as_mut().filter(|_| reason.is_paused()) {
+        let (was_noop, result_with_timings) = match &mut *scheduler {
+            SchedulerStatus::Active(scheduler) if reason.is_paused() => {
                 scheduler.pause_for_recent_blockhash();
                 (false, None)
-            } else if let Some(scheduler) = scheduler.take() {
+            }
+            SchedulerStatus::Active(_scheduler) => {
+                let scheduler = scheduler.transition_from_active_to_unavailable();
                 let (result_with_timings, uninstalled_scheduler) =
                     scheduler.wait_for_termination(reason.is_dropped());
                 uninstalled_scheduler.return_to_pool();
                 (false, Some(result_with_timings))
-            } else {
-                (true, None)
-            };
+            }
+            SchedulerStatus::Stale(_pool, _result_with_timings) => {
+                let result_with_timings = scheduler.transition_from_stale_to_unavailable();
+                (true, Some(result_with_timings))
+            }
+            SchedulerStatus::Unavailable => (true, None),
+        };
         debug!(
             "wait_for_scheduler_termination(slot: {}, reason: {:?}): noop: {:?}, result: {:?} at {:?}...",
             bank.slot(),

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -1780,6 +1780,7 @@ mod tests {
 
         let (result, timings) = bank.wait_for_completed_scheduler().unwrap();
         assert_matches!(result, Ok(()));
+        // ResultWithTimings should be carried over across active=>stale=>active transitions.
         assert_eq!(timings.metrics[ExecuteTimingType::CheckUs], 246);
     }
 

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -68,6 +68,7 @@ enum CheckPoint {
     SchedulerThreadAborted,
     IdleSchedulerCleaned(usize),
     TrashedSchedulerCleaned(usize),
+    TimeoutListenerTriggered(usize),
 }
 
 type AtomicSchedulerId = AtomicU64;
@@ -238,29 +239,36 @@ where
                     trashed_inner_count
                 };
 
-                // Pre-allocate rather large capacity to avoid reallocation inside the lock.
-                let mut expired_listeners = Vec::with_capacity(128);
-                let Ok(mut timeout_listeners) = scheduler_pool.timeout_listeners.lock() else {
-                    break;
-                };
-                #[allow(unstable_name_collisions)]
-                expired_listeners.extend(timeout_listeners.extract_if(
-                    |(_callback, registered_at)| {
-                        now.duration_since(*registered_at) > timeout_duration
-                    },
-                ));
-                drop(timeout_listeners);
+                let triggered_timeout_listener_count = {
+                    // Pre-allocate rather large capacity to avoid reallocation inside the lock.
+                    let mut expired_listeners = Vec::with_capacity(128);
+                    let Ok(mut timeout_listeners) = scheduler_pool.timeout_listeners.lock() else {
+                        break;
+                    };
+                    #[allow(unstable_name_collisions)]
+                    expired_listeners.extend(timeout_listeners.extract_if(
+                        |(_callback, registered_at)| {
+                            now.duration_since(*registered_at) > timeout_duration
+                        },
+                    ));
+                    drop(timeout_listeners);
 
-                for (timeout_listener, _registered_at) in expired_listeners {
-                    timeout_listener.trigger(scheduler_pool.clone());
-                }
+                    let count = expired_listeners.len();
+                    for (timeout_listener, _registered_at) in expired_listeners {
+                        timeout_listener.trigger(scheduler_pool.clone());
+                    }
+                    count
+                };
 
                 info!(
-                    "Scheduler pool cleaner: dropped {} idle inners, {} trashed inners",
-                    idle_inner_count, trashed_inner_count,
+                    "Scheduler pool cleaner: dropped {} idle inners, {} trashed inners, triggered {} timeout listeners",
+                    idle_inner_count, trashed_inner_count, triggered_timeout_listener_count,
                 );
                 sleepless_testing::at(CheckPoint::IdleSchedulerCleaned(idle_inner_count));
                 sleepless_testing::at(CheckPoint::TrashedSchedulerCleaned(trashed_inner_count));
+                sleepless_testing::at(CheckPoint::TimeoutListenerTriggered(
+                    triggered_timeout_listener_count,
+                ));
             }
         };
 
@@ -1289,7 +1297,10 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
             debug!("end_session(): skipping; already result resides within thread manager..");
             return;
         }
-        debug!("end_session(): will end session...");
+        debug!(
+            "end_session(): will end session at {:?}...",
+            thread::current(),
+        );
 
         let mut abort_detected = self
             .new_task_sender
@@ -1309,6 +1320,7 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
         if abort_detected {
             self.ensure_join_threads_after_abort(false);
         }
+        debug!("end_session(): ended session at {:?}...", thread::current());
     }
 
     fn start_session(
@@ -1446,6 +1458,7 @@ mod tests {
         super::*,
         crate::sleepless_testing,
         assert_matches::assert_matches,
+        solana_program_runtime::timings::ExecuteTimingType,
         solana_runtime::{
             bank::Bank,
             bank_forks::BankForks,
@@ -1472,6 +1485,8 @@ mod tests {
         AfterIdleSchedulerCleaned,
         BeforeTrashedSchedulerCleaned,
         AfterTrashedSchedulerCleaned,
+        BeforeTimeoutListenerTriggered,
+        AfterTimeoutListenerTriggered,
         BeforeThreadManagerDrop,
         BeforeEndSession,
     }
@@ -1508,6 +1523,7 @@ mod tests {
     }
 
     const SHORTENED_POOL_CLEANER_INTERVAL: Duration = Duration::from_millis(1);
+    const SHORTENED_MAX_POOLING_DURATION: Duration = Duration::from_millis(10);
 
     #[test]
     fn test_scheduler_drop_idle() {
@@ -1521,7 +1537,6 @@ mod tests {
         ]);
 
         let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
-        let shortened_max_pooling_duration = Duration::from_millis(10);
         let pool_raw = DefaultSchedulerPool::do_new(
             None,
             None,
@@ -1529,7 +1544,7 @@ mod tests {
             None,
             ignored_prioritization_fee_cache,
             SHORTENED_POOL_CLEANER_INTERVAL,
-            shortened_max_pooling_duration,
+            SHORTENED_MAX_POOLING_DURATION,
             DEFAULT_MAX_USAGE_QUEUE_COUNT,
             DEFAULT_TIMEOUT_DURATION,
         );
@@ -1544,7 +1559,7 @@ mod tests {
         Box::new(old_scheduler.into_inner().1).return_to_pool();
 
         // sleepless_testing can't be used; wait a bit here to see real progress of wall time...
-        sleep(shortened_max_pooling_duration * 10);
+        sleep(SHORTENED_MAX_POOLING_DURATION * 10);
         Box::new(new_scheduler.into_inner().1).return_to_pool();
 
         // Block solScCleaner until we see returned schedlers...
@@ -1639,10 +1654,223 @@ mod tests {
         );
     }
 
+    const SHORTENED_TIMEOUT_DURATION: Duration = Duration::from_millis(1);
+
+    #[test]
+    fn test_scheduler_drop_stale() {
+        solana_logger::setup();
+
+        let _progress = sleepless_testing::setup(&[
+            &TestCheckPoint::BeforeTimeoutListenerTriggered,
+            &CheckPoint::TimeoutListenerTriggered(0),
+            &CheckPoint::TimeoutListenerTriggered(1),
+            &TestCheckPoint::AfterTimeoutListenerTriggered,
+            &CheckPoint::IdleSchedulerCleaned(1),
+            &TestCheckPoint::AfterIdleSchedulerCleaned,
+        ]);
+
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool_raw = DefaultSchedulerPool::do_new(
+            None,
+            None,
+            None,
+            None,
+            ignored_prioritization_fee_cache,
+            SHORTENED_POOL_CLEANER_INTERVAL,
+            SHORTENED_MAX_POOLING_DURATION,
+            DEFAULT_MAX_USAGE_QUEUE_COUNT,
+            SHORTENED_TIMEOUT_DURATION,
+        );
+        let pool = pool_raw.clone();
+        let bank = Arc::new(Bank::default_for_tests());
+        let context = SchedulingContext::new(bank.clone());
+        let scheduler = pool.take_scheduler(context);
+        let bank = BankWithScheduler::new(bank, Some(scheduler));
+        pool.register_timeout_listener(bank.create_timeout_listener());
+        assert_eq!(pool_raw.scheduler_inners.lock().unwrap().len(), 0);
+        assert_eq!(pool_raw.trashed_scheduler_inners.lock().unwrap().len(), 0);
+        sleepless_testing::at(TestCheckPoint::BeforeTimeoutListenerTriggered);
+
+        sleepless_testing::at(TestCheckPoint::AfterTimeoutListenerTriggered);
+        assert_eq!(pool_raw.scheduler_inners.lock().unwrap().len(), 1);
+        assert_eq!(pool_raw.trashed_scheduler_inners.lock().unwrap().len(), 0);
+        assert_matches!(bank.wait_for_completed_scheduler(), Some((Ok(()), _)));
+
+        // See the stale scheduler gone only after solScCleaner did its job...
+        sleepless_testing::at(&TestCheckPoint::AfterIdleSchedulerCleaned);
+        assert_eq!(pool_raw.scheduler_inners.lock().unwrap().len(), 0);
+        assert_eq!(pool_raw.trashed_scheduler_inners.lock().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_scheduler_active_after_stale() {
+        solana_logger::setup();
+
+        let _progress = sleepless_testing::setup(&[
+            &TestCheckPoint::BeforeTimeoutListenerTriggered,
+            &CheckPoint::TimeoutListenerTriggered(0),
+            &CheckPoint::TimeoutListenerTriggered(1),
+            &TestCheckPoint::AfterTimeoutListenerTriggered,
+        ]);
+
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool_raw = SchedulerPool::<PooledScheduler<ExecuteTimingCounter>, _>::do_new(
+            None,
+            None,
+            None,
+            None,
+            ignored_prioritization_fee_cache,
+            SHORTENED_POOL_CLEANER_INTERVAL,
+            DEFAULT_MAX_POOLING_DURATION,
+            DEFAULT_MAX_USAGE_QUEUE_COUNT,
+            SHORTENED_TIMEOUT_DURATION,
+        );
+
+        #[derive(Debug)]
+        struct ExecuteTimingCounter;
+        impl TaskHandler for ExecuteTimingCounter {
+            fn handle(
+                _result: &mut Result<()>,
+                timings: &mut ExecuteTimings,
+                _bank: &Arc<Bank>,
+                _transaction: &SanitizedTransaction,
+                _index: usize,
+                _handler_context: &HandlerContext,
+            ) {
+                timings.metrics[ExecuteTimingType::CheckUs] += 123;
+            }
+        }
+        let pool = pool_raw.clone();
+
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let bank = setup_dummy_fork_graph(bank);
+
+        let context = SchedulingContext::new(bank.clone());
+
+        let scheduler = pool.take_scheduler(context);
+        let bank = BankWithScheduler::new(bank, Some(scheduler));
+        pool.register_timeout_listener(bank.create_timeout_listener());
+
+        let tx_before_stale =
+            &SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+                &mint_keypair,
+                &solana_sdk::pubkey::new_rand(),
+                2,
+                genesis_config.hash(),
+            ));
+        bank.schedule_transaction_executions([(tx_before_stale, &0)].into_iter())
+            .unwrap();
+        sleepless_testing::at(TestCheckPoint::BeforeTimeoutListenerTriggered);
+
+        sleepless_testing::at(TestCheckPoint::AfterTimeoutListenerTriggered);
+        let tx_after_stale =
+            &SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+                &mint_keypair,
+                &solana_sdk::pubkey::new_rand(),
+                2,
+                genesis_config.hash(),
+            ));
+        bank.schedule_transaction_executions([(tx_after_stale, &1)].into_iter())
+            .unwrap();
+
+        let (result, timings) = bank.wait_for_completed_scheduler().unwrap();
+        assert_matches!(result, Ok(()));
+        assert_eq!(timings.metrics[ExecuteTimingType::CheckUs], 246);
+    }
+
+    #[test]
+    fn test_scheduler_remain_stale_after_error() {
+        solana_logger::setup();
+
+        let _progress = sleepless_testing::setup(&[
+            &TestCheckPoint::BeforeTimeoutListenerTriggered,
+            &CheckPoint::TimeoutListenerTriggered(0),
+            &CheckPoint::SchedulerThreadAborted,
+            &TestCheckPoint::AfterSchedulerThreadAborted,
+            &CheckPoint::TimeoutListenerTriggered(1),
+            &TestCheckPoint::AfterTimeoutListenerTriggered,
+        ]);
+
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool_raw = SchedulerPool::<PooledScheduler<FaultyHandler>, _>::do_new(
+            None,
+            None,
+            None,
+            None,
+            ignored_prioritization_fee_cache,
+            SHORTENED_POOL_CLEANER_INTERVAL,
+            DEFAULT_MAX_POOLING_DURATION,
+            DEFAULT_MAX_USAGE_QUEUE_COUNT,
+            SHORTENED_TIMEOUT_DURATION,
+        );
+
+        let pool = pool_raw.clone();
+
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let bank = setup_dummy_fork_graph(bank);
+
+        let context = SchedulingContext::new(bank.clone());
+
+        let scheduler = pool.take_scheduler(context);
+        let bank = BankWithScheduler::new(bank, Some(scheduler));
+        pool.register_timeout_listener(bank.create_timeout_listener());
+
+        let tx_before_stale =
+            &SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+                &mint_keypair,
+                &solana_sdk::pubkey::new_rand(),
+                2,
+                genesis_config.hash(),
+            ));
+        bank.schedule_transaction_executions([(tx_before_stale, &0)].into_iter())
+            .unwrap();
+        sleepless_testing::at(TestCheckPoint::BeforeTimeoutListenerTriggered);
+        sleepless_testing::at(TestCheckPoint::AfterSchedulerThreadAborted);
+
+        sleepless_testing::at(TestCheckPoint::AfterTimeoutListenerTriggered);
+        let tx_after_stale =
+            &SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+                &mint_keypair,
+                &solana_sdk::pubkey::new_rand(),
+                2,
+                genesis_config.hash(),
+            ));
+        let result = bank.schedule_transaction_executions([(tx_after_stale, &1)].into_iter());
+        assert_matches!(result, Err(TransactionError::AccountNotFound));
+
+        let (result, _timings) = bank.wait_for_completed_scheduler().unwrap();
+        assert_matches!(result, Err(TransactionError::AccountNotFound));
+    }
+
     enum AbortCase {
         Unhandled,
         UnhandledWhilePanicking,
         Handled,
+    }
+
+    #[derive(Debug)]
+    struct FaultyHandler;
+    impl TaskHandler for FaultyHandler {
+        fn handle(
+            result: &mut Result<()>,
+            _timings: &mut ExecuteTimings,
+            _bank: &Arc<Bank>,
+            _transaction: &SanitizedTransaction,
+            _index: usize,
+            _handler_context: &HandlerContext,
+        ) {
+            *result = Err(TransactionError::AccountNotFound);
+        }
     }
 
     fn do_test_scheduler_drop_abort(abort_case: AbortCase) {
@@ -1655,21 +1883,6 @@ mod tests {
             ],
             _ => &[],
         });
-
-        #[derive(Debug)]
-        struct FaultyHandler;
-        impl TaskHandler for FaultyHandler {
-            fn handle(
-                result: &mut Result<()>,
-                _timings: &mut ExecuteTimings,
-                _bank: &Arc<Bank>,
-                _transaction: &SanitizedTransaction,
-                _index: usize,
-                _handler_context: &HandlerContext,
-            ) {
-                *result = Err(TransactionError::AccountNotFound);
-            }
-        }
 
         let GenesisConfigInfo {
             genesis_config,


### PR DESCRIPTION
#### Problem

From https://github.com/anza-xyz/agave/pull/1211:

> Specifically, there are following several termination conditions which it must handle respectively:
> 
> ...
> 5. There could be many active (= taken-out-of-the-pool) unified schedulers under very forky network conditions for extended duration of lack of rooting. In that case, many native os threads will be created just to sit idling collectively because each unified scheduler instance separately creates and manages its own set of threads individually (for perf reasons). So, idling scheduler should be returned back to the pool. Then, eventually those pooled-back schedulers will be retired according to the (3) after the forky situation is resolved.


#### Summary of Changes

This pr addresses (5).

The impl is a bit involved.

In a gist, `BankWithScheduler` now registers a callback (`TimeoutListener`) to `solScCleaner` to detect its own stalemate from outside. for that end, `solScCleaner` unconditionally invokes the callback after fixed duration (>> 1 slot = 400ms). Then the callback returns back schedulers to the pool, if the bank isn't yet frozen. So, there's new state of `BankWithScheduler` in which it has stale scheduler. that's modeled with new `SchedulerStatus` with tri-state `enum`, replacing `Option`.

This whole setup is needed, because this stale scheduler returning must be done transparently from the view point of transaction scheduling. Accordingly, the scheduling code path is adjusted to revive the stale state when it detects and re-take the scheduler from the pool (= called _resuming_ in code) with the last-saved `ResultWithTimings` in the `SchedulerStaus::Stale`.

Thanks to the nature of this ouf-of-band mechanism, there's no addtional overhead in the latency-sensitive code path and it works even if there's no newly-arriving transactions at all.

Lastly, note that encapsulating this inside `solana-unifinied-scheduler` would necessitate introduction of some kind of synchronization mechanism. Also, this is why i used the term session in the crate not to associate 1-to-1 for slot-to-session. it's now 1-to-N. (most of time, it's practically still 1-to-1, though).