### PR TITLE
chore: remove publish=false from transaction-metrics-tracker/Cargo.toml

### DIFF
--- a/transaction-metrics-tracker/Cargo.toml
+++ b/transaction-metrics-tracker/Cargo.toml
@@ -8,7 +8,6 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-publish = false
 
 [dependencies]
 Inflector = { workspace = true }


### PR DESCRIPTION
#### Problem

we publish `solana-streamer` and it uses `solana-transaction-metrics-tracker` so `solana-transaction-metrics-tracker` need to be published as well.

#### Summary of Changes

remove `publish = false` from `solana-transaction-metrics-tracker`