### PR TITLE
transaction_status_service: remove get_account_locks_unchecked

### DIFF
--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate lazy_static;
 
 pub mod account_info;
-mod account_locks;
+pub mod account_locks;
 pub mod account_storage;
 pub mod accounts;
 mod accounts_cache;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2868,12 +2868,11 @@ impl Blockstore {
         }
     }
 
-    pub fn write_transaction_status(
+    pub fn write_transaction_status<'a>(
         &self,
         slot: Slot,
         signature: Signature,
-        writable_keys: Vec<&Pubkey>,
-        readonly_keys: Vec<&Pubkey>,
+        keys_with_writable: impl Iterator<Item = (&'a Pubkey, bool)>,
         status: TransactionStatusMeta,
         transaction_index: usize,
     ) -> Result<()> {
@@ -2882,18 +2881,14 @@ impl Blockstore {
             .map_err(|_| BlockstoreError::TransactionIndexOverflow)?;
         self.transaction_status_cf
             .put_protobuf((signature, slot), &status)?;
-        for address in writable_keys {
+
+        for (address, writeable) in keys_with_writable {
             self.address_signatures_cf.put(
                 (*address, slot, transaction_index, signature),
-                &AddressSignatureMeta { writeable: true },
+                &AddressSignatureMeta { writeable },
             )?;
         }
-        for address in readonly_keys {
-            self.address_signatures_cf.put(
-                (*address, slot, transaction_index, signature),
-                &AddressSignatureMeta { writeable: false },
-            )?;
-        }
+
         Ok(())
     }
 
@@ -8673,8 +8668,11 @@ pub mod tests {
             .write_transaction_status(
                 slot,
                 signature,
-                vec![&Pubkey::new_unique()],
-                vec![&Pubkey::new_unique()],
+                vec![
+                    (&Pubkey::new_unique(), true),
+                    (&Pubkey::new_unique(), false),
+                ]
+                .into_iter(),
                 TransactionStatusMeta {
                     fee: slot * 1_000,
                     ..TransactionStatusMeta::default()
@@ -9061,8 +9059,7 @@ pub mod tests {
             .write_transaction_status(
                 lowest_cleanup_slot,
                 signature1,
-                vec![&address0],
-                vec![],
+                vec![(&address0, true)].into_iter(),
                 TransactionStatusMeta::default(),
                 0,
             )
@@ -9071,8 +9068,7 @@ pub mod tests {
             .write_transaction_status(
                 lowest_available_slot,
                 signature2,
-                vec![&address1],
-                vec![],
+                vec![(&address1, true)].into_iter(),
                 TransactionStatusMeta::default(),
                 0,
             )
@@ -9440,8 +9436,7 @@ pub mod tests {
                 .write_transaction_status(
                     slot1,
                     signature,
-                    vec![&address0],
-                    vec![&address1],
+                    vec![(&address0, true), (&address1, false)].into_iter(),
                     TransactionStatusMeta::default(),
                     x as usize,
                 )
@@ -9454,8 +9449,7 @@ pub mod tests {
                 .write_transaction_status(
                     slot2,
                     signature,
-                    vec![&address0],
-                    vec![&address1],
+                    vec![(&address0, true), (&address1, false)].into_iter(),
                     TransactionStatusMeta::default(),
                     x as usize,
                 )
@@ -9467,8 +9461,7 @@ pub mod tests {
                 .write_transaction_status(
                     slot2,
                     signature,
-                    vec![&address0],
-                    vec![&address1],
+                    vec![(&address0, true), (&address1, false)].into_iter(),
                     TransactionStatusMeta::default(),
                     x as usize,
                 )
@@ -9481,8 +9474,7 @@ pub mod tests {
                 .write_transaction_status(
                     slot3,
                     signature,
-                    vec![&address0],
-                    vec![&address1],
+                    vec![(&address0, true), (&address1, false)].into_iter(),
                     TransactionStatusMeta::default(),
                     x as usize,
                 )
@@ -9565,8 +9557,11 @@ pub mod tests {
                         .write_transaction_status(
                             slot,
                             transaction.signatures[0],
-                            transaction.message.static_account_keys().iter().collect(),
-                            vec![],
+                            transaction
+                                .message
+                                .static_account_keys()
+                                .iter()
+                                .map(|key| (key, true)),
                             TransactionStatusMeta::default(),
                             counter,
                         )
@@ -9593,8 +9588,11 @@ pub mod tests {
                         .write_transaction_status(
                             slot,
                             transaction.signatures[0],
-                            transaction.message.static_account_keys().iter().collect(),
-                            vec![],
+                            transaction
+                                .message
+                                .static_account_keys()
+                                .iter()
+                                .map(|key| (key, true)),
                             TransactionStatusMeta::default(),
                             counter,
                         )

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -582,8 +582,11 @@ pub mod tests {
                 .write_transaction_status(
                     x,
                     Signature::from(random_bytes),
-                    vec![&Pubkey::try_from(&random_bytes[..32]).unwrap()],
-                    vec![&Pubkey::try_from(&random_bytes[32..]).unwrap()],
+                    vec![
+                        (&Pubkey::try_from(&random_bytes[..32]).unwrap(), true),
+                        (&Pubkey::try_from(&random_bytes[32..]).unwrap(), false),
+                    ]
+                    .into_iter(),
                     TransactionStatusMeta::default(),
                     0,
                 )
@@ -640,8 +643,11 @@ pub mod tests {
                 .write_transaction_status(
                     x,
                     signature,
-                    vec![&Pubkey::try_from(&random_bytes[..32]).unwrap()],
-                    vec![&Pubkey::try_from(&random_bytes[32..]).unwrap()],
+                    vec![
+                        (&Pubkey::try_from(&random_bytes[..32]).unwrap(), true),
+                        (&Pubkey::try_from(&random_bytes[32..]).unwrap(), false),
+                    ]
+                    .into_iter(),
                     TransactionStatusMeta::default(),
                     0,
                 )
@@ -715,8 +721,11 @@ pub mod tests {
                     .write_transaction_status(
                         slot,
                         transaction.signatures[0],
-                        transaction.message.static_account_keys().iter().collect(),
-                        vec![],
+                        transaction
+                            .message
+                            .static_account_keys()
+                            .iter()
+                            .map(|key| (key, true)),
                         TransactionStatusMeta::default(),
                         0,
                     )

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -111,7 +111,6 @@ impl TransactionStatusService {
                         rent_debits,
                         ..
                     } = committed_tx;
-                    let tx_account_locks = transaction.get_account_locks_unchecked();
 
                     let fee = fee_details.total_fee();
                     let inner_instructions = inner_instructions.map(|inner_instructions| {
@@ -171,12 +170,18 @@ impl TransactionStatusService {
                                 .expect("Expect database write to succeed: TransactionMemos");
                         }
 
+                        let message = transaction.message();
+                        let keys_with_writable = message
+                            .account_keys()
+                            .iter()
+                            .enumerate()
+                            .map(|(index, key)| (key, message.is_writable(index)));
+
                         blockstore
                             .write_transaction_status(
                                 slot,
                                 *transaction.signature(),
-                                tx_account_locks.writable,
-                                tx_account_locks.readonly,
+                                keys_with_writable,
                                 transaction_status_meta,
                                 transaction_index,
                             )


### PR DESCRIPTION
#### Problem
- `validate_account_locks` function got pulled into `account_locks` from `sdk`
- following that change, `get_account_locks` and `get_account_locks_unchecked` will be deprecated
- transaction_status_service uses `get_account_locks_unchecked`

#### Summary of Changes
- Replace use of `get_account_locks_unchecked` with more direct access
- Refactor `blockstore::write_transaction_status` to take a single iterator (simplifies code)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->