### PR TITLE
refactor: bank transaction counts

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -74,10 +74,7 @@ impl Committer {
         bank: &Arc<Bank>,
         pre_balance_info: &mut PreBalanceInfo,
         execute_and_commit_timings: &mut LeaderExecuteAndCommitTimings,
-        signature_count: u64,
-        executed_transactions_count: usize,
-        executed_non_vote_transactions_count: usize,
-        executed_with_successful_result_count: usize,
+        execution_counts: &ExecutedTransactionCounts,
     ) -> (u64, Vec<CommitTransactionDetails>) {
         let executed_transactions = execution_results
             .iter()
@@ -90,14 +87,7 @@ impl Committer {
             execution_results,
             last_blockhash,
             lamports_per_signature,
-            ExecutedTransactionCounts {
-                executed_transactions_count: executed_transactions_count as u64,
-                executed_non_vote_transactions_count: executed_non_vote_transactions_count as u64,
-                executed_with_failure_result_count: executed_transactions_count
-                    .saturating_sub(executed_with_successful_result_count)
-                    as u64,
-                signature_count,
-            },
+            execution_counts,
             &mut execute_and_commit_timings.execute_timings,
         ));
         execute_and_commit_timings.commit_us = commit_time_us;

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -224,9 +224,7 @@ impl ConsumeWorkerMetrics {
     fn update_on_execute_and_commit_transactions_output(
         &self,
         ExecuteAndCommitTransactionsOutput {
-            transactions_attempted_execution_count,
-            executed_transactions_count,
-            executed_with_successful_result_count,
+            transaction_counts,
             retryable_transaction_indexes,
             execute_and_commit_timings,
             error_counters,
@@ -237,13 +235,19 @@ impl ConsumeWorkerMetrics {
     ) {
         self.count_metrics
             .transactions_attempted_execution_count
-            .fetch_add(*transactions_attempted_execution_count, Ordering::Relaxed);
+            .fetch_add(
+                transaction_counts.attempted_execution_count,
+                Ordering::Relaxed,
+            );
         self.count_metrics
             .executed_transactions_count
-            .fetch_add(*executed_transactions_count, Ordering::Relaxed);
+            .fetch_add(transaction_counts.executed_count, Ordering::Relaxed);
         self.count_metrics
             .executed_with_successful_result_count
-            .fetch_add(*executed_with_successful_result_count, Ordering::Relaxed);
+            .fetch_add(
+                transaction_counts.executed_with_successful_result_count,
+                Ordering::Relaxed,
+            );
         self.count_metrics
             .retryable_transaction_count
             .fetch_add(retryable_transaction_indexes.len(), Ordering::Relaxed);
@@ -406,12 +410,12 @@ impl ConsumeWorkerMetrics {
 }
 
 struct ConsumeWorkerCountMetrics {
-    transactions_attempted_execution_count: AtomicUsize,
-    executed_transactions_count: AtomicUsize,
-    executed_with_successful_result_count: AtomicUsize,
+    transactions_attempted_execution_count: AtomicU64,
+    executed_transactions_count: AtomicU64,
+    executed_with_successful_result_count: AtomicU64,
     retryable_transaction_count: AtomicUsize,
     retryable_expired_bank_count: AtomicUsize,
-    cost_model_throttled_transactions_count: AtomicUsize,
+    cost_model_throttled_transactions_count: AtomicU64,
     min_prioritization_fees: AtomicU64,
     max_prioritization_fees: AtomicU64,
 }
@@ -419,12 +423,12 @@ struct ConsumeWorkerCountMetrics {
 impl Default for ConsumeWorkerCountMetrics {
     fn default() -> Self {
         Self {
-            transactions_attempted_execution_count: AtomicUsize::default(),
-            executed_transactions_count: AtomicUsize::default(),
-            executed_with_successful_result_count: AtomicUsize::default(),
+            transactions_attempted_execution_count: AtomicU64::default(),
+            executed_transactions_count: AtomicU64::default(),
+            executed_with_successful_result_count: AtomicU64::default(),
             retryable_transaction_count: AtomicUsize::default(),
             retryable_expired_bank_count: AtomicUsize::default(),
-            cost_model_throttled_transactions_count: AtomicUsize::default(),
+            cost_model_throttled_transactions_count: AtomicU64::default(),
             min_prioritization_fees: AtomicU64::new(u64::MAX),
             max_prioritization_fees: AtomicU64::default(),
         }

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -23,27 +23,29 @@ use {
 /// 3) Were executed and committed, captured by `transaction_counts` below.
 /// 4) Were executed and failed commit, captured by `transaction_counts` below.
 pub(crate) struct ProcessTransactionsSummary {
-    // Returns true if we hit the end of the block/max PoH height for the block before
-    // processing all the transactions in the batch.
+    /// Returns true if we hit the end of the block/max PoH height for the block
+    /// before processing all the transactions in the batch.
     pub reached_max_poh_height: bool,
 
-    // Total transaction counts tracked for reporting `LeaderSlotMetrics`. See
-    // description of struct above for possible outcomes for these transactions
+    /// Total transaction counts tracked for reporting `LeaderSlotMetrics`. See
+    /// description of struct above for possible outcomes for these transactions
     pub transaction_counts: ProcessTransactionsCounts,
 
-    // Indexes of transactions in the transactions slice that were not committed but are retryable
+    /// Indexes of transactions in the transactions slice that were not
+    /// committed but are retryable
     pub retryable_transaction_indexes: Vec<usize>,
 
-    // The number of transactions filtered out by the cost model
+    /// The number of transactions filtered out by the cost model
     pub cost_model_throttled_transactions_count: u64,
 
-    // Total amount of time spent running the cost model
+    /// Total amount of time spent running the cost model
     pub cost_model_us: u64,
 
-    // Breakdown of time spent executing and committing transactions
+    /// Breakdown of time spent executing and committing transactions
     pub execute_and_commit_timings: LeaderExecuteAndCommitTimings,
 
-    // Breakdown of all the transaction errors from transactions passed for execution
+    /// Breakdown of all the transaction errors from transactions passed for
+    /// execution
     pub error_counters: TransactionErrorMetrics,
 
     pub min_prioritization_fees: u64,
@@ -52,15 +54,15 @@ pub(crate) struct ProcessTransactionsSummary {
 
 #[derive(Debug, Default, PartialEq)]
 pub struct ProcessTransactionsCounts {
-    // Total number of transactions that were passed as candidates for execution
+    /// Total number of transactions that were passed as candidates for execution
     pub attempted_execution_count: u64,
-    // Total number of transactions that made it into the block
+    /// Total number of transactions that made it into the block
     pub committed_transactions_count: u64,
-    // Total number of transactions that made it into the block where the transactions
-    // output from execution was success/no error.
+    /// Total number of transactions that made it into the block where the
+    /// transactions output from execution was success/no error.
     pub committed_transactions_with_successful_result_count: u64,
-    // All transactions that were executed but then failed record because the
-    // slot ended
+    /// All transactions that were executed but then failed record because the
+    /// slot ended
     pub executed_but_failed_commit: u64,
 }
 

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -1,5 +1,6 @@
 use {
     super::{
+        consumer::ExecuteAndCommitTransactionsCounts,
         leader_slot_timing_metrics::{LeaderExecuteAndCommitTimings, LeaderSlotTimingMetrics},
         packet_deserializer::PacketReceiverStats,
         unprocessed_transaction_storage::{
@@ -19,33 +20,22 @@ use {
 /// counted in `Self::retryable_transaction_indexes`.
 /// 2) Did not execute due to some fatal error like too old, or duplicate signature. These
 /// will be dropped from the transactions queue and not counted in `Self::retryable_transaction_indexes`
-/// 3) Were executed and committed, captured by `committed_transactions_count` below.
-/// 4) Were executed and failed commit, captured by `failed_commit_count` below.
+/// 3) Were executed and committed, captured by `transaction_counts` below.
+/// 4) Were executed and failed commit, captured by `transaction_counts` below.
 pub(crate) struct ProcessTransactionsSummary {
     // Returns true if we hit the end of the block/max PoH height for the block before
     // processing all the transactions in the batch.
     pub reached_max_poh_height: bool,
 
-    // Total number of transactions that were passed as candidates for execution. See description
-    // of struct above for possible outcomes for these transactions
-    pub transactions_attempted_execution_count: usize,
-
-    // Total number of transactions that made it into the block
-    pub committed_transactions_count: usize,
-
-    // Total number of transactions that made it into the block where the transactions
-    // output from execution was success/no error.
-    pub committed_transactions_with_successful_result_count: usize,
-
-    // All transactions that were executed but then failed record because the
-    // slot ended
-    pub failed_commit_count: usize,
+    // Total transaction counts tracked for reporting `LeaderSlotMetrics`. See
+    // description of struct above for possible outcomes for these transactions
+    pub transaction_counts: ProcessTransactionsCounts,
 
     // Indexes of transactions in the transactions slice that were not committed but are retryable
     pub retryable_transaction_indexes: Vec<usize>,
 
     // The number of transactions filtered out by the cost model
-    pub cost_model_throttled_transactions_count: usize,
+    pub cost_model_throttled_transactions_count: u64,
 
     // Total amount of time spent running the cost model
     pub cost_model_us: u64,
@@ -58,6 +48,48 @@ pub(crate) struct ProcessTransactionsSummary {
 
     pub min_prioritization_fees: u64,
     pub max_prioritization_fees: u64,
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct ProcessTransactionsCounts {
+    // Total number of transactions that were passed as candidates for execution
+    pub attempted_execution_count: u64,
+    // Total number of transactions that made it into the block
+    pub committed_transactions_count: u64,
+    // Total number of transactions that made it into the block where the transactions
+    // output from execution was success/no error.
+    pub committed_transactions_with_successful_result_count: u64,
+    // All transactions that were executed but then failed record because the
+    // slot ended
+    pub executed_but_failed_commit: u64,
+}
+
+impl ProcessTransactionsCounts {
+    pub fn accumulate(
+        &mut self,
+        transaction_counts: &ExecuteAndCommitTransactionsCounts,
+        committed: bool,
+    ) {
+        saturating_add_assign!(
+            self.attempted_execution_count,
+            transaction_counts.attempted_execution_count
+        );
+        if committed {
+            saturating_add_assign!(
+                self.committed_transactions_count,
+                transaction_counts.executed_count
+            );
+            saturating_add_assign!(
+                self.committed_transactions_with_successful_result_count,
+                transaction_counts.executed_with_successful_result_count
+            );
+        } else {
+            saturating_add_assign!(
+                self.executed_but_failed_commit,
+                transaction_counts.executed_count
+            );
+        }
+    }
 }
 
 // Metrics describing prioritization fee information for each transaction storage before processing transactions
@@ -559,10 +591,7 @@ impl LeaderSlotMetricsTracker {
     ) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
             let ProcessTransactionsSummary {
-                transactions_attempted_execution_count,
-                committed_transactions_count,
-                committed_transactions_with_successful_result_count,
-                failed_commit_count,
+                transaction_counts,
                 ref retryable_transaction_indexes,
                 cost_model_throttled_transactions_count,
                 cost_model_us,
@@ -577,28 +606,28 @@ impl LeaderSlotMetricsTracker {
                 leader_slot_metrics
                     .packet_count_metrics
                     .transactions_attempted_execution_count,
-                *transactions_attempted_execution_count as u64
+                transaction_counts.attempted_execution_count
             );
 
             saturating_add_assign!(
                 leader_slot_metrics
                     .packet_count_metrics
                     .committed_transactions_count,
-                *committed_transactions_count as u64
+                transaction_counts.committed_transactions_count
             );
 
             saturating_add_assign!(
                 leader_slot_metrics
                     .packet_count_metrics
                     .committed_transactions_with_successful_result_count,
-                *committed_transactions_with_successful_result_count as u64
+                transaction_counts.committed_transactions_with_successful_result_count
             );
 
             saturating_add_assign!(
                 leader_slot_metrics
                     .packet_count_metrics
                     .executed_transactions_failed_commit_count,
-                *failed_commit_count as u64
+                transaction_counts.executed_but_failed_commit
             );
 
             saturating_add_assign!(
@@ -612,9 +641,10 @@ impl LeaderSlotMetricsTracker {
                 leader_slot_metrics
                     .packet_count_metrics
                     .nonretryable_errored_transactions_count,
-                transactions_attempted_execution_count
-                    .saturating_sub(*committed_transactions_count)
-                    .saturating_sub(retryable_transaction_indexes.len()) as u64
+                transaction_counts
+                    .attempted_execution_count
+                    .saturating_sub(transaction_counts.committed_transactions_count)
+                    .saturating_sub(retryable_transaction_indexes.len() as u64)
             );
 
             saturating_add_assign!(
@@ -635,7 +665,7 @@ impl LeaderSlotMetricsTracker {
                 leader_slot_metrics
                     .packet_count_metrics
                     .cost_model_throttled_transactions_count,
-                *cost_model_throttled_transactions_count as u64
+                *cost_model_throttled_transactions_count
             );
 
             saturating_add_assign!(

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -44,7 +44,7 @@ impl QosService {
         bank: &Bank,
         transactions: &[SanitizedTransaction],
         pre_results: impl Iterator<Item = transaction::Result<()>>,
-    ) -> (Vec<transaction::Result<TransactionCost>>, usize) {
+    ) -> (Vec<transaction::Result<TransactionCost>>, u64) {
         let transaction_costs =
             self.compute_transaction_costs(&bank.feature_set, transactions.iter(), pre_results);
         let (transactions_qos_cost_results, num_included) = self.select_transactions_per_cost(
@@ -56,7 +56,7 @@ impl QosService {
             transactions_qos_cost_results.iter(),
         ));
         let cost_model_throttled_transactions_count =
-            transactions.len().saturating_sub(num_included);
+            transactions.len().saturating_sub(num_included) as u64;
 
         (
             transactions_qos_cost_results,


### PR DESCRIPTION
#### Problem
Hard to follow how transaction counts are used throughout the runtime

#### Summary of Changes
- Extract a few new structs for tracking transaction counts: `ExecuteAndCommitTransactionsCounts`  and `ProcessTransactionsCounts`
- Switch to `u64` from `usize` for a number of counts

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
