### PR TITLE
refactor: load transaction result supports fee only transactions

### DIFF
--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -41,7 +41,8 @@ pub enum TransactionLoadResult {
     /// All transaction accounts were loaded successfully
     Loaded(LoadedTransaction),
     /// Some transaction accounts needed for execution were unable to be loaded
-    /// but the accounts needed for fee collection were loaded successfully
+    /// but the fee payer and any nonce account needed for fee collection were
+    /// loaded successfully
     FeesOnly(FeesOnlyTransaction),
     /// Some transaction accounts needed for fee collection were unable to be
     /// loaded

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -38,8 +38,13 @@ pub type TransactionValidationResult = Result<ValidatedTransactionDetails>;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum TransactionLoadResult {
+    /// All transaction accounts were loaded successfully
     Loaded(LoadedTransaction),
+    /// Some transaction accounts needed for execution were unable to be loaded
+    /// but the accounts needed for fee collection were loaded successfully
     FeesOnly(FeesOnlyTransaction),
+    /// Some transaction accounts needed for fee collection were unable to be
+    /// loaded
     NotLoaded(TransactionError),
 }
 


### PR DESCRIPTION
#### Problem
In order to support fee validated transactions that aren't executable, transaction account loading needs to be able to indicate the difference between fee validation errors and other account loading errors that happen post-fee validation

#### Summary of Changes
- Replaced the `TransactionLoadResult` type alias with an enum that includes a variant for `FeeOnly` transactions which have passed fee validation but cannot be executed due to an account loading error
- Created a `FeesOnlyTransaction` struct which holds all relevant details for committing the aforementioned "fee-only" transactions to the ledger. Note that these details aren't used yet since this PR doesn't actually change any behavior to allow such transactions to be committed, this is just plumbing for now.. we still reject transactions unless they are executable.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
