### PR TITLE
remove thiserror from solana-sanitize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7254,9 +7254,6 @@ dependencies = [
 [[package]]
 name = "solana-sanitize"
 version = "2.1.0"
-dependencies = [
- "thiserror",
-]
 
 [[package]]
 name = "solana-sdk"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5651,9 +5651,6 @@ dependencies = [
 [[package]]
 name = "solana-sanitize"
 version = "2.1.0"
-dependencies = [
- "thiserror",
-]
 
 [[package]]
 name = "solana-sbf-programs"

--- a/sanitize/Cargo.toml
+++ b/sanitize/Cargo.toml
@@ -9,8 +9,5 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-thiserror = { workspace = true }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sanitize/src/lib.rs
+++ b/sanitize/src/lib.rs
@@ -1,15 +1,24 @@
 //! A trait for sanitizing values and members of over the wire messages.
 
-use thiserror::Error;
+use {core::fmt, std::error::Error};
 
-#[derive(PartialEq, Debug, Error, Eq, Clone)]
+#[derive(PartialEq, Debug, Eq, Clone)]
 pub enum SanitizeError {
-    #[error("index out of bounds")]
     IndexOutOfBounds,
-    #[error("value out of bounds")]
     ValueOutOfBounds,
-    #[error("invalid value")]
     InvalidValue,
+}
+
+impl Error for SanitizeError {}
+
+impl fmt::Display for SanitizeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SanitizeError::IndexOutOfBounds => f.write_str("index out of bounds"),
+            SanitizeError::ValueOutOfBounds => f.write_str("value out of bounds"),
+            SanitizeError::InvalidValue => f.write_str("invalid value"),
+        }
+    }
 }
 
 /// A trait for sanitizing values and members of over-the-wire messages.


### PR DESCRIPTION
#### Problem
solana-sanitize is a tiny crate that nonetheless takes 2 seconds to build in release mode on my machine. This is because it uses thiserror to do one very trivial thing. Removing thiserror brings the build time down to 0.2s, most of which appears to just be startup time.

#### Summary of Changes
Replace the `Error` derivation with the impl that I got from `rust-analyzer: Expand macro recursively at caret`. As you can see there's very little going on here. To be clear, this doesn't break anything.

The definition of SanitizeError goes back at least four years to [this commit](https://github.com/solana-labs/solana/blob/63db3242043602c7b9765a066b6f8d01ef20454e/sdk/program/src/sanitize.rs) so I am not worried about future contributors yearning for the moderate convenience improvements of thiserror
