### PR TITLE
Simd-118: [HAL-01] add log to unreachable macro

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -150,7 +150,10 @@ impl Bank {
         let (mut account, stake_state): (AccountSharedData, StakeStateV2) = stake_account.into();
         let StakeStateV2::Stake(meta, stake, flags) = stake_state else {
             // StakesCache only stores accounts where StakeStateV2::delegation().is_some()
-            unreachable!()
+            unreachable!(
+                "StakesCache entry {:?} failed StakeStateV2 deserialization",
+                partitioned_stake_reward.stake_pubkey
+            )
         };
         account
             .checked_add_lamports(partitioned_stake_reward.stake_reward_info.lamports as u64)


### PR DESCRIPTION
#### Problem
Per Halborn audit report:
> The `build_updated_stake_reward` function uses the `unreachable!` macro without logging a message if the branch is reached. As noted in the comments of the function, the Anza team explains that this branch should never be reached because the stake state account is always expected to be of type `StakeStateV2::Stake`.
> Even if this assertion is correct, it is a good practice to log the use of the `unreachable!` macro with a message indicating the staking account that triggered the branch. This additional information can help debug the situation more effectively.

#### Summary of Changes
Add log to `unreachable!` macro
