### PR TITLE
clean doesn't try to remove older entries on 1 elem slot list

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1938,6 +1938,7 @@ struct CleanAccountsStats {
     remove_dead_accounts_remove_us: AtomicU64,
     remove_dead_accounts_shrink_us: AtomicU64,
     clean_stored_dead_slots_us: AtomicU64,
+    uncleaned_roots_slot_list_1: AtomicU64,
 }
 
 impl CleanAccountsStats {
@@ -3284,7 +3285,14 @@ impl AccountsDb {
                                                 {
                                                     assert!(slot <= &max_clean_root_inclusive);
                                                 }
-                                                purges_old_accounts.push(*candidate);
+                                                if slot_list.len() > 1 {
+                                                    // no need to purge old accounts if there is only 1 slot in the slot list
+                                                    purges_old_accounts.push(*candidate);
+                                                } else {
+                                                    self.clean_accounts_stats
+                                                        .uncleaned_roots_slot_list_1
+                                                        .fetch_add(1, Ordering::Relaxed);
+                                                }
                                                 useless = false;
                                             }
                                         }
@@ -3500,6 +3508,13 @@ impl AccountsDb {
             ("scan_missing", missing_accum.load(Ordering::Relaxed), i64),
             ("uncleaned_roots_len", uncleaned_roots.len(), i64),
             (
+                "uncleaned_roots_slot_list_1",
+                self.clean_accounts_stats
+                    .uncleaned_roots_slot_list_1
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
                 "clean_old_root_us",
                 self.clean_accounts_stats
                     .clean_old_root_us
@@ -3544,6 +3559,13 @@ impl AccountsDb {
             (
                 "roots_added",
                 self.accounts_index.roots_added.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "purge_older_root_entries_one_slot_list",
+                self.accounts_index
+                    .purge_older_root_entries_one_slot_list
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3288,12 +3288,12 @@ impl AccountsDb {
                                                 if slot_list.len() > 1 {
                                                     // no need to purge old accounts if there is only 1 slot in the slot list
                                                     purges_old_accounts.push(*candidate);
+                                                    useless = false;
                                                 } else {
                                                     self.clean_accounts_stats
                                                         .uncleaned_roots_slot_list_1
                                                         .fetch_add(1, Ordering::Relaxed);
                                                 }
-                                                useless = false;
                                             }
                                         }
                                         None => {


### PR DESCRIPTION
#### Problem
clean tries to remove older entries in the slot list for entries that only have 1 element in the slot list. This is inefficient.

#### Summary of Changes
Only try to remove older slot list entries when there can be older slot list entries.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
