### PR TITLE
Update Dockerfile with apt-get

### DIFF
--- a/sdk/docker-solana/Dockerfile
+++ b/sdk/docker-solana/Dockerfile
@@ -33,7 +33,7 @@ EXPOSE 8008/udp
 # tpu_vote
 EXPOSE 8009/udp
 
-RUN apt update && \
+RUN apt-get update && \
     apt-get install -y bzip2 libssl-dev ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
#### Problem

Even though `apt` can be used effectively, Linux has deprecated the command and it gives warnings. To prevent giving deprecated warnings and to cause cleaner and smoother installing dependency experience, I decided to change `apt upgrade` with `apt-get upgrade` on line 36 `Dockerfile` file on `sdk/docker-solana` on the repo as `apt-get` is the main command used on Linux and not been deprecated.

#### Summary of Changes

Changed apt with apt-get to ensure that no deprecated warning from Linux comes

Fixes #

Changed `apt upgrade` with `apt-get upgrade` at line 36