### PR TITLE
hash-cache-tool: Adds command to diff state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "bytemuck",
  "clap 2.33.3",
  "memmap2",
+ "rayon",
  "solana-accounts-db",
  "solana-program",
  "solana-version",

--- a/accounts-db/accounts-hash-cache-tool/Cargo.toml
+++ b/accounts-db/accounts-hash-cache-tool/Cargo.toml
@@ -14,6 +14,7 @@ ahash = { workspace = true }
 bytemuck = { workspace = true }
 clap = { workspace = true }
 memmap2 = { workspace = true }
+rayon = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-program = { workspace = true }
 solana-version = { workspace = true }


### PR DESCRIPTION
#### Problem

The hash cache tool cannot diff the final state of the accounts hash cache directories.


#### Summary of Changes

Adds command to diff state.