### PR TITLE
TransactionCost - remove allocation

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -521,6 +521,7 @@ impl Consumer {
         // were not included in the block should have their cost removed, the rest
         // should update with their actually consumed units.
         QosService::remove_or_update_costs(
+            txs.iter(),
             transaction_qos_cost_results.iter(),
             commit_transactions_result.as_ref().ok(),
             bank,

--- a/core/src/banking_stage/forward_packet_batches_by_accounts.rs
+++ b/core/src/banking_stage/forward_packet_batches_by_accounts.rs
@@ -110,7 +110,10 @@ impl ForwardPacketBatchesByAccounts {
     ) -> bool {
         let tx_cost = CostModel::calculate_cost(sanitized_transaction, feature_set);
 
-        if let Ok(updated_costs) = self.cost_tracker.try_add(&tx_cost) {
+        if let Ok(updated_costs) = self.cost_tracker.try_add(
+            CostModel::writable_accounts_iter(sanitized_transaction),
+            &tx_cost,
+        ) {
             let batch_index = self.get_batch_index_by_updated_costs(&tx_cost, &updated_costs);
 
             if let Some(forward_batch) = self.forward_batches.get_mut(batch_index) {
@@ -349,9 +352,7 @@ mod tests {
                 ForwardPacketBatchesByAccounts::new_with_default_batch_limits();
             forward_packet_batches_by_accounts.batch_vote_limit = test_cost + 1;
 
-            let transaction_cost = TransactionCost::SimpleVote {
-                writable_accounts: vec![],
-            };
+            let transaction_cost = TransactionCost::SimpleVote;
             assert_eq!(
                 0,
                 forward_packet_batches_by_accounts.get_batch_index_by_updated_costs(

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -580,7 +580,7 @@ mod tests {
             testee.add_transaction_cost(CostModel::writable_accounts_iter(&tx2), &tx_cost2);
         }
         assert_eq!(cost1 + cost2, testee.block_cost);
-        assert_eq!(1, testee.cost_by_writable_accounts.len());
+        assert_eq!(3, testee.cost_by_writable_accounts.len());
         let (_ccostliest_account, costliest_account_cost) = testee.find_costliest_account();
         assert_eq!(cost1 + cost2, costliest_account_cost);
     }

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -610,7 +610,7 @@ mod tests {
             testee.add_transaction_cost(CostModel::writable_accounts_iter(&tx2), &tx_cost2);
         }
         assert_eq!(cost1 + cost2, testee.block_cost);
-        assert_eq!(2, testee.cost_by_writable_accounts.len());
+        assert_eq!(4, testee.cost_by_writable_accounts.len());
         let (_ccostliest_account, costliest_account_cost) = testee.find_costliest_account();
         assert_eq!(std::cmp::max(cost1, cost2), costliest_account_cost);
     }

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -1,4 +1,4 @@
-use {crate::block_cost_limits, solana_sdk::pubkey::Pubkey};
+use crate::block_cost_limits;
 
 /// TransactionCost is used to represent resources required to process
 /// a transaction, denominated in CU (eg. Compute Units).
@@ -12,7 +12,7 @@ const SIMPLE_VOTE_USAGE_COST: u64 = 3428;
 
 #[derive(Debug)]
 pub enum TransactionCost {
-    SimpleVote { writable_accounts: Vec<Pubkey> },
+    SimpleVote,
     Transaction(UsageCostDetails),
 }
 
@@ -85,13 +85,6 @@ impl TransactionCost {
         }
     }
 
-    pub fn writable_accounts(&self) -> &[Pubkey] {
-        match self {
-            Self::SimpleVote { writable_accounts } => writable_accounts,
-            Self::Transaction(usage_cost) => &usage_cost.writable_accounts,
-        }
-    }
-
     pub fn num_transaction_signatures(&self) -> u64 {
         match self {
             Self::SimpleVote { .. } => 1,
@@ -114,12 +107,10 @@ impl TransactionCost {
     }
 }
 
-const MAX_WRITABLE_ACCOUNTS: usize = 256;
-
 // costs are stored in number of 'compute unit's
-#[derive(Debug)]
+#[derive(Debug, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct UsageCostDetails {
-    pub writable_accounts: Vec<Pubkey>,
     pub signature_cost: u64,
     pub write_lock_cost: u64,
     pub data_bytes_cost: u64,
@@ -131,60 +122,7 @@ pub struct UsageCostDetails {
     pub num_ed25519_instruction_signatures: u64,
 }
 
-impl Default for UsageCostDetails {
-    fn default() -> Self {
-        Self {
-            writable_accounts: Vec::with_capacity(MAX_WRITABLE_ACCOUNTS),
-            signature_cost: 0u64,
-            write_lock_cost: 0u64,
-            data_bytes_cost: 0u64,
-            programs_execution_cost: 0u64,
-            loaded_accounts_data_size_cost: 0u64,
-            allocated_accounts_data_size: 0u64,
-            num_transaction_signatures: 0u64,
-            num_secp256k1_instruction_signatures: 0u64,
-            num_ed25519_instruction_signatures: 0u64,
-        }
-    }
-}
-
-#[cfg(test)]
-impl PartialEq for UsageCostDetails {
-    fn eq(&self, other: &Self) -> bool {
-        fn to_hash_set(v: &[Pubkey]) -> std::collections::HashSet<&Pubkey> {
-            v.iter().collect()
-        }
-
-        self.signature_cost == other.signature_cost
-            && self.write_lock_cost == other.write_lock_cost
-            && self.data_bytes_cost == other.data_bytes_cost
-            && self.programs_execution_cost == other.programs_execution_cost
-            && self.loaded_accounts_data_size_cost == other.loaded_accounts_data_size_cost
-            && self.allocated_accounts_data_size == other.allocated_accounts_data_size
-            && self.num_transaction_signatures == other.num_transaction_signatures
-            && self.num_secp256k1_instruction_signatures
-                == other.num_secp256k1_instruction_signatures
-            && self.num_ed25519_instruction_signatures == other.num_ed25519_instruction_signatures
-            && to_hash_set(&self.writable_accounts) == to_hash_set(&other.writable_accounts)
-    }
-}
-
-#[cfg(test)]
-impl Eq for UsageCostDetails {}
-
 impl UsageCostDetails {
-    #[cfg(test)]
-    pub fn new_with_capacity(capacity: usize) -> Self {
-        Self {
-            writable_accounts: Vec::with_capacity(capacity),
-            ..Self::default()
-        }
-    }
-
-    pub fn new_with_default_capacity() -> Self {
-        Self::default()
-    }
-
     pub fn sum(&self) -> u64 {
         self.signature_cost
             .saturating_add(self.write_lock_cost)

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -489,7 +489,8 @@ fn compute_slot_cost(
                 num_programs += transaction.message().instructions().len();
 
                 let tx_cost = CostModel::calculate_cost(&transaction, &feature_set);
-                let result = cost_tracker.try_add(&tx_cost);
+                let result =
+                    cost_tracker.try_add(CostModel::writable_accounts_iter(&transaction), &tx_cost);
                 if result.is_err() {
                     println!(
                         "Slot: {slot}, CostModel rejected transaction {transaction:?}, reason \


### PR DESCRIPTION
#### Problem
- `TransactionCost` holds an allocation to track writable accounts. This is generally not needed since we can always figure out which accounts the transaction writes since the transaction stays in scope longer than `TransactionCost`
- Doing the allocation and free is also bad for performance

#### Summary of Changes
- Remove `writable_accounts` from `TransactionCost`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
