### PR TITLE
use squash to add all roots

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2150,9 +2150,13 @@ fn main() {
                     };
 
                     let bank = if let Some(warp_slot) = warp_slot {
-                        // need to flush the write cache in order to use Storages to calculate
-                        // the accounts hash, and need to root `bank` before flushing the cache
-                        bank.rc.accounts.accounts_db.add_root(bank.slot());
+                        // Need to flush the write cache in order to use
+                        // Storages to calculate the accounts hash, and need to
+                        // root `bank` before flushing the cache. Use squash to
+                        // root all unrooted parents as well and avoid panicking
+                        // during snapshot creation if we try to add roots out
+                        // of order.
+                        bank.squash();
                         bank.force_flush_accounts_cache();
                         Arc::new(Bank::warp_from_parent(
                             bank.clone(),


### PR DESCRIPTION
#### Problem
While playing with ledger tool, I discovered a problem with the `warp-slot` command that results in asserting at this line:
https://github.com/anza-xyz/agave/blob/master/accounts-db/src/accounts_index.rs#L1923

When we run create-snapshot with --warp-slot param, we will add the current bank (derived from optimistically confirmed slot) as a root. However, there can be several parents of this slot that are not rooted. When we go to save a snapshot as part of the subsequent steps, we will squash this bank, attempt to add the unrooted parents as roots, and assert because we are adding roots out of order.

#### Summary of Changes
Use squash to root the current bank slot as well as all of its parents. This better matches what a real world scenario would look like (all blocks on a fork should get rooted). It also resolves the panic described above because when we go to save the snapshot, we won't attempt to add parents as roots because they've already been rooted.