### PR TITLE
fix unexpected tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,14 @@ homepage = "https://anza.xyz/"
 license = "Apache-2.0"
 edition = "2021"
 
+[workspace.lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(target_os, values("solana"))',
+    'cfg(RUSTC_WITH_SPECIALIZATION)',
+    'cfg(RUSTC_WITHOUT_SPECIALIZATION)',
+]
+
 [workspace.dependencies]
 Inflector = "0.11.4"
 agave-transaction-view = { path = "transaction-view", version = "=2.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ edition = "2021"
 level = "warn"
 check-cfg = [
     'cfg(target_os, values("solana"))',
+    'cfg(feature, values("frozen-abi"))',
     'cfg(RUSTC_WITH_SPECIALIZATION)',
     'cfg(RUSTC_WITHOUT_SPECIALIZATION)',
 ]

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -34,3 +34,6 @@ spl-pod = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -111,3 +111,6 @@ harness = false
 [[bench]]
 name = "bench_lock_accounts"
 harness = false
+
+[lints]
+workspace = true

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -41,3 +41,6 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "solana-sdk/frozen-abi",
 ]
+
+[lints]
+workspace = true

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -44,3 +44,6 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "solana-vote-program/frozen-abi",
 ]
+
+[lints]
+workspace = true

--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -22,3 +22,6 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "solana-sdk/frozen-abi",
 ]
+
+[lints]
+workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -152,3 +152,6 @@ name = "sigverify_stage"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -53,3 +53,6 @@ frozen-abi = [
 
 [[bench]]
 name = "cost_tracker"
+
+[lints]
+workspace = true

--- a/curves/bn254/Cargo.toml
+++ b/curves/bn254/Cargo.toml
@@ -25,3 +25,6 @@ array-bytes = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -19,3 +19,6 @@ solana-program = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 curve25519-dalek = { workspace = true, features = ["serde"] }
+
+[lints]
+workspace = true

--- a/curves/secp256k1-recover/Cargo.toml
+++ b/curves/secp256k1-recover/Cargo.toml
@@ -37,3 +37,6 @@ frozen-abi = ["dep:rustc_version", "dep:solana-frozen-abi", "dep:solana-frozen-a
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/define-syscall/Cargo.toml
+++ b/define-syscall/Cargo.toml
@@ -11,3 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(target_feature, values("static-syscalls"))',
+] }

--- a/define-syscall/Cargo.toml
+++ b/define-syscall/Cargo.toml
@@ -12,7 +12,6 @@ edition = { workspace = true }
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(target_feature, values("static-syscalls"))',
-] }
+[workspace.lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(target_feature, values("static-syscalls"))']

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -36,3 +36,6 @@ rustc_version = { workspace = true }
 default = ["frozen-abi"]
 # no reason to deactivate this. It's needed because the build.rs is reused elsewhere
 frozen-abi = []
+
+[lints]
+workspace = true

--- a/frozen-abi/macro/Cargo.toml
+++ b/frozen-abi/macro/Cargo.toml
@@ -24,3 +24,6 @@ rustc_version = { workspace = true }
 default = ["frozen-abi"]
 # no reason to deactivate this. It's needed because the build.rs is reused elsewhere
 frozen-abi = []
+
+[lints]
+workspace = true

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -94,3 +94,6 @@ path = "src/main.rs"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -112,3 +112,6 @@ name = "blockstore"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -64,3 +64,12 @@ name = "discard"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(build_target_feature_avx)',
+    'cfg(build_target_feature_avx2)',
+    'cfg(RUSTC_WITH_SPECIALIZATION)',
+    'cfg(RUSTC_WITHOUT_SPECIALIZATION)',
+]

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -21,3 +21,6 @@ light-poseidon = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -59,3 +59,6 @@ frozen-abi = [
     "solana-sdk/frozen-abi",
 ]
 shuttle-test = ["solana-type-overrides/shuttle-test", "solana_rbpf/shuttle-test"]
+
+[lints]
+workspace = true

--- a/programs/address-lookup-table/Cargo.toml
+++ b/programs/address-lookup-table/Cargo.toml
@@ -32,3 +32,6 @@ name = "solana_address_lookup_table_program"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -7,6 +7,10 @@ homepage = "https://anza.xyz"
 license = "Apache-2.0"
 edition = "2021"
 
