### PR TITLE
Remove deprecated Memcmp filter symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7090,6 +7090,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bs58",
+ "const_format",
  "jsonrpc-core",
  "reqwest",
  "reqwest-middleware",

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -28,6 +28,7 @@ solana-version = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+const_format = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -135,18 +135,10 @@ pub enum MemcmpEncodedBytes {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Memcmp {
     /// Data offset to begin match
-    #[deprecated(
-        since = "1.15.0",
-        note = "Field will be made private in future. Please use a constructor method instead."
-    )]
-    pub offset: usize,
+    offset: usize,
     /// Bytes, encoded with specified encoding, or default Binary
-    #[deprecated(
-        since = "1.15.0",
-        note = "Field will be made private in future. Please use a constructor method instead."
-    )]
     #[serde(flatten)]
-    pub bytes: MemcmpEncodedBytes,
+    bytes: MemcmpEncodedBytes,
     /// Optional encoding specification
     #[deprecated(
         since = "1.11.2",

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -332,20 +332,12 @@ mod tests {
             Memcmp {
                 offset: OFFSET,
                 bytes: MemcmpEncodedBytes::Base58(BASE58_STR.to_string()),
-                encoding: None,
             }
         );
 
-        // Binary input is deserialized as Base58
-        let binary: Memcmp = serde_json::from_str(BINARY_FILTER).unwrap();
-        assert_eq!(
-            binary,
-            Memcmp {
-                offset: OFFSET,
-                bytes: MemcmpEncodedBytes::Base58(BASE58_STR.to_string()),
-                encoding: None,
-            }
-        );
+        // Binary input is no longer supported
+        let binary = serde_json::from_str::<Memcmp>(BINARY_FILTER);
+        assert!(binary.is_err());
 
         // Base58 input
         let base58_filter: Memcmp = serde_json::from_str(BASE58_FILTER).unwrap();
@@ -354,7 +346,6 @@ mod tests {
             Memcmp {
                 offset: OFFSET,
                 bytes: MemcmpEncodedBytes::Base58(BASE58_STR.to_string()),
-                encoding: None,
             }
         );
 
@@ -365,7 +356,6 @@ mod tests {
             Memcmp {
                 offset: OFFSET,
                 bytes: MemcmpEncodedBytes::Base64(BASE64_STR.to_string()),
-                encoding: None,
             }
         );
 
@@ -376,7 +366,6 @@ mod tests {
             Memcmp {
                 offset: OFFSET,
                 bytes: MemcmpEncodedBytes::Bytes(BYTES.to_vec()),
-                encoding: None,
             }
         );
 
