### PR TITLE
chore: add dcou to apply_votes_to_tower

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6555,6 +6555,7 @@ dependencies = [
  "solana-entry",
  "solana-gossip",
  "solana-ledger",
+ "solana-local-cluster",
  "solana-logger",
  "solana-pubsub-client",
  "solana-quic-client",

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -48,8 +48,8 @@ serial_test = { workspace = true }
 solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-download-utils = { workspace = true }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-local-cluster = { path = ".", features = ["dev-context-only-utils"] }
+solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -49,6 +49,7 @@ solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-download-utils = { workspace = true }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-local-cluster = { path = ".", features = ["dev-context-only-utils"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -50,7 +50,6 @@ use {
         time::{Duration, Instant},
     },
 };
-
 #[cfg(feature = "dev-context-only-utils")]
 use {
     solana_core::consensus::tower_storage::{

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -8,10 +8,7 @@ use {
     rand::{thread_rng, Rng},
     rayon::{prelude::*, ThreadPool},
     solana_client::connection_cache::{ConnectionCache, Protocol},
-    solana_core::consensus::{
-        tower_storage::{FileTowerStorage, SavedTower, SavedTowerVersions, TowerStorage},
-        VOTE_THRESHOLD_DEPTH,
-    },
+    solana_core::consensus::VOTE_THRESHOLD_DEPTH,
     solana_entry::entry::{self, Entry, EntrySlice},
     solana_gossip::{
         cluster_info::{self, ClusterInfo},
@@ -44,7 +41,7 @@ use {
     std::{
         collections::{HashMap, HashSet, VecDeque},
         net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener},
-        path::{Path, PathBuf},
+        path::Path,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc, RwLock,
@@ -52,6 +49,14 @@ use {
         thread::{sleep, JoinHandle},
         time::{Duration, Instant},
     },
+};
+
+#[cfg(feature = "dev-context-only-utils")]
+use {
+    solana_core::consensus::tower_storage::{
+        FileTowerStorage, SavedTower, SavedTowerVersions, TowerStorage,
+    },
+    std::path::PathBuf,
 };
 
 pub fn get_client_facing_addr(
@@ -348,6 +353,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
     }
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 pub fn apply_votes_to_tower(node_keypair: &Keypair, votes: Vec<(Slot, Hash)>, tower_path: PathBuf) {
     let tower_storage = FileTowerStorage::new(tower_path);
     let mut tower = tower_storage.load(&node_keypair.pubkey()).unwrap();


### PR DESCRIPTION
#### Problem

We added dcou for `record_vote` in #687 but `apply_votes_to_tower` is still using it. 

#### Summary of Changes

get `apply_votes_to_tower` under dcou as well.