### PR TITLE
refactor: rename `NoncePartial` to `NonceInfo`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -158,7 +158,7 @@ use {
         },
         account_overrides::AccountOverrides,
         account_saver::collect_accounts_to_store,
-        nonce_info::NoncePartial,
+        nonce_info::NonceInfo,
         transaction_commit_result::{CommittedTransaction, TransactionCommitResult},
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_execution_result::{
@@ -3537,7 +3537,7 @@ impl Bank {
     fn load_message_nonce_account(
         &self,
         message: &SanitizedMessage,
-    ) -> Option<(NoncePartial, nonce::state::Data)> {
+    ) -> Option<(NonceInfo, nonce::state::Data)> {
         let nonce_address = message.get_durable_nonce()?;
         let nonce_account = self.get_account_with_fixed_root(nonce_address)?;
         let nonce_data =
@@ -3550,14 +3550,14 @@ impl Bank {
             return None;
         }
 
-        Some((NoncePartial::new(*nonce_address, nonce_account), nonce_data))
+        Some((NonceInfo::new(*nonce_address, nonce_account), nonce_data))
     }
 
     fn check_and_load_message_nonce_account(
         &self,
         message: &SanitizedMessage,
         next_durable_nonce: &DurableNonce,
-    ) -> Option<(NoncePartial, nonce::state::Data)> {
+    ) -> Option<(NonceInfo, nonce::state::Data)> {
         let nonce_is_advanceable = message.recent_blockhash() != next_durable_nonce.as_hash();
         if nonce_is_advanceable {
             self.load_message_nonce_account(message)

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -101,7 +101,7 @@ use {
     },
     solana_stake_program::stake_state::{self, StakeStateV2},
     solana_svm::{
-        account_loader::LoadedTransaction, nonce_info::NoncePartial,
+        account_loader::LoadedTransaction, nonce_info::NonceInfo,
         transaction_commit_result::TransactionCommitResultExtensions,
         transaction_execution_result::ExecutedTransaction,
     },
@@ -4946,7 +4946,7 @@ fn test_check_and_load_message_nonce_account_ok() {
     let nonce_data = get_nonce_data_from_account(&nonce_account).unwrap();
     assert_eq!(
         bank.check_and_load_message_nonce_account(&message, &bank.next_durable_nonce()),
-        Some((NoncePartial::new(nonce_pubkey, nonce_account), nonce_data))
+        Some((NonceInfo::new(nonce_pubkey, nonce_account), nonce_data))
     );
 }
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1,8 +1,7 @@
 use {
     crate::{
-        account_overrides::AccountOverrides, account_rent_state::RentState,
-        nonce_info::NoncePartial, rollback_accounts::RollbackAccounts,
-        transaction_error_metrics::TransactionErrorMetrics,
+        account_overrides::AccountOverrides, account_rent_state::RentState, nonce_info::NonceInfo,
+        rollback_accounts::RollbackAccounts, transaction_error_metrics::TransactionErrorMetrics,
         transaction_processing_callback::TransactionProcessingCallback,
     },
     itertools::Itertools,
@@ -37,7 +36,7 @@ pub type TransactionLoadResult = Result<LoadedTransaction>;
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CheckedTransactionDetails {
-    pub nonce: Option<NoncePartial>,
+    pub nonce: Option<NonceInfo>,
     pub lamports_per_signature: u64,
 }
 

--- a/svm/src/account_saver.rs
+++ b/svm/src/account_saver.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        nonce_info::NonceInfo, rollback_accounts::RollbackAccounts,
+        rollback_accounts::RollbackAccounts,
         transaction_execution_result::TransactionExecutionResult,
     },
     solana_sdk::{
@@ -144,7 +144,7 @@ mod tests {
         super::*,
         crate::{
             account_loader::LoadedTransaction,
-            nonce_info::NoncePartial,
+            nonce_info::NonceInfo,
             transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
         },
         solana_compute_budget::compute_budget_processor::ComputeBudgetLimits,
@@ -383,7 +383,7 @@ mod tests {
             AccountSharedData::new_data(42, &nonce_state, &system_program::id()).unwrap();
         let from_account_pre = AccountSharedData::new(4242, 0, &Pubkey::default());
 
-        let nonce = NoncePartial::new(nonce_address, nonce_account_pre.clone());
+        let nonce = NonceInfo::new(nonce_address, nonce_account_pre.clone());
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
             program_indices: vec![],
@@ -482,7 +482,7 @@ mod tests {
         let nonce_account_pre =
             AccountSharedData::new_data(42, &nonce_state, &system_program::id()).unwrap();
 
-        let nonce = NoncePartial::new(nonce_address, nonce_account_pre.clone());
+        let nonce = NonceInfo::new(nonce_address, nonce_account_pre.clone());
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
             program_indices: vec![],

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -1,5 +1,5 @@
 use {
-    crate::nonce_info::{NonceInfo, NoncePartial},
+    crate::nonce_info::NonceInfo,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         clock::Epoch,
@@ -15,10 +15,10 @@ pub enum RollbackAccounts {
         fee_payer_account: AccountSharedData,
     },
     SameNonceAndFeePayer {
-        nonce: NoncePartial,
+        nonce: NonceInfo,
     },
     SeparateNonceAndFeePayer {
-        nonce: NoncePartial,
+        nonce: NonceInfo,
         fee_payer_account: AccountSharedData,
     },
 }
@@ -34,7 +34,7 @@ impl Default for RollbackAccounts {
 
 impl RollbackAccounts {
     pub fn new(
-        nonce: Option<NoncePartial>,
+        nonce: Option<NonceInfo>,
         fee_payer_address: Pubkey,
         mut fee_payer_account: AccountSharedData,
         fee_payer_rent_debit: u64,
@@ -52,7 +52,7 @@ impl RollbackAccounts {
         if let Some(nonce) = nonce {
             if &fee_payer_address == nonce.address() {
                 RollbackAccounts::SameNonceAndFeePayer {
-                    nonce: NoncePartial::new(fee_payer_address, fee_payer_account),
+                    nonce: NonceInfo::new(fee_payer_address, fee_payer_account),
                 }
             } else {
                 RollbackAccounts::SeparateNonceAndFeePayer {
@@ -149,7 +149,7 @@ mod tests {
             account
         };
 
-        let nonce = NoncePartial::new(nonce_address, rent_collected_nonce_account.clone());
+        let nonce = NonceInfo::new(nonce_address, rent_collected_nonce_account.clone());
         let rollback_accounts = RollbackAccounts::new(
             Some(nonce),
             nonce_address,
@@ -193,7 +193,7 @@ mod tests {
             account
         };
 
-        let nonce = NoncePartial::new(nonce_address, nonce_account.clone());
+        let nonce = NonceInfo::new(nonce_address, nonce_account.clone());
         let rollback_accounts = RollbackAccounts::new(
             Some(nonce),
             fee_payer_address,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -969,7 +969,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            account_loader::ValidatedTransactionDetails, nonce_info::NoncePartial,
+            account_loader::ValidatedTransactionDetails, nonce_info::NonceInfo,
             rollback_accounts::RollbackAccounts,
         },
         solana_compute_budget::compute_budget_processor::ComputeBudgetLimits,
@@ -2145,7 +2145,7 @@ mod tests {
 
             let mut error_counters = TransactionErrorMetrics::default();
             let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-            let nonce = Some(NoncePartial::new(
+            let nonce = Some(NonceInfo::new(
                 *fee_payer_address,
                 fee_payer_account.clone(),
             ));


### PR DESCRIPTION
#### Problem
Now that `NonceFull` has been removed, we don't need a trait for nonce info anymore, we can just use the `NoncePartial` struct directly. And in the absence of a "full" version of nonce info, we can rename the struct to `NonceInfo`.

#### Summary of Changes
- Rename `NoncePartial` to `NonceInfo`
- Remove `NonceInfo` trait and remove unused methods

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
