### PR TITLE
SVM: `message_processor.rs` generic over `SVMMessage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7598,6 +7598,7 @@ dependencies = [
  "solana-sdk",
  "solana-svm",
  "solana-svm-conformance",
+ "solana-svm-transaction",
  "solana-system-program",
  "solana-timings",
  "solana-type-overrides",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6346,6 +6346,7 @@ dependencies = [
  "solana-metrics",
  "solana-program-runtime",
  "solana-sdk",
+ "solana-svm-transaction",
  "solana-system-program",
  "solana-timings",
  "solana-type-overrides",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -27,6 +27,7 @@ solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-sdk = { workspace = true }
+solana-svm-transaction = { workspace = true }
 solana-system-program = { workspace = true }
 solana-timings = { workspace = true }
 solana-type-overrides = { workspace = true }

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -3,13 +3,13 @@ use {
     solana_program_runtime::invoke_context::InvokeContext,
     solana_sdk::{
         account::WritableAccount,
-        message::SanitizedMessage,
         precompiles::is_precompile,
         saturating_add_assign,
         sysvar::instructions,
         transaction::TransactionError,
         transaction_context::{IndexOfAccount, InstructionAccount},
     },
+    solana_svm_transaction::svm_message::SVMMessage,
     solana_timings::{ExecuteDetailsTimings, ExecuteTimings},
 };
 
@@ -32,13 +32,13 @@ impl MessageProcessor {
     /// the call does not violate the bank's accounting rules.
     /// The accounts are committed back to the bank only if every instruction succeeds.
     pub fn process_message(
-        message: &SanitizedMessage,
+        message: &impl SVMMessage,
         program_indices: &[Vec<IndexOfAccount>],
         invoke_context: &mut InvokeContext,
         execute_timings: &mut ExecuteTimings,
         accumulated_consumed_units: &mut u64,
     ) -> Result<(), TransactionError> {
-        debug_assert_eq!(program_indices.len(), message.instructions().len());
+        debug_assert_eq!(program_indices.len(), message.num_instructions());
         for (instruction_index, ((program_id, instruction), program_indices)) in message
             .program_instructions_iter()
             .zip(program_indices.iter())
@@ -95,7 +95,7 @@ impl MessageProcessor {
                         instruction_context.configure(
                             program_indices,
                             &instruction_accounts,
-                            &instruction.data,
+                            instruction.data,
                         );
                     })
                     .and_then(|_| {
@@ -106,7 +106,7 @@ impl MessageProcessor {
                 let time = Measure::start("execute_instruction");
                 let mut compute_units_consumed = 0;
                 let result = invoke_context.process_instruction(
-                    &instruction.data,
+                    instruction.data,
                     &instruction_accounts,
                     program_indices,
                     &mut compute_units_consumed,
@@ -158,7 +158,7 @@ mod tests {
             feature_set::FeatureSet,
             hash::Hash,
             instruction::{AccountMeta, Instruction, InstructionError},
-            message::{AccountKeys, Message},
+            message::{AccountKeys, Message, SanitizedMessage},
             native_loader::{self, create_loadable_account_for_test},
             pubkey::Pubkey,
             rent::Rent,


### PR DESCRIPTION
#### Problem
- #2110 - for SVM to be generic over transaction/message type, message_processor.rs must be generic over the traits

#### Summary of Changes
- make message_processor.rs generic over SVMMessage

Fixes #2110
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
