### PR TITLE
rename "throttle" to "rate-limiting" in the conext of rate limiting

### DIFF
--- a/streamer/src/nonblocking/connection_rate_limiter.rs
+++ b/streamer/src/nonblocking/connection_rate_limiter.rs
@@ -28,7 +28,7 @@ impl ConnectionRateLimiter {
         }
     }
 
-    /// retain only keys whose throttle start date is within the throttle interval.
+    /// retain only keys whose rate-limiting start date is within the rate-limiting interval.
     /// Otherwise drop them as inactive
     pub fn retain_recent(&self) {
         self.limiter.retain_recent()

--- a/streamer/src/nonblocking/keyed_rate_limiter.rs
+++ b/streamer/src/nonblocking/keyed_rate_limiter.rs
@@ -40,13 +40,12 @@ where
         allowed
     }
 
-    /// retain only keys whose throttle start date is within the throttle interval.
+    /// retain only keys whose rate-limiting start date is within the set up interval.
     /// Otherwise drop them as inactive
     pub fn retain_recent(&self) {
         let now = tokio::time::Instant::now();
-        self.limiters.retain(|_key, limiter| {
-            now.duration_since(*limiter.throttle_start_instant()) <= self.interval
-        });
+        self.limiters
+            .retain(|_key, limiter| now.duration_since(*limiter.start_instant()) <= self.interval);
     }
 
     /// Returns the number of "live" keys in the rate limiter.
@@ -79,7 +78,7 @@ pub mod test {
         assert!(!limiter.check_and_update(2));
         assert!(limiter.len() == 2);
 
-        // sleep 150 ms, the throttle parameters should have been reset.
+        // sleep 150 ms, the rate-limiting parameters should have been reset.
         sleep(Duration::from_millis(150)).await;
         assert!(limiter.len() == 2);
 

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -326,7 +326,7 @@ async fn run_server(
                     remote_address.ip()
                 );
                 stats
-                    .connection_throttled_across_all
+                    .connection_rate_limited_across_all
                     .fetch_add(1, Ordering::Relaxed);
                 continue;
             }
@@ -344,7 +344,7 @@ async fn run_server(
                     remote_address
                 );
                 stats
-                    .connection_throttled_per_ipaddr
+                    .connection_rate_limited_per_ipaddr
                     .fetch_add(1, Ordering::Relaxed);
                 continue;
             }

--- a/streamer/src/nonblocking/rate_limiter.rs
+++ b/streamer/src/nonblocking/rate_limiter.rs
@@ -5,28 +5,28 @@ pub struct RateLimiter {
     /// count of requests in an interval
     pub(crate) count: u64,
 
-    /// Throttle start time
-    throttle_start_instant: Instant,
+    /// Rate limit start time
+    start_instant: Instant,
     interval: Duration,
     limit: u64,
 }
 
 /// A naive rate limiter, to be replaced by using governor which has more even
-/// distribution of requests passing through using GCRA algroithm.
+/// distribution of requests passing through using GCRA algorithm.
 impl RateLimiter {
     pub fn new(limit: u64, interval: Duration) -> Self {
         Self {
             count: 0,
-            throttle_start_instant: Instant::now(),
+            start_instant: Instant::now(),
             interval,
             limit,
         }
     }
 
-    /// Reset the counter and throttling start instant if needed.
-    pub fn reset_throttling_params_if_needed(&mut self) {
-        if Instant::now().duration_since(self.throttle_start_instant) > self.interval {
-            self.throttle_start_instant = Instant::now();
+    /// Reset the counter and start instant if needed.
+    pub fn reset_params_if_needed(&mut self) {
+        if Instant::now().duration_since(self.start_instant) > self.interval {
+            self.start_instant = Instant::now();
             self.count = 0;
         }
     }
@@ -35,7 +35,7 @@ impl RateLimiter {
     /// When it is allowed, the rate limiter state is updated to reflect it has been
     /// allowed. For a unique request, the caller should call it only once when it is allowed.
     pub fn check_and_update(&mut self) -> bool {
-        self.reset_throttling_params_if_needed();
+        self.reset_params_if_needed();
         if self.count >= self.limit {
             return false;
         }
@@ -44,9 +44,9 @@ impl RateLimiter {
         true
     }
 
-    /// Return the start instant for the current throttle interval.
-    pub fn throttle_start_instant(&self) -> &Instant {
-        &self.throttle_start_instant
+    /// Return the start instant for the current rate-limiting interval.
+    pub fn start_instant(&self) -> &Instant {
+        &self.start_instant
     }
 }
 
@@ -60,15 +60,15 @@ pub mod test {
         assert!(limiter.check_and_update());
         assert!(limiter.check_and_update());
         assert!(!limiter.check_and_update());
-        let instant1 = *limiter.throttle_start_instant();
+        let instant1 = *limiter.start_instant();
 
-        // sleep 150 ms, the throttle parameters should have been reset.
+        // sleep 150 ms, the rate-limiting parameters should have been reset.
         sleep(Duration::from_millis(150)).await;
         assert!(limiter.check_and_update());
         assert!(limiter.check_and_update());
         assert!(!limiter.check_and_update());
 
-        let instant2 = *limiter.throttle_start_instant();
+        let instant2 = *limiter.start_instant();
         assert!(instant2 > instant1);
     }
 }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -178,8 +178,12 @@ pub struct StreamStats {
     pub(crate) connection_setup_error_locally_closed: AtomicUsize,
     pub(crate) connection_removed: AtomicUsize,
     pub(crate) connection_remove_failed: AtomicUsize,
-    pub(crate) connection_throttled_across_all: AtomicUsize,
-    pub(crate) connection_throttled_per_ipaddr: AtomicUsize,
+    // Number of connections to the endpoint exceeding the allowed limit
+    // regardless of the source IP address.
+    pub(crate) connection_rate_limited_across_all: AtomicUsize,
+    // Per IP rate-limiting is triggered each time when there are too many connections
+    // opened from a particular IP address.
+    pub(crate) connection_rate_limited_per_ipaddr: AtomicUsize,
     pub(crate) throttled_streams: AtomicUsize,
     pub(crate) stream_load_ema: AtomicUsize,
     pub(crate) stream_load_ema_overflow: AtomicUsize,
@@ -328,14 +332,14 @@ impl StreamStats {
                 i64
             ),
             (
-                "connection_throttled_across_all",
-                self.connection_throttled_across_all
+                "connection_rate_limited_across_all",
+                self.connection_rate_limited_across_all
                     .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
-                "connection_throttled_per_ipaddr",
-                self.connection_throttled_per_ipaddr
+                "connection_rate_limited_per_ipaddr",
+                self.connection_rate_limited_per_ipaddr
                     .swap(0, Ordering::Relaxed),
                 i64
             ),


### PR DESCRIPTION
#### Problem

Currently we use one term "throttle" for at least two different things:
* slow down stream processing withing the scope of connection
* rate-limit connections (both on the endpoint level and on the connection level)

#### Summary of Changes

Use term rate-limiting in the context of `RateLimiter` to avoid ambiguity in both metric names and in the code.