### PR TITLE
Deprecate RpcClient::get_stake_activation

### DIFF
--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -2150,6 +2150,10 @@ impl RpcClient {
     /// # })?;
     /// # Ok::<(), Error>(())
     /// ```
+    #[deprecated(
+        since = "1.18.18",
+        note = "Do not use; getStakeActivation is deprecated on the JSON-RPC server"
+    )]
     pub async fn get_stake_activation(
         &self,
         stake_account: Pubkey,

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -1788,6 +1788,11 @@ impl RpcClient {
     /// assert_eq!(activation.state, StakeActivationState::Activating);
     /// # Ok::<(), Error>(())
     /// ```
+    #[deprecated(
+        since = "1.18.18",
+        note = "Do not use; getStakeActivation is deprecated on the JSON-RPC server"
+    )]
+    #[allow(deprecated)]
     pub fn get_stake_activation(
         &self,
         stake_account: Pubkey,


### PR DESCRIPTION
#### Problem
The `getStakeActivation` RPC endpoint has been [deprecated since v1.18](https://github.com/anza-xyz/agave/pull/69), but the client methods have not been. This makes it harder to remove from rpc.rs

#### Summary of Changes
Deprecate RpcClient::get_stake_activation
I'm proposing a v1.18 backport to enable removal in v2.0