### PR TITLE
Remove deprecated RpcClient methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Release channels have their own copy of this changelog:
     getConfirmedTransaction, getConfirmedSignaturesForAddress2, getRecentBlockhash, getFees,
     getFeeCalculatorForBlockhash, getFeeRateGovernor, getSnapshotSlot
   * `--enable-rpc-obsolete_v1_7` flag removed
+  * Deprecated methods are removed from `RpcClient` and `RpcClient::nonblocking`
 * Changes
   * `central-scheduler` as default option for `--block-production-method` (#34891)
   * `solana-rpc-client-api`: `RpcFilterError` depends on `base64` version 0.22, so users may need to upgrade to `base64` version 0.22

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -65,9 +65,6 @@ pub enum CliCommand {
     ClusterVersion,
     Feature(FeatureCliCommand),
     Inflation(InflationCliCommand),
-    Fees {
-        blockhash: Option<Hash>,
-    },
     FindProgramDerivedAddress {
         seeds: Vec<Vec<u8>>,
         program_id: Pubkey,
@@ -640,12 +637,6 @@ pub fn parse_command(
         ("feature", Some(matches)) => {
             parse_feature_subcommand(matches, default_signer, wallet_manager)
         }
-        ("fees", Some(matches)) => {
-            let blockhash = value_of::<Hash>(matches, "blockhash");
-            Ok(CliCommandInfo::without_signers(CliCommand::Fees {
-                blockhash,
-            }))
-        }
         ("first-available-block", Some(_matches)) => Ok(CliCommandInfo::without_signers(
             CliCommand::FirstAvailableBlock,
         )),
@@ -911,7 +902,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             seed,
             program_id,
         } => process_create_address_with_seed(config, from_pubkey.as_ref(), seed, program_id),
-        CliCommand::Fees { ref blockhash } => process_fees(&rpc_client, config, blockhash.as_ref()),
         CliCommand::Feature(feature_subcommand) => {
             process_feature_subcommand(&rpc_client, config, feature_subcommand)
         }

--- a/rpc-client-api/src/request.rs
+++ b/rpc-client-api/src/request.rs
@@ -8,9 +8,7 @@ use {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum RpcRequest {
-    Custom {
-        method: &'static str,
-    },
+    Custom { method: &'static str },
     DeregisterNode,
     GetAccountInfo,
     GetBalance,
@@ -21,43 +19,9 @@ pub enum RpcRequest {
     GetBlocksWithLimit,
     GetBlockTime,
     GetClusterNodes,
-    #[deprecated(since = "1.7.0", note = "Please use RpcRequest::GetBlock instead")]
-    GetConfirmedBlock,
-    #[deprecated(since = "1.7.0", note = "Please use RpcRequest::GetBlocks instead")]
-    GetConfirmedBlocks,
-    #[deprecated(
-        since = "1.7.0",
-        note = "Please use RpcRequest::GetBlocksWithLimit instead"
-    )]
-    GetConfirmedBlocksWithLimit,
-    #[deprecated(
-        since = "1.7.0",
-        note = "Please use RpcRequest::GetSignaturesForAddress instead"
-    )]
-    GetConfirmedSignaturesForAddress2,
-    #[deprecated(
-        since = "1.7.0",
-        note = "Please use RpcRequest::GetTransaction instead"
-    )]
-    GetConfirmedTransaction,
     GetEpochInfo,
     GetEpochSchedule,
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please use RpcRequest::GetFeeForMessage instead"
-    )]
-    GetFeeCalculatorForBlockhash,
     GetFeeForMessage,
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please do not use, will no longer be available in the future"
-    )]
-    GetFeeRateGovernor,
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please use RpcRequest::GetFeeForMessage instead"
-    )]
-    GetFees,
     GetFirstAvailableBlock,
     GetGenesisHash,
     GetHealth,
