### PR TITLE
Remove deprecated symbols from solana-sdk

### DIFF
--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -675,15 +675,6 @@ impl AccountSharedData {
 pub type InheritableAccountFields = (u64, Epoch);
 pub const DUMMY_INHERITABLE_ACCOUNT_FIELDS: InheritableAccountFields = (1, INITIAL_RENT_EPOCH);
 
-/// Create an `Account` from a `Sysvar`.
-#[deprecated(
-    since = "1.5.17",
-    note = "Please use `create_account_for_test` instead"
-)]
-pub fn create_account<S: Sysvar>(sysvar: &S, lamports: u64) -> Account {
-    create_account_with_fields(sysvar, (lamports, INITIAL_RENT_EPOCH))
-}
-
 pub fn create_account_with_fields<S: Sysvar>(
     sysvar: &S,
     (lamports, rent_epoch): InheritableAccountFields,
@@ -700,17 +691,6 @@ pub fn create_account_for_test<S: Sysvar>(sysvar: &S) -> Account {
 }
 
 /// Create an `Account` from a `Sysvar`.
-#[deprecated(
-    since = "1.5.17",
-    note = "Please use `create_account_shared_data_for_test` instead"
-)]
-pub fn create_account_shared_data<S: Sysvar>(sysvar: &S, lamports: u64) -> AccountSharedData {
-    AccountSharedData::from(create_account_with_fields(
-        sysvar,
-        (lamports, INITIAL_RENT_EPOCH),
-    ))
-}
-
 pub fn create_account_shared_data_with_fields<S: Sysvar>(
     sysvar: &S,
     fields: InheritableAccountFields,

--- a/sdk/src/entrypoint.rs
+++ b/sdk/src/entrypoint.rs
@@ -5,30 +5,3 @@
 //! [`bpf_loader`]: crate::bpf_loader
 
 pub use solana_program::entrypoint::*;
-
-#[macro_export]
-#[deprecated(
-    since = "1.4.3",
-    note = "use solana_program::entrypoint::entrypoint instead"
-)]
-macro_rules! entrypoint {
-    ($process_instruction:ident) => {
-        #[cfg(all(not(feature = "custom-heap"), not(test)))]
-        #[global_allocator]
-        static A: $crate::entrypoint::BumpAllocator = $crate::entrypoint::BumpAllocator {
-            start: $crate::entrypoint::HEAP_START_ADDRESS,
-            len: $crate::entrypoint::HEAP_LENGTH,
-        };
-
-        /// # Safety
-        #[no_mangle]
-        pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
-            let (program_id, accounts, instruction_data) =
-                unsafe { $crate::entrypoint::deserialize(input) };
-            match $process_instruction(&program_id, &accounts, &instruction_data) {
-                Ok(()) => $crate::entrypoint::SUCCESS,
-                Err(error) => error.into(),
-            }
-        }
-    };
-}

--- a/sdk/src/entrypoint_deprecated.rs
+++ b/sdk/src/entrypoint_deprecated.rs
@@ -8,23 +8,3 @@
 //! [`bpf_loader_deprecated`]: crate::bpf_loader_deprecated
 
 pub use solana_program::entrypoint_deprecated::*;
-
-#[macro_export]
-#[deprecated(
-    since = "1.4.3",
-    note = "use solana_program::entrypoint::entrypoint instead"
-)]
-macro_rules! entrypoint_deprecated {
-    ($process_instruction:ident) => {
-        /// # Safety
-        #[no_mangle]
-        pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
-            let (program_id, accounts, instruction_data) =
-                unsafe { $crate::entrypoint_deprecated::deserialize(input) };
-            match $process_instruction(&program_id, &accounts, &instruction_data) {
-                Ok(()) => $crate::entrypoint_deprecated::SUCCESS,
-                Err(error) => error.into(),
-            }
-        }
-    };
-}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -157,16 +157,6 @@ pub use solana_sdk_macro::pubkey;
 /// Convenience macro to define multiple static public keys.
 pub use solana_sdk_macro::pubkeys;
 
-// Unused `solana_sdk::program_stubs!()` macro retained for source backwards compatibility with older programs
-#[macro_export]
-#[deprecated(
-    since = "1.4.3",
-    note = "program_stubs macro is obsolete and can be safely removed"
-)]
-macro_rules! program_stubs {
-    () => {};
-}
-
 /// Convenience macro for `AddAssign` with saturating arithmetic.
 /// Replace by `std::num::Saturating` once stable
 #[macro_export]

--- a/sdk/src/log.rs
+++ b/sdk/src/log.rs
@@ -1,14 +1,3 @@
 #![cfg(feature = "program")]
 
 pub use solana_program::log::*;
