### PR TITLE
test-validator: Try to reset deployment slot on all cloned accounts

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -37,7 +37,7 @@ use {
         runtime_config::RuntimeConfig, snapshot_config::SnapshotConfig,
     },
     solana_sdk::{
-        account::{Account, AccountSharedData, WritableAccount},
+        account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
         bpf_loader_upgradeable::UpgradeableLoaderState,
         clock::{Slot, DEFAULT_MS_PER_SLOT},
         commitment_config::CommitmentConfig,
@@ -183,6 +183,47 @@ impl Default for TestValidatorGenesis {
             admin_rpc_service_post_init:
                 Arc::<RwLock<Option<AdminRpcRequestMetadataPostInit>>>::default(),
         }
+    }
+}
+
+fn try_transform_program_data(
+    address: &Pubkey,
+    mut account: AccountSharedData,
+) -> Result<AccountSharedData, String> {
+    if account.owner() == &solana_sdk::bpf_loader_upgradeable::id() {
+        let programdata_offset = UpgradeableLoaderState::size_of_programdata_metadata();
+        let programdata_meta = account.data().get(0..programdata_offset).ok_or(format!(
+            "Failed to get upgradeable programdata data from {address}"
+        ))?;
+        // Ensure the account is a proper programdata account before
+        // attempting to serialize into it.
+        if let Ok(UpgradeableLoaderState::ProgramData {
+            upgrade_authority_address,
+            ..
+        }) = bincode::deserialize::<UpgradeableLoaderState>(programdata_meta)
+        {
+            // Serialize new programdata metadata into the resulting account,
+            // to overwrite the deployment slot to `0`.
+            bincode::serialize_into(
+                account.data_as_mut_slice(),
+                &UpgradeableLoaderState::ProgramData {
+                    slot: 0,
+                    upgrade_authority_address,
+                },
+            )
+            .map(|()| Ok(account))
+            .unwrap_or_else(|_| {
+                Err(format!(
+                    "Failed to write to upgradeable programdata account {address}",
+                ))
+            })
+        } else {
+            Err(format!(
+                "Failed to read upgradeable programdata account {address}"
+            ))
+        }
+    } else {
+        Err(format!("Account {address} not owned by upgradeable loader"))
     }
 }
 
@@ -348,7 +389,14 @@ impl TestValidatorGenesis {
             addresses,
             rpc_client,
             skip_missing,
-            |_address, account| Ok(AccountSharedData::from(account)),
+            |address, account| {
+                let account_shared_data = AccountSharedData::from(account);
+                // ignore the error
+                Ok(
+                    try_transform_program_data(address, account_shared_data.clone())
+                        .unwrap_or(account_shared_data),
+                )
+            },
         )
     }
 
@@ -366,35 +414,7 @@ impl TestValidatorGenesis {
             rpc_client,
             skip_missing,
             |address, account| {
-                let programdata_offset = UpgradeableLoaderState::size_of_programdata_metadata();
-                // Ensure the account is a proper programdata account before
-                // attempting to serialize into it.
-                if let Ok(UpgradeableLoaderState::ProgramData {
-                    upgrade_authority_address,
-                    ..
-                }) = bincode::deserialize(&account.data[..programdata_offset])
-                {
-                    // Serialize new programdata metadata into the resulting account,
-                    // to overwrite the deployment slot to `0`.
-                    let mut programdata_account = AccountSharedData::from(account);
-                    bincode::serialize_into(
-                        programdata_account.data_as_mut_slice(),
-                        &UpgradeableLoaderState::ProgramData {
-                            slot: 0,
-                            upgrade_authority_address,
-                        },
-                    )
-                    .map(|()| Ok(programdata_account))
-                    .unwrap_or_else(|_| {
-                        Err(format!(
-                            "Failed to write to upgradeable programdata account {address}",
-                        ))
-                    })
-                } else {
-                    Err(format!(
-                        "Failed to read upgradeable programdata account {address}",
-                    ))
-                }
+                try_transform_program_data(address, AccountSharedData::from(account))
             },
         )
     }


### PR DESCRIPTION
#### Problem

As pointed out in #522, the deployment slot on program data is only reset if the `--clone-upgradeable-program` flag is used. Previous setups using the plain `--clone` flag will still get a deployment slot in the future.

#### Summary of Changes

Although the better option is to move people to use `--clone-upgradeable-program`, the deployment slot addition was still a breaking change for downstream users, so try to reset the deployment slot on any cloned account, and ignore the error.

Fixes #522
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
