### PR TITLE
clippy: arithmetic-side-effects

### DIFF
--- a/sdk/program/src/epoch_rewards.rs
+++ b/sdk/program/src/epoch_rewards.rs
@@ -6,7 +6,7 @@
 //!
 //! [`sysvar::epoch_rewards`]: crate::sysvar::epoch_rewards
 
-use {crate::hash::Hash, solana_sdk_macro::CloneZeroed, std::ops::AddAssign};
+use {crate::hash::Hash, solana_sdk_macro::CloneZeroed};
 
 #[repr(C, align(16))]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
@@ -44,7 +44,7 @@ impl EpochRewards {
     pub fn distribute(&mut self, amount: u64) {
         assert!(self.distributed_rewards.saturating_add(amount) <= self.total_rewards);
 
-        self.distributed_rewards.add_assign(amount);
+        self.distributed_rewards = self.distributed_rewards.saturating_add(amount);
     }
 }
 

--- a/sdk/program/src/epoch_rewards.rs
+++ b/sdk/program/src/epoch_rewards.rs
@@ -86,9 +86,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "new_distributed_rewards <= self.total_rewards"
-    )]
+    #[should_panic(expected = "new_distributed_rewards <= self.total_rewards")]
     fn test_epoch_rewards_distribute_panic() {
         let mut epoch_rewards = EpochRewards::new(100, 0, 64);
         epoch_rewards.distribute(200);

--- a/sdk/program/src/epoch_rewards.rs
+++ b/sdk/program/src/epoch_rewards.rs
@@ -87,7 +87,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "self.distributed_rewards.saturating_add(amount) <= self.total_rewards"
+        expected = "new_distributed_rewards <= self.total_rewards"
     )]
     fn test_epoch_rewards_distribute_panic() {
         let mut epoch_rewards = EpochRewards::new(100, 0, 64);

--- a/sdk/program/src/epoch_rewards.rs
+++ b/sdk/program/src/epoch_rewards.rs
@@ -42,9 +42,9 @@ pub struct EpochRewards {
 
 impl EpochRewards {
     pub fn distribute(&mut self, amount: u64) {
-        assert!(self.distributed_rewards.saturating_add(amount) <= self.total_rewards);
-
-        self.distributed_rewards = self.distributed_rewards.saturating_add(amount);
+        let new_distributed_rewards = self.distributed_rewards.saturating_add(amount);
+        assert!(new_distributed_rewards <= self.total_rewards);
+        self.distributed_rewards = new_distributed_rewards;
     }
 }
 


### PR DESCRIPTION
(part of #2487)

#### Problem

![Screenshot 2024-08-08 at 21 54 33](https://github.com/user-attachments/assets/b70d995d-3b91-4e75-9730-5d656d7c7654)


#### Summary of Changes

replace `add_assign` with `saturating_add`