### PR TITLE
sdk: Deprecate timing::duration_as_*() functions

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1206,7 +1206,6 @@ pub mod tests {
         solana_sdk::{
             account::{Account, AccountSharedData},
             clock::Slot,
-            timing::duration_as_ms,
         },
         std::{mem::ManuallyDrop, time::Instant},
         test_case::test_case,
@@ -1535,7 +1534,7 @@ pub mod tests {
             indexes.push(pos);
             assert_eq!(sizes, av.get_account_sizes(&indexes));
         }
-        trace!("append time: {} ms", duration_as_ms(&now.elapsed()),);
+        trace!("append time: {} ms", now.elapsed().as_millis());
 
         let now = Instant::now();
         for _ in 0..size {
@@ -1543,7 +1542,7 @@ pub mod tests {
             let account = create_test_account(sample + 1);
             assert_eq!(av.get_account_test(indexes[sample]).unwrap(), account);
         }
-        trace!("random read time: {} ms", duration_as_ms(&now.elapsed()),);
+        trace!("random read time: {} ms", now.elapsed().as_millis());
 
         let now = Instant::now();
         assert_eq!(indexes.len(), size);
@@ -1556,10 +1555,7 @@ pub mod tests {
             assert_eq!(recovered, account.1);
             sample += 1;
         });
-        trace!(
-            "sequential read time: {} ms",
-            duration_as_ms(&now.elapsed()),
-        );
+        trace!("sequential read time: {} ms", now.elapsed().as_millis());
     }
 
     #[test_case(StorageAccess::Mmap)]

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -31,7 +31,7 @@ use {
         pubkey::{self, Pubkey},
         signature::{Keypair, Signature, Signer},
         system_instruction, system_transaction,
-        timing::{duration_as_us, timestamp},
+        timing::timestamp,
         transaction::Transaction,
     },
     solana_streamer::socket::SocketAddrSpace,
@@ -534,7 +534,7 @@ fn main() {
                 bank.slot(),
                 bank.transaction_count(),
             );
-            tx_total_us += duration_as_us(&now.elapsed());
+            tx_total_us += now.elapsed().as_micros() as u64;
 
             let mut poh_time = Measure::start("poh_time");
             poh_recorder
@@ -578,14 +578,14 @@ fn main() {
                 bank.slot(),
                 bank.transaction_count(),
             );
-            tx_total_us += duration_as_us(&now.elapsed());
+            tx_total_us += now.elapsed().as_micros() as u64;
         }
 
         // This signature clear may not actually clear the signatures
         // in this chunk, but since we rotate between CHUNKS then
         // we should clear them by the time we come around again to re-use that chunk.
         bank.clear_signatures();
-        total_us += duration_as_us(&now.elapsed());
+        total_us += now.elapsed().as_micros() as u64;
         total_sent += sent;
 
         if current_iteration_index % num_chunks == 0 {

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -25,7 +25,7 @@ use {
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         system_instruction,
-        timing::{duration_as_ms, duration_as_s, duration_as_us, timestamp},
+        timing::timestamp,
         transaction::Transaction,
     },
     solana_tps_client::*,
@@ -233,12 +233,12 @@ where
             "Done. {:.2} thousand signatures per second, {:.2} us per signature, {} ms total time, {:?}",
             bsps * 1_000_000_f64,
             nsps / 1_000_f64,
-            duration_as_ms(&duration),
+            duration.as_millis(),
             blockhash,
         );
         datapoint_info!(
             "bench-tps-generate_txs",
-            ("duration", duration_as_us(&duration), i64)
+            ("duration", duration.as_micros() as i64, i64)
         );
 
         transactions
