### PR TITLE
Add warning to builtin instruction costs

### DIFF
--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -12,6 +12,14 @@ use {
 // Number of compute units for each built-in programs
 lazy_static! {
     /// Number of compute units for each built-in programs
+    ///
+    /// DEVELOPER WARNING: This map CANNOT be modified without causing a
+    /// consensus failure because this map is used to calculate the compute
+    /// limit for transactions that don't specify a compute limit themselves as
+    /// of https://github.com/anza-xyz/agave/issues/2212.  It's also used to
+    /// calculate the cost of a transaction which is used in replay to enforce
+    /// block cost limits as of
+    /// https://github.com/solana-labs/solana/issues/29595.
     pub static ref BUILTIN_INSTRUCTION_COSTS: AHashMap<Pubkey, u64> = [
         (solana_stake_program::id(), solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS),
         (solana_config_program::id(), solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS),
@@ -26,6 +34,7 @@ lazy_static! {
         // Note: These are precompile, run directly in bank during sanitizing;
         (secp256k1_program::id(), 0),
         (ed25519_program::id(), 0),
+        // DO NOT ADD MORE ENTRIES TO THIS MAP
     ]
     .iter()
     .cloned()


### PR DESCRIPTION
#### Problem
Developers may not know that modifications to `BUILTIN_INSTRUCTION_COSTS` will lead to a consensus failure

#### Summary of Changes
Add dev warning about changing `BUILTIN_INSTRUCTION_COSTS`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
