### PR TITLE
refactor `fn occupy` retrun to avoid introducting mut variable

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -283,15 +283,15 @@ impl<O: BucketOccupied> BucketStorage<O> {
     /// 'is_resizing' false if caller is adding an item to the index (so increment count)
     pub fn occupy(&mut self, ix: u64, is_resizing: bool) -> Result<(), BucketStorageError> {
         debug_assert!(ix < self.capacity(), "occupy: bad index size");
-        let mut e = Err(BucketStorageError::AlreadyOccupied);
         //debug!("ALLOC {} {}", ix, uid);
         if self.try_lock(ix) {
-            e = Ok(());
             if !is_resizing {
                 self.count.fetch_add(1, Ordering::Relaxed);
             }
+            Ok(())
+        } else {
+            Err(BucketStorageError::AlreadyOccupied)
         }
-        e
     }
 
     pub fn free(&mut self, ix: u64) {


### PR DESCRIPTION
#### Problem

`fn occupy` return Result can be refactored to avoid using mut variable.


#### Summary of Changes

Refactor `fn occupy` to direclty return Result (more idiomatic rust).


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
