### PR TITLE
Deprecate --rocksdb-shred-compaction fifo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Release channels have their own copy of this changelog:
     * Partitions are recalculated on boot from snapshot (#1159)
     * `epoch_rewards_status` removed from snapshot (#1274)
   * Added `unified-scheduler` option for `--block-verification-method` (#1668)
+  * Deprecate the `fifo` option for `--rocksdb-shred-compaction` (#1882)
+    * `fifo` will remain supported in v2.0 with plans to fully remove in v2.1
 
 ## [1.18.0]
 * Changes

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1772,16 +1772,19 @@ pub fn main() {
             None => ShredStorageType::default(),
             Some(shred_compaction_string) => match shred_compaction_string {
                 "level" => ShredStorageType::RocksLevel,
-                "fifo" => match matches.value_of("rocksdb_fifo_shred_storage_size") {
-                    None => ShredStorageType::rocks_fifo(default_fifo_shred_storage_size(
-                        &validator_config,
-                    )),
-                    Some(_) => ShredStorageType::rocks_fifo(Some(value_t_or_exit!(
-                        matches,
-                        "rocksdb_fifo_shred_storage_size",
-                        u64
-                    ))),
-                },
+                "fifo" => {
+                    // WARN HERE
+                    match matches.value_of("rocksdb_fifo_shred_storage_size") {
+                        None => ShredStorageType::rocks_fifo(default_fifo_shred_storage_size(
+                            &validator_config,
+                        )),
+                        Some(_) => ShredStorageType::rocks_fifo(Some(value_t_or_exit!(
+                            matches,
+                            "rocksdb_fifo_shred_storage_size",
+                            u64
+                        ))),
+                    }
+                }
                 _ => panic!("Unrecognized rocksdb-shred-compaction: {shred_compaction_string}"),
             },
         },

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1775,11 +1775,11 @@ pub fn main() {
                 "fifo" => {
                     warn!(
                         "The value \"fifo\" for --rocksdb-shred-compaction has been deprecated. \
-                         Use of \"fifo\" will still work for now, but will be completely removed \
-                         in the future. To update, use \"level\" for --rocksdb-shred-compaction, \
-                         or remove the --rocksdb-shred-compaction argument altogether. Note that \
-                         the \"rocksdb_fifo\" subdirectory within the ledger directory will need \
-                         to be manually cleaned up once the validator is running with \"level\"."
+                         Use of \"fifo\" will still work for now, but is planned for full removal \
+                         in v2.1. To update, use \"level\" for --rocksdb-shred-compaction, or \
+                         remove the --rocksdb-shred-compaction argument altogether. Note that the \
+                         entire \"rocksdb_fifo\" subdirectory within the ledger directory will \
+                         need to be manually removed once the validator is running with \"level\"."
                     );
                     match matches.value_of("rocksdb_fifo_shred_storage_size") {
                         None => ShredStorageType::rocks_fifo(default_fifo_shred_storage_size(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1773,7 +1773,14 @@ pub fn main() {
             Some(shred_compaction_string) => match shred_compaction_string {
                 "level" => ShredStorageType::RocksLevel,
                 "fifo" => {
-                    // WARN HERE
+                    warn!(
+                        "The value \"fifo\" for --rocksdb-shred-compaction has been deprecated. \
+                         Use of \"fifo\" will still work for now, but will be completely removed \
+                         in the future. To update, use \"level\" for --rocksdb-shred-compaction, \
+                         or remove the --rocksdb-shred-compaction argument altogether. Note that \
+                         the \"rocksdb_fifo\" subdirectory within the ledger directory will need \
+                         to be manually cleaned up once the validator is running with \"level\"."
+                    );
                     match matches.value_of("rocksdb_fifo_shred_storage_size") {
                         None => ShredStorageType::rocks_fifo(default_fifo_shred_storage_size(
                             &validator_config,


### PR DESCRIPTION
#### Problem
Rocksdb fifo compaction was originally added to decrease I/O and mitigate write stalls that we were encountering with level compaction. Since the introduction of fifo, the level compaction mode has been optimized to significantly reduce I/O amplification (see PR list below). With the reduced I/O, level is comparable and simplifies some other aspects (such as having to budget GB for each column with fifo).

#### Summary of Changes
Add a deprecation warning when the user sets `--rocksdb-shred-compaction fifo`; this will later be completely disallowed

Related PR's:
- https://github.com/solana-labs/solana/pull/26651
- https://github.com/solana-labs/solana/pull/27571
  - https://github.com/solana-labs/solana/pull/32548 (addressed a minor issue with 27571)
- https://github.com/solana-labs/solana/pull/29239
