### PR TITLE
refactor: use structs to serialize extra snapshot fields

### DIFF
--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -11,8 +11,8 @@ mod tests {
             genesis_utils::activate_all_features,
             runtime_config::RuntimeConfig,
             serde_snapshot::{
-                self, BankIncrementalSnapshotPersistence, SerdeAccountsHash,
-                SerdeIncrementalAccountsHash, SnapshotStreams,
+                self, BankIncrementalSnapshotPersistence, ExtraFieldsToSerialize,
+                SerdeAccountsHash, SerdeIncrementalAccountsHash, SnapshotStreams,
             },
             snapshot_bank_utils,
             snapshot_utils::{
@@ -169,8 +169,12 @@ mod tests {
             accounts_db.get_accounts_delta_hash(bank2_slot).unwrap(),
             expected_accounts_hash,
             &get_storages_to_serialize(&bank2.get_snapshot_storages(None)),
-            expected_incremental_snapshot_persistence.as_ref(),
-            expected_epoch_accounts_hash,
+            ExtraFieldsToSerialize {
+                lamports_per_signature: bank2.fee_rate_governor.lamports_per_signature,
+                incremental_snapshot_persistence: expected_incremental_snapshot_persistence
+                    .as_ref(),
+                epoch_accounts_hash: expected_epoch_accounts_hash,
+            },
             accounts_db.write_version.load(Ordering::Acquire),
         )
         .unwrap();
@@ -506,7 +510,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "6riNuebfnAUpS2e3GYb5G8udH5PoEtep48ULchLjRDCB")
+            frozen_abi(digest = "AMm4uzGQ6E7fj8MkDjUtFR7kYAjtUyWddXAPLjwaqKqV")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapper {
@@ -538,8 +542,11 @@ mod tests {
                 AccountsDeltaHash(Hash::new_unique()),
                 AccountsHash(Hash::new_unique()),
                 &get_storages_to_serialize(&snapshot_storages),
-                Some(&incremental_snapshot_persistence),
-                Some(EpochAccountsHash::new(Hash::new_unique())),
+                ExtraFieldsToSerialize {
+                    lamports_per_signature: bank.fee_rate_governor.lamports_per_signature,
+                    incremental_snapshot_persistence: Some(&incremental_snapshot_persistence),
+                    epoch_accounts_hash: Some(EpochAccountsHash::new(Hash::new_unique())),
+                },
                 StoredMetaWriteVersion::default(),
             )
         }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1,7 +1,9 @@
 use {
     crate::{
         bank::{BankFieldsToSerialize, BankSlotDelta},
-        serde_snapshot::{self, BankIncrementalSnapshotPersistence, SnapshotStreams},
+        serde_snapshot::{
+            self, BankIncrementalSnapshotPersistence, ExtraFieldsToSerialize, SnapshotStreams,
+        },
         snapshot_archive_info::{
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfo,
             SnapshotArchiveInfoGetter,
@@ -874,6 +876,11 @@ fn serialize_snapshot(
             );
 
         let bank_snapshot_serializer = move |stream: &mut BufWriter<fs::File>| -> Result<()> {
+            let extra_fields = ExtraFieldsToSerialize {
+                lamports_per_signature: bank_fields.fee_rate_governor.lamports_per_signature,
+                incremental_snapshot_persistence: bank_incremental_snapshot_persistence,
+                epoch_accounts_hash,
+            };
             serde_snapshot::serialize_bank_snapshot_into(
                 stream,
                 bank_fields,
@@ -881,8 +888,7 @@ fn serialize_snapshot(
                 accounts_delta_hash,
                 accounts_hash,
                 &get_storages_to_serialize(snapshot_storages),
-                bank_incremental_snapshot_persistence,
-                epoch_accounts_hash,
+                extra_fields,
                 write_version,
             )?;
             Ok(())


### PR DESCRIPTION
#### Problem
It's difficult to track how extra snapshot fields are deserialized and serialized at the end of snapshots

#### Summary of Changes
Introduced `ExtraFieldsToSerialize` and `ExtraFieldsToDeserialize` structs to improve visibility into the serialization of the extra fields

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
