### PR TITLE
extends Turbine fanout experiment to wider fanout values

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -841,6 +841,10 @@ pub mod vote_only_retransmitter_signed_fec_sets {
     solana_sdk::declare_id!("RfEcA95xnhuwooVAhUUksEJLZBF7xKCLuqrJoqk4Zph");
 }
 
+pub mod enable_turbine_extended_fanout_experiments {
+    solana_sdk::declare_id!("BZn14Liea52wtBwrXUxTv6vojuTTmfc7XGEDTXrvMD7b");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -1046,6 +1050,7 @@ lazy_static! {
         (move_stake_and_move_lamports_ixs::id(), "Enable MoveStake and MoveLamports stake program instructions #1610"),
         (ed25519_precompile_verify_strict::id(), "Use strict verification in ed25519 precompile SIMD-0152"),
         (vote_only_retransmitter_signed_fec_sets::id(), "vote only on retransmitter signed fec sets"),
+        (enable_turbine_extended_fanout_experiments::id(), "enable turbine extended fanout experiments #"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Based on previous Turbine fanout experiment, larger fanouts are more effective in propagating shreds and reducing repairs: https://discord.com/channels/428295358100013066/478692221441409024/1265782094211321897

However the optimal fanout value cannot be inferred from the experiment.

#### Summary of Changes
In order to identify optimal fanout value, this commit extends the experiment with wider fanout values.
