### PR TITLE
Optimizes AppendVec::get_account_sizes() when using file io

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1013,6 +1013,12 @@ impl AppendVec {
                     let Some((stored_meta, _next)) = Self::get_type::<StoredMeta>(bytes, 0) else {
                         break;
                     };
+                    // Since we're only reading the StoredMeta and not the whole account, do a
+                    // quick sanity check that there is likely a valid account at this offset.
+                    debug_assert!(
+                        *offset + STORE_META_OVERHEAD + stored_meta.data_len as usize
+                            <= valid_file_len
+                    );
                     let stored_size = aligned_stored_size(stored_meta.data_len as usize);
                     account_sizes.push(stored_size);
                 }


### PR DESCRIPTION
#### Problem

As noted in https://github.com/anza-xyz/agave/pull/1394#discussion_r1635202566, when using file i/o to access append vecs, the `get_account_sizes()` implementation is not optimal. It currently calls `get_stored_account_meta_callback()`, which will copy all the account fields—including the data—even though only the data len is needed.

We call `get_account_sizes()` from `clean` when removing dead accounts inside `handle_reclaims()`, so having a more-optimal impl is beneficial.


#### Summary of Changes

Only get the data len from each account.