### PR TITLE
fix(geyser-plugin-manager): avoid SIGSEGV when plugin returns on_load…

### DIFF
--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -490,11 +490,9 @@ mod tests {
         );
 
         // Mock having loaded plugin (TestPlugin)
-        let (mut plugin, lib, config) = dummy_plugin_and_library(TestPlugin, DUMMY_CONFIG);
+        let (mut plugin, config) = dummy_plugin_and_library(TestPlugin, DUMMY_CONFIG);
         plugin.on_load(config, false).unwrap();
         plugin_manager_lock.plugins.push(plugin);
-        plugin_manager_lock.libs.push(lib);
-        // plugin_manager_lock.libs.push(lib);
         assert_eq!(plugin_manager_lock.plugins[0].name(), DUMMY_NAME);
         plugin_manager_lock.plugins[0].name();
 
@@ -525,15 +523,13 @@ mod tests {
 
         // Load two plugins
         // First
-        let (mut plugin, lib, config) = dummy_plugin_and_library(TestPlugin, TESTPLUGIN_CONFIG);
+        let (mut plugin, config) = dummy_plugin_and_library(TestPlugin, TESTPLUGIN_CONFIG);
         plugin.on_load(config, false).unwrap();
         plugin_manager_lock.plugins.push(plugin);
-        plugin_manager_lock.libs.push(lib);
         // Second
-        let (mut plugin, lib, config) = dummy_plugin_and_library(TestPlugin2, TESTPLUGIN2_CONFIG);
+        let (mut plugin, config) = dummy_plugin_and_library(TestPlugin2, TESTPLUGIN2_CONFIG);
         plugin.on_load(config, false).unwrap();
         plugin_manager_lock.plugins.push(plugin);
-        plugin_manager_lock.libs.push(lib);
 
         // Check that both plugins are returned in the list
         let plugins = plugin_manager_lock.list_plugins().unwrap();

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -14,9 +14,14 @@ use {
 pub struct LoadedGeyserPlugin {
     name: String,
     plugin: Box<dyn GeyserPlugin>,
-    // NOTE: We store the library after the plugin to ensure that it will live
-    // longer than plugin. We never access the library but we must ensure it is
-    // valid for the full lifetime of plugin else we will most likely SIGSEGV.
+    // NOTE: While we do not access the library, the plugin we have loaded most
+    // certainly does. To ensure we don't SIGSEGV we must declare the library
+    // after the plugin so the plugin is dropped first.
+    //
+    // Furthermore, a well behaved Geyser plugin must ensure it ceases to run
+    // any code before returning from Drop. This means if the Geyser plugins
+    // spawn threads that access the Library, those threads must be `join`ed
+    // before the Geyser plugin returns from on_unload / Drop.
     #[allow(dead_code)]
     library: Library,
 }

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -144,7 +144,7 @@ impl GeyserPluginManager {
         }
 
         if let Err(err) = setup_logger_for_plugin(&*new_plugin.plugin) {
-            // NOTE: Must drop pugin before lib to avoid a segfault.
+            // NOTE: Must drop plugin before lib to avoid a segfault.
             drop(new_plugin);
             drop(new_lib);
             return Err(err);

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -144,7 +144,7 @@ impl GeyserPluginManager {
         }
 
         if let Err(err) = setup_logger_for_plugin(&*new_plugin.plugin) {
-            // NB: Must drop pugin before lib to avoid a segfault.
+            // NOTE: Must drop pugin before lib to avoid a segfault.
             drop(new_plugin);
             drop(new_lib);
             return Err(err);
@@ -152,7 +152,7 @@ impl GeyserPluginManager {
 
         // Call on_load and push plugin
         if let Err(err) = new_plugin.on_load(new_config_file, false) {
-            // NB: Must drop pugin before lib to avoid a segfault.
+            // NOTE: Must drop pugin before lib to avoid a segfault.
             let name = new_plugin.name().to_owned();
             drop(new_plugin);
             drop(new_lib);


### PR DESCRIPTION
#### Problem

When a plugin return an `Err` from `on_load` it will cause the library to be dropped before the plugin. This results in a `SIGSEGV`.

Here is a minimal reproduction: https://github.com/OliverNChalk/agave/commit/708e9a905483d9b7fb7f772c017877c4f9d14e0c

Steps to reproduce:

- Checkout above repo.
- `cargo build`
- `cargo run --bin solana-test-validator -- --geyser-plugin-config geyser-sigsegv/plugin.json --log`
- Observe SIGSEGV

If we want I can convert the repro into a test case in `agave` but it will require an additional crate that contains the plugin so we can load it as a DLL in tests.

#### Summary of Changes

- Manually force the correct drop order & add comments explaining this is needed.