+[workspace.lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(target_os, values("solana"))']
+
 [workspace.dependencies]
 array-bytes = "=1.4.1"
 bincode = { version = "1.1.4", default-features = false }

--- a/programs/sbf/rust/custom_heap/Cargo.toml
+++ b/programs/sbf/rust/custom_heap/Cargo.toml
@@ -17,3 +17,6 @@ custom-heap = []
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/deprecated_loader/Cargo.toml
+++ b/programs/sbf/rust/deprecated_loader/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/membuiltins/Cargo.toml
+++ b/programs/sbf/rust/membuiltins/Cargo.toml
@@ -14,3 +14,6 @@ solana-sbf-rust-mem-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/panic/Cargo.toml
+++ b/programs/sbf/rust/panic/Cargo.toml
@@ -17,3 +17,6 @@ custom-panic = []
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/ro_modify/Cargo.toml
+++ b/programs/sbf/rust/ro_modify/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/sanity/Cargo.toml
+++ b/programs/sbf/rust/sanity/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -35,3 +35,6 @@ name = "solana_stake_program"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -48,3 +48,6 @@ frozen-abi = [
     "solana-program-runtime/frozen-abi",
     "solana-sdk/frozen-abi",
 ]
+
+[lints]
+workspace = true

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -29,3 +29,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
 rustc_version = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -132,3 +132,6 @@ frozen-abi = [
 
 [[bench]]
 name = "prioritization_fee_cache"
+
+[lints]
+workspace = true

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -119,3 +119,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[lints]
+workspace = true

--- a/sdk/msg/Cargo.toml
+++ b/sdk/msg/Cargo.toml
@@ -14,3 +14,6 @@ solana-define-syscall = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/sdk/program-memory/Cargo.toml
+++ b/sdk/program-memory/Cargo.toml
@@ -17,3 +17,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = { workspace = true }
+
+[lints]
+workspace = true

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -104,3 +104,6 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "solana-short-vec/frozen-abi",
 ]
+
+[lints]
+workspace = true

--- a/short-vec/Cargo.toml
+++ b/short-vec/Cargo.toml
@@ -27,3 +27,6 @@ frozen-abi = ["dep:rustc_version", "dep:solana-frozen-abi", "dep:solana-frozen-a
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -76,3 +76,6 @@ shuttle-test = [
     "solana-bpf-loader-program/shuttle-test",
     "solana-loader-v4-program/shuttle-test",
 ]
+
+[lints]
+workspace = true

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -36,3 +36,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
 rustc_version = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -41,3 +41,6 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "solana-sdk/frozen-abi",
 ]
+
+[lints]
+workspace = true

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -39,3 +39,6 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[lints]
+workspace = true

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -41,3 +41,6 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[lints]
+workspace = true


### PR DESCRIPTION
(part of #2487)

#### Problem

```
warning: unexpected `cfg` condition name: `RUSTC_WITH_SPECIALIZATION`
 --> short-vec/src/lib.rs:2:13
  |
2 | #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
  |             ^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: expected names are: `clippy`, `debug_assertions`, `doc`, `docsrs`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, and `windows`
  = help: consider using a Cargo feature instead
  = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
           [lints.rust]
           unexpected_cfgs = { level = "warn", check-cfg = ['cfg(RUSTC_WITH_SPECIALIZATION)'] }
  = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(RUSTC_WITH_SPECIALIZATION)");` to the top of the `build.rs`
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
  = note: `#[warn(unexpected_cfgs)]` on by default
```

https://github.com/anza-xyz/agave/pull/2386#issuecomment-2263033953

#### Summary of Changes

- extract these values as global lints to `Cargo.toml` and apply them where needed 
```
[workspace.lints.rust.unexpected_cfgs]
level = "warn"
check-cfg = [
    'cfg(target_os, values("solana"))',
    'cfg(feature, values("frozen-abi"))',
    'cfg(RUSTC_WITH_SPECIALIZATION)',
    'cfg(RUSTC_WITHOUT_SPECIALIZATION)',
]
```
 
- extract these values as global lints to `programs/sbf/Cargo.toml` and apply them where needed 
```
[workspace.lints.rust.unexpected_cfgs]
level = "warn"
check-cfg = ['cfg(target_os, values("solana"))']
```

there are two exceptions that have special config in them:


- `perf/Cargo.toml`
```
[lints.rust.unexpected_cfgs]
level = "warn"
check-cfg = [
    'cfg(build_target_feature_avx)',
    'cfg(build_target_feature_avx2)',
    'cfg(RUSTC_WITH_SPECIALIZATION)',
    'cfg(RUSTC_WITHOUT_SPECIALIZATION)',
]
```

- `define-syscall/Cargo.toml`

```
[workspace.lints.rust.unexpected_cfgs]
level = "warn"
check-cfg = ['cfg(target_feature, values("static-syscalls"))']
```