-
-#[macro_export]
-#[deprecated(
-    since = "1.4.3",
-    note = "Please use `solana_program::log::info` instead"
-)]
-macro_rules! info {
-    ($msg:expr) => {
-        $crate::log::sol_log($msg)
-    };
-}

--- a/sdk/src/native_loader.rs
+++ b/sdk/src/native_loader.rs
@@ -1,23 +1,12 @@
 //! The native loader native program.
 
-use crate::{
-    account::{
-        Account, AccountSharedData, InheritableAccountFields, DUMMY_INHERITABLE_ACCOUNT_FIELDS,
-    },
-    clock::INITIAL_RENT_EPOCH,
+use crate::account::{
+    Account, AccountSharedData, InheritableAccountFields, DUMMY_INHERITABLE_ACCOUNT_FIELDS,
 };
 
 crate::declare_id!("NativeLoader1111111111111111111111111111111");
 
 /// Create an executable account with the given shared object name.
-#[deprecated(
-    since = "1.5.17",
-    note = "Please use `create_loadable_account_for_test` instead"
-)]
-pub fn create_loadable_account(name: &str, lamports: u64) -> AccountSharedData {
-    create_loadable_account_with_fields(name, (lamports, INITIAL_RENT_EPOCH))
-}
-
 pub fn create_loadable_account_with_fields(
     name: &str,
     (lamports, rent_epoch): InheritableAccountFields,

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -28,14 +28,6 @@ pub struct Signature(GenericArray<u8, U64>);
 impl solana_sanitize::Sanitize for Signature {}
 
 impl Signature {
-    #[deprecated(
-        since = "1.16.4",
-        note = "Please use 'Signature::from' or 'Signature::try_from' instead"
-    )]
-    pub fn new(signature_slice: &[u8]) -> Self {
-        Self(GenericArray::clone_from_slice(signature_slice))
-    }
-
     pub fn new_unique() -> Self {
         Self::from(std::array::from_fn(|_| rand::random()))
     }

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -1125,17 +1125,6 @@ pub fn uses_durable_nonce(tx: &Transaction) -> Option<&CompiledInstruction> {
         })
 }
 
-#[deprecated]
-pub fn get_nonce_pubkey_from_instruction<'a>(
-    ix: &CompiledInstruction,
-    tx: &'a Transaction,
-) -> Option<&'a Pubkey> {
-    ix.accounts.first().and_then(|idx| {
-        let idx = *idx as usize;
-        tx.message().account_keys.get(idx)
-    })
-}
-
 #[cfg(test)]
 mod tests {
     #![allow(deprecated)]
@@ -1628,34 +1617,6 @@ mod tests {
         let message = Message::new(&instructions, Some(&nonce_pubkey));
         let tx = Transaction::new(&[&from_keypair, &nonce_keypair], message, Hash::default());
         assert!(uses_durable_nonce(&tx).is_none());
-    }
-
-    #[test]
-    fn get_nonce_pub_from_ix_ok() {
-        let (_, nonce_pubkey, tx) = nonced_transfer_tx();
-        let nonce_ix = uses_durable_nonce(&tx).unwrap();
-        assert_eq!(
-            get_nonce_pubkey_from_instruction(nonce_ix, &tx),
-            Some(&nonce_pubkey),
-        );
-    }
-
-    #[test]
-    fn get_nonce_pub_from_ix_no_accounts_fail() {
-        let (_, _, tx) = nonced_transfer_tx();
-        let nonce_ix = uses_durable_nonce(&tx).unwrap();
-        let mut nonce_ix = nonce_ix.clone();
-        nonce_ix.accounts.clear();
-        assert_eq!(get_nonce_pubkey_from_instruction(&nonce_ix, &tx), None,);
-    }
-
-    #[test]
-    fn get_nonce_pub_from_ix_bad_acc_idx_fail() {
-        let (_, _, tx) = nonced_transfer_tx();
-        let nonce_ix = uses_durable_nonce(&tx).unwrap();
-        let mut nonce_ix = nonce_ix.clone();
-        nonce_ix.accounts[0] = 255u8;
-        assert_eq!(get_nonce_pubkey_from_instruction(&nonce_ix, &tx), None,);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Deprecated cruft lingering, despite new major version.

#### Summary of Changes
Remove deprecated symbols from solana-sdk older than v1.18. The only exceptions remaining are in https://github.com/anza-xyz/agave/pull/1903 and the `recent_blockhashes_account` module, which [is still used in live runtime code](https://github.com/anza-xyz/agave/blob/1cf61c9809110cc63456e1adb0685da4310ed560/runtime/src/bank.rs#L2751) 🤨. We'd need to remove or at least stop updating the sysvar (both approaches require feature gates) in order to remove.
