### PR TITLE
Sleep packet_batch_sender task when we don't have a packet batch

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -865,11 +865,8 @@ async fn packet_batch_sender(
             }
 
             let timeout_res = if !packet_batch.is_empty() {
-                if let Some(time_left) = coalesce.checked_sub(elapsed) {
-                    timeout(time_left, packet_receiver.recv()).await
-                } else {
-                    continue;
-                }
+                // If we get here, elapsed < coalesce (see above if condition)
+                timeout(coalesce - elapsed, packet_receiver.recv()).await
             } else {
                 // Small bit of non-idealness here: the holder(s) of the other end
                 // of packet_receiver must drop it (without waiting for us to exit)

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -865,7 +865,6 @@ async fn packet_batch_sender(
             }
 
             let timeout_res = if !packet_batch.is_empty() {
-                let elapsed = batch_start_time.elapsed();
                 if let Some(time_left) = coalesce.checked_sub(elapsed) {
                     timeout(time_left, packet_receiver.recv()).await
                 } else {

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -862,7 +862,11 @@ async fn packet_batch_sender(
                 break;
             }
 
-            let timeout_res = timeout(Duration::from_micros(250), packet_receiver.recv()).await;
+            let timeout_res = if !packet_batch.is_empty() {
+                timeout(Duration::from_micros(250), packet_receiver.recv()).await
+            } else {
+                Ok(packet_receiver.recv().await)
+            };
 
             if let Ok(Ok(packet_accumulator)) = timeout_res {
                 // Start the timeout from when the packet batch first becomes non-empty

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -807,6 +807,8 @@ fn handle_connection_error(e: quinn::ConnectionError, stats: &StreamStats, from:
     }
 }
 
+// Holder(s) of the AsyncSender<PacketAccumulator> on the other end should not
+// wait for this function to exit to exit
 async fn packet_batch_sender(
     packet_sender: Sender<PacketBatch>,
     packet_receiver: AsyncReceiver<PacketAccumulator>,
@@ -865,6 +867,13 @@ async fn packet_batch_sender(
             let timeout_res = if !packet_batch.is_empty() {
                 timeout(Duration::from_micros(250), packet_receiver.recv()).await
             } else {
+                // Small bit of non-idealness here: the holder(s) of the other end
+                // of packet_receiver must drop it (without waiting for us to exit)
+                // or we have a chance of sleeping here forever
+                // and never polling exit. Not a huge deal in practice as the
+                // only time this happens is when we tear down the server
+                // and at that time the other end does indeed not wait for us
+                // to exit here
                 Ok(packet_receiver.recv().await)
             };
 
@@ -1786,6 +1795,8 @@ pub mod test {
         }
         assert_eq!(i, num_packets);
         exit.store(true, Ordering::Relaxed);
+        // Explicit drop to wake up packet_batch_sender
+        drop(ptk_sender);
         handle.await.unwrap();
     }
 


### PR DESCRIPTION
#### Problem
Currently the quic packet batcher is taking a lot of CPU spinning.

#### Summary of Changes
First low-hanging fruit change to sleep the packet_batch_sender when we don't have a packet batch we need to send, until we receive a packet.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
