### PR TITLE
accounts-db/add counter for reopen append vec as file-io

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -56,7 +56,7 @@ use {
         },
         append_vec::{
             aligned_stored_size, APPEND_VEC_MMAPPED_FILES_DIRTY, APPEND_VEC_MMAPPED_FILES_OPEN,
-            STORE_META_OVERHEAD,
+            APPEND_VEC_REOPEN_AS_FILE_IO, STORE_META_OVERHEAD,
         },
         cache_hash_data::{
             CacheHashData, CacheHashDataFileReference, DeletionPolicy as CacheHashDeletionPolicy,
@@ -1121,6 +1121,7 @@ impl AccountStorageEntry {
             return None;
         }
 
+        APPEND_VEC_REOPEN_AS_FILE_IO.fetch_add(1, Ordering::Relaxed);
         let count_and_status = self.count_and_status.lock_write();
         self.accounts.reopen_as_readonly().map(|accounts| Self {
             id: self.id,
@@ -1916,6 +1917,11 @@ impl LatestAccountsIndexRootsStats {
             (
                 "append_vecs_dirty",
                 APPEND_VEC_MMAPPED_FILES_DIRTY.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "append_vecs_reopen_as_file_io",
+                APPEND_VEC_REOPEN_AS_FILE_IO.load(Ordering::Relaxed),
                 i64
             )
         );

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1920,7 +1920,7 @@ impl LatestAccountsIndexRootsStats {
                 i64
             ),
             (
-                "append_vecs_reopen_as_file_io",
+                "append_vecs_open_as_file_io",
                 APPEND_VEC_REOPEN_AS_FILE_IO.load(Ordering::Relaxed),
                 i64
             )

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -285,6 +285,7 @@ const fn page_align(size: u64) -> u64 {
 lazy_static! {
     pub static ref APPEND_VEC_MMAPPED_FILES_OPEN: AtomicU64 = AtomicU64::default();
     pub static ref APPEND_VEC_MMAPPED_FILES_DIRTY: AtomicU64 = AtomicU64::default();
+    pub static ref APPEND_VEC_REOPEN_AS_FILE_IO: AtomicU64 = AtomicU64::default();
 }
 
 impl Drop for AppendVec {
@@ -296,7 +297,9 @@ impl Drop for AppendVec {
                     APPEND_VEC_MMAPPED_FILES_DIRTY.fetch_sub(1, Ordering::Relaxed);
                 }
             }
-            AppendVecFileBacking::File(_) => {}
+            AppendVecFileBacking::File(_) => {
+                APPEND_VEC_REOPEN_AS_FILE_IO.fetch_sub(1, Ordering::Relaxed);
+            }
         }
         if self.remove_file_on_drop.load(Ordering::Acquire) {
             // If we're reopening in readonly mode, we don't delete the file. See


### PR DESCRIPTION
#### Problem

We want to track how many appendvecs are reopened as file-io - so that the origianl mmaps are freed.

#### Summary of Changes

Add counter of appendvecs reopened as file-io


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
