### PR TITLE
refactor: move statically defined builtin default costs map from solana-cost-model to its own crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5769,6 +5769,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-builtins-default-costs"
+version = "2.1.0"
+dependencies = [
+ "ahash 0.8.10",
+ "lazy_static",
+ "log",
+ "rand 0.8.5",
+ "rustc_version 0.4.0",
+ "solana-address-lookup-table-program",
+ "solana-bpf-loader-program",
+ "solana-compute-budget-program",
+ "solana-config-program",
+ "solana-frozen-abi",
+ "solana-loader-v4-program",
+ "solana-sdk",
+ "solana-stake-program",
+ "solana-system-program",
+ "solana-vote-program",
+]
+
+[[package]]
 name = "solana-cargo-build-sbf"
 version = "2.1.0"
 dependencies = [
@@ -6096,6 +6117,7 @@ dependencies = [
  "serial_test",
  "solana-accounts-db",
  "solana-bloom",
+ "solana-builtins-default-costs",
  "solana-client",
  "solana-compute-budget",
  "solana-connection-cache",
@@ -6159,18 +6181,13 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustc_version 0.4.0",
- "solana-address-lookup-table-program",
- "solana-bpf-loader-program",
+ "solana-builtins-default-costs",
  "solana-compute-budget",
- "solana-compute-budget-program",
- "solana-config-program",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-loader-v4-program",
  "solana-logger",
  "solana-metrics",
  "solana-sdk",
- "solana-stake-program",
  "solana-system-program",
  "solana-vote-program",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "bench-tps",
     "bloom",
     "bucket_map",
+    "builtins-default-costs",
     "cargo-registry",
     "clap-utils",
     "clap-v3-utils",
@@ -343,6 +344,7 @@ solana-bloom = { path = "bloom", version = "=2.1.0" }
 solana-bn254 = { path = "curves/bn254", version = "=2.1.0" }
 solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.1.0" }
 solana-bucket-map = { path = "bucket_map", version = "=2.1.0" }
+solana-builtins-default-costs = { path = "builtins-default-costs", version = "=2.1.0" }
 agave-cargo-registry = { path = "cargo-registry", version = "=2.1.0" }
 solana-clap-utils = { path = "clap-utils", version = "=2.1.0" }
 solana-clap-v3-utils = { path = "clap-v3-utils", version = "=2.1.0" }

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "solana-builtins-default-costs"
+description = "Solana builtins default costs"
+documentation = "https://docs.rs/solana-builtins-default-costs"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+ahash = { workspace = true }
+lazy_static = { workspace = true }
+log = { workspace = true }
+solana-address-lookup-table-program = { workspace = true }
+solana-bpf-loader-program = { workspace = true }
+solana-compute-budget-program = { workspace = true }
+solana-config-program = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-loader-v4-program = { workspace = true }
+solana-sdk = { workspace = true }
+solana-stake-program = { workspace = true }
+solana-system-program = { workspace = true }
+solana-vote-program = { workspace = true }
+# Add additional builtin programs here
+
+[lib]
+crate-type = ["lib"]
+name = "solana_builtins_default_costs"
+
+[dev-dependencies]
+rand = "0.8.5"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[build-dependencies]
+rustc_version = { workspace = true }
+
+[features]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "solana-vote-program/frozen-abi",
+]

--- a/builtins-default-costs/benches/builtin_instruction_costs.rs
+++ b/builtins-default-costs/benches/builtin_instruction_costs.rs
@@ -2,7 +2,7 @@
 extern crate test;
 use {
     rand::Rng,
-    solana_cost_model::block_cost_limits::BUILTIN_INSTRUCTION_COSTS,
+    solana_builtins_default_costs::BUILTIN_INSTRUCTION_COSTS,
     solana_sdk::{
         address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
         compute_budget, ed25519_program, loader_v4, pubkey::Pubkey, secp256k1_program,

--- a/builtins-default-costs/build.rs
+++ b/builtins-default-costs/build.rs
@@ -1,0 +1,1 @@
+../frozen-abi/build.rs

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -1,0 +1,33 @@
+#![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
+#![allow(clippy::arithmetic_side_effects)]
+use {
+    ahash::AHashMap,
+    lazy_static::lazy_static,
+    solana_sdk::{
+        address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
+        compute_budget, ed25519_program, loader_v4, pubkey::Pubkey, secp256k1_program,
+    },
+};
+
+// Number of compute units for each built-in programs
+lazy_static! {
+    /// Number of compute units for each built-in programs
+    pub static ref BUILTIN_INSTRUCTION_COSTS: AHashMap<Pubkey, u64> = [
+        (solana_stake_program::id(), solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS),
+        (solana_config_program::id(), solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS),
+        (solana_vote_program::id(), solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS),
+        (solana_system_program::id(), solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS),
+        (compute_budget::id(), solana_compute_budget_program::DEFAULT_COMPUTE_UNITS),
+        (address_lookup_table::program::id(), solana_address_lookup_table_program::processor::DEFAULT_COMPUTE_UNITS),
+        (bpf_loader_upgradeable::id(), solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS),
+        (bpf_loader_deprecated::id(), solana_bpf_loader_program::DEPRECATED_LOADER_COMPUTE_UNITS),
+        (bpf_loader::id(), solana_bpf_loader_program::DEFAULT_LOADER_COMPUTE_UNITS),
+        (loader_v4::id(), solana_loader_v4_program::DEFAULT_COMPUTE_UNITS),
+        // Note: These are precompile, run directly in bank during sanitizing;
+        (secp256k1_program::id(), 0),
+        (ed25519_program::id(), 0),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -46,6 +46,7 @@ serde_bytes = { workspace = true }
 serde_derive = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-bloom = { workspace = true }
+solana-builtins-default-costs = { workspace = true }
 solana-client = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-connection-cache = { workspace = true }

--- a/core/src/banking_stage/packet_filter.rs
+++ b/core/src/banking_stage/packet_filter.rs
@@ -1,6 +1,6 @@
 use {
     super::immutable_deserialized_packet::ImmutableDeserializedPacket,
-    solana_cost_model::block_cost_limits::BUILTIN_INSTRUCTION_COSTS,
+    solana_builtins_default_costs::BUILTIN_INSTRUCTION_COSTS,
     solana_sdk::{ed25519_program, saturating_add_assign, secp256k1_program},
     thiserror::Error,
 };

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -13,18 +13,12 @@ edition = { workspace = true }
 ahash = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
-solana-address-lookup-table-program = { workspace = true }
-solana-bpf-loader-program = { workspace = true }
+solana-builtins-default-costs = { workspace = true }
 solana-compute-budget = { workspace = true }
-solana-compute-budget-program = { workspace = true }
-solana-config-program = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
-solana-loader-v4-program = { workspace = true }
 solana-metrics = { workspace = true }
 solana-sdk = { workspace = true }
-solana-stake-program = { workspace = true }
-solana-system-program = { workspace = true }
 solana-vote-program = { workspace = true }
 
 [lib]
@@ -36,6 +30,7 @@ itertools = { workspace = true }
 rand = "0.8.5"
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
+solana-system-program = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/cost-model/src/block_cost_limits.rs
+++ b/cost-model/src/block_cost_limits.rs
@@ -1,13 +1,5 @@
 //! defines block cost related limits
 //!
-use {
-    ahash::AHashMap,
-    lazy_static::lazy_static,
-    solana_sdk::{
-        address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
-        compute_budget, ed25519_program, loader_v4, pubkey::Pubkey, secp256k1_program,
-    },
-};
 
 /// Static configurations:
 ///
@@ -34,28 +26,6 @@ pub const ED25519_VERIFY_STRICT_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 80;
 pub const WRITE_LOCK_UNITS: u64 = COMPUTE_UNIT_TO_US_RATIO * 10;
 /// Number of data bytes per compute units
 pub const INSTRUCTION_DATA_BYTES_COST: u64 = 140 /*bytes per us*/ / COMPUTE_UNIT_TO_US_RATIO;
-// Number of compute units for each built-in programs
-lazy_static! {
-    /// Number of compute units for each built-in programs
-    pub static ref BUILTIN_INSTRUCTION_COSTS: AHashMap<Pubkey, u64> = [
-        (solana_stake_program::id(), solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS),
-        (solana_config_program::id(), solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS),
-        (solana_vote_program::id(), solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS),
-        (solana_system_program::id(), solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS),
-        (compute_budget::id(), solana_compute_budget_program::DEFAULT_COMPUTE_UNITS),
-        (address_lookup_table::program::id(), solana_address_lookup_table_program::processor::DEFAULT_COMPUTE_UNITS),
-        (bpf_loader_upgradeable::id(), solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS),
-        (bpf_loader_deprecated::id(), solana_bpf_loader_program::DEPRECATED_LOADER_COMPUTE_UNITS),
-        (bpf_loader::id(), solana_bpf_loader_program::DEFAULT_LOADER_COMPUTE_UNITS),
-        (loader_v4::id(), solana_loader_v4_program::DEFAULT_COMPUTE_UNITS),
-        // Note: These are precompile, run directly in bank during sanitizing;
-        (secp256k1_program::id(), 0),
-        (ed25519_program::id(), 0),
-    ]
-    .iter()
-    .cloned()
-    .collect();
-}
 
 /// Statically computed data:
 ///

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -8,6 +8,7 @@
 use {
     crate::{block_cost_limits::*, transaction_cost::*},
     log::*,
+    solana_builtins_default_costs::BUILTIN_INSTRUCTION_COSTS,
     solana_compute_budget::compute_budget_processor::{
         process_compute_budget_instructions, DEFAULT_HEAP_COST,
         DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT, MAX_COMPUTE_UNIT_LIMIT,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4661,6 +4661,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-builtins-default-costs"
+version = "2.1.0"
+dependencies = [
+ "ahash 0.8.10",
+ "lazy_static",
+ "log",
+ "rustc_version",
+ "solana-address-lookup-table-program",
+ "solana-bpf-loader-program",
+ "solana-compute-budget-program",
+ "solana-config-program",
+ "solana-loader-v4-program",
+ "solana-sdk",
+ "solana-stake-program",
+ "solana-system-program",
+ "solana-vote-program",
+]
+
+[[package]]
 name = "solana-clap-utils"
 version = "2.1.0"
 dependencies = [
@@ -4831,6 +4850,7 @@ dependencies = [
  "serde_derive",
  "solana-accounts-db",
  "solana-bloom",
+ "solana-builtins-default-costs",
  "solana-client",
  "solana-compute-budget",
  "solana-connection-cache",
@@ -4883,16 +4903,10 @@ dependencies = [
  "lazy_static",
  "log",
  "rustc_version",
- "solana-address-lookup-table-program",
- "solana-bpf-loader-program",
+ "solana-builtins-default-costs",
  "solana-compute-budget",
- "solana-compute-budget-program",
- "solana-config-program",
- "solana-loader-v4-program",
  "solana-metrics",
  "solana-sdk",
- "solana-stake-program",
- "solana-system-program",
  "solana-vote-program",
 ]
 


### PR DESCRIPTION
 #### Problem
Makes sharing builtin costs between crates easier

#### Summary of Changes
- move named static map to `solana_builtins_default_cost` crate

Fixes #2351

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
