### PR TITLE
Update `SlotHashesSysvar` API for more flexibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6875,6 +6875,7 @@ dependencies = [
  "solana-secp256k1-recover",
  "solana-short-vec",
  "static_assertions",
+ "test-case",
  "thiserror",
  "wasm-bindgen",
 ]

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -81,6 +81,7 @@ itertools = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
 static_assertions = { workspace = true }
+test-case = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -89,7 +89,7 @@ impl SlotHashesSysvar {
     /// Get a value from the sysvar entries by its key.
     /// Returns `None` if the key is not found.
     pub fn get(slot: &Slot) -> Result<Option<Hash>, ProgramError> {
-        Self::get_pod_slot_hashes().map(|pod_hashes| {
+        Self::pod_slot_hashes().map(|pod_hashes| {
             pod_hashes
                 .binary_search_by(|PodSlotHash { slot: this, .. }| slot.cmp(this))
                 .map(|idx| pod_hashes[idx].hash)
@@ -100,7 +100,7 @@ impl SlotHashesSysvar {
     /// Get the position of an entry in the sysvar by its key.
     /// Returns `None` if the key is not found.
     pub fn position(slot: &Slot) -> Result<Option<usize>, ProgramError> {
-        Self::get_pod_slot_hashes().map(|pod_hashes| {
+        Self::pod_slot_hashes().map(|pod_hashes| {
             pod_hashes
                 .binary_search_by(|PodSlotHash { slot: this, .. }| slot.cmp(this))
                 .ok()
@@ -108,7 +108,7 @@ impl SlotHashesSysvar {
     }
 
     /// Return the slot hashes sysvar as a vector of `PodSlotHash`.
-    pub fn get_pod_slot_hashes() -> Result<Vec<PodSlotHash>, ProgramError> {
+    pub fn pod_slot_hashes() -> Result<Vec<PodSlotHash>, ProgramError> {
         // First fetch all the sysvar data.
         let sysvar_len = SlotHashes::size_of();
         let mut data = vec![0; sysvar_len];
@@ -207,7 +207,7 @@ mod tests {
 
         // `get_pod_slot_hashes` should match the slot hashes.
         // Note slot hashes are stored largest slot to smallest.
-        for (i, pod_slot_hash) in SlotHashesSysvar::get_pod_slot_hashes()
+        for (i, pod_slot_hash) in SlotHashesSysvar::pod_slot_hashes()
             .unwrap()
             .iter()
             .enumerate()

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -75,8 +75,8 @@ impl Sysvar for SlotHashes {
 #[derive(Copy, Clone, Default, Pod, Zeroable)]
 #[repr(C)]
 pub struct PodSlotHash {
-    slot: Slot,
-    hash: Hash,
+    pub slot: Slot,
+    pub hash: Hash,
 }
 
 const U64_SIZE: usize = std::mem::size_of::<u64>();

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -52,7 +52,6 @@ use {
         clock::Slot,
         hash::Hash,
         program_error::ProgramError,
-        slot_hashes::SlotHash,
         sysvar::{get_sysvar, Sysvar, SysvarId},
     },
     bytemuck_derive::{Pod, Zeroable},
@@ -123,7 +122,7 @@ impl SlotHashesSysvar {
         let slot_hash_count = data
             .get(..U64_SIZE)
             .and_then(|bytes| bytes.try_into().ok())
-            .map(usize::from_le_bytes)
+            .map(u64::from_le_bytes)
             .ok_or(ProgramError::InvalidAccountData)?;
 
         // If the vector length is 0, return an empty vector.
@@ -132,8 +131,8 @@ impl SlotHashesSysvar {
         }
 
         // From the vector length, determine the expected length of the data.
-        let length = slot_hash_count
-            .checked_mul(std::mem::size_of::<SlotHash>())
+        let length = (slot_hash_count as usize)
+            .checked_mul(std::mem::size_of::<PodSlotHash>())
             .ok_or(ProgramError::ArithmeticOverflow)?;
         let start = U64_SIZE;
         let end = start.saturating_add(length);

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -126,7 +126,7 @@ impl SlotHashesSysvar {
     /// Get a value from the sysvar entries by its key.
     /// Returns `None` if the key is not found.
     pub fn get(&self, slot: &Slot) -> Result<Option<Hash>, ProgramError> {
-        self.get_pod_slot_hashes().map(|pod_hashes| {
+        self.as_slice().map(|pod_hashes| {
             pod_hashes
                 .binary_search_by(|PodSlotHash { slot: this, .. }| slot.cmp(this))
                 .map(|idx| pod_hashes[idx].hash)
@@ -137,7 +137,7 @@ impl SlotHashesSysvar {
     /// Get the position of an entry in the sysvar by its key.
     /// Returns `None` if the key is not found.
     pub fn position(&self, slot: &Slot) -> Result<Option<usize>, ProgramError> {
-        self.get_pod_slot_hashes().map(|pod_hashes| {
+        self.as_slice().map(|pod_hashes| {
             pod_hashes
                 .binary_search_by(|PodSlotHash { slot: this, .. }| slot.cmp(this))
                 .ok()
@@ -145,7 +145,7 @@ impl SlotHashesSysvar {
     }
 
     /// Return the slot hashes sysvar as a vector of `PodSlotHash`.
-    pub fn get_pod_slot_hashes(&self) -> Result<&[PodSlotHash], ProgramError> {
+    pub fn as_slice(&self) -> Result<&[PodSlotHash], ProgramError> {
         self.data
             .get(self.slot_hashes_start..self.slot_hashes_end)
             .and_then(|data| bytemuck::try_cast_slice(data).ok())
@@ -214,7 +214,7 @@ mod tests {
 
         // Fetch the slot hashes sysvar.
         let slot_hashes_sysvar = SlotHashesSysvar::fetch().unwrap();
-        let pod_slot_hashes = slot_hashes_sysvar.get_pod_slot_hashes().unwrap();
+        let pod_slot_hashes = slot_hashes_sysvar.as_slice().unwrap();
 
         // `pod_slot_hashes` should match the slot hashes.
         // Note slot hashes are stored largest slot to smallest.

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -89,7 +89,7 @@ impl SlotHashesSysvar {
     /// Get a value from the sysvar entries by its key.
     /// Returns `None` if the key is not found.
     pub fn get(slot: &Slot) -> Result<Option<Hash>, ProgramError> {
-        Self::pod_slot_hashes().map(|pod_hashes| {
+        Self::get_pod_slot_hashes().map(|pod_hashes| {
             pod_hashes
                 .binary_search_by(|PodSlotHash { slot: this, .. }| slot.cmp(this))
                 .map(|idx| pod_hashes[idx].hash)
@@ -100,7 +100,7 @@ impl SlotHashesSysvar {
     /// Get the position of an entry in the sysvar by its key.
     /// Returns `None` if the key is not found.
     pub fn position(slot: &Slot) -> Result<Option<usize>, ProgramError> {
-        Self::pod_slot_hashes().map(|pod_hashes| {
+        Self::get_pod_slot_hashes().map(|pod_hashes| {
             pod_hashes
                 .binary_search_by(|PodSlotHash { slot: this, .. }| slot.cmp(this))
                 .ok()
@@ -108,7 +108,7 @@ impl SlotHashesSysvar {
     }
 
     /// Return the slot hashes sysvar as a vector of `PodSlotHash`.
-    pub fn pod_slot_hashes() -> Result<Vec<PodSlotHash>, ProgramError> {
+    pub fn get_pod_slot_hashes() -> Result<Vec<PodSlotHash>, ProgramError> {
         // First fetch all the sysvar data.
         let sysvar_len = SlotHashes::size_of();
         let mut data = vec![0; sysvar_len];
@@ -207,7 +207,7 @@ mod tests {
 
         // `get_pod_slot_hashes` should match the slot hashes.
         // Note slot hashes are stored largest slot to smallest.
-        for (i, pod_slot_hash) in SlotHashesSysvar::pod_slot_hashes()
+        for (i, pod_slot_hash) in SlotHashesSysvar::get_pod_slot_hashes()
             .unwrap()
             .iter()
             .enumerate()


### PR DESCRIPTION
#### Problem
The new `SlotHashesSysvar` API - used to query slot hashes using the new `sol_get_sysvar`
syscall - works well, but there are a few limitations that can arise when testing on-chain
programs.

For starters, the creation of a `Vec<PodSlotHash>` in the API's internals doesn't play well
with the bump allocator. On-chain programs who wish to run multiple queries will easily
max out their heap size, since the vector won't deallocate. They'd benefit from being able
to access this created vector directly.

Secondly, when the slot hashes sysvar is smaller than its typical fixed-size - such as in
program-test scenarios - the new API won't work properly, since it expects the full
size.

And lastly, the previous implementation was initializing the `Vec<PodSlotHash>` with
`PodSlotHash::default()`, which yields a slot `0` for each entry,. This means that no matter
what was in the slot hashes sysvar data, a query for slot `0` would succeed and yield you
the entry from the middle of the vector.

#### Summary of Changes
First make `get_pod_slot_hashes` public, returning direct access to the vector.

Then, redesign the `get_pod_slot_hashes` method to first query the existing length of
the sysvar data, before making another call to `get_sysvar` to initiate a properly-sized
`Vec<PodSlotHash>`.

Finally, add some more test coverage.