### PR TITLE
accounts-db: throw error explicitly for next_account_offset calculation when overflows

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -932,10 +932,7 @@ impl AppendVec {
                         Self::get_type(bytes_subset, next).unwrap();
                     let (_hash, next): (&AccountHash, _) =
                         Self::get_type(bytes_subset, next).unwrap();
-                    let stored_size_aligned = next
-                        .checked_add(meta.data_len as usize)
-                        .expect("stored size cannot overflow");
-                    let stored_size_aligned = u64_align!(stored_size_aligned);
+                    let stored_size_aligned = u64_align!(next + (meta.data_len as usize));
                     callback(IndexInfo {
                         index_info: {
                             IndexInfoInner {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -863,8 +863,12 @@ impl AppendVec {
     /// data is at the end of each account and is variable sized
     /// the next account is then aligned on a 64 bit boundary.
     /// With these helpers, we can skip over reading some of the data depending on what the caller wants.
+    ///
+    /// *Safety* - The caller must ensure that the `stored_meta.data_len` won't overflow the calculation.
     fn next_account_offset(start_offset: usize, stored_meta: &StoredMeta) -> AccountOffsets {
-        let stored_size_unaligned = STORE_META_OVERHEAD + stored_meta.data_len as usize;
+        let stored_size_unaligned = STORE_META_OVERHEAD
+            .checked_add(stored_meta.data_len as usize)
+            .expect("stored size cannot overflow");
         let stored_size_aligned = u64_align!(stored_size_unaligned);
         let offset_to_end_of_data = start_offset + stored_size_unaligned;
         let next_account_offset = start_offset + stored_size_aligned;
@@ -928,7 +932,10 @@ impl AppendVec {
                         Self::get_type(bytes_subset, next).unwrap();
                     let (_hash, next): (&AccountHash, _) =
                         Self::get_type(bytes_subset, next).unwrap();
-                    let stored_size_aligned = u64_align!(next + (meta.data_len as usize));
+                    let stored_size_aligned = next
+                        .checked_add(meta.data_len as usize)
+                        .expect("stored size cannot overflow");
+                    let stored_size_aligned = u64_align!(stored_size_aligned);
                     callback(IndexInfo {
                         index_info: {
                             IndexInfoInner {


### PR DESCRIPTION
#### Problem
1. When we scanning append_vec, `next_account_offset` calculation is not safe, and it assumes that calculation never overflow. If it overflows, the app will crash. Fortunately, this is only an issue for tests and debug tools. For production validator code, we always sanitize the storage when we load. Therefore, we should (hopefully)never hit overflow for `new_account_offset` calculation. However, it would still be nice to throw the error explicitly when we overflow. 
1. We don't have unit test to cover `scan_index`. And the current test coverage doesn't cover corner cases. 
![image](https://github.com/anza-xyz/agave/assets/219428/097ea4a2-6d7b-40e6-b1fb-6732137f0345)

#### Summary of Changes
1. throw overflow error explicitly when calculating `next_account_offset`.
2. add test to cover `scan_index` with the corner cases, such incomplete account's data and garbage data that cause overflow. (now split into #2123)
3. improve `test_scan_pubkey` to cover mroe corner cases (now split into #2123).


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
