### PR TITLE
Speed up stakes cache by using Entry API and dropping outside write lock

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2474,7 +2474,7 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
         if activated_stake == 0 {
             continue;
         }
-        let vote_state_node_pubkey = vote_account.node_pubkey().unwrap_or_default();
+        let vote_state_node_pubkey = vote_account.node_pubkey().copied().unwrap_or_default();
 
         if let Some(peer) = peers.get(&vote_state_node_pubkey) {
             if peer.shred_version() == my_shred_version {

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -223,7 +223,7 @@ impl Bank {
                     None
                 } else {
                     total_staked += *staked;
-                    Some((account.node_pubkey()?, *staked))
+                    Some((*account.node_pubkey()?, *staked))
                 }
             })
             .collect::<Vec<(Pubkey, u64)>>();

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -477,7 +477,7 @@ impl Stakes<StakeAccount> {
 
     pub(crate) fn highest_staked_node(&self) -> Option<Pubkey> {
         let vote_account = self.vote_accounts.find_max_by_delegated_stake()?;
-        vote_account.node_pubkey()
+        vote_account.node_pubkey().copied()
     }
 }
 

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -11,6 +11,7 @@ use {
         cmp::Ordering,
         collections::{hash_map::Entry, HashMap},
         iter::FromIterator,
+        mem,
         sync::{Arc, OnceLock},
     },
     thiserror::Error,
@@ -144,11 +145,40 @@ impl VoteAccounts {
         Some(vote_account)
     }
 
