### PR TITLE
ledger-tool: Refactor slot recording code

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -553,6 +553,17 @@ fn setup_slot_recording(
     let verify_slots = arg_matches.occurrences_of("verify_slots") > 0;
     match (record_slots, verify_slots) {
         (false, false) => (None, None),
+        (true, true) => {
+            // .default_value() does not work with .conflicts_with() in clap 2.33
+            // .conflicts_with("verify_slots")
+            // https://github.com/clap-rs/clap/issues/1605#issuecomment-722326915
+            // So open-code the conflicts_with() here
+            eprintln!(
+                "error: The argument '--verify-slots <FILENAME>' cannot be used with \
+                '--record-slots <FILENAME>'"
+            );
+            exit(1);
+        }
         (true, false) => {
             let filename = Path::new(arg_matches.value_of_os("record_slots").unwrap());
             let file = File::create(filename).unwrap_or_else(|err| {
@@ -662,17 +673,6 @@ fn setup_slot_recording(
             });
 
             (Some(slot_callback as ProcessSlotCallback), None)
-        }
-        (true, true) => {
-            // .default_value() does not work with .conflicts_with() in clap 2.33
-            // .conflicts_with("verify_slots")
-            // https://github.com/clap-rs/clap/issues/1605#issuecomment-722326915
-            // So open-code the conflicts_with() here
-            eprintln!(
-                "error: The argument '--verify-slots <FILENAME>' cannot be used with \
-                '--record-slots <FILENAME>'"
-            );
-            exit(1);
         }
     }
 }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -538,6 +538,149 @@ fn assert_capitalization(bank: &Bank) {
     assert!(bank.calculate_and_verify_capitalization(debug_verify));
 }
 
+fn setup_slot_recording(
+    arg_matches: &ArgMatches,
+) -> TODO {
+                    // .default_value() does not work with .conflicts_with() in clap 2.33
+                    // .conflicts_with("verify_slots")
+                    // https://github.com/clap-rs/clap/issues/1605#issuecomment-722326915
+                    // So open-code the conflicts_with() here
+                    if arg_matches.occurrences_of("record_slots") > 0
+                        && arg_matches.occurrences_of("verify_slots") > 0
+                    {
+                        eprintln!(
+                            "error: The argument '--verify-slots <FILENAME>' cannot be used with '--record-slots <FILENAME>'"
+                        );
+                        exit(1);
+                    }
+
+                    let mut transaction_status_sender = None;
+                    let mut tx_receiver = None;
+
+                    let (slot_callback, record_slots_file, recorded_slots) = if arg_matches
+                        .occurrences_of("record_slots")
+                        > 0
+                    {
+                        let filename = Path::new(arg_matches.value_of_os("record_slots").unwrap());
+
+                        let file = File::create(filename).unwrap_or_else(|err| {
+                            eprintln!("Unable to write to file: {}: {:#}", filename.display(), err);
+                            exit(1);
+                        });
+
+                        let mut include_bank = false;
+                        let mut include_tx = false;
+
+                        if let Some(args) = arg_matches.values_of("record_slots_config") {
+                            for arg in args {
+                                match arg {
+                                    "tx" => include_tx = true,
+                                    "accounts" => include_bank = true,
+                                    _ => unreachable!(),
+                                }
+                            }
+                        }
+
+                        let slot_hashes = Arc::new(Mutex::new(Vec::new()));
+
+                        if include_tx {
+                            let (sender, receiver) = crossbeam_channel::unbounded();
+
+                            transaction_status_sender = Some(TransactionStatusSender { sender });
+
+                            let slots = Arc::clone(&slot_hashes);
+
+                            tx_receiver = Some(std::thread::spawn(move || {
+                                record_transactions(receiver, slots);
+                            }));
+                        }
+
+                        let slot_callback = Arc::new({
+                            let slots = Arc::clone(&slot_hashes);
+                            move |bank: &Bank| {
+                                let mut details = if include_bank {
+                                    bank_hash_details::SlotDetails::try_from(bank).unwrap()
+                                } else {
+                                    bank_hash_details::SlotDetails {
+                                        slot: bank.slot(),
+                                        bank_hash: bank.hash().to_string(),
+                                        ..Default::default()
+                                    }
+                                };
+
+                                let mut slots = slots.lock().unwrap();
+
+                                if let Some(recorded_slot) =
+                                    slots.iter_mut().find(|f| f.slot == details.slot)
+                                {
+                                    // copy all fields except transactions
+                                    swap(
+                                        &mut recorded_slot.transactions,
+                                        &mut details.transactions,
+                                    );
+
+                                    *recorded_slot = details;
+                                } else {
+                                    slots.push(details);
+                                }
+                            }
+                        });
+
+                        (
+                            Some(slot_callback as ProcessSlotCallback),
+                            Some(file),
+                            Some(slot_hashes),
+                        )
+                    } else if arg_matches.occurrences_of("verify_slots") > 0 {
+                        let filename = Path::new(arg_matches.value_of_os("verify_slots").unwrap());
+
+                        let file = File::open(filename).unwrap_or_else(|err| {
+                            eprintln!("Unable to read file: {}: {err:#}", filename.display());
+                            exit(1);
+                        });
+
+                        let reader = std::io::BufReader::new(file);
+
+                        let details: bank_hash_details::BankHashDetails =
+                            serde_json::from_reader(reader).unwrap_or_else(|err| {
+                                eprintln!("Error loading slots file: {err:#}");
+                                exit(1);
+                            });
+
+                        let slots = Arc::new(Mutex::new(details.bank_hash_details));
+
+                        let slot_callback = Arc::new(move |bank: &Bank| {
+                            if slots.lock().unwrap().is_empty() {
+                                error!(
+                                    "Expected slot: not found got slot: {} hash: {}",
+                                    bank.slot(),
+                                    bank.hash()
+                                );
+                            } else {
+                                let bank_hash_details::SlotDetails {
+                                    slot: expected_slot,
+                                    bank_hash: expected_hash,
+                                    ..
+                                } = slots.lock().unwrap().remove(0);
+                                if bank.slot() != expected_slot
+                                    || bank.hash().to_string() != expected_hash
+                                {
+                                    error!("Expected slot: {expected_slot} hash: {expected_hash} got slot: {} hash: {}",
+                                bank.slot(), bank.hash());
+                                } else {
+                                    info!(
+                                    "Expected slot: {expected_slot} hash: {expected_hash} correct"
+                                );
+                                }
+                            }
+                        });
+
+                        (Some(slot_callback as ProcessSlotCallback), None, None)
+                    } else {
+                        (None, None, None)
+                    };
+}
+
 #[cfg(not(target_env = "msvc"))]
 use jemallocator::Jemalloc;
 
@@ -1469,144 +1612,6 @@ fn main() {
 
                     let mut process_options = parse_process_options(&ledger_path, arg_matches);
 
-                    // .default_value() does not work with .conflicts_with() in clap 2.33
-                    // .conflicts_with("verify_slots")
-                    // https://github.com/clap-rs/clap/issues/1605#issuecomment-722326915
-                    // So open-code the conflicts_with() here
-                    if arg_matches.occurrences_of("record_slots") > 0
-                        && arg_matches.occurrences_of("verify_slots") > 0
-                    {
-                        eprintln!(
-                            "error: The argument '--verify-slots <FILENAME>' cannot be used with '--record-slots <FILENAME>'"
-                        );
-                        exit(1);
-                    }
-
-                    let mut transaction_status_sender = None;
-                    let mut tx_receiver = None;
-
-                    let (slot_callback, record_slots_file, recorded_slots) = if arg_matches
-                        .occurrences_of("record_slots")
-                        > 0
-                    {
-                        let filename = Path::new(arg_matches.value_of_os("record_slots").unwrap());
-
-                        let file = File::create(filename).unwrap_or_else(|err| {
-                            eprintln!("Unable to write to file: {}: {:#}", filename.display(), err);
-                            exit(1);
-                        });
-
-                        let mut include_bank = false;
-                        let mut include_tx = false;
-
-                        if let Some(args) = arg_matches.values_of("record_slots_config") {
-                            for arg in args {
-                                match arg {
-                                    "tx" => include_tx = true,
-                                    "accounts" => include_bank = true,
-                                    _ => unreachable!(),
-                                }
-                            }
-                        }
-
-                        let slot_hashes = Arc::new(Mutex::new(Vec::new()));
-
-                        if include_tx {
-                            let (sender, receiver) = crossbeam_channel::unbounded();
-
-                            transaction_status_sender = Some(TransactionStatusSender { sender });
-
-                            let slots = Arc::clone(&slot_hashes);
-
-                            tx_receiver = Some(std::thread::spawn(move || {
-                                record_transactions(receiver, slots);
-                            }));
-                        }
-
-                        let slot_callback = Arc::new({
-                            let slots = Arc::clone(&slot_hashes);
-                            move |bank: &Bank| {
-                                let mut details = if include_bank {
-                                    bank_hash_details::SlotDetails::try_from(bank).unwrap()
-                                } else {
-                                    bank_hash_details::SlotDetails {
-                                        slot: bank.slot(),
-                                        bank_hash: bank.hash().to_string(),
-                                        ..Default::default()
-                                    }
-                                };
-
-                                let mut slots = slots.lock().unwrap();
-
-                                if let Some(recorded_slot) =
-                                    slots.iter_mut().find(|f| f.slot == details.slot)
-                                {
-                                    // copy all fields except transactions
-                                    swap(
-                                        &mut recorded_slot.transactions,
-                                        &mut details.transactions,
-                                    );
-
-                                    *recorded_slot = details;
-                                } else {
-                                    slots.push(details);
-                                }
-                            }
-                        });
-
-                        (
-                            Some(slot_callback as ProcessSlotCallback),
-                            Some(file),
-                            Some(slot_hashes),
-                        )
-                    } else if arg_matches.occurrences_of("verify_slots") > 0 {
-                        let filename = Path::new(arg_matches.value_of_os("verify_slots").unwrap());
-
-                        let file = File::open(filename).unwrap_or_else(|err| {
-                            eprintln!("Unable to read file: {}: {err:#}", filename.display());
-                            exit(1);
-                        });
-
-                        let reader = std::io::BufReader::new(file);
-
-                        let details: bank_hash_details::BankHashDetails =
-                            serde_json::from_reader(reader).unwrap_or_else(|err| {
-                                eprintln!("Error loading slots file: {err:#}");
-                                exit(1);
-                            });
-
-                        let slots = Arc::new(Mutex::new(details.bank_hash_details));
-
-                        let slot_callback = Arc::new(move |bank: &Bank| {
-                            if slots.lock().unwrap().is_empty() {
-                                error!(
-                                    "Expected slot: not found got slot: {} hash: {}",
-                                    bank.slot(),
-                                    bank.hash()
-                                );
-                            } else {
-                                let bank_hash_details::SlotDetails {
-                                    slot: expected_slot,
-                                    bank_hash: expected_hash,
-                                    ..
-                                } = slots.lock().unwrap().remove(0);
-                                if bank.slot() != expected_slot
-                                    || bank.hash().to_string() != expected_hash
-                                {
-                                    error!("Expected slot: {expected_slot} hash: {expected_hash} got slot: {} hash: {}",
-                                bank.slot(), bank.hash());
-                                } else {
-                                    info!(
-                                    "Expected slot: {expected_slot} hash: {expected_hash} correct"
-                                );
-                                }
-                            }
-                        });
-
-                        (Some(slot_callback as ProcessSlotCallback), None, None)
-                    } else {
-                        (None, None, None)
-                    };
 
                     process_options.slot_callback = slot_callback;
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -538,147 +538,136 @@ fn assert_capitalization(bank: &Bank) {
     assert!(bank.calculate_and_verify_capitalization(debug_verify));
 }
 
-fn setup_slot_recording(
-    arg_matches: &ArgMatches,
-) -> TODO {
-                    // .default_value() does not work with .conflicts_with() in clap 2.33
-                    // .conflicts_with("verify_slots")
-                    // https://github.com/clap-rs/clap/issues/1605#issuecomment-722326915
-                    // So open-code the conflicts_with() here
-                    if arg_matches.occurrences_of("record_slots") > 0
-                        && arg_matches.occurrences_of("verify_slots") > 0
-                    {
-                        eprintln!(
+fn setup_slot_recording(arg_matches: &ArgMatches) -> TODO {
+    // .default_value() does not work with .conflicts_with() in clap 2.33
+    // .conflicts_with("verify_slots")
+    // https://github.com/clap-rs/clap/issues/1605#issuecomment-722326915
+    // So open-code the conflicts_with() here
+    if arg_matches.occurrences_of("record_slots") > 0
+        && arg_matches.occurrences_of("verify_slots") > 0
+    {
+        eprintln!(
                             "error: The argument '--verify-slots <FILENAME>' cannot be used with '--record-slots <FILENAME>'"
                         );
-                        exit(1);
+        exit(1);
+    }
+
+    let mut transaction_status_sender = None;
+    let mut tx_receiver = None;
+
+    let (slot_callback, record_slots_file, recorded_slots) = if arg_matches
+        .occurrences_of("record_slots")
+        > 0
+    {
+        let filename = Path::new(arg_matches.value_of_os("record_slots").unwrap());
+
+        let file = File::create(filename).unwrap_or_else(|err| {
+            eprintln!("Unable to write to file: {}: {:#}", filename.display(), err);
+            exit(1);
+        });
+
+        let mut include_bank = false;
+        let mut include_tx = false;
+
+        if let Some(args) = arg_matches.values_of("record_slots_config") {
+            for arg in args {
+                match arg {
+                    "tx" => include_tx = true,
+                    "accounts" => include_bank = true,
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        let slot_hashes = Arc::new(Mutex::new(Vec::new()));
+
+        if include_tx {
+            let (sender, receiver) = crossbeam_channel::unbounded();
+
+            transaction_status_sender = Some(TransactionStatusSender { sender });
+
+            let slots = Arc::clone(&slot_hashes);
+
+            tx_receiver = Some(std::thread::spawn(move || {
+                record_transactions(receiver, slots);
+            }));
+        }
+
+        let slot_callback = Arc::new({
+            let slots = Arc::clone(&slot_hashes);
+            move |bank: &Bank| {
+                let mut details = if include_bank {
+                    bank_hash_details::SlotDetails::try_from(bank).unwrap()
+                } else {
+                    bank_hash_details::SlotDetails {
+                        slot: bank.slot(),
+                        bank_hash: bank.hash().to_string(),
+                        ..Default::default()
                     }
+                };
 
-                    let mut transaction_status_sender = None;
-                    let mut tx_receiver = None;
+                let mut slots = slots.lock().unwrap();
 
-                    let (slot_callback, record_slots_file, recorded_slots) = if arg_matches
-                        .occurrences_of("record_slots")
-                        > 0
-                    {
-                        let filename = Path::new(arg_matches.value_of_os("record_slots").unwrap());
+                if let Some(recorded_slot) = slots.iter_mut().find(|f| f.slot == details.slot) {
+                    // copy all fields except transactions
+                    swap(&mut recorded_slot.transactions, &mut details.transactions);
 
-                        let file = File::create(filename).unwrap_or_else(|err| {
-                            eprintln!("Unable to write to file: {}: {:#}", filename.display(), err);
-                            exit(1);
-                        });
+                    *recorded_slot = details;
+                } else {
+                    slots.push(details);
+                }
+            }
+        });
 
-                        let mut include_bank = false;
-                        let mut include_tx = false;
+        (
+            Some(slot_callback as ProcessSlotCallback),
+            Some(file),
+            Some(slot_hashes),
+        )
+    } else if arg_matches.occurrences_of("verify_slots") > 0 {
+        let filename = Path::new(arg_matches.value_of_os("verify_slots").unwrap());
 
-                        if let Some(args) = arg_matches.values_of("record_slots_config") {
-                            for arg in args {
-                                match arg {
-                                    "tx" => include_tx = true,
-                                    "accounts" => include_bank = true,
-                                    _ => unreachable!(),
-                                }
-                            }
-                        }
+        let file = File::open(filename).unwrap_or_else(|err| {
+            eprintln!("Unable to read file: {}: {err:#}", filename.display());
+            exit(1);
+        });
 
-                        let slot_hashes = Arc::new(Mutex::new(Vec::new()));
+        let reader = std::io::BufReader::new(file);
 
-                        if include_tx {
-                            let (sender, receiver) = crossbeam_channel::unbounded();
+        let details: bank_hash_details::BankHashDetails = serde_json::from_reader(reader)
+            .unwrap_or_else(|err| {
+                eprintln!("Error loading slots file: {err:#}");
+                exit(1);
+            });
 
-                            transaction_status_sender = Some(TransactionStatusSender { sender });
+        let slots = Arc::new(Mutex::new(details.bank_hash_details));
 
-                            let slots = Arc::clone(&slot_hashes);
-
-                            tx_receiver = Some(std::thread::spawn(move || {
-                                record_transactions(receiver, slots);
-                            }));
-                        }
-
-                        let slot_callback = Arc::new({
-                            let slots = Arc::clone(&slot_hashes);
-                            move |bank: &Bank| {
-                                let mut details = if include_bank {
-                                    bank_hash_details::SlotDetails::try_from(bank).unwrap()
-                                } else {
-                                    bank_hash_details::SlotDetails {
-                                        slot: bank.slot(),
-                                        bank_hash: bank.hash().to_string(),
-                                        ..Default::default()
-                                    }
-                                };
-
-                                let mut slots = slots.lock().unwrap();
-
-                                if let Some(recorded_slot) =
-                                    slots.iter_mut().find(|f| f.slot == details.slot)
-                                {
-                                    // copy all fields except transactions
-                                    swap(
-                                        &mut recorded_slot.transactions,
-                                        &mut details.transactions,
-                                    );
-
-                                    *recorded_slot = details;
-                                } else {
-                                    slots.push(details);
-                                }
-                            }
-                        });
-
-                        (
-                            Some(slot_callback as ProcessSlotCallback),
-                            Some(file),
-                            Some(slot_hashes),
-                        )
-                    } else if arg_matches.occurrences_of("verify_slots") > 0 {
-                        let filename = Path::new(arg_matches.value_of_os("verify_slots").unwrap());
-
-                        let file = File::open(filename).unwrap_or_else(|err| {
-                            eprintln!("Unable to read file: {}: {err:#}", filename.display());
-                            exit(1);
-                        });
-
-                        let reader = std::io::BufReader::new(file);
-
-                        let details: bank_hash_details::BankHashDetails =
-                            serde_json::from_reader(reader).unwrap_or_else(|err| {
-                                eprintln!("Error loading slots file: {err:#}");
-                                exit(1);
-                            });
-
-                        let slots = Arc::new(Mutex::new(details.bank_hash_details));
-
-                        let slot_callback = Arc::new(move |bank: &Bank| {
-                            if slots.lock().unwrap().is_empty() {
-                                error!(
-                                    "Expected slot: not found got slot: {} hash: {}",
-                                    bank.slot(),
-                                    bank.hash()
-                                );
-                            } else {
-                                let bank_hash_details::SlotDetails {
-                                    slot: expected_slot,
-                                    bank_hash: expected_hash,
-                                    ..
-                                } = slots.lock().unwrap().remove(0);
-                                if bank.slot() != expected_slot
-                                    || bank.hash().to_string() != expected_hash
-                                {
-                                    error!("Expected slot: {expected_slot} hash: {expected_hash} got slot: {} hash: {}",
+        let slot_callback = Arc::new(move |bank: &Bank| {
+            if slots.lock().unwrap().is_empty() {
+                error!(
+                    "Expected slot: not found got slot: {} hash: {}",
+                    bank.slot(),
+                    bank.hash()
+                );
+            } else {
+                let bank_hash_details::SlotDetails {
+                    slot: expected_slot,
+                    bank_hash: expected_hash,
+                    ..
+                } = slots.lock().unwrap().remove(0);
+                if bank.slot() != expected_slot || bank.hash().to_string() != expected_hash {
+                    error!("Expected slot: {expected_slot} hash: {expected_hash} got slot: {} hash: {}",
                                 bank.slot(), bank.hash());
-                                } else {
-                                    info!(
-                                    "Expected slot: {expected_slot} hash: {expected_hash} correct"
-                                );
-                                }
-                            }
-                        });
+                } else {
+                    info!("Expected slot: {expected_slot} hash: {expected_hash} correct");
+                }
+            }
+        });
 
-                        (Some(slot_callback as ProcessSlotCallback), None, None)
-                    } else {
-                        (None, None, None)
-                    };
+        (Some(slot_callback as ProcessSlotCallback), None, None)
+    } else {
+        (None, None, None)
+    };
 }
 
 #[cfg(not(target_env = "msvc"))]
@@ -1611,7 +1600,6 @@ fn main() {
                     );
 
                     let mut process_options = parse_process_options(&ledger_path, arg_matches);
-
 
                     process_options.slot_callback = slot_callback;
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1718,7 +1718,12 @@ fn main() {
                             .ok();
                     }
 
-                    if let Some(slot_recorder_config) = slot_recorder_config {
+                    if let Some(mut slot_recorder_config) = slot_recorder_config {
+                        // Drop transaction_status_sender to break transaction_recorder
+                        // out of its' recieve loop
+                        let transaction_status_sender =
+                            slot_recorder_config.transaction_status_sender.take();
+                        drop(transaction_status_sender);
                         if let Some(transaction_recorder) =
                             slot_recorder_config.transaction_recorder
                         {


### PR DESCRIPTION
#### Problem
The logic to record / verify slots is currently inline in the verify
subcommand code. This code is non-trivial and makes it a bit harder
to read through the various commands in main.rs

#### Summary of Changes
So, break this code out into a helper function and perform some minor
cleanup.

These changes done separately from some additions I'll be making to add transaction CU information as an option