### PR TITLE
Make dcou faster and check lib targets as well

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -181,8 +181,9 @@ wait_step() {
 
 all_test_steps() {
   command_step checks1 "ci/docker-run-default-image.sh ci/test-checks.sh" 20 check
-  command_step checks2 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-bins" 15 check
-  command_step checks3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-all-targets" 15 check
+  command_step dcou-1-of-3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh --partition 1/3" 15 check
+  command_step dcou-2-of-3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh --partition 2/3" 15 check
+  command_step dcou-3-of-3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh --partition 3/3" 15 check
   command_step miri "ci/docker-run-default-image.sh ci/test-miri.sh" 5 check
   command_step frozen-abi "ci/docker-run-default-image.sh ./test-abi.sh" 15 check
   wait_step

--- a/ci/test-dev-context-only-utils.sh
+++ b/ci/test-dev-context-only-utils.sh
@@ -2,4 +2,5 @@
 
 set -eo pipefail
 
-scripts/check-dev-context-only-utils.sh "$@"
+scripts/check-dev-context-only-utils.sh check-all-targets "$@"
+scripts/check-dev-context-only-utils.sh check-bins-and-lib "$@"

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -42,8 +42,10 @@ printf -v allowed '"%s",' "${tainted_packages[@]}"
 allowed="${allowed%,}"
 
 mode=${1:-full}
+# consume the mode, so that other arguments are forwarded to cargo-hack
+shift
 case "$mode" in
-  tree | check-bins | check-all-targets | full)
+  tree | check-bins-and-lib | check-all-targets | full)
     ;;
   *)
     echo "$0: unrecognized mode: $mode";
@@ -156,9 +158,9 @@ fi
 # consistency with other CI steps and for the possibility of new similar lints.
 export RUSTFLAGS="-D warnings -Z threads=8 $RUSTFLAGS"
 
-if [[ $mode = "check-bins" || $mode = "full" ]]; then
-  _ cargo "+${rust_nightly}" hack check --bins
+if [[ $mode = "check-bins-and-lib" || $mode = "full" ]]; then
+  _ cargo "+${rust_nightly}" hack "$@" check
 fi
 if [[ $mode = "check-all-targets" || $mode = "full" ]]; then
-  _ cargo "+${rust_nightly}" hack check --all-targets
+  _ cargo "+${rust_nightly}" hack "$@" check --all-targets
 fi


### PR DESCRIPTION
#### Problem

- the `lib` targets aren't checked for dcou. see https://github.com/anza-xyz/agave/pull/1913 for details of this problem.
- dcou ci build is getting slow.

#### Summary of Changes

Check `lib` targets as well and that makes dcou ci jobs even longer. so, use `cargo-hack --partition` to accelerate dcou checks. really thanks @taiki-e 

Before:

![image](https://github.com/user-attachments/assets/e4af852f-da5e-4f3f-a6ab-bbf7ecd45dd7)


After:

![image](https://github.com/user-attachments/assets/770efccd-9501-456a-826d-e87410666192)



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
