### PR TITLE
CHANGELOG: `Copy` no longer derived on Rent and EpochSchedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Release channels have their own copy of this changelog:
 ## [2.0.0] - Unreleased
 * Breaking
   * SDK: Support for Borsh v0.9 removed, please use v1 or v0.10 (#1440)
+  * SDK: `Copy` is no longer derived on `Rent` and `EpochSchedule`, please switch to using `clone()` (solana-labs#32767)
 * Changes
   * `central-scheduler` as default option for `--block-production-method` (#34891)
   * `solana-rpc-client-api`: `RpcFilterError` depends on `base64` version 0.22, so users may need to upgrade to `base64` version 0.22


### PR DESCRIPTION
#### Problem

There was a breaking change for `Rent` and `EpochSchedule` no longer deriving `Copy` with https://github.com/solana-labs/solana/pull/32767, but it's not mentioned in the changelog

#### Summary of Changes

Add a changelog entry for the change

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
