### PR TITLE
Remove tower_save-ms metric counter

### DIFF
--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -69,13 +69,13 @@ impl VotingService {
         vote_op: VoteOp,
     ) {
         if let VoteOp::PushVote { saved_tower, .. } = &vote_op {
-            let mut measure = Measure::start("tower_save-ms");
+            let mut measure = Measure::start("tower storage save");
             if let Err(err) = tower_storage.store(saved_tower) {
                 error!("Unable to save tower to storage: {:?}", err);
                 std::process::exit(1);
             }
             measure.stop();
-            inc_new_counter_info!("tower_save-ms", measure.as_ms() as usize);
+            trace!("{measure}");
         }
 
         let _ = cluster_info.send_transaction(


### PR DESCRIPTION
#### Problem
The metric tracked the amount of time taken to store the tower to disk. Moreso, it updated the counter everytime VotingService receives a VoteOp::PushVote message. This is excessive for this metric. Moreso, the process exits if the operation fails, so this metric isn't useful for a heartbeat either.

#### Summary of Changes
Replace the metric with a trace log statement.

Note that the trace statement will now read like this (assuming trace enabled):
```
[2024-08-13T20:30:28.729557000Z TRACE  ...] tower storage save took 5ms
```
given that `Measure` supports `std::fmt::Display`:
https://github.com/anza-xyz/agave/blob/955cf6c3f42082700ec36e69b00a8f4a4bc4b195/measure/src/measure.rs#L70-L84