### PR TITLE
Refactor and additional metrics for cost tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6847,6 +6847,7 @@ dependencies = [
  "bincode",
  "eager",
  "enum-iterator",
+ "histogram",
  "itertools 0.12.1",
  "libc",
  "log",

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -132,88 +132,48 @@ impl QosService {
         (select_results, num_included)
     }
 
-    /// Updates the transaction costs for committed transactions. Does not handle removing costs
-    /// for transactions that didn't get recorded or committed
-    pub fn update_costs<'a>(
-        transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost>>,
-        transaction_committed_status: Option<&Vec<CommitTransactionDetails>>,
-        bank: &Bank,
-    ) {
-        if let Some(transaction_committed_status) = transaction_committed_status {
-            Self::update_committed_transaction_costs(
-                transaction_cost_results,
-                transaction_committed_status,
-                bank,
-            )
-        }
-    }
-
-    /// Removes transaction costs from the cost tracker if not committed or recorded
-    pub fn remove_costs<'a>(
+    /// Removes transaction costs from the cost tracker if not committed or recorded, or
+    /// updates the transaction costs for committed transactions.
+    pub fn remove_or_update_costs<'a>(
         transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost>>,
         transaction_committed_status: Option<&Vec<CommitTransactionDetails>>,
         bank: &Bank,
     ) {
         match transaction_committed_status {
-            Some(transaction_committed_status) => Self::remove_uncommitted_transaction_costs(
-                transaction_cost_results,
-                transaction_committed_status,
-                bank,
-            ),
+            Some(transaction_committed_status) => {
+                let mut cost_tracker = bank.write_cost_tracker().unwrap();
+                let mut num_included = 0;
+                transaction_cost_results
+                    .zip(transaction_committed_status)
+                    .for_each(|(tx_cost, transaction_committed_details)| {
+                        // Only transactions that the qos service included have to be
+                        // checked for update
+                        if let Ok(tx_cost) = tx_cost {
+                            num_included += 1;
+                            match transaction_committed_details {
+                                CommitTransactionDetails::Committed {
+                                    compute_units,
+                                    loaded_accounts_data_size,
+                                } => {
+                                    cost_tracker.update_execution_cost(
+                                        tx_cost,
+                                        *compute_units,
+                                        CostModel::calculate_loaded_accounts_data_size_cost(
+                                            *loaded_accounts_data_size,
+                                            &bank.feature_set,
+                                        ),
+                                    );
+                                }
+                                CommitTransactionDetails::NotCommitted => {
+                                    cost_tracker.remove(tx_cost);
+                                }
+                            }
+                        }
+                    });
+                cost_tracker.sub_transactions_in_flight(num_included);
+            }
             None => Self::remove_transaction_costs(transaction_cost_results, bank),
         }
-    }
-
-    fn remove_uncommitted_transaction_costs<'a>(
-        transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost>>,
-        transaction_committed_status: &Vec<CommitTransactionDetails>,
-        bank: &Bank,
-    ) {
-        let mut cost_tracker = bank.write_cost_tracker().unwrap();
-        let mut num_included = 0;
-        transaction_cost_results
-            .zip(transaction_committed_status)
-            .for_each(|(tx_cost, transaction_committed_details)| {
-                // Only transactions that the qos service included have to be
-                // checked for update
-                if let Ok(tx_cost) = tx_cost {
-                    num_included += 1;
-                    if *transaction_committed_details == CommitTransactionDetails::NotCommitted {
-                        cost_tracker.remove(tx_cost)
-                    }
-                }
-            });
-        cost_tracker.sub_transactions_in_flight(num_included);
-    }
-
-    fn update_committed_transaction_costs<'a>(
-        transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost>>,
-        transaction_committed_status: &Vec<CommitTransactionDetails>,
-        bank: &Bank,
-    ) {
-        let mut cost_tracker = bank.write_cost_tracker().unwrap();
-        transaction_cost_results
-            .zip(transaction_committed_status)
-            .for_each(|(estimated_tx_cost, transaction_committed_details)| {
-                // Only transactions that the qos service included have to be
-                // checked for update
-                if let Ok(estimated_tx_cost) = estimated_tx_cost {
-                    if let CommitTransactionDetails::Committed {
-                        compute_units,
-                        loaded_accounts_data_size,
-                    } = transaction_committed_details
-                    {
-                        cost_tracker.update_execution_cost(
-                            estimated_tx_cost,
-                            *compute_units,
-                            CostModel::calculate_loaded_accounts_data_size_cost(
-                                *loaded_accounts_data_size,
-                                &bank.feature_set,
-                            ),
-                        )
-                    }
-                }
-            });
     }
 
     fn remove_transaction_costs<'a>(
