### PR TITLE
ledger-tool: Set initial last full snapshot slot

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -365,7 +365,7 @@ pub fn load_and_process_ledger(
         exit.clone(),
         abs_request_handler,
         process_options.accounts_db_test_hash_calculation,
-        None,
+        starting_snapshot_hashes.map(|x| x.full.0 .0),
     );
 
     let enable_rpc_transaction_history = arg_matches.is_present("enable_rpc_transaction_history");


### PR DESCRIPTION
#### Problem

ledger-tool does not set the initial last full snapshot slot for AccountBackgroundService. This could produce invalid incremental snapshots. Ones that are *missing* zero lamport accounts. In the full snapshot these accounts would still have non-zero lamports, and thus would be resurrected on startup. This is bad.


#### Summary of Changes

Set the initial last full snapshot slot.