### PR TITLE
prioritization_fee_cache: remove get_account_locks

### DIFF
--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate lazy_static;
 
 pub mod account_info;
-mod account_locks;
+pub mod account_locks;
 pub mod account_storage;
 pub mod accounts;
 mod accounts_cache;

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -2,6 +2,7 @@ use {
     crate::{bank::Bank, prioritization_fee::*},
     crossbeam_channel::{unbounded, Receiver, Sender},
     log::*,
+    solana_accounts_db::account_locks::validate_account_locks,
     solana_measure::measure_us,
     solana_runtime_transaction::instructions_processor::process_compute_budget_instructions,
     solana_sdk::{
@@ -205,10 +206,14 @@ impl PrioritizationFeeCache {
                 let compute_budget_limits = process_compute_budget_instructions(
                     sanitized_transaction.message().program_instructions_iter(),
                 );
-                let account_locks = sanitized_transaction
-                    .get_account_locks(bank.get_transaction_account_lock_limit());
 
-                if compute_budget_limits.is_err() || account_locks.is_err() {
+                let message = sanitized_transaction.message();
+                let lock_result = validate_account_locks(
+                    message.account_keys(),
+                    bank.get_transaction_account_lock_limit(),
+                );
+
+                if compute_budget_limits.is_err() || lock_result.is_err() {
                     continue;
                 }
                 let compute_budget_limits = compute_budget_limits.unwrap();
@@ -219,12 +224,13 @@ impl PrioritizationFeeCache {
                     continue;
                 }
 
-                let writable_accounts = account_locks
-                    .unwrap()
-                    .writable
+                let writable_accounts = message
+                    .account_keys()
                     .iter()
-                    .map(|key| **key)
-                    .collect::<Vec<_>>();
+                    .enumerate()
+                    .filter(|(index, _)| message.is_writable(*index))
+                    .map(|(_, key)| *key)
+                    .collect();
 
                 self.sender
                     .send(CacheServiceUpdate::TransactionUpdate {


### PR DESCRIPTION
#### Problem
- `validate_account_locks` function got pulled into `account_locks` from `sdk`
- following that change, `get_account_locks` and `get_account_locks_unchecked` will be deprecated
- prioritization_fee_cache uses `get_account_locks`

#### Summary of Changes
- Replace use of `get_account_locks` with more direct access

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->