@@ -784,18 +744,11 @@ mod tests {
                 + (execute_units_adjustment + loaded_accounts_data_size_cost_adjustment)
                     * transaction_count;
 
-            // All transactions are committed, no costs should be removed
-            QosService::remove_costs(qos_cost_results.iter(), Some(&committed_status), &bank);
-            assert_eq!(
-                total_txs_cost,
-                bank.read_cost_tracker().unwrap().block_cost()
+            QosService::remove_or_update_costs(
+                qos_cost_results.iter(),
+                Some(&committed_status),
+                &bank,
             );
-            assert_eq!(
-                transaction_count,
-                bank.read_cost_tracker().unwrap().transaction_count()
-            );
-
-            QosService::update_costs(qos_cost_results.iter(), Some(&committed_status), &bank);
             assert_eq!(
                 final_txs_cost,
                 bank.read_cost_tracker().unwrap().block_cost()
@@ -843,18 +796,7 @@ mod tests {
                 bank.read_cost_tracker().unwrap().block_cost()
             );
 
-            // update costs doesn't impact non-committed
-            QosService::update_costs(qos_cost_results.iter(), None, &bank);
-            assert_eq!(
-                total_txs_cost,
-                bank.read_cost_tracker().unwrap().block_cost()
-            );
-            assert_eq!(
-                transaction_count,
-                bank.read_cost_tracker().unwrap().transaction_count()
-            );
-
-            QosService::remove_costs(qos_cost_results.iter(), None, &bank);
+            QosService::remove_or_update_costs(qos_cost_results.iter(), None, &bank);
             assert_eq!(0, bank.read_cost_tracker().unwrap().block_cost());
             assert_eq!(0, bank.read_cost_tracker().unwrap().transaction_count());
         }
@@ -926,8 +868,11 @@ mod tests {
                 })
                 .collect();
 
-            QosService::remove_costs(qos_cost_results.iter(), Some(&committed_status), &bank);
-            QosService::update_costs(qos_cost_results.iter(), Some(&committed_status), &bank);
+            QosService::remove_or_update_costs(
+                qos_cost_results.iter(),
+                Some(&committed_status),
+                &bank,
+            );
 
             // assert the final block cost
             let mut expected_final_txs_count = 0u64;

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -51,6 +51,37 @@ impl CostModel {
         }
     }
 
