### PR TITLE
Demote unnecessarily pub fns in bank.rs, and remove unused ones

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -206,7 +206,6 @@ use {
     },
     solana_program_runtime::{loaded_programs::ProgramCacheForTxBatch, sysvar_cache::SysvarCache},
     solana_svm::program_loader::load_program_with_pubkey,
-    solana_system_program::{get_system_account_kind, SystemAccountKind},
 };
 
 /// params to `verify_accounts_hash`
@@ -6947,6 +6946,7 @@ impl Bank {
         self.transaction_processor.get_sysvar_cache_for_tests()
     }
 
+    #[cfg(test)]
     pub(crate) fn update_accounts_hash_for_tests(&self) -> AccountsHash {
         self.update_accounts_hash(CalcAccountsHashDataSource::IndexForTests, false, false)
     }
@@ -6971,11 +6971,12 @@ impl Bank {
         load_program_with_pubkey(self, &environments, pubkey, self.slot(), reload)
     }
 
+    #[cfg(test)]
     pub(crate) fn withdraw(&self, pubkey: &Pubkey, lamports: u64) -> Result<()> {
         match self.get_account_with_fixed_root(pubkey) {
             Some(mut account) => {
-                let min_balance = match get_system_account_kind(&account) {
-                    Some(SystemAccountKind::Nonce) => self
+                let min_balance = match solana_system_program::get_system_account_kind(&account) {
+                    Some(solana_system_program::SystemAccountKind::Nonce) => self
                         .rent_collector
                         .rent
                         .minimum_balance(nonce::State::size()),
@@ -7165,6 +7166,7 @@ impl Drop for Bank {
 }
 
 /// utility function used for testing and benchmarking.
+#[cfg(test)]
 pub mod test_utils {
     use {
         super::Bank,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5279,7 +5279,10 @@ impl Bank {
     }
 
     /// Returns all the accounts this bank can load
-    pub(crate) fn get_all_accounts(&self, sort_results: bool) -> ScanResult<Vec<PubkeyAccountSlot>> {
+    pub(crate) fn get_all_accounts(
+        &self,
+        sort_results: bool,
+    ) -> ScanResult<Vec<PubkeyAccountSlot>> {
         self.rc
             .accounts
             .load_all(&self.ancestors, self.bank_id, sort_results)
@@ -5673,7 +5676,10 @@ impl Bank {
     /// Get this bank's storages to use for snapshots.
     ///
     /// If a base slot is provided, return only the storages that are *higher* than this slot.
-    pub(crate) fn get_snapshot_storages(&self, base_slot: Option<Slot>) -> Vec<Arc<AccountStorageEntry>> {
+    pub(crate) fn get_snapshot_storages(
+        &self,
+        base_slot: Option<Slot>,
+    ) -> Vec<Arc<AccountStorageEntry>> {
         // if a base slot is provided, request storages starting at the slot *after*
         let start_slot = base_slot.map_or(0, |slot| slot.saturating_add(1));
         // we want to *include* the storage at our slot
@@ -5905,7 +5911,10 @@ impl Bank {
     }
 
     /// Calculate the incremental accounts hash from `base_slot` to `self`
-    pub(crate) fn update_incremental_accounts_hash(&self, base_slot: Slot) -> IncrementalAccountsHash {
+    pub(crate) fn update_incremental_accounts_hash(
+        &self,
+        base_slot: Slot,
+    ) -> IncrementalAccountsHash {
         let config = CalcAccountsHashConfig {
             use_bg_thread_pool: true,
             ancestors: None, // does not matter, will not be used
@@ -6864,7 +6873,10 @@ impl Bank {
 
     /// Intended for use by benches only.
     /// create new bank with the given config and paths.
-    pub(crate) fn new_with_paths_for_benches(genesis_config: &GenesisConfig, paths: Vec<PathBuf>) -> Self {
+    pub(crate) fn new_with_paths_for_benches(
+        genesis_config: &GenesisConfig,
+        paths: Vec<PathBuf>,
+    ) -> Self {
         Self::new_with_paths(
             genesis_config,
             Arc::<RuntimeConfig>::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6873,10 +6873,7 @@ impl Bank {
 
     /// Intended for use by benches only.
     /// create new bank with the given config and paths.
-    pub fn new_with_paths_for_benches(
-        genesis_config: &GenesisConfig,
-        paths: Vec<PathBuf>,
-    ) -> Self {
+    pub fn new_with_paths_for_benches(genesis_config: &GenesisConfig, paths: Vec<PathBuf>) -> Self {
         Self::new_with_paths(
             genesis_config,
             Arc::<RuntimeConfig>::default(),
@@ -7191,11 +7188,7 @@ impl Drop for Bank {
 #[cfg(any(test, feature = "dev-context-only-utils"))]
 pub mod test_utils {
     use {
-        super::Bank,
-        crate::installed_scheduler_pool::BankWithScheduler,
-        solana_sdk::{
-            hash::hashv,
-        },
+        super::Bank, crate::installed_scheduler_pool::BankWithScheduler, solana_sdk::hash::hashv,
         std::sync::Arc,
     };
     pub fn goto_end_of_slot(bank: Arc<Bank>) {
@@ -7221,7 +7214,8 @@ pub mod test_utils {
         vote_pubkey: &solana_sdk::pubkey::Pubkey,
     ) {
         let mut vote_account = bank.get_account(vote_pubkey).unwrap_or_default();
-        let mut vote_state = solana_vote_program::vote_state::from(&vote_account).unwrap_or_default();
+        let mut vote_state =
+            solana_vote_program::vote_state::from(&vote_account).unwrap_or_default();
         vote_state.last_timestamp = timestamp;
         let versioned = solana_vote_program::vote_state::VoteStateVersions::new_current(vote_state);
         solana_vote_program::vote_state::to(&versioned, &mut vote_account).unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2757,7 +2757,7 @@ impl Bank {
         });
     }
 
-    pub(crate) fn update_recent_blockhashes(&self) {
+    pub fn update_recent_blockhashes(&self) {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
         self.update_recent_blockhashes_locked(&blockhash_queue);
     }
@@ -6207,7 +6207,7 @@ impl Bank {
         !self.is_delta.load(Relaxed)
     }
 
-    pub(crate) fn add_mockup_builtin(
+    pub fn add_mockup_builtin(
         &mut self,
         program_id: Pubkey,
         builtin_function: BuiltinFunctionWithContext,
@@ -6873,7 +6873,7 @@ impl Bank {
 
     /// Intended for use by benches only.
     /// create new bank with the given config and paths.
-    pub(crate) fn new_with_paths_for_benches(
+    pub fn new_with_paths_for_benches(
         genesis_config: &GenesisConfig,
         paths: Vec<PathBuf>,
     ) -> Self {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6971,6 +6971,16 @@ impl Bank {
         )
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn get_transaction_processor(&self) -> &TransactionBatchProcessor<BankForks> {
+        &self.transaction_processor
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn set_fee_structure(&mut self, fee_structure: &FeeStructure) {
+        self.fee_structure = fee_structure.clone();
+    }
+
     pub fn load_program(
         &self,
         pubkey: &Pubkey,


### PR DESCRIPTION
#### Problem
bank.rs has some functions and methods that are pub but only used inside the runtime crate. It also has some pub fns that are not used in this repo at all. I am making an assumption that they are not used outside this repo


#### Summary of Changes
Demote some methods to pub(crate), and remove some others entirely