### PR TITLE
clippy: manual_inspect

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -130,9 +130,8 @@ fn download_to_temp(
 
     impl<R: Read> Read for DownloadProgress<R> {
         fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-            self.response.read(buf).map(|n| {
+            self.response.read(buf).inspect(|&n| {
                 self.progress_bar.inc(n as u64);
-                n
             })
         }
     }

--- a/ledger/src/ancestor_iterator.rs
+++ b/ledger/src/ancestor_iterator.rs
@@ -35,7 +35,7 @@ impl<'a> Iterator for AncestorIterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let current = self.current;
-        current.map(|slot| {
+        current.inspect(|&slot| {
             if slot != 0 {
                 self.current = self
                     .blockstore
@@ -45,7 +45,6 @@ impl<'a> Iterator for AncestorIterator<'a> {
             } else {
                 self.current = None;
             }
-            slot
         })
     }
 }

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -992,11 +992,10 @@ impl PohRecorder {
                 self.send_entry_us += send_entry_us;
                 send_entry_res?;
                 let starting_transaction_index =
-                    working_bank.transaction_index.map(|transaction_index| {
+                    working_bank.transaction_index.inspect(|transaction_index| {
                         let next_starting_transaction_index =
                             transaction_index.saturating_add(num_transactions);
                         working_bank.transaction_index = Some(next_starting_transaction_index);
-                        transaction_index
                     });
                 return Ok(starting_transaction_index);
             }

--- a/remote-wallet/src/bin/ledger-udev.rs
+++ b/remote-wallet/src/bin/ledger-udev.rs
@@ -27,9 +27,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .append(true)
                 .create(true)
                 .open(LEDGER_UDEV_RULES_LOCATION)
-                .map_err(|e| {
+                .inspect_err(|_e| {
                     println!("Could not write to file; this script requires sudo privileges");
-                    e
                 })?;
             file.write_all(LEDGER_UDEV_RULES.as_bytes())?;
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -407,9 +407,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let compute_budget_limits = process_compute_budget_instructions(
             message.program_instructions_iter(),
         )
-        .map_err(|err| {
+        .inspect_err(|_err| {
             error_counters.invalid_compute_budget += 1;
-            err
         })?;
 
         let fee_payer_address = message.fee_payer();

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -602,14 +602,13 @@ impl TestValidatorGenesis {
             socket_addr_space,
             rpc_to_plugin_manager_receiver,
         )
-        .map(|test_validator| {
+        .inspect(|test_validator| {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_io()
                 .enable_time()
                 .build()
                 .unwrap();
             runtime.block_on(test_validator.wait_for_nonzero_fees());
-            test_validator
         })
     }
 

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -265,9 +265,8 @@ fn retransmit(
                     quic_endpoint_sender,
                     stats,
                 )
-                .map_err(|err| {
-                    stats.record_error(&err);
-                    err
+                .inspect_err(|err| {
+                    stats.record_error(err);
                 })
                 .ok()?;
                 Some((key.slot(), root_distance, num_nodes))
@@ -290,9 +289,8 @@ fn retransmit(
                         quic_endpoint_sender,
                         stats,
                     )
-                    .map_err(|err| {
-                        stats.record_error(&err);
-                        err
+                    .inspect_err(|err| {
+                        stats.record_error(err);
                     })
                     .ok()?;
                     Some((key.slot(), root_distance, num_nodes))


### PR DESCRIPTION
(part of #2487 )

#### Problem

![Screenshot 2024-08-08 at 22 27 54](https://github.com/user-attachments/assets/860f7951-f49b-4a42-b561-757b827ef49a)

https://rust-lang.github.io/rust-clippy/master/index.html#manual_inspect

#### Summary of Changes

- replace `map` with `inspect` when possible
- replace `map_err` with `inspect_err` when possible