### PR TITLE
Upgrades rust stable toolchain to 1.80.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.80.0"


### PR DESCRIPTION
Rust 1.80.0 has been released.
https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html