### PR TITLE
ci: update the private pipeline script

### DIFF
--- a/.buildkite/solana-private.sh
+++ b/.buildkite/solana-private.sh
@@ -8,7 +8,6 @@
 #
 
 set -e
-# NAME=$(buildkite-agent meta-data get name)
 cd "$(dirname "$0")"/..
 source ci/_
 sudo chmod 0777 ci/buildkite-solana-private.sh

--- a/.buildkite/solana-private.sh
+++ b/.buildkite/solana-private.sh
@@ -10,7 +10,6 @@
 set -e
 cd "$(dirname "$0")"/..
 source ci/_
-sudo chmod 0777 ci/buildkite-solana-private.sh
 
 _ ci/buildkite-solana-private.sh pipeline.yml
 echo +++ pipeline


### PR DESCRIPTION
#### Problem

it's weird to update the file permission each time

#### Summary of Changes

- chmod 755 for ci/buildkite-solana-private.sh (sync with the `.buildkite/pipeline-upload.sh`)
- remove useless code