### PR TITLE
fixup: Avoid host build of SBPF program test crates (#1711)

### DIFF
--- a/programs/sbf/tests/simulation.rs
+++ b/programs/sbf/tests/simulation.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "sbf_rust")]
+
 use {
     agave_validator::test_validator::*,
     solana_runtime::{
@@ -17,7 +19,6 @@ use {
 };
 
 #[test]
-#[cfg(feature = "sbf_rust")]
 fn test_no_panic_banks_client() {
     solana_logger::setup();
 
@@ -55,7 +56,6 @@ fn test_no_panic_banks_client() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
 fn test_no_panic_rpc_client() {
     solana_logger::setup();
 

--- a/programs/sbf/tests/sysvar.rs
+++ b/programs/sbf/tests/sysvar.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "sbf_rust")]
+
 use {
     solana_runtime::{
         bank::Bank,
@@ -20,7 +22,6 @@ use {
 };
 
 #[test]
-#[cfg(feature = "sbf_rust")]
 fn test_sysvar_syscalls() {
     solana_logger::setup();
 


### PR DESCRIPTION
#### Problem

In

  commit da6f7f2d317ed978701b08c3cc3e8d62756e565a
  Author: Alexander Meißner <AlexanderMeissner@gmx.net>
  Date:   Tue Jun 18 23:10:40 2024 +0200

      Refactor - Avoid host build of SBPF program test crates (#1711)

we changed the test selection process slightly, switching from the `test-bpf` feature to `sbf_rust` feature, and marking individual tests, rather then the whole module.  The problem is that now when I run

    cd program/sbf
   ../../cargo check --bins --tests

I see unused warnings for all the modules imported by the `simulation` and `sysvar` modules.  At the later are, effectively, empty when `sbf_rust` is not set.

#### Summary of Changes
Moving the config flag back to the module level seems to do the intended thing and removes the warnings.  Alternatively, we could mark the `use` statement with an explicit `#[cfg(feature = "sbf_rust")]`, but it seems that all the tests are designed to be run only when `sbf_rust` is set.