### PR TITLE
v2.0: fix solana-stake-program-tests version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7371,7 +7371,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program-tests"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "assert_matches",
  "bincode",


### PR DESCRIPTION
#### Problem

we introduced `solana-stake-program-tests` with version v2.0.2 in #1928 but v2.0 has bumped to v2.0.3 so the lock file isn't correct.

the failed build: https://buildkite.com/anza/agave/builds/7800#0190c311-1d04-4d7a-bb93-def77a8abdf3/196-206

#### Summary of Changes

fix it