### PR TITLE
Renames AccountStorageEntry::append_vec_id() to id()

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -61,7 +61,7 @@ impl AccountStorage {
         lookup_in_map()
             .or_else(|| {
                 self.shrink_in_progress_map.get(&slot).and_then(|entry| {
-                    (entry.value().append_vec_id() == store_id).then(|| Arc::clone(entry.value()))
+                    (entry.value().id() == store_id).then(|| Arc::clone(entry.value()))
                 })
             })
             .or_else(lookup_in_map)
@@ -151,7 +151,7 @@ impl AccountStorage {
             .insert(
                 slot,
                 AccountStorageReference {
-                    id: store.append_vec_id(),
+                    id: store.id(),
                     storage: store,
                 }
             )
@@ -248,11 +248,11 @@ impl<'a> Drop for ShrinkInProgress<'a> {
                     self.slot,
                     AccountStorageReference {
                         storage: Arc::clone(&self.new_store),
-                        id: self.new_store.append_vec_id()
+                        id: self.new_store.id()
                     }
                 )
                 .map(|store| store.id),
-            Some(self.old_store.append_vec_id())
+            Some(self.old_store.id())
         );
 
         // The new store can be removed from 'shrink_in_progress_map'
@@ -489,25 +489,19 @@ pub(crate) mod tests {
         );
         let shrinking_in_progress = storage.shrinking_in_progress(slot, sample.clone());
         assert!(storage.map.contains_key(&slot));
-        assert_eq!(
-            id_to_shrink,
-            storage.map.get(&slot).unwrap().storage.append_vec_id()
-        );
+        assert_eq!(id_to_shrink, storage.map.get(&slot).unwrap().storage.id());
         assert_eq!(
             (slot, id_shrunk),
             storage
                 .shrink_in_progress_map
                 .iter()
                 .next()
-                .map(|r| (*r.key(), r.value().append_vec_id()))
+                .map(|r| (*r.key(), r.value().id()))
                 .unwrap()
         );
         drop(shrinking_in_progress);
         assert!(storage.map.contains_key(&slot));
-        assert_eq!(
-            id_shrunk,
-            storage.map.get(&slot).unwrap().storage.append_vec_id()
-        );
+        assert_eq!(id_shrunk, storage.map.get(&slot).unwrap().storage.id());
         assert!(storage.shrink_in_progress_map.is_empty());
         storage.shrinking_in_progress(slot, sample);
     }
