### PR TITLE
Use less memory when serializing versioned epoch stakes

### DIFF
--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -6,8 +6,7 @@ mod tests {
                 epoch_accounts_hash_utils, test_utils as bank_test_utils, Bank, EpochRewardStatus,
             },
             epoch_stakes::{
-                EpochAuthorizedVoters, EpochStakes, NodeIdToVoteAccounts, StakesSerdeWrapper,
-                VersionedEpochStakes,
+                EpochAuthorizedVoters, EpochStakes, NodeIdToVoteAccounts, VersionedEpochStakes,
             },
             genesis_utils::activate_all_features,
             runtime_config::RuntimeConfig,
@@ -20,7 +19,7 @@ mod tests {
                 create_tmp_accounts_dir_for_tests, get_storages_to_serialize, ArchiveFormat,
                 StorageAndNextAccountsFileId,
             },
-            stakes::{Stakes, StakesEnum},
+            stakes::{SerdeStakesToStakeFormat, Stakes, StakesEnum},
         },
         solana_accounts_db::{
             account_storage::{AccountStorageMap, AccountStorageReference},
@@ -307,7 +306,7 @@ mod tests {
         bank.epoch_stakes.insert(
             42,
             EpochStakes::from(VersionedEpochStakes::Current {
-                stakes: StakesSerdeWrapper::Stake(Stakes::<Stake>::default()),
+                stakes: SerdeStakesToStakeFormat::Stake(Stakes::<Stake>::default()),
                 total_stake: 42,
                 node_id_to_vote_accounts: Arc::<NodeIdToVoteAccounts>::default(),
                 epoch_authorized_voters: Arc::<EpochAuthorizedVoters>::default(),
@@ -536,7 +535,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "HRBDXrGrHMZU4cNebKHT7jEmhrgd3h1c2qUMMywrGPiq")
+            frozen_abi(digest = "J7MnnLU99fYk2hfZPjdqyTYxgHstwRUDk2Yr8fFnXxFp")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapper {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -28,6 +28,7 @@ use {
 
 mod serde_stakes;
 pub(crate) use serde_stakes::serde_stakes_to_delegation_format;
+pub use serde_stakes::SerdeStakesToStakeFormat;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -566,23 +567,6 @@ impl From<Stakes<StakeAccount>> for Stakes<Stake> {
             unused: stakes.unused,
             epoch: stakes.epoch,
             stake_history: stakes.stake_history,
-        }
-    }
-}
-
-impl<'a> From<&'a Stakes<StakeAccount>> for Stakes<&'a Stake> {
-    fn from(stakes: &'a Stakes<StakeAccount>) -> Self {
-        let stake_delegations = stakes
-            .stake_delegations
-            .iter()
-            .map(|(pubkey, stake_account)| (*pubkey, stake_account.stake()))
-            .collect();
-        Self {
-            vote_accounts: stakes.vote_accounts.clone(),
-            stake_delegations,
-            unused: stakes.unused,
-            epoch: stakes.epoch,
-            stake_history: stakes.stake_history.clone(),
         }
     }
 }

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -2,12 +2,73 @@ use {
     super::{StakeAccount, Stakes, StakesEnum},
     crate::stake_history::StakeHistory,
     im::HashMap as ImHashMap,
-    serde::{ser::SerializeMap, Serialize, Serializer},
+    serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer},
     solana_sdk::{clock::Epoch, pubkey::Pubkey, stake::state::Delegation},
     solana_stake_program::stake_state::Stake,
     solana_vote::vote_account::VoteAccounts,
     std::sync::Arc,
 };
+
+/// Wrapper struct with custom serialization to support serializing
+/// `Stakes<StakeAccount>` as `Stakes<Stake>` without doing a full deep clone of
+/// the stake data. Serialization works by building a `Stakes<&Stake>` map which
+/// borrows `&Stake` from `StakeAccount` entries in `Stakes<StakeAccount>`. Note
+/// that `Stakes<&Stake>` still copies `Pubkey` keys so the `Stakes<&Stake>`
+/// data structure still allocates a fair amount of memory but the memory only
+/// remains allocated during serialization.
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Debug, Clone)]
+pub enum SerdeStakesToStakeFormat {
+    Stake(Stakes<Stake>),
+    Account(Stakes<StakeAccount>),
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl PartialEq<Self> for SerdeStakesToStakeFormat {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Stake(stakes), Self::Stake(other)) => stakes == other,
+            (Self::Account(stakes), Self::Account(other)) => stakes == other,
+            (Self::Stake(stakes), Self::Account(other)) => {
+                stakes == &Stakes::<Stake>::from(other.clone())
+            }
+            (Self::Account(stakes), Self::Stake(other)) => {
+                other == &Stakes::<Stake>::from(stakes.clone())
+            }
+        }
+    }
+}
+
+impl From<SerdeStakesToStakeFormat> for StakesEnum {
+    fn from(stakes: SerdeStakesToStakeFormat) -> Self {
+        match stakes {
+            SerdeStakesToStakeFormat::Stake(stakes) => Self::Stakes(stakes),
+            SerdeStakesToStakeFormat::Account(stakes) => Self::Accounts(stakes),
+        }
+    }
+}
+
+impl Serialize for SerdeStakesToStakeFormat {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Stake(stakes) => stakes.serialize(serializer),
+            Self::Account(stakes) => serialize_stake_accounts_to_stake_format(stakes, serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SerdeStakesToStakeFormat {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let stakes = Stakes::<Stake>::deserialize(deserializer)?;
+        Ok(Self::Stake(stakes))
+    }
+}
 
 // In order to maintain backward compatibility, the StakesEnum in EpochStakes
 // and SerializableVersionedBank should be serialized as Stakes<Delegation>.
@@ -53,6 +114,13 @@ fn serialize_stake_accounts_to_delegation_format<S: Serializer>(
     SerdeStakeAccountsToDelegationFormat::from(stakes.clone()).serialize(serializer)
 }
 
+fn serialize_stake_accounts_to_stake_format<S: Serializer>(
+    stakes: &Stakes<StakeAccount>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    SerdeStakeAccountsToStakeFormat::from(stakes.clone()).serialize(serializer)
+}
+
 impl From<Stakes<Stake>> for SerdeStakesToDelegationFormat {
     fn from(stakes: Stakes<Stake>) -> Self {
         let Stakes {
@@ -93,6 +161,26 @@ impl From<Stakes<StakeAccount>> for SerdeStakeAccountsToDelegationFormat {
     }
 }
 
+impl From<Stakes<StakeAccount>> for SerdeStakeAccountsToStakeFormat {
+    fn from(stakes: Stakes<StakeAccount>) -> Self {
+        let Stakes {
+            vote_accounts,
+            stake_delegations,
+            unused,
+            epoch,
+            stake_history,
+        } = stakes;
+
+        Self {
+            vote_accounts,
+            stake_delegations: SerdeStakeAccountMapToStakeFormat(stake_delegations),
+            unused,
+            epoch,
+            stake_history,
+        }
+    }
+}
+
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Serialize)]
 struct SerdeStakesToDelegationFormat {
@@ -108,6 +196,16 @@ struct SerdeStakesToDelegationFormat {
 struct SerdeStakeAccountsToDelegationFormat {
     vote_accounts: VoteAccounts,
     stake_delegations: SerdeStakeAccountMapToDelegationFormat,
+    unused: u64,
+    epoch: Epoch,
+    stake_history: StakeHistory,
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Serialize)]
+struct SerdeStakeAccountsToStakeFormat {
+    vote_accounts: VoteAccounts,
+    stake_delegations: SerdeStakeAccountMapToStakeFormat,
     unused: u64,
     epoch: Epoch,
     stake_history: StakeHistory,
@@ -143,12 +241,64 @@ impl Serialize for SerdeStakeAccountMapToDelegationFormat {
     }
 }
 
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+struct SerdeStakeAccountMapToStakeFormat(ImHashMap<Pubkey, StakeAccount>);
+impl Serialize for SerdeStakeAccountMapToStakeFormat {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_map(Some(self.0.len()))?;
+        for (pubkey, stake_account) in self.0.iter() {
+            s.serialize_entry(pubkey, stake_account.stake())?;
+        }
+        s.end()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
         super::*, crate::stakes::StakesCache, rand::Rng, solana_sdk::rent::Rent,
         solana_stake_program::stake_state, solana_vote_program::vote_state,
     };
+
+    #[test]
+    fn test_serde_stakes_to_stake_format() {
+        let mut stake_delegations = ImHashMap::new();
+        stake_delegations.insert(
+            Pubkey::new_unique(),
+            StakeAccount::try_from(stake_state::create_account(
+                &Pubkey::new_unique(),
+                &Pubkey::new_unique(),
+                &vote_state::create_account(
+                    &Pubkey::new_unique(),
+                    &Pubkey::new_unique(),
+                    0,
+                    1_000_000_000,
+                ),
+                &Rent::default(),
+                1_000_000_000,
+            ))
+            .unwrap(),
+        );
+
+        let stake_account_stakes = Stakes {
+            vote_accounts: VoteAccounts::default(),
+            stake_delegations,
+            unused: 0,
+            epoch: 0,
+            stake_history: StakeHistory::default(),
+        };
+
+        let wrapped_stakes = SerdeStakesToStakeFormat::Account(stake_account_stakes.clone());
+        let serialized_stakes = bincode::serialize(&wrapped_stakes).unwrap();
+        let stake_stakes = bincode::deserialize::<Stakes<Stake>>(&serialized_stakes).unwrap();
+        assert_eq!(
+            StakesEnum::Stakes(stake_stakes),
+            StakesEnum::Accounts(stake_account_stakes)
+        );
+    }
 
     #[test]
     fn test_serde_stakes_to_delegation_format() {

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -10,12 +10,8 @@ use {
 };
 
 /// Wrapper struct with custom serialization to support serializing
-/// `Stakes<StakeAccount>` as `Stakes<Stake>` without doing a full deep clone of
-/// the stake data. Serialization works by building a `Stakes<&Stake>` map which
-/// borrows `&Stake` from `StakeAccount` entries in `Stakes<StakeAccount>`. Note
-/// that `Stakes<&Stake>` still copies `Pubkey` keys so the `Stakes<&Stake>`
-/// data structure still allocates a fair amount of memory but the memory only
-/// remains allocated during serialization.
+/// `Stakes<StakeAccount>` as `Stakes<Stake>` without doing an intermediate
+/// clone of the stake data.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
 #[derive(Debug, Clone)]
 pub enum SerdeStakesToStakeFormat {


### PR DESCRIPTION
#### Problem
When serializing versioned epoch stakes, we do a shallow clone of the stake delegations map when serializing stake accounts in the stake format. Even this shallow clone uses more memory than necessary.

#### Summary of Changes
Use a streaming serializing approach when serializing stake accounts in the stake format similar to https://github.com/anza-xyz/agave/pull/2455

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
