### PR TITLE
refactor and optimize `collect_accounts_for_store`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7602,6 +7602,7 @@ dependencies = [
  "solana-timings",
  "solana-type-overrides",
  "solana-vote",
+ "thiserror",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6350,6 +6350,7 @@ dependencies = [
  "solana-timings",
  "solana-type-overrides",
  "solana-vote",
+ "thiserror",
 ]
 
 [[package]]

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -31,6 +31,7 @@ solana-system-program = { workspace = true }
 solana-timings = { workspace = true }
 solana-type-overrides = { workspace = true }
 solana-vote = { workspace = true }
+thiserror = { workspace = true }
 
 [lib]
 crate-type = ["lib"]

--- a/svm/src/account_saver.rs
+++ b/svm/src/account_saver.rs
@@ -4,15 +4,8 @@ use {
         transaction_results::TransactionExecutionResult,
     },
     solana_sdk::{
-        account::AccountSharedData,
-        account_utils::StateMut,
-        message::SanitizedMessage,
-        nonce::{
-            state::{DurableNonce, Versions as NonceVersions},
-            State as NonceState,
-        },
-        pubkey::Pubkey,
-        transaction::SanitizedTransaction,
+        account::AccountSharedData, nonce::state::DurableNonce, pubkey::Pubkey,
+        transaction::SanitizedTransaction, transaction_context::TransactionAccount,
     },
 };
 
@@ -58,100 +51,87 @@ pub fn collect_accounts_to_store<'a>(
             continue;
         };
 
-        let loaded_transaction = &mut executed_tx.loaded_transaction;
-        let execution_status = &executed_tx.execution_details.status;
-
-        // Accounts that are invoked and also not passed as an instruction
-        // account to a program don't need to be stored because it's assumed
-        // to be impossible for a committable transaction to modify an
-        // invoked account if said account isn't passed to some program.
-        //
-        // Note that this assumption might not hold in the future after
-        // SIMD-0082 is implemented because we may decide to commit
-        // transactions that incorrectly attempt to invoke a fee payer or
-        // durable nonce account. If that happens, we would NOT want to use
-        // this filter because we always NEED to store those accounts even
-        // if they aren't passed to any programs (because they are mutated
-        // outside of the VM).
-        let is_storable_account = |message: &SanitizedMessage, key_index: usize| -> bool {
-            !message.is_invoked(key_index) || message.is_instruction_account(key_index)
-        };
-
-        let message = tx.message();
-        let rollback_accounts = &loaded_transaction.rollback_accounts;
-        let maybe_nonce_address = rollback_accounts.nonce().map(|account| account.address());
-
-        for (i, (address, account)) in (0..message.account_keys().len())
-            .zip(loaded_transaction.accounts.iter_mut())
-            .filter(|(i, _)| is_storable_account(message, *i))
-        {
-            if message.is_writable(i) {
-                let should_collect_account = match execution_status {
-                    Ok(()) => true,
-                    Err(_) => {
-                        let is_fee_payer = i == 0;
-                        let is_nonce_account = Some(&*address) == maybe_nonce_address;
-                        post_process_failed_tx(
-                            account,
-                            is_fee_payer,
-                            is_nonce_account,
-                            rollback_accounts,
-                            durable_nonce,
-                            lamports_per_signature,
-                        );
-
-                        is_fee_payer || is_nonce_account
-                    }
-                };
-
-                if should_collect_account {
-                    // Add to the accounts to store
-                    accounts.push((&*address, &*account));
-                    transactions.push(Some(tx));
-                }
-            }
+        if executed_tx.execution_details.status.is_ok() {
+            collect_accounts_for_successful_tx(
+                &mut accounts,
+                &mut transactions,
+                tx,
+                &executed_tx.loaded_transaction.accounts,
+            );
+        } else {
+            collect_accounts_for_failed_tx(
+                &mut accounts,
+                &mut transactions,
+                tx,
+                &mut executed_tx.loaded_transaction.rollback_accounts,
+                durable_nonce,
+                lamports_per_signature,
+            );
         }
     }
     (accounts, transactions)
 }
 
