### PR TITLE
Removes accounts hash calculation with index from AccountsHashVerifier

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -333,14 +333,6 @@ impl AccountsHashVerifier {
             let calculate_accounts_hash_config = CalcAccountsHashConfig {
                 // since we're going to assert, use the fg thread pool to go faster
                 use_bg_thread_pool: false,
-                ..calculate_accounts_hash_config
-            };
-            let result_with_index = accounts_package
-                .accounts
-                .accounts_db
-                .calculate_accounts_hash_from_index(slot, &calculate_accounts_hash_config);
-            info!("hash calc with index: {slot}, {result_with_index:?}",);
-            let calculate_accounts_hash_config = CalcAccountsHashConfig {
                 // now that we've failed, store off the failing contents that produced a bad capitalization
                 store_detailed_debug_info_on_failure: true,
                 ..calculate_accounts_hash_config


### PR DESCRIPTION
#### Problem

If there is a capitalization mismatch in AccountsHashVerifier when calculating the full accounts hash (e.g. during a full snapshot), we rerun the hash calculation; first with the index, then a second time from storages.

Since the full hash calc takes ~15-20 minutes, by the time the index version runs, we've definitely run `clean` *past* the slot we're doing the hash calc on. This means the index will have a very different view of the world. One that is much newer. And it will not be possible to run the hash calc with the index and have it match on a slot this old where `clean` has run much past it.

Thus, the results from the hash calc with index are invalid and confusing.


#### Summary of Changes

Remove the hash calc with index from AHV.