### PR TITLE
reserved_account_keys - generic hash function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6452,6 +6452,7 @@ dependencies = [
 name = "solana-ledger"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "assert_matches",
  "bincode",
  "bitflags 2.6.0",
@@ -7140,6 +7141,7 @@ dependencies = [
 name = "solana-runtime"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "aquamarine",
  "arrayref",
  "assert_matches",
@@ -7242,6 +7244,7 @@ dependencies = [
 name = "solana-sdk"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "anyhow",
  "assert_matches",
  "bincode",

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -103,11 +103,11 @@ impl ImmutableDeserializedPacket {
 
     // This function deserializes packets into transactions, computes the blake3 hash of transaction
     // messages.
-    pub fn build_sanitized_transaction(
+    pub fn build_sanitized_transaction<S: core::hash::BuildHasher>(
         &self,
         votes_only: bool,
         address_loader: impl AddressLoader,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, S>,
     ) -> Option<SanitizedTransaction> {
         if votes_only && !self.is_simple_vote() {
             return None;

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true, features = ["serde"] }

--- a/ledger/src/transaction_address_lookup_table_scanner.rs
+++ b/ledger/src/transaction_address_lookup_table_scanner.rs
@@ -1,4 +1,5 @@
 use {
+    ahash::AHashSet,
     bincode::deserialize,
     lazy_static::lazy_static,
     solana_sdk::{
@@ -7,11 +8,10 @@ use {
         reserved_account_keys::ReservedAccountKeys,
         transaction::SanitizedVersionedTransaction,
     },
-    std::collections::HashSet,
 };
 
 lazy_static! {
-    static ref RESERVED_IDS_SET: HashSet<Pubkey> = ReservedAccountKeys::new_all_activated().active;
+    static ref RESERVED_IDS_SET: AHashSet<Pubkey> = ReservedAccountKeys::new_all_activated().active;
 }
 
 pub struct ScannedLookupTableExtensions {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5083,6 +5083,7 @@ dependencies = [
 name = "solana-ledger"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "assert_matches",
  "bincode",
  "bitflags 2.6.0",
@@ -5565,6 +5566,7 @@ dependencies = [
 name = "solana-runtime"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "aquamarine",
  "arrayref",
  "base64 0.22.1",
@@ -6100,6 +6102,7 @@ dependencies = [
 name = "solana-sdk"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "bincode",
  "bitflags 2.6.0",
  "borsh 1.5.1",

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4703,10 +4703,10 @@ where
         .map(|output| (wire_output, output))
 }
 
-fn sanitize_transaction(
+fn sanitize_transaction<S: core::hash::BuildHasher>(
     transaction: VersionedTransaction,
     address_loader: impl AddressLoader,
-    reserved_account_keys: &HashSet<Pubkey>,
+    reserved_account_keys: &HashSet<Pubkey, S>,
 ) -> Result<SanitizedTransaction> {
     SanitizedTransaction::try_create(
         transaction,

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -100,10 +100,10 @@ impl RuntimeTransaction<SanitizedVersionedMessage> {
 }
 
 impl RuntimeTransaction<SanitizedMessage> {
-    pub fn try_from(
+    pub fn try_from<S: core::hash::BuildHasher>(
         statically_loaded_runtime_tx: RuntimeTransaction<SanitizedVersionedMessage>,
         address_loader: impl AddressLoader,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, S>,
     ) -> Result<Self> {
         let mut tx = Self {
             signatures: statically_loaded_runtime_tx.signatures,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 aquamarine = { workspace = true }
 arrayref = { workspace = true }
 base64 = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -58,6 +58,7 @@ use {
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::TransactionBatch,
     },
+    ahash::AHashSet,
     byteorder::{ByteOrder, LittleEndian},
     dashmap::{DashMap, DashSet},
     itertools::izip,
@@ -6353,7 +6354,7 @@ impl Bank {
 
     /// Get a set of all actively reserved account keys that are not allowed to
     /// be write-locked during transaction processing.
-    pub fn get_reserved_account_keys(&self) -> &HashSet<Pubkey> {
+    pub fn get_reserved_account_keys(&self) -> &AHashSet<Pubkey> {
         &self.reserved_account_keys.active
     }
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -45,6 +45,7 @@ frozen-abi = [
 ]
 
 [dependencies]
+ahash = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true, features = ["serde"] }
 borsh = { workspace = true, optional = true }

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -632,10 +632,10 @@ impl Message {
     /// fetching the latest set of reserved account keys. If this method is
     /// called by the runtime, the latest set of reserved account keys must be
     /// passed.
-    pub fn is_maybe_writable(
+    pub fn is_maybe_writable<S: core::hash::BuildHasher>(
         &self,
         i: usize,
-        reserved_account_keys: Option<&HashSet<Pubkey>>,
+        reserved_account_keys: Option<&HashSet<Pubkey, S>>,
     ) -> bool {
         (self.is_writable_index(i))
             && !self.is_account_maybe_reserved(i, reserved_account_keys)
@@ -644,10 +644,10 @@ impl Message {
 
     /// Returns true if the account at the specified index is in the optional
     /// reserved account keys set.
-    fn is_account_maybe_reserved(
+    fn is_account_maybe_reserved<S: core::hash::BuildHasher>(
         &self,
         key_index: usize,
-        reserved_account_keys: Option<&HashSet<Pubkey>>,
+        reserved_account_keys: Option<&HashSet<Pubkey, S>>,
     ) -> bool {
         let mut is_maybe_reserved = false;
         if let Some(reserved_account_keys) = reserved_account_keys {
@@ -667,7 +667,7 @@ impl Message {
         let mut writable_keys = vec![];
         let mut readonly_keys = vec![];
         for (i, key) in self.account_keys.iter().enumerate() {
-            if self.is_maybe_writable(i, None) {
+            if self.is_maybe_writable::<std::hash::RandomState>(i, None) {
                 writable_keys.push(key);
             } else {
                 readonly_keys.push(key);
@@ -881,7 +881,7 @@ mod tests {
         assert!(!message.is_maybe_writable(1, Some(&reserved_account_keys)));
         assert!(!message.is_maybe_writable(2, Some(&reserved_account_keys)));
         assert!(!message.is_maybe_writable(3, Some(&reserved_account_keys)));
-        assert!(message.is_maybe_writable(3, None));
+        assert!(message.is_maybe_writable::<std::hash::RandomState>(3, None));
         assert!(message.is_maybe_writable(4, Some(&reserved_account_keys)));
         assert!(!message.is_maybe_writable(5, Some(&reserved_account_keys)));
         assert!(!message.is_maybe_writable(6, Some(&reserved_account_keys)));
@@ -902,9 +902,9 @@ mod tests {
         assert!(!message.is_account_maybe_reserved(0, Some(&reserved_account_keys)));
         assert!(message.is_account_maybe_reserved(1, Some(&reserved_account_keys)));
         assert!(!message.is_account_maybe_reserved(2, Some(&reserved_account_keys)));
-        assert!(!message.is_account_maybe_reserved(0, None));
-        assert!(!message.is_account_maybe_reserved(1, None));
-        assert!(!message.is_account_maybe_reserved(2, None));
+        assert!(!message.is_account_maybe_reserved::<std::hash::RandomState>(0, None));
+        assert!(!message.is_account_maybe_reserved::<std::hash::RandomState>(1, None));
+        assert!(!message.is_account_maybe_reserved::<std::hash::RandomState>(2, None));
     }
 
     #[test]

--- a/sdk/program/src/message/versions/mod.rs
+++ b/sdk/program/src/message/versions/mod.rs
@@ -81,10 +81,10 @@ impl VersionedMessage {
     /// instructions in this message. Since dynamically loaded addresses can't
     /// have write locks demoted without loading addresses, this shouldn't be
     /// used in the runtime.
-    pub fn is_maybe_writable(
+    pub fn is_maybe_writable<S: core::hash::BuildHasher>(
         &self,
         index: usize,
-        reserved_account_keys: Option<&HashSet<Pubkey>>,
+        reserved_account_keys: Option<&HashSet<Pubkey, S>>,
     ) -> bool {
         match self {
             Self::Legacy(message) => message.is_maybe_writable(index, reserved_account_keys),

--- a/sdk/program/src/message/versions/v0/mod.rs
+++ b/sdk/program/src/message/versions/v0/mod.rs
@@ -343,10 +343,10 @@ impl Message {
     /// so this should not be used by the runtime. The `reserved_account_keys`
     /// param is optional to allow clients to approximate writability without
     /// requiring fetching the latest set of reserved account keys.
-    pub fn is_maybe_writable(
+    pub fn is_maybe_writable<S: core::hash::BuildHasher>(
         &self,
         key_index: usize,
-        reserved_account_keys: Option<&HashSet<Pubkey>>,
+        reserved_account_keys: Option<&HashSet<Pubkey, S>>,
     ) -> bool {
         self.is_writable_index(key_index)
             && !self.is_account_maybe_reserved(key_index, reserved_account_keys)
@@ -360,10 +360,10 @@ impl Message {
     /// Returns true if the account at the specified index is in the reserved
     /// account keys set. Before loading addresses, we can't detect reserved
     /// account keys properly so this shouldn't be used by the runtime.
-    fn is_account_maybe_reserved(
+    fn is_account_maybe_reserved<S: core::hash::BuildHasher>(
         &self,
         key_index: usize,
-        reserved_account_keys: Option<&HashSet<Pubkey>>,
+        reserved_account_keys: Option<&HashSet<Pubkey, S>>,
     ) -> bool {
         let mut is_maybe_reserved = false;
         if let Some(reserved_account_keys) = reserved_account_keys {
@@ -737,7 +737,7 @@ mod tests {
         assert!(!message.is_maybe_writable(1, Some(&reserved_account_keys)));
         assert!(!message.is_maybe_writable(2, Some(&reserved_account_keys)));
         assert!(!message.is_maybe_writable(3, Some(&reserved_account_keys)));
-        assert!(message.is_maybe_writable(3, None));
+        assert!(message.is_maybe_writable::<std::hash::RandomState>(3, None));
         assert!(message.is_maybe_writable(4, Some(&reserved_account_keys)));
         assert!(!message.is_maybe_writable(5, Some(&reserved_account_keys)));
         assert!(message.is_maybe_writable(6, Some(&reserved_account_keys)));
@@ -767,10 +767,10 @@ mod tests {
         assert!(!message.is_account_maybe_reserved(2, Some(&reserved_account_keys)));
         assert!(!message.is_account_maybe_reserved(3, Some(&reserved_account_keys)));
         assert!(!message.is_account_maybe_reserved(4, Some(&reserved_account_keys)));
-        assert!(!message.is_account_maybe_reserved(0, None));
-        assert!(!message.is_account_maybe_reserved(1, None));
-        assert!(!message.is_account_maybe_reserved(2, None));
-        assert!(!message.is_account_maybe_reserved(3, None));
-        assert!(!message.is_account_maybe_reserved(4, None));
+        assert!(!message.is_account_maybe_reserved::<std::hash::RandomState>(0, None));
+        assert!(!message.is_account_maybe_reserved::<std::hash::RandomState>(1, None));
+        assert!(!message.is_account_maybe_reserved::<std::hash::RandomState>(2, None));
+        assert!(!message.is_account_maybe_reserved::<std::hash::RandomState>(3, None));
+        assert!(!message.is_account_maybe_reserved::<std::hash::RandomState>(4, None));
     }
 }

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -306,7 +306,7 @@ mod tests {
     };
 
     fn new_sanitized_message(message: LegacyMessage) -> SanitizedMessage {
-        SanitizedMessage::try_from_legacy_message(message, &HashSet::default()).unwrap()
+        SanitizedMessage::try_from_legacy_message(message, &HashSet::new()).unwrap()
     }
 
     #[test]

--- a/sdk/src/reserved_account_keys.rs
+++ b/sdk/src/reserved_account_keys.rs
@@ -13,8 +13,8 @@ use {
         pubkey::Pubkey,
         secp256k1_program, stake, system_program, sysvar, vote,
     },
+    ahash::{AHashMap, AHashSet},
     lazy_static::lazy_static,
-    std::collections::{HashMap, HashSet},
 };
 
 // Inline zk token program id since it isn't available in the sdk
@@ -43,10 +43,10 @@ impl ::solana_frozen_abi::abi_example::AbiExample for ReservedAccountKeys {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReservedAccountKeys {
     /// Set of currently active reserved account keys
-    pub active: HashSet<Pubkey>,
+    pub active: AHashSet<Pubkey>,
     /// Set of currently inactive reserved account keys that will be moved to the
     /// active set when their feature id is activated
-    inactive: HashMap<Pubkey, Pubkey>,
+    inactive: AHashMap<Pubkey, Pubkey>,
 }
 
 impl Default for ReservedAccountKeys {
@@ -83,7 +83,7 @@ impl ReservedAccountKeys {
     pub fn new_all_activated() -> Self {
         Self {
             active: Self::all_keys_iter().copied().collect(),
-            inactive: HashMap::default(),
+            inactive: AHashMap::default(),
         }
     }
 
@@ -116,8 +116,8 @@ impl ReservedAccountKeys {
 
     /// Return an empty set of reserved keys for visibility when using in
     /// tests where the dynamic reserved key set is not available
-    pub fn empty_key_set() -> HashSet<Pubkey> {
-        HashSet::default()
+    pub fn empty_key_set() -> AHashSet<Pubkey> {
+        AHashSet::default()
     }
 }
 
@@ -262,7 +262,7 @@ mod tests {
 
     #[test]
     fn test_static_list_compat() {
-        let mut static_set = HashSet::new();
+        let mut static_set = AHashSet::new();
         static_set.extend(ALL_IDS.iter().cloned());
         static_set.extend(BUILTIN_PROGRAMS_KEYS.iter().cloned());
 

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -63,12 +63,12 @@ impl SanitizedTransaction {
     /// Create a sanitized transaction from a sanitized versioned transaction.
     /// If the input transaction uses address tables, attempt to lookup the
     /// address for each table index.
-    pub fn try_new(
+    pub fn try_new<S: core::hash::BuildHasher>(
         tx: SanitizedVersionedTransaction,
         message_hash: Hash,
         is_simple_vote_tx: bool,
         address_loader: impl AddressLoader,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, S>,
     ) -> Result<Self> {
         let signatures = tx.signatures;
         let SanitizedVersionedMessage { message } = tx.message;
@@ -98,12 +98,12 @@ impl SanitizedTransaction {
     /// Create a sanitized transaction from an un-sanitized versioned
     /// transaction.  If the input transaction uses address tables, attempt to
     /// lookup the address for each table index.
-    pub fn try_create(
+    pub fn try_create<S: core::hash::BuildHasher>(
         tx: VersionedTransaction,
         message_hash: impl Into<MessageHash>,
         is_simple_vote_tx: Option<bool>,
         address_loader: impl AddressLoader,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, S>,
     ) -> Result<Self> {
         let sanitized_versioned_tx = SanitizedVersionedTransaction::try_from(tx)?;
         let is_simple_vote_tx = is_simple_vote_tx
@@ -122,9 +122,9 @@ impl SanitizedTransaction {
     }
 
     /// Create a sanitized transaction from a legacy transaction
-    pub fn try_from_legacy_transaction(
+    pub fn try_from_legacy_transaction<S: core::hash::BuildHasher>(
         tx: Transaction,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, S>,
     ) -> Result<Self> {
         tx.sanitize()?;
 


### PR DESCRIPTION
#### Problem
- All functions the reserved account set from `ReservedAccountKeys` force us into using the slow default hash function

#### Summary of Changes
- Make all functions taking the set from `ReservedAccountKeys` generic on hash impl
- `ReservedAccountKeys` uses ahash internally

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
