### PR TITLE
[zk-elgamal-proof-program] Remove stack height restriction in elgamal proof program invocation

### DIFF
--- a/programs/zk-elgamal-proof/src/lib.rs
+++ b/programs/zk-elgamal-proof/src/lib.rs
@@ -3,10 +3,7 @@
 use {
     bytemuck::Pod,
     solana_program_runtime::{declare_process_instruction, ic_msg, invoke_context::InvokeContext},
-    solana_sdk::{
-        instruction::{InstructionError, TRANSACTION_LEVEL_STACK_HEIGHT},
-        system_program,
-    },
+    solana_sdk::{instruction::InstructionError, system_program},
     solana_zk_sdk::elgamal_program::{
         id,
         instruction::ProofInstruction,
@@ -177,13 +174,6 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
     let instruction_data = instruction_context.get_instruction_data();
     let instruction = ProofInstruction::instruction_type(instruction_data)
         .ok_or(InstructionError::InvalidInstructionData)?;
-
-    if invoke_context.get_stack_height() != TRANSACTION_LEVEL_STACK_HEIGHT
-        && instruction != ProofInstruction::CloseContextState
-    {
-        // Proof verification instructions are not supported as an inner instruction
-        return Err(InstructionError::UnsupportedProgramId);
-    }
 
     match instruction {
         ProofInstruction::CloseContextState => {


### PR DESCRIPTION
#### Problem
Currently, the ElGamal proof program cannot be invoked by another program. This restriction was originally put in place as a safety measure since it is almost impossible to generate the proofs inside the vm. However, it is possible for the proof data to have been generated on the client and then included in the transactions as part of a different instruction. The on-chain program can then put together an ElGamal proof instruction and invoke CPI.

#### Summary of Changes
Remove the restriction to allow the ZK ElGamal proof program to be invoked by a different program.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
