### PR TITLE
fix inline-spl deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6443,7 +6443,6 @@ name = "solana-inline-spl"
 version = "2.1.0"
 dependencies = [
  "bytemuck",
- "rustc_version 0.4.0",
  "solana-program",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6444,7 +6444,7 @@ version = "2.1.0"
 dependencies = [
  "bytemuck",
  "rustc_version 0.4.0",
- "solana-sdk",
+ "solana-program",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -382,7 +382,7 @@ solana-package-metadata-macro = { path = "sdk/package-metadata-macro", version =
 solana-perf = { path = "perf", version = "=2.1.0" }
 solana-poh = { path = "poh", version = "=2.1.0" }
 solana-poseidon = { path = "poseidon", version = "=2.1.0" }
-solana-program = { path = "sdk/program", version = "=2.1.0" }
+solana-program = { path = "sdk/program", version = "=2.1.0", default-features = false }
 solana-program-runtime = { path = "program-runtime", version = "=2.1.0" }
 solana-program-test = { path = "program-test", version = "=2.1.0" }
 solana-pubsub-client = { path = "pubsub-client", version = "=2.1.0" }

--- a/inline-spl/Cargo.toml
+++ b/inline-spl/Cargo.toml
@@ -21,6 +21,3 @@ name = "solana_inline_spl"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-
-[build-dependencies]
-rustc_version = { workspace = true }

--- a/inline-spl/Cargo.toml
+++ b/inline-spl/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 bytemuck = { workspace = true }
-solana-program = { workspace = true }
+solana-program = { workspace = true, default-features = false }
 
 [lib]
 crate-type = ["lib"]

--- a/inline-spl/Cargo.toml
+++ b/inline-spl/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 bytemuck = { workspace = true }
-solana-sdk = { workspace = true }
+solana-program = { workspace = true }
 
 [lib]
 crate-type = ["lib"]

--- a/inline-spl/src/associated_token_account.rs
+++ b/inline-spl/src/associated_token_account.rs
@@ -1,6 +1,6 @@
 // Partial SPL Associated Token Account declarations inlined to avoid an external dependency on the spl-associated-token-account crate
-solana_sdk::declare_id!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+solana_program::declare_id!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 
 pub mod program_v1_1_0 {
-    solana_sdk::declare_id!("NatA1Zyo48dJ7yuwR7cGURwhskKA8ywUyxb9GvG7mTC");
+    solana_program::declare_id!("NatA1Zyo48dJ7yuwR7cGURwhskKA8ywUyxb9GvG7mTC");
 }

--- a/inline-spl/src/token.rs
+++ b/inline-spl/src/token.rs
@@ -1,10 +1,10 @@
 /// Partial SPL Token declarations inlined to avoid an external dependency on the spl-token crate
-use solana_sdk::pubkey::{Pubkey, PUBKEY_BYTES};
+use solana_program::pubkey::{Pubkey, PUBKEY_BYTES};
 
-solana_sdk::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+solana_program::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
 pub mod program_v3_4_0 {
-    solana_sdk::declare_id!("NToK4t5AQzxPNpUA84DkxgfXaVDbDQQjpHKCqsbY46B");
+    solana_program::declare_id!("NToK4t5AQzxPNpUA84DkxgfXaVDbDQQjpHKCqsbY46B");
 }
 
 /*
@@ -72,7 +72,7 @@ impl GenericTokenAccount for Account {
 }
 
 pub mod native_mint {
-    solana_sdk::declare_id!("So11111111111111111111111111111111111111112");
+    solana_program::declare_id!("So11111111111111111111111111111111111111112");
 
     /*
         Mint {

--- a/inline-spl/src/token_2022.rs
+++ b/inline-spl/src/token_2022.rs
@@ -1,7 +1,7 @@
 /// Partial SPL Token declarations inlined to avoid an external dependency on the spl-token-2022 crate
 use crate::token::{self, GenericTokenAccount};
 
-solana_sdk::declare_id!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+solana_program::declare_id!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 
 // `spl_token_program_2022::extension::AccountType::Account` ordinal value
 pub const ACCOUNTTYPE_ACCOUNT: u8 = 2;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5086,8 +5086,7 @@ name = "solana-inline-spl"
 version = "2.1.0"
 dependencies = [
  "bytemuck",
- "rustc_version",
- "solana-sdk",
+ "solana-program",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Summary of Changes
- Replace unnecessary solana-sdk dep with solana-program
- Remove unused build dep
- Set solana-program default-features to false in both the workspace deps and the inline-spl deps. The workspace deps change is required because if you don't set `default-features = false` in the workspace dep, then any package that inherits the dependency is unable to disable default features. This doesn't change the behaviour of any other packages in this workspace because none of them express a preference for solana-program `default-features`, which means they still get `default-features = true` even though it's now set to false in the workspace. More info here https://doc.rust-lang.org/nightly/edition-guide/rust-2024/cargo-inherited-default-features.html

