### PR TITLE
PrioGraphScheduler::try_schedule_transaction remove TransactionAccountLocks allocation

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -550,10 +550,20 @@ fn try_schedule_transaction(
     }
 
     // Schedule the transaction if it can be.
-    let transaction_locks = transaction.get_account_locks_unchecked();
+    let message = transaction.message();
+    let account_keys = message.account_keys();
+    let write_account_locks = account_keys
+        .iter()
+        .enumerate()
+        .filter_map(|(index, key)| message.is_writable(index).then_some(key));
+    let read_account_locks = account_keys
+        .iter()
+        .enumerate()
+        .filter_map(|(index, key)| (!message.is_writable(index)).then_some(key));
+
     let Some(thread_id) = account_locks.try_lock_accounts(
-        transaction_locks.writable.into_iter(),
-        transaction_locks.readonly.into_iter(),
+        write_account_locks,
+        read_account_locks,
         ThreadSet::any(num_threads),
         thread_selector,
     ) else {

--- a/sdk/program/src/message/account_keys.rs
+++ b/sdk/program/src/message/account_keys.rs
@@ -33,7 +33,7 @@ impl<'a> AccountKeys<'a> {
     /// Returns an iterator of account key segments. The ordering of segments
     /// affects how account indexes from compiled instructions are resolved and
     /// so should not be changed.
-    fn key_segment_iter(&self) -> impl Iterator<Item = &'a [Pubkey]> {
+    fn key_segment_iter(&self) -> impl Iterator<Item = &'a [Pubkey]> + Clone {
         if let Some(dynamic_keys) = self.dynamic_keys {
             [
                 self.static_keys,
@@ -77,7 +77,7 @@ impl<'a> AccountKeys<'a> {
     }
 
     /// Iterator for the addresses of the loaded accounts for a message
-    pub fn iter(&self) -> impl Iterator<Item = &'a Pubkey> {
+    pub fn iter(&self) -> impl Iterator<Item = &'a Pubkey> + Clone {
         self.key_segment_iter().flatten()
     }
 


### PR DESCRIPTION
#### Problem
- `get_account_locks_unchecked` does some allocations for locks
- `try_lock_accounts` takes arbitrary iterators (clone-able) so we do not need to allocate

#### Summary of Changes
- Make `AccountKeys::key_segment_iter` return clonable iterator. (No change to impl, just exposes `clone`)
- Make `AccountKeys::iter` return clonable iterator. (No change to impl, just exposes `clone`)
- Iterate over write/read accounts, do not allocate.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