@@ -1029,12 +1029,12 @@ fn do_tx_transfers<T: TpsClient + ?Sized>(
             total_tx_sent_count.fetch_add(num_txs, Ordering::Relaxed);
             info!(
                 "Tx send done. {} ms {} tps",
-                duration_as_ms(&transfer_start.elapsed()),
-                num_txs as f32 / duration_as_s(&transfer_start.elapsed()),
+                transfer_start.elapsed().as_millis(),
+                num_txs as f32 / transfer_start.elapsed().as_secs_f32(),
             );
             datapoint_info!(
                 "bench-tps-do_tx_transfers",
-                ("duration", duration_as_us(&transfer_start.elapsed()), i64),
+                ("duration", transfer_start.elapsed().as_micros() as i64, i64),
                 ("count", num_txs, i64)
             );
         }
@@ -1107,7 +1107,7 @@ fn compute_and_report_stats(
     );
     info!(
         "\tAverage TPS: {}",
-        max_tx_count as f32 / duration_as_s(tx_send_elapsed)
+        max_tx_count as f32 / tx_send_elapsed.as_secs_f32()
     );
 }
 

--- a/bench-tps/src/perf_utils.rs
+++ b/bench-tps/src/perf_utils.rs
@@ -1,6 +1,6 @@
 use {
     log::*,
-    solana_sdk::{commitment_config::CommitmentConfig, timing::duration_as_s},
+    solana_sdk::commitment_config::CommitmentConfig,
     solana_tps_client::TpsClient,
     std::{
         sync::{
@@ -60,7 +60,7 @@ pub fn sample_txs<T>(
         let sample_txs = txs - last_txs;
         last_txs = txs;
 
-        let tps = sample_txs as f32 / duration_as_s(&elapsed);
+        let tps = sample_txs as f32 / elapsed.as_secs_f32();
         if tps > max_tps {
             max_tps = tps;
         }

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -49,7 +49,7 @@ use {
         pubkey,
         signature::{Keypair, Signature, Signer},
         system_instruction, system_transaction,
-        timing::{duration_as_us, timestamp},
+        timing::timestamp,
         transaction::{Transaction, VersionedTransaction},
     },
     solana_streamer::socket::SocketAddrSpace,
@@ -355,7 +355,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
         bank.clear_signatures();
         trace!(
             "time: {} checked: {} sent: {}",
-            duration_as_us(&now.elapsed()),
+            now.elapsed().as_micros(),
             txes / CHUNKS,
             sent,
         );

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -26,7 +26,6 @@ use {
         packet::PacketFlags,
         signature::{Keypair, Signer},
         system_transaction,
-        timing::duration_as_ms,
     },
     std::time::{Duration, Instant},
     test::Bencher,
@@ -167,7 +166,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
         let batches = gen_batches(use_same_tx);
         trace!(
             "starting... generation took: {} ms batches: {}",
-            duration_as_ms(&now.elapsed()),
+            now.elapsed().as_millis(),
             batches.len()
         );
 

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -41,7 +41,7 @@ use {
         pubkey::{Pubkey, PUBKEY_BYTES},
         signature::{Signable, Signature, Signer, SIGNATURE_BYTES},
         signer::keypair::Keypair,
-        timing::{duration_as_ms, timestamp},
+        timing::timestamp,
     },
     solana_streamer::{
         sendmmsg::{batch_send, SendPktsError},
@@ -517,7 +517,7 @@ impl ServeRepair {
     }
 
     fn report_time_spent(label: &str, time: &Duration, extra: &str) {
-        let count = duration_as_ms(time);
+        let count = time.as_millis();
         if count > 5 {
             info!("{} took: {} ms {}", label, count, extra);
         }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -466,10 +466,7 @@ impl SigVerifyStage {
 mod tests {
     use {
         super::*,
-        crate::{
-            banking_trace::BankingTracer, sigverify::TransactionSigVerifier,
-            sigverify_stage::timing::duration_as_ms,
-        },
+        crate::{banking_trace::BankingTracer, sigverify::TransactionSigVerifier},
         crossbeam_channel::unbounded,
         solana_perf::{
             packet::{to_packet_batches, Packet},
@@ -563,7 +560,7 @@ mod tests {
         let batches = gen_batches(use_same_tx, packets_per_batch, total_packets);
         trace!(
             "starting... generation took: {} ms batches: {}",
-            duration_as_ms(&now.elapsed()),
+            now.elapsed().as_millis(),
             batches.len()
         );
 

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -24,7 +24,6 @@ use {
     solana_sdk::{
         hash::Hash,
         packet::Meta,
-        timing,
         transaction::{
             Result, SanitizedTransaction, Transaction, TransactionError,
             TransactionVerificationMode, VersionedTransaction,
@@ -670,7 +669,7 @@ impl EntrySlice for [Entry] {
                 r
             })
         });
-        let poh_duration_us = timing::duration_as_us(&now.elapsed());
+        let poh_duration_us = now.elapsed().as_micros() as u64;
         EntryVerificationState {
             verification_status: if res {
                 EntryVerificationStatus::Success
@@ -756,7 +755,7 @@ impl EntrySlice for [Entry] {
                         })
                 })
         });
-        let poh_duration_us = timing::duration_as_us(&now.elapsed());
+        let poh_duration_us = now.elapsed().as_micros() as u64;
         EntryVerificationState {
             verification_status: if res {
                 EntryVerificationStatus::Success
@@ -849,9 +848,9 @@ impl EntrySlice for [Entry] {
                 assert!(res == 0, "GPU PoH verify many failed");
                 inc_new_counter_info!(
                     "entry_verify-gpu_thread",
-                    timing::duration_as_us(&gpu_wait.elapsed()) as usize
+                    gpu_wait.elapsed().as_micros() as usize
                 );
-                timing::duration_as_us(&gpu_wait.elapsed())
+                gpu_wait.elapsed().as_micros() as u64
             })
             .unwrap();
 
@@ -879,7 +878,7 @@ impl EntrySlice for [Entry] {
         });
         EntryVerificationState {
             verification_status: EntryVerificationStatus::Pending,
-            poh_duration_us: timing::duration_as_us(&start.elapsed()),
+            poh_duration_us: start.elapsed().as_micros() as u64,
             device_verification_data,
         }
     }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -32,7 +32,7 @@ use {
         signature::{Keypair, Signer},
         signer::keypair::read_keypair_file,
         stake::state::StakeStateV2,
-        system_program, timing,
+        system_program,
     },
     solana_stake_program::stake_state,
     solana_vote_program::vote_state::{self, VoteState},
@@ -144,8 +144,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         .max(rent.minimum_balance(StakeStateV2::size_of()))
         .to_string();
 
-    let default_target_tick_duration =
-        timing::duration_as_us(&PohConfig::default().target_tick_duration);
+    let default_target_tick_duration = PohConfig::default().target_tick_duration;
     let default_ticks_per_slot = &clock::DEFAULT_TICKS_PER_SLOT.to_string();
     let default_cluster_type = "mainnet-beta";
     let default_genesis_archive_unpacked_size = MAX_GENESIS_ARCHIVE_UNPACKED_SIZE.to_string();
@@ -473,7 +472,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         target_tick_duration: if matches.is_present("target_tick_duration") {
             Duration::from_micros(value_t_or_exit!(matches, "target_tick_duration", u64))
         } else {
-            Duration::from_micros(default_target_tick_duration)
+            default_target_tick_duration
         },
         ..PohConfig::default()
     };

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -50,7 +50,6 @@ use {
         pubkey::Pubkey,
         saturating_add_assign,
         signature::{Keypair, Signature},
-        timing,
         transaction::{
             Result, SanitizedTransaction, TransactionError, TransactionVerificationMode,
             VersionedTransaction,
@@ -1572,8 +1571,7 @@ fn confirm_slot_entries(
         recyclers.clone(),
         Arc::new(verify_transaction),
     );
-    let transaction_cpu_duration_us =
-        timing::duration_as_us(&transaction_verification_start.elapsed());
+    let transaction_cpu_duration_us = transaction_verification_start.elapsed().as_micros() as u64;
 
     let mut transaction_verification_result = match transaction_verification_result {
         Ok(transaction_verification_result) => transaction_verification_result,

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -30,7 +30,7 @@ use {
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer},
         system_transaction,
-        timing::{duration_as_ms, timestamp},
+        timing::timestamp,
         transaction::Transaction,
         transport::TransportError,
     },
@@ -231,7 +231,7 @@ pub fn sleep_n_epochs(
     ticks_per_slot: u64,
     slots_per_epoch: u64,
 ) {
-    let num_ticks_per_second = (1000 / duration_as_ms(&config.target_tick_duration)) as f64;
+    let num_ticks_per_second = config.target_tick_duration.as_secs_f64().recip();
     let num_ticks_to_sleep = num_epochs * ticks_per_slot as f64 * slots_per_epoch as f64;
     let secs = ((num_ticks_to_sleep + num_ticks_per_second - 1.0) / num_ticks_per_second) as u64;
     warn!("sleep_n_epochs: {} seconds", secs);

--- a/measure/src/macros.rs
+++ b/measure/src/macros.rs
@@ -85,7 +85,7 @@ macro_rules! measure_us {
     ($val:expr) => {{
         let start = std::time::Instant::now();
         let result = $val;
-        (result, solana_sdk::timing::duration_as_us(&start.elapsed()))
+        (result, start.elapsed().as_micros() as u64)
     }};
 }
 

--- a/measure/src/measure.rs
+++ b/measure/src/measure.rs
@@ -1,9 +1,6 @@
-use {
-    solana_sdk::timing::{duration_as_ms, duration_as_ns, duration_as_s, duration_as_us},
-    std::{
-        fmt,
-        time::{Duration, Instant},
-    },
+use std::{
+    fmt,
+    time::{Duration, Instant},
 };
 
 #[derive(Debug)]
@@ -23,7 +20,7 @@ impl Measure {
     }
 
     pub fn stop(&mut self) {
-        self.duration = duration_as_ns(&self.start.elapsed());
+        self.duration = self.start.elapsed().as_nanos() as u64;
     }
 
     pub fn as_ns(&self) -> u64 {
@@ -47,19 +44,19 @@ impl Measure {
     }
 
     pub fn end_as_ns(self) -> u64 {
-        duration_as_ns(&self.start.elapsed())
+        self.start.elapsed().as_nanos() as u64
     }
 
     pub fn end_as_us(self) -> u64 {
-        duration_as_us(&self.start.elapsed())
+        self.start.elapsed().as_micros() as u64
     }
 
     pub fn end_as_ms(self) -> u64 {
-        duration_as_ms(&self.start.elapsed())
+        self.start.elapsed().as_millis() as u64
     }
 
     pub fn end_as_s(self) -> f32 {
-        duration_as_s(&self.start.elapsed())
+        self.start.elapsed().as_secs_f32()
     }
 
     pub fn end_as_duration(self) -> Duration {

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -386,7 +386,7 @@ mod tests {
         solana_measure::measure::Measure,
         solana_perf::test_tx::test_tx,
         solana_runtime::bank::Bank,
-        solana_sdk::{clock, hash::hash, timing, transaction::VersionedTransaction},
+        solana_sdk::{clock, hash::hash, transaction::VersionedTransaction},
         std::{thread::sleep, time::Duration},
     };
 
@@ -402,7 +402,7 @@ mod tests {
             .expect("Expected to be able to open database ledger");
 
         let default_target_tick_duration =
-            timing::duration_as_us(&PohConfig::default().target_tick_duration);
+            PohConfig::default().target_tick_duration.as_micros() as u64;
         let target_tick_duration = Duration::from_micros(default_target_tick_duration);
         let poh_config = PohConfig {
             hashes_per_tick: Some(clock::DEFAULT_HASHES_PER_TICK),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -92,7 +92,7 @@ use {
             MAX_PERMITTED_DATA_LENGTH,
         },
         system_program, system_transaction, sysvar,
-        timing::{duration_as_s, years_as_slots},
+        timing::years_as_slots,
         transaction::{
             Result, SanitizedTransaction, Transaction, TransactionError,
             TransactionVerificationMode,
@@ -268,9 +268,9 @@ fn test_bank_unix_timestamp_from_genesis() {
         genesis_config.creation_time,
         bank.unix_timestamp_from_genesis()
     );
-    let slots_per_sec = 1.0
-        / (duration_as_s(&genesis_config.poh_config.target_tick_duration)
-            * genesis_config.ticks_per_slot as f32);
+    let slots_per_sec = (genesis_config.poh_config.target_tick_duration.as_secs_f32()
+        * genesis_config.ticks_per_slot as f32)
+        .recip();
 
     for _i in 0..slots_per_sec as usize + 1 {
         bank = Arc::new(new_from_parent(bank));

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -16,7 +16,6 @@ use {
     solana_sdk::{
         clock::{Epoch, Slot},
         hash::Hash,
-        timing,
     },
     std::{
         collections::{hash_map::Entry, HashMap, HashSet},
@@ -494,7 +493,7 @@ impl BankForks {
             "bank-forks_set_root",
             (
                 "elapsed_ms",
-                timing::duration_as_ms(&set_root_start.elapsed()) as usize,
+                set_root_start.elapsed().as_millis() as usize,
                 i64
             ),
             ("slot", root, i64),
@@ -569,7 +568,7 @@ impl BankForks {
             ),
             (
                 "program_cache_prune_ms",
-                timing::duration_as_ms(&program_cache_prune_start.elapsed()),
+                program_cache_prune_start.elapsed().as_millis() as i64,
                 i64
             ),
             ("dropped_banks_len", set_root_metrics.dropped_banks_len, i64),

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -22,10 +22,10 @@ pub fn duration_as_s(d: &Duration) -> f32 {
 
 /// return timestamp as ms
 pub fn timestamp() -> u64 {
-    let now = SystemTime::now()
+    SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .expect("create timestamp in timing");
-    duration_as_ms(&now)
+        .expect("create timestamp in timing")
+        .as_millis() as u64
 }
 
 pub const SECONDS_PER_YEAR: f64 = 365.242_199 * 24.0 * 60.0 * 60.0;
@@ -37,7 +37,7 @@ pub fn years_as_slots(years: f64, tick_duration: &Duration, ticks_per_slot: u64)
     //  slots/year  is  seconds/year ...
         SECONDS_PER_YEAR
     //  * (ns/s)/(ns/tick) / ticks/slot = 1/s/1/tick = ticks/s
-        * (1_000_000_000.0 / duration_as_ns(tick_duration) as f64)
+        * (1_000_000_000.0 / tick_duration.as_nanos() as f64)
     //  / ticks/slot
         / ticks_per_slot as f64
 }

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -4,18 +4,22 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+#[deprecated(since = "2.1.0", note = "Use `Duration::as_nanos()` directly")]
 pub fn duration_as_ns(d: &Duration) -> u64 {
     d.as_nanos() as u64
 }
 
+#[deprecated(since = "2.1.0", note = "Use `Duration::as_micros()` directly")]
 pub fn duration_as_us(d: &Duration) -> u64 {
     d.as_micros() as u64
 }
 
+#[deprecated(since = "2.1.0", note = "Use `Duration::as_millis()` directly")]
 pub fn duration_as_ms(d: &Duration) -> u64 {
     d.as_millis() as u64
 }
 
+#[deprecated(since = "2.1.0", note = "Use `Duration::as_secs_f32()` directly")]
 pub fn duration_as_s(d: &Duration) -> f32 {
     d.as_secs_f32()
 }

--- a/thin-client/src/thin_client.rs
+++ b/thin-client/src/thin_client.rs
@@ -27,7 +27,6 @@ use {
         signature::{Keypair, Signature, Signer},
         signers::Signers,
         system_instruction,
-        timing::duration_as_ms,
         transaction::{self, Transaction, VersionedTransaction},
         transport::Result as TransportResult,
     },
@@ -480,7 +479,8 @@ where
         let now = Instant::now();
         match self.rpc_client().get_transaction_count() {
             Ok(transaction_count) => {
-                self.optimizer.report(index, duration_as_ms(&now.elapsed()));
+                self.optimizer
+                    .report(index, now.elapsed().as_millis() as u64);
                 Ok(transaction_count)
             }
             Err(e) => {
@@ -501,7 +501,8 @@ where
             .get_transaction_count_with_commitment(commitment_config)
         {
             Ok(transaction_count) => {
-                self.optimizer.report(index, duration_as_ms(&now.elapsed()));
+                self.optimizer
+                    .report(index, now.elapsed().as_millis() as u64);
                 Ok(transaction_count)
             }
             Err(e) => {
@@ -542,7 +543,8 @@ where
         let now = Instant::now();
         match self.rpc_clients[index].get_latest_blockhash_with_commitment(commitment_config) {
             Ok((blockhash, last_valid_block_height)) => {
-                self.optimizer.report(index, duration_as_ms(&now.elapsed()));
+                self.optimizer
+                    .report(index, now.elapsed().as_millis() as u64);
                 Ok((blockhash, last_valid_block_height))
             }
             Err(e) => {

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -12,10 +12,7 @@ use {
         shred::{shred_code, ProcessShredsStats, ReedSolomonCache, Shred, ShredFlags, Shredder},
     },
     solana_sdk::{
-        genesis_config::ClusterType,
-        hash::Hash,
-        signature::Keypair,
-        timing::{duration_as_us, AtomicInterval},
+        genesis_config::ClusterType, hash::Hash, signature::Keypair, timing::AtomicInterval,
     },
     std::{sync::RwLock, time::Duration},
     tokio::sync::mpsc::Sender as AsyncSender,
@@ -344,8 +341,8 @@ impl StandardBroadcastRun {
 
         process_stats.shredding_elapsed = to_shreds_time.as_us();
         process_stats.get_leader_schedule_elapsed = get_leader_schedule_time.as_us();
-        process_stats.receive_elapsed = duration_as_us(&receive_elapsed);
-        process_stats.coalesce_elapsed = duration_as_us(&coalesce_elapsed);
+        process_stats.receive_elapsed = receive_elapsed.as_micros() as u64;
+        process_stats.coalesce_elapsed = coalesce_elapsed.as_micros() as u64;
         process_stats.coding_send_elapsed = coding_send_time.as_us();
 
         self.process_shreds_stats += process_stats;
@@ -382,7 +379,7 @@ impl StandardBroadcastRun {
             .expect("Failed to insert shreds in blockstore");
         let insert_shreds_elapsed = insert_shreds_start.elapsed();
         let new_insert_shreds_stats = InsertShredsStats {
-            insert_shreds_elapsed: duration_as_us(&insert_shreds_elapsed),
+            insert_shreds_elapsed: insert_shreds_elapsed.as_micros() as u64,
             num_shreds,
         };
         self.update_insertion_metrics(&new_insert_shreds_stats, &broadcast_shred_batch_info);


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/pull/2584 for a bit more context, but essentially, the `sdk::timing::duration_as_*()` provided functionality that is now natively supported in `std::time::Duration`. Thus, there is no need for for these functions any longer

#### Summary of Changes
- Remove all usage of `sdk::timing::duration_as_*()` functions in the repo.
- Add deprecation notes to the `sdk::timing::duration_as_*()` functions

Note: This will currently fail CI until https://github.com/anza-xyz/agave/pull/2584 lands; will update this PR once that happens