### PR TITLE
Waits for initial startup verification to complete in ledger-tool create-snapshot

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1887,11 +1887,6 @@ fn main() {
                         process_options,
                         None,
                     );
-                    // Snapshot creation will implicitly perform AccountsDb
-                    // flush and clean operations. These operations cannot be
-                    // run concurrently, so ensure ABS is stopped to avoid that
-                    // possibility.
-                    accounts_background_service.join().unwrap();
 
                     let mut bank = bank_forks
                         .read()
@@ -1901,6 +1896,24 @@ fn main() {
                             eprintln!("Error: Slot {snapshot_slot} is not available");
                             exit(1);
                         });
+
+                    // Snapshot creation will implicitly perform AccountsDb
+                    // flush and clean operations. These operations cannot be
+                    // run concurrently, so ensure ABS is stopped to avoid that
+                    // possibility.
+                    accounts_background_service.join().unwrap();
+
+                    // Similar to waiting for ABS to stop, we also wait for the initial startup
+                    // verification to complete. The startup verification runs in the background
+                    // and verifies the snapshot's accounts hashes are correct. We only want a
+                    // single accounts hash calculation to run at a time, and since snapshot
+                    // creation below will calculate the accounts hash, we wait for the startup
+                    // verification to complete before proceeding.
+                    bank.rc
+                        .accounts
+                        .accounts_db
+                        .verify_accounts_hash_in_bg
+                        .wait_for_complete();
 
                     let child_bank_required = rent_burn_percentage.is_ok()
                         || hashes_per_tick.is_some()


### PR DESCRIPTION
#### Problem

In `ledger-tool create-snapshot`, startup will kick off an initial accounts verification that runs the accounts hash calculation in the background. After processing the ledger completes, we generate a new snapshot, which also does an accounts hash calculation. There's nothing in the code that prevents these explicitly from running concurrently.


#### Summary of Changes

Wait for the initial startup verification to complete before generating a new snapshot.