### PR TITLE
handle shredding error

### DIFF
--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -80,6 +80,8 @@ pub enum Error {
     Serialize(#[from] std::boxed::Box<bincode::ErrorKind>),
     #[error("Shred not found, slot: {slot}, index: {index}")]
     ShredNotFound { slot: Slot, index: u64 },
+    #[error("Too many shreds for slot {0}")]
+    TooManyShreds(Slot),
     #[error(transparent)]
     TransportError(#[from] solana_sdk::transport::TransportError),
     #[error("Unknown last index, slot: {0}")]


### PR DESCRIPTION
#### Problem
The current broadcast code will panic if we try and generate more than the max shred limit (32k) because it tries to unwrap the error results returned from `entries_to_shreds`. It would be better to be able to handle this error.

#### Summary of Changes
Use a match arm for the result returned from `entries_to_shreds` and in case of `TooManyShreds` error, finish the current slot and propagate error up to the caller.