### PR TITLE
test-validator: Add flag to clone feature set from a cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Release channels have their own copy of this changelog:
 * Changes
   * SDK: removed the `respan` macro. This was marked as "internal use only" and was no longer used internally.
   * `agave-validator`: Update PoH speed check to compare against current hash rate from a Bank (#2447)
+  * `solana-test-validator`: Add `--clone-feature-set` flag to mimic features from a target cluster (#2480)
 
 ## [2.0.0]
 * Breaking

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -281,6 +281,8 @@ fn main() {
             .map(|v| v.into_iter().collect())
             .unwrap_or_default();
 
+    let clone_feature_set = matches.is_present("clone_feature_set");
+
     let warp_slot = if matches.is_present("warp_slot") {
         Some(match matches.value_of("warp_slot") {
             Some(_) => value_t_or_exit!(matches, "warp_slot", Slot),
@@ -507,6 +509,17 @@ fn main() {
                 .expect("bug: --url argument missing?"),
         ) {
             println!("Error: clone_upgradeable_programs failed: {e}");
+            exit(1);
+        }
+    }
+
+    if clone_feature_set {
+        if let Err(e) = genesis.clone_feature_set(
+            cluster_rpc_client
+                .as_ref()
+                .expect("bug: --url argument missing?"),
+        ) {
+            println!("Error: clone_feature_set failed: {e}");
             exit(1);
         }
     }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2811,6 +2811,17 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .validator(is_parsable::<u64>)
                 .takes_value(true)
                 .help("Override the runtime's account lock limit per transaction"),
+        )
+        .arg(
+            Arg::with_name("clone_feature_set")
+                .long("clone-feature-set")
+                .takes_value(false)
+                .requires("json_rpc_url")
+                .help(
+                    "Copy a feature set from the cluster referenced by the --url \
+                     argument in the genesis configuration. If the ledger \
+                     already exists then this parameter is silently ignored",
+                ),
         );
 }
 


### PR DESCRIPTION
#### Problem

Program devs run into issues when testing, where everything works great with a solana-test-validator, and then fails once they deploy to a real cluster. Most times, this happens because the test validator enables all features by default, and their program depended on a new feature without their knowledge.

#### Summary of changes

To make local development much easier, add a `--clone-feature-set` flag to solana-test-validator to easily mimic the functionality on the cluster targeted with `--url`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
