### PR TITLE
Fixes metric for counting number of append vecs open as file io

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -57,7 +57,7 @@ use {
         },
         append_vec::{
             aligned_stored_size, APPEND_VEC_MMAPPED_FILES_DIRTY, APPEND_VEC_MMAPPED_FILES_OPEN,
-            APPEND_VEC_REOPEN_AS_FILE_IO, STORE_META_OVERHEAD,
+            APPEND_VEC_OPEN_AS_FILE_IO, STORE_META_OVERHEAD,
         },
         cache_hash_data::{CacheHashData, DeletionPolicy as CacheHashDeletionPolicy},
         contains::Contains,
@@ -1113,7 +1113,6 @@ impl AccountStorageEntry {
             return None;
         }
 
-        APPEND_VEC_REOPEN_AS_FILE_IO.fetch_add(1, Ordering::Relaxed);
         let count_and_status = self.count_and_status.lock_write();
         self.accounts.reopen_as_readonly().map(|accounts| Self {
             id: self.id,
@@ -1913,7 +1912,7 @@ impl LatestAccountsIndexRootsStats {
             ),
             (
                 "append_vecs_open_as_file_io",
-                APPEND_VEC_REOPEN_AS_FILE_IO.load(Ordering::Relaxed),
+                APPEND_VEC_OPEN_AS_FILE_IO.load(Ordering::Relaxed),
                 i64
             )
         );

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -285,7 +285,7 @@ const fn page_align(size: u64) -> u64 {
 lazy_static! {
     pub static ref APPEND_VEC_MMAPPED_FILES_OPEN: AtomicU64 = AtomicU64::default();
     pub static ref APPEND_VEC_MMAPPED_FILES_DIRTY: AtomicU64 = AtomicU64::default();
-    pub static ref APPEND_VEC_REOPEN_AS_FILE_IO: AtomicU64 = AtomicU64::default();
+    pub static ref APPEND_VEC_OPEN_AS_FILE_IO: AtomicU64 = AtomicU64::default();
 }
 
 impl Drop for AppendVec {
@@ -298,7 +298,7 @@ impl Drop for AppendVec {
                 }
             }
             AppendVecFileBacking::File(_) => {
-                APPEND_VEC_REOPEN_AS_FILE_IO.fetch_sub(1, Ordering::Relaxed);
+                APPEND_VEC_OPEN_AS_FILE_IO.fetch_sub(1, Ordering::Relaxed);
             }
         }
         if self.remove_file_on_drop.load(Ordering::Acquire) {
@@ -503,6 +503,7 @@ impl AppendVec {
         // we must use mmap on non-linux
         if storage_access == StorageAccess::File {
             APPEND_VEC_MMAPPED_FILES_OPEN.fetch_add(1, Ordering::Relaxed);
+            APPEND_VEC_OPEN_AS_FILE_IO.fetch_add(1, Ordering::Relaxed);
 
             return Ok(AppendVec {
                 path,


### PR DESCRIPTION
#### Problem

The metrics for tracking the number of append vecs open as file io is busted.

We currently always decrement the counter on `Drop`, but only _conditionally_ increment the counter if we create a new append vec and write to it first. This means at startup when we open existing append vecs as file io, they do *not* increment the counter, but they *do* decrement it when dropped (like from shrink).

So we end up with metrics like this:
![Screenshot 2024-07-10 at 1 13 31 PM](https://github.com/anza-xyz/agave/assets/840349/852cb0f1-3e98-46fa-a439-145669f0d3dd)
where the counts are negative.


#### Summary of Changes

Always increment the counter when opening an append vec from file when using file io.