### PR TITLE
Rename/deprecate num_signatures to num_total_signatures

### DIFF
--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -378,6 +378,9 @@ impl SanitizedMessage {
         self.num_total_signatures()
     }
 
+    /// Returns the total number of signatures in the message.
+    /// This includes required transaction signatures as well as any
+    /// pre-compile signatures that are attached in instructions.
     pub fn num_total_signatures(&self) -> u64 {
         self.get_signature_details().total_signatures()
     }

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -370,7 +370,15 @@ impl SanitizedMessage {
             })
     }
 
+    #[deprecated(
+        since = "2.1.0",
+        note = "Please use `SanitizedMessage::num_total_signatures` instead."
+    )]
     pub fn num_signatures(&self) -> u64 {
+        self.num_total_signatures()
+    }
+
+    pub fn num_total_signatures(&self) -> u64 {
         self.get_signature_details().total_signatures()
     }
 

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -161,7 +161,7 @@ impl FeeStructure {
         }
 
         let signature_fee = message
-            .num_signatures()
+            .num_total_signatures()
             .saturating_mul(self.lamports_per_signature);
         let write_lock_fee = message
             .num_write_locks()

--- a/svm-transaction/src/svm_message.rs
+++ b/svm-transaction/src/svm_message.rs
@@ -11,7 +11,9 @@ mod sanitized_transaction;
 
 // - Debug to support legacy logging
 pub trait SVMMessage: Debug {
-    /// Return the number of signatures in the message.
+    /// Returns the total number of signatures in the message.
+    /// This includes required transaction signatures as well as any
+    /// pre-compile signatures that are attached in instructions.
     fn num_total_signatures(&self) -> u64;
 
     /// Returns the number of requested write-locks in this message.

--- a/svm-transaction/src/svm_message.rs
+++ b/svm-transaction/src/svm_message.rs
@@ -12,7 +12,7 @@ mod sanitized_transaction;
 // - Debug to support legacy logging
 pub trait SVMMessage: Debug {
     /// Return the number of signatures in the message.
-    fn num_signatures(&self) -> u64;
+    fn num_total_signatures(&self) -> u64;
 
     /// Returns the number of requested write-locks in this message.
     /// This does not consider if write-locks are demoted.

--- a/svm-transaction/src/svm_message/sanitized_message.rs
+++ b/svm-transaction/src/svm_message/sanitized_message.rs
@@ -12,8 +12,8 @@ use {
 
 // Implement for the "reference" `SanitizedMessage` type.
 impl SVMMessage for SanitizedMessage {
-    fn num_signatures(&self) -> u64 {
-        SanitizedMessage::num_signatures(self)
+    fn num_total_signatures(&self) -> u64 {
+        SanitizedMessage::num_total_signatures(self)
     }
 
     fn num_write_locks(&self) -> u64 {

--- a/svm-transaction/src/svm_message/sanitized_transaction.rs
+++ b/svm-transaction/src/svm_message/sanitized_transaction.rs
@@ -9,8 +9,8 @@ use {
 };
 
 impl SVMMessage for SanitizedTransaction {
-    fn num_signatures(&self) -> u64 {
-        SVMMessage::num_signatures(SanitizedTransaction::message(self))
+    fn num_total_signatures(&self) -> u64 {
+        SVMMessage::num_total_signatures(SanitizedTransaction::message(self))
     }
 
     fn num_write_locks(&self) -> u64 {


### PR DESCRIPTION
#### Problem
- The `num_signatures` function name is confusing since it includes "actual" signatures on the transaction, as well as "pre-compile" signatures that are attached as instructions.

#### Summary of Changes
- deprecate `SantizedMessage::num_signatures`
- add new function `SanitizedMessage::num_total_signatures`
- rename `SVMMessage::num_signatures` to `SVMMessage::num_total_signatures` to match

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
