### PR TITLE
local-cluster: ignore flaky test_duplicate_with_pruned_ancestor

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -4614,6 +4614,7 @@ fn test_slot_hash_expiry() {
 //
 #[test]
 #[serial]
+#[ignore]
 fn test_duplicate_with_pruned_ancestor() {
     solana_logger::setup_with("info,solana_metrics=off");
     solana_core::repair::duplicate_repair_status::set_ancestor_hash_repair_sample_size_for_tests_only(3);


### PR DESCRIPTION
#### Problem
With the recent detection changes, this test cannot reliably setup the necessary conditions.

#### Summary of Changes
Ignore until we can overhaul the test. 

Fixes #1287 
