### PR TITLE
removed unused struct, MockInstruction

### DIFF
--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -170,15 +170,6 @@ mod tests {
         std::sync::Arc,
     };
 
-    #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize)]
-    enum MockInstruction {
-        NoopSuccess,
-        NoopFail,
-        ModifyOwned,
-        ModifyNotOwned,
-        ModifyReadonly,
-    }
-
     fn new_sanitized_message(message: Message) -> SanitizedMessage {
         SanitizedMessage::try_from_legacy_message(message, &ReservedAccountKeys::empty_key_set())
             .unwrap()


### PR DESCRIPTION
(part of #2487)

#### Problem

![Screenshot 2024-08-08 at 21 45 20](https://github.com/user-attachments/assets/078a830d-8a59-4c39-a852-10cb1edaeda2)

look like this one doesn't be used.

#### Summary of Changes

remove it! (let me know if we wanna keep it.)