### PR TITLE
Reuse compute budget processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5511,6 +5511,7 @@ dependencies = [
  "smallvec",
  "solana-accounts-db",
  "solana-bucket-map",
+ "solana-compute-budget",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-inline-spl",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -65,6 +65,7 @@ rand_chacha = { workspace = true }
 serde_bytes = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-accounts-db = { path = ".", features = ["dev-context-only-utils"] }
+solana-compute-budget = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 solana-svm = { workspace = true, features = ["dev-context-only-utils"] }

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -822,6 +822,7 @@ mod tests {
     use {
         super::*,
         assert_matches::assert_matches,
+        solana_compute_budget::compute_budget_processor::ComputeBudgetLimits,
         solana_sdk::{
             account::{AccountSharedData, WritableAccount},
             address_lookup_table::state::LookupTableMeta,
@@ -1566,6 +1567,7 @@ mod tests {
             program_indices: vec![],
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
+            compute_budget_limits: ComputeBudgetLimits::default(),
             rent: 0,
             rent_debits: RentDebits::default(),
             loaded_accounts_data_size: 0,
@@ -1576,6 +1578,7 @@ mod tests {
             program_indices: vec![],
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
+            compute_budget_limits: ComputeBudgetLimits::default(),
             rent: 0,
             rent_debits: RentDebits::default(),
             loaded_accounts_data_size: 0,
@@ -1829,6 +1832,7 @@ mod tests {
                 nonce: nonce.clone(),
                 fee_payer_account: from_account_pre.clone(),
             },
+            compute_budget_limits: ComputeBudgetLimits::default(),
             rent: 0,
             rent_debits: RentDebits::default(),
             loaded_accounts_data_size: 0,
@@ -1928,6 +1932,7 @@ mod tests {
             rollback_accounts: RollbackAccounts::SameNonceAndFeePayer {
                 nonce: nonce.clone(),
             },
+            compute_budget_limits: ComputeBudgetLimits::default(),
             rent: 0,
             rent_debits: RentDebits::default(),
             loaded_accounts_data_size: 0,

--- a/compute-budget/src/compute_budget_processor.rs
+++ b/compute-budget/src/compute_budget_processor.rs
@@ -23,7 +23,7 @@ pub const MIN_HEAP_FRAME_BYTES: u32 = HEAP_LENGTH as u32;
 /// anyone in Mainnet-beta today. It can be set by set_loaded_accounts_data_size_limit instruction
 pub const MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES: u32 = 64 * 1024 * 1024;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ComputeBudgetLimits {
     pub updated_heap_bytes: u32,
     pub compute_unit_limit: u32,

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -318,6 +318,7 @@ impl ConsumeWorkerMetrics {
             invalid_account_for_fee,
             invalid_account_index,
             invalid_program_for_execution,
+            invalid_compute_budget,
             not_allowed_during_cluster_maintenance,
             invalid_writable_account,
             invalid_rent_paying_account,
@@ -371,6 +372,9 @@ impl ConsumeWorkerMetrics {
         self.error_metrics
             .invalid_program_for_execution
             .fetch_add(*invalid_program_for_execution, Ordering::Relaxed);
+        self.error_metrics
+            .invalid_compute_budget
+            .fetch_add(*invalid_compute_budget, Ordering::Relaxed);
         self.error_metrics
             .not_allowed_during_cluster_maintenance
             .fetch_add(*not_allowed_during_cluster_maintenance, Ordering::Relaxed);
@@ -561,6 +565,7 @@ struct ConsumeWorkerTransactionErrorMetrics {
     invalid_account_for_fee: AtomicUsize,
     invalid_account_index: AtomicUsize,
     invalid_program_for_execution: AtomicUsize,
+    invalid_compute_budget: AtomicUsize,
     not_allowed_during_cluster_maintenance: AtomicUsize,
     invalid_writable_account: AtomicUsize,
     invalid_rent_paying_account: AtomicUsize,
@@ -641,6 +646,12 @@ impl ConsumeWorkerTransactionErrorMetrics {
             (
                 "invalid_program_for_execution",
                 self.invalid_program_for_execution
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "invalid_compute_budget",
+                self.invalid_compute_budget
                     .swap(0, Ordering::Relaxed),
                 i64
             ),

--- a/program-runtime/src/timings.rs
+++ b/program-runtime/src/timings.rs
@@ -242,13 +242,6 @@ eager_macro_rules! { $eager_1
                 i64
             ),
             (
-                "execute_accessories_compute_budget_process_transaction_us",
-                $self
-                    .execute_accessories
-                    .compute_budget_process_transaction_us,
-                i64
-            ),
-            (
                 "execute_accessories_get_executors_us",
                 $self.execute_accessories.get_executors_us,
                 i64
@@ -348,7 +341,6 @@ impl ExecuteProcessInstructionTimings {
 #[derive(Default, Debug)]
 pub struct ExecuteAccessoryTimings {
     pub feature_set_clone_us: u64,
-    pub compute_budget_process_transaction_us: u64,
     pub get_executors_us: u64,
     pub process_message_us: u64,
     pub update_executors_us: u64,
@@ -358,10 +350,6 @@ pub struct ExecuteAccessoryTimings {
 impl ExecuteAccessoryTimings {
     pub fn accumulate(&mut self, other: &ExecuteAccessoryTimings) {
         saturating_add_assign!(self.feature_set_clone_us, other.feature_set_clone_us);
-        saturating_add_assign!(
-            self.compute_budget_process_transaction_us,
-            other.compute_budget_process_transaction_us
-        );
         saturating_add_assign!(self.get_executors_us, other.get_executors_us);
         saturating_add_assign!(self.process_message_us, other.process_message_us);
         saturating_add_assign!(self.update_executors_us, other.update_executors_us);

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1145,10 +1145,9 @@ mod tests {
             &mock_bank,
             sanitized_transaction.message(),
             ValidatedTransactionDetails {
-                rollback_accounts: RollbackAccounts::default(),
-                fee_details: FeeDetails::default(),
                 fee_payer_account: fee_payer_account_data.clone(),
                 fee_payer_rent_debit,
+                ..ValidatedTransactionDetails::default()
             },
             &mut error_metrics,
             None,
@@ -1169,6 +1168,7 @@ mod tests {
                 program_indices: vec![],
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
+                compute_budget_limits: ComputeBudgetLimits::default(),
                 rent: fee_payer_rent_debit,
                 rent_debits: expected_rent_debits,
                 loaded_accounts_data_size: 0,
@@ -1213,10 +1213,8 @@ mod tests {
             &mock_bank,
             sanitized_transaction.message(),
             ValidatedTransactionDetails {
-                rollback_accounts: RollbackAccounts::default(),
-                fee_details: FeeDetails::default(),
                 fee_payer_account: fee_payer_account_data.clone(),
-                fee_payer_rent_debit: 0,
+                ..ValidatedTransactionDetails::default()
             },
             &mut error_metrics,
             None,
@@ -1238,6 +1236,7 @@ mod tests {
                 program_indices: vec![vec![]],
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
+                compute_budget_limits: ComputeBudgetLimits::default(),
                 rent: 0,
                 rent_debits: RentDebits::default(),
                 loaded_accounts_data_size: 0,
@@ -1421,10 +1420,8 @@ mod tests {
             &mock_bank,
             sanitized_transaction.message(),
             ValidatedTransactionDetails {
-                rollback_accounts: RollbackAccounts::default(),
-                fee_details: FeeDetails::default(),
                 fee_payer_account: fee_payer_account_data.clone(),
-                fee_payer_rent_debit: 0,
+                ..ValidatedTransactionDetails::default()
             },
             &mut error_metrics,
             None,
@@ -1445,6 +1442,7 @@ mod tests {
                 ],
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
+                compute_budget_limits: ComputeBudgetLimits::default(),
                 program_indices: vec![vec![1]],
                 rent: 0,
                 rent_debits: RentDebits::default(),
@@ -1603,10 +1601,8 @@ mod tests {
             &mock_bank,
             sanitized_transaction.message(),
             ValidatedTransactionDetails {
-                rollback_accounts: RollbackAccounts::default(),
-                fee_details: FeeDetails::default(),
                 fee_payer_account: fee_payer_account_data.clone(),
-                fee_payer_rent_debit: 0,
+                ..ValidatedTransactionDetails::default()
             },
             &mut error_metrics,
             None,
@@ -1632,6 +1628,7 @@ mod tests {
                 program_indices: vec![vec![2, 1]],
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
+                compute_budget_limits: ComputeBudgetLimits::default(),
                 rent: 0,
                 rent_debits: RentDebits::default(),
                 loaded_accounts_data_size: 0,
@@ -1694,10 +1691,8 @@ mod tests {
             &mock_bank,
             sanitized_transaction.message(),
             ValidatedTransactionDetails {
-                rollback_accounts: RollbackAccounts::default(),
-                fee_details: FeeDetails::default(),
                 fee_payer_account: fee_payer_account_data.clone(),
-                fee_payer_rent_debit: 0,
+                ..ValidatedTransactionDetails::default()
             },
             &mut error_metrics,
             None,
@@ -1726,6 +1721,7 @@ mod tests {
                 program_indices: vec![vec![3, 1], vec![3, 1]],
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
+                compute_budget_limits: ComputeBudgetLimits::default(),
                 rent: 0,
                 rent_debits: RentDebits::default(),
                 loaded_accounts_data_size: 0,
@@ -1846,10 +1842,8 @@ mod tests {
             false,
         );
         let validation_result = Ok(ValidatedTransactionDetails {
-            rollback_accounts: RollbackAccounts::default(),
-            fee_details: FeeDetails::default(),
             fee_payer_account: fee_payer_account_data,
-            fee_payer_rent_debit: 0,
+            ..ValidatedTransactionDetails::default()
         });
 
         let results = load_accounts(
@@ -1889,6 +1883,7 @@ mod tests {
                 program_indices: vec![vec![3, 1], vec![3, 1]],
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
+                compute_budget_limits: ComputeBudgetLimits::default(),
                 rent: 0,
                 rent_debits: RentDebits::default(),
                 loaded_accounts_data_size: 0,
@@ -1920,13 +1915,7 @@ mod tests {
             false,
         );
 
-        let validation_result = Ok(ValidatedTransactionDetails {
-            rollback_accounts: RollbackAccounts::default(),
-            fee_details: FeeDetails::default(),
-            fee_payer_account: AccountSharedData::default(),
-            fee_payer_rent_debit: 0,
-        });
-
+        let validation_result = Ok(ValidatedTransactionDetails::default());
         let result = load_accounts(
             &mock_bank,
             &[sanitized_transaction.clone()],

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -6,7 +6,9 @@ use {
         transaction_processing_callback::TransactionProcessingCallback,
     },
     itertools::Itertools,
-    solana_compute_budget::compute_budget_processor::process_compute_budget_instructions,
+    solana_compute_budget::compute_budget_processor::{
+        process_compute_budget_instructions, ComputeBudgetLimits,
+    },
     solana_program_runtime::loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
@@ -45,6 +47,7 @@ pub struct CheckedTransactionDetails {
 #[cfg_attr(feature = "dev-context-only-utils", derive(Default))]
 pub struct ValidatedTransactionDetails {
     pub rollback_accounts: RollbackAccounts,
+    pub compute_budget_limits: ComputeBudgetLimits,
     pub fee_details: FeeDetails,
     pub fee_payer_account: AccountSharedData,
     pub fee_payer_rent_debit: u64,
@@ -56,6 +59,7 @@ pub struct LoadedTransaction {
     pub program_indices: TransactionProgramIndices,
     pub fee_details: FeeDetails,
     pub rollback_accounts: RollbackAccounts,
+    pub compute_budget_limits: ComputeBudgetLimits,
     pub rent: TransactionRent,
     pub rent_debits: RentDebits,
     pub loaded_accounts_data_size: usize,
@@ -358,6 +362,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
         program_indices,
         fee_details: tx_details.fee_details,
         rollback_accounts: tx_details.rollback_accounts,
+        compute_budget_limits: tx_details.compute_budget_limits,
         rent: tx_rent,
         rent_debits,
         loaded_accounts_data_size: accumulated_accounts_data_size,

--- a/svm/src/transaction_error_metrics.rs
+++ b/svm/src/transaction_error_metrics.rs
@@ -16,6 +16,7 @@ pub struct TransactionErrorMetrics {
     pub invalid_account_for_fee: usize,
     pub invalid_account_index: usize,
     pub invalid_program_for_execution: usize,
+    pub invalid_compute_budget: usize,
     pub not_allowed_during_cluster_maintenance: usize,
     pub invalid_writable_account: usize,
     pub invalid_rent_paying_account: usize,
@@ -50,6 +51,7 @@ impl TransactionErrorMetrics {
             self.invalid_program_for_execution,
             other.invalid_program_for_execution
         );
+        saturating_add_assign!(self.invalid_compute_budget, other.invalid_compute_budget);
         saturating_add_assign!(
             self.not_allowed_during_cluster_maintenance,
             other.not_allowed_during_cluster_maintenance
@@ -125,6 +127,11 @@ impl TransactionErrorMetrics {
             (
                 "invalid_program_for_execution",
                 self.invalid_program_for_execution as i64,
+                i64
+            ),
+            (
+                "invalid_compute_budget",
+                self.invalid_compute_budget as i64,
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem
Compute budget instruction processing for transactions is performed multiple times in the transaction pipeline. The computed budget limits should be reused through the pipeline.

#### Summary of Changes
- Remove one instance of re-processing compute budget instructions in the SVM transaction processor 
- Add metrics for transactions rejected due to invalid compute budget issues (this should never happen since banking stage filters these transactions out)
- Fail earlier in SVM if compute budget processing fails (again, this shouldn't make any difference because banking stage filters these transactions)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
