### PR TITLE
Hardens local-cluster test_boot_from_local_state()

### DIFF
--- a/local-cluster/src/local_cluster_snapshot_utils.rs
+++ b/local-cluster/src/local_cluster_snapshot_utils.rs
@@ -122,7 +122,7 @@ impl LocalCluster {
                     "Waiting for next {next_snapshot_type:?} snapshot exceeded the {max_wait_duration:?} maximum wait duration!",
                 );
             }
-            sleep(Duration::from_secs(5));
+            sleep(Duration::from_secs(1));
         };
         trace!(
             "Waited {:?} for next snapshot archive: {:?}",


### PR DESCRIPTION
#### Problem

The local-cluster test, `test_boot_from_local_state()`, is flaky.

When this test fails, it is a false negative. We are checking snapshots between multiple nodes. Some nodes run faster, or start earlier, than others. So occasionally the snapshots being compared are not for the same slots, and thus the comparisons fail—as expected—but is erroneous.


#### Summary of Changes

The main observation is that validator1 is started first and has been running the longest. It is likely the furthest ahead of all three validators. So we should use its snapshots as the basis for comparison. (Previously we were using validator3 as the basis, but it is likely the furthest *behind*.)

Fixes #1175