### PR TITLE
Clean up disable_fees_sysvar feature

### DIFF
--- a/programs/sbf/rust/sysvar/src/lib.rs
+++ b/programs/sbf/rust/sysvar/src/lib.rs
@@ -2,8 +2,6 @@
 
 extern crate solana_program;
 #[allow(deprecated)]
-use solana_program::sysvar::fees::Fees;
-#[allow(deprecated)]
 use solana_program::sysvar::recent_blockhashes::RecentBlockhashes;
 use solana_program::{
     account_info::AccountInfo,
@@ -70,7 +68,6 @@ pub fn process_instruction(
                 AccountMeta::new_readonly(*accounts[8].key, false),
                 AccountMeta::new_readonly(*accounts[9].key, false),
                 AccountMeta::new_readonly(*accounts[10].key, false),
-                AccountMeta::new_readonly(*accounts[11].key, false),
             ],
         )
     );
@@ -114,21 +111,11 @@ pub fn process_instruction(
     sysvar::stake_history::id().log();
     let _ = StakeHistory::from_account_info(&accounts[9]).unwrap();
 
-    // Fees
-    #[allow(deprecated)]
-    if instruction_data[0] == 1 {
-        msg!("Fee identifier:");
-        sysvar::fees::id().log();
-        let fees = Fees::from_account_info(&accounts[10]).unwrap();
-        let got_fees = Fees::get().unwrap();
-        assert_eq!(fees, got_fees);
-    }
-
     // Epoch Rewards
     {
         msg!("EpochRewards identifier:");
         sysvar::epoch_rewards::id().log();
-        let epoch_rewards = EpochRewards::from_account_info(&accounts[11]).unwrap();
+        let epoch_rewards = EpochRewards::from_account_info(&accounts[10]).unwrap();
         let got_epoch_rewards = EpochRewards::get().unwrap();
         assert_eq!(epoch_rewards, got_epoch_rewards);
     }

--- a/programs/sbf/tests/sysvar.rs
+++ b/programs/sbf/tests/sysvar.rs
@@ -12,7 +12,7 @@ use {
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         sysvar::{
-            clock, epoch_rewards, epoch_schedule, fees, instructions, recent_blockhashes, rent,
+            clock, epoch_rewards, epoch_schedule, instructions, recent_blockhashes, rent,
             slot_hashes, slot_history, stake_history,
         },
         transaction::{SanitizedTransaction, Transaction},
@@ -67,8 +67,6 @@ fn test_sysvar_syscalls() {
                 AccountMeta::new_readonly(slot_hashes::id(), false),
                 AccountMeta::new_readonly(slot_history::id(), false),
                 AccountMeta::new_readonly(stake_history::id(), false),
-                #[allow(deprecated)]
-                AccountMeta::new_readonly(fees::id(), false),
                 AccountMeta::new_readonly(epoch_rewards::id(), false),
             ],
         );

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -5,7 +5,6 @@ use {
     solana_sdk::{
         clock::{Epoch, Slot, UnixTimestamp},
         fee_calculator::{FeeCalculator, FeeRateGovernor},
-        hash::Hash,
         inflation::Inflation,
         transaction::{Result, TransactionError},
     },
@@ -116,31 +115,6 @@ pub struct RpcBlockhashFeeCalculator {
 #[serde(rename_all = "camelCase")]
 pub struct RpcBlockhash {
     pub blockhash: String,
-    pub last_valid_block_height: u64,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct RpcFees {
-    pub blockhash: String,
-    pub fee_calculator: FeeCalculator,
-    pub last_valid_slot: Slot,
-    pub last_valid_block_height: u64,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct DeprecatedRpcFees {
-    pub blockhash: String,
-    pub fee_calculator: FeeCalculator,
-    pub last_valid_slot: Slot,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct Fees {
-    pub blockhash: Hash,
-    pub fee_calculator: FeeCalculator,
     pub last_valid_block_height: u64,
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1298,7 +1298,6 @@ impl Bank {
             new.update_slot_hashes();
             new.update_stake_history(Some(parent.epoch()));
             new.update_clock(Some(parent.epoch()));
-            new.update_fees();
             new.update_last_restart_slot()
         });
 
@@ -2030,21 +2029,6 @@ impl Bank {
             }
             self.epoch_stakes
                 .insert(leader_schedule_epoch, new_epoch_stakes);
-        }
-    }
-
-    #[allow(deprecated)]
-    fn update_fees(&self) {
-        if !self
-            .feature_set
-            .is_active(&feature_set::disable_fees_sysvar::id())
-        {
-            self.update_sysvar_account(&sysvar::fees::id(), |account| {
-                create_account(
-                    &sysvar::fees::Fees::new(&self.fee_rate_governor.create_fee_calculator()),
-                    self.inherit_specially_retained_account_fields(account),
-                )
-            });
         }
     }
 
@@ -2935,9 +2919,6 @@ impl Bank {
             self.capitalization.fetch_add(account.lamports(), Relaxed);
             self.accounts_data_size_initial += account.data().len() as u64;
         }
-        // updating sysvars (the fees sysvar in this case) now depends on feature activations in
-        // genesis_config.accounts above
-        self.update_fees();
 
         for (pubkey, account) in genesis_config.rewards_pools.iter() {
             assert!(

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -21,12 +21,10 @@ mod tests {
         let bank0_sysvar_cache = bank0.transaction_processor.sysvar_cache();
         let bank0_cached_clock = bank0_sysvar_cache.get_clock();
         let bank0_cached_epoch_schedule = bank0_sysvar_cache.get_epoch_schedule();
-        let bank0_cached_fees = bank0_sysvar_cache.get_fees();
         let bank0_cached_rent = bank0_sysvar_cache.get_rent();
 
         assert!(bank0_cached_clock.is_ok());
         assert!(bank0_cached_epoch_schedule.is_ok());
-        assert!(bank0_cached_fees.is_ok());
         assert!(bank0_cached_rent.is_ok());
         assert!(bank0_sysvar_cache.get_slot_hashes().is_err());
         assert!(bank0_sysvar_cache.get_epoch_rewards().is_err()); // partitioned epoch reward feature is not enabled
@@ -41,19 +39,16 @@ mod tests {
         let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache();
         let bank1_cached_clock = bank1_sysvar_cache.get_clock();
         let bank1_cached_epoch_schedule = bank1_sysvar_cache.get_epoch_schedule();
-        let bank1_cached_fees = bank1_sysvar_cache.get_fees();
         let bank1_cached_rent = bank1_sysvar_cache.get_rent();
 
         assert!(bank1_cached_clock.is_ok());
         assert!(bank1_cached_epoch_schedule.is_ok());
-        assert!(bank1_cached_fees.is_ok());
         assert!(bank1_cached_rent.is_ok());
         assert!(bank1_sysvar_cache.get_slot_hashes().is_ok());
         assert!(bank1_sysvar_cache.get_epoch_rewards().is_err());
 
         assert_ne!(bank0_cached_clock, bank1_cached_clock);
         assert_eq!(bank0_cached_epoch_schedule, bank1_cached_epoch_schedule);
-        assert_ne!(bank0_cached_fees, bank1_cached_fees);
         assert_eq!(bank0_cached_rent, bank1_cached_rent);
 
         let bank2_slot = bank1.slot() + 1;
@@ -62,19 +57,16 @@ mod tests {
         let bank2_sysvar_cache = bank2.transaction_processor.sysvar_cache();
         let bank2_cached_clock = bank2_sysvar_cache.get_clock();
         let bank2_cached_epoch_schedule = bank2_sysvar_cache.get_epoch_schedule();
-        let bank2_cached_fees = bank2_sysvar_cache.get_fees();
         let bank2_cached_rent = bank2_sysvar_cache.get_rent();
 
         assert!(bank2_cached_clock.is_ok());
         assert!(bank2_cached_epoch_schedule.is_ok());
-        assert!(bank2_cached_fees.is_ok());
         assert!(bank2_cached_rent.is_ok());
         assert!(bank2_sysvar_cache.get_slot_hashes().is_ok());
         assert!(bank2_sysvar_cache.get_epoch_rewards().is_err()); // partitioned epoch reward feature is not enabled
 
         assert_ne!(bank1_cached_clock, bank2_cached_clock);
         assert_eq!(bank1_cached_epoch_schedule, bank2_cached_epoch_schedule);
-        assert_eq!(bank1_cached_fees, bank2_cached_fees);
         assert_eq!(bank1_cached_rent, bank2_cached_rent);
         assert_ne!(
             bank1_sysvar_cache.get_slot_hashes(),
@@ -100,7 +92,6 @@ mod tests {
 
         assert!(bank1_cached_clock.is_ok());
         assert!(bank1_cached_epoch_schedule.is_ok());
-        assert!(bank1_cached_fees.is_ok());
         assert!(bank1_cached_rent.is_ok());
         assert!(bank1_cached_slot_hashes.is_ok());
         assert!(bank1_cached_epoch_rewards.is_err());
@@ -111,7 +102,6 @@ mod tests {
         let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache();
         assert!(bank1_sysvar_cache.get_clock().is_err());
         assert!(bank1_sysvar_cache.get_epoch_schedule().is_err());
-        assert!(bank1_sysvar_cache.get_fees().is_err());
         assert!(bank1_sysvar_cache.get_rent().is_err());
         assert!(bank1_sysvar_cache.get_slot_hashes().is_err());
         assert!(bank1_sysvar_cache.get_epoch_rewards().is_err());

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6395,26 +6395,26 @@ fn test_bank_hash_consistency() {
         if bank.slot == 0 {
             assert_eq!(
                 bank.hash().to_string(),
-                "i5hGiQ3WtEehNrvhbfPFkUdm267t18fSpujcYtkBioW",
+                "Hn2FoJuoFWXVFVnwcQ6peuT24mUPmhDtXHXVjKD7M4yP",
             );
         }
 
         if bank.slot == 32 {
             assert_eq!(
                 bank.hash().to_string(),
-                "7NmBtNvbhoqzatJv8NgBs84qWrm4ZhpuC75DCpbqwiS"
+                "7FPfwBut4b7bXtKPsobQS1cuFgF47SZHDb4teQcJRomv"
             );
         }
         if bank.slot == 64 {
             assert_eq!(
                 bank.hash().to_string(),
-                "A1jjuUaENeDcsSvwejFGaZ5zWmnJ77doSzqdKtfzpoFk"
+                "28CWiEuA3izdt5xe4LyS4Q1DTALmYgrVctSTazFiPVcW"
             );
         }
         if bank.slot == 128 {
             assert_eq!(
                 bank.hash().to_string(),
-                "ApnMkFt5Bs4yDJ8S2CCPsQRL1He6vWXw6vMzAyc5i811"
+                "AdCmEvRXWKpvXb9fG6AFQhzGgB5ciAXnDajvaNK7YUg8"
             );
             break;
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1,6 +1,4 @@
 #![cfg(test)]
-#[allow(deprecated)]
-use solana_sdk::sysvar::fees::Fees;
 use {
     super::{
         test_utils::{goto_end_of_slot, update_vote_account_timestamp},
@@ -4251,22 +4249,6 @@ fn test_bank_cloned_stake_delegations() {
     let stake_delegations = bank.stakes_cache.stakes().stake_delegations().clone();
     assert_eq!(stake_delegations.len(), 2);
     assert!(stake_delegations.get(&stake_keypair.pubkey()).is_some());
-}
-
-#[allow(deprecated)]
-#[test]
-fn test_bank_fees_account() {
-    let (mut genesis_config, _) = create_genesis_config(500);
-    genesis_config.fee_rate_governor = FeeRateGovernor::new(12345, 0);
-    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-
-    let fees_account = bank.get_account(&sysvar::fees::id()).unwrap();
-    let fees = from_account::<Fees, _>(&fees_account).unwrap();
-    assert_eq!(
-        bank.fee_rate_governor.lamports_per_signature,
-        fees.fee_calculator.lamports_per_signature
-    );
-    assert_eq!(fees.fee_calculator.lamports_per_signature, 12345);
 }
 
 #[test]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6637,7 +6637,7 @@ fn test_shrink_candidate_slots_cached() {
     // No more slots should be shrunk
     assert_eq!(bank2.shrink_candidate_slots(), 0);
     // alive_counts represents the count of alive accounts in the three slots 0,1,2
-    assert_eq!(alive_counts, vec![15, 1, 7]);
+    assert_eq!(alive_counts, vec![15, 1, 6]);
 }
 
 #[test]

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -29,15 +29,13 @@ pub fn bootstrap_validator_stake_lamports() -> u64 {
 pub const fn genesis_sysvar_and_builtin_program_lamports() -> u64 {
     const NUM_BUILTIN_PROGRAMS: u64 = 9;
     const NUM_PRECOMPILES: u64 = 2;
-    const FEES_SYSVAR_MIN_BALANCE: u64 = 946_560;
     const STAKE_HISTORY_MIN_BALANCE: u64 = 114_979_200;
     const CLOCK_SYSVAR_MIN_BALANCE: u64 = 1_169_280;
     const RENT_SYSVAR_MIN_BALANCE: u64 = 1_009_200;
     const EPOCH_SCHEDULE_SYSVAR_MIN_BALANCE: u64 = 1_120_560;
     const RECENT_BLOCKHASHES_SYSVAR_MIN_BALANCE: u64 = 42_706_560;
 
-    FEES_SYSVAR_MIN_BALANCE
-        + STAKE_HISTORY_MIN_BALANCE
+    STAKE_HISTORY_MIN_BALANCE
         + CLOCK_SYSVAR_MIN_BALANCE
         + RENT_SYSVAR_MIN_BALANCE
         + EPOCH_SCHEDULE_SYSVAR_MIN_BALANCE


### PR DESCRIPTION
#### Problem
The Fees sysvar is no longer being updated as of the `disable_fees_sysvar` feature (live on all clusters).

#### Summary of Changes
Clean up runtime logic
Remove unused RPC response types
