### PR TITLE
Updates static assert of cache hash data Header size

### DIFF
--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -31,9 +31,11 @@ pub struct Header {
 // In order to safely guarantee Header is Pod, it cannot have any padding
 // This is obvious by inspection, but this will also catch any inadvertent
 // changes in the future (i.e. it is a test).
+// Additionally, we compare the header size with `u64` instead of `usize`
+// to ensure binary compatibility doesn't break.
 const _: () = assert!(
-    std::mem::size_of::<Header>() == std::mem::size_of::<usize>(),
-    "Header cannot have any padding"
+    std::mem::size_of::<Header>() == std::mem::size_of::<u64>(),
+    "Header cannot have any padding and must be the same size as u64",
 );
 
 /// cache hash data file to be mmapped later


### PR DESCRIPTION
#### Problem

The account hash cache data file contains a header with the number of entries in the file. The count itself is a usize. Since we are writing this to disk, we annotate the struct with `repr(C)`, but `usize` does not have a fixed binary size. If somehow we tried to mix a 32-bit and 64-bit system, the header's count would be interpreted wrong.


#### Summary of Changes

Add a static assert that the size of the header is 8 bytes.

This is an easy fix to ensure binary compatibility is not broken, and doesn't require refactoring types more broadly (which can still be done in a subsequent PR).