### PR TITLE
ci: Add rule for Firedancer review on native programs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -183,7 +183,7 @@ pull_request_rules:
           2. Open a follow-up PR to update the JavaScript client `@solana/web3.js` ([example](https://github.com/solana-labs/solana-web3.js/pull/2868/files))
 
           Thank you for keeping the RPC clients in sync with the server API @{{author}}.
-  - name: Reminder to add Firedancer team to changes in `programs/`
+  - name: Reminder to add Firedancer team to changes in `programs/` and `sdk/`
     conditions:
       - or:
         - files~=^programs/address-lookup-table/src/.*\.rs$
@@ -200,9 +200,12 @@ pull_request_rules:
     actions:
       comment:
         message: |
-          If this PR represents a change to a native program implementation, even
-          a refactor, please include someone from the Firedancer team as one of the
-          reviewers.
+          The Firedancer team maintains a line-for-line reimplementation of the
+          native programs, and until native programs are moved to BPF, those
+          implementations must exactly match their Agave counterparts.
+          If this PR represents a change to a native program implementation (not
+          tests), please include a reviewer from the Firedancer team. And please
+          keep refactors to a minimum.
 
 commands_restrictions:
   # The author of copied PRs is the Mergify user.

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -183,6 +183,24 @@ pull_request_rules:
           2. Open a follow-up PR to update the JavaScript client `@solana/web3.js` ([example](https://github.com/solana-labs/solana-web3.js/pull/2868/files))
 
           Thank you for keeping the RPC clients in sync with the server API @{{author}}.
+  - name: Reminder to add Firedancer team to changes in `programs/`
+    conditions:
+      - or:
+        - files~=^programs/address-lookup-table/src/.*\.rs$
+        - files~=^programs/bpf_loader/src/.*\.rs$
+        - files~=^programs/compute_budget/src/.*\.rs$
+        - files~=^programs/config/src/.*\.rs$
+        - files~=^programs/loader-v4/src/.*\.rs$
+        - files~=^programs/stake/src/.*\.rs$
+        - files~=^programs/system/src/.*\.rs$
+        - files~=^programs/vote/src/.*\.rs$
+        - files~=^programs/zk-elgamal-proof/src/.*\.rs$
+    actions:
+      comment:
+        message: |
+          If this PR represents a change to a native program implementation, even
+          a refactor, please include someone from the Firedancer team as one of the
+          reviewers.
 
 commands_restrictions:
   # The author of copied PRs is the Mergify user.

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -195,6 +195,8 @@ pull_request_rules:
         - files~=^programs/system/src/.*\.rs$
         - files~=^programs/vote/src/.*\.rs$
         - files~=^programs/zk-elgamal-proof/src/.*\.rs$
+        - files~=^sdk/program/src/stake.*\.rs$  # includes stake_history.rs
+        - files~=^sdk/program/src/vote/.*\.rs$
     actions:
       comment:
         message: |


### PR DESCRIPTION
#### Problem

The Firedancer team maintains a line-for-line reimplementation of the native programs, and until native programs are moved to BPF, those implementations must exactly match their Agave counterparts. In the past, the Firedancer team has requested to be included in reviews that touch code in the native programs.

#### Summary of Changes

To make it harder to forget, add an automated message to any PRs that touch native programs. I've omitted test crates and the ZK Token Proof program, since I believe that won't be included in Firedancer.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
