### PR TITLE
changelog: Lists removed validator args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ Release channels have their own copy of this changelog:
   * `--enable-rpc-obsolete_v1_7` flag removed
   * Deprecated methods are removed from `RpcClient` and `RpcClient::nonblocking`
   * `solana-client`: deprecated re-exports removed; please import `solana-connection-cache`, `solana-quic-client`, or `solana-udp-client` directly
+  * Deprecated arguments are removed from `agave-validator`. Such as:
+    * `--accounts-db-caching-enabled` (#2063)
+    * `--accounts-db-index-hashing` (#2063)
+    * `--no-accounts-db-index-hashing` (#2063)
+    * `--incremental-snapshots` (#2148)
+    * `--halt-on-known-validators-accounts-hash-mismatch` (#2157)
 * Changes
   * `central-scheduler` as default option for `--block-production-method` (#34891)
   * `solana-rpc-client-api`: `RpcFilterError` depends on `base64` version 0.22, so users may need to upgrade to `base64` version 0.22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,10 @@ Release channels have their own copy of this changelog:
     getConfirmedSignaturesForAddress, getConfirmedBlock, getConfirmedBlocks, getConfirmedBlocksWithLimit,
     getConfirmedTransaction, getConfirmedSignaturesForAddress2, getRecentBlockhash, getFees,
     getFeeCalculatorForBlockhash, getFeeRateGovernor, getSnapshotSlot getStakeActivation
-  * `--enable-rpc-obsolete_v1_7` flag removed
   * Deprecated methods are removed from `RpcClient` and `RpcClient::nonblocking`
   * `solana-client`: deprecated re-exports removed; please import `solana-connection-cache`, `solana-quic-client`, or `solana-udp-client` directly
-  * Deprecated arguments are removed from `agave-validator`. Such as:
+  * Deprecated arguments removed from `agave-validator`:
+    * `--enable-rpc-obsolete_v1_7` (#1886)
     * `--accounts-db-caching-enabled` (#2063)
     * `--accounts-db-index-hashing` (#2063)
     * `--no-accounts-db-index-hashing` (#2063)


### PR DESCRIPTION
#### Problem

We've removed long-deprecated cli args from `agave-validator`. They should be noted in the changelog, as per https://github.com/anza-xyz/agave/pull/2154#pullrequestreview-2181436597.


#### Summary of Changes

Add them to the changelog.