### PR TITLE
Remove deprecated CommitmentLevel variants

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -269,23 +269,13 @@ impl JsonRpcRequestProcessor {
             .slot_with_commitment(commitment.commitment);
 
         match commitment.commitment {
-            // Recent variant is deprecated
-            CommitmentLevel::Recent | CommitmentLevel::Processed => {
+            CommitmentLevel::Processed => {
                 debug!("RPC using the heaviest slot: {:?}", slot);
             }
-            // Root variant is deprecated
-            CommitmentLevel::Root => {
-                debug!("RPC using node root: {:?}", slot);
-            }
-            // Single variant is deprecated
-            CommitmentLevel::Single => {
-                debug!("RPC using confirmed slot: {:?}", slot);
-            }
-            // Max variant is deprecated
-            CommitmentLevel::Max | CommitmentLevel::Finalized => {
+            CommitmentLevel::Finalized => {
                 debug!("RPC using block: {:?}", slot);
             }
-            CommitmentLevel::SingleGossip | CommitmentLevel::Confirmed => unreachable!(), // SingleGossip variant is deprecated
+            CommitmentLevel::Confirmed => unreachable!(), // SingleGossip variant is deprecated
         };
 
         let r_bank_forks = self.bank_forks.read().unwrap();

--- a/runtime/src/commitment.rs
+++ b/runtime/src/commitment.rs
@@ -111,16 +111,11 @@ impl BlockCommitmentCache {
         self.highest_confirmed_slot()
     }
 
-    #[allow(deprecated)]
     pub fn slot_with_commitment(&self, commitment_level: CommitmentLevel) -> Slot {
         match commitment_level {
-            CommitmentLevel::Recent | CommitmentLevel::Processed => self.slot(),
-            CommitmentLevel::Root => self.root(),
-            CommitmentLevel::Single => self.highest_confirmed_slot(),
-            CommitmentLevel::SingleGossip | CommitmentLevel::Confirmed => {
-                self.highest_gossip_confirmed_slot()
-            }
-            CommitmentLevel::Max | CommitmentLevel::Finalized => self.highest_super_majority_root(),
+            CommitmentLevel::Processed => self.slot(),
+            CommitmentLevel::Confirmed => self.highest_gossip_confirmed_slot(),
+            CommitmentLevel::Finalized => self.highest_super_majority_root(),
         }
     }
 

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -1,6 +1,5 @@
 //! Definitions of commitment levels.
 
-#![allow(deprecated)]
 #![cfg(feature = "full")]
 
 use {std::str::FromStr, thiserror::Error};
@@ -12,56 +11,6 @@ pub struct CommitmentConfig {
 }
 
 impl CommitmentConfig {
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentConfig::processed() instead"
-    )]
-    pub fn recent() -> Self {
-        Self {
-            commitment: CommitmentLevel::Recent,
-        }
-    }
-
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentConfig::finalized() instead"
-    )]
-    pub fn max() -> Self {
-        Self {
-            commitment: CommitmentLevel::Max,
-        }
-    }
-
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentConfig::finalized() instead"
-    )]
-    pub fn root() -> Self {
-        Self {
-            commitment: CommitmentLevel::Root,
-        }
-    }
-
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentConfig::confirmed() instead"
-    )]
-    pub fn single() -> Self {
-        Self {
-            commitment: CommitmentLevel::Single,
-        }
-    }
-
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentConfig::confirmed() instead"
-    )]
-    pub fn single_gossip() -> Self {
-        Self {
-            commitment: CommitmentLevel::SingleGossip,
-        }
-    }
-
     pub const fn finalized() -> Self {
         Self {
             commitment: CommitmentLevel::Finalized,
@@ -89,37 +38,27 @@ impl CommitmentConfig {
     }
 
     pub fn is_finalized(&self) -> bool {
-        matches!(
-            &self.commitment,
-            CommitmentLevel::Finalized | CommitmentLevel::Max | CommitmentLevel::Root
-        )
+        self.commitment == CommitmentLevel::Finalized
     }
 
     pub fn is_confirmed(&self) -> bool {
-        matches!(
-            &self.commitment,
-            CommitmentLevel::Confirmed | CommitmentLevel::SingleGossip | CommitmentLevel::Single
-        )
+        self.commitment == CommitmentLevel::Confirmed
     }
 
     pub fn is_processed(&self) -> bool {
-        matches!(
-            &self.commitment,
-            CommitmentLevel::Processed | CommitmentLevel::Recent
-        )
+        self.commitment == CommitmentLevel::Processed
     }
 
     pub fn is_at_least_confirmed(&self) -> bool {
         self.is_confirmed() || self.is_finalized()
     }
 
+    #[deprecated(
+        since = "2.0.2",
+        note = "Returns self. Please do not use. Will be removed in the future."
+    )]
     pub fn use_deprecated_commitment(commitment: CommitmentConfig) -> Self {
-        match commitment.commitment {
-            CommitmentLevel::Finalized => CommitmentConfig::max(),
-            CommitmentLevel::Confirmed => CommitmentConfig::single_gossip(),
-            CommitmentLevel::Processed => CommitmentConfig::recent(),
-            _ => commitment,
-        }
+        commitment
     }
 }
 
