### PR TITLE
clippy: allow all clippy for mod google in storage-bigtable

### DIFF
--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -16,7 +16,7 @@ use {
     tonic::{codegen::InterceptedService, transport::ClientTlsConfig, Request, Status},
 };
 
-#[allow(clippy::enum_variant_names)]
+#[allow(clippy::all)]
 mod google {
     mod rpc {
         include!(concat!(


### PR DESCRIPTION
(part of #2487)

#### Problem

the files in `storage-bigtable/proto/*.rs` are generated by https://github.com/anza-xyz/agave/blob/master/storage-bigtable/build-proto/build.sh (https://github.com/anza-xyz/agave/pull/2497#discussion_r1711621816)

we should ignore clippy checks for those files otherwise we will need to make the same modifications during the next round generation if the upstream doesn't fix the clippy issue.

#### Summary of Changes

allow all for mod google