### PR TITLE
EpochRewards: decode points and rewards fields as Strings

### DIFF
--- a/account-decoder/src/parse_sysvar.rs
+++ b/account-decoder/src/parse_sysvar.rs
@@ -245,9 +245,9 @@ pub struct UiEpochRewards {
     pub distribution_starting_block_height: u64,
     pub num_partitions: u64,
     pub parent_blockhash: String,
-    pub total_points: u128,
-    pub total_rewards: u64,
-    pub distributed_rewards: u64,
+    pub total_points: String,
+    pub total_rewards: String,
+    pub distributed_rewards: String,
     pub active: bool,
 }
 
@@ -257,9 +257,9 @@ impl From<EpochRewards> for UiEpochRewards {
             distribution_starting_block_height: epoch_rewards.distribution_starting_block_height,
             num_partitions: epoch_rewards.num_partitions,
             parent_blockhash: epoch_rewards.parent_blockhash.to_string(),
-            total_points: epoch_rewards.total_points,
-            total_rewards: epoch_rewards.total_rewards,
-            distributed_rewards: epoch_rewards.distributed_rewards,
+            total_points: epoch_rewards.total_points.to_string(),
+            total_rewards: epoch_rewards.total_rewards.to_string(),
+            distributed_rewards: epoch_rewards.distributed_rewards.to_string(),
             active: epoch_rewards.active,
         }
     }


### PR DESCRIPTION
#### Problem
`EpochRewards::points` can easily overflow the max JSON integer, but we are trying to use `serde_json::Number` in `solana-account-decoder`: https://github.com/anza-xyz/agave/pull/760

This results in RPC results that fail JSON parsing, eg:
```
$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getAccountInfo", "params":["SysvarEpochRewards1111111111111111111111111",{"encoding":"jsonParsed","commitment":"confirmed"}]}' 127.0.0.1:8899 | jq
{
  "jsonrpc": "2.0",
  "result": {
    "context": {
      "apiVersion": "2.0.3",
      "slot": 475138
    },
    "value": {
      "data": [
        "AUAHAAAAAAApAAAAAAAAAIUNPEmDh+dINbalmdonQUN3ihFWtNs3TkzSdK+Iq7bWAAAtdN6RBR8BAAAAAAAAAIYkzjTLAQAA5yWbrzUAAAAB",
        "base64"
      ],
      "executable": false,
      "lamports": 1454640,
      "owner": "Sysvar1111111111111111111111111111111111111",
      "rentEpoch": 0,
      "space": 81
    }
  },
  "id": 1
}
```

#### Summary of Changes
Decode `points`, `distributedRewards`, and `totalRewards` as strings
`numPartitions` should never overflow as it is capped at 43,200
`startingBlockHeight` could overflow some day, but there are lots of other decoders passing Slot as a number, so this is a more systemic problem and can/should be addressed in one fell swoop.
