### PR TITLE
Clean up metrics in `Bank::commit_transactions`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -135,7 +135,6 @@ use {
         rent_debits::RentDebits,
         reserved_account_keys::ReservedAccountKeys,
         reward_info::RewardInfo,
-        saturating_add_assign,
         signature::{Keypair, Signature},
         slot_hashes::SlotHashes,
         slot_history::{Check, SlotHistory},
@@ -4014,15 +4013,12 @@ impl Bank {
             "loaded_account_stats and execution_results are not the same size"
         );
 
-        saturating_add_assign!(
-            timings.execute_accessories.update_executors_us,
-            update_executors_us
-        );
         timings.saturating_add_in_place(ExecuteTimingType::StoreUs, store_accounts_us);
         timings.saturating_add_in_place(
             ExecuteTimingType::UpdateStakesCacheUs,
             update_stakes_cache_us,
         );
+        timings.saturating_add_in_place(ExecuteTimingType::UpdateExecutorsUs, update_executors_us);
         timings.saturating_add_in_place(
             ExecuteTimingType::UpdateTransactionStatuses,
             update_transaction_statuses_us,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3966,31 +3966,24 @@ impl Bank {
 
         // Cached vote and stake accounts are synchronized with accounts-db
         // after each transaction.
-        let mut update_stakes_cache_time = Measure::start("update_stakes_cache_time");
-        self.update_stakes_cache(sanitized_txs, &execution_results);
-        update_stakes_cache_time.stop();
+        let ((), update_stakes_cache_us) =
+            measure_us!(self.update_stakes_cache(sanitized_txs, &execution_results));
 
-        let mut store_executors_which_were_deployed_time =
-            Measure::start("store_executors_which_were_deployed_time");
-        let mut cache = None;
-        for execution_result in &execution_results {
-            if let TransactionExecutionResult::Executed(executed_tx) = execution_result {
-                let programs_modified_by_tx = &executed_tx.programs_modified_by_tx;
-                if executed_tx.was_successful() && !programs_modified_by_tx.is_empty() {
-                    cache
-                        .get_or_insert_with(|| {
-                            self.transaction_processor.program_cache.write().unwrap()
-                        })
-                        .merge(programs_modified_by_tx);
+        let ((), update_executors_us) = measure_us!({
+            let mut cache = None;
+            for execution_result in &execution_results {
+                if let TransactionExecutionResult::Executed(executed_tx) = execution_result {
+                    let programs_modified_by_tx = &executed_tx.programs_modified_by_tx;
+                    if executed_tx.was_successful() && !programs_modified_by_tx.is_empty() {
+                        cache
+                            .get_or_insert_with(|| {
+                                self.transaction_processor.program_cache.write().unwrap()
+                            })
+                            .merge(programs_modified_by_tx);
+                    }
                 }
             }
-        }
-        drop(cache);
-        store_executors_which_were_deployed_time.stop();
-        saturating_add_assign!(
-            timings.execute_accessories.update_executors_us,
-            store_executors_which_were_deployed_time.as_us()
-        );
+        });
 
         let accounts_data_len_delta = execution_results
             .iter()
@@ -4004,31 +3997,35 @@ impl Bank {
             .sum();
         self.update_accounts_data_size_delta_on_chain(accounts_data_len_delta);
 
-        timings.saturating_add_in_place(ExecuteTimingType::StoreUs, store_accounts_us);
-        timings.saturating_add_in_place(
-            ExecuteTimingType::UpdateStakesCacheUs,
-            update_stakes_cache_time.as_us(),
-        );
+        let ((), update_transaction_statuses_us) =
+            measure_us!(self.update_transaction_statuses(sanitized_txs, &execution_results));
 
-        let mut update_transaction_statuses_time = Measure::start("update_transaction_statuses");
-        self.update_transaction_statuses(sanitized_txs, &execution_results);
         let fee_collection_results = if self.feature_set.is_active(&reward_full_priority_fee::id())
         {
             self.filter_program_errors_and_collect_fee_details(&execution_results)
         } else {
             self.filter_program_errors_and_collect_fee(&execution_results)
         };
-        update_transaction_statuses_time.stop();
-        timings.saturating_add_in_place(
-            ExecuteTimingType::UpdateTransactionStatuses,
-            update_transaction_statuses_time.as_us(),
-        );
 
         let loaded_accounts_stats = Self::collect_loaded_accounts_stats(&execution_results);
         assert_eq!(
             loaded_accounts_stats.len(),
             execution_results.len(),
             "loaded_account_stats and execution_results are not the same size"
+        );
+
+        saturating_add_assign!(
+            timings.execute_accessories.update_executors_us,
+            update_executors_us
+        );
+        timings.saturating_add_in_place(ExecuteTimingType::StoreUs, store_accounts_us);
+        timings.saturating_add_in_place(
+            ExecuteTimingType::UpdateStakesCacheUs,
+            update_stakes_cache_us,
+        );
+        timings.saturating_add_in_place(
+            ExecuteTimingType::UpdateTransactionStatuses,
+            update_transaction_statuses_us,
         );
 
         TransactionResults {

--- a/timings/src/lib.rs
+++ b/timings/src/lib.rs
@@ -50,6 +50,7 @@ pub enum ExecuteTimingType {
     ExecuteUs,
     StoreUs,
     UpdateStakesCacheUs,
+    UpdateExecutorsUs,
     NumExecuteBatches,
     CollectLogsUs,
     TotalBatchesLen,
@@ -148,6 +149,11 @@ eager_macro_rules! { $eager_1
 
                     .metrics
                     .index(ExecuteTimingType::UpdateStakesCacheUs),
+                i64
+            ),
+            (
+                "execute_accessories_update_executors_us",
+                *$self.metrics.index(ExecuteTimingType::UpdateExecutorsUs),
                 i64
             ),
             (
@@ -260,11 +266,6 @@ eager_macro_rules! { $eager_1
                 i64
             ),
             (
-                "execute_accessories_update_executors_us",
-                $self.execute_accessories.update_executors_us,
-                i64
-            ),
-            (
                 "execute_accessories_process_instructions_total_us",
                 $self
                     .execute_accessories
@@ -351,7 +352,6 @@ pub struct ExecuteAccessoryTimings {
     pub feature_set_clone_us: u64,
     pub get_executors_us: u64,
     pub process_message_us: u64,
-    pub update_executors_us: u64,
     pub process_instructions: ExecuteProcessInstructionTimings,
 }
 
@@ -360,7 +360,6 @@ impl ExecuteAccessoryTimings {
         saturating_add_assign!(self.feature_set_clone_us, other.feature_set_clone_us);
         saturating_add_assign!(self.get_executors_us, other.get_executors_us);
         saturating_add_assign!(self.process_message_us, other.process_message_us);
-        saturating_add_assign!(self.update_executors_us, other.update_executors_us);
         self.process_instructions
             .accumulate(&other.process_instructions);
     }


### PR DESCRIPTION
#### Problem
- A few metrics in `commit_transactions` cover more operations than their name would suggest
- Time measurement is generally disorganized in this method

#### Summary of Changes
- Tighten the scope of `store_us` and `update_transaction_statuses_us` metric measurement
- Improve code readability of metrics collection

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
