### PR TITLE
Fixes test_add_builtin_account()

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6755,7 +6755,12 @@ fn test_add_builtin_account() {
         activate_all_features(&mut genesis_config);
 
         let slot = 123;
-        let program_id = solana_sdk::pubkey::new_rand();
+        // The account at program_id will be created initially with just 1 lamport.
+        // This is below the rent-exempt minimum.  If the program_id is in the
+        // rent collection partition for the banks used in this test, then the
+        // account will be rent-collected away.  That'll make the test fail.
+        // So pick a pubkey that is guaranteed to *not* be part of rent collection.
+        let program_id = Pubkey::new_from_array([0xFF; 32]);
 
         let bank = Arc::new(Bank::new_from_parent(
             Arc::new(Bank::new_for_tests(&genesis_config)),


### PR DESCRIPTION
#### Problem

The account used by `test_add_builtin_account()` sometimes gets rent-collected away, which causes the test to erroneously fail.

See https://github.com/anza-xyz/agave/issues/1696 for more information.


#### Summary of Changes

Since this is a unit test for `add_builtin_account()`, use a pubkey that won't be part of rent collection.

Fixes #1696