### PR TITLE
extract solana-program-memory crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5723,6 +5723,7 @@ dependencies = [
  "solana-log-collector",
  "solana-measure",
  "solana-poseidon",
+ "solana-program-memory",
  "solana-program-runtime",
  "solana-sdk",
  "solana-timings",
@@ -6857,6 +6858,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-logger",
+ "solana-program-memory",
  "solana-sanitize",
  "solana-sdk-macro",
  "solana-secp256k1-recover",
@@ -6864,6 +6866,14 @@ dependencies = [
  "static_assertions",
  "thiserror",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-program-memory"
+version = "2.1.0"
+dependencies = [
+ "num-traits",
+ "solana-define-syscall",
 ]
 
 [[package]]
@@ -7330,6 +7340,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-logger",
  "solana-program",
+ "solana-program-memory",
  "solana-sanitize",
  "solana-sdk",
  "solana-sdk-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ members = [
     "sdk/macro",
     "sdk/package-metadata-macro",
     "sdk/program",
+    "sdk/program-memory",
     "send-transaction-service",
     "short-vec",
     "stake-accounts",
@@ -383,6 +384,7 @@ solana-perf = { path = "perf", version = "=2.1.0" }
 solana-poh = { path = "poh", version = "=2.1.0" }
 solana-poseidon = { path = "poseidon", version = "=2.1.0" }
 solana-program = { path = "sdk/program", version = "=2.1.0", default-features = false }
+solana-program-memory = { path = "sdk/program-memory", version = "=2.1.0" }
 solana-program-runtime = { path = "program-runtime", version = "=2.1.0" }
 solana-program-test = { path = "program-test", version = "=2.1.0" }
 solana-pubsub-client = { path = "pubsub-client", version = "=2.1.0" }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -21,6 +21,7 @@ solana-curve25519 = { workspace = true }
 solana-log-collector = { workspace = true }
 solana-measure = { workspace = true }
 solana-poseidon = { workspace = true }
+solana-program-memory = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 solana-timings = { workspace = true }

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -20,6 +20,7 @@ use {
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_log_collector::{ic_logger_msg, ic_msg},
     solana_poseidon as poseidon,
+    solana_program_memory::is_nonoverlapping,
     solana_program_runtime::{invoke_context::InvokeContext, stable_log},
     solana_rbpf::{
         declare_builtin_function,
@@ -48,7 +49,6 @@ use {
         keccak, native_loader,
         precompiles::is_precompile,
         program::MAX_RETURN_DATA,
-        program_stubs::is_nonoverlapping,
         pubkey::{Pubkey, PubkeyError, MAX_SEEDS, MAX_SEED_LEN, PUBKEY_BYTES},
         secp256k1_recover::{
             Secp256k1RecoverError, SECP256K1_PUBLIC_KEY_LENGTH, SECP256K1_SIGNATURE_LENGTH,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4662,6 +4662,7 @@ dependencies = [
  "solana-log-collector",
  "solana-measure",
  "solana-poseidon",
+ "solana-program-memory",
  "solana-program-runtime",
  "solana-sdk",
  "solana-timings",
@@ -5330,12 +5331,21 @@ dependencies = [
  "solana-atomic-u64",
  "solana-decode-error",
  "solana-define-syscall",
+ "solana-program-memory",
  "solana-sanitize",
  "solana-sdk-macro",
  "solana-secp256k1-recover",
  "solana-short-vec",
  "thiserror",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-program-memory"
+version = "2.1.0"
+dependencies = [
+ "num-traits",
+ "solana-define-syscall",
 ]
 
 [[package]]
@@ -6176,6 +6186,7 @@ dependencies = [
  "solana-bn254",
  "solana-decode-error",
  "solana-program",
+ "solana-program-memory",
  "solana-sanitize",
  "solana-sdk-macro",
  "solana-secp256k1-recover",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -86,6 +86,7 @@ solana-decode-error = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-program = { workspace = true }
+solana-program-memory = { workspace = true }
 solana-sanitize = { workspace = true }
 solana-sdk-macro = { workspace = true }
 solana-secp256k1-recover = { workspace = true }

--- a/sdk/program-memory/Cargo.toml
+++ b/sdk/program-memory/Cargo.toml
@@ -10,7 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-num-traits.workspace = true
+num-traits = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/program-memory/Cargo.toml
+++ b/sdk/program-memory/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-program-memory"
+description = "Basic low-level memory operations for Solana."
+documentation = "https://docs.rs/solana-program-memory"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+num-traits.workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[target.'cfg(target_os = "solana")'.dependencies]
+solana-define-syscall = { workspace = true }

--- a/sdk/program-memory/src/lib.rs
+++ b/sdk/program-memory/src/lib.rs
@@ -2,11 +2,10 @@
 //!
 //! Within the SBF environment, these are implemented as syscalls and executed by
 //! the runtime in native code.
-#[cfg(target_os = "solana")]
-use solana_define_syscall::define_syscall;
 
 #[cfg(target_os = "solana")]
 pub mod syscalls {
+    use solana_define_syscall::define_syscall;
     define_syscall!(fn sol_memcpy_(dst: *mut u8, src: *const u8, n: u64));
     define_syscall!(fn sol_memmove_(dst: *mut u8, src: *const u8, n: u64));
     define_syscall!(fn sol_memcmp_(s1: *const u8, s2: *const u8, n: u64, result: *mut i32));

--- a/sdk/program-memory/src/lib.rs
+++ b/sdk/program-memory/src/lib.rs
@@ -6,7 +6,7 @@
 use solana_define_syscall::define_syscall;
 
 #[cfg(target_os = "solana")]
-mod syscalls {
+pub mod syscalls {
     define_syscall!(fn sol_memcpy_(dst: *mut u8, src: *const u8, n: u64));
     define_syscall!(fn sol_memmove_(dst: *mut u8, src: *const u8, n: u64));
     define_syscall!(fn sol_memcmp_(s1: *const u8, s2: *const u8, n: u64, result: *mut i32));

--- a/sdk/program-memory/src/lib.rs
+++ b/sdk/program-memory/src/lib.rs
@@ -2,6 +2,73 @@
 //!
 //! Within the SBF environment, these are implemented as syscalls and executed by
 //! the runtime in native code.
+#[cfg(target_os = "solana")]
+use solana_define_syscall::define_syscall;
+
+#[cfg(target_os = "solana")]
+mod syscalls {
+    define_syscall!(fn sol_memcpy_(dst: *mut u8, src: *const u8, n: u64));
+    define_syscall!(fn sol_memmove_(dst: *mut u8, src: *const u8, n: u64));
+    define_syscall!(fn sol_memcmp_(s1: *const u8, s2: *const u8, n: u64, result: *mut i32));
+    define_syscall!(fn sol_memset_(s: *mut u8, c: u8, n: u64));
+}
+
+/// Check that two regions do not overlap.
+///
+/// Hidden to share with bpf_loader without being part of the API surface.
+#[doc(hidden)]
+pub fn is_nonoverlapping<N>(src: N, src_len: N, dst: N, dst_len: N) -> bool
+where
+    N: Ord + num_traits::SaturatingSub,
+{
+    // If the absolute distance between the ptrs is at least as big as the size of the other,
+    // they do not overlap.
+    if src > dst {
+        src.saturating_sub(&dst) >= dst_len
+    } else {
+        dst.saturating_sub(&src) >= src_len
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+#[allow(clippy::arithmetic_side_effects)]
+pub mod stubs {
+    use super::is_nonoverlapping;
+    /// # Safety
+    pub unsafe fn sol_memcpy(dst: *mut u8, src: *const u8, n: usize) {
+        // cannot be overlapping
+        assert!(
+            is_nonoverlapping(src as usize, n, dst as usize, n),
+            "memcpy does not support overlapping regions"
+        );
+        std::ptr::copy_nonoverlapping(src, dst, n);
+    }
+    /// # Safety
+    pub unsafe fn sol_memmove(dst: *mut u8, src: *const u8, n: usize) {
+        std::ptr::copy(src, dst, n);
+    }
+    /// # Safety
+    pub unsafe fn sol_memcmp(s1: *const u8, s2: *const u8, n: usize, result: *mut i32) {
+        let mut i = 0;
+        while i < n {
+            let a = *s1.add(i);
+            let b = *s2.add(i);
+            if a != b {
+                *result = a as i32 - b as i32;
+                return;
+            }
+            i += 1;
+        }
+        *result = 0
+    }
+    /// # Safety
+    pub unsafe fn sol_memset(s: *mut u8, c: u8, n: usize) {
+        let s = std::slice::from_raw_parts_mut(s, n);
+        for val in s.iter_mut().take(n) {
+            *val = c;
+        }
+    }
+}
 
 /// Like C `memcpy`.
 ///
@@ -35,11 +102,13 @@
 pub fn sol_memcpy(dst: &mut [u8], src: &[u8], n: usize) {
     #[cfg(target_os = "solana")]
     unsafe {
-        crate::syscalls::sol_memcpy_(dst.as_mut_ptr(), src.as_ptr(), n as u64);
+        syscalls::sol_memcpy_(dst.as_mut_ptr(), src.as_ptr(), n as u64);
     }
 
     #[cfg(not(target_os = "solana"))]
-    crate::program_stubs::sol_memcpy(dst.as_mut_ptr(), src.as_ptr(), n);
+    unsafe {
+        stubs::sol_memcpy(dst.as_mut_ptr(), src.as_ptr(), n);
+    }
 }
 
 /// Like C `memmove`.
@@ -64,10 +133,10 @@ pub fn sol_memcpy(dst: &mut [u8], src: &[u8], n: usize) {
 #[inline]
 pub unsafe fn sol_memmove(dst: *mut u8, src: *mut u8, n: usize) {
     #[cfg(target_os = "solana")]
-    crate::syscalls::sol_memmove_(dst, src, n as u64);
+    syscalls::sol_memmove_(dst, src, n as u64);
 
     #[cfg(not(target_os = "solana"))]
-    crate::program_stubs::sol_memmove(dst, src, n);
+    stubs::sol_memmove(dst, src, n);
 }
 
 /// Like C `memcmp`.
@@ -100,11 +169,13 @@ pub fn sol_memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
 
     #[cfg(target_os = "solana")]
     unsafe {
-        crate::syscalls::sol_memcmp_(s1.as_ptr(), s2.as_ptr(), n as u64, &mut result as *mut i32);
+        syscalls::sol_memcmp_(s1.as_ptr(), s2.as_ptr(), n as u64, &mut result as *mut i32);
     }
 
     #[cfg(not(target_os = "solana"))]
-    crate::program_stubs::sol_memcmp(s1.as_ptr(), s2.as_ptr(), n, &mut result as *mut i32);
+    unsafe {
+        stubs::sol_memcmp(s1.as_ptr(), s2.as_ptr(), n, &mut result as *mut i32);
+    }
 
     result
 }
@@ -137,9 +208,31 @@ pub fn sol_memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
 pub fn sol_memset(s: &mut [u8], c: u8, n: usize) {
     #[cfg(target_os = "solana")]
     unsafe {
-        crate::syscalls::sol_memset_(s.as_mut_ptr(), c, n as u64);
+        syscalls::sol_memset_(s.as_mut_ptr(), c, n as u64);
     }
 
     #[cfg(not(target_os = "solana"))]
-    crate::program_stubs::sol_memset(s.as_mut_ptr(), c, n);
+    unsafe {
+        stubs::sol_memset(s.as_mut_ptr(), c, n);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_nonoverlapping() {
+        for dst in 0..8 {
+            assert!(is_nonoverlapping(10, 3, dst, 3));
+        }
+        for dst in 8..13 {
+            assert!(!is_nonoverlapping(10, 3, dst, 3));
+        }
+        for dst in 13..20 {
+            assert!(is_nonoverlapping(10, 3, dst, 3));
+        }
+        assert!(is_nonoverlapping::<u8>(255, 3, 254, 1));
+        assert!(!is_nonoverlapping::<u8>(255, 2, 254, 3));
+    }
 }

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -35,6 +35,7 @@ solana-atomic-u64 = { workspace = true }
 solana-decode-error = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-program-memory = { workspace = true }
 solana-sanitize = { workspace = true }
 solana-sdk-macro = { workspace = true }
 solana-secp256k1-recover = { workspace = true }

--- a/sdk/program/src/account_info.rs
+++ b/sdk/program/src/account_info.rs
@@ -3,8 +3,9 @@
 use {
     crate::{
         clock::Epoch, debug_account_data::*, entrypoint::MAX_PERMITTED_DATA_INCREASE,
-        program_error::ProgramError, program_memory::sol_memset, pubkey::Pubkey,
+        program_error::ProgramError, pubkey::Pubkey,
     },
+    solana_program_memory::sol_memset,
     std::{
         cell::{Ref, RefCell, RefMut},
         fmt,

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -509,7 +509,6 @@ pub mod native_token;
 pub mod nonce;
 pub mod program;
 pub mod program_error;
-pub mod program_memory;
 pub mod program_option;
 pub mod program_pack;
 pub mod program_stubs;
@@ -531,6 +530,8 @@ pub mod sysvar;
 pub mod vote;
 pub mod wasm;
 
+#[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]
+pub use solana_program_memory as program_memory;
 #[deprecated(since = "2.1.0", note = "Use `solana-sanitize` crate instead")]
 pub use solana_sanitize as sanitize;
 #[deprecated(since = "2.1.0", note = "Use `solana-secp256k1-recover` crate instead")]

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -8,6 +8,7 @@ use {
         program_error::UNSUPPORTED_SYSVAR, pubkey::Pubkey,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
+    solana_program_memory::stubs,
     std::sync::{Arc, RwLock},
 };
 
@@ -21,7 +22,6 @@ pub fn set_syscall_stubs(syscall_stubs: Box<dyn SyscallStubs>) -> Box<dyn Syscal
     std::mem::replace(&mut SYSCALL_STUBS.write().unwrap(), syscall_stubs)
 }
 
-#[allow(clippy::arithmetic_side_effects)]
 pub trait SyscallStubs: Sync + Send {
     fn sol_log(&self, message: &str) {
         println!("{message}");
@@ -74,37 +74,19 @@ pub trait SyscallStubs: Sync + Send {
     }
     /// # Safety
     unsafe fn sol_memcpy(&self, dst: *mut u8, src: *const u8, n: usize) {
-        // cannot be overlapping
-        assert!(
-            is_nonoverlapping(src as usize, n, dst as usize, n),
-            "memcpy does not support overlapping regions"
-        );
-        std::ptr::copy_nonoverlapping(src, dst, n);
+        stubs::sol_memcpy(dst, src, n)
     }
     /// # Safety
     unsafe fn sol_memmove(&self, dst: *mut u8, src: *const u8, n: usize) {
-        std::ptr::copy(src, dst, n);
+        stubs::sol_memmove(dst, src, n)
     }
     /// # Safety
     unsafe fn sol_memcmp(&self, s1: *const u8, s2: *const u8, n: usize, result: *mut i32) {
-        let mut i = 0;
-        while i < n {
-            let a = *s1.add(i);
-            let b = *s2.add(i);
-            if a != b {
-                *result = a as i32 - b as i32;
-                return;
-            }
-            i += 1;
-        }
-        *result = 0
+        stubs::sol_memcmp(s1, s2, n, result)
     }
     /// # Safety
     unsafe fn sol_memset(&self, s: *mut u8, c: u8, n: usize) {
-        let s = std::slice::from_raw_parts_mut(s, n);
-        for val in s.iter_mut().take(n) {
-            *val = c;
-        }
+        stubs::sol_memset(s, c, n)
     }
     fn sol_get_return_data(&self) -> Option<(Pubkey, Vec<u8>)> {
         None
@@ -206,30 +188,6 @@ pub(crate) fn sol_get_epoch_stake(vote_address: *const u8) -> u64 {
         .sol_get_epoch_stake(vote_address)
 }
 
-pub(crate) fn sol_memcpy(dst: *mut u8, src: *const u8, n: usize) {
-    unsafe {
-        SYSCALL_STUBS.read().unwrap().sol_memcpy(dst, src, n);
-    }
-}
-
-pub(crate) fn sol_memmove(dst: *mut u8, src: *const u8, n: usize) {
-    unsafe {
-        SYSCALL_STUBS.read().unwrap().sol_memmove(dst, src, n);
-    }
-}
-
-pub(crate) fn sol_memcmp(s1: *const u8, s2: *const u8, n: usize, result: *mut i32) {
-    unsafe {
-        SYSCALL_STUBS.read().unwrap().sol_memcmp(s1, s2, n, result);
-    }
-}
-
-pub(crate) fn sol_memset(s: *mut u8, c: u8, n: usize) {
-    unsafe {
-        SYSCALL_STUBS.read().unwrap().sol_memset(s, c, n);
-    }
-}
-
 pub(crate) fn sol_get_return_data() -> Option<(Pubkey, Vec<u8>)> {
     SYSCALL_STUBS.read().unwrap().sol_get_return_data()
 }
@@ -258,41 +216,4 @@ pub(crate) fn sol_get_epoch_rewards_sysvar(var_addr: *mut u8) -> u64 {
         .read()
         .unwrap()
         .sol_get_epoch_rewards_sysvar(var_addr)
-}
-
-/// Check that two regions do not overlap.
-///
-/// Hidden to share with bpf_loader without being part of the API surface.
-#[doc(hidden)]
-pub fn is_nonoverlapping<N>(src: N, src_len: N, dst: N, dst_len: N) -> bool
-where
-    N: Ord + num_traits::SaturatingSub,
-{
-    // If the absolute distance between the ptrs is at least as big as the size of the other,
-    // they do not overlap.
-    if src > dst {
-        src.saturating_sub(&dst) >= dst_len
-    } else {
-        dst.saturating_sub(&src) >= src_len
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_is_nonoverlapping() {
-        for dst in 0..8 {
-            assert!(is_nonoverlapping(10, 3, dst, 3));
-        }
-        for dst in 8..13 {
-            assert!(!is_nonoverlapping(10, 3, dst, 3));
-        }
-        for dst in 13..20 {
-            assert!(is_nonoverlapping(10, 3, dst, 3));
-        }
-        assert!(is_nonoverlapping::<u8>(255, 3, 254, 1));
-        assert!(!is_nonoverlapping::<u8>(255, 2, 254, 3));
-    }
 }

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -22,10 +22,6 @@ define_syscall!(fn sol_try_find_program_address(seeds_addr: *const u8, seeds_len
 define_syscall!(fn sol_sha256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_keccak256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_blake3(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
-define_syscall!(fn sol_memcpy_(dst: *mut u8, src: *const u8, n: u64));
-define_syscall!(fn sol_memmove_(dst: *mut u8, src: *const u8, n: u64));
-define_syscall!(fn sol_memcmp_(s1: *const u8, s2: *const u8, n: u64, result: *mut i32));
-define_syscall!(fn sol_memset_(s: *mut u8, c: u8, n: u64));
 define_syscall!(fn sol_invoke_signed_c(instruction_addr: *const u8, account_infos_addr: *const u8, account_infos_len: u64, signers_seeds_addr: *const u8, signers_seeds_len: u64) -> u64);
 define_syscall!(fn sol_invoke_signed_rust(instruction_addr: *const u8, account_infos_addr: *const u8, account_infos_len: u64, signers_seeds_addr: *const u8, signers_seeds_len: u64) -> u64);
 define_syscall!(fn sol_set_return_data(data: *const u8, length: u64));

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -2,6 +2,11 @@
 pub use solana_define_syscall::sys_hash;
 #[deprecated(
     since = "2.1.0",
+    note = "Use `solana_program_memory::syscalls` instead"
+)]
+pub use solana_program_memory::syscalls::{sol_memcmp_, sol_memcpy_, sol_memmove_, sol_memset_};
+#[deprecated(
+    since = "2.1.0",
     note = "Use `solana_secp256k1_recover::sol_secp256k1_recover` instead"
 )]
 pub use solana_secp256k1_recover::sol_secp256k1_recover;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -52,9 +52,9 @@ pub use solana_program::{
     epoch_rewards, epoch_schedule, fee_calculator, impl_sysvar_get, incinerator, instruction,
     keccak, lamports, loader_instruction, loader_upgradeable_instruction, loader_v4,
     loader_v4_instruction, message, msg, native_token, nonce, program, program_error,
-    program_memory, program_option, program_pack, rent, secp256k1_program, serde_varint,
-    serialize_utils, slot_hashes, slot_history, stable_layout, stake, stake_history, syscalls,
-    system_instruction, system_program, sysvar, unchecked_div_by_const, vote,
+    program_option, program_pack, rent, secp256k1_program, serde_varint, serialize_utils,
+    slot_hashes, slot_history, stable_layout, stake, stake_history, syscalls, system_instruction,
+    system_program, sysvar, unchecked_div_by_const, vote,
 };
 #[cfg(feature = "borsh")]
 pub use solana_program::{borsh, borsh0_10, borsh1};
@@ -113,6 +113,8 @@ pub mod wasm;
 pub use solana_bn254 as alt_bn128;
 #[deprecated(since = "2.1.0", note = "Use `solana-decode-error` crate instead")]
 pub use solana_decode_error as decode_error;
+#[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]
+pub use solana_program_memory as program_memory;
 #[deprecated(since = "2.1.0", note = "Use `solana-sanitize` crate instead")]
 pub use solana_sanitize as sanitize;
 /// Same as `declare_id` except report that this id has been deprecated.


### PR DESCRIPTION
#### Problem
`solana_program::program_memory`  is one of the blockers for giving account_info.rs its own crate

#### Summary of Changes
- Move program_memory.rs to a new crate `solana-program-memory`
- Move the definition of the sol_memcpy_, sol_memmove_, sol_memcmp_ and sol_memset_ syscalls to solana-program-memory and re-export them in definitions.rs with a deprecation notice
- Move the stub definitions for the above syscalls into solana-program-memory
- Re-export the new crate in solana-program and solana-sdk with a deprecation warning

