### PR TITLE
fix docs format

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -43,6 +43,7 @@ impl AccountStorage {
     /// Callers to this function have 2 choices:
     /// 1. hold the account index read lock for the pubkey so that the account index entry cannot be changed prior to or during this call. (scans do this)
     /// 2. expect to be ready to start over and read the index again if this function returns None
+    ///
     ///    Operations like shrinking or write cache flushing may have updated the index between when the caller read the index and called this function to
     ///    load from the append vec specified in the index.
     ///

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -43,8 +43,9 @@ impl AccountStorage {
     /// Callers to this function have 2 choices:
     /// 1. hold the account index read lock for the pubkey so that the account index entry cannot be changed prior to or during this call. (scans do this)
     /// 2. expect to be ready to start over and read the index again if this function returns None
-    /// Operations like shrinking or write cache flushing may have updated the index between when the caller read the index and called this function to
-    /// load from the append vec specified in the index.
+    ///    Operations like shrinking or write cache flushing may have updated the index between when the caller read the index and called this function to
+    ///    load from the append vec specified in the index.
+    ///
     /// In practice, this fn will return the entry from the map in the very first lookup unless a shrink is in progress.
     /// The third lookup will only be called if a requesting thread exactly interposes itself between the 2 map manipulations in the drop of 'shrink_in_progress'.
     pub(crate) fn get_account_storage_entry(

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -44,8 +44,8 @@ impl AccountStorage {
     /// 1. hold the account index read lock for the pubkey so that the account index entry cannot be changed prior to or during this call. (scans do this)
     /// 2. expect to be ready to start over and read the index again if this function returns None
     ///
-    ///    Operations like shrinking or write cache flushing may have updated the index between when the caller read the index and called this function to
-    ///    load from the append vec specified in the index.
+    /// Operations like shrinking or write cache flushing may have updated the index between when the caller read the index and called this function to
+    /// load from the append vec specified in the index.
     ///
     /// In practice, this fn will return the entry from the map in the very first lookup unless a shrink is in progress.
     /// The third lookup will only be called if a requesting thread exactly interposes itself between the 2 map manipulations in the drop of 'shrink_in_progress'.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -325,6 +325,7 @@ pub enum StoreReclaims {
 /// 3. use it (slot, append_vec, etc.)
 /// 4. re-create it sometimes
 /// 5. goto 3
+///
 /// If a caller uses it before initializing it, it will be a runtime unwrap() error, similar to an assert.
 /// That condition is an illegal use pattern and is justifiably an assertable condition.
 #[derive(Default)]
@@ -9099,6 +9100,7 @@ impl AccountsDb {
     /// 1. get the _duplicate_ accounts data len from the given pubkeys
     /// 2. get the slots that contained duplicate pubkeys
     /// 3. update rent stats
+    ///
     /// Note this should only be used when ALL entries in the accounts index are roots.
     /// returns (data len sum of all older duplicates, slots that contained duplicate pubkeys)
     fn visit_duplicate_pubkeys_during_startup(

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -376,6 +376,7 @@ impl<T: IndexValue> PreAllocatedAccountMapEntry<T> {
     /// create an entry that is equivalent to this process:
     /// 1. new empty (refcount=0, slot_list={})
     /// 2. update(slot, account_info)
+    ///
     /// This code is called when the first entry [ie. (slot,account_info)] for a pubkey is inserted into the index.
     pub fn new<U: DiskIndexValue + From<T> + Into<T>>(
         slot: Slot,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -3,7 +3,7 @@
 //! 1. a slot that is older than an epoch old
 //! 2. multiple 'slots' squashed into a single older (ie. ancient) slot for convenience and performance
 //!
-//!    Otherwise, an ancient append vec is the same as any other append vec
+//! Otherwise, an ancient append vec is the same as any other append vec
 use {
     crate::{
         account_storage::ShrinkInProgress,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -2,6 +2,7 @@
 //! an ancient append vec is:
 //! 1. a slot that is older than an epoch old
 //! 2. multiple 'slots' squashed into a single older (ie. ancient) slot for convenience and performance
+//!
 //!    Otherwise, an ancient append vec is the same as any other append vec
 use {
     crate::{

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -2,7 +2,7 @@
 //! an ancient append vec is:
 //! 1. a slot that is older than an epoch old
 //! 2. multiple 'slots' squashed into a single older (ie. ancient) slot for convenience and performance
-//! Otherwise, an ancient append vec is the same as any other append vec
+//!    Otherwise, an ancient append vec is the same as any other append vec
 use {
     crate::{
         account_storage::ShrinkInProgress,
@@ -717,8 +717,9 @@ impl AccountsDb {
     /// given all accounts per ancient slot, in slots that we want to combine together:
     /// 1. Look up each pubkey in the index
     /// 2. separate, by slot, into:
-    /// 2a. pubkeys with refcount = 1. This means this pubkey exists NOWHERE else in accounts db.
-    /// 2b. pubkeys with refcount > 1
+    ///    2a. pubkeys with refcount = 1. This means this pubkey exists NOWHERE else in accounts db.
+    ///    2b. pubkeys with refcount > 1
+    ///
     /// Note that the return value can contain fewer items than 'accounts_per_storage' if we find storages which won't be affected.
     /// 'accounts_per_storage' should be sorted by slot
     fn calc_accounts_to_combine<'a>(


### PR DESCRIPTION
(part of #2487)

#### Problem

![Screenshot 2024-08-08 at 21 49 51](https://github.com/user-attachments/assets/287f4eb5-d00d-4445-a4ff-c4e1122362fa)

docs take a stricter approach to indentation rules…

#### Summary of Changes

fix it