-    pub fn insert(&mut self, pubkey: Pubkey, (stake, vote_account): (u64, VoteAccount)) {
-        self.add_node_stake(stake, &vote_account);
+    pub fn insert(
+        &mut self,
+        pubkey: Pubkey,
+        new_vote_account: VoteAccount,
+        calculate_stake: impl FnOnce() -> u64,
+    ) -> Option<VoteAccount> {
         let vote_accounts = Arc::make_mut(&mut self.vote_accounts);
-        if let Some((stake, vote_account)) = vote_accounts.insert(pubkey, (stake, vote_account)) {
-            self.sub_node_stake(stake, &vote_account);
+        match vote_accounts.entry(pubkey) {
+            Entry::Occupied(mut entry) => {
+                // This is an upsert, we need to update the vote state and move the stake if needed.
+                let (stake, old_vote_account) = entry.get_mut();
+
+                if let Some(staked_nodes) = self.staked_nodes.get_mut() {
+                    let old_node_pubkey = old_vote_account.node_pubkey();
+                    let new_node_pubkey = new_vote_account.node_pubkey();
+                    if new_node_pubkey != old_node_pubkey {
+                        // The node keys have changed, we move the stake from the old node to the
+                        // new one
+                        Self::do_sub_node_stake(staked_nodes, *stake, old_node_pubkey);
+                        Self::do_add_node_stake(staked_nodes, *stake, new_node_pubkey);
+                    }
+                }
+
+                // Update the vote state
+                Some(mem::replace(old_vote_account, new_vote_account))
+            }
+            Entry::Vacant(entry) => {
+                // This is a new vote account. We don't know the stake yet, so we need to compute it.
+                let (stake, vote_account) = entry.insert((calculate_stake(), new_vote_account));
+                if let Some(staked_nodes) = self.staked_nodes.get_mut() {
+                    Self::do_add_node_stake(staked_nodes, *stake, vote_account.node_pubkey());
+                }
+                None
+            }
         }
     }
 
@@ -185,15 +215,28 @@ impl VoteAccounts {
         if stake == 0u64 {
             return;
         }
+
         let Some(staked_nodes) = self.staked_nodes.get_mut() else {
             return;
         };
-        if let Some(node_pubkey) = vote_account.node_pubkey().copied() {
+
+        VoteAccounts::do_add_node_stake(staked_nodes, stake, vote_account.node_pubkey());
+    }
+
+    fn do_add_node_stake(
+        staked_nodes: &mut Arc<HashMap<Pubkey, u64>>,
+        stake: u64,
+        node_pubkey: Option<&Pubkey>,
+    ) {
+        node_pubkey.map(|node_pubkey| {
             Arc::make_mut(staked_nodes)
-                .entry(node_pubkey)
+                // Note we take an Option<&Pubkey> instead of taking by value, which is usually a
+                // bit of an anti pattern, but none of the callers of this function have an owned
+                // Option<Pubkey> so effectively this avoids a copy when node_pubkey is None.
+                .entry(*node_pubkey)
                 .and_modify(|s| *s += stake)
-                .or_insert(stake);
-        }
+                .or_insert(stake)
+        });
     }
 
     fn sub_node_stake(&mut self, stake: u64, vote_account: &VoteAccount) {
@@ -203,16 +246,26 @@ impl VoteAccounts {
         let Some(staked_nodes) = self.staked_nodes.get_mut() else {
             return;
         };
-        if let Some(node_pubkey) = vote_account.node_pubkey().copied() {
-            let Entry::Occupied(mut entry) = Arc::make_mut(staked_nodes).entry(node_pubkey) else {
-                panic!("this should not happen!");
-            };
-            match entry.get().cmp(&stake) {
+
+        VoteAccounts::do_sub_node_stake(staked_nodes, stake, vote_account.node_pubkey());
+    }
+
+    fn do_sub_node_stake(
+        staked_nodes: &mut Arc<HashMap<Pubkey, u64>>,
+        stake: u64,
+        node_pubkey: Option<&Pubkey>,
+    ) {
+        if let Some(node_pubkey) = node_pubkey {
+            let staked_nodes = Arc::make_mut(staked_nodes);
+            let current_stake = staked_nodes
+                .get_mut(node_pubkey)
+                .expect("this should not happen");
+            match (*current_stake).cmp(&stake) {
                 Ordering::Less => panic!("subtraction value exceeds node's stake"),
                 Ordering::Equal => {
-                    entry.remove_entry();
+                    staked_nodes.remove(node_pubkey);
                 }
-                Ordering::Greater => *entry.get_mut() -= stake,
+                Ordering::Greater => *current_stake -= stake,
             }
         }
     }
@@ -488,7 +541,7 @@ mod tests {
         let mut vote_accounts = VoteAccounts::default();
         // Add vote accounts.
         for (k, (pubkey, (stake, vote_account))) in accounts.iter().enumerate() {
-            vote_accounts.insert(*pubkey, (*stake, vote_account.clone()));
+            vote_accounts.insert(*pubkey, vote_account.clone(), || *stake);
             if (k + 1) % 128 == 0 {
                 assert_eq!(
                     staked_nodes(&accounts[..k + 1]),
@@ -540,13 +593,13 @@ mod tests {
         // Add vote accounts.
         let mut vote_accounts = VoteAccounts::default();
         for (pubkey, (stake, vote_account)) in (&mut accounts).take(1024) {
-            vote_accounts.insert(pubkey, (stake, vote_account));
+            vote_accounts.insert(pubkey, vote_account, || stake);
         }
         let staked_nodes = vote_accounts.staked_nodes();
         let (pubkey, (more_stake, vote_account)) =
             accounts.find(|(_, (stake, _))| *stake != 0).unwrap();
         let node_pubkey = *vote_account.node_pubkey().unwrap();
-        vote_accounts.insert(pubkey, (more_stake, vote_account));
+        vote_accounts.insert(pubkey, vote_account, || more_stake);
         assert_ne!(staked_nodes, vote_accounts.staked_nodes());
         assert_eq!(
             vote_accounts.staked_nodes()[&node_pubkey],
@@ -572,7 +625,7 @@ mod tests {
         // Add vote accounts.
         let mut vote_accounts = VoteAccounts::default();
         for (pubkey, (stake, vote_account)) in (&mut accounts).take(1024) {
-            vote_accounts.insert(pubkey, (stake, vote_account));
+            vote_accounts.insert(pubkey, vote_account, || stake);
         }
         let vote_accounts_hashmap = Arc::<VoteAccountsHashMap>::from(&vote_accounts);
         assert_eq!(vote_accounts_hashmap, vote_accounts.vote_accounts);
@@ -582,7 +635,7 @@ mod tests {
         ));
         let (pubkey, (more_stake, vote_account)) =
             accounts.find(|(_, (stake, _))| *stake != 0).unwrap();
-        vote_accounts.insert(pubkey, (more_stake, vote_account.clone()));
+        vote_accounts.insert(pubkey, vote_account.clone(), || more_stake);
         assert!(!Arc::ptr_eq(
             &vote_accounts_hashmap,
             &vote_accounts.vote_accounts

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -656,6 +656,18 @@ mod tests {
         assert_eq!(vote_accounts.get_delegated_stake(&pubkey), 0);
         // ensure that we didn't add a 0 stake entry to staked_nodes
         assert_eq!(vote_accounts.staked_nodes().get(&node_pubkey), None);
+
+        // update with new node pubkey, stake is 0 and should remain 0
+        let new_node_pubkey = Pubkey::new_unique();
+        let (account2, _) = new_rand_vote_account(&mut rng, Some(new_node_pubkey));
+        let vote_account2 = VoteAccount::try_from(account2).unwrap();
+        let ret = vote_accounts.insert(pubkey, vote_account2.clone(), || {
+            panic!("should not be called")
+        });
+        assert_eq!(ret, Some(vote_account1));
+        assert_eq!(vote_accounts.get_delegated_stake(&pubkey), 0);
+        assert_eq!(vote_accounts.staked_nodes().get(&node_pubkey), None);
+        assert_eq!(vote_accounts.staked_nodes().get(&new_node_pubkey), None);
     }
 
     // Asserts that returned staked-nodes are copy-on-write references.


### PR DESCRIPTION
This is PR 1/n to optimize Bank::update_stakes_cache. 

This PR includes 3 commits: one which makes node_pubkey() return by ref instead of by value, one which uses the Entry API to avoid extra hashing, and finally one that delays dropping old VoteState values until after a write lock gets released.

Relevant metrics, left is master right is with this PR:

<img width="1981" alt="Screenshot 2024-07-24 at 8 51 50 pm" src="https://github.com/user-attachments/assets/00b82805-fa07-4d5a-9cc7-f886741f36c0">
