### PR TITLE
Deprecate DecodeError

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -23,7 +23,6 @@ use {
     solana_sdk::{
         clock::{Epoch, Slot},
         commitment_config::CommitmentConfig,
-        decode_error::DecodeError,
         hash::Hash,
         instruction::InstructionError,
         offchain_message::OffchainMessage,
@@ -1732,10 +1731,10 @@ pub fn request_and_confirm_airdrop(
 
 pub fn common_error_adapter<E>(ix_error: &InstructionError) -> Option<E>
 where
-    E: 'static + std::error::Error + DecodeError<E> + FromPrimitive,
+    E: 'static + std::error::Error + FromPrimitive,
 {
     if let InstructionError::Custom(code) = ix_error {
-        E::decode_custom_error_to_enum(*code)
+        E::from_u32(*code)
     } else {
         None
     }
@@ -1746,7 +1745,7 @@ pub fn log_instruction_custom_error<E>(
     config: &CliConfig,
 ) -> ProcessResult
 where
-    E: 'static + std::error::Error + DecodeError<E> + FromPrimitive,
+    E: 'static + std::error::Error + FromPrimitive,
 {
     log_instruction_custom_error_ex::<E, _>(result, &config.output_format, common_error_adapter)
 }
@@ -1757,7 +1756,7 @@ pub fn log_instruction_custom_error_ex<E, F>(
     error_adapter: F,
 ) -> ProcessResult
 where
-    E: 'static + std::error::Error + DecodeError<E> + FromPrimitive,
+    E: 'static + std::error::Error + FromPrimitive,
     F: Fn(&InstructionError) -> Option<E>,
 {
     match result {

--- a/programs/sbf/rust/error_handling/src/lib.rs
+++ b/programs/sbf/rust/error_handling/src/lib.rs
@@ -6,7 +6,6 @@ use {
     num_traits::FromPrimitive,
     solana_program::{
         account_info::AccountInfo,
-        decode_error::DecodeError,
         entrypoint::ProgramResult,
         msg,
         program_error::{PrintProgramError, ProgramError},
@@ -28,15 +27,10 @@ impl From<MyError> for ProgramError {
         ProgramError::Custom(e as u32)
     }
 }
-impl<T> DecodeError<T> for MyError {
-    fn type_of() -> &'static str {
-        "MyError"
-    }
-}
 impl PrintProgramError for MyError {
     fn print<E>(&self)
     where
-        E: 'static + std::error::Error + DecodeError<E> + PrintProgramError + FromPrimitive,
+        E: 'static + std::error::Error + PrintProgramError + FromPrimitive,
     {
         match self {
             MyError::DefaultEnumStart => msg!("Error: Default enum start"),

--- a/sdk/program/src/decode_error.rs
+++ b/sdk/program/src/decode_error.rs
@@ -1,3 +1,7 @@
+#![deprecated(
+    since = "2.1.0",
+    note = "The DecodeError trait has been replaced by simply using num_traits::FromPrimitive directly."
+)]
 //! Converting custom error codes to enums.
 
 use num_traits::FromPrimitive;

--- a/sdk/program/src/program_error.rs
+++ b/sdk/program/src/program_error.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "borsh")]
 use borsh::io::Error as BorshIoError;
 use {
-    crate::{decode_error::DecodeError, instruction::InstructionError, msg, pubkey::PubkeyError},
+    crate::{instruction::InstructionError, msg, pubkey::PubkeyError},
     num_traits::{FromPrimitive, ToPrimitive},
     std::convert::TryFrom,
     thiserror::Error,
@@ -73,17 +73,17 @@ pub enum ProgramError {
 pub trait PrintProgramError {
     fn print<E>(&self)
     where
-        E: 'static + std::error::Error + DecodeError<E> + PrintProgramError + FromPrimitive;
+        E: 'static + std::error::Error + PrintProgramError + FromPrimitive;
 }
 
 impl PrintProgramError for ProgramError {
     fn print<E>(&self)
     where
-        E: 'static + std::error::Error + DecodeError<E> + PrintProgramError + FromPrimitive,
+        E: 'static + std::error::Error + PrintProgramError + FromPrimitive,
     {
         match self {
             Self::Custom(error) => {
-                if let Some(custom_error) = E::decode_custom_error_to_enum(*error) {
+                if let Some(custom_error) = E::from_u32(*error) {
                     custom_error.print::<E>();
                 } else {
                     msg!("Error: Unknown");

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -9,7 +9,7 @@ use arbitrary::Arbitrary;
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use {
-    crate::{decode_error::DecodeError, hash::hashv},
+    crate::hash::hash,
     bytemuck_derive::{Pod, Zeroable},
     num_derive::{FromPrimitive, ToPrimitive},
     std::{
@@ -40,11 +40,6 @@ pub enum PubkeyError {
     InvalidSeeds,
     #[error("Provided owner is not allowed")]
     IllegalOwner,
-}
-impl<T> DecodeError<T> for PubkeyError {
-    fn type_of() -> &'static str {
-        "PubkeyError"
-    }
 }
 impl From<u64> for PubkeyError {
     fn from(error: u64) -> Self {
@@ -108,12 +103,6 @@ pub enum ParsePubkeyError {
 impl From<Infallible> for ParsePubkeyError {
     fn from(_: Infallible) -> Self {
         unreachable!("Infallible uninhabited");
-    }
-}
-
-impl<T> DecodeError<T> for ParsePubkeyError {
-    fn type_of() -> &'static str {
-        "ParsePubkeyError"
     }
 }
 

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -9,7 +9,7 @@ use arbitrary::Arbitrary;
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use {
-    crate::hash::hash,
+    crate::hash::hashv,
     bytemuck_derive::{Pod, Zeroable},
     num_derive::{FromPrimitive, ToPrimitive},
     std::{

--- a/sdk/program/src/stake/instruction.rs
+++ b/sdk/program/src/stake/instruction.rs
@@ -3,7 +3,6 @@ use crate::stake::config;
 use {
     crate::{
         clock::{Epoch, UnixTimestamp},
-        decode_error::DecodeError,
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,
         pubkey::Pubkey,
@@ -83,12 +82,6 @@ pub enum StakeError {
 impl From<StakeError> for ProgramError {
     fn from(e: StakeError) -> Self {
         ProgramError::Custom(e as u32)
-    }
-}
-
-impl<E> DecodeError<E> for StakeError {
-    fn type_of() -> &'static str {
-        "StakeError"
     }
 }
 
@@ -926,10 +919,10 @@ mod tests {
         use num_traits::FromPrimitive;
         fn pretty_err<T>(err: InstructionError) -> String
         where
-            T: 'static + std::error::Error + DecodeError<T> + FromPrimitive,
+            T: 'static + std::error::Error + FromPrimitive,
         {
             if let InstructionError::Custom(code) = err {
-                let specific_error: T = T::decode_custom_error_to_enum(code).unwrap();
+                let specific_error: T = T::from_u32(code).unwrap();
                 format!(
                     "{:?}: {}::{:?} - {}",
                     err,

--- a/sdk/program/src/system_instruction.rs
+++ b/sdk/program/src/system_instruction.rs
@@ -42,7 +42,6 @@
 #[allow(deprecated)]
 use {
     crate::{
-        decode_error::DecodeError,
         instruction::{AccountMeta, Instruction},
         nonce,
         pubkey::Pubkey,
@@ -73,12 +72,6 @@ pub enum SystemError {
     NonceBlockhashNotExpired,
     #[error("specified nonce does not match stored nonce")]
     NonceUnexpectedBlockhashValue,
-}
-
-impl<T> DecodeError<T> for SystemError {
-    fn type_of() -> &'static str {
-        "SystemError"
-    }
 }
 
 /// Maximum permitted size of account data (10 MiB).

--- a/sdk/program/src/vote/error.rs
+++ b/sdk/program/src/vote/error.rs
@@ -1,7 +1,6 @@
 //! Vote program errors
 
 use {
-    crate::decode_error::DecodeError,
     num_derive::{FromPrimitive, ToPrimitive},
     thiserror::Error,
 };
@@ -74,12 +73,6 @@ pub enum VoteError {
     AssertionFailed,
 }
 
-impl<E> DecodeError<E> for VoteError {
-    fn type_of() -> &'static str {
-        "VoteError"
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use {super::*, crate::instruction::InstructionError};
@@ -89,10 +82,10 @@ mod tests {
         use num_traits::FromPrimitive;
         fn pretty_err<T>(err: InstructionError) -> String
         where
-            T: 'static + std::error::Error + DecodeError<T> + FromPrimitive,
+            T: 'static + std::error::Error + FromPrimitive,
         {
             if let InstructionError::Custom(code) = err {
-                let specific_error: T = T::decode_custom_error_to_enum(code).unwrap();
+                let specific_error: T = T::from_u32(code).unwrap();
                 format!(
                     "{:?}: {}::{:?} - {}",
                     err,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -39,19 +39,15 @@ extern crate self as solana_sdk;
 pub use signer::signers;
 #[cfg(not(target_os = "solana"))]
 pub use solana_program::program_stubs;
-// These solana_program imports could be *-imported, but that causes a bunch of
-// confusing duplication in the docs due to a rustdoc bug. #26211
-#[allow(deprecated)]
-pub use solana_program::{decode_error, sdk_ids};
 #[cfg(target_arch = "wasm32")]
 pub use solana_program::wasm_bindgen;
 pub use solana_program::{
     account_info, address_lookup_table, alt_bn128, big_mod_exp, blake3, bpf_loader,
     bpf_loader_deprecated, bpf_loader_upgradeable, clock, config, custom_heap_default,
     custom_panic_default, debug_account_data, declare_deprecated_sysvar_id, declare_sysvar_id,
-    ed25519_program, epoch_rewards, epoch_schedule, fee_calculator, impl_sysvar_get,
-    incinerator, instruction, keccak, lamports, loader_instruction, loader_upgradeable_instruction,
-    loader_v4, loader_v4_instruction, message, msg, native_token, nonce, program, program_error,
+    ed25519_program, epoch_rewards, epoch_schedule, fee_calculator, impl_sysvar_get, incinerator,
+    instruction, keccak, lamports, loader_instruction, loader_upgradeable_instruction, loader_v4,
+    loader_v4_instruction, message, msg, native_token, nonce, program, program_error,
     program_memory, program_option, program_pack, rent, secp256k1_program, secp256k1_recover,
     serde_varint, serialize_utils, short_vec, slot_hashes, slot_history, stable_layout, stake,
     stake_history, syscalls, system_instruction, system_program, sysvar, unchecked_div_by_const,
@@ -59,6 +55,10 @@ pub use solana_program::{
 };
 #[cfg(feature = "borsh")]
 pub use solana_program::{borsh, borsh0_10, borsh1};
+// These solana_program imports could be *-imported, but that causes a bunch of
+// confusing duplication in the docs due to a rustdoc bug. #26211
+#[allow(deprecated)]
+pub use solana_program::{decode_error, sdk_ids};
 
 pub mod account;
 pub mod account_utils;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -42,14 +42,14 @@ pub use solana_program::program_stubs;
 // These solana_program imports could be *-imported, but that causes a bunch of
 // confusing duplication in the docs due to a rustdoc bug. #26211
 #[allow(deprecated)]
-pub use solana_program::sdk_ids;
+pub use solana_program::{decode_error, sdk_ids};
 #[cfg(target_arch = "wasm32")]
 pub use solana_program::wasm_bindgen;
 pub use solana_program::{
     account_info, address_lookup_table, alt_bn128, big_mod_exp, blake3, bpf_loader,
     bpf_loader_deprecated, bpf_loader_upgradeable, clock, config, custom_heap_default,
     custom_panic_default, debug_account_data, declare_deprecated_sysvar_id, declare_sysvar_id,
-    decode_error, ed25519_program, epoch_rewards, epoch_schedule, fee_calculator, impl_sysvar_get,
+    ed25519_program, epoch_rewards, epoch_schedule, fee_calculator, impl_sysvar_get,
     incinerator, instruction, keccak, lamports, loader_instruction, loader_upgradeable_instruction,
     loader_v4, loader_v4_instruction, message, msg, native_token, nonce, program, program_error,
     program_memory, program_option, program_pack, rent, secp256k1_program, secp256k1_recover,

--- a/sdk/src/precompiles.rs
+++ b/sdk/src/precompiles.rs
@@ -3,10 +3,7 @@
 #![cfg(feature = "full")]
 
 use {
-    crate::{
-        feature_set::FeatureSet, instruction::CompiledInstruction,
-        pubkey::Pubkey,
-    },
+    crate::{feature_set::FeatureSet, instruction::CompiledInstruction, pubkey::Pubkey},
     lazy_static::lazy_static,
     thiserror::Error,
 };

--- a/sdk/src/precompiles.rs
+++ b/sdk/src/precompiles.rs
@@ -4,7 +4,7 @@
 
 use {
     crate::{
-        decode_error::DecodeError, feature_set::FeatureSet, instruction::CompiledInstruction,
+        feature_set::FeatureSet, instruction::CompiledInstruction,
         pubkey::Pubkey,
     },
     lazy_static::lazy_static,
@@ -24,11 +24,6 @@ pub enum PrecompileError {
     InvalidDataOffsets,
     #[error("instruction is incorrect size")]
     InvalidInstructionDataSize,
-}
-impl<T> DecodeError<T> for PrecompileError {
-    fn type_of() -> &'static str {
-        "PrecompileError"
-    }
 }
 
 /// All precompiled programs must implement the `Verify` function


### PR DESCRIPTION
#### Problem
DecodeError is just a useless wrapper around `num_traits::FromPrimitive` since the `type_of()` method isn't used

#### Summary of Changes
- Deprecate it and don't implement it for anything in the repo
- Remove it as a constraint from PrintProgramError
