### PR TITLE
Use system libc jemalloc instead of tikv-jemallocator on FreeBSD

### DIFF
--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -59,7 +59,7 @@ solana_rbpf = { workspace = true, features = ["debugger"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 jemallocator = { workspace = true }
 
 [dev-dependencies]

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -796,10 +796,10 @@ fn record_transactions(
     }
 }
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 use jemallocator::Jemalloc;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -77,7 +77,7 @@ solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 tempfile = { workspace = true }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 jemallocator = { workspace = true }
 
 [target."cfg(unix)".dependencies]

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::arithmetic_side_effects)]
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 use jemallocator::Jemalloc;
 use {
     agave_validator::{
@@ -87,7 +87,7 @@ use {
     },
 };
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
#### Problem

Validator compiled out of the box and run on mainnet on FreeBSD 14.1-RELEASE leaks memory.
Virtual memory size as reported as SIZE by top steadily increases until process is OOM killed.
Periodic sampling of `procstat vm` shows an steadily increasing number of anonymous memory maps.
The system memory laundry list increases over time until swap is consumed and exhausted.

As the validator does not leak memory on Linux, the tikv-jemallocator crate which replaces the standard memory allocator with a version of jemalloc was removed. After a day of running on mainnet, the modified validator virtual memory size remained under 600G with no increase in the memory laundry list or use of swap.

It is unclear why the tikv-jemallocator installed memory allocator leaked memory on FreeBSD though it worth noting tikv-jemallocator's README lists only Linux and MacOS as supported OS's and the version of tikv-jemallocator in the checked in Cargo.lock is v0.4.1 which is quite old - the last release is v0.5.4 and the main trunk has been bumped to v0.6.0.

#### Summary of Changes

Dependencies on the tikv-jemallocator package as well as code referencing it has been made conditionally compiled whenever `target_os` is `FreeBSD` or `target_env` is `msvc` (as before).

#### Notes

First few lines from FreeBSD malloc man page below for reference.

```
# man malloc|head -n16
JEMALLOC(3)                       User Manual                      JEMALLOC(3)

NAME
       jemalloc - general purpose memory allocation functions

LIBRARY
       This manual describes jemalloc
       5.2.1-0-gea6b3e973b477b8061e0076bb257dbd7f3faa756. More information can
       be found at the jemalloc website[1].

       The following configuration options are enabled in libc's built-in
       jemalloc: --enable-fill, --enable-lazy-lock, --enable-stats,
       --enable-utrace, --enable-xmalloc, and
       --with-malloc-conf=abort_conf:false. Additionally, --enable-debug is
       enabled in development versions of FreeBSD (controlled by the
       MK_MALLOC_PRODUCTION make variable).
```