### PR TITLE
Remove deprecated spl-token conversion methods

### DIFF
--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -26,37 +26,6 @@ pub fn is_known_spl_token_id(program_id: &Pubkey) -> bool {
     *program_id == spl_token::id() || *program_id == spl_token_2022::id()
 }
 
-// A helper function to convert spl_token::native_mint::id() as spl_sdk::pubkey::Pubkey to
-// solana_sdk::pubkey::Pubkey
-#[deprecated(
-    since = "1.16.0",
-    note = "Pubkey conversions no longer needed. Please use spl_token::native_mint::id() directly"
-)]
-pub fn spl_token_native_mint() -> Pubkey {
-    Pubkey::new_from_array(spl_token::native_mint::id().to_bytes())
-}
-
-// The program id of the `spl_token_native_mint` account
-#[deprecated(
-    since = "1.16.0",
-    note = "Pubkey conversions no longer needed. Please use spl_token::id() directly"
-)]
-pub fn spl_token_native_mint_program_id() -> Pubkey {
-    spl_token::id()
-}
-
-// A helper function to convert a solana_sdk::pubkey::Pubkey to spl_sdk::pubkey::Pubkey
-#[deprecated(since = "1.16.0", note = "Pubkey conversions no longer needed")]
-pub fn spl_token_pubkey(pubkey: &Pubkey) -> SplTokenPubkey {
-    SplTokenPubkey::new_from_array(pubkey.to_bytes())
-}
-
-// A helper function to convert a spl_sdk::pubkey::Pubkey to solana_sdk::pubkey::Pubkey
-#[deprecated(since = "1.16.0", note = "Pubkey conversions no longer needed")]
-pub fn pubkey_from_spl_token(pubkey: &SplTokenPubkey) -> Pubkey {
-    Pubkey::new_from_array(pubkey.to_bytes())
-}
-
 #[deprecated(since = "2.0.0", note = "Use `parse_token_v2` instead")]
 pub fn parse_token(
     data: &[u8],

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -14,17 +14,11 @@ use {
         parse_account_data::SplTokenAdditionalData,
         parse_token::{token_amount_to_ui_amount_v2, UiAccountState},
     },
-    solana_sdk::{
-        instruction::{AccountMeta, CompiledInstruction, Instruction},
-        message::AccountKeys,
-    },
+    solana_sdk::{instruction::CompiledInstruction, message::AccountKeys},
     spl_token_2022::{
         extension::ExtensionType,
         instruction::{AuthorityType, TokenInstruction},
-        solana_program::{
-            instruction::Instruction as SplTokenInstruction, program_option::COption,
-            pubkey::Pubkey,
-        },
+        solana_program::{program_option::COption, pubkey::Pubkey},
     },
     spl_token_group_interface::instruction::TokenGroupInstruction,
     spl_token_metadata_interface::instruction::TokenMetadataInstruction,
@@ -849,23 +843,6 @@ fn parse_signers(
 
 fn check_num_token_accounts(accounts: &[u8], num: usize) -> Result<(), ParseInstructionError> {
     check_num_accounts(accounts, num, ParsableProgram::SplToken)
-}
-
-#[deprecated(since = "1.16.0", note = "Instruction conversions no longer needed")]
-pub fn spl_token_instruction(instruction: SplTokenInstruction) -> Instruction {
-    Instruction {
-        program_id: instruction.program_id,
-        accounts: instruction
-            .accounts
-            .iter()
-            .map(|meta| AccountMeta {
-                pubkey: meta.pubkey,
-                is_signer: meta.is_signer,
-                is_writable: meta.is_writable,
-            })
-            .collect(),
-        data: instruction.data,
-    }
 }
 
 fn map_coption_pubkey(pubkey: COption<Pubkey>) -> Option<String> {


### PR DESCRIPTION
#### Problem
SPL Token conversion methods are no longer needed and have been deprecated for several minor versions.

#### Summary of Changes
Remove them
