### PR TITLE
Adds accounts-hash-cache-tool to inspect accounts hash cache files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-accounts-hash-cache-tool"
+version = "2.0.0"
+dependencies = [
+ "bytemuck",
+ "clap 2.33.3",
+ "solana-accounts-db",
+ "solana-version",
+]
+
+[[package]]
 name = "agave-cargo-registry"
 version = "2.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "accounts-bench",
     "accounts-cluster-bench",
     "accounts-db",
+    "accounts-db/accounts-hash-cache-tool",
     "accounts-db/store-tool",
     "banking-bench",
     "banks-client",

--- a/accounts-db/accounts-hash-cache-tool/Cargo.toml
+++ b/accounts-db/accounts-hash-cache-tool/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "agave-accounts-hash-cache-tool"
+description = "Tool to inspect accounts hash cache files"
+publish = false
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+bytemuck = { workspace = true }
+clap = { workspace = true }
+solana-accounts-db = { workspace = true }
+solana-version = { workspace = true }
+
+[features]
+dev-context-only-utils = []

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -1,0 +1,99 @@
+use {
+    bytemuck::Zeroable as _,
+    clap::{crate_description, crate_name, value_t_or_exit, App, Arg},
+    solana_accounts_db::{CacheHashDataFileEntry, CacheHashDataFileHeader},
+    std::{
+        fs::File,
+        io::{self, BufReader, Read as _},
+        mem::size_of,
+        num::Saturating,
+    },
+};
+
+fn main() {
+    let matches = App::new(crate_name!())
+        .about(crate_description!())
+        .version(solana_version::version!())
+        .arg(
+            Arg::with_name("path")
+                .index(1)
+                .takes_value(true)
+                .value_name("PATH")
+                .help("Accounts hash cache file to inspect"),
+        )
+        .arg(
+            Arg::with_name("force")
+                .long("force")
+                .takes_value(false)
+                .help("Continue even if sanity checks fail"),
+        )
+        .get_matches();
+
+    let force = matches.is_present("force");
+    let path = value_t_or_exit!(matches, "path", String);
+
+    let file = File::open(&path).unwrap_or_else(|err| {
+        eprintln!("Failed to open accounts hash cache file '{path}': {err}");
+        std::process::exit(1);
+    });
+    let actual_file_size = file
+        .metadata()
+        .unwrap_or_else(|err| {
+            eprintln!("Failed to query file metadata: {err}");
+            std::process::exit(1);
+        })
+        .len();
+    let mut reader = BufReader::new(file);
+
+    let header = {
+        let mut header = CacheHashDataFileHeader::zeroed();
+        reader
+            .read_exact(bytemuck::bytes_of_mut(&mut header))
+            .unwrap_or_else(|err| {
+                eprintln!("Failed to read header: {err}");
+                std::process::exit(1);
+            });
+        header
+    };
+
+    // Sanity checks -- ensure the actual file size matches the expected file size
+    let expected_file_size = size_of::<CacheHashDataFileHeader>()
+        .saturating_add(size_of::<CacheHashDataFileEntry>().saturating_mul(header.count));
+    if actual_file_size != expected_file_size as u64 {
+        eprintln!(
+            "Failed sanitization: actual file size does not match expected file size! \
+             actual: {actual_file_size}, expected: {expected_file_size}",
+        );
+        if !force {
+            std::process::exit(1);
+        }
+        eprintln!("Forced. Continuing... Results may be incorrect.");
+    }
+
+    let count_width = (header.count as f64).log10().ceil() as usize;
+    let mut count = Saturating(0usize);
+    loop {
+        let mut entry = CacheHashDataFileEntry::zeroed();
+        let result = reader.read_exact(bytemuck::bytes_of_mut(&mut entry));
+        match result {
+            Ok(()) => {}
+            Err(err) => {
+                if err.kind() == io::ErrorKind::UnexpectedEof && count.0 == header.count {
+                    // we've hit the expected end of the file
+                } else {
+                    eprintln!("Failed to read entry {count}: {err}");
+                }
+                break;
+            }
+        };
+        println!(
+            "{count:count_width$}: pubkey: {:44}, hash: {:44}, lamports: {}",
+            entry.pubkey.to_string(),
+            entry.hash.0.to_string(),
+            entry.lamports,
+        );
+        count += 1;
+    }
+
+    println!("actual entries: {count}, expected: {}", header.count);
+}

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -25,7 +25,7 @@ pub type SavedType = Vec<Vec<EntryType>>;
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
 pub struct Header {
-    count: usize,
+    pub count: usize,
 }
 
 // In order to safely guarantee Header is Pod, it cannot have any padding

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -43,6 +43,12 @@ pub mod utils;
 mod verify_accounts_hash_in_background;
 pub mod waitable_condvar;
 
