### PR TITLE
bump rust to 1.80.1 / 2024-08-08

### DIFF
--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["v0.29.0", "v0.30.0"]
+        version: ["master"]
     steps:
       - uses: actions/checkout@v4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,15 @@ homepage = "https://anza.xyz/"
 license = "Apache-2.0"
 edition = "2021"
 
+[workspace.lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(target_os, values("solana"))',
+    'cfg(feature, values("frozen-abi"))',
+    'cfg(RUSTC_WITH_SPECIALIZATION)',
+    'cfg(RUSTC_WITHOUT_SPECIALIZATION)',
+]
+
 [workspace.dependencies]
 Inflector = "0.11.4"
 agave-transaction-view = { path = "transaction-view", version = "=2.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ edition = "2021"
 level = "warn"
 check-cfg = [
     'cfg(target_os, values("solana"))',
-    'cfg(feature, values("frozen-abi"))',
+    'cfg(feature, values("frozen-abi", "no-entrypoint"))',
     'cfg(RUSTC_WITH_SPECIALIZATION)',
     'cfg(RUSTC_WITHOUT_SPECIALIZATION)',
 ]

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -34,3 +34,6 @@ spl-pod = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -111,3 +111,6 @@ harness = false
 [[bench]]
 name = "bench_lock_accounts"
 harness = false
+
+[lints]
+workspace = true

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -41,3 +41,6 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "solana-sdk/frozen-abi",
 ]
+
+[lints]
+workspace = true

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -44,3 +44,6 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "solana-vote-program/frozen-abi",
 ]
+
+[lints]
+workspace = true

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -70,11 +70,11 @@ RUN \
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y && \
   rustup component add rustfmt && \
   rustup component add clippy && \
-  rustup component add llvm-tools-preview && \
   rustup install $RUST_NIGHTLY_VERSION && \
   rustup component add clippy --toolchain=$RUST_NIGHTLY_VERSION && \
   rustup component add rustfmt --toolchain=$RUST_NIGHTLY_VERSION && \
   rustup component add miri --toolchain=$RUST_NIGHTLY_VERSION && \
+  rustup component add llvm-tools-preview --toolchain=$RUST_NIGHTLY_VERSION && \
   rustup target add wasm32-unknown-unknown && \
   cargo install cargo-audit && \
   cargo install cargo-hack && \

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2024-05-02
+  nightly_version=2024-07-21
 fi
 
 

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2024-07-21
+  nightly_version=2024-08-08
 fi
 
 

--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -22,3 +22,6 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "solana-sdk/frozen-abi",
 ]
+
+[lints]
+workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -152,3 +152,6 @@ name = "sigverify_stage"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -53,3 +53,6 @@ frozen-abi = [
 
 [[bench]]
 name = "cost_tracker"
+
+[lints]
+workspace = true

--- a/curves/bn254/Cargo.toml
+++ b/curves/bn254/Cargo.toml
@@ -25,3 +25,6 @@ array-bytes = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -19,3 +19,6 @@ solana-program = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 curve25519-dalek = { workspace = true, features = ["serde"] }
+
+[lints]
+workspace = true

--- a/curves/secp256k1-recover/Cargo.toml
+++ b/curves/secp256k1-recover/Cargo.toml
@@ -37,3 +37,6 @@ frozen-abi = ["dep:rustc_version", "dep:solana-frozen-abi", "dep:solana-frozen-a
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/define-syscall/Cargo.toml
+++ b/define-syscall/Cargo.toml
@@ -11,3 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(target_feature, values("static-syscalls"))',
+] }

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -36,3 +36,6 @@ rustc_version = { workspace = true }
 default = ["frozen-abi"]
 # no reason to deactivate this. It's needed because the build.rs is reused elsewhere
 frozen-abi = []
+
+[lints]
+workspace = true

--- a/frozen-abi/macro/Cargo.toml
+++ b/frozen-abi/macro/Cargo.toml
@@ -24,3 +24,6 @@ rustc_version = { workspace = true }
 default = ["frozen-abi"]
 # no reason to deactivate this. It's needed because the build.rs is reused elsewhere
 frozen-abi = []
+
+[lints]
+workspace = true

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -94,3 +94,6 @@ path = "src/main.rs"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -112,3 +112,6 @@ name = "blockstore"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -58,7 +58,10 @@ macro_rules! create_counter {
 #[macro_export]
 macro_rules! inc_counter {
     ($name:expr, $level:expr, $count:expr) => {
-        unsafe { $name.inc($level, $count) };
+        #[allow(clippy::macro_metavars_in_unsafe)]
+        unsafe {
+            $name.inc($level, $count)
+        };
     };
 }
 

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -64,3 +64,12 @@ name = "discard"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(build_target_feature_avx)',
+    'cfg(build_target_feature_avx2)',
+    'cfg(RUSTC_WITH_SPECIALIZATION)',
+    'cfg(RUSTC_WITHOUT_SPECIALIZATION)',
+]

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -21,3 +21,6 @@ light-poseidon = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -59,3 +59,6 @@ frozen-abi = [
     "solana-sdk/frozen-abi",
 ]
 shuttle-test = ["solana-type-overrides/shuttle-test", "solana_rbpf/shuttle-test"]
