### PR TITLE
Revert "Bump platform tools version to v1.42 (#2310)"

### DIFF
--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -913,7 +913,7 @@ fn main() {
 
     // The following line is scanned by CI configuration script to
     // separate cargo caches according to the version of platform-tools.
-    let platform_tools_version = String::from("v1.42");
+    let platform_tools_version = String::from("v1.41");
     let rust_base_version = get_base_rust_version(platform_tools_version.as_str());
     let version = format!(
         "{}\nplatform-tools {}\n{}",

--- a/sdk/sbf/scripts/install.sh
+++ b/sdk/sbf/scripts/install.sh
@@ -109,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install platform tools
-version=v1.42
+version=v1.41
 if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
   (
     set -e


### PR DESCRIPTION
#### Problem

The release was created with the wrong Rust commit.

#### Summary of Changes

This reverts commit f4b87f9814040dc5abc65224ed6d7e163b0b7756.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
