### PR TITLE
Improve type safety in stake state module

### DIFF
--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -105,23 +105,23 @@ impl StakeState {
 
     pub fn stake(&self) -> Option<Stake> {
         match self {
-            StakeState::Stake(_meta, stake) => Some(*stake),
-            _ => None,
+            Self::Stake(_meta, stake) => Some(*stake),
+            Self::Uninitialized | Self::Initialized(_) | Self::RewardsPool => None,
         }
     }
 
     pub fn delegation(&self) -> Option<Delegation> {
         match self {
-            StakeState::Stake(_meta, stake) => Some(stake.delegation),
-            _ => None,
+            Self::Stake(_meta, stake) => Some(stake.delegation),
+            Self::Uninitialized | Self::Initialized(_) | Self::RewardsPool => None,
         }
     }
 
     pub fn authorized(&self) -> Option<Authorized> {
         match self {
-            StakeState::Stake(meta, _stake) => Some(meta.authorized),
-            StakeState::Initialized(meta) => Some(meta.authorized),
-            _ => None,
+            Self::Stake(meta, _stake) => Some(meta.authorized),
+            Self::Initialized(meta) => Some(meta.authorized),
+            Self::Uninitialized | Self::RewardsPool => None,
         }
     }
 
@@ -131,9 +131,9 @@ impl StakeState {
 
     pub fn meta(&self) -> Option<Meta> {
         match self {
-            StakeState::Stake(meta, _stake) => Some(*meta),
-            StakeState::Initialized(meta) => Some(*meta),
-            _ => None,
+            Self::Stake(meta, _stake) => Some(*meta),
+            Self::Initialized(meta) => Some(*meta),
+            Self::Uninitialized | Self::RewardsPool => None,
         }
     }
 }
@@ -208,22 +208,22 @@ impl StakeStateV2 {
 
     pub fn stake(&self) -> Option<Stake> {
         match self {
-            StakeStateV2::Stake(_meta, stake, _stake_flags) => Some(*stake),
-            _ => None,
+            Self::Stake(_meta, stake, _stake_flags) => Some(*stake),
+            Self::Uninitialized | Self::Initialized(_) | Self::RewardsPool => None,
         }
     }
 
     pub fn stake_ref(&self) -> Option<&Stake> {
         match self {
-            StakeStateV2::Stake(_meta, stake, _stake_flags) => Some(stake),
-            _ => None,
+            Self::Stake(_meta, stake, _stake_flags) => Some(stake),
+            Self::Uninitialized | Self::Initialized(_) | Self::RewardsPool => None,
         }
     }
 
     pub fn delegation(&self) -> Option<Delegation> {
         match self {
-            StakeStateV2::Stake(_meta, stake, _stake_flags) => Some(stake.delegation),
-            _ => None,
+            Self::Stake(_meta, stake, _stake_flags) => Some(stake.delegation),
+            Self::Uninitialized | Self::Initialized(_) | Self::RewardsPool => None,
         }
     }
 
@@ -236,9 +236,9 @@ impl StakeStateV2 {
 
     pub fn authorized(&self) -> Option<Authorized> {
         match self {
-            StakeStateV2::Stake(meta, _stake, _stake_flags) => Some(meta.authorized),
-            StakeStateV2::Initialized(meta) => Some(meta.authorized),
-            _ => None,
+            Self::Stake(meta, _stake, _stake_flags) => Some(meta.authorized),
+            Self::Initialized(meta) => Some(meta.authorized),
+            Self::Uninitialized | Self::RewardsPool => None,
         }
     }
 
@@ -248,9 +248,9 @@ impl StakeStateV2 {
 
     pub fn meta(&self) -> Option<Meta> {
         match self {
-            StakeStateV2::Stake(meta, _stake, _stake_flags) => Some(*meta),
-            StakeStateV2::Initialized(meta) => Some(*meta),
-            _ => None,
+            Self::Stake(meta, _stake, _stake_flags) => Some(*meta),
+            Self::Initialized(meta) => Some(*meta),
+            Self::Uninitialized | Self::RewardsPool => None,
         }
     }
 }

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -231,7 +231,7 @@ impl StakeStateV2 {
     pub fn delegation_ref(&self) -> Option<&Delegation> {
         match self {
             StakeStateV2::Stake(_meta, stake, _stake_flags) => Some(&stake.delegation),
-            _ => None,
+            Self::Uninitialized | Self::Initialized(_) | Self::RewardsPool => None,
         }
     }
 


### PR DESCRIPTION
#### Problem
Many stake state methods use catch-all match cases for remaining variants, so a new variant could be unintentionally unhandled.

Brought up by @behzadnouri in https://github.com/anza-xyz/agave/pull/2453#discussion_r1705974342
            
#### Summary of Changes
Add explicit match cases for all stake state variants.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
