### PR TITLE
add stat for zero lamport accounts found in hash calc

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -205,6 +205,7 @@ pub struct HashStats {
     pub sum_ancient_scans_us: AtomicU64,
     pub count_ancient_scans: AtomicU64,
     pub pubkey_bin_search_us: AtomicU64,
+    pub zero_lamport_accounts_found: AtomicU64,
 }
 impl HashStats {
     pub fn calc_storage_size_quartiles(&mut self, storages: &[Arc<AccountStorageEntry>]) {
@@ -304,6 +305,11 @@ impl HashStats {
             (
                 "pubkey_bin_search_us",
                 self.pubkey_bin_search_us.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "zero_lamport_accounts_found",
+                self.zero_lamport_accounts_found.load(Ordering::Relaxed),
                 i64
             ),
         );
@@ -1173,6 +1179,10 @@ impl<'a> AccountsHasher<'a> {
                     let hash = blake3::hash(bytemuck::bytes_of(&item.pubkey));
                     let hash = Hash::new_from_array(hash.into());
                     hashes.write(&hash);
+                } else {
+                    stats
+                        .zero_lamport_accounts_found
+                        .fetch_add(1, Ordering::Relaxed);
                 }
             }
 

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -205,7 +205,7 @@ pub struct HashStats {
     pub sum_ancient_scans_us: AtomicU64,
     pub count_ancient_scans: AtomicU64,
     pub pubkey_bin_search_us: AtomicU64,
-    pub num_excluded_zero_lamport_accounts: AtomicU64,
+    pub num_zero_lamport_accounts: AtomicU64,
 }
 impl HashStats {
     pub fn calc_storage_size_quartiles(&mut self, storages: &[Arc<AccountStorageEntry>]) {
@@ -308,9 +308,8 @@ impl HashStats {
                 i64
             ),
             (
-                "num_excluded_zero_lamport_accounts",
-                self.num_excluded_zero_lamport_accounts
-                    .load(Ordering::Relaxed),
+                "num_zero_lamport_accounts",
+                self.num_zero_lamport_accounts.load(Ordering::Relaxed),
                 i64
             ),
         );
@@ -1174,7 +1173,7 @@ impl<'a> AccountsHasher<'a> {
                 hashes.write(&item.hash.0);
             } else {
                 stats
-                    .num_excluded_zero_lamport_accounts
+                    .num_zero_lamport_accounts
                     .fetch_add(1, Ordering::Relaxed);
                 // if lamports == 0, check if they should be included
                 if self.zero_lamport_accounts == ZeroLamportAccounts::Included {

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1173,6 +1173,9 @@ impl<'a> AccountsHasher<'a> {
                     .expect("summing lamports cannot overflow");
                 hashes.write(&item.hash.0);
             } else {
+                stats
+                    .num_excluded_zero_lamport_accounts
+                    .fetch_add(1, Ordering::Relaxed);
                 // if lamports == 0, check if they should be included
                 if self.zero_lamport_accounts == ZeroLamportAccounts::Included {
                     // For incremental accounts hash, the hash of a zero lamport account is
@@ -1180,10 +1183,6 @@ impl<'a> AccountsHasher<'a> {
                     let hash = blake3::hash(bytemuck::bytes_of(&item.pubkey));
                     let hash = Hash::new_from_array(hash.into());
                     hashes.write(&hash);
-                } else {
-                    stats
-                        .num_excluded_zero_lamport_accounts
-                        .fetch_add(1, Ordering::Relaxed);
                 }
             }
 

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -205,7 +205,7 @@ pub struct HashStats {
     pub sum_ancient_scans_us: AtomicU64,
     pub count_ancient_scans: AtomicU64,
     pub pubkey_bin_search_us: AtomicU64,
-    pub zero_lamport_accounts_found: AtomicU64,
+    pub num_excluded_zero_lamport_accounts: AtomicU64,
 }
 impl HashStats {
     pub fn calc_storage_size_quartiles(&mut self, storages: &[Arc<AccountStorageEntry>]) {
@@ -308,8 +308,9 @@ impl HashStats {
                 i64
             ),
             (
-                "zero_lamport_accounts_found",
-                self.zero_lamport_accounts_found.load(Ordering::Relaxed),
+                "num_excluded_zero_lamport_accounts",
+                self.num_excluded_zero_lamport_accounts
+                    .load(Ordering::Relaxed),
                 i64
             ),
         );
@@ -1181,7 +1182,7 @@ impl<'a> AccountsHasher<'a> {
                     hashes.write(&hash);
                 } else {
                     stats
-                        .zero_lamport_accounts_found
+                        .num_excluded_zero_lamport_accounts
                         .fetch_add(1, Ordering::Relaxed);
                 }
             }


### PR DESCRIPTION
#### Problem
We have discovered that zero lamport accounts don't get removed from the system effectively.

#### Summary of Changes
Add a stat to keep track of how many zero lamport accounts remain when we are doing a full hash of all accounts.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
