### PR TITLE
SVM: Reduce public visibility of sysvar_cache

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6821,10 +6821,8 @@ impl Bank {
 
     pub fn is_in_slot_hashes_history(&self, slot: &Slot) -> bool {
         if slot < &self.slot {
-            if let Ok(sysvar_cache) = self.transaction_processor.sysvar_cache.read() {
-                if let Ok(slot_hashes) = sysvar_cache.get_slot_hashes() {
-                    return slot_hashes.get(slot).is_some();
-                }
+            if let Ok(slot_hashes) = self.transaction_processor.sysvar_cache().get_slot_hashes() {
+                return slot_hashes.get(slot).is_some();
             }
         }
         false

--- a/runtime/src/bank/address_lookup_table.rs
+++ b/runtime/src/bank/address_lookup_table.rs
@@ -28,9 +28,7 @@ impl AddressLoader for &Bank {
     ) -> Result<LoadedAddresses, AddressLoaderError> {
         let slot_hashes = self
             .transaction_processor
-            .sysvar_cache
-            .read()
-            .unwrap()
+            .sysvar_cache()
             .get_slot_hashes()
             .map_err(|_| AddressLoaderError::SlotHashesSysvarNotFound)?;
 

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -18,7 +18,7 @@ mod tests {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
 
-        let bank0_sysvar_cache = bank0.transaction_processor.sysvar_cache.read().unwrap();
+        let bank0_sysvar_cache = bank0.transaction_processor.sysvar_cache();
         let bank0_cached_clock = bank0_sysvar_cache.get_clock();
         let bank0_cached_epoch_schedule = bank0_sysvar_cache.get_epoch_schedule();
         let bank0_cached_fees = bank0_sysvar_cache.get_fees();
@@ -38,7 +38,7 @@ mod tests {
             bank1_slot,
         ));
 
-        let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache.read().unwrap();
+        let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache();
         let bank1_cached_clock = bank1_sysvar_cache.get_clock();
         let bank1_cached_epoch_schedule = bank1_sysvar_cache.get_epoch_schedule();
         let bank1_cached_fees = bank1_sysvar_cache.get_fees();
@@ -59,7 +59,7 @@ mod tests {
         let bank2_slot = bank1.slot() + 1;
         let bank2 = Bank::new_from_parent(bank1.clone(), &Pubkey::default(), bank2_slot);
 
-        let bank2_sysvar_cache = bank2.transaction_processor.sysvar_cache.read().unwrap();
+        let bank2_sysvar_cache = bank2.transaction_processor.sysvar_cache();
         let bank2_cached_clock = bank2_sysvar_cache.get_clock();
         let bank2_cached_epoch_schedule = bank2_sysvar_cache.get_epoch_schedule();
         let bank2_cached_fees = bank2_sysvar_cache.get_fees();
@@ -90,7 +90,7 @@ mod tests {
         let bank1_slot = bank0.slot() + 1;
         let mut bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), bank1_slot);
 
-        let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache.read().unwrap();
+        let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache();
         let bank1_cached_clock = bank1_sysvar_cache.get_clock();
         let bank1_cached_epoch_schedule = bank1_sysvar_cache.get_epoch_schedule();
         let bank1_cached_fees = bank1_sysvar_cache.get_fees();
@@ -108,7 +108,7 @@ mod tests {
         drop(bank1_sysvar_cache);
         bank1.transaction_processor.reset_sysvar_cache();
 
-        let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache.read().unwrap();
+        let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache();
         assert!(bank1_sysvar_cache.get_clock().is_err());
         assert!(bank1_sysvar_cache.get_epoch_schedule().is_err());
         assert!(bank1_sysvar_cache.get_fees().is_err());
@@ -143,7 +143,7 @@ mod tests {
             .transaction_processor
             .fill_missing_sysvar_cache_entries(&bank1);
 
-        let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache.read().unwrap();
+        let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache();
         assert_eq!(bank1_sysvar_cache.get_clock(), bank1_cached_clock);
         assert_eq!(
             bank1_sysvar_cache.get_epoch_schedule(),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -60,6 +60,7 @@ use {
         collections::{hash_map::Entry, HashMap, HashSet},
         fmt::{Debug, Formatter},
         rc::Rc,
+        sync::RwLockReadGuard,
     },
 };
 
@@ -147,7 +148,7 @@ pub struct TransactionBatchProcessor<FG: ForkGraph> {
     /// SysvarCache is a collection of system variables that are
     /// accessible from on chain programs. It is passed to SVM from
     /// client code (e.g. Bank) and forwarded to the MessageProcessor.
-    pub sysvar_cache: RwLock<SysvarCache>,
+    sysvar_cache: RwLock<SysvarCache>,
 
     /// Programs required for transaction batch processing
     pub program_cache: Arc<RwLock<ProgramCache<FG>>>,
@@ -211,6 +212,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .try_read()
             .ok()
             .map(|cache| cache.get_environments_for_epoch(epoch))
+    }
+
+    pub fn sysvar_cache(&self) -> RwLockReadGuard<SysvarCache> {
+        self.sysvar_cache.read().unwrap()
     }
 
     /// Main entrypoint to the SVM.

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -265,9 +265,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
 
     #[allow(deprecated)]
     let (blockhash, lamports_per_signature) = batch_processor
-        .sysvar_cache
-        .read()
-        .unwrap()
+        .sysvar_cache()
         .get_recent_blockhashes()
         .ok()
         .and_then(|x| (*x).last().cloned())
@@ -400,7 +398,7 @@ fn execute_fixture_as_instr(
     filename: OsString,
     cu_avail: u64,
 ) {
-    let rent = if let Ok(rent) = batch_processor.sysvar_cache.read().unwrap().get_rent() {
+    let rent = if let Ok(rent) = batch_processor.sysvar_cache().get_rent() {
         (*rent).clone()
     } else {
         Rent::default()
@@ -455,7 +453,7 @@ fn execute_fixture_as_instr(
 
     let log_collector = LogCollector::new_ref();
 
-    let sysvar_cache = &batch_processor.sysvar_cache.read().unwrap();
+    let sysvar_cache = &batch_processor.sysvar_cache();
     let env_config = EnvironmentConfig::new(
         Hash::default(),
         None,


### PR DESCRIPTION
#### Problem
SVM is exposing writable instance of sysvar_cache. No other part of the system is writing to the cache directly. The visiblity can be reduced to a readonly instance.

#### Summary of Changes
- New function to return a readonly instance of sysvar cache
- Update callsites to use this new function instead of directly accessing the field.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
