### PR TITLE
specify msrv 1.76 in accounts-db

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+rust-version = "1.76.0"
 
 [dependencies]
 bincode = { workspace = true }


### PR DESCRIPTION
#### Problem
#650 introduced `ptr::from_ref` to solana-accounts-db. This function is only stable from Rust 1.76 onwards: https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html

Users of older Rust currently have to dig this information out themselves when they get a compiler error.

#### Summary of Changes
Add `rust-version = "1.76.0"` to the accounts-db Cargo.toml