### PR TITLE
Rename cost_tracker.account_data_size to better describe its purpose is to track per-block new accounts (re)allocation

### DIFF
--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -43,7 +43,8 @@ impl CostModel {
             Self::get_signature_cost(&mut tx_cost, transaction);
             Self::get_write_lock_cost(&mut tx_cost, transaction, feature_set);
             Self::get_transaction_cost(&mut tx_cost, transaction, feature_set);
-            tx_cost.account_data_size = Self::calculate_account_data_size(transaction);
+            tx_cost.allocated_accounts_data_size =
+                Self::calculate_allocated_accounts_data_size(transaction);
 
             debug!("transaction {:?} has cost {:?}", transaction, tx_cost);
             TransactionCost::Transaction(tx_cost)
@@ -218,7 +219,7 @@ impl CostModel {
 
     /// eventually, potentially determine account data size of all writable accounts
     /// at the moment, calculate account data size of account creation
-    fn calculate_account_data_size(transaction: &SanitizedTransaction) -> u64 {
+    fn calculate_allocated_accounts_data_size(transaction: &SanitizedTransaction) -> u64 {
         transaction
             .message()
             .program_instructions_iter()

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -56,10 +56,10 @@ impl TransactionCost {
         }
     }
 
-    pub fn account_data_size(&self) -> u64 {
+    pub fn allocated_accounts_data_size(&self) -> u64 {
         match self {
             Self::SimpleVote { .. } => 0,
-            Self::Transaction(usage_cost) => usage_cost.account_data_size,
+            Self::Transaction(usage_cost) => usage_cost.allocated_accounts_data_size,
         }
     }
 
@@ -125,7 +125,7 @@ pub struct UsageCostDetails {
     pub data_bytes_cost: u64,
     pub programs_execution_cost: u64,
     pub loaded_accounts_data_size_cost: u64,
-    pub account_data_size: u64,
+    pub allocated_accounts_data_size: u64,
     pub num_transaction_signatures: u64,
     pub num_secp256k1_instruction_signatures: u64,
     pub num_ed25519_instruction_signatures: u64,
@@ -140,7 +140,7 @@ impl Default for UsageCostDetails {
             data_bytes_cost: 0u64,
             programs_execution_cost: 0u64,
             loaded_accounts_data_size_cost: 0u64,
-            account_data_size: 0u64,
+            allocated_accounts_data_size: 0u64,
             num_transaction_signatures: 0u64,
             num_secp256k1_instruction_signatures: 0u64,
             num_ed25519_instruction_signatures: 0u64,
@@ -160,7 +160,7 @@ impl PartialEq for UsageCostDetails {
             && self.data_bytes_cost == other.data_bytes_cost
             && self.programs_execution_cost == other.programs_execution_cost
             && self.loaded_accounts_data_size_cost == other.loaded_accounts_data_size_cost
-            && self.account_data_size == other.account_data_size
+            && self.allocated_accounts_data_size == other.allocated_accounts_data_size
             && self.num_transaction_signatures == other.num_transaction_signatures
             && self.num_secp256k1_instruction_signatures
                 == other.num_secp256k1_instruction_signatures


### PR DESCRIPTION
#### Problem

`cost_tracker.account_data_size` isn't appropriately named, especially next to  `cost_tracker.loaded_accounts_data_size_cost`, it could be confusing to read.
 
#### Summary of Changes
- rename it to reflect its purpose is to track and limit per-block accounts (re)allocation.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
