### PR TITLE
AccountLocks: validate_account_locks

### DIFF
--- a/accounts-db/src/account_locks.rs
+++ b/accounts-db/src/account_locks.rs
@@ -134,10 +134,12 @@ thread_local! {
 
 /// Check for duplicate account keys.
 fn has_duplicates(account_keys: AccountKeys) -> bool {
+    // Benchmarking has shown that for sets of 32 or more keys, it is faster to
+    // use a HashSet to check for duplicates.
+    // For smaller sets a brute-force O(n^2) check seems to be faster.
     const USE_ACCOUNT_LOCK_SET_SIZE: usize = 32;
     if account_keys.len() >= USE_ACCOUNT_LOCK_SET_SIZE {
-        HAS_DUPLICATES_SET.with(|set| {
-            let mut set = set.borrow_mut();
+        HAS_DUPLICATES_SET.with_borrow_mut(|set| {
             let has_duplicates = account_keys.iter().any(|key| !set.insert(*key));
             set.clear();
             has_duplicates

--- a/accounts-db/src/account_locks.rs
+++ b/accounts-db/src/account_locks.rs
@@ -120,13 +120,12 @@ pub fn validate_account_locks(
     tx_account_lock_limit: usize,
 ) -> Result<(), TransactionError> {
     if account_keys.len() > tx_account_lock_limit {
-        return Err(TransactionError::TooManyAccountLocks);
+        Err(TransactionError::TooManyAccountLocks)
+    } else if has_duplicates(account_keys) {
+        Err(TransactionError::AccountLoadedTwice)
+    } else {
+        Ok(())
     }
-    if has_duplicates(account_keys) {
-        return Err(TransactionError::AccountLoadedTwice);
-    }
-
-    Ok(())
 }
 
 thread_local! {
@@ -134,7 +133,6 @@ thread_local! {
 }
 
 /// Check for duplicate account keys.
-#[inline]
 fn has_duplicates(account_keys: AccountKeys) -> bool {
     const USE_ACCOUNT_LOCK_SET_SIZE: usize = 32;
     if account_keys.len() >= USE_ACCOUNT_LOCK_SET_SIZE {

--- a/sdk/program/src/message/account_keys.rs
+++ b/sdk/program/src/message/account_keys.rs
@@ -17,6 +17,7 @@ pub struct AccountKeys<'a> {
 
 impl Index<usize> for AccountKeys<'_> {
     type Output = Pubkey;
+    #[inline]
     fn index(&self, index: usize) -> &Self::Output {
         self.get(index).expect("index is invalid")
     }
@@ -33,6 +34,7 @@ impl<'a> AccountKeys<'a> {
     /// Returns an iterator of account key segments. The ordering of segments
     /// affects how account indexes from compiled instructions are resolved and
     /// so should not be changed.
+    #[inline]
     fn key_segment_iter(&self) -> impl Iterator<Item = &'a [Pubkey]> + Clone {
         if let Some(dynamic_keys) = self.dynamic_keys {
             [
@@ -51,6 +53,7 @@ impl<'a> AccountKeys<'a> {
     /// message account keys constructed from static keys, followed by dynamically
     /// loaded writable addresses, and lastly the list of dynamically loaded
     /// readonly addresses.
+    #[inline]
     pub fn get(&self, mut index: usize) -> Option<&'a Pubkey> {
         for key_segment in self.key_segment_iter() {
             if index < key_segment.len() {
@@ -63,6 +66,7 @@ impl<'a> AccountKeys<'a> {
     }
 
     /// Returns the total length of loaded accounts for a message
+    #[inline]
     pub fn len(&self) -> usize {
         let mut len = 0usize;
         for key_segment in self.key_segment_iter() {
@@ -77,6 +81,7 @@ impl<'a> AccountKeys<'a> {
     }
 
     /// Iterator for the addresses of the loaded accounts for a message
+    #[inline]
     pub fn iter(&self) -> impl Iterator<Item = &'a Pubkey> + Clone {
         self.key_segment_iter().flatten()
     }


### PR DESCRIPTION
#### Problem
- We want account lock validation should be possible for any `SVMMessage`:
	- Code currently lives in `SanitizedTransaction`

#### Summary of Changes
- Add `account_locks::validate_account_locks` that takes `AccountKeys` and limit
- Add custom `has_duplicates`:
	- for >= 32 accounts, use a **pre-allocated** `AHashSet`
	- for <  32 accounts, use brute-force `O(n^2)` algorithm

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
