### PR TITLE
Handle deprecated Instructions sysvar methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6827,6 +6827,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "parking_lot 0.12.3",
+ "qualifier_attr",
  "rand 0.8.5",
  "rustc_version 0.4.0",
  "serde",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -98,6 +98,7 @@ assert_matches = { workspace = true }
 curve25519-dalek = { workspace = true }
 hex = { workspace = true }
 solana-logger = { workspace = true }
+solana-program = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { path = ".", features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 tiny-bip39 = { workspace = true }

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -25,6 +25,7 @@ log = { workspace = true }
 memoffset = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true, features = ["i128"] }
+qualifier_attr = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_derive = { workspace = true }
@@ -93,4 +94,5 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["borsh"]
 borsh = ["dep:borsh", "dep:borsh0-10"]
+dev-context-only-utils = ["dep:qualifier_attr"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -274,13 +274,11 @@ pub fn get_instruction_relative(
     }
 
     let instruction_sysvar = instruction_sysvar_account_info.data.borrow();
-    #[allow(deprecated)]
     let current_index = load_current_index(&instruction_sysvar) as i64;
     let index = current_index.saturating_add(index_relative_to_current);
     if index < 0 {
         return Err(ProgramError::InvalidArgument);
     }
-    #[allow(deprecated)]
     load_instruction_at(
         current_index.saturating_add(index_relative_to_current) as usize,
         &instruction_sysvar,

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -149,11 +149,10 @@ fn serialize_instructions(instructions: &[BorrowedInstruction]) -> Vec<u8> {
 /// `Transaction`.
 ///
 /// `data` is the instructions sysvar account data.
-#[deprecated(
-    since = "1.8.0",
-    note = "Unsafe because the sysvar accounts address is not checked, please use `load_current_index_checked` instead"
-)]
-pub fn load_current_index(data: &[u8]) -> u16 {
+///
+/// Unsafe because the sysvar accounts address is not checked; only used
+/// internally after such a check.
+fn load_current_index(data: &[u8]) -> u16 {
     let mut instr_fixed_data = [0u8; 2];
     let len = data.len();
     instr_fixed_data.copy_from_slice(&data[len - 2..len]);
@@ -174,10 +173,8 @@ pub fn load_current_index_checked(
     }
 
     let instruction_sysvar = instruction_sysvar_account_info.try_borrow_data()?;
-    let mut instr_fixed_data = [0u8; 2];
-    let len = instruction_sysvar.len();
-    instr_fixed_data.copy_from_slice(&instruction_sysvar[len - 2..len]);
-    Ok(u16::from_le_bytes(instr_fixed_data))
+    let index = load_current_index(&instruction_sysvar);
+    Ok(index)
 }
 
 /// Store the current `Instruction`'s index in the instructions sysvar data.

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -231,11 +231,10 @@ fn deserialize_instruction(index: usize, data: &[u8]) -> Result<Instruction, San
 /// specified index.
 ///
 /// `data` is the instructions sysvar account data.
-#[deprecated(
-    since = "1.8.0",
-    note = "Unsafe because the sysvar accounts address is not checked, please use `load_instruction_at_checked` instead"
-)]
-pub fn load_instruction_at(index: usize, data: &[u8]) -> Result<Instruction, SanitizeError> {
+///
+/// Unsafe because the sysvar accounts address is not checked; only used
+/// internally after such a check.
+fn load_instruction_at(index: usize, data: &[u8]) -> Result<Instruction, SanitizeError> {
     deserialize_instruction(index, data)
 }
 
@@ -254,7 +253,7 @@ pub fn load_instruction_at_checked(
     }
 
     let instruction_sysvar = instruction_sysvar_account_info.try_borrow_data()?;
-    deserialize_instruction(index, &instruction_sysvar).map_err(|err| match err {
+    load_instruction_at(index, &instruction_sysvar).map_err(|err| match err {
         SanitizeError::IndexOutOfBounds => ProgramError::InvalidArgument,
         _ => ProgramError::InvalidInstructionData,
     })

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -29,6 +29,8 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 #[cfg(not(target_os = "solana"))]
 use {
     crate::serialize_utils::{append_slice, append_u16, append_u8},
@@ -234,6 +236,7 @@ fn deserialize_instruction(index: usize, data: &[u8]) -> Result<Instruction, San
 ///
 /// Unsafe because the sysvar accounts address is not checked; only used
 /// internally after such a check.
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn load_instruction_at(index: usize, data: &[u8]) -> Result<Instruction, SanitizeError> {
     deserialize_instruction(index, data)
 }


### PR DESCRIPTION
#### Problem
Deprecated `sysvar::instructions` methods are eligible for removal. However, they are used internally by `get_instruction_relative()` instead of the checked versions of those methods because it saves having to do the account-owner check and borrow the sysvar data twice.

#### Summary of Changes
Unpublish the deprecated methods `load_current_index()` and `load_instruction_at()`. Use them in the checked versions of those methods to dedupe code.

(Needs rebase on a commit from https://github.com/anza-xyz/agave/pull/1958, because a deprecated legacy-message method was also using `load_instruction_at()`)
