### PR TITLE
A collection of dump tools for accounts-db debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-query"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "clap 2.33.3",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-store-query"
+version = "2.0.0"
+dependencies = [
+ "clap 2.33.3",
+ "rayon",
+ "solana-accounts-db",
+ "solana-sdk",
+ "solana-version",
+]
+
+[[package]]
 name = "agave-store-tool"
 version = "2.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-hash-cache-dump"
+version = "2.1.0"
+dependencies = [
+ "clap 2.33.3",
+ "rayon",
+ "solana-accounts-db",
+ "solana-sdk",
+ "solana-version",
+]
+
+[[package]]
 name = "agave-install"
 version = "2.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "accounts-db",
     "accounts-db/accounts-hash-cache-tool",
     "accounts-db/store-tool",
+    "accounts-db/hash-cache-dump",
     "banking-bench",
     "banks-client",
     "banks-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "accounts-db",
     "accounts-db/accounts-hash-cache-tool",
     "accounts-db/store-tool",
+    "accounts-db/store-query",
     "accounts-db/hash-cache-dump",
     "banking-bench",
     "banks-client",

--- a/accounts-db/hash-cache-dump/Cargo.toml
+++ b/accounts-db/hash-cache-dump/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "agave-hash-cache-dump"
+description = "Tool to dump hash cache files"
+publish = false
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+clap = { workspace = true }
+solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
+solana-sdk = { workspace = true }
+solana-version = { workspace = true }
+rayon = { workspace = true }
+
+[features]
+dev-context-only-utils = []

