### PR TITLE
Roll back poh

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2043,7 +2043,7 @@ impl ReplayStage {
         assert!(!poh_recorder.read().unwrap().has_bank());
 
         let (poh_slot, parent_slot) =
-            match poh_recorder.read().unwrap().reached_leader_slot(my_pubkey) {
+            match poh_recorder.write().unwrap().reached_leader_slot(my_pubkey) {
                 PohLeaderStatus::Reached {
                     poh_slot,
                     parent_slot,


### PR DESCRIPTION
Note: I consider this solution controversial. This PR is intended to aid a discussion on the right way to fix this issue.

#### Problem
Nodes that respect grace ticks kind of get screwed by missing out on their leader slots

#### Summary of Changes
Roll back PoH to the start of a leader's set of slots once it determines it is time to be leader.