### PR TITLE
replay: reevaluate duplicate proofs on restart and exclude root slot

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -282,6 +282,7 @@ impl Tvu {
             wait_to_vote_slot,
             replay_forks_threads: tvu_config.replay_forks_threads,
             replay_transactions_threads: tvu_config.replay_transactions_threads,
+            shred_version: tvu_config.shred_version,
         };
 
         let (voting_sender, voting_receiver) = unbounded();

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -101,7 +101,7 @@ pub enum Error {
 ///       LAST_SHRED_IN_SLOT, however the other shred must have a higher index.
 ///     - If `shred1` and `shred2` do not share the same index and are coding shreds
 ///       verify that they have conflicting erasure metas
-fn check_shreds<F>(
+pub fn check_shreds<F>(
     leader_schedule: Option<F>,
     shred1: &Shred,
     shred2: &Shred,


### PR DESCRIPTION
#### Problem
Blockstore might contain duplicate proofs from pre restart that are no longer valid.

#### Summary of Changes
Reevaluate the validity of proofs before feeding it to fork choice.
Also never allow the root slot to be marked invalid.
