### PR TITLE
ci: ignore curve25519-dalek audit temporarily

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -30,6 +30,9 @@ cargo_audit_ignores=(
   --ignore RUSTSEC-2023-0001
 
   --ignore RUSTSEC-2022-0093
+
+  # curve25519-dalek
+  --ignore RUSTSEC-2024-0344
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem

audit failed
![Screenshot 2024-06-19 at 11 12 26](https://github.com/anza-xyz/agave/assets/8209234/49b98819-5564-43c5-8da4-3258c813d1d7)

I had a PR for this one weeks ago, but it's still stuck in the SPL downstream project test. I will prioritize this one. Ignore this audit to unblock CI.
 
https://github.com/anza-xyz/agave/pull/1693


#### Summary of Changes

ignore the audit temporarily