### PR TITLE
transaction-status: Use string instead of int for `amount` in `amountToUiAmount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Release channels have their own copy of this changelog:
     when the `replaceRecentBlockhash` config param is `true` (#380)
   * SDK: `cargo test-sbf` accepts `--tools-version`, just like `build-sbf` (#1359)
   * CLI: Can specify `--full-snapshot-archive-path` (#1631)
-  * transaction-status: The SPL Token `amountToUiAmount` instruction parses the amount as a string instead of a number (#1737)
+  * transaction-status: The SPL Token `amountToUiAmount` instruction parses the amount into a string instead of a number (#1737)
 
 ## [1.18.0]
 * Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Release channels have their own copy of this changelog:
     when the `replaceRecentBlockhash` config param is `true` (#380)
   * SDK: `cargo test-sbf` accepts `--tools-version`, just like `build-sbf` (#1359)
   * CLI: Can specify `--full-snapshot-archive-path` (#1631)
+  * transaction-status: The SPL Token `amountToUiAmount` instruction parses the amount as a string instead of a number (#1737)
 
 ## [1.18.0]
 * Changes

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -498,7 +498,7 @@ pub fn parse_token(
                     instruction_type: "amountToUiAmount".to_string(),
                     info: json!({
                         "mint": account_keys[instruction.accounts[0] as usize].to_string(),
-                        "amount": amount,
+                        "amount": amount.to_string(),
                     }),
                 })
             }
@@ -1737,7 +1737,7 @@ mod test {
                 instruction_type: "amountToUiAmount".to_string(),
                 info: json!({
                    "mint": mint_pubkey.to_string(),
-                   "amount": 4242,
+                   "amount": "4242",
                 })
             }
         );


### PR DESCRIPTION
#### Problem

As pointed out by a user, the `"amount"` field is almost always a string when parsing token instructions, but in the `amountToUiAmount` instruction, it's a raw number.

#### Summary of Changes

Since this instruction is still relatively unused, maybe we can just fix the parsing directly to be a string. If this is too destructive, let me know!

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
