### PR TITLE
ignore path dev deps in circular deps check (attempt 2)

### DIFF
--- a/ci/order-crates-for-publishing.py
+++ b/ci/order-crates-for-publishing.py
@@ -63,13 +63,37 @@ def is_self_dev_dep_with_dev_context_only_utils(package, dependency, wrong_self_
 
     return is_special_cased
 
+
+# `cargo publish`` is fine with circular dev-dependencies if
+# they are path deps.
+# However, cargo still fails if deps are path deps with versions
+# (this when you use `workspace = true`): https://github.com/rust-lang/cargo/issues/4242
+# Unlike in is_self_dev_dep_with_dev_context_only_utils(),
+# we don't have a clean way of checking if someone used a workspace dev
+# dep when they probably meant to use a path dev dep,
+# so this function just checks if a dev dep is a path dep
+# and provides no special warnings.
+def is_path_dev_dep(dependency):
+    no_explicit_version = '*'
+    return (
+        dependency['kind'] == 'dev'
+        and 'path' in dependency
+        and dependency['req'] == no_explicit_version
+    )
+
 def should_add(package, dependency, wrong_self_dev_dependencies):
     related_to_solana = dependency['name'].startswith('solana')
     self_dev_dep_with_dev_context_only_utils = is_self_dev_dep_with_dev_context_only_utils(
         package, dependency, wrong_self_dev_dependencies
     )
-
-    return related_to_solana and not self_dev_dep_with_dev_context_only_utils
+    if package["name"] == "solana-sanitize":
+        print(dependency)
+        print(is_path_dev_dep(dependency))
+    return (
+        related_to_solana
+        and not self_dev_dep_with_dev_context_only_utils
+        and not is_path_dev_dep(dependency)
+    )
 
 def get_packages():
     metadata = load_metadata()

--- a/ci/order-crates-for-publishing.py
+++ b/ci/order-crates-for-publishing.py
@@ -64,7 +64,7 @@ def is_self_dev_dep_with_dev_context_only_utils(package, dependency, wrong_self_
     return is_special_cased
 
 
-# `cargo publish`` is fine with circular dev-dependencies if
+# `cargo publish` is fine with circular dev-dependencies if
 # they are path deps.
 # However, cargo still fails if deps are path deps with versions
 # (this when you use `workspace = true`): https://github.com/rust-lang/cargo/issues/4242

--- a/ci/order-crates-for-publishing.py
+++ b/ci/order-crates-for-publishing.py
@@ -86,9 +86,6 @@ def should_add(package, dependency, wrong_self_dev_dependencies):
     self_dev_dep_with_dev_context_only_utils = is_self_dev_dep_with_dev_context_only_utils(
         package, dependency, wrong_self_dev_dependencies
     )
-    if package["name"] == "solana-sanitize":
-        print(dependency)
-        print(is_path_dev_dep(dependency))
     return (
         related_to_solana
         and not self_dev_dep_with_dev_context_only_utils


### PR DESCRIPTION
Doing what https://github.com/anza-xyz/agave/pull/2471 was trying to do, this time just adding an extra check to filter out path dev deps with no version constraint and leaving `is_self_dev_dep_with_dev_context_only_utils` unchanged

I tested this locally by adding `solana-program` as  a path dev dependency to the `solana-sanitize` crate, and seeing that `order-crates-for-publishing.py` passes. I then changed it to a workspace dev dep and observed that `order-crates-for-publishing.py` failed because of the circular dependency