### PR TITLE
Refactor - `last_written_slot` in program loading

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7023,6 +7023,7 @@ impl Bank {
             .transaction_processor
             .get_environments_for_epoch(effective_epoch)?;
         load_program_with_pubkey(self, &environments, pubkey, self.slot(), reload)
+            .map(|(program, _last_written_slot)| program)
     }
 
     pub fn withdraw(&self, pubkey: &Pubkey, lamports: u64) -> Result<()> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6754,12 +6754,11 @@ impl TransactionProcessingCallback for Bank {
             .ok()
     }
 
-    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
         self.rc
             .accounts
             .accounts_db
             .load_with_fixed_root(&self.ancestors, pubkey)
-            .map(|(acc, _)| acc)
     }
 
     // NOTE: must hold idempotent for the same set of arguments

--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -130,7 +130,7 @@ information.
 pub trait TransactionProcessingCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize>;
 
-    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)>;
 
     fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {}
 }

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,10 +1,10 @@
-use solana_sdk::{account::AccountSharedData, pubkey::Pubkey};
+use solana_sdk::{account::AccountSharedData, clock::Slot, pubkey::Pubkey};
 
 /// Runtime callbacks for transaction processing.
 pub trait TransactionProcessingCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize>;
 
-    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)>;
 
     fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {}
 }

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -437,7 +437,8 @@ fn execute_fixture_as_instr(
         42,
         false,
     )
-    .unwrap();
+    .unwrap()
+    .0;
 
     loaded_programs.replenish(program_id, loaded_program);
     loaded_programs.replenish(

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -207,7 +207,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
             account_data.set_executable(item.executable);
             account_data.set_rent_epoch(item.rent_epoch);
 
-            account_data_map.insert(pubkey, account_data);
+            account_data_map.insert(pubkey, (account_data, 0));
         }
         let mut account_data = AccountSharedData::default();
         account_data.set_lamports(800000);
@@ -216,7 +216,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
             // The fee payer must not coincide with any of the previous accounts
             fee_payer = Pubkey::new_unique();
         }
-        account_data_map.insert(fee_payer, account_data);
+        account_data_map.insert(fee_payer, (account_data, 0));
     }
 
     let Ok(transaction) =
