### PR TITLE
Program cache index v2 [Draft 07-01]

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1611,7 +1611,45 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     *candidate = Arc::new(unloaded);
                 }
             }
-            IndexImplementation::V2(_) => unimplemented!(),
+            IndexImplementation::V2(index) => {
+                let key = IndexV2Key::new(*program, remove_entry.deployment_slot);
+                let candidate = index
+                    .entries
+                    .get_mut(&key)
+                    // .expect("Cache lookup failed")
+                    .and_then(|value| match value {
+                        IndexV2Value::WithEnvironment(secondary_index) => {
+                            if let Some(env) = remove_entry.program.get_environment() {
+                                secondary_index.get_mut(env)
+                            } else {
+                                None
+                            }
+                        }
+                        IndexV2Value::NoEnvironment(entry) => {
+                            if entry == remove_entry {
+                                Some(entry)
+                            } else {
+                                None
+                            }
+                        }
+                    })
+                    .expect("Program entry not found");
+
+                // Certain entry types cannot be unloaded, such as tombstones, or already unloaded entries.
+                // For such entries, `to_unloaded()` will return None.
+                // These entry types do not occupy much memory.
+                if let Some(unloaded) = candidate.to_unloaded() {
+                    if candidate.tx_usage_counter.load(Ordering::Relaxed) == 1 {
+                        self.stats.one_hit_wonders.fetch_add(1, Ordering::Relaxed);
+                    }
+                    self.stats
+                        .evictions
+                        .entry(*program)
+                        .and_modify(|c| saturating_add_assign!(*c, 1))
+                        .or_insert(1);
+                    *candidate = Arc::new(unloaded);
+                }
+            }
         }
     }
 
@@ -2884,9 +2922,10 @@ mod tests {
         assert!(match_missing(&missing, &program1, true));
     }
 
-    #[test]
-    fn test_unloaded() {
-        let mut cache = new_mock_cache::<TestForkGraph>(false);
+    #[test_case(false ; "index v1")]
+    #[test_case(true ; "index v2")]
+    fn test_unloaded(use_index_v2: bool) {
+        let mut cache = new_mock_cache::<TestForkGraph>(use_index_v2);
         for program_cache_entry_type in [
             ProgramCacheEntryType::FailedVerification(
                 cache.environments.program_runtime_v1.clone(),
@@ -2911,7 +2950,10 @@ mod tests {
             let program_id = Pubkey::new_unique();
             cache.assign_program(program_id, entry.clone());
             cache.unload_program_entry(&program_id, &entry);
-            assert_eq!(cache.get_slot_versions_for_tests(&program_id).len(), 1);
+            if !use_index_v2 {
+                // Index v2 does not keep slot versions.
+                assert_eq!(cache.get_slot_versions_for_tests(&program_id).len(), 1);
+            }
             assert!(cache.stats.evictions.is_empty());
         }
 


### PR DESCRIPTION
Here's my draft of the program cache's V2 index implementation.

This design uses the two-level index, where the secondary level's key
is the program's environment.