### PR TITLE
Fix broken parallelism in quic-client

### DIFF
--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -26,11 +26,7 @@ use {
         pubkey::Pubkey,
         signature::{Keypair, Signer},
     },
-    solana_streamer::{
-        nonblocking::quic::{compute_max_allowed_uni_streams, ConnectionPeerType},
-        streamer::StakedNodes,
-        tls_certificates::new_dummy_x509_certificate,
-    },
+    solana_streamer::{streamer::StakedNodes, tls_certificates::new_dummy_x509_certificate},
     std::{
         net::{IpAddr, SocketAddr},
         sync::{Arc, RwLock},
@@ -65,13 +61,12 @@ impl ConnectionPool for QuicPool {
 
     fn create_pool_entry(
         &self,
-        config: &Self::NewConnectionConfig,
+        _config: &Self::NewConnectionConfig,
         addr: &SocketAddr,
     ) -> Arc<Self::BaseClientConnection> {
         Arc::new(Quic(Arc::new(QuicClient::new(
             self.endpoint.clone(),
             *addr,
-            config.compute_max_parallel_streams(),
         ))))
     }
 }
@@ -118,24 +113,6 @@ impl QuicConfig {
     fn create_endpoint(&self) -> QuicLazyInitializedEndpoint {
         let cert_guard = self.client_certificate.read().unwrap();
         QuicLazyInitializedEndpoint::new(cert_guard.clone(), self.client_endpoint.as_ref().cloned())
-    }
-
-    fn compute_max_parallel_streams(&self) -> usize {
-        let (client_type, total_stake) =
-            self.maybe_client_pubkey
-                .map_or((ConnectionPeerType::Unstaked, 0), |pubkey| {
-                    self.maybe_staked_nodes.as_ref().map_or(
-                        (ConnectionPeerType::Unstaked, 0),
-                        |stakes| {
-                            let rstakes = stakes.read().unwrap();
-                            rstakes.get_node_stake(&pubkey).map_or(
-                                (ConnectionPeerType::Unstaked, rstakes.total_stake()),
-                                |stake| (ConnectionPeerType::Staked(stake), rstakes.total_stake()),
-                            )
-                        },
-                    )
-                });
-        compute_max_allowed_uni_streams(client_type, total_stake)
     }
 
     pub fn update_client_certificate(&mut self, keypair: &Keypair, _ipaddr: IpAddr) {
@@ -253,56 +230,27 @@ pub fn new_quic_connection_cache(
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        solana_sdk::quic::{
-            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS, QUIC_MIN_STAKED_CONCURRENT_STREAMS,
-            QUIC_TOTAL_STAKED_CONCURRENT_STREAMS,
-        },
-        std::collections::HashMap,
-    };
+    use {super::*, std::collections::HashMap};
 
     #[test]
     fn test_connection_cache_max_parallel_chunks() {
         solana_logger::setup();
 
         let mut connection_config = QuicConfig::new().unwrap();
-        assert_eq!(
-            connection_config.compute_max_parallel_streams(),
-            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS
-        );
 
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let pubkey = Pubkey::new_unique();
         connection_config.set_staked_nodes(&staked_nodes, &pubkey);
-        assert_eq!(
-            connection_config.compute_max_parallel_streams(),
-            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS
-        );
         let overrides = HashMap::<Pubkey, u64>::default();
         let mut stakes = HashMap::from([(Pubkey::new_unique(), 10_000)]);
         *staked_nodes.write().unwrap() =
             StakedNodes::new(Arc::new(stakes.clone()), overrides.clone());
-        assert_eq!(
-            connection_config.compute_max_parallel_streams(),
-            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS
-        );
 
         stakes.insert(pubkey, 1);
         *staked_nodes.write().unwrap() =
             StakedNodes::new(Arc::new(stakes.clone()), overrides.clone());
-        let delta =
-            (QUIC_TOTAL_STAKED_CONCURRENT_STREAMS - QUIC_MIN_STAKED_CONCURRENT_STREAMS) as f64;
 
-        assert_eq!(
-            connection_config.compute_max_parallel_streams(),
-            (QUIC_MIN_STAKED_CONCURRENT_STREAMS as f64 + (1f64 / 10000f64) * delta) as usize
-        );
         stakes.insert(pubkey, 1_000);
         *staked_nodes.write().unwrap() = StakedNodes::new(Arc::new(stakes.clone()), overrides);
-        assert_ne!(
-            connection_config.compute_max_parallel_streams(),
-            QUIC_MIN_STAKED_CONCURRENT_STREAMS
-        );
     }
 }

--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -227,30 +227,3 @@ pub fn new_quic_connection_cache(
     let connection_manager = QuicConnectionManager::new_with_connection_config(config);
     ConnectionCache::new(name, connection_manager, connection_pool_size)
 }
-
-#[cfg(test)]
-mod tests {
-    use {super::*, std::collections::HashMap};
-
-    #[test]
-    fn test_connection_cache_max_parallel_chunks() {
-        solana_logger::setup();
-
-        let mut connection_config = QuicConfig::new().unwrap();
-
-        let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
-        let pubkey = Pubkey::new_unique();
-        connection_config.set_staked_nodes(&staked_nodes, &pubkey);
-        let overrides = HashMap::<Pubkey, u64>::default();
-        let mut stakes = HashMap::from([(Pubkey::new_unique(), 10_000)]);
-        *staked_nodes.write().unwrap() =
-            StakedNodes::new(Arc::new(stakes.clone()), overrides.clone());
-
-        stakes.insert(pubkey, 1);
-        *staked_nodes.write().unwrap() =
-            StakedNodes::new(Arc::new(stakes.clone()), overrides.clone());
-
-        stakes.insert(pubkey, 1_000);
-        *staked_nodes.write().unwrap() = StakedNodes::new(Arc::new(stakes.clone()), overrides);
-    }
-}


### PR DESCRIPTION
Fixes excessive fragmentation by TPU clients leading to a large
number of streams per conn in 'sending' state simultaneously.
This, in turn, requires excessive in-memory buffering server-side
to reassemble fragmented transactions.

- Simplifies QuicClient::send_batch to enqueue send operations
  in sequential order
- Removes the "max_parallel_streams" config option

The quic-client now produces an ordered fragment stream when
scheduling send operations from a single-thread.
