### PR TITLE
cli: Use `WithComputeUnitConfig` for compute unit limit

### DIFF
--- a/clap-utils/src/compute_budget.rs
+++ b/clap-utils/src/compute_budget.rs
@@ -35,8 +35,8 @@ pub fn compute_unit_limit_arg<'a, 'b>() -> Arg<'a, 'b> {
 
 pub enum ComputeUnitLimit {
     /// Do not include a compute unit limit instruction, which will give the
-    /// transaction `min(1_400_000, 200_000 * num_top_level_instructions)`
-    /// compute units
+    /// transaction a compute unit limit of:
+    /// `min(1_400_000, 200_000 * (num_top_level_instructions - num_compute_budget_instructions))`
     Default,
     /// Use a static predefined limit
     Static(u32),

--- a/clap-utils/src/compute_budget.rs
+++ b/clap-utils/src/compute_budget.rs
@@ -32,3 +32,14 @@ pub fn compute_unit_limit_arg<'a, 'b>() -> Arg<'a, 'b> {
         .validator(is_parsable::<u32>)
         .help(COMPUTE_UNIT_LIMIT_ARG.help)
 }
+
+pub enum ComputeUnitLimit {
+    /// Do not include a compute unit limit instruction, which will give the
+    /// transaction `min(1_400_000, 200_000 * num_top_level_instructions)`
+    /// compute units
+    Default,
+    /// Use a static predefined limit
+    Static(u32),
+    /// Simulate the transaction to find out the compute unit usage
+    Simulated,
+}

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -996,7 +996,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
                 timeout,
                 blockhash,
                 *print_timestamp,
-                compute_unit_price.as_ref(),
+                *compute_unit_price,
                 &rpc_client,
             )
         }
