### PR TITLE
clean up uses of activated `vote_state_add_vote_latency` feature

### DIFF
--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -31,7 +31,7 @@ use {
     solana_rpc_client_api::config::RpcGetVoteAccountsConfig,
     solana_rpc_client_nonce_utils::blockhash_query::BlockhashQuery,
     solana_sdk::{
-        account::Account, commitment_config::CommitmentConfig, feature, message::Message,
+        account::Account, commitment_config::CommitmentConfig, message::Message,
         native_token::lamports_to_sol, pubkey::Pubkey, system_instruction::SystemError,
         transaction::Transaction,
     },
@@ -819,13 +819,7 @@ pub fn process_create_vote_account(
 
     let fee_payer = config.signers[fee_payer];
     let nonce_authority = config.signers[nonce_authority];
-
-    let is_feature_active = (!sign_only)
-        .then(solana_sdk::feature_set::vote_state_add_vote_latency::id)
-        .and_then(|feature_address| rpc_client.get_account(&feature_address).ok())
-        .and_then(|account| feature::from_account(&account))
-        .map_or(false, |feature| feature.activated_at.is_some());
-    let space = VoteStateVersions::vote_state_size_of(is_feature_active) as u64;
+    let space = VoteStateVersions::vote_state_size_of(true) as u64;
 
     let build_message = |lamports| {
         let vote_init = VoteInit {

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -32,7 +32,6 @@ use {
         clock::{Slot, DEFAULT_DEV_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT, MAX_PROCESSING_AGE},
         commitment_config::CommitmentConfig,
         epoch_schedule::EpochSchedule,
-        feature_set,
         genesis_config::{ClusterType, GenesisConfig},
         message::Message,
         poh_config::PohConfig,
@@ -771,18 +770,6 @@ impl LocalCluster {
             == 0
         {
             // 1) Create vote account
-            // Unlike the bootstrap validator we have to check if the new vote state is being used
-            // as the cluster is already running, and using the wrong account size will cause the
-            // InitializeAccount tx to fail
-            let use_current_vote_state = client
-                .rpc_client()
-                .poll_get_balance_with_commitment(
-                    &feature_set::vote_state_add_vote_latency::id(),
-                    CommitmentConfig::processed(),
-                )
-                .unwrap_or(0)
-                > 0;
-
             let instructions = vote_instruction::create_account_with_config(
                 &from_account.pubkey(),
                 &vote_account_pubkey,
@@ -794,8 +781,7 @@ impl LocalCluster {
                 },
                 amount,
                 vote_instruction::CreateVoteAccountConfig {
-                    space: vote_state::VoteStateVersions::vote_state_size_of(use_current_vote_state)
-                        as u64,
+                    space: vote_state::VoteStateVersions::vote_state_size_of(true) as u64,
                     ..vote_instruction::CreateVoteAccountConfig::default()
                 },
             );


### PR DESCRIPTION
#### Problem
Now that the `vote_state_add_vote_latency` feature gate is activated, it can be cleaned up

#### Summary of Changes
Clean up callers of `vote_state_add_vote_latency` feature

Closes https://github.com/solana-labs/solana/issues/31264
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
