### PR TITLE
AccountLocks use ahash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5453,6 +5453,7 @@ dependencies = [
 name = "solana-accounts-db"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "assert_matches",
  "bincode",
  "blake3",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 bincode = { workspace = true }
 blake3 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
@@ -81,7 +82,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustc_version = { workspace = true }
 
 [features]
-dev-context-only-utils = ["dep:qualifier_attr", "dep:solana-stake-program", "dep:solana-vote-program"]
+dev-context-only-utils = [
+    "dep:qualifier_attr",
+    "dep:solana-stake-program",
+    "dep:solana-vote-program",
+]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -8,6 +8,7 @@ use {
         ancestors::Ancestors,
         storable_accounts::StorableAccounts,
     },
+    ahash::{AHashMap, AHashSet},
     dashmap::DashMap,
     log::*,
     solana_sdk::{
@@ -22,7 +23,7 @@ use {
     },
     std::{
         cmp::Reverse,
-        collections::{hash_map, BinaryHeap, HashMap, HashSet},
+        collections::{hash_map, BinaryHeap, HashSet},
         ops::RangeBounds,
         sync::{
             atomic::{AtomicUsize, Ordering},
@@ -35,8 +36,8 @@ pub type PubkeyAccountSlot = (Pubkey, AccountSharedData, Slot);
 
 #[derive(Debug, Default)]
 pub struct AccountLocks {
-    write_locks: HashSet<Pubkey>,
-    readonly_locks: HashMap<Pubkey, u64>,
+    write_locks: AHashSet<Pubkey>,
+    readonly_locks: AHashMap<Pubkey, u64>,
 }
 
 impl AccountLocks {
@@ -691,6 +692,7 @@ mod tests {
         },
         std::{
             borrow::Cow,
+            collections::HashMap,
             iter,
             sync::atomic::{AtomicBool, AtomicU64, Ordering},
             thread, time,

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -692,7 +692,6 @@ mod tests {
         },
         std::{
             borrow::Cow,
-            collections::HashMap,
             iter,
             sync::atomic::{AtomicBool, AtomicU64, Ordering},
             thread, time,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4514,6 +4514,7 @@ dependencies = [
 name = "solana-accounts-db"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "bincode",
  "blake3",
  "bv",


### PR DESCRIPTION
#### Problem
- We do not need cluster-wide consistency in our hashing of accounts
- Default hashing is slow

#### Summary of Changes
- Use ahash in `AccountLocks`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
