### PR TITLE
Add Bank::set_epoch_stakes_for_test() so that we can adjust epoch_stakes in tests easily.

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1973,12 +1973,8 @@ impl Bank {
     }
 
     #[cfg(feature = "dev-context-only-utils")]
-    pub fn set_epoch_stakes_for_test(&mut self, epoch: Epoch, stakes: Option<EpochStakes>) {
-        if let Some(stakes) = stakes {
-            self.epoch_stakes.insert(epoch, stakes);
-        } else {
-            self.epoch_stakes.remove(&epoch);
-        }
+    pub fn set_epoch_stakes_for_test(&mut self, epoch: Epoch, stakes: EpochStakes) {
+        self.epoch_stakes.insert(epoch, stakes);
     }
 
     fn update_rent(&self) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1972,6 +1972,15 @@ impl Bank {
         }
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn set_epoch_stakes_for_test(&mut self, epoch: Epoch, stakes: Option<EpochStakes>) {
+        if let Some(stakes) = stakes {
+            self.epoch_stakes.insert(epoch, stakes);
+        } else {
+            self.epoch_stakes.remove(&epoch);
+        }
+    }
+
     fn update_rent(&self) {
         self.update_sysvar_account(&sysvar::rent::id(), |account| {
             create_account(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13031,8 +13031,6 @@ fn test_bank_epoch_stakes() {
         );
     }
 
-    bank1.set_epoch_stakes_for_test(1, None);
-    assert_eq!(bank1.epoch_total_stake(1), None);
     let new_epoch_stakes = EpochStakes::new_for_tests(
         voting_keypairs
             .iter()
@@ -13052,7 +13050,7 @@ fn test_bank_epoch_stakes() {
             .collect::<HashMap<_, _>>(),
         1,
     );
-    bank1.set_epoch_stakes_for_test(1, Some(new_epoch_stakes));
+    bank1.set_epoch_stakes_for_test(1, new_epoch_stakes);
     assert_eq!(bank1.epoch_total_stake(1), Some(100 * num_of_nodes));
     assert_eq!(bank1.epoch_node_id_to_stake(1, &Pubkey::new_unique()), None);
     for keypair in voting_keypairs.iter() {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -109,7 +109,8 @@ use {
     solana_vote_program::{
         vote_instruction,
         vote_state::{
-            self, BlockTimestamp, Vote, VoteInit, VoteState, VoteStateVersions, MAX_LOCKOUT_HISTORY,
+            self, create_account_with_authorized, BlockTimestamp, Vote, VoteInit, VoteState,
+            VoteStateVersions, MAX_LOCKOUT_HISTORY,
         },
     },
     std::{
@@ -13002,7 +13003,7 @@ fn test_bank_epoch_stakes() {
         create_genesis_config_with_vote_accounts(1_000_000_000, &voting_keypairs, stakes.clone());
 
     let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
-    let bank1 = Bank::new_from_parent(
+    let mut bank1 = Bank::new_from_parent(
         bank0.clone(),
         &Pubkey::default(),
         bank0.get_slots_in_epoch(0) + 1,
@@ -13027,6 +13028,37 @@ fn test_bank_epoch_stakes() {
         assert_eq!(
             bank1.epoch_node_id_to_stake(1, &keypair.node_keypair.pubkey()),
             Some(stakes[i])
+        );
+    }
+
+    bank1.set_epoch_stakes_for_test(1, None);
+    assert_eq!(bank1.epoch_total_stake(1), None);
+    let new_epoch_stakes = EpochStakes::new_for_tests(
+        voting_keypairs
+            .iter()
+            .map(|keypair| {
+                let node_id = keypair.node_keypair.pubkey();
+                let authorized_voter = keypair.vote_keypair.pubkey();
+                let vote_account = VoteAccount::try_from(create_account_with_authorized(
+                    &node_id,
+                    &authorized_voter,
+                    &node_id,
+                    0,
+                    100,
+                ))
+                .unwrap();
+                (authorized_voter, (100_u64, vote_account))
+            })
+            .collect::<HashMap<_, _>>(),
+        1,
+    );
+    bank1.set_epoch_stakes_for_test(1, Some(new_epoch_stakes));
+    assert_eq!(bank1.epoch_total_stake(1), Some(100 * num_of_nodes));
+    assert_eq!(bank1.epoch_node_id_to_stake(1, &Pubkey::new_unique()), None);
+    for keypair in voting_keypairs.iter() {
+        assert_eq!(
+            bank1.epoch_node_id_to_stake(1, &keypair.node_keypair.pubkey()),
+            Some(100)
         );
     }
 }

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -44,6 +44,21 @@ impl EpochStakes {
         }
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn new_for_tests(
+        vote_accounts_hash_map: VoteAccountsHashMap,
+        leader_schedule_epoch: Epoch,
+    ) -> Self {
+        Self::new(
+            Arc::new(StakesEnum::Accounts(Stakes::new_for_tests(
+                0,
+                solana_vote::vote_account::VoteAccounts::from(Arc::new(vote_accounts_hash_map)),
+                im::HashMap::default(),
+            ))),
+            leader_schedule_epoch,
+        )
+    }
+
     pub fn stakes(&self) -> &StakesEnum {
         &self.stakes
     }
@@ -290,10 +305,9 @@ pub(crate) mod tests {
     use {
         super::*,
         crate::{stake_account::StakeAccount, stakes::StakesCache},
-        im::HashMap as ImHashMap,
         solana_sdk::{account::AccountSharedData, rent::Rent},
         solana_stake_program::stake_state::{self, Delegation},
-        solana_vote::vote_account::{VoteAccount, VoteAccounts},
+        solana_vote::vote_account::VoteAccount,
         solana_vote_program::vote_state::{self, create_account_with_authorized},
         std::iter,
     };
@@ -606,14 +620,7 @@ pub(crate) mod tests {
         let epoch_vote_accounts = new_epoch_vote_accounts(&vote_accounts_map, |node_id| {
             *node_id_to_stake_map.get(node_id).unwrap()
         });
-        let epoch_stakes = EpochStakes::new(
-            Arc::new(StakesEnum::Accounts(Stakes::new_for_tests(
-                0,
-                VoteAccounts::from(Arc::new(epoch_vote_accounts)),
-                ImHashMap::default(),
-            ))),
-            0,
-        );
+        let epoch_stakes = EpochStakes::new_for_tests(epoch_vote_accounts, 0);
 
         assert_eq!(epoch_stakes.total_stake(), 11000);
         for (node_id, stake) in node_id_to_stake_map.iter() {

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -46,7 +46,7 @@ impl EpochStakes {
         leader_schedule_epoch: Epoch,
     ) -> Self {
         Self::new(
-            Arc::new(StakesEnum::Accounts(Stakes::new_for_tests(
+            Arc::new(StakesEnum::Accounts(crate::stakes::Stakes::new_for_tests(
                 0,
                 solana_vote::vote_account::VoteAccounts::from(Arc::new(vote_accounts_hash_map)),
                 im::HashMap::default(),

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -319,7 +319,7 @@ impl Stakes<StakeAccount> {
         })
     }
 
-    #[cfg(test)]
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn new_for_tests(
         epoch: Epoch,
         vote_accounts: VoteAccounts,


### PR DESCRIPTION
Add Bank::set_epoch_stakes_for_test() so that you can simulate all kinds of situations with epoch_stakes in tests.