### PR TITLE
Bump platform tools version to v1.42

### DIFF
--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -913,7 +913,7 @@ fn main() {
 
     // The following line is scanned by CI configuration script to
     // separate cargo caches according to the version of platform-tools.
-    let platform_tools_version = String::from("v1.41");
+    let platform_tools_version = String::from("v1.42");
     let rust_base_version = get_base_rust_version(platform_tools_version.as_str());
     let version = format!(
         "{}\nplatform-tools {}\n{}",

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -156,7 +156,7 @@ fn find_installed_platform_tools() -> Vec<String> {
 }
 
 fn get_latest_platform_tools_version() -> Result<String, String> {
-    let url = "https://github.com/solana-labs/platform-tools/releases/latest";
+    let url = "https://github.com/anza-xyz/platform-tools/releases/latest";
     let resp = reqwest::blocking::get(url).map_err(|err| format!("Failed to GET {url}: {err}"))?;
     let path = std::path::Path::new(resp.url().path());
     let version = path.file_name().unwrap().to_string_lossy().to_string();
@@ -618,7 +618,7 @@ fn build_solana_package(
     install_if_missing(
         config,
         package,
-        "https://github.com/solana-labs/platform-tools/releases/download",
+        "https://github.com/anza-xyz/platform-tools/releases/download",
         platform_tools_download_file_name.as_str(),
         &target_path,
     )

--- a/sdk/sbf/scripts/install.sh
+++ b/sdk/sbf/scripts/install.sh
@@ -109,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install platform tools
-version=v1.41
+version=v1.42
 if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
   (
     set -e


### PR DESCRIPTION
#### Problem

Platform tools version v1.41 misses many stack errors and does not provide a good experience to developers. It still miscomplies contracts with propers warnings about their possible misbehavior during execution.

#### Summary of Changes

These problems have been fixed in the new platform tools version. It does not yet bring Rust 1.79, but it has several improvements in terms of the stack limitation in SBF.

I also updated the links in `carg-build-sbf` to `anza-xyz`.