@@ -73,19 +37,9 @@ pub enum RpcRequest {
     GetMinimumBalanceForRentExemption,
     GetMultipleAccounts,
     GetProgramAccounts,
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please use RpcRequest::GetLatestBlockhash instead"
-    )]
-    GetRecentBlockhash,
     GetRecentPerformanceSamples,
     GetRecentPrioritizationFees,
     GetHighestSnapshotSlot,
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please use RpcRequest::GetHighestSnapshotSlot instead"
-    )]
-    GetSnapshotSlot,
     GetSignaturesForAddress,
     GetSignatureStatuses,
     GetSlot,
@@ -131,17 +85,9 @@ impl fmt::Display for RpcRequest {
             RpcRequest::GetBlocksWithLimit => "getBlocksWithLimit",
             RpcRequest::GetBlockTime => "getBlockTime",
             RpcRequest::GetClusterNodes => "getClusterNodes",
-            RpcRequest::GetConfirmedBlock => "getConfirmedBlock",
-            RpcRequest::GetConfirmedBlocks => "getConfirmedBlocks",
-            RpcRequest::GetConfirmedBlocksWithLimit => "getConfirmedBlocksWithLimit",
-            RpcRequest::GetConfirmedSignaturesForAddress2 => "getConfirmedSignaturesForAddress2",
-            RpcRequest::GetConfirmedTransaction => "getConfirmedTransaction",
             RpcRequest::GetEpochInfo => "getEpochInfo",
             RpcRequest::GetEpochSchedule => "getEpochSchedule",
-            RpcRequest::GetFeeCalculatorForBlockhash => "getFeeCalculatorForBlockhash",
             RpcRequest::GetFeeForMessage => "getFeeForMessage",
-            RpcRequest::GetFeeRateGovernor => "getFeeRateGovernor",
-            RpcRequest::GetFees => "getFees",
             RpcRequest::GetFirstAvailableBlock => "getFirstAvailableBlock",
             RpcRequest::GetGenesisHash => "getGenesisHash",
             RpcRequest::GetHealth => "getHealth",
@@ -157,11 +103,9 @@ impl fmt::Display for RpcRequest {
             RpcRequest::GetMinimumBalanceForRentExemption => "getMinimumBalanceForRentExemption",
             RpcRequest::GetMultipleAccounts => "getMultipleAccounts",
             RpcRequest::GetProgramAccounts => "getProgramAccounts",
-            RpcRequest::GetRecentBlockhash => "getRecentBlockhash",
             RpcRequest::GetRecentPerformanceSamples => "getRecentPerformanceSamples",
             RpcRequest::GetRecentPrioritizationFees => "getRecentPrioritizationFees",
             RpcRequest::GetHighestSnapshotSlot => "getHighestSnapshotSlot",
-            RpcRequest::GetSnapshotSlot => "getSnapshotSlot",
             RpcRequest::GetSignaturesForAddress => "getSignaturesForAddress",
             RpcRequest::GetSignatureStatuses => "getSignatureStatuses",
             RpcRequest::GetSlot => "getSlot",
@@ -303,20 +247,9 @@ mod tests {
         let request = test_request.build_request_json(1, Value::Null);
         assert_eq!(request["method"], "getEpochInfo");
 
-        #[allow(deprecated)]
-        let test_request = RpcRequest::GetRecentBlockhash;
+        let test_request = RpcRequest::GetLatestBlockhash;
         let request = test_request.build_request_json(1, Value::Null);
-        assert_eq!(request["method"], "getRecentBlockhash");
-
-        #[allow(deprecated)]
-        let test_request = RpcRequest::GetFeeCalculatorForBlockhash;
-        let request = test_request.build_request_json(1, json!([addr]));
-        assert_eq!(request["method"], "getFeeCalculatorForBlockhash");
-
-        #[allow(deprecated)]
-        let test_request = RpcRequest::GetFeeRateGovernor;
-        let request = test_request.build_request_json(1, Value::Null);
-        assert_eq!(request["method"], "getFeeRateGovernor");
+        assert_eq!(request["method"], "getLatestBlockhash");
 
         let test_request = RpcRequest::GetSlot;
         let request = test_request.build_request_json(1, Value::Null);
@@ -347,8 +280,7 @@ mod tests {
         let addr = json!("deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhx");
 
         // Test request with CommitmentConfig and no params
-        #[allow(deprecated)]
-        let test_request = RpcRequest::GetRecentBlockhash;
+        let test_request = RpcRequest::GetLatestBlockhash;
         let request = test_request.build_request_json(1, json!([commitment_config]));
         assert_eq!(request["params"], json!([commitment_config.clone()]));
 

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -4809,7 +4809,6 @@ impl RpcClient {
             .value)
     }
 
-    #[allow(deprecated)]
     pub async fn get_fee_for_message(
         &self,
         message: &impl SerializableMessage,

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -7,11 +7,6 @@
 //! [JSON-RPC]: https://www.jsonrpc.org/specification
 
 pub use crate::mock_sender::Mocks;
-#[allow(deprecated)]
-use solana_rpc_client_api::deprecated_config::{
-    RpcConfirmedBlockConfig, RpcConfirmedTransactionConfig,
-    RpcGetConfirmedSignaturesForAddress2Config,
-};
 #[cfg(feature = "spinner")]
 use {crate::spinner, solana_sdk::clock::MAX_HASH_AGE_IN_SECONDS, std::cmp::min};
 use {

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -40,7 +40,6 @@ use {
         epoch_info::EpochInfo,
         epoch_schedule::EpochSchedule,
         feature::Feature,
-        fee_calculator::{FeeCalculator, FeeRateGovernor},
         hash::Hash,
         message::{v0, Message as LegacyMessage},
         pubkey::Pubkey,
@@ -1175,15 +1174,6 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).get_highest_snapshot_slot())
     }
 
-    #[deprecated(
-        since = "1.8.0",
-        note = "Please use RpcClient::get_highest_snapshot_slot() instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_snapshot_slot(&self) -> ClientResult<Slot> {
-        self.invoke((self.rpc_client.as_ref()).get_snapshot_slot())
-    }
-
     /// Check if a transaction has been processed with the default [commitment level][cl].
     ///
     /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
@@ -2122,38 +2112,6 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).get_block_with_config(slot, config))
     }
 
