### PR TITLE
[ed25519] Use `verify_strict` for signature verification in ed25519 precompile

### DIFF
--- a/cost-model/src/block_cost_limits.rs
+++ b/cost-model/src/block_cost_limits.rs
@@ -27,7 +27,9 @@ pub const SIGNATURE_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 24;
 /// Number of compute units for one secp256k1 signature verification.
 pub const SECP256K1_VERIFY_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 223;
 /// Number of compute units for one ed25519 signature verification.
-pub const ED25519_VERIFY_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 80;
+pub const ED25519_VERIFY_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 76;
+/// Number of compute units for one ed25519 strict signature verification.
+pub const ED25519_VERIFY_STRICT_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 80;
 /// Number of compute units for one write lock
 pub const WRITE_LOCK_UNITS: u64 = COMPUTE_UNIT_TO_US_RATIO * 10;
 /// Number of data bytes per compute units

--- a/cost-model/src/block_cost_limits.rs
+++ b/cost-model/src/block_cost_limits.rs
@@ -27,7 +27,7 @@ pub const SIGNATURE_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 24;
 /// Number of compute units for one secp256k1 signature verification.
 pub const SECP256K1_VERIFY_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 223;
 /// Number of compute units for one ed25519 signature verification.
-pub const ED25519_VERIFY_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 76;
+pub const ED25519_VERIFY_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 80;
 /// Number of compute units for one write lock
 pub const WRITE_LOCK_UNITS: u64 = COMPUTE_UNIT_TO_US_RATIO * 10;
 /// Number of data bytes per compute units

--- a/sdk/src/ed25519_instruction.rs
+++ b/sdk/src/ed25519_instruction.rs
@@ -199,8 +199,8 @@ pub mod test {
             signature::{Keypair, Signer},
             transaction::Transaction,
         },
-        rand0_7::{thread_rng, Rng},
         hex,
