### PR TITLE
Adds accounts-db utils::create_and_canonicalize_directory()

### DIFF
--- a/accounts-db/src/utils.rs
+++ b/accounts-db/src/utils.rs
@@ -4,7 +4,7 @@ use {
     solana_measure::measure,
     std::{
         collections::HashSet,
-        fs,
+        fs, io,
         path::{Path, PathBuf},
         sync::Mutex,
         thread,
@@ -166,18 +166,20 @@ pub fn delete_contents_of_path(path: impl AsRef<Path>) {
     }
 }
 
-/// Creates directories if they do not exist, and canonicalizes the paths.
+/// Creates `directories` if they do not exist, and canonicalizes their paths
 pub fn create_and_canonicalize_directories(
     directories: impl IntoIterator<Item = impl AsRef<Path>>,
-) -> std::io::Result<Vec<PathBuf>> {
+) -> io::Result<Vec<PathBuf>> {
     directories
         .into_iter()
-        .map(|path| {
-            fs::create_dir_all(&path)?;
-            let path = fs::canonicalize(&path)?;
-            Ok(path)
-        })
+        .map(create_and_canonicalize_directory)
         .collect()
+}
+
+/// Creates `directory` if it does not exist, and canonicalizes its path
+pub fn create_and_canonicalize_directory(directory: impl AsRef<Path>) -> io::Result<PathBuf> {
+    fs::create_dir_all(&directory)?;
+    fs::canonicalize(directory)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem

Occasionally I want to create and canonicalize a single directory. We already have `create_and_canonicalize_directories()`, so I end up calling this function with a `std::iter::once()`. It would be more convenient to have a standalone function that does the create-and-canonicalize for a single directory.


#### Summary of Changes

Adds `create_and_canonicalize_directory()`