### PR TITLE
use new `validate_account_locks`

### DIFF
--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate lazy_static;
 
 pub mod account_info;
-mod account_locks;
+pub mod account_locks;
 pub mod account_storage;
 pub mod accounts;
 mod accounts_cache;

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -23,6 +23,7 @@ use {
     },
     arrayvec::ArrayVec,
     crossbeam_channel::RecvTimeoutError,
+    solana_accounts_db::account_locks::validate_account_locks,
     solana_cost_model::cost_model::CostModel,
     solana_measure::measure_us,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
@@ -526,8 +527,8 @@ impl SchedulerController {
                 })
                 .inspect(|_| saturating_add_assign!(post_sanitization_count, 1))
                 .filter(|(_packet, tx)| {
-                    SanitizedTransaction::validate_account_locks(
-                        tx.message(),
+                    validate_account_locks(
+                        tx.message().account_keys(),
                         transaction_account_lock_limit,
                     )
                     .is_ok()

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -17,6 +17,7 @@ use {
     },
     itertools::Itertools,
     min_max_heap::MinMaxHeap,
+    solana_accounts_db::account_locks::validate_account_locks,
     solana_measure::measure_us,
     solana_runtime::bank::Bank,
     solana_sdk::{
@@ -171,8 +172,8 @@ fn consume_scan_should_process_packet(
         let message = sanitized_transaction.message();
 
         // Check the number of locks and whether there are duplicates
-        if SanitizedTransaction::validate_account_locks(
-            message,
+        if validate_account_locks(
+            message.account_keys(),
             bank.get_transaction_account_lock_limit(),
         )
         .is_err()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -66,6 +66,7 @@ use {
     },
     serde::Serialize,
     solana_accounts_db::{
+        account_locks::validate_account_locks,
         accounts::{AccountAddressFilter, Accounts, PubkeyAccountSlot},
         accounts_db::{
             AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig,
@@ -3281,10 +3282,8 @@ impl Bank {
         transaction: &'a SanitizedTransaction,
     ) -> TransactionBatch<'_, '_> {
         let tx_account_lock_limit = self.get_transaction_account_lock_limit();
-        let lock_result = SanitizedTransaction::validate_account_locks(
-            transaction.message(),
-            tx_account_lock_limit,
-        );
+        let lock_result =
+            validate_account_locks(transaction.message().account_keys(), tx_account_lock_limit);
         let mut batch = TransactionBatch::new(
             vec![lock_result],
             self,


### PR DESCRIPTION
#### Problem
- Legacy `SanitizedTransaction::validate_account_locks` is used in a few places
- We want to use the new function which does not force specific transaction/message type(s)

#### Summary of Changes
- Change direct uses of `SanitizedTransaction::validate_account_locks` to `validate_account_locks`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
