### PR TITLE
clippy: Applies automatic v1.80.0 fixes

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2439,7 +2439,7 @@ impl Blockstore {
             DEFAULT_TICKS_PER_SECOND * timestamp().saturating_sub(first_timestamp) / 1000;
 
         // Seek to the first shred with index >= start_index
-        db_iterator.seek(&C::key((slot, start_index)));
+        db_iterator.seek(C::key((slot, start_index)));
 
         // The index of the first missing shred in the slot
         let mut prev_index = start_index;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -432,7 +432,7 @@ where
     let mut bank_fields: BankFieldsToDeserialize =
         deserialize_from::<_, DeserializableVersionedBank>(&mut stream)?.into();
     let accounts_db_fields = deserialize_accounts_db_fields(stream)?;
-    let extra_fields = deserialize_from(&mut stream)?;
+    let extra_fields = deserialize_from(stream)?;
 
     // Process extra fields
     let ExtraFieldsToDeserialize {

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -229,7 +229,7 @@ mod tests {
         let _ref_signer = Foo {
             signer: &Keypair::new(),
         };
-        foo(&Keypair::new());
+        foo(Keypair::new());
 
         let _box_signer = Foo {
             signer: Box::new(Keypair::new()),


### PR DESCRIPTION
#### Problem

While upgrading rust in #2386, I ran across new clippy lints. Some are able to be fixed automatically.


#### Summary of Changes

Use `cargo clippy --fix` to automatically fix those new lints.