### PR TITLE
Extract precompile-error crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7271,7 +7271,6 @@ dependencies = [
 name = "solana-precompile-error"
 version = "2.1.0"
 dependencies = [
- "num-derive",
  "num-traits",
  "solana-decode-error",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7268,6 +7268,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-precompile-error"
+version = "2.1.0"
+dependencies = [
+ "num-derive",
+ "num-traits",
+ "solana-decode-error",
+ "thiserror",
+]
+
+[[package]]
 name = "solana-program"
 version = "2.1.0"
 dependencies = [
@@ -7914,6 +7924,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-logger",
  "solana-native-token",
+ "solana-precompile-error",
  "solana-program",
  "solana-program-memory",
  "solana-pubkey",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7274,7 +7274,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "solana-decode-error",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7922,6 +7922,7 @@ dependencies = [
  "solana-feature-set",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-instruction",
  "solana-logger",
  "solana-native-token",
  "solana-precompile-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ members = [
     "sdk/native-token",
     "sdk/package-metadata",
     "sdk/package-metadata-macro",
+    "sdk/precompile-error",
     "sdk/program",
     "sdk/program-entrypoint",
     "sdk/program-error",
@@ -444,6 +445,7 @@ solana-package-metadata-macro = { path = "sdk/package-metadata-macro", version =
 solana-perf = { path = "perf", version = "=2.1.0" }
 solana-poh = { path = "poh", version = "=2.1.0" }
 solana-poseidon = { path = "poseidon", version = "=2.1.0" }
+solana-precompile-error = { path = "sdk/precompile-error", version = "=2.1.0" }
 solana-program = { path = "sdk/program", version = "=2.1.0", default-features = false }
 solana-program-error = { path = "sdk/program-error", version = "=2.1.0" }
 solana-program-memory = { path = "sdk/program-memory", version = "=2.1.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5663,6 +5663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-precompile-error"
+version = "2.1.0"
+dependencies = [
+ "num-derive",
+ "num-traits",
+ "solana-decode-error",
+]
+
+[[package]]
 name = "solana-program"
 version = "2.1.0"
 dependencies = [
@@ -6674,7 +6683,9 @@ dependencies = [
  "solana-decode-error",
  "solana-derivation-path",
  "solana-feature-set",
+ "solana-instruction",
  "solana-native-token",
+ "solana-precompile-error",
  "solana-program",
  "solana-program-memory",
  "solana-pubkey",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5666,7 +5666,6 @@ dependencies = [
 name = "solana-precompile-error"
 version = "2.1.0"
 dependencies = [
- "num-derive",
  "num-traits",
  "solana-decode-error",
 ]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -113,6 +113,7 @@ solana-signature = { workspace = true, features = [
     "std",
     "verify",
 ], optional = true }
+solana-instruction = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -34,6 +34,7 @@ full = [
     "sha3",
     "digest",
     "solana-pubkey/rand",
+    "dep:solana-precompile-error"
 ]
 borsh = ["dep:borsh", "solana-program/borsh", "solana-secp256k1-recover/borsh"]
 dev-context-only-utils = ["qualifier_attr", "solana-account/dev-context-only-utils"]
@@ -97,6 +98,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-native-token = { workspace = true }
+solana-precompile-error = { workspace = true, optional = true }
 solana-program = { workspace = true }
 solana-program-memory = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false, features = ["std"] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -97,6 +97,7 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
+solana-instruction = { workspace = true }
 solana-native-token = { workspace = true }
 solana-precompile-error = { workspace = true, optional = true }
 solana-program = { workspace = true }
@@ -113,7 +114,6 @@ solana-signature = { workspace = true, features = [
     "std",
     "verify",
 ], optional = true }
-solana-instruction = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/sdk/precompile-error/Cargo.toml
+++ b/sdk/precompile-error/Cargo.toml
@@ -11,7 +11,6 @@ edition = { workspace = true }
 
 [dependencies]
 solana-decode-error = { workspace = true }
-num-derive = { workspace = true }
 num-traits = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/sdk/precompile-error/Cargo.toml
+++ b/sdk/precompile-error/Cargo.toml
@@ -13,7 +13,6 @@ edition = { workspace = true }
 solana-decode-error = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
-thiserror = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/precompile-error/Cargo.toml
+++ b/sdk/precompile-error/Cargo.toml
@@ -10,8 +10,8 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-solana-decode-error = { workspace = true }
 num-traits = { workspace = true }
+solana-decode-error = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/precompile-error/Cargo.toml
+++ b/sdk/precompile-error/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-precompile-error"
+description = "Solana PrecompileError type"
+documentation = "https://docs.rs/solana-precompile-error"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-decode-error = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
+thiserror = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/precompile-error/src/lib.rs
+++ b/sdk/precompile-error/src/lib.rs
@@ -1,5 +1,9 @@
 /// Precompile errors
-use {core::fmt, num_derive::{FromPrimitive, ToPrimitive}, solana_decode_error::DecodeError};
+use {
+    core::fmt,
+    num_derive::{FromPrimitive, ToPrimitive},
+    solana_decode_error::DecodeError,
+};
 
 /// Precompile errors
 #[derive(Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]

--- a/sdk/precompile-error/src/lib.rs
+++ b/sdk/precompile-error/src/lib.rs
@@ -1,23 +1,32 @@
-use {
-    num_derive::{FromPrimitive, ToPrimitive},
-    solana_decode_error::DecodeError,
-    thiserror::Error
-};
+/// Precompile errors
+use {core::fmt, num_derive::{FromPrimitive, ToPrimitive}, solana_decode_error::DecodeError};
 
 /// Precompile errors
-#[derive(Error, Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
 pub enum PrecompileError {
-    #[error("public key is not valid")]
     InvalidPublicKey,
-    #[error("id is not valid")]
     InvalidRecoveryId,
-    #[error("signature is not valid")]
     InvalidSignature,
-    #[error("offset not valid")]
     InvalidDataOffsets,
-    #[error("instruction is incorrect size")]
     InvalidInstructionDataSize,
 }
+
+impl std::error::Error for PrecompileError {}
+
+impl fmt::Display for PrecompileError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PrecompileError::InvalidPublicKey => f.write_str("public key is not valid"),
+            PrecompileError::InvalidRecoveryId => f.write_str("id is not valid"),
+            PrecompileError::InvalidSignature => f.write_str("signature is not valid"),
+            PrecompileError::InvalidDataOffsets => f.write_str("offset not valid"),
+            PrecompileError::InvalidInstructionDataSize => {
+                f.write_str("instruction is incorrect size")
+            }
+        }
+    }
+}
+
 impl<T> DecodeError<T> for PrecompileError {
     fn type_of() -> &'static str {
         "PrecompileError"

--- a/sdk/precompile-error/src/lib.rs
+++ b/sdk/precompile-error/src/lib.rs
@@ -1,18 +1,56 @@
 /// Precompile errors
-use {
-    core::fmt,
-    num_derive::{FromPrimitive, ToPrimitive},
-    solana_decode_error::DecodeError,
-};
+use {core::fmt, solana_decode_error::DecodeError};
 
 /// Precompile errors
-#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PrecompileError {
     InvalidPublicKey,
     InvalidRecoveryId,
     InvalidSignature,
     InvalidDataOffsets,
     InvalidInstructionDataSize,
+}
+
+impl num_traits::FromPrimitive for PrecompileError {
+    #[inline]
+    fn from_i64(n: i64) -> Option<Self> {
+        if n == PrecompileError::InvalidPublicKey as i64 {
+            Some(PrecompileError::InvalidPublicKey)
+        } else if n == PrecompileError::InvalidRecoveryId as i64 {
+            Some(PrecompileError::InvalidRecoveryId)
+        } else if n == PrecompileError::InvalidSignature as i64 {
+            Some(PrecompileError::InvalidSignature)
+        } else if n == PrecompileError::InvalidDataOffsets as i64 {
+            Some(PrecompileError::InvalidDataOffsets)
+        } else if n == PrecompileError::InvalidInstructionDataSize as i64 {
+            Some(PrecompileError::InvalidInstructionDataSize)
+        } else {
+            None
+        }
+    }
+    #[inline]
+    fn from_u64(n: u64) -> Option<Self> {
+        Self::from_i64(n as i64)
+    }
+}
+
+impl num_traits::ToPrimitive for PrecompileError {
+    #[inline]
+    fn to_i64(&self) -> Option<i64> {
+        Some(match *self {
+            PrecompileError::InvalidPublicKey => PrecompileError::InvalidPublicKey as i64,
+            PrecompileError::InvalidRecoveryId => PrecompileError::InvalidRecoveryId as i64,
+            PrecompileError::InvalidSignature => PrecompileError::InvalidSignature as i64,
+            PrecompileError::InvalidDataOffsets => PrecompileError::InvalidDataOffsets as i64,
+            PrecompileError::InvalidInstructionDataSize => {
+                PrecompileError::InvalidInstructionDataSize as i64
+            }
+        })
+    }
+    #[inline]
+    fn to_u64(&self) -> Option<u64> {
+        self.to_i64().map(|x| x as u64)
+    }
 }
 
 impl std::error::Error for PrecompileError {}

--- a/sdk/precompile-error/src/lib.rs
+++ b/sdk/precompile-error/src/lib.rs
@@ -1,0 +1,25 @@
+use {
+    num_derive::{FromPrimitive, ToPrimitive},
+    solana_decode_error::DecodeError,
+    thiserror::Error
+};
+
+/// Precompile errors
+#[derive(Error, Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+pub enum PrecompileError {
+    #[error("public key is not valid")]
+    InvalidPublicKey,
+    #[error("id is not valid")]
+    InvalidRecoveryId,
+    #[error("signature is not valid")]
+    InvalidSignature,
+    #[error("offset not valid")]
+    InvalidDataOffsets,
+    #[error("instruction is incorrect size")]
+    InvalidInstructionDataSize,
+}
+impl<T> DecodeError<T> for PrecompileError {
+    fn type_of() -> &'static str {
+        "PrecompileError"
+    }
+}

--- a/sdk/src/ed25519_instruction.rs
+++ b/sdk/src/ed25519_instruction.rs
@@ -5,11 +5,12 @@
 #![cfg(feature = "full")]
 
 use {
-    crate::{instruction::Instruction, precompiles::PrecompileError},
     bytemuck::bytes_of,
     bytemuck_derive::{Pod, Zeroable},
     ed25519_dalek::{ed25519::signature::Signature, Signer, Verifier},
     solana_feature_set::{ed25519_precompile_verify_strict, FeatureSet},
+    solana_instruction::Instruction,
+    solana_precompile_error::PrecompileError
 };
 
 pub const PUBKEY_SERIALIZED_SIZE: usize = 32;

--- a/sdk/src/ed25519_instruction.rs
+++ b/sdk/src/ed25519_instruction.rs
@@ -10,7 +10,7 @@ use {
     ed25519_dalek::{ed25519::signature::Signature, Signer, Verifier},
     solana_feature_set::{ed25519_precompile_verify_strict, FeatureSet},
     solana_instruction::Instruction,
-    solana_precompile_error::PrecompileError
+    solana_precompile_error::PrecompileError,
 };
 
 pub const PUBKEY_SERIALIZED_SIZE: usize = 32;

--- a/sdk/src/precompiles.rs
+++ b/sdk/src/precompiles.rs
@@ -2,6 +2,10 @@
 
 #![cfg(feature = "full")]
 
+#[deprecated(since = "2.1.0", note = "Use `solana-precompile-error` crate instead.")]
+pub use solana_precompile_error::PrecompileError;
+#[deprecated(since = "2.1.0", note = "Use `solana-precompile-error` crate instead.")]
+pub use solana_precompile_error::PrecompileError;
 use {
     lazy_static::lazy_static,
     solana_decode_error::DecodeError,
@@ -10,9 +14,6 @@ use {
     solana_pubkey::Pubkey,
     thiserror::Error,
 };
-
-#[deprecated(since = "2.1.0", note = "Use `solana-precompile-error` crate instead.")]
-pub use solana_precompile_error::PrecompileError;
 
 /// All precompiled programs must implement the `Verify` function
 pub type Verify = fn(&[u8], &[&[u8]], &FeatureSet) -> std::result::Result<(), PrecompileError>;

--- a/sdk/src/precompiles.rs
+++ b/sdk/src/precompiles.rs
@@ -4,15 +4,11 @@
 
 #[deprecated(since = "2.1.0", note = "Use `solana-precompile-error` crate instead.")]
 pub use solana_precompile_error::PrecompileError;
-#[deprecated(since = "2.1.0", note = "Use `solana-precompile-error` crate instead.")]
-pub use solana_precompile_error::PrecompileError;
 use {
     lazy_static::lazy_static,
-    solana_decode_error::DecodeError,
     solana_feature_set::FeatureSet,
     solana_program::instruction::CompiledInstruction,
     solana_pubkey::Pubkey,
-    thiserror::Error,
 };
 
 /// All precompiled programs must implement the `Verify` function

--- a/sdk/src/precompiles.rs
+++ b/sdk/src/precompiles.rs
@@ -5,10 +5,8 @@
 #[deprecated(since = "2.1.0", note = "Use `solana-precompile-error` crate instead.")]
 pub use solana_precompile_error::PrecompileError;
 use {
-    lazy_static::lazy_static,
-    solana_feature_set::FeatureSet,
-    solana_program::instruction::CompiledInstruction,
-    solana_pubkey::Pubkey,
+    lazy_static::lazy_static, solana_feature_set::FeatureSet,
+    solana_program::instruction::CompiledInstruction, solana_pubkey::Pubkey,
 };
 
 /// All precompiled programs must implement the `Verify` function

--- a/sdk/src/precompiles.rs
+++ b/sdk/src/precompiles.rs
@@ -4,33 +4,15 @@
 
 use {
     lazy_static::lazy_static,
-    num_derive::{FromPrimitive, ToPrimitive},
     solana_decode_error::DecodeError,
     solana_feature_set::FeatureSet,
-    solana_program::{instruction::CompiledInstruction, pubkey::Pubkey},
+    solana_program::instruction::CompiledInstruction,
+    solana_pubkey::Pubkey,
     thiserror::Error,
 };
 
-/// Precompile errors
-#[derive(Error, Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
-pub enum PrecompileError {
-    #[error("public key is not valid")]
-    InvalidPublicKey,
-    #[error("id is not valid")]
-    InvalidRecoveryId,
-    #[error("signature is not valid")]
-    InvalidSignature,
-    #[error("offset not valid")]
-    InvalidDataOffsets,
-    #[error("instruction is incorrect size")]
-    InvalidInstructionDataSize,
-}
-
-impl<T> DecodeError<T> for PrecompileError {
-    fn type_of() -> &'static str {
-        "PrecompileError"
-    }
-}
+#[deprecated(since = "2.1.0", note = "Use `solana-precompile-error` crate instead.")]
+pub use solana_precompile_error::PrecompileError;
 
 /// All precompiled programs must implement the `Verify` function
 pub type Verify = fn(&[u8], &[&[u8]], &FeatureSet) -> std::result::Result<(), PrecompileError>;

--- a/sdk/src/secp256k1_instruction.rs
+++ b/sdk/src/secp256k1_instruction.rs
@@ -792,7 +792,7 @@ use {
     serde_derive::{Deserialize, Serialize},
     solana_feature_set::FeatureSet,
     solana_instruction::Instruction,
-    solana_precompile_error::PrecompileError
+    solana_precompile_error::PrecompileError,
 };
 
 pub const HASHED_PUBKEY_SERIALIZED_SIZE: usize = 20;

--- a/sdk/src/secp256k1_instruction.rs
+++ b/sdk/src/secp256k1_instruction.rs
@@ -788,10 +788,11 @@
 #![cfg(feature = "full")]
 
 use {
-    crate::{instruction::Instruction, precompiles::PrecompileError},
     digest::Digest,
     serde_derive::{Deserialize, Serialize},
     solana_feature_set::FeatureSet,
+    solana_instruction::Instruction,
+    solana_precompile_error::PrecompileError
 };
 
 pub const HASHED_PUBKEY_SERIALIZED_SIZE: usize = 20;


### PR DESCRIPTION
#### Problem
Pulling out a `solana_sdk::transaction` crate requires pulling out `solana_sdk::precompiles` which requires pulling out `solana_sdk::ed25519_instruction`. But `ed25519_instruction` depends on the `PrecompileError` type from `solana_sdk::precompiles`, so `PrecompileError` needs to be pulled out to avoid a circular dependency

#### Summary of Changes
- Move `PrecompileError` to its own crate
- Remove `thiserror` from the new crate
- Update `PrecompileError` usage in this repo
- Re-export with deprecation