### PR TITLE
test: don't reimplement on-curve logic in test_pubkey_off_curve

### DIFF
--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -947,12 +947,7 @@ mod tests {
             if let Ok(program_address) =
                 Pubkey::create_program_address(&[&bytes1, &bytes2], &program_id)
             {
-                let is_on_curve = curve25519_dalek::edwards::CompressedEdwardsY::from_slice(
-                    &program_address.to_bytes(),
-                )
-                .decompress()
-                .is_some();
-                assert!(!is_on_curve);
+                assert!(!program_address.is_on_curve());
                 assert!(!addresses.contains(&program_address));
                 addresses.push(program_address);
             }


### PR DESCRIPTION
#### Problem

I found we reimplement the on-curve logic again in the `test_pubkey_off_curve`. we can call the func directly!

https://github.com/anza-xyz/agave/blob/a6bc917f36d80221862e6731fe7dbd261c728be2/sdk/program/src/pubkey.rs#L642-L644

https://github.com/anza-xyz/agave/blob/a6bc917f36d80221862e6731fe7dbd261c728be2/sdk/program/src/pubkey.rs#L171-L180


#### Summary of Changes

fix it!
