### PR TITLE
geyser: build block info struct once

### DIFF
--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -37,21 +37,22 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         if plugin_manager.plugins.is_empty() {
             return;
         }
+
         let rewards = Self::build_rewards(rewards);
+        let block_info = Self::build_replica_block_info(
+            parent_slot,
+            parent_blockhash,
+            slot,
+            blockhash,
+            &rewards,
+            block_time,
+            block_height,
+            executed_transaction_count,
+            entry_count,
+        );
 
         for plugin in plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-update-slot");
-            let block_info = Self::build_replica_block_info(
-                parent_slot,
-                parent_blockhash,
-                slot,
-                blockhash,
-                &rewards,
-                block_time,
-                block_height,
-                executed_transaction_count,
-                entry_count,
-            );
             let block_info = ReplicaBlockInfoVersions::V0_0_4(&block_info);
             match plugin.notify_block_metadata(block_info) {
                 Err(err) => {


### PR DESCRIPTION
#### Problem

`ReplicaBlockInfoV3` is created for every plugin but we can create it once.

#### Summary of Changes


<!-- Fixes # -->
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
