### PR TITLE
feat: add intermediate InstructionDetails struct for instruction processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7347,8 +7347,10 @@ dependencies = [
  "rustc_version 0.4.0",
  "solana-builtins-default-costs",
  "solana-compute-budget",
+ "solana-compute-budget-program",
  "solana-program",
  "solana-sdk",
+ "solana-system-program",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7345,6 +7345,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustc_version 0.4.0",
+ "solana-builtins-default-costs",
  "solana-compute-budget",
  "solana-program",
  "solana-sdk",

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -50,7 +50,7 @@ lazy_static! {
         let mut temp_table: [bool; 256] = [false; 256];
         BUILTIN_INSTRUCTION_COSTS
             .keys()
-            .for_each(|key| temp_table[key.to_bytes()[0] as usize] = true);
+            .for_each(|key| temp_table[key.as_ref()[0] as usize] = true);
         temp_table
     };
 }

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -40,3 +40,17 @@ lazy_static! {
     .cloned()
     .collect();
 }
+
+lazy_static! {
+    /// A table of 256 booleans indicates whether the first `u8` of a Pubkey exists in
+    /// BUILTIN_INSTRUCTION_COSTS. If the value is true, the Pubkey might be a builtin key;
+    /// if false, it cannot be a builtin key. This table allows for quick filtering of
+    /// builtin program IDs without the need for hashing.
+    pub static ref MAYBE_BUILTIN_KEY: [bool; 256] = {
+        let mut temp_table: [bool; 256] = [false; 256];
+        BUILTIN_INSTRUCTION_COSTS
+            .keys()
+            .for_each(|key| temp_table[key.to_bytes()[0] as usize] = true);
+        temp_table
+    };
+}

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5679,6 +5679,7 @@ name = "solana-runtime-transaction"
 version = "2.1.0"
 dependencies = [
  "log",
+ "solana-builtins-default-costs",
  "solana-compute-budget",
  "solana-sdk",
  "thiserror",

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 log = { workspace = true }
+solana-builtins-default-costs = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-sdk = { workspace = true }
 thiserror = { workspace = true }

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -23,7 +23,9 @@ name = "solana_runtime_transaction"
 [dev-dependencies]
 bincode = { workspace = true }
 rand = { workspace = true }
-solana-program ={ workspace = true }
+solana-compute-budget-program = { workspace = true }
+solana-program = { workspace = true }
+solana-system-program = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime-transaction/src/builtin_instruction_details.rs
+++ b/runtime-transaction/src/builtin_instruction_details.rs
@@ -1,0 +1,78 @@
+use {
+    solana_builtins_default_costs::BUILTIN_INSTRUCTION_COSTS,
+    solana_sdk::{
+        instruction::CompiledInstruction, pubkey::Pubkey, saturating_add_assign,
+        transaction::Result,
+    },
+};
+
+#[cfg_attr(test, derive(Clone, Eq, PartialEq))]
+#[derive(Default, Debug)]
+pub struct BuiltinInstructionDetails {
+    // builtin instruction details
+    pub sum_builtin_compute_units: u32,
+    pub count_builtin_instructions: u32,
+    pub count_non_builtin_instructions: u32,
+}
+
+impl BuiltinInstructionDetails {
+    pub fn process_instruction<'a>(
+        &mut self,
+        program_id: &'a Pubkey,
+        _instruction: &'a CompiledInstruction, // reserved to identify builtin cost pby instruction
+                                               // instead of by program_id
+    ) -> Result<()> {
+        if let Some(builtin_ix_cost) = BUILTIN_INSTRUCTION_COSTS.get(program_id) {
+            saturating_add_assign!(
+                self.sum_builtin_compute_units,
+                u32::try_from(*builtin_ix_cost).unwrap()
+            );
+            saturating_add_assign!(self.count_builtin_instructions, 1);
+        } else {
+            saturating_add_assign!(self.count_non_builtin_instructions, 1);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_process_instruction() {
+        let mut builtin_instruction_details = BuiltinInstructionDetails::default();
+        let dummy_ix = CompiledInstruction::new_from_raw_parts(0, vec![], vec![]);
+
+        // process all builtin with default costs
+        for (pubkey, cost) in BUILTIN_INSTRUCTION_COSTS.iter() {
+            let expected_value = BuiltinInstructionDetails {
+                sum_builtin_compute_units: builtin_instruction_details.sum_builtin_compute_units
+                    + *cost as u32,
+                count_builtin_instructions: builtin_instruction_details.count_builtin_instructions
+                    + 1,
+                count_non_builtin_instructions: 0,
+            };
+
+            assert!(builtin_instruction_details
+                .process_instruction(pubkey, &dummy_ix)
+                .is_ok());
+            assert_eq!(builtin_instruction_details, expected_value);
+        }
+
+        // continue process non-builtin instruction
+        let expected_value = BuiltinInstructionDetails {
+            sum_builtin_compute_units: builtin_instruction_details.sum_builtin_compute_units,
+            count_builtin_instructions: builtin_instruction_details.count_builtin_instructions,
+            count_non_builtin_instructions: builtin_instruction_details
+                .count_non_builtin_instructions
+                + 1,
+        };
+
+        assert!(builtin_instruction_details
+            .process_instruction(&Pubkey::new_unique(), &dummy_ix)
+            .is_ok());
+        assert_eq!(builtin_instruction_details, expected_value);
+    }
+}

--- a/runtime-transaction/src/builtin_instruction_details.rs
+++ b/runtime-transaction/src/builtin_instruction_details.rs
@@ -8,7 +8,7 @@ use {
 
 #[cfg_attr(test, derive(Clone, Eq, PartialEq))]
 #[derive(Default, Debug)]
-pub struct BuiltinInstructionDetails {
+pub(crate) struct BuiltinInstructionDetails {
     // builtin instruction details
     pub sum_builtin_compute_units: u32,
     pub count_builtin_instructions: u32,

--- a/runtime-transaction/src/builtin_instruction_details.rs
+++ b/runtime-transaction/src/builtin_instruction_details.rs
@@ -1,4 +1,5 @@
 use {
+    crate::instruction_details::InstructionDetails,
     solana_builtins_default_costs::BUILTIN_INSTRUCTION_COSTS,
     solana_sdk::{
         instruction::CompiledInstruction, pubkey::Pubkey, saturating_add_assign,
@@ -6,17 +7,8 @@ use {
     },
 };
 
-#[cfg_attr(test, derive(Clone, Eq, PartialEq))]
-#[derive(Default, Debug)]
-pub(crate) struct BuiltinInstructionDetails {
-    // builtin instruction details
-    pub sum_builtin_compute_units: u32,
-    pub count_builtin_instructions: u32,
-    pub count_non_builtin_instructions: u32,
-}
-
-impl BuiltinInstructionDetails {
-    pub fn process_instruction<'a>(
+impl InstructionDetails {
+    pub fn process_builtin_instruction<'a>(
         &mut self,
         program_id: &'a Pubkey,
         _instruction: &'a CompiledInstruction, // reserved to identify builtin cost by instruction
@@ -41,37 +33,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_process_instruction() {
-        let mut builtin_instruction_details = BuiltinInstructionDetails::default();
+    fn test_process_builtin_instruction() {
+        let mut builtin_instruction_details = InstructionDetails::default();
         let dummy_ix = CompiledInstruction::new_from_raw_parts(0, vec![], vec![]);
 
         // process all builtin with default costs
         for (pubkey, cost) in BUILTIN_INSTRUCTION_COSTS.iter() {
-            let expected_value = BuiltinInstructionDetails {
+            let expected_value = InstructionDetails {
                 sum_builtin_compute_units: builtin_instruction_details.sum_builtin_compute_units
                     + *cost as u32,
                 count_builtin_instructions: builtin_instruction_details.count_builtin_instructions
                     + 1,
                 count_non_builtin_instructions: 0,
+                ..InstructionDetails::default()
             };
 
             assert!(builtin_instruction_details
-                .process_instruction(pubkey, &dummy_ix)
+                .process_builtin_instruction(pubkey, &dummy_ix)
                 .is_ok());
             assert_eq!(builtin_instruction_details, expected_value);
         }
 
         // continue process non-builtin instruction
-        let expected_value = BuiltinInstructionDetails {
+        let expected_value = InstructionDetails {
             sum_builtin_compute_units: builtin_instruction_details.sum_builtin_compute_units,
             count_builtin_instructions: builtin_instruction_details.count_builtin_instructions,
             count_non_builtin_instructions: builtin_instruction_details
                 .count_non_builtin_instructions
                 + 1,
+            ..InstructionDetails::default()
         };
 
         assert!(builtin_instruction_details
-            .process_instruction(&Pubkey::new_unique(), &dummy_ix)
+            .process_builtin_instruction(&Pubkey::new_unique(), &dummy_ix)
             .is_ok());
         assert_eq!(builtin_instruction_details, expected_value);
     }

--- a/runtime-transaction/src/builtin_instruction_details.rs
+++ b/runtime-transaction/src/builtin_instruction_details.rs
@@ -19,7 +19,7 @@ impl BuiltinInstructionDetails {
     pub fn process_instruction<'a>(
         &mut self,
         program_id: &'a Pubkey,
-        _instruction: &'a CompiledInstruction, // reserved to identify builtin cost pby instruction
+        _instruction: &'a CompiledInstruction, // reserved to identify builtin cost by instruction
                                                // instead of by program_id
     ) -> Result<()> {
         if let Some(builtin_ix_cost) = BUILTIN_INSTRUCTION_COSTS.get(program_id) {

--- a/runtime-transaction/src/compute_budget_instruction_details.rs
+++ b/runtime-transaction/src/compute_budget_instruction_details.rs
@@ -12,7 +12,7 @@ use {
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 #[derive(Default, Debug)]
-pub struct ComputeBudgetInstructionDetails {
+pub(crate) struct ComputeBudgetInstructionDetails {
     // compute-budget instruction details:
     // the first field in tuple is instruction index, second field is the unsanitized value set by user
     pub requested_compute_unit_limit: Option<(u8, u32)>,

--- a/runtime-transaction/src/compute_budget_instruction_details.rs
+++ b/runtime-transaction/src/compute_budget_instruction_details.rs
@@ -1,0 +1,349 @@
+use {
+    solana_compute_budget::compute_budget_limits::*,
+    solana_sdk::{
+        borsh1::try_from_slice_unchecked,
+        compute_budget::{self, ComputeBudgetInstruction},
+        instruction::{CompiledInstruction, InstructionError},
+        pubkey::Pubkey,
+        saturating_add_assign,
+        transaction::{Result, TransactionError},
+    },
+};
+
+#[cfg_attr(test, derive(Eq, PartialEq))]
+#[derive(Default, Debug)]
+pub struct ComputeBudgetInstructionDetails {
+    // compute-budget instruction details:
+    // the first field in tuple is instruction index, second field is the unsanitized value set by user
+    pub requested_compute_unit_limit: Option<(u8, u32)>,
+    pub requested_compute_unit_price: Option<(u8, u64)>,
+    pub requested_heap_size: Option<(u8, u32)>,
+    pub requested_loaded_accounts_data_size_limit: Option<(u8, u32)>,
+    pub count_compute_budget_instructions: u32,
+}
+
+impl ComputeBudgetInstructionDetails {
+    pub fn process_instruction<'a>(
+        &mut self,
+        index: u8,
+        program_id: &'a Pubkey,
+        instruction: &'a CompiledInstruction,
+    ) -> Result<()> {
+        if compute_budget::check_id(program_id) {
+            let invalid_instruction_data_error =
+                TransactionError::InstructionError(index, InstructionError::InvalidInstructionData);
+            let duplicate_instruction_error = TransactionError::DuplicateInstruction(index);
+
+            match try_from_slice_unchecked(&instruction.data) {
+                Ok(ComputeBudgetInstruction::RequestHeapFrame(bytes)) => {
+                    if self.requested_heap_size.is_some() {
+                        return Err(duplicate_instruction_error);
+                    }
+                    if Self::sanitize_requested_heap_size(bytes) {
+                        self.requested_heap_size = Some((index, bytes));
+                    } else {
+                        return Err(invalid_instruction_data_error);
+                    }
+                }
+                Ok(ComputeBudgetInstruction::SetComputeUnitLimit(compute_unit_limit)) => {
+                    if self.requested_compute_unit_limit.is_some() {
+                        return Err(duplicate_instruction_error);
+                    }
+                    self.requested_compute_unit_limit = Some((index, compute_unit_limit));
+                }
+                Ok(ComputeBudgetInstruction::SetComputeUnitPrice(micro_lamports)) => {
+                    if self.requested_compute_unit_price.is_some() {
+                        return Err(duplicate_instruction_error);
+                    }
+                    self.requested_compute_unit_price = Some((index, micro_lamports));
+                }
+                Ok(ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit(bytes)) => {
+                    if self.requested_loaded_accounts_data_size_limit.is_some() {
+                        return Err(duplicate_instruction_error);
+                    }
+                    self.requested_loaded_accounts_data_size_limit = Some((index, bytes));
+                }
+                _ => return Err(invalid_instruction_data_error),
+            }
+            saturating_add_assign!(self.count_compute_budget_instructions, 1);
+        }
+
+        Ok(())
+    }
+
+    fn sanitize_requested_heap_size(bytes: u32) -> bool {
+        (MIN_HEAP_FRAME_BYTES..=MAX_HEAP_FRAME_BYTES).contains(&bytes) && bytes % 1024 == 0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {super::*, solana_sdk::instruction::Instruction};
+
+    fn setup_test_instruction(
+        index: u8,
+        instruction: Instruction,
+    ) -> (Pubkey, CompiledInstruction) {
+        (
+            instruction.program_id,
+            CompiledInstruction {
+                program_id_index: index,
+                data: instruction.data.clone(),
+                accounts: vec![],
+            },
+        )
+    }
+
+    #[test]
+    fn test_process_instruction_request_heap() {
+        let mut index = 0;
+        let mut expected_details = ComputeBudgetInstructionDetails::default();
+        let mut compute_budget_instruction_details = ComputeBudgetInstructionDetails::default();
+
+        // invalid data results error
+        let expected_err = Err(TransactionError::InstructionError(
+            index,
+            InstructionError::InvalidInstructionData,
+        ));
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            ComputeBudgetInstruction::request_heap_frame(MIN_HEAP_FRAME_BYTES - 1),
+        );
+        assert_eq!(
+            compute_budget_instruction_details.process_instruction(index, &program_id, &ix),
+            expected_err
+        );
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            ComputeBudgetInstruction::request_heap_frame(MAX_HEAP_FRAME_BYTES + 1),
+        );
+        assert_eq!(
+            compute_budget_instruction_details.process_instruction(index, &program_id, &ix),
+            expected_err
+        );
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            ComputeBudgetInstruction::request_heap_frame(1024 + 1),
+        );
+        assert_eq!(
+            compute_budget_instruction_details.process_instruction(index, &program_id, &ix),
+            expected_err
+        );
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            ComputeBudgetInstruction::request_heap_frame(31 * 1024),
+        );
+        assert_eq!(
+            compute_budget_instruction_details.process_instruction(index, &program_id, &ix),
+            expected_err
+        );
+
+        // irrelevant instruction makes no change
+        index += 1;
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+        );
+        assert!(compute_budget_instruction_details
+            .process_instruction(index, &program_id, &ix)
+            .is_ok());
+        assert_eq!(compute_budget_instruction_details, expected_details);
+
+        // valid instruction
+        index += 1;
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            ComputeBudgetInstruction::request_heap_frame(40 * 1024),
+        );
+        expected_details.requested_heap_size = Some((index, 40 * 1024));
+        expected_details.count_compute_budget_instructions = 1;
+        assert!(compute_budget_instruction_details
+            .process_instruction(index, &program_id, &ix)
+            .is_ok());
+        assert_eq!(compute_budget_instruction_details, expected_details);
+
+        // duplicate instruction results error
+        index += 1;
+        let expected_err = Err(TransactionError::DuplicateInstruction(index));
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            ComputeBudgetInstruction::request_heap_frame(50 * 1024),
+        );
+        assert_eq!(
+            compute_budget_instruction_details.process_instruction(index, &program_id, &ix),
+            expected_err
+        );
+        assert_eq!(compute_budget_instruction_details, expected_details);
+
+        // irrelevant instruction makes no change
+        index += 1;
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+        );
+        assert!(compute_budget_instruction_details
+            .process_instruction(index, &program_id, &ix)
+            .is_ok());
+        assert_eq!(compute_budget_instruction_details, expected_details);
+    }
+
+    #[test]
+    fn test_process_instruction_compute_unit_limit() {
+        let mut index = 0;
+        let mut expected_details = ComputeBudgetInstructionDetails::default();
+        let mut compute_budget_instruction_details = ComputeBudgetInstructionDetails::default();
+
+        // irrelevant instruction makes no change
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+        );
+        assert!(compute_budget_instruction_details
+            .process_instruction(index, &program_id, &ix)
+            .is_ok());
+        assert_eq!(compute_budget_instruction_details, expected_details);
+
+        // valid instruction,
+        index += 1;
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            ComputeBudgetInstruction::set_compute_unit_limit(u32::MAX),
+        );
+        expected_details.requested_compute_unit_limit = Some((index, u32::MAX));
+        expected_details.count_compute_budget_instructions = 1;
+        assert!(compute_budget_instruction_details
+            .process_instruction(index, &program_id, &ix)
+            .is_ok());
+        assert_eq!(compute_budget_instruction_details, expected_details);
+
+        // duplicate instruction results error
+        index += 1;
+        let expected_err = Err(TransactionError::DuplicateInstruction(index));
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            ComputeBudgetInstruction::set_compute_unit_limit(MAX_COMPUTE_UNIT_LIMIT),
+        );
+        assert_eq!(
+            compute_budget_instruction_details.process_instruction(index, &program_id, &ix),
+            expected_err
+        );
+        assert_eq!(compute_budget_instruction_details, expected_details);
+
+        // irrelevant instruction makes no change
+        index += 1;
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+        );
+        assert!(compute_budget_instruction_details
+            .process_instruction(index, &program_id, &ix)
+            .is_ok());
+        assert_eq!(compute_budget_instruction_details, expected_details);
+    }
+
+    #[test]
+    fn test_process_instruction_compute_unit_price() {
+        let mut index = 0;
+        let mut expected_details = ComputeBudgetInstructionDetails::default();
+        let mut compute_budget_instruction_details = ComputeBudgetInstructionDetails::default();
+
+        // irrelevant instruction makes no change
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+        );
+        assert!(compute_budget_instruction_details
+            .process_instruction(index, &program_id, &ix)
+            .is_ok());
+        assert_eq!(compute_budget_instruction_details, expected_details);
+
+        // valid instruction,
+        index += 1;
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            ComputeBudgetInstruction::set_compute_unit_price(u64::MAX),
+        );
+        expected_details.requested_compute_unit_price = Some((index, u64::MAX));
+        expected_details.count_compute_budget_instructions = 1;
+        assert!(compute_budget_instruction_details
+            .process_instruction(index, &program_id, &ix)
+            .is_ok());
+        assert_eq!(compute_budget_instruction_details, expected_details);
+
+        // duplicate instruction results error
+        index += 1;
+        let expected_err = Err(TransactionError::DuplicateInstruction(index));
+        let (program_id, ix) =
+            setup_test_instruction(index, ComputeBudgetInstruction::set_compute_unit_price(0));
+        assert_eq!(
+            compute_budget_instruction_details.process_instruction(index, &program_id, &ix),
+            expected_err
+        );
+        assert_eq!(compute_budget_instruction_details, expected_details);
+
+        // irrelevant instruction makes no change
+        index += 1;
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+        );
+        assert!(compute_budget_instruction_details
+            .process_instruction(index, &program_id, &ix)
+            .is_ok());
+        assert_eq!(compute_budget_instruction_details, expected_details);
+    }
+
+    #[test]
+    fn test_process_instruction_loaded_accounts_data_size_limit() {
+        let mut index = 0;
+        let mut expected_details = ComputeBudgetInstructionDetails::default();
+        let mut compute_budget_instruction_details = ComputeBudgetInstructionDetails::default();
+
+        // irrelevant instruction makes no change
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+        );
+        assert!(compute_budget_instruction_details
+            .process_instruction(index, &program_id, &ix)
+            .is_ok());
+        assert_eq!(compute_budget_instruction_details, expected_details);
+
+        // valid instruction,
+        index += 1;
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(u32::MAX),
+        );
+        expected_details.requested_loaded_accounts_data_size_limit = Some((index, u32::MAX));
+        expected_details.count_compute_budget_instructions = 1;
+        assert!(compute_budget_instruction_details
+            .process_instruction(index, &program_id, &ix)
+            .is_ok());
+        assert_eq!(compute_budget_instruction_details, expected_details);
+
+        // duplicate instruction results error
+        index += 1;
+        let expected_err = Err(TransactionError::DuplicateInstruction(index));
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(0),
+        );
+        assert_eq!(
+            compute_budget_instruction_details.process_instruction(index, &program_id, &ix),
+            expected_err
+        );
+        assert_eq!(compute_budget_instruction_details, expected_details);
+
+        // irrelevant instruction makes no change
+        index += 1;
+        let (program_id, ix) = setup_test_instruction(
+            index,
+            Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+        );
+        assert!(compute_budget_instruction_details
+            .process_instruction(index, &program_id, &ix)
+            .is_ok());
+        assert_eq!(compute_budget_instruction_details, expected_details);
+    }
+}

