### PR TITLE
add set_sysvar_for_tests to SysvarCache

### DIFF
--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -27,25 +27,25 @@ impl ::solana_frozen_abi::abi_example::AbiExample for SysvarCache {
 #[derive(Default, Clone, Debug)]
 pub struct SysvarCache {
     // full account data as provided by bank, including any trailing zero bytes
-    clock: Option<Vec<u8>>,
-    epoch_schedule: Option<Vec<u8>>,
-    epoch_rewards: Option<Vec<u8>>,
-    rent: Option<Vec<u8>>,
-    slot_hashes: Option<Vec<u8>>,
-    stake_history: Option<Vec<u8>>,
-    last_restart_slot: Option<Vec<u8>>,
+    pub clock: Option<Vec<u8>>,
+    pub epoch_schedule: Option<Vec<u8>>,
+    pub epoch_rewards: Option<Vec<u8>>,
+    pub rent: Option<Vec<u8>>,
+    pub slot_hashes: Option<Vec<u8>>,
+    pub stake_history: Option<Vec<u8>>,
+    pub last_restart_slot: Option<Vec<u8>>,
 
     // object representations of large sysvars for convenience
     // these are used by the stake and vote builtin programs
     // these should be removed once those programs are ported to bpf
-    slot_hashes_obj: Option<Arc<SlotHashes>>,
-    stake_history_obj: Option<Arc<StakeHistory>>,
+    pub slot_hashes_obj: Option<Arc<SlotHashes>>,
+    pub stake_history_obj: Option<Arc<StakeHistory>>,
 
     // deprecated sysvars, these should be removed once practical
     #[allow(deprecated)]
-    fees: Option<Fees>,
+    pub fees: Option<Fees>,
     #[allow(deprecated)]
-    recent_blockhashes: Option<RecentBlockhashes>,
+    pub recent_blockhashes: Option<RecentBlockhashes>,
 }
 
 impl SysvarCache {

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -58,8 +58,7 @@ impl SysvarCache {
     /// Overwrite a sysvar. For testing purposes only.
     #[allow(deprecated)]
     pub fn set_sysvar_for_tests<T: Sysvar + SysvarId>(&mut self, sysvar: &T) {
-        let data =
-            bincode::serialize(sysvar).expect("Failed to serialize sysvar. This shouldn't happen.");
+        let data = bincode::serialize(sysvar).expect("Failed to serialize sysvar.");
         let sysvar_id = T::id();
         match sysvar_id {
             sysvar::clock::ID => {
@@ -72,31 +71,30 @@ impl SysvarCache {
                 self.epoch_schedule = Some(data);
             }
             FEES_ID => {
-                let fees: Fees = bincode::deserialize(&data)
-                    .expect("Failed to deserialize Fees sysvar. This shouldn't happen.");
+                let fees: Fees =
+                    bincode::deserialize(&data).expect("Failed to deserialize Fees sysvar.");
                 self.fees = Some(fees);
             }
             sysvar::last_restart_slot::ID => {
                 self.last_restart_slot = Some(data);
             }
             RECENT_BLOCKHASHES_ID => {
-                let recent_blockhashes: RecentBlockhashes = bincode::deserialize(&data).expect(
-                    "Failed to deserialize RecentBlockhashes sysvar. This shouldn't happen.",
-                );
+                let recent_blockhashes: RecentBlockhashes = bincode::deserialize(&data)
+                    .expect("Failed to deserialize RecentBlockhashes sysvar.");
                 self.recent_blockhashes = Some(recent_blockhashes);
             }
             sysvar::rent::ID => {
                 self.rent = Some(data);
             }
             sysvar::slot_hashes::ID => {
-                let slot_hashes: SlotHashes = bincode::deserialize(&data)
-                    .expect("Failed to deserialize SlotHashes sysvar. This shouldn't happen.");
+                let slot_hashes: SlotHashes =
+                    bincode::deserialize(&data).expect("Failed to deserialize SlotHashes sysvar.");
                 self.slot_hashes = Some(data);
                 self.slot_hashes_obj = Some(Arc::new(slot_hashes));
             }
             sysvar::stake_history::ID => {
                 let stake_history: StakeHistory = bincode::deserialize(&data)
-                    .expect("Failed to deserialize StakeHistory sysvar. This shouldn't happen.");
+                    .expect("Failed to deserialize StakeHistory sysvar.");
                 self.stake_history = Some(data);
                 self.stake_history_obj = Some(Arc::new(stake_history));
             }

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -7,7 +7,7 @@ use {
         instruction::InstructionError,
         pubkey::Pubkey,
         sysvar::{
-            clock::Clock, epoch_rewards::EpochRewards, epoch_schedule::EpochSchedule,
+            self, clock::Clock, epoch_rewards::EpochRewards, epoch_schedule::EpochSchedule,
             last_restart_slot::LastRestartSlot, rent::Rent, slot_hashes::SlotHashes,
             stake_history::StakeHistory, Sysvar, SysvarId,
         },
@@ -48,7 +48,62 @@ pub struct SysvarCache {
     pub recent_blockhashes: Option<RecentBlockhashes>,
 }
 
+// declare_deprecated_sysvar_id doesn't support const.
+// These sysvars are going away anyway.
+const FEES_ID: Pubkey = solana_sdk::pubkey!("SysvarFees111111111111111111111111111111111");
+const RECENT_BLOCKHASHES_ID: Pubkey =
+    solana_sdk::pubkey!("SysvarRecentB1ockHashes11111111111111111111");
+
 impl SysvarCache {
+    /// Overwrite a sysvar. For testing purposes only.
+    #[allow(deprecated)]
+    pub fn set_sysvar_for_tests<T: Sysvar + SysvarId>(&mut self, sysvar: &T) {
+        let data =
+            bincode::serialize(sysvar).expect("Failed to serialize sysvar. This shouldn't happen.");
+        let sysvar_id = T::id();
+        match sysvar_id {
+            sysvar::clock::ID => {
+                self.clock = Some(data);
+            }
+            sysvar::epoch_rewards::ID => {
+                self.epoch_rewards = Some(data);
+            }
+            sysvar::epoch_schedule::ID => {
+                self.epoch_schedule = Some(data);
+            }
+            FEES_ID => {
+                let fees: Fees = bincode::deserialize(&data)
+                    .expect("Failed to deserialize Fees sysvar. This shouldn't happen.");
+                self.fees = Some(fees);
+            }
+            sysvar::last_restart_slot::ID => {
+                self.last_restart_slot = Some(data);
+            }
+            RECENT_BLOCKHASHES_ID => {
+                let recent_blockhashes: RecentBlockhashes = bincode::deserialize(&data).expect(
+                    "Failed to deserialize RecentBlockhashes sysvar. This shouldn't happen.",
+                );
+                self.recent_blockhashes = Some(recent_blockhashes);
+            }
+            sysvar::rent::ID => {
+                self.rent = Some(data);
+            }
+            sysvar::slot_hashes::ID => {
+                let slot_hashes: SlotHashes = bincode::deserialize(&data)
+                    .expect("Failed to deserialize SlotHashes sysvar. This shouldn't happen.");
+                self.slot_hashes = Some(data);
+                self.slot_hashes_obj = Some(Arc::new(slot_hashes));
+            }
+            sysvar::stake_history::ID => {
+                let stake_history: StakeHistory = bincode::deserialize(&data)
+                    .expect("Failed to deserialize StakeHistory sysvar. This shouldn't happen.");
+                self.stake_history = Some(data);
+                self.stake_history_obj = Some(Arc::new(stake_history));
+            }
+            _ => panic!("Unrecognized Sysvar ID: {sysvar_id}"),
+        }
+    }
+
     // this is exposed for SyscallGetSysvar and should not otherwise be used
     pub fn sysvar_id_to_buffer(&self, sysvar_id: &Pubkey) -> &Option<Vec<u8>> {
         if Clock::check_id(sysvar_id) {

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -27,25 +27,25 @@ impl ::solana_frozen_abi::abi_example::AbiExample for SysvarCache {
 #[derive(Default, Clone, Debug)]
 pub struct SysvarCache {
     // full account data as provided by bank, including any trailing zero bytes
-    pub clock: Option<Vec<u8>>,
-    pub epoch_schedule: Option<Vec<u8>>,
-    pub epoch_rewards: Option<Vec<u8>>,
-    pub rent: Option<Vec<u8>>,
-    pub slot_hashes: Option<Vec<u8>>,
-    pub stake_history: Option<Vec<u8>>,
-    pub last_restart_slot: Option<Vec<u8>>,
+    clock: Option<Vec<u8>>,
+    epoch_schedule: Option<Vec<u8>>,
+    epoch_rewards: Option<Vec<u8>>,
+    rent: Option<Vec<u8>>,
+    slot_hashes: Option<Vec<u8>>,
+    stake_history: Option<Vec<u8>>,
+    last_restart_slot: Option<Vec<u8>>,
 
     // object representations of large sysvars for convenience
     // these are used by the stake and vote builtin programs
     // these should be removed once those programs are ported to bpf
-    pub slot_hashes_obj: Option<Arc<SlotHashes>>,
-    pub stake_history_obj: Option<Arc<StakeHistory>>,
+    slot_hashes_obj: Option<Arc<SlotHashes>>,
+    stake_history_obj: Option<Arc<StakeHistory>>,
 
     // deprecated sysvars, these should be removed once practical
     #[allow(deprecated)]
-    pub fees: Option<Fees>,
+    fees: Option<Fees>,
     #[allow(deprecated)]
-    pub recent_blockhashes: Option<RecentBlockhashes>,
+    recent_blockhashes: Option<RecentBlockhashes>,
 }
 
 // declare_deprecated_sysvar_id doesn't support const.


### PR DESCRIPTION
#### Problem
litesvm was calling the `set_*`  methods on SysvarCache previously whenever it detected that a sysvar account was written to.  Now that these methods are gone and the SysvarCache fields are private, it needs a new way to update individual fields in the SysvarCache.

#### Summary of Changes
~Makes all the fields pub~ Add a `set_sysvar_for_tests` method