-fn post_process_failed_tx(
-    account: &mut AccountSharedData,
-    is_fee_payer: bool,
-    is_nonce_account: bool,
-    rollback_accounts: &RollbackAccounts,
-    &durable_nonce: &DurableNonce,
-    lamports_per_signature: u64,
+fn collect_accounts_for_successful_tx<'a>(
+    collected_accounts: &mut Vec<(&'a Pubkey, &'a AccountSharedData)>,
+    collected_account_transactions: &mut Vec<Option<&'a SanitizedTransaction>>,
+    transaction: &'a SanitizedTransaction,
+    transaction_accounts: &'a [TransactionAccount],
 ) {
-    // For the case of RollbackAccounts::SameNonceAndFeePayer, it's crucial
-    // for `is_nonce_account` to be checked earlier than `is_fee_payer`.
-    if is_nonce_account {
-        if let Some(nonce) = rollback_accounts.nonce() {
-            // The transaction failed which would normally drop the account
-            // processing changes, since this account is now being included
-            // in the accounts written back to the db, roll it back to
-            // pre-processing state.
-            *account = nonce.account().clone();
-
-            // Advance the stored blockhash to prevent fee theft by someone
-            // replaying nonce transactions that have failed with an
-            // `InstructionError`.
-            //
-            // Since we know we are dealing with a valid nonce account,
-            // unwrap is safe here
-            let nonce_versions = StateMut::<NonceVersions>::state(account).unwrap();
-            if let NonceState::Initialized(ref data) = nonce_versions.state() {
-                let nonce_state = NonceState::new_initialized(
-                    &data.authority,
-                    durable_nonce,
-                    lamports_per_signature,
-                );
-                let nonce_versions = NonceVersions::new(nonce_state);
-                account.set_state(&nonce_versions).unwrap();
+    let message = transaction.message();
+    for (i, (address, account)) in (0..message.account_keys().len()).zip(transaction_accounts) {
+        if message.is_writable(i) {
+            // Accounts that are invoked and also not passed as an instruction
+            // account to a program don't need to be stored because it's assumed
+            // to be impossible for a committable transaction to modify an
+            // invoked account if said account isn't passed to some program.
+            if !message.is_invoked(i) || message.is_instruction_account(i) {
+                collected_accounts.push((address, account));
+                collected_account_transactions.push(Some(transaction));
             }
         }
-    } else if is_fee_payer {
-        *account = rollback_accounts.fee_payer_account().clone();
+    }
+}
+
+fn collect_accounts_for_failed_tx<'a>(
+    collected_accounts: &mut Vec<(&'a Pubkey, &'a AccountSharedData)>,
+    collected_account_transactions: &mut Vec<Option<&'a SanitizedTransaction>>,
+    transaction: &'a SanitizedTransaction,
+    rollback_accounts: &'a mut RollbackAccounts,
+    durable_nonce: &DurableNonce,
+    lamports_per_signature: u64,
+) {
+    let message = transaction.message();
+    let fee_payer_address = message.fee_payer();
+    match rollback_accounts {
+        RollbackAccounts::FeePayerOnly { fee_payer_account } => {
+            collected_accounts.push((fee_payer_address, &*fee_payer_account));
+            collected_account_transactions.push(Some(transaction));
+        }
+        RollbackAccounts::SameNonceAndFeePayer { nonce } => {
+            // Since we know we are dealing with a valid nonce account,
+            // unwrap is safe here
+            nonce
+                .try_advance_account(*durable_nonce, lamports_per_signature)
+                .unwrap();
+            collected_accounts.push((nonce.address(), nonce.account()));
+            collected_account_transactions.push(Some(transaction));
+        }
+        RollbackAccounts::SeparateNonceAndFeePayer {
+            nonce,
+            fee_payer_account,
+        } => {
+            collected_accounts.push((fee_payer_address, &*fee_payer_account));
+            collected_account_transactions.push(Some(transaction));
+
+            // Since we know we are dealing with a valid nonce account,
+            // unwrap is safe here
+            nonce
+                .try_advance_account(*durable_nonce, lamports_per_signature)
+                .unwrap();
+            collected_accounts.push((nonce.address(), nonce.account()));
+            collected_account_transactions.push(Some(transaction));
+        }
     }
 }
 
@@ -166,13 +146,16 @@ mod tests {
         },
         solana_compute_budget::compute_budget_processor::ComputeBudgetLimits,
         solana_sdk::{
-            account::{AccountSharedData, ReadableAccount, WritableAccount},
+            account::{AccountSharedData, ReadableAccount},
             fee::FeeDetails,
             hash::Hash,
             instruction::{CompiledInstruction, InstructionError},
             message::Message,
             native_loader,
-            nonce::state::Data as NonceData,
+            nonce::{
+                state::{Data as NonceData, Versions as NonceVersions},
+                State as NonceState,
+            },
             nonce_account,
             rent_debits::RentDebits,
             signature::{keypair_from_seed, signers::Signers, Keypair, Signer},
@@ -295,133 +278,65 @@ mod tests {
         assert!(transactions.iter().any(|txn| txn.unwrap().eq(&tx1)));
     }
 
-    fn create_accounts_post_process_failed_tx() -> (
-        Pubkey,
-        AccountSharedData,
-        AccountSharedData,
-        DurableNonce,
-        u64,
-    ) {
-        let data = NonceVersions::new(NonceState::Initialized(NonceData::default()));
-        let account = AccountSharedData::new_data(42, &data, &system_program::id()).unwrap();
-        let mut pre_account = account.clone();
-        pre_account.set_lamports(43);
-        let durable_nonce = DurableNonce::from_blockhash(&Hash::new(&[1u8; 32]));
-        (Pubkey::default(), pre_account, account, durable_nonce, 1234)
-    }
+    #[test]
+    fn test_nonced_failure_accounts_rollback_fee_payer_only() {
+        let from = keypair_from_seed(&[1; 32]).unwrap();
+        let from_address = from.pubkey();
+        let to_address = Pubkey::new_unique();
+        let from_account_post = AccountSharedData::new(4199, 0, &Pubkey::default());
+        let to_account = AccountSharedData::new(2, 0, &Pubkey::default());
 
-    fn run_post_process_failed_tx_test(
-        account: &mut AccountSharedData,
-        is_fee_payer: bool,
-        is_nonce_account: bool,
-        rollback_accounts: &RollbackAccounts,
-        durable_nonce: &DurableNonce,
-        lamports_per_signature: u64,
-        expect_account: &AccountSharedData,
-    ) -> bool {
-        // Verify expect_account's relationship
-        if !is_fee_payer {
-            if is_nonce_account {
-                assert_ne!(expect_account, rollback_accounts.nonce().unwrap().account());
-            } else {
-                assert_eq!(expect_account, account);
-            }
-        }
+        let instructions = vec![system_instruction::transfer(&from_address, &to_address, 42)];
+        let message = Message::new(&instructions, Some(&from_address));
+        let blockhash = Hash::new_unique();
+        let transaction_accounts = vec![
+            (message.account_keys[0], from_account_post),
+            (message.account_keys[1], to_account),
+        ];
+        let tx = new_sanitized_tx(&[&from], message, blockhash);
 
-        post_process_failed_tx(
-            account,
-            is_fee_payer,
-            is_nonce_account,
-            rollback_accounts,
-            durable_nonce,
-            lamports_per_signature,
+        let from_account_pre = AccountSharedData::new(4242, 0, &Pubkey::default());
+
+        let loaded = LoadedTransaction {
+            accounts: transaction_accounts,
+            program_indices: vec![],
+            fee_details: FeeDetails::default(),
+            rollback_accounts: RollbackAccounts::FeePayerOnly {
+                fee_payer_account: from_account_pre.clone(),
+            },
+            compute_budget_limits: ComputeBudgetLimits::default(),
+            rent: 0,
+            rent_debits: RentDebits::default(),
+            loaded_accounts_data_size: 0,
+        };
+
+        let txs = vec![tx];
+        let mut execution_results = vec![new_execution_result(
+            Err(TransactionError::InstructionError(
+                1,
+                InstructionError::InvalidArgument,
+            )),
+            loaded,
+        )];
+        let max_collected_accounts = max_number_of_accounts_to_collect(&txs, &execution_results);
+        assert_eq!(max_collected_accounts, 1);
+        let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
+        let (collected_accounts, _) =
+            collect_accounts_to_store(&txs, &mut execution_results, &durable_nonce, 0);
+        assert_eq!(collected_accounts.len(), 1);
+        assert_eq!(
+            collected_accounts
+                .iter()
+                .find(|(pubkey, _account)| *pubkey == &from_address)
+                .map(|(_pubkey, account)| *account)
+                .cloned()
+                .unwrap(),
+            from_account_pre,
         );
-        assert_eq!(expect_account, account);
-        expect_account == account
     }
 
     #[test]
-    fn test_post_process_failed_tx_expected() {
-        let (pre_account_address, pre_account, mut post_account, blockhash, lamports_per_signature) =
-            create_accounts_post_process_failed_tx();
-        let rollback_accounts = RollbackAccounts::SameNonceAndFeePayer {
-            nonce: NoncePartial::new(pre_account_address, pre_account.clone()),
-        };
-
-        let mut expect_account = pre_account;
-        expect_account
-            .set_state(&NonceVersions::new(NonceState::Initialized(
-                NonceData::new(Pubkey::default(), blockhash, lamports_per_signature),
-            )))
-            .unwrap();
-
-        assert!(run_post_process_failed_tx_test(
-            &mut post_account,
-            false, // is_fee_payer
-            true,  // is_nonce_account
-            &rollback_accounts,
-            &blockhash,
-            lamports_per_signature,
-            &expect_account,
-        ));
-    }
-
-    #[test]
-    fn test_post_process_failed_tx_not_nonce_address() {
-        let (pre_account_address, pre_account, mut post_account, blockhash, lamports_per_signature) =
-            create_accounts_post_process_failed_tx();
-
-        let rollback_accounts = RollbackAccounts::SameNonceAndFeePayer {
-            nonce: NoncePartial::new(pre_account_address, pre_account.clone()),
-        };
-
-        let expect_account = post_account.clone();
-        assert!(run_post_process_failed_tx_test(
-            &mut post_account,
-            false, // is_fee_payer
-            false, // is_nonce_account
-            &rollback_accounts,
-            &blockhash,
-            lamports_per_signature,
-            &expect_account,
-        ));
-    }
-
-    #[test]
-    fn test_rollback_nonce_fee_payer() {
-        let nonce_account = AccountSharedData::new_data(1, &(), &system_program::id()).unwrap();
-        let pre_fee_payer_account =
-            AccountSharedData::new_data(42, &(), &system_program::id()).unwrap();
-        let post_fee_payer_account =
-            AccountSharedData::new_data(84, &[1, 2, 3, 4], &system_program::id()).unwrap();
-        let rollback_accounts = RollbackAccounts::SeparateNonceAndFeePayer {
-            nonce: NoncePartial::new(Pubkey::new_unique(), nonce_account),
-            fee_payer_account: pre_fee_payer_account.clone(),
-        };
-
-        assert!(run_post_process_failed_tx_test(
-            &mut post_fee_payer_account.clone(),
-            false, // is_fee_payer
-            false, // is_nonce_account
-            &rollback_accounts,
-            &DurableNonce::default(),
-            1,
-            &post_fee_payer_account,
-        ));
-
-        assert!(run_post_process_failed_tx_test(
-            &mut post_fee_payer_account.clone(),
-            true,  // is_fee_payer
-            false, // is_nonce_account
-            &rollback_accounts,
-            &DurableNonce::default(),
-            1,
-            &pre_fee_payer_account,
-        ));
-    }
-
-    #[test]
-    fn test_nonced_failure_accounts_rollback_from_pays() {
+    fn test_nonced_failure_accounts_rollback_separate_nonce_and_fee_payer() {
         let nonce_address = Pubkey::new_unique();
         let nonce_authority = keypair_from_seed(&[0; 32]).unwrap();
         let from = keypair_from_seed(&[1; 32]).unwrap();
@@ -521,7 +436,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nonced_failure_accounts_rollback_nonce_pays() {
+    fn test_nonced_failure_accounts_rollback_same_nonce_and_fee_payer() {
         let nonce_authority = keypair_from_seed(&[0; 32]).unwrap();
         let nonce_address = nonce_authority.pubkey();
         let from = keypair_from_seed(&[1; 32]).unwrap();

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -39,7 +39,7 @@ impl NoncePartial {
     // Advance the stored blockhash to prevent fee theft by someone
     // replaying nonce transactions that have failed with an
     // `InstructionError`.
-    pub fn try_advance_account(
+    pub fn try_advance_nonce(
         &mut self,
         durable_nonce: DurableNonce,
         lamports_per_signature: u64,
@@ -114,7 +114,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_advance_account_success() {
+    fn test_try_advance_nonce_success() {
         let authority = Pubkey::new_unique();
         let mut nonce_partial = NoncePartial::new(
             Pubkey::new_unique(),
@@ -127,7 +127,7 @@ mod tests {
 
         let new_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
         let new_lamports_per_signature = 100;
-        let result = nonce_partial.try_advance_account(new_nonce, new_lamports_per_signature);
+        let result = nonce_partial.try_advance_nonce(new_nonce, new_lamports_per_signature);
         assert_eq!(result, Ok(()));
 
         let nonce_versions = StateMut::<NonceVersions>::state(&nonce_partial.account).unwrap();
@@ -142,26 +142,26 @@ mod tests {
     }
 
     #[test]
-    fn test_try_advance_account_invalid() {
+    fn test_try_advance_nonce_invalid() {
         let mut nonce_partial = NoncePartial::new(
             Pubkey::new_unique(),
             AccountSharedData::new(1_000_000, 0, &Pubkey::default()),
         );
 
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
-        let result = nonce_partial.try_advance_account(durable_nonce, 5000);
+        let result = nonce_partial.try_advance_nonce(durable_nonce, 5000);
         assert_eq!(result, Err(AdvanceNonceError::Invalid));
     }
 
     #[test]
-    fn test_try_advance_account_uninitialized() {
+    fn test_try_advance_nonce_uninitialized() {
         let mut nonce_partial = NoncePartial::new(
             Pubkey::new_unique(),
             create_nonce_account(NonceState::Uninitialized),
         );
 
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
-        let result = nonce_partial.try_advance_account(durable_nonce, 5000);
+        let result = nonce_partial.try_advance_nonce(durable_nonce, 5000);
         assert_eq!(result, Err(AdvanceNonceError::Uninitialized));
     }
 }

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -1,4 +1,13 @@
-use solana_sdk::{account::AccountSharedData, nonce_account, pubkey::Pubkey};
+use {
+    solana_sdk::{
+        account::AccountSharedData,
+        account_utils::StateMut,
+        nonce::state::{DurableNonce, State as NonceState, Versions as NonceVersions},
+        nonce_account,
+        pubkey::Pubkey,
+    },
+    thiserror::Error,
+};
 
 pub trait NonceInfo {
     fn address(&self) -> &Pubkey;
@@ -14,9 +23,38 @@ pub struct NoncePartial {
     account: AccountSharedData,
 }
 
+#[derive(Error, Debug, PartialEq)]
+pub enum AdvanceNonceError {
+    #[error("Invalid account")]
+    Invalid,
+    #[error("Uninitialized nonce")]
+    Uninitialized,
+}
+
 impl NoncePartial {
     pub fn new(address: Pubkey, account: AccountSharedData) -> Self {
         Self { address, account }
+    }
+
+    // Advance the stored blockhash to prevent fee theft by someone
+    // replaying nonce transactions that have failed with an
+    // `InstructionError`.
+    pub fn try_advance_account(
+        &mut self,
+        durable_nonce: DurableNonce,
+        lamports_per_signature: u64,
+    ) -> Result<(), AdvanceNonceError> {
+        let nonce_versions = StateMut::<NonceVersions>::state(&self.account)
+            .map_err(|_| AdvanceNonceError::Invalid)?;
+        if let NonceState::Initialized(ref data) = nonce_versions.state() {
+            let nonce_state =
+                NonceState::new_initialized(&data.authority, durable_nonce, lamports_per_signature);
+            let nonce_versions = NonceVersions::new(nonce_state);
+            self.account.set_state(&nonce_versions).unwrap();
+            Ok(())
+        } else {
+            Err(AdvanceNonceError::Uninitialized)
+        }
     }
 }
 
@@ -48,21 +86,21 @@ mod tests {
         },
     };
 
+    fn create_nonce_account(state: NonceState) -> AccountSharedData {
+        AccountSharedData::new_data(1_000_000, &NonceVersions::new(state), &system_program::id())
+            .unwrap()
+    }
+
     #[test]
     fn test_nonce_info() {
         let nonce_address = Pubkey::new_unique();
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
         let lamports_per_signature = 42;
-        let nonce_account = AccountSharedData::new_data(
-            43,
-            &NonceVersions::new(NonceState::Initialized(NonceData::new(
-                Pubkey::default(),
-                durable_nonce,
-                lamports_per_signature,
-            ))),
-            &system_program::id(),
-        )
-        .unwrap();
+        let nonce_account = create_nonce_account(NonceState::Initialized(NonceData::new(
+            Pubkey::default(),
+            durable_nonce,
+            lamports_per_signature,
+        )));
 
         // NoncePartial create + NonceInfo impl
         let partial = NoncePartial::new(nonce_address, nonce_account.clone());
@@ -73,5 +111,57 @@ mod tests {
             Some(lamports_per_signature)
         );
         assert_eq!(partial.fee_payer_account(), None);
+    }
+
+    #[test]
+    fn test_try_advance_account_success() {
+        let authority = Pubkey::new_unique();
+        let mut nonce_partial = NoncePartial::new(
+            Pubkey::new_unique(),
+            create_nonce_account(NonceState::Initialized(NonceData::new(
+                authority,
+                DurableNonce::from_blockhash(&Hash::new_unique()),
+                42,
+            ))),
+        );
+
+        let new_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
+        let new_lamports_per_signature = 100;
+        let result = nonce_partial.try_advance_account(new_nonce, new_lamports_per_signature);
+        assert_eq!(result, Ok(()));
+
+        let nonce_versions = StateMut::<NonceVersions>::state(&nonce_partial.account).unwrap();
+        assert_eq!(
+            &NonceState::Initialized(NonceData::new(
+                authority,
+                new_nonce,
+                new_lamports_per_signature
+            )),
+            nonce_versions.state()
+        );
+    }
+
+    #[test]
+    fn test_try_advance_account_invalid() {
+        let mut nonce_partial = NoncePartial::new(
+            Pubkey::new_unique(),
+            AccountSharedData::new(1_000_000, 0, &Pubkey::default()),
+        );
+
+        let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
+        let result = nonce_partial.try_advance_account(durable_nonce, 5000);
+        assert_eq!(result, Err(AdvanceNonceError::Invalid));
+    }
+
+    #[test]
+    fn test_try_advance_account_uninitialized() {
+        let mut nonce_partial = NoncePartial::new(
+            Pubkey::new_unique(),
+            create_nonce_account(NonceState::Uninitialized),
+        );
+
+        let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
+        let result = nonce_partial.try_advance_account(durable_nonce, 5000);
+        assert_eq!(result, Err(AdvanceNonceError::Uninitialized));
     }
 }

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -72,25 +72,6 @@ impl RollbackAccounts {
         }
     }
 
-    pub fn nonce(&self) -> Option<&NoncePartial> {
-        match self {
-            Self::FeePayerOnly { .. } => None,
-            Self::SameNonceAndFeePayer { nonce } | Self::SeparateNonceAndFeePayer { nonce, .. } => {
-                Some(nonce)
-            }
-        }
-    }
-
-    pub fn fee_payer_account(&self) -> &AccountSharedData {
-        match self {
-            Self::FeePayerOnly { fee_payer_account }
-            | Self::SeparateNonceAndFeePayer {
-                fee_payer_account, ..
-            } => fee_payer_account,
-            Self::SameNonceAndFeePayer { nonce } => nonce.account(),
-        }
-    }
-
     /// Number of accounts tracked for rollback
     pub fn count(&self) -> usize {
         match self {


### PR DESCRIPTION
#### Problem
1. We shouldn't need to iterate through all tx accounts when collecting accounts to store for failed transactions, we only need to collect the fee payer and nonce account
2. In the future, when transaction constraints are relaxed, we won't always have all the loaded tx accounts available for iteration because we need to be able to include transactions that fail loading (besides fee payer and nonce).

#### Summary of Changes
- Split the logic inside `collect_accounts_for_store` so that successful and failed transactions are handled separately
- Add a `try_advance_account` function to `NoncePartial` to allow advancing the blockhash in place (this allows us to avoid allocating when advancing accounts).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
