### PR TITLE
Correct description of ShortU16's 3rd byte

### DIFF
--- a/short-vec/src/lib.rs
+++ b/short-vec/src/lib.rs
@@ -15,8 +15,8 @@ use {
 /// Same as u16, but serialized with 1 to 3 bytes. If the value is above
 /// 0x7f, the top bit is set and the remaining value is stored in the next
 /// bytes. Each byte follows the same pattern until the 3rd byte. The 3rd
-/// byte, if needed, uses all 8 bits to store the last byte of the original
-/// value.
+/// byte may only have the 2 least-significant bits set, otherwise the encoded
+/// value will overflow the u16.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub struct ShortU16(pub u16);
 


### PR DESCRIPTION
#### Problem
- The 3rd byte in `ShortU16` cannot use all 8 bits. Only the 2 least significant bits are allowed to be set.

#### Summary of Changes
- Update description of `ShortU16`s 3rd byte

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
