### PR TITLE
Destake fixes

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -813,11 +813,11 @@ pub struct Bank {
     inflation: Arc<RwLock<Inflation>>,
 
     /// cache of vote_account and stake_account state for this fork
-    stakes_cache: StakesCache,
+    pub stakes_cache: StakesCache,
 
     /// staked nodes on epoch boundaries, saved off when a bank.slot() is at
     ///   a leader schedule calculation boundary
-    epoch_stakes: HashMap<Epoch, EpochStakes>,
+    pub epoch_stakes: HashMap<Epoch, EpochStakes>,
 
     /// A boolean reflecting whether any entries were recorded into the PoH
     /// stream for the slot == self.slot
@@ -2000,7 +2000,7 @@ impl Bank {
         from_account(&self.get_account(&sysvar::slot_history::id()).unwrap()).unwrap()
     }
 
-    fn update_epoch_stakes(&mut self, leader_schedule_epoch: Epoch) {
+    pub fn update_epoch_stakes(&mut self, leader_schedule_epoch: Epoch) {
         // update epoch_stakes cache
         //  if my parent didn't populate for this staker's epoch, we've
         //  crossed a boundary

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -53,7 +53,7 @@ type StakeAccount = stake_account::StakeAccount<Delegation>;
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Default, Debug)]
-pub(crate) struct StakesCache(RwLock<Stakes<StakeAccount>>);
+pub struct StakesCache(RwLock<Stakes<StakeAccount>>);
 
 impl StakesCache {
     pub(crate) fn new(stakes: Stakes<StakeAccount>) -> Self {
@@ -149,7 +149,7 @@ impl StakesCache {
         )
     }
 
-    pub(crate) fn handle_invalid_keys(
+    pub fn handle_invalid_keys(
         &self,
         invalid_vote_keys: DashMap<Pubkey, InvalidCacheEntryReason>,
         current_slot: Slot,


### PR DESCRIPTION
#### Problem
`--destake-vote-account` will undelegate stake accounts from passed in vote account, but it does not update other state in the bank such as stakes cache and epoch stakes. What I end up seeing is the leader schedule does not remove the destaked nodes and we end up skipping a ton of leader slots and in some cases not rooting any blocks and eventually panicking because we never try and compute the EAH. This draft PR attempts to resolve this.

Passed simple test on the bench where 2 nodes are in a cluster with 10% and 90% stake respectively. Snapshot is created where the 90% stake vote account is destaked. Cluster was able to start up successfully and because epoch stakes were updated, leader schedule only includes currently staked nodes and thinks function as expected.

Note that a better solution might be to use the warp-slot param to warp forward in time and force recompute everything. I also discovered some problems with this option and a PR has been opened to address them: https://github.com/anza-xyz/agave/pull/1981

#### Summary of Changes
Remove designated vote accounts from the stakes cache and update the epoch stakes as part of creating a new snapshot when vote accounts are destaked.