### PR TITLE
Add --skip-notify-account-restore-from-snapshot optional flag to speed up booting with geyser plugins

### DIFF
--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -39,7 +39,13 @@ impl AccountsDb {
     /// in the reverse order of the slots so that an account is only streamed once. At a slot, if the accounts is updated
     /// multiple times only the last write (with highest write_version) is notified.
     pub fn notify_account_restore_from_snapshot(&self) {
-        if self.accounts_update_notifier.is_none() {
+        if self
+            .accounts_update_notifier
+            .as_ref()
+            .map_or(true, |notifier| {
+                notifier.should_skip_notify_account_restore_from_snapshot()
+            })
+        {
             return;
         }
 
@@ -224,6 +230,10 @@ pub mod tests {
 
         fn notify_end_of_restore_from_snapshot(&self) {
             self.is_startup_done.store(true, Ordering::Relaxed);
+        }
+
+        fn should_skip_notify_account_restore_from_snapshot(&self) -> bool {
+            false
         }
     }
 

--- a/accounts-db/src/accounts_update_notifier_interface.rs
+++ b/accounts-db/src/accounts_update_notifier_interface.rs
@@ -23,6 +23,8 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
 
     /// Notified when all accounts have been notified when restoring from a snapshot.
     fn notify_end_of_restore_from_snapshot(&self);
+    // Signals if the notifier wants notifications about updates when restoring from a snapshot.
+    fn should_skip_notify_account_restore_from_snapshot(&self) -> bool;
 }
 
 pub type AccountsUpdateNotifier = Arc<dyn AccountsUpdateNotifierInterface + Sync + Send>;

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -215,6 +215,7 @@ pub struct ValidatorConfig {
     pub rpc_config: JsonRpcConfig,
     /// Specifies which plugins to start up with
     pub on_start_geyser_plugin_config_files: Option<Vec<PathBuf>>,
+    pub skip_notify_account_restore_from_snapshot: bool,
     pub rpc_addrs: Option<(SocketAddr, SocketAddr)>, // (JsonRpc, JsonRpcPubSub)
     pub pubsub_config: PubSubConfig,
     pub snapshot_config: SnapshotConfig,
@@ -290,6 +291,7 @@ impl Default for ValidatorConfig {
             account_snapshot_paths: Vec::new(),
             rpc_config: JsonRpcConfig::default(),
             on_start_geyser_plugin_config_files: None,
+            skip_notify_account_restore_from_snapshot: false,
             rpc_addrs: None,
             pubsub_config: PubSubConfig::default(),
             snapshot_config: SnapshotConfig::new_load_only(),
@@ -545,6 +547,7 @@ impl Validator {
                         confirmed_bank_receiver,
                         geyser_plugin_config_files,
                         rpc_to_plugin_manager_receiver_and_exit,
+                        config.skip_notify_account_restore_from_snapshot,
                     )
                     .map_err(|err| format!("Failed to load the Geyser plugin: {err:?}"))?,
                 )

--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -22,6 +22,7 @@ use {
 #[derive(Debug)]
 pub(crate) struct AccountsUpdateNotifierImpl {
     plugin_manager: Arc<RwLock<GeyserPluginManager>>,
+    skip_notify_account_restore_from_snapshot: bool,
 }
 
 impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
@@ -94,11 +95,21 @@ impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
             );
         }
     }
+
+    fn should_skip_notify_account_restore_from_snapshot(&self) -> bool {
+        self.skip_notify_account_restore_from_snapshot
+    }
 }
 
 impl AccountsUpdateNotifierImpl {
-    pub fn new(plugin_manager: Arc<RwLock<GeyserPluginManager>>) -> Self {
-        AccountsUpdateNotifierImpl { plugin_manager }
+    pub fn new(
+        plugin_manager: Arc<RwLock<GeyserPluginManager>>,
+        skip_notify_account_restore_from_snapshot: bool,
+    ) -> Self {
+        AccountsUpdateNotifierImpl {
+            plugin_manager,
+            skip_notify_account_restore_from_snapshot,
+        }
     }
 
     fn accountinfo_from_shared_account_data<'a>(

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -55,8 +55,9 @@ impl GeyserPluginService {
     pub fn new(
         confirmed_bank_receiver: Receiver<SlotNotification>,
         geyser_plugin_config_files: &[PathBuf],
+        skip_notify_account_restore_from_snapshot: bool,
     ) -> Result<Self, GeyserPluginServiceError> {
-        Self::new_with_receiver(confirmed_bank_receiver, geyser_plugin_config_files, None)
+        Self::new_with_receiver(confirmed_bank_receiver, geyser_plugin_config_files, None, skip_notify_account_restore_from_snapshot)
     }
 
     pub fn new_with_receiver(
@@ -66,6 +67,7 @@ impl GeyserPluginService {
             Receiver<GeyserPluginManagerRequest>,
             Arc<AtomicBool>,
         )>,
+        skip_notify_account_restore_from_snapshot: bool,
     ) -> Result<Self, GeyserPluginServiceError> {
         info!(
             "Starting GeyserPluginService from config files: {:?}",
@@ -86,7 +88,7 @@ impl GeyserPluginService {
         let accounts_update_notifier: Option<AccountsUpdateNotifier> =
             if account_data_notifications_enabled {
                 let accounts_update_notifier =
-                    AccountsUpdateNotifierImpl::new(plugin_manager.clone());
+                    AccountsUpdateNotifierImpl::new(plugin_manager.clone(), skip_notify_account_restore_from_snapshot);
                 Some(Arc::new(accounts_update_notifier))
             } else {
                 None

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -272,7 +272,7 @@ pub fn load_and_process_ledger(
         let (confirmed_bank_sender, confirmed_bank_receiver) = unbounded();
         drop(confirmed_bank_sender);
         let geyser_service =
-            GeyserPluginService::new(confirmed_bank_receiver, &geyser_config_files)
+            GeyserPluginService::new(confirmed_bank_receiver, &geyser_config_files, false)
                 .map_err(LoadAndProcessLedgerError::GeyserServiceSetup)?;
         (
             geyser_service.get_accounts_update_notifier(),

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -15,6 +15,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         account_snapshot_paths: config.account_snapshot_paths.clone(),
         rpc_config: config.rpc_config.clone(),
         on_start_geyser_plugin_config_files: config.on_start_geyser_plugin_config_files.clone(),
+        skip_notify_account_restore_from_snapshot: config.skip_notify_account_restore_from_snapshot,
         rpc_addrs: config.rpc_addrs,
         pubsub_config: config.pubsub_config.clone(),
         snapshot_config: config.snapshot_config.clone(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1179,6 +1179,11 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Specify the configuration file for the Geyser plugin."),
         )
         .arg(
+            Arg::with_name("skip_notify_account_restore_from_snapshot")
+                .long("skip-notify-account-restore-from-snapshot")
+                .help("Do not notify geyser plugins about account updates during restore from snapshot"),
+        )
+        .arg(
             Arg::with_name("snapshot_archive_format")
                 .long("snapshot-archive-format")
                 .alias("snapshot-compression") // Legacy name used by Solana v1.5.x and older

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1523,6 +1523,8 @@ pub fn main() {
         replay_transactions_threads,
         delay_leader_block_for_pending_fork: matches
             .is_present("delay_leader_block_for_pending_fork"),
+        skip_notify_account_restore_from_snapshot: matches
+            .is_present("skip_notify_account_restore_from_snapshot"),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem
When restoring the bank from a snapshot, geyser plugins are notified about all accounts which takes significant time. If Geyser plugin is used for streaming of realtime updates, those stale updates are of no use and just slow down the startup time, usually for about ~10 mins.

#### Summary of Changes
* Add the `--skip-notify-account-restore-from-snapshot` flag to validator, which will prevent the account update notifications to Geyser plugins during restoring of the bank
* Add a `should_skip_notify_account_restore_from_snapshot() -> bool` method to the account update notifier interface
* Allow passing the `skip_notify_account_restore_from_snapshot` flag to the `AccountsUpdateNotifierImpl`
* In the `AccountDb::notify_account_restore_from_snapshot()` check if notifier wants us to skip the updates,  then return early

Fixes #
