### PR TITLE
Fix multinode demo, bank-hash is deprecated in ledger tool

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -263,7 +263,7 @@ EOF
       agave-ledger-tool -l config/bootstrap-validator shred-version --max-genesis-archive-unpacked-size 1073741824 | tee config/shred-version
 
       if [[ -n "$maybeWaitForSupermajority" ]]; then
-        bankHash=$(agave-ledger-tool -l config/bootstrap-validator bank-hash --halt-at-slot 0)
+        bankHash=$(agave-ledger-tool -l config/bootstrap-validator verify --print-bank-hash --halt-at-slot 0 | cut -d':' -f2)
         shredVersion="$(cat "$SOLANA_CONFIG_DIR"/shred-version)"
         extraNodeArgs="$extraNodeArgs --expected-bank-hash $bankHash --expected-shred-version $shredVersion"
         echo "$bankHash" > config/bank-hash

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -263,7 +263,7 @@ EOF
       agave-ledger-tool -l config/bootstrap-validator shred-version --max-genesis-archive-unpacked-size 1073741824 | tee config/shred-version
 
       if [[ -n "$maybeWaitForSupermajority" ]]; then
-        bankHash=$(agave-ledger-tool -l config/bootstrap-validator verify --print-bank-hash --halt-at-slot 0 | cut -d':' -f2)
+        bankHash=$(agave-ledger-tool -l config/bootstrap-validator verify --print-bank-hash --halt-at-slot 0 | cut -d':' -f2 | xargs)
         shredVersion="$(cat "$SOLANA_CONFIG_DIR"/shred-version)"
         extraNodeArgs="$extraNodeArgs --expected-bank-hash $bankHash --expected-shred-version $shredVersion"
         echo "$bankHash" > config/bank-hash


### PR DESCRIPTION
ledger-tool has deprecated bank-hash in https://github.com/anza-xyz/agave/pull/1710, use the new command and parse the output.
