### PR TITLE
sdk: Extract clock crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6916,6 +6916,7 @@ dependencies = [
  "sha2 0.10.8",
  "sha3 0.10.8",
  "solana-atomic-u64",
+ "solana-clock",
  "solana-decode-error",
  "solana-define-syscall",
  "solana-frozen-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6023,6 +6023,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-clock"
+version = "2.1.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-macro",
+ "static_assertions",
+]
+
+[[package]]
 name = "solana-compute-budget"
 version = "2.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,6 +2401,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen-headers"
+version = "2.1.0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "gen-syscall-list"
 version = "2.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,14 +2401,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gen-headers"
-version = "2.1.0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "gen-syscall-list"
 version = "2.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,8 +103,7 @@ members = [
     "sdk/atomic-u64",
     "sdk/cargo-build-sbf",
     "sdk/cargo-test-sbf",
-    "sdk/decode-error",
-    "sdk/gen-headers",
+    "sdk/clock",
     "sdk/macro",
     "sdk/msg",
     "sdk/package-metadata-macro",
@@ -352,6 +351,7 @@ solana-cli = { path = "cli", version = "=2.1.0" }
 solana-cli-config = { path = "cli-config", version = "=2.1.0" }
 solana-cli-output = { path = "cli-output", version = "=2.1.0" }
 solana-client = { path = "client", version = "=2.1.0" }
