### PR TITLE
add metric for timeout streams

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -190,6 +190,7 @@ pub struct StreamStats {
     pub(crate) total_unstaked_packets_sent_for_batching: AtomicUsize,
     pub(crate) throttled_staked_streams: AtomicUsize,
     pub(crate) throttled_unstaked_streams: AtomicUsize,
+    pub(crate) timeout_streams: AtomicUsize,
     pub(crate) connection_rate_limiter_length: AtomicUsize,
     pub(crate) outstanding_incoming_connection_attempts: AtomicUsize,
     pub(crate) total_incoming_connection_attempts: AtomicUsize,
@@ -477,6 +478,11 @@ impl StreamStats {
             (
                 "throttled_unstaked_streams",
                 self.throttled_unstaked_streams.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "timeout_streams",
+                self.timeout_streams.swap(0, Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem

1. When throttling timeout happens, we drop streams by timeout and we don't count it.
2. This code uses deep indentation, which makes it it more difficult to read.
3. Another problem is that all the throttle-related metrics are irrelevant, because they count only the first throttled stream.

Not sure how to resolve (3) so far:
* it looks like there is no way to count exactly streams that happen to be timeout due to sleep in case of throttling
* one way would be to rename these metrics to count number of throttling events instead.

To add some details on that:
When throttling happens, we sleep here: https://github.com/anza-xyz/agave/blob/master/streamer/src/nonblocking/quic.rs#L992
So all the streams which will be opened during this `throttle_duration` will be dropped by timeout (100ms). 
Hence, I think that timeout metric is more interesting.

#### Discussion

https://discord.com/channels/428295358100013066/439194979856809985/1258053265300656179

