### PR TITLE
v1.18: Re-enable SPL downstream job with last v1.18 commit

### DIFF
--- a/.github/scripts/downstream-project-spl-common.sh
+++ b/.github/scripts/downstream-project-spl-common.sh
@@ -8,7 +8,7 @@ source "$here"/../../ci/downstream-projects/common.sh
 
 set -x
 rm -rf spl
-git clone https://github.com/solana-labs/solana-program-library.git spl
+git clone https://github.com/solana-labs/solana-program-library.git spl -b v1.18
 
 # copy toolchain file to use solana's rust version
 cp "$SOLANA_DIR"/rust-toolchain.toml spl/


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/pull/1961/files did a great job with avoiding issues on the downstream build. However, it means that we might not catch a breaking change during a backport.

#### Summary of Changes

Checkout the v1.18 branch from SPL, which is tagged to the last commit using v1.18: https://github.com/solana-labs/solana-program-library/tree/v1.18, which will allow the job to resume for v1.18 backports

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