+solana-clock = { path = "sdk/clock", version = "=2.1.0" }
 solana-compute-budget = { path = "compute-budget", version = "=2.1.0" }
 solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.1.0" }
 solana-config-program = { path = "programs/config", version = "=2.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,8 @@ members = [
     "sdk/cargo-build-sbf",
     "sdk/cargo-test-sbf",
     "sdk/clock",
+    "sdk/decode-error",
+    "sdk/gen-headers",
     "sdk/macro",
     "sdk/msg",
     "sdk/package-metadata-macro",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4766,6 +4766,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-clock"
+version = "2.1.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-macro",
+]
+
+[[package]]
 name = "solana-compute-budget"
 version = "2.1.0"
 dependencies = [
@@ -5341,6 +5350,7 @@ dependencies = [
  "sha2 0.10.8",
  "sha3 0.10.8",
  "solana-atomic-u64",
+ "solana-clock",
  "solana-decode-error",
  "solana-define-syscall",
  "solana-msg",

--- a/sdk/clock/Cargo.toml
+++ b/sdk/clock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-clock"
-description = "Solana Message Sanitization"
+description = "Solana Clock and Time Definitions"
 documentation = "https://docs.rs/solana-sanitize"
 version = { workspace = true }
 authors = { workspace = true }

--- a/sdk/clock/Cargo.toml
+++ b/sdk/clock/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "solana-clock"
+description = "Solana Message Sanitization"
+documentation = "https://docs.rs/solana-sanitize"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+serde = { workspace = true }
+serde_derive = { workspace = true }
+solana-sdk-macro = { workspace = true }
+
+[dev-dependencies]
+static_assertions = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/clock/Cargo.toml
+++ b/sdk/clock/Cargo.toml
@@ -10,12 +10,15 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-serde = { workspace = true }
-serde_derive = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
 
 [dev-dependencies]
 static_assertions = { workspace = true }
+
+[features]
+serde = ["dep:serde", "dep:serde_derive"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/clock/Cargo.toml
+++ b/sdk/clock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-clock"
 description = "Solana Clock and Time Definitions"
-documentation = "https://docs.rs/solana-sanitize"
+documentation = "https://docs.rs/solana-clock"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/sdk/clock/src/lib.rs
+++ b/sdk/clock/src/lib.rs
@@ -20,10 +20,9 @@
 //!
 //! [oracle]: https://docs.solanalabs.com/implemented-proposals/validator-timestamp-oracle
 
-use {
-    serde_derive::{Deserialize, Serialize},
-    solana_sdk_macro::CloneZeroed,
-};
+#[cfg(feature = "serde")]
+use serde_derive::{Deserialize, Serialize};
+use solana_sdk_macro::CloneZeroed;
 
 /// The default tick rate that the cluster attempts to achieve (160 per second).
 ///
@@ -175,7 +174,8 @@ pub type UnixTimestamp = i64;
 ///
 /// All members of `Clock` start from 0 upon network boot.
 #[repr(C)]
-#[derive(Serialize, Deserialize, Debug, CloneZeroed, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, CloneZeroed, Default, PartialEq, Eq)]
 pub struct Clock {
     /// The current `Slot`.
     pub slot: Slot,

--- a/sdk/clock/src/lib.rs
+++ b/sdk/clock/src/lib.rs
@@ -20,7 +20,10 @@
 //!
 //! [oracle]: https://docs.solanalabs.com/implemented-proposals/validator-timestamp-oracle
 
-use {serde_derive::{Deserialize, Serialize}, solana_sdk_macro::CloneZeroed};
+use {
+    serde_derive::{Deserialize, Serialize},
+    solana_sdk_macro::CloneZeroed,
+};
 
 /// The default tick rate that the cluster attempts to achieve (160 per second).
 ///

--- a/sdk/clock/src/lib.rs
+++ b/sdk/clock/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! [oracle]: https://docs.solanalabs.com/implemented-proposals/validator-timestamp-oracle
 
-use solana_sdk_macro::CloneZeroed;
+use {serde_derive::{Deserialize, Serialize}, solana_sdk_macro::CloneZeroed};
 
 /// The default tick rate that the cluster attempts to achieve (160 per second).
 ///

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -32,6 +32,7 @@ serde_derive = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
 solana-atomic-u64 = { workspace = true }
+solana-clock = { workspace = true }
 solana-decode-error = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -32,7 +32,7 @@ serde_derive = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
 solana-atomic-u64 = { workspace = true }
-solana-clock = { workspace = true }
+solana-clock = { workspace = true, features = ["serde"] }
 solana-decode-error = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }

--- a/sdk/program/src/account_info.rs
+++ b/sdk/program/src/account_info.rs
@@ -2,9 +2,10 @@
 
 use {
     crate::{
-        clock::Epoch, debug_account_data::*, entrypoint::MAX_PERMITTED_DATA_INCREASE,
+        debug_account_data::*, entrypoint::MAX_PERMITTED_DATA_INCREASE,
         program_error::ProgramError, pubkey::Pubkey,
     },
+    solana_clock::Epoch,
     solana_program_memory::sol_memset,
     std::{
         cell::{Ref, RefCell, RefMut},

--- a/sdk/program/src/address_lookup_table/instruction.rs
+++ b/sdk/program/src/address_lookup_table/instruction.rs
@@ -1,12 +1,12 @@
 use {
     crate::{
         address_lookup_table::program::id,
-        clock::Slot,
         instruction::{AccountMeta, Instruction},
         pubkey::Pubkey,
         system_program,
     },
     serde_derive::{Deserialize, Serialize},
+    solana_clock::Slot,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]

--- a/sdk/program/src/address_lookup_table/state.rs
+++ b/sdk/program/src/address_lookup_table/state.rs
@@ -2,9 +2,9 @@
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
 use {
     serde_derive::{Deserialize, Serialize},
+    solana_clock::Slot,
     solana_program::{
         address_lookup_table::error::AddressLookupError,
-        clock::Slot,
         instruction::InstructionError,
         pubkey::Pubkey,
         slot_hashes::{SlotHashes, MAX_ENTRIES},

--- a/sdk/program/src/epoch_schedule.rs
+++ b/sdk/program/src/epoch_schedule.rs
@@ -11,7 +11,7 @@
 //! the chain there is a "warmup" period, where epochs are short, with subsequent
 //! epochs increasing in slots until they last for [`DEFAULT_SLOTS_PER_EPOCH`].
 
-pub use crate::clock::{Epoch, Slot, DEFAULT_SLOTS_PER_EPOCH};
+pub use solana_clock::{Epoch, Slot, DEFAULT_SLOTS_PER_EPOCH};
 use solana_sdk_macro::CloneZeroed;
 
 /// The default number of slots before an epoch starts to calculate the leader schedule.

--- a/sdk/program/src/example_mocks.rs
+++ b/sdk/program/src/example_mocks.rs
@@ -123,7 +123,7 @@ pub mod solana_sdk {
     };
 
     pub mod account {
-        use crate::{clock::Epoch, pubkey::Pubkey};
+        use {crate::pubkey::Pubkey, solana_clock::Epoch};
         #[derive(Clone)]
         pub struct Account {
             pub lamports: u64,

--- a/sdk/program/src/feature.rs
+++ b/sdk/program/src/feature.rs
@@ -11,9 +11,12 @@
 //! 2. When the next epoch is entered the runtime will check for new activation requests and
 //!    active them.  When this occurs, the activation slot is recorded in the feature account
 
-use crate::{
-    account_info::AccountInfo, clock::Slot, instruction::Instruction, program_error::ProgramError,
-    pubkey::Pubkey, rent::Rent, system_instruction,
+use {
+    crate::{
+        account_info::AccountInfo, instruction::Instruction, program_error::ProgramError,
+        pubkey::Pubkey, rent::Rent, system_instruction,
+    },
+    solana_clock::Slot,
 };
 
 crate::declare_id!("Feature111111111111111111111111111111111111");
@@ -60,7 +63,7 @@ pub fn activate_with_lamports(
 
 #[cfg(test)]
 mod test {
-    use {super::*, solana_program::clock::Slot};
+    use super::*;
 
     #[test]
     fn test_feature_size_of() {

--- a/sdk/program/src/fee_calculator.rs
+++ b/sdk/program/src/fee_calculator.rs
@@ -1,7 +1,7 @@
 //! Calculation of transaction fees.
 
 #![allow(clippy::arithmetic_side_effects)]
-use {solana_clock::DEFAULT_MS_PER_SLOT, log::*};
+use {log::*, solana_clock::DEFAULT_MS_PER_SLOT};
 
 #[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]

--- a/sdk/program/src/fee_calculator.rs
+++ b/sdk/program/src/fee_calculator.rs
@@ -1,7 +1,7 @@
 //! Calculation of transaction fees.
 
 #![allow(clippy::arithmetic_side_effects)]
-use {crate::clock::DEFAULT_MS_PER_SLOT, log::*};
+use {solana_clock::DEFAULT_MS_PER_SLOT, log::*};
 
 #[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]

--- a/sdk/program/src/last_restart_slot.rs
+++ b/sdk/program/src/last_restart_slot.rs
@@ -1,6 +1,6 @@
 //! Information about the last restart slot (hard fork).
 
-use {crate::clock::Slot, solana_sdk_macro::CloneZeroed};
+use {solana_clock::Slot, solana_sdk_macro::CloneZeroed};
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, CloneZeroed, PartialEq, Eq, Default)]

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -532,6 +532,7 @@ pub mod wasm;
 pub use solana_msg::msg;
 #[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]
 pub use solana_program_memory as program_memory;
+pub use solana_clock as clock;
 #[deprecated(since = "2.1.0", note = "Use `solana-sanitize` crate instead")]
 pub use solana_sanitize as sanitize;
 #[deprecated(since = "2.1.0", note = "Use `solana-secp256k1-recover` crate instead")]

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -482,7 +482,6 @@ pub mod borsh1;
 pub mod bpf_loader;
 pub mod bpf_loader_deprecated;
 pub mod bpf_loader_upgradeable;
-pub mod clock;
 pub mod compute_units;
 pub mod debug_account_data;
 pub mod ed25519_program;

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -529,10 +529,10 @@ pub mod sysvar;
 pub mod vote;
 pub mod wasm;
 
+pub use solana_clock as clock;
 pub use solana_msg::msg;
 #[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]
 pub use solana_program_memory as program_memory;
-pub use solana_clock as clock;
 #[deprecated(since = "2.1.0", note = "Use `solana-sanitize` crate instead")]
 pub use solana_sanitize as sanitize;
 #[deprecated(since = "2.1.0", note = "Use `solana-secp256k1-recover` crate instead")]

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -529,8 +529,6 @@ pub mod sysvar;
 pub mod vote;
 pub mod wasm;
 
-pub use solana_clock as clock;
-pub use solana_msg::msg;
 #[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]
 pub use solana_program_memory as program_memory;
 #[deprecated(since = "2.1.0", note = "Use `solana-sanitize` crate instead")]
@@ -541,6 +539,7 @@ pub use solana_secp256k1_recover as secp256k1_recover;
 pub use solana_short_vec as short_vec;
 #[cfg(target_arch = "wasm32")]
 pub use wasm_bindgen::prelude::wasm_bindgen;
+pub use {solana_clock as clock, solana_msg::msg};
 
 /// The [config native program][np].
 ///

--- a/sdk/program/src/program.rs
+++ b/sdk/program/src/program.rs
@@ -8,9 +8,12 @@
 //! [`invoke_signed`]: invoke_signed
 //! [cpi]: https://solana.com/docs/core/cpi
 
-use crate::{
-    account_info::AccountInfo, entrypoint::ProgramResult, instruction::Instruction, pubkey::Pubkey,
-    stable_layout::stable_instruction::StableInstruction,
+use {
+    crate::{
+        account_info::AccountInfo, entrypoint::ProgramResult, instruction::Instruction,
+        pubkey::Pubkey, stable_layout::stable_instruction::StableInstruction,
+    },
+    solana_clock::Epoch,
 };
 
 /// Invoke a cross-program instruction.
@@ -396,7 +399,7 @@ pub fn get_return_data() -> Option<(Pubkey, Vec<u8>)> {
 pub fn check_type_assumptions() {
     extern crate memoffset;
     use {
-        crate::{clock::Epoch, instruction::AccountMeta},
+        crate::instruction::AccountMeta,
         memoffset::offset_of,
         std::{
             cell::RefCell,

--- a/sdk/program/src/rent.rs
+++ b/sdk/program/src/rent.rs
@@ -4,7 +4,7 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 
-use {crate::clock::DEFAULT_SLOTS_PER_EPOCH, solana_sdk_macro::CloneZeroed};
+use {solana_clock::DEFAULT_SLOTS_PER_EPOCH, solana_sdk_macro::CloneZeroed};
 
 /// Configuration of network rent.
 #[repr(C)]

--- a/sdk/program/src/slot_hashes.rs
+++ b/sdk/program/src/slot_hashes.rs
@@ -6,7 +6,7 @@
 //!
 //! [`sysvar::slot_hashes`]: crate::sysvar::slot_hashes
 
-pub use crate::clock::Slot;
+pub use solana_clock::Slot;
 use {
     crate::hash::Hash,
     std::{

--- a/sdk/program/src/stake/instruction.rs
+++ b/sdk/program/src/stake/instruction.rs
@@ -5,7 +5,6 @@
 
 use {
     crate::{
-        clock::{Epoch, UnixTimestamp},
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,
         pubkey::Pubkey,
@@ -19,6 +18,7 @@ use {
     log::*,
     num_derive::{FromPrimitive, ToPrimitive},
     serde_derive::{Deserialize, Serialize},
+    solana_clock::{Epoch, UnixTimestamp},
     solana_decode_error::DecodeError,
     thiserror::Error,
 };

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -7,7 +7,6 @@
 use borsh::{io, BorshDeserialize, BorshSchema, BorshSerialize};
 use {
     crate::{
-        clock::{Clock, Epoch, UnixTimestamp},
         instruction::InstructionError,
         pubkey::Pubkey,
         stake::{
@@ -16,6 +15,7 @@ use {
         },
         stake_history::{StakeHistoryEntry, StakeHistoryGetEntry},
     },
+    solana_clock::{Clock, Epoch, UnixTimestamp},
     std::collections::HashSet,
 };
 

--- a/sdk/program/src/stake/tools.rs
+++ b/sdk/program/src/stake/tools.rs
@@ -1,6 +1,7 @@
 //! Utility functions
-use crate::{
-    clock::Epoch, program_error::ProgramError, stake::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION,
+use {
+    crate::{program_error::ProgramError, stake::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION},
+    solana_clock::Epoch,
 };
 
 /// Helper function for programs to call [`GetMinimumDelegation`] and then fetch the return data

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -6,7 +6,7 @@
 //!
 //! [`sysvar::stake_history`]: crate::sysvar::stake_history
 
-pub use crate::clock::Epoch;
+pub use solana_clock::Epoch;
 use std::ops::Deref;
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down

--- a/sdk/program/src/sysvar/clock.rs
+++ b/sdk/program/src/sysvar/clock.rs
@@ -126,8 +126,8 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 
-pub use crate::clock::Clock;
 use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
+pub use solana_clock::Clock;
 
 crate::declare_sysvar_id!("SysvarC1ock11111111111111111111111111111111", Clock);
 

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -283,12 +283,12 @@ mod tests {
     use {
         super::*,
         crate::{
-            clock::Epoch,
             entrypoint::SUCCESS,
             program_error::ProgramError,
             program_stubs::{set_syscall_stubs, SyscallStubs},
             pubkey::Pubkey,
         },
+        solana_clock::Epoch,
         std::{cell::RefCell, rc::Rc},
     };
 

--- a/sdk/program/src/sysvar/recent_blockhashes.rs
+++ b/sdk/program/src/sysvar/recent_blockhashes.rs
@@ -162,7 +162,7 @@ impl Deref for RecentBlockhashes {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::clock::MAX_PROCESSING_AGE};
+    use {super::*, solana_clock::MAX_PROCESSING_AGE};
 
     #[test]
     #[allow(clippy::assertions_on_constants)]

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -49,13 +49,13 @@ pub use crate::slot_hashes::SlotHashes;
 use {
     crate::{
         account_info::AccountInfo,
-        clock::Slot,
         hash::Hash,
         program_error::ProgramError,
         slot_hashes::MAX_ENTRIES,
         sysvar::{get_sysvar, Sysvar, SysvarId},
     },
     bytemuck_derive::{Pod, Zeroable},
+    solana_clock::Slot,
 };
 
 crate::declare_sysvar_id!("SysvarS1otHashes111111111111111111111111111", SlotHashes);
@@ -128,7 +128,6 @@ mod tests {
     use {
         super::*,
         crate::{
-            clock::Slot,
             hash::{hash, Hash},
             slot_hashes::MAX_ENTRIES,
             sysvar::tests::mock_get_sysvar_syscall,

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -46,10 +46,12 @@
 //! ```
 
 pub use crate::stake_history::StakeHistory;
-use crate::{
-    clock::Epoch,
-    stake_history::{StakeHistoryEntry, StakeHistoryGetEntry, MAX_ENTRIES},
-    sysvar::{get_sysvar, Sysvar, SysvarId},
+use {
+    crate::{
+        stake_history::{StakeHistoryEntry, StakeHistoryGetEntry, MAX_ENTRIES},
+        sysvar::{get_sysvar, Sysvar, SysvarId},
+    },
+    solana_clock::Epoch,
 };
 
 crate::declare_sysvar_id!("SysvarStakeHistory1111111111111111111111111", StakeHistory);

--- a/sdk/program/src/vote/authorized_voters.rs
+++ b/sdk/program/src/vote/authorized_voters.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 use arbitrary::Arbitrary;
 use {
-    crate::{clock::Epoch, pubkey::Pubkey},
+    crate::pubkey::Pubkey,
     serde_derive::{Deserialize, Serialize},
+    solana_clock::Epoch,
     std::collections::BTreeMap,
 };
 

--- a/sdk/program/src/vote/instruction.rs
+++ b/sdk/program/src/vote/instruction.rs
@@ -3,7 +3,6 @@
 use {
     super::state::TowerSync,
     crate::{
-        clock::{Slot, UnixTimestamp},
         hash::Hash,
         instruction::{AccountMeta, Instruction},
         pubkey::Pubkey,
@@ -18,6 +17,7 @@ use {
         },
     },
     serde_derive::{Deserialize, Serialize},
+    solana_clock::{Slot, UnixTimestamp},
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -963,10 +963,7 @@ impl VoteState {
 pub mod serde_compact_vote_state_update {
     use {
         super::*,
-        crate::{
-            serde_varint,
-            vote::state::Lockout,
-        },
+        crate::{serde_varint, vote::state::Lockout},
         serde::{Deserialize, Deserializer, Serialize, Serializer},
         solana_short_vec as short_vec,
     };
@@ -1060,10 +1057,7 @@ pub mod serde_compact_vote_state_update {
 pub mod serde_tower_sync {
     use {
         super::*,
-        crate::{
-            serde_varint,
-            vote::state::Lockout,
-        },
+        crate::{serde_varint, vote::state::Lockout},
         serde::{Deserialize, Deserializer, Serialize, Serializer},
         solana_short_vec as short_vec,
     };

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -19,13 +19,13 @@ use {
     },
     bincode::{serialize_into, ErrorKind},
     serde_derive::{Deserialize, Serialize},
+    solana_clock::{Epoch, Slot, UnixTimestamp},
     std::{
         collections::VecDeque,
         fmt::Debug,
         io::Cursor,
         mem::{self, MaybeUninit},
     },
-    solana_clock::{Epoch, Slot, UnixTimestamp},
 };
 
 mod vote_state_0_23_5;

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -9,7 +9,6 @@ use {
 };
 use {
     crate::{
-        clock::{Epoch, Slot, UnixTimestamp},
         hash::Hash,
         instruction::InstructionError,
         pubkey::Pubkey,
@@ -26,6 +25,7 @@ use {
         io::Cursor,
         mem::{self, MaybeUninit},
     },
+    solana_clock::{Epoch, Slot, UnixTimestamp},
 };
 
 mod vote_state_0_23_5;
@@ -964,7 +964,6 @@ pub mod serde_compact_vote_state_update {
     use {
         super::*,
         crate::{
-            clock::{Slot, UnixTimestamp},
             serde_varint,
             vote::state::Lockout,
         },
@@ -1062,7 +1061,6 @@ pub mod serde_tower_sync {
     use {
         super::*,
         crate::{
-            clock::{Slot, UnixTimestamp},
             serde_varint,
             vote::state::Lockout,
         },


### PR DESCRIPTION
#### Problem
solana_program::clock is another module that gets used everywhere and makes it hard to pull stuff out of solana-program.

#### Summary of Changes
Move clock.rs to a new crate `solana-clock` and re-export it in solana-program. I haven't put a deprecation warning because the clock is quite core to solana-program and I think people will get upset

The only code I updated to use the new solana-clock crate is solana-program. Everything else in the repo continues to use the re-exported solana_program::clock, because the PR would have been huge otherwise
