### PR TITLE
Optimizes AppendVec::scan_pubkeys() when using file io

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1035,7 +1035,7 @@ impl AppendVec {
                 }
             }
             AppendVecFileBacking::File(file) => {
-                let buffer_size = std::cmp::min(SCAN_BUFFER_SIZE, self.len());
+                let buffer_size = std::cmp::min(PAGE_SIZE, self.len());
                 let mut reader =
                     BufferedReader::new(buffer_size, self.len(), file, STORE_META_OVERHEAD);
                 while reader.read().ok() == Some(BufferedReaderStatus::Success) {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1034,10 +1034,18 @@ impl AppendVec {
                     offset = next.next_account_offset;
                 }
             }
-            AppendVecFileBacking::File(_file) => {
-                self.scan_accounts(|stored_meta| {
-                    callback(stored_meta.pubkey());
-                });
+            AppendVecFileBacking::File(file) => {
+                let buffer_size = std::cmp::min(SCAN_BUFFER_SIZE, self.len());
+                let mut reader =
+                    BufferedReader::new(buffer_size, self.len(), file, STORE_META_OVERHEAD);
+                while reader.read().ok() == Some(BufferedReaderStatus::Success) {
+                    let (_offset, bytes) = reader.get_offset_and_data();
+                    let (stored_meta, _next) = Self::get_type::<StoredMeta>(bytes, 0).unwrap();
+                    callback(&stored_meta.pubkey);
+                    // since we only needed to read the pubkey, skip ahead to the next account
+                    let stored_size = aligned_stored_size(stored_meta.data_len as usize);
+                    reader.advance_offset(stored_size);
+                }
             }
         }
     }


### PR DESCRIPTION
#### Problem

As noted in https://github.com/anza-xyz/agave/pull/1394#discussion_r1635202566, when using file i/o to access append vecs, the `scan_pubkeys()` implementation is not optimal. It currently calls `scan_accounts()`, which will copy all the account fields—including the data—even though only the pubkey is needed.

We call `scan_pubkeys()` from `clean` inside of `construct_candidate_clean_keys()`, so having a more-optimal impl is beneficial.


#### Summary of Changes

Only get the pubkey from each account when scanning.