### PR TITLE
TransactionView: InstructionsIterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
  "bincode",
  "criterion",
  "solana-sdk",
+ "solana-svm-transaction",
 ]
 
 [[package]]

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 solana-sdk = { workspace = true }
+solana-svm-transaction = { workspace = true }
 
 [dev-dependencies]
 # See order-crates-for-publishing.py for using this unusual `path = "."`


### PR DESCRIPTION
#### Problem
- #2255
- Accessor for Instructions on the transaction

#### Summary of Changes
- Add `instructions_iter` to `TransactionMeta` to allow iterating over instructions

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
