### PR TITLE
rename `BUILT_IN_INSTRUCTION_COSTS` to `BUILTIN_INSTRUCTION_COSTS`

### DIFF
--- a/core/src/banking_stage/packet_filter.rs
+++ b/core/src/banking_stage/packet_filter.rs
@@ -1,6 +1,6 @@
 use {
     super::immutable_deserialized_packet::ImmutableDeserializedPacket,
-    solana_cost_model::block_cost_limits::BUILT_IN_INSTRUCTION_COSTS,
+    solana_cost_model::block_cost_limits::BUILTIN_INSTRUCTION_COSTS,
     solana_sdk::{ed25519_program, saturating_add_assign, secp256k1_program},
     thiserror::Error,
 };
@@ -22,7 +22,7 @@ impl ImmutableDeserializedPacket {
     pub fn check_insufficent_compute_unit_limit(&self) -> Result<(), PacketFilterFailure> {
         let mut static_builtin_cost_sum: u64 = 0;
         for (program_id, _) in self.transaction().get_message().program_instructions_iter() {
-            if let Some(ix_cost) = BUILT_IN_INSTRUCTION_COSTS.get(program_id) {
+            if let Some(ix_cost) = BUILTIN_INSTRUCTION_COSTS.get(program_id) {
                 saturating_add_assign!(static_builtin_cost_sum, *ix_cost);
             }
         }

--- a/cost-model/src/block_cost_limits.rs
+++ b/cost-model/src/block_cost_limits.rs
@@ -37,7 +37,7 @@ pub const INSTRUCTION_DATA_BYTES_COST: u64 = 140 /*bytes per us*/ / COMPUTE_UNIT
 // Number of compute units for each built-in programs
 lazy_static! {
     /// Number of compute units for each built-in programs
-    pub static ref BUILT_IN_INSTRUCTION_COSTS: HashMap<Pubkey, u64> = [
+    pub static ref BUILTIN_INSTRUCTION_COSTS: HashMap<Pubkey, u64> = [
         (solana_stake_program::id(), solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS),
         (solana_config_program::id(), solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS),
         (solana_vote_program::id(), solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS),

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -160,7 +160,7 @@ impl CostModel {
 
         for (program_id, instruction) in transaction.message().program_instructions_iter() {
             let ix_execution_cost =
-                if let Some(builtin_cost) = BUILT_IN_INSTRUCTION_COSTS.get(program_id) {
+                if let Some(builtin_cost) = BUILTIN_INSTRUCTION_COSTS.get(program_id) {
                     *builtin_cost
                 } else {
                     has_user_space_instructions = true;
@@ -370,7 +370,7 @@ mod tests {
         );
 
         // expected cost for one system transfer instructions
-        let expected_execution_cost = BUILT_IN_INSTRUCTION_COSTS
+        let expected_execution_cost = BUILTIN_INSTRUCTION_COSTS
             .get(&system_program::id())
             .unwrap();
 
@@ -538,7 +538,7 @@ mod tests {
         debug!("many transfer transaction {:?}", tx);
 
         // expected cost for two system transfer instructions
-        let program_cost = BUILT_IN_INSTRUCTION_COSTS
+        let program_cost = BUILTIN_INSTRUCTION_COSTS
             .get(&system_program::id())
             .unwrap();
         let expected_cost = program_cost * 2;
@@ -622,7 +622,7 @@ mod tests {
         ));
 
         let expected_account_cost = WRITE_LOCK_UNITS * 2;
-        let expected_execution_cost = BUILT_IN_INSTRUCTION_COSTS
+        let expected_execution_cost = BUILTIN_INSTRUCTION_COSTS
             .get(&system_program::id())
             .unwrap();
         const DEFAULT_PAGE_COST: u64 = 8;
@@ -660,10 +660,10 @@ mod tests {
 
         let feature_set = FeatureSet::all_enabled();
         let expected_account_cost = WRITE_LOCK_UNITS * 2;
-        let expected_execution_cost = BUILT_IN_INSTRUCTION_COSTS
+        let expected_execution_cost = BUILTIN_INSTRUCTION_COSTS
             .get(&system_program::id())
             .unwrap()
-            + BUILT_IN_INSTRUCTION_COSTS
+            + BUILTIN_INSTRUCTION_COSTS
                 .get(&compute_budget::id())
                 .unwrap();
         let expected_loaded_accounts_data_size_cost = (data_limit as u64) / (32 * 1024) * 8;
@@ -693,7 +693,7 @@ mod tests {
                 start_hash,
             ));
         // transaction has one builtin instruction, and one bpf instruction, no ComputeBudget::compute_unit_limit
-        let expected_builtin_cost = *BUILT_IN_INSTRUCTION_COSTS
+        let expected_builtin_cost = *BUILTIN_INSTRUCTION_COSTS
             .get(&solana_system_program::id())
             .unwrap();
         let expected_bpf_cost = DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT;
@@ -722,10 +722,10 @@ mod tests {
                 start_hash,
             ));
         // transaction has one builtin instruction, and one ComputeBudget::compute_unit_limit
-        let expected_cost = *BUILT_IN_INSTRUCTION_COSTS
+        let expected_cost = *BUILTIN_INSTRUCTION_COSTS
             .get(&solana_system_program::id())
             .unwrap()
-            + BUILT_IN_INSTRUCTION_COSTS
+            + BUILTIN_INSTRUCTION_COSTS
                 .get(&compute_budget::id())
                 .unwrap();
 


### PR DESCRIPTION
#### Problem
I can never grep correctly for this constant because it uses `BUILT_IN` rather than `BUILTIN` in its name unlike all the other `BUILTIN` prefixed constants.

#### Summary of Changes
- Use `BUILTIN` prefix for the constant name

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
