### PR TITLE
Use real data for program account throughout runtime

### DIFF
--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -88,7 +88,9 @@ impl Bank {
         };
         let lamports =
             self.get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program());
-        let account = AccountSharedData::new_data(lamports, &state, &bpf_loader_upgradeable::id())?;
+        let mut account =
+            AccountSharedData::new_data(lamports, &state, &bpf_loader_upgradeable::id())?;
+        account.set_executable(true);
         Ok(account)
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7152,11 +7152,12 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
             .copy_from_slice(&elf);
         account
     };
-    let program_account = AccountSharedData::new(
+    let mut program_account = AccountSharedData::new(
         min_programdata_balance,
         UpgradeableLoaderState::size_of_program(),
         &bpf_loader_upgradeable::id(),
     );
+    program_account.set_executable(true);
     let programdata_account = AccountSharedData::new(
         1,
         UpgradeableLoaderState::size_of_programdata(elf.len()),
@@ -7196,10 +7197,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     let transaction = Transaction::new(&[&binding], message, bank.last_blockhash());
     assert_eq!(
         bank.process_transaction(&transaction),
-        Err(TransactionError::InstructionError(
-            0,
-            InstructionError::InvalidAccountData,
-        )),
+        Err(TransactionError::InvalidProgramForExecution),
     );
     {
         let program_cache = bank.transaction_processor.program_cache.read().unwrap();

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -191,6 +191,7 @@ fn deploy_program(name: String, mock_bank: &mut MockBankCallback) -> Pubkey {
     let mut account_data = AccountSharedData::default();
     account_data.set_data(bincode::serialize(&state).unwrap());
     account_data.set_lamports(25);
+    account_data.set_executable(true);
     account_data.set_owner(bpf_loader_upgradeable::id());
     mock_bank
         .account_shared_data


### PR DESCRIPTION
#### Problem

There is an optimization in the account loader that creates a fake account data for a program that was already loaded in the program cache. This has three problems:

1. The criteria to load a program is if it's owned by one of the loaders, but the transaction only succeeds if the `executable` flag is set to true.
2. Since we discard the data from the real account, we can execute accounts whose flags are set to false, so the check below is always true:

https://github.com/anza-xyz/agave/blob/d5a84daebd2a7225684aa3f722b330e9d5381e76/svm/src/account_loader.rs#L317-L320

3. When we return the transaction data, the program accounts appear with balance zero after a transaction, as if it has consumed its balance, which is not true.

4. The optimization does not optimize anything, because we still load the account from the data base.

#### Summary of Changes

I removed the function that would create a fake `AccountSharedData` for the program.