### PR TITLE
validator: unify and colorize help

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -73,8 +73,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
     return App::new(crate_name!())
         .about(crate_description!())
         .version(version)
-        .setting(AppSettings::VersionlessSubcommands)
-        .setting(AppSettings::InferSubcommands)
+        .global_setting(AppSettings::ColoredHelp)
+        .global_setting(AppSettings::InferSubcommands)
+        .global_setting(AppSettings::UnifiedHelpMessage)
+        .global_setting(AppSettings::VersionlessSubcommands)
         .arg(
             Arg::with_name(SKIP_SEED_PHRASE_VALIDATION_ARG.name)
                 .long(SKIP_SEED_PHRASE_VALIDATION_ARG.long)


### PR DESCRIPTION
#### Problem

The help for ledger-tool could be more user-friendly. One, we could add color. Two, we could unify the flags and the options, like most man pages/help. To me, the unification is very helpful given the large number of args to the validator.


#### Summary of Changes

Colorize and unify the validator's help.

To see a comparison of how the old and new help looks, please see #2322 for an example.