### PR TITLE
Adds last_full_snapshot_slot field to AccountsDb

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -817,7 +817,6 @@ impl Validator {
         let pruned_banks_request_handler = PrunedBanksRequestHandler {
             pruned_banks_receiver,
         };
-        let last_full_snapshot_slot = starting_snapshot_hashes.map(|x| x.full.0 .0);
         let accounts_background_service = AccountsBackgroundService::new(
             bank_forks.clone(),
             exit.clone(),
@@ -826,7 +825,6 @@ impl Validator {
                 pruned_banks_request_handler,
             },
             config.accounts_db_test_hash_calculation,
-            last_full_snapshot_slot,
         );
         info!(
             "Using: block-verification-method: {}, block-production-method: {}",

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -220,7 +220,6 @@ impl BackgroundServices {
                 pruned_banks_request_handler,
             },
             false,
-            None,
         );
 
         info!("Starting background services... DONE");

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -235,12 +235,7 @@ fn run_bank_forks_snapshot_n<F>(
                 .unwrap()
                 .set_root(bank.slot(), &request_sender, None)
                 .unwrap();
-            snapshot_request_handler.handle_snapshot_requests(
-                false,
-                0,
-                &mut None,
-                &AtomicBool::new(false),
-            );
+            snapshot_request_handler.handle_snapshot_requests(false, 0, &AtomicBool::new(false));
         }
     }
 
@@ -500,18 +495,14 @@ fn test_bank_forks_incremental_snapshot(
                 .unwrap()
                 .set_root(bank.slot(), &request_sender, None)
                 .unwrap();
-            snapshot_request_handler.handle_snapshot_requests(
-                false,
-                0,
-                &mut last_full_snapshot_slot,
-                &AtomicBool::new(false),
-            );
+            snapshot_request_handler.handle_snapshot_requests(false, 0, &AtomicBool::new(false));
         }
 
         // Since AccountsBackgroundService isn't running, manually make a full snapshot archive
         // at the right interval
         if snapshot_utils::should_take_full_snapshot(slot, FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS) {
             make_full_snapshot_archive(&bank, &snapshot_test_config.snapshot_config).unwrap();
+            last_full_snapshot_slot = Some(slot);
         }
         // Similarly, make an incremental snapshot archive at the right interval, but only if
         // there's been at least one full snapshot first, and a full snapshot wasn't already
@@ -731,7 +722,6 @@ fn test_snapshots_with_background_services(
         exit.clone(),
         abs_request_handler,
         false,
-        None,
     );
 
     let mut last_full_snapshot_slot = None;

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -365,7 +365,6 @@ pub fn load_and_process_ledger(
         exit.clone(),
         abs_request_handler,
         process_options.accounts_db_test_hash_calculation,
-        starting_snapshot_hashes.map(|x| x.full.0 .0),
     );
 
     let enable_rpc_transaction_history = arg_matches.is_present("enable_rpc_transaction_history");

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -336,6 +336,14 @@ fn bank_forks_from_snapshot(
         bank
     };
 