+        rand0_7::{thread_rng, Rng},
     };
 
     pub fn new_ed25519_instruction_raw(
@@ -240,11 +240,11 @@ pub mod test {
 
         debug_assert_eq!(instruction_data.len(), public_key_offset);
 
-        instruction_data.extend_from_slice(&pubkey);
+        instruction_data.extend_from_slice(pubkey);
 
         debug_assert_eq!(instruction_data.len(), signature_offset);
 
-        instruction_data.extend_from_slice(&signature);
+        instruction_data.extend_from_slice(signature);
 
         debug_assert_eq!(instruction_data.len(), message_data_offset);
 

--- a/sdk/src/ed25519_instruction.rs
+++ b/sdk/src/ed25519_instruction.rs
@@ -200,7 +200,62 @@ pub mod test {
             transaction::Transaction,
         },
         rand0_7::{thread_rng, Rng},
+        hex,
     };
+
+    pub fn new_ed25519_instruction_raw(
+        pubkey: &[u8],
+        signature: &[u8],
+        message: &[u8],
+    ) -> Instruction {
+        assert_eq!(pubkey.len(), PUBKEY_SERIALIZED_SIZE);
+        assert_eq!(signature.len(), SIGNATURE_SERIALIZED_SIZE);
+
+        let mut instruction_data = Vec::with_capacity(
+            DATA_START
+                .saturating_add(SIGNATURE_SERIALIZED_SIZE)
+                .saturating_add(PUBKEY_SERIALIZED_SIZE)
+                .saturating_add(message.len()),
+        );
+
+        let num_signatures: u8 = 1;
+        let public_key_offset = DATA_START;
+        let signature_offset = public_key_offset.saturating_add(PUBKEY_SERIALIZED_SIZE);
+        let message_data_offset = signature_offset.saturating_add(SIGNATURE_SERIALIZED_SIZE);
+
+        // add padding byte so that offset structure is aligned
+        instruction_data.extend_from_slice(bytes_of(&[num_signatures, 0]));
+
+        let offsets = Ed25519SignatureOffsets {
+            signature_offset: signature_offset as u16,
+            signature_instruction_index: u16::MAX,
+            public_key_offset: public_key_offset as u16,
+            public_key_instruction_index: u16::MAX,
+            message_data_offset: message_data_offset as u16,
+            message_data_size: message.len() as u16,
+            message_instruction_index: u16::MAX,
+        };
+
+        instruction_data.extend_from_slice(bytes_of(&offsets));
+
+        debug_assert_eq!(instruction_data.len(), public_key_offset);
+
+        instruction_data.extend_from_slice(&pubkey);
+
+        debug_assert_eq!(instruction_data.len(), signature_offset);
+
+        instruction_data.extend_from_slice(&signature);
+
+        debug_assert_eq!(instruction_data.len(), message_data_offset);
+
+        instruction_data.extend_from_slice(message);
+
+        Instruction {
+            program_id: solana_sdk::ed25519_program::id(),
+            accounts: vec![],
+            data: instruction_data,
+        }
+    }
 
     fn test_case(
         num_signatures: u16,
@@ -389,5 +444,51 @@ pub mod test {
             Hash::default(),
         );
         assert!(tx.verify_precompiles(&feature_set).is_err());
+    }
+
+    #[test]
+    fn test_ed25519_malleability() {
+        solana_logger::setup();
+        let mint_keypair = Keypair::new();
+
+        // sig created via ed25519_dalek: both pass
+        let privkey = ed25519_dalek::Keypair::generate(&mut thread_rng());
+        let message_arr = b"hello";
+        let instruction = new_ed25519_instruction(&privkey, message_arr);
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction.clone()],
+            Some(&mint_keypair.pubkey()),
+            &[&mint_keypair],
+            Hash::default(),
+        );
+
+        let feature_set = FeatureSet::default();
+        assert!(tx.verify_precompiles(&feature_set).is_ok());
+
+        let feature_set = FeatureSet::all_enabled();
+        assert!(tx.verify_precompiles(&feature_set).is_ok());
+
+        // malleable sig: verify_strict does NOT pass
+        // for example, test number 5:
+        // https://github.com/C2SP/CCTV/tree/main/ed25519
+        // R has low order (in fact R == 0)
+        let pubkey =
+            &hex::decode("10eb7c3acfb2bed3e0d6ab89bf5a3d6afddd1176ce4812e38d9fd485058fdb1f")
+                .unwrap();
+        let signature = &hex::decode("00000000000000000000000000000000000000000000000000000000000000009472a69cd9a701a50d130ed52189e2455b23767db52cacb8716fb896ffeeac09").unwrap();
+        let message = b"ed25519vectors 3";
+        let instruction = new_ed25519_instruction_raw(pubkey, signature, message);
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction.clone()],
+            Some(&mint_keypair.pubkey()),
+            &[&mint_keypair],
+            Hash::default(),
+        );
+
+        let feature_set = FeatureSet::default();
+        assert!(tx.verify_precompiles(&feature_set).is_ok());
+
+        let feature_set = FeatureSet::all_enabled();
+        assert!(tx.verify_precompiles(&feature_set).is_err()); // verify_strict does NOT pass
     }
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -837,6 +837,10 @@ pub mod move_stake_and_move_lamports_ixs {
     solana_sdk::declare_id!("7bTK6Jis8Xpfrs8ZoUfiMDPazTcdPcTWheZFJTA5Z6X4");
 }
 
+pub mod ed25519_precompile_verify_strict {
+    solana_sdk::declare_id!("ed9tNscbWLYBooxWA7FE2B5KHWs8A6sxfY8EzezEcoo");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -1041,6 +1045,7 @@ lazy_static! {
         (zk_elgamal_proof_program_enabled::id(), "Enable ZkElGamalProof program SIMD-0153"),
         (verify_retransmitter_signature::id(), "Verify retransmitter signature #1840"),
         (move_stake_and_move_lamports_ixs::id(), "Enable MoveStake and MoveLamports stake program instructions #1610"),
+        (ed25519_precompile_verify_strict::id(), "Use strict verification in ed25519 precompile SIMD-0152"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
[simd 152](https://github.com/solana-foundation/solana-improvement-documents/pull/152) is merged. This PR is change # 1, which updates ed25519 precompile signature verification to use the strict verification.

#### Summary of Changes
Replaced signature verification in the ed25519 precompile to use strict verification under a feature gate.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
