### PR TITLE
banking_stage: do not drain votes that cannot land on our leader fork

### DIFF
--- a/sdk/program/src/vote/instruction.rs
+++ b/sdk/program/src/vote/instruction.rs
@@ -209,6 +209,19 @@ impl VoteInstruction {
         }
     }
 
+    /// Only to be used on vote instructions (guard with is_simple_vote), panics otherwise
+    pub fn hash(&self) -> Hash {
+        assert!(self.is_simple_vote());
+        match self {
+            Self::Vote(v) | Self::VoteSwitch(v, _) => v.hash,
+            Self::UpdateVoteState(vote_state_update)
+            | Self::UpdateVoteStateSwitch(vote_state_update, _)
+            | Self::CompactUpdateVoteState(vote_state_update)
+            | Self::CompactUpdateVoteStateSwitch(vote_state_update, _) => vote_state_update.hash,
+            Self::TowerSync(tower_sync) | Self::TowerSyncSwitch(tower_sync, _) => tower_sync.hash,
+            _ => panic!("Tried to get hash on non simple vote instruction"),
+        }
+    }
     /// Only to be used on vote instructions (guard with is_simple_vote),  panics otherwise
     pub fn timestamp(&self) -> Option<UnixTimestamp> {
         assert!(self.is_simple_vote());


### PR DESCRIPTION
First part of addressing #2183 
#### Problem
Votes from the banking stage buffer will be drained to the leader bank regardless of whether they were casted for the fork the leader bank is on.

This leads us to draining votes that we know will fail. This could also lead to votes being lost if a leader resets and decides to build a later leader block off a different fork. 

#### Summary of Changes
Perform the slot hashes check when we drain votes to the bank.
