### PR TITLE
Remove deprecated address_lookup_table_account re-export

### DIFF
--- a/programs/address-lookup-table/src/lib.rs
+++ b/programs/address-lookup-table/src/lib.rs
@@ -3,13 +3,3 @@
 
 #[cfg(not(target_os = "solana"))]
 pub mod processor;
-
-#[deprecated(
-    since = "1.17.0",
-    note = "Please use `solana_program::address_lookup_table` instead"
-)]
-pub use solana_program::address_lookup_table::{
-    error, instruction,
-    program::{check_id, id, ID},
-    state,
-};

--- a/sdk/program/src/example_mocks.rs
+++ b/sdk/program/src/example_mocks.rs
@@ -274,44 +274,5 @@ pub mod solana_sdk {
         }
     }
 
-    #[deprecated(
-        since = "1.17.0",
-        note = "Please use `solana_sdk::address_lookup_table` instead"
-    )]
-    pub use crate::address_lookup_table as address_lookup_table_account;
-}
-
-#[deprecated(
-    since = "1.17.0",
-    note = "Please use `solana_sdk::address_lookup_table` instead"
-)]
-pub mod solana_address_lookup_table_program {
-    pub use crate::address_lookup_table::program::{check_id, id, ID};
-
-    pub mod state {
-        use {
-            crate::{instruction::InstructionError, pubkey::Pubkey},
-            std::borrow::Cow,
-        };
-
-        pub struct AddressLookupTable<'a> {
-            pub addresses: Cow<'a, [Pubkey]>,
-        }
-
-        impl<'a> AddressLookupTable<'a> {
-            pub fn serialize_for_tests(self) -> Result<Vec<u8>, InstructionError> {
-                let mut data = vec![];
-                self.addresses.iter().for_each(|address| {
-                    data.extend_from_slice(address.as_ref());
-                });
-                Ok(data)
-            }
-
-            pub fn deserialize(data: &'a [u8]) -> Result<AddressLookupTable<'a>, InstructionError> {
-                Ok(Self {
-                    addresses: Cow::Borrowed(bytemuck::try_cast_slice(data).unwrap()),
-                })
-            }
-        }
-    }
+    pub use crate::address_lookup_table;
 }

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -536,14 +536,6 @@ pub mod sysvar;
 pub mod vote;
 pub mod wasm;
 
-#[deprecated(
-    since = "1.17.0",
-    note = "Please use `solana_sdk::address_lookup_table::AddressLookupTableAccount` instead"
-)]
-pub mod address_lookup_table_account {
-    pub use crate::address_lookup_table::AddressLookupTableAccount;
-}
-
 #[deprecated(since = "2.1.0", note = "Use `solana-sanitize` crate instead")]
 pub use solana_sanitize as sanitize;
 #[cfg(target_arch = "wasm32")]

--- a/sdk/program/src/message/compiled_keys.rs
+++ b/sdk/program/src/message/compiled_keys.rs
@@ -1,6 +1,6 @@
 #[cfg(not(target_os = "solana"))]
 use crate::{
-    address_lookup_table_account::AddressLookupTableAccount,
+    address_lookup_table::AddressLookupTableAccount,
     message::v0::{LoadedAddresses, MessageAddressTableLookup},
 };
 use {

--- a/sdk/program/src/message/versions/v0/mod.rs
+++ b/sdk/program/src/message/versions/v0/mod.rs
@@ -200,7 +200,7 @@ impl Message {
     /// use solana_rpc_client::rpc_client::RpcClient;
     /// use solana_program::address_lookup_table::{self, state::{AddressLookupTable, LookupTableMeta}};
     /// use solana_sdk::{
-    ///      address_lookup_table_account::AddressLookupTableAccount,
+    ///      address_lookup_table::AddressLookupTableAccount,
     ///      instruction::{AccountMeta, Instruction},
     ///      message::{VersionedMessage, v0},
     ///      pubkey::Pubkey,

--- a/sdk/program/src/message/versions/v0/mod.rs
+++ b/sdk/program/src/message/versions/v0/mod.rs
@@ -12,7 +12,7 @@
 pub use loaded::*;
 use {
     crate::{
-        address_lookup_table_account::AddressLookupTableAccount,
+        address_lookup_table::AddressLookupTableAccount,
         bpf_loader_upgradeable,
         hash::Hash,
         instruction::{CompiledInstruction, Instruction},

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -41,6 +41,8 @@ pub use signer::signers;
 pub use solana_program::program_stubs;
 // These solana_program imports could be *-imported, but that causes a bunch of
 // confusing duplication in the docs due to a rustdoc bug. #26211
+#[allow(deprecated)]
+pub use solana_program::sdk_ids;
 #[cfg(target_arch = "wasm32")]
 pub use solana_program::wasm_bindgen;
 pub use solana_program::{
@@ -55,8 +57,6 @@ pub use solana_program::{
     stake_history, syscalls, system_instruction, system_program, sysvar, unchecked_div_by_const,
     vote,
 };
-#[allow(deprecated)]
-pub use solana_program::{address_lookup_table_account, sdk_ids};
 #[cfg(feature = "borsh")]
 pub use solana_program::{borsh, borsh0_10, borsh1};
 


### PR DESCRIPTION
#### Problem
`address_lookup_table_account` re-export has been deprecated for multiple minor versions

#### Summary of Changes
Remove deprecated symbols
