### PR TITLE
Uses hash_account() for LoadedAccount

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6798,12 +6798,8 @@ impl AccountsDb {
                                             let hash_is_missing =
                                                 loaded_hash == AccountHash(Hash::default());
                                             if hash_is_missing {
-                                                let computed_hash = Self::hash_account_data(
-                                                    loaded_account.lamports(),
-                                                    loaded_account.owner(),
-                                                    loaded_account.executable(),
-                                                    loaded_account.rent_epoch(),
-                                                    loaded_account.data(),
+                                                let computed_hash = Self::hash_account(
+                                                    &loaded_account,
                                                     loaded_account.pubkey(),
                                                 );
                                                 loaded_hash = computed_hash;
@@ -7497,14 +7493,7 @@ impl AccountsDb {
                 |accum: &DashMap<Pubkey, AccountHash>, loaded_account: &LoadedAccount, _data| {
                     let mut loaded_hash = loaded_account.loaded_hash();
                     if loaded_hash == AccountHash(Hash::default()) {
-                        loaded_hash = Self::hash_account_data(
-                            loaded_account.lamports(),
-                            loaded_account.owner(),
-                            loaded_account.executable(),
-                            loaded_account.rent_epoch(),
-                            loaded_account.data(),
-                            loaded_account.pubkey(),
-                        )
+                        loaded_hash = Self::hash_account(loaded_account, loaded_account.pubkey())
                     }
                     accum.insert(*loaded_account.pubkey(), loaded_hash);
                 },

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -79,14 +79,7 @@ impl<'a> AppendVecScan for ScanState<'a> {
 
         let hash_is_missing = account_hash == AccountHash(Hash::default());
         if hash_is_missing {
-            let computed_hash = AccountsDb::hash_account_data(
-                loaded_account.lamports(),
-                loaded_account.owner(),
-                loaded_account.executable(),
-                loaded_account.rent_epoch(),
-                loaded_account.data(),
-                loaded_account.pubkey(),
-            );
+            let computed_hash = AccountsDb::hash_account(loaded_account, loaded_account.pubkey());
             account_hash = computed_hash;
         }
         let source_item = CalculateHashIntermediate {


### PR DESCRIPTION
#### Problem

As alluded in #2259, when we have a LoadedAccount and want its AccountHash, we call `hash_account_data()`. This requires extracting all the fields manually to pass them as parameters to the function. Instead, we can call `hash_account()` and pass just the LoadedAccount.


#### Summary of Changes

Use hash_account() instead of hash_account_data() with LoadedAccount.