-    #[deprecated(since = "1.7.0", note = "Please use RpcClient::get_block() instead")]
-    #[allow(deprecated)]
-    pub fn get_confirmed_block(&self, slot: Slot) -> ClientResult<EncodedConfirmedBlock> {
-        self.invoke((self.rpc_client.as_ref()).get_confirmed_block(slot))
-    }
-
-    #[deprecated(
-        since = "1.7.0",
-        note = "Please use RpcClient::get_block_with_encoding() instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_confirmed_block_with_encoding(
-        &self,
-        slot: Slot,
-        encoding: UiTransactionEncoding,
-    ) -> ClientResult<EncodedConfirmedBlock> {
-        self.invoke((self.rpc_client.as_ref()).get_confirmed_block_with_encoding(slot, encoding))
-    }
-
-    #[deprecated(
-        since = "1.7.0",
-        note = "Please use RpcClient::get_block_with_config() instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_confirmed_block_with_config(
-        &self,
-        slot: Slot,
-        config: RpcConfirmedBlockConfig,
-    ) -> ClientResult<UiConfirmedBlock> {
-        self.invoke((self.rpc_client.as_ref()).get_confirmed_block_with_config(slot, config))
-    }
-
     /// Returns a list of finalized blocks between two slots.
     ///
     /// The range is inclusive, with results including the block for both
@@ -2358,69 +2316,6 @@ impl RpcClient {
         )
     }
 
