### PR TITLE
ci: update docs pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,9 +79,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
 
       - name: Build
         working-directory: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     needs:
       - check
     if: >
-      github.repository == 'solana-labs/solana' &&
+      github.repository == 'anza-xyz/agave' &&
       needs.check.outputs.continue == 1
     # the name is used by .mergify.yml as well
     name: build & deploy docs

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -12,16 +12,6 @@ source ../ci/rust-version.sh
 ../ci/docker-run-default-image.sh docs/convert-ascii-to-svg.sh
 ./set-solana-release-tag.sh
 
-# Get current channel
-eval "$(../ci/channel-info.sh)"
-
-# Synchronize translations with Crowdin only on stable channel
-if [ "$CHANNEL" = stable ]; then
-  echo "Downloading & updating translations..."
-  npm run crowdin:download
-  npm run crowdin:upload
-fi
-
 # Build from /src into /build
 npm run build
 echo $?

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -25,14 +25,3 @@ fi
 # Build from /src into /build
 npm run build
 echo $?
-
-# Publish only from merge commits and beta release tags
-if [[ -n $CI ]]; then
-  if [[ -z $CI_PULL_REQUEST ]]; then
-    if [[ -n $CI_TAG ]] && [[ $CI_TAG != $BETA_CHANNEL* ]]; then
-      echo "not a beta tag"
-      exit 0
-    fi
-    ./publish-docs.sh
-  fi
-fi

--- a/docs/src/operations/requirements.md
+++ b/docs/src/operations/requirements.md
@@ -20,12 +20,12 @@ The hardware recommendations below are provided as a guide.  Operators are encou
 
 | Component | Validator Requirements | Additional RPC Node Requirements |
 |-----------|------------------------|----------------------------------|
-| **CPU**   | - 2.8GHz base clock speed, or faster<br>- SHA extensions instruction support<br>- AMD Gen 3 or newer<br>- Intel Ice Lake or newer<br>- Higher clock speed is preferable over more cores<br>- AVX2 instruction support (to use official release binaries, self-compile otherwise)<br>- Support for AVX512f is helpful<br>||
+| **CPU**   | - 2.8GHz base clock speed, or faster<br />- SHA extensions instruction support<br />- AMD Gen 3 or newer<br />- Intel Ice Lake or newer<br />- Higher clock speed is preferable over more cores<br />- AVX2 instruction support (to use official release binaries, self-compile otherwise)<br />- Support for AVX512f is helpful<br />||
 | | 12 cores / 24 threads, or more  | 16 cores / 32 threads, or more |
-| **RAM**   | Error Correction Code (ECC) memory is suggested<br>Motherboard with 512GB capacity suggested ||
+| **RAM**   | Error Correction Code (ECC) memory is suggested<br />Motherboard with 512GB capacity suggested ||
 | | 256GB or more| 512 GB or more for **all [account indexes](https://docs.solanalabs.com/operations/setup-an-rpc-node#account-indexing)** |
-| **Disk**  | PCIe Gen3 x4 NVME SSD, or better, on each of: <br>- **Accounts**: 500GB, or larger. High TBW (Total Bytes Written)<br>- **Ledger**: 1TB or larger. High TBW suggested<br>- **Snapshots**: 250GB or larger. High TBW suggested<br>- **OS**: (Optional) 500GB, or larger. SATA OK<br><br>The OS may be installed on the ledger disk, though testing has shown better performance with the ledger on its own disk<br><br>Accounts and ledger *can* be stored on the same disk, however due to high IOPS, this is not recommended<br><br>The Samsung 970 and 980 Pro series SSDs are popular with the validator community | Consider a larger ledger disk if longer transaction history is required<br><br>Accounts and ledger **should not** be stored on the same disk |
-| **GPUs**  | Not necessary at this time<br>Operators in the validator community do not use GPUs currently | |
+| **Disk**  | PCIe Gen3 x4 NVME SSD, or better, on each of: <br />- **Accounts**: 500GB, or larger. High TBW (Total Bytes Written)<br />- **Ledger**: 1TB or larger. High TBW suggested<br />- **Snapshots**: 250GB or larger. High TBW suggested<br />- **OS**: (Optional) 500GB, or larger. SATA OK<br /><br />The OS may be installed on the ledger disk, though testing has shown better performance with the ledger on its own disk<br /><br />Accounts and ledger *can* be stored on the same disk, however due to high IOPS, this is not recommended<br /><br />The Samsung 970 and 980 Pro series SSDs are popular with the validator community | Consider a larger ledger disk if longer transaction history is required<br /><br />Accounts and ledger **should not** be stored on the same disk |
+| **GPUs**  | Not necessary at this time<br />Operators in the validator community do not use GPUs currently | |
 
 
 ## Virtual machines on Cloud Platforms


### PR DESCRIPTION
#### Problem

1. we don't have a clear plan/setup for docs page
2. the docs pipeline has been skipping (mergify will fail for some situations because of this one)

#### Summary of Changes

I think we can still keep the current docs structure/workflow till we have a well-defined strategy.

- update the repository name for solving 2.
- remove `crowdin` syncing process (we don't have it atm)
- don't publish docs page (will resume/update it when we have a roadmap)