### PR TITLE
Round up correctly when truncating max ancient storages

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -203,7 +203,7 @@ impl AncientSlotInfos {
         for (i, info) in self.all_infos.iter().enumerate() {
             cumulative_bytes += info.alive_bytes;
             let ancient_storages_required =
-                (cumulative_bytes.0 / tuning.ideal_storage_size + 1) as usize;
+                div_ceil(cumulative_bytes.0, tuning.ideal_storage_size) as usize;
             let storages_remaining = total_storages - i - 1;
 
             // if the remaining uncombined storages and the # of resulting
@@ -1087,6 +1087,25 @@ pub fn is_ancient(storage: &AccountsFile) -> bool {
     storage.capacity() >= get_ancient_append_vec_capacity()
 }
 
+/// Divides `x` by `y` and rounds up
+///
+/// # Notes
+///
+/// It is undefined behavior if `x + y` overflows a u64.
+/// Debug builds check this invariant, and will panic if broken.
+fn div_ceil(x: u64, y: NonZeroU64) -> u64 {
+    let y = y.get();
+    debug_assert!(
+        x.checked_add(y).is_some(),
+        "x + y must not overflow! x: {x}, y: {y}",
+    );
+    // SAFETY: The caller guaranteed `x + y` does not overflow
+    // SAFETY: Since `y` is NonZero:
+    // - we know the denominator is > 0, and thus safe (cannot have divide-by-zero)
+    // - we know `x + y` is non-zero, and thus the numerator is safe (cannot underflow)
+    (x + y - 1) / y
+}
+
 #[cfg(test)]
 pub mod tests {
     use {
@@ -1106,7 +1125,10 @@ pub mod tests {
             },
             accounts_hash::AccountHash,
             accounts_index::UpsertReclaim,
-            append_vec::{aligned_stored_size, AppendVec, AppendVecStoredAccountMeta},
+            append_vec::{
+                aligned_stored_size, AppendVec, AppendVecStoredAccountMeta,
+                MAXIMUM_APPEND_VEC_FILE_SIZE,
+            },
             storable_accounts::{tests::build_accounts_from_storage, StorableAccountsBySlot},
         },
         rand::seq::SliceRandom as _,
@@ -1118,6 +1140,7 @@ pub mod tests {
         std::{collections::HashSet, ops::Range},
         strum::IntoEnumIterator,
         strum_macros::EnumIter,
+        test_case::test_case,
     };
 
     fn get_sample_storages(
@@ -2853,7 +2876,7 @@ pub mod tests {
             .collect();
         assert_eq!(
             infos.all_infos.len() as u64,
-            tuning.max_resulting_storages.get() - 1,
+            tuning.max_resulting_storages.get(),
         );
         assert!(high_slots
             .iter()
@@ -3785,5 +3808,30 @@ pub mod tests {
             // should have removed all of them
             assert!(expected_ref_counts.is_empty());
         }
+    }
+
+    #[test_case(0, 1 => 0)]
+    #[test_case(1, 1 => 1)]
+    #[test_case(2, 1 => 2)]
+    #[test_case(2, 2 => 1)]
+    #[test_case(2, 3 => 1)]
+    #[test_case(2, 4 => 1)]
+    #[test_case(3, 4 => 1)]
+    #[test_case(4, 4 => 1)]
+    #[test_case(5, 4 => 2)]
+    #[test_case(0, u64::MAX => 0)]
+    #[test_case(MAXIMUM_APPEND_VEC_FILE_SIZE - 1, MAXIMUM_APPEND_VEC_FILE_SIZE => 1)]
+    #[test_case(MAXIMUM_APPEND_VEC_FILE_SIZE + 1, MAXIMUM_APPEND_VEC_FILE_SIZE => 2)]
+    fn test_div_ceil(x: u64, y: u64) -> u64 {
+        div_ceil(x, NonZeroU64::new(y).unwrap())
+    }
+
+    #[should_panic(expected = "x + y must not overflow")]
+    #[test_case(1, u64::MAX)]
+    #[test_case(u64::MAX, 1)]
+    #[test_case(u64::MAX/2 + 2, u64::MAX/2)]
+    #[test_case(u64::MAX/2,     u64::MAX/2 + 2)]
+    fn test_div_ceil_overflow(x: u64, y: u64) {
+        div_ceil(x, NonZeroU64::new(y).unwrap());
     }
 }


### PR DESCRIPTION
#### Problem

When truncating the ancient storages to the max, the number of required storages is computed like this:
```
let ancient_storages_required = (cumulative_bytes.0 / tuning.ideal_storage_size + 1) as usize;
```

In the tests, the tuning's ideal storage size is 1 , and each storage in all_infos has a size of 1 too.

So when iterating all_infos, the first info computes
```
ancient storages required = cumulative bytes / ideal size + 1
                          = 1 / 1 + 1
                          = 1 + 1
                          = 2
```

This likely only happens in tests where the cumulative bytes is exactly the same as the ideal storage size. I understand that this + 1 is meant to be an integer ceiling/round up function.

And here's debug output from running the `test_filter_by_smallest_capacity_high_slot_less` test from PR #1730:
```
tuning: PackedAncientStorageTuning { percent_of_alive_shrunk_data: 0, max_ancient_slots: 0, ideal_storage_size: 1, can_randomly_shrink: false, max_resulting_storages: 10 }
added 0, ancient storages required: 2, storages remaining: 24, cumulative bytes: 1 // <-- Problem! We should only need 1 storage here.
added 1, ancient storages required: 3, storages remaining: 23, cumulative bytes: 2
added 2, ancient storages required: 4, storages remaining: 22, cumulative bytes: 3
added 3, ancient storages required: 5, storages remaining: 21, cumulative bytes: 4
added 4, ancient storages required: 6, storages remaining: 20, cumulative bytes: 5
added 5, ancient storages required: 7, storages remaining: 19, cumulative bytes: 6
added 6, ancient storages required: 8, storages remaining: 18, cumulative bytes: 7
added 7, ancient storages required: 9, storages remaining: 17, cumulative bytes: 8
added 8, ancient storages required: 10, storages remaining: 16, cumulative bytes: 9
added 9, ancient storages required: 11, storages remaining: 15, cumulative bytes: 10
DONE! truncating at 9
final storages: (len: 9) [20, 22, 23, 24, 21, 19, 1, 15, 5]
```

We end up with 9 storages, not 10. Because the first iteration says that there are 2 storages required


#### Summary of Changes

Round up correctly.
