### PR TITLE
add ancient pack stats for unmovable slots

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1951,6 +1951,8 @@ pub(crate) struct ShrinkAncientStats {
     pub(crate) ancient_scanned: AtomicU64,
     pub(crate) bytes_ancient_created: AtomicU64,
     pub(crate) many_ref_slots_skipped: AtomicU64,
+    pub(crate) slots_cannot_move_count: AtomicU64,
+    pub(crate) many_refs_old_alive: AtomicU64,
 }
 
 #[derive(Debug, Default)]
@@ -2243,6 +2245,16 @@ impl ShrinkAncientStats {
             (
                 "many_ref_slots_skipped",
                 self.many_ref_slots_skipped.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "slots_cannot_move_count",
+                self.slots_cannot_move_count.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "many_refs_old_alive",
+                self.many_refs_old_alive.swap(0, Ordering::Relaxed),
                 i64
             ),
         );


### PR DESCRIPTION
#### Problem
1.18 struggles in certain conditions on mnb with many ref alive accounts.

#### Summary of Changes
Add some stats to track how often this is happening.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
