### PR TITLE
Remove deprecated BanksClient methods and dependent ProgramTest methods

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -17,8 +17,7 @@ use {
         BanksTransactionResultWithSimulation,
     },
     solana_program::{
-        clock::Slot, fee_calculator::FeeCalculator, hash::Hash, program_pack::Pack, pubkey::Pubkey,
-        rent::Rent, sysvar::Sysvar,
+        clock::Slot, hash::Hash, program_pack::Pack, pubkey::Pubkey, rent::Rent, sysvar::Sysvar,
     },
     solana_sdk::{
         account::{from_account, Account},
@@ -66,21 +65,6 @@ impl BanksClient {
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
         self.inner
             .send_transaction_with_context(ctx, transaction.into())
-            .map_err(Into::into)
-    }
-
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please use `get_fee_for_message` or `is_blockhash_valid` instead"
-    )]
-    pub fn get_fees_with_commitment_and_context(
-        &mut self,
-        ctx: Context,
-        commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<(FeeCalculator, Hash, u64), BanksClientError>> + '_ {
-        #[allow(deprecated)]
-        self.inner
-            .get_fees_with_commitment_and_context(ctx, commitment)
             .map_err(Into::into)
     }
 
@@ -185,20 +169,6 @@ impl BanksClient {
         self.send_transaction_with_context(context::current(), transaction.into())
     }
 
-    /// Return the fee parameters associated with a recent, rooted blockhash. The cluster
-    /// will use the transaction's blockhash to look up these same fee parameters and
-    /// use them to calculate the transaction fee.
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please use `get_fee_for_message` or `is_blockhash_valid` instead"
-    )]
-    pub fn get_fees(
-        &mut self,
-    ) -> impl Future<Output = Result<(FeeCalculator, Hash, u64), BanksClientError>> + '_ {
-        #[allow(deprecated)]
-        self.get_fees_with_commitment_and_context(context::current(), CommitmentLevel::default())
-    }
-
     /// Return the cluster Sysvar
     pub fn get_sysvar<T: Sysvar>(
         &mut self,
@@ -214,17 +184,6 @@ impl BanksClient {
     /// Return the cluster rent
     pub fn get_rent(&mut self) -> impl Future<Output = Result<Rent, BanksClientError>> + '_ {
         self.get_sysvar::<Rent>()
-    }
-
-    /// Return a recent, rooted blockhash from the server. The cluster will only accept
-    /// transactions with a blockhash that has not yet expired. Use the `get_fees`
-    /// method to get both a blockhash and the blockhash's last valid slot.
-    #[deprecated(since = "1.9.0", note = "Please use `get_latest_blockhash` instead")]
-    pub fn get_recent_blockhash(
-        &mut self,
-    ) -> impl Future<Output = Result<Hash, BanksClientError>> + '_ {
-        #[allow(deprecated)]
-        self.get_fees().map(|result| Ok(result?.1))
     }
 
     /// Send a transaction and return after the transaction has been rejected or

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -6,7 +6,6 @@ use {
         account::Account,
         clock::Slot,
         commitment_config::CommitmentLevel,
-        fee_calculator::FeeCalculator,
         hash::Hash,
         inner_instruction::InnerInstructions,
         message::Message,
@@ -64,13 +63,6 @@ pub struct BanksTransactionResultWithMetadata {
 #[tarpc::service]
 pub trait Banks {
     async fn send_transaction_with_context(transaction: VersionedTransaction);
-    #[deprecated(
-        since = "1.9.0",
-        note = "Please use `get_fee_for_message_with_commitment_and_context` instead"
-    )]
-    async fn get_fees_with_commitment_and_context(
-        commitment: CommitmentLevel,
-    ) -> (FeeCalculator, Hash, Slot);
     async fn get_transaction_status_with_context(signature: Signature)
         -> Option<TransactionStatus>;
     async fn get_slot_with_context(commitment: CommitmentLevel) -> Slot;

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -18,7 +18,6 @@ use {
         clock::Slot,
         commitment_config::CommitmentLevel,
         feature_set::FeatureSet,
-        fee_calculator::FeeCalculator,
         hash::Hash,
         message::{Message, SanitizedMessage},
         pubkey::Pubkey,
@@ -230,24 +229,6 @@ impl Banks for BanksServer {
             None,
         );
         self.transaction_sender.send(info).unwrap();
-    }
-
-    async fn get_fees_with_commitment_and_context(
-        self,
-        _: Context,
-        commitment: CommitmentLevel,
-    ) -> (FeeCalculator, Hash, u64) {
-        let bank = self.bank(commitment);
-        let blockhash = bank.last_blockhash();
-        let lamports_per_signature = bank.get_lamports_per_signature();
-        let last_valid_block_height = bank
-            .get_blockhash_last_valid_block_height(&blockhash)
-            .unwrap();
-        (
-            FeeCalculator::new(lamports_per_signature),
-            blockhash,
-            last_valid_block_height,
-        )
     }
 
     async fn get_transaction_status_with_context(


### PR DESCRIPTION
#### Problem
Deprecated cruft lingering, despite new major version.

#### Summary of Changes
Remove it
