### PR TITLE
Simd-118: [HAL-04] simplify assertion that epoch contains enough slots for partitions

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -50,7 +50,7 @@ impl Bank {
             distribution_starting_block_height + status.stake_rewards_by_partition.len() as u64;
         assert!(
             self.epoch_schedule.get_slots_in_epoch(self.epoch)
-                > distribution_end_exclusive.saturating_sub(distribution_starting_block_height)
+                > status.stake_rewards_by_partition.len() as u64
         );
 
         if height >= distribution_starting_block_height && height < distribution_end_exclusive {


### PR DESCRIPTION
#### Problem
Assertion in `distribute_partitioned_epoch_rewards()` undoes math done in the immediately preceding line.

As per Halborn audit report:
> At the beginning of the rewards distribution process, the `distribute_partitioned_epoch_rewards` function validates that the number of slots in the epoch is sufficient for distributing the rewards. It does this by ensuring that the number of slots in the epoch is greater than the difference between the ending and starting blocks of the distribution process.
> The number of blocks required to distribute the rewards, M, has already been calculated and corresponds to the length of the `status.stake_rewards_by_partition` array.

#### Summary of Changes
Use `status.stake_rewards_by_partition.len()` directly
