### PR TITLE
always pack a few newest ancient slots

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -250,7 +250,7 @@ impl AncientSlotInfos {
         self.all_infos.sort_unstable_by(|l, r| {
             r.is_high_slot
                 .cmp(&l.is_high_slot)
-                .then_with(|| (r.should_shrink.cmp(&l.should_shrink)))
+                .then_with(|| r.should_shrink.cmp(&l.should_shrink))
                 .then_with(|| l.capacity.cmp(&r.capacity))
         });
 


### PR DESCRIPTION
#### Problem
skipping rewrites and ancient packing testing are illustrating some real world issues against mnb.
Specifically, the algorithm can get stuck only considering old slots and then failing on the same old slots each time it is called. This prevents the algorithm from making progress. A way to tweak this is to alter slot selection.

#### Summary of Changes
Always include some newest ancient slots so that we have fresh storages in the mix each time and high # target slots. This allows us to handle the multi ref newest ancient storages. This also results in us continuing to select the highest slot #s possible. This keeps the set of ancient storages at the highest slot #s, which helps overall performance, such as root checking.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
