### PR TITLE
Remove solang from the tools suite

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -179,40 +179,6 @@ if [[ -z "$validatorOnly" ]]; then
   cp -a sdk/sbf/* "$installDir"/bin/sdk/sbf
 fi
 
-# Add Solidity Compiler
-if [[ -z "$validatorOnly" ]]; then
-  base="https://github.com/hyperledger/solang/releases/download"
-  version="v0.3.3"
-  curlopt="-sSfL --retry 5 --retry-delay 2 --retry-connrefused"
-
-  case $(uname -s) in
-  "Linux")
-    if [[ $(uname -m) == "x86_64" ]]; then
-      arch="x86-64"
-    else
-      arch="arm64"
-    fi
-    # shellcheck disable=SC2086
-    curl $curlopt -o "$installDir/bin/solang" $base/$version/solang-linux-$arch
-    chmod 755 "$installDir/bin/solang"
-    ;;
-  "Darwin")
-    if [[ $(uname -m) == "x86_64" ]]; then
-      arch="intel"
-    else
-      arch="arm"
-    fi
-    # shellcheck disable=SC2086
-    curl $curlopt -o "$installDir/bin/solang" $base/$version/solang-mac-$arch
-    chmod 755 "$installDir/bin/solang"
-    ;;
-  *)
-    # shellcheck disable=SC2086
-    curl $curlopt -o "$installDir/bin/solang.exe" $base/$version/solang.exe
-    ;;
-  esac
-fi
-
 (
   set -x
   # deps dir can be empty


### PR DESCRIPTION
Solang is no longer maintained and does not work with Anchor cli 0.30.0.

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