-    #[deprecated(since = "1.7.0", note = "Please use RpcClient::get_blocks() instead")]
-    #[allow(deprecated)]
-    pub fn get_confirmed_blocks(
-        &self,
-        start_slot: Slot,
-        end_slot: Option<Slot>,
-    ) -> ClientResult<Vec<Slot>> {
-        self.invoke((self.rpc_client.as_ref()).get_confirmed_blocks(start_slot, end_slot))
-    }
-
-    #[deprecated(
-        since = "1.7.0",
-        note = "Please use RpcClient::get_blocks_with_commitment() instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_confirmed_blocks_with_commitment(
-        &self,
-        start_slot: Slot,
-        end_slot: Option<Slot>,
-        commitment_config: CommitmentConfig,
-    ) -> ClientResult<Vec<Slot>> {
-        self.invoke(
-            (self.rpc_client.as_ref()).get_confirmed_blocks_with_commitment(
-                start_slot,
-                end_slot,
-                commitment_config,
-            ),
-        )
-    }
-
-    #[deprecated(
-        since = "1.7.0",
-        note = "Please use RpcClient::get_blocks_with_limit() instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_confirmed_blocks_with_limit(
-        &self,
-        start_slot: Slot,
-        limit: usize,
-    ) -> ClientResult<Vec<Slot>> {
-        self.invoke((self.rpc_client.as_ref()).get_confirmed_blocks_with_limit(start_slot, limit))
-    }
-
-    #[deprecated(
-        since = "1.7.0",
-        note = "Please use RpcClient::get_blocks_with_limit_and_commitment() instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_confirmed_blocks_with_limit_and_commitment(
-        &self,
-        start_slot: Slot,
-        limit: usize,
-        commitment_config: CommitmentConfig,
-    ) -> ClientResult<Vec<Slot>> {
-        self.invoke(
-            (self.rpc_client.as_ref()).get_confirmed_blocks_with_limit_and_commitment(
-                start_slot,
-                limit,
-                commitment_config,
-            ),
-        )
-    }
-
     /// Get confirmed signatures for transactions involving an address.
     ///
     /// Returns up to 1000 signatures, ordered from newest to oldest.
@@ -2515,34 +2410,6 @@ impl RpcClient {
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
         self.invoke(
             (self.rpc_client.as_ref()).get_signatures_for_address_with_config(address, config),
-        )
-    }
-
-    #[deprecated(
-        since = "1.7.0",
-        note = "Please use RpcClient::get_signatures_for_address() instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_confirmed_signatures_for_address2(
-        &self,
-        address: &Pubkey,
-    ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-        self.invoke((self.rpc_client.as_ref()).get_confirmed_signatures_for_address2(address))
-    }
-
-    #[deprecated(
-        since = "1.7.0",
-        note = "Please use RpcClient::get_signatures_for_address_with_config() instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_confirmed_signatures_for_address2_with_config(
-        &self,
-        address: &Pubkey,
-        config: GetConfirmedSignaturesForAddress2Config,
-    ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-        self.invoke(
-            (self.rpc_client.as_ref())
-                .get_confirmed_signatures_for_address2_with_config(address, config),
         )
     }
 
@@ -2654,34 +2521,6 @@ impl RpcClient {
         config: RpcTransactionConfig,
     ) -> ClientResult<EncodedConfirmedTransactionWithStatusMeta> {
         self.invoke((self.rpc_client.as_ref()).get_transaction_with_config(signature, config))
-    }
-
-    #[deprecated(
-        since = "1.7.0",
-        note = "Please use RpcClient::get_transaction() instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_confirmed_transaction(
-        &self,
-        signature: &Signature,
-        encoding: UiTransactionEncoding,
-    ) -> ClientResult<EncodedConfirmedTransactionWithStatusMeta> {
-        self.invoke((self.rpc_client.as_ref()).get_confirmed_transaction(signature, encoding))
-    }
-
-    #[deprecated(
-        since = "1.7.0",
-        note = "Please use RpcClient::get_transaction_with_config() instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_confirmed_transaction_with_config(
-        &self,
-        signature: &Signature,
-        config: RpcConfirmedTransactionConfig,
-    ) -> ClientResult<EncodedConfirmedTransactionWithStatusMeta> {
-        self.invoke(
-            (self.rpc_client.as_ref()).get_confirmed_transaction_with_config(signature, config),
-        )
     }
 
     /// Returns the estimated production time of a block.
