### PR TITLE
remove qualifer_attr from svm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7488,7 +7488,6 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "qualifier_attr",
  "rand 0.8.5",
  "rustc_version 0.4.0",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7488,6 +7488,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "qualifier_attr",
  "rand 0.8.5",
  "rustc_version 0.4.0",
  "serde",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6286,7 +6286,6 @@ dependencies = [
  "log",
  "percentage",
  "prost-build",
- "qualifier_attr",
  "rustc_version",
  "serde",
  "serde_derive",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6286,6 +6286,7 @@ dependencies = [
  "log",
  "percentage",
  "prost-build",
+ "qualifier_attr",
  "rustc_version",
  "serde",
  "serde_derive",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -110,7 +110,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustc_version = { workspace = true }
 
 [features]
-dev-context-only-utils = []
+dev-context-only-utils = ["solana-svm/dev-context-only-utils"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -13,7 +13,6 @@ edition = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 percentage = { workspace = true }
-qualifier_attr = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
 solana-bpf-loader-program = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -13,7 +13,6 @@ edition = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 percentage = { workspace = true }
-qualifier_attr = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
@@ -55,7 +54,7 @@ prost-build = { workspace = true }
 rustc_version = { workspace = true }
 
 [features]
-dev-context-only-utils = ["dep:qualifier_attr"]
+dev-context-only-utils = []
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 percentage = { workspace = true }
+qualifier_attr = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
@@ -54,7 +55,7 @@ prost-build = { workspace = true }
 rustc_version = { workspace = true }
 
 [features]
-dev-context-only-utils = []
+dev-context-only-utils = ["dep:qualifier_attr"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "dev-context-only-utils")]
-use qualifier_attr::qualifiers;
 use {
     crate::{
         account_loader::{
@@ -208,7 +206,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
     /// Returns the current environments depending on the given epoch
     /// Returns None if the call could result in a deadlock
-    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub fn get_environments_for_epoch(&self, epoch: Epoch) -> Option<ProgramRuntimeEnvironments> {
         self.program_cache
             .try_read()

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -206,7 +206,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
     /// Returns the current environments depending on the given epoch
     /// Returns None if the call could result in a deadlock
-    pub fn get_environments_for_epoch(&self, epoch: Epoch) -> Option<ProgramRuntimeEnvironments> {
+    #[cfg_attr(feature = "dev-context-only-utils", qualifier_attr::qualifiers(pub))]
+    fn get_environments_for_epoch(&self, epoch: Epoch) -> Option<ProgramRuntimeEnvironments> {
         self.program_cache
             .try_read()
             .ok()

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -27,7 +27,7 @@ use {
         invoke_context::{EnvironmentConfig, InvokeContext},
         loaded_programs::{
             ForkGraph, ProgramCache, ProgramCacheEntry, ProgramCacheForTxBatch,
-            ProgramCacheMatchCriteria, ProgramRuntimeEnvironments,
+            ProgramCacheMatchCriteria,
         },
         log_collector::LogCollector,
         sysvar_cache::SysvarCache,
@@ -206,8 +206,11 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
     /// Returns the current environments depending on the given epoch
     /// Returns None if the call could result in a deadlock
-    #[cfg_attr(feature = "dev-context-only-utils", qualifier_attr::qualifiers(pub))]
-    fn get_environments_for_epoch(&self, epoch: Epoch) -> Option<ProgramRuntimeEnvironments> {
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn get_environments_for_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> Option<solana_program_runtime::loaded_programs::ProgramRuntimeEnvironments> {
         self.program_cache
             .try_read()
             .ok()


### PR DESCRIPTION
#### Problem
The qualifer_attr usage in solana-svm isn't doing anything - it's applying `pub` to something that is already `pub`. ~I'm guessing it used to do something.~ As it happens, the code in question only needs to exist when dev-context-only-utils is active


#### Summary of Changes
~Remove it~Replace it with a simple `#[cfg(feature = "dev-context-only-utils"]`
