### PR TITLE
ledger-tool: Use helper for AccountsDb args

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -26,7 +26,7 @@ use {
 };
 
 /// Returns the arguments that configure AccountsDb
-pub fn accounts_db_args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
+pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
     vec![
         Arg::with_name("account_paths")
             .long("accounts")
@@ -109,6 +109,7 @@ pub fn accounts_db_args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             )
             .hidden(hidden_unless_forced()),
     ]
+    .into_boxed_slice()
 }
 
 /// Parse a `ProcessOptions` from subcommand arguments. This function attempts

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -1,13 +1,17 @@
 use {
     crate::LEDGER_TOOL_DIRECTORY,
-    clap::{value_t, value_t_or_exit, values_t, values_t_or_exit, ArgMatches},
+    clap::{value_t, value_t_or_exit, values_t, values_t_or_exit, Arg, ArgMatches},
     solana_accounts_db::{
         accounts_db::{AccountsDb, AccountsDbConfig},
         accounts_index::{AccountsIndexConfig, IndexLimitMb},
         partitioned_rewards::TestPartitionedEpochRewards,
         utils::create_and_canonicalize_directories,
     },
-    solana_clap_utils::input_parsers::pubkeys_of,
+    solana_clap_utils::{
+        hidden_unless_forced,
+        input_parsers::pubkeys_of,
+        input_validators::{is_parsable, is_pow2},
+    },
     solana_ledger::{
         blockstore_processor::ProcessOptions,
         use_snapshot_archives_at_startup::{self, UseSnapshotArchivesAtStartup},
@@ -20,6 +24,92 @@ use {
         sync::Arc,
     },
 };
+
+/// Returns the arguments that configure AccountsDb
+pub fn accounts_db_args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
+    vec![
+        Arg::with_name("account_paths")
+            .long("accounts")
+            .value_name("PATHS")
+            .takes_value(true)
+            .help(
+                "Persistent accounts location. May be specified multiple times. \
+                [default: <LEDGER>/accounts]",
+            ),
+        Arg::with_name("accounts_index_path")
+            .long("accounts-index-path")
+            .value_name("PATH")
+            .takes_value(true)
+            .multiple(true)
+            .help(
+                "Persistent accounts-index location. May be specified multiple times. \
+                [default: <LEDGER>/accounts_index]",
+            ),
+        Arg::with_name("accounts_hash_cache_path")
+            .long("accounts-hash-cache-path")
+            .value_name("PATH")
+            .takes_value(true)
+            .help(
+                "Use PATH as accounts hash cache location [default: <LEDGER>/accounts_hash_cache]",
+            ),
+        Arg::with_name("accounts_index_bins")
+            .long("accounts-index-bins")
+            .value_name("BINS")
+            .validator(is_pow2)
+            .takes_value(true)
+            .help("Number of bins to divide the accounts index into"),
+        Arg::with_name("accounts_index_memory_limit_mb")
+            .long("accounts-index-memory-limit-mb")
+            .value_name("MEGABYTES")
+            .validator(is_parsable::<usize>)
+            .takes_value(true)
+            .help(
+                "How much memory the accounts index can consume. If this is exceeded, some \
+                 account index entries will be stored on disk.",
+            ),
+        Arg::with_name("disable_accounts_disk_index")
+            .long("disable-accounts-disk-index")
+            .help(
+                "Disable the disk-based accounts index. It is enabled by default. The entire \
+                 accounts index will be kept in memory.",
+            )
+            .conflicts_with("accounts_index_memory_limit_mb"),
+        Arg::with_name("accounts_db_skip_shrink")
+            .long("accounts-db-skip-shrink")
+            .help(
+                "Enables faster starting of ledger-tool by skipping shrink. This option is for \
+                use during testing.",
+            ),
+        Arg::with_name("accounts_db_verify_refcounts")
+            .long("accounts-db-verify-refcounts")
+            .help(
+                "Debug option to scan all AppendVecs and verify account index refcounts prior to \
+                clean",
+            )
+            .hidden(hidden_unless_forced()),
+        Arg::with_name("accounts_db_test_skip_rewrites")
+            .long("accounts-db-test-skip-rewrites")
+            .help(
+                "Debug option to skip rewrites for rent-exempt accounts but still add them in \
+                 bank delta hash calculation",
+            )
+            .hidden(hidden_unless_forced()),
+        Arg::with_name("accounts_db_skip_initial_hash_calculation")
+            .long("accounts-db-skip-initial-hash-calculation")
+            .help("Do not verify accounts hash at startup.")
+            .hidden(hidden_unless_forced()),
+        Arg::with_name("accounts_db_ancient_append_vecs")
+            .long("accounts-db-ancient-append-vecs")
+            .value_name("SLOT-OFFSET")
+            .validator(is_parsable::<i64>)
+            .takes_value(true)
+            .help(
+                "AppendVecs that are older than (slots_per_epoch - SLOT-OFFSET) are squashed \
+                 together.",
+            )
+            .hidden(hidden_unless_forced()),
+    ]
+}
 
 /// Parse a `ProcessOptions` from subcommand arguments. This function attempts
 /// to parse all flags related to `ProcessOptions`; however, subcommands that


### PR DESCRIPTION
#### Problem
There are a handful of commands that specify AccountsDb config. 

#### Summary of Changes
To create consistency between all these commands and remove repeated code, build all of the arguments in a helper function that is passed to the relevant commands.

This will be especially useful for commands that need to specify these types of arguments that are NOT in `main.rs`. Currently, one such example are the commands in `program.rs`, but there will be more to come like the command introduced in https://github.com/anza-xyz/agave/pull/1638

There are probably some arguments that could be hidden by default, but I'm going to hold off on those for now; this PR is only the movement of args from `main.rs` to `args.rs`