### PR TITLE
ci: update files diff method in pipeline

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -14,9 +14,11 @@ if [[ -n $CI_PULL_REQUEST ]]; then
   pr_number=${BASH_REMATCH[1]}
   echo "get affected files from PR: $pr_number"
 
-  # shellcheck disable=SC2016
-  # shellcheck disable=SC2046
   # ref: https://github.com/cli/cli/issues/5368#issuecomment-1087515074
+  #
+  # Variable value contains dollar prefixed words that look like bash variable
+  # references.  This is intentional.
+  # shellcheck disable=SC2016
   query='
   query($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
     repository(owner: $owner, name: $repo) {

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -14,6 +14,18 @@ if [[ -n $CI_PULL_REQUEST ]]; then
   pr_number=${BASH_REMATCH[1]}
   echo "get affected files from PR: $pr_number"
 
+  if [[ $BUILDKITE_REPO =~ ^https:\/\/github\.com\/([^\/]+)\/([^\/\.]+) ]]; then
+    owner="${BASH_REMATCH[1]}"
+    repo="${BASH_REMATCH[2]}"
+  elif [[ $BUILDKITE_REPO =~ ^git@github\.com:([^\/]+)\/([^\/\.]+) ]]; then
+    owner="${BASH_REMATCH[1]}"
+    repo="${BASH_REMATCH[2]}"
+  else
+    echo "couldn't parse owner and repo. use defaults"
+    owner="anza-xyz"
+    repo="agave"
+  fi
+
   # ref: https://github.com/cli/cli/issues/5368#issuecomment-1087515074
   #
   # Variable value contains dollar prefixed words that look like bash variable
@@ -38,8 +50,8 @@ if [[ -n $CI_PULL_REQUEST ]]; then
     gh api graphql \
       -f query="$query" \
       -F pr="$pr_number" \
-      -F owner='anza-xyz' \
-      -F repo='agave' \
+      -F owner="$owner" \
+      -F repo="$repo" \
       --paginate \
       --jq '.data.repository.pullRequest.files.nodes.[].path'
   )


### PR DESCRIPTION
#### Problem

`$(gh pr view "$pr_number" --json commits --jq '.commits | length')`  will only return 100 files...

#### Summary of Changes

fix it!

~~(this one should be able to fetch up to 3,000 files)~~ should be able to fetch all affected files back