### PR TITLE
remove redundant timeout metric

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2269,9 +2269,6 @@ impl ClusterInfo {
         self.stats.process_pull_response_count.add_relaxed(1);
         self.stats.process_pull_response_len.add_relaxed(len as u64);
         self.stats
-            .process_pull_response_timeout
-            .add_relaxed(pull_stats.timeout_count as u64);
-        self.stats
             .process_pull_response_fail_insert
             .add_relaxed(pull_stats.failed_insert as u64);
         self.stats
@@ -2283,7 +2280,7 @@ impl ClusterInfo {
 
         (
             pull_stats.failed_insert + pull_stats.failed_timeout,
-            pull_stats.timeout_count,
+            pull_stats.failed_timeout,
             pull_stats.success,
         )
     }

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -153,7 +153,6 @@ pub struct GossipStats {
     pub(crate) process_pull_response_fail_timeout: Counter,
     pub(crate) process_pull_response_len: Counter,
     pub(crate) process_pull_response_success: Counter,
-    pub(crate) process_pull_response_timeout: Counter,
     pub(crate) process_push_message: Counter,
     pub(crate) prune_message_count: Counter,
     pub(crate) prune_message_len: Counter,
@@ -309,11 +308,6 @@ pub(crate) fn submit_gossip_stats(
         (
             "pull_response_success",
             stats.process_pull_response_success.clear(),
-            i64
-        ),
-        (
-            "process_pull_resp_timeout",
-            stats.process_pull_response_timeout.clear(),
             i64
         ),
         (

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -200,7 +200,6 @@ pub struct ProcessPullStats {
     pub success: usize,
     pub failed_insert: usize,
     pub failed_timeout: usize,
-    pub timeout_count: usize,
 }
 
 pub struct CrdsGossipPull {
@@ -354,7 +353,6 @@ impl CrdsGossipPull {
                 expired_values.push(response);
                 None
             } else {
-                stats.timeout_count += 1;
                 stats.failed_timeout += 1;
                 Some(response)
             }
@@ -564,7 +562,7 @@ impl CrdsGossipPull {
         );
         (
             stats.failed_timeout + stats.failed_insert,
-            stats.timeout_count,
+            stats.failed_timeout,
             stats.success,
         )
     }


### PR DESCRIPTION
#### Problem
We have two metrics measuring failed inserts for CrdsValues received via PullResponse.
1) `process_pull_response_timeout`
2) `process_pull_response_fail_timeout`

Both track old CrdsValues that have timed out. 

#### Summary of Changes
Removed `process_pull_response_timeout`. I thought `process_pull_response_fail_timeout` was a little more descriptive so kept that.