@@ -386,74 +375,16 @@ mod tests {
             Memcmp {
                 offset: OFFSET,
                 bytes: MemcmpEncodedBytes::Bytes(BYTES.to_vec()),
-                encoding: None,
             }
         );
     }
 
     #[test]
     fn test_filter_serialize() {
-        // Binary variants
-        let binary_default = Memcmp {
-            offset: OFFSET,
-            bytes: MemcmpEncodedBytes::Binary(BASE58_STR.to_string()),
-            encoding: None,
-        };
-        let serialized_json = json!(binary_default);
-        assert_eq!(
-            serialized_json,
-            serde_json::from_str::<Value>(BINARY_FILTER).unwrap()
-        );
-
-        let binary_default = Memcmp {
-            offset: OFFSET,
-            bytes: MemcmpEncodedBytes::Binary(BASE58_STR.to_string()),
-            encoding: Some(MemcmpEncoding::Binary),
-        };
-        let serialized_json = json!(binary_default);
-        assert_eq!(
-            serialized_json,
-            serde_json::from_str::<Value>(BINARY_FILTER).unwrap()
-        );
-
-        let binary_base58 = Memcmp {
-            offset: OFFSET,
-            bytes: MemcmpEncodedBytes::Base58(BASE58_STR.to_string()),
-            encoding: Some(MemcmpEncoding::Binary),
-        };
-        let serialized_json = json!(binary_base58);
-        assert_eq!(
-            serialized_json,
-            serde_json::from_str::<Value>(BASE58_FILTER).unwrap()
-        );
-
-        let binary_base64 = Memcmp {
-            offset: OFFSET,
-            bytes: MemcmpEncodedBytes::Base64(BASE64_STR.to_string()),
-            encoding: Some(MemcmpEncoding::Binary),
-        };
-        let serialized_json = json!(binary_base64);
-        assert_eq!(
-            serialized_json,
-            serde_json::from_str::<Value>(BASE64_FILTER).unwrap()
-        );
-
-        let binary_bytes = Memcmp {
-            offset: OFFSET,
-            bytes: MemcmpEncodedBytes::Bytes(BYTES.to_vec()),
-            encoding: Some(MemcmpEncoding::Binary),
-        };
-        let serialized_json = json!(binary_bytes);
-        assert_eq!(
-            serialized_json,
-            serde_json::from_str::<Value>(BYTES_FILTER).unwrap()
-        );
-
         // Base58
         let base58 = Memcmp {
             offset: OFFSET,
             bytes: MemcmpEncodedBytes::Base58(BASE58_STR.to_string()),
-            encoding: None,
         };
         let serialized_json = json!(base58);
         assert_eq!(
@@ -465,7 +396,6 @@ mod tests {
         let base64 = Memcmp {
             offset: OFFSET,
             bytes: MemcmpEncodedBytes::Base64(BASE64_STR.to_string()),
-            encoding: None,
         };
         let serialized_json = json!(base64);
         assert_eq!(
@@ -477,12 +407,11 @@ mod tests {
         let bytes = Memcmp {
             offset: OFFSET,
             bytes: MemcmpEncodedBytes::Bytes(BYTES.to_vec()),
-            encoding: None,
         };
         let serialized_json = json!(bytes);
         assert_eq!(
             serialized_json,
-            serde_json::from_str::<Value>(BYTES_FILTER).unwrap()
+            serde_json::from_str::<Value>(BYTES_FILTER_WITH_ENCODING).unwrap()
         );
     }
 }

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -1,5 +1,5 @@
-#![allow(deprecated)]
 use {
+    base64::{prelude::BASE64_STANDARD, Engine},
     serde::Deserialize,
     solana_inline_spl::{token::GenericTokenAccount, token_2022::Account},
     solana_sdk::account::{AccountSharedData, ReadableAccount},
@@ -41,7 +41,7 @@ impl RpcFilterType {
                         if bytes.len() > MAX_DATA_BASE64_SIZE {
                             return Err(RpcFilterError::DataTooLarge);
                         }
-                        let bytes = base64::decode(bytes)?;
+                        let bytes = BASE64_STANDARD.decode(bytes)?;
                         if bytes.len() > MAX_DATA_SIZE {
                             Err(RpcFilterError::DataTooLarge)
                         } else {
@@ -171,7 +171,7 @@ impl Memcmp {
         use MemcmpEncodedBytes::*;
         match &self.bytes {
             Base58(bytes) => bs58::decode(bytes).into_vec().ok().map(Cow::Owned),
-            Base64(bytes) => base64::decode(bytes).ok().map(Cow::Owned),
+            Base64(bytes) => BASE64_STANDARD.decode(bytes).ok().map(Cow::Owned),
             Bytes(bytes) => Some(Cow::Borrowed(bytes)),
         }
     }
@@ -185,7 +185,7 @@ impl Memcmp {
                 Ok(())
             }
             Base64(bytes) => {
-                let bytes = base64::decode(bytes)?;
+                let bytes = BASE64_STANDARD.decode(bytes)?;
                 self.bytes = Bytes(bytes);
                 Ok(())
             }
@@ -234,7 +234,7 @@ mod tests {
         let ff_data = vec![0xffu8; MAX_DATA_SIZE];
         let data58 = bs58::encode(&ff_data).into_string();
         assert_eq!(data58.len(), MAX_DATA_BASE58_SIZE);
-        let data64 = base64::encode(&ff_data);
+        let data64 = BASE64_STANDARD.encode(&ff_data);
         assert_eq!(data64.len(), MAX_DATA_BASE64_SIZE);
     }
 

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -163,6 +163,10 @@ impl Memcmp {
         }
     }
 
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
     pub fn bytes(&self) -> Option<Cow<Vec<u8>>> {
         use MemcmpEncodedBytes::*;
         match &self.bytes {
@@ -201,6 +205,18 @@ impl Memcmp {
                 data[self.offset..self.offset + bytes.len()] == bytes[..]
             }
             None => false,
+        }
+    }
+
+    /// Returns reference to bytes if variant is MemcmpEncodedBytes::Bytes;
+    /// otherwise returns None. Used exclusively by solana-rpc to check
+    /// SPL-token filters.
+    pub fn raw_bytes_as_ref(&self) -> Option<&[u8]> {
+        use MemcmpEncodedBytes::*;
+        if let Bytes(bytes) = &self.bytes {
+            Some(bytes)
+        } else {
+            None
         }
     }
 }

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -76,18 +76,6 @@ impl RpcFilterType {
 pub enum RpcFilterError {
     #[error("encoded binary data should be less than 129 bytes")]
     DataTooLarge,
-    #[deprecated(
-        since = "1.8.1",
-        note = "Error for MemcmpEncodedBytes::Binary which is deprecated"
-    )]
-    #[error("encoded binary (base 58) data should be less than 129 bytes")]
-    Base58DataTooLarge,
-    #[deprecated(
-        since = "1.8.1",
-        note = "Error for MemcmpEncodedBytes::Binary which is deprecated"
-    )]
-    #[error("bs58 decode error")]
-    DecodeError(bs58::decode::Error),
     #[error("base58 decode error")]
     Base58DecodeError(#[from] bs58::decode::Error),
     #[error("base64 decode error")]


### PR DESCRIPTION
#### Problem
Deprecated symbols persist in `solana_rpc_client_api::filter`.

#### Summary of Changes
Unpub or remove deprecated Memcmp fields
Remove MemcmpEncodedBytes variant and support for it
Remove custom serialization
Remove deprecated error variants

✅  ~Needs rebase on https://github.com/anza-xyz/agave/pull/2045, only because `maybe_map_filters` depends on the removed MemcmpEncodedBytes variant. Otherwise, they are not dependent.~
