### PR TITLE
SVM: Move `fee_structure` to environment input

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3714,6 +3714,7 @@ impl Bank {
             epoch_total_stake: self.epoch_total_stake(self.epoch()),
             epoch_vote_accounts: self.epoch_vote_accounts(self.epoch()),
             feature_set: Arc::clone(&self.feature_set),
+            fee_structure: Some(self.fee_structure()),
             lamports_per_signature,
             rent_collector: Some(&self.rent_collector),
         };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -600,6 +600,7 @@ impl PartialEq for Bank {
             collector_fee_details: _,
             compute_budget: _,
             transaction_account_lock_limit: _,
+            fee_structure: _,
             // Ignore new fields explicitly if they do not impact PartialEq.
             // Adding ".." will remove compile-time checks that if a new field
             // is added to the struct, this PartialEq is accordingly updated.
@@ -885,6 +886,9 @@ pub struct Bank {
 
     /// The max number of accounts that a transaction may lock.
     transaction_account_lock_limit: Option<usize>,
+
+    /// Fee structure to use for assessing transaction fees.
+    fee_structure: FeeStructure,
 }
 
 struct VoteWithStakeDelegations {
@@ -1002,6 +1006,7 @@ impl Bank {
             collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
             compute_budget: None,
             transaction_account_lock_limit: None,
+            fee_structure: FeeStructure::default(),
         };
 
         bank.transaction_processor =
@@ -1247,6 +1252,7 @@ impl Bank {
             collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
             compute_budget: parent.compute_budget,
             transaction_account_lock_limit: parent.transaction_account_lock_limit,
+            fee_structure: parent.fee_structure.clone(),
         };
 
         let (_, ancestors_time_us) = measure_us!({
@@ -1638,6 +1644,7 @@ impl Bank {
             collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
             compute_budget: runtime_config.compute_budget,
             transaction_account_lock_limit: runtime_config.transaction_account_lock_limit,
+            fee_structure: FeeStructure::default(),
         };
 
         bank.transaction_processor =
@@ -3714,7 +3721,7 @@ impl Bank {
             epoch_total_stake: self.epoch_total_stake(self.epoch()),
             epoch_vote_accounts: self.epoch_vote_accounts(self.epoch()),
             feature_set: Arc::clone(&self.feature_set),
-            fee_structure: Some(self.fee_structure()),
+            fee_structure: Some(&self.fee_structure),
             lamports_per_signature,
             rent_collector: Some(&self.rent_collector),
         };
@@ -6826,7 +6833,7 @@ impl Bank {
     }
 
     pub fn fee_structure(&self) -> &FeeStructure {
-        &self.transaction_processor.fee_structure
+        &self.fee_structure
     }
 
     pub fn compute_budget(&self) -> Option<ComputeBudget> {
@@ -7148,7 +7155,7 @@ impl Bank {
     }
 
     pub fn set_fee_structure(&mut self, fee_structure: &FeeStructure) {
-        self.transaction_processor.fee_structure = fee_structure.clone();
+        self.fee_structure = fee_structure.clone();
     }
 
     pub fn load_program(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -131,6 +131,8 @@ pub struct TransactionProcessingEnvironment<'a> {
     pub epoch_vote_accounts: Option<&'a VoteAccountsHashMap>,
     /// Runtime feature set to use for the transaction batch.
     pub feature_set: Arc<FeatureSet>,
+    /// Fee structure to use for assessing transaction fees.
+    pub fee_structure: Option<&'a FeeStructure>,
     /// Lamports per signature to charge per transaction.
     pub lamports_per_signature: u64,
     /// Rent collector to use for the transaction batch.


### PR DESCRIPTION
#### Problem
The `TransactionBatchProcessor` requires `FeeStructure` as a global config, but
its functionality is shared with Bank. As a result, it actually makes more sense for Bank
to provide its own `FeeStructure` instance to the transaction processor.

#### Summary of Changes
Move `fee_structure: FeeStructure` to the `TransactionProcessingEnvironment` input.