+// the accounts-hash-cache-tool needs access to these types
+pub use {
+    accounts_hash::CalculateHashIntermediate as CacheHashDataFileEntry,
+    cache_hash_data::Header as CacheHashDataFileHeader,
+};
+
 #[macro_use]
 extern crate solana_metrics;
 #[macro_use]

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -34,6 +34,7 @@ declare tainted_packages=(
   agave-ledger-tool
   solana-bench-tps
   agave-store-tool
+  agave-accounts-hash-cache-tool
 )
 
 # convert to comma separeted (ref: https://stackoverflow.com/a/53839433)


### PR DESCRIPTION
#### Problem

We are investigating intermittent accounts hash calculation mismatches, and think it may be in the accounts hash cache files. However, it's not easy to inspect the files.


#### Summary of Changes

Add a tool for inspecting the files: `accounts-hash-cache-tool`

Note, this new tool will not do *everything* in this first version 😸 

<details><summary>Example Output</summary>
<p>

Here's a snippet of what the output looks like:

```
[..]
3382386: pubkey: JEGwUWrb7jwi9aPGnQgzxaqvnpd1jEGSNP4bQpcry6oU, hash: 11111111111111111111111111111111            , lamports: 0
3382387: pubkey: JEH5qqysNyw9fdPeE25a9zagrk8AiGSphht7SPbV9aPS, hash: GqDfiybzRBqftQ3BWLuTbFgbqP4ydJsvuy1zH6og9a17, lamports: 2039280
3382388: pubkey: JEH8JYTkUVZ9zVvz1qkSW75Fto3UeTU1yKW8aeUJwUtV, hash: 11111111111111111111111111111111            , lamports: 0
3382389: pubkey: JEHy28hRjREAAgDqYaTNyNQW1vQJo6Wgc2cvrWaZVdsc, hash: BQ3mtuCbY7FkzMgn78Cck85JoKndVLBzStpjELimdvBq, lamports: 2039280
3382390: pubkey: JEHy28hRjREAAgDqYaTNyNQW1vQJo6Wgc2cvrWaZVdsc, hash: ETQzWqtHji3EGUMuujCUZZEkc98hN8qCp1WBxsLJu5uz, lamports: 2039280
3382391: pubkey: JEJML39HoHdtQ6q15PcLzkB5442PKp4p666RSCV9qAGR, hash: 11111111111111111111111111111111            , lamports: 0
3382392: pubkey: JEJdL9wEW633QDVp2iwFgGC8eZiHaNH8kHZm8gicjFux, hash: 11111111111111111111111111111111            , lamports: 0
3382393: pubkey: JEK2Q4FHZSGSo41hdXxFSK7oJ8X8SQQMKgWz8MZZkAAw, hash: 4pGk1E18cGM7XJ4HqWvPEWGL4X1GSXHkUS3nP8RzJwaU, lamports: 2039280
3382394: pubkey: JEKE7B7tAX61MbFL3uSCNCsKWpyyou2TPUG3htztu225, hash: 11111111111111111111111111111111            , lamports: 0
actual count: 3382395, expected count: 3382395
```

</p>
</details> 