@@ -138,48 +77,6 @@ impl FromStr for CommitmentConfig {
 /// finalized. When querying the ledger state, use lower levels of commitment to report progress and higher
 /// levels to ensure state changes will not be rolled back.
 pub enum CommitmentLevel {
-    /// (DEPRECATED) The highest slot having reached max vote lockout, as recognized by a supermajority of the cluster.
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentLevel::Finalized instead"
-    )]
-    Max,
-
-    /// (DEPRECATED) The highest slot of the heaviest fork. Ledger state at this slot is not derived from a finalized
-    /// block, but if multiple forks are present, is from the fork the validator believes is most likely
-    /// to finalize.
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentLevel::Processed instead"
-    )]
-    Recent,
-
-    /// (DEPRECATED) The highest slot having reached max vote lockout.
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentLevel::Finalized instead"
-    )]
-    Root,
-
-    /// (DEPRECATED) The highest slot having reached 1 confirmation by supermajority of the cluster.
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentLevel::Confirmed instead"
-    )]
-    Single,
-
-    /// (DEPRECATED) The highest slot that has been voted on by supermajority of the cluster
-    /// This differs from `single` in that:
-    /// 1) It incorporates votes from gossip and replay.
-    /// 2) It does not count votes on descendants of a block, only direct votes on that block.
-    /// 3) This confirmation level also upholds "optimistic confirmation" guarantees in
-    /// release 1.3 and onwards.
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentLevel::Confirmed instead"
-    )]
-    SingleGossip,
-
     /// The highest slot of the heaviest fork processed by the node. Ledger state at this slot is
     /// not derived from a confirmed or finalized block, but if multiple forks are present, is from
     /// the fork the validator believes is most likely to finalize.
@@ -207,11 +104,6 @@ impl FromStr for CommitmentLevel {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "max" => Ok(CommitmentLevel::Max),
-            "recent" => Ok(CommitmentLevel::Recent),
-            "root" => Ok(CommitmentLevel::Root),
-            "single" => Ok(CommitmentLevel::Single),
-            "singleGossip" => Ok(CommitmentLevel::SingleGossip),
             "processed" => Ok(CommitmentLevel::Processed),
             "confirmed" => Ok(CommitmentLevel::Confirmed),
             "finalized" => Ok(CommitmentLevel::Finalized),
@@ -223,11 +115,6 @@ impl FromStr for CommitmentLevel {
 impl std::fmt::Display for CommitmentLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let s = match self {
-            CommitmentLevel::Max => "max",
-            CommitmentLevel::Recent => "recent",
-            CommitmentLevel::Root => "root",
-            CommitmentLevel::Single => "single",
-            CommitmentLevel::SingleGossip => "singleGossip",
             CommitmentLevel::Processed => "processed",
             CommitmentLevel::Confirmed => "confirmed",
             CommitmentLevel::Finalized => "finalized",


### PR DESCRIPTION
#### Problem
There's a lot of cruft hanging around related to deprecated CommitmentLevels (not supported by any nodes in the last 2 years).

#### Summary of Changes
Remove deprecated CommitmentLevel variants and CommitmentConfig methods
Clean up existing users

Will conflict with https://github.com/anza-xyz/agave/pull/1899, though logically separate
