### PR TITLE
test-validator: Improve `expect` messages

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -480,7 +480,7 @@ fn main() {
             accounts_to_clone,
             cluster_rpc_client
                 .as_ref()
-                .expect("bug: --url argument missing?"),
+                .expect("--clone-account requires --json-rpc-url argument"),
             false,
         ) {
             println!("Error: clone_accounts failed: {e}");
@@ -493,7 +493,7 @@ fn main() {
             accounts_to_maybe_clone,
             cluster_rpc_client
                 .as_ref()
-                .expect("bug: --url argument missing?"),
+                .expect("--maybe-clone requires --json-rpc-url argument"),
             true,
         ) {
             println!("Error: clone_accounts failed: {e}");
@@ -506,7 +506,7 @@ fn main() {
             upgradeable_programs_to_clone,
             cluster_rpc_client
                 .as_ref()
-                .expect("bug: --url argument missing?"),
+                .expect("--clone-upgradeable-program requires --json-rpc-url argument"),
         ) {
             println!("Error: clone_upgradeable_programs failed: {e}");
             exit(1);
@@ -517,7 +517,7 @@ fn main() {
         if let Err(e) = genesis.clone_feature_set(
             cluster_rpc_client
                 .as_ref()
-                .expect("bug: --url argument missing?"),
+                .expect("--clone-feature-set requires --json-rpc-url argument"),
         ) {
             println!("Error: clone_feature_set failed: {e}");
             exit(1);


### PR DESCRIPTION
#### Problem

As pointed out at
https://github.com/anza-xyz/agave/pull/2480#discussion_r1710053543, the expect messages in solana-test-validator are a bit strange since clap ensure that the rpc client will be there.

#### Summary of changes

Improve the messages with some more information.