### PR TITLE
Add --block-verification-method=unified-scheduler for v2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Release channels have their own copy of this changelog:
     * Updated type in Bank::epoch_rewards_status (#1277)
     * Partitions are recalculated on boot from snapshot (#1159)
     * `epoch_rewards_status` removed from snapshot (#1274)
+  * Added `unified-scheduler` option for `--block-verification-method` (#1668)
 
 ## [1.18.0]
 * Changes


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/pull/1668 was resolved as not enabling it by default.

#### Summary of Changes

Add changelog entry, reflecting that.