### PR TITLE
[zk-sdk] Expose function to convert a grouped ElGamal ciphertext to a regular ciphertext

### DIFF
--- a/zk-sdk/src/encryption/grouped_elgamal.rs
+++ b/zk-sdk/src/encryption/grouped_elgamal.rs
@@ -132,6 +132,15 @@ pub struct GroupedElGamalCiphertext<const N: usize> {
 }
 
 impl<const N: usize> GroupedElGamalCiphertext<N> {
+    /// Converts a grouped ElGamal ciphertext into a regular ElGamal ciphertext using the decrypt
+    /// handle at a specified index.
+    pub fn to_elgamal_ciphertext(
+        &self,
+        index: usize,
+    ) -> Result<ElGamalCiphertext, GroupedElGamalError> {
+        GroupedElGamal::to_elgamal_ciphertext(self, index)
+    }
+
     /// Decrypts the grouped ElGamal ciphertext using an ElGamal secret key pertaining to a
     /// specified index.
     ///


### PR DESCRIPTION
#### Problem
The function to convert a grouped ElGamal ciphertext (encrypted under multiple public keys) to a regular ElGamal ciphertext (encrypted under a single public key) is useful. In particular, this function can be used to simplify the way the remaining balance is used is computed in token accounts when generating split transfer instructions.

However, this function is private.

#### Summary of Changes
Convert this function to public.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