@@ -536,7 +530,7 @@ pub(crate) mod tests {
         // verify data structures during and after shrink and then with subsequent shrink call
         let storage = AccountStorage::default();
         let sample = storage.get_test_storage();
-        let id = sample.append_vec_id();
+        let id = sample.id();
         let missing_id = 9999;
         let slot = sample.slot();
         // id is missing since not in maps at all

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -2104,11 +2104,11 @@ pub mod tests {
             assert_eq!(
                 shrinks_in_progress
                     .iter()
-                    .map(|(_, shrink_in_progress)| shrink_in_progress.old_storage().append_vec_id())
+                    .map(|(_, shrink_in_progress)| shrink_in_progress.old_storage().id())
                     .collect::<Vec<_>>(),
                 storages
                     .iter()
-                    .map(|storage| storage.append_vec_id())
+                    .map(|storage| storage.id())
                     .collect::<Vec<_>>()
             );
             // assert that we wrote the 2_ref account to the newly shrunk append vec
@@ -2325,7 +2325,7 @@ pub mod tests {
 
                 let map = |info: &SlotInfo| {
                     (
-                        info.storage.append_vec_id(),
+                        info.storage.id(),
                         info.slot,
                         info.capacity,
                         info.alive_bytes,
@@ -2466,7 +2466,7 @@ pub mod tests {
     }
 
     fn assert_storage_info(info: &SlotInfo, storage: &AccountStorageEntry, should_shrink: bool) {
-        assert_eq!(storage.append_vec_id(), info.storage.append_vec_id());
+        assert_eq!(storage.id(), info.storage.id());
         assert_eq!(storage.slot(), info.slot);
         assert_eq!(storage.capacity(), info.capacity);
         assert_eq!(storage.alive_bytes(), info.alive_bytes as usize);
@@ -3298,8 +3298,8 @@ pub mod tests {
                             assert_eq!(1, one.len());
                             assert_eq!(target_slot, one.first().unwrap().0);
                             assert_eq!(
-                                one.first().unwrap().1.old_storage().append_vec_id(),
-                                storages[combine_into].append_vec_id()
+                                one.first().unwrap().1.old_storage().id(),
+                                storages[combine_into].id()
                             );
                             // make sure the single new append vec contains all the same accounts
                             let mut two = Vec::default();

--- a/accounts-db/src/sorted_storages.rs
+++ b/accounts-db/src/sorted_storages.rs
@@ -297,7 +297,7 @@ mod tests {
             assert!(
                 (slot != 2 && slot != 4)
                     ^ storage
-                        .map(|storage| storage.append_vec_id() == (slot as AccountsFileId))
+                        .map(|storage| storage.id() == (slot as AccountsFileId))
                         .unwrap_or(false),
                 "slot: {slot}, storage: {storage:?}"
             );
@@ -434,10 +434,7 @@ mod tests {
         );
         assert_eq!(result.slot_count(), 1);
         assert_eq!(result.storages.len(), 1);
-        assert_eq!(
-            result.get(slot).unwrap().append_vec_id(),
-            store.append_vec_id()
-        );
+        assert_eq!(result.get(slot).unwrap().id(), store.id());
     }
 
     fn create_sample_store(id: AccountsFileId) -> Arc<AccountStorageEntry> {
@@ -479,13 +476,7 @@ mod tests {
         assert!(result.get(5).is_none());
         assert!(result.get(6).is_none());
         assert!(result.get(8).is_none());
-        assert_eq!(
-            result.get(slots[0]).unwrap().append_vec_id(),
-            store.append_vec_id()
-        );
-        assert_eq!(
-            result.get(slots[1]).unwrap().append_vec_id(),
-            store2.append_vec_id()
-        );
+        assert_eq!(result.get(slots[0]).unwrap().id(), store.id());
+        assert_eq!(result.get(slots[1]).unwrap().id(), store2.id());
     }
 }

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -59,8 +59,7 @@ mod tests {
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory
             let storage_path = storage_entry.path();
-            let file_name =
-                AccountsFile::file_name(storage_entry.slot(), storage_entry.append_vec_id());
+            let file_name = AccountsFile::file_name(storage_entry.slot(), storage_entry.id());
             let output_path = output_dir.as_ref().join(file_name);
             std::fs::copy(storage_path, &output_path)?;
 
@@ -72,15 +71,15 @@ mod tests {
             )?;
             let new_storage_entry = AccountStorageEntry::new_existing(
                 storage_entry.slot(),
-                storage_entry.append_vec_id(),
+                storage_entry.id(),
                 accounts_file,
                 num_accounts,
             );
-            next_append_vec_id = next_append_vec_id.max(new_storage_entry.append_vec_id());
+            next_append_vec_id = next_append_vec_id.max(new_storage_entry.id());
             storage.insert(
                 new_storage_entry.slot(),
                 AccountStorageReference {
-                    id: new_storage_entry.append_vec_id(),
+                    id: new_storage_entry.id(),
                     storage: Arc::new(new_storage_entry),
                 },
             );

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -30,7 +30,7 @@ impl SerializableStorage for SerializableAccountStorageEntry {
 impl From<&AccountStorageEntry> for SerializableAccountStorageEntry {
     fn from(rhs: &AccountStorageEntry) -> Self {
         Self {
-            id: rhs.append_vec_id() as SerializedAccountsFileId,
+            id: rhs.id() as SerializedAccountsFileId,
             accounts_current_len: rhs.accounts.len(),
         }
     }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -140,8 +140,7 @@ mod serde_snapshot_tests {
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory
             let storage_path = storage_entry.path();
-            let file_name =
-                AccountsFile::file_name(storage_entry.slot(), storage_entry.append_vec_id());
+            let file_name = AccountsFile::file_name(storage_entry.slot(), storage_entry.id());
             let output_path = output_dir.as_ref().join(file_name);
             std::fs::copy(storage_path, &output_path)?;
 
@@ -153,15 +152,15 @@ mod serde_snapshot_tests {
             )?;
             let new_storage_entry = AccountStorageEntry::new_existing(
                 storage_entry.slot(),
-                storage_entry.append_vec_id(),
+                storage_entry.id(),
                 accounts_file,
                 num_accounts,
             );
-            next_append_vec_id = next_append_vec_id.max(new_storage_entry.append_vec_id());
+            next_append_vec_id = next_append_vec_id.max(new_storage_entry.id());
             storage.insert(
                 new_storage_entry.slot(),
                 AccountStorageReference {
-                    id: new_storage_entry.append_vec_id(),
+                    id: new_storage_entry.id(),
                     storage: Arc::new(new_storage_entry),
                 },
             );

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1043,10 +1043,8 @@ fn archive_snapshot(
                 .map_err(E::ArchiveSnapshotsDir)?;
 
             for storage in snapshot_storages {
-                let path_in_archive = Path::new(ACCOUNTS_DIR).join(AccountsFile::file_name(
-                    storage.slot(),
-                    storage.append_vec_id(),
-                ));
+                let path_in_archive = Path::new(ACCOUNTS_DIR)
+                    .join(AccountsFile::file_name(storage.slot(), storage.id()));
                 match storage.accounts.internals_for_archive() {
                     InternalsForArchive::Mmap(data) => {
                         let mut header = tar::Header::new_gnu();
@@ -1479,7 +1477,7 @@ pub fn hard_link_storages_to_snapshot(
         )?;
         // The appendvec could be recycled, so its filename may not be consistent to the slot and id.
         // Use the storage slot and id to compose a consistent file name for the hard-link file.
-        let hardlink_filename = AccountsFile::file_name(storage.slot(), storage.append_vec_id());
+        let hardlink_filename = AccountsFile::file_name(storage.slot(), storage.id());
         let hard_link_path = snapshot_hardlink_dir.join(hardlink_filename);
         fs::hard_link(storage_path, &hard_link_path).map_err(|err| {
             HardLinkStoragesToSnapshotError::HardLinkStorage(

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -338,7 +338,7 @@ impl SnapshotStorageRebuilder {
                     )?,
                 };
 
-                Ok((storage_entry.append_vec_id(), storage_entry))
+                Ok((storage_entry.id(), storage_entry))
             })
             .collect::<Result<HashMap<AccountsFileId, Arc<AccountStorageEntry>>, SnapshotError>>(
             )?;


### PR DESCRIPTION
#### Problem

We have multiple account storage file formats (append vecs and tiered storage), yet we still refer to the storage's id as "append vec id" in places.


#### Summary of Changes

Rename append_vec_id() to id().

Note, there are no functional changes.