+    // Calculate executed transaction CU cost, with actual execution and loaded accounts size
+    // costs.
+    pub fn calculate_cost_for_executed_transaction(
+        transaction: &SanitizedTransaction,
+        actual_programs_execution_cost: u64,
+        actual_loaded_accounts_data_size_bytes: usize,
+        feature_set: &FeatureSet,
+    ) -> TransactionCost {
+        if transaction.is_simple_vote_transaction() {
+            TransactionCost::SimpleVote {
+                writable_accounts: Self::get_writable_accounts(transaction),
+            }
+        } else {
+            let mut tx_cost = UsageCostDetails::new_with_default_capacity();
+
+            Self::get_signature_cost(&mut tx_cost, transaction);
+            Self::get_write_lock_cost(&mut tx_cost, transaction, feature_set);
+            Self::get_instructions_data_cost(&mut tx_cost, transaction);
+            tx_cost.allocated_accounts_data_size =
+                Self::calculate_allocated_accounts_data_size(transaction);
+
+            tx_cost.programs_execution_cost = actual_programs_execution_cost;
+            tx_cost.loaded_accounts_data_size_cost = Self::calculate_loaded_accounts_data_size_cost(
+                actual_loaded_accounts_data_size_bytes,
+                feature_set,
+            );
+
+            TransactionCost::Transaction(tx_cost)
+        }
+    }
+
     fn get_signature_cost(tx_cost: &mut UsageCostDetails, transaction: &SanitizedTransaction) {
         let signatures_count_detail = transaction.message().get_signature_details();
         tx_cost.num_transaction_signatures = signatures_count_detail.num_transaction_signatures();
@@ -167,6 +198,20 @@ impl CostModel {
         tx_cost.programs_execution_cost = programs_execution_costs;
         tx_cost.loaded_accounts_data_size_cost = loaded_accounts_data_size_cost;
         tx_cost.data_bytes_cost = data_bytes_len_total / INSTRUCTION_DATA_BYTES_COST;
+    }
+
+    fn get_instructions_data_cost(
+        tx_cost: &mut UsageCostDetails,
+        transaction: &SanitizedTransaction,
+    ) {
+        let ix_data_bytes_len_total: u64 = transaction
+            .message()
+            .instructions()
+            .iter()
+            .map(|instruction| instruction.data.len() as u64)
+            .sum();
+
+        tx_cost.data_bytes_cost = ix_data_bytes_len_total / INSTRUCTION_DATA_BYTES_COST;
     }
 
     pub fn calculate_loaded_accounts_data_size_cost(

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -62,7 +62,8 @@ use {
     solana_svm::{
         transaction_processor::ExecutionRecordingConfig,
         transaction_results::{
-            TransactionExecutionDetails, TransactionExecutionResult, TransactionResults,
+            TransactionExecutionDetails, TransactionExecutionResult,
+            TransactionLoadedAccountsStats, TransactionResults,
         },
     },
     solana_transaction_status::token_balances::TransactionTokenBalancesSet,
@@ -181,10 +182,39 @@ pub fn execute_batch(
 
     let TransactionResults {
         fee_collection_results,
+        loaded_accounts_stats,
         execution_results,
         rent_debits,
         ..
     } = tx_results;
+
+    let (check_block_cost_limits_result, check_block_cost_limits_time): (Result<()>, Measure) =
+        measure!(if bank
+            .feature_set
+            .is_active(&feature_set::apply_cost_tracker_during_replay::id())
+        {
+            check_block_cost_limits(
+                bank,
+                &loaded_accounts_stats,
+                &execution_results,
+                batch.sanitized_transactions(),
+            )
+        } else {
+            Ok(())
+        });
+
+    timings.saturating_add_in_place(
+        ExecuteTimingType::CheckBlockLimitsUs,
+        check_block_cost_limits_time.as_us(),
+    );
+    for tx_loaded_accounts_stats in loaded_accounts_stats.iter().flatten() {
+        timings
+            .execute_accounts_details
+            .increment_loaded_accounts_data_size(
+                tx_loaded_accounts_stats.loaded_accounts_data_size as u64,
+            );
+    }
+    check_block_cost_limits_result?;
 
     let executed_transactions = execution_results
         .iter()
@@ -218,6 +248,49 @@ pub fn execute_batch(
 
     let first_err = get_first_error(batch, fee_collection_results);
     first_err.map(|(result, _)| result).unwrap_or(Ok(()))
+}
+
+// collect transactions actual execution costs, subject to block limits;
+// block will be marked as dead if exceeds cost limits, details will be
+// reported to metric `replay-stage-mark_dead_slot`
+fn check_block_cost_limits(
+    bank: &Bank,
+    loaded_accounts_stats: &[Result<TransactionLoadedAccountsStats>],
+    execution_results: &[TransactionExecutionResult],
+    sanitized_transactions: &[SanitizedTransaction],
+) -> Result<()> {
+    assert_eq!(loaded_accounts_stats.len(), execution_results.len());
+
+    let tx_costs_with_actual_execution_units: Vec<_> = execution_results
+        .iter()
+        .zip(loaded_accounts_stats)
+        .zip(sanitized_transactions)
+        .filter_map(|((execution_result, loaded_accounts_stats), tx)| {
+            if let Some(details) = execution_result.details() {
+                let tx_cost = CostModel::calculate_cost_for_executed_transaction(
+                    tx,
+                    details.executed_units,
+                    loaded_accounts_stats
+                        .as_ref()
+                        .map_or(0, |stats| stats.loaded_accounts_data_size),
+                    &bank.feature_set,
+                );
+                Some(tx_cost)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    {
+        let mut cost_tracker = bank.write_cost_tracker().unwrap();
+        for tx_cost in &tx_costs_with_actual_execution_units {
+            cost_tracker
+                .try_add(tx_cost)
+                .map_err(TransactionError::from)?;
+        }
+    }
+    Ok(())
 }
 
 #[derive(Default)]
@@ -456,21 +529,9 @@ fn rebatch_and_execute_batches(
             let cost = tx_cost.sum();
             minimal_tx_cost = std::cmp::min(minimal_tx_cost, cost);
             total_cost = total_cost.saturating_add(cost);
-            tx_cost
+            cost
         })
         .collect::<Vec<_>>();
-
-    if bank
-        .feature_set
-        .is_active(&feature_set::apply_cost_tracker_during_replay::id())
-    {
-        let mut cost_tracker = bank.write_cost_tracker().unwrap();
-        for tx_cost in &tx_costs {
-            cost_tracker
-                .try_add(tx_cost)
-                .map_err(TransactionError::from)?;
-        }
-    }
 
     let target_batch_count = get_thread_count() as u64;
 
@@ -479,26 +540,23 @@ fn rebatch_and_execute_batches(
         let target_batch_cost = total_cost / target_batch_count;
         let mut batch_cost: u64 = 0;
         let mut slice_start = 0;
-        tx_costs
-            .into_iter()
-            .enumerate()
-            .for_each(|(index, tx_cost)| {
-                let next_index = index + 1;
-                batch_cost = batch_cost.saturating_add(tx_cost.sum());
-                if batch_cost >= target_batch_cost || next_index == sanitized_txs.len() {
-                    let tx_batch = rebatch_transactions(
-                        &lock_results,
-                        bank,
-                        &sanitized_txs,
-                        slice_start,
-                        index,
-                        &transaction_indexes,
-                    );
-                    slice_start = next_index;
-                    tx_batches.push(tx_batch);
-                    batch_cost = 0;
-                }
-            });
+        tx_costs.into_iter().enumerate().for_each(|(index, cost)| {
+            let next_index = index + 1;
+            batch_cost = batch_cost.saturating_add(cost);
+            if batch_cost >= target_batch_cost || next_index == sanitized_txs.len() {
+                let tx_batch = rebatch_transactions(
+                    &lock_results,
+                    bank,
+                    &sanitized_txs,
+                    slice_start,
+                    index,
+                    &transaction_indexes,
+                );
+                slice_start = next_index;
+                tx_batches.push(tx_batch);
+                batch_cost = 0;
+            }
+        });
         &tx_batches[..]
     } else {
         batches
@@ -2199,6 +2257,7 @@ pub mod tests {
         },
         assert_matches::assert_matches,
         rand::{thread_rng, Rng},
+        solana_cost_model::transaction_cost::TransactionCost,
         solana_entry::entry::{create_ticks, next_entry, next_entry_mut},
         solana_program_runtime::declare_process_instruction,
         solana_runtime::{
@@ -5022,5 +5081,70 @@ pub mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_check_block_cost_limit() {
+        let dummy_leader_pubkey = solana_sdk::pubkey::new_rand();
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config_with_leader(500, &dummy_leader_pubkey, 100);
+        let bank = Bank::new_for_tests(&genesis_config);
+
+        let tx = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            genesis_config.hash(),
+        ));
+        let mut tx_cost = CostModel::calculate_cost(&tx, &bank.feature_set);
+        let actual_execution_cu = 1;
+        let actual_loaded_accounts_data_size = 64 * 1024;
+        let TransactionCost::Transaction(ref mut usage_cost_details) = tx_cost else {
+            unreachable!("test tx is non-vote tx");
+        };
+        usage_cost_details.programs_execution_cost = actual_execution_cu;
+        usage_cost_details.loaded_accounts_data_size_cost =
+            CostModel::calculate_loaded_accounts_data_size_cost(
+                actual_loaded_accounts_data_size,
+                &bank.feature_set,
+            );
+        // set block-limit to be able to just have one transaction
+        let block_limit = tx_cost.sum();
+
+        bank.write_cost_tracker()
+            .unwrap()
+            .set_limits(u64::MAX, block_limit, u64::MAX);
+        let txs = vec![tx.clone(), tx];
+        let results = vec![
+            TransactionExecutionResult::Executed {
+                details: TransactionExecutionDetails {
+                    status: Ok(()),
+                    log_messages: None,
+                    inner_instructions: None,
+                    fee_details: solana_sdk::fee::FeeDetails::default(),
+                    return_data: None,
+                    executed_units: actual_execution_cu,
+                    accounts_data_len_delta: 0,
+                },
+                programs_modified_by_tx: HashMap::new(),
+            },
+            TransactionExecutionResult::NotExecuted(TransactionError::AccountNotFound),
+        ];
+        let loaded_accounts_stats = vec![
+            Ok(TransactionLoadedAccountsStats {
+                loaded_accounts_data_size: actual_loaded_accounts_data_size,
+                loaded_accounts_count: 2
+            });
+            2
+        ];
+
+        assert!(check_block_cost_limits(&bank, &loaded_accounts_stats, &results, &txs).is_ok());
+        assert_eq!(
+            Err(TransactionError::WouldExceedMaxBlockCostLimit),
+            check_block_cost_limits(&bank, &loaded_accounts_stats, &results, &txs)
+        );
     }
 }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -386,7 +386,7 @@ fn test_restart_node() {
     );
     cluster.exit_restart_node(&nodes[0], validator_config, SocketAddrSpace::Unspecified);
     cluster_tests::sleep_n_epochs(
-        0.5,
+        0.6,
         &cluster.genesis_config.poh_config,
         clock::DEFAULT_TICKS_PER_SLOT,
         slots_per_epoch,

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -14,6 +14,7 @@ base64 = { workspace = true }
 bincode = { workspace = true }
 eager = { workspace = true }
 enum-iterator = { workspace = true }
+histogram = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5326,6 +5326,7 @@ dependencies = [
  "bincode",
  "eager",
  "enum-iterator",
+ "histogram",
  "itertools 0.12.1",
  "libc",
  "log",

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -858,11 +858,13 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         loaded_transaction.accounts = accounts;
         saturating_add_assign!(
-            execute_timings.details.total_account_count,
+            execute_timings.execute_accounts_details.total_account_count,
             loaded_transaction.accounts.len() as u64
         );
         saturating_add_assign!(
-            execute_timings.details.changed_account_count,
+            execute_timings
+                .execute_accounts_details
+                .changed_account_count,
             touched_account_count
         );
 


### PR DESCRIPTION
#### Problem

- Some implementation can be refactored for efficiency 
- Can use more metrics

#### Summary of Changes
- Combine remove_* and update_* functions to reduce locking on cost-tracker and iteration.
- Add method to calculate executed transaction cost by directly using actual execution cost and loaded accounts size;
- Wireup histogram to report loaded accounts size;
- Report time of block limits checking;
- Move account counters from ExecuteDetailsTimings to ExecuteAccountsDetails;


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
