### PR TITLE
Allow the registration of genesis hash and recent block hash for fuzzing

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -843,6 +843,7 @@ pub(crate) fn process_blockstore_for_bank_0(
         accounts_update_notifier,
         None,
         exit,
+        None,
     );
     let bank0_slot = bank0.slot();
     let bank_forks = BankForks::new_rw_arc(bank0);

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -863,6 +863,7 @@ impl ProgramTest {
             None,
             None,
             Arc::default(),
+            None,
         );
 
         // Add commonly-used SPL programs as a convenience to the user

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -937,7 +937,7 @@ impl ProgramTest {
                     .read()
                     .unwrap()
                     .working_bank()
-                    .register_unique_recent_blockhash_for_test(&Hash::new_unique());
+                    .register_unique_recent_blockhash_for_test();
             }
         });
 
@@ -1097,7 +1097,7 @@ impl ProgramTestContext {
                         .read()
                         .unwrap()
                         .working_bank()
-                        .register_unique_recent_blockhash_for_test(&Hash::new_unique());
+                        .register_unique_recent_blockhash_for_test();
                 }
             }),
         );

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -937,7 +937,7 @@ impl ProgramTest {
                     .read()
                     .unwrap()
                     .working_bank()
-                    .register_unique_recent_blockhash_for_test();
+                    .register_unique_recent_blockhash_for_test(&Hash::new_unique());
             }
         });
 