@@ -405,7 +405,7 @@ fn execute_fixture_as_instr(
     let transaction_accounts: Vec<TransactionAccount> = sanitized_message
         .account_keys()
         .iter()
-        .map(|key| (*key, mock_bank.get_account_shared_data(key).unwrap()))
+        .map(|key| (*key, mock_bank.get_account_shared_data(key).unwrap().0))
         .collect();
 
     let mut transaction_context = TransactionContext::new(

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -162,7 +162,7 @@ fn create_executable_environment(
     mock_bank
         .account_shared_data
         .borrow_mut()
-        .insert(Clock::id(), account_data);
+        .insert(Clock::id(), (account_data, 0));
 }
 
 fn load_program(name: String) -> Vec<u8> {
@@ -195,7 +195,7 @@ fn deploy_program(name: String, mock_bank: &mut MockBankCallback) -> Pubkey {
     mock_bank
         .account_shared_data
         .borrow_mut()
-        .insert(program_account, account_data);
+        .insert(program_account, (account_data, 0));
 
     let mut account_data = AccountSharedData::default();
     let state = UpgradeableLoaderState::ProgramData {
@@ -217,7 +217,7 @@ fn deploy_program(name: String, mock_bank: &mut MockBankCallback) -> Pubkey {
     mock_bank
         .account_shared_data
         .borrow_mut()
-        .insert(program_data_account, account_data);
+        .insert(program_data_account, (account_data, 0));
 
     program_account
 }
@@ -280,7 +280,7 @@ fn prepare_transactions(
     mock_bank
         .account_shared_data
         .borrow_mut()
-        .insert(fee_payer, account_data);
+        .insert(fee_payer, (account_data, 0));
 
     // A simple funds transfer between accounts
     let transfer_program_account = deploy_program("simple-transfer".to_string(), mock_bank);
@@ -328,7 +328,7 @@ fn prepare_transactions(
     mock_bank
         .account_shared_data
         .borrow_mut()
-        .insert(fee_payer, account_data);
+        .insert(fee_payer, (account_data, 0));
 
     // sender
     let mut account_data = AccountSharedData::default();
@@ -336,7 +336,7 @@ fn prepare_transactions(
     mock_bank
         .account_shared_data
         .borrow_mut()
-        .insert(sender, account_data);
+        .insert(sender, (account_data, 0));
 
     // recipient
     let mut account_data = AccountSharedData::default();
@@ -344,7 +344,7 @@ fn prepare_transactions(
     mock_bank
         .account_shared_data
         .borrow_mut()
-        .insert(recipient, account_data);
+        .insert(recipient, (account_data, 0));
 
     // The system account is set in `create_executable_environment`
 
@@ -367,7 +367,7 @@ fn prepare_transactions(
     mock_bank
         .account_shared_data
         .borrow_mut()
-        .insert(fee_payer, account_data);
+        .insert(fee_payer, (account_data, 0));
 
     // A transaction that fails
     let sender = Pubkey::new_unique();
@@ -412,7 +412,7 @@ fn prepare_transactions(
     mock_bank
         .account_shared_data
         .borrow_mut()
-        .insert(fee_payer, account_data);
+        .insert(fee_payer, (account_data, 0));
 
     // Sender without enough funds
     let mut account_data = AccountSharedData::default();
@@ -420,7 +420,7 @@ fn prepare_transactions(
     mock_bank
         .account_shared_data
         .borrow_mut()
-        .insert(sender, account_data);
+        .insert(sender, (account_data, 0));
 
     // recipient
     let mut account_data = AccountSharedData::default();
@@ -428,7 +428,7 @@ fn prepare_transactions(
     mock_bank
         .account_shared_data
         .borrow_mut()
-        .insert(recipient, account_data);
+        .insert(recipient, (account_data, 0));
 
     // A transaction whose verification has already failed
     all_transactions.push(sanitized_transaction.unwrap());
@@ -511,7 +511,7 @@ fn svm_integration() {
         .as_ref()
         .unwrap();
     let time = i64::from_be_bytes(return_data.data[0..8].try_into().unwrap());
-    let clock_data = mock_bank.get_account_shared_data(&Clock::id()).unwrap();
+    let (clock_data, _last_written_slot) = mock_bank.get_account_shared_data(&Clock::id()).unwrap();
     let clock_info: Clock = bincode::deserialize(clock_data.data()).unwrap();
     assert_eq!(clock_info.unix_timestamp, time);
 

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -31,12 +31,12 @@ impl ForkGraph for MockForkGraph {
 #[derive(Default)]
 pub struct MockBankCallback {
     pub feature_set: Arc<FeatureSet>,
-    pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
+    pub account_shared_data: RefCell<HashMap<Pubkey, (AccountSharedData, Slot)>>,
 }
 
 impl TransactionProcessingCallback for MockBankCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {
-        if let Some(data) = self.account_shared_data.borrow().get(account) {
+        if let Some((data, _last_written_slot)) = self.account_shared_data.borrow().get(account) {
             if data.lamports() == 0 {
                 None
             } else {
@@ -47,7 +47,7 @@ impl TransactionProcessingCallback for MockBankCallback {
         }
     }
 
-    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
         self.account_shared_data.borrow().get(pubkey).cloned()
     }
 
@@ -56,7 +56,7 @@ impl TransactionProcessingCallback for MockBankCallback {
 
         self.account_shared_data
             .borrow_mut()
-            .insert(*program_id, account_data);
+            .insert(*program_id, (account_data, 0));
     }
 }
 


### PR DESCRIPTION
#### Problem
#1997 requires an external (to the global program cache) source of the fork graph in form of a `last_written_slot`.

#### Summary of Changes
Adds `last_written_slot` to the return value of:
- `TransactionProcessingCallback::get_account_shared_data()`
- `load_program_accounts()`
- `load_program_with_pubkey()`
- and affected mock-ups / tests