### PR TITLE
purge zero lamport accounts in clean

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -10906,8 +10906,7 @@ pub mod tests {
         // Slot 1 should be cleaned, but the clean has no impact
         assert_eq!(accounts.alive_account_count_in_slot(1), 2);
 
-        // zero lamport account, should no longer exist in accounts index
-        // because it has been removed
+        // zero lamport account, should still exist in accounts index
         assert!(accounts
             .accounts_index
             .contains_with(&pubkey_zero, None, None));

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1938,6 +1938,8 @@ struct CleanAccountsStats {
     remove_dead_accounts_shrink_us: AtomicU64,
     clean_stored_dead_slots_us: AtomicU64,
     uncleaned_roots_slot_list_1: AtomicU64,
+    zero_lamport_single_entry_accounts_purge_failed: AtomicU64,
+    zero_lamport_single_entry_accounts_purged: AtomicU64,
 }
 
 impl CleanAccountsStats {
@@ -3589,6 +3591,20 @@ impl AccountsDb {
                 i64
             ),
             ("next_store_id", self.next_id.load(Ordering::Relaxed), i64),
+            (
+                "zero_lamport_single_entry_accounts_purge_failed",
+                self.clean_accounts_stats
+                    .zero_lamport_single_entry_accounts_purge_failed
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "zero_lamport_single_entry_accounts_purged",
+                self.clean_accounts_stats
+                    .zero_lamport_single_entry_accounts_purged
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
         );
     }
 
@@ -3695,13 +3711,39 @@ impl AccountsDb {
         );
 
         purges_zero_lamports.retain(|pubkey, (slot_account_infos, ref_count)| {
-            // a zero lamport account with a single ref count and single slot list entry can be removed completely, even if the slot it is in is not being deleted
-            if !(slot_account_infos.len() == 1
+            // Only keep purges_zero_lamports where the entire history of the account in the root set
+            // can be purged. All AppendVecs for those updates are dead.
+            let mut force_allow_purge = false;
+            if slot_account_infos.len() == 1
                 && slot_account_infos.first().unwrap().1.is_zero_lamport()
-                && ref_count == &1)
+                && ref_count == &1
             {
-                // Only keep purges_zero_lamports where the entire history of the account in the root set
-                // can be purged. All AppendVecs for those updates are dead.
+                // `ref_count` is modified based on assumptions of what will happen in this active clean. Clean is in the middle of figuring out what will be
+                // dropped. We cannot rely on `ref_count` here. We need to check the actual index. ref_count may really be 2 and we may be hoping to drop the older element from the slot list.
+                // but, if that drop gets cancelled, then we would now resurrect an older version of this account in the index.
+                self.accounts_index.scan(
+                    [pubkey].into_iter(),
+                    |_k, info, _entry| {
+                        if let Some(info) = info {
+                            if info.0.len() == 1 && info.1 == 1 {
+                                force_allow_purge = true;
+                                self.clean_accounts_stats
+                                    .zero_lamport_single_entry_accounts_purged
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                        AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
+                    },
+                    None,
+                    false,
+                );
+                if !force_allow_purge {
+                    self.clean_accounts_stats
+                        .zero_lamport_single_entry_accounts_purged
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            if !force_allow_purge {
                 for (slot, _account_info) in slot_account_infos.iter() {
                     if let Some(store_count) = store_counts.get(slot) {
                         if store_count.0 != 0 {
@@ -3820,6 +3862,17 @@ impl AccountsDb {
                         // not exist in the re-written slot. Unref it to keep the index consistent with
                         // rewriting the storage entries.
                         unrefed_pubkeys.push(pubkey);
+                        if ref_count == 2 && slot_list.len() == 1 {
+                            // this is the last remaining older entry for a zero lamport account. When this account at this slot is shrunk away, the
+                            // zero lamport account that is still alive can be marked dead, removed from the index, and then shrunk away.
+                            let entry = slot_list.first().unwrap();
+                            if entry.1.is_zero_lamport() {
+                                self.add_uncleaned_pubkeys_after_shrink(
+                                    entry.0,
+                                    [*pubkey].into_iter(),
+                                );
+                            }
+                        }
                         result = AccountsIndexScanResult::Unref;
                         dead += 1;
                     } else {
@@ -11081,9 +11134,10 @@ pub mod tests {
 
         accounts.clean_accounts_for_tests();
 
-        //Old state behind zero-lamport account is cleaned up
+        // Old state behind zero-lamport account and normal account is cleaned up in slot 0
         assert_eq!(accounts.alive_account_count_in_slot(0), 0);
-        assert_eq!(accounts.alive_account_count_in_slot(1), 2);
+        // zero lamport account can be marked dead in slot 1 since the entry in slot 1 is the only instance in all storages
+        assert_eq!(accounts.alive_account_count_in_slot(1), 1);
     }
 
     #[test]

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3739,7 +3739,7 @@ impl AccountsDb {
                 );
                 if !force_allow_purge {
                     self.clean_accounts_stats
-                        .zero_lamport_single_entry_accounts_purged
+                        .zero_lamport_single_entry_accounts_purge_failed
                         .fetch_add(1, Ordering::Relaxed);
                 }
             }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3862,17 +3862,6 @@ impl AccountsDb {
                         // not exist in the re-written slot. Unref it to keep the index consistent with
                         // rewriting the storage entries.
                         unrefed_pubkeys.push(pubkey);
-                        if ref_count == 2 && slot_list.len() == 1 {
-                            // this is the last remaining older entry for a zero lamport account. When this account at this slot is shrunk away, the
-                            // zero lamport account that is still alive can be marked dead, removed from the index, and then shrunk away.
-                            let entry = slot_list.first().unwrap();
-                            if entry.1.is_zero_lamport() {
-                                self.add_uncleaned_pubkeys_after_shrink(
-                                    entry.0,
-                                    [*pubkey].into_iter(),
-                                );
-                            }
-                        }
                         result = AccountsIndexScanResult::Unref;
                         dead += 1;
                     } else {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9627,7 +9627,7 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
     bank2.clean_accounts_for_tests();
 
     let expected_ref_count_for_cleaned_up_keys = 0;
-    let expected_ref_count_for_keys_in_both_slot1_and_slot2 = 1;
+    let expected_ref_count_for_zero_lamport_keys_in_both_slot1_and_slot2 = 0;
 
     assert_eq!(
         bank2
@@ -9663,7 +9663,7 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
             .accounts_db
             .accounts_index
             .ref_count_from_storage(&key5.pubkey()),
-        expected_ref_count_for_keys_in_both_slot1_and_slot2,
+        expected_ref_count_for_zero_lamport_keys_in_both_slot1_and_slot2,
     );
 
     assert_eq!(


### PR DESCRIPTION
#### Problem
scenario:
slot 1 contains account a with zero lamports. ref_count=1, slot_list.len()=1
clean comes across account 'a'. Account a should be marked dead and removed from the index.
It currently is not.

#### Summary of Changes
Recognize this special case and allow clean to remove account a.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
