### PR TITLE
Uses &mut instead of RwLockWriteGuard in slot_list_mut()

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -35,7 +35,7 @@ use {
         path::PathBuf,
         sync::{
             atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
-            Arc, Mutex, OnceLock, RwLock, RwLockWriteGuard,
+            Arc, Mutex, OnceLock, RwLock,
         },
     },
     thiserror::Error,
@@ -1160,10 +1160,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     fn slot_list_mut<RT>(
         &self,
         pubkey: &Pubkey,
-        user: impl for<'a> FnOnce(&mut RwLockWriteGuard<'a, SlotList<T>>) -> RT,
+        user_fn: impl FnOnce(&mut SlotList<T>) -> RT,
     ) -> Option<RT> {
         let read_lock = self.get_bin(pubkey);
-        read_lock.slot_list_mut(pubkey, user)
+        read_lock.slot_list_mut(pubkey, user_fn)
     }
 
     /// Remove keys from the account index if the key's slot list is empty.


### PR DESCRIPTION
#### Problem

The accounts index method `slot_list_mut()` takes a parameter that is a function for modifying the slot list. That function takes the slot list as a RwLockWriteGuard. The implementation details of the RwLockWriteGuard are not important; only that the slot list is mutable.

#### Summary of Changes

Remove the RwLockWriteGuard; only the &mut is needed.