### PR TITLE
add stats for ancient bytes_from_newest_storages

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1956,6 +1956,7 @@ pub(crate) struct ShrinkAncientStats {
     pub(crate) bytes_ancient_created: AtomicU64,
     pub(crate) bytes_from_must_shrink: AtomicU64,
     pub(crate) bytes_from_smallest_storages: AtomicU64,
+    pub(crate) bytes_from_newest_storages: AtomicU64,
     pub(crate) many_ref_slots_skipped: AtomicU64,
     pub(crate) slots_cannot_move_count: AtomicU64,
     pub(crate) many_refs_old_alive: AtomicU64,
@@ -2256,6 +2257,11 @@ impl ShrinkAncientStats {
             (
                 "bytes_from_smallest_storages",
                 self.bytes_from_smallest_storages.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "bytes_from_newest_storages",
+                self.bytes_from_newest_storages.swap(0, Ordering::Relaxed) as i64,
                 i64
             ),
             (

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -210,6 +210,7 @@ impl AncientSlotInfos {
         let low_threshold = tuning.max_ancient_slots * 50 / 100;
         let mut bytes_from_must_shrink = 0;
         let mut bytes_from_smallest_storages = 0;
+        let mut bytes_from_newest_storages = 0;
         for (i, info) in self.all_infos.iter().enumerate() {
             cumulative_bytes += info.alive_bytes;
             let ancient_storages_required =
@@ -235,6 +236,9 @@ impl AncientSlotInfos {
             }
             if info.should_shrink {
                 bytes_from_must_shrink += info.alive_bytes;
+            }
+            if info.is_high_slot {
+                bytes_from_newest_storages += info.alive_bytes;
             } else {
                 bytes_from_smallest_storages += info.alive_bytes;
             }
@@ -245,6 +249,9 @@ impl AncientSlotInfos {
         stats
             .bytes_from_smallest_storages
             .fetch_add(bytes_from_smallest_storages, Ordering::Relaxed);
+        stats
+            .bytes_from_newest_storages
+            .fetch_add(bytes_from_newest_storages, Ordering::Relaxed);
     }
 
     /// remove entries from 'all_infos' such that combining

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -236,8 +236,7 @@ impl AncientSlotInfos {
             }
             if info.should_shrink {
                 bytes_from_must_shrink += info.alive_bytes;
-            }
-            if info.is_high_slot {
+            } else if info.is_high_slot {
                 bytes_from_newest_storages += info.alive_bytes;
             } else {
                 bytes_from_smallest_storages += info.alive_bytes;
@@ -3747,6 +3746,20 @@ pub mod tests {
             &target_slots_sorted,
             &tuning
         ));
+    }
+
+    #[test]
+    fn testabc() {
+        solana_logger::setup();
+        let abc = 1;
+        let f = format!("{}", 123);
+        let (_, us) = measure_us!({
+            log::error!("her");
+        });
+        log::error!(
+            "abc, {abc}, {:?}, {f}, {us}",
+            ("jeff", 1, vec![2, 3, 4u64], AncientSlotInfos::default())
+        );
     }
 
     #[test]

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -3749,20 +3749,6 @@ pub mod tests {
     }
 
     #[test]
-    fn testabc() {
-        solana_logger::setup();
-        let abc = 1;
-        let f = format!("{}", 123);
-        let (_, us) = measure_us!({
-            log::error!("her");
-        });
-        log::error!(
-            "abc, {abc}, {:?}, {f}, {us}",
-            ("jeff", 1, vec![2, 3, 4u64], AncientSlotInfos::default())
-        );
-    }
-
-    #[test]
     fn test_addref_accounts_failed_to_shrink_ancient() {
         let db = AccountsDb::new_single_for_tests();
         let empty_account = AccountSharedData::default();


### PR DESCRIPTION
#### Problem
we recently added a new category of storages to ancient pack (newest slots).

#### Summary of Changes
Add a metric to capture the bytes attempted to pack based on being newest slots.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
