### PR TITLE
Pass slot instead of Bank to TransactionStatusService

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -157,7 +157,7 @@ impl Committer {
                 })
                 .collect();
             transaction_status_sender.send_transaction_status_batch(
-                bank.clone(),
+                bank.slot(),
                 txs,
                 commit_results,
                 TransactionBalancesSet::new(

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -683,8 +683,6 @@ fn record_transactions(
 ) {
     for tsm in recv {
         if let TransactionStatusMessage::Batch(batch) = tsm {
-            let slot = batch.bank.slot();
-
             assert_eq!(batch.transactions.len(), batch.commit_results.len());
 
             let transactions: Vec<_> = batch
@@ -725,11 +723,11 @@ fn record_transactions(
 
             let mut slots = slots.lock().unwrap();
 
-            if let Some(recorded_slot) = slots.iter_mut().find(|f| f.slot == slot) {
+            if let Some(recorded_slot) = slots.iter_mut().find(|f| f.slot == batch.slot) {
                 recorded_slot.transactions.extend(transactions);
             } else {
                 slots.push(SlotDetails {
-                    slot,
+                    slot: batch.slot,
                     transactions,
                     ..Default::default()
                 });

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -207,7 +207,7 @@ pub fn execute_batch(
             TransactionTokenBalancesSet::new(pre_token_balances, post_token_balances);
 
         transaction_status_sender.send_transaction_status_batch(
-            bank.clone(),
+            bank.slot(),
             transactions,
             commit_results,
             balances,
@@ -2108,7 +2108,7 @@ pub enum TransactionStatusMessage {
 }
 
 pub struct TransactionStatusBatch {
-    pub bank: Arc<Bank>,
+    pub slot: Slot,
     pub transactions: Vec<SanitizedTransaction>,
     pub commit_results: Vec<TransactionCommitResult>,
     pub balances: TransactionBalancesSet,
@@ -2124,19 +2124,17 @@ pub struct TransactionStatusSender {
 impl TransactionStatusSender {
     pub fn send_transaction_status_batch(
         &self,
-        bank: Arc<Bank>,
+        slot: Slot,
         transactions: Vec<SanitizedTransaction>,
         commit_results: Vec<TransactionCommitResult>,
         balances: TransactionBalancesSet,
         token_balances: TransactionTokenBalancesSet,
         transaction_indexes: Vec<usize>,
     ) {
-        let slot = bank.slot();
-
         if let Err(e) = self
             .sender
             .send(TransactionStatusMessage::Batch(TransactionStatusBatch {
-                bank,
+                slot,
                 transactions,
                 commit_results,
                 balances,

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -69,14 +69,13 @@ impl TransactionStatusService {
     ) -> Result<(), RecvTimeoutError> {
         match write_transaction_status_receiver.recv_timeout(Duration::from_secs(1))? {
             TransactionStatusMessage::Batch(TransactionStatusBatch {
-                bank,
+                slot,
                 transactions,
                 commit_results,
                 balances,
                 token_balances,
                 transaction_indexes,
             }) => {
-                let slot = bank.slot();
                 for (
                     transaction,
                     commit_result,
@@ -384,7 +383,7 @@ pub(crate) mod tests {
         let signature = *transaction.signature();
         let transaction_index: usize = bank.transaction_count().try_into().unwrap();
         let transaction_status_batch = TransactionStatusBatch {
-            bank,
+            slot,
             transactions: vec![transaction],
             commit_results: vec![commit_result],
             balances,


### PR DESCRIPTION
#### Problem
We pass an Arc of Bank in each transaction status service batch message. All we need from Bank is the slot. This will reduce bank clones in a couple of places (every batch we execute in replay or commit in banking stage) and might allow us to drop Banks sooner in some cases.

#### Summary of Changes
Just pass 8 byte slot number instead of Arc pointer to Bank in each message.