### PR TITLE
hash-cache-tool: Scan files with mmap and bins

### DIFF
--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -31,7 +31,7 @@ pub mod epoch_accounts_hash;
 mod file_io;
 pub mod hardened_unpack;
 pub mod partitioned_rewards;
-mod pubkey_bins;
+pub mod pubkey_bins;
 mod read_only_accounts_cache;
 mod rolling_bit_field;
 pub mod secondary_index;

--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -11,7 +11,7 @@ impl PubkeyBinCalculator24 {
         std::mem::size_of::<T>() * 8
     }
 
-    pub fn log_2(x: u32) -> u32 {
+    pub(crate) fn log_2(x: u32) -> u32 {
         assert!(x > 0);
         Self::num_bits::<u32>() as u32 - x.leading_zeros() - 1
     }

--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -11,12 +11,12 @@ impl PubkeyBinCalculator24 {
         std::mem::size_of::<T>() * 8
     }
 
-    pub(crate) fn log_2(x: u32) -> u32 {
+    pub fn log_2(x: u32) -> u32 {
         assert!(x > 0);
         Self::num_bits::<u32>() as u32 - x.leading_zeros() - 1
     }
 
-    pub(crate) fn new(bins: usize) -> Self {
+    pub fn new(bins: usize) -> Self {
         const MAX_BITS: u32 = 24;
         assert!(bins > 0);
         let max_plus_1 = 1 << MAX_BITS;
@@ -29,7 +29,7 @@ impl PubkeyBinCalculator24 {
     }
 
     #[inline]
-    pub(crate) fn bin_from_pubkey(&self, pubkey: &Pubkey) -> usize {
+    pub fn bin_from_pubkey(&self, pubkey: &Pubkey) -> usize {
         let as_ref = pubkey.as_ref();
         ((as_ref[0] as usize) << 16 | (as_ref[1] as usize) << 8 | (as_ref[2] as usize))
             >> self.shift_bits


### PR DESCRIPTION
#### Problem

The accounts hash cache tool can be faster by scanning mmap'd files, and then optionally binning the results by pubkey. These binned results will be used when constructing the full state to diff in the next PR.


#### Summary of Changes

Scanning entries uses mmap'd files into bins.