### PR TITLE
Feature - Infer account `executable` flag from owners

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -544,6 +544,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .get_current_instruction_context()
             .unwrap(),
         true, // copy_account_data
+        Some(invoke_context.program_cache_for_tx_batch),
     )
     .unwrap();
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -23,7 +23,7 @@ use {
         bpf_loader_deprecated,
         clock::Slot,
         epoch_schedule::EpochSchedule,
-        feature_set::FeatureSet,
+        feature_set::{infer_account_is_executable_flag, FeatureSet},
         hash::Hash,
         instruction::{AccountMeta, InstructionError},
         native_loader,
@@ -434,7 +434,11 @@ impl<'a> InvokeContext<'a> {
             })?;
         let borrowed_program_account = instruction_context
             .try_borrow_instruction_account(self.transaction_context, program_account_index)?;
-        if !borrowed_program_account.is_executable() {
+        if !self
+            .get_feature_set()
+            .is_active(&infer_account_is_executable_flag::id())
+            && !borrowed_program_account.is_executable()
+        {
             ic_msg!(self, "Account {} is not executable", callee_program_id);
             return Err(InstructionError::AccountNotExecutable);
         }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -434,6 +434,7 @@ impl<'a> InvokeContext<'a> {
             })?;
         let borrowed_program_account = instruction_context
             .try_borrow_instruction_account(self.transaction_context, program_account_index)?;
+        #[allow(deprecated)]
         if !self
             .get_feature_set()
             .is_active(&infer_account_is_executable_flag::id())

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -136,6 +136,7 @@ pub fn invoke_builtin_function(
             .transaction_context
             .get_current_instruction_context()?,
         true, // copy_account_data // There is no VM so direct mapping can not be implemented here
+        Some(invoke_context.program_cache_for_tx_batch),
     )?;
 
     // Deserialize data back into instruction params

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -4,6 +4,7 @@ extern crate test;
 
 use {
     solana_bpf_loader_program::serialization::serialize_parameters,
+    solana_program_runtime::loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments},
     solana_sdk::{
         account::{Account, AccountSharedData},
         bpf_loader, bpf_loader_deprecated,
@@ -125,8 +126,16 @@ fn bench_serialize_unaligned(bencher: &mut Bencher) {
     let instruction_context = transaction_context
         .get_current_instruction_context()
         .unwrap();
+    let program_cache_for_tx_batch =
+        ProgramCacheForTxBatch::new(0, ProgramRuntimeEnvironments::default(), None, 0);
     bencher.iter(|| {
-        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
+        let _ = serialize_parameters(
+            &transaction_context,
+            instruction_context,
+            false,
+            Some(&program_cache_for_tx_batch),
+        )
+        .unwrap();
     });
 }
 
@@ -136,8 +145,16 @@ fn bench_serialize_unaligned_copy_account_data(bencher: &mut Bencher) {
     let instruction_context = transaction_context
         .get_current_instruction_context()
         .unwrap();
+    let program_cache_for_tx_batch =
+        ProgramCacheForTxBatch::new(0, ProgramRuntimeEnvironments::default(), None, 0);
     bencher.iter(|| {
-        let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
+        let _ = serialize_parameters(
+            &transaction_context,
+            instruction_context,
+            true,
+            Some(&program_cache_for_tx_batch),
+        )
+        .unwrap();
     });
 }
 
@@ -147,9 +164,16 @@ fn bench_serialize_aligned(bencher: &mut Bencher) {
     let instruction_context = transaction_context
         .get_current_instruction_context()
         .unwrap();
-
+    let program_cache_for_tx_batch =
+        ProgramCacheForTxBatch::new(0, ProgramRuntimeEnvironments::default(), None, 0);
     bencher.iter(|| {
-        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
+        let _ = serialize_parameters(
+            &transaction_context,
+            instruction_context,
+            false,
+            Some(&program_cache_for_tx_batch),
+        )
+        .unwrap();
     });
 }
 
@@ -159,9 +183,16 @@ fn bench_serialize_aligned_copy_account_data(bencher: &mut Bencher) {
     let instruction_context = transaction_context
         .get_current_instruction_context()
         .unwrap();
-
+    let program_cache_for_tx_batch =
+        ProgramCacheForTxBatch::new(0, ProgramRuntimeEnvironments::default(), None, 0);
     bencher.iter(|| {
-        let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
+        let _ = serialize_parameters(
+            &transaction_context,
+            instruction_context,
+            true,
+            Some(&program_cache_for_tx_batch),
+        )
+        .unwrap();
     });
 }
 
@@ -171,8 +202,16 @@ fn bench_serialize_unaligned_max_accounts(bencher: &mut Bencher) {
     let instruction_context = transaction_context
         .get_current_instruction_context()
         .unwrap();
+    let program_cache_for_tx_batch =
+        ProgramCacheForTxBatch::new(0, ProgramRuntimeEnvironments::default(), None, 0);
     bencher.iter(|| {
-        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
+        let _ = serialize_parameters(
+            &transaction_context,
+            instruction_context,
+            false,
+            Some(&program_cache_for_tx_batch),
+        )
+        .unwrap();
     });
 }
 
@@ -182,8 +221,15 @@ fn bench_serialize_aligned_max_accounts(bencher: &mut Bencher) {
     let instruction_context = transaction_context
         .get_current_instruction_context()
         .unwrap();
-
+    let program_cache_for_tx_batch =
+        ProgramCacheForTxBatch::new(0, ProgramRuntimeEnvironments::default(), None, 0);
     bencher.iter(|| {
-        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
+        let _ = serialize_parameters(
+            &transaction_context,
+            instruction_context,
+            false,
+            Some(&program_cache_for_tx_batch),
+        )
+        .unwrap();
     });
 }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -431,6 +431,7 @@ pub fn process_instruction_inner(
     }
 
     // Program Invocation
+    #[allow(deprecated)]
     if !invoke_context
         .get_feature_set()
         .is_active(&infer_account_is_executable_flag::id())
@@ -723,6 +724,7 @@ fn process_loader_upgradeable_instruction(
 
             let program =
                 instruction_context.try_borrow_instruction_account(transaction_context, 1)?;
+            #[allow(deprecated)]
             if !invoke_context
                 .get_feature_set()
                 .is_active(&infer_account_is_executable_flag::id())
@@ -1471,6 +1473,7 @@ fn execute<'a, 'b: 'a>(
                             )?;
 
                             error = EbpfError::SyscallError(Box::new(
+                                #[allow(deprecated)]
                                 if !invoke_context
                                     .get_feature_set()
                                     .is_active(&infer_account_is_executable_flag::id())

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1367,6 +1367,7 @@ fn execute<'a, 'b: 'a>(
         invoke_context.transaction_context,
         instruction_context,
         !direct_mapping,
+        Some(invoke_context.program_cache_for_tx_batch),
     )?;
     serialize_time.stop();
 

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -193,6 +193,7 @@ impl<'a> Serializer<'a> {
                 .map(|entry| !matches!(entry.program, ProgramCacheEntryType::Closed))
                 .unwrap_or(false)
         } else {
+            #[allow(deprecated)]
             account.is_executable()
         }
     }

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -893,6 +893,7 @@ where
                 .map(|entry| !matches!(entry.program, ProgramCacheEntryType::Closed))
                 .unwrap_or(false)
         } else {
+            #[allow(deprecated)]
             callee_account.is_executable()
         };
         if is_executable {

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -258,6 +258,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .get_current_instruction_context()
             .unwrap(),
         !direct_mapping, // copy_account_data,
+        Some(invoke_context.program_cache_for_tx_batch),
     )
     .unwrap();
 
