### PR TITLE
fix: remove more cargo-(build|test)-bpf

### DIFF
--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -13,8 +13,6 @@ on:
       - "**.rs"
       - "Cargo.toml"
       - "Cargo.lock"
-      - "cargo-build-bpf"
-      - "cargo-test-bpf"
       - "cargo-build-sbf"
       - "cargo-test-sbf"
       - "scripts/build-downstream-anchor-projects.sh"

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -13,8 +13,6 @@ on:
       - "**.rs"
       - "Cargo.toml"
       - "Cargo.lock"
-      - "cargo-build-bpf"
-      - "cargo-test-bpf"
       - "cargo-build-sbf"
       - "cargo-test-sbf"
       - "ci/downstream-projects/run-spl.sh"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -64,7 +64,7 @@ pull_request_rules:
             - check-success=clippy-nightly (macos-latest)
             - check-success=clippy-nightly (macos-latest-large)
         - or:
-          - -files~=(\.rs|Cargo\.toml|Cargo\.lock|cargo-build-bpf|cargo-test-bpf|cargo-build-sbf|cargo-test-sbf|ci/downstream-projects/run-spl\.sh|\.github/workflows/downstream-project-spl\.yml)$
+          - -files~=(\.rs|Cargo\.toml|Cargo\.lock|cargo-build-sbf|cargo-test-sbf|ci/downstream-projects/run-spl\.sh|\.github/workflows/downstream-project-spl\.yml)$
           - and:
             - status-success=cargo-test-sbf (token/program)
             - status-success=cargo-test-sbf (instruction-padding/program, token/program-2022, token/program-2022-test)

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -181,8 +181,6 @@ all_test_steps() {
              ^fetch-perf-libs.sh \
              ^programs/ \
              ^sdk/ \
-             cargo-build-bpf$ \
-             cargo-test-bpf$ \
              cargo-build-sbf$ \
              cargo-test-sbf$ \
       ; then
@@ -212,8 +210,6 @@ EOF
              ^fetch-perf-libs.sh \
              ^programs/ \
              ^sdk/ \
-             cargo-build-bpf$ \
-             cargo-test-bpf$ \
              cargo-build-sbf$ \
              cargo-test-sbf$ \
              ^ci/downstream-projects \

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -86,9 +86,7 @@ if [[ $CI_OS_NAME = windows ]]; then
   # Limit windows to end-user command-line tools.  Full validator support is not
   # yet available on windows
   BINS=(
-    cargo-build-bpf
     cargo-build-sbf
-    cargo-test-bpf
     cargo-test-sbf
     solana
     agave-install
@@ -118,9 +116,7 @@ else
   # Speed up net.sh deploys by excluding unused binaries
   if [[ -z "$validatorOnly" ]]; then
     BINS+=(
-      cargo-build-bpf
       cargo-build-sbf
-      cargo-test-bpf
       cargo-test-sbf
       solana-dos
       agave-install-init


### PR DESCRIPTION
#### Problem

we removed `cargo-build-bpf` and `cargo-test-bpf` in https://github.com/anza-xyz/agave/pull/2040 but we missed some other places.

#### Summary of Changes

remove all of them

