### PR TITLE
log ancient zero lamport accounts in hash of all accounts

### DIFF
--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -27,7 +27,7 @@ trait AppendVecScan: Send + Sync + Clone {
     /// return true if this pubkey should be included
     fn filter(&mut self, pubkey: &Pubkey) -> bool;
     /// set current slot of the scan
-    fn set_slot(&mut self, slot: Slot);
+    fn set_slot(&mut self, slot: Slot, is_ancient: bool);
     /// found `account` in the append vec
     fn found_account(&mut self, account: &LoadedAccount);
     /// scanning is done
@@ -51,11 +51,14 @@ struct ScanState<'a> {
     range: usize,
     sort_time: Arc<AtomicU64>,
     pubkey_to_bin_index: usize,
+    is_ancient: bool,
+    stats_num_zero_lamport_accounts_ancient: Arc<AtomicU64>,
 }
 
 impl<'a> AppendVecScan for ScanState<'a> {
-    fn set_slot(&mut self, slot: Slot) {
+    fn set_slot(&mut self, slot: Slot, is_ancient: bool) {
         self.current_slot = slot;
+        self.is_ancient = is_ancient;
     }
     fn filter(&mut self, pubkey: &Pubkey) -> bool {
         self.pubkey_to_bin_index = self.bin_calculator.bin_from_pubkey(pubkey);
@@ -82,6 +85,12 @@ impl<'a> AppendVecScan for ScanState<'a> {
             let computed_hash = AccountsDb::hash_account(loaded_account, loaded_account.pubkey());
             account_hash = computed_hash;
         }
+
+        if balance == 0 && self.is_ancient {
+            self.stats_num_zero_lamport_accounts_ancient
+                .fetch_add(1, Ordering::Relaxed);
+        }
+
         let source_item = CalculateHashIntermediate {
             hash: account_hash,
             lamports: balance,
@@ -135,6 +144,10 @@ impl AccountsDb {
             bin_range,
             sort_time: sort_time.clone(),
             pubkey_to_bin_index: 0,
+            is_ancient: false,
+            stats_num_zero_lamport_accounts_ancient: Arc::clone(
+                &stats.num_zero_lamport_accounts_ancient,
+            ),
         };
 
         let result = self.scan_account_storage_no_bank(
@@ -295,7 +308,7 @@ impl AccountsDb {
                                     scanner.init_accum(range);
                                     init_accum = false;
                                 }
-                                scanner.set_slot(slot);
+                                scanner.set_slot(slot, ancient);
 
                                 Self::scan_single_account_storage(storage, &mut scanner);
                             });
@@ -404,7 +417,7 @@ mod tests {
         fn filter(&mut self, _pubkey: &Pubkey) -> bool {
             true
         }
-        fn set_slot(&mut self, slot: Slot) {
+        fn set_slot(&mut self, slot: Slot, _is_ancient: bool) {
             self.current_slot = slot;
         }
         fn init_accum(&mut self, _count: usize) {}
@@ -434,7 +447,7 @@ mod tests {
     }
 
     impl AppendVecScan for TestScanSimple {
-        fn set_slot(&mut self, slot: Slot) {
+        fn set_slot(&mut self, slot: Slot, _is_ancient: bool) {
             self.current_slot = slot;
         }
         fn filter(&mut self, _pubkey: &Pubkey) -> bool {

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -207,6 +207,7 @@ pub struct HashStats {
     pub count_ancient_scans: AtomicU64,
     pub pubkey_bin_search_us: AtomicU64,
     pub num_zero_lamport_accounts: AtomicU64,
+    pub num_zero_lamport_accounts_ancient: Arc<AtomicU64>,
 }
 impl HashStats {
     pub fn calc_storage_size_quartiles(&mut self, storages: &[Arc<AccountStorageEntry>]) {
@@ -311,6 +312,12 @@ impl HashStats {
             (
                 "num_zero_lamport_accounts",
                 self.num_zero_lamport_accounts.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "num_zero_lamport_accounts_ancient",
+                self.num_zero_lamport_accounts_ancient
+                    .load(Ordering::Relaxed),
                 i64
             ),
         );


### PR DESCRIPTION
#### Problem
When we eliminate rewrites, it will become important to track whether we are succeeding in purging zero lamport accounts from ancient storages.

#### Summary of Changes
Add logging to monitor.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
