### PR TITLE
Fix aliasing in syscalls

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -739,17 +739,21 @@ declare_builtin_function!(
             .create_program_address_units;
         consume_compute_meter(invoke_context, cost)?;
 
-        let (seeds, program_id) = translate_and_check_program_address_inputs(
-            seeds_addr,
-            seeds_len,
-            program_id_addr,
-            memory_mapping,
-            invoke_context.get_check_aligned(),
-        )?;
+        let new_address = {
+            let (seeds, program_id) = translate_and_check_program_address_inputs(
+                seeds_addr,
+                seeds_len,
+                program_id_addr,
+                memory_mapping,
+                invoke_context.get_check_aligned(),
+            )?;
 
-        let Ok(new_address) = Pubkey::create_program_address(&seeds, program_id) else {
-            return Ok(1);
+            let Ok(new_address) = Pubkey::create_program_address(&seeds, program_id) else {
+                return Ok(1);
+            };
+            new_address
         };
+
         let address = translate_slice_mut::<u8>(
             memory_mapping,
             address_addr,
@@ -974,18 +978,18 @@ declare_builtin_function!(
                         .curve25519_edwards_add_cost;
                     consume_compute_meter(invoke_context, cost)?;
 
-                    let left_point = translate_type::<edwards::PodEdwardsPoint>(
+                    let left_point = *translate_type::<edwards::PodEdwardsPoint>(
                         memory_mapping,
                         left_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
-                    let right_point = translate_type::<edwards::PodEdwardsPoint>(
+                    let right_point = *translate_type::<edwards::PodEdwardsPoint>(
                         memory_mapping,
                         right_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
 
-                    if let Some(result_point) = edwards::add_edwards(left_point, right_point) {
+                    if let Some(result_point) = edwards::add_edwards(&left_point, &right_point) {
                         *translate_type_mut::<edwards::PodEdwardsPoint>(
                             memory_mapping,
                             result_point_addr,
@@ -1002,18 +1006,19 @@ declare_builtin_function!(
                         .curve25519_edwards_subtract_cost;
                     consume_compute_meter(invoke_context, cost)?;
 
-                    let left_point = translate_type::<edwards::PodEdwardsPoint>(
+                    let left_point = *translate_type::<edwards::PodEdwardsPoint>(
                         memory_mapping,
                         left_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
-                    let right_point = translate_type::<edwards::PodEdwardsPoint>(
+                    let right_point = *translate_type::<edwards::PodEdwardsPoint>(
                         memory_mapping,
                         right_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
 
-                    if let Some(result_point) = edwards::subtract_edwards(left_point, right_point) {
+                    if let Some(result_point) = edwards::subtract_edwards(&left_point, &right_point)
+                    {
                         *translate_type_mut::<edwards::PodEdwardsPoint>(
                             memory_mapping,
                             result_point_addr,
@@ -1030,18 +1035,18 @@ declare_builtin_function!(
                         .curve25519_edwards_multiply_cost;
                     consume_compute_meter(invoke_context, cost)?;
 
-                    let scalar = translate_type::<scalar::PodScalar>(
+                    let scalar = *translate_type::<scalar::PodScalar>(
                         memory_mapping,
                         left_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
-                    let input_point = translate_type::<edwards::PodEdwardsPoint>(
+                    let input_point = *translate_type::<edwards::PodEdwardsPoint>(
                         memory_mapping,
                         right_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
 
-                    if let Some(result_point) = edwards::multiply_edwards(scalar, input_point) {
+                    if let Some(result_point) = edwards::multiply_edwards(&scalar, &input_point) {
                         *translate_type_mut::<edwards::PodEdwardsPoint>(
                             memory_mapping,
                             result_point_addr,
@@ -1071,18 +1076,19 @@ declare_builtin_function!(
                         .curve25519_ristretto_add_cost;
                     consume_compute_meter(invoke_context, cost)?;
 
-                    let left_point = translate_type::<ristretto::PodRistrettoPoint>(
+                    let left_point = *translate_type::<ristretto::PodRistrettoPoint>(
                         memory_mapping,
                         left_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
-                    let right_point = translate_type::<ristretto::PodRistrettoPoint>(
+                    let right_point = *translate_type::<ristretto::PodRistrettoPoint>(
                         memory_mapping,
                         right_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
 
-                    if let Some(result_point) = ristretto::add_ristretto(left_point, right_point) {
+                    if let Some(result_point) = ristretto::add_ristretto(&left_point, &right_point)
+                    {
                         *translate_type_mut::<ristretto::PodRistrettoPoint>(
                             memory_mapping,
                             result_point_addr,
@@ -1099,19 +1105,19 @@ declare_builtin_function!(
                         .curve25519_ristretto_subtract_cost;
                     consume_compute_meter(invoke_context, cost)?;
 
-                    let left_point = translate_type::<ristretto::PodRistrettoPoint>(
+                    let left_point = *translate_type::<ristretto::PodRistrettoPoint>(
                         memory_mapping,
                         left_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
-                    let right_point = translate_type::<ristretto::PodRistrettoPoint>(
+                    let right_point = *translate_type::<ristretto::PodRistrettoPoint>(
                         memory_mapping,
                         right_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
 
                     if let Some(result_point) =
-                        ristretto::subtract_ristretto(left_point, right_point)
+                        ristretto::subtract_ristretto(&left_point, &right_point)
                     {
                         *translate_type_mut::<ristretto::PodRistrettoPoint>(
                             memory_mapping,
@@ -1129,18 +1135,19 @@ declare_builtin_function!(
                         .curve25519_ristretto_multiply_cost;
                     consume_compute_meter(invoke_context, cost)?;
 
-                    let scalar = translate_type::<scalar::PodScalar>(
+                    let scalar = *translate_type::<scalar::PodScalar>(
                         memory_mapping,
                         left_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
-                    let input_point = translate_type::<ristretto::PodRistrettoPoint>(
+                    let input_point = *translate_type::<ristretto::PodRistrettoPoint>(
                         memory_mapping,
                         right_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
 
-                    if let Some(result_point) = ristretto::multiply_ristretto(scalar, input_point) {
+                    if let Some(result_point) = ristretto::multiply_ristretto(&scalar, &input_point)
+                    {
                         *translate_type_mut::<ristretto::PodRistrettoPoint>(
                             memory_mapping,
                             result_point_addr,
@@ -1210,21 +1217,24 @@ declare_builtin_function!(
                     );
                 consume_compute_meter(invoke_context, cost)?;
 
-                let scalars = translate_slice::<scalar::PodScalar>(
-                    memory_mapping,
-                    scalars_addr,
-                    points_len,
-                    invoke_context.get_check_aligned(),
-                )?;
+                let result_point = {
+                    let scalars = translate_slice::<scalar::PodScalar>(
+                        memory_mapping,
+                        scalars_addr,
+                        points_len,
+                        invoke_context.get_check_aligned(),
+                    )?;
 
-                let points = translate_slice::<edwards::PodEdwardsPoint>(
-                    memory_mapping,
-                    points_addr,
-                    points_len,
-                    invoke_context.get_check_aligned(),
-                )?;
+                    let points = translate_slice::<edwards::PodEdwardsPoint>(
+                        memory_mapping,
+                        points_addr,
+                        points_len,
+                        invoke_context.get_check_aligned(),
+                    )?;
+                    edwards::multiscalar_multiply_edwards(scalars, points)
+                };
 
-                if let Some(result_point) = edwards::multiscalar_multiply_edwards(scalars, points) {
+                if let Some(result_point) = result_point {
                     *translate_type_mut::<edwards::PodEdwardsPoint>(
                         memory_mapping,
                         result_point_addr,
@@ -1248,23 +1258,24 @@ declare_builtin_function!(
                     );
                 consume_compute_meter(invoke_context, cost)?;
 
-                let scalars = translate_slice::<scalar::PodScalar>(
-                    memory_mapping,
-                    scalars_addr,
-                    points_len,
-                    invoke_context.get_check_aligned(),
-                )?;
+                let result_point = {
+                    let scalars = translate_slice::<scalar::PodScalar>(
+                        memory_mapping,
+                        scalars_addr,
+                        points_len,
+                        invoke_context.get_check_aligned(),
+                    )?;
 
-                let points = translate_slice::<ristretto::PodRistrettoPoint>(
-                    memory_mapping,
-                    points_addr,
-                    points_len,
-                    invoke_context.get_check_aligned(),
-                )?;
-
-                if let Some(result_point) =
+                    let points = translate_slice::<ristretto::PodRistrettoPoint>(
+                        memory_mapping,
+                        points_addr,
+                        points_len,
+                        invoke_context.get_check_aligned(),
+                    )?;
                     ristretto::multiscalar_multiply_ristretto(scalars, points)
-                {
+                };
+
+                if let Some(result_point) = result_point {
                     *translate_type_mut::<ristretto::PodRistrettoPoint>(
                         memory_mapping,
                         result_point_addr,
@@ -1363,14 +1374,13 @@ declare_builtin_function!(
                 .unwrap_or(u64::MAX);
             consume_compute_meter(invoke_context, cost)?;
 
-            let return_data_result = translate_slice_mut::<u8>(
+            let to_slice = translate_slice_mut::<u8>(
                 memory_mapping,
                 return_data_addr,
                 length,
                 invoke_context.get_check_aligned(),
             )?;
 
-            let to_slice = return_data_result;
             let from_slice = return_data
                 .get(..length as usize)
                 .ok_or(SyscallError::InvokeContextBorrowFailed)?;
@@ -1694,28 +1704,30 @@ declare_builtin_function!(
             ),
         )?;
 
-        let base = translate_slice::<u8>(
-            memory_mapping,
-            params.base as *const _ as u64,
-            params.base_len,
-            invoke_context.get_check_aligned(),
-        )?;
+        let value = {
+            let base = translate_slice::<u8>(
+                memory_mapping,
+                params.base as *const _ as u64,
+                params.base_len,
+                invoke_context.get_check_aligned(),
+            )?;
 
-        let exponent = translate_slice::<u8>(
-            memory_mapping,
-            params.exponent as *const _ as u64,
-            params.exponent_len,
-            invoke_context.get_check_aligned(),
-        )?;
+            let exponent = translate_slice::<u8>(
+                memory_mapping,
+                params.exponent as *const _ as u64,
+                params.exponent_len,
+                invoke_context.get_check_aligned(),
+            )?;
 
-        let modulus = translate_slice::<u8>(
-            memory_mapping,
-            params.modulus as *const _ as u64,
-            params.modulus_len,
-            invoke_context.get_check_aligned(),
-        )?;
+            let modulus = translate_slice::<u8>(
+                memory_mapping,
+                params.modulus as *const _ as u64,
+                params.modulus_len,
+                invoke_context.get_check_aligned(),
+            )?;
 
-        let value = big_mod_exp(base, exponent, modulus);
+            big_mod_exp(base, exponent, modulus)
+        };
 
         let return_value = translate_slice_mut::<u8>(
             memory_mapping,


### PR DESCRIPTION
#### Problem

Some read-only and mutable references may alias each other in the same scope.
This theoretically breaks Rust's aliasing assumptions, although practically not an issue.

#### Summary of Changes

Improve lexical scoping such that read-only references go out of scope before a writable reference is created. This ensures that no unsound aliasing occurs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
