### PR TITLE
only mark status as shrinking when we have something to shrink

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4817,7 +4817,8 @@ impl AccountsDb {
             return 0;
         }
 
-        let _guard = self.active_stats.activate(ActiveStatItem::Shrink);
+        let _guard = (!shrink_slots.is_empty())
+            .then_some(|| self.active_stats.activate(ActiveStatItem::Shrink));
 
         let mut measure_shrink_all_candidates = Measure::start("shrink_all_candidate_slots-ms");
         let num_candidates = shrink_slots.len();


### PR DESCRIPTION
#### Problem
for quite some time, we are logging that we are shrinking many times in a row. This is confusing. When shrinking is a no-op, it would be great if we didn't log we were shrinking.

#### Summary of Changes
only set the active state for shrinking when we have shrinking to do.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
