### PR TITLE
Don't skip sending tx to current leader

### DIFF
--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -208,6 +208,10 @@ mod test {
             leader_info.get_leader_tpus(1, Protocol::UDP),
             vec![&recent_peers.get(&first_leader).unwrap().0]
         );
+        assert_eq!(
+            leader_info.get_leader_tpus_with_slots(1, Protocol::UDP),
+            vec![(&recent_peers.get(&first_leader).unwrap().0, 0)]
+        );
 
         let second_leader = solana_ledger::leader_schedule_utils::slot_leader_at(
             slot + NUM_CONSECUTIVE_LEADER_SLOTS,
@@ -222,6 +226,13 @@ mod test {
         assert_eq!(
             leader_info.get_leader_tpus(2, Protocol::UDP),
             expected_leader_sockets
+        );
+        assert_eq!(
+            leader_info.get_leader_tpus_with_slots(2, Protocol::UDP),
+            expected_leader_sockets
+                .into_iter()
+                .zip([0, 4])
+                .collect::<Vec<_>>()
         );
 
         let third_leader = solana_ledger::leader_schedule_utils::slot_leader_at(
@@ -239,9 +250,24 @@ mod test {
             leader_info.get_leader_tpus(3, Protocol::UDP),
             expected_leader_sockets
         );
+        // Only 2 leader tpus are returned always... so [0, 4, 8] isn't right here.
+        // This assumption is safe. After all, leader schedule generation must be deterministic.
+        assert_eq!(
+            leader_info.get_leader_tpus_with_slots(3, Protocol::UDP),
+            expected_leader_sockets
+                .into_iter()
+                .zip([0, 4])
+                .collect::<Vec<_>>()
+        );
 
         for x in 4..8 {
             assert!(leader_info.get_leader_tpus(x, Protocol::UDP).len() <= recent_peers.len());
+            assert!(
+                leader_info
+                    .get_leader_tpus_with_slots(x, Protocol::UDP)
+                    .len()
+                    <= recent_peers.len()
+            );
         }
     }
 }

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -75,8 +75,8 @@ impl TpuInfo for ClusterTpuInfo {
     ) -> Vec<(&SocketAddr, Slot)> {
         let recorder = self.poh_recorder.read().unwrap();
         let leaders: Vec<_> = (0..max_count)
+            .rev()
             .filter_map(|future_slot| {
-                let future_slot = max_count.wrapping_sub(future_slot);
                 NUM_CONSECUTIVE_LEADER_SLOTS
                     .checked_mul(future_slot)
                     .and_then(|slots_in_the_future| {


### PR DESCRIPTION
#### Problem

Surprisingly `SendTransactionService` isn't sending transactions to _current_ leaders until retried. That's because the initial transaction sending is using `get_leader_tpus_with_slots()`, which is buggy. On the other hand, retry code is using `get_leader_tpus()`, which isn't buggy.

This bug introduced at https://github.com/solana-labs/solana/pull/32942.

#### Summary of Changes

Fix that classic off-by-one bug.

_Theoretically_, this improves confirmation time by 0.8s overall.

However, considering 80% of mainnet-beta stake is operated by jito (ref: https://www.jito.network/ja/stakenet/), the actual improvement should be ~0.16s instead? (note: there's an planned experiment for this).

That said, I think this fix contributes overall stability of our lovely local-cluster tests. lol

So, i wonder bp-ing this to v1.18 should worth or not...

context: found when evaluating unified scheduler for the banking stage: #2019 