### PR TITLE
replay: add option to use vote slot to select leader to send vote txs to

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4498,6 +4498,7 @@ pub(crate) mod tests {
             },
             replay_stage::ReplayStage,
             vote_simulator::{self, VoteSimulator},
+            voting_service::VoteTxLeaderSelectionMethod,
         },
         crossbeam_channel::unbounded,
         itertools::Itertools,
@@ -7777,6 +7778,7 @@ pub(crate) mod tests {
             &poh_recorder,
             &tower_storage,
             vote_info,
+            VoteTxLeaderSelectionMethod::VoteSlot,
         );
 
         let mut cursor = Cursor::default();
@@ -7852,6 +7854,7 @@ pub(crate) mod tests {
             &poh_recorder,
             &tower_storage,
             vote_info,
+            VoteTxLeaderSelectionMethod::VoteSlot,
         );
         let votes = cluster_info.get_votes(&mut cursor);
         assert_eq!(votes.len(), 1);
@@ -7935,6 +7938,7 @@ pub(crate) mod tests {
             &poh_recorder,
             &tower_storage,
             vote_info,
+            VoteTxLeaderSelectionMethod::VoteSlot,
         );
 
         assert!(last_vote_refresh_time.last_refresh_time > clone_refresh_time);
@@ -8053,6 +8057,7 @@ pub(crate) mod tests {
             poh_recorder,
             tower_storage,
             vote_info,
+            VoteTxLeaderSelectionMethod::VoteSlot,
         );
 
         let votes = cluster_info.get_votes(cursor);

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -21,7 +21,7 @@ use {
         replay_stage::{ReplayStage, ReplayStageConfig},
         rewards_recorder_service::RewardsRecorderSender,
         shred_fetch_stage::ShredFetchStage,
-        voting_service::VotingService,
+        voting_service::{VoteTxLeaderSelectionMethod, VotingService},
         warm_quic_cache_service::WarmQuicCacheService,
         window_service::WindowService,
     },
