### PR TITLE
Removes StoredAccountMeta::write_version()

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -66,15 +66,6 @@ impl<'storage> StoredAccountMeta<'storage> {
         }
     }
 
-    pub fn write_version(&self) -> StoredMetaWriteVersion {
-        match self {
-            Self::AppendVec(av) => av.write_version(),
-            // Hot account does not support this API as it does not
-            // use a write version.
-            Self::Hot(_) => StoredMetaWriteVersion::default(),
-        }
-    }
-
     pub fn meta(&self) -> &StoredMeta {
         match self {
             Self::AppendVec(av) => av.meta(),

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -6,9 +6,7 @@
 
 use {
     crate::{
-        account_storage::meta::{
-            AccountMeta, StoredAccountMeta, StoredMeta, StoredMetaWriteVersion,
-        },
+        account_storage::meta::{AccountMeta, StoredAccountMeta, StoredMeta},
         accounts_file::{
             AccountsFileError, InternalsForArchive, MatchAccountOwnerError, Result, StorageAccess,
             StoredAccountsInfo, ALIGN_BOUNDARY_OFFSET,
@@ -141,10 +139,6 @@ impl<'append_vec> AppendVecStoredAccountMeta<'append_vec> {
 
     pub fn data_len(&self) -> u64 {
         self.meta.data_len
-    }
-
-    pub fn write_version(&self) -> StoredMetaWriteVersion {
-        self.meta.write_version_obsolete
     }
 
     pub fn meta(&self) -> &StoredMeta {


### PR DESCRIPTION
#### Problem

Write version is obsolete. The accessor method on StoredAccountMeta is no longer used (nor should it be).


#### Summary of Changes

Remove it.