### PR TITLE
Add suggestion to deprecation message

### DIFF
--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -2078,7 +2078,9 @@ impl RpcClient {
     /// ```
     #[deprecated(
         since = "1.18.18",
-        note = "Do not use; getStakeActivation is deprecated on the JSON-RPC server"
+        note = "Do not use; getStakeActivation is deprecated on the JSON-RPC server. Please use \
+                the stake account and StakeHistory sysvar to call \
+                `Delegation::stake_activating_and_deactivating()` instead"
     )]
     pub async fn get_stake_activation(
         &self,

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -1776,7 +1776,9 @@ impl RpcClient {
     /// ```
     #[deprecated(
         since = "1.18.18",
-        note = "Do not use; getStakeActivation is deprecated on the JSON-RPC server"
+        note = "Do not use; getStakeActivation is deprecated on the JSON-RPC server. Please use \
+                the stake account and StakeHistory sysvar to call \
+                `Delegation::stake_activating_and_deactivating()` instead"
     )]
     #[allow(deprecated)]
     pub fn get_stake_activation(


### PR DESCRIPTION
#### Problem
As per [this discussion](https://github.com/anza-xyz/agave/pull/1924#discussion_r1663433851), deprecation tag on `RpcClient::get_stake_activation()` doesn't offer an alternative.

#### Summary of Changes
While the replacement process is multistep, at least point users in the right direction.
