### PR TITLE
Remove rpc endpoint deprecated in v1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Release channels have their own copy of this changelog:
     confirmTransaction, getSignatureStatus, getSignatureConfirmation, getTotalSupply,
     getConfirmedSignaturesForAddress, getConfirmedBlock, getConfirmedBlocks, getConfirmedBlocksWithLimit,
     getConfirmedTransaction, getConfirmedSignaturesForAddress2, getRecentBlockhash, getFees,
-    getFeeCalculatorForBlockhash, getFeeRateGovernor, getSnapshotSlot
+    getFeeCalculatorForBlockhash, getFeeRateGovernor, getSnapshotSlot getStakeActivation
   * `--enable-rpc-obsolete_v1_7` flag removed
 * Changes
   * `central-scheduler` as default option for `--block-production-method` (#34891)

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4240,42 +4240,6 @@ fn rpc_perf_sample_from_perf_sample(slot: u64, sample: PerfSample) -> RpcPerfSam
     }
 }
 
-pub mod rpc_deprecated_v1_18 {
-    use super::*;
-    #[rpc]
-    pub trait DeprecatedV1_18 {
-        type Metadata;
-
-        // DEPRECATED
-        #[rpc(meta, name = "getStakeActivation")]
-        fn get_stake_activation(
-            &self,
-            meta: Self::Metadata,
-            pubkey_str: String,
-            config: Option<RpcEpochConfig>,
-        ) -> Result<RpcStakeActivation>;
-    }
-
-    pub struct DeprecatedV1_18Impl;
-    impl DeprecatedV1_18 for DeprecatedV1_18Impl {
-        type Metadata = JsonRpcRequestProcessor;
-
-        fn get_stake_activation(
-            &self,
-            meta: Self::Metadata,
-            pubkey_str: String,
-            config: Option<RpcEpochConfig>,
-        ) -> Result<RpcStakeActivation> {
-            debug!(
-                "get_stake_activation rpc request received: {:?}",
-                pubkey_str
-            );
-            let pubkey = verify_pubkey(&pubkey_str)?;
-            meta.get_stake_activation(&pubkey, config)
-        }
-    }
-}
-
 const MAX_BASE58_SIZE: usize = 1683; // Golden, bump if PACKET_DATA_SIZE changes
 const MAX_BASE64_SIZE: usize = 1644; // Golden, bump if PACKET_DATA_SIZE changes
 fn decode_and_deserialize<T>(

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -5,10 +5,7 @@ use {
         cluster_tpu_info::ClusterTpuInfo,
         max_slots::MaxSlots,
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
-        rpc::{
-            rpc_accounts::*, rpc_accounts_scan::*, rpc_bank::*, rpc_deprecated_v1_18::*,
-            rpc_full::*, rpc_minimal::*, *,
-        },
+        rpc::{rpc_accounts::*, rpc_accounts_scan::*, rpc_bank::*, rpc_full::*, rpc_minimal::*, *},
         rpc_cache::LargestAccountsCache,
         rpc_health::*,
     },
@@ -506,7 +503,6 @@ impl JsonRpcService {
                     io.extend_with(rpc_accounts::AccountsDataImpl.to_delegate());
                     io.extend_with(rpc_accounts_scan::AccountsScanImpl.to_delegate());
                     io.extend_with(rpc_full::FullImpl.to_delegate());
-                    io.extend_with(rpc_deprecated_v1_18::DeprecatedV1_18Impl.to_delegate());
                 }
 
                 let request_middleware = RpcRequestMiddleware::new(


### PR DESCRIPTION
#### Problem
After https://github.com/anza-xyz/agave/pull/1895, everything related to `getStakeActivation` will be deprecated, enabling its removal in v2.0

#### Summary of Changes
Remove `rpc_deprecated_v1_18`
