### PR TITLE
adds feature-gate code to enforce retransmitter signature verification

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -828,6 +828,10 @@ pub mod zk_elgamal_proof_program_enabled {
     solana_sdk::declare_id!("zkhiy5oLowR7HY4zogXjCjeMXyruLqBwSWH21qcFtnv");
 }
 
+pub mod verify_retransmitter_signature {
+    solana_sdk::declare_id!("BZ5g4hRbu5hLQQBdPyo2z9icGyJ8Khiyj3QS6dhWijTb");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -1030,6 +1034,7 @@ lazy_static! {
         (enable_get_epoch_stake_syscall::id(), "Enable syscall: sol_get_epoch_stake #884"),
         (migrate_address_lookup_table_program_to_core_bpf::id(), "Migrate Address Lookup Table program to Core BPF #1651"),
         (zk_elgamal_proof_program_enabled::id(), "Enable ZkElGamalProof program SIMD-0153"),
+        (verify_retransmitter_signature::id(), "Verify retransmitter signature #1840"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Need to verify if the shred is retransmitted by the expected parent node in Turbine tree.

#### Summary of Changes
Added feature-gate code to enforce retransmitter signature verification