--- a/accounts-db/hash-cache-dump/src/main.rs
+++ b/accounts-db/hash-cache-dump/src/main.rs
@@ -1,0 +1,44 @@
+//! A tool to dump accounts_hash_cache files.
+//!
+//! If there are multiple files provided in the commandline, the tool will dump them in parallel.
+//!
+//! For example, the following command will dump all accounts_hash_cache files in the `accounts_hash_cache_directory`.
+//!  > $ find  /home/sol/ledger/accounts_hash_cache/ -type f -print0 | xargs -0 ~/src/solana/target/debug/agave-hash-cache-dump -i
+
+use {
+    clap::{crate_description, crate_name, App, Arg},
+    rayon::prelude::*,
+    solana_accounts_db::cache_hash_data::CacheHashData,
+    std::{fs::File, io::Write},
+};
+
+fn main() {
+    let matches = App::new(crate_name!())
+        .about(crate_description!())
+        .version(solana_version::version!())
+        .arg(
+            Arg::with_name("input")
+                .multiple(true)
+                .short("i")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let files: Vec<&str> = matches.values_of("input").unwrap().collect();
+
+    files.par_iter().for_each(|file| {
+        if let Ok(cache_hash_data) = CacheHashData::load_from_file(file) {
+            let dump_file = format!("{file}.hashdump");
+            println!("dumping {file} into {dump_file} ...");
+            let mut output = File::create(dump_file).unwrap();
+
+            for entry in cache_hash_data.get_cache_hash_data() {
+                writeln!(output, "{}", entry).unwrap();
+            }
+        } else {
+            println!("unable to load {file}, skipping");
+        }
+    });
+
+    println!("Done!");
+}

--- a/accounts-db/hash-cache-dump/src/main.rs
+++ b/accounts-db/hash-cache-dump/src/main.rs
@@ -3,11 +3,13 @@
 //! If there are multiple files provided in the command line, the tool will dump them in parallel.
 //!
 //! For example, the following command will dump all accounts_hash_cache files in the `accounts_hash_cache_directory`.
-//!  >$ find  /home/sol/ledger/accounts_hash_cache/ -type f -print0 | xargs -0 ~/src/solana/target/debug/agave-hash-cache-dump -i
+//!  >$ find  /home/sol/ledger/accounts_hash_cache/ -type f -print0 | xargs -0 ~/src/solana/target/release/agave-hash-cache-dump -i
 //!
 use {
     clap::{crate_description, crate_name, App, Arg},
     rayon::prelude::*,
+    solana_accounts_db::accounts_hash::AccountsHasher,
+    solana_accounts_db::accounts_hash::HashStats,
     solana_accounts_db::cache_hash_data::CacheHashData,
     std::{fs::File, io::Write},
 };
@@ -24,21 +26,67 @@ fn main() {
         )
         .get_matches();
 
-    let files: Vec<&str> = matches.values_of("input").unwrap().collect();
-
-    files.par_iter().for_each(|file| {
-        if let Ok(cache_hash_data) = CacheHashData::load_from_file(file) {
-            let dump_file = format!("{file}.hashdump");
-            println!("dumping {file} into {dump_file} ...");
-            let mut output = File::create(dump_file).unwrap();
-
-            for entry in cache_hash_data.get_cache_hash_data() {
-                writeln!(output, "{}", entry).unwrap();
-            }
-        } else {
-            println!("unable to load {file}, skipping");
-        }
+    let mut files: Vec<&str> = matches.values_of("input").unwrap().collect();
+    files.sort_by(|p1, p2| {
+        let k1 = p1.split('.').next().unwrap();
+        let k2 = p2.split('.').next().unwrap();
+        k1.cmp(k2)
     });
+
+    for f in files.iter() {
+        println!("{:?}", f);
+    }
+
+    let dedup = |files: Vec<&str>| {
+        let cache_data_files: Vec<_> = files
+            .iter()
+            .map(|file| {
+                if let Ok(cache_hash_data) = CacheHashData::load_from_file(file) {
+                    cache_hash_data
+                } else {
+                    panic!("unable to load {file}!");
+                }
+            })
+            .collect();
+
+        let cached_data: Vec<_> = cache_data_files
+            .iter()
+            .map(|d| d.get_cache_hash_data())
+            .collect();
+
+        let pubkey_bins = 65536;
+
+        let accounts_hash = AccountsHasher::new(".".into());
+
+        let (hashes, total_lamports) =
+            accounts_hash.de_dup_accounts(&cached_data, &mut HashStats::default(), pubkey_bins);
+
+        println!("dump files: ");
+        for f in hashes {
+            println!("{:?}", f);
+        }
+
+        println!("total_lamports: {}", total_lamports);
+    };
+
+    let dump = |files: Vec<&str>| {
+        files.par_iter().for_each(|file| {
+            if let Ok(cache_hash_data) = CacheHashData::load_from_file(file) {
+                let dump_file = format!("{file}.hashdump");
+                println!("dumping {file} into {dump_file} ...");
+                let mut output = File::create(dump_file).unwrap();
+
+                for entry in cache_hash_data.get_cache_hash_data() {
+                    writeln!(output, "{}", entry).unwrap();
+                }
+            } else {
+                println!("unable to load {file}, skipping");
+            }
+        });
+    };
+
+    // dump(files);
+    dedup(files);
 
     println!("Done!");
 }

--- a/accounts-db/hash-cache-dump/src/main.rs
+++ b/accounts-db/hash-cache-dump/src/main.rs
@@ -1,10 +1,10 @@
 //! A tool to dump accounts_hash_cache files.
 //!
-//! If there are multiple files provided in the commandline, the tool will dump them in parallel.
+//! If there are multiple files provided in the command line, the tool will dump them in parallel.
 //!
 //! For example, the following command will dump all accounts_hash_cache files in the `accounts_hash_cache_directory`.
-//!  > $ find  /home/sol/ledger/accounts_hash_cache/ -type f -print0 | xargs -0 ~/src/solana/target/debug/agave-hash-cache-dump -i
-
+//!  >$ find  /home/sol/ledger/accounts_hash_cache/ -type f -print0 | xargs -0 ~/src/solana/target/debug/agave-hash-cache-dump -i
+//!
 use {
     clap::{crate_description, crate_name, App, Arg},
     rayon::prelude::*,

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -6,6 +6,7 @@ use {
         pubkey_bins::PubkeyBinCalculator24,
     },
     bytemuck_derive::{Pod, Zeroable},
+    core::fmt,
     log::*,
     memmap2::MmapMut,
     rayon::prelude::*,
@@ -319,6 +320,12 @@ pub struct CalculateHashIntermediate {
     pub hash: AccountHash,
     pub lamports: u64,
     pub pubkey: Pubkey,
+}
+
+impl fmt::Display for CalculateHashIntermediate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} {} {}", self.pubkey, self.lamports, self.hash.0)
+    }
 }
 
 // In order to safely guarantee CalculateHashIntermediate is Pod, it cannot have any padding

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -23,7 +23,7 @@ pub mod blockhash_queue;
 mod bucket_map_holder;
 mod bucket_map_holder_stats;
 mod buffered_reader;
