### PR TITLE
clippy: allow macro_metavars_in_unsafe

### DIFF
--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -58,7 +58,10 @@ macro_rules! create_counter {
 #[macro_export]
 macro_rules! inc_counter {
     ($name:expr, $level:expr, $count:expr) => {
-        unsafe { $name.inc($level, $count) };
+        #[allow(clippy::macro_metavars_in_unsafe)]
+        unsafe {
+            $name.inc($level, $count)
+        };
     };
 }
 


### PR DESCRIPTION
(part of #2487)

#### Problem

https://rust-lang.github.io/rust-clippy/master/index.html#/macro_metavars_in_unsafe

#### Summary of Changes

it works for years. I guess we can just allow it 🤔 