### PR TITLE
fix duplicate import

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6372,13 +6372,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-svm-transaction"
-version = "2.1.0"
-dependencies = [
- "solana-sdk",
-]
-
-[[package]]
 name = "solana-system-program"
 version = "2.1.0"
 dependencies = [


### PR DESCRIPTION
#### Problem

we accidentally import `solana-svm-transaction` twice. 

https://github.com/anza-xyz/agave/blob/fe9d5836af918ce4d81cae9f459f2ced94613d50/programs/sbf/Cargo.lock#L6367-L6380

maybe the pr order or something 🫠 

#### Summary of Changes

remove the duplicate one