@@ -3697,87 +3536,6 @@ impl RpcClient {
         )
     }
 
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please use `get_latest_blockhash` and `get_fee_for_message` instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_fees(&self) -> ClientResult<Fees> {
-        self.invoke((self.rpc_client.as_ref()).get_fees())
-    }
-
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please use `get_latest_blockhash_with_commitment` and `get_fee_for_message` instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_fees_with_commitment(&self, commitment_config: CommitmentConfig) -> RpcResult<Fees> {
-        self.invoke((self.rpc_client.as_ref()).get_fees_with_commitment(commitment_config))
-    }
-
-    #[deprecated(since = "1.9.0", note = "Please use `get_latest_blockhash` instead")]
-    #[allow(deprecated)]
-    pub fn get_recent_blockhash(&self) -> ClientResult<(Hash, FeeCalculator)> {
-        self.invoke((self.rpc_client.as_ref()).get_recent_blockhash())
-    }
-
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please use `get_latest_blockhash_with_commitment` instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_recent_blockhash_with_commitment(
-        &self,
-        commitment_config: CommitmentConfig,
-    ) -> RpcResult<(Hash, FeeCalculator, Slot)> {
-        self.invoke(
-            (self.rpc_client.as_ref()).get_recent_blockhash_with_commitment(commitment_config),
-        )
-    }
-
-    #[deprecated(since = "1.9.0", note = "Please `get_fee_for_message` instead")]
-    #[allow(deprecated)]
-    pub fn get_fee_calculator_for_blockhash(
-        &self,
-        blockhash: &Hash,
-    ) -> ClientResult<Option<FeeCalculator>> {
-        self.invoke((self.rpc_client.as_ref()).get_fee_calculator_for_blockhash(blockhash))
-    }
-
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please `get_latest_blockhash_with_commitment` and `get_fee_for_message` instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_fee_calculator_for_blockhash_with_commitment(
-        &self,
-        blockhash: &Hash,
-        commitment_config: CommitmentConfig,
-    ) -> RpcResult<Option<FeeCalculator>> {
-        self.invoke(
-            (self.rpc_client.as_ref())
-                .get_fee_calculator_for_blockhash_with_commitment(blockhash, commitment_config),
-        )
-    }
-
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please do not use, will no longer be available in the future"
-    )]
-    #[allow(deprecated)]
-    pub fn get_fee_rate_governor(&self) -> RpcResult<FeeRateGovernor> {
-        self.invoke((self.rpc_client.as_ref()).get_fee_rate_governor())
-    }
-
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please do not use, will no longer be available in the future"
-    )]
-    #[allow(deprecated)]
-    pub fn get_new_blockhash(&self, blockhash: &Hash) -> ClientResult<(Hash, FeeCalculator)> {
-        self.invoke((self.rpc_client.as_ref()).get_new_blockhash(blockhash))
-    }
-
     pub fn get_first_available_block(&self) -> ClientResult<Slot> {
         self.invoke((self.rpc_client.as_ref()).get_first_available_block())
     }
@@ -4137,7 +3895,7 @@ mod tests {
                 future::ok(Value::Number(Number::from(50)))
             });
             // Failed request
