### PR TITLE
Removes deprecated --halt-on-known-validators-accounts-hash-mismatch cli arg

### DIFF
--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -164,9 +164,6 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --known-validator ]]; then
       args+=("$1" "$2")
       shift 2
-    elif [[ $1 = --halt-on-known-validators-accounts-hash-mismatch ]]; then
-      args+=("$1")
-      shift
     elif [[ $1 = --max-genesis-archive-unpacked-size ]]; then
       args+=("$1" "$2")
       shift 2

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2047,17 +2047,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .long("enable-quic-servers"),
         usage_warning: "The quic server is now enabled by default.",
     );
-    add_arg!(
-        Arg::with_name("halt_on_known_validators_accounts_hash_mismatch")
-            .alias("halt-on-trusted-validators-accounts-hash-mismatch")
-            .long("halt-on-known-validators-accounts-hash-mismatch")
-            .requires("known_validators")
-            .takes_value(false)
-            .help(
-                "Abort the validator if a bank hash mismatch is detected within known validator \
-                 set"
-            ),
-    );
     add_arg!(Arg::with_name("minimal_rpc_api")
         .long("minimal-rpc-api")
         .takes_value(false)


### PR DESCRIPTION
#### Problem

The `--halt-on-known-validators-accounts-hash-mismatch` is deprecated[^1] and not used anywhere. It should be removed.

[^1]: The arg was deprecated on May 16, 2023 by https://github.com/solana-labs/solana/pull/31279


#### Summary of Changes

Remove it.