### PR TITLE
fix: remove expensive versioned epoch stakes clone

### DIFF
--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -6,7 +6,8 @@ mod tests {
                 epoch_accounts_hash_utils, test_utils as bank_test_utils, Bank, EpochRewardStatus,
             },
             epoch_stakes::{
-                EpochAuthorizedVoters, EpochStakes, NodeIdToVoteAccounts, VersionedEpochStakes,
+                EpochAuthorizedVoters, EpochStakes, NodeIdToVoteAccounts, StakesSerdeWrapper,
+                VersionedEpochStakes,
             },
             genesis_utils::activate_all_features,
             runtime_config::RuntimeConfig,
@@ -306,7 +307,7 @@ mod tests {
         bank.epoch_stakes.insert(
             42,
             EpochStakes::from(VersionedEpochStakes::Current {
-                stakes: Stakes::<Stake>::default(),
+                stakes: StakesSerdeWrapper::Stake(Stakes::<Stake>::default()),
                 total_stake: 42,
                 node_id_to_vote_accounts: Arc::<NodeIdToVoteAccounts>::default(),
                 epoch_authorized_voters: Arc::<EpochAuthorizedVoters>::default(),
@@ -535,7 +536,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "CeNFPePrUfgJT2GNr7zYfMQVuJwGyU46bz1Skq7hAPht")
+            frozen_abi(digest = "7a6C1oFtgZiMtZig7FbX9289xn55QadQ962rX61Gheef")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapper {

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -389,7 +389,8 @@ where
 /// added to this struct a minor release before they are added to the serialize
 /// struct.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
+#[derive(Clone, Debug, Deserialize)]
 struct ExtraFieldsToDeserialize {
     #[serde(deserialize_with = "default_on_eof")]
     lamports_per_signature: u64,
@@ -408,8 +409,8 @@ struct ExtraFieldsToDeserialize {
 /// be added to the deserialize struct a minor release before they are added to
 /// this one.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[cfg_attr(feature = "dev-context-only-utils", derive(Default))]
-#[derive(Debug, Serialize, PartialEq)]
+#[cfg_attr(feature = "dev-context-only-utils", derive(Default, PartialEq))]
+#[derive(Debug, Serialize)]
 pub struct ExtraFieldsToSerialize<'a> {
     pub lamports_per_signature: u64,
     pub incremental_snapshot_persistence: Option<&'a BankIncrementalSnapshotPersistence>,

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -55,10 +55,10 @@ impl StakeAccount<Delegation> {
     }
 
     #[inline]
-    pub(crate) fn stake(&self) -> Stake {
+    pub(crate) fn stake(&self) -> &Stake {
         // Safe to unwrap here because StakeAccount<Delegation> will always
         // only wrap a stake-state.
-        self.stake_state.stake().unwrap()
+        self.stake_state.stake_ref().unwrap()
     }
 }
 

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -213,6 +213,13 @@ impl StakeStateV2 {
         }
     }
 
+    pub fn stake_ref(&self) -> Option<&Stake> {
+        match self {
+            StakeStateV2::Stake(_meta, stake, _stake_flags) => Some(stake),
+            _ => None,
+        }
+    }
+
     pub fn delegation(&self) -> Option<Delegation> {
         match self {
             StakeStateV2::Stake(_meta, stake, _stake_flags) => Some(stake.delegation),


### PR DESCRIPTION
#### Problem
During snapshot creation, versioned epoch stakes are created by cloning a lot of stake data which consumes a lot of memory. This issue was introduced by https://github.com/anza-xyz/agave/pull/2282

#### Summary of Changes
- Avoid the deep clone from `Stakes<StakeAccount>` to `Stakes<Stake>` by using a serialization wrapper struct which can serialize `Stakes<StakeAccount>` as a `Stakes<Stake>` with minimal allocation.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
