### PR TITLE
refactor: fail earlier on invalid loaded account bytes limit

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -27,7 +27,7 @@ use {
 pub enum CommitTransactionDetails {
     Committed {
         compute_units: u64,
-        loaded_accounts_data_size: usize,
+        loaded_accounts_data_size: u32,
     },
     NotCommitted,
 }

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -707,10 +707,10 @@ mod tests {
         // calculate their costs, apply to cost_tracker
         let transaction_count = 5;
         let keypair = Keypair::new();
-        let loaded_accounts_data_size: usize = 1_000_000;
+        let loaded_accounts_data_size: u32 = 1_000_000;
         let transaction = solana_sdk::transaction::Transaction::new_unsigned(solana_sdk::message::Message::new(
             &[
-                solana_sdk::compute_budget::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(loaded_accounts_data_size as u32),
+                solana_sdk::compute_budget::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(loaded_accounts_data_size),
                 solana_sdk::system_instruction::transfer(&keypair.pubkey(), &solana_sdk::pubkey::Pubkey::new_unique(), 1),
             ],
             Some(&keypair.pubkey()),
@@ -720,7 +720,7 @@ mod tests {
             .map(|_| transfer_tx.clone())
             .collect();
         let execute_units_adjustment: u64 = 10;
-        let loaded_accounts_data_size_adjustment: usize = 32000;
+        let loaded_accounts_data_size_adjustment: u32 = 32000;
         let loaded_accounts_data_size_cost_adjustment =
             CostModel::calculate_loaded_accounts_data_size_cost(
                 loaded_accounts_data_size_adjustment,
@@ -827,10 +827,10 @@ mod tests {
         // calculate their costs, apply to cost_tracker
         let transaction_count = 5;
         let keypair = Keypair::new();
-        let loaded_accounts_data_size: usize = 1_000_000;
+        let loaded_accounts_data_size: u32 = 1_000_000;
         let transaction = solana_sdk::transaction::Transaction::new_unsigned(solana_sdk::message::Message::new(
             &[
-                solana_sdk::compute_budget::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(loaded_accounts_data_size as u32),
+                solana_sdk::compute_budget::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(loaded_accounts_data_size),
                 solana_sdk::system_instruction::transfer(&keypair.pubkey(), &solana_sdk::pubkey::Pubkey::new_unique(), 1),
             ],
             Some(&keypair.pubkey()),
@@ -840,7 +840,7 @@ mod tests {
             .map(|_| transfer_tx.clone())
             .collect();
         let execute_units_adjustment: u64 = 10;
-        let loaded_accounts_data_size_adjustment: usize = 32000;
+        let loaded_accounts_data_size_adjustment: u32 = 32000;
         let loaded_accounts_data_size_cost_adjustment =
             CostModel::calculate_loaded_accounts_data_size_cost(
                 loaded_accounts_data_size_adjustment,

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -56,7 +56,7 @@ impl CostModel {
     pub fn calculate_cost_for_executed_transaction(
         transaction: &SanitizedTransaction,
         actual_programs_execution_cost: u64,
-        actual_loaded_accounts_data_size_bytes: usize,
+        actual_loaded_accounts_data_size_bytes: u32,
         feature_set: &FeatureSet,
     ) -> TransactionCost {
         if transaction.is_simple_vote_transaction() {
@@ -198,7 +198,7 @@ impl CostModel {
                 }
 
                 loaded_accounts_data_size_cost = Self::calculate_loaded_accounts_data_size_cost(
-                    usize::try_from(compute_budget_limits.loaded_accounts_bytes).unwrap(),
+                    compute_budget_limits.loaded_accounts_bytes.get(),
                     feature_set,
                 );
             }
@@ -227,7 +227,7 @@ impl CostModel {
     }
 
     pub fn calculate_loaded_accounts_data_size_cost(
-        loaded_accounts_data_size: usize,
+        loaded_accounts_data_size: u32,
         _feature_set: &FeatureSet,
     ) -> u64 {
         FeeStructure::calculate_memory_usage_cost(loaded_accounts_data_size, DEFAULT_HEAP_COST)
@@ -628,7 +628,7 @@ mod tests {
         const DEFAULT_PAGE_COST: u64 = 8;
         let expected_loaded_accounts_data_size_cost =
             solana_compute_budget::compute_budget_processor::MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES
-                as u64
+                .get() as u64
                 / ACCOUNT_DATA_COST_PAGE_SIZE
                 * DEFAULT_PAGE_COST;
 

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -89,7 +89,7 @@ impl RuntimeTransaction<SanitizedVersionedMessage> {
         } = process_compute_budget_instructions(message.program_instructions_iter())?;
         meta.set_compute_unit_limit(compute_unit_limit);
         meta.set_compute_unit_price(compute_unit_price);
-        meta.set_loaded_accounts_bytes(loaded_accounts_bytes);
+        meta.set_loaded_accounts_bytes(loaded_accounts_bytes.get());
 
         Ok(Self {
             signatures,

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -1,8 +1,8 @@
 //! Fee structures.
 
-use crate::native_token::sol_to_lamports;
 #[cfg(not(target_os = "solana"))]
 use solana_program::message::SanitizedMessage;
+use {crate::native_token::sol_to_lamports, std::num::NonZeroU32};
 
 /// A fee and its associated compute unit limit
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
@@ -14,7 +14,7 @@ pub struct FeeBin {
 }
 
 pub struct FeeBudgetLimits {
-    pub loaded_accounts_data_size_limit: usize,
+    pub loaded_accounts_data_size_limit: NonZeroU32,
     pub heap_cost: u64,
     pub compute_unit_limit: u64,
     pub prioritization_fee: u64,
@@ -115,7 +115,7 @@ impl FeeStructure {
     }
 
     pub fn calculate_memory_usage_cost(
-        loaded_accounts_data_size_limit: usize,
+        loaded_accounts_data_size_limit: u32,
         heap_cost: u64,
     ) -> u64 {
         (loaded_accounts_data_size_limit as u64)
@@ -171,7 +171,7 @@ impl FeeStructure {
         // requested_loaded_account_data_size
         let loaded_accounts_data_size_cost = if include_loaded_account_data_size_in_fee {
             FeeStructure::calculate_memory_usage_cost(
-                budget_limits.loaded_accounts_data_size_limit,
+                budget_limits.loaded_accounts_data_size_limit.get(),
                 budget_limits.heap_cost,
             )
         } else {
@@ -221,7 +221,7 @@ mod tests {
     #[test]
     fn test_calculate_memory_usage_cost() {
         let heap_cost = 99;
-        const K: usize = 1024;
+        const K: u32 = 1024;
 
         // accounts data size are priced in block of 32K, ...
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -6,9 +6,7 @@ use {
         transaction_processing_callback::TransactionProcessingCallback,
     },
     itertools::Itertools,
-    solana_compute_budget::compute_budget_processor::{
-        process_compute_budget_instructions, ComputeBudgetLimits,
-    },
+    solana_compute_budget::compute_budget_processor::ComputeBudgetLimits,
     solana_program_runtime::loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
@@ -27,7 +25,7 @@ use {
         transaction_context::{IndexOfAccount, TransactionAccount},
     },
     solana_system_program::{get_system_account_kind, SystemAccountKind},
-    std::num::NonZeroUsize,
+    std::num::NonZeroU32,
 };
 
 // for the load instructions
@@ -62,7 +60,7 @@ pub struct LoadedTransaction {
     pub compute_budget_limits: ComputeBudgetLimits,
     pub rent: TransactionRent,
     pub rent_debits: RentDebits,
-    pub loaded_accounts_data_size: usize,
+    pub loaded_accounts_data_size: u32,
 }
 
 /// Collect rent from an account if rent is still enabled and regardless of
@@ -201,10 +199,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
     let account_keys = message.account_keys();
     let mut accounts_found = Vec::with_capacity(account_keys.len());
     let mut rent_debits = RentDebits::default();
-
-    let requested_loaded_accounts_data_size_limit =
-        get_requested_loaded_accounts_data_size_limit(message)?;
-    let mut accumulated_accounts_data_size: usize = 0;
+    let mut accumulated_accounts_data_size: u32 = 0;
 
     let instruction_accounts = message
         .instructions()
@@ -278,7 +273,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                 accumulate_and_check_loaded_account_data_size(
                     &mut accumulated_accounts_data_size,
                     account_size,
-                    requested_loaded_accounts_data_size_limit,
+                    tx_details.compute_budget_limits.loaded_accounts_bytes,
                     error_metrics,
                 )?;
 
@@ -342,7 +337,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                     accumulate_and_check_loaded_account_data_size(
                         &mut accumulated_accounts_data_size,
                         owner_account.data().len(),
-                        requested_loaded_accounts_data_size_limit,
+                        tx_details.compute_budget_limits.loaded_accounts_bytes,
                         error_metrics,
                     )?;
                     accounts.push((*owner_id, owner_account));
@@ -369,28 +364,6 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
     })
 }
 
-/// Total accounts data a transaction can load is limited to
-///   if `set_tx_loaded_accounts_data_size` instruction is not activated or not used, then
-///     default value of 64MiB to not break anyone in Mainnet-beta today
-///   else
-///     user requested loaded accounts size.
-///     Note, requesting zero bytes will result transaction error
-fn get_requested_loaded_accounts_data_size_limit(
-    sanitized_message: &SanitizedMessage,
-) -> Result<Option<NonZeroUsize>> {
-    let compute_budget_limits =
-        process_compute_budget_instructions(sanitized_message.program_instructions_iter())
-            .unwrap_or_default();
-    // sanitize against setting size limit to zero
-    NonZeroUsize::new(
-        usize::try_from(compute_budget_limits.loaded_accounts_bytes).unwrap_or_default(),
-    )
-    .map_or(
-        Err(TransactionError::InvalidLoadedAccountsDataSizeLimit),
-        |v| Ok(Some(v)),
-    )
-}
-
 fn account_shared_data_from_program(loaded_program: &ProgramCacheEntry) -> AccountSharedData {
     // It's an executable program account. The program is already loaded in the cache.
     // So the account data is not needed. Return a dummy AccountSharedData with meta
@@ -403,22 +376,22 @@ fn account_shared_data_from_program(loaded_program: &ProgramCacheEntry) -> Accou
 
 /// Accumulate loaded account data size into `accumulated_accounts_data_size`.
 /// Returns TransactionErr::MaxLoadedAccountsDataSizeExceeded if
-/// `requested_loaded_accounts_data_size_limit` is specified and
-/// `accumulated_accounts_data_size` exceeds it.
+/// `accumulated_accounts_data_size` exceeds
+/// `requested_loaded_accounts_data_size_limit`.
 fn accumulate_and_check_loaded_account_data_size(
-    accumulated_loaded_accounts_data_size: &mut usize,
+    accumulated_loaded_accounts_data_size: &mut u32,
     account_data_size: usize,
-    requested_loaded_accounts_data_size_limit: Option<NonZeroUsize>,
+    requested_loaded_accounts_data_size_limit: NonZeroU32,
     error_metrics: &mut TransactionErrorMetrics,
 ) -> Result<()> {
-    if let Some(requested_loaded_accounts_data_size) = requested_loaded_accounts_data_size_limit {
-        saturating_add_assign!(*accumulated_loaded_accounts_data_size, account_data_size);
-        if *accumulated_loaded_accounts_data_size > requested_loaded_accounts_data_size.get() {
-            error_metrics.max_loaded_accounts_data_size_exceeded += 1;
-            Err(TransactionError::MaxLoadedAccountsDataSizeExceeded)
-        } else {
-            Ok(())
-        }
+    let Ok(account_data_size) = u32::try_from(account_data_size) else {
+        error_metrics.max_loaded_accounts_data_size_exceeded += 1;
+        return Err(TransactionError::MaxLoadedAccountsDataSizeExceeded);
+    };
+    saturating_add_assign!(*accumulated_loaded_accounts_data_size, account_data_size);
+    if *accumulated_loaded_accounts_data_size > requested_loaded_accounts_data_size_limit.get() {
+        error_metrics.max_loaded_accounts_data_size_exceeded += 1;
+        Err(TransactionError::MaxLoadedAccountsDataSizeExceeded)
     } else {
         Ok(())
     }
@@ -467,7 +440,7 @@ mod tests {
             transaction::{Result, SanitizedTransaction, Transaction, TransactionError},
             transaction_context::{TransactionAccount, TransactionContext},
         },
-        std::{borrow::Cow, collections::HashMap, convert::TryFrom, sync::Arc},
+        std::{borrow::Cow, collections::HashMap, sync::Arc},
     };
 
     #[derive(Default)]
@@ -851,105 +824,31 @@ mod tests {
     #[test]
     fn test_accumulate_and_check_loaded_account_data_size() {
         let mut error_metrics = TransactionErrorMetrics::default();
+        let mut accumulated_data_size: u32 = 0;
+        let data_size: usize = 123;
+        let requested_data_size_limit = NonZeroU32::new(data_size as u32).unwrap();
 
-        // assert check is OK if data limit is not enabled
-        {
-            let mut accumulated_data_size: usize = 0;
-            let data_size = usize::MAX;
-            let requested_data_size_limit = None;
+        // OK - loaded data size is up to limit
+        assert!(accumulate_and_check_loaded_account_data_size(
+            &mut accumulated_data_size,
+            data_size,
+            requested_data_size_limit,
+            &mut error_metrics
+        )
+        .is_ok());
+        assert_eq!(data_size as u32, accumulated_data_size);
 
-            assert!(accumulate_and_check_loaded_account_data_size(
+        // fail - loading more data that would exceed limit
+        let another_byte: usize = 1;
+        assert_eq!(
+            accumulate_and_check_loaded_account_data_size(
                 &mut accumulated_data_size,
-                data_size,
+                another_byte,
                 requested_data_size_limit,
                 &mut error_metrics
-            )
-            .is_ok());
-        }
-
-        // assert check will fail with correct error if loaded data exceeds limit
-        {
-            let mut accumulated_data_size: usize = 0;
-            let data_size: usize = 123;
-            let requested_data_size_limit = NonZeroUsize::new(data_size);
-
-            // OK - loaded data size is up to limit
-            assert!(accumulate_and_check_loaded_account_data_size(
-                &mut accumulated_data_size,
-                data_size,
-                requested_data_size_limit,
-                &mut error_metrics
-            )
-            .is_ok());
-            assert_eq!(data_size, accumulated_data_size);
-
-            // fail - loading more data that would exceed limit
-            let another_byte: usize = 1;
-            assert_eq!(
-                accumulate_and_check_loaded_account_data_size(
-                    &mut accumulated_data_size,
-                    another_byte,
-                    requested_data_size_limit,
-                    &mut error_metrics
-                ),
-                Err(TransactionError::MaxLoadedAccountsDataSizeExceeded)
-            );
-        }
-    }
-
-    #[test]
-    fn test_get_requested_loaded_accounts_data_size_limit() {
-        // an prrivate helper function
-        fn test(
-            instructions: &[solana_sdk::instruction::Instruction],
-            expected_result: &Result<Option<NonZeroUsize>>,
-        ) {
-            let payer_keypair = Keypair::new();
-            let tx = SanitizedTransaction::from_transaction_for_tests(Transaction::new(
-                &[&payer_keypair],
-                Message::new(instructions, Some(&payer_keypair.pubkey())),
-                Hash::default(),
-            ));
-            assert_eq!(
-                *expected_result,
-                get_requested_loaded_accounts_data_size_limit(tx.message())
-            );
-        }
-
-        let tx_not_set_limit = &[solana_sdk::instruction::Instruction::new_with_bincode(
-            Pubkey::new_unique(),
-            &0_u8,
-            vec![],
-        )];
-        let tx_set_limit_99 =
-            &[
-                solana_sdk::compute_budget::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(99u32),
-                solana_sdk::instruction::Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
-            ];
-        let tx_set_limit_0 =
-            &[
-                solana_sdk::compute_budget::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(0u32),
-                solana_sdk::instruction::Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
-            ];
-
-        let result_default_limit = Ok(Some(
-            NonZeroUsize::new(
-                usize::try_from(compute_budget_processor::MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES)
-                    .unwrap(),
-            )
-            .unwrap(),
-        ));
-        let result_requested_limit: Result<Option<NonZeroUsize>> =
-            Ok(Some(NonZeroUsize::new(99).unwrap()));
-        let result_invalid_limit = Err(TransactionError::InvalidLoadedAccountsDataSizeLimit);
-
-        // the results should be:
-        //    if tx doesn't set limit, then default limit (64MiB)
-        //    if tx sets limit, then requested limit
-        //    if tx sets limit to zero, then TransactionError::InvalidLoadedAccountsDataSizeLimit
-        test(tx_not_set_limit, &result_default_limit);
-        test(tx_set_limit_99, &result_requested_limit);
-        test(tx_set_limit_0, &result_invalid_limit);
+            ),
+            Err(TransactionError::MaxLoadedAccountsDataSizeExceeded)
+        );
     }
 
     struct ValidateFeePayerTestParameter {

--- a/svm/src/transaction_results.rs
+++ b/svm/src/transaction_results.rs
@@ -26,7 +26,7 @@ pub struct TransactionResults {
 
 #[derive(Debug, Default, Clone)]
 pub struct TransactionLoadedAccountsStats {
-    pub loaded_accounts_data_size: usize,
+    pub loaded_accounts_data_size: u32,
     pub loaded_accounts_count: usize,
 }
 


### PR DESCRIPTION
#### Problem
When calculating the transaction's loaded account data size limit, the runtime re-processes the compute budget instructions for the transaction and only then will return an error if the transaction's specified limit is incorrectly set to zero. This processing step is redundant and we should be using the compute budget limits calculated earlier and also filter out zero values earlier in the pipeline.

#### Summary of Changes
- Use `NonZeroU32` for all "loaded accounts bytes limit" values
- Return an error in `process_compute_budget_instructions` if the "loaded accounts bytes limit" is zero
- Reuse computed `compute_budget_limits` to determine the loaded accounts bytes limit

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
