### PR TITLE
SVM: Unify different instances of epoch_schedule in SVM and Bank into one

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9116,10 +9116,7 @@ fn test_epoch_schedule_from_genesis_config() {
         Arc::default(),
     ));
 
-    assert_eq!(
-        &bank.transaction_processor.epoch_schedule,
-        &genesis_config.epoch_schedule
-    );
+    assert_eq!(bank.epoch_schedule(), &genesis_config.epoch_schedule);
 }
 
 fn check_stake_vote_account_validity<F>(check_owner_change: bool, load_vote_and_stake_accounts: F)

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -13,7 +13,6 @@ use {
         bpf_loader, bpf_loader_deprecated,
         bpf_loader_upgradeable::UpgradeableLoaderState,
         clock::Slot,
-        epoch_schedule::EpochSchedule,
         instruction::InstructionError,
         loader_v4::{self, LoaderV4State, LoaderV4Status},
         pubkey::Pubkey,
@@ -126,7 +125,6 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     environments: &ProgramRuntimeEnvironments,
     pubkey: &Pubkey,
     slot: Slot,
-    _epoch_schedule: &EpochSchedule,
     reload: bool,
 ) -> Option<Arc<ProgramCacheEntry>> {
     let mut load_program_metrics = LoadProgramMetrics {
@@ -494,7 +492,6 @@ mod tests {
             &batch_processor.get_environments_for_epoch(50).unwrap(),
             &key,
             500,
-            &batch_processor.epoch_schedule,
             false,
         );
         assert!(result.is_none());
@@ -517,7 +514,6 @@ mod tests {
             &batch_processor.get_environments_for_epoch(20).unwrap(),
             &key,
             0, // Slot 0
-            &batch_processor.epoch_schedule,
             false,
         );
 
@@ -552,7 +548,6 @@ mod tests {
             &batch_processor.get_environments_for_epoch(20).unwrap(),
             &key,
             200,
-            &batch_processor.epoch_schedule,
             false,
         );
         let loaded_program = ProgramCacheEntry::new_tombstone(
@@ -580,7 +575,6 @@ mod tests {
             &batch_processor.get_environments_for_epoch(20).unwrap(),
             &key,
             200,
-            &batch_processor.epoch_schedule,
             false,
         );
 
@@ -634,7 +628,6 @@ mod tests {
             &batch_processor.get_environments_for_epoch(0).unwrap(),
             &key1,
             0,
-            &batch_processor.epoch_schedule,
             false,
         );
         let loaded_program = ProgramCacheEntry::new_tombstone(
@@ -672,7 +665,6 @@ mod tests {
             &batch_processor.get_environments_for_epoch(20).unwrap(),
             &key1,
             200,
-            &batch_processor.epoch_schedule,
             false,
         );
 
@@ -722,7 +714,6 @@ mod tests {
             &batch_processor.get_environments_for_epoch(0).unwrap(),
             &key,
             0,
-            &batch_processor.epoch_schedule,
             false,
         );
         let loaded_program = ProgramCacheEntry::new_tombstone(
@@ -756,7 +747,6 @@ mod tests {
             &batch_processor.get_environments_for_epoch(20).unwrap(),
             &key,
             200,
-            &batch_processor.epoch_schedule,
             false,
         );
 
@@ -807,7 +797,6 @@ mod tests {
                     .unwrap(),
                 &key,
                 200,
-                &batch_processor.epoch_schedule,
                 false,
             )
             .unwrap();

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -38,7 +38,6 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, PROGRAM_OWNERS},
         clock::{Epoch, Slot},
-        epoch_schedule::EpochSchedule,
         feature_set::{
             include_loaded_accounts_data_size_in_fee_calculation,
             remove_rounding_in_fee_calculation, FeatureSet,
@@ -146,9 +145,6 @@ pub struct TransactionBatchProcessor<FG: ForkGraph> {
     /// Bank epoch
     epoch: Epoch,
 
-    /// initialized from genesis
-    pub epoch_schedule: EpochSchedule,
-
     /// Transaction fee structure
     pub fee_structure: FeeStructure,
 
@@ -169,7 +165,6 @@ impl<FG: ForkGraph> Debug for TransactionBatchProcessor<FG> {
         f.debug_struct("TransactionBatchProcessor")
             .field("slot", &self.slot)
             .field("epoch", &self.epoch)
-            .field("epoch_schedule", &self.epoch_schedule)
             .field("fee_structure", &self.fee_structure)
             .field("sysvar_cache", &self.sysvar_cache)
             .field("program_cache", &self.program_cache)
@@ -182,7 +177,6 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
         Self {
             slot: Slot::default(),
             epoch: Epoch::default(),
-            epoch_schedule: EpochSchedule::default(),
             fee_structure: FeeStructure::default(),
             sysvar_cache: RwLock::<SysvarCache>::default(),
             program_cache: Arc::new(RwLock::new(ProgramCache::new(
@@ -195,16 +189,10 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
 }
 
 impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
-    pub fn new(
-        slot: Slot,
-        epoch: Epoch,
-        epoch_schedule: EpochSchedule,
-        builtin_program_ids: HashSet<Pubkey>,
-    ) -> Self {
+    pub fn new(slot: Slot, epoch: Epoch, builtin_program_ids: HashSet<Pubkey>) -> Self {
         Self {
             slot,
             epoch,
-            epoch_schedule,
             fee_structure: FeeStructure::default(),
             sysvar_cache: RwLock::<SysvarCache>::default(),
             program_cache: Arc::new(RwLock::new(ProgramCache::new(slot, epoch))),
@@ -216,7 +204,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         Self {
             slot,
             epoch,
-            epoch_schedule: self.epoch_schedule.clone(),
             fee_structure: self.fee_structure.clone(),
             sysvar_cache: RwLock::<SysvarCache>::default(),
             program_cache: self.program_cache.clone(),
@@ -589,7 +576,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         &program_cache.get_environments_for_epoch(self.epoch),
                         &key,
                         self.slot,
-                        &self.epoch_schedule,
                         false,
                     )
                     .expect("called load_program_with_pubkey() with nonexistent account");
@@ -637,10 +623,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         callbacks: &CB,
         upcoming_feature_set: &FeatureSet,
         compute_budget: &ComputeBudget,
+        slot_index: u64,
+        slots_in_epoch: u64,
     ) {
         // Recompile loaded programs one at a time before the next epoch hits
-        let (_epoch, slot_index) = self.epoch_schedule.get_epoch_and_slot_index(self.slot);
-        let slots_in_epoch = self.epoch_schedule.get_slots_in_epoch(self.epoch);
         let slots_in_recompilation_phase =
             (solana_program_runtime::loaded_programs::MAX_LOADED_ENTRY_COUNT as u64)
                 .min(slots_in_epoch)
@@ -661,7 +647,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     &environments_for_epoch,
                     &key,
                     self.slot,
-                    &self.epoch_schedule,
                     false,
                 ) {
                     recompiled
@@ -1010,6 +995,7 @@ mod tests {
             bpf_loader,
             bpf_loader_upgradeable::{self, UpgradeableLoaderState},
             compute_budget::ComputeBudgetInstruction,
+            epoch_schedule::EpochSchedule,
             feature_set::FeatureSet,
             fee::FeeDetails,
             fee_calculator::FeeCalculator,
@@ -1856,12 +1842,7 @@ mod tests {
     #[test]
     fn fast_concur_test() {
         let mut mock_bank = MockBankCallback::default();
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::new(
-            5,
-            5,
-            EpochSchedule::default(),
-            HashSet::new(),
-        );
+        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::new(5, 5, HashSet::new());
         batch_processor.program_cache.write().unwrap().fork_graph =
             Some(Arc::new(RwLock::new(TestForkGraph {})));
 

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -21,7 +21,6 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         bpf_loader_upgradeable,
-        epoch_schedule::EpochSchedule,
         feature_set::{FeatureSet, FEATURE_NAMES},
         hash::Hash,
         instruction::AccountMeta,
@@ -247,12 +246,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
         create_program_runtime_environment_v1(&feature_set, &compute_budget, false, false).unwrap();
 
     mock_bank.override_feature_set(feature_set);
-    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(
-        42,
-        2,
-        EpochSchedule::default(),
-        HashSet::new(),
-    );
+    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(42, 2, HashSet::new());
 
     {
         let mut program_cache = batch_processor.program_cache.write().unwrap();
@@ -445,7 +439,6 @@ fn execute_fixture_as_instr(
         &batch_processor.get_environments_for_epoch(2).unwrap(),
         &program_id,
         42,
-        &batch_processor.epoch_schedule,
         false,
     )
     .unwrap();

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -21,7 +21,6 @@ use {
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{Clock, Epoch, Slot, UnixTimestamp},
-        epoch_schedule::EpochSchedule,
         hash::Hash,
         instruction::AccountMeta,
         pubkey::Pubkey,
@@ -445,7 +444,6 @@ fn svm_integration() {
     let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(
         EXECUTION_SLOT,
         EXECUTION_EPOCH,
-        EpochSchedule::default(),
         HashSet::new(),
     );
 


### PR DESCRIPTION
#### Problem
`EpochSchedule` is currently held in `Bank` and `SVM`. This could lead to inconsistencies in future.

#### Summary of Changes
- Use `SVM`'s instance of epoch_schedule
- Limit the visibility of the field

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
