### PR TITLE
Removes deprecated --incremental-snapshots cli arg

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2048,16 +2048,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
                  set"
             ),
     );
-    add_arg!(Arg::with_name("incremental_snapshots")
-        .long("incremental-snapshots")
-        .takes_value(false)
-        .conflicts_with("no_incremental_snapshots")
-        .help("Enable incremental snapshots")
-        .long_help(
-            "Enable incremental snapshots by setting this flag.  When enabled, \
-             --snapshot-interval-slots will set the incremental snapshot interval. To set the \
-             full snapshot interval, use --full-snapshot-interval-slots.",
-        ));
     add_arg!(Arg::with_name("minimal_rpc_api")
         .long("minimal-rpc-api")
         .takes_value(false)


### PR DESCRIPTION
#### Problem

Now that incremental snapshots are on by default (as of v1.10, if I remember correctly), the `--incremental-snapshots` cli arg is a noop. This cli arg is not connected to anything, is deprecated, and can be removed.

(The `--no-incremental-snapshots` arg exists (also added in v1.10, iirc) to allow operators to disable incremental snapshots.)


#### Summary of Changes

Remove it.