### PR TITLE
Deprecate RpcRequest::GetStakeActivation

### DIFF
--- a/rpc-client-api/src/request.rs
+++ b/rpc-client-api/src/request.rs
@@ -8,7 +8,9 @@ use {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum RpcRequest {
-    Custom { method: &'static str },
+    Custom {
+        method: &'static str,
+    },
     DeregisterNode,
     GetAccountInfo,
     GetBalance,
@@ -48,6 +50,10 @@ pub enum RpcRequest {
     GetStorageTurn,
     GetStorageTurnRate,
     GetSlotsPerSegment,
+    #[deprecated(
+        since = "1.18.18",
+        note = "Do not use; getStakeActivation is not supported by the JSON-RPC server."
+    )]
     GetStakeActivation,
     GetStakeMinimumDelegation,
     GetStoragePubkeysForSlot,

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -2082,6 +2082,7 @@ impl RpcClient {
                 use the stake account and StakeHistory sysvar to call \
                 `Delegation::stake_activating_and_deactivating()` instead"
     )]
+    #[allow(deprecated)]
     pub async fn get_stake_activation(
         &self,
         stake_account: Pubkey,

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -2078,8 +2078,8 @@ impl RpcClient {
     /// ```
     #[deprecated(
         since = "1.18.18",
-        note = "Do not use; getStakeActivation is deprecated on the JSON-RPC server. Please use \
-                the stake account and StakeHistory sysvar to call \
+        note = "Do not use; getStakeActivation is not supported by the JSON-RPC server. Please \
+                use the stake account and StakeHistory sysvar to call \
                 `Delegation::stake_activating_and_deactivating()` instead"
     )]
     pub async fn get_stake_activation(

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -1776,8 +1776,8 @@ impl RpcClient {
     /// ```
     #[deprecated(
         since = "1.18.18",
-        note = "Do not use; getStakeActivation is deprecated on the JSON-RPC server. Please use \
-                the stake account and StakeHistory sysvar to call \
+        note = "Do not use; getStakeActivation is not supported by the JSON-RPC server. Please \
+                use the stake account and StakeHistory sysvar to call \
                 `Delegation::stake_activating_and_deactivating()` instead"
     )]
     #[allow(deprecated)]


### PR DESCRIPTION
#### Problem
I forgot to deprecate `solana_rpc_client_api::request::RpcRequest::GetStakeActivation` in https://github.com/anza-xyz/agave/pull/1895

#### Summary of Changes
Deprecate it
Also, make RpcClient deprecation-tag notes more correct while I'm here
