### PR TITLE
hash-cache-tool: Adds fn to extract latest entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "clap 2.33.3",
  "memmap2",
  "solana-accounts-db",
+ "solana-program",
  "solana-version",
 ]
 

--- a/accounts-db/accounts-hash-cache-tool/Cargo.toml
+++ b/accounts-db/accounts-hash-cache-tool/Cargo.toml
@@ -15,6 +15,7 @@ bytemuck = { workspace = true }
 clap = { workspace = true }
 memmap2 = { workspace = true }
 solana-accounts-db = { workspace = true }
+solana-program = { workspace = true }
 solana-version = { workspace = true }
 
 [features]


### PR DESCRIPTION
#### Problem

I'm going to add a command to the accounts-hash-cache-tool to diff the total state. It'll need to extract the latest entries from all the files. We already do this same thing when diffing files, but that impl lives within the diff files function.


#### Summary of Changes

Move the code that extract the latest entries to its own function.
