### PR TITLE
accounts db/sort remove dup optimization

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -346,8 +346,6 @@ fn bench_load_largest_accounts(b: &mut Bencher) {
     });
 }
 
-// old: test bench_sort_and_dedups                             ... bench:     322,798 ns/iter (+/- 8,451)
-// new: test bench_sort_and_dedups                             ... bench:      89,960 ns/iter (+/- 2,934)
 #[bench]
 fn bench_sort_and_dedups(b: &mut Bencher) {
     fn generate_sample_account_from_storage(i: u8) -> AccountFromStorage {
@@ -361,9 +359,10 @@ fn bench_sort_and_dedups(b: &mut Bencher) {
     }
 
     let mut rng = rand::thread_rng();
-    let accounts: Vec<_> = (0..1000)
-        .map(|_i| generate_sample_account_from_storage(rng.gen::<u8>()))
-        .collect();
+    let accounts: Vec<_> =
+        std::iter::repeat_with(|| generate_sample_account_from_storage(rng.gen::<u8>()))
+            .take(1000)
+            .collect();
 
     b.iter(|| AccountsDb::sort_and_remove_dups(&mut accounts.clone()));
 }

--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -347,7 +347,7 @@ fn bench_load_largest_accounts(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_sort_and_dedups(b: &mut Bencher) {
+fn bench_sort_and_remove_dups(b: &mut Bencher) {
     fn generate_sample_account_from_storage(i: u8) -> AccountFromStorage {
         // offset has to be 8 byte aligned
         let offset = (i as usize) * std::mem::size_of::<u64>();
@@ -358,7 +358,8 @@ fn bench_sort_and_dedups(b: &mut Bencher) {
         }
     }
 
-    let mut rng = rand::thread_rng();
+    use rand::prelude::*;
+    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234);
     let accounts: Vec<_> =
         std::iter::repeat_with(|| generate_sample_account_from_storage(rng.gen::<u8>()))
             .take(1000)

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -10060,15 +10060,19 @@ pub mod tests {
                 .collect();
 
         let mut accounts1 = accounts.clone();
-        AccountsDb::sort_and_remove_dups(&mut accounts1);
+        let num_dups1 = AccountsDb::sort_and_remove_dups(&mut accounts1);
 
         // Use BTreeMap to calculate sort and remove dups alternatively.
         let mut map = std::collections::BTreeMap::default();
+        let mut num_dups2 = 0;
         for account in accounts.iter() {
-            map.insert(*account.pubkey(), *account);
+            if map.insert(*account.pubkey(), *account).is_some() {
+                num_dups2 += 1;
+            }
         }
         let accounts2: Vec<_> = map.into_values().collect();
         assert_eq!(accounts1, accounts2);
+        assert_eq!(num_dups1, num_dups2);
     }
 
     /// Reserve ancient storage size is not supported for TiredStorage

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -10067,7 +10067,7 @@ pub mod tests {
         for account in accounts.iter() {
             map.insert(*account.pubkey(), *account);
         }
-        let accounts2: Vec<_> = map.values().cloned().collect();
+        let accounts2: Vec<_> = map.into_values().collect();
         assert_eq!(accounts1, accounts2);
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3932,7 +3932,7 @@ impl AccountsDb {
     /// sort `accounts` by pubkey.
     /// Remove earlier entries with the same pubkey as later entries.
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-    fn sort_and_remove_dups(accounts: &mut Vec<AccountFromStorage>) {
+    fn sort_and_remove_dups(accounts: &mut Vec<AccountFromStorage>) -> usize {
         // stable sort because we want the most recent only
         accounts.sort_by(|a, b| a.pubkey().cmp(b.pubkey()));
         let len0 = accounts.len();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3929,8 +3929,10 @@ impl AccountsDb {
         }
     }
 
-    /// sort `accounts` by pubkey.
-    /// Remove earlier entries with the same pubkey as later entries.
+    /// Sort `accounts` by pubkey and removes all but the *last* of consecutive
+    /// accounts in the vector with the same pubkey.
+    ///
+    /// Return the number of duplicated elements in the vector.
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn sort_and_remove_dups(accounts: &mut Vec<AccountFromStorage>) -> usize {
         // stable sort because we want the most recent only

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3936,19 +3936,22 @@ impl AccountsDb {
         accounts.sort_by(|a, b| a.pubkey().cmp(b.pubkey()));
         let len0 = accounts.len();
         if accounts.len() > 1 {
-            let mut i = 0;
-            // iterate 0..1 less than end
-            while i < accounts.len() - 1 {
-                let current = accounts[i];
-                let next = accounts[i + 1];
-                if current.pubkey() == next.pubkey() {
-                    // remove the first duplicate
-                    accounts.remove(i);
-                    // do not advance i, we just removed an element at i
-                    continue;
+            let mut last = 0;
+            let mut curr = 1;
+
+            loop {
+                if accounts[curr].pubkey() == accounts[last].pubkey() {
+                    accounts[last] = accounts[curr];
+                } else {
+                    last += 1;
+                    accounts[last] = accounts[curr];
                 }
-                i += 1;
+                curr += 1;
+                if curr == accounts.len() {
+                    break;
+                }
             }
+            accounts.truncate(last + 1);
         }
         len0 - accounts.len()
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3931,7 +3931,7 @@ impl AccountsDb {
 
     /// sort `accounts` by pubkey.
     /// Remove earlier entries with the same pubkey as later entries.
-    fn sort_and_remove_dups(accounts: &mut Vec<AccountFromStorage>) -> usize {
+    pub fn sort_and_remove_dups(accounts: &mut Vec<AccountFromStorage>) {
         // stable sort because we want the most recent only
         accounts.sort_by(|a, b| a.pubkey().cmp(b.pubkey()));
         let len0 = accounts.len();


### PR DESCRIPTION
#### Problem

When we shrink and pack account storages or ancient account storages, one of the steps is to extract, sort and remove duplicated accounts in the source storages. 

This is done in `AccountsDb::sort_and_remove_dups` function. This function uses an algorithm that calls "vec::remove()" iteratively. The total complexity is $O(n^2)$. For large account storages, the function is inefficient.


#### Summary of Changes

Implement an $O(n)$ algorithm for account storage 'sort_and_remove_dups'.

- optimize sort and remove dups for shrinking
- add bench

Bench Result
```
// old: test bench_sort_and_dedups                             ... bench:     322,798 ns/iter (+/- 8,451)
// new: test bench_sort_and_dedups                             ... bench:      89,960 ns/iter (+/- 2,934)

```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
