### PR TITLE
[zk-token-sdk] Specify version in deprecations in `zk-token-sdk`

### DIFF
--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -221,7 +221,7 @@ impl ElGamalKeypair {
         &self.secret
     }
 
-    #[deprecated(note = "please use `into()` instead")]
+    #[deprecated(since = "2.0.0", note = "please use `into()` instead")]
     #[allow(deprecated)]
     pub fn to_bytes(&self) -> [u8; ELGAMAL_KEYPAIR_LEN] {
         let mut bytes = [0u8; ELGAMAL_KEYPAIR_LEN];
@@ -230,7 +230,7 @@ impl ElGamalKeypair {
         bytes
     }
 
-    #[deprecated(note = "please use `try_from()` instead")]
+    #[deprecated(since = "2.0.0", note = "please use `try_from()` instead")]
     #[allow(deprecated)]
     pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
         if bytes.len() != ELGAMAL_KEYPAIR_LEN {
@@ -367,12 +367,12 @@ impl ElGamalPubkey {
         &self.0
     }
 
-    #[deprecated(note = "please use `into()` instead")]
+    #[deprecated(since = "2.0.0", note = "please use `into()` instead")]
     pub fn to_bytes(&self) -> [u8; ELGAMAL_PUBKEY_LEN] {
         self.0.compress().to_bytes()
     }
 
-    #[deprecated(note = "please use `try_from()` instead")]
+    #[deprecated(since = "2.0.0", note = "please use `try_from()` instead")]
     pub fn from_bytes(bytes: &[u8]) -> Option<ElGamalPubkey> {
         if bytes.len() != ELGAMAL_PUBKEY_LEN {
             return None;
@@ -544,12 +544,12 @@ impl ElGamalSecretKey {
         self.0.as_bytes()
     }
 
-    #[deprecated(note = "please use `into()` instead")]
+    #[deprecated(since = "2.0.0", note = "please use `into()` instead")]
     pub fn to_bytes(&self) -> [u8; ELGAMAL_SECRET_KEY_LEN] {
         self.0.to_bytes()
     }
 
-    #[deprecated(note = "please use `try_from()` instead")]
+    #[deprecated(since = "2.0.0", note = "please use `try_from()` instead")]
     pub fn from_bytes(bytes: &[u8]) -> Option<ElGamalSecretKey> {
         match bytes.try_into() {
             Ok(bytes) => Scalar::from_canonical_bytes(bytes).map(ElGamalSecretKey),


### PR DESCRIPTION
#### Problem
Some deprecation notes in `zk-token-sdk` does not specify the version.

#### Summary of Changes
Add the versions.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
