### PR TITLE
Fix false negatives in dcou by using patched cargo

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -182,6 +182,7 @@ wait_step() {
 all_test_steps() {
   command_step checks1 "ci/docker-run-default-image.sh ci/test-checks.sh" 20 check
   command_step checks2 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-bins" 15 check
+  command_step checks2 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-lib" 15 check
   command_step checks3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-all-targets" 15 check
   command_step miri "ci/docker-run-default-image.sh ci/test-miri.sh" 5 check
   wait_step

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -181,8 +181,9 @@ wait_step() {
 
 all_test_steps() {
   command_step checks1 "ci/docker-run-default-image.sh ci/test-checks.sh" 20 check
-  command_step checks2 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-bins" 15 check
-  command_step checks2 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-lib" 15 check
+  command_step checks2b "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-bins" 15 check
+  command_step checks2l "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-lib" 15 check
+  command_step checks2bl "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-bins-and-lib" 15 check
   command_step checks3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-all-targets" 15 check
   command_step miri "ci/docker-run-default-image.sh ci/test-miri.sh" 5 check
   wait_step

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -184,9 +184,9 @@ if [[ $mode = "check-bins" || $mode = "full" ]]; then
 
   # Use `cargo "+${rust_nightly}" hack ..` once we stop using custom-built one.
   PATH="./cargo-for-dcou/target/release:$PATH" \
-    RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --lib
-  PATH="./cargo-for-dcou/target/release:$PATH" \
     RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --bins
+  PATH="./cargo-for-dcou/target/release:$PATH" \
+    RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --lib
 fi
 if [[ $mode = "check-all-targets" || $mode = "full" ]]; then
   _ cargo "+${rust_nightly}" hack check --all-targets

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -43,7 +43,7 @@ allowed="${allowed%,}"
 
 mode=${1:-full}
 case "$mode" in
-  tree | check-bins | check-lib | check-all-targets | full)
+  tree | check-bins | check-lib | check-bins-and-lib | check-all-targets | full)
     ;;
   *)
     echo "$0: unrecognized mode: $mode";
@@ -156,7 +156,7 @@ fi
 # consistency with other CI steps and for the possibility of new similar lints.
 export RUSTFLAGS="-D warnings -Z threads=8 $RUSTFLAGS"
 
-if [[ $mode = "check-bins" || $mode = "check-lib" || $mode = "full" ]]; then
+if [[ $mode = "check-bins" || $mode = "check-lib" || $mode = "check-bins-and-lib" || $mode = "full" ]]; then
   # Until https://github.com/rust-lang/cargo/pull/14163 is applied for our
   # chosen nightly toolchain, dcou needs custom-built cargo to avoid
   # false-negatives.
@@ -186,9 +186,12 @@ if [[ $mode = "check-bins" || $mode = "check-lib" || $mode = "full" ]]; then
   if [[ $mode = "check-bins" ]]; then
     PATH="./cargo-for-dcou/target/release:$PATH" \
       RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --bins
-  else
+  elif [[ $mode = "check-lib" ]]; then
     PATH="./cargo-for-dcou/target/release:$PATH" \
       RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --lib
+  else
+    PATH="./cargo-for-dcou/target/release:$PATH" \
+      RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --bins --lib
   fi
 fi
 if [[ $mode = "check-all-targets" || $mode = "full" ]]; then

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -43,7 +43,7 @@ allowed="${allowed%,}"
 
 mode=${1:-full}
 case "$mode" in
-  tree | check-bins | check-all-targets | full)
+  tree | check-bins | check-lib | check-all-targets | full)
     ;;
   *)
     echo "$0: unrecognized mode: $mode";
@@ -156,7 +156,7 @@ fi
 # consistency with other CI steps and for the possibility of new similar lints.
 export RUSTFLAGS="-D warnings -Z threads=8 $RUSTFLAGS"
 
-if [[ $mode = "check-bins" || $mode = "full" ]]; then
+if [[ $mode = "check-bins" || $mode = "check-lib" || $mode = "full" ]]; then
   # Until https://github.com/rust-lang/cargo/pull/14163 is applied for our
   # chosen nightly toolchain, dcou needs custom-built cargo to avoid
   # false-negatives.
@@ -183,10 +183,13 @@ if [[ $mode = "check-bins" || $mode = "full" ]]; then
   )
 
   # Use `cargo "+${rust_nightly}" hack ..` once we stop using custom-built one.
-  PATH="./cargo-for-dcou/target/release:$PATH" \
-    RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --bins
-  PATH="./cargo-for-dcou/target/release:$PATH" \
-    RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --lib
+  if [[ $mode = "check-bins" ]]; then
+    PATH="./cargo-for-dcou/target/release:$PATH" \
+      RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --bins
+  else
+    PATH="./cargo-for-dcou/target/release:$PATH" \
+      RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --lib
+  fi
 fi
 if [[ $mode = "check-all-targets" || $mode = "full" ]]; then
   _ cargo "+${rust_nightly}" hack check --all-targets

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -184,7 +184,9 @@ if [[ $mode = "check-bins" || $mode = "full" ]]; then
 
   # Use `cargo "+${rust_nightly}" hack ..` once we stop using custom-built one.
   PATH="./cargo-for-dcou/target/release:$PATH" \
-    RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --lib --bins
+    RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --lib
+  PATH="./cargo-for-dcou/target/release:$PATH" \
+    RUSTUP_TOOLCHAIN="${rust_nightly}" _ cargo hack check --bins
 fi
 if [[ $mode = "check-all-targets" || $mode = "full" ]]; then
   _ cargo "+${rust_nightly}" hack check --all-targets


### PR DESCRIPTION
#### Problem

scripts/check-dev-context-only-utils.sh has a bug, causing false negatives in edge cases.

as an example, #687 introduced dcou misuse because ci incorrectly passed due to the false negative, which is fixed by #1831..

#### Summary of Changes

Fix it.

Unfortunately, this needs to fix cargo (https://github.com/rust-lang/cargo/pull/14163).

sample now correctly detected errors: https://buildkite.com/anza/agave/builds/6770#01905db5-39a1-4a8a-972e-1161950f9e6f/639-3443