### PR TITLE
when shrinking a dead zero lamport account, kick clean

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3272,8 +3272,8 @@ impl AccountsDb {
                                             } else {
                                                 found_not_zero += 1;
                                             }
-                                            // if the highest rooted slot for this pubkey is in the list of uncleaned roots, then we may want to purge it.
-                                            // We may want to remove older slots from the slot list. That's what purges_old_accounts does.
+                                            // if the highest rooted slot for this pubkey is in the list of uncleaned roots, then
+                                            // we may want to remove older slots from the slot list. That's what purges_old_accounts does.
                                             if uncleaned_roots.contains(slot) {
                                                 // Assertion enforced by `accounts_index.get()`, the latest slot
                                                 // will not be greater than the given `max_clean_root`
@@ -12139,6 +12139,93 @@ pub mod tests {
             pubkey_count_after_shrink,
             accounts.all_account_count_in_accounts_file(shrink_slot)
         );
+    }
+
+    #[test]
+    fn test_shrink_zero_lamport_clean_alive_later() {
+        solana_logger::setup();
+
+        let accounts = AccountsDb::new_single_for_tests();
+
+        let pubkey_count = 30000;
+        let pubkeys: Vec<_> = (0..5).map(|_| solana_sdk::pubkey::new_rand()).collect();
+        let zero_pubkeys: Vec<_> = (0..pubkey_count)
+            .map(|_| solana_sdk::pubkey::new_rand())
+            .collect();
+
+        let some_lamport = 223;
+        let no_data = 0;
+        let owner = *AccountSharedData::default().owner();
+
+        let account = AccountSharedData::new(some_lamport, no_data, &owner);
+        let zero_account = AccountSharedData::new(0, 0, &owner);
+
+        let mut current_slot = 0;
+
+        current_slot += 1;
+        for pubkey in &pubkeys {
+            accounts.store_for_tests(current_slot, &[(pubkey, &account)]);
+        }
+        for pubkey in &zero_pubkeys {
+            accounts.store_for_tests(current_slot, &[(pubkey, &zero_account)]);
+        }
+
+        accounts.calculate_accounts_delta_hash(current_slot);
+        accounts.add_root_and_flush_write_cache(current_slot);
+
+        let prior_slot = current_slot;
+        current_slot += 1;
+
+        for pubkey in &zero_pubkeys {
+            accounts.store_for_tests(current_slot, &[(pubkey, &account)]);
+        }
+
+        accounts.calculate_accounts_delta_hash(current_slot);
+        accounts.add_root_and_flush_write_cache(current_slot);
+
+        // remove pubkey zero in prior_slot as dead. Then, it will be shrunk away.
+        for pubkey_zero in &zero_pubkeys {
+            accounts
+                .accounts_index
+                .get_and_then(pubkey_zero, |account| {
+                    account
+                        .unwrap()
+                        .slot_list
+                        .write()
+                        .unwrap()
+                        .retain(|(slot, _info)| slot != &prior_slot);
+                    (false, ())
+                });
+            accounts
+                .storage
+                .get_slot_storage_entry(prior_slot)
+                .unwrap()
+                .alive_bytes
+                .fetch_sub(aligned_stored_size(0), Ordering::Relaxed);
+        }
+
+        accounts.shrink_all_slots(false, None, &EpochSchedule::default());
+
+        // after shrinking, all zero lamport dead accounts in prior_slot should be gone.
+        // pubkeys_to_clean should contain all the zero lamport accounts alive in
+        // 'current_slot'
+        assert_eq!(
+            pubkeys.len(),
+            accounts.all_account_count_in_accounts_file(prior_slot)
+        );
+        let mut pubkeys_to_clean = accounts
+            .uncleaned_pubkeys
+            .get(&current_slot)
+            .unwrap()
+            .value()
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+
+        for pubkey_zero in &zero_pubkeys {
+            assert!(pubkeys_to_clean.remove(pubkey_zero));
+        }
+        assert!(pubkeys_to_clean.is_empty());
     }
 
     #[test]

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3803,7 +3803,7 @@ impl AccountsDb {
                             if entry.1.is_zero_lamport() {
                                 self.add_uncleaned_pubkeys_after_shrink(
                                     entry.0,
-                                    [*pubkey].into_iter(),
+                                    std::iter::once(*pubkey),
                                 );
                             }
                         }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -12158,7 +12158,7 @@ pub mod tests {
         let owner = *AccountSharedData::default().owner();
 
         let account = AccountSharedData::new(some_lamport, no_data, &owner);
-        let zero_account = AccountSharedData::new(0, 0, &owner);
+        let zero_account = AccountSharedData::new(0, no_data, &owner);
 
         let mut current_slot = 0;
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3272,6 +3272,8 @@ impl AccountsDb {
                                             } else {
                                                 found_not_zero += 1;
                                             }
+                                            // if the highest rooted slot for this pubkey is in the list of uncleaned roots, then we may want to purge it.
+                                            // We may want to remove older slots from the slot list. That's what purges_old_accounts does.
                                             if uncleaned_roots.contains(slot) {
                                                 // Assertion enforced by `accounts_index.get()`, the latest slot
                                                 // will not be greater than the given `max_clean_root`
@@ -3794,6 +3796,17 @@ impl AccountsDb {
                         // not exist in the re-written slot. Unref it to keep the index consistent with
                         // rewriting the storage entries.
                         unrefed_pubkeys.push(pubkey);
+                        if ref_count == 2 && slot_list.len() == 1 {
+                            // this is the last remaining older entry for a zero lamport account. When this account at this slot is shrunk away, the
+                            // zero lamport account that is still alive can be marked dead, removed from the index, and then shrunk away.
+                            let entry = slot_list.first().unwrap();
+                            if entry.1.is_zero_lamport() {
+                                self.add_uncleaned_pubkeys_after_shrink(
+                                    entry.0,
+                                    [*pubkey].into_iter(),
+                                );
+                            }
+                        }
                         result = AccountsIndexScanResult::Unref;
                         dead += 1;
                     } else {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -12201,7 +12201,7 @@ pub mod tests {
                 .get_slot_storage_entry(prior_slot)
                 .unwrap()
                 .alive_bytes
-                .fetch_sub(aligned_stored_size(0), Ordering::Relaxed);
+                .fetch_sub(aligned_stored_size(no_data), Ordering::Relaxed);
         }
 
         accounts.shrink_all_slots(false, None, &EpochSchedule::default());


### PR DESCRIPTION
#### Problem
scenario:
write account a, lamports=1, slot=1
write account a, lamports=0, slot=101
slot list will be [101,1]
refcount will be 2

clean will run on slot 101.
clean will remove [1] from [101,1]
slot list for a in the index will then be [101]

a in 101 cannot be marked dead and a cannot be removed from the index until a in storage 1 is removed completely.
This occurs when storage 1 is completely marked dead and dropped or when storage 1 is shrunk and a no longer exists in storage 1.

#### Summary of Changes
From this example, when storage 1 is shrunk and we encounter account a, we find it has refcount = 2(soon to be 1), slot list len = 1, and the element in the slot list is zero lamports, then we tell clean that it should look at a in 101.
Clean will find account a with 1 ref count and 1 slot list entry and will mark a as dead in slot 101 and remove a from the index.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
