### PR TITLE
Adds bench for scan_pubkeys()

### DIFF
--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -1,14 +1,25 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
     criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput},
+    rand::{distributions::WeightedIndex, prelude::*},
+    rand_chacha::ChaChaRng,
     solana_accounts_db::{
-        append_vec::{self, AppendVec},
-        tiered_storage::hot::HotStorageWriter,
+        accounts_file::StorageAccess,
+        append_vec::{self, AppendVec, SCAN_BUFFER_SIZE_WITHOUT_DATA},
+        tiered_storage::{
+            file::TieredReadableFile,
+            hot::{HotStorageReader, HotStorageWriter},
+        },
     },
     solana_sdk::{
-        account::AccountSharedData, clock::Slot, pubkey::Pubkey,
+        account::{AccountSharedData, ReadableAccount},
+        clock::Slot,
+        pubkey::Pubkey,
+        rent::Rent,
         rent_collector::RENT_EXEMPT_RENT_EPOCH,
+        system_instruction::MAX_PERMITTED_DATA_LENGTH,
     },
+    std::{iter, mem::ManuallyDrop},
 };
 
 const ACCOUNTS_COUNTS: [usize; 4] = [
@@ -87,5 +98,118 @@ fn bench_write_accounts_file(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_write_accounts_file);
+fn bench_scan_pubkeys(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scan_pubkeys");
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    // distribution of account data sizes to use when creating accounts
+    // 3% of accounts have no data
+    // 75% of accounts are 165 bytes (a token account)
+    // 20% of accounts are 200 bytes (a stake account)
+    // 1% of accounts are 256 kibibytes (pathological case for the scan buffer)
+    // 1% of accounts are 10 mebibytes (the max size for an account)
+    let data_sizes = [
+        0,
+        165,
+        200,
+        SCAN_BUFFER_SIZE_WITHOUT_DATA,
+        MAX_PERMITTED_DATA_LENGTH as usize,
+    ];
+    let weights = [3, 75, 20, 1, 1];
+    let distribution = WeightedIndex::new(weights).unwrap();
+
+    let rent = Rent::default();
+    let rent_minimum_balances: Vec<_> = data_sizes
+        .iter()
+        .map(|data_size| rent.minimum_balance(*data_size))
+        .collect();
+
+    for accounts_count in ACCOUNTS_COUNTS {
+        group.throughput(Throughput::Elements(accounts_count as u64));
+        let mut rng = ChaChaRng::seed_from_u64(accounts_count as u64);
+
+        let pubkeys: Vec<_> = iter::repeat_with(Pubkey::new_unique)
+            .take(accounts_count)
+            .collect();
+        let accounts: Vec<_> = iter::repeat_with(|| {
+            let index = distribution.sample(&mut rng);
+            AccountSharedData::new_rent_epoch(
+                rent_minimum_balances[index],
+                data_sizes[index],
+                &Pubkey::default(),
+                RENT_EXEMPT_RENT_EPOCH,
+            )
+        })
+        .take(pubkeys.len())
+        .collect();
+        let storable_accounts: Vec<_> = iter::zip(&pubkeys, &accounts).collect();
+
+        // create an append vec file
+        let append_vec_path = temp_dir.path().join(format!("append_vec_{accounts_count}"));
+        _ = std::fs::remove_file(&append_vec_path);
+        let file_size = accounts
+            .iter()
+            .map(|account| append_vec::aligned_stored_size(account.data().len()))
+            .sum();
+        let append_vec = AppendVec::new(append_vec_path, true, file_size);
+        let stored_accounts_info = append_vec
+            .append_accounts(&(Slot::MAX, storable_accounts.as_slice()), 0)
+            .unwrap();
+        assert_eq!(stored_accounts_info.offsets.len(), accounts_count);
+        append_vec.flush().unwrap();
+        // Open append vecs for reading here, outside of the bench function, so we don't open lots
+        // of file handles and run out/crash.  We also need to *not* remove the backing file in
+        // these new append vecs because that would cause double-free (or triple-free here).
+        // Wrap the append vecs in ManuallyDrop to *not* remove the backing file on drop.
+        let append_vec_mmap = ManuallyDrop::new(
+            AppendVec::new_from_file(append_vec.path(), append_vec.len(), StorageAccess::Mmap)
+                .unwrap()
+                .0,
+        );
+        let append_vec_file = ManuallyDrop::new(
+            AppendVec::new_from_file(append_vec.path(), append_vec.len(), StorageAccess::File)
+                .unwrap()
+                .0,
+        );
+
+        // create a hot storage file
+        let hot_storage_path = temp_dir
+            .path()
+            .join(format!("hot_storage_{accounts_count}"));
+        _ = std::fs::remove_file(&hot_storage_path);
+        let mut hot_storage_writer = HotStorageWriter::new(&hot_storage_path).unwrap();
+        let stored_accounts_info = hot_storage_writer
+            .write_accounts(&(Slot::MAX, storable_accounts.as_slice()), 0)
+            .unwrap();
+        assert_eq!(stored_accounts_info.offsets.len(), accounts_count);
+        hot_storage_writer.flush().unwrap();
+        // Similar to the append vec case above, open the hot storage for reading here.
+        let hot_storage_file = TieredReadableFile::new(&hot_storage_path).unwrap();
+        let hot_storage_reader = HotStorageReader::new(hot_storage_file).unwrap();
+
+        group.bench_function(BenchmarkId::new("append_vec_mmap", accounts_count), |b| {
+            b.iter(|| {
+                let mut count = 0;
+                append_vec_mmap.scan_pubkeys(|_| count += 1);
+                assert_eq!(count, accounts_count);
+            });
+        });
+        group.bench_function(BenchmarkId::new("append_vec_file", accounts_count), |b| {
+            b.iter(|| {
+                let mut count = 0;
+                append_vec_file.scan_pubkeys(|_| count += 1);
+                assert_eq!(count, accounts_count);
+            });
+        });
+        group.bench_function(BenchmarkId::new("hot_storage", accounts_count), |b| {
+            b.iter(|| {
+                let mut count = 0;
+                hot_storage_reader.scan_pubkeys(|_| count += 1).unwrap();
+                assert_eq!(count, accounts_count);
+            });
+        });
+    }
+}
+
+criterion_group!(benches, bench_write_accounts_file, bench_scan_pubkeys);
 criterion_main!(benches);

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -297,6 +297,7 @@ const fn page_align(size: u64) -> u64 {
 /// be able to hold about half of the accounts, so there would not be many syscalls needed to scan
 /// the file.  Since we also expect some larger accounts, this will also avoid reading/copying
 /// large account data.  This should be a decent starting value, and can be modified over time.
+#[cfg_attr(feature = "dev-context-only-utils", qualifier_attr::qualifiers(pub))]
 const SCAN_BUFFER_SIZE_WITHOUT_DATA: usize = 1 << 18;
 
 lazy_static! {
@@ -1049,7 +1050,7 @@ impl AppendVec {
     /// `data` is completely ignored, for example.
     /// Also, no references have to be maintained/returned from an iterator function.
     /// This fn can operate on a batch of data at once.
-    pub(crate) fn scan_pubkeys(&self, mut callback: impl FnMut(&Pubkey)) {
+    pub fn scan_pubkeys(&self, mut callback: impl FnMut(&Pubkey)) {
         let mut offset = 0;
         match &self.backing {
             AppendVecFileBacking::Mmap(Mmap { mmap, .. }) => {


### PR DESCRIPTION
#### Problem

There are no benchmarks for how fast/slow the append vec file io is compared to mmap.


#### Summary of Changes

Add a benchmark for `scan_pubkeys()`.

We recently pushed a change to optimize this function for file io, but it was not straightforward to know how large the scan buffer should be. This benchmark was used to inform the buffer size.


<details><summary>Example benchmark results</summary>
<p>

Running the benchmark on a shared dev box, I saw these results from a run:

```
scan_pubkeys/append_vec_mmap/1
                        time:   [9.5220 ns 9.5265 ns 9.5307 ns]
                        thrpt:  [104.92 Melem/s 104.97 Melem/s 105.02 Melem/s]
scan_pubkeys/append_vec_file/1
                        time:   [864.41 ns 865.25 ns 866.12 ns]
                        thrpt:  [1.1546 Melem/s 1.1557 Melem/s 1.1569 Melem/s]
scan_pubkeys/hot_storage/1
                        time:   [5.0997 ns 5.1031 ns 5.1074 ns]
                        thrpt:  [195.79 Melem/s 195.96 Melem/s 196.09 Melem/s]
scan_pubkeys/append_vec_mmap/100
                        time:   [528.48 ns 528.94 ns 529.42 ns]
                        thrpt:  [188.89 Melem/s 189.06 Melem/s 189.22 Melem/s]
scan_pubkeys/append_vec_file/100
                        time:   [58.098 µs 58.137 µs 58.176 µs]
                        thrpt:  [1.7189 Melem/s 1.7201 Melem/s 1.7212 Melem/s]
scan_pubkeys/hot_storage/100
                        time:   [453.75 ns 453.94 ns 454.14 ns]
                        thrpt:  [220.20 Melem/s 220.29 Melem/s 220.38 Melem/s]
scan_pubkeys/append_vec_mmap/1000
                        time:   [6.0991 µs 6.1027 µs 6.1064 µs]
                        thrpt:  [163.76 Melem/s 163.86 Melem/s 163.96 Melem/s]
scan_pubkeys/append_vec_file/1000
                        time:   [800.59 µs 800.70 µs 800.82 µs]
                        thrpt:  [1.2487 Melem/s 1.2489 Melem/s 1.2491 Melem/s]
scan_pubkeys/hot_storage/1000
                        time:   [4.4630 µs 4.4647 µs 4.4663 µs]
                        thrpt:  [223.90 Melem/s 223.98 Melem/s 224.07 Melem/s]
scan_pubkeys/append_vec_mmap/10000
                        time:   [89.066 µs 89.112 µs 89.167 µs]
                        thrpt:  [112.15 Melem/s 112.22 Melem/s 112.28 Melem/s]
scan_pubkeys/append_vec_file/10000
                        time:   [6.1940 ms 6.1949 ms 6.1958 ms]
                        thrpt:  [1.6140 Melem/s 1.6142 Melem/s 1.6145 Melem/s]
scan_pubkeys/hot_storage/10000
                        time:   [43.545 µs 43.579 µs 43.617 µs]
                        thrpt:  [229.27 Melem/s 229.47 Melem/s 229.65 Melem/s]
```

</p>
</details> 