### PR TITLE
Fix vec capacity when collecting accounts for storage

### DIFF
--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -90,6 +90,14 @@ impl RollbackAccounts {
             Self::SameNonceAndFeePayer { nonce } => nonce.account(),
         }
     }
+
+    /// Number of accounts tracked for rollback
+    pub fn count(&self) -> usize {
+        match self {
+            Self::FeePayerOnly { .. } | Self::SameNonceAndFeePayer { .. } => 1,
+            Self::SeparateNonceAndFeePayer { .. } => 2,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
The capacity used for allocating the vectors in account storage is way too low leading to extra allocations

#### Summary of Changes
Efficiently calculate a reasonably low max number of accounts that could be collected and use that for the vector capacity

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
