### PR TITLE
[curve25519] Remove `ElGamalError` from curve25519 crate

### DIFF
--- a/curves/curve25519/src/errors.rs
+++ b/curves/curve25519/src/errors.rs
@@ -5,21 +5,3 @@ pub enum Curve25519Error {
     #[error("pod conversion failed")]
     PodConversion,
 }
-
-#[derive(Error, Clone, Debug, Eq, PartialEq)]
-pub enum ElGamalError {
-    #[error("key derivation method not supported")]
-    DerivationMethodNotSupported,
-    #[error("seed length too short for derivation")]
-    SeedLengthTooShort,
-    #[error("seed length too long for derivation")]
-    SeedLengthTooLong,
-    #[error("failed to deserialize ciphertext")]
-    CiphertextDeserialization,
-    #[error("failed to deserialize public key")]
-    PubkeyDeserialization,
-    #[error("failed to deserialize keypair")]
-    KeypairDeserialization,
-    #[error("failed to deserialize secret key")]
-    SecretKeyDeserialization,
-}

--- a/curves/curve25519/src/scalar.rs
+++ b/curves/curve25519/src/scalar.rs
@@ -6,11 +6,7 @@ pub struct PodScalar(pub [u8; 32]);
 
 #[cfg(not(target_os = "solana"))]
 mod target_arch {
-    use {
-        super::*,
-        crate::errors::{Curve25519Error, ElGamalError},
-        curve25519_dalek::scalar::Scalar,
-    };
+    use {super::*, crate::errors::Curve25519Error, curve25519_dalek::scalar::Scalar};
 
     impl From<&Scalar> for PodScalar {
         fn from(scalar: &Scalar) -> Self {
@@ -33,10 +29,10 @@ mod target_arch {
     }
 
     impl TryFrom<PodScalar> for Scalar {
-        type Error = ElGamalError;
+        type Error = Curve25519Error;
 
         fn try_from(pod: PodScalar) -> Result<Self, Self::Error> {
-            Scalar::from_canonical_bytes(pod.0).ok_or(ElGamalError::CiphertextDeserialization)
+            Scalar::from_canonical_bytes(pod.0).ok_or(Curve25519Error::PodConversion)
         }
     }
 }

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -21,6 +21,7 @@ use {
                 Pedersen, PedersenCommitment, PedersenOpening, G, H, PEDERSEN_COMMITMENT_LEN,
             },
         },
+        errors::ElGamalError,
         RISTRETTO_POINT_LEN, SCALAR_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
@@ -31,7 +32,6 @@ use {
         traits::Identity,
     },
     serde::{Deserialize, Serialize},
-    solana_curve25519::errors::ElGamalError,
     solana_sdk::{
         derivation_path::DerivationPath,
         signature::Signature,

--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -3,9 +3,26 @@
 use crate::range_proof::errors::RangeProofGenerationError;
 use {
     crate::{range_proof::errors::RangeProofVerificationError, sigma_proofs::errors::*},
-    solana_curve25519::errors::ElGamalError,
     thiserror::Error,
 };
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum ElGamalError {
+    #[error("key derivation method not supported")]
+    DerivationMethodNotSupported,
+    #[error("seed length too short for derivation")]
+    SeedLengthTooShort,
+    #[error("seed length too long for derivation")]
+    SeedLengthTooLong,
+    #[error("failed to deserialize ciphertext")]
+    CiphertextDeserialization,
+    #[error("failed to deserialize public key")]
+    PubkeyDeserialization,
+    #[error("failed to deserialize keypair")]
+    KeypairDeserialization,
+    #[error("failed to deserialize secret key")]
+    SecretKeyDeserialization,
+}
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum AuthenticatedEncryptionError {

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -2,9 +2,11 @@
 
 #[cfg(not(target_os = "solana"))]
 use {
-    crate::encryption::elgamal::{self as decoded},
+    crate::{
+        encryption::elgamal::{self as decoded},
+        errors::ElGamalError,
+    },
     curve25519_dalek::ristretto::CompressedRistretto,
-    solana_curve25519::errors::ElGamalError,
 };
 use {
     crate::{

--- a/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
@@ -3,12 +3,14 @@
 #[cfg(not(target_os = "solana"))]
 use crate::encryption::grouped_elgamal::GroupedElGamalCiphertext;
 use {
-    crate::zk_token_elgamal::pod::{
-        elgamal::{ElGamalCiphertext, DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN},
-        pedersen::{PedersenCommitment, PEDERSEN_COMMITMENT_LEN},
-        Pod, Zeroable,
+    crate::{
+        errors::ElGamalError,
+        zk_token_elgamal::pod::{
+            elgamal::{ElGamalCiphertext, DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN},
+            pedersen::{PedersenCommitment, PEDERSEN_COMMITMENT_LEN},
+            Pod, Zeroable,
+        },
     },
-    solana_curve25519::errors::ElGamalError,
     std::fmt,
 };
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -3,7 +3,7 @@ use crate::zk_token_elgamal::pod::{
     Zeroable,
 };
 #[cfg(not(target_os = "solana"))]
-use {crate::instruction::transfer as decoded, solana_curve25519::errors::ElGamalError};
+use crate::{errors::ElGamalError, instruction::transfer as decoded};
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]

--- a/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
@@ -2,8 +2,8 @@
 
 #[cfg(not(target_os = "solana"))]
 use {
-    crate::encryption::pedersen as decoded, curve25519_dalek::ristretto::CompressedRistretto,
-    solana_curve25519::errors::ElGamalError,
+    crate::{encryption::pedersen as decoded, errors::ElGamalError},
+    curve25519_dalek::ristretto::CompressedRistretto,
 };
 use {
     crate::{


### PR DESCRIPTION
#### Problem
The `ElGamalError` that should be part of the zk-token-sdk has been moved to the `curve25519` crate with https://github.com/anza-xyz/agave/pull/951.

#### Summary of Changes
Remove `ElGamalError `from the curve25519 crate and add it back to `zk-token-sdk`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
