### PR TITLE
Adding bench_poh_recorder_record_transaction_index

### DIFF
--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -734,9 +734,14 @@ impl PohRecorder {
         self.set_bank(BankWithScheduler::new_without_scheduler(bank), false)
     }
 
-    #[cfg(test)]
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn set_bank_with_transaction_index_for_test(&mut self, bank: Arc<Bank>) {
         self.set_bank(BankWithScheduler::new_without_scheduler(bank), true)
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn clear_bank_for_test(&mut self) {
+        self.clear_bank();
     }
 
     // Flush cache will delay flushing the cache for a bank until it past the WorkingBank::min_tick_height


### PR DESCRIPTION
Adapted from test_poh_recorder_record_transaction_index

./cargo nightly bench --manifest-path poh/Cargo.toml
```
test bench_poh_lock_time_per_batch               ... bench:      11,426 ns/iter (+/- 251)
test bench_poh_recorder_record_transaction_index ... bench:       1,334 ns/iter (+/- 106)
test bench_poh_recorder_set_bank                 ... bench:   5,468,741 ns/iter (+/- 255)
```