### PR TITLE
[zk-sdk] Add functions to derive `ElGamalKeypair` and `AeKey` from `Signature`

### DIFF
--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -113,11 +113,22 @@ impl AeKey {
             return Err(SignerError::Custom("Rejecting default signature".into()));
         }
 
+        Ok(Self::seed_from_signature(&signature))
+    }
+
+    /// Derive an authenticated encryption key from a signature.
+    pub fn new_from_signature(signature: &Signature) -> Result<Self, Box<dyn error::Error>> {
+        let seed = Self::seed_from_signature(signature);
+        Self::from_seed(&seed)
+    }
+
+    /// Derive a seed from a signature used to generate an authenticated encryption key.
+    pub fn seed_from_signature(signature: &Signature) -> Vec<u8> {
         let mut hasher = Sha3_512::new();
-        hasher.update(signature.as_ref());
+        hasher.update(signature);
         let result = hasher.finalize();
 
-        Ok(result.to_vec())
+        result.to_vec()
     }
 
     /// Generates a random authenticated encryption key.

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -57,7 +57,6 @@ impl ElGamal {
     /// Generates an ElGamal keypair.
     ///
     /// This function is randomized. It internally samples a scalar element using `OsRng`.
-    #[allow(non_snake_case)]
     fn keygen() -> ElGamalKeypair {
         // secret scalar should be non-zero except with negligible probability
         let mut s = Scalar::random(&mut OsRng);
@@ -70,7 +69,6 @@ impl ElGamal {
     /// Generates an ElGamal keypair from a scalar input that determines the ElGamal private key.
     ///
     /// This function panics if the input scalar is zero, which is not a valid key.
-    #[allow(non_snake_case)]
     fn keygen_with_scalar(s: &Scalar) -> ElGamalKeypair {
         let secret = ElGamalSecretKey(*s);
         let public = ElGamalPubkey::new(&secret);
@@ -174,7 +172,6 @@ impl ElGamalKeypair {
     /// wallets, the signing key is not exposed in the API. Therefore, this function uses a signer
     /// to sign a public seed and the resulting signature is then hashed to derive an ElGamal
     /// keypair.
-    #[allow(non_snake_case)]
     pub fn new_from_signer(
         signer: &dyn Signer,
         public_seed: &[u8],
@@ -316,7 +313,6 @@ impl EncodableKeypair for ElGamalKeypair {
 pub struct ElGamalPubkey(RistrettoPoint);
 impl ElGamalPubkey {
     /// Derives the `ElGamalPubkey` that uniquely corresponds to an `ElGamalSecretKey`.
-    #[allow(non_snake_case)]
     pub fn new(secret: &ElGamalSecretKey) -> Self {
         let s = &secret.0;
         assert!(s != &Scalar::zero());
@@ -586,7 +582,6 @@ impl ConstantTimeEq for ElGamalSecretKey {
 }
 
 /// Ciphertext for the ElGamal encryption scheme.
-#[allow(non_snake_case)]
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ElGamalCiphertext {
     pub commitment: PedersenCommitment,

--- a/zk-sdk/src/encryption/pedersen.rs
+++ b/zk-sdk/src/encryption/pedersen.rs
@@ -44,7 +44,6 @@ impl Pedersen {
     /// corresponding Pedersen commitment.
     ///
     /// This function is deterministic.
-    #[allow(non_snake_case)]
     pub fn with<T: Into<Scalar>>(amount: T, opening: &PedersenOpening) -> PedersenCommitment {
         let x: Scalar = amount.into();
         let r = opening.get_scalar();


### PR DESCRIPTION
#### Problem
Currently in zk-sdk, there are functions to derive `ElGamalKeypair` or `AeKey` from Solana signers. The derivation is done so that a fixed message signed with a signer, and then the resulting signature is hashed as a seed to generate the encryption keys.

It would actually be useful to have functions to derive the encryption keys directly from signatures. When interacting with wallets that do not support the keys in zk-sdk, the app can request a signature on a fixed message from the wallet, receive the signature, and then use the signature to derive the encryption keys.

#### Summary of Changes
Add functions to derive the encryption keys from signatures. In addition, I made some smaller additional changes:
- Added a function convert an `ElGamalSecretKey` to `ElGamalKeypair`, which would be quite useful
- Removed unnecessary `allow(non_snake_case)` lines

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
