### PR TITLE
Remove deprecated SyncClient methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Release channels have their own copy of this changelog:
 * Breaking
   * SDK: Support for Borsh v0.9 removed, please use v1 or v0.10 (#1440)
   * SDK: `Copy` is no longer derived on `Rent` and `EpochSchedule`, please switch to using `clone()` (solana-labs#32767)
+  * SDK: deprecated SyncClient trait methods removed
   * RPC: obsolete and deprecated v1 endpoints are removed. These endpoints are:
     confirmTransaction, getSignatureStatus, getSignatureConfirmation, getTotalSupply,
     getConfirmedSignaturesForAddress, getConfirmedBlock, getConfirmedBlocks, getConfirmedBlocksWithLimit,

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -11,10 +11,8 @@ use {
     solana_sdk::{
         account::Account,
         client::{AsyncClient, Client, SyncClient},
-        clock::Slot,
         commitment_config::CommitmentConfig,
         epoch_info::EpochInfo,
-        fee_calculator::{FeeCalculator, FeeRateGovernor},
         hash::Hash,
         instruction::Instruction,
         message::Message,
@@ -213,20 +211,6 @@ impl SyncClient for ThinClient {
 
     dispatch!(fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> TransportResult<u64>);
 
-    dispatch!(#[allow(deprecated)] fn get_recent_blockhash(&self) -> TransportResult<(Hash, FeeCalculator)>);
-
-    dispatch!(#[allow(deprecated)] fn get_recent_blockhash_with_commitment(
-        &self,
-        commitment_config: CommitmentConfig
-    ) -> TransportResult<(Hash, FeeCalculator, Slot)>);
-
-    dispatch!(#[allow(deprecated)] fn get_fee_calculator_for_blockhash(
-        &self,
-        blockhash: &Hash
-    ) -> TransportResult<Option<FeeCalculator>>);
-
-    dispatch!(#[allow(deprecated)] fn get_fee_rate_governor(&self) -> TransportResult<FeeRateGovernor>);
-
     dispatch!(fn get_signature_status(
         &self,
         signature: &Signature
@@ -261,8 +245,6 @@ impl SyncClient for ThinClient {
     ) -> TransportResult<usize>);
 
     dispatch!(fn poll_for_signature(&self, signature: &Signature) -> TransportResult<()>);
-
-    dispatch!(#[allow(deprecated)] fn get_new_blockhash(&self, blockhash: &Hash) -> TransportResult<(Hash, FeeCalculator)>);
 
     dispatch!(fn get_latest_blockhash(&self) -> TransportResult<Hash>);
 

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -14,7 +14,6 @@ use crate::{
     clock::Slot,
     commitment_config::CommitmentConfig,
     epoch_info::EpochInfo,
-    fee_calculator::{FeeCalculator, FeeRateGovernor},
     hash::Hash,
     instruction::Instruction,
     message::Message,
@@ -82,35 +81,6 @@ pub trait SyncClient {
 
     fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> Result<u64>;
 
-    /// Get recent blockhash
-    #[deprecated(since = "1.9.0", note = "Please use `get_latest_blockhash` instead")]
-    fn get_recent_blockhash(&self) -> Result<(Hash, FeeCalculator)>;
-
-    /// Get recent blockhash. Uses explicit commitment configuration.
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please use `get_latest_blockhash_with_commitment` and `get_latest_blockhash_with_commitment` instead"
-    )]
-    fn get_recent_blockhash_with_commitment(
-        &self,
-        commitment_config: CommitmentConfig,
-    ) -> Result<(Hash, FeeCalculator, Slot)>;
-
-    /// Get `Some(FeeCalculator)` associated with `blockhash` if it is still in
-    /// the BlockhashQueue`, otherwise `None`
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please use `get_fee_for_message` or `is_blockhash_valid` instead"
-    )]
-    fn get_fee_calculator_for_blockhash(&self, blockhash: &Hash) -> Result<Option<FeeCalculator>>;
-
-    /// Get recent fee rate governor
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please do not use, will no longer be available in the future"
-    )]
-    fn get_fee_rate_governor(&self) -> Result<FeeRateGovernor>;
-
     /// Get signature status.
     fn get_signature_status(
         &self,
@@ -150,12 +120,6 @@ pub trait SyncClient {
 
     /// Poll to confirm a transaction.
     fn poll_for_signature(&self, signature: &Signature) -> Result<()>;
-
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please do not use, will no longer be available in the future"
-    )]
-    fn get_new_blockhash(&self, blockhash: &Hash) -> Result<(Hash, FeeCalculator)>;
 
     /// Get last known blockhash
     fn get_latest_blockhash(&self) -> Result<Hash>;

--- a/thin-client/src/thin_client.rs
+++ b/thin-client/src/thin_client.rs
@@ -13,14 +13,13 @@ use {
         },
     },
     solana_rpc_client::rpc_client::RpcClient,
-    solana_rpc_client_api::{config::RpcProgramAccountsConfig, response::Response},
+    solana_rpc_client_api::config::RpcProgramAccountsConfig,
     solana_sdk::{
         account::Account,
         client::{AsyncClient, Client, SyncClient},
-        clock::{Slot, MAX_PROCESSING_AGE},
+        clock::MAX_PROCESSING_AGE,
         commitment_config::CommitmentConfig,
         epoch_info::EpochInfo,
-        fee_calculator::{FeeCalculator, FeeRateGovernor},
         hash::Hash,
         instruction::Instruction,
         message::Message,
@@ -419,52 +418,6 @@ where
             .map_err(|e| e.into())
     }
 
-    fn get_recent_blockhash(&self) -> TransportResult<(Hash, FeeCalculator)> {
-        #[allow(deprecated)]
-        let (blockhash, fee_calculator, _last_valid_slot) =
-            self.get_recent_blockhash_with_commitment(CommitmentConfig::default())?;
-        Ok((blockhash, fee_calculator))
-    }
-
-    fn get_recent_blockhash_with_commitment(
-        &self,
-        commitment_config: CommitmentConfig,
-    ) -> TransportResult<(Hash, FeeCalculator, Slot)> {
-        let index = self.optimizer.experiment();
-        let now = Instant::now();
-        #[allow(deprecated)]
-        let recent_blockhash =
-            self.rpc_clients[index].get_recent_blockhash_with_commitment(commitment_config);
-        match recent_blockhash {
-            Ok(Response { value, .. }) => {
-                self.optimizer.report(index, duration_as_ms(&now.elapsed()));
-                Ok((value.0, value.1, value.2))
-            }
-            Err(e) => {
-                self.optimizer.report(index, u64::MAX);
-                Err(e.into())
-            }
-        }
-    }
-
-    fn get_fee_calculator_for_blockhash(
-        &self,
-        blockhash: &Hash,
-    ) -> TransportResult<Option<FeeCalculator>> {
-        #[allow(deprecated)]
-        self.rpc_client()
-            .get_fee_calculator_for_blockhash(blockhash)
-            .map_err(|e| e.into())
-    }
-
-    fn get_fee_rate_governor(&self) -> TransportResult<FeeRateGovernor> {
-        #[allow(deprecated)]
-        self.rpc_client()
-            .get_fee_rate_governor()
-            .map_err(|e| e.into())
-            .map(|r| r.value)
-    }
-
     fn get_signature_status(
         &self,
         signature: &Signature,
@@ -572,13 +525,6 @@ where
     fn poll_for_signature(&self, signature: &Signature) -> TransportResult<()> {
         self.rpc_client()
             .poll_for_signature(signature)
-            .map_err(|e| e.into())
-    }
-
-    fn get_new_blockhash(&self, blockhash: &Hash) -> TransportResult<(Hash, FeeCalculator)> {
-        #[allow(deprecated)]
-        self.rpc_client()
-            .get_new_blockhash(blockhash)
             .map_err(|e| e.into())
     }
 


### PR DESCRIPTION
#### Problem
SyncClient has a bunch of deprecated methods, which parallel deprecated RPC endpoints. v2.0 RPC servers will no longer support these endpoints; we should remove them from SyncClient in v2.0 as well.

#### Summary of Changes
Remove deprecated SyncClient methods:
- `get_recent_blockhash()`
- `get_recent_blockhash_with_commitment()`
- `get_fee_calculator_for_blockhash()`
- `get_fee_rate_governor()`
- `get_new_blockhash()`