### PR TITLE
genesis: Make "cluster-type" aware of features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6386,6 +6386,8 @@ dependencies = [
  "solana-entry",
  "solana-ledger",
  "solana-logger",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
  "solana-runtime",
  "solana-sdk",
  "solana-stake-program",

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -23,6 +23,8 @@ solana-cli-config = { workspace = true }
 solana-entry = { workspace = true }
 solana-ledger = { workspace = true }
 solana-logger = { workspace = true }
+solana-rpc-client = { workspace = true }
+solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 solana-stake-program = { workspace = true }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -11,17 +11,23 @@ use {
             cluster_type_of, pubkey_of, pubkeys_of, unix_timestamp_from_rfc3339_datetime,
         },
         input_validators::{
-            is_pubkey, is_pubkey_or_keypair, is_rfc3339_datetime, is_slot, is_valid_percentage,
+            is_pubkey, is_pubkey_or_keypair, is_rfc3339_datetime, is_slot, is_url_or_moniker,
+            is_valid_percentage, normalize_to_url_if_moniker,
         },
     },
     solana_entry::poh::compute_hashes_per_tick,
     solana_genesis::{genesis_accounts::add_genesis_accounts, Base64Account},
     solana_ledger::{blockstore::create_new_ledger, blockstore_options::LedgerColumnOptions},
+    solana_rpc_client::rpc_client::RpcClient,
+    solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS,
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
         bpf_loader_upgradeable::UpgradeableLoaderState,
         clock,
+        commitment_config::CommitmentConfig,
         epoch_schedule::EpochSchedule,
+        feature,
+        feature_set::FEATURE_NAMES,
         fee_calculator::FeeRateGovernor,
         genesis_config::{ClusterType, GenesisConfig},
         inflation::Inflation,
@@ -104,6 +110,74 @@ pub fn load_genesis_accounts(file: &str, genesis_config: &mut GenesisConfig) -> 
     }
 
     Ok(lamports)