-mod cache_hash_data;
+pub mod cache_hash_data;
 mod cache_hash_data_stats;
 pub mod contains;
 pub mod epoch_accounts_hash;

--- a/accounts-db/store-query/Cargo.toml
+++ b/accounts-db/store-query/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "agave-store-query"
+description = "Tool to query account storage files by pubkey"
+publish = false
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+clap = { workspace = true }
+solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
+solana-sdk = { workspace = true }
+solana-version = { workspace = true }
+rayon = { workspace = true }
+
+[features]
+dev-context-only-utils = []

--- a/accounts-db/store-query/src/main.rs
+++ b/accounts-db/store-query/src/main.rs
@@ -1,0 +1,84 @@
+//! A tool to query account storage files by pubkeys.
+//!
+//! If there are multiple files provided in the command line, the tool will query them in parallel.
+//!
+//! Example usage:
+//!  >$ find  /home/sol/ledger/accounts/run/ -type f -print0 | xargs -0 agave-store-query -k DYJtneuqXmjzpm2ixFXSUCPYZymUUVUimixr4b8m8PSr -i
+//!
+use {
+    clap::{crate_description, crate_name, App, Arg},
+    rayon::prelude::*,
+    solana_accounts_db::append_vec::AppendVec,
+    solana_sdk::{
+        account::ReadableAccount, pubkey::Pubkey, system_instruction::MAX_PERMITTED_DATA_LENGTH,
+    },
+    std::{mem::ManuallyDrop, str::FromStr},
+};
+
+fn main() {
+    let matches = App::new(crate_name!())
+        .about(crate_description!())
+        .version(solana_version::version!())
+        .arg(
+            Arg::with_name("input")
+                .multiple(true)
+                .short("i")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("key")
+                .multiple(true)
+                .short("k")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("verbose")
+                .short("v")
+                .long("verbose")
+                .takes_value(false)
+                .help("Show full account information"),
+        )
+        .get_matches();
+
+    let verbose = matches.is_present("verbose");
+    let files: Vec<&str> = matches.values_of("input").unwrap().collect();
+    let keys: Vec<&str> = matches.values_of("key").unwrap().collect();
+    let keys: Vec<_> = keys.iter().map(|s| Pubkey::from_str(s).unwrap()).collect();
+
+    files.par_iter().for_each(|file| {
+        let store = AppendVec::new_for_store_tool(&file);
+        if store.is_err() {
+            eprintln!("failed to open storage file '{file}': {:?}, skipping ...", store);
+            return;
+        };
+        let store = store.unwrap();
+
+        // By default, when the AppendVec is dropped, the backing file will be removed.
+        // We do not want to remove the backing file here in the store-tool, so prevent dropping.
+        let store = ManuallyDrop::new(store);
+
+        // max data size is 10 MiB (10,485,760 bytes)
+        // therefore, the max width is ceil(log(10485760))
+        let data_size_width = (MAX_PERMITTED_DATA_LENGTH as f64).log10().ceil() as usize;
+        let offset_width = (store.capacity() as f64).log(16.0).ceil() as usize;
+
+        store.scan_accounts(|account| {
+            if !keys.contains(account.pubkey()) {
+                return;
+            }
+            if verbose {
+                println!("{file} {:#0offset_width$x} {account:?}", account.offset());
+            } else {
+                println!(
+                    "{} {:#0offset_width$x}: {:44}, owner: {:44}, data size: {:data_size_width$}, lamports: {}",
+                    file,
+                    account.offset(),
+                    account.pubkey().to_string(),
+                    account.owner().to_string(),
+                    account.data_len(),
+                    account.lamports(),
+                );
+            }
+        });
+    });
+}


