### PR TITLE
Support SSLKEYLOGFILE

### DIFF
--- a/core/src/repair/quic_endpoint.rs
+++ b/core/src/repair/quic_endpoint.rs
@@ -9,7 +9,7 @@ use {
         EndpointConfig, IdleTimeout, ReadError, ReadToEndError, RecvStream, SendStream,
         ServerConfig, TokioRuntime, TransportConfig, VarInt, WriteError,
     },
-    rustls::{Certificate, PrivateKey},
+    rustls::{Certificate, KeyLogFile, PrivateKey},
     serde_bytes::ByteBuf,
     solana_quic_client::nonblocking::quic_client::SkipServerVerification,
     solana_runtime::bank_forks::BankForks,
@@ -174,6 +174,7 @@ fn new_server_config(cert: Certificate, key: PrivateKey) -> Result<ServerConfig,
         .with_client_cert_verifier(Arc::new(SkipClientVerification {}))
         .with_single_cert(vec![cert], key)?;
     config.alpn_protocols = vec![ALPN_REPAIR_PROTOCOL_ID.to_vec()];
+    config.key_log = Arc::new(KeyLogFile::new());
     let mut config = ServerConfig::with_crypto(Arc::new(config));
     config
         .transport_config(Arc::new(new_transport_config()))

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -6,7 +6,7 @@ use {
     crossbeam_channel::Sender,
     pem::Pem,
     quinn::{Endpoint, IdleTimeout, ServerConfig},
-    rustls::{server::ClientCertVerified, Certificate, DistinguishedName},
+    rustls::{server::ClientCertVerified, Certificate, DistinguishedName, KeyLogFile},
     solana_perf::packet::PacketBatch,
     solana_sdk::{
         packet::PACKET_DATA_SIZE,
@@ -78,6 +78,7 @@ pub(crate) fn configure_server(
         .with_client_cert_verifier(SkipClientVerification::new())
         .with_single_cert(vec![cert], priv_key)?;
     server_tls_config.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
+    server_tls_config.key_log = Arc::new(KeyLogFile::new());
 
     let mut server_config = ServerConfig::with_crypto(Arc::new(server_tls_config));
     server_config.concurrent_connections(max_concurrent_connections as u32);

--- a/turbine/src/quic_endpoint.rs
+++ b/turbine/src/quic_endpoint.rs
@@ -8,7 +8,7 @@ use {
         EndpointConfig, IdleTimeout, SendDatagramError, ServerConfig, TokioRuntime,
         TransportConfig, VarInt,
     },
-    rustls::{Certificate, PrivateKey},
+    rustls::{Certificate, KeyLogFile, PrivateKey},
     solana_quic_client::nonblocking::quic_client::SkipServerVerification,
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{pubkey::Pubkey, signature::Keypair},
@@ -154,6 +154,7 @@ fn new_server_config(cert: Certificate, key: PrivateKey) -> Result<ServerConfig,
         .with_client_cert_verifier(Arc::new(SkipClientVerification {}))
         .with_single_cert(vec![cert], key)?;
     config.alpn_protocols = vec![ALPN_TURBINE_PROTOCOL_ID.to_vec()];
+    config.key_log = Arc::new(KeyLogFile::new());
     let mut config = ServerConfig::with_crypto(Arc::new(config));
     config
         .transport_config(Arc::new(new_transport_config()))


### PR DESCRIPTION
#### Problem

It's currently impossible to do in-depth analysis of mainnet QUIC traffic without patches (such as this one) to the validator.

#### Summary of Changes

Supports `$SSLKEYLOGFILE`, a de-facto standard option for locally viewing TLS traffic in packet captures.

This change will help production debugging of QUIC traffic which is otherwise impossible to analyze. Activates logging of TLS encryption keys for incoming encryption keys when the SSLKEYLOGFILE env var is set. Otherwise (by default) does not log anything or change any existing behavior.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
