### PR TITLE
Cleanup: remove obsolete code comments

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -495,8 +495,6 @@ impl AppendVec {
 
         let (sanitized, num_accounts) = new.sanitize_layout_and_length();
         if !sanitized {
-            // This info show the failing accountvec file path.  It helps debugging
-            // the appendvec data corrupution issues related to recycling.
             return Err(AccountsFileError::AppendVecError(
                 AppendVecError::IncorrectLayout(new.path.clone()),
             ));


### PR DESCRIPTION
#### Problem

Remove obsolete code comments for append_vec sanitize_layout_and_length. 

We no longer recycle storage. There are also typos in this code comment. So
remove it.


#### Summary of Changes

Delete obsolete code comments.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
