### PR TITLE
Adds AccountLtHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5492,6 +5492,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-inline-spl",
+ "solana-lattice-hash",
  "solana-logger",
  "solana-measure",
  "solana-metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,6 +368,7 @@ agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=
 solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.1.0" }
 solana-gossip = { path = "gossip", version = "=2.1.0" }
 solana-inline-spl = { path = "inline-spl", version = "=2.1.0" }
+solana-lattice-hash = { path = "lattice-hash", version = "=2.1.0" }
 solana-ledger = { path = "ledger", version = "=2.1.0" }
 solana-loader-v4-program = { path = "programs/loader-v4", version = "=2.1.0" }
 solana-local-cluster = { path = "local-cluster", version = "=2.1.0" }

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -39,6 +39,7 @@ solana-bucket-map = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-inline-spl = { workspace = true }
+solana-lattice-hash = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-nohash-hasher = { workspace = true }

--- a/accounts-db/benches/bench_hashing.rs
+++ b/accounts-db/benches/bench_hashing.rs
@@ -24,7 +24,7 @@ const DATA_SIZES: [usize; 6] = [
 /// part of computing an account's hash.
 ///
 /// Ensure this constant stays in sync with the value of `META_SIZE` in
-/// AccountsDb::hash_account_data().
+/// AccountsDb::hash_account_helper().
 const META_SIZE: usize = 81;
 
 fn bench_hash_account(c: &mut Criterion) {
@@ -37,8 +37,11 @@ fn bench_hash_account(c: &mut Criterion) {
         let num_bytes = META_SIZE.checked_add(data_size).unwrap();
         group.throughput(Throughput::Bytes(num_bytes as u64));
         let account = AccountSharedData::new(lamports, data_size, &owner);
-        group.bench_function(BenchmarkId::new("data_size", data_size), |b| {
+        group.bench_function(BenchmarkId::new("blake3", data_size), |b| {
             b.iter(|| AccountsDb::hash_account(&account, &address));
+        });
+        group.bench_function(BenchmarkId::new("lattice", data_size), |b| {
+            b.iter(|| AccountsDb::lt_hash_account(&account, &address));
         });
     }
 }

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -9,9 +9,10 @@ use {
     log::*,
     memmap2::MmapMut,
     rayon::prelude::*,
+    solana_lattice_hash::lt_hash::LtHash,
     solana_measure::{measure::Measure, measure_us},
     solana_sdk::{
-        hash::{Hash, Hasher},
+        hash::{Hash, Hasher, HASH_BYTES},
         pubkey::Pubkey,
         rent_collector::RentCollector,
         slot_history::Slot,
@@ -1244,6 +1245,18 @@ pub struct AccountHash(pub Hash);
 // Ensure the newtype wrapper never changes size from the underlying Hash
 // This also ensures there are no padding bytes, which is required to safely implement Pod
 const _: () = assert!(std::mem::size_of::<AccountHash>() == std::mem::size_of::<Hash>());
+
+/// The AccountHash for a zero-lamport account
+pub const ZERO_LAMPORT_ACCOUNT_HASH: AccountHash =
+    AccountHash(Hash::new_from_array([0; HASH_BYTES]));
+
+/// Lattice hash of an account
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct AccountLtHash(pub LtHash);
+
+/// The AccountLtHash for a zero-lamport account
+pub const ZERO_LAMPORT_ACCOUNT_LT_HASH: AccountLtHash =
+    AccountLtHash(LtHash([0; LtHash::NUM_ELEMENTS]));
 
 /// Hash of accounts
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4541,6 +4541,7 @@ dependencies = [
  "smallvec",
  "solana-bucket-map",
  "solana-inline-spl",
+ "solana-lattice-hash",
  "solana-measure",
  "solana-metrics",
  "solana-nohash-hasher",
@@ -5088,6 +5089,15 @@ version = "2.1.0"
 dependencies = [
  "bytemuck",
  "solana-program",
+]
+
+[[package]]
+name = "solana-lattice-hash"
+version = "2.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "blake3",
+ "bytemuck",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem

We'll be using a lattice-based hash for accounts. Right now, there's no way to calculate the LtHash of an account. Also, how fast/slow is it for various account data sizes?


#### Summary of Changes

* Adds AccountLtHash
* Adds function to calculate the AccountLtHash from an account
* Updates the hash_account benchmark to also bench calculating the AccountLtHash