### PR TITLE
bench_lock_accounts: remove test

### DIFF
--- a/accounts-db/benches/bench_lock_accounts.rs
+++ b/accounts-db/benches/bench_lock_accounts.rs
@@ -1,10 +1,5 @@
-#![feature(test)]
-#![allow(clippy::arithmetic_side_effects)]
-
-extern crate test;
-
 use {
-    criterion::{criterion_group, criterion_main, Criterion, Throughput},
+    criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput},
     itertools::iproduct,
     solana_accounts_db::{accounts::Accounts, accounts_db::AccountsDb},
     solana_sdk::{
@@ -89,7 +84,7 @@ fn bench_entry_lock_accounts(c: &mut Criterion) {
             b.iter(|| {
                 for batch in &transaction_batches {
                     let results =
-                        accounts.lock_accounts(test::black_box(batch.iter()), MAX_TX_ACCOUNT_LOCKS);
+                        accounts.lock_accounts(black_box(batch.iter()), MAX_TX_ACCOUNT_LOCKS);
                     accounts.unlock_accounts(batch.iter().zip(&results));
                 }
             })


### PR DESCRIPTION
#### Problem
- Using `test` library makes us need nightly cargo
- We were only using it for `black_box`, and there's a criterion alternative

#### Summary of Changes
- use `black_box` from criterion

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
