### PR TITLE
ledger-tool: Subfunction for snapshot args

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -112,6 +112,38 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
     .into_boxed_slice()
 }
 
+/// Returns the arguments that configure snapshot loading
+pub fn snapshot_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
+    vec![
+        Arg::with_name("no_snapshot")
+            .long("no-snapshot")
+            .takes_value(false)
+            .help("Do not start from a local snapshot if present"),
+        Arg::with_name("snapshots")
+            .long("snapshots")
+            .alias("snapshot-archive-path")
+            .alias("full-snapshot-archive-path")
+            .value_name("DIR")
+            .takes_value(true)
+            .global(true)
+            .help("Use DIR for snapshot location [default: --ledger value]"),
+        Arg::with_name("incremental_snapshot_archive_path")
+            .long("incremental-snapshot-archive-path")
+            .value_name("DIR")
+            .takes_value(true)
+            .global(true)
+            .help("Use DIR for separate incremental snapshot location"),
+        Arg::with_name(use_snapshot_archives_at_startup::cli::NAME)
+            .long(use_snapshot_archives_at_startup::cli::LONG_ARG)
+            .takes_value(true)
+            .possible_values(use_snapshot_archives_at_startup::cli::POSSIBLE_VALUES)
+            .default_value(use_snapshot_archives_at_startup::cli::default_value_for_ledger_tool())
+            .help(use_snapshot_archives_at_startup::cli::HELP)
+            .long_help(use_snapshot_archives_at_startup::cli::LONG_HELP),
+    ]
+    .into_boxed_slice()
+}
+
 /// Parse a `ProcessOptions` from subcommand arguments. This function attempts
 /// to parse all flags related to `ProcessOptions`; however, subcommands that
 /// use this function may not support all flags.

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1337,14 +1337,6 @@ fn main() {
     info!("{} {}", crate_name!(), solana_version::version!());
 
     let ledger_path = PathBuf::from(value_t_or_exit!(matches, "ledger_path", String));
-    let snapshot_archive_path = value_t!(matches, "snapshots", String)
-        .ok()
-        .map(PathBuf::from);
-    let incremental_snapshot_archive_path =
-        value_t!(matches, "incremental_snapshot_archive_path", String)
-            .ok()
-            .map(PathBuf::from);
-
     let verbose_level = matches.occurrences_of("verbose");
 
     // Name the rayon global thread pool
@@ -1452,8 +1444,6 @@ fn main() {
                         &genesis_config,
                         Arc::new(blockstore),
                         process_options,
-                        snapshot_archive_path,
-                        incremental_snapshot_archive_path,
                         None,
                     );
 
@@ -1644,8 +1634,6 @@ fn main() {
                         &genesis_config,
                         Arc::new(blockstore),
                         process_options,
-                        snapshot_archive_path,
-                        incremental_snapshot_archive_path,
                         transaction_status_sender,
                     );
 
@@ -1712,8 +1700,6 @@ fn main() {
                         &genesis_config,
                         Arc::new(blockstore),
                         process_options,
-                        snapshot_archive_path,
-                        incremental_snapshot_archive_path,
                         None,
                     );
 
@@ -1738,6 +1724,13 @@ fn main() {
                     let is_minimized = arg_matches.is_present("minimized");
                     let output_directory = value_t!(arg_matches, "output_directory", PathBuf)
                         .unwrap_or_else(|_| {
+                            let snapshot_archive_path = value_t!(matches, "snapshots", String)
+                                .ok()
+                                .map(PathBuf::from);
+                            let incremental_snapshot_archive_path =
+                                value_t!(matches, "incremental_snapshot_archive_path", String)
+                                    .ok()
+                                    .map(PathBuf::from);
                             match (
                                 is_incremental,
                                 &snapshot_archive_path,
@@ -1876,8 +1869,6 @@ fn main() {
                         &genesis_config,
                         blockstore.clone(),
                         process_options,
-                        snapshot_archive_path,
-                        incremental_snapshot_archive_path,
                         None,
                     );
                     let mut bank = bank_forks
@@ -2266,8 +2257,6 @@ fn main() {
                         &genesis_config,
                         Arc::new(blockstore),
                         process_options,
-                        snapshot_archive_path,
-                        incremental_snapshot_archive_path,
                         None,
                     );
                     let bank = bank_forks.read().unwrap().working_bank();
@@ -2319,8 +2308,6 @@ fn main() {
                         &genesis_config,
                         Arc::new(blockstore),
                         process_options,
-                        snapshot_archive_path,
-                        incremental_snapshot_archive_path,
                         None,
                     );
                     let bank_forks = bank_forks.read().unwrap();

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -43,7 +43,6 @@ use {
         blockstore_processor::{
             ProcessSlotCallback, TransactionStatusMessage, TransactionStatusSender,
         },
-        use_snapshot_archives_at_startup,
     },
     solana_measure::{measure, measure::Measure},
     solana_runtime::{
@@ -563,11 +562,8 @@ fn main() {
     solana_logger::setup_with_default_filter();
 
     let accounts_db_config_args = accounts_db_args();
+    let snapshot_config_args = snapshot_args();
 
-    let no_snapshot_arg = Arg::with_name("no_snapshot")
-        .long("no-snapshot")
-        .takes_value(false)
-        .help("Do not start from a local snapshot if present");
     let accounts_db_test_hash_calculation_arg = Arg::with_name("accounts_db_test_hash_calculation")
         .long("accounts-db-test-hash-calculation")
         .help("Enable hash calculation test");
@@ -641,14 +637,6 @@ fn main() {
         .multiple(true)
         .takes_value(true)
         .help("Log when transactions are processed that reference the given key(s).");
-    let use_snapshot_archives_at_startup =
-        Arg::with_name(use_snapshot_archives_at_startup::cli::NAME)
-            .long(use_snapshot_archives_at_startup::cli::LONG_ARG)
-            .takes_value(true)
-            .possible_values(use_snapshot_archives_at_startup::cli::POSSIBLE_VALUES)
-            .default_value(use_snapshot_archives_at_startup::cli::default_value_for_ledger_tool())
-            .help(use_snapshot_archives_at_startup::cli::HELP)
-            .long_help(use_snapshot_archives_at_startup::cli::LONG_HELP);
 
     let geyser_plugin_args = Arg::with_name("geyser_plugin_config")
         .long("geyser-plugin-config")
@@ -732,24 +720,6 @@ fn main() {
                      descriptor limit cannot be configured. Use with caution as some commands may \
                      run fine with a reduced file descriptor limit while others will not",
                 ),
-        )
-        .arg(
-            Arg::with_name("snapshots")
-                .long("snapshots")
-                .alias("snapshot-archive-path")
-                .alias("full-snapshot-archive-path")
-                .value_name("DIR")
-                .takes_value(true)
-                .global(true)
-                .help("Use DIR for snapshot location [default: --ledger value]"),
-        )
-        .arg(
-            Arg::with_name("incremental_snapshot_archive_path")
-                .long("incremental-snapshot-archive-path")
-                .value_name("DIR")
-                .takes_value(true)
-                .global(true)
-                .help("Use DIR for separate incremental snapshot location"),
         )
         .arg(
             Arg::with_name("block_verification_method")
@@ -846,23 +816,23 @@ fn main() {
             SubCommand::with_name("shred-version")
                 .about("Prints the ledger's shred hash")
                 .args(&accounts_db_config_args)
+                .args(&snapshot_config_args)
                 .arg(&hard_forks_arg)
                 .arg(&max_genesis_archive_unpacked_size_arg)
-                .arg(&use_snapshot_archives_at_startup),
         )
         .subcommand(
             SubCommand::with_name("bank-hash")
                 .about("Prints the hash of the working bank after reading the ledger")
                 .args(&accounts_db_config_args)
+                .args(&snapshot_config_args)
                 .arg(&max_genesis_archive_unpacked_size_arg)
                 .arg(&halt_at_slot_arg)
-                .arg(&use_snapshot_archives_at_startup),
         )
         .subcommand(
             SubCommand::with_name("verify")
                 .about("Verify the ledger")
                 .args(&accounts_db_config_args)
-                .arg(&no_snapshot_arg)
+                .args(&snapshot_config_args)
                 .arg(&halt_at_slot_arg)
                 .arg(&limit_load_slot_count_from_snapshot_arg)
                 .arg(&verify_index_arg)
@@ -875,7 +845,6 @@ fn main() {
                 .arg(&debug_key_arg)
                 .arg(&geyser_plugin_args)
                 .arg(&log_messages_bytes_limit_arg)
-                .arg(&use_snapshot_archives_at_startup)
                 .arg(
                     Arg::with_name("skip_poh_verify")
                         .long("skip-poh-verify")
@@ -999,11 +968,10 @@ fn main() {
             SubCommand::with_name("graph")
                 .about("Create a Graphviz rendering of the ledger")
                 .args(&accounts_db_config_args)
-                .arg(&no_snapshot_arg)
+                .args(&snapshot_config_args)
                 .arg(&halt_at_slot_arg)
                 .arg(&hard_forks_arg)
                 .arg(&max_genesis_archive_unpacked_size_arg)
-                .arg(&use_snapshot_archives_at_startup)
                 .arg(
                     Arg::with_name("include_all_votes")
                         .long("include-all-votes")
@@ -1033,13 +1001,12 @@ fn main() {
             SubCommand::with_name("create-snapshot")
                 .about("Create a new ledger snapshot")
                 .args(&accounts_db_config_args)
-                .arg(&no_snapshot_arg)
+                .args(&snapshot_config_args)
                 .arg(&hard_forks_arg)
                 .arg(&max_genesis_archive_unpacked_size_arg)
                 .arg(&snapshot_version_arg)
                 .arg(&geyser_plugin_args)
                 .arg(&log_messages_bytes_limit_arg)
-                .arg(&use_snapshot_archives_at_startup)
                 .arg(
                     Arg::with_name("snapshot_slot")
                         .index(1)
@@ -1240,13 +1207,12 @@ fn main() {
             SubCommand::with_name("accounts")
                 .about("Print account stats and contents after processing the ledger")
                 .args(&accounts_db_config_args)
-                .arg(&no_snapshot_arg)
+                .args(&snapshot_config_args)
                 .arg(&halt_at_slot_arg)
                 .arg(&hard_forks_arg)
                 .arg(&geyser_plugin_args)
                 .arg(&log_messages_bytes_limit_arg)
                 .arg(&accounts_data_encoding_arg)
-                .arg(&use_snapshot_archives_at_startup)
                 .arg(&max_genesis_archive_unpacked_size_arg)
                 .arg(
                     Arg::with_name("include_sysvars")
@@ -1295,13 +1261,12 @@ fn main() {
             SubCommand::with_name("capitalization")
                 .about("Print capitalization (aka, total supply) while checksumming it")
                 .args(&accounts_db_config_args)
-                .arg(&no_snapshot_arg)
+                .args(&snapshot_config_args)
                 .arg(&halt_at_slot_arg)
                 .arg(&hard_forks_arg)
                 .arg(&max_genesis_archive_unpacked_size_arg)
                 .arg(&geyser_plugin_args)
                 .arg(&log_messages_bytes_limit_arg)
-                .arg(&use_snapshot_archives_at_startup)
                 .arg(
                     Arg::with_name("warp_epoch")
                         .required(false)


### PR DESCRIPTION
#### Problem
There are several arguments to control snapshot configuration in the
various ledger-tool commands. The inclusion of args in each command
is inconsistent, especially for commands outside of main.rs

#### Summary of Changes
This change consolidates the snapshot related arguments into a single
helper.

The top level CLI is getting a bit cleaner too - the 3 `Blockstore` ones can be shifted to only the relevant commands in a subsequent PR as well.

<details>
<summary>ledger-tool --help</summary>

```
agave-ledger-tool 2.0.0 (src:00000000; feat:1227758527, client:Agave)
Blockchain, Rebuilt for Scale

USAGE:
    agave-ledger-tool [FLAGS] [OPTIONS] <SUBCOMMAND>

FLAGS:
        --force-update-to-open          Allow commands that would otherwise not alter the blockstore to make necessary
                                        updates in order to open it
    -h, --help                          Prints help information
        --ignore-ulimit-nofile-error    Allow opening the blockstore to succeed even if the desired open file descriptor
                                        limit cannot be configured. Use with caution as some commands may run fine with
                                        a reduced file descriptor limit while others will not
    -V, --version                       Prints version information
    -v, --verbose                       Show additional information where supported

OPTIONS:
    -l, --ledger <DIR>                Use DIR as ledger location [default: ledger]
        --output <FORMAT>             Return information in specified output format, currently only available for
                                      bigtable and program subcommands [possible values: json, json-compact]
        --wal-recovery-mode <MODE>    Mode to recovery the ledger db write ahead log [possible values:
                                      tolerate_corrupted_tail_records, absolute_consistency, point_in_time,
                                      skip_any_corrupted_record]

SUBCOMMANDS:
    accounts                   Print account stats and contents after processing the ledger
    bank-hash                  Prints the hash of the working bank after reading the ledger
    bigtable                   Ledger data on a BigTable instance
    blockstore                 Commands to interact with a local Blockstore
    capitalization             Print capitalization (aka, total supply) while checksumming it
    compute-slot-cost          runs cost_model over the block at the given slots, computes how expensive a block was
                               based on cost_model
    create-snapshot            Create a new ledger snapshot
    genesis                    Prints the ledger's genesis config
    genesis-hash               Prints the ledger's genesis hash
    graph                      Create a Graphviz rendering of the ledger
    help                       Prints this message or the help of the given subcommand(s)
    latest-optimistic-slots    Output up to the most recent <num-slots> optimistic slots with their hashes and
                               timestamps.
    modify-genesis             Modifies genesis parameters
    program                    Run to test, debug, and analyze on-chain programs.
    shred-version              Prints the ledger's shred hash
    verify                     Verify the ledger
```

</details>