### PR TITLE
clippy: needless_borrows_for_generic_args

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -703,7 +703,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                                     .count
                                     .fetch_sub(1, Ordering::Relaxed);
                                 if !no_outfile {
-                                    write_keypair_file(&keypair, &format!("{}.json", keypair.pubkey()))
+                                    write_keypair_file(&keypair, format!("{}.json", keypair.pubkey()))
                                     .unwrap();
                                     println!(
                                         "Wrote keypair to {}",


### PR DESCRIPTION
(part of #2487)

#### Problem

![Screenshot 2024-08-07 at 00 08 17](https://github.com/user-attachments/assets/ce79b1ad-b850-4402-b4b2-4e7468e3f792)

https://rust-lang.github.io/rust-clippy/master/index.html#/needless_borrows_for_generic_args

#### Summary of Changes

fix it