### PR TITLE
Simd-118: [HAL-02] add lamports burned to error log

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -207,8 +207,8 @@ impl Bank {
                 }
                 Err(err) => {
                     error!(
-                        "bank::distribution::store_stake_accounts_in_partition() failed for {}: {:?}",
-                        stake_pubkey, err
+                        "bank::distribution::store_stake_accounts_in_partition() failed for \
+                         {stake_pubkey}, {reward_amount} lamports burned: {err:?}"
                     );
                     lamports_burned += reward_amount;
                 }


### PR DESCRIPTION
#### Problem
As per Halborn audit report:
> There are multiple situations where a partitioned reward can’t be distributed, such as not finding the recipient account or a mathematical overflow. In the case that it is not possible to deliver a partitioned reward, it is then considered “burned”. No matter the reason that this reward can’t be distributed, it is necessary to log such situations in order to have the registers to fix any problem.
> Currently, the store_stake_accounts_in_partition function is logging these errors, including both the stake account public key and the error message that originated the situation, but it is not logging the amount to be burned for that specific stake account.

#### Summary of Changes
Add burned `reward_amount` to error log
