### PR TITLE
ci: split local-cluster test into 10 jobs

### DIFF
--- a/.buildkite/scripts/build-stable.sh
+++ b/.buildkite/scripts/build-stable.sh
@@ -28,7 +28,7 @@ local_cluster_partitions=$(
   "command": "ci/docker-run-default-image.sh ci/stable/run-local-cluster-partially.sh",
   "timeout_in_minutes": 30,
   "agent": "$agent",
-  "parallelism": 5,
+  "parallelism": 10,
   "retry": 3
 }
 EOF

--- a/.buildkite/scripts/build-stable.sh
+++ b/.buildkite/scripts/build-stable.sh
@@ -26,7 +26,7 @@ local_cluster_partitions=$(
 {
   "name": "local-cluster",
   "command": "ci/docker-run-default-image.sh ci/stable/run-local-cluster-partially.sh",
-  "timeout_in_minutes": 30,
+  "timeout_in_minutes": 15,
   "agent": "$agent",
   "parallelism": 10,
   "retry": 3


### PR DESCRIPTION
#### Problem

- it's painful to retry a 30 mins timeout job
- we have lots of agents, we should able to afford more parallelism jobs

#### Summary of Changes

try to split local-cluster jobs into smaller pieces and reduce the timeout minutes. ~~we can retry a 15mins timeout job now :trollface:~~