### PR TITLE
Add tx signature to ledger-tool verify --record-slots-config=tx

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2908,6 +2908,7 @@ fn record_transactions(
                     let execution_results = execution_results.map(|(details, _)| details);
 
                     TransactionDetails {
+                        signature: tx.signature().to_string(),
                         accounts,
                         instructions,
                         is_simple_vote_tx,

--- a/runtime/src/bank/bank_hash_details.rs
+++ b/runtime/src/bank/bank_hash_details.rs
@@ -69,6 +69,7 @@ impl BankHashDetails {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
 pub struct TransactionDetails {
+    pub signature: String,
     pub index: usize,
     pub accounts: Vec<String>,
     pub instructions: Vec<UiInstruction>,


### PR DESCRIPTION
#### Problem

The json produced by `--record-slots-config=tx` does not include the tx hash.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->

