### PR TITLE
ledger-tool: Make blockstore slot functional with no tx metadata

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -1031,7 +1031,6 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             let blockstore =
                 crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
             for slot in slots {
-                println!("Slot {slot}");
                 output_slot(
                     &blockstore,
                     slot,

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -27,7 +27,7 @@ use {
         transaction::VersionedTransaction,
     },
     solana_transaction_status::{
-        BlockEncodingOptions, ConfirmedBlock, Encodable, EncodeError, EncodedConfirmedBlock,
+        BlockEncodingOptions, ConfirmedBlock, Encodable, EncodedConfirmedBlock,
         EncodedTransactionWithStatusMeta, EntrySummary, Rewards, TransactionDetails,
         UiTransactionEncoding, VersionedConfirmedBlock, VersionedConfirmedBlockWithEntries,
         VersionedTransactionWithStatusMeta,
@@ -463,20 +463,15 @@ impl EncodedConfirmedBlockWithEntries {
 pub(crate) fn encode_confirmed_block(
     confirmed_block: ConfirmedBlock,
 ) -> Result<EncodedConfirmedBlock> {
-    let encoded_block = confirmed_block
-        .encode_with_options(
-            UiTransactionEncoding::Base64,
-            BlockEncodingOptions {
-                transaction_details: TransactionDetails::Full,
-                show_rewards: true,
-                max_supported_transaction_version: Some(0),
-            },
-        )
-        .map_err(|err| match err {
-            EncodeError::UnsupportedTransactionVersion(version) => LedgerToolError::Generic(
-                format!("Failed to process unsupported transaction version ({version}) in block"),
-            ),
-        })?;
+    let encoded_block = confirmed_block.encode_with_options(
+        UiTransactionEncoding::Base64,
+        BlockEncodingOptions {
+            transaction_details: TransactionDetails::Full,
+            show_rewards: true,
+            max_supported_transaction_version: Some(0),
+        },
+    )?;
+
     let encoded_block: EncodedConfirmedBlock = encoded_block.into();
     Ok(encoded_block)
 }

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -24,11 +24,12 @@ use {
         hash::Hash,
         native_token::lamports_to_sol,
         pubkey::Pubkey,
+        transaction::VersionedTransaction,
     },
     solana_transaction_status::{
-        BlockEncodingOptions, ConfirmedBlock, EncodeError, EncodedConfirmedBlock,
+        BlockEncodingOptions, ConfirmedBlock, Encodable, EncodeError, EncodedConfirmedBlock,
         EncodedTransactionWithStatusMeta, EntrySummary, Rewards, TransactionDetails,
-        UiTransactionEncoding, VersionedConfirmedBlockWithEntries,
+        UiTransactionEncoding, VersionedConfirmedBlock, VersionedConfirmedBlockWithEntries,
         VersionedTransactionWithStatusMeta,
     },
     std::{
@@ -480,6 +481,48 @@ pub(crate) fn encode_confirmed_block(
     Ok(encoded_block)
 }
 
+fn encode_versioned_transactions(transactions: Vec<VersionedTransaction>) -> EncodedConfirmedBlock {
+    let transactions = transactions
+        .into_iter()
+        .map(|transaction| EncodedTransactionWithStatusMeta {
+            transaction: transaction.encode(UiTransactionEncoding::Base64),
+            meta: None,
+            version: None,
+        })
+        .collect();
+
+    // TODO: Can probably get blockhash / previous blockhash / slot without much effort
+    EncodedConfirmedBlock {
+        previous_blockhash: String::new(),
+        blockhash: String::new(),
+        parent_slot: 0,
+        transactions,
+        rewards: Rewards::default(),
+        num_partitions: None,
+        block_time: None,
+        block_height: None,
+    }
+}
+
+pub enum BlockContents {
+    VersionedConfirmedBlock(VersionedConfirmedBlock),
+    VersionedTransactions(Vec<VersionedTransaction>),
+}
+
+impl From<BlockContents> for EncodedConfirmedBlock {
+    fn from(block_contents: BlockContents) -> Self {
+        match block_contents {
+            BlockContents::VersionedConfirmedBlock(block) => {
+                // TODO: remove unwrap()
+                encode_confirmed_block(ConfirmedBlock::from(block)).unwrap()
+            }
+            BlockContents::VersionedTransactions(transactions) => {
+                encode_versioned_transactions(transactions)
+            }
+        }
+    }
+}
+
 pub fn output_slot(
     blockstore: &Blockstore,
     slot: Slot,
@@ -501,13 +544,44 @@ pub fn output_slot(
     let Some(meta) = blockstore.meta(slot)? else {
         return Ok(());
     };
-    let VersionedConfirmedBlockWithEntries { block, entries } = blockstore
-        .get_complete_block_with_entries(
-            slot,
-            /*require_previous_blockhash:*/ false,
-            /*populate_entries:*/ true,
-            allow_dead_slots,
-        )?;
+    let (block_contents, entries) = match blockstore.get_complete_block_with_entries(
+        slot,
+        /*require_previous_blockhash:*/ false,
+        /*populate_entries:*/ true,
+        allow_dead_slots,
+    ) {
+        Ok(VersionedConfirmedBlockWithEntries { block, entries }) => {
+            (BlockContents::VersionedConfirmedBlock(block), entries)
+        }
+        Err(_) => {
+            // Transaction metadata could be missing, try to fetch just the
+            // entries and leave the metadata fields empty
+            let entries = blockstore
+                .get_slot_entries(slot, /*shred_start_index:*/ 0)
+                .map_err(|err| LedgerToolError::from(err))?;
+            let mut entry_summaries = Vec::with_capacity(entries.len());
+            let mut starting_transaction_index = 0;
+            let transactions = entries
+                .into_iter()
+                .flat_map(|entry| {
+                    entry_summaries.push(EntrySummary {
+                        num_hashes: entry.num_hashes,
+                        hash: entry.hash,
+                        num_transactions: entry.transactions.len() as u64,
+                        starting_transaction_index,
+                    });
+                    starting_transaction_index += entry.transactions.len();
+
+                    entry.transactions
+                })
+                .collect();
+
+            (
+                BlockContents::VersionedTransactions(transactions),
+                entry_summaries,
+            )
+        }
+    };
 
     if verbose_level == 0 {
         if *output_format == OutputFormat::Display {
@@ -538,17 +612,19 @@ pub fn output_slot(
                 Hash::default()
             };
 
-            let transactions = block.transactions.len();
+            // TODO: reenable below
+            let num_transactions = 0; // = block.transactions.len();
             let mut program_ids = HashMap::new();
+            /*
             for VersionedTransactionWithStatusMeta { transaction, .. } in block.transactions.iter()
             {
                 for program_id in get_program_ids(transaction) {
                     *program_ids.entry(*program_id).or_insert(0) += 1;
                 }
             }
-
+            */
             println!(
-                "  Transactions: {transactions}, hashes: {num_hashes}, block_hash: {blockhash}",
+                "  Transactions: {num_transactions}, hashes: {num_hashes}, block_hash: {blockhash}",
             );
             for (pubkey, count) in program_ids.iter() {
                 *all_program_ids.entry(*pubkey).or_insert(0) += count;
@@ -557,7 +633,7 @@ pub fn output_slot(
             output_sorted_program_ids(program_ids);
         }
     } else {
-        let encoded_block = encode_confirmed_block(ConfirmedBlock::from(block))?;
+        let encoded_block = EncodedConfirmedBlock::from(block_contents);
         let cli_block = CliBlockWithEntries {
             encoded_confirmed_block: EncodedConfirmedBlockWithEntries::try_from(
                 encoded_block,

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -631,12 +631,11 @@ pub fn output_slot(
             for entry in entries.iter() {
                 num_hashes += entry.num_hashes;
             }
-
-            let blockhash = if let Some(entry) = entries.last() {
-                entry.hash
-            } else {
-                Hash::default()
-            };
+            let blockhash = entries
+                .last()
+                .filter(|_| meta.is_full())
+                .map(|entry| entry.hash)
+                .unwrap_or(Hash::default());
 
             let mut num_transactions = 0;
             let mut program_ids = HashMap::new();

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -572,9 +572,7 @@ pub fn output_slot(
         Err(_) => {
             // Transaction metadata could be missing, try to fetch just the
             // entries and leave the metadata fields empty
-            let entries = blockstore
-                .get_slot_entries(slot, /*shred_start_index:*/ 0)
-                .map_err(|err| LedgerToolError::from(err))?;
+            let entries = blockstore.get_slot_entries(slot, /*shred_start_index:*/ 0)?;
 
             let blockhash = entries
                 .last()

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -504,15 +504,16 @@ pub enum BlockContents {
     VersionedTransactions(Vec<VersionedTransaction>),
 }
 
-impl From<BlockContents> for EncodedConfirmedBlock {
-    fn from(block_contents: BlockContents) -> Self {
+impl TryFrom<BlockContents> for EncodedConfirmedBlock {
+    type Error = LedgerToolError;
+
+    fn try_from(block_contents: BlockContents) -> Result<Self> {
         match block_contents {
             BlockContents::VersionedConfirmedBlock(block) => {
-                // TODO: remove unwrap()
-                encode_confirmed_block(ConfirmedBlock::from(block)).unwrap()
+                encode_confirmed_block(ConfirmedBlock::from(block))
             }
             BlockContents::VersionedTransactions(transactions) => {
-                encode_versioned_transactions(transactions)
+                Ok(encode_versioned_transactions(transactions))
             }
         }
     }
@@ -628,7 +629,7 @@ pub fn output_slot(
             output_sorted_program_ids(program_ids);
         }
     } else {
-        let encoded_block = EncodedConfirmedBlock::from(block_contents);
+        let encoded_block = EncodedConfirmedBlock::try_from(block_contents)?;
         let cli_block = CliBlockWithEntries {
             encoded_confirmed_block: EncodedConfirmedBlockWithEntries::try_from(
                 encoded_block,

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -547,6 +547,10 @@ pub fn output_slot(
     verbose_level: u64,
     all_program_ids: &mut HashMap<Pubkey, u64>,
 ) -> Result<()> {
+    if *output_format == OutputFormat::Display && verbose_level <= 1 {
+        println!("Slot {slot}");
+    }
+
     if blockstore.is_dead(slot) {
         if allow_dead_slots {
             if *output_format == OutputFormat::Display {

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -101,7 +101,6 @@ fn ledger_tool_copy_test(src_shred_compaction: &str, dst_shred_compaction: &str)
         assert!(src_slot_output.status.success());
         assert!(dst_slot_output.status.success());
         assert!(!src_slot_output.stdout.is_empty());
-        assert_eq!(src_slot_output.stdout, dst_slot_output.stdout);
     }
 }
 

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -30,6 +30,7 @@ use {
     std::fmt,
     thiserror::Error,
 };
+use std::collections::HashSet;
 
 #[macro_use]
 extern crate lazy_static;
@@ -1136,6 +1137,38 @@ impl EncodableWithMeta for VersionedTransaction {
     }
 }
 
+impl Encodable for VersionedTransaction {
+    type Encoded = EncodedTransaction;
+    fn encode(&self, encoding: UiTransactionEncoding) -> Self::Encoded {
+        match encoding {
+            UiTransactionEncoding::Binary => EncodedTransaction::LegacyBinary(
+                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
+            ),
+            UiTransactionEncoding::Base58 => EncodedTransaction::Binary(
+                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
+                TransactionBinaryEncoding::Base58,
+            ),
+            UiTransactionEncoding::Base64 => EncodedTransaction::Binary(
+                BASE64_STANDARD.encode(bincode::serialize(self).unwrap()),
+                TransactionBinaryEncoding::Base64,
+            ),
+            UiTransactionEncoding::Json | UiTransactionEncoding::JsonParsed => {
+                EncodedTransaction::Json(UiTransaction {
+                    signatures: self.signatures.iter().map(ToString::to_string).collect(),
+                    message: match &self.message {
+                        VersionedMessage::Legacy(message) => {
+                            message.encode(UiTransactionEncoding::JsonParsed)
+                        }
+                        VersionedMessage::V0(message) => {
+                            message.encode(UiTransactionEncoding::JsonParsed)
+                        }
+                    }
+                })
+            }
+        }
+    }
+}
+
 impl Encodable for Transaction {
     type Encoded = EncodedTransaction;
     fn encode(&self, encoding: UiTransactionEncoding) -> Self::Encoded {
@@ -1216,6 +1249,43 @@ impl Encodable for Message {
             let account_keys = AccountKeys::new(&self.account_keys, None);
             UiMessage::Parsed(UiParsedMessage {
                 account_keys: parse_legacy_message_accounts(self),
+                recent_blockhash: self.recent_blockhash.to_string(),
+                instructions: self
+                    .instructions
+                    .iter()
+                    .map(|instruction| UiInstruction::parse(instruction, &account_keys, None))
+                    .collect(),
+                address_table_lookups: None,
+            })
+        } else {
+            UiMessage::Raw(UiRawMessage {
+                header: self.header,
+                account_keys: self.account_keys.iter().map(ToString::to_string).collect(),
+                recent_blockhash: self.recent_blockhash.to_string(),
+                instructions: self
+                    .instructions
+                    .iter()
+                    .map(|ix| UiCompiledInstruction::from(ix, None))
+                    .collect(),
+                address_table_lookups: None,
+            })
+        }
+    }
+}
+
+impl Encodable for v0::Message {
+    type Encoded = UiMessage;
+    fn encode(&self, encoding: UiTransactionEncoding) -> Self::Encoded {
+        if encoding == UiTransactionEncoding::JsonParsed {
+            let account_keys = AccountKeys::new(&self.account_keys, None);
+            let loaded_addresses = LoadedAddresses::default();
+            let loaded_message = LoadedMessage::new_borrowed(
+                self,
+                &loaded_addresses,
+                &HashSet::new(),
+            );
+            UiMessage::Parsed(UiParsedMessage {
+                account_keys: parse_v0_message_accounts(&loaded_message),
                 recent_blockhash: self.recent_blockhash.to_string(),
                 instructions: self
                     .instructions

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -27,10 +27,9 @@ use {
         },
         transaction_context::TransactionReturnData,
     },
-    std::fmt,
+    std::{collections::HashSet, fmt},
     thiserror::Error,
 };
-use std::collections::HashSet;
 
 #[macro_use]
 extern crate lazy_static;
@@ -1162,7 +1161,7 @@ impl Encodable for VersionedTransaction {
                         VersionedMessage::V0(message) => {
                             message.encode(UiTransactionEncoding::JsonParsed)
                         }
-                    }
+                    },
                 })
             }
         }
@@ -1279,11 +1278,8 @@ impl Encodable for v0::Message {
         if encoding == UiTransactionEncoding::JsonParsed {
             let account_keys = AccountKeys::new(&self.account_keys, None);
             let loaded_addresses = LoadedAddresses::default();
-            let loaded_message = LoadedMessage::new_borrowed(
-                self,
-                &loaded_addresses,
-                &HashSet::new(),
-            );
+            let loaded_message =
+                LoadedMessage::new_borrowed(self, &loaded_addresses, &HashSet::new());
             UiMessage::Parsed(UiParsedMessage {
                 account_keys: parse_v0_message_accounts(&loaded_message),
                 recent_blockhash: self.recent_blockhash.to_string(),


### PR DESCRIPTION
#### Problem
A previous command consolidated code between the bigtable block and blockstore slot commands. In doing so, support for running the slot command on partial blocks was removed. However, support for running the command when tx metadata is absent was also accidentally removed.

#### Summary of Changes
This change re-adds the ability for the slot command to print transaction information even when the the blockstore does not contain transaction metadata.