### PR TITLE
ci: "Fix" the downstream anchor build

### DIFF
--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -16,6 +16,7 @@ on:
       - "cargo-build-sbf"
       - "cargo-test-sbf"
       - "scripts/build-downstream-anchor-projects.sh"
+      - "scripts/patch-spl-crates-for-anchor.sh"
       - ".github/scripts/purge-ubuntu-runner.sh"
       - ".github/scripts/downstream-project-spl-install-deps.sh"
       - ".github/workflows/downstream-project-anchor.yml"

--- a/scripts/patch-spl-crates-for-anchor.sh
+++ b/scripts/patch-spl-crates-for-anchor.sh
@@ -70,7 +70,10 @@ patch_crates_io() {
     spl-memo = { path = "$spl_dir/memo/program" }
     spl-pod = { path = "$spl_dir/libraries/pod" }
     spl-token = { path = "$spl_dir/token/program" }
-    spl-token-2022 = { path = "$spl_dir/token/program-2022" }
+    # Avoid patching spl-token-2022 to avoid forcing anchor to use 4.0.1, which
+    # doesn't work with the monorepo forcing 4.0.0. Allow the patching again once
+    # the monorepo is on 4.0.1, or relax the dependency in the monorepo.
+    #spl-token-2022 = { path = "$spl_dir/token/program-2022" }
     spl-token-group-interface = { path = "$spl_dir/token-group/interface" }
     spl-token-metadata-interface = { path = "$spl_dir/token-metadata/interface" }
     spl-tlv-account-resolution = { path = "$spl_dir/libraries/tlv-account-resolution" }


### PR DESCRIPTION
#### Problem

There's an issue with the downstream anchor build, because spl-token-2022 4.0.1 exists, and we patch anchor to use that, but the monorepo is forced to use 4.0.0. Apparently cargo doesn't figure out that it should use 4.0.0 for everyone.

#### Summary of Changes

Longterm, we should consider relaxing the spl-token-2022 dependency at https://github.com/anza-xyz/agave/blob/2c4b61e777c20379d91396340aea4f0b8d9984c1/Cargo.toml#L438 -- I'll have to look back and remember why we pinned all of those.

But for now, we just don't patch token-2022. Everything still seems to pass since 4.0.0 and 4.0.1 are mostly the same.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