+
+[lints]
+workspace = true

--- a/programs/address-lookup-table/Cargo.toml
+++ b/programs/address-lookup-table/Cargo.toml
@@ -32,3 +32,6 @@ name = "solana_address_lookup_table_program"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -7,6 +7,10 @@ homepage = "https://anza.xyz"
 license = "Apache-2.0"
 edition = "2021"
 
+[workspace.lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(target_os, values("solana"))']
+
 [workspace.dependencies]
 array-bytes = "=1.4.1"
 bincode = { version = "1.1.4", default-features = false }

--- a/programs/sbf/rust/custom_heap/Cargo.toml
+++ b/programs/sbf/rust/custom_heap/Cargo.toml
@@ -17,3 +17,6 @@ custom-heap = []
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/deprecated_loader/Cargo.toml
+++ b/programs/sbf/rust/deprecated_loader/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/membuiltins/Cargo.toml
+++ b/programs/sbf/rust/membuiltins/Cargo.toml
@@ -14,3 +14,6 @@ solana-sbf-rust-mem-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/panic/Cargo.toml
+++ b/programs/sbf/rust/panic/Cargo.toml
@@ -17,3 +17,6 @@ custom-panic = []
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/ro_modify/Cargo.toml
+++ b/programs/sbf/rust/ro_modify/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/sanity/Cargo.toml
+++ b/programs/sbf/rust/sanity/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -35,3 +35,6 @@ name = "solana_stake_program"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -48,3 +48,6 @@ frozen-abi = [
     "solana-program-runtime/frozen-abi",
     "solana-sdk/frozen-abi",
 ]
+
+[lints]
+workspace = true

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -35,3 +35,6 @@ rustc_version = { workspace = true, optional = true }
 [[bench]]
 name = "process_compute_budget_instructions"
 harness = false
+
+[lints]
+workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -132,3 +132,6 @@ frozen-abi = [
 
 [[bench]]
 name = "prioritization_fee_cache"
+
+[lints]
+workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.80.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.80.1"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -28,6 +28,14 @@ fi
 # shellcheck source=ci/rust-version.sh
 source "$here/../ci/rust-version.sh" nightly
 
+# Check llvm path
+llvm_profdata="$(find "$(rustc +"$rust_nightly" --print sysroot)" -name llvm-profdata)"
+if [ -z "$llvm_profdata" ]; then
+  echo "Error: couldn't find llvm-profdata. Try installing the llvm-tools component with \`rustup component add llvm-tools-preview --toolchain=$rust_nightly\`"
+  exit 1
+fi
+llvm_path="$(dirname "$llvm_profdata")"
+
 # get commit hash. it will be used to name output folder
 if [ -z "$COMMIT_HASH" ]; then
   COMMIT_HASH=$(git rev-parse --short=9 HEAD)
@@ -66,6 +74,7 @@ grcov_common_args=(
   --source-dir "$here/.."
   --binary-path "$here/../target/cov/debug"
   --llvm
+  --llvm-path "$llvm_path"
   --ignore \*.cargo\*
   --ignore \*build.rs
   --ignore bench-tps\*

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -119,3 +119,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[lints]
+workspace = true

--- a/sdk/msg/Cargo.toml
+++ b/sdk/msg/Cargo.toml
@@ -14,3 +14,6 @@ solana-define-syscall = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/sdk/program-memory/Cargo.toml
+++ b/sdk/program-memory/Cargo.toml
@@ -17,3 +17,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = { workspace = true }
+
+[lints]
+workspace = true

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -104,3 +104,6 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "solana-short-vec/frozen-abi",
 ]
+
+[lints]
+workspace = true

--- a/short-vec/Cargo.toml
+++ b/short-vec/Cargo.toml
@@ -27,3 +27,6 @@ frozen-abi = ["dep:rustc_version", "dep:solana-frozen-abi", "dep:solana-frozen-a
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -76,3 +76,6 @@ shuttle-test = [
     "solana-bpf-loader-program/shuttle-test",
     "solana-loader-v4-program/shuttle-test",
 ]
+
+[lints]
+workspace = true

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -36,3 +36,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
 rustc_version = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -41,3 +41,6 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "solana-sdk/frozen-abi",
 ]
+
+[lints]
+workspace = true

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -39,3 +39,6 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[lints]
+workspace = true

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -41,3 +41,6 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[lints]
+workspace = true


### PR DESCRIPTION
#### Summary of Changes

- bump rust stable to 1.80.1 from 1.78.0
- bump rust nightly to 2024-08-08 from 2024-05-02
- cherry-pick #2488 
- cherry-pick #2499 + add `no-entrypoint` to the workspace-level lint config.
- run anchor test with their master branch