@@ -159,6 +159,7 @@ impl Tvu {
         outstanding_repair_requests: Arc<RwLock<OutstandingShredRepairs>>,
         cluster_slots: Arc<ClusterSlots>,
         wen_restart_repair_slots: Option<Arc<RwLock<Vec<Slot>>>>,
+        leader_selection_method: VoteTxLeaderSelectionMethod,
     ) -> Result<Self, String> {
         let TvuSockets {
             repair: repair_socket,
@@ -290,6 +291,7 @@ impl Tvu {
             cluster_info.clone(),
             poh_recorder.clone(),
             tower_storage,
+            leader_selection_method,
         );
 
         let warm_quic_cache_service = connection_cache.and_then(|connection_cache| {
@@ -520,6 +522,7 @@ pub mod tests {
             outstanding_repair_requests,
             cluster_slots,
             None,
+            VoteTxLeaderSelectionMethod::VoteSlot,
         )
         .expect("assume success");
         exit.store(true, Ordering::Relaxed);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -26,6 +26,7 @@ use {
         },
         tpu::{Tpu, TpuSockets, DEFAULT_TPU_COALESCE},
         tvu::{Tvu, TvuConfig, TvuSockets},
+        voting_service::VoteTxLeaderSelectionMethod,
     },
     crossbeam_channel::{bounded, unbounded, Receiver},
     lazy_static::lazy_static,
@@ -274,6 +275,7 @@ pub struct ValidatorConfig {
     pub replay_forks_threads: NonZeroUsize,
     pub replay_transactions_threads: NonZeroUsize,
     pub delay_leader_block_for_pending_fork: bool,
+    pub vote_tx_leader_selection_method: VoteTxLeaderSelectionMethod,
 }
 
 impl Default for ValidatorConfig {
@@ -345,6 +347,7 @@ impl Default for ValidatorConfig {
             replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             replay_transactions_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             delay_leader_block_for_pending_fork: false,
+            vote_tx_leader_selection_method: VoteTxLeaderSelectionMethod::default(),
         }
     }
 }
@@ -358,6 +361,7 @@ impl ValidatorConfig {
             replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             replay_transactions_threads: NonZeroUsize::new(get_max_thread_count())
                 .expect("thread count is non-zero"),
+            vote_tx_leader_selection_method: VoteTxLeaderSelectionMethod::VoteSlot,
             ..Self::default()
         }
     }
@@ -1366,6 +1370,7 @@ impl Validator {
             outstanding_repair_requests.clone(),
             cluster_slots.clone(),
             wen_restart_repair_slots.clone(),
+            config.vote_tx_leader_selection_method,
         )?;
 
         if in_wen_restart {

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -1,18 +1,80 @@
 use {
     crate::{
         consensus::tower_storage::{SavedTowerVersions, TowerStorage},
-        next_leader::next_leader_tpu_vote,
+        next_leader::{next_leader_tpu_vote, next_vote_slot_leader_tpu_vote},
     },
     crossbeam_channel::Receiver,
-    solana_gossip::cluster_info::ClusterInfo,
+    lazy_static::lazy_static,
+    solana_gossip::{cluster_info::ClusterInfo, gossip_error::GossipError},
     solana_measure::measure::Measure,
     solana_poh::poh_recorder::PohRecorder,
-    solana_sdk::{clock::Slot, transaction::Transaction},
+    solana_sdk::{clock::Slot, pubkey::Pubkey, transaction::Transaction},
     std::{
+        net::SocketAddr,
         sync::{Arc, RwLock},
         thread::{self, Builder, JoinHandle},
     },
+    strum::VariantNames,
+    strum_macros::{Display, EnumString, EnumVariantNames, IntoStaticStr},
 };
+
+#[derive(Clone, Copy, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
+#[strum(serialize_all = "kebab-case")]
+pub enum VoteTxLeaderSelectionMethod {
+    #[default]
+    PohRecorder,
+    VoteSlot,
+    Both,
+}
+
+impl VoteTxLeaderSelectionMethod {
+    pub const fn cli_names() -> &'static [&'static str] {
+        Self::VARIANTS
+    }
+
+    pub fn cli_message() -> &'static str {
+        lazy_static! {
+            static ref MESSAGE: String = format!(
+                "Choose the source of truth to determine which leader to send a vote to [default: {}]",
+                VoteTxLeaderSelectionMethod::default()
+            );
+        };
+
+        &MESSAGE
+    }
+
+    pub(crate) fn select_leaders(
+        &self,
+        vote_op: &VoteOp,
+        cluster_info: &ClusterInfo,
+        poh_recorder: &RwLock<PohRecorder>,
+    ) -> Vec<Option<(Pubkey, SocketAddr)>> {
+        let vote_slot = vote_op
+            .last_voted_slot()
+            .expect("Should not send an empty vote");
+        match (self, vote_op.is_refresh_vote()) {
+            (_, true) | (VoteTxLeaderSelectionMethod::PohRecorder, _) => {
+                // Refresh votes should always select leaders based on PoH, as the vote slot is outdated
+                vec![next_leader_tpu_vote(cluster_info, poh_recorder)]
+            }
+            (VoteTxLeaderSelectionMethod::VoteSlot, _) => {
+                // Send to the leader of vote_slot + 1
+                vec![next_vote_slot_leader_tpu_vote(
+                    vote_slot,
+                    cluster_info,
+                    poh_recorder,
+                )]
+            }
+            (VoteTxLeaderSelectionMethod::Both, _) => {
+                // Send to both the PoH leader, and the leader of vote_slot + 1
+                vec![
+                    next_vote_slot_leader_tpu_vote(vote_slot, cluster_info, poh_recorder),
+                    next_leader_tpu_vote(cluster_info, poh_recorder),
+                ]
+            }
+        }
+    }
+}
 
 pub enum VoteOp {
     PushVote {
@@ -33,6 +95,19 @@ impl VoteOp {
             VoteOp::RefreshVote { tx, .. } => tx,
         }
     }
+
+    fn last_voted_slot(&self) -> Option<Slot> {
+        match self {
+            VoteOp::PushVote { tower_slots, .. } => tower_slots.last().copied(),
+            VoteOp::RefreshVote {
+                last_voted_slot, ..
+            } => Some(*last_voted_slot),
+        }
+    }
+
+    fn is_refresh_vote(&self) -> bool {
+        matches!(self, VoteOp::RefreshVote { .. })
+    }
 }
 
 pub struct VotingService {
@@ -45,7 +120,12 @@ impl VotingService {
         cluster_info: Arc<ClusterInfo>,
         poh_recorder: Arc<RwLock<PohRecorder>>,
         tower_storage: Arc<dyn TowerStorage>,
+        leader_selection_method: VoteTxLeaderSelectionMethod,
     ) -> Self {
+        info!(
+            "Starting voting service with leader selection method {}",
+            leader_selection_method
+        );
         let thread_hdl = Builder::new()
             .name("solVoteService".to_string())
             .spawn(move || {
@@ -55,6 +135,7 @@ impl VotingService {
                         &poh_recorder,
                         tower_storage.as_ref(),
                         vote_op,
+                        leader_selection_method,
                     );
                 }
             })
@@ -62,11 +143,29 @@ impl VotingService {
         Self { thread_hdl }
     }
 
+    fn push_vote(
+        vote_op: &VoteOp,
+        cluster_info: &ClusterInfo,
+        poh_recorder: &RwLock<PohRecorder>,
+        leader_selection_method: VoteTxLeaderSelectionMethod,
+    ) -> Result<(), GossipError> {
+        leader_selection_method
+            .select_leaders(vote_op, cluster_info, poh_recorder)
+            .into_iter()
+            .try_for_each(|leader| {
+                cluster_info.send_transaction(
+                    vote_op.tx(),
+                    leader.map(|(_pubkey, target_addr)| target_addr),
+                )
+            })
+    }
+
     pub fn handle_vote(
         cluster_info: &ClusterInfo,
         poh_recorder: &RwLock<PohRecorder>,
         tower_storage: &dyn TowerStorage,
         vote_op: VoteOp,
+        leader_selection_method: VoteTxLeaderSelectionMethod,
     ) {
         if let VoteOp::PushVote { saved_tower, .. } = &vote_op {
             let mut measure = Measure::start("tower_save-ms");
@@ -78,11 +177,22 @@ impl VotingService {
             inc_new_counter_info!("tower_save-ms", measure.as_ms() as usize);
         }
 
-        let _ = cluster_info.send_transaction(
-            vote_op.tx(),
-            next_leader_tpu_vote(cluster_info, poh_recorder)
-                .map(|(_pubkey, target_addr)| target_addr),
-        );
+        if let Err(e) = Self::push_vote(
+            &vote_op,
+            cluster_info,
+            poh_recorder,
+            leader_selection_method,
+        ) {
+            warn!(
+                "Failed to send vote tx for {:?}: {}",
+                vote_op.last_voted_slot(),
+                e
+            );
+            datapoint_warn!(
+                "voting-service-send-failure",
+                ("vote_slot", vote_op.last_voted_slot(), Option<i64>),
+            );
+        }
 
         match vote_op {
             VoteOp::PushVote {

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -72,6 +72,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         replay_forks_threads: config.replay_forks_threads,
         replay_transactions_threads: config.replay_transactions_threads,
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
+        vote_tx_leader_selection_method: config.vote_tx_leader_selection_method,
     }
 }
 

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -393,6 +393,10 @@ impl PohRecorder {
             .map(|leader| (leader, target_slot))
     }
 
+    pub fn leader_at_slot(&self, slot: Slot) -> Option<Pubkey> {
+        self.leader_schedule_cache.slot_leader_at(slot, None)
+    }
+
     pub fn next_slot_leader(&self) -> Option<Pubkey> {
         self.leader_after_n_slots(1)
     }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -22,6 +22,7 @@ use {
     solana_core::{
         banking_trace::{DirByteLimit, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
         validator::{BlockProductionMethod, BlockVerificationMethod},
+        voting_service::VoteTxLeaderSelectionMethod,
     },
     solana_faucet::faucet::{self, FAUCET_PORT},
     solana_ledger::use_snapshot_archives_at_startup,
@@ -1518,6 +1519,14 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                     confirm that block's fork rather than our leader block's fork because it \
                     was created before we started creating ours.",
                 ),
+        )
+        .arg(
+            Arg::with_name("vote_tx_leader_selection_method")
+            .long("vote-tx-leader-selection-method")
+            .value_name("METHOD")
+            .takes_value(true)
+            .possible_values(VoteTxLeaderSelectionMethod::cli_names())
+            .help(VoteTxLeaderSelectionMethod::cli_message()),
         )
         .arg(
             Arg::with_name("block_verification_method")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -36,6 +36,7 @@ use {
             is_snapshot_config_valid, BlockProductionMethod, BlockVerificationMethod, Validator,
             ValidatorConfig, ValidatorStartProgress,
         },
+        voting_service::VoteTxLeaderSelectionMethod,
     },
     solana_gossip::{
         cluster_info::{Node, NodeConfig},
@@ -1756,6 +1757,13 @@ pub fn main() {
     .unwrap_or_default();
     validator_config.unified_scheduler_handler_threads =
         value_t!(matches, "unified_scheduler_handler_threads", usize).ok();
+
+    validator_config.vote_tx_leader_selection_method = value_t!(
+        matches,
+        "vote_tx_leader_selection_method",
+        VoteTxLeaderSelectionMethod
+    )
+    .unwrap_or_default();
 
     validator_config.ledger_column_options = LedgerColumnOptions {
         compression_type: match matches.value_of("rocksdb_ledger_compression") {


### PR DESCRIPTION
#### Problem
Currently votes are sent to the leader producing block `poh_slot + 2`. In the absence of forks we'd like a vote for slot `S` to land in block `S + 1`. https://github.com/anza-xyz/agave/issues/1851#issuecomment-2190134040 indicates that the leader producing `poh_slot + 2` might not always be the leader producing `S + 1`. 

#### Summary of Changes
Add a flag to experiment with 3 different leader selection method for vote txs:
* current `poh_slot + 2`
* `vote_slot + 1`
* both `poh_slot + 2` and `vote_slot + 1`

Additionally add metrics for when sending a vote transaction fails. 