### PR TITLE
solana-program: improve VoteState::deserialize_into()

### DIFF
--- a/sdk/program/src/vote/state/vote_state_0_23_5.rs
+++ b/sdk/program/src/vote/state/vote_state_0_23_5.rs
@@ -1,9 +1,12 @@
 #![allow(clippy::arithmetic_side_effects)]
 use super::*;
+#[cfg(test)]
+use arbitrary::{Arbitrary, Unstructured};
 
 const MAX_ITEMS: usize = 32;
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct VoteState0_23_5 {
     /// the node that votes in this account
     pub node_pubkey: Pubkey,
@@ -57,5 +60,63 @@ impl<I> CircBuf<I> {
         self.idx %= MAX_ITEMS;
 
         self.buf[self.idx] = item;
+    }
+}
+
+#[cfg(test)]
+impl<'a, I: Default + Copy> Arbitrary<'a> for CircBuf<I>
+where
+    I: Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let mut circbuf = Self::default();
+
+        let len = u.arbitrary_len::<I>()?;
+        for _ in 0..len {
+            circbuf.append(I::arbitrary(u)?);
+        }
+
+        Ok(circbuf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vote_deserialize_0_23_5() {
+        // base case
+        let target_vote_state = VoteState0_23_5::default();
+        let target_vote_state_versions = VoteStateVersions::V0_23_5(Box::new(target_vote_state));
+        let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
+
+        let mut test_vote_state = VoteState::default();
+        VoteState::deserialize_into(&vote_state_buf, &mut test_vote_state).unwrap();
+
+        assert_eq!(
+            target_vote_state_versions.convert_to_current(),
+            test_vote_state
+        );
+
+        // variant
+        // provide 4x the minimum struct size in bytes to ensure we typically touch every field
+        let struct_bytes_x4 = std::mem::size_of::<VoteState0_23_5>() * 4;
+        for _ in 0..100 {
+            let raw_data: Vec<u8> = (0..struct_bytes_x4).map(|_| rand::random::<u8>()).collect();
+            let mut unstructured = Unstructured::new(&raw_data);
+
+            let arbitrary_vote_state = VoteState0_23_5::arbitrary(&mut unstructured).unwrap();
+            let target_vote_state_versions =
+                VoteStateVersions::V0_23_5(Box::new(arbitrary_vote_state));
+
+            let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
+            let target_vote_state = target_vote_state_versions.convert_to_current();
+
+            let mut test_vote_state = VoteState::default();
+            VoteState::deserialize_into(&vote_state_buf, &mut test_vote_state).unwrap();
+
+            assert_eq!(target_vote_state, test_vote_state);
+        }
     }
 }

--- a/sdk/program/src/vote/state/vote_state_0_23_5.rs
+++ b/sdk/program/src/vote/state/vote_state_0_23_5.rs
@@ -38,6 +38,7 @@ pub struct VoteState0_23_5 {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct CircBuf<I> {
     pub buf: [I; MAX_ITEMS],
     /// next pointer
@@ -60,23 +61,6 @@ impl<I> CircBuf<I> {
         self.idx %= MAX_ITEMS;
 
         self.buf[self.idx] = item;
-    }
-}
-
-#[cfg(test)]
-impl<'a, I: Default + Copy> Arbitrary<'a> for CircBuf<I>
-where
-    I: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let mut circbuf = Self::default();
-
-        let len = u.arbitrary_len::<I>()?;
-        for _ in 0..len {
-            circbuf.append(I::arbitrary(u)?);
-        }
-
-        Ok(circbuf)
     }
 }
 

--- a/sdk/program/src/vote/state/vote_state_deserialize.rs
+++ b/sdk/program/src/vote/state/vote_state_deserialize.rs
@@ -1,13 +1,15 @@
 use {
     crate::{
         instruction::InstructionError,
-        pubkey::Pubkey,
         serialize_utils::cursor::*,
         vote::state::{BlockTimestamp, LandedVote, Lockout, VoteState, MAX_ITEMS},
     },
-    bincode::serialized_size,
     std::io::Cursor,
 };
+
+// hardcode this number to avoid calculating onchain; this is a fixed-size ringbuffer
+// `serialized_size()` must be used over `mem::size_of()` because of alignment
+const PRIOR_VOTERS_SERIALIZED_SIZE: u64 = 1545;
 
 pub(super) fn deserialize_vote_state_into(
     cursor: &mut Cursor<&[u8]>,
@@ -70,10 +72,8 @@ fn read_prior_voters_into<T: AsRef<[u8]>>(
     // record our position at the start of the struct
     let prior_voters_position = cursor.position();
 
-    // `serialized_size()` must be used over `mem::size_of()` because of alignment
-    let is_empty_position = serialized_size(&vote_state.prior_voters)
-        .ok()
-        .and_then(|v| v.checked_add(prior_voters_position))
+    let is_empty_position = PRIOR_VOTERS_SERIALIZED_SIZE
+        .checked_add(prior_voters_position)
         .and_then(|v| v.checked_sub(1))
         .ok_or(InstructionError::InvalidAccountData)?;
 
@@ -86,21 +86,12 @@ fn read_prior_voters_into<T: AsRef<[u8]>>(
     if !is_empty {
         cursor.set_position(prior_voters_position);
 
-        let mut encountered_null_voter = false;
         for i in 0..MAX_ITEMS {
             let prior_voter = read_pubkey(cursor)?;
             let from_epoch = read_u64(cursor)?;
             let until_epoch = read_u64(cursor)?;
-            let item = (prior_voter, from_epoch, until_epoch);
 
-            if item == (Pubkey::default(), 0, 0) {
-                encountered_null_voter = true;
-            } else if encountered_null_voter {
-                // `prior_voters` should never be sparse
-                return Err(InstructionError::InvalidAccountData);
-            } else {
-                vote_state.prior_voters.buf[i] = item;
-            }
+            vote_state.prior_voters.buf[i] = (prior_voter, from_epoch, until_epoch);
         }
 
         vote_state.prior_voters.idx = read_u64(cursor)? as usize;
@@ -139,4 +130,18 @@ fn read_last_timestamp_into<T: AsRef<[u8]>>(
     vote_state.last_timestamp = BlockTimestamp { slot, timestamp };
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, bincode::serialized_size};
+
+    #[test]
+    fn test_prior_voters_serialized_size() {
+        let vote_state = VoteState::default();
+        assert_eq!(
+            serialized_size(&vote_state.prior_voters).unwrap(),
+            PRIOR_VOTERS_SERIALIZED_SIZE
+        );
+    }
 }


### PR DESCRIPTION
#### Problem
earlier this year we implemented `VoteState::deserialize_into()`, a custom parser intended to be suitable for usage in a bpf context. we want to use the new parser everywhere because, with some optimizations, it is 7-20x faster than bincode depending on the input

```
HANA custom vs bincode
* we win: 10000, they win: 0
* our max 22.422µs, their max 471.89µs
* our avg 5.76µs, their avg 35.956µs
* avg speedup 30.195µs
```

it also uses half as much memory for `V1_14_11` because conversion to `Current` happens during parsing

#### Summary of Changes
implement those optimizations, and also remove some constraints that make this parser behave differently from `bincode::deserialize`. this allows `VoteState::deserialize_into` to be used in optimized vote processing

in the future we would like to replace `VoteState::deserialize` to use `deserialize_into` for everything, but this requires testing on mainnet-beta because it affects sensitive parts of the codebase which cannot be feature-gated

part of https://github.com/solana-labs/solana/issues/35101