-            io.add_method("getRecentBlockhash", |params: Params| {
+            io.add_method("getLatestBlockhash", |params: Params| {
                 if params != Params::None {
                     future::err(Error::invalid_request())
                 } else {
@@ -4169,16 +3927,14 @@ mod tests {
             .unwrap();
         assert_eq!(balance, 50);
 
-        #[allow(deprecated)]
         let blockhash: String = rpc_client
-            .send(RpcRequest::GetRecentBlockhash, Value::Null)
+            .send(RpcRequest::GetLatestBlockhash, Value::Null)
             .unwrap();
         assert_eq!(blockhash, "deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhx");
 
         // Send erroneous parameter
-        #[allow(deprecated)]
         let blockhash: ClientResult<String> =
-            rpc_client.send(RpcRequest::GetRecentBlockhash, json!(["parameter"]));
+            rpc_client.send(RpcRequest::GetLatestBlockhash, json!(["parameter"]));
         assert!(blockhash.is_err());
     }
 
@@ -4203,22 +3959,6 @@ mod tests {
         let rpc_client = RpcClient::new_mock("malicious".to_string());
         let signature = rpc_client.send_transaction(&tx);
         assert!(signature.is_err());
-    }
-
-    #[test]
-    fn test_get_recent_blockhash() {
-        let rpc_client = RpcClient::new_mock("succeeds".to_string());
-
-        let expected_blockhash: Hash = PUBKEY.parse().unwrap();
-
-        let blockhash = rpc_client.get_latest_blockhash().expect("blockhash ok");
-        assert_eq!(blockhash, expected_blockhash);
-
-        let rpc_client = RpcClient::new_mock("fails".to_string());
-
-        #[allow(deprecated)]
-        let result = rpc_client.get_recent_blockhash();
-        assert!(result.is_err());
     }
 
     #[test]
@@ -4320,7 +4060,6 @@ mod tests {
 
         let rpc_client = RpcClient::new_mock("fails".to_string());
 
-        #[allow(deprecated)]
         let is_err = rpc_client.get_latest_blockhash().is_err();
         assert!(is_err);
     }

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -3754,7 +3754,6 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).get_latest_blockhash())
     }
 
-    #[allow(deprecated)]
     pub fn get_latest_blockhash_with_commitment(
         &self,
         commitment: CommitmentConfig,
@@ -3762,7 +3761,6 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).get_latest_blockhash_with_commitment(commitment))
     }
 
