### PR TITLE
ignore path dev deps in circular deps check

### DIFF
--- a/ci/order-crates-for-publishing.py
+++ b/ci/order-crates-for-publishing.py
@@ -38,7 +38,8 @@ def is_path_dev_dep(package, dependency, wrong_path_dev_dependencies):
     return is_special_cased
 
 def should_add(package, dependency, wrong_path_dev_dependencies):
-    related_to_solana = dependency['name'].startswith('solana')
+    name = dependency['name']
+    related_to_solana = name.startswith('solana') or name.startswith('agave')
     path_dev_dep = is_path_dev_dep(
         package, dependency, wrong_path_dev_dependencies
     )

--- a/ci/order-crates-for-publishing.py
+++ b/ci/order-crates-for-publishing.py
@@ -70,9 +70,9 @@ def get_packages():
     for dependency in circular_dependencies:
         sys.stderr.write('Error: Circular dependency: {}\n'.format(dependency))
     for dependency in wrong_path_dev_dependencies:
-        sys.stderr.write('Error: wrong dev-context-only-utils circular dependency. try: ' +
-            '{} = {{ path = ".", features = {} }}\n'
-            .format(dependency['name'], json.dumps(dependency['features']))
+        sys.stderr.write('Error: wrong circular dev dependency. try using a path dependency: ' +
+            '{} = {{ path = "$path_to_crate" }}\n'
+            .format(dependency['name'])
         )
 
     if len(circular_dependencies) != 0 or len(wrong_path_dev_dependencies) != 0:

--- a/ci/order-crates-for-publishing.py
+++ b/ci/order-crates-for-publishing.py
@@ -39,11 +39,11 @@ def is_path_dev_dep(package, dependency, wrong_path_dev_dependencies):
 
 def should_add(package, dependency, wrong_path_dev_dependencies):
     related_to_solana = dependency['name'].startswith('solana')
-    self_dev_dep_with_dev_context_only_utils = is_path_dev_dep(
+    path_dev_dep = is_path_dev_dep(
         package, dependency, wrong_path_dev_dependencies
     )
 
-    return related_to_solana and not self_dev_dep_with_dev_context_only_utils
+    return related_to_solana and not path_dev_dep
 
 def get_packages():
     metadata = load_metadata()

--- a/ci/order-crates-for-publishing.py
+++ b/ci/order-crates-for-publishing.py
@@ -21,8 +21,11 @@ def load_metadata():
     return json.loads(subprocess.Popen(
         cmd, shell=True, stdout=subprocess.PIPE).communicate()[0])
 
-# Cargo publish if fine with circular dev-dependencies if
+# Cargo publish is fine with circular dev-dependencies if
 # they are path deps.
+# However, cargo still fails if deps are path deps with versions
+# (this when you use `workspace = true`): https://github.com/rust-lang/cargo/issues/4242
+# This function checks for these good and bad uses of dev dependencies.
 def is_path_dev_dep(package, dependency, wrong_path_dev_dependencies):
     no_explicit_version = '*'
     is_special_cased = False


### PR DESCRIPTION
#### Problem
`cargo publish` is fine with circular dev-dependencies if they are just path dependencies. One place where the need for such dependencies arises is doctests: if you pull a crate out of solana-program, its doc examples may still use other parts of solana-program


#### Summary of Changes
Update order-crates-for-publishing.py to special case all path dev-dependencies that don't specify a version. This replaces the previous check that allowed only deps where `path = "."`  and `feautres` included `dev-context-only-utils` (ref: https://github.com/solana-labs/solana/pull/32432)

Fixes #2428 