### PR TITLE
Make a loop instead of using filter

### DIFF
--- a/core/src/banking_stage/latest_unprocessed_votes.rs
+++ b/core/src/banking_stage/latest_unprocessed_votes.rs
@@ -275,39 +275,41 @@ impl LatestUnprocessedVotes {
         forward_packet_batches_by_accounts: &mut ForwardPacketBatchesByAccounts,
     ) -> usize {
         let binding = self.latest_votes_per_pubkey.read().unwrap();
-        let pubkeys_by_stake = weighted_random_order_by_stake(
-            &bank,
-            binding.keys(),
-        );
+        let pubkeys_by_stake = weighted_random_order_by_stake(&bank, binding.keys());
         let mut count: usize = 0;
         for pubkey in pubkeys_by_stake {
-            if let Some(lock) = self.get_entry(pubkey) {
-                let mut vote = lock.write().unwrap();
-                if !vote.is_vote_taken() && !vote.is_forwarded() {
-                    let deserialized_vote_packet = vote.vote.as_ref().unwrap().clone();
-                    if let Some(sanitized_vote_transaction) = deserialized_vote_packet
-                        .build_sanitized_transaction(
-                            bank.vote_only_bank(),
-                            bank.as_ref(),
-                            bank.get_reserved_account_keys(),
-                        )
-                    {
-                        if forward_packet_batches_by_accounts.try_add_packet(
-                            &sanitized_vote_transaction,
-                            deserialized_vote_packet,
-                            &bank.feature_set,
-                        ) {
-                            vote.forwarded = true;
-                        } else {
-                            // To match behavior of regular transactions we stop
-                            // forwarding votes as soon as one fails. We are
-                            // assuming that failure (try_add_packet) means no more space available.
-                            break;
-                        }
-                        count += 1;
-                    }
-                }
+            let Some(lock) = self.get_entry(pubkey) else {
+                continue;
+            };
+            let mut vote = lock.write().unwrap();
+            if vote.is_vote_taken() || vote.is_forwarded() {
+                continue;
             }
+
+            let deserialized_vote_packet = vote.vote.as_ref().unwrap().clone();
+            let Some(sanitized_vote_transaction) = deserialized_vote_packet
+                .build_sanitized_transaction(
+                    bank.vote_only_bank(),
+                    bank.as_ref(),
+                    bank.get_reserved_account_keys(),
+                )
+            else {
+                continue;
+            };
+
+            if !forward_packet_batches_by_accounts.try_add_packet(
+                &sanitized_vote_transaction,
+                deserialized_vote_packet,
+                &bank.feature_set,
+            ) {
+                // To match behavior of regular transactions we stop
+                // forwarding votes as soon as one fails. We are
+                // assuming that failure (try_add_packet) means no more space available.
+                break;
+            }
+
+            vote.forwarded = true;
+            count += 1;
         }
         count
     }

--- a/core/src/banking_stage/latest_unprocessed_votes.rs
+++ b/core/src/banking_stage/latest_unprocessed_votes.rs
@@ -274,11 +274,11 @@ impl LatestUnprocessedVotes {
         bank: Arc<Bank>,
         forward_packet_batches_by_accounts: &mut ForwardPacketBatchesByAccounts,
     ) -> usize {
+        let binding = self.latest_votes_per_pubkey.read().unwrap();
         let pubkeys_by_stake = weighted_random_order_by_stake(
             &bank,
-            self.latest_votes_per_pubkey.read().unwrap().keys(),
-        )
-        .collect_vec();
+            binding.keys(),
+        );
         let mut count: usize = 0;
         for pubkey in pubkeys_by_stake {
             if let Some(lock) = self.get_entry(pubkey) {


### PR DESCRIPTION
Simplifies the code by avoiding redundant iteration, and collection.