### PR TITLE
Renames last_full_snapshot_slot to latest_full_snapshot_slot

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -73,7 +73,7 @@ impl SnapshotPackagerService {
 
                     // Archiving the snapshot package is not allowed to fail.
                     // AccountsBackgroundService calls `clean_accounts()` with a value for
-                    // last_full_snapshot_slot that requires this archive call to succeed.
+                    // latest_full_snapshot_slot that requires this archive call to succeed.
                     let (archive_result, archive_time_us) = measure_us!(snapshot_utils::serialize_and_archive_snapshot_package(
                         snapshot_package,
                         &snapshot_config,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -336,13 +336,13 @@ fn bank_forks_from_snapshot(
         bank
     };
 
-    // We must inform accounts-db of the last full snapshot slot, which is used by the background
+    // We must inform accounts-db of the latest full snapshot slot, which is used by the background
     // processes to handle zero lamport accounts.  Since we've now successfully loaded the bank
     // from snapshots, this is a good time to do that update.
     bank.rc
         .accounts
         .accounts_db
-        .set_last_full_snapshot_slot(full_snapshot_archive_info.slot());
+        .set_latest_full_snapshot_slot(full_snapshot_archive_info.slot());
 
     let full_snapshot_hash = FullSnapshotHash((
         full_snapshot_archive_info.slot(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5847,7 +5847,7 @@ impl Bank {
         test_hash_calculation: bool,
         skip_shrink: bool,
         force_clean: bool,
-        last_full_snapshot_slot: Slot,
+        latest_full_snapshot_slot: Slot,
         base: Option<(Slot, /*capitalization*/ u64)>,
     ) -> bool {
         let (_, clean_time_us) = measure_us!({
@@ -5859,7 +5859,7 @@ impl Bank {
                 // that slot, then accounts could be removed from older storages, which would
                 // change the accounts hash.
                 self.rc.accounts.accounts_db.clean_accounts(
-                    Some(last_full_snapshot_slot),
+                    Some(latest_full_snapshot_slot),
                     true,
                     self.epoch_schedule(),
                 );

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -906,12 +906,12 @@ fn bank_to_full_snapshot_archive_with(
     archive_format: ArchiveFormat,
 ) -> snapshot_utils::Result<FullSnapshotArchiveInfo> {
     assert!(bank.is_complete());
-    // set accounts-db's last full snapshot slot here to ensure zero lamport
+    // set accounts-db's latest full snapshot slot here to ensure zero lamport
     // accounts are handled properly.
     bank.rc
         .accounts
         .accounts_db
-        .set_last_full_snapshot_slot(bank.slot());
+        .set_latest_full_snapshot_slot(bank.slot());
     bank.squash(); // Bank may not be a root
     bank.rehash(); // Bank accounts may have been manually modified by the caller
     bank.force_flush_accounts_cache();
@@ -969,12 +969,12 @@ pub fn bank_to_incremental_snapshot_archive(
 
     assert!(bank.is_complete());
     assert!(bank.slot() > full_snapshot_slot);
-    // set accounts-db's last full snapshot slot here to ensure zero lamport
+    // set accounts-db's latest full snapshot slot here to ensure zero lamport
     // accounts are handled properly.
     bank.rc
         .accounts
         .accounts_db
-        .set_last_full_snapshot_slot(full_snapshot_slot);
+        .set_latest_full_snapshot_slot(full_snapshot_slot);
     bank.squash(); // Bank may not be a root
     bank.rehash(); // Bank accounts may have been manually modified by the caller
     bank.force_flush_accounts_cache();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2537,10 +2537,10 @@ pub fn should_take_full_snapshot(
 pub fn should_take_incremental_snapshot(
     block_height: Slot,
     incremental_snapshot_archive_interval_slots: Slot,
-    last_full_snapshot_slot: Option<Slot>,
+    latest_full_snapshot_slot: Option<Slot>,
 ) -> bool {
     block_height % incremental_snapshot_archive_interval_slots == 0
-        && last_full_snapshot_slot.is_some()
+        && latest_full_snapshot_slot.is_some()
 }
 
 /// Creates an "accounts path" directory for tests

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -466,7 +466,7 @@ pub(crate) fn generate_snapshot(
     // slot new_root_slot is less than the the current highest full_snapshot_slot, that means the
     // locally rooted full_snapshot_slot will be rolled back. this requires human inspection。
     //
-    // In even rarer cases, the selected slot might be the last full snapshot slot. We could
+    // In even rarer cases, the selected slot might be the latest full snapshot slot. We could
     // just re-generate a new snapshot to make sure the snapshot is up to date after hard fork,
     // but for now we just return an error to keep the code simple.
     check_slot_smaller_than_intended_snapshot_slot(full_snapshot_slot, new_root_slot, directory)?;


### PR DESCRIPTION
#### Problem

The concept of the last full snapshot slot is used by accounts-db. Sometimes in the repo "last" is the newest, sometimes it is the previous, sometimes is it the oldest. The last full snapshot slot is used as the *latest*. This minor ambiguity can be fixed.


#### Summary of Changes

Rename from `last_` to `latest_`.