### PR TITLE
validator cli: Clarifies snapshot intervals

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -499,20 +499,21 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("no-incremental-snapshots")
                 .takes_value(false)
                 .help("Disable incremental snapshots")
-                .long_help(
-                    "Disable incremental snapshots by setting this flag. When enabled, \
-                     --snapshot-interval-slots will set the incremental snapshot interval. To set \
-                     the full snapshot interval, use --full-snapshot-interval-slots.",
-                ),
         )
         .arg(
-            Arg::with_name("incremental_snapshot_interval_slots")
-                .long("incremental-snapshot-interval-slots")
-                .alias("snapshot-interval-slots")
+            Arg::with_name("snapshot_interval_slots")
+                .long("snapshot-interval-slots")
+                .alias("incremental-snapshot-interval-slots")
                 .value_name("NUMBER")
                 .takes_value(true)
                 .default_value(&default_args.incremental_snapshot_archive_interval_slots)
-                .help("Number of slots between generating snapshots, 0 to disable snapshots"),
+                .help("Number of slots between generating snapshots")
+                .long_help(
+                    "Number of slots between generating snapshots. \
+                     If incremental snapshots are enabled, this sets the incremental snapshot interval. \
+                     If incremental snapshots are disabled, this sets the full snapshot interval. \
+                     Setting this to 0 disables all snapshots.",
+                ),
         )
         .arg(
             Arg::with_name("full_snapshot_interval_slots")
@@ -520,9 +521,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER")
                 .takes_value(true)
                 .default_value(&default_args.full_snapshot_archive_interval_slots)
-                .help(
+                .help("Number of slots between generating full snapshots")
+                .long_help(
                     "Number of slots between generating full snapshots. Must be a multiple of the \
-                     incremental snapshot interval.",
+                     incremental snapshot interval. Only used when incremental snapshots are enabled.",
                 ),
         )
         .arg(


### PR DESCRIPTION
### Problem

The snapshot cli arguments are not the clearest. The confusion is how the snapshot intervals are set w.r.t. if incremental snapshots are enabled or disabled.

Current help:

```
--no-incremental-snapshots                
    Disable incremental snapshots by setting this flag. When enabled, --snapshot-interval-slots will set the
    incremental snapshot interval. To set the full snapshot interval, use --full-snapshot-interval-slots.

--incremental-snapshot-interval-slots <NUMBER>
    Number of slots between generating snapshots, 0 to disable snapshots [default: 100]

--full-snapshot-interval-slots <NUMBER>
    Number of slots between generating full snapshots. Must be a multiple of the incremental snapshot interval.
    [default: 25000]
```

How do these three flags interact? It is often unexpected. Here are some examples.

<details><summary>Example 1: All defaults</summary>
<p>

If a node is started with the following args
```
--full-snapshot-interval-slots 25000 --incremental-snapshot-interval-slots 100
```
The result will be:
* full snapshots every 25k slots
* incremental snapshots every 100 slots

This makes sense.

</p>
</details> 


<details><summary>Example 2: No incremental snapshots</summary>
<p>

If a node is started with the following args
```
--full-snapshot-interval-slots 25000 --no-incremental-snapshots
```
The result will be:
* full snapshots every 100 slots
* no incremental snapshots

This does *not* make sense. I would imagine the operator intended for the full snapshot interval to be 25k slots, not 100...

</p>
</details> 


<details><summary>Example 3: No incremental snapshots, different full snapshot interval</summary>
<p>

If a node is started with the following args
```
--incremental-snapshot-interval-slots 2000 --no-incremental-snapshots
```
The result will be:
* full snapshots every 2000 slots
* no incremental snapshots

This does *not* make sense. This is actually how you can set the full snapshot interval when incremental snapshots are disabled. Maybe the operator knows this, but it is weird. 

</p>
</details> 


<details><summary>Example 4: Trying to disable all snapshots</summary>
<p>

If a node is started with the following args
```
--full-snapshot-interval-slots 0 --no-incremental-snapshots
```
The result will be:
* full snapshots every 100 slots
* no incremental snapshots

This does *not* make sense. I imagine the operator was trying to disable all snapshots.

</p>
</details> 


<details><summary>Example 5: Disabling all snapshots</summary>
<p>

If a node is started with the following args
```
--incremental-snapshot-interval-slots 0 --no-incremental-snapshots
```
The result will be:
* no full snapshots
* no incremental snapshots

This makes some? sense? I dunno, still seems strange to me that incremental snapshots are disabled, yet setting the incremental snapshot interval disables all snapshots...

</p>
</details> 


Another note, `--snapshot-interval-slots` is an alias for `--incremental-snapshot-interval-slots`. So you can redo all the above examples with substituting the alias and see if it makes more/less sense.


### Summary of Changes

Here's what the new help looks like:

```
--no-incremental-snapshots                
    Disable incremental snapshots

--snapshot-interval-slots <NUMBER>
    Number of slots between generating snapshots. If incremental snapshots are enabled, this sets the
    incremental snapshot interval. If incremental snapshots are disabled, this sets the full snapshot interval.
    Setting this to 0 disables all snapshots. [default: 100]

--full-snapshot-interval-slots <NUMBER>
    Number of slots between generating full snapshots. Must be a multiple of the incremental snapshot interval.
    Only used when incremental snapshots are enabled. [default: 25000]
```

The old `--incremental-snapshots-interval-slots` is an alias to `--snapshot-interval-slots`, so scripts will continue to work as before.


And here's what happens:

<details><summary>Example 6: Disable all snapshots</summary>
<p>

```
--snapshot-interval-slots 0
```
disables all snapshots

</p>
</details> 


<details><summary>Example 7: Conflicting args</summary>
<p>

```
--no-incremental-snapshots --full-snapshot-interval-slots 2000
```
will now log a warning, since these two args conflict with eachother. When incremental snapshots are disabled, only `--snapshot-interval-slots` is used.

</p>
</details> 


<details><summary>Example 8: Setting snapshot interval, with incremental snapshots enabled</summary>
<p>

```
--snapshot-interval-slots 500
```
sets the incremental snapshot interval to 500, and the full snapshot interval uses the default of 25k

</p>
</details> 


<details><summary>Example 9: Setting snapshot interval, with incremental snapshots disabled</summary>
<p>

```
--snapshot-interval-slots 500 --no-incremental-snapshots
```
disables incremental snapshots, and so the only snapshots to make are full snapshots, and their interval is 500.

</p>
</details> 

Note that *behavior* hasn't changed. Hopefully now the help makes more sense, logging is more helpful, and the logic is clearer.