### PR TITLE
Reorganize SVM concurrent tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7557,6 +7557,7 @@ dependencies = [
  "log",
  "percentage",
  "prost",
+ "qualifier_attr",
  "rand 0.8.5",
  "rustc_version 0.4.0",
  "serde",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6337,6 +6337,7 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "percentage",
+ "qualifier_attr",
  "rustc_version",
  "serde",
  "serde_derive",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 percentage = { workspace = true }
+qualifier_attr = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
@@ -55,7 +56,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustc_version = { workspace = true }
 
 [features]
-dev-context-only-utils = []
+dev-context-only-utils = ["dep:qualifier_attr"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -1,0 +1,64 @@
+use {
+    crate::mock_bank::{deploy_program, MockForkGraph},
+    mock_bank::MockBankCallback,
+    solana_program_runtime::loaded_programs::ProgramCacheEntryType,
+    solana_sdk::pubkey::Pubkey,
+    solana_svm::transaction_processor::TransactionBatchProcessor,
+    solana_type_overrides::sync::RwLock,
+    std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+        thread,
+    },
+};
+
+mod mock_bank;
+
+#[test]
+fn fast_concur_test() {
+    let mut mock_bank = MockBankCallback::default();
+    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(5, 5, HashSet::new());
+    let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
+    batch_processor.program_cache.write().unwrap().fork_graph = Some(Arc::downgrade(&fork_graph));
+
+    let programs = vec![
+        deploy_program("hello-solana".to_string(), 0, &mut mock_bank),
+        deploy_program("simple-transfer".to_string(), 0, &mut mock_bank),
+        deploy_program("clock-sysvar".to_string(), 0, &mut mock_bank),
+    ];
+
+    let account_maps: HashMap<Pubkey, u64> = programs
+        .iter()
+        .enumerate()
+        .map(|(idx, key)| (*key, idx as u64))
+        .collect();
+
+    for _ in 0..10 {
+        let ths: Vec<_> = (0..4)
+            .map(|_| {
+                let local_bank = mock_bank.clone();
+                let processor = TransactionBatchProcessor::new_from(
+                    &batch_processor,
+                    batch_processor.slot,
+                    batch_processor.epoch,
+                );
+                let maps = account_maps.clone();
+                let programs = programs.clone();
+                thread::spawn(move || {
+                    let result = processor.replenish_program_cache(&local_bank, &maps, false, true);
+                    for key in &programs {
+                        let cache_entry = result.find(key);
+                        assert!(matches!(
+                            cache_entry.unwrap().program,
+                            ProgramCacheEntryType::Loaded(_)
+                        ));
+                    }
+                })
+            })
+            .collect();
+
+        for th in ths {
+            th.join().unwrap();
+        }
+    }
+}

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -197,7 +197,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
     let mut fee_payer = Pubkey::new_unique();
     let mut mock_bank = MockBankCallback::default();
     {
-        let mut account_data_map = mock_bank.account_shared_data.borrow_mut();
+        let mut account_data_map = mock_bank.account_shared_data.write().unwrap();
         for item in input.accounts {
             let pubkey = Pubkey::new_from_array(item.address.try_into().unwrap());
             let mut account_data = AccountSharedData::default();


### PR DESCRIPTION
#### Problem

Now that rBPF 0.8.2 has been released, I can adopt shuttle for concurrent tests in the SVM. It is now a good time to reorganize the tests and make a separate file for those targeting concurrent execution.

#### Summary of Changes

I removed extra functions and moved the concurrent test for the program cache to its own file.