### PR TITLE
v1.18: ci: fix downstream tests

### DIFF
--- a/.github/scripts/downstream-project-spl-common.sh
+++ b/.github/scripts/downstream-project-spl-common.sh
@@ -18,6 +18,7 @@ project_used_solana_version=$(sed -nE 's/solana-sdk = \"[>=<~]*(.*)\"/\1/p' <"to
 echo "used solana version: $project_used_solana_version"
 if semverGT "$project_used_solana_version" "$SOLANA_VER"; then
   echo "skip"
+  export SKIP_SPL_DOWNSTREAM_PROJECT_TEST=1
   return
 fi
 

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -54,6 +54,9 @@ jobs:
         run: |
           source .github/scripts/downstream-project-spl-common.sh
           source .github/scripts/downstream-project-spl-install-deps.sh
+          if [ -n "$SKIP_SPL_DOWNSTREAM_PROJECT_TEST" ]; then
+            exit 0
+          fi
 
           cargo check
 
@@ -103,6 +106,9 @@ jobs:
         run: |
           source .github/scripts/downstream-project-spl-common.sh
           source .github/scripts/downstream-project-spl-install-deps.sh
+          if [ -n "$SKIP_SPL_DOWNSTREAM_PROJECT_TEST" ]; then
+            exit 0
+          fi
 
           programStr="${{ tojson(matrix.arrays.required_programs) }}"
           IFS=', ' read -ra programs <<<"${programStr//[\[\]$'\n'$'\r' ]/}"
@@ -154,6 +160,9 @@ jobs:
         run: |
           source .github/scripts/downstream-project-spl-install-deps.sh
           source .github/scripts/downstream-project-spl-common.sh
+          if [ -n "$SKIP_SPL_DOWNSTREAM_PROJECT_TEST" ]; then
+            exit 0
+          fi
 
           programStr="${{ tojson(matrix.programs) }}"
           IFS=', ' read -ra programs <<<"${programStr//[\[\]$'\n'$'\r' ]/}"

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -152,6 +152,7 @@ jobs:
 
       - shell: bash
         run: |
+          source .github/scripts/downstream-project-spl-install-deps.sh
           source .github/scripts/downstream-project-spl-common.sh
 
           programStr="${{ tojson(matrix.programs) }}"


### PR DESCRIPTION
#### Problem

in current logic, we will always pull spl master and build it. (as Joe mentioned: https://discord.com/channels/428295358100013066/560503042458517505/1257370653795811401 🫶)
it means we will need to build `solana-svm v2.0.0`. we have had patch it on master and v2.0. looks like we need it in v1.18 as well 🫠 
https://github.com/anza-xyz/agave/commit/08c658dc5548e9c7a782db5f93dfd9acaa3969ed#diff-8a9809831c9c46b49c232e9735043e71b17915276e8cbf50d3b14c12dab3f19aR153

#### Summary of Changes

run `.github/scripts/downstream-project-spl-install-deps.sh` before each cargo-test-sbf test