--- a/runtime-transaction/src/instruction_details.rs
+++ b/runtime-transaction/src/instruction_details.rs
@@ -35,7 +35,7 @@ impl InstructionDetails {
         let mut instruction_details = InstructionDetails::default();
 
         for (i, (program_id, instruction)) in instructions.enumerate() {
-            if MAYBE_BUILTIN_KEY[program_id.to_bytes()[0] as usize] {
+            if MAYBE_BUILTIN_KEY[program_id.as_ref()[0] as usize] {
                 instruction_details.process_compute_budget_instruction(
                     i as u8,
                     program_id,

--- a/runtime-transaction/src/instruction_details.rs
+++ b/runtime-transaction/src/instruction_details.rs
@@ -1,0 +1,199 @@
+use {
+    solana_builtins_default_costs::BUILTIN_INSTRUCTION_COSTS,
+    solana_compute_budget::compute_budget_limits::*,
+    solana_sdk::{
+        borsh1::try_from_slice_unchecked,
+        compute_budget::{self, ComputeBudgetInstruction},
+        instruction::{CompiledInstruction, InstructionError},
+        pubkey::Pubkey,
+        saturating_add_assign,
+        transaction::{Result, TransactionError},
+    },
+    std::num::NonZeroU32,
+};
+
+#[derive(Default, Debug)]
+struct ComputeBudgetInstructionDetails {
+    // compute-budget instruction details:
+    // the first field in tuple is instruction index, second field is the unsanitized value set by user
+    requested_compute_unit_limit: Option<(u8, u32)>,
+    requested_compute_unit_price: Option<(u8, u64)>,
+    requested_heap_size: Option<(u8, u32)>,
+    requested_loaded_accounts_data_size_limit: Option<(u8, u32)>,
+    count_compute_budget_instructions: u32,
+}
+
+impl ComputeBudgetInstructionDetails {
+    pub fn process_instruction<'a>(
+        &mut self,
+        index: u8,
+        program_id: &'a Pubkey,
+        instruction: &'a CompiledInstruction,
+    ) -> Result<()> {
+        if compute_budget::check_id(program_id) {
+            saturating_add_assign!(self.count_compute_budget_instructions, 1);
+
+            let invalid_instruction_data_error =
+                TransactionError::InstructionError(index, InstructionError::InvalidInstructionData);
+            let duplicate_instruction_error = TransactionError::DuplicateInstruction(index);
+
+            match try_from_slice_unchecked(&instruction.data) {
+                Ok(ComputeBudgetInstruction::RequestHeapFrame(bytes)) => {
+                    if self.requested_heap_size.is_some() {
+                        return Err(duplicate_instruction_error);
+                    }
+                    if Self::sanitize_requested_heap_size(bytes) {
+                        self.requested_heap_size = Some((index, bytes));
+                    } else {
+                        return Err(invalid_instruction_data_error);
+                    }
+                }
+                Ok(ComputeBudgetInstruction::SetComputeUnitLimit(compute_unit_limit)) => {
+                    if self.requested_compute_unit_limit.is_some() {
+                        return Err(duplicate_instruction_error);
+                    }
+                    self.requested_compute_unit_limit = Some((index, compute_unit_limit));
+                }
+                Ok(ComputeBudgetInstruction::SetComputeUnitPrice(micro_lamports)) => {
+                    if self.requested_compute_unit_price.is_some() {
+                        return Err(duplicate_instruction_error);
+                    }
+                    self.requested_compute_unit_price = Some((index, micro_lamports));
+                }
+                Ok(ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit(bytes)) => {
+                    if self.requested_loaded_accounts_data_size_limit.is_some() {
+                        return Err(duplicate_instruction_error);
+                    }
+                    self.requested_loaded_accounts_data_size_limit = Some((index, bytes));
+                }
+                _ => return Err(invalid_instruction_data_error),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn sanitize_requested_heap_size(bytes: u32) -> bool {
+        (MIN_HEAP_FRAME_BYTES..=MAX_HEAP_FRAME_BYTES).contains(&bytes) && bytes % 1024 == 0
+    }
+}
+
+#[derive(Default, Debug)]
+struct BuiltinInstructionDetails {
+    // builtin instruction details
+    sum_builtin_compute_units: u32,
+    count_builtin_instructions: u32,
+    count_non_builtin_instructions: u32,
+}
+
+impl BuiltinInstructionDetails {
+    pub fn process_instruction<'a>(
+        &mut self,
+        program_id: &'a Pubkey,
+        _instruction: &'a CompiledInstruction,
+    ) -> Result<()> {
+        if let Some(builtin_ix_cost) = BUILTIN_INSTRUCTION_COSTS.get(program_id) {
+            saturating_add_assign!(
+                self.sum_builtin_compute_units,
+                u32::try_from(*builtin_ix_cost).unwrap()
+            );
+            saturating_add_assign!(self.count_builtin_instructions, 1);
+        } else {
+            saturating_add_assign!(self.count_non_builtin_instructions, 1);
+        }
+
+        Ok(())
+    }
+}
+
+/// Information about instructions gathered after scan over transaction;
+/// These are "raw" information that suitable for cache and reuse.
+#[derive(Default, Debug)]
+pub struct InstructionDetails {
+    compute_budget_instruction_details: ComputeBudgetInstructionDetails,
+    builtin_instruction_details: BuiltinInstructionDetails,
+}
+
+impl InstructionDetails {
+    pub fn sanitize_and_convert_to_compute_budget_limits(&self) -> Result<ComputeBudgetLimits> {
+        // Sanitize requested heap size
+        let updated_heap_bytes = self
+            .compute_budget_instruction_details
+            .requested_heap_size
+            .map_or(MIN_HEAP_FRAME_BYTES, |(_index, requested_heap_size)| {
+                requested_heap_size
+            })
+            .min(MAX_HEAP_FRAME_BYTES);
+
+        // Calculate compute unit limit
+        let compute_unit_limit = self
+            .compute_budget_instruction_details
+            .requested_compute_unit_limit
+            .map_or_else(
+                || {
+                    // NOTE: to match current behavior of:
+                    // num_non_compute_budget_instructions * DEFAULT
+                    self.builtin_instruction_details
+                        .count_builtin_instructions
+                        .saturating_add(
+                            self.builtin_instruction_details
+                                .count_non_builtin_instructions,
+                        )
+                        .saturating_sub(
+                            self.compute_budget_instruction_details
+                                .count_compute_budget_instructions,
+                        )
+                        .saturating_mul(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT)
+                },
+                |(_index, requested_compute_unit_limit)| requested_compute_unit_limit,
+            )
+            .min(MAX_COMPUTE_UNIT_LIMIT);
+
+        let compute_unit_price = self
+            .compute_budget_instruction_details
+            .requested_compute_unit_price
+            .map_or(0, |(_index, requested_compute_unit_price)| {
+                requested_compute_unit_price
+            });
+
+        let loaded_accounts_bytes =
+            if let Some((_index, requested_loaded_accounts_data_size_limit)) = self
+                .compute_budget_instruction_details
+                .requested_loaded_accounts_data_size_limit
+            {
+                NonZeroU32::new(requested_loaded_accounts_data_size_limit)
+                    .ok_or(TransactionError::InvalidLoadedAccountsDataSizeLimit)?
+            } else {
+                MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES
+            }
+            .min(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
+
+        Ok(ComputeBudgetLimits {
+            updated_heap_bytes,
+            compute_unit_limit,
+            compute_unit_price,
+            loaded_accounts_bytes,
+        })
+    }
+
+    pub fn try_from<'a>(
+        instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
+    ) -> Result<Self> {
+        let mut compute_budget_instruction_details = ComputeBudgetInstructionDetails::default();
+        let mut builtin_instruction_details = BuiltinInstructionDetails::default();
+
+        for (i, (program_id, instruction)) in instructions.enumerate() {
+            compute_budget_instruction_details.process_instruction(
+                i as u8,
+                program_id,
+                instruction,
+            )?;
+            builtin_instruction_details.process_instruction(program_id, instruction)?;
+        }
+
+        Ok(Self {
+            compute_budget_instruction_details,
+            builtin_instruction_details,
+        })
+    }
+}

--- a/runtime-transaction/src/instruction_details.rs
+++ b/runtime-transaction/src/instruction_details.rs
@@ -58,16 +58,7 @@ impl InstructionDetails {
                 || {
                     // NOTE: to match current behavior of:
                     // num_non_compute_budget_instructions * DEFAULT
-                    self.builtin_instruction_details
-                        .count_builtin_instructions
-                        .saturating_add(
-                            self.builtin_instruction_details
-                                .count_non_builtin_instructions,
-                        )
-                        .saturating_sub(
-                            self.compute_budget_instruction_details
-                                .count_compute_budget_instructions,
-                        )
+                    self.num_non_compute_budget_instructions()
                         .saturating_mul(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT)
                 },
                 |(_index, requested_compute_unit_limit)| requested_compute_unit_limit,
@@ -99,6 +90,19 @@ impl InstructionDetails {
             compute_unit_price,
             loaded_accounts_bytes,
         })
+    }
+
+    fn num_non_compute_budget_instructions(&self) -> u32 {
+        self.builtin_instruction_details
+            .count_builtin_instructions
+            .saturating_add(
+                self.builtin_instruction_details
+                    .count_non_builtin_instructions,
+            )
+            .saturating_sub(
+                self.compute_budget_instruction_details
+                    .count_compute_budget_instructions,
+            )
     }
 }
 

--- a/runtime-transaction/src/instruction_details.rs
+++ b/runtime-transaction/src/instruction_details.rs
@@ -1,5 +1,6 @@
 use {
     crate::{builtin_instruction_details::*, compute_budget_instruction_details::*},
+    solana_builtins_default_costs::MAYBE_BUILTIN_KEY,
     solana_compute_budget::compute_budget_limits::*,
     solana_sdk::{
         instruction::{CompiledInstruction, InstructionError},
@@ -25,7 +26,10 @@ impl InstructionDetails {
         let mut compute_budget_instruction_details = ComputeBudgetInstructionDetails::default();
         let mut builtin_instruction_details = BuiltinInstructionDetails::default();
 
-        for (i, (program_id, instruction)) in instructions.enumerate() {
+        for (i, (program_id, instruction)) in instructions
+            .enumerate()
+            .filter(|(_, (program_id, _))| MAYBE_BUILTIN_KEY[program_id.to_bytes()[0] as usize])
+        {
             compute_budget_instruction_details.process_instruction(
                 i as u8,
                 program_id,

--- a/runtime-transaction/src/instruction_details.rs
+++ b/runtime-transaction/src/instruction_details.rs
@@ -1,120 +1,45 @@
 use {
-    solana_builtins_default_costs::BUILTIN_INSTRUCTION_COSTS,
+    crate::{builtin_instruction_details::*, compute_budget_instruction_details::*},
     solana_compute_budget::compute_budget_limits::*,
     solana_sdk::{
-        borsh1::try_from_slice_unchecked,
-        compute_budget::{self, ComputeBudgetInstruction},
-        instruction::{CompiledInstruction, InstructionError},
+        instruction::CompiledInstruction,
         pubkey::Pubkey,
-        saturating_add_assign,
         transaction::{Result, TransactionError},
     },
     std::num::NonZeroU32,
 };
 
-#[derive(Default, Debug)]
-struct ComputeBudgetInstructionDetails {
-    // compute-budget instruction details:
-    // the first field in tuple is instruction index, second field is the unsanitized value set by user
-    requested_compute_unit_limit: Option<(u8, u32)>,
-    requested_compute_unit_price: Option<(u8, u64)>,
-    requested_heap_size: Option<(u8, u32)>,
-    requested_loaded_accounts_data_size_limit: Option<(u8, u32)>,
-    count_compute_budget_instructions: u32,
-}
-
-impl ComputeBudgetInstructionDetails {
-    pub fn process_instruction<'a>(
-        &mut self,
-        index: u8,
-        program_id: &'a Pubkey,
-        instruction: &'a CompiledInstruction,
-    ) -> Result<()> {
-        if compute_budget::check_id(program_id) {
-            saturating_add_assign!(self.count_compute_budget_instructions, 1);
-
-            let invalid_instruction_data_error =
-                TransactionError::InstructionError(index, InstructionError::InvalidInstructionData);
-            let duplicate_instruction_error = TransactionError::DuplicateInstruction(index);
-
-            match try_from_slice_unchecked(&instruction.data) {
-                Ok(ComputeBudgetInstruction::RequestHeapFrame(bytes)) => {
-                    if self.requested_heap_size.is_some() {
-                        return Err(duplicate_instruction_error);
-                    }
-                    if Self::sanitize_requested_heap_size(bytes) {
-                        self.requested_heap_size = Some((index, bytes));
-                    } else {
-                        return Err(invalid_instruction_data_error);
-                    }
-                }
-                Ok(ComputeBudgetInstruction::SetComputeUnitLimit(compute_unit_limit)) => {
-                    if self.requested_compute_unit_limit.is_some() {
-                        return Err(duplicate_instruction_error);
-                    }
-                    self.requested_compute_unit_limit = Some((index, compute_unit_limit));
-                }
-                Ok(ComputeBudgetInstruction::SetComputeUnitPrice(micro_lamports)) => {
-                    if self.requested_compute_unit_price.is_some() {
-                        return Err(duplicate_instruction_error);
-                    }
-                    self.requested_compute_unit_price = Some((index, micro_lamports));
-                }
-                Ok(ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit(bytes)) => {
-                    if self.requested_loaded_accounts_data_size_limit.is_some() {
-                        return Err(duplicate_instruction_error);
-                    }
-                    self.requested_loaded_accounts_data_size_limit = Some((index, bytes));
-                }
-                _ => return Err(invalid_instruction_data_error),
-            }
-        }
-
-        Ok(())
-    }
-
-    fn sanitize_requested_heap_size(bytes: u32) -> bool {
-        (MIN_HEAP_FRAME_BYTES..=MAX_HEAP_FRAME_BYTES).contains(&bytes) && bytes % 1024 == 0
-    }
-}
-
-#[derive(Default, Debug)]
-struct BuiltinInstructionDetails {
-    // builtin instruction details
-    sum_builtin_compute_units: u32,
-    count_builtin_instructions: u32,
-    count_non_builtin_instructions: u32,
-}
-
-impl BuiltinInstructionDetails {
-    pub fn process_instruction<'a>(
-        &mut self,
-        program_id: &'a Pubkey,
-        _instruction: &'a CompiledInstruction,
-    ) -> Result<()> {
-        if let Some(builtin_ix_cost) = BUILTIN_INSTRUCTION_COSTS.get(program_id) {
-            saturating_add_assign!(
-                self.sum_builtin_compute_units,
-                u32::try_from(*builtin_ix_cost).unwrap()
-            );
-            saturating_add_assign!(self.count_builtin_instructions, 1);
-        } else {
-            saturating_add_assign!(self.count_non_builtin_instructions, 1);
-        }
-
-        Ok(())
-    }
-}
-
 /// Information about instructions gathered after scan over transaction;
 /// These are "raw" information that suitable for cache and reuse.
+#[cfg_attr(test, derive(Eq, PartialEq))]
 #[derive(Default, Debug)]
 pub struct InstructionDetails {
-    compute_budget_instruction_details: ComputeBudgetInstructionDetails,
     builtin_instruction_details: BuiltinInstructionDetails,
+    compute_budget_instruction_details: ComputeBudgetInstructionDetails,
 }
 
 impl InstructionDetails {
+    pub fn try_from<'a>(
+        instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
+    ) -> Result<Self> {
+        let mut compute_budget_instruction_details = ComputeBudgetInstructionDetails::default();
+        let mut builtin_instruction_details = BuiltinInstructionDetails::default();
+
+        for (i, (program_id, instruction)) in instructions.enumerate() {
+            compute_budget_instruction_details.process_instruction(
+                i as u8,
+                program_id,
+                instruction,
+            )?;
+            builtin_instruction_details.process_instruction(program_id, instruction)?;
+        }
+
+        Ok(Self {
+            builtin_instruction_details,
+            compute_budget_instruction_details,
+        })
+    }
+
     pub fn sanitize_and_convert_to_compute_budget_limits(&self) -> Result<ComputeBudgetLimits> {
         // Sanitize requested heap size
         let updated_heap_bytes = self
@@ -175,25 +100,174 @@ impl InstructionDetails {
             loaded_accounts_bytes,
         })
     }
+}
 
-    pub fn try_from<'a>(
-        instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
-    ) -> Result<Self> {
-        let mut compute_budget_instruction_details = ComputeBudgetInstructionDetails::default();
-        let mut builtin_instruction_details = BuiltinInstructionDetails::default();
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        solana_sdk::{
+            compute_budget::ComputeBudgetInstruction,
+            instruction::{Instruction, InstructionError},
+            message::Message,
+            pubkey::Pubkey,
+            signature::Keypair,
+            signer::Signer,
+            system_instruction::{self},
+            transaction::{SanitizedTransaction, Transaction},
+        },
+    };
 
-        for (i, (program_id, instruction)) in instructions.enumerate() {
-            compute_budget_instruction_details.process_instruction(
-                i as u8,
-                program_id,
-                instruction,
-            )?;
-            builtin_instruction_details.process_instruction(program_id, instruction)?;
-        }
+    macro_rules! test {
+        ( $payer_keypair: expr, $instructions: expr, $expected_result: expr) => {
+            let tx = SanitizedTransaction::from_transaction_for_tests(Transaction::new_unsigned(
+                Message::new($instructions, Some(&$payer_keypair.pubkey())),
+            ));
 
-        Ok(Self {
-            compute_budget_instruction_details,
+            let result = InstructionDetails::try_from(tx.message().program_instructions_iter());
+            assert_eq!($expected_result, result);
+        };
+    }
+
+    #[test]
+    fn test_try_from() {
+        let payer_keypair = Keypair::new();
+        test!(payer_keypair, &[], Ok(InstructionDetails::default()));
+
+        test!(
+            payer_keypair,
+            &[
+                Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+                ComputeBudgetInstruction::request_heap_frame(40 * 1024),
+                ComputeBudgetInstruction::set_compute_unit_limit(u32::MAX),
+                ComputeBudgetInstruction::set_compute_unit_price(u64::MAX),
+                ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(u32::MAX),
+                Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+                system_instruction::transfer(&payer_keypair.pubkey(), &Pubkey::new_unique(), 1),
+            ],
+            Ok(InstructionDetails {
+                builtin_instruction_details: BuiltinInstructionDetails {
+                    sum_builtin_compute_units: 4
+                        * solana_compute_budget_program::DEFAULT_COMPUTE_UNITS as u32
+                        + solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS as u32,
+                    count_builtin_instructions: 5,
+                    count_non_builtin_instructions: 2,
+                },
+                compute_budget_instruction_details: ComputeBudgetInstructionDetails {
+                    requested_compute_unit_limit: Some((2, u32::MAX)),
+                    requested_compute_unit_price: Some((3, u64::MAX)),
+                    requested_heap_size: Some((1, 40 * 1024)),
+                    requested_loaded_accounts_data_size_limit: Some((4, u32::MAX)),
+                    count_compute_budget_instructions: 4,
+                },
+            })
+        );
+
+        // any invalid intruction would error out
+        test!(
+            payer_keypair,
+            &[
+                Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+                ComputeBudgetInstruction::request_heap_frame(0), // invalid
+                Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
+            ],
+            Err(TransactionError::InstructionError(
+                1,
+                InstructionError::InvalidInstructionData,
+            ))
+        );
+    }
+
+    #[test]
+    fn test_sanitize_and_convert_to_compute_budget_limits() {
+        let instruction_details = InstructionDetails::default();
+        assert_eq!(
+            instruction_details.sanitize_and_convert_to_compute_budget_limits(),
+            Ok(ComputeBudgetLimits {
+                compute_unit_limit: 0,
+                ..ComputeBudgetLimits::default()
+            })
+        );
+
+        let count_builtin_instructions = 5;
+        let count_non_builtin_instructions = 2;
+        let count_compute_budget_instructions = 4;
+        let builtin_instruction_details = BuiltinInstructionDetails {
+            count_builtin_instructions,
+            count_non_builtin_instructions,
+            ..BuiltinInstructionDetails::default()
+        };
+
+        // no compute-budget instructions, all default ComputeBudgetLimits except cu-limit
+        let instruction_details = InstructionDetails {
+            builtin_instruction_details: builtin_instruction_details.clone(),
+            ..InstructionDetails::default()
+        };
+        let expected_compute_unit_limit = (count_builtin_instructions
+            + count_non_builtin_instructions)
+            * DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT;
+        assert_eq!(
+            instruction_details.sanitize_and_convert_to_compute_budget_limits(),
+            Ok(ComputeBudgetLimits {
+                compute_unit_limit: expected_compute_unit_limit,
+                ..ComputeBudgetLimits::default()
+            })
+        );
+
+        let instruction_details = InstructionDetails {
+            builtin_instruction_details: builtin_instruction_details.clone(),
+            compute_budget_instruction_details: ComputeBudgetInstructionDetails {
+                requested_compute_unit_limit: Some((1, 0)),
+                requested_compute_unit_price: Some((2, 0)),
+                requested_heap_size: Some((3, 0)),
+                requested_loaded_accounts_data_size_limit: Some((4, 0)),
+                count_compute_budget_instructions,
+            },
+        };
+        assert_eq!(
+            instruction_details.sanitize_and_convert_to_compute_budget_limits(),
+            Err(TransactionError::InvalidLoadedAccountsDataSizeLimit)
+        );
+
+        let instruction_details = InstructionDetails {
+            builtin_instruction_details: builtin_instruction_details.clone(),
+            compute_budget_instruction_details: ComputeBudgetInstructionDetails {
+                requested_compute_unit_limit: Some((1, u32::MAX)),
+                requested_compute_unit_price: Some((2, u64::MAX)),
+                requested_heap_size: Some((3, u32::MAX)),
+                requested_loaded_accounts_data_size_limit: Some((4, u32::MAX)),
+                count_compute_budget_instructions,
+            },
+        };
+        assert_eq!(
+            instruction_details.sanitize_and_convert_to_compute_budget_limits(),
+            Ok(ComputeBudgetLimits {
+                updated_heap_bytes: MAX_HEAP_FRAME_BYTES,
+                compute_unit_limit: MAX_COMPUTE_UNIT_LIMIT,
+                compute_unit_price: u64::MAX,
+                loaded_accounts_bytes: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
+            })
+        );
+
+        let val: u32 = 1024;
+        let instruction_details = InstructionDetails {
             builtin_instruction_details,
-        })
+            compute_budget_instruction_details: ComputeBudgetInstructionDetails {
+                requested_compute_unit_limit: Some((1, val)),
+                requested_compute_unit_price: Some((2, val as u64)),
+                requested_heap_size: Some((3, val)),
+                requested_loaded_accounts_data_size_limit: Some((4, val)),
+                count_compute_budget_instructions,
+            },
+        };
+        assert_eq!(
+            instruction_details.sanitize_and_convert_to_compute_budget_limits(),
+            Ok(ComputeBudgetLimits {
+                updated_heap_bytes: val,
+                compute_unit_limit: val,
+                compute_unit_price: val as u64,
+                loaded_accounts_bytes: NonZeroU32::new(val).unwrap(),
+            })
+        );
     }
 }

--- a/runtime-transaction/src/instructions_processor.rs
+++ b/runtime-transaction/src/instructions_processor.rs
@@ -1,106 +1,16 @@
 use {
+    crate::instruction_details::*,
     solana_compute_budget::compute_budget_limits::*,
-    solana_sdk::{
-        borsh1::try_from_slice_unchecked,
-        compute_budget::{self, ComputeBudgetInstruction},
-        instruction::{CompiledInstruction, InstructionError},
-        pubkey::Pubkey,
-        transaction::TransactionError,
-    },
-    std::num::NonZeroU32,
+    solana_sdk::{instruction::CompiledInstruction, pubkey::Pubkey, transaction::Result},
 };
 
-/// Processing compute_budget could be part of tx sanitizing, failed to process
-/// these instructions will drop the transaction eventually without execution,
-/// may as well fail it early.
-/// If succeeded, the transaction's specific limits/requests (could be default)
-/// are retrieved and returned,
+// NOTE - temp adaptor to keep compiler happy for the time being
+// all call sites will be updated with this two-step calls, using actual feature-set
+// or access runtime-transaction directly
 pub fn process_compute_budget_instructions<'a>(
     instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
-) -> Result<ComputeBudgetLimits, TransactionError> {
-    let mut num_non_compute_budget_instructions: u32 = 0;
-    let mut updated_compute_unit_limit = None;
-    let mut updated_compute_unit_price = None;
-    let mut requested_heap_size = None;
-    let mut updated_loaded_accounts_data_size_limit = None;
-
-    for (i, (program_id, instruction)) in instructions.enumerate() {
-        if compute_budget::check_id(program_id) {
-            let invalid_instruction_data_error = TransactionError::InstructionError(
-                i as u8,
-                InstructionError::InvalidInstructionData,
-            );
-            let duplicate_instruction_error = TransactionError::DuplicateInstruction(i as u8);
-
-            match try_from_slice_unchecked(&instruction.data) {
-                Ok(ComputeBudgetInstruction::RequestHeapFrame(bytes)) => {
-                    if requested_heap_size.is_some() {
-                        return Err(duplicate_instruction_error);
-                    }
-                    if sanitize_requested_heap_size(bytes) {
-                        requested_heap_size = Some(bytes);
-                    } else {
-                        return Err(invalid_instruction_data_error);
-                    }
-                }
-                Ok(ComputeBudgetInstruction::SetComputeUnitLimit(compute_unit_limit)) => {
-                    if updated_compute_unit_limit.is_some() {
-                        return Err(duplicate_instruction_error);
-                    }
-                    updated_compute_unit_limit = Some(compute_unit_limit);
-                }
-                Ok(ComputeBudgetInstruction::SetComputeUnitPrice(micro_lamports)) => {
-                    if updated_compute_unit_price.is_some() {
-                        return Err(duplicate_instruction_error);
-                    }
-                    updated_compute_unit_price = Some(micro_lamports);
-                }
-                Ok(ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit(bytes)) => {
-                    if updated_loaded_accounts_data_size_limit.is_some() {
-                        return Err(duplicate_instruction_error);
-                    }
-                    updated_loaded_accounts_data_size_limit = Some(
-                        NonZeroU32::new(bytes)
-                            .ok_or(TransactionError::InvalidLoadedAccountsDataSizeLimit)?,
-                    );
-                }
-                _ => return Err(invalid_instruction_data_error),
-            }
-        } else {
-            // only include non-request instructions in default max calc
-            num_non_compute_budget_instructions =
-                num_non_compute_budget_instructions.saturating_add(1);
-        }
-    }
-
-    // sanitize limits
-    let updated_heap_bytes = requested_heap_size
-        .unwrap_or(MIN_HEAP_FRAME_BYTES) // loader's default heap_size
-        .min(MAX_HEAP_FRAME_BYTES);
-
-    let compute_unit_limit = updated_compute_unit_limit
-        .unwrap_or_else(|| {
-            num_non_compute_budget_instructions
-                .saturating_mul(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT)
-        })
-        .min(MAX_COMPUTE_UNIT_LIMIT);
-
-    let compute_unit_price = updated_compute_unit_price.unwrap_or(0);
-
-    let loaded_accounts_bytes = updated_loaded_accounts_data_size_limit
-        .unwrap_or(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES)
-        .min(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
-
-    Ok(ComputeBudgetLimits {
-        updated_heap_bytes,
-        compute_unit_limit,
-        compute_unit_price,
-        loaded_accounts_bytes,
-    })
-}
-
-fn sanitize_requested_heap_size(bytes: u32) -> bool {
-    (MIN_HEAP_FRAME_BYTES..=MAX_HEAP_FRAME_BYTES).contains(&bytes) && bytes % 1024 == 0
+) -> Result<ComputeBudgetLimits> {
+    InstructionDetails::try_from(instructions)?.sanitize_and_convert_to_compute_budget_limits()
 }
 
 #[cfg(test)]
@@ -108,15 +18,17 @@ mod tests {
     use {
         super::*,
         solana_sdk::{
+            compute_budget::ComputeBudgetInstruction,
             hash::Hash,
-            instruction::Instruction,
+            instruction::{Instruction, InstructionError},
             message::Message,
             pubkey::Pubkey,
             signature::Keypair,
             signer::Signer,
             system_instruction::{self},
-            transaction::{SanitizedTransaction, Transaction},
+            transaction::{SanitizedTransaction, Transaction, TransactionError},
         },
+        std::num::NonZeroU32,
     };
 
     macro_rules! test {

--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 
-pub mod builtin_instruction_details;
-pub mod compute_budget_instruction_details;
-pub mod instruction_details;
+mod builtin_instruction_details;
+mod compute_budget_instruction_details;
+mod instruction_details;
 pub mod instructions_processor;
 pub mod runtime_transaction;
 pub mod transaction_meta;

--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 
+pub mod builtin_instruction_details;
+pub mod compute_budget_instruction_details;
 pub mod instruction_details;
 pub mod instructions_processor;
 pub mod runtime_transaction;

--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 
+pub mod instruction_details;
 pub mod instructions_processor;
 pub mod runtime_transaction;
 pub mod transaction_meta;


### PR DESCRIPTION
#### Problem
Process instructions (for a transaction) is really 2 steps: parse tx to gather deterministic ixs info; then (optionally) use current working bank to sanitize and convert gather instruction details to something else.

An intermediate struct between these two steps can be useful.

#### Summary of Changes
- add `InstructionDetails` struct
- break `process_compute_budget_instruction()` into two steps: `try_from()` to built `Result<InstructionDetails>`, and `sanitize_and_convert_to_compute_budget_limits()` to get `Result<ComputeBudgetLimits>`.
- keep `process_compute_budget_instructions()` as a wrapper for backward compatibility, temporarily (it will be refactored out in follow up changes)
 
Fixes #2352 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