@@ -1097,7 +1097,7 @@ impl ProgramTestContext {
                         .read()
                         .unwrap()
                         .working_bank()
-                        .register_unique_recent_blockhash_for_test();
+                        .register_unique_recent_blockhash_for_test(&Hash::new_unique());
                 }
             }),
         );

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4051,7 +4051,7 @@ fn test_cpi_account_ownership_writability() {
                 TEST_FORBID_WRITE_AFTER_OWNERSHIP_CHANGE_IN_CALLEE,
                 TEST_FORBID_WRITE_AFTER_OWNERSHIP_CHANGE_IN_CALLER,
             ] {
-                bank.register_unique_recent_blockhash_for_test(&Hash::new_unique());
+                bank.register_unique_recent_blockhash_for_test();
                 let account = AccountSharedData::new(42, account_size, &invoke_program_id);
                 bank.store_account(&account_keypair.pubkey(), &account);
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4051,7 +4051,7 @@ fn test_cpi_account_ownership_writability() {
                 TEST_FORBID_WRITE_AFTER_OWNERSHIP_CHANGE_IN_CALLEE,
                 TEST_FORBID_WRITE_AFTER_OWNERSHIP_CHANGE_IN_CALLER,
             ] {
-                bank.register_unique_recent_blockhash_for_test();
+                bank.register_unique_recent_blockhash_for_test(&Hash::new_unique());
                 let account = AccountSharedData::new(42, account_size, &invoke_program_id);
                 bank.store_account(&account_keypair.pubkey(), &account);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3235,6 +3235,11 @@ impl Bank {
         )
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn register_recent_blockhash_for_test(&self, hash: &Hash) {
+        self.register_recent_blockhash(hash, &BankWithScheduler::no_scheduler_available());
+    }
+
     /// Tell the bank which Entry IDs exist on the ledger. This function assumes subsequent calls
     /// correspond to later entries, and will boot the oldest ones once its internal cache is full.
     /// Once boot, the bank will reject transactions using that `hash`.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2959,7 +2959,6 @@ impl Bank {
         self.collector_id =
             collector_id.expect("genesis processing failed because no staked nodes exist");
 
-
         #[cfg(not(feature = "dev-context-only-utils"))]
         let default_genesis_hash = genesis_config.hash();
         #[cfg(feature = "dev-context-only-utils")]
@@ -3229,11 +3228,8 @@ impl Bank {
 
     // gating this under #[cfg(feature = "dev-context-only-utils")] isn't easy due to
     // solana-program-test's usage...
-    pub fn register_unique_recent_blockhash_for_test(&self) {
-        self.register_recent_blockhash(
-            &Hash::new_unique(),
-            &BankWithScheduler::no_scheduler_available(),
-        )
+    pub fn register_unique_recent_blockhash_for_test(&self, hash: &Hash) {
+        self.register_recent_blockhash(hash, &BankWithScheduler::no_scheduler_available())
     }
 
     /// Tell the bank which Entry IDs exist on the ledger. This function assumes subsequent calls

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2959,6 +2959,7 @@ impl Bank {
         self.collector_id =
             collector_id.expect("genesis processing failed because no staked nodes exist");
 
+
         #[cfg(not(feature = "dev-context-only-utils"))]
         let default_genesis_hash = genesis_config.hash();
         #[cfg(feature = "dev-context-only-utils")]
@@ -3228,8 +3229,11 @@ impl Bank {
 
     // gating this under #[cfg(feature = "dev-context-only-utils")] isn't easy due to
     // solana-program-test's usage...
-    pub fn register_unique_recent_blockhash_for_test(&self, hash: &Hash) {
-        self.register_recent_blockhash(hash, &BankWithScheduler::no_scheduler_available())
+    pub fn register_unique_recent_blockhash_for_test(&self) {
+        self.register_recent_blockhash(
+            &Hash::new_unique(),
+            &BankWithScheduler::no_scheduler_available(),
+        )
     }
 
     /// Tell the bank which Entry IDs exist on the ledger. This function assumes subsequent calls

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2959,16 +2959,15 @@ impl Bank {
         self.collector_id =
             collector_id.expect("genesis processing failed because no staked nodes exist");
 
-
         #[cfg(not(feature = "dev-context-only-utils"))]
-        let default_genesis_hash = genesis_config.hash();
+        let genesis_hash = genesis_config.hash();
         #[cfg(feature = "dev-context-only-utils")]
-        let default_genesis_hash = genesis_hash.unwrap_or(genesis_config.hash());
+        let genesis_hash = genesis_hash.unwrap_or(genesis_config.hash());
 
-        self.blockhash_queue.write().unwrap().genesis_hash(
-            &default_genesis_hash,
-            self.fee_rate_governor.lamports_per_signature,
-        );
+        self.blockhash_queue
+            .write()
+            .unwrap()
+            .genesis_hash(&genesis_hash, self.fee_rate_governor.lamports_per_signature);
 
         self.hashes_per_tick = genesis_config.hashes_per_tick();
         self.ticks_per_slot = genesis_config.ticks_per_slot();

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -379,6 +379,7 @@ mod tests {
             None,
             Some(Pubkey::new_unique()),
             Arc::default(),
+            None,
         );
 
         // Fill bank_forks with banks with votes landing in the next slot
@@ -486,6 +487,7 @@ mod tests {
             None,
             Some(Pubkey::new_unique()),
             Arc::default(),
+            None,
         );
 
         let stake_account_stores_per_block =

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -276,7 +276,6 @@ mod tests {
         solana_sdk::{
             account::Account,
             epoch_schedule::EpochSchedule,
-            hash::Hash,
             native_token::LAMPORTS_PER_SOL,
             reward_type::RewardType,
             signature::Signer,
@@ -829,7 +828,7 @@ mod tests {
             // Push a dummy blockhash, so that the latest_blockhash() for the transfer transaction in each
             // iteration are different. Otherwise, all those transactions will be the same, and will not be
             // executed by the bank except the first one.
-            bank.register_unique_recent_blockhash_for_test(&Hash::new_unique());
+            bank.register_unique_recent_blockhash_for_test();
             previous_bank = bank;
         }
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -276,6 +276,7 @@ mod tests {
         solana_sdk::{
             account::Account,
             epoch_schedule::EpochSchedule,
+            hash::Hash,
             native_token::LAMPORTS_PER_SOL,
             reward_type::RewardType,
             signature::Signer,
@@ -828,7 +829,7 @@ mod tests {
             // Push a dummy blockhash, so that the latest_blockhash() for the transfer transaction in each
             // iteration are different. Otherwise, all those transactions will be the same, and will not be
             // executed by the bank except the first one.
-            bank.register_unique_recent_blockhash_for_test();
+            bank.register_unique_recent_blockhash_for_test(&Hash::new_unique());
             previous_bank = bank;
         }
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9072,6 +9072,7 @@ fn test_epoch_schedule_from_genesis_config() {
         None,
         None,
         Arc::default(),
+        None,
     ));
 
     assert_eq!(bank.epoch_schedule(), &genesis_config.epoch_schedule);
@@ -9102,6 +9103,7 @@ where
         None,
         None,
         Arc::default(),
+        None,
     ));
     let vote_and_stake_accounts =
         load_vote_and_stake_accounts(&bank).vote_with_stake_delegations_map;
@@ -12645,6 +12647,7 @@ fn test_rehash_with_skipped_rewrites() {
         None,
         Some(Pubkey::new_unique()),
         Arc::new(AtomicBool::new(false)),
+        None,
     ));
     // This test is only meaningful while the bank hash contains rewrites.
     // Once this feature is enabled, it may be possible to remove this test entirely.
@@ -12706,6 +12709,7 @@ fn test_rebuild_skipped_rewrites() {
         None,
         Some(Pubkey::new_unique()),
         Arc::new(AtomicBool::new(false)),
+        None,
     ));
     // This test is only meaningful while the bank hash contains rewrites.
     // Once this feature is enabled, it may be possible to remove this test entirely.
@@ -12816,6 +12820,7 @@ fn test_get_accounts_for_bank_hash_details(skip_rewrites: bool) {
         None,
         Some(Pubkey::new_unique()),
         Arc::new(AtomicBool::new(false)),
+        None,
     ));
     // This test is only meaningful while the bank hash contains rewrites.
     // Once this feature is enabled, it may be possible to remove this test entirely.


### PR DESCRIPTION
#### Problem

I am working on the transaction fuzzer with Firedancer, and we want to include the hashes generation in the fuzzer. None of the Agave's APIs allows us to manually set the genesis hash and register a recent block hash.

#### Summary of Changes

I added a new argument to `Bank::new_with_paths` that receives a genesis hash and modified `register_unique_recent_blockhash_for_test` so that is receives the hash as an argument.

