### PR TITLE
add ancient pack metrics

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1957,6 +1957,8 @@ pub(crate) struct ShrinkAncientStats {
     pub(crate) many_ref_slots_skipped: AtomicU64,
     pub(crate) slots_cannot_move_count: AtomicU64,
     pub(crate) many_refs_old_alive: AtomicU64,
+    pub(crate) slots_eligible_to_shrink: AtomicU64,
+    pub(crate) total_dead_bytes: AtomicU64,
 }
 
 #[derive(Debug, Default)]
@@ -2237,6 +2239,16 @@ impl ShrinkAncientStats {
             (
                 "random",
                 self.random_shrink.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "slots_eligible_to_shrink",
+                self.slots_eligible_to_shrink.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "total_dead_bytes",
+                self.total_dead_bytes.swap(0, Ordering::Relaxed),
                 i64
             ),
             (

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -565,6 +565,20 @@ impl AccountsDb {
                 }
             }
         }
+        let mut total_dead_bytes = 0;
+        let should_shrink_count = infos
+            .all_infos
+            .iter()
+            .filter(|info| info.should_shrink)
+            .map(|info| total_dead_bytes += info.capacity.saturating_sub(info.alive_bytes))
+            .count()
+            .saturating_sub(randoms as usize);
+        self.shrink_ancient_stats
+            .slots_eligible_to_shrink
+            .fetch_add(should_shrink_count as u64, Ordering::Relaxed);
+        self.shrink_ancient_stats
+            .total_dead_bytes
+            .fetch_add(total_dead_bytes, Ordering::Relaxed);
         if randoms > 0 {
             self.shrink_ancient_stats
                 .random_shrink


### PR DESCRIPTION
#### Problem
Testing with skipping rewrites and ancient packing have resulted in a steady state where we have too many ancient storages that need to be 'shrunk'. These already large, ancient storages dominate the budget of a maximum of 10 ancient append vecs of ideal size. The result is that packing fails to make progress on keeping a limit on the number of ancient storages/roots.

#### Summary of Changes
Add metrics for total # of ancient storages that need to be re-packed/shrunk and total dead bytes across all ancient storages.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
