### PR TITLE
Implements ReadableAccount for LoadedAccount

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1002,21 +1002,22 @@ impl<'a> LoadedAccount<'a> {
     pub fn data_len(&self) -> usize {
         self.data().len()
     }
+}
 
+impl<'a> ReadableAccount for LoadedAccount<'a> {
     fn lamports(&self) -> u64 {
         match self {
             LoadedAccount::Stored(stored_account_meta) => stored_account_meta.lamports(),
             LoadedAccount::Cached(cached_account) => cached_account.account.lamports(),
         }
     }
-
     fn data(&self) -> &[u8] {
         match self {
             LoadedAccount::Stored(stored_account_meta) => stored_account_meta.data(),
             LoadedAccount::Cached(cached_account) => cached_account.account.data(),
         }
     }
-    pub(crate) fn owner(&self) -> &Pubkey {
+    fn owner(&self) -> &Pubkey {
         match self {
             LoadedAccount::Stored(stored_account_meta) => stored_account_meta.owner(),
             LoadedAccount::Cached(cached_account) => cached_account.account.owner(),
@@ -1033,6 +1034,9 @@ impl<'a> LoadedAccount<'a> {
             LoadedAccount::Stored(stored_account_meta) => stored_account_meta.rent_epoch(),
             LoadedAccount::Cached(cached_account) => cached_account.account.rent_epoch(),
         }
+    }
+    fn to_account_shared_data(&self) -> AccountSharedData {
+        self.take_account()
     }
 }
 

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -11,7 +11,7 @@ use {
     },
     rayon::prelude::*,
     solana_measure::{measure::Measure, measure_us},
-    solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey},
+    solana_sdk::{account::ReadableAccount as _, clock::Slot, hash::Hash, pubkey::Pubkey},
     std::{
         hash::{DefaultHasher, Hash as _, Hasher as _},
         ops::Range,
@@ -367,7 +367,7 @@ mod tests {
             append_vec::AppendVec,
             cache_hash_data::{CacheHashDataFile, DeletionPolicy as CacheHashDeletionPolicy},
         },
-        solana_sdk::account::{AccountSharedData, ReadableAccount as _},
+        solana_sdk::account::AccountSharedData,
         tempfile::TempDir,
         test_case::test_case,
     };


### PR DESCRIPTION
#### Problem

LoadedAccount does not implement ReadableAccount. This means we end up duplicating logic in some places. Specifically, when getting the AccountHash of a LoadedAccount, we have to use `hash_account_data()` and manually extract all the fields. This would not be required if LoadedAccount implemented ReadableAccount.


#### Summary of Changes

Implements ReadableAccount for LoadedAccount.