### PR TITLE
SDK: Add `PodSlotHashes` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6929,6 +6929,7 @@ dependencies = [
  "solana-secp256k1-recover",
  "solana-short-vec",
  "static_assertions",
+ "test-case",
  "thiserror",
  "wasm-bindgen",
 ]

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -83,6 +83,7 @@ itertools = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
 static_assertions = { workspace = true }
+test-case = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -58,6 +58,8 @@ use {
     bytemuck_derive::{Pod, Zeroable},
 };
 
+const U64_SIZE: usize = std::mem::size_of::<u64>();
+
 crate::declare_sysvar_id!("SysvarS1otHashes111111111111111111111111111", SlotHashes);
 
 impl Sysvar for SlotHashes {
@@ -72,11 +74,97 @@ impl Sysvar for SlotHashes {
     }
 }
 
+/// A bytemuck-compatible (plain old data) version of `SlotHash`.
 #[derive(Copy, Clone, Default, Pod, Zeroable)]
 #[repr(C)]
-struct PodSlotHash {
-    slot: Slot,
-    hash: Hash,
+pub struct PodSlotHash {
+    pub slot: Slot,
+    pub hash: Hash,
+}
+
+/// API for querying of the `SlotHashes` sysvar by on-chain programs.
+///
+/// Hangs onto the allocated raw buffer from the account data, which can be
+/// queried or accessed directly as a slice of `PodSlotHash`.
+#[derive(Default)]
+pub struct PodSlotHashes {
+    data: Vec<u8>,
+    slot_hashes_start: usize,
+    slot_hashes_end: usize,
+}
+
+impl PodSlotHashes {
+    /// Fetch all of the raw sysvar data using the `sol_get_sysvar` syscall.
+    pub fn fetch() -> Result<Self, ProgramError> {
+        // Allocate an uninitialized buffer for the raw sysvar data.
+        let sysvar_len = SlotHashes::size_of();
+        let mut data = vec![0; sysvar_len];
+
+        // Ensure the created buffer is aligned to 8.
+        if data.as_ptr().align_offset(8) != 0 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        // Populate the buffer by fetching all sysvar data using the
+        // `sol_get_sysvar` syscall.
+        get_sysvar(
+            &mut data,
+            &SlotHashes::id(),
+            /* offset */ 0,
+            /* length */ sysvar_len as u64,
+        )?;
+
+        // Get the number of slot hashes present in the data by reading the
+        // `u64` length at the beginning of the data, then use that count to
+        // calculate the length of the slot hashes data.
+        //
+        // The rest of the buffer is uninitialized and should not be accessed.
+        let length = data
+            .get(..U64_SIZE)
+            .and_then(|bytes| bytes.try_into().ok())
+            .map(u64::from_le_bytes)
+            .and_then(|length| length.checked_mul(std::mem::size_of::<PodSlotHash>() as u64))
+            .ok_or(ProgramError::InvalidAccountData)?;
+
+        let slot_hashes_start = U64_SIZE;
+        let slot_hashes_end = slot_hashes_start.saturating_add(length as usize);
+
+        Ok(Self {
+            data,
+            slot_hashes_start,
+            slot_hashes_end,
+        })
+    }
+
+    /// Return the `SlotHashes` sysvar data as a slice of `PodSlotHash`.
+    /// Returns a slice of only the initialized sysvar data.
+    pub fn as_slice(&self) -> Result<&[PodSlotHash], ProgramError> {
+        self.data
+            .get(self.slot_hashes_start..self.slot_hashes_end)
+            .and_then(|data| bytemuck::try_cast_slice(data).ok())
+            .ok_or(ProgramError::InvalidAccountData)
+    }
+
+    /// Given a slot, get its corresponding hash in the `SlotHashes` sysvar
+    /// data. Returns `None` if the slot is not found.
+    pub fn get(&self, slot: &Slot) -> Result<Option<Hash>, ProgramError> {
+        self.as_slice().map(|pod_hashes| {
+            pod_hashes
+                .binary_search_by(|PodSlotHash { slot: this, .. }| slot.cmp(this))
+                .map(|idx| pod_hashes[idx].hash)
+                .ok()
+        })
+    }
+
+    /// Given a slot, get its position in the `SlotHashes` sysvar data. Returns
+    /// `None` if the slot is not found.
+    pub fn position(&self, slot: &Slot) -> Result<Option<usize>, ProgramError> {
+        self.as_slice().map(|pod_hashes| {
+            pod_hashes
+                .binary_search_by(|PodSlotHash { slot: this, .. }| slot.cmp(this))
+                .ok()
+        })
+    }
 }
 
 /// API for querying the `SlotHashes` sysvar.

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -168,8 +168,10 @@ impl PodSlotHashes {
 }
 
 /// API for querying the `SlotHashes` sysvar.
+#[deprecated(since = "2.1.0", note = "Please use `PodSlotHashes` instead")]
 pub struct SlotHashesSysvar;
 
+#[allow(deprecated)]
 impl SlotHashesSysvar {
     /// Get a value from the sysvar entries by its key.
     /// Returns `None` if the key is not found.
@@ -317,6 +319,7 @@ mod tests {
         assert_eq!(pod_slot_hashes.position(&not_a_slot).unwrap(), None);
     }
 
+    #[allow(deprecated)]
     #[serial]
     #[test]
     fn test_slot_hashes_sysvar() {


### PR DESCRIPTION
#### Problem
Building on the issue proposed in #1948, the new `SlotHashesSysvar` API poses two potential issues for on-chain programs.

1. The creation of a `Vec<PodSlotHash>` in the API's internals allocates a large vector that is inaccessible by the user, therefore wasting a lot of space on the bump-allocated heap. It would be better if this vector was kept around, so it could be queried more than once.
2. In a testing environment, when the list of slot hashes is less than `MAX_ENTRIES`, the uninitialized sysvar data registers in the `Vec<PodSlotHash>` as a collection of `PodSlotHash::default()`, meaning that querying slot `0` will always succeed and return `Hash::default()`.

#### Summary of Changes

Introduce a new version of the same API - `PodSlotHashes`. Similar to `SlotHashesSysvar`, it offers two querying methods for slot hashes: `get` and `position`.

This new API addresses issue number 1 by holding onto the raw buffer of fetched sysvar data, so it can be queried multiple times or accessed via `as_slice()`, which returns a slice of `PodSlotHash`.

This new API also addresses issue number 2 by reading the start and end indices where actual slot hashes exist, which allows the API to ignore any uninitialized data.

This change also deprecates the previous `SlotHashesSysvar` API in favor of the new `PodSlotHashes` API.
