### PR TITLE
accounts-db-tools/add option of file_diff to hash cache tool diff directory

### DIFF
--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -91,6 +91,13 @@ fn main() {
                                 .takes_value(true)
                                 .value_name("PATH2")
                                 .help("Accounts hash cache directory 2 to diff"),
+                        )
+                        .arg(
+                            Arg::with_name("filediff")
+                                .long("include-file-diff")
+                                .short("f")
+                                .takes_value(false)
+                                .help("Include file diff"),
                         ),
                 ),
         )
@@ -144,7 +151,8 @@ fn cmd_diff_dirs(
 ) -> Result<(), String> {
     let path1 = value_t_or_exit!(subcommand_matches, "path1", String);
     let path2 = value_t_or_exit!(subcommand_matches, "path2", String);
-    do_diff_dirs(path1, path2)
+    let file_diff = subcommand_matches.is_present("filediff");
+    do_diff_dirs(path1, path2, file_diff)
 }
 
 fn do_inspect(file: impl AsRef<Path>, force: bool) -> Result<(), String> {
@@ -291,7 +299,11 @@ fn do_diff_files(file1: impl AsRef<Path>, file2: impl AsRef<Path>) -> Result<(),
     Ok(())
 }
 
-fn do_diff_dirs(dir1: impl AsRef<Path>, dir2: impl AsRef<Path>) -> Result<(), String> {
+fn do_diff_dirs(
+    dir1: impl AsRef<Path>,
+    dir2: impl AsRef<Path>,
+    file_diff: bool,
+) -> Result<(), String> {
     let get_files_in = |dir: &Path| {
         let mut files = Vec::new();
         let entries = fs::read_dir(dir)?;
@@ -446,6 +458,11 @@ fn do_diff_dirs(dir1: impl AsRef<Path>, dir2: impl AsRef<Path>) -> Result<(), St
                 file1.0 .0.display(),
                 file2.0 .0.display(),
             );
+            if file_diff {
+                if let Err(e) = do_diff_files(&file1.0 .0, &file2.0 .0) {
+                    println!("Failed to compare files {}", e);
+                }
+            }
         }
     }
 

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -151,8 +151,8 @@ fn cmd_diff_dirs(
 ) -> Result<(), String> {
     let path1 = value_t_or_exit!(subcommand_matches, "path1", String);
     let path2 = value_t_or_exit!(subcommand_matches, "path2", String);
-    let file_diff = subcommand_matches.is_present("filediff");
-    do_diff_dirs(path1, path2, file_diff)
+    let then_diff_files = subcommand_matches.is_present("then_diff_files");
+    do_diff_dirs(path1, path2, then_diff_files)
 }
 
 fn do_inspect(file: impl AsRef<Path>, force: bool) -> Result<(), String> {

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -94,7 +94,7 @@ fn main() {
                         )
                         .arg(
                             Arg::with_name("then_diff_files")
-                                .long("then_diff_files")
+                                .long("then-diff-files")
                                 .takes_value(false)
                                 .help("After diff-ing the directories, diff the files that were found to have mismatches"),
                         ),

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -460,7 +460,11 @@ fn do_diff_dirs(
         }
         if then_diff_files {
             for (file1, file2) in &mismatches {
-                println!("Differences between '{}' and '{}':", file1.0.0.display(), file2.0.0.display());
+                println!(
+                    "Differences between '{}' and '{}':",
+                    file1.0 .0.display(),
+                    file2.0 .0.display(),
+                );
                 if let Err(err) = do_diff_files(&file1.0 .0, &file2.0 .0) {
                     eprintln!("Error: failed to diff files: {err}");
                 }

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -96,7 +96,7 @@ fn main() {
                             Arg::with_name("then_diff_files")
                                 .long("then_diff_files")
                                 .takes_value(false)
-                                .help("After diff-ing the directories, diff the files that were found to have mismatches."),
+                                .help("After diff-ing the directories, diff the files that were found to have mismatches"),
                         ),
                 ),
         )

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -302,7 +302,7 @@ fn do_diff_files(file1: impl AsRef<Path>, file2: impl AsRef<Path>) -> Result<(),
 fn do_diff_dirs(
     dir1: impl AsRef<Path>,
     dir2: impl AsRef<Path>,
-    file_diff: bool,
+    then_diff_files: bool,
 ) -> Result<(), String> {
     let get_files_in = |dir: &Path| {
         let mut files = Vec::new();

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -93,11 +93,11 @@ fn main() {
                                 .help("Accounts hash cache directory 2 to diff"),
                         )
                         .arg(
-                            Arg::with_name("filediff")
-                                .long("include-file-diff")
-                                .short("f")
+                            Arg::with_name("then_diff_files") // <-- use same name as long
+                                .long("then_diff_files")
+                                // remove .short(), since "f" is almost always used to mean "force"
                                 .takes_value(false)
-                                .help("Include file diff"),
+                                .help("After diff-ing the directories, diff the files that were found to have mismatches."),
                         ),
                 ),
         )

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -93,9 +93,8 @@ fn main() {
                                 .help("Accounts hash cache directory 2 to diff"),
                         )
                         .arg(
-                            Arg::with_name("then_diff_files") // <-- use same name as long
+                            Arg::with_name("then_diff_files")
                                 .long("then_diff_files")
-                                // remove .short(), since "f" is almost always used to mean "force"
                                 .takes_value(false)
                                 .help("After diff-ing the directories, diff the files that were found to have mismatches."),
                         ),

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -458,9 +458,12 @@ fn do_diff_dirs(
                 file1.0 .0.display(),
                 file2.0 .0.display(),
             );
-            if file_diff {
-                if let Err(e) = do_diff_files(&file1.0 .0, &file2.0 .0) {
-                    println!("Failed to compare files {}", e);
+        }
+        if then_diff_files {
+            for (file1, file2) in &mismatches {
+                println!("Differences between '{}' and '{}':", file1.0.0.display(), file2.0.0.display());
+                if let Err(err) = do_diff_files(&file1.0 .0, &file2.0 .0) {
+                    eprintln!("Error: failed to diff files: {err}");
                 }
             }
         }


### PR DESCRIPTION
#### Problem

The current work flow of accounts-hash-cache-diff tool requires manually launch `file diff` for each mismatch, after `directory diff`, which can be automated.

#### Summary of Changes

Add an option of 'file_diff' to hash_cache_tool 'diff directories' subcommand.

Example:

```
> /home/sol/src/solana/target/release/agave-accounts-hash-cache-tool diff directories accounts_hash_cache pop2_ledger_tool_hash_cache --then-diff-files
```


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
