### PR TITLE
Update changlog re: removal of deprecated symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ Release channels have their own copy of this changelog:
   * SDK:
     * Support for Borsh v0.9 removed, please use v1 or v0.10 (#1440)
     * `Copy` is no longer derived on `Rent` and `EpochSchedule`, please switch to using `clone()` (solana-labs#32767)
-    * Deprecated symbols removed
-  * `solana-program`: deprecated symbols removed
+    * `solana-sdk`: deprecated symbols removed
+    * `solana-program`: deprecated symbols removed
   * RPC: obsolete and deprecated v1 endpoints are removed. These endpoints are:
     confirmTransaction, getSignatureStatus, getSignatureConfirmation, getTotalSupply,
     getConfirmedSignaturesForAddress, getConfirmedBlock, getConfirmedBlocks, getConfirmedBlocksWithLimit,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ Release channels have their own copy of this changelog:
 
 ## [2.0.0]
 * Breaking
-  * SDK: Support for Borsh v0.9 removed, please use v1 or v0.10 (#1440)
-  * SDK: `Copy` is no longer derived on `Rent` and `EpochSchedule`, please switch to using `clone()` (solana-labs#32767)
-  * SDK: deprecated SyncClient trait methods removed
+  * SDK:
+    * Support for Borsh v0.9 removed, please use v1 or v0.10 (#1440)
+    * `Copy` is no longer derived on `Rent` and `EpochSchedule`, please switch to using `clone()` (solana-labs#32767)
+    * Deprecated symbols removed
   * RPC: obsolete and deprecated v1 endpoints are removed. These endpoints are:
     confirmTransaction, getSignatureStatus, getSignatureConfirmation, getTotalSupply,
     getConfirmedSignaturesForAddress, getConfirmedBlock, getConfirmedBlocks, getConfirmedBlocksWithLimit,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Release channels have their own copy of this changelog:
     getFeeCalculatorForBlockhash, getFeeRateGovernor, getSnapshotSlot getStakeActivation
   * `--enable-rpc-obsolete_v1_7` flag removed
   * Deprecated methods are removed from `RpcClient` and `RpcClient::nonblocking`
+  * `solana-client`: deprecated re-exports removed; please import `solana-connection-cache`, `solana-quic-client`, or `solana-udp-client` directly
 * Changes
   * `central-scheduler` as default option for `--block-production-method` (#34891)
   * `solana-rpc-client-api`: `RpcFilterError` depends on `base64` version 0.22, so users may need to upgrade to `base64` version 0.22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Release channels have their own copy of this changelog:
     * Support for Borsh v0.9 removed, please use v1 or v0.10 (#1440)
     * `Copy` is no longer derived on `Rent` and `EpochSchedule`, please switch to using `clone()` (solana-labs#32767)
     * Deprecated symbols removed
+  * `solana-program`: deprecated symbols removed
   * RPC: obsolete and deprecated v1 endpoints are removed. These endpoints are:
     confirmTransaction, getSignatureStatus, getSignatureConfirmation, getTotalSupply,
     getConfirmedSignaturesForAddress, getConfirmedBlock, getConfirmedBlocks, getConfirmedBlocksWithLimit,


### PR DESCRIPTION
#### Problem
We removed a bunch of deprecated pub symbols from important crates like solana-sdk and solana-program

#### Summary of Changes
Call out in changelog
