### PR TITLE
chore: Mergify now gently nudges folks who update RPC code to also update the Rust and JavaScript clients

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -168,6 +168,21 @@ pull_request_rules:
           into master and ride the normal stabilization schedule. Exceptions
           include CI/metrics changes, CLI improvements and documentation
           updates on a case by case basis.
+  - name: Reminder to update RPC clients for changes in `rpc/`
+    conditions:
+      - or:
+        - files~=^rpc/src/rpc\.rs$
+        - files~=^rpc/src/rpc_pubsub\.rs$
+        - files~=^rpc-client-api/src/.*\.rs$
+    actions:
+      comment:
+        message: |
+          If this PR represents a change to the public RPC API:
+
+          1. Make sure it includes a complementary update to `rpc-client/` ([example](https://github.com/solana-labs/solana/pull/29558/files))
+          2. Open a follow-up PR to update the JavaScript client `@solana/web3.js` ([example](https://github.com/solana-labs/solana-web3.js/pull/2868/files))
+
+          Thank you for keeping the RPC clients in sync with the server API @{{author}}.
 
 commands_restrictions:
   # The author of copied PRs is the Mergify user.


### PR DESCRIPTION
#### Problem

Sometimes folks add, remove, or deprecate parts of the RPC server API but don't make a related change to the Rust/JavaScript clients.

#### Summary of Changes

This PR makes Mergify comment on PRs that change these files, gently suggesting that the author make a change to the clients.

#### Test Plan

Tested in the Mergify console on PR #69.

<img width="692" alt="image" src="https://github.com/anza-xyz/agave/assets/13243/4872775d-87ea-4292-b9f0-350fa50b10b7">