### PR TITLE
extract solana-msg crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6688,6 +6688,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-msg"
+version = "2.1.0"
+dependencies = [
+ "solana-define-syscall",
+]
+
+[[package]]
 name = "solana-net-shaper"
 version = "2.1.0"
 dependencies = [
@@ -6873,6 +6880,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-logger",
+ "solana-msg",
  "solana-program-memory",
  "solana-sanitize",
  "solana-sdk-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ members = [
     "sdk/decode-error",
     "sdk/gen-headers",
     "sdk/macro",
+    "sdk/msg",
     "sdk/package-metadata-macro",
     "sdk/program",
     "sdk/program-memory",
@@ -378,6 +379,7 @@ solana-logger = { path = "logger", version = "=2.1.0" }
 solana-measure = { path = "measure", version = "=2.1.0" }
 solana-merkle-tree = { path = "merkle-tree", version = "=2.1.0" }
 solana-metrics = { path = "metrics", version = "=2.1.0" }
+solana-msg = { path = "sdk/msg", version = "=2.1.0" }
 solana-net-utils = { path = "net-utils", version = "=2.1.0" }
 solana-nohash-hasher = "0.2.1"
 solana-notifier = { path = "notifier", version = "=2.1.0" }

--- a/ci/nits.sh
+++ b/ci/nits.sh
@@ -28,6 +28,7 @@ declare print_free_tree=(
   ':sdk/sbf/rust/rust-utils/**.rs'
   ':sdk/**.rs'
   ':^sdk/cargo-build-sbf/**.rs'
+  ':^sdk/msg/src/lib.rs'
   ':^sdk/program/src/program_option.rs'
   ':^sdk/program/src/program_stubs.rs'
   ':programs/**.rs'

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5199,6 +5199,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-msg"
+version = "2.1.0"
+dependencies = [
+ "solana-define-syscall",
+]
+
+[[package]]
 name = "solana-net-utils"
 version = "2.1.0"
 dependencies = [
@@ -5309,6 +5316,7 @@ dependencies = [
  "solana-atomic-u64",
  "solana-decode-error",
  "solana-define-syscall",
+ "solana-msg",
  "solana-program-memory",
  "solana-sanitize",
  "solana-sdk-macro",

--- a/sdk/msg/Cargo.toml
+++ b/sdk/msg/Cargo.toml
@@ -9,7 +9,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
+[target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/sdk/msg/Cargo.toml
+++ b/sdk/msg/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "solana-msg"
+description = "Solana msg macro."
+documentation = "https://docs.rs/solana-msg"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-define-syscall = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/msg/src/lib.rs
+++ b/sdk/msg/src/lib.rs
@@ -16,7 +16,7 @@
 /// # Examples
 ///
 /// ```
-/// use solana_msg:msg;
+/// use solana_msg::msg;
 ///
 /// // The fast form
 /// msg!("verifying multisig");

--- a/sdk/msg/src/lib.rs
+++ b/sdk/msg/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "solana")]
+use solana_define_syscall::define_syscall;
 /// Print a message to the log.
 ///
 /// Supports simple strings as well as Rust [format strings][fs]. When passed a
@@ -34,7 +36,7 @@ macro_rules! msg {
 }
 
 #[cfg(target_os = "solana")]
-solana_define_syscall::define_syscall!(fn sol_log_(message: *const u8, len: u64));
+define_syscall!(fn sol_log_(message: *const u8, len: u64));
 
 /// Print a string to the log.
 #[inline]

--- a/sdk/msg/src/lib.rs
+++ b/sdk/msg/src/lib.rs
@@ -1,0 +1,49 @@
+/// Print a message to the log.
+///
+/// Supports simple strings as well as Rust [format strings][fs]. When passed a
+/// single expression it will be passed directly to [`sol_log`]. The expression
+/// must have type `&str`, and is typically used for logging static strings.
+/// When passed something other than an expression, particularly
+/// a sequence of expressions, the tokens will be passed through the
+/// [`format!`] macro before being logged with `sol_log`.
+///
+/// [fs]: https://doc.rust-lang.org/std/fmt/
+/// [`format!`]: https://doc.rust-lang.org/std/fmt/fn.format.html
+///
+/// Note that Rust's formatting machinery is relatively CPU-intensive
+/// for constrained environments like the Solana VM.
+///
+/// # Examples
+///
+/// ```
+/// use solana_msg:msg;
+///
+/// // The fast form
+/// msg!("verifying multisig");
+///
+/// // With formatting
+/// let err = "not enough signers";
+/// msg!("multisig failed: {}", err);
+/// ```
+#[macro_export]
+macro_rules! msg {
+    ($msg:expr) => {
+        $crate::sol_log($msg)
+    };
+    ($($arg:tt)*) => ($crate::sol_log(&format!($($arg)*)));
+}
+
+#[cfg(target_os = "solana")]
+solana_define_syscall::define_syscall!(fn sol_log_(message: *const u8, len: u64));
+
+/// Print a string to the log.
+#[inline]
+pub fn sol_log(message: &str) {
+    #[cfg(target_os = "solana")]
+    unsafe {
+        sol_log_(message.as_ptr(), message.len() as u64);
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    println!("{message}");
+}

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -35,6 +35,7 @@ solana-atomic-u64 = { workspace = true }
 solana-decode-error = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-msg = { workspace = true }
 solana-program-memory = { workspace = true }
 solana-sanitize = { workspace = true }
 solana-sdk-macro = { workspace = true }

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -530,6 +530,7 @@ pub mod sysvar;
 pub mod vote;
 pub mod wasm;
 
+pub use solana_msg::msg;
 #[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]
 pub use solana_program_memory as program_memory;
 #[deprecated(since = "2.1.0", note = "Use `solana-sanitize` crate instead")]

--- a/sdk/program/src/log.rs
+++ b/sdk/program/src/log.rs
@@ -34,53 +34,7 @@
 //! [`Pubkey::log`]: crate::pubkey::Pubkey::log
 
 use crate::account_info::AccountInfo;
-
-/// Print a message to the log.
-///
-/// Supports simple strings as well as Rust [format strings][fs]. When passed a
-/// single expression it will be passed directly to [`sol_log`]. The expression
-/// must have type `&str`, and is typically used for logging static strings.
-/// When passed something other than an expression, particularly
-/// a sequence of expressions, the tokens will be passed through the
-/// [`format!`] macro before being logged with `sol_log`.
-///
-/// [fs]: https://doc.rust-lang.org/std/fmt/
-/// [`format!`]: https://doc.rust-lang.org/std/fmt/fn.format.html
-///
-/// Note that Rust's formatting machinery is relatively CPU-intensive
-/// for constrained environments like the Solana VM.
-///
-/// # Examples
-///
-/// ```
-/// use solana_program::msg;
-///
-/// // The fast form
-/// msg!("verifying multisig");
-///
-/// // With formatting
-/// let err = "not enough signers";
-/// msg!("multisig failed: {}", err);
-/// ```
-#[macro_export]
-macro_rules! msg {
-    ($msg:expr) => {
-        $crate::log::sol_log($msg)
-    };
-    ($($arg:tt)*) => ($crate::log::sol_log(&format!($($arg)*)));
-}
-
-/// Print a string to the log.
-#[inline]
-pub fn sol_log(message: &str) {
-    #[cfg(target_os = "solana")]
-    unsafe {
-        crate::syscalls::sol_log_(message.as_ptr(), message.len() as u64);
-    }
-
-    #[cfg(not(target_os = "solana"))]
-    crate::program_stubs::sol_log(message);
-}
+pub use solana_msg::{msg, sol_log};
 
 /// Print 64-bit values represented as hexadecimal to the log.
 #[inline]

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -1,5 +1,7 @@
 #[cfg(target_feature = "static-syscalls")]
 pub use solana_define_syscall::sys_hash;
+#[deprecated(since = "2.1.0", note = "Use `solana-msg::sol_log` instead.")]
+pub use solana_msg::sol_log;
 #[deprecated(
     since = "2.1.0",
     note = "Use `solana_program_memory::syscalls` instead"
@@ -17,8 +19,6 @@ use {
     },
     solana_define_syscall::define_syscall,
 };
-
-define_syscall!(fn sol_log_(message: *const u8, len: u64));
 define_syscall!(fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64));
 define_syscall!(fn sol_log_compute_units_());
 define_syscall!(fn sol_log_pubkey(pubkey_addr: *const u8));


### PR DESCRIPTION
#### Problem
The `msg!` macro is another thing that is too important to be locked away in solana-program


#### Summary of Changes
- Make a new `solana-msg` crate containing the msg macro, the sol_log function and the sol_log_ syscall.
- Re-export these things where they used to be, but put a deprecation notice on the sol_log_ syscall because that is not essential to solana-program imo
