### PR TITLE
Hardens local-cluster fastboot test

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -4959,22 +4959,11 @@ fn test_boot_from_local_state() {
     info!("Waiting for validator2 to create a new bank snapshot...");
     let timer = Instant::now();
     let bank_snapshot = loop {
-        if let Some(full_snapshot_slot) = snapshot_utils::get_highest_full_snapshot_archive_slot(
-            &validator2_config.full_snapshot_archives_dir,
-        ) {
-            if let Some(incremental_snapshot_slot) =
-                snapshot_utils::get_highest_incremental_snapshot_archive_slot(
-                    &validator2_config.incremental_snapshot_archives_dir,
-                    full_snapshot_slot,
-                )
-            {
-                if let Some(bank_snapshot) = snapshot_utils::get_highest_bank_snapshot_post(
-                    &validator2_config.bank_snapshots_dir,
-                ) {
-                    if bank_snapshot.slot > incremental_snapshot_slot {
-                        break bank_snapshot;
-                    }
-                }
+        if let Some(bank_snapshot) =
+            snapshot_utils::get_highest_bank_snapshot_post(&validator2_config.bank_snapshots_dir)
+        {
+            if bank_snapshot.slot > incremental_snapshot_archive.slot() {
+                break bank_snapshot;
             }
         }
         assert!(


### PR DESCRIPTION
#### Problem

The fastboot local-cluster test, `test_boot_from_local_state`, is flaky. Occasionally it fails while waiting for validator2 to take a new (bank) snapshot.


#### Summary of Changes

No need to re-query for validator2's snapshot *archives*, we already know what they will be, since a few lines up in the code we just copied the snapshot archives from validator1 to validator2. So we can use that information directly.

There may still be non-determinism here in case the background services are not getting scheduled immediately and SnapshotPackagerService is stuck waiting. I can/will look into this again if the test remains flaky. This PR should help though, as we previously were doing extra/unnecessary work.

Fixes #2020 