### PR TITLE
deps: Use bytemuck_derive explicitly instead of "derive" feature on bytemuck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5482,6 +5482,7 @@ dependencies = [
  "blake3",
  "bv",
  "bytemuck",
+ "bytemuck_derive",
  "bzip2",
  "criterion",
  "crossbeam-channel",
@@ -5744,6 +5745,7 @@ version = "2.0.0"
 dependencies = [
  "bv",
  "bytemuck",
+ "bytemuck_derive",
  "fs_extra",
  "log",
  "memmap2",
@@ -6171,6 +6173,7 @@ name = "solana-curve25519"
 version = "2.0.0"
 dependencies = [
  "bytemuck",
+ "bytemuck_derive",
  "curve25519-dalek",
  "solana-program",
  "thiserror",
@@ -7898,6 +7901,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bytemuck",
+ "bytemuck_derive",
  "curve25519-dalek",
  "itertools 0.12.1",
  "lazy_static",
@@ -7951,6 +7955,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bytemuck",
+ "bytemuck_derive",
  "byteorder",
  "curve25519-dalek",
  "itertools 0.12.1",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -14,6 +14,7 @@ bincode = { workspace = true }
 blake3 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true }
+bytemuck_derive = { workspace = true }
 bzip2 = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api"] }

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -5,7 +5,7 @@ use {
         ancestors::Ancestors,
         pubkey_bins::PubkeyBinCalculator24,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
     log::*,
     memmap2::MmapMut,
     rayon::prelude::*,

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -3,7 +3,7 @@
 use crate::pubkey_bins::PubkeyBinCalculator24;
 use {
     crate::{accounts_hash::CalculateHashIntermediate, cache_hash_data_stats::CacheHashDataStats},
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
     memmap2::MmapMut,
     solana_measure::measure::Measure,
     solana_sdk::clock::Slot,

--- a/accounts-db/src/tiered_storage/file.rs
+++ b/accounts-db/src/tiered_storage/file.rs
@@ -1,6 +1,6 @@
 use {
     super::{error::TieredStorageError, TieredStorageResult},
-    bytemuck::{AnyBitPattern, NoUninit, Pod, Zeroable},
+    bytemuck::{AnyBitPattern, NoUninit, Zeroable},
     std::{
         fs::{File, OpenOptions},
         io::{BufWriter, Read, Result as IoResult, Seek, SeekFrom, Write},
@@ -13,7 +13,7 @@ use {
 /// The ending 8 bytes of a valid tiered account storage file.
 pub const FILE_MAGIC_NUMBER: u64 = u64::from_le_bytes(*b"AnzaTech");
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Pod, Zeroable)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(C)]
 pub struct TieredStorageMagicNumber(pub u64);
 

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -19,7 +19,7 @@ use {
             StorableAccounts, TieredStorageError, TieredStorageFormat, TieredStorageResult,
         },
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
     memmap2::{Mmap, MmapOptions},
     modular_bitfield::prelude::*,
     solana_sdk::{

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -24,7 +24,7 @@ pub trait AccountOffset: Clone + Copy + Pod + Zeroable {}
 /// This can be used to obtain the AccountOffset and address by looking through
 /// the accounts index block.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 pub struct IndexOffset(pub u32);
 
 // Ensure there are no implicit padding bytes

--- a/accounts-db/src/tiered_storage/meta.rs
+++ b/accounts-db/src/tiered_storage/meta.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::tiered_storage::owners::OwnerOffset,
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
     modular_bitfield::prelude::*,
     solana_sdk::{pubkey::Pubkey, stake_history::Epoch},
 };

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -12,7 +12,8 @@ edition = { workspace = true }
 
 [dependencies]
 bv = { workspace = true, features = ["serde"] }
-bytemuck = { workspace = true, features = ["derive"] }
+bytemuck = { workspace = true }
+bytemuck_derive = { workspace = true }
 log = { workspace = true }
 memmap2 = { workspace = true }
 modular-bitfield = { workspace = true }

--- a/bucket_map/src/restart.rs
+++ b/bucket_map/src/restart.rs
@@ -1,7 +1,7 @@
 //! Persistent info of disk index files to allow files to be reused on restart.
 use {
     crate::bucket_map::{BucketMapConfig, MAX_SEARCH_DEFAULT},
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
     memmap2::MmapMut,
     std::{
         collections::HashMap,

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -10,7 +10,8 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-bytemuck = { workspace = true, features = ["derive"] }
+bytemuck = { workspace = true }
+bytemuck_derive = { workspace = true }
 solana-program = { workspace = true }
 thiserror = { workspace = true }
 

--- a/curves/curve25519/src/edwards.rs
+++ b/curves/curve25519/src/edwards.rs
@@ -1,4 +1,4 @@
-use bytemuck::{Pod, Zeroable};
+use bytemuck_derive::{Pod, Zeroable};
 pub use target_arch::*;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]

--- a/curves/curve25519/src/edwards.rs
+++ b/curves/curve25519/src/edwards.rs
@@ -138,6 +138,7 @@ mod target_arch {
             curve_syscall_traits::{ADD, CURVE25519_EDWARDS, MUL, SUB},
             scalar::PodScalar,
         },
+        bytemuck::Zeroable,
     };
 
     pub fn validate_edwards(point: &PodEdwardsPoint) -> bool {

--- a/curves/curve25519/src/ristretto.rs
+++ b/curves/curve25519/src/ristretto.rs
@@ -139,6 +139,7 @@ mod target_arch {
             curve_syscall_traits::{ADD, CURVE25519_RISTRETTO, MUL, SUB},
             scalar::PodScalar,
         },
+        bytemuck::Zeroable,
     };
 
     pub fn validate_ristretto(point: &PodRistrettoPoint) -> bool {

--- a/curves/curve25519/src/ristretto.rs
+++ b/curves/curve25519/src/ristretto.rs
@@ -1,4 +1,4 @@
-use bytemuck::{Pod, Zeroable};
+use bytemuck_derive::{Pod, Zeroable};
 pub use target_arch::*;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]

--- a/curves/curve25519/src/scalar.rs
+++ b/curves/curve25519/src/scalar.rs
@@ -1,4 +1,4 @@
-pub use bytemuck::{Pod, Zeroable};
+pub use bytemuck_derive::{Pod, Zeroable};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
 #[repr(transparent)]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4549,6 +4549,7 @@ dependencies = [
  "blake3",
  "bv",
  "bytemuck",
+ "bytemuck_derive",
  "bzip2",
  "crossbeam-channel",
  "dashmap",
@@ -4683,6 +4684,7 @@ version = "2.0.0"
 dependencies = [
  "bv",
  "bytemuck",
+ "bytemuck_derive",
  "log",
  "memmap2",
  "modular-bitfield",
@@ -4926,6 +4928,7 @@ name = "solana-curve25519"
 version = "2.0.0"
 dependencies = [
  "bytemuck",
+ "bytemuck_derive",
  "curve25519-dalek",
  "solana-program",
  "thiserror",
@@ -6577,6 +6580,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bytemuck",
+ "bytemuck_derive",
  "curve25519-dalek",
  "itertools 0.12.1",
  "lazy_static",
@@ -6615,6 +6619,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bytemuck",
+ "bytemuck_derive",
  "byteorder 1.5.0",
  "curve25519-dalek",
  "itertools 0.12.1",

--- a/programs/zk-elgamal-proof/Cargo.toml
+++ b/programs/zk-elgamal-proof/Cargo.toml
@@ -9,7 +9,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-bytemuck = { workspace = true, features = ["derive"] }
+bytemuck = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 solana-program-runtime = { workspace = true }

--- a/programs/zk-token-proof-tests/Cargo.toml
+++ b/programs/zk-token-proof-tests/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dev-dependencies]
-bytemuck = { workspace = true, features = ["derive"] }
+bytemuck = { workspace = true }
 curve25519-dalek = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-program-test = { workspace = true }

--- a/programs/zk-token-proof/Cargo.toml
+++ b/programs/zk-token-proof/Cargo.toml
@@ -9,7 +9,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-bytemuck = { workspace = true, features = ["derive"] }
+bytemuck = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 solana-program-runtime = { workspace = true }

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -11,7 +11,8 @@ edition = { workspace = true }
 
 [dependencies]
 base64 = { workspace = true }
-bytemuck = { workspace = true, features = ["derive"] }
+bytemuck = { workspace = true }
+bytemuck_derive = { workspace = true }
 merlin = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }

--- a/zk-sdk/src/encryption/pod/elgamal.rs
+++ b/zk-sdk/src/encryption/pod/elgamal.rs
@@ -5,7 +5,7 @@ use {
         pod::impl_from_str, DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN, ELGAMAL_PUBKEY_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
-    bytemuck::{Pod, Zeroable},
+    bytemuck::Zeroable,
     std::fmt,
 };
 #[cfg(not(target_os = "solana"))]
@@ -24,7 +24,7 @@ const ELGAMAL_PUBKEY_MAX_BASE64_LEN: usize = 44;
 const ELGAMAL_CIPHERTEXT_MAX_BASE64_LEN: usize = 88;
 
 /// The `ElGamalCiphertext` type as a `Pod`.
-#[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct PodElGamalCiphertext(pub(crate) [u8; ELGAMAL_CIPHERTEXT_LEN]);
 
@@ -69,7 +69,7 @@ impl TryFrom<PodElGamalCiphertext> for ElGamalCiphertext {
 }
 
 /// The `ElGamalPubkey` type as a `Pod`.
-#[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, bytemuck_derive::Pod, bytemuck_derive::Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct PodElGamalPubkey(pub(crate) [u8; ELGAMAL_PUBKEY_LEN]);
 
@@ -108,7 +108,7 @@ impl TryFrom<PodElGamalPubkey> for ElGamalPubkey {
 }
 
 /// The `DecryptHandle` type as a `Pod`.
-#[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, bytemuck_derive::Pod, bytemuck_derive::Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct PodDecryptHandle(pub(crate) [u8; DECRYPT_HANDLE_LEN]);
 

--- a/zk-sdk/src/encryption/pod/grouped_elgamal.rs
+++ b/zk-sdk/src/encryption/pod/grouped_elgamal.rs
@@ -10,7 +10,7 @@ use {
         },
         errors::ElGamalError,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck::Zeroable,
     std::fmt,
 };
 
@@ -61,7 +61,7 @@ const GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES: usize =
     PEDERSEN_COMMITMENT_LEN + DECRYPT_HANDLE_LEN + DECRYPT_HANDLE_LEN + DECRYPT_HANDLE_LEN;
 
 /// The `GroupedElGamalCiphertext` type with two decryption handles as a `Pod`
-#[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct PodGroupedElGamalCiphertext2Handles(
     pub(crate) [u8; GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES],
@@ -97,7 +97,7 @@ impl TryFrom<PodGroupedElGamalCiphertext2Handles> for GroupedElGamalCiphertext<2
 impl_extract!(TYPE = PodGroupedElGamalCiphertext2Handles);
 
 /// The `GroupedElGamalCiphertext` type with three decryption handles as a `Pod`
-#[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct PodGroupedElGamalCiphertext3Handles(
     pub(crate) [u8; GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES],

--- a/zk-sdk/src/encryption/pod/pedersen.rs
+++ b/zk-sdk/src/encryption/pod/pedersen.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::encryption::PEDERSEN_COMMITMENT_LEN,
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
     std::fmt,
 };
 #[cfg(not(target_os = "solana"))]

--- a/zk-sdk/src/pod.rs
+++ b/zk-sdk/src/pod.rs
@@ -1,4 +1,4 @@
-use bytemuck::{Pod, Zeroable};
+use bytemuck_derive::{Pod, Zeroable};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
 #[repr(transparent)]

--- a/zk-sdk/src/sigma_proofs/pod.rs
+++ b/zk-sdk/src/sigma_proofs/pod.rs
@@ -192,7 +192,7 @@ impl TryFrom<PodZeroCiphertextProof> for ZeroCiphertextProof {
 }
 
 /// The `PercentageWithCapProof` type as a `Pod`.
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(transparent)]
 pub struct PodPercentageWithCapProof(pub(crate) [u8; PERCENTAGE_WITH_CAP_PROOF_LEN]);
 
@@ -213,7 +213,7 @@ impl TryFrom<PodPercentageWithCapProof> for PercentageWithCapProof {
 }
 
 /// The `PubkeyValidityProof` type as a `Pod`.
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(transparent)]
 pub struct PodPubkeyValidityProof(pub(crate) [u8; PUBKEY_VALIDITY_PROOF_LEN]);
 

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_grouped_ciphertext_validity/handles_2.rs
@@ -13,7 +13,7 @@ use {
         sigma_proofs::pod::PodBatchedGroupedCiphertext2HandlesValidityProof,
         zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 #[cfg(not(target_os = "solana"))]
 use {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_grouped_ciphertext_validity/handles_3.rs
@@ -13,7 +13,7 @@ use {
         sigma_proofs::pod::PodBatchedGroupedCiphertext3HandlesValidityProof,
         zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 #[cfg(not(target_os = "solana"))]
 use {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
@@ -19,7 +19,7 @@ use {
             batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData,
         },
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u256.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u256.rs
@@ -19,7 +19,7 @@ use {
             batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData,
         },
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u64.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u64.rs
@@ -19,7 +19,7 @@ use {
             batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData,
         },
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/mod.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/mod.rs
@@ -20,14 +20,14 @@ pub mod batched_range_proof_u128;
 pub mod batched_range_proof_u256;
 pub mod batched_range_proof_u64;
 
-use {crate::encryption::pod::pedersen::PodPedersenCommitment, bytemuck::Zeroable};
+use crate::encryption::pod::pedersen::PodPedersenCommitment;
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{
         encryption::pedersen::{PedersenCommitment, PedersenOpening},
         zk_elgamal_proof_program::errors::{ProofGenerationError, ProofVerificationError},
     },
-    bytemuck::bytes_of,
+    bytemuck::{bytes_of, Zeroable},
     curve25519_dalek::traits::IsIdentity,
     merlin::Transcript,
     std::convert::TryInto,

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/mod.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/mod.rs
@@ -20,10 +20,7 @@ pub mod batched_range_proof_u128;
 pub mod batched_range_proof_u256;
 pub mod batched_range_proof_u64;
 
-use {
-    crate::encryption::pod::pedersen::PodPedersenCommitment,
-    bytemuck::{Pod, Zeroable},
-};
+use {crate::encryption::pod::pedersen::PodPedersenCommitment, bytemuck::Zeroable};
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{
@@ -48,7 +45,7 @@ const MAX_SINGLE_BIT_LENGTH: usize = 128;
 /// The context data needed to verify a range-proof for a Pedersen committed value.
 ///
 /// The context data is shared by all `VerifyBatchedRangeProof{N}` instructions.
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(C)]
 pub struct BatchedRangeProofContext {
     pub commitments: [PodPedersenCommitment; MAX_COMMITMENTS],

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/ciphertext_ciphertext_equality.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/ciphertext_ciphertext_equality.rs
@@ -11,7 +11,7 @@ use {
         sigma_proofs::pod::PodCiphertextCiphertextEqualityProof,
         zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 #[cfg(not(target_os = "solana"))]
 use {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/ciphertext_commitment_equality.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/ciphertext_commitment_equality.rs
@@ -14,7 +14,7 @@ use {
         sigma_proofs::pod::PodCiphertextCommitmentEqualityProof,
         zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 #[cfg(not(target_os = "solana"))]
 use {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/grouped_ciphertext_validity/handles_2.rs
@@ -13,7 +13,7 @@ use {
         sigma_proofs::pod::PodGroupedCiphertext2HandlesValidityProof,
         zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 #[cfg(not(target_os = "solana"))]
 use {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/grouped_ciphertext_validity/handles_3.rs
@@ -13,7 +13,7 @@ use {
         sigma_proofs::pod::PodGroupedCiphertext3HandlesValidityProof,
         zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 #[cfg(not(target_os = "solana"))]
 use {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/percentage_with_cap.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/percentage_with_cap.rs
@@ -24,7 +24,7 @@ use {
         sigma_proofs::pod::PodPercentageWithCapProof,
         zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the `ProofInstruction::VerifyPercentageWithCap`

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/pod.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/pod.rs
@@ -1,6 +1,6 @@
 use {
     crate::zk_elgamal_proof_program::proof_data::{errors::ProofDataError, ProofType},
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
     num_traits::{FromPrimitive, ToPrimitive},
 };
 

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/pubkey_validity.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/pubkey_validity.rs
@@ -22,7 +22,7 @@ use {
         sigma_proofs::pod::PodPubkeyValidityProof,
         zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the `ProofInstruction::VerifyPubkeyValidity`

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/zero_ciphertext.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/zero_ciphertext.rs
@@ -21,7 +21,7 @@ use {
         sigma_proofs::pod::PodZeroCiphertextProof,
         zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the `ProofInstruction::ZeroCiphertext` instruction.

--- a/zk-sdk/src/zk_elgamal_proof_program/state.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/state.rs
@@ -53,7 +53,7 @@ impl<T: Pod> ProofContextState<T> {
 
 /// The `ProofContextState` without the proof context itself. This struct exists to facilitate the
 /// decoding of generic-independent fields in `ProofContextState`.
-#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, PartialEq, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(C)]
 pub struct ProofContextStateMeta {
     /// The proof context authority that can close the account

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -11,7 +11,8 @@ edition = { workspace = true }
 
 [dependencies]
 base64 = { workspace = true }
-bytemuck = { workspace = true, features = ["derive"] }
+bytemuck = { workspace = true }
+bytemuck_derive = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 solana-curve25519 = { workspace = true }

--- a/zk-token-sdk/src/instruction/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-token-sdk/src/instruction/batched_grouped_ciphertext_validity/handles_2.rs
@@ -30,7 +30,7 @@ use {
         instruction::{ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the

--- a/zk-token-sdk/src/instruction/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-token-sdk/src/instruction/batched_grouped_ciphertext_validity/handles_3.rs
@@ -29,7 +29,7 @@ use {
         instruction::{ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the

--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u128.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u128.rs
@@ -15,7 +15,7 @@ use {
         instruction::{batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the

--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u256.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u256.rs
@@ -15,7 +15,7 @@ use {
         instruction::{batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u64.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u64.rs
@@ -15,7 +15,7 @@ use {
         instruction::{batched_range_proof::BatchedRangeProofContext, ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the

--- a/zk-token-sdk/src/instruction/batched_range_proof/mod.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/mod.rs
@@ -20,14 +20,14 @@ pub mod batched_range_proof_u128;
 pub mod batched_range_proof_u256;
 pub mod batched_range_proof_u64;
 
-use {crate::zk_token_elgamal::pod, bytemuck::Zeroable};
+use crate::zk_token_elgamal::pod;
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{
         encryption::pedersen::{PedersenCommitment, PedersenOpening},
         errors::{ProofGenerationError, ProofVerificationError},
     },
-    bytemuck::bytes_of,
+    bytemuck::{bytes_of, Zeroable},
     curve25519_dalek::traits::IsIdentity,
     merlin::Transcript,
     std::convert::TryInto,

--- a/zk-token-sdk/src/instruction/batched_range_proof/mod.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/mod.rs
@@ -20,10 +20,7 @@ pub mod batched_range_proof_u128;
 pub mod batched_range_proof_u256;
 pub mod batched_range_proof_u64;
 
-use {
-    crate::zk_token_elgamal::pod,
-    bytemuck::{Pod, Zeroable},
-};
+use {crate::zk_token_elgamal::pod, bytemuck::Zeroable};
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{
@@ -48,7 +45,7 @@ const MAX_SINGLE_BIT_LENGTH: usize = 128;
 /// The context data needed to verify a range-proof for a Pedersen committed value.
 ///
 /// The context data is shared by all `VerifyBatchedRangeProof{N}` instructions.
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(C)]
 pub struct BatchedRangeProofContext {
     pub commitments: [pod::PedersenCommitment; MAX_COMMITMENTS],

--- a/zk-token-sdk/src/instruction/ciphertext_ciphertext_equality.rs
+++ b/zk-token-sdk/src/instruction/ciphertext_ciphertext_equality.rs
@@ -27,7 +27,7 @@ use {
         instruction::{ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the

--- a/zk-token-sdk/src/instruction/ciphertext_commitment_equality.rs
+++ b/zk-token-sdk/src/instruction/ciphertext_commitment_equality.rs
@@ -24,7 +24,7 @@ use {
         instruction::{ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 /// The instruction data that is needed for the
 /// `ProofInstruction::VerifyCiphertextCommitmentEquality` instruction.

--- a/zk-token-sdk/src/instruction/fee_sigma.rs
+++ b/zk-token-sdk/src/instruction/fee_sigma.rs
@@ -24,7 +24,7 @@ use {
         instruction::{ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the `ProofInstruction::VerifyFeeSigma` instruction.

--- a/zk-token-sdk/src/instruction/grouped_ciphertext_validity/handles_2.rs
+++ b/zk-token-sdk/src/instruction/grouped_ciphertext_validity/handles_2.rs
@@ -28,7 +28,7 @@ use {
         instruction::{ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the `ProofInstruction::VerifyGroupedCiphertextValidity`

--- a/zk-token-sdk/src/instruction/grouped_ciphertext_validity/handles_3.rs
+++ b/zk-token-sdk/src/instruction/grouped_ciphertext_validity/handles_3.rs
@@ -28,7 +28,7 @@ use {
         instruction::{ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the

--- a/zk-token-sdk/src/instruction/pubkey_validity.rs
+++ b/zk-token-sdk/src/instruction/pubkey_validity.rs
@@ -21,7 +21,7 @@ use {
         instruction::{ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the `ProofInstruction::VerifyPubkeyValidity`

--- a/zk-token-sdk/src/instruction/range_proof.rs
+++ b/zk-token-sdk/src/instruction/range_proof.rs
@@ -20,7 +20,7 @@ use {
         instruction::{ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The context data needed to verify a range-proof for a committed value in a Pedersen commitment.

--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -1,3 +1,7 @@
+use crate::{
+    instruction::{ProofType, ZkProofData},
+    zk_token_elgamal::pod,
+};
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{
@@ -28,13 +32,6 @@ use {
     merlin::Transcript,
     std::convert::TryInto,
     subtle::{ConditionallySelectable, ConstantTimeGreater},
-};
-use {
-    crate::{
-        instruction::{ProofType, ZkProofData},
-        zk_token_elgamal::pod,
-    },
-    bytemuck::{Pod, Zeroable},
 };
 
 #[cfg(not(target_os = "solana"))]
@@ -71,7 +68,7 @@ lazy_static::lazy_static! {
 ///
 /// It includes the cryptographic proof as well as the context data information needed to verify
 /// the proof.
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(C)]
 pub struct TransferWithFeeData {
     /// The context data for the transfer with fee proof
@@ -82,7 +79,7 @@ pub struct TransferWithFeeData {
 }
 
 /// The context data needed to verify a transfer-with-fee proof.
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(C)]
 pub struct TransferWithFeeProofContext {
     /// Group encryption of the low 16 bites of the transfer amount
@@ -108,7 +105,7 @@ pub struct TransferWithFeeProofContext {
 }
 
 /// The ElGamal public keys needed for a transfer with fee
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(C)]
 pub struct TransferWithFeePubkeys {
     pub source: pod::ElGamalPubkey,
@@ -453,7 +450,7 @@ impl TransferWithFeeProofContext {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 pub struct TransferWithFeeProof {
     pub new_source_commitment: pod::PedersenCommitment,
     pub claimed_commitment: pod::PedersenCommitment,
@@ -820,7 +817,7 @@ fn compute_delta_commitment(
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use {super::*, bytemuck::Zeroable};
 
     #[test]
     fn test_fee_correctness() {

--- a/zk-token-sdk/src/instruction/transfer/without_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/without_fee.rs
@@ -29,7 +29,7 @@ use {
         instruction::{ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 #[cfg(not(target_os = "solana"))]
@@ -470,7 +470,7 @@ impl TransferProof {
 
 #[cfg(test)]
 mod test {
-    use {super::*, crate::encryption::elgamal::ElGamalKeypair};
+    use {super::*, crate::encryption::elgamal::ElGamalKeypair, bytemuck::Zeroable};
 
     #[test]
     fn test_transfer_correctness() {

--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -18,7 +18,7 @@ use {
         instruction::{ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-token-sdk/src/instruction/zero_balance.rs
+++ b/zk-token-sdk/src/instruction/zero_balance.rs
@@ -20,7 +20,7 @@ use {
         instruction::{ProofType, ZkProofData},
         zk_token_elgamal::pod,
     },
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
 };
 
 /// The instruction data that is needed for the `ProofInstruction::ZeroBalance` instruction.

--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -3,8 +3,9 @@
 #[cfg(not(target_os = "solana"))]
 use crate::{encryption::auth_encryption as decoded, errors::AuthenticatedEncryptionError};
 use {
-    crate::zk_token_elgamal::pod::{impl_from_str, Pod, Zeroable},
+    crate::zk_token_elgamal::pod::impl_from_str,
     base64::{prelude::BASE64_STANDARD, Engine},
+    bytemuck::{Pod, Zeroable},
     std::fmt,
 };
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -10,10 +10,11 @@ use {
 };
 use {
     crate::{
-        zk_token_elgamal::pod::{impl_from_str, pedersen::PEDERSEN_COMMITMENT_LEN, Pod, Zeroable},
+        zk_token_elgamal::pod::{impl_from_str, pedersen::PEDERSEN_COMMITMENT_LEN},
         RISTRETTO_POINT_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
+    bytemuck::Zeroable,
     std::fmt,
 };
 
@@ -33,7 +34,7 @@ pub(crate) const ELGAMAL_CIPHERTEXT_LEN: usize = PEDERSEN_COMMITMENT_LEN + DECRY
 const ELGAMAL_CIPHERTEXT_MAX_BASE64_LEN: usize = 88;
 
 /// The `ElGamalCiphertext` type as a `Pod`.
-#[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct ElGamalCiphertext(pub [u8; ELGAMAL_CIPHERTEXT_LEN]);
 
@@ -78,7 +79,7 @@ impl TryFrom<ElGamalCiphertext> for decoded::ElGamalCiphertext {
 }
 
 /// The `ElGamalPubkey` type as a `Pod`.
-#[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, bytemuck_derive::Pod, bytemuck_derive::Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct ElGamalPubkey(pub [u8; ELGAMAL_PUBKEY_LEN]);
 
@@ -117,7 +118,7 @@ impl TryFrom<ElGamalPubkey> for decoded::ElGamalPubkey {
 }
 
 /// The `DecryptHandle` type as a `Pod`.
-#[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, bytemuck_derive::Pod, bytemuck_derive::Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct DecryptHandle(pub [u8; DECRYPT_HANDLE_LEN]);
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
@@ -8,9 +8,9 @@ use {
         zk_token_elgamal::pod::{
             elgamal::{ElGamalCiphertext, DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN},
             pedersen::{PedersenCommitment, PEDERSEN_COMMITMENT_LEN},
-            Pod, Zeroable,
         },
     },
+    bytemuck::Zeroable,
     std::fmt,
 };
 
@@ -61,7 +61,7 @@ const GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES: usize =
     PEDERSEN_COMMITMENT_LEN + DECRYPT_HANDLE_LEN + DECRYPT_HANDLE_LEN + DECRYPT_HANDLE_LEN;
 
 /// The `GroupedElGamalCiphertext` type with two decryption handles as a `Pod`
-#[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct GroupedElGamalCiphertext2Handles(pub [u8; GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES]);
 
@@ -95,7 +95,7 @@ impl TryFrom<GroupedElGamalCiphertext2Handles> for GroupedElGamalCiphertext<2> {
 impl_extract!(TYPE = GroupedElGamalCiphertext2Handles);
 
 /// The `GroupedElGamalCiphertext` type with three decryption handles as a `Pod`
-#[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct GroupedElGamalCiphertext3Handles(pub [u8; GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES]);
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -1,11 +1,10 @@
 use crate::zk_token_elgamal::pod::{
-    GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles, Pod, PodU16, PodU64,
-    Zeroable,
+    GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles, PodU16, PodU64,
 };
 #[cfg(not(target_os = "solana"))]
 use crate::{errors::ElGamalError, instruction::transfer as decoded};
 
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(C)]
 pub struct TransferAmountCiphertext(pub GroupedElGamalCiphertext3Handles);
 
@@ -25,7 +24,7 @@ impl TryFrom<TransferAmountCiphertext> for decoded::TransferAmountCiphertext {
     }
 }
 
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(C)]
 pub struct FeeEncryption(pub GroupedElGamalCiphertext2Handles);
 
@@ -45,7 +44,7 @@ impl TryFrom<FeeEncryption> for decoded::FeeEncryption {
     }
 }
 
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(C)]
 pub struct FeeParameters {
     /// Fee rate expressed as basis points of the transfer amount, i.e. increments of 0.01%

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -14,7 +14,7 @@ use {
 };
 pub use {
     auth_encryption::AeCiphertext,
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
     elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalPubkey},
     grouped_elgamal::{GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles},
     instruction::{FeeEncryption, FeeParameters, TransferAmountCiphertext},

--- a/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/mod.rs
@@ -14,7 +14,7 @@ use {
 };
 pub use {
     auth_encryption::AeCiphertext,
-    bytemuck_derive::{Pod, Zeroable},
+    bytemuck::{Pod, Zeroable},
     elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalPubkey},
     grouped_elgamal::{GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles},
     instruction::{FeeEncryption, FeeParameters, TransferAmountCiphertext},
@@ -36,7 +36,9 @@ pub enum ParseError {
     Invalid,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, bytemuck_derive::Pod, bytemuck_derive::Zeroable,
+)]
 #[repr(transparent)]
 pub struct PodU16([u8; 2]);
 impl From<u16> for PodU16 {
@@ -50,7 +52,9 @@ impl From<PodU16> for u16 {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, bytemuck_derive::Pod, bytemuck_derive::Zeroable,
+)]
 #[repr(transparent)]
 pub struct PodU64([u8; 8]);
 impl From<u64> for PodU64 {
@@ -64,7 +68,9 @@ impl From<PodU64> for u64 {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, bytemuck_derive::Pod, bytemuck_derive::Zeroable,
+)]
 #[repr(transparent)]
 pub struct PodProofType(u8);
 impl From<ProofType> for PodProofType {
@@ -80,7 +86,7 @@ impl TryFrom<PodProofType> for ProofType {
     }
 }
 
-#[derive(Clone, Copy, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct CompressedRistretto(pub [u8; 32]);
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
@@ -1,23 +1,17 @@
 //! Plain Old Data type for the Pedersen commitment scheme.
 
+use {crate::RISTRETTO_POINT_LEN, std::fmt};
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{encryption::pedersen as decoded, errors::ElGamalError},
     curve25519_dalek::ristretto::CompressedRistretto,
-};
-use {
-    crate::{
-        zk_token_elgamal::pod::{Pod, Zeroable},
-        RISTRETTO_POINT_LEN,
-    },
-    std::fmt,
 };
 
 /// Byte length of a Pedersen commitment
 pub(crate) const PEDERSEN_COMMITMENT_LEN: usize = RISTRETTO_POINT_LEN;
 
 /// The `PedersenCommitment` type as a `Pod`.
-#[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, bytemuck_derive::Pod, bytemuck_derive::Zeroable, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct PedersenCommitment(pub [u8; PEDERSEN_COMMITMENT_LEN]);
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/range_proof.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/range_proof.rs
@@ -5,9 +5,9 @@ use crate::{
     range_proof::{self as decoded, errors::RangeProofVerificationError},
     UNIT_LEN,
 };
-use crate::{
-    zk_token_elgamal::pod::{Pod, Zeroable},
-    RISTRETTO_POINT_LEN, SCALAR_LEN,
+use {
+    crate::{RISTRETTO_POINT_LEN, SCALAR_LEN},
+    bytemuck::{Pod, Zeroable},
 };
 
 /// Byte length of a range proof excluding the inner-product proof component

--- a/zk-token-sdk/src/zk_token_elgamal/pod/sigma_proofs.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/sigma_proofs.rs
@@ -12,7 +12,7 @@ use crate::sigma_proofs::{
     pubkey_proof::PubkeyValidityProof as DecodedPubkeyValidityProof,
     zero_balance_proof::ZeroBalanceProof as DecodedZeroBalanceProof,
 };
-use crate::zk_token_elgamal::pod::{Pod, Zeroable};
+use bytemuck::{Pod, Zeroable};
 
 /// Byte length of a ciphertext-commitment equality proof
 const CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_LEN: usize = 192;

--- a/zk-token-sdk/src/zk_token_elgamal/pod/sigma_proofs.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/sigma_proofs.rs
@@ -217,7 +217,7 @@ impl TryFrom<ZeroBalanceProof> for DecodedZeroBalanceProof {
 }
 
 /// The `FeeSigmaProof` type as a `Pod`.
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(transparent)]
 pub struct FeeSigmaProof(pub [u8; FEE_SIGMA_PROOF_LEN]);
 
@@ -238,7 +238,7 @@ impl TryFrom<FeeSigmaProof> for DecodedFeeSigmaProof {
 }
 
 /// The `PubkeyValidityProof` type as a `Pod`.
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(transparent)]
 pub struct PubkeyValidityProof(pub [u8; PUBKEY_VALIDITY_PROOF_LEN]);
 

--- a/zk-token-sdk/src/zk_token_proof_state.rs
+++ b/zk-token-sdk/src/zk_token_proof_state.rs
@@ -53,7 +53,7 @@ impl<T: Pod> ProofContextState<T> {
 
 /// The `ProofContextState` without the proof context itself. This struct exists to facilitate the
 /// decoding of generic-independent fields in `ProofContextState`.
-#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, PartialEq, bytemuck_derive::Pod, bytemuck_derive::Zeroable)]
 #[repr(C)]
 pub struct ProofContextStateMeta {
     /// The proof context authority that can close the account


### PR DESCRIPTION
#### Problem

As done in #1793, we can use `bytemuck_derive` explicitly over enabling the `derive` feature on the bytemuck crate.

#### Summary of Changes

This continues the work from #1793 and removes all usage of the `derive` feature on the bytemuck crate.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
