### PR TITLE
Do not run elapsed slots loop in tests

### DIFF
--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -61,7 +61,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustc_version = { workspace = true }
 
 [features]
-dev-context-only-utils = ["dep:qualifier_attr"]
+dev-context-only-utils = ["dep:qualifier_attr", "solana-sdk/dev-context-only-utils"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",


### PR DESCRIPTION
#### Problem

A loop that calculates the number of elapsed slots between two epochs depend on the difference between the start and the end epoch:

https://github.com/anza-xyz/agave/blob/bb70670048f589264f83111a4fdb4972eea18a41/sdk/src/rent_collector.rs#L93

This loop can get quite slow (>20 minutes) if the difference between them is too large (around 2^40). Although this case may not happen on the network, it slows down fuzzing efforts.

#### Summary of Changes

I added a condition to avoid running the loop when the number of iterations is too high.
