### PR TITLE
Clean up reject_callx_r10

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -42,7 +42,7 @@ use {
             enable_big_mod_exp_syscall, enable_get_epoch_stake_syscall,
             enable_partitioned_epoch_reward, enable_poseidon_syscall,
             error_on_syscall_bpf_function_hash_collisions, get_sysvar_syscall_enabled,
-            last_restart_slot_sysvar, partitioned_epoch_rewards_superfeature, reject_callx_r10,
+            last_restart_slot_sysvar, partitioned_epoch_rewards_superfeature,
             remaining_compute_units_syscall_enabled,
         },
         hash::{Hash, Hasher},
@@ -301,7 +301,7 @@ pub fn create_program_runtime_environment_v1<'a>(
         sanitize_user_provided_values: true,
         external_internal_function_hash_collision: feature_set
             .is_active(&error_on_syscall_bpf_function_hash_collisions::id()),
-        reject_callx_r10: feature_set.is_active(&reject_callx_r10::id()),
+        reject_callx_r10: true,
         enable_sbpf_v1: true,
         enable_sbpf_v2: false,
         optimize_rodata: false,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11915,7 +11915,7 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase() {
     let (mut genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
     genesis_config
         .accounts
-        .remove(&feature_set::reject_callx_r10::id());
+        .remove(&feature_set::disable_fees_sysvar::id());
     let (root_bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     // Program Setup
@@ -11956,7 +11956,7 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase() {
     let feature_account_balance =
         std::cmp::max(genesis_config.rent.minimum_balance(Feature::size_of()), 1);
     bank.store_account(
-        &feature_set::reject_callx_r10::id(),
+        &feature_set::disable_fees_sysvar::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
 
@@ -12028,7 +12028,7 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
     let (mut genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
     genesis_config
         .accounts
-        .remove(&feature_set::reject_callx_r10::id());
+        .remove(&feature_set::disable_fees_sysvar::id());
     let (root_bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     // Program Setup
@@ -12061,7 +12061,7 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
     let feature_account_balance =
         std::cmp::max(genesis_config.rent.minimum_balance(Feature::size_of()), 1);
     bank.store_account(
-        &feature_set::reject_callx_r10::id(),
+        &feature_set::disable_fees_sysvar::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
 
@@ -12997,9 +12997,9 @@ fn test_deploy_last_epoch_slot() {
     let (mut genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
     genesis_config
         .accounts
-        .remove(&feature_set::reject_callx_r10::id());
+        .remove(&feature_set::disable_fees_sysvar::id());
     let mut bank = Bank::new_for_tests(&genesis_config);
-    bank.activate_feature(&feature_set::reject_callx_r10::id());
+    bank.activate_feature(&feature_set::disable_fees_sysvar::id());
 
     // go to the last slot in the epoch
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -269,7 +269,7 @@ fn create_custom_environment<'a>() -> BuiltinProgram<InvokeContext<'a>> {
         noop_instruction_rate: 256,
         sanitize_user_provided_values: true,
         external_internal_function_hash_collision: false,
-        reject_callx_r10: false,
+        reject_callx_r10: true,
         enable_sbpf_v1: true,
         enable_sbpf_v2: false,
         optimize_rodata: false,


### PR DESCRIPTION
#### Problem

Firedancer always cleans up features after Agave does.
We do so to ensure latest version Firedancer can replay a ledger produced by latest version Agave.

We'd like to see `reject_callx_r10` (activated on all networks) cleaned up in Agave to allow Firedancer to also clean up the feature.

#### Summary of Changes

Hardcodes `reject_callx_r10` to on.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