@@ -292,6 +293,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .get_current_instruction_context()
             .unwrap(),
         !direct_mapping, // copy_account_data
+        Some(invoke_context.program_cache_for_tx_batch),
     )
     .unwrap();
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -927,15 +927,15 @@ fn test_program_sbf_invoke_sanity() {
 
         do_invoke_failure_test_local(
             TEST_PPROGRAM_NOT_OWNED_BY_LOADER,
-            TransactionError::InstructionError(0, InstructionError::AccountNotExecutable),
-            &[],
+            TransactionError::InstructionError(0, InstructionError::UnsupportedProgramId),
+            &[argument_keypair.pubkey()],
             None,
         );
 
         do_invoke_failure_test_local(
             TEST_PPROGRAM_NOT_EXECUTABLE,
-            TransactionError::InstructionError(0, InstructionError::AccountNotExecutable),
-            &[],
+            TransactionError::InstructionError(0, InstructionError::InvalidAccountData),
+            &[unexecutable_program_keypair.pubkey()],
             None,
         );
 
@@ -4653,7 +4653,7 @@ fn test_deny_executable_write() {
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert_eq!(
             result.unwrap_err().unwrap(),
-            TransactionError::InstructionError(0, InstructionError::ExecutableDataModified)
+            TransactionError::InstructionError(0, InstructionError::ReadonlyDataModified)
         );
     }
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -841,6 +841,10 @@ pub mod ed25519_precompile_verify_strict {
     solana_sdk::declare_id!("ed9tNscbWLYBooxWA7FE2B5KHWs8A6sxfY8EzezEcoo");
 }
 
+pub mod infer_account_is_executable_flag {
+    solana_sdk::declare_id!("FfgtauHUWKeXTzjXkua9Px4tNGBFHKZ9WaigM5VbbzFx");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -1046,6 +1050,7 @@ lazy_static! {
         (verify_retransmitter_signature::id(), "Verify retransmitter signature #1840"),
         (move_stake_and_move_lamports_ixs::id(), "Enable MoveStake and MoveLamports stake program instructions #1610"),
         (ed25519_precompile_verify_strict::id(), "Use strict verification in ed25519 precompile SIMD-0152"),
+        (infer_account_is_executable_flag::id(), "Infer accounts is_executable flag from their owner #2034"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -757,6 +757,7 @@ impl<'a> BorrowedAccount<'a> {
             return Err(InstructionError::ModifiedProgramId);
         }
         // and only if the account is not executable
+        #[allow(deprecated)]
         if self.is_executable() {
             return Err(InstructionError::ModifiedProgramId);
         }
@@ -791,6 +792,7 @@ impl<'a> BorrowedAccount<'a> {
             return Err(InstructionError::ReadonlyLamportChange);
         }
         // The balance of executable accounts may not change
+        #[allow(deprecated)]
         if self.is_executable() {
             return Err(InstructionError::ExecutableLamportChange);
         }
@@ -1003,6 +1005,7 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Returns whether this account is executable (transaction wide)
     #[inline]
+    #[deprecated(since = "2.1.0", note = "Use `get_owner` instead")]
     pub fn is_executable(&self) -> bool {
         #[cfg(target_os = "solana")]
         {
@@ -1034,10 +1037,12 @@ impl<'a> BorrowedAccount<'a> {
             return Err(InstructionError::ExecutableModified);
         }
         // one can not clear the executable flag
+        #[allow(deprecated)]
         if self.is_executable() && !is_executable {
             return Err(InstructionError::ExecutableModified);
         }
         // don't touch the account if the executable flag does not change
+        #[allow(deprecated)]
         if self.is_executable() == is_executable {
             return Ok(());
         }
@@ -1091,6 +1096,7 @@ impl<'a> BorrowedAccount<'a> {
     #[cfg(not(target_os = "solana"))]
     pub fn can_data_be_changed(&self) -> Result<(), InstructionError> {
         // Only non-executable accounts data can be changed
+        #[allow(deprecated)]
         if self.is_executable() {
             return Err(InstructionError::ExecutableDataModified);
         }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -701,7 +701,15 @@ mod tests {
             instructions,
         );
 
-        let loaded_accounts = load_accounts_aux_test(tx, &accounts, &mut error_metrics);
+        let mut feature_set = FeatureSet::all_enabled();
+        feature_set.deactivate(&feature_set::infer_account_is_executable_flag::id());
+        let loaded_accounts = load_accounts_with_features_and_rent(
+            tx,
+            &accounts,
+            &RentCollector::default(),
+            &mut error_metrics,
+            &mut feature_set,
+        );
 
         assert_eq!(error_metrics.invalid_program_for_execution, 1);
         assert_eq!(loaded_accounts.len(), 1);

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -314,7 +314,9 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                 return Err(TransactionError::ProgramAccountNotFound);
             }
 
-            if !program_account.executable() {
+            if !feature_set.is_active(&feature_set::infer_account_is_executable_flag::id())
+                && !program_account.executable()
+            {
                 error_metrics.invalid_program_for_execution += 1;
                 return Err(TransactionError::InvalidProgramForExecution);
             }
@@ -334,7 +336,9 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                 let owner_index = accounts.len();
                 if let Some(owner_account) = callbacks.get_account_shared_data(owner_id) {
                     if !native_loader::check_id(owner_account.owner())
-                        || !owner_account.executable()
+                        || (!feature_set
+                            .is_active(&feature_set::infer_account_is_executable_flag::id())
+                            && !owner_account.executable())
                     {
                         error_metrics.invalid_program_for_execution += 1;
                         return Err(TransactionError::InvalidProgramForExecution);

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -37,7 +37,7 @@ use {
         account::{AccountSharedData, ReadableAccount, PROGRAM_OWNERS},
         clock::{Epoch, Slot},
         feature_set::{
-            include_loaded_accounts_data_size_in_fee_calculation,
+            include_loaded_accounts_data_size_in_fee_calculation, infer_account_is_executable_flag,
             remove_rounding_in_fee_calculation, FeatureSet,
         },
         fee::{FeeBudgetLimits, FeeStructure},
@@ -743,6 +743,11 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             rent.clone(),
             compute_budget.max_instruction_stack_depth,
             compute_budget.max_instruction_trace_length,
+        );
+        transaction_context.set_infer_account_is_executable_flag(
+            environment
+                .feature_set
+                .is_active(&infer_account_is_executable_flag::id()),
         );
         #[cfg(debug_assertions)]
         transaction_context.set_signature(tx.signature());


### PR DESCRIPTION
#### Problem
The `executable` flag was originally meant to mark finalized programs as read-only. However, with the introduction of the upgradeable loader (loader-v3) this mechanism was circumvented. The workaround in the upgradeable loader is to use a proxy account that gets marked as executable (thus read-only) and which in turn points to the actual program-data account (which is not marked as executable and can be written to).

Hence, the `executable` flag is useless and gets in the way. It perpetuates the workaround with the proxy account, which in turn complicates transaction account loading, program loading, the program runtime and even CPI for dApp devs. To solve this loader-v4 was designed without the need for a proxy account by ignoring the `executable` flag. In fact the entire program runtime can ignore the `executable` flag, instead relying on the owner field and content of program accounts.

#### Summary of Changes
- Adds `Serializer::infer_is_executable()` as the VM needs to continue to emulate it (in serialization) to stay ABI compatible
- Adds the feature
- Adds the feature gate logic, which disables all `executable` flag related errors
- Adds deprecation attributes
- Adjusts tests