### PR TITLE
Undo deprecation message edit on RpcClient::get_stake_activation

### DIFF
--- a/rpc-client-api/src/request.rs
+++ b/rpc-client-api/src/request.rs
@@ -96,7 +96,7 @@ pub enum RpcRequest {
     GetSlotsPerSegment,
     #[deprecated(
         since = "1.18.18",
-        note = "Do not use; getStakeActivation is not supported by the JSON-RPC server."
+        note = "Do not use; getStakeActivation is deprecated on the JSON-RPC server."
     )]
     GetStakeActivation,
     GetStakeMinimumDelegation,

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -2152,8 +2152,8 @@ impl RpcClient {
     /// ```
     #[deprecated(
         since = "1.18.18",
-        note = "Do not use; getStakeActivation is not supported by the JSON-RPC server. Please \
-                use the stake account and StakeHistory sysvar to call \
+        note = "Do not use; getStakeActivation is deprecated on the JSON-RPC server. Please use \
+                the stake account and StakeHistory sysvar to call \
                 `Delegation::stake_activating_and_deactivating()` instead"
     )]
     #[allow(deprecated)]

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -1790,8 +1790,8 @@ impl RpcClient {
     /// ```
     #[deprecated(
         since = "1.18.18",
-        note = "Do not use; getStakeActivation is not supported by the JSON-RPC server. Please \
-                use the stake account and StakeHistory sysvar to call \
+        note = "Do not use; getStakeActivation is deprecated on the JSON-RPC server. Please use \
+                the stake account and StakeHistory sysvar to call \
                 `Delegation::stake_activating_and_deactivating()` instead"
     )]
     #[allow(deprecated)]


### PR DESCRIPTION
#### Problem
The message edits in https://github.com/anza-xyz/agave/pull/2005 should only have gone as deep as v2.0; the `getStakeActivation` RPC endpoint still exists on v1.18, although it is deprecated. This is apparently confusing to users.

#### Summary of Changes
Revert changes to RpcClient deprecation notes. Fixup RpcRequest deprecation note.
