### PR TITLE
chore: publish solana-tps-client

### DIFF
--- a/tps-client/Cargo.toml
+++ b/tps-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-tps-client"
-publish = false
+description = "Blockchain, Rebuilt for Scale"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
#### Problem

`solana-cli` needs `solana-tps-client`

#### Summary of Changes

publish `solana-tps-client`