### PR TITLE
Add lamports per signature field for registering recent blockhash for tests

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3144,11 +3144,7 @@ impl Bank {
     }
 
     #[cfg(feature = "dev-context-only-utils")]
-    pub fn register_recent_blockhash_for_test(&self, hash: &Hash, lamports_per_signature: Option<u64>) {
-        // This is needed because recent_blockhash updates necessitate synchronizations for
-        // consistent tx check_age handling.
-        BankWithScheduler::wait_for_paused_scheduler(self, scheduler);
-
+    pub fn register_recent_blockhash_for_test(&self, blockhash: &Hash, lamports_per_signature: Option<u64>) {
         // Only acquire the write lock for the blockhash queue on block boundaries because
         // readers can starve this write lock acquisition and ticks would be slowed down too
         // much if the write lock is acquired for each tick.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3144,7 +3144,11 @@ impl Bank {
     }
 
     #[cfg(feature = "dev-context-only-utils")]
-    pub fn register_recent_blockhash_for_test(&self, blockhash: &Hash, lamports_per_signature: Option<u64>) {
+    pub fn register_recent_blockhash_for_test(
+        &self,
+        blockhash: &Hash,
+        lamports_per_signature: Option<u64>,
+    ) {
         // Only acquire the write lock for the blockhash queue on block boundaries because
         // readers can starve this write lock acquisition and ticks would be slowed down too
         // much if the write lock is acquired for each tick.
@@ -3152,7 +3156,8 @@ impl Bank {
         if let Some(lamports_per_signature) = lamports_per_signature {
             w_blockhash_queue.register_hash(blockhash, lamports_per_signature);
         } else {
-            w_blockhash_queue.register_hash(blockhash, self.fee_rate_governor.lamports_per_signature);
+            w_blockhash_queue
+                .register_hash(blockhash, self.fee_rate_governor.lamports_per_signature);
         }
         self.update_recent_blockhashes_locked(&w_blockhash_queue);
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3134,6 +3134,19 @@ impl Bank {
         self.update_recent_blockhashes_locked(&w_blockhash_queue);
     }
 
+    fn register_recent_blockhash_with_lamports_per_signature(&self, blockhash: &Hash, lamports_per_signature: u64, scheduler: &InstalledSchedulerRwLock) {
+        // This is needed because recent_blockhash updates necessitate synchronizations for
+        // consistent tx check_age handling.
+        BankWithScheduler::wait_for_paused_scheduler(self, scheduler);
+
+        // Only acquire the write lock for the blockhash queue on block boundaries because
+        // readers can starve this write lock acquisition and ticks would be slowed down too
+        // much if the write lock is acquired for each tick.
+        let mut w_blockhash_queue = self.blockhash_queue.write().unwrap();
+        w_blockhash_queue.register_hash(blockhash, lamports_per_signature);
+        self.update_recent_blockhashes_locked(&w_blockhash_queue);
+    }
+
     // gating this under #[cfg(feature = "dev-context-only-utils")] isn't easy due to
     // solana-program-test's usage...
     pub fn register_unique_recent_blockhash_for_test(&self) {
@@ -3144,8 +3157,12 @@ impl Bank {
     }
 
     #[cfg(feature = "dev-context-only-utils")]
-    pub fn register_recent_blockhash_for_test(&self, hash: &Hash) {
-        self.register_recent_blockhash(hash, &BankWithScheduler::no_scheduler_available());
+    pub fn register_recent_blockhash_for_test(&self, hash: &Hash, lamports_per_signature: Option<u64>) {
+        if let Some(lamports_per_signature) = lamports_per_signature {
+            self.register_recent_blockhash_with_lamports_per_signature(hash, lamports_per_signature, &BankWithScheduler::no_scheduler_available());
+        } else {
+            self.register_recent_blockhash(hash, &BankWithScheduler::no_scheduler_available());
+        }
     }
 
     /// Tell the bank which Entry IDs exist on the ledger. This function assumes subsequent calls


### PR DESCRIPTION
#### Problem

Working from [solfuzz-agave](https://github.com/firedancer-io/solfuzz-agave) to be able to replay transactions from ledgers. For tests, we need to be able to register blockhashes with the correct lamports per signature if the recent blockhashes sysvar account is provided.

#### Summary of Changes

Add a new function for tests, `register_recent_blockhash_for_test_with_lamports_per_signature`


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
