### PR TITLE
[zk-sdk] Keep ProofType consistent with ProofInstruction

### DIFF
--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/mod.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/mod.rs
@@ -57,8 +57,8 @@ pub enum ProofType {
     BatchedRangeProofU128,
     BatchedRangeProofU256,
     GroupedCiphertext2HandlesValidity,
-    GroupedCiphertext3HandlesValidity,
     BatchedGroupedCiphertext2HandlesValidity,
+    GroupedCiphertext3HandlesValidity,
     BatchedGroupedCiphertext3HandlesValidity,
 }
 


### PR DESCRIPTION
#### Problem

ProofType and ProofInstruction have 2 values swapped (`0x0a`, `0x0b`).

#### Summary of Changes

Simply align the values. Note that this has never been activated, so we don't need feature gates.