### PR TITLE
solana-genesis: deactivate specific features for development clusters

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -11,7 +11,7 @@ use {
             cluster_type_of, pubkey_of, pubkeys_of, unix_timestamp_from_rfc3339_datetime,
         },
         input_validators::{
-            is_pubkey_or_keypair, is_rfc3339_datetime, is_slot, is_valid_percentage,
+            is_pubkey, is_pubkey_or_keypair, is_rfc3339_datetime, is_slot, is_valid_percentage,
         },
     },
     solana_entry::poh::compute_hashes_per_tick,
@@ -37,7 +37,7 @@ use {
     solana_stake_program::stake_state,
     solana_vote_program::vote_state::{self, VoteState},
     std::{
-        collections::{HashMap, HashSet},
+        collections::HashMap,
         error,
         fs::File,
         io::{self, Read},
@@ -364,12 +364,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 ),
         )
         .arg(
-            Arg::with_name("deactivate_feature_set")
-                .long("deactivate-feature-set")
-                .value_name("Vec<Feature Pubkeys>")
+            Arg::with_name("deactivate_feature")
+                .long("deactivate-feature")
                 .takes_value(true)
+                .value_name("FEATURE_PUBKEY")
+                .validator(is_pubkey)
                 .multiple(true)
-                .help("A list of features in the genesis to disable. Compatable with ClusterType::Development")
+                .help("deactivate this feature in genesis. Compatable with ClusterType::Development"),
         )
         .arg(
             Arg::with_name("max_genesis_archive_unpacked_size")
@@ -479,16 +480,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let cluster_type = cluster_type_of(&matches, "cluster_type").unwrap();
 
-    // Get the features to disable if provided
-    let deactivate_feature_set: HashSet<Pubkey> = matches
-        .values_of("deactivate_feature_set")
-        .map_or(HashSet::new(), |values| {
-            values
-                .map(|s| Pubkey::from_str(s).expect("Invalid Pubkey"))
-                .collect()
-        });
+    // Get the features to deactivate if provided
+    let features_to_deactivate = pubkeys_of(&matches, "deactivate_feature").unwrap_or_default();
 
-    if cluster_type != ClusterType::Development && !deactivate_feature_set.is_empty() {
+    if cluster_type != ClusterType::Development && !features_to_deactivate.is_empty() {
         eprintln!("Error: The --deactivate-feature-set argument cannot be used with --cluster-type={cluster_type:?}");
         std::process::exit(1);
     }
@@ -601,12 +596,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     solana_stake_program::add_genesis_accounts(&mut genesis_config);
     if genesis_config.cluster_type == ClusterType::Development {
-        if deactivate_feature_set.is_empty() {
-            solana_runtime::genesis_utils::activate_all_features(&mut genesis_config);
-        } else {
-            solana_runtime::genesis_utils::activate_all_features_except(
+        solana_runtime::genesis_utils::activate_all_features(&mut genesis_config);
+        if !features_to_deactivate.is_empty() {
+            solana_runtime::genesis_utils::deactivate_features(
                 &mut genesis_config,
-                &deactivate_feature_set,
+                &features_to_deactivate,
             );
         }
     }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -370,7 +370,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .value_name("FEATURE_PUBKEY")
                 .validator(is_pubkey)
                 .multiple(true)
-                .help("deactivate this feature in genesis. Compatable with ClusterType::Development"),
+                .help("Deactivate this feature in genesis. Compatible with --cluster-type development"),
         )
         .arg(
             Arg::with_name("max_genesis_archive_unpacked_size")
@@ -484,7 +484,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let features_to_deactivate = pubkeys_of(&matches, "deactivate_feature").unwrap_or_default();
 
     if cluster_type != ClusterType::Development && !features_to_deactivate.is_empty() {
-        eprintln!("Error: The --deactivate-feature-set argument cannot be used with --cluster-type={cluster_type:?}");
+        eprintln!("Error: The --deativate-feature argument cannot be used with --cluster-type={cluster_type:?}");
         std::process::exit(1);
     }
 

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -201,9 +201,12 @@ pub fn activate_all_features(genesis_config: &mut GenesisConfig) {
     }
 }
 
-pub fn deactivate_features(genesis_config: &mut GenesisConfig, features_to_skip: &Vec<Pubkey>) {
+pub fn deactivate_features(
+    genesis_config: &mut GenesisConfig,
+    features_to_deactivate: &Vec<Pubkey>,
+) {
     // Remove all features in `features_to_skip` from genesis
-    for deactivate_feature_pk in features_to_skip {
+    for deactivate_feature_pk in features_to_deactivate {
         if FEATURE_NAMES.contains_key(deactivate_feature_pk) {
             genesis_config.accounts.remove(deactivate_feature_pk);
         } else {

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -14,7 +14,7 @@ use {
     },
     solana_stake_program::stake_state,
     solana_vote_program::vote_state,
-    std::borrow::Borrow,
+    std::{borrow::Borrow, collections::HashSet},
 };
 
 // Default amount received by the validator
@@ -197,6 +197,18 @@ pub fn activate_all_features(genesis_config: &mut GenesisConfig) {
     // Activate all features at genesis in development mode
     for feature_id in FeatureSet::default().inactive {
         activate_feature(genesis_config, feature_id);
+    }
+}
+
+pub fn activate_all_features_except(
+    genesis_config: &mut GenesisConfig,
+    features: &HashSet<Pubkey>,
+) {
+    // Activate all features at genesis in development mode except for those provided in "features" hashset
+    for feature_id in FeatureSet::default().inactive {
+        if !features.contains(&feature_id) {
+            activate_feature(genesis_config, feature_id);
+        }
     }
 }
 

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -1,8 +1,9 @@
 use {
+    log::*,
     solana_sdk::{
         account::{Account, AccountSharedData},
         feature::{self, Feature},
-        feature_set::FeatureSet,
+        feature_set::{FeatureSet, FEATURE_NAMES},
         fee_calculator::FeeRateGovernor,
         genesis_config::{ClusterType, GenesisConfig},
         native_token::sol_to_lamports,
@@ -14,7 +15,7 @@ use {
     },
     solana_stake_program::stake_state,
     solana_vote_program::vote_state,
-    std::{borrow::Borrow, collections::HashSet},
+    std::borrow::Borrow,
 };
 
 // Default amount received by the validator
@@ -200,14 +201,16 @@ pub fn activate_all_features(genesis_config: &mut GenesisConfig) {
     }
 }
 
-pub fn activate_all_features_except(
-    genesis_config: &mut GenesisConfig,
-    features: &HashSet<Pubkey>,
-) {
-    // Activate all features at genesis in development mode except for those provided in "features" hashset
-    for feature_id in FeatureSet::default().inactive {
-        if !features.contains(&feature_id) {
-            activate_feature(genesis_config, feature_id);
+pub fn deactivate_features(genesis_config: &mut GenesisConfig, features_to_skip: &Vec<Pubkey>) {
+    // Remove all features in `features_to_skip` from genesis
+    for deactivate_feature_pk in features_to_skip {
+        if FEATURE_NAMES.contains_key(deactivate_feature_pk) {
+            genesis_config.accounts.remove(deactivate_feature_pk);
+        } else {
+            warn!(
+                "Feature {:?} set for deactivation is not a known Feature public key",
+                deactivate_feature_pk
+            );
         }
     }
 }


### PR DESCRIPTION
#### Problem
It's not very easy to deactivate specific features in development clusters. This is a step towards increasing feature activation granularity

#### Summary of Changes
1) Add `--deactivate-feature-set<feature-pubkey0> <feature-pubkey1> ... <feature-pubkeyN>`
    * For `ClusterType::Development` clusters, all features are activated, this lets us deactivate specific ones. Example: in a development cluster we do not want to activate `timely_vote_credits` for a cluster running both v1.17 and v1.18 validators

Note: naming convention is kept in line with `test-validator` genesis