### PR DESCRIPTION
#### Problem

Here is my collection of dump tools for accounts-db debugging.

- hash-cache-dump : dump account's hash cache files, (key, lamports, hash). When passing multiple files, the tool will process them in parallel.
```
>$ find /home/sol/ledger/accounts_hash_cache/ -type f -print0 | xargs -0 agave-hash-cache-dump -i
dumping /home/sol/ledger/accounts_hash_cache/224725000.224727500.0.65536.f0355bb8c1b0c813 into /home/sol/ledger/accounts_hash_cache/224725000.224727500.0.65536.f0355bb8c1b0c813.hashdump ...
...

>$ head /home/sol/ledger/accounts_hash_cache/224725000.224727500.0.65536.f0355bb8c1b0c813.hashdump
11CfdzFSabbvmbcZqnkiKJnCzA7mdxw9bEgH7RKHNT2 0 11111111111111111111111111111111
11dhk6R7Fci4ycu7DxZG1jdzmV1TS9rkZjEBH7QMMcr 0 11111111111111111111111111111111
11k6hjhodfMA6ZCxyLA9XK3HdRdoyctbyDGyopmjYrD 0 11111111111111111111111111111111
12EDehQxMQLJkdEN3K3Wg67Gt2CNL7ufiVXiNpvEHci 0 11111111111111111111111111111111
12HRM77Gw4WrTu99RY5Epcund5aFks94U1Q7KCUcTg4 0 11111111111111111111111111111111
12HRM77Gw4WrTu99RY5Epcund5aFks94U1Q7KCUcTg4 0 11111111111111111111111111111111
12pMx42poxuEzn14Eqyx7nUSs4cGupY8knCDU3bBi5y 0 11111111111111111111111111111111
13GrbvPUk6uDGaQfp5piDasDMGRkCr9k8toKueVfJ17 0 11111111111111111111111111111111
13LneE3isq15HY5UZrYBz3SjE34qmGMzUBGiE4GW4WJ 2039280 CgbdnvvaoQk9vjWcx4buZKKrzAHTjK7e1c2Qi435hv2n
13LneE3isq15HY5UZrYBz3SjE34qmGMzUBGiE4GW4WJ 2039280 9TvFgqMJd3N3MQweqSQcUmBmGwSX5Hc3UGy6kZFMa9zu


```

- store-query: query accounts storage by pubkey.  When passing multiple files, the tool will process them in parallel.
```
> $ find /home/sol/ledger/accounts/run/ -type f -print0 | xargs -0 agave-store-query -k DYJtneuqXmjzpm2ixFXSUCPYZymUUVUimixr4b8m8PSr -i

/home/sol/ledger/271178412.307040 0x1cf08: DYJtneuqXmjzpm2ixFXSUCPYZymUUVUimixr4b8m8PSr, owner: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA , data size:      165, lamports: 2039280
/home/sol/ledger/271178492.307039 0x1cf08: DYJtneuqXmjzpm2ixFXSUCPYZymUUVUimixr4b8m8PSr, owner: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA , data size:      165, lamports: 2039280


```




#### Summary of Changes




Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
