### PR TITLE
replay: extend last fec set check for 32+ retransmitter signed shreds

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3082,7 +3082,6 @@ impl ReplayStage {
                     match blockstore.check_last_fec_set_and_get_block_id(
                         bank.slot(),
                         bank.hash(),
-                        bank.cluster_type(),
                         &bank.feature_set,
                     ) {
                         Ok(block_id) => block_id,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3082,6 +3082,7 @@ impl ReplayStage {
                     match blockstore.check_last_fec_set_and_get_block_id(
                         bank.slot(),
                         bank.hash(),
+                        bank.cluster_type(),
                         &bank.feature_set,
                     ) {
                         Ok(block_id) => block_id,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3077,48 +3077,51 @@ impl ReplayStage {
                 }
 
                 if bank.collector_id() != my_pubkey {
-                    // If the block does not have at least DATA_SHREDS_PER_FEC_BLOCK shreds in the last FEC set,
-                    // mark it dead. No reason to perform this check on our leader block.
-                    if !blockstore
-                        .is_last_fec_set_full(bank.slot())
-                        .inspect_err(|e| {
+                    // If the block does not have at least DATA_SHREDS_PER_FEC_BLOCK correctly retransmitted
+                    // shreds in the last FEC set, mark it dead. No reason to perform this check on our leader block.
+                    let check_result = match blockstore.check_last_fec_set(bank.slot()) {
+                        Ok(last_fec_set_check_results) => {
+                            // Update metrics regardless of feature flag
+                            last_fec_set_check_results.report_metrics(bank_slot, bank.hash());
+                            // Get a final result based on the feature flags
+                            last_fec_set_check_results.get_result(&bank.feature_set)
+                        }
+                        Err(e) => {
                             warn!(
-                                "Unable to determine if last fec set is full for slot {} {},
+                                "Unable to check the last fec set for slot {} {},
                                 marking as dead: {e:?}",
                                 bank.slot(),
                                 bank.hash()
-                            )
-                        })
-                        .unwrap_or(false)
-                    {
-                        // Update metric regardless of feature flag
-                        datapoint_warn!(
-                            "incomplete_final_fec_set",
-                            ("slot", bank_slot, i64),
-                            ("hash", bank.hash().to_string(), String)
-                        );
-                        if bank
-                            .feature_set
-                            .is_active(&solana_sdk::feature_set::vote_only_full_fec_sets::id())
-                        {
-                            let root = bank_forks.read().unwrap().root();
-                            Self::mark_dead_slot(
-                                blockstore,
-                                bank,
-                                root,
-                                &BlockstoreProcessorError::IncompleteFinalFecSet,
-                                rpc_subscriptions,
-                                duplicate_slots_tracker,
-                                duplicate_confirmed_slots,
-                                epoch_slots_frozen_slots,
-                                progress,
-                                heaviest_subtree_fork_choice,
-                                duplicate_slots_to_repair,
-                                ancestor_hashes_replay_update_sender,
-                                purge_repair_slot_counter,
                             );
-                            continue;
+                            if bank
+                                .feature_set
+                                .is_active(&solana_sdk::feature_set::vote_only_full_fec_sets::id())
+                            {
+                                Err(BlockstoreProcessorError::IncompleteFinalFecSet)
+                            } else {
+                                Ok(())
+                            }
                         }
+                    };
+
+                    if let Err(result_err) = check_result {
+                        let root = bank_forks.read().unwrap().root();
+                        Self::mark_dead_slot(
+                            blockstore,
+                            bank,
+                            root,
+                            &result_err,
+                            rpc_subscriptions,
+                            duplicate_slots_tracker,
+                            duplicate_confirmed_slots,
+                            epoch_slots_frozen_slots,
+                            progress,
+                            heaviest_subtree_fork_choice,
+                            duplicate_slots_to_repair,
+                            ancestor_hashes_replay_update_sender,
+                            purge_repair_slot_counter,
+                        );
+                        continue;
                     }
                 }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -179,19 +179,19 @@ pub struct LastFECSetCheckResults {
 }
 
 impl LastFECSetCheckResults {
-    pub fn report_metrics(&self, slot: Slot, hash: Hash) {
+    pub fn report_metrics(&self, slot: Slot, bank_hash: Hash) {
         if !self.is_full {
             datapoint_warn!(
                 "incomplete_final_fec_set",
                 ("slot", slot, i64),
-                ("hash", hash.to_string(), String)
+                ("bank_hash", bank_hash.to_string(), String)
             );
         }
         if !self.is_retransmitter_signed {
             datapoint_warn!(
                 "invalid_retransmitter_signature_final_fec_set",
                 ("slot", slot, i64),
-                ("hash", hash.to_string(), String)
+                ("bank_hash", bank_hash.to_string(), String)
             );
         }
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3771,8 +3771,8 @@ impl Blockstore {
                     warn!("Missing shred for {slot} index {shred_index}");
                     BlockstoreError::MissingShred(slot, shred_index)
                 })?;
-                let is_retransmitter_signed = shred::layout::is_retransmitter_signed(&shred_bytes)
-                    .map_err(|_| {
+                let is_retransmitter_signed =
+                    shred::layout::is_retransmitter_signed_variant(&shred_bytes).map_err(|_| {
                         let shred_index = start_index + u64::try_from(offset).unwrap();
                         warn!("Found legacy shred for {slot}, index {shred_index}");
                         BlockstoreError::LegacyShred(slot, shred_index)

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3733,7 +3733,7 @@ impl Blockstore {
     ///   invalid signatures on ingestion, this indicates that the last FEC set is properly
     ///   signed by retransmitters.
     ///
-    /// Will fail if:
+    /// Will error if:
     ///     - Slot meta is missing
     ///     - LAST_SHRED_IN_SLOT flag has not been received
     ///     - There are missing shreds in the last fec set

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -205,7 +205,7 @@ impl LastFECSetCheckResults {
         {
             return Err(BlockstoreProcessorError::IncompleteFinalFecSet);
         } else if feature_set
-            .is_active(&solana_sdk::feature_set::verify_retransmitter_signature::id())
+            .is_active(&solana_sdk::feature_set::vote_only_retransmitter_signed_fec_sets::id())
             && !self.is_retransmitter_signed
         {
             return Err(BlockstoreProcessorError::InvalidRetransmitterSignatureFinalFecSet);
@@ -5302,7 +5302,7 @@ pub mod tests {
         solana_runtime::bank::{Bank, RewardType},
         solana_sdk::{
             clock::{DEFAULT_MS_PER_SLOT, DEFAULT_TICKS_PER_SLOT},
-            feature_set::{verify_retransmitter_signature, vote_only_full_fec_sets},
+            feature_set::{vote_only_full_fec_sets, vote_only_retransmitter_signed_fec_sets},
             hash::{self, hash, Hash},
             instruction::CompiledInstruction,
             message::v0::LoadedAddresses,
@@ -12154,7 +12154,7 @@ pub mod tests {
         let mut full_only = FeatureSet::default();
         full_only.activate(&vote_only_full_fec_sets::id(), 0);
         let mut retransmitter_only = FeatureSet::default();
-        retransmitter_only.activate(&verify_retransmitter_signature::id(), 0);
+        retransmitter_only.activate(&vote_only_retransmitter_signed_fec_sets::id(), 0);
 
         let results = LastFECSetCheckResults {
             is_full: false,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -50,7 +50,7 @@ use {
         clock::{Slot, UnixTimestamp, DEFAULT_TICKS_PER_SECOND},
         feature_set::FeatureSet,
         genesis_config::{
-            ClusterType, GenesisConfig, DEFAULT_GENESIS_ARCHIVE, DEFAULT_GENESIS_FILE,
+            GenesisConfig, DEFAULT_GENESIS_ARCHIVE, DEFAULT_GENESIS_FILE,
         },
         hash::Hash,
         pubkey::Pubkey,
@@ -3719,7 +3719,6 @@ impl Blockstore {
         &self,
         slot: Slot,
         bank_hash: Hash,
-        cluster_type: ClusterType,
         feature_set: &FeatureSet,
     ) -> std::result::Result<Option<Hash>, BlockstoreProcessorError> {
         let results = self.check_last_fec_set(slot);
@@ -3737,15 +3736,6 @@ impl Blockstore {
         // Update metrics
         if results.block_id.is_none() {
             datapoint_warn!("incomplete_final_fec_set", ("slot", slot, i64),);
-        }
-        // These metrics are expensive to send because hash does not compress well.
-        // Only send these metrics when we are sure the appropriate shred format is being sent
-        if !results.is_retransmitter_signed && shred::should_chain_merkle_shreds(slot, cluster_type)
-        {
-            datapoint_warn!(
-                "invalid_retransmitter_signature_final_fec_set",
-                ("slot", slot, i64),
-            );
         }
         // Return block id / error based on feature flags
         results.get_block_id(feature_set)

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -159,6 +159,8 @@ pub enum BlockstoreError {
     MissingShred(Slot, u64),
     #[error("legacy shred slot {0}, index {1}")]
     LegacyShred(Slot, u64),
+    #[error("unable to read merkle root slot {0}, index {1}")]
+    MissingMerkleRoot(Slot, u64),
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -768,6 +768,9 @@ pub enum BlockstoreProcessorError {
 
     #[error("incomplete final fec set")]
     IncompleteFinalFecSet,
+
+    #[error("invalid retransmitter signature final fec set")]
+    InvalidRetransmitterSignatureFinalFecSet,
 }
 
 /// Callback for accessing bank state after each slot is confirmed while

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -341,7 +341,7 @@ macro_rules! dispatch {
     }
 }
 
-use dispatch;
+use {dispatch, solana_sdk::genesis_config::ClusterType};
 
 impl Shred {
     dispatch!(fn common_header(&self) -> &ShredCommonHeader);
@@ -1281,6 +1281,10 @@ pub fn verify_test_data_shred(
     } else {
         assert!(!shred.data_complete());
     }
+}
+
+pub fn should_chain_merkle_shreds(_slot: Slot, cluster_type: ClusterType) -> bool {
+    cluster_type == ClusterType::Development
 }
 
 #[cfg(test)]

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -786,9 +786,9 @@ pub mod layout {
             .ok_or(Error::InvalidPayloadSize(shred.len()))
     }
 
-    pub fn is_retransmitter_signed(shred: &[u8]) -> Result<bool, Error> {
+    pub fn is_retransmitter_signed_variant(shred: &[u8]) -> Result<bool, Error> {
         match get_shred_variant(shred)? {
-            ShredVariant::LegacyCode | ShredVariant::LegacyData => Err(Error::InvalidShredVariant),
+            ShredVariant::LegacyCode | ShredVariant::LegacyData => Ok(false),
             ShredVariant::MerkleCode {
                 proof_size: _,
                 chained: _,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -786,6 +786,22 @@ pub mod layout {
             .ok_or(Error::InvalidPayloadSize(shred.len()))
     }
 
+    pub fn is_retransmitter_signed(shred: &[u8]) -> Result<bool, Error> {
+        match get_shred_variant(shred)? {
+            ShredVariant::LegacyCode | ShredVariant::LegacyData => Err(Error::InvalidShredVariant),
+            ShredVariant::MerkleCode {
+                proof_size: _,
+                chained: _,
+                resigned,
+            } => Ok(resigned),
+            ShredVariant::MerkleData {
+                proof_size: _,
+                chained: _,
+                resigned,
+            } => Ok(resigned),
+        }
+    }
+
     pub(crate) fn set_retransmitter_signature(
         shred: &mut [u8],
         signature: &Signature,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -341,7 +341,7 @@ macro_rules! dispatch {
     }
 }
 
-use {dispatch, solana_sdk::genesis_config::ClusterType};
+use dispatch;
 
 impl Shred {
     dispatch!(fn common_header(&self) -> &ShredCommonHeader);
@@ -1281,10 +1281,6 @@ pub fn verify_test_data_shred(
     } else {
         assert!(!shred.data_complete());
     }
-}
-
-pub fn should_chain_merkle_shreds(_slot: Slot, cluster_type: ClusterType) -> bool {
-    cluster_type == ClusterType::Development
 }
 
 #[cfg(test)]

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -841,6 +841,10 @@ pub mod ed25519_precompile_verify_strict {
     solana_sdk::declare_id!("ed9tNscbWLYBooxWA7FE2B5KHWs8A6sxfY8EzezEcoo");
 }
 
+pub mod vote_only_retransmitter_signed_fec_sets {
+    solana_sdk::declare_id!("RfEcA95xnhuwooVAhUUksEJLZBF7xKCLuqrJoqk4Zph");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -1046,6 +1050,7 @@ lazy_static! {
         (verify_retransmitter_signature::id(), "Verify retransmitter signature #1840"),
         (move_stake_and_move_lamports_ixs::id(), "Enable MoveStake and MoveLamports stake program instructions #1610"),
         (ed25519_precompile_verify_strict::id(), "Use strict verification in ed25519 precompile SIMD-0152"),
+        (vote_only_retransmitter_signed_fec_sets::id(), "vote only on retransmitter signed fec sets"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -9,7 +9,10 @@ use {
     solana_entry::entry::Entry,
     solana_ledger::{
         blockstore,
-        shred::{shred_code, ProcessShredsStats, ReedSolomonCache, Shred, ShredFlags, Shredder},
+        shred::{
+            should_chain_merkle_shreds, shred_code, ProcessShredsStats, ReedSolomonCache, Shred,
+            ShredFlags, Shredder,
+        },
     },
     solana_sdk::{
         genesis_config::ClusterType,
@@ -504,10 +507,6 @@ impl BroadcastRun for StandardBroadcastRun {
         self.insert(blockstore, shreds, slot_start_ts);
         Ok(())
     }
-}
-
-fn should_chain_merkle_shreds(_slot: Slot, cluster_type: ClusterType) -> bool {
-    cluster_type == ClusterType::Development
 }
 
 #[cfg(test)]

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -9,10 +9,7 @@ use {
     solana_entry::entry::Entry,
     solana_ledger::{
         blockstore,
-        shred::{
-            should_chain_merkle_shreds, shred_code, ProcessShredsStats, ReedSolomonCache, Shred,
-            ShredFlags, Shredder,
-        },
+        shred::{shred_code, ProcessShredsStats, ReedSolomonCache, Shred, ShredFlags, Shredder},
     },
     solana_sdk::{
         genesis_config::ClusterType,
@@ -507,6 +504,10 @@ impl BroadcastRun for StandardBroadcastRun {
         self.insert(blockstore, shreds, slot_start_ts);
         Ok(())
     }
+}
+
+fn should_chain_merkle_shreds(_slot: Slot, cluster_type: ClusterType) -> bool {
+    cluster_type == ClusterType::Development
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
When the feature flag is turned on, we need to verify that the last fec set uses the new shred format.

Because the last fec set is not known when receiving shreds, and the new shred format is only used for the last set, we cannot perform this check until replay has completed.

#### Summary of Changes
Extend the check which compares the merkle roots of the last fec set to additionally check that they are all of the retransmitter shred variant.
