### PR TITLE
Bump ThinClient since version

### DIFF
--- a/thin-client/README.md
+++ b/thin-client/README.md
@@ -1,4 +1,4 @@
 # thin-client
-This crate for `thin-client` is deprecated as of v1.19.0. It will receive no bugfixes or updates.
+This crate for `thin-client` is deprecated as of v2.0.0. It will receive no bugfixes or updates.
 
 Please use `tpu-client` or `rpc-client`.

--- a/thin-client/src/thin_client.rs
+++ b/thin-client/src/thin_client.rs
@@ -110,7 +110,7 @@ impl ClientOptimizer {
 }
 
 /// An object for querying and sending transactions to the network.
-#[deprecated(since = "1.19.0", note = "Use [RpcClient] or [TpuClient] instead.")]
+#[deprecated(since = "2.0.0", note = "Use [RpcClient] or [TpuClient] instead.")]
 pub struct ThinClient<
     P, // ConnectionPool
     M, // ConnectionManager


### PR DESCRIPTION
#### Problem
No one remembered to search for "1.19.0" usage when we bumped the master minor version.

#### Summary of Changes
Fix ThinClient deprecation message and docs
