### PR TITLE
geyser: add num_partitions to block info

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3236,7 +3236,7 @@ impl ReplayStage {
                         &parent_blockhash.to_string(),
                         bank.slot(),
                         &bank.last_blockhash().to_string(),
-                        &bank.rewards,
+                        &bank.get_rewards_and_num_partitions(),
                         Some(bank.clock().unix_timestamp),
                         Some(bank.block_height()),
                         bank.executed_transaction_count(),

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -251,7 +251,7 @@ pub struct ReplicaBlockInfoV3<'a> {
     pub entry_count: u64,
 }
 
-/// Extending ReplicaBlockInfo by sending the entries_count.
+/// Extending ReplicaBlockInfo by sending RewardsAndNumPartitions.
 #[derive(Clone, Debug)]
 #[repr(C)]
 pub struct ReplicaBlockInfoV4<'a> {

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -8,7 +8,7 @@ use {
         signature::Signature,
         transaction::SanitizedTransaction,
     },
-    solana_transaction_status::{Reward, TransactionStatusMeta},
+    solana_transaction_status::{Reward, RewardsAndNumPartitions, TransactionStatusMeta},
     std::{any::Any, error, io},
     thiserror::Error,
 };
@@ -251,11 +251,27 @@ pub struct ReplicaBlockInfoV3<'a> {
     pub entry_count: u64,
 }
 
+/// Extending ReplicaBlockInfo by sending the entries_count.
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaBlockInfoV4<'a> {
+    pub parent_slot: Slot,
+    pub parent_blockhash: &'a str,
+    pub slot: Slot,
+    pub blockhash: &'a str,
+    pub rewards: &'a RewardsAndNumPartitions,
+    pub block_time: Option<UnixTimestamp>,
+    pub block_height: Option<u64>,
+    pub executed_transaction_count: u64,
+    pub entry_count: u64,
+}
+
 #[repr(u32)]
 pub enum ReplicaBlockInfoVersions<'a> {
     V0_0_1(&'a ReplicaBlockInfo<'a>),
     V0_0_2(&'a ReplicaBlockInfoV2<'a>),
     V0_0_3(&'a ReplicaBlockInfoV3<'a>),
+    V0_0_4(&'a ReplicaBlockInfoV4<'a>),
 }
 
 /// Errors returned by plugin calls

--- a/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
@@ -1,6 +1,6 @@
 use {
-    solana_sdk::{clock::UnixTimestamp, pubkey::Pubkey, reward_info::RewardInfo},
-    std::sync::{Arc, RwLock},
+    solana_runtime::bank::KeyedRewardsAndNumPartitions, solana_sdk::clock::UnixTimestamp,
+    std::sync::Arc,
 };
 
 /// Interface for notifying block metadata changes
@@ -13,7 +13,7 @@ pub trait BlockMetadataNotifier {
         parent_blockhash: &str,
         slot: u64,
         blockhash: &str,
-        rewards: &RwLock<Vec<(Pubkey, RewardInfo)>>,
+        rewards: &KeyedRewardsAndNumPartitions,
         block_time: Option<UnixTimestamp>,
         block_height: Option<u64>,
         executed_transaction_count: u64,

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -628,6 +628,7 @@ pub struct Reward {
 
 pub type Rewards = Vec<Reward>;
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RewardsAndNumPartitions {
     pub rewards: Rewards,
     pub num_partitions: Option<u64>,


### PR DESCRIPTION
#### Problem

`num_partitions` added to proto definitions https://github.com/anza-xyz/agave/pull/1601 and the feature already exists in v2.0.0 but still no support in the Geyser.

#### Summary of Changes

Add `ReplicaBlockInfoV4`

<!-- Fixes # -->
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
