### PR TITLE
Cleanup PoH speed check error

### DIFF
--- a/entry/src/poh.rs
+++ b/entry/src/poh.rs
@@ -109,18 +109,18 @@ impl Poh {
     }
 }
 
-pub fn compute_hash_time_ns(hashes_sample_size: u64) -> u64 {
+pub fn compute_hash_time(hashes_sample_size: u64) -> Duration {
     info!("Running {} hashes...", hashes_sample_size);
     let mut v = Hash::default();
     let start = Instant::now();
     for _ in 0..hashes_sample_size {
         v = hash(v.as_ref());
     }
-    start.elapsed().as_nanos() as u64
+    start.elapsed()
 }
 
 pub fn compute_hashes_per_tick(duration: Duration, hashes_sample_size: u64) -> u64 {
-    let elapsed_ms = compute_hash_time_ns(hashes_sample_size) / (1000 * 1000);
+    let elapsed_ms = compute_hash_time(hashes_sample_size).as_millis() as u64;
     duration.as_millis() as u64 * hashes_sample_size / elapsed_ms
 }
 


### PR DESCRIPTION
#### Problem
The current logging and error message from the Poh speed check are
confusing. If the node fails, the error message states that the node is
too slow. But, the reported numbers are slot durations in nanoseconds
where a slower node will have a larger number. Lastly, the reported
numbers aren't labeled with a unit so it is hard to make sense of this
without looking at the actual code.

#### Summary of Changes
The check now computes and reports hashes per second.

Sample output from restarting a node with the change:
```
[2024-08-02T20:48:46.306126768Z INFO  solana_core::validator] PoH speed check: computed hashes per second 14118760, target hashes per second 2000000
```