### PR TITLE
accounts-db: reopen mmap as file-backed storage after shrink_progress drop

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3979,6 +3979,11 @@ impl AccountsDb {
         }
     }
 
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    fn set_storage_access(&mut self, storage_access: StorageAccess) {
+        self.storage_access = storage_access;
+    }
+
     /// Sort `accounts` by pubkey and removes all but the *last* of consecutive
     /// accounts in the vector with the same pubkey.
     ///

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3979,6 +3979,7 @@ impl AccountsDb {
         }
     }
 
+    #[allow(dead_code)]
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn set_storage_access(&mut self, storage_access: StorageAccess) {
         self.storage_access = storage_access;

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3979,9 +3979,8 @@ impl AccountsDb {
         }
     }
 
-    #[allow(dead_code)]
-    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-    fn set_storage_access(&mut self, storage_access: StorageAccess) {
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn set_storage_access(&mut self, storage_access: StorageAccess) {
         self.storage_access = storage_access;
     }
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1690,7 +1690,7 @@ pub mod tests {
                                 // Here we use can_append() as a proxy to assert the backup storage of the accounts after shrinking.
                                 // When storage_access is set to `File`, after shrinking an ancient slot, the backup storage should be
                                 // open as File, which means can_append() will return false.
-                                // When storage_access is set to `Mmap`, backup storage is still open Mmap, and can_append() will return true.
+                                // When storage_access is set to `Mmap`, backup storage is still Mmap, and can_append() will return true.
                                 assert_eq!(
                                     storage.unwrap().accounts.can_append(),
                                     storage_access == StorageAccess::Mmap


### PR DESCRIPTION
#### Problem

'reopen_storage' after ancient storage packing, while 'shrink_progress' is still alive, is not safe. 

Storage map could still point to the old storage while 'shrink_progress' is still alive. Storage map is, for sure, updated to
point to the new storage, when 'shrink_progress' is dropped. 

Therefore, we should 'reopen_storage' after 'shrink_progress' is dropped.


#### Summary of Changes

- reopen packed storage after 'shrink_progress' is dropped.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
