### PR TITLE
Update crate ownership transfer name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -268,7 +268,7 @@ edition = "2021"
 
 * Once all review feedback has been addressed, publish v0.0.1 of the crate
   under your personal crates.io account, and then transfer the crate ownership
-  to solana-grimes.
+  to "anza-team".
   https://crates.io/policies#package-ownership
 
 * After successful publication, update the PR by replacing the v0.0.1 version


### PR DESCRIPTION
#### Problem
- agave repo still lists `solana-grimes` as the owner to transfer ownership to
- #1497 changed the CI pipeline to check that `anza-team` is an owner

#### Summary of Changes
- `solana-grimes` -> `"anza-team"`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
