### PR TITLE
fix: borrow stakes delegation during snapshot serialization

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2234,8 +2234,7 @@ impl Bank {
                 .fold(
                     HashSet::default,
                     |mut voter_pubkeys, (_stake_pubkey, stake_account)| {
-                        let delegation = stake_account.delegation();
-                        voter_pubkeys.insert(delegation.voter_pubkey);
+                        voter_pubkeys.insert(stake_account.delegation().voter_pubkey);
                         voter_pubkeys
                     },
                 )
@@ -2299,7 +2298,7 @@ impl Bank {
             };
             if let Some(reward_calc_tracer) = reward_calc_tracer.as_ref() {
                 let delegation =
-                    InflationPointCalculationEvent::Delegation(delegation, solana_vote_program);
+                    InflationPointCalculationEvent::Delegation(*delegation, solana_vote_program);
                 let event = RewardCalculationEvent::Staking(stake_pubkey, &delegation);
                 reward_calc_tracer(&event);
             }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -378,10 +378,9 @@ impl Bank {
                     let stake_pubkey = **stake_pubkey;
                     let stake_account = (*stake_account).to_owned();
 
-                    let delegation = stake_account.delegation();
+                    let vote_pubkey = stake_account.delegation().voter_pubkey;
                     let (mut stake_account, stake_state) =
                         <(AccountSharedData, StakeStateV2)>::from(stake_account);
-                    let vote_pubkey = delegation.voter_pubkey;
                     let vote_account = get_vote_account(&vote_pubkey)?;
                     if vote_account.owner() != &solana_vote_program {
                         return None;
@@ -501,8 +500,7 @@ impl Bank {
             stake_delegations
                 .par_iter()
                 .map(|(_stake_pubkey, stake_account)| {
-                    let delegation = stake_account.delegation();
-                    let vote_pubkey = delegation.voter_pubkey;
+                    let vote_pubkey = stake_account.delegation().voter_pubkey;
 
                     let Some(vote_account) = get_vote_account(&vote_pubkey) else {
                         return 0;

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -536,7 +536,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "7a6C1oFtgZiMtZig7FbX9289xn55QadQ962rX61Gheef")
+            frozen_abi(digest = "DnUdXXELygo14vA8d6QoXo5bkJAQbTWqWW5Qf9RXXWgZ")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapper {

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -48,10 +48,10 @@ impl<T> StakeAccount<T> {
 
 impl StakeAccount<Delegation> {
     #[inline]
-    pub(crate) fn delegation(&self) -> Delegation {
+    pub(crate) fn delegation(&self) -> &Delegation {
         // Safe to unwrap here because StakeAccount<Delegation> will always
         // only wrap a stake-state which is a delegation.
-        self.stake_state.delegation().unwrap()
+        self.stake_state.delegation_ref().unwrap()
     }
 
     #[inline]

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -26,6 +26,9 @@ use {
     thiserror::Error,
 };
 
+mod serde_stakes;
+pub(crate) use serde_stakes::serde_stakes_enum_compat;
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Invalid delegation: {0}")]
@@ -547,23 +550,6 @@ impl From<Stakes<StakeAccount>> for Stakes<Delegation> {
     }
 }
 
-impl<'a> From<&'a Stakes<StakeAccount>> for Stakes<&'a Delegation> {
-    fn from(stakes: &'a Stakes<StakeAccount>) -> Self {
-        let stake_delegations = stakes
-            .stake_delegations
-            .iter()
-            .map(|(pubkey, stake_account)| (*pubkey, stake_account.delegation()))
-            .collect();
-        Self {
-            vote_accounts: stakes.vote_accounts.clone(),
-            stake_delegations,
-            unused: stakes.unused,
-            epoch: stakes.epoch,
-            stake_history: stakes.stake_history.clone(),
-        }
-    }
-}
-
 /// This conversion is very memory intensive so should only be used in
 /// development contexts.
 #[cfg(feature = "dev-context-only-utils")]
@@ -621,23 +607,6 @@ impl From<Stakes<Stake>> for Stakes<Delegation> {
     }
 }
 
-impl<'a> From<&'a Stakes<Stake>> for Stakes<&'a Delegation> {
-    fn from(stakes: &'a Stakes<Stake>) -> Self {
-        let stake_delegations = stakes
-            .stake_delegations
-            .iter()
-            .map(|(pubkey, stake)| (*pubkey, &stake.delegation))
-            .collect();
-        Self {
-            vote_accounts: stakes.vote_accounts.clone(),
-            stake_delegations,
-            unused: stakes.unused,
-            epoch: stakes.epoch,
-            stake_history: stakes.stake_history.clone(),
-        }
-    }
-}
-
 #[cfg(feature = "dev-context-only-utils")]
 impl From<StakesEnum> for Stakes<Delegation> {
     fn from(stakes: StakesEnum) -> Self {
@@ -679,36 +648,6 @@ impl PartialEq<StakesEnum> for StakesEnum {
                 stakes == other
             }
         }
-    }
-}
-
-// In order to maintain backward compatibility, the StakesEnum in EpochStakes
-// and SerializableVersionedBank should be serialized as Stakes<Delegation>.
-pub(crate) mod serde_stakes_enum_compat {
-    use {
-        super::*,
-        serde::{Deserialize, Deserializer, Serialize, Serializer},
-    };
-
-    pub(crate) fn serialize<S>(stakes: &StakesEnum, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match stakes {
-            StakesEnum::Delegations(stakes) => stakes.serialize(serializer),
-            StakesEnum::Stakes(stakes) => Stakes::<&Delegation>::from(stakes).serialize(serializer),
-            StakesEnum::Accounts(stakes) => {
-                Stakes::<&Delegation>::from(stakes).serialize(serializer)
-            }
-        }
-    }
-
-    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Arc<StakesEnum>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let stakes = Stakes::<Delegation>::deserialize(deserializer)?;
-        Ok(Arc::new(StakesEnum::Delegations(stakes)))
     }
 }
 
@@ -757,7 +696,6 @@ fn refresh_vote_accounts(
 pub(crate) mod tests {
     use {
         super::*,
-        rand::Rng,
         rayon::ThreadPoolBuilder,
         solana_sdk::{account::WritableAccount, pubkey::Pubkey, rent::Rent, stake},
         solana_stake_program::stake_state,
@@ -1183,64 +1121,5 @@ pub(crate) mod tests {
                 *expected_warmed_stake
             );
         }
-    }
-
-    #[test]
-    fn test_serde_stakes_enum_compat() {
-        #[derive(Debug, PartialEq, Deserialize, Serialize)]
-        struct Dummy {
-            head: String,
-            #[serde(with = "serde_stakes_enum_compat")]
-            stakes: Arc<StakesEnum>,
-            tail: String,
-        }
-        let mut rng = rand::thread_rng();
-        let stakes_cache = StakesCache::new(Stakes {
-            unused: rng.gen(),
-            epoch: rng.gen(),
-            ..Stakes::default()
-        });
-        for _ in 0..rng.gen_range(5usize..10) {
-            let vote_pubkey = solana_sdk::pubkey::new_rand();
-            let vote_account = vote_state::create_account(
-                &vote_pubkey,
-                &solana_sdk::pubkey::new_rand(), // node_pubkey
-                rng.gen_range(0..101),           // commission
-                rng.gen_range(0..1_000_000),     // lamports
-            );
-            stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
-            for _ in 0..rng.gen_range(10usize..20) {
-                let stake_pubkey = solana_sdk::pubkey::new_rand();
-                let rent = Rent::with_slots_per_epoch(rng.gen());
-                let stake_account = stake_state::create_account(
-                    &stake_pubkey, // authorized
-                    &vote_pubkey,
-                    &vote_account,
-                    &rent,
-                    rng.gen_range(0..1_000_000), // lamports
-                );
-                stakes_cache.check_and_store(&stake_pubkey, &stake_account, None);
-            }
-        }
-        let stakes: Stakes<StakeAccount> = stakes_cache.stakes().clone();
-        assert!(stakes.vote_accounts.as_ref().len() >= 5);
-        assert!(stakes.stake_delegations.len() >= 50);
-        let dummy = Dummy {
-            head: String::from("dummy-head"),
-            stakes: Arc::new(StakesEnum::from(stakes.clone())),
-            tail: String::from("dummy-tail"),
-        };
-        assert!(dummy.stakes.vote_accounts().as_ref().len() >= 5);
-        let data = bincode::serialize(&dummy).unwrap();
-        let other: Dummy = bincode::deserialize(&data).unwrap();
-        assert_eq!(other, dummy);
-        let stakes = Stakes::<Delegation>::from(stakes);
-        assert!(stakes.vote_accounts.as_ref().len() >= 5);
-        assert!(stakes.stake_delegations.len() >= 50);
-        let other = match &*other.stakes {
-            StakesEnum::Accounts(_) | StakesEnum::Stakes(_) => panic!("wrong type!"),
-            StakesEnum::Delegations(delegations) => delegations,
-        };
-        assert_eq!(other, &stakes)
     }
 }

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -607,6 +607,8 @@ impl From<Stakes<Stake>> for Stakes<Delegation> {
     }
 }
 
+/// This conversion is memory intensive so should only be used in development
+/// contexts.
 #[cfg(feature = "dev-context-only-utils")]
 impl From<StakesEnum> for Stakes<Delegation> {
     fn from(stakes: StakesEnum) -> Self {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -283,7 +283,7 @@ impl Stakes<StakeAccount> {
                 let stake_account = StakeAccount::try_from(stake_account)?;
                 // Sanity check that the delegation is consistent with what is
                 // stored in the account.
-                if stake_account.delegation() == *delegation {
+                if stake_account.delegation() == delegation {
                     map.insert(*pubkey, stake_account);
                     Ok(map)
                 } else {
@@ -526,13 +526,12 @@ impl StakesEnum {
         }
     }
 }
-
 impl From<Stakes<StakeAccount>> for Stakes<Delegation> {
     fn from(stakes: Stakes<StakeAccount>) -> Self {
         let stake_delegations = stakes
             .stake_delegations
             .into_iter()
-            .map(|(pubkey, stake_account)| (pubkey, stake_account.delegation()))
+            .map(|(pubkey, stake_account)| (pubkey, *stake_account.delegation()))
             .collect();
         Self {
             vote_accounts: stakes.vote_accounts,

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -1,0 +1,211 @@
+use {
+    super::{StakeAccount, Stakes, StakesEnum},
+    crate::stake_history::StakeHistory,
+    im::HashMap as ImHashMap,
+    serde::{ser::SerializeMap, Serialize, Serializer},
+    solana_sdk::{clock::Epoch, pubkey::Pubkey, stake::state::Delegation},
+    solana_stake_program::stake_state::Stake,
+    solana_vote::vote_account::VoteAccounts,
+    std::sync::Arc,
+};
+
+// In order to maintain backward compatibility, the StakesEnum in EpochStakes
+// and SerializableVersionedBank should be serialized as Stakes<Delegation>.
+pub(crate) mod serde_stakes_enum_compat {
+    use {
+        super::*,
+        serde::{Deserialize, Deserializer, Serialize, Serializer},
+    };
+
+    pub(crate) fn serialize<S>(stakes: &StakesEnum, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match stakes {
+            StakesEnum::Delegations(stakes) => stakes.serialize(serializer),
+            StakesEnum::Stakes(stakes) => serialize_stakes_as_delegations(stakes, serializer),
+            StakesEnum::Accounts(stakes) => {
+                serialize_stake_accounts_as_delegations(stakes, serializer)
+            }
+        }
+    }
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Arc<StakesEnum>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let stakes = Stakes::<Delegation>::deserialize(deserializer)?;
+        Ok(Arc::new(StakesEnum::Delegations(stakes)))
+    }
+}
+
+fn serialize_stakes_as_delegations<S: Serializer>(
+    stakes: &Stakes<Stake>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    SerdeStakeVariantStakes::from(stakes.clone()).serialize(serializer)
+}
+
+fn serialize_stake_accounts_as_delegations<S: Serializer>(
+    stakes: &Stakes<StakeAccount>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    SerdeStakeAccountVariantStakes::from(stakes.clone()).serialize(serializer)
+}
+
+impl From<Stakes<Stake>> for SerdeStakeVariantStakes {
+    fn from(stakes: Stakes<Stake>) -> Self {
+        let Stakes {
+            vote_accounts,
+            stake_delegations,
+            unused,
+            epoch,
+            stake_history,
+        } = stakes;
+
+        Self {
+            vote_accounts,
+            stake_delegations: SerdeStakeMapWrapper(stake_delegations),
+            unused,
+            epoch,
+            stake_history,
+        }
+    }
+}
+
+impl From<Stakes<StakeAccount>> for SerdeStakeAccountVariantStakes {
+    fn from(stakes: Stakes<StakeAccount>) -> Self {
+        let Stakes {
+            vote_accounts,
+            stake_delegations,
+            unused,
+            epoch,
+            stake_history,
+        } = stakes;
+
+        Self {
+            vote_accounts,
+            stake_delegations: SerdeStakeAccountMapWrapper(stake_delegations),
+            unused,
+            epoch,
+            stake_history,
+        }
+    }
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize)]
+struct SerdeStakeVariantStakes {
+    vote_accounts: VoteAccounts,
+    stake_delegations: SerdeStakeMapWrapper,
+    unused: u64,
+    epoch: Epoch,
+    stake_history: StakeHistory,
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize)]
+struct SerdeStakeAccountVariantStakes {
+    vote_accounts: VoteAccounts,
+    stake_delegations: SerdeStakeAccountMapWrapper,
+    unused: u64,
+    epoch: Epoch,
+    stake_history: StakeHistory,
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+struct SerdeStakeMapWrapper(ImHashMap<Pubkey, Stake>);
+impl Serialize for SerdeStakeMapWrapper {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_map(Some(self.0.len()))?;
+        for (pubkey, stake) in self.0.iter() {
+            s.serialize_entry(pubkey, &stake.delegation)?;
+        }
+        s.end()
+    }
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+struct SerdeStakeAccountMapWrapper(ImHashMap<Pubkey, StakeAccount>);
+impl Serialize for SerdeStakeAccountMapWrapper {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_map(Some(self.0.len()))?;
+        for (pubkey, stake_account) in self.0.iter() {
+            s.serialize_entry(pubkey, stake_account.delegation())?;
+        }
+        s.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, crate::stakes::StakesCache, rand::Rng, solana_sdk::rent::Rent,
+        solana_stake_program::stake_state, solana_vote_program::vote_state,
+    };
+
+    #[test]
+    fn test_serde_stakes_enum_compat() {
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Dummy {
+            head: String,
+            #[serde(with = "serde_stakes_enum_compat")]
+            stakes: Arc<StakesEnum>,
+            tail: String,
+        }
+        let mut rng = rand::thread_rng();
+        let stakes_cache = StakesCache::new(Stakes {
+            unused: rng.gen(),
+            epoch: rng.gen(),
+            ..Stakes::default()
+        });
+        for _ in 0..rng.gen_range(5usize..10) {
+            let vote_pubkey = solana_sdk::pubkey::new_rand();
+            let vote_account = vote_state::create_account(
+                &vote_pubkey,
+                &solana_sdk::pubkey::new_rand(), // node_pubkey
+                rng.gen_range(0..101),           // commission
+                rng.gen_range(0..1_000_000),     // lamports
+            );
+            stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
+            for _ in 0..rng.gen_range(10usize..20) {
+                let stake_pubkey = solana_sdk::pubkey::new_rand();
+                let rent = Rent::with_slots_per_epoch(rng.gen());
+                let stake_account = stake_state::create_account(
+                    &stake_pubkey, // authorized
+                    &vote_pubkey,
+                    &vote_account,
+                    &rent,
+                    rng.gen_range(0..1_000_000), // lamports
+                );
+                stakes_cache.check_and_store(&stake_pubkey, &stake_account, None);
+            }
+        }
+        let stakes: Stakes<StakeAccount> = stakes_cache.stakes().clone();
+        assert!(stakes.vote_accounts.as_ref().len() >= 5);
+        assert!(stakes.stake_delegations.len() >= 50);
+        let dummy = Dummy {
+            head: String::from("dummy-head"),
+            stakes: Arc::new(StakesEnum::from(stakes.clone())),
+            tail: String::from("dummy-tail"),
+        };
+        assert!(dummy.stakes.vote_accounts().as_ref().len() >= 5);
+        let data = bincode::serialize(&dummy).unwrap();
+        let other: Dummy = bincode::deserialize(&data).unwrap();
+        assert_eq!(other, dummy);
+        let stakes = Stakes::<Delegation>::from(stakes);
+        assert!(stakes.vote_accounts.as_ref().len() >= 5);
+        assert!(stakes.stake_delegations.len() >= 50);
+        let other = match &*other.stakes {
+            StakesEnum::Accounts(_) | StakesEnum::Stakes(_) => panic!("wrong type!"),
+            StakesEnum::Delegations(delegations) => delegations,
+        };
+        assert_eq!(other, &stakes)
+    }
+}

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -227,6 +227,13 @@ impl StakeStateV2 {
         }
     }
 
+    pub fn delegation_ref(&self) -> Option<&Delegation> {
+        match self {
+            StakeStateV2::Stake(_meta, stake, _stake_flags) => Some(&stake.delegation),
+            _ => None,
+        }
+    }
+
     pub fn authorized(&self) -> Option<Authorized> {
         match self {
             StakeStateV2::Stake(meta, _stake, _stake_flags) => Some(meta.authorized),


### PR DESCRIPTION
#### Problem
When serializing snapshots, we do a full deep clone of the stake delegations when serializing `Stakes<Delegation>`. As of v2.1 this serialization flow is limited to serializing the stakes cache since epoch stakes are serialized with versioned epoch stakes as of https://github.com/anza-xyz/agave/pull/2282.

#### Summary of Changes
Build a shallow copy of stake delegations by borrowing the `delegation` field from the stake accounts to avoid allocating so much when serializing `Stakes<Delegation>` during snapshot creation.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
