### PR TITLE
Make the CI accept PRs with more than 20k lines

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -11,9 +11,15 @@ output_file=${1:-/dev/stderr}
 if [[ -n $CI_PULL_REQUEST ]]; then
   # filter pr number from ci branch.
   [[ $CI_BRANCH =~ pull/([0-9]+)/head ]]
+  pr_number=${BASH_REMATCH[1]}
+  echo "get affected files from PR: $pr_number"
 
+  base_name=$(gh pr view "$pr_number" --json baseRefName --jq '.baseRefName')
+
+  # Fetch the updated base branch
+  git fetch origin "$base_name":"$base_name"
   # get affected files
-  readarray -t affected_files < <(git diff origin/master..HEAD --name-status | cut -f2)
+  readarray -t affected_files < <(git diff origin/"$base_name"..HEAD --name-status | cut -f2)
   if [[ ${#affected_files[*]} -eq 0 ]]; then
     echo "Unable to determine the files affected by this PR"
     exit 1

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -14,12 +14,12 @@ if [[ -n $CI_PULL_REQUEST ]]; then
   pr_number=${BASH_REMATCH[1]}
   echo "get affected files from PR: $pr_number"
 
-  base_name=$(gh pr view "$pr_number" --json baseRefName --jq '.baseRefName')
+  # Fetch the number of commits in the PR
+  commits_no=$(gh pr view "$pr_number" --json commits --jq '.commits | length')
+  echo "number of commits in this PR: $commits_no"
 
-  # Fetch the updated base branch
-  git fetch origin "$base_name":"$base_name"
   # get affected files
-  readarray -t affected_files < <(git diff origin/"$base_name"..HEAD --name-status | cut -f2)
+  readarray -t affected_files < <(git diff HEAD~"$commits_no"..HEAD --name-status | cut -f2)
   if [[ ${#affected_files[*]} -eq 0 ]]; then
     echo "Unable to determine the files affected by this PR"
     exit 1

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -11,11 +11,9 @@ output_file=${1:-/dev/stderr}
 if [[ -n $CI_PULL_REQUEST ]]; then
   # filter pr number from ci branch.
   [[ $CI_BRANCH =~ pull/([0-9]+)/head ]]
-  pr_number=${BASH_REMATCH[1]}
-  echo "get affected files from PR: $pr_number"
 
   # get affected files
-  readarray -t affected_files < <(gh pr diff --name-only "$pr_number")
+  readarray -t affected_files < <(git diff origin/master..HEAD --name-status | cut -f2)
   if [[ ${#affected_files[*]} -eq 0 ]]; then
     echo "Unable to determine the files affected by this PR"
     exit 1


### PR DESCRIPTION
#### Problem

The `buildkite-pipeline.sh` does not work with PRs that touch more than 20k lines.

#### Summary of Changes

I replaced `gh pr diff --name-only "$pr_number"` by `git diff origin/master..HEAD --name-status | cut -f2`, which displays the files changed in the branch compared to master.
