### PR TITLE
Fix metrics enum variant for validate fees

### DIFF
--- a/program-runtime/src/timings.rs
+++ b/program-runtime/src/timings.rs
@@ -43,7 +43,6 @@ impl ProgramTiming {
 #[derive(Debug, Sequence)]
 pub enum ExecuteTimingType {
     CheckUs,
-    ValidateFeesUs,
     LoadUs,
     ExecuteUs,
     StoreUs,
@@ -53,6 +52,10 @@ pub enum ExecuteTimingType {
     TotalBatchesLen,
     UpdateTransactionStatuses,
     ProgramCacheUs,
+    ValidateFeesUs,
+    // New variants should be appended to the enum variant list and existing
+    // variants shouldn't be removed, they should be replaced with an unused
+    // placeholder to keep consistent indexes
 }
 
 pub struct Metrics([u64; ExecuteTimingType::CARDINALITY]);


### PR DESCRIPTION
#### Problem
New `ValidateFeesUs` enum variant took the place of an existing enum index rather than being appended to the end

#### Summary of Changes
Fix variant order and add comment to devs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
