### PR TITLE
Runtime: Core BPF Migration: Add checks for executable program account

### DIFF
--- a/runtime/src/bank/builtins/core_bpf_migration/error.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/error.rs
@@ -21,6 +21,9 @@ pub enum CoreBpfMigrationError {
     /// Incorrect account owner
     #[error("Incorrect account owner for {0:?}")]
     IncorrectOwner(Pubkey),
+    /// Program account not executable
+    #[error("Program account not executable for program {0:?}")]
+    ProgramAccountNotExecutable(Pubkey),
     /// Program has a data account
     #[error("Data account exists for program {0:?}")]
     ProgramHasDataAccount(Pubkey),

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -887,6 +887,7 @@ pub(crate) mod tests {
             let owner = &bpf_loader_upgradeable::id();
 
             let mut account = AccountSharedData::new(lamports, space, owner);
+            account.set_executable(true);
             account.data_as_mut_slice().copy_from_slice(&data);
             bank.store_account_and_update_capitalization(program_address, &account);
             account

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -88,7 +88,9 @@ impl Bank {
         };
         let lamports =
             self.get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program());
-        let account = AccountSharedData::new_data(lamports, &state, &bpf_loader_upgradeable::id())?;
+        let mut account =
+            AccountSharedData::new_data(lamports, &state, &bpf_loader_upgradeable::id())?;
+        account.set_executable(true);
         Ok(account)
     }
 
@@ -556,6 +558,9 @@ pub(crate) mod tests {
 
             // Program account is owned by the upgradeable loader.
             assert_eq!(program_account.owner(), &bpf_loader_upgradeable::id());
+
+            // Program account is executable.
+            assert!(program_account.executable());
 
             // Program account has the correct state, with a pointer to its program
             // data address.


### PR DESCRIPTION
#### Problem

When the Core BPF migration module was being added to the runtime, the `executable` flag for accounts was being deprecated, so checks for this flag were not added to the mechanisms for migrating and upgrading Core BPF programs. See #309.

These changes were reverted, and the Core BPF migration code must be aware of the `executable` flag on accounts.

Additionally, even though the program can still be invoked via instruction, the program account must be set as `executable` when performing a migration, to ensure all `executable` flag checks are successful on the new program.

#### Summary of Changes

Two small changes:

- Add a check for `executable` when loading an existing Core BPF program in preparation for an upgrade.
- Manually set the program account to `executable: true` when performing a migration from builtin to BPF.