### PR TITLE
Refactors summing the number of entries when saving a cache hash data file

### DIFF
--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -332,11 +332,7 @@ impl CacheHashData {
         let _ignored = remove_file(&cache_path);
         let cell_size = std::mem::size_of::<EntryType>() as u64;
         let mut m1 = Measure::start("create save");
-        let entries = data
-            .iter()
-            .map(|x: &Vec<EntryType>| x.len())
-            .collect::<Vec<_>>();
-        let entries = entries.iter().sum::<usize>();
+        let entries = data.iter().map(Vec::len).sum::<usize>();
         let capacity = cell_size * (entries as u64) + std::mem::size_of::<Header>() as u64;
 
         let mmap = CacheHashDataFile::new_map(&cache_path, capacity)?;


### PR DESCRIPTION
#### Problem

When writing a cache hash data file, we write the number of entries into the header. To compute the number of entries, we iterate the binned hash data and sum the vector lengths. This is currently done in two steps, with the intermediate one creating a vector of the inner-vector lengths. This intermediate step can be bypassed entirely.


#### Summary of Changes

Simplify.