### PR TITLE
rolls out chained Merkle shreds to ~21% of testnet

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -511,8 +511,8 @@ fn should_chain_merkle_shreds(slot: Slot, cluster_type: ClusterType) -> bool {
         ClusterType::Development => true,
         ClusterType::Devnet => false,
         ClusterType::MainnetBeta => false,
-        // Roll out chained Merkle shreds to ~5% of testnet.
-        ClusterType::Testnet => slot % 19 == 1,
+        // Roll out chained Merkle shreds to ~21% of testnet.
+        ClusterType::Testnet => slot % 19 < 4,
     }
 }
 


### PR DESCRIPTION
#### Problem
Rolling out chained Merkle shreds to testnet.

#### Summary of Changes
The commit rolls out chained Merkle shreds to ~21% of testnet slots.