### PR TITLE
AccountLocks: Remove per-transaction allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5501,6 +5501,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-stake-program",
+ "solana-svm-transaction",
  "solana-vote-program",
  "static_assertions",
  "strum",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -46,6 +46,7 @@ solana-metrics = { workspace = true }
 solana-nohash-hasher = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-sdk = { workspace = true }
+solana-svm-transaction = { workspace = true }
 solana-stake-program = { workspace = true, optional = true }
 solana-vote-program = { workspace = true, optional = true }
 static_assertions = { workspace = true }

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -46,8 +46,8 @@ solana-metrics = { workspace = true }
 solana-nohash-hasher = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-sdk = { workspace = true }
-solana-svm-transaction = { workspace = true }
 solana-stake-program = { workspace = true, optional = true }
+solana-svm-transaction = { workspace = true }
 solana-vote-program = { workspace = true, optional = true }
 static_assertions = { workspace = true }
 tar = { workspace = true }

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -540,19 +540,19 @@ impl Accounts {
         self.accounts_db.store_uncached(slot, &[(pubkey, account)]);
     }
 
-    fn lock_account(
+    fn lock_account<'a>(
         &self,
         account_locks: &mut AccountLocks,
-        writable_keys: Vec<&Pubkey>,
-        readonly_keys: Vec<&Pubkey>,
+        writable_keys: impl Iterator<Item = &'a Pubkey> + Clone,
+        readonly_keys: impl Iterator<Item = &'a Pubkey> + Clone,
     ) -> Result<()> {
-        for k in writable_keys.iter() {
+        for k in writable_keys.clone() {
             if account_locks.is_locked_write(k) || account_locks.is_locked_readonly(k) {
                 debug!("Writable account in use: {:?}", k);
                 return Err(TransactionError::AccountInUse);
             }
         }
-        for k in readonly_keys.iter() {
+        for k in readonly_keys.clone() {
             if account_locks.is_locked_write(k) {
                 debug!("Read-only account in use: {:?}", k);
                 return Err(TransactionError::AccountInUse);
@@ -572,11 +572,11 @@ impl Accounts {
         Ok(())
     }
 
-    fn unlock_account(
+    fn unlock_account<'a>(
         &self,
         account_locks: &mut AccountLocks,
-        writable_keys: Vec<&Pubkey>,
-        readonly_keys: Vec<&Pubkey>,
+        writable_keys: impl Iterator<Item = &'a Pubkey>,
+        readonly_keys: impl Iterator<Item = &'a Pubkey>,
     ) {
         for k in writable_keys {
             account_locks.unlock_write(k);
@@ -628,8 +628,8 @@ impl Accounts {
             .map(|tx_account_locks_result| match tx_account_locks_result {
                 Ok(tx_account_locks) => self.lock_account(
                     account_locks,
-                    tx_account_locks.writable,
-                    tx_account_locks.readonly,
+                    tx_account_locks.writable.into_iter(),
+                    tx_account_locks.readonly.into_iter(),
                 ),
                 Err(err) => Err(err),
             })
@@ -652,7 +652,11 @@ impl Accounts {
         let mut account_locks = self.account_locks.lock().unwrap();
         debug!("bank unlock accounts");
         keys.into_iter().for_each(|keys| {
-            self.unlock_account(&mut account_locks, keys.writable, keys.readonly);
+            self.unlock_account(
+                &mut account_locks,
+                keys.writable.into_iter(),
+                keys.readonly.into_iter(),
+            );
         });
     }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4517,6 +4517,7 @@ dependencies = [
  "solana-nohash-hasher",
  "solana-rayon-threadlimit",
  "solana-sdk",
+ "solana-svm-transaction",
  "static_assertions",
  "tar",
  "tempfile",
@@ -6338,6 +6339,13 @@ dependencies = [
  "solana-timings",
  "solana-type-overrides",
  "solana-vote",
+]
+
+[[package]]
+name = "solana-svm-transaction"
+version = "2.1.0"
+dependencies = [
+ "solana-sdk",
 ]
 
 [[package]]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3407,7 +3407,7 @@ impl Bank {
 
     pub fn unlock_accounts<'a>(
         &self,
-        txs_and_results: impl Iterator<Item = (&'a SanitizedTransaction, &'a Result<()>)>,
+        txs_and_results: impl Iterator<Item = (&'a SanitizedTransaction, &'a Result<()>)> + Clone,
     ) {
         self.rc.accounts.unlock_accounts(txs_and_results)
     }


### PR DESCRIPTION
#### Problem
- `get_account_locks` performs allocations to store the account locks for each transaction

#### Summary of Changes
- iterate over keys in account keys using is_writable to distinguish

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
