### PR TITLE
Add since field to deprecation note

### DIFF
--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -79,7 +79,10 @@ impl RpcFilterType {
         }
     }
 
-    #[deprecated = "Use solana_rpc::filter::filter_allows instead"]
+    #[deprecated(
+        since = "2.0.0",
+        note = "Use solana_rpc::filter::filter_allows instead"
+    )]
     pub fn allows(&self, account: &AccountSharedData) -> bool {
         match self {
             RpcFilterType::DataSize(size) => account.data().len() as u64 == *size,


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/941 deprecated `solana_rpc_client_api::filter::allows()`, but I forgot to request a `since` field on the tag

#### Summary of Changes
Add the field

Should be backported, since the deprecation tag landed in v2.0.0