@@ -1075,7 +1075,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *nonce_authority,
             memo.as_ref(),
             new_authority,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         // Create nonce account
         CliCommand::CreateNonceAccount {
@@ -1093,7 +1093,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *nonce_authority,
             memo.as_ref(),
             *amount,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         // Get the current nonce
         CliCommand::GetNonce(nonce_account_pubkey) => {
@@ -1111,7 +1111,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             nonce_account,
             *nonce_authority,
             memo.as_ref(),
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         // Show the contents of a nonce account
         CliCommand::ShowNonceAccount {
@@ -1139,7 +1139,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             memo.as_ref(),
             destination_account_pubkey,
             *lamports,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         // Upgrade nonce account out of blockhash domain.
         CliCommand::UpgradeNonceAccount {
@@ -1151,7 +1151,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             config,
             *nonce_account,
             memo.as_ref(),
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
 
         // Program Deployment
@@ -1209,7 +1209,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             memo.as_ref(),
             *fee_payer,
             *from,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         CliCommand::DeactivateStake {
             stake_account_pubkey,
@@ -1238,7 +1238,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             memo.as_ref(),
             seed.as_ref(),
             *fee_payer,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         CliCommand::DelegateStake {
             stake_account_pubkey,
@@ -1269,7 +1269,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             memo.as_ref(),
             *fee_payer,
             *redelegation_stake_account,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         CliCommand::SplitStake {
             stake_account_pubkey,
@@ -1301,7 +1301,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             seed,
             *lamports,
             *fee_payer,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
             rent_exempt_reserve.as_ref(),
         ),
         CliCommand::MergeStake {
@@ -1329,7 +1329,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *nonce_authority,
             memo.as_ref(),
             *fee_payer,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         CliCommand::ShowStakeAccount {
             pubkey: stake_account_pubkey,
@@ -1375,7 +1375,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             memo.as_ref(),
             *fee_payer,
             *no_wait,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         CliCommand::StakeSetLockup {
             stake_account_pubkey,
@@ -1404,7 +1404,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *nonce_authority,
             memo.as_ref(),
             *fee_payer,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         CliCommand::WithdrawStake {
             stake_account_pubkey,
@@ -1437,7 +1437,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             memo.as_ref(),
             seed.as_ref(),
             *fee_payer,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         CliCommand::StakeMinimumDelegation { use_lamports_unit } => {
             process_stake_minimum_delegation(&rpc_client, config, *use_lamports_unit)
@@ -1461,7 +1461,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             validator_info,
             *force_keybase,
             *info_pubkey,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
 
         // Vote Commands
@@ -1498,7 +1498,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *nonce_authority,
             memo.as_ref(),
             *fee_payer,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         CliCommand::ShowVoteAccount {
             pubkey: vote_account_pubkey,
@@ -1540,7 +1540,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *nonce_authority,
             memo.as_ref(),
             *fee_payer,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         CliCommand::CloseVoteAccount {
             vote_account_pubkey,
@@ -1557,7 +1557,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             destination_account_pubkey,
             memo.as_ref(),
             *fee_payer,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         CliCommand::VoteAuthorize {
             vote_account_pubkey,
@@ -1588,7 +1588,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *nonce_authority,
             memo.as_ref(),
             *fee_payer,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         CliCommand::VoteUpdateValidator {
             vote_account_pubkey,
@@ -1615,7 +1615,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *nonce_authority,
             memo.as_ref(),
             *fee_payer,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         CliCommand::VoteUpdateCommission {
             vote_account_pubkey,
@@ -1642,7 +1642,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *nonce_authority,
             memo.as_ref(),
             *fee_payer,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
 
         // Wallet Commands
@@ -1706,7 +1706,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *fee_payer,
             derived_address_seed.clone(),
             derived_address_program_id.as_ref(),
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
         ),
         // Address Lookup Table Commands
         CliCommand::AddressLookupTable(subcommand) => {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},
-        compute_budget::WithComputeUnitPrice,
+        compute_budget::{ComputeUnitConfig, WithComputeUnitConfig},
         feature::get_feature_activation_epoch,
         spend_utils::{resolve_spend_tx_and_check_account_balance, SpendAmount},
     },
@@ -10,7 +10,7 @@ use {
     crossbeam_channel::unbounded,
     serde::{Deserialize, Serialize},
     solana_clap_utils::{
-        compute_unit_price::{compute_unit_price_arg, COMPUTE_UNIT_PRICE_ARG},
+        compute_budget::{compute_unit_price_arg, ComputeUnitLimit, COMPUTE_UNIT_PRICE_ARG},
         input_parsers::*,
         input_validators::*,
         keypair::DefaultSigner,
@@ -1526,7 +1526,10 @@ pub fn process_ping(
                 &to,
                 lamports,
             )]
-            .with_compute_unit_price(compute_unit_price);
+            .with_compute_unit_config(&ComputeUnitConfig {
+                compute_unit_price,
+                compute_unit_limit: ComputeUnitLimit::Default,
+            });
             Message::new(&ixs, Some(&config.signers[0].pubkey()))
         };
         let (message, _) = resolve_spend_tx_and_check_account_balance(

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1480,7 +1480,7 @@ pub fn process_ping(
     timeout: &Duration,
     fixed_blockhash: &Option<Hash>,
     print_timestamp: bool,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
     rpc_client: &RpcClient,
 ) -> ProcessResult {
     let (signal_sender, signal_receiver) = unbounded();

--- a/cli/src/compute_budget.rs
+++ b/cli/src/compute_budget.rs
@@ -77,24 +77,9 @@ pub(crate) fn simulate_and_update_compute_unit_limit(
     ))
 }
 
-pub(crate) struct ComputeUnitConfig<'a> {
-    pub(crate) compute_unit_price: Option<&'a u64>,
+pub(crate) struct ComputeUnitConfig {
+    pub(crate) compute_unit_price: Option<u64>,
     pub(crate) compute_unit_limit: ComputeUnitLimit,
-}
-
-pub(crate) trait WithComputeUnitPrice {
-    fn with_compute_unit_price(self, compute_unit_price: Option<&u64>) -> Self;
-}
-
-impl WithComputeUnitPrice for Vec<Instruction> {
-    fn with_compute_unit_price(mut self, compute_unit_price: Option<&u64>) -> Self {
-        if let Some(compute_unit_price) = compute_unit_price {
-            self.push(ComputeBudgetInstruction::set_compute_unit_price(
-                *compute_unit_price,
-            ));
-        }
-        self
-    }
 }
 
 pub(crate) trait WithComputeUnitConfig {
@@ -105,7 +90,7 @@ impl WithComputeUnitConfig for Vec<Instruction> {
     fn with_compute_unit_config(mut self, config: &ComputeUnitConfig) -> Self {
         if let Some(compute_unit_price) = config.compute_unit_price {
             self.push(ComputeBudgetInstruction::set_compute_unit_price(
-                *compute_unit_price,
+                compute_unit_price,
             ));
             match config.compute_unit_limit {
                 ComputeUnitLimit::Default => {}

--- a/cli/src/compute_budget.rs
+++ b/cli/src/compute_budget.rs
@@ -1,4 +1,5 @@
 use {
+    solana_clap_utils::compute_budget::ComputeUnitLimit,
     solana_client::rpc_config::RpcSimulateTransactionConfig,
     solana_compute_budget::compute_budget_processor::MAX_COMPUTE_UNIT_LIMIT,
     solana_rpc_client::rpc_client::RpcClient,
@@ -76,6 +77,11 @@ pub(crate) fn simulate_and_update_compute_unit_limit(
     ))
 }
 
+pub(crate) struct ComputeUnitConfig<'a> {
+    pub(crate) compute_unit_price: Option<&'a u64>,
+    pub(crate) compute_unit_limit: ComputeUnitLimit,
+}
+
 pub(crate) trait WithComputeUnitPrice {
     fn with_compute_unit_price(self, compute_unit_price: Option<&u64>) -> Self;
 }
@@ -91,10 +97,6 @@ impl WithComputeUnitPrice for Vec<Instruction> {
     }
 }
 
-pub(crate) struct ComputeUnitConfig {
-    pub(crate) compute_unit_price: Option<u64>,
-}
-
 pub(crate) trait WithComputeUnitConfig {
     fn with_compute_unit_config(self, config: &ComputeUnitConfig) -> Self;
 }
@@ -103,14 +105,23 @@ impl WithComputeUnitConfig for Vec<Instruction> {
     fn with_compute_unit_config(mut self, config: &ComputeUnitConfig) -> Self {
         if let Some(compute_unit_price) = config.compute_unit_price {
             self.push(ComputeBudgetInstruction::set_compute_unit_price(
-                compute_unit_price,
+                *compute_unit_price,
             ));
-
-            // Default to the max compute unit limit because later transactions will be
-            // simulated to get the exact compute units consumed.
-            self.push(ComputeBudgetInstruction::set_compute_unit_limit(
-                MAX_COMPUTE_UNIT_LIMIT,
-            ));
+            match config.compute_unit_limit {
+                ComputeUnitLimit::Default => {}
+                ComputeUnitLimit::Static(compute_unit_limit) => {
+                    self.push(ComputeBudgetInstruction::set_compute_unit_limit(
+                        compute_unit_limit,
+                    ));
+                }
+                ComputeUnitLimit::Simulated => {
+                    // Default to the max compute unit limit because later transactions will be
+                    // simulated to get the exact compute units consumed.
+                    self.push(ComputeBudgetInstruction::set_compute_unit_limit(
+                        MAX_COMPUTE_UNIT_LIMIT,
+                    ));
+                }
+            }
         }
         self
     }

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -5,13 +5,13 @@ use {
             log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError,
             ProcessResult,
         },
-        compute_budget::WithComputeUnitPrice,
+        compute_budget::{ComputeUnitConfig, WithComputeUnitConfig},
         memo::WithMemo,
         spend_utils::{resolve_spend_tx_and_check_account_balance, SpendAmount},
     },
     clap::{App, Arg, ArgMatches, SubCommand},
     solana_clap_utils::{
-        compute_unit_price::{compute_unit_price_arg, COMPUTE_UNIT_PRICE_ARG},
+        compute_budget::{compute_unit_price_arg, ComputeUnitLimit, COMPUTE_UNIT_PRICE_ARG},
         input_parsers::*,
         input_validators::*,
         keypair::{CliSigners, DefaultSigner, SignerIndex},
@@ -419,7 +419,10 @@ pub fn process_authorize_nonce_account(
         new_authority,
     )]
     .with_memo(memo)
-    .with_compute_unit_price(compute_unit_price);
+    .with_compute_unit_config(&ComputeUnitConfig {
+        compute_unit_price,
+        compute_unit_limit: ComputeUnitLimit::Default,
+    });
     let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
@@ -470,7 +473,10 @@ pub fn process_create_nonce_account(
                 lamports,
             )
             .with_memo(memo)
-            .with_compute_unit_price(compute_unit_price)
+            .with_compute_unit_config(&ComputeUnitConfig {
+                compute_unit_price,
+                compute_unit_limit: ComputeUnitLimit::Default,
+            })
         } else {
             create_nonce_account(
                 &config.signers[0].pubkey(),
@@ -479,7 +485,10 @@ pub fn process_create_nonce_account(
                 lamports,
             )
             .with_memo(memo)
-            .with_compute_unit_price(compute_unit_price)
+            .with_compute_unit_config(&ComputeUnitConfig {
+                compute_unit_price,
+                compute_unit_limit: ComputeUnitLimit::Default,
+            })
         };
         Message::new(&ixs, Some(&config.signers[0].pubkey()))
     };
@@ -560,7 +569,10 @@ pub fn process_new_nonce(
         &nonce_authority.pubkey(),
     )]
     .with_memo(memo)
-    .with_compute_unit_price(compute_unit_price);
+    .with_compute_unit_config(&ComputeUnitConfig {
+        compute_unit_price,
+        compute_unit_limit: ComputeUnitLimit::Default,
+    });
     let latest_blockhash = rpc_client.get_latest_blockhash()?;
     let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
@@ -626,7 +638,10 @@ pub fn process_withdraw_from_nonce_account(
         lamports,
     )]
     .with_memo(memo)
-    .with_compute_unit_price(compute_unit_price);
+    .with_compute_unit_config(&ComputeUnitConfig {
+        compute_unit_price,
+        compute_unit_limit: ComputeUnitLimit::Default,
+    });
     let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
@@ -651,7 +666,10 @@ pub(crate) fn process_upgrade_nonce_account(
     let latest_blockhash = rpc_client.get_latest_blockhash()?;
     let ixs = vec![upgrade_nonce_account(nonce_account)]
         .with_memo(memo)
-        .with_compute_unit_price(compute_unit_price);
+        .with_compute_unit_config(&ComputeUnitConfig {
+            compute_unit_price,
+            compute_unit_limit: ComputeUnitLimit::Default,
+        });
     let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -408,7 +408,7 @@ pub fn process_authorize_nonce_account(
     nonce_authority: SignerIndex,
     memo: Option<&String>,
     new_authority: &Pubkey,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let latest_blockhash = rpc_client.get_latest_blockhash()?;
 
@@ -446,7 +446,7 @@ pub fn process_create_nonce_account(
     nonce_authority: Option<Pubkey>,
     memo: Option<&String>,
     amount: SpendAmount,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let nonce_account_pubkey = config.signers[nonce_account].pubkey();
     let nonce_account_address = if let Some(ref seed) = seed {
@@ -549,7 +549,7 @@ pub fn process_new_nonce(
     nonce_account: &Pubkey,
     nonce_authority: SignerIndex,
     memo: Option<&String>,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (&config.signers[0].pubkey(), "cli keypair".to_string()),
@@ -626,7 +626,7 @@ pub fn process_withdraw_from_nonce_account(
     memo: Option<&String>,
     destination_account_pubkey: &Pubkey,
     lamports: u64,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let latest_blockhash = rpc_client.get_latest_blockhash()?;
 
@@ -661,7 +661,7 @@ pub(crate) fn process_upgrade_nonce_account(
     config: &CliConfig,
     nonce_account: Pubkey,
     memo: Option<&String>,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let latest_blockhash = rpc_client.get_latest_blockhash()?;
     let ixs = vec![upgrade_nonce_account(nonce_account)]

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1019,7 +1019,7 @@ pub fn process_program_subcommand(
             *is_final,
             *max_len,
             *skip_fee_check,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
             *max_sign_attempts,
             *auto_extend,
             *use_rpc,
@@ -1067,7 +1067,7 @@ pub fn process_program_subcommand(
             *buffer_authority_signer_index,
             *max_len,
             *skip_fee_check,
-            compute_unit_price.as_ref(),
+            *compute_unit_price,
             *max_sign_attempts,
             *use_rpc,
         ),
@@ -1200,7 +1200,7 @@ fn process_program_deploy(
     is_final: bool,
     max_len: Option<usize>,
     skip_fee_check: bool,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
     max_sign_attempts: usize,
     auto_extend: bool,
     use_rpc: bool,
@@ -1583,7 +1583,7 @@ fn process_write_buffer(
     buffer_authority_signer_index: SignerIndex,
     max_len: Option<usize>,
     skip_fee_check: bool,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
     max_sign_attempts: usize,
     use_rpc: bool,
 ) -> ProcessResult {
@@ -2395,7 +2395,7 @@ fn do_process_program_deploy(
     buffer_program_data: Option<Vec<u8>>,
     buffer_authority_signer: &dyn Signer,
     skip_fee_check: bool,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
     max_sign_attempts: usize,
     use_rpc: bool,
 ) -> ProcessResult {
@@ -2420,8 +2420,10 @@ fn do_process_program_deploy(
 
     let initial_message = if !initial_instructions.is_empty() {
         Some(Message::new_with_blockhash(
-            &initial_instructions
-                .with_compute_unit_config(&ComputeUnitConfig { compute_unit_price, compute_unit_limit: ComputeUnitLimit::Simulated }),
+            &initial_instructions.with_compute_unit_config(&ComputeUnitConfig {
+                compute_unit_price,
+                compute_unit_limit: ComputeUnitLimit::Simulated,
+            }),
             Some(&fee_payer_signer.pubkey()),
             &blockhash,
         ))
@@ -2438,8 +2440,10 @@ fn do_process_program_deploy(
             bytes,
         );
 
-        let instructions =
-            vec![instruction].with_compute_unit_config(&ComputeUnitConfig { compute_unit_price, compute_unit_limit: ComputeUnitLimit::Simulated });
+        let instructions = vec![instruction].with_compute_unit_config(&ComputeUnitConfig {
+            compute_unit_price,
+            compute_unit_limit: ComputeUnitLimit::Simulated,
+        });
         Message::new_with_blockhash(&instructions, Some(&fee_payer_signer.pubkey()), &blockhash)
     };
 
@@ -2463,7 +2467,10 @@ fn do_process_program_deploy(
                 .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())?,
             program_data_max_len,
         )?
-        .with_compute_unit_config(&ComputeUnitConfig { compute_unit_price, compute_unit_limit: ComputeUnitLimit::Simulated });
+        .with_compute_unit_config(&ComputeUnitConfig {
+            compute_unit_price,
+            compute_unit_limit: ComputeUnitLimit::Simulated,
+        });
 
         Some(Message::new_with_blockhash(
             &instructions,
@@ -2518,7 +2525,7 @@ fn do_process_write_buffer(
     buffer_program_data: Option<Vec<u8>>,
     buffer_authority_signer: &dyn Signer,
     skip_fee_check: bool,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
     max_sign_attempts: usize,
     use_rpc: bool,
 ) -> ProcessResult {
@@ -2543,8 +2550,10 @@ fn do_process_write_buffer(
 
     let initial_message = if !initial_instructions.is_empty() {
         Some(Message::new_with_blockhash(
-            &initial_instructions
-                .with_compute_unit_config(&ComputeUnitConfig { compute_unit_price, compute_unit_limit: ComputeUnitLimit::Simulated }),
+            &initial_instructions.with_compute_unit_config(&ComputeUnitConfig {
+                compute_unit_price,
+                compute_unit_limit: ComputeUnitLimit::Simulated,
+            }),
             Some(&fee_payer_signer.pubkey()),
             &blockhash,
         ))
@@ -2561,8 +2570,10 @@ fn do_process_write_buffer(
             bytes,
         );
 
-        let instructions =
-            vec![instruction].with_compute_unit_config(&ComputeUnitConfig { compute_unit_price, compute_unit_limit: ComputeUnitLimit::Simulated });
+        let instructions = vec![instruction].with_compute_unit_config(&ComputeUnitConfig {
+            compute_unit_price,
+            compute_unit_limit: ComputeUnitLimit::Simulated,
+        });
         Message::new_with_blockhash(&instructions, Some(&fee_payer_signer.pubkey()), &blockhash)
     };
 
@@ -2621,7 +2632,7 @@ fn do_process_program_upgrade(
     buffer_signer: Option<&dyn Signer>,
     buffer_program_data: Option<Vec<u8>>,
     skip_fee_check: bool,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
     max_sign_attempts: usize,
     auto_extend: bool,
     use_rpc: bool,
@@ -2661,8 +2672,10 @@ fn do_process_program_upgrade(
 
         let initial_message = if !initial_instructions.is_empty() {
             Some(Message::new_with_blockhash(
-                &initial_instructions
-                    .with_compute_unit_config(&ComputeUnitConfig { compute_unit_price, compute_unit_limit: ComputeUnitLimit::Simulated }),
+                &initial_instructions.with_compute_unit_config(&ComputeUnitConfig {
+                    compute_unit_price,
+                    compute_unit_limit: ComputeUnitLimit::Simulated,
+                }),
                 Some(&fee_payer_signer.pubkey()),
                 &blockhash,
             ))
@@ -2679,7 +2692,10 @@ fn do_process_program_upgrade(
                 offset,
                 bytes,
             )]
-            .with_compute_unit_config(&ComputeUnitConfig { compute_unit_price, compute_unit_limit: ComputeUnitLimit::Simulated });
+            .with_compute_unit_config(&ComputeUnitConfig {
+                compute_unit_price,
+                compute_unit_limit: ComputeUnitLimit::Simulated,
+            });
             Message::new_with_blockhash(&instructions, Some(&fee_payer_signer.pubkey()), &blockhash)
         };
 
@@ -2705,7 +2721,10 @@ fn do_process_program_upgrade(
         &upgrade_authority.pubkey(),
         &fee_payer_signer.pubkey(),
     )]
-    .with_compute_unit_config(&ComputeUnitConfig { compute_unit_price, compute_unit_limit: ComputeUnitLimit::Simulated });
+    .with_compute_unit_config(&ComputeUnitConfig {
+        compute_unit_price,
+        compute_unit_limit: ComputeUnitLimit::Simulated,
+    });
     let final_message = Message::new_with_blockhash(
         &final_instructions,
         Some(&fee_payer_signer.pubkey()),

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -5,7 +5,7 @@ use {
             log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError,
             ProcessResult,
         },
-        compute_budget::WithComputeUnitPrice,
+        compute_budget::{ComputeUnitConfig, WithComputeUnitConfig},
         feature::get_feature_activation_epoch,
         memo::WithMemo,
         nonce::check_nonce_account,
@@ -13,7 +13,7 @@ use {
     },
     clap::{value_t, App, Arg, ArgGroup, ArgMatches, SubCommand},
     solana_clap_utils::{
-        compute_unit_price::{compute_unit_price_arg, COMPUTE_UNIT_PRICE_ARG},
+        compute_budget::{compute_unit_price_arg, ComputeUnitLimit, COMPUTE_UNIT_PRICE_ARG},
         fee_payer::{fee_payer_arg, FEE_PAYER_ARG},
         hidden_unless_forced,
         input_parsers::*,
@@ -1478,7 +1478,10 @@ pub fn process_create_stake_account(
             ),
         }
         .with_memo(memo)
-        .with_compute_unit_price(compute_unit_price);
+        .with_compute_unit_config(&ComputeUnitConfig {
+            compute_unit_price,
+            compute_unit_limit: ComputeUnitLimit::Default,
+        });
         if let Some(nonce_account) = &nonce_account {
             Message::new_with_nonce(
                 ixs,
@@ -1635,7 +1638,10 @@ pub fn process_stake_authorize(
     }
     ixs = ixs
         .with_memo(memo)
-        .with_compute_unit_price(compute_unit_price);
+        .with_compute_unit_config(&ComputeUnitConfig {
+            compute_unit_price,
+            compute_unit_limit: ComputeUnitLimit::Default,
+        });
 
     let recent_blockhash = blockhash_query.get_blockhash(rpc_client, config.commitment)?;
 
@@ -1780,7 +1786,10 @@ pub fn process_deactivate_stake_account(
         stake_instruction::deactivate_stake(&stake_account_address, &stake_authority.pubkey())
     }]
     .with_memo(memo)
-    .with_compute_unit_price(compute_unit_price);
+    .with_compute_unit_config(&ComputeUnitConfig {
+        compute_unit_price,
+        compute_unit_limit: ComputeUnitLimit::Default,
+    });
 
     let nonce_authority = config.signers[nonce_authority];
     let fee_payer = config.signers[fee_payer];
@@ -1869,7 +1878,10 @@ pub fn process_withdraw_stake(
             custodian.map(|signer| signer.pubkey()).as_ref(),
         )]
         .with_memo(memo)
-        .with_compute_unit_price(compute_unit_price);
+        .with_compute_unit_config(&ComputeUnitConfig {
+            compute_unit_price,
+            compute_unit_limit: ComputeUnitLimit::Default,
+        });
 
         if let Some(nonce_account) = &nonce_account {
             Message::new_with_nonce(
@@ -2048,7 +2060,10 @@ pub fn process_split_stake(
                 seed,
             )
             .with_memo(memo)
-            .with_compute_unit_price(compute_unit_price),
+            .with_compute_unit_config(&ComputeUnitConfig {
+                compute_unit_price,
+                compute_unit_limit: ComputeUnitLimit::Default,
+            }),
         )
     } else {
         ixs.append(
@@ -2059,7 +2074,10 @@ pub fn process_split_stake(
                 &split_stake_account_address,
             )
             .with_memo(memo)
-            .with_compute_unit_price(compute_unit_price),
+            .with_compute_unit_config(&ComputeUnitConfig {
+                compute_unit_price,
+                compute_unit_limit: ComputeUnitLimit::Default,
+            }),
         )
     };
 
@@ -2167,7 +2185,10 @@ pub fn process_merge_stake(
         &stake_authority.pubkey(),
     )
     .with_memo(memo)
-    .with_compute_unit_price(compute_unit_price);
+    .with_compute_unit_config(&ComputeUnitConfig {
+        compute_unit_price,
+        compute_unit_limit: ComputeUnitLimit::Default,
+    });
 
     let nonce_authority = config.signers[nonce_authority];
 
@@ -2243,7 +2264,10 @@ pub fn process_stake_set_lockup(
         stake_instruction::set_lockup(stake_account_pubkey, lockup, &custodian.pubkey())
     }]
     .with_memo(memo)
-    .with_compute_unit_price(compute_unit_price);
+    .with_compute_unit_config(&ComputeUnitConfig {
+        compute_unit_price,
+        compute_unit_limit: ComputeUnitLimit::Default,
+    });
     let nonce_authority = config.signers[nonce_authority];
     let fee_payer = config.signers[fee_payer];
 
@@ -2749,7 +2773,10 @@ pub fn process_delegate_stake(
         )]
     }
     .with_memo(memo)
-    .with_compute_unit_price(compute_unit_price);
+    .with_compute_unit_config(&ComputeUnitConfig {
+        compute_unit_price,
+        compute_unit_limit: ComputeUnitLimit::Default,
+    });
 
     let nonce_authority = config.signers[nonce_authority];
     let fee_payer = config.signers[fee_payer];

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1420,7 +1420,7 @@ pub fn process_create_stake_account(
     memo: Option<&String>,
     fee_payer: SignerIndex,
     from: SignerIndex,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let stake_account = config.signers[stake_account];
     let stake_account_address = if let Some(seed) = seed {
@@ -1570,7 +1570,7 @@ pub fn process_stake_authorize(
     memo: Option<&String>,
     fee_payer: SignerIndex,
     no_wait: bool,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let mut ixs = Vec::new();
     let custodian = custodian.map(|index| config.signers[index]);
@@ -1709,7 +1709,7 @@ pub fn process_deactivate_stake_account(
     memo: Option<&String>,
     seed: Option<&String>,
     fee_payer: SignerIndex,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let recent_blockhash = blockhash_query.get_blockhash(rpc_client, config.commitment)?;
 
@@ -1853,7 +1853,7 @@ pub fn process_withdraw_stake(
     memo: Option<&String>,
     seed: Option<&String>,
     fee_payer: SignerIndex,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let withdraw_authority = config.signers[withdraw_authority];
     let custodian = custodian.map(|index| config.signers[index]);
@@ -1954,7 +1954,7 @@ pub fn process_split_stake(
     split_stake_account_seed: &Option<String>,
     lamports: u64,
     fee_payer: SignerIndex,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
     rent_exempt_reserve: Option<&u64>,
 ) -> ProcessResult {
     let split_stake_account = config.signers[split_stake_account];
@@ -2139,7 +2139,7 @@ pub fn process_merge_stake(
     nonce_authority: SignerIndex,
     memo: Option<&String>,
     fee_payer: SignerIndex,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let fee_payer = config.signers[fee_payer];
 
@@ -2253,7 +2253,7 @@ pub fn process_stake_set_lockup(
     nonce_authority: SignerIndex,
     memo: Option<&String>,
     fee_payer: SignerIndex,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let recent_blockhash = blockhash_query.get_blockhash(rpc_client, config.commitment)?;
     let custodian = config.signers[custodian];
@@ -2682,7 +2682,7 @@ pub fn process_delegate_stake(
     memo: Option<&String>,
     fee_payer: SignerIndex,
     redelegation_stake_account: Option<SignerIndex>,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (&config.signers[0].pubkey(), "cli keypair".to_string()),

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -362,7 +362,10 @@ pub fn process_set_validator_info(
                 lamports,
                 keys.clone(),
             )
-            .with_compute_unit_price(compute_unit_price);
+            .with_compute_unit_config(&ComputeUnitConfig {
+                compute_unit_price,
+                compute_unit_limit: ComputeUnitLimit::Default,
+            });
             instructions.extend_from_slice(&[config_instruction::store(
                 &info_pubkey,
                 true,
@@ -382,7 +385,10 @@ pub fn process_set_validator_info(
                 keys,
                 &validator_info,
             )]
-            .with_compute_unit_price(compute_unit_price);
+            .with_compute_unit_config(&ComputeUnitConfig {
+                compute_unit_price,
+                compute_unit_limit: ComputeUnitLimit::Default,
+            });
             Message::new(&instructions, Some(&config.signers[0].pubkey()))
         }
     };

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},
-        compute_budget::WithComputeUnitPrice,
+        compute_budget::{ComputeUnitConfig, WithComputeUnitConfig},
         spend_utils::{resolve_spend_tx_and_check_account_balance, SpendAmount},
     },
     bincode::{deserialize, serialized_size},
@@ -12,7 +12,7 @@ use {
         self, ValidatorInfo, MAX_LONG_FIELD_LENGTH, MAX_SHORT_FIELD_LENGTH,
     },
     solana_clap_utils::{
-        compute_unit_price::{compute_unit_price_arg, COMPUTE_UNIT_PRICE_ARG},
+        compute_budget::{compute_unit_price_arg, ComputeUnitLimit, COMPUTE_UNIT_PRICE_ARG},
         hidden_unless_forced,
         input_parsers::{pubkey_of, value_of},
         input_validators::{is_pubkey, is_url},
@@ -275,7 +275,7 @@ pub fn process_set_validator_info(
     validator_info: &Value,
     force_keybase: bool,
     info_pubkey: Option<Pubkey>,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     // Validate keybase username
     if let Some(string) = validator_info.get("keybaseUsername") {

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -5,7 +5,7 @@ use {
             log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError,
             ProcessResult,
         },
-        compute_budget::WithComputeUnitPrice,
+        compute_budget::{ComputeUnitConfig, WithComputeUnitConfig},
         memo::WithMemo,
         nonce::check_nonce_account,
         spend_utils::{resolve_spend_tx_and_check_account_balances, SpendAmount},
@@ -13,7 +13,7 @@ use {
     },
     clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand},
     solana_clap_utils::{
-        compute_unit_price::{compute_unit_price_arg, COMPUTE_UNIT_PRICE_ARG},
+        compute_budget::{compute_unit_price_arg, ComputeUnitLimit, COMPUTE_UNIT_PRICE_ARG},
         fee_payer::{fee_payer_arg, FEE_PAYER_ARG},
         input_parsers::*,
         input_validators::*,
@@ -853,7 +853,10 @@ pub fn process_create_vote_account(
             create_vote_account_config,
         )
         .with_memo(memo)
-        .with_compute_unit_price(compute_unit_price);
+        .with_compute_unit_config(&ComputeUnitConfig {
+            compute_unit_price,
+            compute_unit_limit: ComputeUnitLimit::Default,
+        });
 
         if let Some(nonce_account) = &nonce_account {
             Message::new_with_nonce(
@@ -1004,7 +1007,10 @@ pub fn process_vote_authorize(
     };
     let ixs = vec![vote_ix]
         .with_memo(memo)
-        .with_compute_unit_price(compute_unit_price);
+        .with_compute_unit_config(&ComputeUnitConfig {
+            compute_unit_price,
+            compute_unit_limit: ComputeUnitLimit::Default,
+        });
 
     let recent_blockhash = blockhash_query.get_blockhash(rpc_client, config.commitment)?;
 
@@ -1083,7 +1089,10 @@ pub fn process_vote_update_validator(
         &new_identity_pubkey,
     )]
     .with_memo(memo)
-    .with_compute_unit_price(compute_unit_price);
+    .with_compute_unit_config(&ComputeUnitConfig {
+        compute_unit_price,
+        compute_unit_limit: ComputeUnitLimit::Default,
+    });
     let nonce_authority = config.signers[nonce_authority];
     let fee_payer = config.signers[fee_payer];
 
@@ -1153,7 +1162,10 @@ pub fn process_vote_update_commission(
         commission,
     )]
     .with_memo(memo)
-    .with_compute_unit_price(compute_unit_price);
+    .with_compute_unit_config(&ComputeUnitConfig {
+        compute_unit_price,
+        compute_unit_limit: ComputeUnitLimit::Default,
+    });
     let nonce_authority = config.signers[nonce_authority];
     let fee_payer = config.signers[fee_payer];
 
@@ -1318,7 +1330,10 @@ pub fn process_withdraw_from_vote_account(
             destination_account_pubkey,
         )]
         .with_memo(memo)
-        .with_compute_unit_price(compute_unit_price);
+        .with_compute_unit_config(&ComputeUnitConfig {
+            compute_unit_price,
+            compute_unit_limit: ComputeUnitLimit::Default,
+        });
 
         if let Some(nonce_account) = &nonce_account {
             Message::new_with_nonce(
@@ -1435,7 +1450,10 @@ pub fn process_close_vote_account(
         destination_account_pubkey,
     )]
     .with_memo(memo)
-    .with_compute_unit_price(compute_unit_price);
+    .with_compute_unit_config(&ComputeUnitConfig {
+        compute_unit_price,
+        compute_unit_limit: ComputeUnitLimit::Default,
+    });
 
     let message = Message::new(&ixs, Some(&fee_payer.pubkey()));
     let mut tx = Transaction::new_unsigned(message);

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -791,7 +791,7 @@ pub fn process_create_vote_account(
     nonce_authority: SignerIndex,
     memo: Option<&String>,
     fee_payer: SignerIndex,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let vote_account = config.signers[vote_account];
     let vote_account_pubkey = vote_account.pubkey();
@@ -942,7 +942,7 @@ pub fn process_vote_authorize(
     nonce_authority: SignerIndex,
     memo: Option<&String>,
     fee_payer: SignerIndex,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let authorized = config.signers[authorized];
     let new_authorized_signer = new_authorized.map(|index| config.signers[index]);
@@ -1073,7 +1073,7 @@ pub fn process_vote_update_validator(
     nonce_authority: SignerIndex,
     memo: Option<&String>,
     fee_payer: SignerIndex,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let authorized_withdrawer = config.signers[withdraw_authority];
     let new_identity_account = config.signers[new_identity_account];
@@ -1152,7 +1152,7 @@ pub fn process_vote_update_commission(
     nonce_authority: SignerIndex,
     memo: Option<&String>,
     fee_payer: SignerIndex,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let authorized_withdrawer = config.signers[withdraw_authority];
     let recent_blockhash = blockhash_query.get_blockhash(rpc_client, config.commitment)?;
@@ -1314,7 +1314,7 @@ pub fn process_withdraw_from_vote_account(
     nonce_authority: SignerIndex,
     memo: Option<&String>,
     fee_payer: SignerIndex,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let withdraw_authority = config.signers[withdraw_authority];
     let recent_blockhash = blockhash_query.get_blockhash(rpc_client, config.commitment)?;
@@ -1415,7 +1415,7 @@ pub fn process_close_vote_account(
     destination_account_pubkey: &Pubkey,
     memo: Option<&String>,
     fee_payer: SignerIndex,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let vote_account_status =
         rpc_client.get_vote_accounts_with_config(RpcGetVoteAccountsConfig {

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -4,7 +4,7 @@ use {
             log_instruction_custom_error, request_and_confirm_airdrop, CliCommand, CliCommandInfo,
             CliConfig, CliError, ProcessResult,
         },
-        compute_budget::WithComputeUnitPrice,
+        compute_budget::{ComputeUnitConfig, WithComputeUnitConfig},
         memo::WithMemo,
         nonce::check_nonce_account,
         spend_utils::{resolve_spend_tx_and_check_account_balances, SpendAmount},
@@ -12,7 +12,7 @@ use {
     clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand},
     hex::FromHex,
     solana_clap_utils::{
-        compute_unit_price::{compute_unit_price_arg, COMPUTE_UNIT_PRICE_ARG},
+        compute_budget::{compute_unit_price_arg, ComputeUnitLimit, COMPUTE_UNIT_PRICE_ARG},
         fee_payer::*,
         hidden_unless_forced,
         input_parsers::*,
@@ -922,11 +922,17 @@ pub fn process_transfer(
                 lamports,
             )]
             .with_memo(memo)
-            .with_compute_unit_price(compute_unit_price)
+            .with_compute_unit_config(&ComputeUnitConfig {
+                compute_unit_price,
+                compute_unit_limit: ComputeUnitLimit::Default,
+            })
         } else {
             vec![system_instruction::transfer(&from_pubkey, to, lamports)]
                 .with_memo(memo)
-                .with_compute_unit_price(compute_unit_price)
+                .with_compute_unit_config(&ComputeUnitConfig {
+                    compute_unit_price,
+                    compute_unit_limit: ComputeUnitLimit::Default,
+                })
         };
 
         if let Some(nonce_account) = &nonce_account {

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -879,7 +879,7 @@ pub fn process_transfer(
     fee_payer: SignerIndex,
     derived_address_seed: Option<String>,
     derived_address_program_id: Option<&Pubkey>,
-    compute_unit_price: Option<&u64>,
+    compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let from = config.signers[from];
     let mut from_pubkey = from.pubkey();


### PR DESCRIPTION
#### Problem

Although #850 added in the concept of `ComputeUnitConfig` for specifying more than just the price, it wasn't really used.

#### Summary of Changes

This PR contains no functional changes, just refactoring to eventually allow users to specify a static compute unit limit or for the CLI to use a simulated compute unit limit in more places.

* Introduce `ComputeUnitLimit` for specifying simulated, default, or static limits for the transaction, just like the token-cli https://github.com/solana-labs/solana-program-library/blob/3c60545668eafa2294365e2edfb5799c657971c3/token/client/src/token.rs#L336-L340
* Add a `ComputeUnitLimit` instance to `ComputeUnitConfig`
* Use `with_compute_unit_config` everywhere instead of `with_compute_unit_price` -- the `program` subcommand always uses `ComputeUnitLimit::Simulated`, every other use stays with `ComputeUnitLimit::Default`
* Update uses of `Option<&u64>` to `Option<u64>` for easier use with `ComputeUnitConfig`

The follow-up work will be much easier to parallelize -- it involves including a `--with-compute-unit-limit` arg to all commands, and adding a call to `simulate_and_update_compute_unit_limit`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