+    // We must inform accounts-db of the last full snapshot slot, which is used by the background
+    // processes to handle zero lamport accounts.  Since we've now successfully loaded the bank
+    // from snapshots, this is a good time to do that update.
+    bank.rc
+        .accounts
+        .accounts_db
+        .set_last_full_snapshot_slot(full_snapshot_archive_info.slot());
+
     let full_snapshot_hash = FullSnapshotHash((
         full_snapshot_archive_info.slot(),
         *full_snapshot_archive_info.hash(),

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -147,7 +147,6 @@ impl SnapshotRequestHandler {
         &self,
         test_hash_calculation: bool,
         non_snapshot_time_us: u128,
-        last_full_snapshot_slot: &mut Option<Slot>,
         exit: &AtomicBool,
     ) -> Option<Result<u64, SnapshotError>> {
         let (
@@ -155,7 +154,7 @@ impl SnapshotRequestHandler {
             accounts_package_kind,
             num_outstanding_requests,
             num_re_enqueued_requests,
-        ) = self.get_next_snapshot_request(*last_full_snapshot_slot)?;
+        ) = self.get_next_snapshot_request()?;
 
         datapoint_info!(
             "handle_snapshot_requests",
@@ -171,7 +170,6 @@ impl SnapshotRequestHandler {
         Some(self.handle_snapshot_request(
             test_hash_calculation,
             non_snapshot_time_us,
-            last_full_snapshot_slot,
             snapshot_request,
             accounts_package_kind,
             exit,
@@ -189,7 +187,6 @@ impl SnapshotRequestHandler {
     /// ones re-enqueued.
     fn get_next_snapshot_request(
         &self,
-        last_full_snapshot_slot: Option<Slot>,
     ) -> Option<(
         SnapshotRequest,
         AccountsPackageKind,
@@ -200,11 +197,8 @@ impl SnapshotRequestHandler {
             .snapshot_request_receiver
             .try_iter()
             .map(|request| {
-                let accounts_package_kind = new_accounts_package_kind(
-                    &request,
-                    &self.snapshot_config,
-                    last_full_snapshot_slot,
-                );
+                let accounts_package_kind =
+                    new_accounts_package_kind(&request, &self.snapshot_config);
                 (request, accounts_package_kind)
             })
             .collect();
@@ -293,7 +287,6 @@ impl SnapshotRequestHandler {
         &self,
         test_hash_calculation: bool,
         non_snapshot_time_us: u128,
-        last_full_snapshot_slot: &mut Option<Slot>,
         snapshot_request: SnapshotRequest,
         accounts_package_kind: AccountsPackageKind,
         exit: &AtomicBool,
@@ -311,7 +304,14 @@ impl SnapshotRequestHandler {
         assert!(snapshot_root_bank.is_startup_verification_complete());
 
         if accounts_package_kind == AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot) {
-            *last_full_snapshot_slot = Some(snapshot_root_bank.slot());
+            // The last full snapshot slot is what accounts-db uses to properly handle zero lamport
+            // accounts.  We are handling a full snapshot request here, and since taking a snapshot
+            // is not allowed to fail, we can update accounts-db now.
+            snapshot_root_bank
+                .rc
+                .accounts
+                .accounts_db
+                .set_last_full_snapshot_slot(snapshot_root_bank.slot());
         }
 
         let previous_accounts_hash = test_hash_calculation.then(|| {
@@ -365,7 +365,7 @@ impl SnapshotRequestHandler {
         });
 
         let mut clean_time = Measure::start("clean_time");
-        snapshot_root_bank.clean_accounts(*last_full_snapshot_slot);
+        snapshot_root_bank.clean_accounts();
         clean_time.stop();
 
         let (_, shrink_ancient_time_us) = measure_us!(snapshot_root_bank.shrink_ancient_slots());
@@ -551,13 +551,11 @@ impl AbsRequestHandlers {
         &self,
         test_hash_calculation: bool,
         non_snapshot_time_us: u128,
-        last_full_snapshot_slot: &mut Option<Slot>,
         exit: &AtomicBool,
     ) -> Option<Result<u64, SnapshotError>> {
         self.snapshot_request_handler.handle_snapshot_requests(
             test_hash_calculation,
             non_snapshot_time_us,
-            last_full_snapshot_slot,
             exit,
         )
     }
@@ -573,7 +571,6 @@ impl AccountsBackgroundService {
         exit: Arc<AtomicBool>,
         request_handlers: AbsRequestHandlers,
         test_hash_calculation: bool,
-        mut last_full_snapshot_slot: Option<Slot>,
     ) -> Self {
         let mut last_cleaned_block_height = 0;
         let mut removed_slots_count = 0;
@@ -637,7 +634,6 @@ impl AccountsBackgroundService {
                             request_handlers.handle_snapshot_requests(
                                 test_hash_calculation,
                                 non_snapshot_time,
-                                &mut last_full_snapshot_slot,
                                 &exit,
                             )
                         })
@@ -675,7 +671,7 @@ impl AccountsBackgroundService {
                             // as any later snapshots that are taken are of
                             // slots >= bank.slot()
                             bank.force_flush_accounts_cache();
-                            bank.clean_accounts(last_full_snapshot_slot);
+                            bank.clean_accounts();
                             last_cleaned_block_height = bank.block_height();
                             // See justification below for why we skip 'shrink' here.
                             if bank.is_startup_verification_complete() {
@@ -736,9 +732,14 @@ impl AccountsBackgroundService {
 fn new_accounts_package_kind(
     snapshot_request: &SnapshotRequest,
     snapshot_config: &SnapshotConfig,
-    last_full_snapshot_slot: Option<Slot>,
 ) -> AccountsPackageKind {
     let block_height = snapshot_request.snapshot_root_bank.block_height();
+    let last_full_snapshot_slot = snapshot_request
+        .snapshot_root_bank
+        .rc
+        .accounts
+        .accounts_db
+        .last_full_snapshot_slot();
     match snapshot_request.request_kind {
         SnapshotRequestKind::EpochAccountsHash => AccountsPackageKind::EpochAccountsHash,
         SnapshotRequestKind::Snapshot => {
@@ -930,6 +931,20 @@ mod test {
             .epoch_accounts_hash_manager
             .set_valid(EpochAccountsHash::new(Hash::new_unique()), 0);
 
+        // We need to get and set accounts-db's last full snapshot slot to test
+        // get_next_snapshot_request().  To workaround potential borrowing issues
+        // caused by make_banks() below, Arc::clone bank0 and add helper functions.
+        let bank0 = bank.clone();
+        fn last_full_snapshot_slot(bank: &Bank) -> Option<Slot> {
+            bank.rc.accounts.accounts_db.last_full_snapshot_slot()
+        }
+        fn set_last_full_snapshot_slot(bank: &Bank, slot: Slot) {
+            bank.rc
+                .accounts
+                .accounts_db
+                .set_last_full_snapshot_slot(slot);
+        }
+
         // Create new banks and send snapshot requests so that the following requests will be in
         // the channel before handling the requests:
         //
@@ -976,8 +991,9 @@ mod test {
         make_banks(303);
 
         // Ensure the EAH is handled 1st
+        assert_eq!(last_full_snapshot_slot(&bank0), None,);
         let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
-            .get_next_snapshot_request(None)
+            .get_next_snapshot_request()
             .unwrap();
         assert_eq!(
             accounts_package_kind,
@@ -987,19 +1003,22 @@ mod test {
 
         // Ensure the full snapshot from slot 240 is handled 2nd
         // (the older full snapshots are skipped and dropped)
+        assert_eq!(last_full_snapshot_slot(&bank0), None,);
         let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
-            .get_next_snapshot_request(None)
+            .get_next_snapshot_request()
             .unwrap();
         assert_eq!(
             accounts_package_kind,
             AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot)
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 240);
+        set_last_full_snapshot_slot(&bank0, 240);
 
         // Ensure the incremental snapshot from slot 300 is handled 3rd
         // (the older incremental snapshots are skipped and dropped)
+        assert_eq!(last_full_snapshot_slot(&bank0), Some(240),);
         let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
-            .get_next_snapshot_request(Some(240))
+            .get_next_snapshot_request()
             .unwrap();
         assert_eq!(
             accounts_package_kind,
@@ -1009,8 +1028,9 @@ mod test {
 
         // Ensure the accounts hash verifier from slot 303 is handled 4th
         // (the older accounts hash verifiers are skipped and dropped)
+        assert_eq!(last_full_snapshot_slot(&bank0), Some(240),);
         let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
-            .get_next_snapshot_request(Some(240))
+            .get_next_snapshot_request()
             .unwrap();
         assert_eq!(
             accounts_package_kind,
@@ -1019,8 +1039,9 @@ mod test {
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 303);
 
         // And now ensure the snapshot request channel is empty!
+        assert_eq!(last_full_snapshot_slot(&bank0), Some(240),);
         assert!(snapshot_request_handler
-            .get_next_snapshot_request(Some(240))
+            .get_next_snapshot_request()
             .is_none());
 
         // Create more banks and send snapshot requests so that the following requests will be in
@@ -1039,18 +1060,21 @@ mod test {
         make_banks(240);
 
         // Ensure the full snapshot is handled 1st
+        assert_eq!(last_full_snapshot_slot(&bank0), Some(240),);
         let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
-            .get_next_snapshot_request(None)
+            .get_next_snapshot_request()
             .unwrap();
         assert_eq!(
             accounts_package_kind,
             AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot)
         );
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 480);
+        set_last_full_snapshot_slot(&bank0, 480);
 
         // Ensure the EAH is handled 2nd
+        assert_eq!(last_full_snapshot_slot(&bank0), Some(480),);
         let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
-            .get_next_snapshot_request(Some(480))
+            .get_next_snapshot_request()
             .unwrap();
         assert_eq!(
             accounts_package_kind,
@@ -1059,8 +1083,9 @@ mod test {
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 500);
 
         // Ensure the incremental snapshot is handled 3rd
+        assert_eq!(last_full_snapshot_slot(&bank0), Some(480),);
         let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
-            .get_next_snapshot_request(Some(480))
+            .get_next_snapshot_request()
             .unwrap();
         assert_eq!(
             accounts_package_kind,
@@ -1069,8 +1094,9 @@ mod test {
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 540);
 
         // Ensure the accounts hash verifier is handled 4th
+        assert_eq!(last_full_snapshot_slot(&bank0), Some(480),);
         let (snapshot_request, accounts_package_kind, ..) = snapshot_request_handler
-            .get_next_snapshot_request(Some(480))
+            .get_next_snapshot_request()
             .unwrap();
         assert_eq!(
             accounts_package_kind,
@@ -1079,8 +1105,9 @@ mod test {
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 543);
 
         // And now ensure the snapshot request channel is empty!
+        assert_eq!(last_full_snapshot_slot(&bank0), Some(480),);
         assert!(snapshot_request_handler
-            .get_next_snapshot_request(Some(480))
+            .get_next_snapshot_request()
             .is_none());
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5886,7 +5886,6 @@ impl Bank {
                 self.rc.accounts.accounts_db.clean_accounts(
                     Some(last_full_snapshot_slot),
                     true,
-                    Some(last_full_snapshot_slot),
                     self.epoch_schedule(),
                 );
                 info!("Cleaning... Done.");
@@ -5901,7 +5900,6 @@ impl Bank {
                 info!("Shrinking...");
                 self.rc.accounts.accounts_db.shrink_all_slots(
                     true,
-                    Some(last_full_snapshot_slot),
                     self.epoch_schedule(),
                     // we cannot allow the snapshot slot to be shrunk
                     Some(self.slot()),
@@ -6174,7 +6172,7 @@ impl Bank {
     //
     // This fn is meant to be called by the snapshot handler in Accounts Background Service.  If
     // calling from elsewhere, ensure the same invariants hold/expectations are met.
-    pub(crate) fn clean_accounts(&self, last_full_snapshot_slot: Option<Slot>) {
+    pub(crate) fn clean_accounts(&self) {
         // Don't clean the slot we're snapshotting because it may have zero-lamport
         // accounts that were included in the bank delta hash when the bank was frozen,
         // and if we clean them here, any newly created snapshot's hash for this bank
@@ -6186,7 +6184,6 @@ impl Bank {
         self.rc.accounts.accounts_db.clean_accounts(
             Some(highest_slot_to_clean),
             false,
-            last_full_snapshot_slot,
             self.epoch_schedule(),
         );
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8511,7 +8511,7 @@ fn test_store_scan_consistency_root() {
                 current_bank.squash();
                 if current_bank.slot() % 2 == 0 {
                     current_bank.force_flush_accounts_cache();
-                    current_bank.clean_accounts(None);
+                    current_bank.clean_accounts();
                 }
                 prev_bank = current_bank.clone();
                 let slot = current_bank.slot() + 1;
@@ -12251,7 +12251,7 @@ where
         )
         .unwrap();
 
-    // super fun time; callback chooses to .clean_accounts(None) or not
+    // super fun time; callback chooses to .clean_accounts() or not
     let slot = bank.slot() + 1;
     let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
     callback(&bank);
@@ -12281,7 +12281,7 @@ fn test_create_zero_lamport_with_clean() {
         bank.force_flush_accounts_cache();
         // do clean and assert that it actually did its job
         assert_eq!(4, bank.get_snapshot_storages(None).len());
-        bank.clean_accounts(None);
+        bank.clean_accounts();
         assert_eq!(3, bank.get_snapshot_storages(None).len());
     });
 }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -823,7 +823,7 @@ mod serde_snapshot_tests {
                 pubkey_count,
                 accounts.all_account_count_in_accounts_file(shrink_slot)
             );
-            accounts.shrink_all_slots(*startup, None, &EpochSchedule::default(), None);
+            accounts.shrink_all_slots(*startup, &EpochSchedule::default(), None);
             assert_eq!(
                 pubkey_count_after_shrink,
                 accounts.all_account_count_in_accounts_file(shrink_slot)
@@ -851,7 +851,7 @@ mod serde_snapshot_tests {
                 .unwrap();
 
             // repeating should be no-op
-            accounts.shrink_all_slots(*startup, None, &epoch_schedule, None);
+            accounts.shrink_all_slots(*startup, &epoch_schedule, None);
             assert_eq!(
                 pubkey_count_after_shrink,
                 accounts.all_account_count_in_accounts_file(shrink_slot)

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -40,7 +40,7 @@ fn test_shrink_and_clean() {
             if exit_for_shrink.load(Ordering::Relaxed) {
                 break;
             }
-            accounts_for_shrink.shrink_all_slots(false, None, &EpochSchedule::default(), None);
+            accounts_for_shrink.shrink_all_slots(false, &EpochSchedule::default(), None);
         });
 
         let mut alive_accounts = vec![];


### PR DESCRIPTION
#### Problem

The last full snapshot slot is a concept used by accounts-db to properly handle zero lamport accounts. Right now, we pass the last full snapshot slot as a parameter to the functions that require it. Soon we'll be using the last full snapshot slot in more places within accounts-db. It makes sense to have accounts-db own this state.


#### Summary of Changes

Adds last_full_snapshot_slot as a field in AccountsDb.