### PR TITLE
Changes scan buffer size (without data) to 64 KiB

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -293,12 +293,12 @@ const fn page_align(size: u64) -> u64 {
 ///
 /// On mnb, the overwhelming majority of accounts are token accounts, which use 165 bytes of data.
 /// Including storage overhead and alignment, that's 304 bytes per account.
-/// Per slot, *with* rent rewrites, we store 1,200 to 1,500 accounts.  With a 256 KiB buffer, we'd
-/// be able to hold about half of the accounts, so there would not be many syscalls needed to scan
+/// Per slot, *with* rent rewrites, we store 1,200 to 1,500 accounts.  With a 64 KiB buffer, we'd
+/// be able to hold about 215 accounts, so there would not be many syscalls needed to scan
 /// the file.  Since we also expect some larger accounts, this will also avoid reading/copying
 /// large account data.  This should be a decent starting value, and can be modified over time.
 #[cfg_attr(feature = "dev-context-only-utils", qualifier_attr::qualifiers(pub))]
-const SCAN_BUFFER_SIZE_WITHOUT_DATA: usize = 1 << 18;
+const SCAN_BUFFER_SIZE_WITHOUT_DATA: usize = 1 << 16;
 
 lazy_static! {
     pub static ref APPEND_VEC_MMAPPED_FILES_OPEN: AtomicU64 = AtomicU64::default();


### PR DESCRIPTION
### Problem

While benchmarking `AppendVec::scan_pubkeys()` with different buffer sizes and file io, I found smaller buffers are faster: https://github.com/anza-xyz/agave/pull/2095#issuecomment-2225704941.


### Summary of Changes

Change the buffer size to 64 KiB.

Using a very small buffer, like 4 KiB, may not be desirable, as it'll likely require more syscalls, which may impact overall validator performance. A moderate 64 KiB buffer may be a better default than the current 256 KiB buffer.

Here's a subset of the benchmark results when scanning pubkeys in an append vec with 10,000 accounts:

```
scan_pubkeys/append_vec_file/accounts_10000_buffer_4096
                        time:   [1.0762 ms 1.0766 ms 1.0770 ms]
                        thrpt:  [9.2853 Melem/s 9.2886 Melem/s 9.2921 Melem/s]
scan_pubkeys/append_vec_file/accounts_10000_buffer_65536
                        time:   [1.9335 ms 1.9342 ms 1.9348 ms]
                        thrpt:  [5.1685 Melem/s 5.1701 Melem/s 5.1719 Melem/s]
scan_pubkeys/append_vec_file/accounts_10000_buffer_131072
                        time:   [3.7189 ms 3.7200 ms 3.7212 ms]
                        thrpt:  [2.6873 Melem/s 2.6882 Melem/s 2.6890 Melem/s]
scan_pubkeys/append_vec_file/accounts_10000_buffer_262144
                        time:   [6.6761 ms 6.6775 ms 6.6788 ms]
                        thrpt:  [1.4973 Melem/s 1.4976 Melem/s 1.4979 Melem/s]
scan_pubkeys/append_vec_file/accounts_10000_buffer_1048576
                        time:   [14.215 ms 14.218 ms 14.221 ms]
                        thrpt:  [703.21 Kelem/s 703.34 Kelem/s 703.48 Kelem/s]
scan_pubkeys/append_vec_file/accounts_10000_buffer_10485760
                        time:   [145.74 ms 145.77 ms 145.80 ms]
                        thrpt:  [68.585 Kelem/s 68.600 Kelem/s 68.615 Kelem/s]
scan_pubkeys/append_vec_file/accounts_10000_buffer_31461376
                        time:   [187.31 ms 187.33 ms 187.34 ms]
                        thrpt:  [53.378 Kelem/s 53.382 Kelem/s 53.386 Kelem/s]
```

Going from a buffer of 256 KiB to 64 KiB reduced the scan time from 6.6 milliseconds to 1.9 milliseconds.

