### PR TITLE
Flushes hash cache data file's mmap after done writing

### DIFF
--- a/accounts-db/src/cache_hash_data_stats.rs
+++ b/accounts-db/src/cache_hash_data_stats.rs
@@ -11,6 +11,7 @@ pub struct CacheHashDataStats {
     pub save_us: AtomicU64,
     pub saved_to_cache: AtomicUsize,
     pub write_to_mmap_us: AtomicU64,
+    pub flush_mmap_us: AtomicU64,
     pub create_save_us: AtomicU64,
     pub load_us: AtomicU64,
     pub read_us: AtomicU64,
@@ -59,6 +60,11 @@ impl CacheHashDataStats {
             (
                 "write_to_mmap_us",
                 self.write_to_mmap_us.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "flush_mmap_us",
+                self.flush_mmap_us.load(Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem

We've been seen intermittent issues with the accounts hash calculation where the cache files have large chunks of zeroes. This is very elusive to observe in the wild.

Right now, when saving a new cache data file we:
1. create new file
2. write a zero to the last byte
3. flush the file
4. mmap this file
5. write the header and all entries through the mmap

We never flush *after* writing all the entries though!

When the reader used to also mmap, I think we handed the same mmap from writer to reader, so we had the full memory resident in the same process and there was no issue. Now, however, the reader does *not* use the same mmap (or no mmap at all). So if the file is opened and the OS hasn't flushed the mmap back to the file, it is possible the reader does not see the data.




#### Summary of Changes

Flush the mmap after writing. Also add a stat for how long the flushing takes.