### PR TITLE
extract transaction-error crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8534,6 +8534,7 @@ dependencies = [
 name = "solana-transaction-error"
 version = "2.1.0"
 dependencies = [
+ "rustc_version 0.4.0",
  "serde",
  "serde_derive",
  "solana-frozen-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8538,6 +8538,7 @@ dependencies = [
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-instruction",
  "solana-program",
  "solana-sanitize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7365,6 +7365,7 @@ dependencies = [
  "solana-short-vec",
  "solana-slot-hashes",
  "solana-stable-layout",
+ "solana-transaction-error",
  "static_assertions",
  "test-case",
  "thiserror",
@@ -8539,7 +8540,6 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-instruction",
- "solana-program",
  "solana-sanitize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7953,6 +7953,7 @@ dependencies = [
  "solana-serde-varint",
  "solana-short-vec",
  "solana-signature",
+ "solana-transaction-error",
  "static_assertions",
  "thiserror",
  "tiny-bip39",
@@ -8527,6 +8528,19 @@ dependencies = [
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
+]
+
+[[package]]
+name = "solana-transaction-error"
+version = "2.1.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-program",
+ "solana-sanitize",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8534,7 +8534,6 @@ dependencies = [
 name = "solana-transaction-error"
 version = "2.1.0"
 dependencies = [
- "rustc_version 0.4.1",
  "serde",
  "serde_derive",
  "solana-frozen-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8541,7 +8541,6 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-program",
  "solana-sanitize",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8534,7 +8534,7 @@ dependencies = [
 name = "solana-transaction-error"
 version = "2.1.0"
 dependencies = [
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "serde",
  "serde_derive",
  "solana-frozen-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ members = [
     "sdk/signature",
     "sdk/slot-hashes",
     "sdk/stable-layout",
+    "sdk/transaction-error",
     "send-transaction-service",
     "short-vec",
     "stake-accounts",
@@ -495,6 +496,7 @@ solana-svm-transaction = { path = "svm-transaction", version = "=2.1.0" }
 solana-system-program = { path = "programs/system", version = "=2.1.0" }
 solana-test-validator = { path = "test-validator", version = "=2.1.0" }
 solana-thin-client = { path = "thin-client", version = "=2.1.0" }
+solana-transaction-error = { path = "sdk/transaction-error", version = "=2.1.0" }
 solana-tpu-client = { path = "tpu-client", version = "=2.1.0", default-features = false }
 solana-transaction-status = { path = "transaction-status", version = "=2.1.0" }
 solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=2.1.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7047,6 +7047,7 @@ dependencies = [
 name = "solana-transaction-error"
 version = "2.1.0"
 dependencies = [
+ "rustc_version",
  "serde",
  "serde_derive",
  "solana-program",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7051,7 +7051,6 @@ dependencies = [
  "serde_derive",
  "solana-program",
  "solana-sanitize",
- "thiserror",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5741,6 +5741,7 @@ dependencies = [
  "solana-short-vec",
  "solana-slot-hashes",
  "solana-stable-layout",
+ "solana-transaction-error",
  "thiserror",
  "wasm-bindgen",
 ]
@@ -7050,7 +7051,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-instruction",
- "solana-program",
  "solana-sanitize",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6706,6 +6706,7 @@ dependencies = [
  "solana-serde-varint",
  "solana-short-vec",
  "solana-signature",
+ "solana-transaction-error",
  "thiserror",
  "wasm-bindgen",
 ]
@@ -7040,6 +7041,17 @@ dependencies = [
  "solana-sdk",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "solana-transaction-error"
+version = "2.1.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-program",
+ "solana-sanitize",
+ "thiserror",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7047,7 +7047,6 @@ dependencies = [
 name = "solana-transaction-error"
 version = "2.1.0"
 dependencies = [
- "rustc_version",
  "serde",
  "serde_derive",
  "solana-program",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7049,6 +7049,7 @@ version = "2.1.0"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-instruction",
  "solana-program",
  "solana-sanitize",
 ]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -253,7 +253,7 @@ struct RentMetrics {
 pub type BankStatusCache = StatusCache<Result<()>>;
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(digest = "BswQL6n7kKwgHFKcwMCQcrWjt8h59Vh6KkNb75iaqG2B")
+    frozen_abi(digest = "BHg4qpwegtaJypLUqAdjQYzYeLfEGf6tA4U5cREbHMHi")
 )]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -35,6 +35,7 @@ full = [
     "digest",
     "solana-pubkey/rand",
     "dep:solana-precompile-error"
+    "dep:solana-transaction-error"
 ]
 borsh = ["dep:borsh", "solana-program/borsh", "solana-secp256k1-recover/borsh"]
 dev-context-only-utils = ["qualifier_attr", "solana-account/dev-context-only-utils"]
@@ -45,7 +46,7 @@ frozen-abi = [
     "solana-account/frozen-abi",
     "solana-program/frozen-abi",
     "solana-short-vec/frozen-abi",
-    "solana-signature/frozen-abi"
+    "solana-signature/frozen-abi",
     "solana-transaction-error/frozen-abi"
 ]
 
@@ -115,7 +116,7 @@ solana-signature = { workspace = true, features = [
     "std",
     "verify",
 ], optional = true }
-solana-transaction-error = { workspace = true, features = ["serde"] }
+solana-transaction-error = { workspace = true, features = ["serde"], optional = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -46,6 +46,7 @@ frozen-abi = [
     "solana-program/frozen-abi",
     "solana-short-vec/frozen-abi",
     "solana-signature/frozen-abi"
+    "solana-transaction-error/frozen-abi"
 ]
 
 [dependencies]
@@ -114,6 +115,7 @@ solana-signature = { workspace = true, features = [
     "std",
     "verify",
 ], optional = true }
+solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -34,7 +34,7 @@ full = [
     "sha3",
     "digest",
     "solana-pubkey/rand",
-    "dep:solana-precompile-error"
+    "dep:solana-precompile-error",
     "dep:solana-transaction-error"
 ]
 borsh = ["dep:borsh", "solana-program/borsh", "solana-secp256k1-recover/borsh"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -115,7 +115,7 @@ solana-signature = { workspace = true, features = [
     "std",
     "verify",
 ], optional = true }
-solana-transaction-error = { workspace = true }
+solana-transaction-error = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -87,6 +87,7 @@ bitflags = { workspace = true }
 curve25519-dalek = { workspace = true }
 num-bigint = { workspace = true }
 rand = { workspace = true }
+solana-transaction-error = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 arbitrary = { workspace = true, features = ["derive"] }

--- a/sdk/program/src/message/address_loader.rs
+++ b/sdk/program/src/message/address_loader.rs
@@ -1,4 +1,8 @@
 use super::v0::{LoadedAddresses, MessageAddressTableLookup};
+#[deprecated(
+    since = "2.1.0",
+    note = "Use solana_transaction_error::AddressLoaderError instead"
+)]
 pub use solana_transaction_error::AddressLoaderError;
 
 pub trait AddressLoader: Clone {

--- a/sdk/program/src/message/address_loader.rs
+++ b/sdk/program/src/message/address_loader.rs
@@ -1,34 +1,5 @@
-use {
-    super::v0::{LoadedAddresses, MessageAddressTableLookup},
-    thiserror::Error,
-};
-
-#[derive(Debug, Error, PartialEq, Eq, Clone)]
-pub enum AddressLoaderError {
-    /// Address loading from lookup tables is disabled
-    #[error("Address loading from lookup tables is disabled")]
-    Disabled,
-
-    /// Failed to load slot hashes sysvar
-    #[error("Failed to load slot hashes sysvar")]
-    SlotHashesSysvarNotFound,
-
-    /// Attempted to lookup addresses from a table that does not exist
-    #[error("Attempted to lookup addresses from a table that does not exist")]
-    LookupTableAccountNotFound,
-
-    /// Attempted to lookup addresses from an account owned by the wrong program
-    #[error("Attempted to lookup addresses from an account owned by the wrong program")]
-    InvalidAccountOwner,
-
-    /// Attempted to lookup addresses from an invalid account
-    #[error("Attempted to lookup addresses from an invalid account")]
-    InvalidAccountData,
-
-    /// Address lookup contains an invalid index
-    #[error("Address lookup contains an invalid index")]
-    InvalidLookupIndex,
-}
+use super::v0::{LoadedAddresses, MessageAddressTableLookup};
+pub use solana_transaction_error::AddressLoaderError;
 
 pub trait AddressLoader: Clone {
     fn load_addresses(

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -1,3 +1,7 @@
+#[deprecated(
+    since = "2.1.0",
+    note = "Use solana_transaction_error::SanitizeMessageError instead"
+)]
 pub use solana_transaction_error::SanitizeMessageError;
 use {
     crate::{

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -1,3 +1,4 @@
+pub use solana_transaction_error::SanitizeMessageError;
 use {
     crate::{
         ed25519_program,
@@ -6,8 +7,7 @@ use {
         message::{
             legacy,
             v0::{self, LoadedAddresses},
-            AccountKeys, AddressLoader, AddressLoaderError, MessageHeader,
-            SanitizedVersionedMessage, VersionedMessage,
+            AccountKeys, AddressLoader, MessageHeader, SanitizedVersionedMessage, VersionedMessage,
         },
         nonce::NONCED_TX_MARKER_IX_INDEX,
         program_utils::limited_deserialize,
@@ -16,9 +16,8 @@ use {
         solana_program::{system_instruction::SystemInstruction, system_program},
         sysvar::instructions::{BorrowedAccountMeta, BorrowedInstruction},
     },
-    solana_sanitize::{Sanitize, SanitizeError},
+    solana_sanitize::Sanitize,
     std::{borrow::Cow, collections::HashSet, convert::TryFrom},
-    thiserror::Error,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -78,28 +77,6 @@ pub enum SanitizedMessage {
     Legacy(LegacyMessage<'static>),
     /// Sanitized version #0 message with dynamically loaded addresses
     V0(v0::LoadedMessage<'static>),
-}
-
-#[derive(PartialEq, Debug, Error, Eq, Clone)]
-pub enum SanitizeMessageError {
-    #[error("index out of bounds")]
-    IndexOutOfBounds,
-    #[error("value out of bounds")]
-    ValueOutOfBounds,
-    #[error("invalid value")]
-    InvalidValue,
-    #[error("{0}")]
-    AddressLoaderError(#[from] AddressLoaderError),
-}
-
-impl From<SanitizeError> for SanitizeMessageError {
-    fn from(err: SanitizeError) -> Self {
-        match err {
-            SanitizeError::IndexOutOfBounds => Self::IndexOutOfBounds,
-            SanitizeError::ValueOutOfBounds => Self::ValueOutOfBounds,
-            SanitizeError::InvalidValue => Self::InvalidValue,
-        }
-    }
 }
 
 impl SanitizedMessage {

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -6,10 +6,10 @@ use {
     crate::{
         pubkey::Pubkey,
         signature::{PresignerError, Signature},
-        transaction::TransactionError,
     },
     itertools::Itertools,
     solana_derivation_path::DerivationPath,
+    solana_transaction_error::TransactionError,
     std::{
         error,
         fs::{self, File, OpenOptions},

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -133,11 +133,10 @@ use {
     std::result,
 };
 
-mod error;
 mod sanitized;
 mod versioned;
 
-pub use {error::*, sanitized::*, versioned::*};
+pub use {solana_transaction_error::*, sanitized::*, versioned::*};
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum TransactionVerificationMode {

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -136,7 +136,9 @@ use {
 mod sanitized;
 mod versioned;
 
-pub use {sanitized::*, solana_transaction_error::*, versioned::*};
+#[deprecated(since = "2.1.0", note = "Use solana_transaction_error crate instead")]
+pub use solana_transaction_error::*;
+pub use {sanitized::*, versioned::*};
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum TransactionVerificationMode {

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -136,7 +136,7 @@ use {
 mod sanitized;
 mod versioned;
 
-pub use {solana_transaction_error::*, sanitized::*, versioned::*};
+pub use {sanitized::*, solana_transaction_error::*, versioned::*};
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum TransactionVerificationMode {

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -15,11 +15,12 @@ use {
         reserved_account_keys::ReservedAccountKeys,
         signature::Signature,
         simple_vote_transaction_checker::is_simple_vote_transaction,
-        transaction::{Result, Transaction, TransactionError, VersionedTransaction},
+        transaction::{Result, Transaction, VersionedTransaction},
     },
     solana_feature_set as feature_set,
     solana_program::{instruction::InstructionError, message::SanitizedVersionedMessage},
     solana_sanitize::Sanitize,
+    solana_transaction_error::TransactionError,
     std::collections::HashSet,
 };
 

--- a/sdk/src/transaction/versioned/mod.rs
+++ b/sdk/src/transaction/versioned/mod.rs
@@ -9,11 +9,12 @@ use {
         signature::Signature,
         signer::SignerError,
         signers::Signers,
-        transaction::{Result, Transaction, TransactionError},
+        transaction::{Result, Transaction},
     },
     serde::Serialize,
     solana_sanitize::SanitizeError,
     solana_short_vec as short_vec,
+    solana_transaction_error::TransactionError,
     std::cmp::Ordering,
 };
 

--- a/sdk/src/transport.rs
+++ b/sdk/src/transport.rs
@@ -2,7 +2,7 @@
 
 #![cfg(feature = "full")]
 
-use {crate::transaction::TransactionError, std::io, thiserror::Error};
+use {solana_transaction_error::TransactionError, std::io, thiserror::Error};
 
 #[derive(Debug, Error)]
 pub enum TransportError {

--- a/sdk/src/transport.rs
+++ b/sdk/src/transport.rs
@@ -1,27 +1,4 @@
 //! Defines the [`TransportError`] type.
 
 #![cfg(feature = "full")]
-
-use {solana_transaction_error::TransactionError, std::io, thiserror::Error};
-
-#[derive(Debug, Error)]
-pub enum TransportError {
-    #[error("transport io error: {0}")]
-    IoError(#[from] io::Error),
-    #[error("transport transaction error: {0}")]
-    TransactionError(#[from] TransactionError),
-    #[error("transport custom error: {0}")]
-    Custom(String),
-}
-
-impl TransportError {
-    pub fn unwrap(&self) -> TransactionError {
-        if let TransportError::TransactionError(err) = self {
-            err.clone()
-        } else {
-            panic!("unexpected transport error")
-        }
-    }
-}
-
-pub type Result<T> = std::result::Result<T, TransportError>;
+pub use solana_transaction_error::{TransportError, TransportResult as Result};

--- a/sdk/src/transport.rs
+++ b/sdk/src/transport.rs
@@ -1,4 +1,5 @@
 //! Defines the [`TransportError`] type.
 
 #![cfg(feature = "full")]
+#[deprecated(since = "2.1.0", note = "Use solana_transaction_error crate instead")]
 pub use solana_transaction_error::{TransportError, TransportResult as Result};

--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -31,3 +31,6 @@ serde = ["dep:serde", "dep:serde_derive"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -25,6 +25,8 @@ serde = ["dep:serde", "dep:serde_derive"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -18,6 +18,9 @@ solana-program = { workspace = true }
 solana-sanitize = { workspace = true }
 thiserror = { workspace = true }
 
+[build-dependencies]
+rustc_version = { workspace = true }
+
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 

--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -14,15 +14,13 @@ serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
-solana-instruction = { workspace = true }
-solana-program = { workspace = true }
+solana-instruction = { workspace = true, default-features = false, features = [
+    "std",
+] }
 solana-sanitize = { workspace = true }
 
 [features]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro"
-]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [package.metadata.docs.rs]

--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -31,6 +31,3 @@ serde = ["dep:serde", "dep:serde_derive"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-
-[lints]
-workspace = true

--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -27,3 +27,6 @@ serde = ["dep:serde", "dep:serde_derive"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -14,6 +14,7 @@ serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-instruction = { workspace = true }
 solana-program = { workspace = true }
 solana-sanitize = { workspace = true }
 

--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -17,12 +17,8 @@ solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-program = { workspace = true }
 solana-sanitize = { workspace = true }
 
-[build-dependencies]
-rustc_version = { workspace = true, optional = true }
-
 [features]
 frozen-abi = [
-    "dep:rustc_version",
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro"
 ]

--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -10,8 +10,8 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-serde = { workspace = true }
-serde_derive = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-program = { workspace = true }
@@ -23,6 +23,7 @@ rustc_version = { workspace = true }
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = ["dep:serde", "dep:serde_derive"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "solana-transaction-error"
+description = "Solana TransactionError type"
+documentation = "https://docs.rs/solana-transaction-error"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+serde = { workspace = true }
+serde_derive = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-program = { workspace = true }
+solana-sanitize = { workspace = true }
+thiserror = { workspace = true }
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -16,7 +16,6 @@ solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-program = { workspace = true }
 solana-sanitize = { workspace = true }
-thiserror = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true, optional = true }

--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -19,10 +19,14 @@ solana-sanitize = { workspace = true }
 thiserror = { workspace = true }
 
 [build-dependencies]
-rustc_version = { workspace = true }
+rustc_version = { workspace = true, optional = true }
 
 [features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:rustc_version",
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro"
+]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [package.metadata.docs.rs]

--- a/sdk/transaction-error/build.rs
+++ b/sdk/transaction-error/build.rs
@@ -1,1 +1,0 @@
-../../frozen-abi/build.rs

--- a/sdk/transaction-error/build.rs
+++ b/sdk/transaction-error/build.rs
@@ -1,0 +1,1 @@
+../../frozen-abi/build.rs

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -5,7 +5,7 @@ use serde_derive::{Deserialize, Serialize};
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
 #[cfg(not(target_os = "solana"))]
 use solana_program::message::{AddressLoaderError, SanitizeMessageError};
-use {core::fmt, solana_program::instruction::InstructionError, solana_sanitize::SanitizeError};
+use {core::fmt, solana_instruction::error::InstructionError, solana_sanitize::SanitizeError};
 
 /// Reasons a transaction might be rejected.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 use {
     solana_program::{
         instruction::InstructionError,
@@ -7,6 +8,8 @@ use {
     solana_sanitize::SanitizeError,
     thiserror::Error,
 };
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi_macro::{AbiExample, AbiEnumVisitor};
 
 /// Reasons a transaction might be rejected.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -6,9 +6,7 @@ use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
 #[cfg(not(target_os = "solana"))]
 use solana_program::message::{AddressLoaderError, SanitizeMessageError};
 use {
-    solana_program::instruction::InstructionError,
-    solana_sanitize::SanitizeError,
-    thiserror::Error,
+    solana_program::instruction::InstructionError, solana_sanitize::SanitizeError, thiserror::Error,
 };
 
 /// Reasons a transaction might be rejected.

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -4,16 +4,18 @@ use {
         instruction::InstructionError,
         message::{AddressLoaderError, SanitizeMessageError},
     },
-    serde_derive::{Deserialize, Serialize},
     solana_sanitize::SanitizeError,
     thiserror::Error,
 };
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiExample, AbiEnumVisitor};
+#[cfg(feature = "serde")]
+use serde_derive::{Deserialize, Serialize};
 
 /// Reasons a transaction might be rejected.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
-#[derive(Error, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum TransactionError {
     /// An account is already being processed in another transaction in a way
     /// that does not support parallelism

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -3,11 +3,10 @@
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
+#[cfg(not(target_os = "solana"))]
+use solana_program::message::{AddressLoaderError, SanitizeMessageError};
 use {
-    solana_program::{
-        instruction::InstructionError,
-        message::{AddressLoaderError, SanitizeMessageError},
-    },
+    solana_program::instruction::InstructionError,
     solana_sanitize::SanitizeError,
     thiserror::Error,
 };
@@ -185,6 +184,7 @@ impl From<SanitizeError> for TransactionError {
     }
 }
 
+#[cfg(not(target_os = "solana"))]
 impl From<SanitizeMessageError> for TransactionError {
     fn from(err: SanitizeMessageError) -> Self {
         match err {
@@ -194,6 +194,7 @@ impl From<SanitizeMessageError> for TransactionError {
     }
 }
 
+#[cfg(not(target_os = "solana"))]
 impl From<AddressLoaderError> for TransactionError {
     fn from(err: AddressLoaderError) -> Self {
         match err {

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -5,175 +5,222 @@ use serde_derive::{Deserialize, Serialize};
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
 #[cfg(not(target_os = "solana"))]
 use solana_program::message::{AddressLoaderError, SanitizeMessageError};
-use {
-    solana_program::instruction::InstructionError, solana_sanitize::SanitizeError, thiserror::Error,
-};
+use {core::fmt, solana_program::instruction::InstructionError, solana_sanitize::SanitizeError};
 
 /// Reasons a transaction might be rejected.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Error, Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TransactionError {
     /// An account is already being processed in another transaction in a way
     /// that does not support parallelism
-    #[error("Account in use")]
     AccountInUse,
 
     /// A `Pubkey` appears twice in the transaction's `account_keys`.  Instructions can reference
     /// `Pubkey`s more than once but the message must contain a list with no duplicate keys
-    #[error("Account loaded twice")]
     AccountLoadedTwice,
 
     /// Attempt to debit an account but found no record of a prior credit.
-    #[error("Attempt to debit an account but found no record of a prior credit.")]
     AccountNotFound,
 
     /// Attempt to load a program that does not exist
-    #[error("Attempt to load a program that does not exist")]
     ProgramAccountNotFound,
 
     /// The from `Pubkey` does not have sufficient balance to pay the fee to schedule the transaction
-    #[error("Insufficient funds for fee")]
     InsufficientFundsForFee,
 
     /// This account may not be used to pay transaction fees
-    #[error("This account may not be used to pay transaction fees")]
     InvalidAccountForFee,
 
     /// The bank has seen this transaction before. This can occur under normal operation
     /// when a UDP packet is duplicated, as a user error from a client not updating
     /// its `recent_blockhash`, or as a double-spend attack.
-    #[error("This transaction has already been processed")]
     AlreadyProcessed,
 
     /// The bank has not seen the given `recent_blockhash` or the transaction is too old and
     /// the `recent_blockhash` has been discarded.
-    #[error("Blockhash not found")]
     BlockhashNotFound,
 
     /// An error occurred while processing an instruction. The first element of the tuple
     /// indicates the instruction index in which the error occurred.
-    #[error("Error processing Instruction {0}: {1}")]
     InstructionError(u8, InstructionError),
 
     /// Loader call chain is too deep
-    #[error("Loader call chain is too deep")]
     CallChainTooDeep,
 
     /// Transaction requires a fee but has no signature present
-    #[error("Transaction requires a fee but has no signature present")]
     MissingSignatureForFee,
 
     /// Transaction contains an invalid account reference
-    #[error("Transaction contains an invalid account reference")]
     InvalidAccountIndex,
 
     /// Transaction did not pass signature verification
-    #[error("Transaction did not pass signature verification")]
     SignatureFailure,
 
     /// This program may not be used for executing instructions
-    #[error("This program may not be used for executing instructions")]
     InvalidProgramForExecution,
 
     /// Transaction failed to sanitize accounts offsets correctly
     /// implies that account locks are not taken for this TX, and should
     /// not be unlocked.
-    #[error("Transaction failed to sanitize accounts offsets correctly")]
     SanitizeFailure,
 
-    #[error("Transactions are currently disabled due to cluster maintenance")]
     ClusterMaintenance,
 
     /// Transaction processing left an account with an outstanding borrowed reference
-    #[error("Transaction processing left an account with an outstanding borrowed reference")]
     AccountBorrowOutstanding,
 
     /// Transaction would exceed max Block Cost Limit
-    #[error("Transaction would exceed max Block Cost Limit")]
     WouldExceedMaxBlockCostLimit,
 
     /// Transaction version is unsupported
-    #[error("Transaction version is unsupported")]
     UnsupportedVersion,
 
     /// Transaction loads a writable account that cannot be written
-    #[error("Transaction loads a writable account that cannot be written")]
     InvalidWritableAccount,
 
     /// Transaction would exceed max account limit within the block
-    #[error("Transaction would exceed max account limit within the block")]
     WouldExceedMaxAccountCostLimit,
 
     /// Transaction would exceed account data limit within the block
-    #[error("Transaction would exceed account data limit within the block")]
     WouldExceedAccountDataBlockLimit,
 
     /// Transaction locked too many accounts
-    #[error("Transaction locked too many accounts")]
     TooManyAccountLocks,
 
     /// Address lookup table not found
-    #[error("Transaction loads an address table account that doesn't exist")]
     AddressLookupTableNotFound,
 
     /// Attempted to lookup addresses from an account owned by the wrong program
-    #[error("Transaction loads an address table account with an invalid owner")]
     InvalidAddressLookupTableOwner,
 
     /// Attempted to lookup addresses from an invalid account
-    #[error("Transaction loads an address table account with invalid data")]
     InvalidAddressLookupTableData,
 
     /// Address table lookup uses an invalid index
-    #[error("Transaction address table lookup uses an invalid index")]
     InvalidAddressLookupTableIndex,
 
     /// Transaction leaves an account with a lower balance than rent-exempt minimum
-    #[error("Transaction leaves an account with a lower balance than rent-exempt minimum")]
     InvalidRentPayingAccount,
 
     /// Transaction would exceed max Vote Cost Limit
-    #[error("Transaction would exceed max Vote Cost Limit")]
     WouldExceedMaxVoteCostLimit,
 
     /// Transaction would exceed total account data limit
-    #[error("Transaction would exceed total account data limit")]
     WouldExceedAccountDataTotalLimit,
 
     /// Transaction contains a duplicate instruction that is not allowed
-    #[error("Transaction contains a duplicate instruction ({0}) that is not allowed")]
     DuplicateInstruction(u8),
 
     /// Transaction results in an account with insufficient funds for rent
-    #[error(
-        "Transaction results in an account ({account_index}) with insufficient funds for rent"
-    )]
-    InsufficientFundsForRent { account_index: u8 },
+    InsufficientFundsForRent {
+        account_index: u8,
+    },
 
     /// Transaction exceeded max loaded accounts data size cap
-    #[error("Transaction exceeded max loaded accounts data size cap")]
     MaxLoadedAccountsDataSizeExceeded,
 
     /// LoadedAccountsDataSizeLimit set for transaction must be greater than 0.
-    #[error("LoadedAccountsDataSizeLimit set for transaction must be greater than 0.")]
     InvalidLoadedAccountsDataSizeLimit,
 
     /// Sanitized transaction differed before/after feature activiation. Needs to be resanitized.
-    #[error("ResanitizationNeeded")]
     ResanitizationNeeded,
 
     /// Program execution is temporarily restricted on an account.
-    #[error("Execution of the program referenced by account at index {account_index} is temporarily restricted.")]
-    ProgramExecutionTemporarilyRestricted { account_index: u8 },
+    ProgramExecutionTemporarilyRestricted {
+        account_index: u8,
+    },
 
     /// The total balance before the transaction does not equal the total balance after the transaction
-    #[error("Sum of account balances before and after transaction do not match")]
     UnbalancedTransaction,
 
     /// Program cache hit max limit.
-    #[error("Program cache hit max limit")]
     ProgramCacheHitMaxLimit,
+}
+
+impl std::error::Error for TransactionError {}
+
+impl fmt::Display for TransactionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::AccountInUse
+             => f.write_str("Account in use"),
+            Self::AccountLoadedTwice
+             => f.write_str("Account loaded twice"),
+            Self::AccountNotFound
+             => f.write_str("Attempt to debit an account but found no record of a prior credit."),
+            Self::ProgramAccountNotFound
+             => f.write_str("Attempt to load a program that does not exist"),
+            Self::InsufficientFundsForFee
+             => f.write_str("Insufficient funds for fee"),
+            Self::InvalidAccountForFee
+             => f.write_str("This account may not be used to pay transaction fees"),
+            Self::AlreadyProcessed
+             => f.write_str("This transaction has already been processed"),
+            Self::BlockhashNotFound
+             => f.write_str("Blockhash not found"),
+            Self::InstructionError(idx, err) =>  write!(f, "Error processing Instruction {idx}: {err}"),
+            Self::CallChainTooDeep
+             => f.write_str("Loader call chain is too deep"),
+            Self::MissingSignatureForFee
+             => f.write_str("Transaction requires a fee but has no signature present"),
+            Self::InvalidAccountIndex
+             => f.write_str("Transaction contains an invalid account reference"),
+            Self::SignatureFailure
+             => f.write_str("Transaction did not pass signature verification"),
+            Self::InvalidProgramForExecution
+             => f.write_str("This program may not be used for executing instructions"),
+            Self::SanitizeFailure
+             => f.write_str("Transaction failed to sanitize accounts offsets correctly"),
+            Self::ClusterMaintenance
+             => f.write_str("Transactions are currently disabled due to cluster maintenance"),
+            Self::AccountBorrowOutstanding
+             => f.write_str("Transaction processing left an account with an outstanding borrowed reference"),
+            Self::WouldExceedMaxBlockCostLimit
+             => f.write_str("Transaction would exceed max Block Cost Limit"),
+            Self::UnsupportedVersion
+             => f.write_str("Transaction version is unsupported"),
+            Self::InvalidWritableAccount
+             => f.write_str("Transaction loads a writable account that cannot be written"),
+            Self::WouldExceedMaxAccountCostLimit
+             => f.write_str("Transaction would exceed max account limit within the block"),
+            Self::WouldExceedAccountDataBlockLimit
+             => f.write_str("Transaction would exceed account data limit within the block"),
+            Self::TooManyAccountLocks
+             => f.write_str("Transaction locked too many accounts"),
+            Self::AddressLookupTableNotFound
+             => f.write_str("Transaction loads an address table account that doesn't exist"),
+            Self::InvalidAddressLookupTableOwner
+             => f.write_str("Transaction loads an address table account with an invalid owner"),
+            Self::InvalidAddressLookupTableData
+             => f.write_str("Transaction loads an address table account with invalid data"),
+            Self::InvalidAddressLookupTableIndex
+             => f.write_str("Transaction address table lookup uses an invalid index"),
+            Self::InvalidRentPayingAccount
+             => f.write_str("Transaction leaves an account with a lower balance than rent-exempt minimum"),
+            Self::WouldExceedMaxVoteCostLimit
+             => f.write_str("Transaction would exceed max Vote Cost Limit"),
+            Self::WouldExceedAccountDataTotalLimit
+             => f.write_str("Transaction would exceed total account data limit"),
+            Self::DuplicateInstruction(idx) =>  write!(f, "Transaction contains a duplicate instruction ({idx}) that is not allowed"),
+            Self::InsufficientFundsForRent {
+                account_index
+            } =>  write!(f,"Transaction results in an account ({account_index}) with insufficient funds for rent"),
+            Self::MaxLoadedAccountsDataSizeExceeded
+             => f.write_str("Transaction exceeded max loaded accounts data size cap"),
+            Self::InvalidLoadedAccountsDataSizeLimit
+             => f.write_str("LoadedAccountsDataSizeLimit set for transaction must be greater than 0."),
+            Self::ResanitizationNeeded
+             => f.write_str("ResanitizationNeeded"),
+            Self::ProgramExecutionTemporarilyRestricted {
+                account_index
+            } =>  write!(f,"Execution of the program referenced by account at index {account_index} is temporarily restricted."),
+            Self::UnbalancedTransaction
+             => f.write_str("Sum of account balances before and after transaction do not match"),
+            Self::ProgramCacheHitMaxLimit
+             => f.write_str("Program cache hit max limit"),
+        }
+    }
 }
 
 impl From<SanitizeError> for TransactionError {

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -1,9 +1,9 @@
 use {
-    crate::{
+    solana_program::{
         instruction::InstructionError,
         message::{AddressLoaderError, SanitizeMessageError},
     },
-    serde::Serialize,
+    serde_derive::{Deserialize, Serialize},
     solana_sanitize::SanitizeError,
     thiserror::Error,
 };

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -333,7 +333,7 @@ impl fmt::Display for SanitizeMessageError {
 #[cfg(not(target_os = "solana"))]
 impl From<AddressLoaderError> for SanitizeMessageError {
     fn from(source: AddressLoaderError) -> Self {
-        SanitizeMessageError::AddressLoaderError { 0: source }
+        SanitizeMessageError::AddressLoaderError(source)
     }
 }
 

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -1,4 +1,8 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
+#[cfg(feature = "serde")]
+use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
 use {
     solana_program::{
         instruction::InstructionError,
@@ -7,10 +11,6 @@ use {
     solana_sanitize::SanitizeError,
     thiserror::Error,
 };
-#[cfg(feature = "frozen-abi")]
-use solana_frozen_abi_macro::{AbiExample, AbiEnumVisitor};
-#[cfg(feature = "serde")]
-use serde_derive::{Deserialize, Serialize};
 
 /// Reasons a transaction might be rejected.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]


### PR DESCRIPTION
#### Problem
`solana_sdk::signer` and `solana_sdk::transaction` would be great to have outside the SDK. For that to happen, `solana_sdk::transaction::error` needs to move to its own crate, otherwise we get a circular dependency.

#### Summary of Changes
- move error.rs to its own crate
- update usage of TransctionError in solana-sdk
- move SanitizeMessageError, AddressLoaderError and TransportError to the transaction-error crate, and re-export for backwards compatibility. These types already depend on TransactionError and need to be pulled out but aren't interesting enough for their own crates. They have a negligible impact on build time