### PR TITLE
refactor file version of get_account_shared_data

### DIFF
--- a/accounts-db/src/append_vec/test_utils.rs
+++ b/accounts-db/src/append_vec/test_utils.rs
@@ -52,9 +52,8 @@ pub fn create_test_account(sample: usize) -> (StoredMeta, AccountSharedData) {
 
 /// Create a test account for the given `data_len`.
 /// This is useful to create very large test account.
-pub fn create_large_test_account(data_len: usize) -> (StoredMeta, AccountSharedData) {
-    let mut account = AccountSharedData::new(100, data_len, &Pubkey::default());
-    account.set_data_from_slice(&vec![data_len as u8; data_len]);
+pub fn create_test_account_with(data_len: usize) -> (StoredMeta, AccountSharedData) {
+    let account = AccountSharedData::new(100, data_len, &Pubkey::default());
     let stored_meta = StoredMeta {
         write_version_obsolete: 0,
         pubkey: Pubkey::default(),

--- a/accounts-db/src/append_vec/test_utils.rs
+++ b/accounts-db/src/append_vec/test_utils.rs
@@ -49,3 +49,16 @@ pub fn create_test_account(sample: usize) -> (StoredMeta, AccountSharedData) {
     };
     (stored_meta, account)
 }
+
+/// Create a test account for the given `data_len`.
+/// This is useful to create very large test account.
+pub fn create_large_test_account(data_len: usize) -> (StoredMeta, AccountSharedData) {
+    let mut account = AccountSharedData::new(100, data_len, &Pubkey::default());
+    account.set_data_from_slice(&vec![data_len as u8; data_len]);
+    let stored_meta = StoredMeta {
+        write_version_obsolete: 0,
+        pubkey: Pubkey::default(),
+        data_len: data_len as u64,
+    };
+    (stored_meta, account)
+}


### PR DESCRIPTION
#### Problem
Working on getting rid of mmaps for append vecs.
mmaps are poorly managed by linux kernel. file i/o for cold accounts will work more efficiently

#### Summary of Changes
`get_account_shared_data` is in the critical path for tx processing.
If we're using file based storages, avoid an unnecessary vec allocation for data.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
