### PR TITLE
Cleanup - Remove loader from `program_indices` for top-level instructions

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -768,9 +768,11 @@ pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut Invo
             is_writable: account_meta.is_writable,
         });
     }
-    program_indices.insert(0, transaction_accounts.len() as IndexOfAccount);
-    let processor_account = AccountSharedData::new(0, 0, &native_loader::id());
-    transaction_accounts.push((*loader_id, processor_account));
+    if program_indices.is_empty() {
+        program_indices.insert(0, transaction_accounts.len() as IndexOfAccount);
+        let processor_account = AccountSharedData::new(0, 0, &native_loader::id());
+        transaction_accounts.push((*loader_id, processor_account));
+    }
     let pop_epoch_schedule_account = if !transaction_accounts
         .iter()
         .any(|(key, _)| *key == sysvar::epoch_schedule::id())

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -475,6 +475,7 @@ impl<'a> InvokeContext<'a> {
         let process_executable_chain_time = Measure::start("process_executable_chain_time");
 
         let builtin_id = {
+            debug_assert!(instruction_context.get_number_of_program_accounts() <= 1);
             let borrowed_root_account = instruction_context
                 .try_borrow_program_account(self.transaction_context, 0)
                 .map_err(|_| InstructionError::UnsupportedProgramId)?;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -3577,7 +3577,7 @@ mod tests {
         program_account = accounts.get(3).unwrap().clone();
         process_instruction(
             &loader_id,
-            &[0, 1],
+            &[1],
             &[],
             vec![
                 (programdata_address, programdata_account.clone()),

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -1589,7 +1589,7 @@ mod tests {
             &[0, 1, 2, 3],
             transaction_accounts.clone(),
             &[(1, false, true)],
-            Err(InstructionError::InvalidAccountOwner),
+            Err(InstructionError::UnsupportedProgramId),
         );
 
         // Error: Program is uninitialized

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -299,7 +299,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
         .iter()
         .map(|instruction| {
             let mut account_indices = Vec::with_capacity(2);
-            let mut program_index = instruction.program_id_index as usize;
+            let program_index = instruction.program_id_index as usize;
             // This command may never return error, because the transaction is sanitized
             let (program_id, program_account) = accounts
                 .get(program_index)
@@ -323,7 +323,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
             if native_loader::check_id(owner_id) {
                 return Ok(account_indices);
             }
-            program_index = if let Some(owner_index) = accounts
+            if let Some(owner_index) = accounts
                 .get(builtins_start_index..)
                 .ok_or(TransactionError::ProgramAccountNotFound)?
                 .iter()
@@ -351,8 +351,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                     return Err(TransactionError::ProgramAccountNotFound);
                 }
                 owner_index
-            };
-            account_indices.insert(0, program_index as IndexOfAccount);
+            }
             Ok(account_indices)
         })
         .collect::<Result<Vec<Vec<IndexOfAccount>>>>()?;

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -750,21 +750,8 @@ mod tests {
                 assert_eq!(loaded_transaction.accounts.len(), 4);
                 assert_eq!(loaded_transaction.accounts[0].1, accounts[0].1);
                 assert_eq!(loaded_transaction.program_indices.len(), 2);
-                assert_eq!(loaded_transaction.program_indices[0].len(), 1);
-                assert_eq!(loaded_transaction.program_indices[1].len(), 2);
-                for program_indices in loaded_transaction.program_indices.iter() {
-                    for (i, program_index) in program_indices.iter().enumerate() {
-                        // +1 to skip first not loader account
-                        assert_eq!(
-                            loaded_transaction.accounts[*program_index as usize].0,
-                            accounts[i + 1].0
-                        );
-                        assert_eq!(
-                            loaded_transaction.accounts[*program_index as usize].1,
-                            accounts[i + 1].1
-                        );
-                    }
-                }
+                assert_eq!(loaded_transaction.program_indices[0], &[1]);
+                assert_eq!(loaded_transaction.program_indices[1], &[2]);
             }
             Err(e) => panic!("{e}"),
         }
@@ -1620,7 +1607,7 @@ mod tests {
                         mock_bank.accounts_map[&key3.pubkey()].clone()
                     ),
                 ],
-                program_indices: vec![vec![2, 1]],
+                program_indices: vec![vec![1]],
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
                 compute_budget_limits: ComputeBudgetLimits::default(),
@@ -1713,7 +1700,7 @@ mod tests {
                         mock_bank.accounts_map[&key3.pubkey()].clone()
                     ),
                 ],
-                program_indices: vec![vec![3, 1], vec![3, 1]],
+                program_indices: vec![vec![1], vec![1]],
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
                 compute_budget_limits: ComputeBudgetLimits::default(),
@@ -1875,7 +1862,7 @@ mod tests {
                         mock_bank.accounts_map[&key3.pubkey()].clone()
                     ),
                 ],
-                program_indices: vec![vec![3, 1], vec![3, 1]],
+                program_indices: vec![vec![1], vec![1]],
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
                 compute_budget_limits: ComputeBudgetLimits::default(),

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -323,15 +323,12 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
             if native_loader::check_id(owner_id) {
                 return Ok(account_indices);
             }
-            if let Some(owner_index) = accounts
+            if !accounts
                 .get(builtins_start_index..)
                 .ok_or(TransactionError::ProgramAccountNotFound)?
                 .iter()
-                .position(|(key, _)| key == owner_id)
+                .any(|(key, _)| key == owner_id)
             {
-                builtins_start_index.saturating_add(owner_index)
-            } else {
-                let owner_index = accounts.len();
                 if let Some(owner_account) = callbacks.get_account_shared_data(owner_id) {
                     if !native_loader::check_id(owner_account.owner())
                         || !owner_account.executable()
@@ -350,7 +347,6 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                     error_metrics.account_not_found += 1;
                     return Err(TransactionError::ProgramAccountNotFound);
                 }
-                owner_index
             }
             Ok(account_indices)
         })


### PR DESCRIPTION
#### Problem
Currently we add the loader to the `program_indices`, but only for top-level instructions.
The program runtime does not require that as CPI instructions work without it.

#### Summary of Changes
- Removes loader from `program_indices` of top-level instructions in account loading.
- Adds a `debug_assert!` to make sure `program_indices` is essentially an `Option` (containing 0 or 1 entries)
- Adjusts the tests.