### PR TITLE
Improves panic message if send() fails in streaming_unpack_snapshot()

### DIFF
--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -339,7 +339,13 @@ pub fn streaming_unpack_snapshot<A: Read>(
         |_, _| {},
         |entry_path_buf| {
             if entry_path_buf.is_file() {
-                sender.send(entry_path_buf).unwrap();
+                let result = sender.send(entry_path_buf);
+                if let Err(err) = result {
+                    panic!(
+                        "failed to send path '{}' from unpacker to rebuilder: {err}",
+                        err.0.display(),
+                    );
+                }
             }
         },
     )


### PR DESCRIPTION
#### Problem

There are reports on Discord[^1][^2] of people hitting panics while sending on a channel during snapshot unpacking. Here's an example:

```
thread 'solUnpkSnpsht01' panicked at /var/lib/buildkite-agent/builds/release/anza/agave-secondary/accounts-db/src/hardened_unpack.rs:338:45:
called `Result::unwrap()` on an `Err` value: "SendError(..)"
stack backtrace:
```

The `unwrap` doesn't yield the best panic message...

[^1]: https://discord.com/channels/428295358100013066/560174212967432193/1270412894026207305
[^2]: https://discord.com/channels/428295358100013066/837340113067049050/1270052679309328408

#### Summary of Changes

Improve the panic message.