+}
+
+fn check_rpc_genesis_hash(
+    cluster_type: &ClusterType,
+    rpc_client: &RpcClient,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(genesis_hash) = cluster_type.get_genesis_hash() {
+        let rpc_genesis_hash = rpc_client.get_genesis_hash()?;
+        if rpc_genesis_hash != genesis_hash {
+            return Err(format!(
+                "The genesis hash for the specified cluster {cluster_type:?} does not match the \
+                 genesis hash reported by the specified RPC. Cluster genesis hash: \
+                 {genesis_hash}, RPC reported genesis hash: {rpc_genesis_hash}"
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn features_to_deactivate_for_cluster(
+    cluster_type: &ClusterType,
+    matches: &ArgMatches<'_>,
+) -> Result<Vec<Pubkey>, Box<dyn error::Error>> {
+    if cluster_type == &ClusterType::Development {
+        return Ok(pubkeys_of(matches, "deactivate_feature").unwrap_or_default());
+    }
+
+    if matches.is_present("deactivate_feature") {
+        return Err("Error: The --deactivate-feature argument cannot be used with --cluster-type={cluster_type:?}".into());
+    }
+
+    // if we're here, the cluster type must be one of "mainnet-beta", "testnet", or "devnet"
+    assert!(matches!(
+        cluster_type,
+        ClusterType::MainnetBeta | ClusterType::Testnet | ClusterType::Devnet
+    ));
+    let json_rpc_url = normalize_to_url_if_moniker(
+        matches
+            .value_of("json_rpc_url")
+            .unwrap_or(matches.value_of("cluster_type").unwrap()),
+    );
+    let rpc_client = RpcClient::new_with_commitment(json_rpc_url, CommitmentConfig::confirmed());
+    check_rpc_genesis_hash(cluster_type, &rpc_client)?;
+    let mut features_to_deactivate = vec![];
+    for feature_ids in FEATURE_NAMES
+        .keys()
+        .cloned()
+        .collect::<Vec<Pubkey>>()
+        .chunks(MAX_MULTIPLE_ACCOUNTS)
+    {
+        rpc_client
+            .get_multiple_accounts(feature_ids)
+            .map_err(|err| format!("Failed to fetch: {err}"))?
+            .into_iter()
+            .zip(feature_ids)
+            .for_each(|(maybe_account, feature_id)| {
+                if maybe_account
+                    .as_ref()
+                    .and_then(feature::from_account)
+                    .and_then(|feature| feature.activated_at)
+                    .is_none()
+                {
+                    features_to_deactivate.push(*feature_id);
+                }
+            });
+    }
+    Ok(features_to_deactivate)
 }
 
 #[allow(clippy::cognitive_complexity)]
@@ -408,6 +482,20 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .possible_values(&["pico", "full", "none"])
                 .help("Selects inflation"),
         )
+        .arg(
+            Arg::with_name("json_rpc_url")
+                .short("u")
+                .long("url")
+                .value_name("URL_OR_MONIKER")
+                .takes_value(true)
+                .global(true)
+                .validator(is_url_or_moniker)
+                .help(
+                    "URL for Solana's JSON RPC or moniker (or their first letter): \
+                    [mainnet-beta, testnet, devnet, localhost]. Used for cloning \
+                    feature sets",
+                ),
+        )
         .get_matches();
 
     let ledger_path = PathBuf::from(matches.value_of("ledger_path").unwrap());
@@ -481,12 +569,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let cluster_type = cluster_type_of(&matches, "cluster_type").unwrap();
 
     // Get the features to deactivate if provided
-    let features_to_deactivate = pubkeys_of(&matches, "deactivate_feature").unwrap_or_default();
-
-    if cluster_type != ClusterType::Development && !features_to_deactivate.is_empty() {
-        eprintln!("Error: The --deativate-feature argument cannot be used with --cluster-type={cluster_type:?}");
-        std::process::exit(1);
-    }
+    let features_to_deactivate = features_to_deactivate_for_cluster(&cluster_type, &matches)
+        .unwrap_or_else(|e| {
+            eprintln!("{e}");
+            std::process::exit(1);
+        });
 
     match matches.value_of("hashes_per_tick").unwrap() {
         "auto" => match cluster_type {
@@ -595,14 +682,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     }
 
     solana_stake_program::add_genesis_accounts(&mut genesis_config);
-    if genesis_config.cluster_type == ClusterType::Development {
-        solana_runtime::genesis_utils::activate_all_features(&mut genesis_config);
-        if !features_to_deactivate.is_empty() {
-            solana_runtime::genesis_utils::deactivate_features(
-                &mut genesis_config,
-                &features_to_deactivate,
-            );
-        }
+    solana_runtime::genesis_utils::activate_all_features(&mut genesis_config);
+    if !features_to_deactivate.is_empty() {
+        solana_runtime::genesis_utils::deactivate_features(
+            &mut genesis_config,
+            &features_to_deactivate,
+        );
     }
 
     if let Some(files) = matches.values_of("primordial_accounts_file") {

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -134,12 +134,9 @@ fn features_to_deactivate_for_cluster(
     cluster_type: &ClusterType,
     matches: &ArgMatches<'_>,
 ) -> Result<Vec<Pubkey>, Box<dyn error::Error>> {
+    let mut features_to_deactivate = pubkeys_of(matches, "deactivate_feature").unwrap_or_default();
     if cluster_type == &ClusterType::Development {
-        return Ok(pubkeys_of(matches, "deactivate_feature").unwrap_or_default());
-    }
-
-    if matches.is_present("deactivate_feature") {
-        return Err("Error: The --deactivate-feature argument cannot be used with --cluster-type={cluster_type:?}".into());
+        return Ok(features_to_deactivate);
     }
 
     // if we're here, the cluster type must be one of "mainnet-beta", "testnet", or "devnet"
@@ -154,7 +151,6 @@ fn features_to_deactivate_for_cluster(
     );
     let rpc_client = RpcClient::new_with_commitment(json_rpc_url, CommitmentConfig::confirmed());
     check_rpc_genesis_hash(cluster_type, &rpc_client)?;
-    let mut features_to_deactivate = vec![];
     for feature_ids in FEATURE_NAMES
         .keys()
         .cloned()


### PR DESCRIPTION
#### Problem

The `--cluster-type` parameter in solana-genesis mentions cluster features, but refers to things like epoch length and  hashes per tick. This behavior is confusing because it doesn't include the feature set.

This issue was brought up in https://github.com/anza-xyz/agave/pull/2480#pullrequestreview-2228569730

#### Summary of changes

For "mainnet-beta", "testnet", and "devnet", clone the cluster feature set, and deactivate the appropriate features. I tested this by running it with "development" and "mainnet-beta", and checking to make sure the correct features were enabled.