### PR TITLE
accounts-db: don't scan and check when reopening mmap file

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -437,9 +437,14 @@ impl AppendVec {
                 self.flush().expect("flush must succeed");
                 // we are re-opening the file, so don't remove the file on disk when the old mmapped one is dropped
                 self.remove_file_on_drop.store(false, Ordering::Release);
-                AppendVec::new_from_file(self.path.clone(), self.len(), StorageAccess::File)
-                    .ok()
-                    .map(|(av, _size)| av)
+
+                // The file should have already been sanitized. Don't need to check when we open the file again.
+                AppendVec::new_from_file_unchecked(
+                    self.path.clone(),
+                    self.len(),
+                    StorageAccess::File,
+                )
+                .ok()
             }
         }
     }


### PR DESCRIPTION
#### Problem

When we reopen mmap based file storage for file backed storage, we don't need to scan the file again. The file was loaded before and has already been sanitized. 


#### Summary of Changes
- reopen account storage without check scan.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
