### PR TITLE
Move more logic in blockstore_processor behind allow_dead_slots flag

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1733,10 +1733,7 @@ fn process_next_slots(
 
     // This is a fork point if there are multiple children, create a new child bank for each fork
     for next_slot in &meta.next_slots {
-        let skip_next_slot = halt_at_slot
-            .map(|halt_at_slot| *next_slot > halt_at_slot)
-            .unwrap_or(false);
-        if skip_next_slot {
+        if halt_at_slot.is_some_and(|halt_at_slot| *next_slot > halt_at_slot) {
             continue;
         }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1725,7 +1725,7 @@ fn process_next_slots(
     blockstore: &Blockstore,
     leader_schedule_cache: &LeaderScheduleCache,
     pending_slots: &mut Vec<(SlotMeta, Bank, Hash)>,
-    halt_at_slot: Option<Slot>,
+    opts: &ProcessOptions,
 ) -> result::Result<(), BlockstoreProcessorError> {
     if meta.next_slots.is_empty() {
         return Ok(());
@@ -1733,7 +1733,13 @@ fn process_next_slots(
 
     // This is a fork point if there are multiple children, create a new child bank for each fork
     for next_slot in &meta.next_slots {
-        if halt_at_slot.is_some_and(|halt_at_slot| *next_slot > halt_at_slot) {
+        if opts
+            .halt_at_slot
+            .is_some_and(|halt_at_slot| *next_slot > halt_at_slot)
+        {
+            continue;
+        }
+        if !opts.allow_dead_slots && blockstore.is_dead(*next_slot) {
             continue;
         }
 
@@ -1812,7 +1818,7 @@ fn load_frozen_forks(
         blockstore,
         leader_schedule_cache,
         &mut pending_slots,
-        opts.halt_at_slot,
+        opts,
     )?;
 
     let on_halt_store_hash_raw_data_for_debug = opts.on_halt_store_hash_raw_data_for_debug;
@@ -1991,7 +1997,7 @@ fn load_frozen_forks(
                 blockstore,
                 leader_schedule_cache,
                 &mut pending_slots,
-                opts.halt_at_slot,
+                opts,
             )?;
         }
     } else if on_halt_store_hash_raw_data_for_debug {


### PR DESCRIPTION
#### Problem
A flag in ProcessOptions can be set to allow dead slots. If the flag is
not set and a block is marked dead, fetching the entries will fail as
the blockstore method to retrive entries checks if the slot is dead.

Within process_next_slots(), new Banks are created as children of
already replayed banks are discovered. The children Banks are created
prior to fetching entries, and thus, a Bank could be created for a
dead slot that will eventually be discarded.
    
#### Summary of Changes
Instead of allowing the extra work of creating a Bank to proceed, check
if a slot is dead (and allow_dead_slots=false) BEFORE creating a Bank
for the slot.


For the case of a validator, `allow_dead_slots=false` for the local ledger replay at startup. So, we will avoid processing any known dead slots altogether. On the other hand, `ReplayStage` will create a `Bank` for dead slots, see it is dead and then proceed on other forks. By avoiding the creation of `Bank` in local ledger replay, we'll avoid this non-fatal error:
```
[... ERROR solana_accounts_db::accounts_db] set_hash: already exists; multiple forks with shared slot X as child (parent: Y)!?
```

Fixes https://github.com/solana-labs/solana/issues/28343