### PR TITLE
Introduce VoteState::deserialize_into_uninit

### DIFF
--- a/sdk/program/src/serialize_utils/cursor.rs
+++ b/sdk/program/src/serialize_utils/cursor.rs
@@ -1,8 +1,11 @@
 use {
-    crate::{instruction::InstructionError, pubkey::Pubkey},
+    crate::{
+        instruction::InstructionError,
+        pubkey::{Pubkey, PUBKEY_BYTES},
+    },
     std::{
         io::{BufRead as _, Cursor, Read},
-        mem, ptr,
+        ptr,
     },
 };
 
@@ -57,18 +60,16 @@ pub(crate) fn read_pubkey_into(
     cursor: &mut Cursor<&[u8]>,
     pubkey: *mut Pubkey,
 ) -> Result<(), InstructionError> {
-    const PUBKEY_SIZE: usize = mem::size_of::<Pubkey>();
-
     match cursor.fill_buf() {
-        Ok(buf) if buf.len() >= PUBKEY_SIZE => {
+        Ok(buf) if buf.len() >= PUBKEY_BYTES => {
             // Safety: `buf` is guaranteed to be at least `PUBKEY_SIZE` bytes
             // long. Pubkey a #[repr(transparent)] wrapper around a byte array,
             // so this is a byte to byte copy and it's safe.
             unsafe {
-                ptr::copy_nonoverlapping(buf.as_ptr(), pubkey as *mut u8, PUBKEY_SIZE);
+                ptr::copy_nonoverlapping(buf.as_ptr(), pubkey as *mut u8, PUBKEY_BYTES);
             }
 
-            cursor.consume(PUBKEY_SIZE);
+            cursor.consume(PUBKEY_BYTES);
         }
         _ => return Err(InstructionError::InvalidAccountData),
     }

--- a/sdk/program/src/serialize_utils/cursor.rs
+++ b/sdk/program/src/serialize_utils/cursor.rs
@@ -61,7 +61,9 @@ pub(crate) fn read_pubkey_into(
 
     match cursor.fill_buf() {
         Ok(buf) if buf.len() >= PUBKEY_SIZE => {
-            // Safety: `buf` is guaranteed to be at least `PUBKEY_SIZE` bytes long
+            // Safety: `buf` is guaranteed to be at least `PUBKEY_SIZE` bytes
+            // long. Pubkey a #[repr(transparent)] wrapper around a byte array,
+            // so this is a byte to byte copy and it's safe.
             unsafe {
                 ptr::copy_nonoverlapping(buf.as_ptr(), pubkey as *mut u8, PUBKEY_SIZE);
             }

--- a/sdk/program/src/serialize_utils/cursor.rs
+++ b/sdk/program/src/serialize_utils/cursor.rs
@@ -62,7 +62,7 @@ pub(crate) fn read_pubkey_into(
 ) -> Result<(), InstructionError> {
     match cursor.fill_buf() {
         Ok(buf) if buf.len() >= PUBKEY_BYTES => {
-            // Safety: `buf` is guaranteed to be at least `PUBKEY_SIZE` bytes
+            // Safety: `buf` is guaranteed to be at least `PUBKEY_BYTES` bytes
             // long. Pubkey a #[repr(transparent)] wrapper around a byte array,
             // so this is a byte to byte copy and it's safe.
             unsafe {

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -487,7 +487,14 @@ impl VoteState {
         input: &[u8],
         vote_state: &mut VoteState,
     ) -> Result<(), InstructionError> {
-        VoteState::deserialize_into_ptr(input, vote_state as *mut VoteState)
+        // Safety: vote_state is valid to_drop (see drop_in_place() docs). After
+        // dropping, the pointer is treated as uninitialized and only accessed
+        // through ptr::write, which is safe as per drop_in_place docs.
+        unsafe {
+            std::ptr::drop_in_place(vote_state);
+        }
+
+        VoteState::deserialize_into_ptr(input, vote_state)
     }
 
     /// Deserializes the input `VoteStateVersions` buffer directly into the provided

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -526,6 +526,11 @@ impl VoteState {
             0 => {
                 #[cfg(not(target_os = "solana"))]
                 {
+                    // Safety: vote_state is valid as it comes from `&mut MaybeUninit<VoteState>` or
+                    // `&mut VoteState`. In the first case, the value is uninitialized so we write()
+                    // to avoid dropping invalid data; in the latter case, we `drop_in_place()`
+                    // before writing so the value has already been dropped and we just write a new
+                    // one in place.
                     unsafe {
                         vote_state.write(
                             bincode::deserialize::<VoteStateVersions>(input)

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -498,7 +498,7 @@ impl VoteState {
         // Rebind vote_state to *mut VoteState so that the &mut binding isn't
         // accessible anymore, preventing accidental use after this point.
         //
-        // NOTE: switch to ptr::from_mut() once platform-tools moves to rustc >= 1.56
+        // NOTE: switch to ptr::from_mut() once platform-tools moves to rustc >= 1.76
         let vote_state = vote_state as *mut VoteState;
 
         // Safety: vote_state is valid to_drop (see drop_in_place() docs). After

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -1,7 +1,5 @@
 //! Vote state
 
-use std::mem;
-
 #[cfg(not(target_os = "solana"))]
 use bincode::deserialize;
 #[cfg(test)]
@@ -22,7 +20,12 @@ use {
     },
     bincode::{serialize_into, ErrorKind},
     serde_derive::{Deserialize, Serialize},
-    std::{collections::VecDeque, fmt::Debug, io::Cursor, mem::MaybeUninit},
+    std::{
+        collections::VecDeque,
+        fmt::Debug,
+        io::Cursor,
+        mem::{self, MaybeUninit},
+    },
 };
 
 mod vote_state_0_23_5;

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -1,6 +1,6 @@
 //! Vote state
 
-use std::{mem, ptr};
+use std::mem;
 
 #[cfg(not(target_os = "solana"))]
 use bincode::deserialize;
@@ -494,7 +494,9 @@ impl VoteState {
     ) -> Result<(), InstructionError> {
         // Rebind vote_state to *mut VoteState so that the &mut binding isn't
         // accessible anymore, preventing accidental use after this point.
-        let vote_state = ptr::from_mut(vote_state);
+        //
+        // NOTE: switch to ptr::from_mut() once platform-tools moves to rustc >= 1.56
+        let vote_state = vote_state as *mut VoteState;
 
         // Safety: vote_state is valid to_drop (see drop_in_place() docs). After
         // dropping, the pointer is treated as uninitialized and only accessed

--- a/sdk/program/src/vote/state/vote_state_0_23_5.rs
+++ b/sdk/program/src/vote/state/vote_state_0_23_5.rs
@@ -76,7 +76,7 @@ mod tests {
         let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
 
         let mut test_vote_state = MaybeUninit::uninit();
-        VoteState::deserialize_into(&vote_state_buf, &mut test_vote_state).unwrap();
+        VoteState::deserialize_into_uninit(&vote_state_buf, &mut test_vote_state).unwrap();
         let test_vote_state = unsafe { test_vote_state.assume_init() };
 
         assert_eq!(
@@ -99,7 +99,7 @@ mod tests {
             let target_vote_state = target_vote_state_versions.convert_to_current();
 
             let mut test_vote_state = MaybeUninit::uninit();
-            VoteState::deserialize_into(&vote_state_buf, &mut test_vote_state).unwrap();
+            VoteState::deserialize_into_uninit(&vote_state_buf, &mut test_vote_state).unwrap();
             let test_vote_state = unsafe { test_vote_state.assume_init() };
 
             assert_eq!(target_vote_state, test_vote_state);

--- a/sdk/program/src/vote/state/vote_state_0_23_5.rs
+++ b/sdk/program/src/vote/state/vote_state_0_23_5.rs
@@ -75,8 +75,9 @@ mod tests {
         let target_vote_state_versions = VoteStateVersions::V0_23_5(Box::new(target_vote_state));
         let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
 
-        let mut test_vote_state = VoteState::default();
+        let mut test_vote_state = MaybeUninit::uninit();
         VoteState::deserialize_into(&vote_state_buf, &mut test_vote_state).unwrap();
+        let test_vote_state = unsafe { test_vote_state.assume_init() };
 
         assert_eq!(
             target_vote_state_versions.convert_to_current(),
@@ -97,8 +98,9 @@ mod tests {
             let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
             let target_vote_state = target_vote_state_versions.convert_to_current();
 
-            let mut test_vote_state = VoteState::default();
+            let mut test_vote_state = MaybeUninit::uninit();
             VoteState::deserialize_into(&vote_state_buf, &mut test_vote_state).unwrap();
+            let test_vote_state = unsafe { test_vote_state.assume_init() };
 
             assert_eq!(target_vote_state, test_vote_state);
         }

--- a/sdk/program/src/vote/state/vote_state_1_14_11.rs
+++ b/sdk/program/src/vote/state/vote_state_1_14_11.rs
@@ -94,8 +94,9 @@ mod tests {
         let target_vote_state_versions = VoteStateVersions::V1_14_11(Box::new(target_vote_state));
         let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
 
-        let mut test_vote_state = VoteState::default();
+        let mut test_vote_state = MaybeUninit::uninit();
         VoteState::deserialize_into(&vote_state_buf, &mut test_vote_state).unwrap();
+        let test_vote_state = unsafe { test_vote_state.assume_init() };
 
         assert_eq!(
             target_vote_state_versions.convert_to_current(),
@@ -116,8 +117,9 @@ mod tests {
             let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
             let target_vote_state = target_vote_state_versions.convert_to_current();
 
-            let mut test_vote_state = VoteState::default();
+            let mut test_vote_state = MaybeUninit::uninit();
             VoteState::deserialize_into(&vote_state_buf, &mut test_vote_state).unwrap();
+            let test_vote_state = unsafe { test_vote_state.assume_init() };
 
             assert_eq!(target_vote_state, test_vote_state);
         }

--- a/sdk/program/src/vote/state/vote_state_1_14_11.rs
+++ b/sdk/program/src/vote/state/vote_state_1_14_11.rs
@@ -95,7 +95,7 @@ mod tests {
         let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
 
         let mut test_vote_state = MaybeUninit::uninit();
-        VoteState::deserialize_into(&vote_state_buf, &mut test_vote_state).unwrap();
+        VoteState::deserialize_into_uninit(&vote_state_buf, &mut test_vote_state).unwrap();
         let test_vote_state = unsafe { test_vote_state.assume_init() };
 
         assert_eq!(
@@ -118,7 +118,7 @@ mod tests {
             let target_vote_state = target_vote_state_versions.convert_to_current();
 
             let mut test_vote_state = MaybeUninit::uninit();
-            VoteState::deserialize_into(&vote_state_buf, &mut test_vote_state).unwrap();
+            VoteState::deserialize_into_uninit(&vote_state_buf, &mut test_vote_state).unwrap();
             let test_vote_state = unsafe { test_vote_state.assume_init() };
 
             assert_eq!(target_vote_state, test_vote_state);

--- a/sdk/program/src/vote/state/vote_state_deserialize.rs
+++ b/sdk/program/src/vote/state/vote_state_deserialize.rs
@@ -1,36 +1,53 @@
 use {
+    super::{MAX_EPOCH_CREDITS_HISTORY, MAX_LOCKOUT_HISTORY},
     crate::{
         instruction::InstructionError,
+        pubkey::Pubkey,
         serialize_utils::cursor::*,
-        vote::state::{BlockTimestamp, LandedVote, Lockout, VoteState, MAX_ITEMS},
+        vote::{
+            authorized_voters::AuthorizedVoters,
+            state::{BlockTimestamp, LandedVote, Lockout, VoteState, MAX_ITEMS},
+        },
     },
-    std::io::Cursor,
+    std::{collections::VecDeque, io::Cursor, ptr::addr_of_mut},
 };
 
 pub(super) fn deserialize_vote_state_into(
     cursor: &mut Cursor<&[u8]>,
-    vote_state: &mut VoteState,
+    vote_state: *mut VoteState,
     has_latency: bool,
 ) -> Result<(), InstructionError> {
-    vote_state.node_pubkey = read_pubkey(cursor)?;
-    vote_state.authorized_withdrawer = read_pubkey(cursor)?;
-    vote_state.commission = read_u8(cursor)?;
-    read_votes_into(cursor, vote_state, has_latency)?;
-    vote_state.root_slot = read_option_u64(cursor)?;
-    read_authorized_voters_into(cursor, vote_state)?;
+    unsafe {
+        addr_of_mut!((*vote_state).node_pubkey).write(read_pubkey(cursor)?);
+        addr_of_mut!((*vote_state).authorized_withdrawer).write(read_pubkey(cursor)?);
+        addr_of_mut!((*vote_state).commission).write(read_u8(cursor)?);
+    }
+    let votes = read_votes(cursor, has_latency)?;
+    unsafe {
+        addr_of_mut!((*vote_state).root_slot).write(read_option_u64(cursor)?);
+    }
+    let authorized_voters = read_authorized_voters(cursor)?;
     read_prior_voters_into(cursor, vote_state)?;
-    read_epoch_credits_into(cursor, vote_state)?;
+    let epoch_credits = read_epoch_credits(cursor)?;
     read_last_timestamp_into(cursor, vote_state)?;
+
+    // Defer writing the collections until we know we're going to succeed. This way if we fail we
+    // still drop the collections and don't leak memory.
+    unsafe {
+        addr_of_mut!((*vote_state).votes).write(votes);
+        addr_of_mut!((*vote_state).authorized_voters).write(authorized_voters);
+        addr_of_mut!((*vote_state).epoch_credits).write(epoch_credits);
+    }
 
     Ok(())
 }
 
-fn read_votes_into<T: AsRef<[u8]>>(
+fn read_votes<T: AsRef<[u8]>>(
     cursor: &mut Cursor<T>,
-    vote_state: &mut VoteState,
     has_latency: bool,
-) -> Result<(), InstructionError> {
-    let vote_count = read_u64(cursor)?;
+) -> Result<VecDeque<LandedVote>, InstructionError> {
+    let vote_count = read_u64(cursor)? as usize;
+    let mut votes = VecDeque::with_capacity(vote_count.min(MAX_LOCKOUT_HISTORY));
 
     for _ in 0..vote_count {
         let latency = if has_latency { read_u8(cursor)? } else { 0 };
@@ -39,73 +56,79 @@ fn read_votes_into<T: AsRef<[u8]>>(
         let confirmation_count = read_u32(cursor)?;
         let lockout = Lockout::new_with_confirmation_count(slot, confirmation_count);
 
-        vote_state.votes.push_back(LandedVote { latency, lockout });
+        votes.push_back(LandedVote { latency, lockout });
     }
 
-    Ok(())
+    Ok(votes)
 }
 
-fn read_authorized_voters_into<T: AsRef<[u8]>>(
+fn read_authorized_voters<T: AsRef<[u8]>>(
     cursor: &mut Cursor<T>,
-    vote_state: &mut VoteState,
-) -> Result<(), InstructionError> {
+) -> Result<AuthorizedVoters, InstructionError> {
     let authorized_voter_count = read_u64(cursor)?;
+    let mut authorized_voters = AuthorizedVoters::default();
 
     for _ in 0..authorized_voter_count {
         let epoch = read_u64(cursor)?;
         let authorized_voter = read_pubkey(cursor)?;
-
-        vote_state.authorized_voters.insert(epoch, authorized_voter);
+        authorized_voters.insert(epoch, authorized_voter);
     }
 
-    Ok(())
+    Ok(authorized_voters)
 }
 
 fn read_prior_voters_into<T: AsRef<[u8]>>(
     cursor: &mut Cursor<T>,
-    vote_state: &mut VoteState,
+    vote_state: *mut VoteState,
 ) -> Result<(), InstructionError> {
-    for i in 0..MAX_ITEMS {
-        let prior_voter = read_pubkey(cursor)?;
-        let from_epoch = read_u64(cursor)?;
-        let until_epoch = read_u64(cursor)?;
+    unsafe {
+        let prior_voters = addr_of_mut!((*vote_state).prior_voters);
+        let prior_voters_buf = addr_of_mut!((*prior_voters).buf) as *mut (Pubkey, u64, u64);
 
-        vote_state.prior_voters.buf[i] = (prior_voter, from_epoch, until_epoch);
+        for i in 0..MAX_ITEMS {
+            let prior_voter = read_pubkey(cursor)?;
+            let from_epoch = read_u64(cursor)?;
+            let until_epoch = read_u64(cursor)?;
+
+            prior_voters_buf
+                .add(i)
+                .write((prior_voter, from_epoch, until_epoch));
+        }
+
+        (*vote_state).prior_voters.idx = read_u64(cursor)? as usize;
+        (*vote_state).prior_voters.is_empty = read_bool(cursor)?;
     }
-
-    vote_state.prior_voters.idx = read_u64(cursor)? as usize;
-    vote_state.prior_voters.is_empty = read_bool(cursor)?;
-
     Ok(())
 }
 
-fn read_epoch_credits_into<T: AsRef<[u8]>>(
+fn read_epoch_credits<T: AsRef<[u8]>>(
     cursor: &mut Cursor<T>,
-    vote_state: &mut VoteState,
-) -> Result<(), InstructionError> {
-    let epoch_credit_count = read_u64(cursor)?;
+) -> Result<Vec<(u64, u64, u64)>, InstructionError> {
+    let epoch_credit_count = read_u64(cursor)? as usize;
+    let mut epoch_credits = Vec::with_capacity(epoch_credit_count.min(MAX_EPOCH_CREDITS_HISTORY));
 
     for _ in 0..epoch_credit_count {
         let epoch = read_u64(cursor)?;
         let credits = read_u64(cursor)?;
         let prev_credits = read_u64(cursor)?;
-
-        vote_state
-            .epoch_credits
-            .push((epoch, credits, prev_credits));
+        epoch_credits.push((epoch, credits, prev_credits));
     }
 
-    Ok(())
+    Ok(epoch_credits)
 }
 
 fn read_last_timestamp_into<T: AsRef<[u8]>>(
     cursor: &mut Cursor<T>,
-    vote_state: &mut VoteState,
+    vote_state: *mut VoteState,
 ) -> Result<(), InstructionError> {
     let slot = read_u64(cursor)?;
     let timestamp = read_i64(cursor)?;
 
-    vote_state.last_timestamp = BlockTimestamp { slot, timestamp };
+    let last_timestamp = BlockTimestamp { slot, timestamp };
+
+    unsafe {
+        addr_of_mut!((*vote_state).last_timestamp).write(last_timestamp);
+    }
 
     Ok(())
 }

--- a/sdk/program/src/vote/state/vote_state_deserialize.rs
+++ b/sdk/program/src/vote/state/vote_state_deserialize.rs
@@ -17,12 +17,15 @@ pub(super) fn deserialize_vote_state_into(
     vote_state: *mut VoteState,
     has_latency: bool,
 ) -> Result<(), InstructionError> {
+    // Safety: if vote_state is non-null, all the fields are guaranteed to be valid pointers
     unsafe {
         addr_of_mut!((*vote_state).node_pubkey).write(read_pubkey(cursor)?);
         addr_of_mut!((*vote_state).authorized_withdrawer).write(read_pubkey(cursor)?);
         addr_of_mut!((*vote_state).commission).write(read_u8(cursor)?);
     }
+
     let votes = read_votes(cursor, has_latency)?;
+    // Safety: if vote_state is non-null, root_slot is guaranteed to be valid too
     unsafe {
         addr_of_mut!((*vote_state).root_slot).write(read_option_u64(cursor)?);
     }
@@ -33,6 +36,8 @@ pub(super) fn deserialize_vote_state_into(
 
     // Defer writing the collections until we know we're going to succeed. This way if we fail we
     // still drop the collections and don't leak memory.
+    //
+    // Safety: if vote_state is non-null, all the fields are guaranteed to be valid pointers
     unsafe {
         addr_of_mut!((*vote_state).votes).write(votes);
         addr_of_mut!((*vote_state).authorized_voters).write(authorized_voters);
@@ -81,6 +86,7 @@ fn read_prior_voters_into<T: AsRef<[u8]>>(
     cursor: &mut Cursor<T>,
     vote_state: *mut VoteState,
 ) -> Result<(), InstructionError> {
+    // Safety: if vote_state is non-null, prior_voters is guaranteed to be valid too
     unsafe {
         let prior_voters = addr_of_mut!((*vote_state).prior_voters);
         let prior_voters_buf = addr_of_mut!((*prior_voters).buf) as *mut (Pubkey, u64, u64);

--- a/sdk/program/src/vote/state/vote_state_deserialize.rs
+++ b/sdk/program/src/vote/state/vote_state_deserialize.rs
@@ -119,7 +119,7 @@ fn read_prior_voters_into<T: AsRef<[u8]>>(
 
 fn read_epoch_credits<T: AsRef<[u8]>>(
     cursor: &mut Cursor<T>,
-) -> Result<Vec<(u64, u64, u64)>, InstructionError> {
+) -> Result<Vec<(Epoch, u64, u64)>, InstructionError> {
     let epoch_credit_count = read_u64(cursor)? as usize;
     let mut epoch_credits = Vec::with_capacity(epoch_credit_count.min(MAX_EPOCH_CREDITS_HISTORY));
 
@@ -142,6 +142,7 @@ fn read_last_timestamp_into<T: AsRef<[u8]>>(
 
     let last_timestamp = BlockTimestamp { slot, timestamp };
 
+    // Safety: if vote_state is non-null, last_timestamp is guaranteed to be valid too
     unsafe {
         addr_of_mut!((*vote_state).last_timestamp).write(last_timestamp);
     }


### PR DESCRIPTION
Deserializing into `MaybeUninit<VoteState>` saves the extra cost of initializing into a value initialized with VoteState::default().

I am planning to use this to speed up VoteAccount::try_from() in a followup PR. 