### PR TITLE
rename throttled streams to throttle events

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -990,7 +990,6 @@ async fn handle_connection(
                                     max_streams_per_interval: {max_streams_per_throttling_interval}, read_interval_streams: {streams_read_in_throttle_interval} \
                                     throttle_duration: {throttle_duration:?}",
                                     params.peer_type, params.total_stake);
-                            stats.throttled_streams.fetch_add(1, Ordering::Relaxed);
                             match params.peer_type {
                                 ConnectionPeerType::Unstaked => {
                                     stats

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -994,13 +994,11 @@ async fn handle_connection(
                             match params.peer_type {
                                 ConnectionPeerType::Unstaked => {
                                     stats
-                                        .throttled_unstaked_streams
+                                        .throttle_events_unstaked
                                         .fetch_add(1, Ordering::Relaxed);
                                 }
                                 ConnectionPeerType::Staked(_) => {
-                                    stats
-                                        .throttled_staked_streams
-                                        .fetch_add(1, Ordering::Relaxed);
+                                    stats.throttle_events_staked.fetch_add(1, Ordering::Relaxed);
                                 }
                             }
                             sleep(throttle_duration).await;

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -184,7 +184,6 @@ pub struct StreamerStats {
     // Per IP rate-limiting is triggered each time when there are too many connections
     // opened from a particular IP address.
     pub(crate) connection_rate_limited_per_ipaddr: AtomicUsize,
-    pub(crate) throttled_streams: AtomicUsize,
     pub(crate) stream_load_ema: AtomicUsize,
     pub(crate) stream_load_ema_overflow: AtomicUsize,
     pub(crate) stream_load_capacity_overflow: AtomicUsize,
@@ -458,11 +457,6 @@ impl StreamerStats {
             (
                 "stream_read_timeouts",
                 self.total_stream_read_timeouts.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "throttled_streams",
-                self.throttled_streams.swap(0, Ordering::Relaxed),
                 i64
             ),
             (

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -192,8 +192,10 @@ pub struct StreamerStats {
     pub(crate) perf_track_overhead_us: AtomicU64,
     pub(crate) total_staked_packets_sent_for_batching: AtomicUsize,
     pub(crate) total_unstaked_packets_sent_for_batching: AtomicUsize,
-    pub(crate) throttled_staked_streams: AtomicUsize,
-    pub(crate) throttled_unstaked_streams: AtomicUsize,
+    // Counters for staked/unstaked throttling events i.e. when the stream handling
+    // is intentionally slowed down.
+    pub(crate) throttle_events_staked: AtomicUsize,
+    pub(crate) throttle_events_unstaked: AtomicUsize,
     pub(crate) connection_rate_limiter_length: AtomicUsize,
     pub(crate) outstanding_incoming_connection_attempts: AtomicUsize,
     pub(crate) total_incoming_connection_attempts: AtomicUsize,
@@ -479,13 +481,13 @@ impl StreamerStats {
                 i64
             ),
             (
-                "throttled_unstaked_streams",
-                self.throttled_unstaked_streams.swap(0, Ordering::Relaxed),
+                "throttle_events_staked",
+                self.throttle_events_staked.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
-                "throttled_staked_streams",
-                self.throttled_staked_streams.swap(0, Ordering::Relaxed),
+                "throttle_events_unstaked",
+                self.throttle_events_unstaked.swap(0, Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem

~When throttling timeout happens, we sleep for 100ms. Hence, on the next iteration of the loop we drop streams by timeout so we don't count them.~

When there are more than `r` requests per interval `w` (for unstaked, `r = 10, `w =100ms`), we slow down connection by sleeping before handling the current stream. This way the next stream will wait longer as well. Hence in terms of terminology, our intention is more about slowing down the connection and not the stream (although it is implemented in this form). 

#### Changes

Split by commits:

1. Rename metrics `throttled_staked_streams` to `throttle_events_staked` (and the same for unstaked). 
2. Delete metric `throttled_streams` because it is a sum of staked/unstaked.
~3. Reduce code indentation by using early exit with let/else statement. c219ec8b6a24bf9846efcc52da92ad86888f8776~


