### PR TITLE
Log more info when capitalization mismatches

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -337,7 +337,7 @@ impl AccountsHashVerifier {
                 store_detailed_debug_info_on_failure: true,
                 ..calculate_accounts_hash_config
             };
-            _ = accounts_package
+            let second_accounts_hash = accounts_package
                 .accounts
                 .accounts_db
                 .calculate_accounts_hash(
@@ -345,12 +345,14 @@ impl AccountsHashVerifier {
                     &sorted_storages,
                     HashStats::default(),
                 );
+            panic!(
+                "accounts hash capitalization mismatch: expected {}, but calculated {} (then recalculated {})",
+                accounts_package.expected_capitalization,
+                lamports,
+                second_accounts_hash.1,
+            );
         }
 
-        assert_eq!(
-            accounts_package.expected_capitalization, lamports,
-            "accounts hash capitalization mismatch"
-        );
         if let Some(expected_hash) = accounts_package.accounts_hash_for_testing {
             assert_eq!(expected_hash, accounts_hash);
         };


### PR DESCRIPTION
#### Problem

We're hunting a bug in the accounts hash calculationg where the capitalization doesn't match what's expected. Additionally, when there is a mismatch, we recalculate the accounts hash again, but its result is not in the panic message.

Here's what the panic message looks like today:
```
[2024-06-28T05:07:39.245730762Z ERROR solana_metrics::metrics] datapoint: panic program="validator" thread="solAcctHashVer" one=1i message="panicked at core/src/accounts_hash_verifier.rs:358:9:
    assertion `left == right` failed: accounts hash capitalization mismatch
      left: 579076186525574687
     right: 579076186515761087" location="core/src/accounts_hash_verifier.rs:358:9" version="2.0.2 (src:d40aa491; feat:4288794394, client:Agave)"
```

I always have to look at the code to know which one is the expected value and which one is the calculated value. I then also need to search through the logs to find what the result of the second hash calculation was. It would be more convenient if this information was all displayed.


#### Summary of Changes

Expand the panic message to specify which is expected vs calculated, and also include the second calculation's result.