### PR TITLE
ci: skip spl test when version is too high

### DIFF
--- a/.github/scripts/downstream-project-spl-common.sh
+++ b/.github/scripts/downstream-project-spl-common.sh
@@ -19,6 +19,7 @@ project_used_solana_version=$(sed -nE 's/solana-sdk = \"[>=<~]*(.*)\"/\1/p' <"to
 echo "used solana version: $project_used_solana_version"
 if semverGT "$project_used_solana_version" "$SOLANA_VER"; then
   echo "skip"
+  export SKIP_SPL_DOWNSTREAM_PROJECT_TEST=1
   return
 fi
 

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -55,6 +55,10 @@ jobs:
         run: |
           source .github/scripts/downstream-project-spl-install-deps.sh
           source .github/scripts/downstream-project-spl-common.sh
+          if [ -n "$SKIP_SPL_DOWNSTREAM_PROJECT_TEST" ]; then
+            exit 0
+          fi
+
           cargo check
 
   test:
@@ -103,6 +107,9 @@ jobs:
         run: |
           source .github/scripts/downstream-project-spl-install-deps.sh
           source .github/scripts/downstream-project-spl-common.sh
+          if [ -n "$SKIP_SPL_DOWNSTREAM_PROJECT_TEST" ]; then
+            exit 0
+          fi
 
           programStr="${{ tojson(matrix.arrays.required_programs) }}"
           IFS=', ' read -ra programs <<<"${programStr//[\[\]$'\n'$'\r' ]/}"
@@ -154,6 +161,9 @@ jobs:
         run: |
           source .github/scripts/downstream-project-spl-install-deps.sh
           source .github/scripts/downstream-project-spl-common.sh
+          if [ -n "$SKIP_SPL_DOWNSTREAM_PROJECT_TEST" ]; then
+            exit 0
+          fi
 
           programStr="${{ tojson(matrix.programs) }}"
           IFS=', ' read -ra programs <<<"${programStr//[\[\]$'\n'$'\r' ]/}"


### PR DESCRIPTION
#### Problem

it makes no sense to run spl tests with lower version. actually we did it before but the logic missed accidentally. https://github.com/solana-labs/solana/pull/27326 


#### Summary of Changes

stop running spl tests when it bump to higher version