### PR TITLE
Bump platform tools version to v1.42

### DIFF
--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -913,7 +913,7 @@ fn main() {
 
     // The following line is scanned by CI configuration script to
     // separate cargo caches according to the version of platform-tools.
-    let platform_tools_version = String::from("v1.41");
+    let platform_tools_version = String::from("v1.42");
     let rust_base_version = get_base_rust_version(platform_tools_version.as_str());
     let version = format!(
         "{}\nplatform-tools {}\n{}",

--- a/sdk/sbf/scripts/install.sh
+++ b/sdk/sbf/scripts/install.sh
@@ -109,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install platform tools
-version=v1.41
+version=v1.42
 if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
   (
     set -e


### PR DESCRIPTION
#### Problem

Platform tools version v1.41 misses many stack errors and does not provide a good experience to developers. It still miscomplies contracts with propers warnings about their possible misbehavior during execution.

#### Summary of Changes

These problems have been fixed in the new platform tools version. It does not yet bring Rust 1.79, but it has several improvements in terms of the stack limitation in SBF.