### PR TITLE
chore: add v2.0 mergify rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -168,6 +168,45 @@ pull_request_rules:
           into master and ride the normal stabilization schedule. Exceptions
           include CI/metrics changes, CLI improvements and documentation
           updates on a case by case basis.
+  - name: v2.0 feature-gate backport
+    conditions:
+      - label=v2.0
+      - label=feature-gate
+    actions:
+      backport:
+        assignees: *BackportAssignee
+        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
+        ignore_conflicts: true
+        labels:
+          - feature-gate
+        branches:
+          - v2.0
+  - name: v2.0 non-feature-gate backport
+    conditions:
+      - label=v2.0
+      - label!=feature-gate
+    actions:
+      backport:
+        assignees: *BackportAssignee
+        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
+        ignore_conflicts: true
+        branches:
+          - v2.0
+  - name: v2.0 backport warning comment
+    conditions:
+      - label=v2.0
+    actions:
+      comment:
+        message: >
+          Backports to the beta branch are to be avoided unless absolutely
+          necessary for fixing bugs, security issues, and perf regressions.
+          Changes intended for backport should be structured such that a
+          minimum effective diff can be committed separately from any
+          refactoring, plumbing, cleanup, etc that are not strictly
+          necessary to achieve the goal. Any of the latter should go only
+          into master and ride the normal stabilization schedule. Exceptions
+          include CI/metrics changes, CLI improvements and documentation
+          updates on a case by case basis.
 
 commands_restrictions:
   # The author of copied PRs is the Mergify user.


### PR DESCRIPTION
#### Summary of Changes

add v2.0 bp rule.

(will remove v1.17 when v1.18 run on mainnet-beta for more epochs)