### PR TITLE
unified_scheduler_logic: replace get_account_locks_unchecked

### DIFF
--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -803,15 +803,15 @@ impl SchedulingStateMachine {
         // `Bank::prepare_unlocked_batch_from_single_tx()` as well.
         // This redundancy is known. It was just left as-is out of abundance
         // of caution.
-        let message = transaction.message();
-        let lock_contexts = message
+        let lock_contexts = transaction
+            .message()
             .account_keys()
             .iter()
             .enumerate()
             .map(|(index, address)| {
                 LockContext::new(
                     usage_queue_loader(*address),
-                    if message.is_writable(index) {
+                    if transaction.message().is_writable(index) {
                         RequestedUsage::Writable
                     } else {
                         RequestedUsage::Readonly

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -772,35 +772,22 @@ impl SchedulingStateMachine {
         index: usize,
         usage_queue_loader: &mut impl FnMut(Pubkey) -> UsageQueue,
     ) -> Task {
-        // Calling the _unchecked() version here is safe for faster operation, because
-        // `get_account_locks()` (the safe variant) is ensured to be called in
-        // DefaultTransactionHandler::handle() via Bank::prepare_unlocked_batch_from_single_tx().
-        //
-        // The safe variant has additional account-locking related verifications, which is crucial.
-        //
-        // Currently the replaying stage is redundantly calling `get_account_locks()` when unified
-        // scheduler is enabled on the given transaction at the blockstore. This will be relaxed
-        // for optimization in the future. As for banking stage with unified scheduler, it will
-        // need to run .get_account_locks() at least once somewhere in the code path. In the
-        // distant future, this function `create_task()` should be adjusted so that both stages do
-        // the checks before calling this (say, with some ad-hoc type like
-        // `SanitizedTransactionWithCheckedAccountLocks`) or do the checks here, resulting in
-        // eliminating the redundant one in the replaying stage and in the handler.
-        let locks = transaction.get_account_locks_unchecked();
-
-        let writable_locks = locks
-            .writable
+        // Locks are validated later in the pipeline. Here we create a task
+        // without checking that locks are valid.
+        let message = transaction.message();
+        let lock_contexts = message
+            .account_keys()
             .iter()
-            .map(|address| (address, RequestedUsage::Writable));
-        let readonly_locks = locks
-            .readonly
-            .iter()
-            .map(|address| (address, RequestedUsage::Readonly));
-
-        let lock_contexts = writable_locks
-            .chain(readonly_locks)
-            .map(|(address, requested_usage)| {
-                LockContext::new(usage_queue_loader(**address), requested_usage)
+            .enumerate()
+            .map(|(index, address)| {
+                LockContext::new(
+                    usage_queue_loader(*address),
+                    if message.is_writable(index) {
+                        RequestedUsage::Writable
+                    } else {
+                        RequestedUsage::Readonly
+                    },
+                )
             })
             .collect();
 


### PR DESCRIPTION
#### Problem
- `validate_account_locks` function got pulled into `account_locks` from `sdk`
- following that change, `get_account_locks` and `get_account_locks_unchecked` will be deprecated
- unified-scheduler-logic crate uses `get_account_locks_unchecked`

#### Summary of Changes
- Replace use of `get_account_locks_unchecked` with more direct access

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
