### PR TITLE
PoC - move `process_compute_budget_instructions()` into own crate and more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5768,6 +5768,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-builtins-default-costs"
+version = "2.1.0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "rustc_version 0.4.0",
+ "solana-address-lookup-table-program",
+ "solana-bpf-loader-program",
+ "solana-compute-budget-program",
+ "solana-config-program",
+ "solana-frozen-abi",
+ "solana-loader-v4-program",
+ "solana-sdk",
+ "solana-stake-program",
+ "solana-system-program",
+ "solana-vote-program",
+]
+
+[[package]]
 name = "solana-cargo-build-sbf"
 version = "2.1.0"
 dependencies = [
@@ -6095,6 +6114,7 @@ dependencies = [
  "serial_test",
  "solana-accounts-db",
  "solana-bloom",
+ "solana-builtins-default-costs",
  "solana-client",
  "solana-compute-budget",
  "solana-connection-cache",
@@ -6156,18 +6176,13 @@ dependencies = [
  "lazy_static",
  "log",
  "rustc_version 0.4.0",
- "solana-address-lookup-table-program",
- "solana-bpf-loader-program",
+ "solana-builtins-default-costs",
  "solana-compute-budget",
- "solana-compute-budget-program",
- "solana-config-program",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-loader-v4-program",
  "solana-logger",
  "solana-metrics",
  "solana-sdk",
- "solana-stake-program",
  "solana-system-program",
  "solana-vote-program",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6028,6 +6028,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-compute-budget-processor"
+version = "2.1.0"
+dependencies = [
+ "itertools 0.12.1",
+ "log",
+ "rustc_version 0.4.0",
+ "solana-builtins-default-costs",
+ "solana-compute-budget",
+ "solana-frozen-abi",
+ "solana-logger",
+ "solana-sdk",
+ "static_assertions",
+ "test-case",
+]
+
+[[package]]
 name = "solana-compute-budget-program"
 version = "2.1.0"
 dependencies = [
@@ -6117,6 +6133,7 @@ dependencies = [
  "solana-builtins-default-costs",
  "solana-client",
  "solana-compute-budget",
+ "solana-compute-budget-processor",
  "solana-connection-cache",
  "solana-core",
  "solana-cost-model",
@@ -6178,6 +6195,7 @@ dependencies = [
  "rustc_version 0.4.0",
  "solana-builtins-default-costs",
  "solana-compute-budget",
+ "solana-compute-budget-processor",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-logger",
@@ -7261,6 +7279,7 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-bucket-map",
  "solana-compute-budget",
+ "solana-compute-budget-processor",
  "solana-compute-budget-program",
  "solana-config-program",
  "solana-cost-model",
@@ -7308,6 +7327,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc_version 0.4.0",
  "solana-compute-budget",
+ "solana-compute-budget-processor",
  "solana-program",
  "solana-sdk",
  "thiserror",
@@ -7590,6 +7610,7 @@ dependencies = [
  "serde_derive",
  "solana-bpf-loader-program",
  "solana-compute-budget",
+ "solana-compute-budget-processor",
  "solana-compute-budget-program",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6039,6 +6039,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-logger",
  "solana-sdk",
+ "solana-svm-transaction",
  "static_assertions",
  "test-case",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "bench-tps",
     "bloom",
     "bucket_map",
+    "builtins-default-costs",
     "cargo-registry",
     "clap-utils",
     "clap-v3-utils",
@@ -341,6 +342,7 @@ solana-bloom = { path = "bloom", version = "=2.1.0" }
 solana-bn254 = { path = "curves/bn254", version = "=2.1.0" }
 solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.1.0" }
 solana-bucket-map = { path = "bucket_map", version = "=2.1.0" }
+solana-builtins-default-costs = { path = "builtins-default-costs", version = "=2.1.0" }
 agave-cargo-registry = { path = "cargo-registry", version = "=2.1.0" }
 solana-clap-utils = { path = "clap-utils", version = "=2.1.0" }
 solana-clap-v3-utils = { path = "clap-v3-utils", version = "=2.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "client",
     "client-test",
     "compute-budget",
+    "compute-budget-processor",
     "connection-cache",
     "core",
     "cost-model",
@@ -351,6 +352,7 @@ solana-cli-config = { path = "cli-config", version = "=2.1.0" }
 solana-cli-output = { path = "cli-output", version = "=2.1.0" }
 solana-client = { path = "client", version = "=2.1.0" }
 solana-compute-budget = { path = "compute-budget", version = "=2.1.0" }
+solana-compute-budget-processor = { path = "compute-budget-processor", version = "=2.1.0" }
 solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.1.0" }
 solana-config-program = { path = "programs/config", version = "=2.1.0" }
 solana-connection-cache = { path = "connection-cache", version = "=2.1.0", default-features = false }

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "solana-builtins-default-costs"
+description = "Solana builtins default costs"
+documentation = "https://docs.rs/solana-builtins-default-costs"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+lazy_static = { workspace = true }
+log = { workspace = true }
+solana-address-lookup-table-program = { workspace = true }
+solana-bpf-loader-program = { workspace = true }
+solana-compute-budget-program = { workspace = true }
+solana-config-program = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-loader-v4-program = { workspace = true }
+solana-sdk = { workspace = true }
+solana-stake-program = { workspace = true }
+solana-system-program = { workspace = true }
+solana-vote-program = { workspace = true }
+# Add additional builtin programs here
+
+[lib]
+crate-type = ["lib"]
+name = "solana_builtins_default_costs"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[build-dependencies]
+rustc_version = { workspace = true }
+
+[features]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "solana-vote-program/frozen-abi",
+]

--- a/builtins-default-costs/build.rs
+++ b/builtins-default-costs/build.rs
@@ -1,0 +1,1 @@
+../frozen-abi/build.rs

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -1,0 +1,33 @@
+#![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
+#![allow(clippy::arithmetic_side_effects)]
+use {
+    lazy_static::lazy_static,
+    solana_sdk::{
+        address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
+        compute_budget, ed25519_program, loader_v4, pubkey::Pubkey, secp256k1_program,
+    },
+    std::collections::HashMap,
+};
+
+// Number of compute units for each built-in programs
+lazy_static! {
+    /// Number of compute units for each built-in programs
+    pub static ref BUILTIN_INSTRUCTION_COSTS: HashMap<Pubkey, u64> = [
+        (solana_stake_program::id(), solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS),
+        (solana_config_program::id(), solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS),
+        (solana_vote_program::id(), solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS),
+        (solana_system_program::id(), solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS),
+        (compute_budget::id(), solana_compute_budget_program::DEFAULT_COMPUTE_UNITS),
+        (address_lookup_table::program::id(), solana_address_lookup_table_program::processor::DEFAULT_COMPUTE_UNITS),
+        (bpf_loader_upgradeable::id(), solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS),
+        (bpf_loader_deprecated::id(), solana_bpf_loader_program::DEPRECATED_LOADER_COMPUTE_UNITS),
+        (bpf_loader::id(), solana_bpf_loader_program::DEFAULT_LOADER_COMPUTE_UNITS),
+        (loader_v4::id(), solana_loader_v4_program::DEFAULT_COMPUTE_UNITS),
+        // Note: These are precompile, run directly in bank during sanitizing;
+        (secp256k1_program::id(), 0),
+        (ed25519_program::id(), 0),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+}

--- a/cli/src/compute_budget.rs
+++ b/cli/src/compute_budget.rs
@@ -1,6 +1,6 @@
 use {
     solana_clap_utils::compute_budget::ComputeUnitLimit,
-    solana_compute_budget::compute_budget_processor::MAX_COMPUTE_UNIT_LIMIT,
+    solana_compute_budget::compute_budget_limits::MAX_COMPUTE_UNIT_LIMIT,
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::config::RpcSimulateTransactionConfig,
     solana_sdk::{

--- a/compute-budget-processor/Cargo.toml
+++ b/compute-budget-processor/Cargo.toml
@@ -15,6 +15,7 @@ solana-builtins-default-costs = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-sdk = { workspace = true }
+solana-svm-transaction = { workspace = true }
 
 [lib]
 crate-type = ["lib"]

--- a/compute-budget-processor/Cargo.toml
+++ b/compute-budget-processor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "solana-cost-model"
-description = "Solana cost model"
-documentation = "https://docs.rs/solana-cost-model"
+name = "solana-compute-budget-processor"
+description = "Solana compute budget instructions processor"
+documentation = "https://docs.rs/solana-compute-budget-processor"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
@@ -10,27 +10,20 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-ahash = { workspace = true }
-lazy_static = { workspace = true }
 log = { workspace = true }
 solana-builtins-default-costs = { workspace = true }
 solana-compute-budget = { workspace = true }
-solana-compute-budget-processor = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
-solana-frozen-abi-macro = { workspace = true, optional = true }
-solana-metrics = { workspace = true }
 solana-sdk = { workspace = true }
-solana-vote-program = { workspace = true }
 
 [lib]
 crate-type = ["lib"]
-name = "solana_cost_model"
+name = "solana_compute_budget_processor"
 
 [dev-dependencies]
 itertools = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
-solana-system-program = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 
@@ -43,11 +36,5 @@ rustc_version = { workspace = true }
 [features]
 frozen-abi = [
     "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-compute-budget/frozen-abi",
     "solana-sdk/frozen-abi",
-    "solana-vote-program/frozen-abi",
 ]
-
-[[bench]]
-name = "cost_tracker"

--- a/compute-budget-processor/build.rs
+++ b/compute-budget-processor/build.rs
@@ -1,0 +1,1 @@
+../frozen-abi/build.rs

--- a/compute-budget-processor/src/lib.rs
+++ b/compute-budget-processor/src/lib.rs
@@ -1,65 +1,16 @@
+//! Solana compute budget instruction processor
+#![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
+
 use {
-    crate::prioritization_fee::{PrioritizationFeeDetails, PrioritizationFeeType},
+    solana_compute_budget::compute_budget_limits::*,
     solana_sdk::{
         borsh1::try_from_slice_unchecked,
         compute_budget::{self, ComputeBudgetInstruction},
-        entrypoint::HEAP_LENGTH,
-        fee::FeeBudgetLimits,
         instruction::{CompiledInstruction, InstructionError},
         pubkey::Pubkey,
         transaction::TransactionError,
     },
-    std::num::NonZeroU32,
 };
-
-/// Roughly 0.5us/page, where page is 32K; given roughly 15CU/us, the
-/// default heap page cost = 0.5 * 15 ~= 8CU/page
-pub const DEFAULT_HEAP_COST: u64 = 8;
-pub const DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT: u32 = 200_000;
-pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
-pub const MAX_HEAP_FRAME_BYTES: u32 = 256 * 1024;
-pub const MIN_HEAP_FRAME_BYTES: u32 = HEAP_LENGTH as u32;
-
-/// The total accounts data a transaction can load is limited to 64MiB to not break
-/// anyone in Mainnet-beta today. It can be set by set_loaded_accounts_data_size_limit instruction
-pub const MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES: NonZeroU32 =
-    unsafe { NonZeroU32::new_unchecked(64 * 1024 * 1024) };
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ComputeBudgetLimits {
-    pub updated_heap_bytes: u32,
-    pub compute_unit_limit: u32,
-    pub compute_unit_price: u64,
-    pub loaded_accounts_bytes: NonZeroU32,
-}
-
-impl Default for ComputeBudgetLimits {
-    fn default() -> Self {
-        ComputeBudgetLimits {
-            updated_heap_bytes: MIN_HEAP_FRAME_BYTES,
-            compute_unit_limit: MAX_COMPUTE_UNIT_LIMIT,
-            compute_unit_price: 0,
-            loaded_accounts_bytes: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
-        }
-    }
-}
-
-impl From<ComputeBudgetLimits> for FeeBudgetLimits {
-    fn from(val: ComputeBudgetLimits) -> Self {
-        let prioritization_fee_details = PrioritizationFeeDetails::new(
-            PrioritizationFeeType::ComputeUnitPrice(val.compute_unit_price),
-            u64::from(val.compute_unit_limit),
-        );
-        let prioritization_fee = prioritization_fee_details.get_fee();
-
-        FeeBudgetLimits {
-            loaded_accounts_data_size_limit: val.loaded_accounts_bytes,
-            heap_cost: DEFAULT_HEAP_COST,
-            compute_unit_limit: u64::from(val.compute_unit_limit),
-            prioritization_fee,
-        }
-    }
-}
 
 /// Processing compute_budget could be part of tx sanitizing, failed to process
 /// these instructions will drop the transaction eventually without execution,

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -1,4 +1,4 @@
-use crate::compute_budget_processor::{self, ComputeBudgetLimits, DEFAULT_HEAP_COST};
+use crate::compute_budget_limits::{self, ComputeBudgetLimits, DEFAULT_HEAP_COST};
 
 #[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl ::solana_frozen_abi::abi_example::AbiExample for ComputeBudget {
@@ -127,7 +127,7 @@ pub struct ComputeBudget {
 
 impl Default for ComputeBudget {
     fn default() -> Self {
-        Self::new(compute_budget_processor::MAX_COMPUTE_UNIT_LIMIT as u64)
+        Self::new(compute_budget_limits::MAX_COMPUTE_UNIT_LIMIT as u64)
     }
 }
 

--- a/compute-budget/src/compute_budget_limits.rs
+++ b/compute-budget/src/compute_budget_limits.rs
@@ -1,0 +1,54 @@
+use {
+    crate::prioritization_fee::{PrioritizationFeeDetails, PrioritizationFeeType},
+    solana_sdk::{entrypoint::HEAP_LENGTH, fee::FeeBudgetLimits},
+    std::num::NonZeroU32,
+};
+
+/// Roughly 0.5us/page, where page is 32K; given roughly 15CU/us, the
+/// default heap page cost = 0.5 * 15 ~= 8CU/page
+pub const DEFAULT_HEAP_COST: u64 = 8;
+pub const DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT: u32 = 200_000;
+pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+pub const MAX_HEAP_FRAME_BYTES: u32 = 256 * 1024;
+pub const MIN_HEAP_FRAME_BYTES: u32 = HEAP_LENGTH as u32;
+
+/// The total accounts data a transaction can load is limited to 64MiB to not break
+/// anyone in Mainnet-beta today. It can be set by set_loaded_accounts_data_size_limit instruction
+pub const MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES: NonZeroU32 =
+    unsafe { NonZeroU32::new_unchecked(64 * 1024 * 1024) };
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ComputeBudgetLimits {
+    pub updated_heap_bytes: u32,
+    pub compute_unit_limit: u32,
+    pub compute_unit_price: u64,
+    pub loaded_accounts_bytes: NonZeroU32,
+}
+
+impl Default for ComputeBudgetLimits {
+    fn default() -> Self {
+        ComputeBudgetLimits {
+            updated_heap_bytes: MIN_HEAP_FRAME_BYTES,
+            compute_unit_limit: MAX_COMPUTE_UNIT_LIMIT,
+            compute_unit_price: 0,
+            loaded_accounts_bytes: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
+        }
+    }
+}
+
+impl From<ComputeBudgetLimits> for FeeBudgetLimits {
+    fn from(val: ComputeBudgetLimits) -> Self {
+        let prioritization_fee_details = PrioritizationFeeDetails::new(
+            PrioritizationFeeType::ComputeUnitPrice(val.compute_unit_price),
+            u64::from(val.compute_unit_limit),
+        );
+        let prioritization_fee = prioritization_fee_details.get_fee();
+
+        FeeBudgetLimits {
+            loaded_accounts_data_size_limit: val.loaded_accounts_bytes,
+            heap_cost: DEFAULT_HEAP_COST,
+            compute_unit_limit: u64::from(val.compute_unit_limit),
+            prioritization_fee,
+        }
+    }
+}

--- a/compute-budget/src/lib.rs
+++ b/compute-budget/src/lib.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 
 pub mod compute_budget;
-pub mod compute_budget_processor;
+pub mod compute_budget_limits;
 pub mod prioritization_fee;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -46,6 +46,7 @@ serde_bytes = { workspace = true }
 serde_derive = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-bloom = { workspace = true }
+solana-builtins-default-costs = { workspace = true }
 solana-client = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-connection-cache = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,6 +49,7 @@ solana-bloom = { workspace = true }
 solana-builtins-default-costs = { workspace = true }
 solana-client = { workspace = true }
 solana-compute-budget = { workspace = true }
+solana-compute-budget-processor = { workspace = true }
 solana-connection-cache = { workspace = true }
 solana-cost-model = { workspace = true }
 solana-entry = { workspace = true }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -9,7 +9,7 @@ use {
         BankingStageStats,
     },
     itertools::Itertools,
-    solana_compute_budget::compute_budget_processor::process_compute_budget_instructions,
+    solana_compute_budget_processor::process_compute_budget_instructions,
     solana_ledger::token_balances::collect_token_balances,
     solana_measure::{measure::Measure, measure_us},
     solana_poh::poh_recorder::{

--- a/core/src/banking_stage/packet_filter.rs
+++ b/core/src/banking_stage/packet_filter.rs
@@ -1,6 +1,6 @@
 use {
     super::immutable_deserialized_packet::ImmutableDeserializedPacket,
-    solana_cost_model::block_cost_limits::BUILTIN_INSTRUCTION_COSTS,
+    solana_builtins_default_costs::BUILTIN_INSTRUCTION_COSTS,
     solana_sdk::{ed25519_program, saturating_add_assign, secp256k1_program},
     thiserror::Error,
 };

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -23,7 +23,7 @@ use {
     },
     arrayvec::ArrayVec,
     crossbeam_channel::RecvTimeoutError,
-    solana_compute_budget::compute_budget_processor::process_compute_budget_instructions,
+    solana_compute_budget_processor::process_compute_budget_instructions,
     solana_cost_model::cost_model::CostModel,
     solana_measure::measure_us,
     solana_runtime::{bank::Bank, bank_forks::BankForks},

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -13,18 +13,12 @@ edition = { workspace = true }
 ahash = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
-solana-address-lookup-table-program = { workspace = true }
-solana-bpf-loader-program = { workspace = true }
+solana-builtins-default-costs = { workspace = true }
 solana-compute-budget = { workspace = true }
-solana-compute-budget-program = { workspace = true }
-solana-config-program = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
-solana-loader-v4-program = { workspace = true }
 solana-metrics = { workspace = true }
 solana-sdk = { workspace = true }
-solana-stake-program = { workspace = true }
-solana-system-program = { workspace = true }
 solana-vote-program = { workspace = true }
 
 [lib]
@@ -35,6 +29,7 @@ name = "solana_cost_model"
 itertools = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
+solana-system-program = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/cost-model/src/block_cost_limits.rs
+++ b/cost-model/src/block_cost_limits.rs
@@ -1,13 +1,5 @@
 //! defines block cost related limits
 //!
-use {
-    lazy_static::lazy_static,
-    solana_sdk::{
-        address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
-        compute_budget, ed25519_program, loader_v4, pubkey::Pubkey, secp256k1_program,
-    },
-    std::collections::HashMap,
-};
 
 /// Static configurations:
 ///
@@ -34,28 +26,6 @@ pub const ED25519_VERIFY_STRICT_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 80;
 pub const WRITE_LOCK_UNITS: u64 = COMPUTE_UNIT_TO_US_RATIO * 10;
 /// Number of data bytes per compute units
 pub const INSTRUCTION_DATA_BYTES_COST: u64 = 140 /*bytes per us*/ / COMPUTE_UNIT_TO_US_RATIO;
-// Number of compute units for each built-in programs
-lazy_static! {
-    /// Number of compute units for each built-in programs
-    pub static ref BUILTIN_INSTRUCTION_COSTS: HashMap<Pubkey, u64> = [
-        (solana_stake_program::id(), solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS),
-        (solana_config_program::id(), solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS),
-        (solana_vote_program::id(), solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS),
-        (solana_system_program::id(), solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS),
-        (compute_budget::id(), solana_compute_budget_program::DEFAULT_COMPUTE_UNITS),
-        (address_lookup_table::program::id(), solana_address_lookup_table_program::processor::DEFAULT_COMPUTE_UNITS),
-        (bpf_loader_upgradeable::id(), solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS),
-        (bpf_loader_deprecated::id(), solana_bpf_loader_program::DEPRECATED_LOADER_COMPUTE_UNITS),
-        (bpf_loader::id(), solana_bpf_loader_program::DEFAULT_LOADER_COMPUTE_UNITS),
-        (loader_v4::id(), solana_loader_v4_program::DEFAULT_COMPUTE_UNITS),
-        // Note: These are precompile, run directly in bank during sanitizing;
-        (secp256k1_program::id(), 0),
-        (ed25519_program::id(), 0),
-    ]
-    .iter()
-    .cloned()
-    .collect();
-}
 
 /// Statically computed data:
 ///

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -9,10 +9,10 @@ use {
     crate::{block_cost_limits::*, transaction_cost::*},
     log::*,
     solana_builtins_default_costs::BUILTIN_INSTRUCTION_COSTS,
-    solana_compute_budget::compute_budget_processor::{
-        process_compute_budget_instructions, DEFAULT_HEAP_COST,
-        DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT, MAX_COMPUTE_UNIT_LIMIT,
+    solana_compute_budget::compute_budget_limits::{
+        DEFAULT_HEAP_COST, DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT, MAX_COMPUTE_UNIT_LIMIT,
     },
+    solana_compute_budget_processor::process_compute_budget_instructions,
     solana_sdk::{
         borsh1::try_from_slice_unchecked,
         compute_budget::{self, ComputeBudgetInstruction},
@@ -628,8 +628,8 @@ mod tests {
             .unwrap();
         const DEFAULT_PAGE_COST: u64 = 8;
         let expected_loaded_accounts_data_size_cost =
-            solana_compute_budget::compute_budget_processor::MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES
-                .get() as u64
+            solana_compute_budget::compute_budget_limits::MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get()
+                as u64
                 / ACCOUNT_DATA_COST_PAGE_SIZE
                 * DEFAULT_PAGE_COST;
 

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -8,6 +8,7 @@
 use {
     crate::{block_cost_limits::*, transaction_cost::*},
     log::*,
+    solana_builtins_default_costs::BUILTIN_INSTRUCTION_COSTS,
     solana_compute_budget::compute_budget_processor::{
         process_compute_budget_instructions, DEFAULT_HEAP_COST,
         DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT, MAX_COMPUTE_UNIT_LIMIT,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -815,7 +815,7 @@ mod tests {
     use {
         super::*,
         serde::{Deserialize, Serialize},
-        solana_compute_budget::compute_budget_processor,
+        solana_compute_budget::compute_budget_limits::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
         solana_sdk::{account::WritableAccount, instruction::Instruction, rent::Rent},
     };
 
@@ -1142,9 +1142,8 @@ mod tests {
             vec![(solana_sdk::pubkey::new_rand(), AccountSharedData::default())];
 
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
-        invoke_context.compute_budget = ComputeBudget::new(
-            compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
-        );
+        invoke_context.compute_budget =
+            ComputeBudget::new(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64);
 
         invoke_context
             .transaction_context
@@ -1154,9 +1153,7 @@ mod tests {
         invoke_context.push().unwrap();
         assert_eq!(
             *invoke_context.get_compute_budget(),
-            ComputeBudget::new(
-                compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64
-            )
+            ComputeBudget::new(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64)
         );
         invoke_context.pop().unwrap();
     }

--- a/program-runtime/src/mem_pool.rs
+++ b/program-runtime/src/mem_pool.rs
@@ -1,7 +1,7 @@
 use {
     solana_compute_budget::{
         compute_budget::{MAX_CALL_DEPTH, MAX_INSTRUCTION_STACK_DEPTH, STACK_FRAME_SIZE},
-        compute_budget_processor::{MAX_HEAP_FRAME_BYTES, MIN_HEAP_FRAME_BYTES},
+        compute_budget_limits::{MAX_HEAP_FRAME_BYTES, MIN_HEAP_FRAME_BYTES},
     },
     solana_rbpf::{aligned_memory::AlignedMemory, ebpf::HOST_ALIGN},
     std::array,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4779,6 +4779,7 @@ dependencies = [
  "solana-builtins-default-costs",
  "solana-compute-budget",
  "solana-sdk",
+ "solana-svm-transaction",
 ]
 
 [[package]]
@@ -6367,6 +6368,13 @@ dependencies = [
  "solana-timings",
  "solana-type-overrides",
  "solana-vote",
+]
+
+[[package]]
+name = "solana-svm-transaction"
+version = "2.1.0"
+dependencies = [
+ "solana-sdk",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4660,6 +4660,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-builtins-default-costs"
+version = "2.1.0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "rustc_version",
+ "solana-address-lookup-table-program",
+ "solana-bpf-loader-program",
+ "solana-compute-budget-program",
+ "solana-config-program",
+ "solana-loader-v4-program",
+ "solana-sdk",
+ "solana-stake-program",
+ "solana-system-program",
+ "solana-vote-program",
+]
+
+[[package]]
 name = "solana-clap-utils"
 version = "2.1.0"
 dependencies = [
@@ -4830,6 +4848,7 @@ dependencies = [
  "serde_derive",
  "solana-accounts-db",
  "solana-bloom",
+ "solana-builtins-default-costs",
  "solana-client",
  "solana-compute-budget",
  "solana-connection-cache",
@@ -4881,16 +4900,10 @@ dependencies = [
  "lazy_static",
  "log",
  "rustc_version",
- "solana-address-lookup-table-program",
- "solana-bpf-loader-program",
+ "solana-builtins-default-costs",
  "solana-compute-budget",
- "solana-compute-budget-program",
- "solana-config-program",
- "solana-loader-v4-program",
  "solana-metrics",
  "solana-sdk",
- "solana-stake-program",
- "solana-system-program",
  "solana-vote-program",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4771,6 +4771,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-compute-budget-processor"
+version = "2.1.0"
+dependencies = [
+ "log",
+ "rustc_version",
+ "solana-builtins-default-costs",
+ "solana-compute-budget",
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-compute-budget-program"
 version = "2.1.0"
 dependencies = [
@@ -4851,6 +4862,7 @@ dependencies = [
  "solana-builtins-default-costs",
  "solana-client",
  "solana-compute-budget",
+ "solana-compute-budget-processor",
  "solana-connection-cache",
  "solana-cost-model",
  "solana-entry",
@@ -4902,6 +4914,7 @@ dependencies = [
  "rustc_version",
  "solana-builtins-default-costs",
  "solana-compute-budget",
+ "solana-compute-budget-processor",
  "solana-metrics",
  "solana-sdk",
  "solana-vote-program",
@@ -5630,6 +5643,7 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-bucket-map",
  "solana-compute-budget",
+ "solana-compute-budget-processor",
  "solana-compute-budget-program",
  "solana-config-program",
  "solana-cost-model",
@@ -5684,6 +5698,7 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-cli-output",
  "solana-compute-budget",
+ "solana-compute-budget-processor",
  "solana-ledger",
  "solana-log-collector",
  "solana-logger",
@@ -6341,6 +6356,7 @@ dependencies = [
  "serde_derive",
  "solana-bpf-loader-program",
  "solana-compute-budget",
+ "solana-compute-budget-processor",
  "solana-loader-v4-program",
  "solana-log-collector",
  "solana-measure",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -31,6 +31,7 @@ solana-bn254 = { path = "../../curves/bn254", version = "=2.1.0" }
 solana-bpf-loader-program = { path = "../bpf_loader", version = "=2.1.0" }
 solana-cli-output = { path = "../../cli-output", version = "=2.1.0" }
 solana-compute-budget = { path = "../../compute-budget", version = "=2.1.0" }
+solana-compute-budget-processor = { path = "../../compute-budget-processor", version = "=2.1.0" }
 solana-curve25519 = { path = "../../curves/curve25519", version = "=2.1.0" }
 solana-decode-error = { path = "../../sdk/decode-error", version = "=2.1.0" }
 solana-ledger = { path = "../../ledger", version = "=2.1.0" }
@@ -99,6 +100,7 @@ solana-accounts-db = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
 solana-cli-output = { workspace = true }
 solana-compute-budget = { workspace = true }
+solana-compute-budget-processor = { workspace = true }
 solana-ledger = { workspace = true }
 solana-log-collector = { workspace = true }
 solana-logger = { workspace = true }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -13,10 +13,8 @@ use {
     solana_account_decoder::parse_bpf_loader::{
         parse_bpf_upgradeable_loader, BpfUpgradeableLoaderAccountType,
     },
-    solana_compute_budget::{
-        compute_budget::ComputeBudget,
-        compute_budget_processor::process_compute_budget_instructions,
-    },
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_compute_budget_processor::process_compute_budget_instructions,
     solana_ledger::token_balances::collect_token_balances,
     solana_program_runtime::invoke_context::mock_process_instruction,
     solana_rbpf::vm::ContextObject,

--- a/programs/zk-token-proof-tests/tests/process_transaction.rs
+++ b/programs/zk-token-proof-tests/tests/process_transaction.rs
@@ -1717,7 +1717,7 @@ impl WithMaxComputeUnitLimit for Vec<solana_sdk::instruction::Instruction> {
     fn with_max_compute_unit_limit(mut self) -> Self {
         self.push(
             solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(
-                solana_compute_budget::compute_budget_processor::MAX_COMPUTE_UNIT_LIMIT,
+                solana_compute_budget::compute_budget_limits::MAX_COMPUTE_UNIT_LIMIT,
             ),
         );
         self

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 [dependencies]
 log = { workspace = true }
 solana-compute-budget = { workspace = true }
+solana-compute-budget-processor = { workspace = true }
 solana-sdk = { workspace = true }
 thiserror = { workspace = true }
 

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -11,9 +11,8 @@
 //!    with its dynamic metadata loaded.
 use {
     crate::transaction_meta::{DynamicMeta, StaticMeta, TransactionMeta},
-    solana_compute_budget::compute_budget_processor::{
-        process_compute_budget_instructions, ComputeBudgetLimits,
-    },
+    solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
+    solana_compute_budget_processor::process_compute_budget_instructions,
     solana_sdk::{
         hash::Hash,
         message::{AddressLoader, SanitizedMessage, SanitizedVersionedMessage},

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -51,6 +51,7 @@ solana-address-lookup-table-program = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
 solana-bucket-map = { workspace = true }
 solana-compute-budget = { workspace = true }
+solana-compute-budget-processor = { workspace = true }
 solana-compute-budget-program = { workspace = true }
 solana-config-program = { workspace = true }
 solana-cost-model = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -85,10 +85,8 @@ use {
         storable_accounts::StorableAccounts,
     },
     solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
-    solana_compute_budget::{
-        compute_budget::ComputeBudget,
-        compute_budget_processor::process_compute_budget_instructions,
-    },
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_compute_budget_processor::process_compute_budget_instructions,
     solana_cost_model::cost_tracker::CostTracker,
     solana_loader_v4_program::create_program_runtime_environment_v2,
     solana_measure::{measure::Measure, measure_time, measure_us},

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -34,9 +34,10 @@ use {
     },
     solana_compute_budget::{
         compute_budget::ComputeBudget,
-        compute_budget_processor::{self, MAX_COMPUTE_UNIT_LIMIT},
+        compute_budget_limits::{DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT, MAX_COMPUTE_UNIT_LIMIT},
         prioritization_fee::{PrioritizationFeeDetails, PrioritizationFeeType},
     },
+    solana_compute_budget_processor::process_compute_budget_instructions,
     solana_inline_spl::token,
     solana_logger,
     solana_program_runtime::{
@@ -9708,9 +9709,7 @@ fn test_compute_budget_program_noop() {
         assert_eq!(
             *compute_budget,
             ComputeBudget {
-                compute_unit_limit: u64::from(
-                    compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
-                ),
+                compute_unit_limit: u64::from(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT),
                 heap_size: 48 * 1024,
                 ..ComputeBudget::default()
             }
@@ -9721,7 +9720,7 @@ fn test_compute_budget_program_noop() {
     let message = Message::new(
         &[
             ComputeBudgetInstruction::set_compute_unit_limit(
-                compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
+                DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
             ),
             ComputeBudgetInstruction::request_heap_frame(48 * 1024),
             Instruction::new_with_bincode(program_id, &0, vec![]),
@@ -9753,9 +9752,7 @@ fn test_compute_request_instruction() {
         assert_eq!(
             *compute_budget,
             ComputeBudget {
-                compute_unit_limit: u64::from(
-                    compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
-                ),
+                compute_unit_limit: u64::from(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT),
                 heap_size: 48 * 1024,
                 ..ComputeBudget::default()
             }
@@ -9766,7 +9763,7 @@ fn test_compute_request_instruction() {
     let message = Message::new(
         &[
             ComputeBudgetInstruction::set_compute_unit_limit(
-                compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
+                DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
             ),
             ComputeBudgetInstruction::request_heap_frame(48 * 1024),
             Instruction::new_with_bincode(program_id, &0, vec![]),
@@ -9806,9 +9803,7 @@ fn test_failed_compute_request_instruction() {
         assert_eq!(
             *compute_budget,
             ComputeBudget {
-                compute_unit_limit: u64::from(
-                    compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
-                ),
+                compute_unit_limit: u64::from(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT),
                 heap_size: 48 * 1024,
                 ..ComputeBudget::default()
             }

--- a/runtime/src/compute_budget_details.rs
+++ b/runtime/src/compute_budget_details.rs
@@ -1,5 +1,5 @@
 use {
-    solana_compute_budget::compute_budget_processor::process_compute_budget_instructions,
+    solana_compute_budget_processor::process_compute_budget_instructions,
     solana_sdk::{
         instruction::CompiledInstruction,
         pubkey::Pubkey,
@@ -89,7 +89,7 @@ mod tests {
             Some(ComputeBudgetDetails {
                 compute_unit_price: 0,
                 compute_unit_limit:
-                solana_compute_budget::compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                solana_compute_budget::compute_budget_limits::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
                     as u64,
             })
         );
@@ -101,7 +101,7 @@ mod tests {
             Some(ComputeBudgetDetails {
                 compute_unit_price: 0,
                 compute_unit_limit:
-                solana_compute_budget::compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                solana_compute_budget::compute_budget_limits::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
                     as u64,
             })
         );
@@ -163,7 +163,7 @@ mod tests {
             Some(ComputeBudgetDetails {
                 compute_unit_price: requested_price,
                 compute_unit_limit:
-                solana_compute_budget::compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                solana_compute_budget::compute_budget_limits::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
                     as u64,
             })
         );
@@ -175,7 +175,7 @@ mod tests {
             Some(ComputeBudgetDetails {
                 compute_unit_price: requested_price,
                 compute_unit_limit:
-                    solana_compute_budget::compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                    solana_compute_budget::compute_budget_limits::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
                     as u64,
             })
         );

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -845,6 +845,10 @@ pub mod vote_only_retransmitter_signed_fec_sets {
     solana_sdk::declare_id!("RfEcA95xnhuwooVAhUUksEJLZBF7xKCLuqrJoqk4Zph");
 }
 
+pub mod compute_budget_uses_builtin_default_costs {
+    solana_sdk::declare_id!("C9oAhLxDBm3ssWtJx1yBGzPY55r2rArHmN1pbQn6HogH");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -1051,6 +1055,7 @@ lazy_static! {
         (move_stake_and_move_lamports_ixs::id(), "Enable MoveStake and MoveLamports stake program instructions #1610"),
         (ed25519_precompile_verify_strict::id(), "Use strict verification in ed25519 precompile SIMD-0152"),
         (vote_only_retransmitter_signed_fec_sets::id(), "vote only on retransmitter signed fec sets"),
+        (compute_budget_uses_builtin_default_costs::id(), "Compute budget allocates default units for builtin instructions #XXXX"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
 solana-compute-budget = { workspace = true }
+solana-compute-budget-processor = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-loader-v4-program = { workspace = true }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -6,7 +6,7 @@ use {
         transaction_processing_callback::TransactionProcessingCallback,
     },
     itertools::Itertools,
-    solana_compute_budget::compute_budget_processor::ComputeBudgetLimits,
+    solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_program_runtime::loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
@@ -410,7 +410,7 @@ mod tests {
             transaction_processing_callback::TransactionProcessingCallback,
         },
         nonce::state::Versions as NonceVersions,
-        solana_compute_budget::{compute_budget::ComputeBudget, compute_budget_processor},
+        solana_compute_budget::{compute_budget::ComputeBudget, compute_budget_limits},
         solana_program_runtime::loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
         solana_sdk::{
             account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
@@ -1652,7 +1652,7 @@ mod tests {
         );
 
         let compute_budget = ComputeBudget::new(u64::from(
-            compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
+            compute_budget_limits::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
         ));
         let transaction_context = TransactionContext::new(
             loaded_txs[0].as_ref().unwrap().accounts.clone(),

--- a/svm/src/account_saver.rs
+++ b/svm/src/account_saver.rs
@@ -141,7 +141,7 @@ mod tests {
             nonce_info::NoncePartial,
             transaction_results::{ExecutedTransaction, TransactionExecutionDetails},
         },
-        solana_compute_budget::compute_budget_processor::ComputeBudgetLimits,
+        solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
         solana_sdk::{
             account::{AccountSharedData, ReadableAccount, WritableAccount},
             fee::FeeDetails,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -21,10 +21,8 @@ use {
     log::debug,
     percentage::Percentage,
     solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
-    solana_compute_budget::{
-        compute_budget::ComputeBudget,
-        compute_budget_processor::process_compute_budget_instructions,
-    },
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_compute_budget_processor::process_compute_budget_instructions,
     solana_loader_v4_program::create_program_runtime_environment_v2,
     solana_log_collector::LogCollector,
     solana_measure::{measure::Measure, measure_us},
@@ -979,7 +977,7 @@ mod tests {
             account_loader::ValidatedTransactionDetails, nonce_info::NoncePartial,
             rollback_accounts::RollbackAccounts,
         },
-        solana_compute_budget::compute_budget_processor::ComputeBudgetLimits,
+        solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
         solana_program_runtime::loaded_programs::{BlockRelation, ProgramCacheEntryType},
         solana_sdk::{
             account::{create_account_shared_data_for_test, WritableAccount},


### PR DESCRIPTION
#### Problem
- `solana-compute-budget` has `process_compute_budget_instructions()`;
- `process_compute_budget_instructions()` needs to access builtin programs' default costs to correctly allocate compute budget for builtin instructions;
- each builtin programs define their own default costs; and they all (in)directly depends on `solana-compute-budget` crate;
So, there will be circular dependencies for `process_compute_budget_instructions()` to builtin default cost.

#### Summary of Changes
1. Commit 1: refactor, move statically defined `BUILT_IN_INSTRUCTION_COSTS` out of `solana-cost-model` into its own crate. 
    - it serves as adaptor to reference to all current, and future, builtin crates
    - being in its own crate, it can be shared between `solana-cost-model` and other crates
    - future works will be isolated into this crate. For example: look up builtin cost by instruction instead of program-id; add ability to build *the map* at compile-time, so dev dont need to worry about updating map when adding new builtin  

2. Commit 2: refactor, move `process_compute_budget_instructions()` out of `solana-compute-budget` into its own crate.
    - new crate `solana-compute-budget-processor` breaks circular dep,
    - `solana-compute-budget` becomes purely "type def", safer and easier to share
    -  encourages `process_compute_budget_instructions()` to do *One Thing*: parse transaction for compute-budget-limits, its result must be consistent regardless of current working_bank. Secondary functions can regulate/validate results on call site using `working_bank`.

3. Commit 3: refactor, Added intermediate InstructionDetails struct to store raw information after instructions iteration; break `process_compute_budget_instructions()` into two steps: one iterate instructions to retrieve `InstructionDetails` that's suitable for caching-n-reusing, then sanitize and convert to `ComputeBudgetLimits`.

4. Commit 4: refactor: Instruction processor takes SVMMessage in place of CompiledInstruction, fixes #2112

5. Commit 5: feat, feature gated, compute budget allocates default cost units for builtin instructions, including compute-budget instructions themselves; Error transaction early if compute-unit-limit is invalid.
    This fixes #885, #2212
   
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
