### PR TITLE
fix conditional borsh usage in compute_budget.rs

### DIFF
--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -12,7 +12,8 @@ crate::declare_id!("ComputeBudget111111111111111111111111111111");
 
 /// Compute Budget Instructions
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
-#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub enum ComputeBudgetInstruction {
     Unused, // deprecated variant, reserved value.
     /// Request a specific transaction-wide program heap region size in bytes.


### PR DESCRIPTION
#### Problem
Borsh traits are being derived on `ComputeBudgetInstruction` without cfg_attr which breaks opting out of borsh in the SDK. This command fails: 
```
agave/sdk$ cargo check --no-default-features -F full
```

#### Summary of Changes
Put the borsh derivations behind cfg_attr like in the rest of solana-sdk and solana-program.
