### PR TITLE
Removes unnecessary copy in LtHash::with()

### DIFF
--- a/lattice-hash/src/lt_hash.rs
+++ b/lattice-hash/src/lt_hash.rs
@@ -1,6 +1,6 @@
 use {
     base64::{display::Base64Display, prelude::BASE64_STANDARD},
-    std::{fmt, mem::size_of},
+    std::fmt,
 };
 
 /// A 16-bit, 1024 element lattice-based incremental hash based on blake3
@@ -20,9 +20,9 @@ impl LtHash {
     #[must_use]
     pub fn with(hasher: &blake3::Hasher) -> Self {
         let mut reader = hasher.finalize_xof();
-        let mut buffer = [0; size_of::<Self>()];
-        reader.fill(&mut buffer);
-        Self(bytemuck::must_cast(buffer))
+        let mut inner = [0; Self::NUM_ELEMENTS];
+        reader.fill(bytemuck::must_cast_slice_mut(inner.as_mut_slice()));
+        Self(inner)
     }
 
     /// Mixes `other` into `self`


### PR DESCRIPTION
#### Problem

If the alignment of the source is less than the destination, `bytemuck::must_cast()` does a copy! The whole point was to not copy...

I saw this because I realized the buffer is `[u8]`, and didn't understand how it was able to cast to `[u16]` while still respecting alignment. Turns out the impl checks for this, and does a copy as the way to solve for it. Boo.


#### Summary of Changes

Instead, create the inner array of u16s, and then cast that to bytes.

Crucially, `bytemuck::must_cast_slice_mut()` does *not* do a copy. It enforces the alignments and sizes are correct, and then does the expected casting. This way something changes and the invariants are broken, it will fail to compile.