### PR TITLE
Adjust replay-related metrics for unified scheduler

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3009,10 +3009,12 @@ impl ReplayStage {
                     .expect("Bank fork progress entry missing for completed bank");
 
                 let replay_stats = bank_progress.replay_stats.clone();
+                let mut is_stats_from_completed_scheduler = false;
 
                 if let Some((result, completed_execute_timings)) =
                     bank.wait_for_completed_scheduler()
                 {
+                    is_stats_from_completed_scheduler = true;
                     let metrics = ExecuteBatchesInternalMetrics::new_with_timings_from_all_threads(
                         completed_execute_timings,
                     );
@@ -3020,7 +3022,7 @@ impl ReplayStage {
                         .write()
                         .unwrap()
                         .batch_execute
-                        .accumulate(metrics);
+                        .accumulate(metrics, is_stats_from_completed_scheduler);
 
                     if let Err(err) = result {
                         let root = bank_forks.read().unwrap().root();
@@ -3219,6 +3221,7 @@ impl ReplayStage {
                     r_replay_progress.num_entries,
                     r_replay_progress.num_shreds,
                     bank_complete_time.as_us(),
+                    is_stats_from_completed_scheduler,
                 );
                 execute_timings.accumulate(&r_replay_stats.batch_execute.totals);
             } else {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3009,12 +3009,14 @@ impl ReplayStage {
                     .expect("Bank fork progress entry missing for completed bank");
 
                 let replay_stats = bank_progress.replay_stats.clone();
-                let mut are_stats_from_completed_scheduler = false;
+                let mut is_unified_scheduler_enabled = false;
 
                 if let Some((result, completed_execute_timings)) =
                     bank.wait_for_completed_scheduler()
                 {
-                    are_stats_from_completed_scheduler = true;
+                    // It's guaranteed that wait_for_completed_scheduler() returns Some(_), iff the
+                    // unified scheduler is enabled for the bank.
+                    is_unified_scheduler_enabled = true;
                     let metrics = ExecuteBatchesInternalMetrics::new_with_timings_from_all_threads(
                         completed_execute_timings,
                     );
@@ -3022,7 +3024,7 @@ impl ReplayStage {
                         .write()
                         .unwrap()
                         .batch_execute
-                        .accumulate(metrics, are_stats_from_completed_scheduler);
+                        .accumulate(metrics, is_unified_scheduler_enabled);
 
                     if let Err(err) = result {
                         let root = bank_forks.read().unwrap().root();
@@ -3221,7 +3223,7 @@ impl ReplayStage {
                     r_replay_progress.num_entries,
                     r_replay_progress.num_shreds,
                     bank_complete_time.as_us(),
-                    are_stats_from_completed_scheduler,
+                    is_unified_scheduler_enabled,
                 );
                 execute_timings.accumulate(&r_replay_stats.batch_execute.totals);
             } else {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3009,12 +3009,12 @@ impl ReplayStage {
                     .expect("Bank fork progress entry missing for completed bank");
 
                 let replay_stats = bank_progress.replay_stats.clone();
-                let mut is_stats_from_completed_scheduler = false;
+                let mut are_stats_from_completed_scheduler = false;
 
                 if let Some((result, completed_execute_timings)) =
                     bank.wait_for_completed_scheduler()
                 {
-                    is_stats_from_completed_scheduler = true;
+                    are_stats_from_completed_scheduler = true;
                     let metrics = ExecuteBatchesInternalMetrics::new_with_timings_from_all_threads(
                         completed_execute_timings,
                     );
@@ -3022,7 +3022,7 @@ impl ReplayStage {
                         .write()
                         .unwrap()
                         .batch_execute
-                        .accumulate(metrics, is_stats_from_completed_scheduler);
+                        .accumulate(metrics, are_stats_from_completed_scheduler);
 
                     if let Err(err) = result {
                         let root = bank_forks.read().unwrap().root();
@@ -3221,7 +3221,7 @@ impl ReplayStage {
                     r_replay_progress.num_entries,
                     r_replay_progress.num_shreds,
                     bank_complete_time.as_us(),
-                    is_stats_from_completed_scheduler,
+                    are_stats_from_completed_scheduler,
                 );
                 execute_timings.accumulate(&r_replay_stats.batch_execute.totals);
             } else {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1145,9 +1145,7 @@ pub struct BatchExecutionTiming {
     /// as a whole for each rayon processing session, also after blockstore_processor's rebatching.
     ///
     /// When unified scheduler is enabled, this field isn't maintained, because it's not batched at
-    /// all and thus execution is fairly evenly distributed across its worker threads in the
-    /// granularity of individual transactions, meaning single-threaded metrics can reliably
-    /// be derived from dividing replay-slot-stats by the number of threads.
+    /// all.
     slowest_thread: ThreadExecuteTimings,
 }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1167,20 +1167,20 @@ impl BatchExecutionTiming {
             totals.accumulate(&thread_times.execute_timings);
         }
 
-        let slowest = new_batch
-            .execution_timings_per_thread
-            .values()
-            .max_by_key(|thread_times| thread_times.total_thread_us);
+        // This metric isn't applicable for the unified scheduler
+        if !is_unified_scheduler_enabled {
+            let slowest = new_batch
+                .execution_timings_per_thread
+                .values()
+                .max_by_key(|thread_times| thread_times.total_thread_us);
 
-        if let Some(slowest) = slowest {
-            slowest_thread.accumulate(slowest);
-            // This metric isn't applicable for the unified scheduler
-            if !is_unified_scheduler_enabled {
+            if let Some(slowest) = slowest {
+                slowest_thread.accumulate(slowest);
                 slowest_thread
                     .execute_timings
                     .saturating_add_in_place(NumExecuteBatches, 1);
-            }
-        };
+            };
+        }
     }
 }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -513,7 +513,8 @@ fn rebatch_and_execute_batches(
         prioritization_fee_cache,
     )?;
 
-    timing.accumulate(execute_batches_internal_metrics);
+    // Pass false because this code-path is never touched by unified scheduler.
+    timing.accumulate(execute_batches_internal_metrics, false);
     Ok(())
 }
 
@@ -1079,11 +1080,15 @@ pub struct ConfirmationTiming {
     /// and replay.  As replay can run in parallel with the verification, this value can not be
     /// recovered from the `replay_elapsed` and or `{poh,transaction}_verify_elapsed`.  This
     /// includes failed cases, when `confirm_slot_entries` exist with an error.  In microseconds.
+    /// When unified scheduler is enabled, replay excludes the transaction execution, only
+    /// accounting for task creation and submission to the scheduler.
     pub confirmation_elapsed: u64,
 
     /// Wall clock time used by the entry replay code.  Does not include the PoH or the transaction
     /// signature/precompiles verification, but can overlap with the PoH and signature verification.
     /// In microseconds.
+    /// When unified scheduler is enabled, replay excludes the transaction execution, only
+    /// accounting for task creation and submission to the scheduler.
     pub replay_elapsed: u64,
 
     /// Wall clock times, used for the PoH verification of entries.  In microseconds.
@@ -1137,7 +1142,11 @@ pub struct BatchExecutionTiming {
 }
 
 impl BatchExecutionTiming {
-    pub fn accumulate(&mut self, new_batch: ExecuteBatchesInternalMetrics) {
+    pub fn accumulate(
+        &mut self,
+        new_batch: ExecuteBatchesInternalMetrics,
+        is_unified_scheduler_enabled: bool,
+    ) {
         let Self {
             totals,
             wall_clock_us,
@@ -1146,9 +1155,13 @@ impl BatchExecutionTiming {
 
         saturating_add_assign!(*wall_clock_us, new_batch.execute_batches_us);
 
-        use ExecuteTimingType::{NumExecuteBatches, TotalBatchesLen};
-        totals.saturating_add_in_place(TotalBatchesLen, new_batch.total_batches_len);
-        totals.saturating_add_in_place(NumExecuteBatches, 1);
+        use ExecuteTimingType::NumExecuteBatches;
+        // These metrics aren't applicable for the unified scheduler
+        if !is_unified_scheduler_enabled {
+            use ExecuteTimingType::TotalBatchesLen;
+            totals.saturating_add_in_place(TotalBatchesLen, new_batch.total_batches_len);
+            totals.saturating_add_in_place(NumExecuteBatches, 1);
+        }
 
         for thread_times in new_batch.execution_timings_per_thread.values() {
             totals.accumulate(&thread_times.execute_timings);
@@ -1161,9 +1174,12 @@ impl BatchExecutionTiming {
 
         if let Some(slowest) = slowest {
             slowest_thread.accumulate(slowest);
-            slowest_thread
-                .execute_timings
-                .saturating_add_in_place(NumExecuteBatches, 1);
+            // This metric isn't applicable for the unified scheduler
+            if !is_unified_scheduler_enabled {
+                slowest_thread
+                    .execute_timings
+                    .saturating_add_in_place(NumExecuteBatches, 1);
+            }
         };
     }
 }
@@ -1176,16 +1192,25 @@ pub struct ThreadExecuteTimings {
 }
 
 impl ThreadExecuteTimings {
-    pub fn report_stats(&self, slot: Slot) {
+    pub fn report_stats(&self, slot: Slot, is_unified_scheduler_enabled: bool) {
+        let (total_thread_us, total_transactions_executed) = if is_unified_scheduler_enabled {
+            (None, None)
+        } else {
+            (
+                Some(self.total_thread_us as i64),
+                Some(self.total_transactions_executed as i64),
+            )
+        };
+
         lazy! {
             datapoint_info!(
                 "replay-slot-end-to-end-stats",
                 ("slot", slot as i64, i64),
-                ("total_thread_us", self.total_thread_us as i64, i64),
-                ("total_transactions_executed", self.total_transactions_executed as i64, i64),
+                ("total_thread_us", total_thread_us, Option<i64>),
+                ("total_transactions_executed", total_transactions_executed, Option<i64>),
                 // Everything inside the `eager!` block will be eagerly expanded before
                 // evaluation of the rest of the surrounding macro.
-                eager!{report_execute_timings!(self.execute_timings)}
+                eager!{report_execute_timings!(self.execute_timings, is_unified_scheduler_enabled)}
             );
         };
     }
@@ -1222,7 +1247,24 @@ impl ReplaySlotStats {
         num_entries: usize,
         num_shreds: u64,
         bank_complete_time_us: u64,
+        is_unified_scheduler_enabled: bool,
     ) {
+        let confirmation_elapsed = if is_unified_scheduler_enabled {
+            "confirmation_without_replay_us"
+        } else {
+            "confirmation_time_us"
+        };
+        let replay_elapsed = if is_unified_scheduler_enabled {
+            "task_submission_us"
+        } else {
+            "replay_time"
+        };
+        let execute_batches_us = if is_unified_scheduler_enabled {
+            None
+        } else {
+            Some(self.batch_execute.wall_clock_us as i64)
+        };
+
         lazy! {
             datapoint_info!(
                 "replay-slot-stats",
@@ -1243,9 +1285,9 @@ impl ReplaySlotStats {
                     self.transaction_verify_elapsed as i64,
                     i64
                 ),
-                ("confirmation_time_us", self.confirmation_elapsed as i64, i64),
-                ("replay_time", self.replay_elapsed as i64, i64),
-                ("execute_batches_us", self.batch_execute.wall_clock_us as i64, i64),
+                (confirmation_elapsed, self.confirmation_elapsed as i64, i64),
+                (replay_elapsed, self.replay_elapsed as i64, i64),
+                ("execute_batches_us", execute_batches_us, Option<i64>),
                 (
                     "replay_total_elapsed",
                     self.started.elapsed().as_micros() as i64,
@@ -1257,11 +1299,13 @@ impl ReplaySlotStats {
                 ("total_shreds", num_shreds as i64, i64),
                 // Everything inside the `eager!` block will be eagerly expanded before
                 // evaluation of the rest of the surrounding macro.
-                eager!{report_execute_timings!(self.batch_execute.totals)}
+                eager!{report_execute_timings!(self.batch_execute.totals, is_unified_scheduler_enabled)}
             );
         };
 
-        self.batch_execute.slowest_thread.report_stats(slot);
+        self.batch_execute
+            .slowest_thread
+            .report_stats(slot, is_unified_scheduler_enabled);
 
         let mut per_pubkey_timings: Vec<_> = self
             .batch_execute

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -80,6 +80,7 @@ use {
         time::{Duration, Instant},
     },
     thiserror::Error,
+    ExecuteTimingType::{NumExecuteBatches, TotalBatchesLen},
 };
 
 pub struct TransactionBatchWithIndexes<'a, 'b> {
@@ -1155,10 +1156,8 @@ impl BatchExecutionTiming {
 
         saturating_add_assign!(*wall_clock_us, new_batch.execute_batches_us);
 
-        use ExecuteTimingType::NumExecuteBatches;
         // These metrics aren't applicable for the unified scheduler
         if !is_unified_scheduler_enabled {
-            use ExecuteTimingType::TotalBatchesLen;
             totals.saturating_add_in_place(TotalBatchesLen, new_batch.total_batches_len);
             totals.saturating_add_in_place(NumExecuteBatches, 1);
         }

--- a/program-runtime/src/timings.rs
+++ b/program-runtime/src/timings.rs
@@ -88,7 +88,7 @@ impl core::fmt::Debug for Metrics {
 eager_macro_rules! { $eager_1
     #[macro_export]
     macro_rules! report_execute_timings {
-        ($self: expr) => {
+        ($self: expr, $is_unified_scheduler_enabled: expr) => {
             (
                 "validate_transactions_us",
                 *$self
@@ -149,19 +149,25 @@ eager_macro_rules! { $eager_1
             ),
             (
                 "total_batches_len",
-                *$self
-
-                    .metrics
-                    .index(ExecuteTimingType::TotalBatchesLen),
-                i64
+                (if $is_unified_scheduler_enabled {
+                    None
+                } else {
+                    Some(*$self
+                        .metrics
+                        .index(ExecuteTimingType::TotalBatchesLen))
+                }),
+                Option<i64>
             ),
             (
                 "num_execute_batches",
-                *$self
-
-                    .metrics
-                    .index(ExecuteTimingType::NumExecuteBatches),
-                i64
+                (if $is_unified_scheduler_enabled {
+                    None
+                } else {
+                    Some(*$self
+                        .metrics
+                        .index(ExecuteTimingType::NumExecuteBatches))
+                }),
+                Option<i64>
             ),
             (
                 "update_transaction_statuses",


### PR DESCRIPTION
#### Problem

Some fields of replay-related metrics are broken if the unified scheduler is enabled with `--block-verification-method unified-scheduler`

#### Summary of Changes

Adjust/Deprecate metrics fields like below _only if unified scheduler is enabled_:

| Field name  | Change |
| ------------- | ------------- |
| `replay-slot-stats.total_batches_len` | Removed |
| `replay-slot-stats.num_execute_batches` | Removed |
| `replay-slot-stats.execute_batches_us`| Removed |
| `replay-slot-stats.replay_time` | Renamed to<br> `.task_submission_us`<br> along with change of definition |
| `replay-slot-stats.confirmation_time_us` | Renamed to<br> `.confirmation_without_replay_us`<br> along with change of definition |
| **`replay-slot-end-to-end-stat.*`** | Removed |

note that these metrics changes are inevitable because of the complete switch of the replay implemention (blockstore_processor => unified_scheduler)

### samples

#### `replay-slot-stats`

before (`--block-verification-method unified-scheduler` is used to show zeroed or hard-coded `1` values for removed fields):

> [2024-06-12T07:33:37.293875680Z INFO  solana_metrics::metrics] datapoint: replay-slot-stats slot=271362801i fetch_entries_time=4334i fetch_entries_fail_time=0i entry_poh_verification_time=57479i entry_transaction_verification_time=14134i confirmation_time_us=79201i replay_time=6921i execute_batches_us=0i replay_total_elapsed=347424i bank_complete_time_us=6074i total_transactions=1063i total_entries=191i total_shreds=440i validate_transactions_us=4813i program_cache_us=12671i load_us=10681i execute_us=443589i collect_logs_us=0i store_us=33453i update_stakes_cache_us=22897i total_batches_len=0i num_execute_batches=1i update_transaction_statuses=6216i execute_details_serialize_us=33597i execute_details_create_vm_us=26055i execute_details_execute_inner_us=312620i execute_details_deserialize_us=9644i execute_details_get_or_create_executor_us=6i execute_details_changed_account_count=1518i execute_details_total_account_count=4960i execute_details_create_executor_register_syscalls_us=0i execute_details_create_executor_load_elf_us=0i execute_details_create_executor_verify_code_us=0i execute_details_create_executor_jit_compile_us=0i execute_accessories_feature_set_clone_us=0i execute_accessories_compute_budget_process_transaction_us=13i execute_accessories_get_executors_us=0i execute_accessories_process_message_us=438390i execute_accessories_update_executors_us=1i execute_accessories_process_instructions_total_us=436692i execute_accessories_process_instructions_verify_caller_us=0i execute_accessories_process_instructions_process_executable_chain_us=434847i execute_accessories_process_instructions_verify_callee_us=0i

after (`--block-verification-method unified-scheduler`):

> [2024-06-19T06:29:10.754587684Z INFO  solana_metrics::metrics] datapoint: replay-slot-stats slot=278036338i fetch_entries_time=9109i fetch_entries_fail_time=0i entry_poh_verification_time=40374i entry_transaction_verification_time=19032i confirmation_without_replay_us=73874i task_submission_us=12465i replay_total_elapsed=372679i bank_complete_time_us=3257i total_transactions=2941i total_entries=145i total_shreds=1033i validate_transactions_us=27020i program_cache_us=28087i load_us=13525i execute_us=125259i collect_logs_us=4i store_us=68007i update_stakes_cache_us=47468i update_transaction_statuses=26068i execute_details_serialize_us=127i execute_details_create_vm_us=594i execute_details_execute_inner_us=1498i execute_details_deserialize_us=18i execute_details_get_or_create_executor_us=0i execute_details_changed_account_count=2963i execute_details_total_account_count=9354i execute_details_create_executor_register_syscalls_us=0i execute_details_create_executor_load_elf_us=0i execute_details_create_executor_verify_code_us=0i execute_details_create_executor_jit_compile_us=0i execute_accessories_feature_set_clone_us=0i execute_accessories_compute_budget_process_transaction_us=25i execute_accessories_get_executors_us=0i execute_accessories_process_message_us=115409i execute_accessories_update_executors_us=1i execute_accessories_process_instructions_total_us=112598i execute_accessories_process_instructions_verify_caller_us=0i execute_accessories_process_instructions_process_executable_chain_us=109290i execute_accessories_process_instructions_verify_callee_us=0i

after (`--block-verification-method blockstore-processor`):

> [2024-06-19T06:29:10.695632206Z INFO  solana_metrics::metrics] datapoint: replay-slot-stats slot=278036338i fetch_entries_time=9486i fetch_entries_fail_time=0i entry_poh_verification_time=38601i entry_transaction_verification_time=20683i confirmation_time_us=93492i replay_time=33025i execute_batches_us=25936i replay_total_elapsed=265723i bank_complete_time_us=3542i total_transactions=2941i total_entries=145i total_shreds=1033i validate_transactions_us=1926i program_cache_us=22630i load_us=18604i execute_us=101587i collect_logs_us=6i store_us=120646i update_stakes_cache_us=89264i total_batches_len=207i num_execute_batches=10i update_transaction_statuses=33832i execute_details_serialize_us=85i execute_details_create_vm_us=628i execute_details_execute_inner_us=1157i execute_details_deserialize_us=11i execute_details_get_or_create_executor_us=0i execute_details_changed_account_count=2963i execute_details_total_account_count=9354i execute_details_create_executor_register_syscalls_us=0i execute_details_create_executor_load_elf_us=0i execute_details_create_executor_verify_code_us=0i execute_details_create_executor_jit_compile_us=0i execute_accessories_feature_set_clone_us=0i execute_accessories_compute_budget_process_transaction_us=2i execute_accessories_get_executors_us=0i execute_accessories_process_message_us=90944i execute_accessories_update_executors_us=0i execute_accessories_process_instructions_total_us=89576i execute_accessories_process_instructions_verify_caller_us=0i execute_accessories_process_instructions_process_executable_chain_us=87066i execute_accessories_process_instructions_verify_callee_us=0i


#### `replay-slot-end-to-end-stats`

before (`--block-verification-method unified-scheduler` is used to show zeroed or hard-coded `1` values for removed fields):

> [2024-06-12T07:30:11.518197708Z INFO  solana_metrics::metrics] datapoint: replay-slot-end-to-end-stats slot=271362338i total_thread_us=0i total_transactions_executed=0i validate_transactions_us=2747i program_cache_us=17670i load_us=18271i execute_us=681804i collect_logs_us=21i store_us=26436i update_stakes_cache_us=15400i total_batches_len=0i num_execute_batches=1i update_transaction_statuses=8456i execute_details_serialize_us=99045i execute_details_create_vm_us=83649i execute_details_execute_inner_us=399716i execute_details_deserialize_us=11800i execute_details_get_or_create_executor_us=41i execute_details_changed_account_count=3085i execute_details_total_account_count=10296i execute_details_create_executor_register_syscalls_us=0i execute_details_create_executor_load_elf_us=0i execute_details_create_executor_verify_code_us=0i execute_details_create_executor_jit_compile_us=0i execute_accessories_feature_set_clone_us=0i execute_accessories_compute_budget_process_transaction_us=20i execute_accessories_get_executors_us=0i execute_accessories_process_message_us=674855i execute_accessories_update_executors_us=0i execute_accessories_process_instructions_total_us=672092i execute_accessories_process_instructions_verify_caller_us=0i execute_accessories_process_instructions_process_executable_chain_us=669463i execute_accessories_process_instructions_verify_callee_us=0i


after (`--block-verification-method unified-scheduler`):


> N/A

after (`--block-verification-method blockstore-processor`):

> 2024-06-19T06:29:10.695654939Z INFO  solana_metrics::metrics] datapoint: replay-slot-end-to-end-stats slot=278036338i total_thread_us=23586i total_transactions_executed=139i validate_transactions_us=191i program_cache_us=1119i load_us=932i execute_us=6703i collect_logs_us=1i store_us=6091i update_stakes_cache_us=4650i total_batches_len=1i num_execute_batches=10i update_transaction_statuses=3779i execute_details_serialize_us=41i execute_details_create_vm_us=269i execute_details_execute_inner_us=557i execute_details_deserialize_us=7i execute_details_get_or_create_executor_us=0i execute_details_changed_account_count=150i execute_details_total_account_count=453i execute_details_create_executor_register_syscalls_us=0i execute_details_create_executor_load_elf_us=0i execute_details_create_executor_verify_code_us=0i execute_details_create_executor_jit_compile_us=0i execute_accessories_feature_set_clone_us=0i execute_accessories_compute_budget_process_transaction_us=0i execute_accessories_get_executors_us=0i execute_accessories_process_message_us=6220i execute_accessories_update_executors_us=0i execute_accessories_process_instructions_total_us=6144i execute_accessories_process_instructions_verify_caller_us=0i execute_accessories_process_instructions_process_executable_chain_us=6011i execute_accessories_process_instructions_verify_callee_us=0i
