### PR TITLE
cli: enable geyser without specified configs

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1179,6 +1179,14 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Specify the configuration file for the Geyser plugin."),
         )
         .arg(
+            Arg::with_name("geyser_plugin_always_enabled")
+                .long("geyser-plugin-always-enabled")
+                .value_name("BOOLEAN")
+                .takes_value(true)
+                .default_value("false")
+                .help("Еnable Geyser interface even if no Geyser configs are specified."),
+        )
+        .arg(
             Arg::with_name("snapshot_archive_format")
                 .long("snapshot-archive-format")
                 .alias("snapshot-compression") // Legacy name used by Solana v1.5.x and older

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1303,7 +1303,7 @@ pub fn main() {
                 .collect(),
         )
     } else {
-        None
+        value_t_or_exit!(matches, "geyser_plugin_always_enabled", bool).then(Vec::new)
     };
     let starting_with_geyser_plugins: bool = on_start_geyser_plugin_config_files.is_some();
 


### PR DESCRIPTION
#### Problem

By default, Geyser interface is disabled if no configs are specified. At the same time, it would be good to load Geyser plugin when the node is finished sync (can be different reasons: making custom plugins, saving resources in the catching up stage). Right now the possible workaround is to load noop plugin and unload it after startup but cli flag is much easier.

#### Summary of Changes

Add cli flag `geyser-plugin-always-enabled`