### PR TITLE
program: move itertools to dev-dependencies

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5291,7 +5291,6 @@ dependencies = [
  "console_log",
  "curve25519-dalek",
  "getrandom 0.2.10",
- "itertools 0.12.1",
  "js-sys",
  "lazy_static",
  "libsecp256k1 0.6.0",

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -19,7 +19,6 @@ borsh0-10 = { package = "borsh", version = "0.10.3", optional = true }
 bs58 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true, features = ["derive"] }
-itertools =  { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 memoffset = { workspace = true }
@@ -53,7 +52,6 @@ ark-serialize = { workspace = true }
 base64 = { workspace = true, features = ["alloc", "std"] }
 bitflags = { workspace = true }
 curve25519-dalek = { workspace = true }
-itertools = { workspace = true }
 libsecp256k1 = { workspace = true }
 num-bigint = { workspace = true }
 rand = { workspace = true }
@@ -77,6 +75,7 @@ parking_lot = { workspace = true }
 anyhow = { workspace = true }
 array-bytes = { workspace = true }
 assert_matches = { workspace = true }
+itertools = { workspace = true }
 serde_json = { workspace = true }
 static_assertions = { workspace = true }
 

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -8,10 +8,7 @@ use {
         program_error::UNSUPPORTED_SYSVAR, pubkey::Pubkey,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
-    std::{
-        fmt::Write,
-        sync::{Arc, RwLock},
-    },
+    std::sync::{Arc, RwLock},
 };
 
 lazy_static::lazy_static! {
@@ -22,29 +19,6 @@ lazy_static::lazy_static! {
 // to swap in alternatives
 pub fn set_syscall_stubs(syscall_stubs: Box<dyn SyscallStubs>) -> Box<dyn SyscallStubs> {
     std::mem::replace(&mut SYSCALL_STUBS.write().unwrap(), syscall_stubs)
-}
-
-// ported from itertools because we don't need anything else
-// from itertools.
-fn join<I>(itr: &mut I, sep: &str) -> String
-where
-    I: Iterator,
-    I::Item: std::fmt::Display,
-{
-    match itr.next() {
-        None => String::new(),
-        Some(first_elt) => {
-            // estimate lower bound of capacity needed
-            let (lower, _) = itr.size_hint();
-            let mut result = String::with_capacity(sep.len() * lower);
-            write!(&mut result, "{}", first_elt).unwrap();
-            itr.for_each(|elt| {
-                result.push_str(sep);
-                write!(&mut result, "{}", elt).unwrap();
-            });
-            result
-        }
-    }
 }
 
 #[allow(clippy::arithmetic_side_effects)]
@@ -139,7 +113,11 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_log_data(&self, fields: &[&[u8]]) {
         println!(
             "data: {}",
-            fields.iter().map(|v| BASE64_STANDARD.encode(v)).collect::<Vec<_>>().join(" ")
+            fields
+                .iter()
+                .map(|v| BASE64_STANDARD.encode(v))
+                .collect::<Vec<_>>()
+                .join(" ")
         );
     }
     fn sol_get_processed_sibling_instruction(&self, _index: usize) -> Option<Instruction> {

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -24,6 +24,8 @@ pub fn set_syscall_stubs(syscall_stubs: Box<dyn SyscallStubs>) -> Box<dyn Syscal
     std::mem::replace(&mut SYSCALL_STUBS.write().unwrap(), syscall_stubs)
 }
 
+// ported from itertools because we don't need anything else
+// from itertools.
 fn join<I>(itr: &mut I, sep: &str) -> String
 where
     I: Iterator,

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -139,7 +139,7 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_log_data(&self, fields: &[&[u8]]) {
         println!(
             "data: {}",
-            join(&mut fields.iter().map(|v| BASE64_STANDARD.encode(v)), " ")
+            fields.iter().map(|v| BASE64_STANDARD.encode(v)).collect::<Vec<_>>().join(" ")
         );
     }
     fn sol_get_processed_sibling_instruction(&self, _index: usize) -> Option<Instruction> {


### PR DESCRIPTION
#### Problem
solana-program only uses itertools for the `.join` method which is just a few lines of code. Itertools is a not a cheap dependency.

#### Summary of Changes
- ~Port `.join` from itertools and use it in program_stubs.rs~ Replace itertools `.join` in program_stubs.rs with one-liner that does the same thing
- Move itertools to dev-dependencies


