### PR TITLE
v1.18: Pin spl-token-cli to 3.4.1

### DIFF
--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,5 +1,5 @@
 # populate this on the stable branch
-splTokenCliVersion=
+splTokenCliVersion=3.4.1
 
 maybeSplTokenCliVersionArg=
 if [[ -n "$splTokenCliVersion" ]]; then


### PR DESCRIPTION
#### Problem
v1.18 is on the cusp of becoming the stable branch; however, it does not yet have a pinned version of `spl-token-cli` to build. CI isn't broken yet, but running `./scripts/cargo-install-all.sh` without this change will select v4.0.0 which has v2.0.0 crate dependencies in this repo. This is obviously problematic for the v1.18 branch

#### Summary of Changes
Pin to the latest version compatible with agave v2.0.0, which is spl 3.4.1
