### PR TITLE
ci: upgrade client-traget macos version

### DIFF
--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-11
+          - macos-12
         target:
           - aarch64-apple-ios
           - x86_64-apple-ios


### PR DESCRIPTION
#### Problem

macos-11 is deprecated

<img width="907" alt="Screenshot 2024-06-18 at 00 44 49" src="https://github.com/anza-xyz/agave/assets/8209234/9f10711c-522f-4d28-b39f-a49087d6350c">

https://github.com/anza-xyz/agave/actions/runs/9548078823

#### Summary of Changes

bump it to 12