### PR TITLE
Make futures crate optional in solana-type-overrides

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6444,7 +6444,6 @@ dependencies = [
 name = "solana-type-overrides"
 version = "2.0.0"
 dependencies = [
- "futures 0.3.30",
  "lazy_static",
  "rand 0.8.5",
 ]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -53,14 +53,13 @@ use {
         transaction::{self, SanitizedTransaction, TransactionError},
         transaction_context::{ExecutionRecord, TransactionContext},
     },
-    solana_type_overrides::sync::{atomic::Ordering, Arc, RwLock},
+    solana_type_overrides::sync::{atomic::Ordering, Arc, RwLock, RwLockReadGuard},
     solana_vote::vote_account::VoteAccountsHashMap,
     std::{
         cell::RefCell,
         collections::{hash_map::Entry, HashMap, HashSet},
         fmt::{Debug, Formatter},
         rc::Rc,
-        sync::RwLockReadGuard,
     },
 };
 

--- a/type-overrides/Cargo.toml
+++ b/type-overrides/Cargo.toml
@@ -9,10 +9,11 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-futures = { workspace = true }
+futures = { workspace = true, optional = true }
 lazy_static = { workspace = true }
 rand = { workspace = true }
 shuttle = { workspace = true, optional = true }
 
 [features]
 shuttle-test = ["dep:shuttle"]
+executor = ["dep:futures"]

--- a/type-overrides/src/lib.rs
+++ b/type-overrides/src/lib.rs
@@ -6,6 +6,8 @@
 ///
 /// Instead of importing from std, rand, and so on, import the following from solana-type-override,
 /// and include the 'shuttle-test' feature in your crate to use shuttle.
+
+#[cfg(feature = "executor")]
 pub mod executor {
     #[cfg(not(feature = "shuttle-test"))]
     pub use futures::executor::*;


### PR DESCRIPTION
#### Problem

As described in #1775, solana-type-overrides introduced an unused dependency in multiple crates.

#### Summary of Changes

1. I made the futures crate optional and only accessible with a cfg flag.
2. Fixed an import in the SVM crate.

Fixes #1775.
