### PR TITLE
program: Add "hmac" feature to libsecp256k1 for doctests

### DIFF
--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -61,6 +61,7 @@ wasm-bindgen = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
+libsecp256k1 = { workspace = true, features = ["hmac"] } # used by doctests
 solana-logger = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
#### Problem

Since #1286, the `solana-program` doctests fail when run directly with `cargo test` from `sdk/program`. This is because the doctests require the "hmac" feature.

#### Summary of Changes

Enable the hmac feature on libsecp256k1 in dev-dependencies.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
