### PR TITLE
Use node's latest vote for commitment calc. too

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -26,8 +26,8 @@ pub struct CommitmentAggregationData {
     bank: Arc<Bank>,
     root: Slot,
     total_stake: Stake,
-    // Node's latest local vote state accompanied to the bank.
-    // Used for commitment aggreagation if the vote account is staked.
+    // The latest local vote state of the node running this service.
+    // Used for commitment aggregation if the node's vote account is staked.
     node_vote_state: (Pubkey, VoteState),
 }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -76,7 +76,7 @@ use {
         timing::timestamp,
         transaction::Transaction,
     },
-    solana_vote_program::vote_state::VoteTransaction,
+    solana_vote_program::vote_state::{VoteState, VoteTransaction},
     std::{
         collections::{HashMap, HashSet},
         num::NonZeroUsize,
@@ -2406,10 +2406,28 @@ impl ReplayStage {
         }
 
         let mut update_commitment_cache_time = Measure::start("update_commitment_cache");
+        // Send (voted) bank along with the updated vote account state for this node, the vote
+        // state is always newer than the one in the bank by definition, because banks can't
+        // contain vote transactions which are voting on its own slot.
+        //
+        // It should be acceptable to aggressively use the vote for our own _local view_ of
+        // commitment aggregation, although it's not guaranteed that the new vote transaction is
+        // observed by other nodes at this point.
+        //
+        // The justification stems from the assumption of the sensible voting behavior from the
+        // consensus subsystem. That's because it means there would be a slashing possibility
+        // otherwise.
+        //
+        // This behavior isn't significant normally for mainnet-beta, because staked nodes aren't
+        // servicing RPC requests. However, this eliminates artificial 1-slot delay of the
+        // `finalized` confirmation if a node is materially staked and servicing RPC requests at
+        // the same time for development purposes.
+        let node_vote_state = (*vote_account_pubkey, tower.vote_state.clone());
         Self::update_commitment_cache(
             bank.clone(),
             bank_forks.read().unwrap().root(),
             progress.get_fork_stats(bank.slot()).unwrap().total_stake,
+            node_vote_state,
             lockouts_sender,
         );
         update_commitment_cache_time.stop();
@@ -2699,11 +2717,15 @@ impl ReplayStage {
         bank: Arc<Bank>,
         root: Slot,
         total_stake: Stake,
+        node_vote_state: (Pubkey, VoteState),
         lockouts_sender: &Sender<CommitmentAggregationData>,
     ) {
-        if let Err(e) =
-            lockouts_sender.send(CommitmentAggregationData::new(bank, root, total_stake))
-        {
+        if let Err(e) = lockouts_sender.send(CommitmentAggregationData::new(
+            bank,
+            root,
+            total_stake,
+            node_vote_state,
+        )) {
             trace!("lockouts_sender failed: {:?}", e);
         }
     }
@@ -5281,13 +5303,14 @@ pub(crate) mod tests {
 
     #[test]
     fn test_replay_commitment_cache() {
-        fn leader_vote(vote_slot: Slot, bank: &Bank, pubkey: &Pubkey) {
+        fn leader_vote(vote_slot: Slot, bank: &Bank, pubkey: &Pubkey) -> (Pubkey, VoteState) {
             let mut leader_vote_account = bank.get_account(pubkey).unwrap();
             let mut vote_state = vote_state::from(&leader_vote_account).unwrap();
             vote_state::process_slot_vote_unchecked(&mut vote_state, vote_slot);
-            let versioned = VoteStateVersions::new_current(vote_state);
+            let versioned = VoteStateVersions::new_current(vote_state.clone());
             vote_state::to(&versioned, &mut leader_vote_account).unwrap();
             bank.store_account(pubkey, &leader_vote_account);
+            (*pubkey, vote_state)
         }
 
         let leader_pubkey = solana_sdk::pubkey::new_rand();
@@ -5353,11 +5376,12 @@ pub(crate) mod tests {
             }
 
             let arc_bank = bank_forks.read().unwrap().get(i).unwrap();
-            leader_vote(i - 1, &arc_bank, &leader_voting_pubkey);
+            let node_vote_state = leader_vote(i - 1, &arc_bank, &leader_voting_pubkey);
             ReplayStage::update_commitment_cache(
                 arc_bank.clone(),
                 0,
                 leader_lamports,
+                node_vote_state,
                 &lockouts_sender,
             );
             arc_bank.freeze();

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1794,12 +1794,9 @@ fn test_validator_saves_tower() {
 
     // Wait for the first new root
     let last_replayed_root = loop {
-        #[allow(deprecated)]
-        // This test depends on knowing the immediate root, without any delay from the commitment
-        // service, so the deprecated CommitmentConfig::root() is retained
         if let Ok(root) = validator_client
             .rpc_client()
-            .get_slot_with_commitment(CommitmentConfig::root())
+            .get_slot_with_commitment(CommitmentConfig::finalized())
         {
             trace!("current root: {}", root);
             if root > 0 {
@@ -1826,12 +1823,9 @@ fn test_validator_saves_tower() {
 
     // Wait for a new root, demonstrating the validator was able to make progress from the older `tower1`
     let new_root = loop {
-        #[allow(deprecated)]
-        // This test depends on knowing the immediate root, without any delay from the commitment
-        // service, so the deprecated CommitmentConfig::root() is retained
         if let Ok(root) = validator_client
             .rpc_client()
-            .get_slot_with_commitment(CommitmentConfig::root())
+            .get_slot_with_commitment(CommitmentConfig::finalized())
         {
             trace!(
                 "current root: {}, last_replayed_root: {}",
@@ -1862,12 +1856,9 @@ fn test_validator_saves_tower() {
 
     // Wait for another new root
     let new_root = loop {
-        #[allow(deprecated)]
-        // This test depends on knowing the immediate root, without any delay from the commitment
-        // service, so the deprecated CommitmentConfig::root() is retained
         if let Ok(root) = validator_client
             .rpc_client()
-            .get_slot_with_commitment(CommitmentConfig::root())
+            .get_slot_with_commitment(CommitmentConfig::finalized())
         {
             trace!("current root: {}, last tower root: {}", root, tower3_root);
             if root > tower3_root {


### PR DESCRIPTION
#### Problem

`test_validator_saves_tower` is rigidly testing things (well, while not being brittle, imo:
https://buildkite.com/organizations/anza/analytics/suites/agave/tests/018d9c5f-d789-7dc6-8749-0c423e6080ac?branch=master).

Because of that, just changing commitment level makes it fail....

After some investigation, it turned out there's needless delay for `finalized`.

#### Summary of Changes

Fix the commitment calc, ~hoping nothing is broken, esp our beloved local-cluster tests...~ (EDIT: seems ci has just passed)