### PR TITLE
Scheduler: buffer packets for forwarding if forwarding is enabled

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -446,7 +446,7 @@ impl SchedulerController {
                 },
                 true,
             ),
-            BufferedPacketsDecision::Forward => (MAX_PACKET_RECEIVE_TIME, false),
+            BufferedPacketsDecision::Forward => (MAX_PACKET_RECEIVE_TIME, self.forwarder.is_some()),
             BufferedPacketsDecision::ForwardAndHold | BufferedPacketsDecision::Hold => {
                 (MAX_PACKET_RECEIVE_TIME, true)
             }


### PR DESCRIPTION
#### Problem
- https://github.com/anza-xyz/agave/pull/2285/files#r1693221400
- We are not actually forwarding in the `Forward` period (nowhere close to being leader)

#### Summary of Changes
- Buffer packets for forwarding if forwarding is enabled

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
