### PR TITLE
Adds directory diffing to accounts-hash-cache-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,8 +67,10 @@ dependencies = [
 name = "agave-accounts-hash-cache-tool"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "bytemuck",
  "clap 2.33.3",
+ "memmap2",
  "solana-accounts-db",
  "solana-version",
 ]

--- a/accounts-db/accounts-hash-cache-tool/Cargo.toml
+++ b/accounts-db/accounts-hash-cache-tool/Cargo.toml
@@ -10,8 +10,10 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 bytemuck = { workspace = true }
 clap = { workspace = true }
+memmap2 = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-version = { workspace = true }
 

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -385,16 +385,16 @@ impl CacheHashData {
 #[derive(Debug)]
 pub struct ParsedFilename {
     pub slot_range_start: Slot,
-    pub _slot_range_end: Slot,
-    pub _bin_range_start: u64,
-    pub _bin_range_end: u64,
-    pub _hash: u64,
+    pub slot_range_end: Slot,
+    pub bin_range_start: u64,
+    pub bin_range_end: u64,
+    pub hash: u64,
 }
 
 /// Parses a cache hash data filename into its parts
 ///
 /// Returns None if the filename is invalid
-fn parse_filename(cache_filename: impl AsRef<Path>) -> Option<ParsedFilename> {
+pub fn parse_filename(cache_filename: impl AsRef<Path>) -> Option<ParsedFilename> {
     let filename = cache_filename.as_ref().to_string_lossy().to_string();
     let parts: Vec<_> = filename.split('.').collect(); // The parts are separated by a `.`
     if parts.len() != 5 {
@@ -407,10 +407,10 @@ fn parse_filename(cache_filename: impl AsRef<Path>) -> Option<ParsedFilename> {
     let hash = u64::from_str_radix(parts.get(4)?, 16).ok()?; // the hash is in hex
     Some(ParsedFilename {
         slot_range_start,
-        _slot_range_end: slot_range_end,
-        _bin_range_start: bin_range_start,
-        _bin_range_end: bin_range_end,
-        _hash: hash,
+        slot_range_end,
+        bin_range_start,
+        bin_range_end,
+        hash,
     })
 }
 
@@ -592,10 +592,10 @@ mod tests {
         let good_filename = "123.456.0.65536.537d65697d9b2baa";
         let parsed_filename = parse_filename(good_filename).unwrap();
         assert_eq!(parsed_filename.slot_range_start, 123);
-        assert_eq!(parsed_filename._slot_range_end, 456);
-        assert_eq!(parsed_filename._bin_range_start, 0);
-        assert_eq!(parsed_filename._bin_range_end, 65536);
-        assert_eq!(parsed_filename._hash, 0x537d65697d9b2baa);
+        assert_eq!(parsed_filename.slot_range_end, 456);
+        assert_eq!(parsed_filename.bin_range_start, 0);
+        assert_eq!(parsed_filename.bin_range_end, 65536);
+        assert_eq!(parsed_filename.hash, 0x537d65697d9b2baa);
 
         let bad_filenames = [
             // bad separator

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -46,7 +46,10 @@ pub mod waitable_condvar;
 // the accounts-hash-cache-tool needs access to these types
 pub use {
     accounts_hash::CalculateHashIntermediate as CacheHashDataFileEntry,
-    cache_hash_data::Header as CacheHashDataFileHeader,
+    cache_hash_data::{
+        parse_filename as parse_cache_hash_data_filename, Header as CacheHashDataFileHeader,
+        ParsedFilename as ParsedCacheHashDataFilename,
+    },
 };
 
 #[macro_use]


### PR DESCRIPTION
#### Problem

Diffing directories from a failed accounts hash calculation is difficult. It would be nice for `agave-accounts-hash-cache-tool` to support this.


#### Summary of Changes

`agave-accounts-hash-cache-tool` learns to diff directories!

The current impl is minimal; the expectation is that a user runs `accounts-hash-cache-tool diff directories` to find the files that are different, then runs `accounts-hash-cache-tool diff files` on those specific files to find what is actually different.

<details><summary>Example output</summary>
<p>

```
$ agave-accounts-hash-cache-tool diff dir accounts_hash_cache/ accounts_hash_cache/failed_calculate_accounts_hash_cache/272720482/
Unique files in directory 1:
(none)
Unique files in directory 2:
(none)
Mismatch files:
0: 'accounts_hash_cache/272627500.272630000.0.65536.7eb0cfed8a55637f', 'accounts_hash_cache/failed_calculate_accounts_hash_cache/272720482/272627500.272630000.0.65536.7eb0cfed8a55637f'
diffing directories took 14.780410787s
```

</p>
</details> 