### PR TITLE
refactor: serde stakes

### DIFF
--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -536,7 +536,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "DnUdXXELygo14vA8d6QoXo5bkJAQbTWqWW5Qf9RXXWgZ")
+            frozen_abi(digest = "HRBDXrGrHMZU4cNebKHT7jEmhrgd3h1c2qUMMywrGPiq")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapper {

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         stake_account::StakeAccount,
-        stakes::{Stakes, StakesEnum},
+        stakes::{serde_stakes_to_delegation_format, Stakes, StakesEnum},
     },
     serde::{Deserialize, Deserializer, Serialize, Serializer},
     solana_sdk::{clock::Epoch, pubkey::Pubkey, stake::state::Stake},
@@ -24,7 +24,7 @@ pub struct NodeVoteAccounts {
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct EpochStakes {
-    #[serde(with = "crate::stakes::serde_stakes_enum_compat")]
+    #[serde(with = "serde_stakes_to_delegation_format")]
     stakes: Arc<StakesEnum>,
     total_stake: u64,
     node_id_to_vote_accounts: Arc<NodeIdToVoteAccounts>,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -10,7 +10,7 @@ use {
         runtime_config::RuntimeConfig,
         serde_snapshot::storage::SerializableAccountStorageEntry,
         snapshot_utils::{SnapshotError, StorageAndNextAccountsFileId},
-        stakes::{serde_stakes_enum_compat, Stakes, StakesEnum},
+        stakes::{serde_stakes_to_delegation_format, Stakes, StakesEnum},
     },
     bincode::{self, config::Options, Error},
     log::*,
@@ -237,7 +237,7 @@ struct SerializableVersionedBank {
     rent_collector: RentCollector,
     epoch_schedule: EpochSchedule,
     inflation: Inflation,
-    #[serde(serialize_with = "serde_stakes_enum_compat::serialize")]
+    #[serde(serialize_with = "serde_stakes_to_delegation_format::serialize")]
     stakes: StakesEnum,
     unused_accounts: UnusedAccounts,
     epoch_stakes: HashMap<Epoch, EpochStakes>,

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -27,7 +27,7 @@ use {
 };
 
 mod serde_stakes;
-pub(crate) use serde_stakes::serde_stakes_enum_compat;
+pub(crate) use serde_stakes::serde_stakes_to_delegation_format;
 
 #[derive(Debug, Error)]
 pub enum Error {


### PR DESCRIPTION
#### Problem
Renamed structs and modules in the `serde_stakes` module to prepare for adding similar code in that module for serializing to the stake format.

#### Summary of Changes
- Renamed `serde_stakes_enum_compat` module to `serde_stakes_to_delegation_format` to be more explicit about what it's doing
- Renamed ambiguous structs like `SerdeStakeAccountVariantStakes` to `SerdeStakeAccountsToDelegationFormat` so that we can add a struct named `SerdeStakeAccountsToStakeFormat` and differentiate between what format is being serialized to

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
