### PR TITLE
Fix flaky test test_banking_stage_entries_only_central_scheduler

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1015,7 +1015,7 @@ mod tests {
                 replay_vote_sender,
                 None,
                 Arc::new(ConnectionCache::new("connection_cache_test")),
-                bank_forks,
+                bank_forks.clone(), // keep a local-copy of bank-forks so worker threads do not lose weak access to bank-forks
                 &Arc::new(PrioritizationFeeCache::new(0u64)),
             );
 


### PR DESCRIPTION
#### Problem
- https://discord.com/channels/428295358100013066/439194979856809985/1260558461540761600
- `test_banking_stage_entries_only_central_scheduler` is flaky due to weak reference upgrade failure inside worker threads (inside program cache code).

#### Summary of Changes
- Make test keep a local clone of `Arc<BankForks>` so weak reference is not lost

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