-    #[allow(deprecated)]
     pub fn is_blockhash_valid(
         &self,
         blockhash: &Hash,

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -10,10 +10,6 @@
 //! in [`crate::nonblocking::rpc_client`].
 
 pub use crate::mock_sender::Mocks;
-#[allow(deprecated)]
-use solana_rpc_client_api::deprecated_config::{
-    RpcConfirmedBlockConfig, RpcConfirmedTransactionConfig,
-};
 use {
     crate::{
         http_sender::HttpSender,

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -2132,12 +2132,9 @@ impl RpcClient {
     ///
     /// # RPC Reference
     ///
-    /// This method corresponds directly to the [`getBlocks`] RPC method, unless
-    /// the remote node version is less than 1.7, in which case it maps to the
-    /// [`getConfirmedBlocks`] RPC method.
+    /// This method corresponds directly to the [`getBlocks`] RPC method.
     ///
     /// [`getBlocks`]: https://solana.com/docs/rpc/http/getblocks
-    /// [`getConfirmedBlocks`]: https://solana.com/docs/rpc/deprecated/getconfirmedblocks
     ///
     /// # Examples
     ///
@@ -2183,12 +2180,9 @@ impl RpcClient {
     ///
     /// # RPC Reference
     ///
-    /// This method corresponds directly to the [`getBlocks`] RPC method, unless
-    /// the remote node version is less than 1.7, in which case it maps to the
-    /// [`getConfirmedBlocks`] RPC method.
+    /// This method corresponds directly to the [`getBlocks`] RPC method.
     ///
     /// [`getBlocks`]: https://solana.com/docs/rpc/http/getblocks
-    /// [`getConfirmedBlocks`]: https://solana.com/docs/rpc/deprecated/getconfirmedblocks
     ///
     /// # Examples
     ///
@@ -2236,11 +2230,9 @@ impl RpcClient {
     /// # RPC Reference
     ///
     /// This method corresponds directly to the [`getBlocksWithLimit`] RPC
-    /// method, unless the remote node version is less than 1.7, in which case
-    /// it maps to the [`getConfirmedBlocksWithLimit`] RPC method.
+    /// method.
     ///
     /// [`getBlocksWithLimit`]: https://solana.com/docs/rpc/http/getblockswithlimit
-    /// [`getConfirmedBlocksWithLimit`]: https://solana.com/docs/rpc/deprecated/getconfirmedblockswithlimit
     ///
     /// # Examples
     ///
@@ -2273,11 +2265,9 @@ impl RpcClient {
     /// # RPC Reference
     ///
     /// This method corresponds directly to the [`getBlocksWithLimit`] RPC
-    /// method, unless the remote node version is less than 1.7, in which case
-    /// it maps to the `getConfirmedBlocksWithLimit` RPC method.
+    /// method.
     ///
     /// [`getBlocksWithLimit`]: https://solana.com/docs/rpc/http/getblockswithlimit
-    /// [`getConfirmedBlocksWithLimit`]: https://solana.com/docs/rpc/deprecated/getconfirmedblockswithlimit
     ///
     /// # Examples
     ///
@@ -2418,12 +2408,9 @@ impl RpcClient {
     ///
     /// # RPC Reference
     ///
-    /// This method corresponds directly to the [`getTransaction`] RPC method,
-    /// unless the remote node version is less than 1.7, in which case it maps
-    /// to the [`getConfirmedTransaction`] RPC method.
+    /// This method corresponds directly to the [`getTransaction`] RPC method.
     ///
     /// [`getTransaction`]: https://solana.com/docs/rpc/http/gettransaction
-    /// [`getConfirmedTransaction`]: https://solana.com/docs/rpc/deprecated/getConfirmedTransaction
     ///
     /// # Examples
     ///
@@ -2470,12 +2457,9 @@ impl RpcClient {
     ///
     /// # RPC Reference
     ///
-    /// This method corresponds directly to the [`getTransaction`] RPC method,
-    /// unless the remote node version is less than 1.7, in which case it maps
-    /// to the [`getConfirmedTransaction`] RPC method.
+    /// This method corresponds directly to the [`getTransaction`] RPC method.
     ///
     /// [`getTransaction`]: https://solana.com/docs/rpc/http/gettransaction
-    /// [`getConfirmedTransaction`]: https://solana.com/docs/rpc/deprecated/getConfirmedTransaction
     ///
     /// # Examples
     ///

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -3749,7 +3749,6 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).is_blockhash_valid(blockhash, commitment))
     }
 
-    #[allow(deprecated)]
     pub fn get_fee_for_message(&self, message: &impl SerializableMessage) -> ClientResult<u64> {
         self.invoke((self.rpc_client.as_ref()).get_fee_for_message(message))
     }

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -44,8 +44,7 @@ use {
         epoch_schedule::EpochSchedule,
         exit::Exit,
         feature_set::FEATURE_NAMES,
-        fee_calculator::{FeeCalculator, FeeRateGovernor},
-        hash::Hash,
+        fee_calculator::FeeRateGovernor,
         instruction::{AccountMeta, Instruction},
         message::Message,
         native_token::sol_to_lamports,
@@ -1161,20 +1160,6 @@ impl TestValidator {
     /// Return the validator's vote account address
     pub fn vote_account_address(&self) -> Pubkey {
         self.vote_account_address
-    }
-
-    /// Return an RpcClient for the validator.  As a convenience, also return a recent blockhash and
-    /// associated fee calculator
-    #[deprecated(since = "1.9.0", note = "Please use `get_rpc_client` instead")]
-    pub fn rpc_client(&self) -> (RpcClient, Hash, FeeCalculator) {
-        let rpc_client =
-            RpcClient::new_with_commitment(self.rpc_url.clone(), CommitmentConfig::processed());
-        #[allow(deprecated)]
-        let (recent_blockhash, fee_calculator) = rpc_client
-            .get_recent_blockhash()
-            .expect("get_recent_blockhash");
-
-        (rpc_client, recent_blockhash, fee_calculator)
     }
 
     /// Return an RpcClient for the validator.


### PR DESCRIPTION
#### Problem
Since v2.0 RPC servers will no longer support previously deprecated endpoints, there is no point in the RpcClient modules supporting them either.

#### Summary of Changes
Remove deprecated client methods

Does not touch `getStakeActivation`/`RpcClient::get_stake_activation`
