### PR TITLE
refactor: use less &mut self and more async-await in BanksClient

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -11,7 +11,7 @@ pub use {
 };
 use {
     borsh::BorshDeserialize,
-    futures::{future::join_all, Future, FutureExt, TryFutureExt},
+    futures::future::join_all,
     solana_banks_interface::{
         BanksRequest, BanksResponse, BanksTransactionResultWithMetadata,
         BanksTransactionResultWithSimulation,
@@ -58,173 +58,185 @@ impl BanksClient {
         TarpcClient::new(config, transport)
     }
 
-    pub fn send_transaction_with_context(
+    pub async fn send_transaction_with_context(
         &self,
         ctx: Context,
         transaction: impl Into<VersionedTransaction>,
-    ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
+    ) -> Result<(), BanksClientError> {
         self.inner
             .send_transaction_with_context(ctx, transaction.into())
+            .await
             .map_err(Into::into)
     }
 
-    pub fn get_transaction_status_with_context(
+    pub async fn get_transaction_status_with_context(
         &self,
         ctx: Context,
         signature: Signature,
-    ) -> impl Future<Output = Result<Option<TransactionStatus>, BanksClientError>> + '_ {
+    ) -> Result<Option<TransactionStatus>, BanksClientError> {
         self.inner
             .get_transaction_status_with_context(ctx, signature)
+            .await
             .map_err(Into::into)
     }
 
-    pub fn get_slot_with_context(
+    pub async fn get_slot_with_context(
         &self,
         ctx: Context,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<Slot, BanksClientError>> + '_ {
+    ) -> Result<Slot, BanksClientError> {
         self.inner
             .get_slot_with_context(ctx, commitment)
+            .await
             .map_err(Into::into)
     }
 
-    pub fn get_block_height_with_context(
+    pub async fn get_block_height_with_context(
         &self,
         ctx: Context,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<Slot, BanksClientError>> + '_ {
+    ) -> Result<Slot, BanksClientError> {
         self.inner
             .get_block_height_with_context(ctx, commitment)
+            .await
             .map_err(Into::into)
     }
 
-    pub fn process_transaction_with_commitment_and_context(
+    pub async fn process_transaction_with_commitment_and_context(
         &self,
         ctx: Context,
         transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<Option<transaction::Result<()>>, BanksClientError>> + '_ {
+    ) -> Result<Option<transaction::Result<()>>, BanksClientError> {
         self.inner
             .process_transaction_with_commitment_and_context(ctx, transaction.into(), commitment)
+            .await
             .map_err(Into::into)
     }
 
-    pub fn process_transaction_with_preflight_and_commitment_and_context(
+    pub async fn process_transaction_with_preflight_and_commitment_and_context(
         &self,
         ctx: Context,
         transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<BanksTransactionResultWithSimulation, BanksClientError>> + '_
-    {
+    ) -> Result<BanksTransactionResultWithSimulation, BanksClientError> {
         self.inner
             .process_transaction_with_preflight_and_commitment_and_context(
                 ctx,
                 transaction.into(),
                 commitment,
             )
+            .await
             .map_err(Into::into)
     }
 
-    pub fn process_transaction_with_metadata_and_context(
+    pub async fn process_transaction_with_metadata_and_context(
         &self,
         ctx: Context,
         transaction: impl Into<VersionedTransaction>,
-    ) -> impl Future<Output = Result<BanksTransactionResultWithMetadata, BanksClientError>> + '_
-    {
+    ) -> Result<BanksTransactionResultWithMetadata, BanksClientError> {
         self.inner
             .process_transaction_with_metadata_and_context(ctx, transaction.into())
+            .await
             .map_err(Into::into)
     }
 
-    pub fn simulate_transaction_with_commitment_and_context(
+    pub async fn simulate_transaction_with_commitment_and_context(
         &self,
         ctx: Context,
         transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<BanksTransactionResultWithSimulation, BanksClientError>> + '_
-    {
+    ) -> Result<BanksTransactionResultWithSimulation, BanksClientError> {
         self.inner
             .simulate_transaction_with_commitment_and_context(ctx, transaction.into(), commitment)
+            .await
             .map_err(Into::into)
     }
 
-    pub fn get_account_with_commitment_and_context(
+    pub async fn get_account_with_commitment_and_context(
         &self,
         ctx: Context,
         address: Pubkey,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<Option<Account>, BanksClientError>> + '_ {
+    ) -> Result<Option<Account>, BanksClientError> {
         self.inner
             .get_account_with_commitment_and_context(ctx, address, commitment)
+            .await
             .map_err(Into::into)
     }
 
     /// Send a transaction and return immediately. The server will resend the
     /// transaction until either it is accepted by the cluster or the transaction's
     /// blockhash expires.
-    pub fn send_transaction(
+    pub async fn send_transaction(
         &self,
         transaction: impl Into<VersionedTransaction>,
-    ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
+    ) -> Result<(), BanksClientError> {
         self.send_transaction_with_context(context::current(), transaction.into())
+            .await
     }
 
     /// Return the cluster Sysvar
-    pub fn get_sysvar<T: Sysvar>(&self) -> impl Future<Output = Result<T, BanksClientError>> + '_ {
-        self.get_account(T::id()).map(|result| {
-            let sysvar = result?.ok_or(BanksClientError::ClientError("Sysvar not present"))?;
-            from_account::<T, _>(&sysvar).ok_or(BanksClientError::ClientError(
-                "Failed to deserialize sysvar",
-            ))
-        })
+    pub async fn get_sysvar<T: Sysvar>(&self) -> Result<T, BanksClientError> {
+        let sysvar = self
+            .get_account(T::id())
+            .await?
+            .ok_or(BanksClientError::ClientError("Sysvar not present"))?;
+        from_account::<T, _>(&sysvar).ok_or(BanksClientError::ClientError(
+            "Failed to deserialize sysvar",
+        ))
     }
 
     /// Return the cluster rent
-    pub fn get_rent(&self) -> impl Future<Output = Result<Rent, BanksClientError>> + '_ {
-        self.get_sysvar::<Rent>()
+    pub async fn get_rent(&self) -> Result<Rent, BanksClientError> {
+        self.get_sysvar::<Rent>().await
     }
 
     /// Send a transaction and return after the transaction has been rejected or
     /// reached the given level of commitment.
-    pub fn process_transaction_with_commitment(
+    pub async fn process_transaction_with_commitment(
         &self,
         transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
+    ) -> Result<(), BanksClientError> {
         let ctx = context::current();
-        self.process_transaction_with_commitment_and_context(ctx, transaction, commitment)
-            .map(|result| match result? {
-                None => Err(BanksClientError::ClientError(
-                    "invalid blockhash or fee-payer",
-                )),
-                Some(transaction_result) => Ok(transaction_result?),
-            })
+        match self
+            .process_transaction_with_commitment_and_context(ctx, transaction, commitment)
+            .await?
+        {
+            None => Err(BanksClientError::ClientError(
+                "invalid blockhash or fee-payer",
+            )),
+            Some(transaction_result) => Ok(transaction_result?),
+        }
     }
 
     /// Process a transaction and return the result with metadata.
-    pub fn process_transaction_with_metadata(
+    pub async fn process_transaction_with_metadata(
         &self,
         transaction: impl Into<VersionedTransaction>,
-    ) -> impl Future<Output = Result<BanksTransactionResultWithMetadata, BanksClientError>> + '_
-    {
+    ) -> Result<BanksTransactionResultWithMetadata, BanksClientError> {
         let ctx = context::current();
         self.process_transaction_with_metadata_and_context(ctx, transaction.into())
+            .await
     }
 
     /// Send a transaction and return any preflight (sanitization or simulation) errors, or return
     /// after the transaction has been rejected or reached the given level of commitment.
-    pub fn process_transaction_with_preflight_and_commitment(
+    pub async fn process_transaction_with_preflight_and_commitment(
         &self,
         transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
+    ) -> Result<(), BanksClientError> {
         let ctx = context::current();
-        self.process_transaction_with_preflight_and_commitment_and_context(
-            ctx,
-            transaction,
-            commitment,
-        )
-        .map(|result| match result? {
+        match self
+            .process_transaction_with_preflight_and_commitment_and_context(
+                ctx,
+                transaction,
+                commitment,
+            )
+            .await?
+        {
             BanksTransactionResultWithSimulation {
                 result: None,
                 simulation_details: _,
@@ -244,27 +256,29 @@ impl BanksClient {
                 result: Some(result),
                 simulation_details: _,
             } => result.map_err(Into::into),
-        })
+        }
     }
 
     /// Send a transaction and return any preflight (sanitization or simulation) errors, or return
     /// after the transaction has been finalized or rejected.
-    pub fn process_transaction_with_preflight(
+    pub async fn process_transaction_with_preflight(
         &self,
         transaction: impl Into<VersionedTransaction>,
-    ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
+    ) -> Result<(), BanksClientError> {
         self.process_transaction_with_preflight_and_commitment(
             transaction,
             CommitmentLevel::default(),
         )
+        .await
     }
 
     /// Send a transaction and return until the transaction has been finalized or rejected.
-    pub fn process_transaction(
+    pub async fn process_transaction(
         &self,
         transaction: impl Into<VersionedTransaction>,
-    ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
+    ) -> Result<(), BanksClientError> {
         self.process_transaction_with_commitment(transaction, CommitmentLevel::default())
+            .await
     }
 
     pub async fn process_transactions_with_commitment<T: Into<VersionedTransaction>>(
@@ -284,112 +298,115 @@ impl BanksClient {
     }
 
     /// Send transactions and return until the transaction has been finalized or rejected.
-    pub fn process_transactions<'a, T: Into<VersionedTransaction> + 'a>(
+    pub async fn process_transactions<'a, T: Into<VersionedTransaction> + 'a>(
         &'a self,
         transactions: Vec<T>,
-    ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
+    ) -> Result<(), BanksClientError> {
         self.process_transactions_with_commitment(transactions, CommitmentLevel::default())
+            .await
     }
 
     /// Simulate a transaction at the given commitment level
-    pub fn simulate_transaction_with_commitment(
+    pub async fn simulate_transaction_with_commitment(
         &self,
         transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<BanksTransactionResultWithSimulation, BanksClientError>> + '_
-    {
+    ) -> Result<BanksTransactionResultWithSimulation, BanksClientError> {
         self.simulate_transaction_with_commitment_and_context(
             context::current(),
             transaction,
             commitment,
         )
+        .await
     }
 
     /// Simulate a transaction at the default commitment level
-    pub fn simulate_transaction(
+    pub async fn simulate_transaction(
         &self,
         transaction: impl Into<VersionedTransaction>,
-    ) -> impl Future<Output = Result<BanksTransactionResultWithSimulation, BanksClientError>> + '_
-    {
+    ) -> Result<BanksTransactionResultWithSimulation, BanksClientError> {
         self.simulate_transaction_with_commitment(transaction, CommitmentLevel::default())
+            .await
     }
 
     /// Return the most recent rooted slot. All transactions at or below this slot
     /// are said to be finalized. The cluster will not fork to a higher slot.
-    pub fn get_root_slot(&self) -> impl Future<Output = Result<Slot, BanksClientError>> + '_ {
+    pub async fn get_root_slot(&self) -> Result<Slot, BanksClientError> {
         self.get_slot_with_context(context::current(), CommitmentLevel::default())
+            .await
     }
 
     /// Return the most recent rooted block height. All transactions at or below this height
     /// are said to be finalized. The cluster will not fork to a higher block height.
-    pub fn get_root_block_height(
-        &self,
-    ) -> impl Future<Output = Result<Slot, BanksClientError>> + '_ {
+    pub async fn get_root_block_height(&self) -> Result<Slot, BanksClientError> {
         self.get_block_height_with_context(context::current(), CommitmentLevel::default())
+            .await
     }
 
     /// Return the account at the given address at the slot corresponding to the given
     /// commitment level. If the account is not found, None is returned.
-    pub fn get_account_with_commitment(
+    pub async fn get_account_with_commitment(
         &self,
         address: Pubkey,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<Option<Account>, BanksClientError>> + '_ {
+    ) -> Result<Option<Account>, BanksClientError> {
         self.get_account_with_commitment_and_context(context::current(), address, commitment)
+            .await
     }
 
     /// Return the account at the given address at the time of the most recent root slot.
     /// If the account is not found, None is returned.
-    pub fn get_account(
-        &self,
-        address: Pubkey,
-    ) -> impl Future<Output = Result<Option<Account>, BanksClientError>> + '_ {
+    pub async fn get_account(&self, address: Pubkey) -> Result<Option<Account>, BanksClientError> {
         self.get_account_with_commitment(address, CommitmentLevel::default())
+            .await
     }
 
     /// Return the unpacked account data at the given address
     /// If the account is not found, an error is returned
-    pub fn get_packed_account_data<T: Pack>(
+    pub async fn get_packed_account_data<T: Pack>(
         &self,
         address: Pubkey,
-    ) -> impl Future<Output = Result<T, BanksClientError>> + '_ {
-        self.get_account(address).map(|result| {
-            let account = result?.ok_or(BanksClientError::ClientError("Account not found"))?;
-            T::unpack_from_slice(&account.data)
-                .map_err(|_| BanksClientError::ClientError("Failed to deserialize account"))
-        })
+    ) -> Result<T, BanksClientError> {
+        let account = self
+            .get_account(address)
+            .await?
+            .ok_or(BanksClientError::ClientError("Account not found"))?;
+        T::unpack_from_slice(&account.data)
+            .map_err(|_| BanksClientError::ClientError("Failed to deserialize account"))
     }
 
     /// Return the unpacked account data at the given address
     /// If the account is not found, an error is returned
-    pub fn get_account_data_with_borsh<T: BorshDeserialize>(
+    pub async fn get_account_data_with_borsh<T: BorshDeserialize>(
         &self,
         address: Pubkey,
-    ) -> impl Future<Output = Result<T, BanksClientError>> + '_ {
-        self.get_account(address).map(|result| {
-            let account = result?.ok_or(BanksClientError::ClientError("Account not found"))?;
-            T::try_from_slice(&account.data).map_err(Into::into)
-        })
+    ) -> Result<T, BanksClientError> {
+        let account = self
+            .get_account(address)
+            .await?
+            .ok_or(BanksClientError::ClientError("Account not found"))?;
+        T::try_from_slice(&account.data).map_err(Into::into)
     }
 
     /// Return the balance in lamports of an account at the given address at the slot
     /// corresponding to the given commitment level.
-    pub fn get_balance_with_commitment(
+    pub async fn get_balance_with_commitment(
         &self,
         address: Pubkey,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<u64, BanksClientError>> + '_ {
-        self.get_account_with_commitment_and_context(context::current(), address, commitment)
-            .map(|result| Ok(result?.map(|x| x.lamports).unwrap_or(0)))
+    ) -> Result<u64, BanksClientError> {
+        Ok(self
+            .get_account_with_commitment_and_context(context::current(), address, commitment)
+            .await?
+            .map(|x| x.lamports)
+            .unwrap_or(0))
     }
 
     /// Return the balance in lamports of an account at the given address at the time
     /// of the most recent root slot.
-    pub fn get_balance(
-        &self,
-        address: Pubkey,
-    ) -> impl Future<Output = Result<u64, BanksClientError>> + '_ {
+    pub async fn get_balance(&self, address: Pubkey) -> Result<u64, BanksClientError> {
         self.get_balance_with_commitment(address, CommitmentLevel::default())
+            .await
     }
 
     /// Return the status of a transaction with a signature matching the transaction's first
@@ -397,11 +414,12 @@ impl BanksClient {
     /// blockhash was expired or the fee-paying account had insufficient funds to pay the
     /// transaction fee. Note that servers rarely store the full transaction history. This
     /// method may return None if the transaction status has been discarded.
-    pub fn get_transaction_status(
+    pub async fn get_transaction_status(
         &self,
         signature: Signature,
-    ) -> impl Future<Output = Result<Option<TransactionStatus>, BanksClientError>> + '_ {
+    ) -> Result<Option<TransactionStatus>, BanksClientError> {
         self.get_transaction_status_with_context(context::current(), signature)
+            .await
     }
 
     /// Same as get_transaction_status, but for multiple transactions.
@@ -425,66 +443,67 @@ impl BanksClient {
         statuses.into_iter().collect()
     }
 
-    pub fn get_latest_blockhash(
-        &self,
-    ) -> impl Future<Output = Result<Hash, BanksClientError>> + '_ {
+    pub async fn get_latest_blockhash(&self) -> Result<Hash, BanksClientError> {
         self.get_latest_blockhash_with_commitment(CommitmentLevel::default())
-            .map(|result| {
-                result?
-                    .map(|x| x.0)
-                    .ok_or(BanksClientError::ClientError("valid blockhash not found"))
-                    .map_err(Into::into)
-            })
-    }
-
-    pub fn get_latest_blockhash_with_commitment(
-        &self,
-        commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<Option<(Hash, u64)>, BanksClientError>> + '_ {
-        self.get_latest_blockhash_with_commitment_and_context(context::current(), commitment)
-    }
-
-    pub fn get_latest_blockhash_with_commitment_and_context(
-        &self,
-        ctx: Context,
-        commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<Option<(Hash, u64)>, BanksClientError>> + '_ {
-        self.inner
-            .get_latest_blockhash_with_commitment_and_context(ctx, commitment)
+            .await?
+            .map(|x| x.0)
+            .ok_or(BanksClientError::ClientError("valid blockhash not found"))
             .map_err(Into::into)
     }
 
-    pub fn get_fee_for_message(
+    pub async fn get_latest_blockhash_with_commitment(
+        &self,
+        commitment: CommitmentLevel,
+    ) -> Result<Option<(Hash, u64)>, BanksClientError> {
+        self.get_latest_blockhash_with_commitment_and_context(context::current(), commitment)
+            .await
+    }
+
+    pub async fn get_latest_blockhash_with_commitment_and_context(
+        &self,
+        ctx: Context,
+        commitment: CommitmentLevel,
+    ) -> Result<Option<(Hash, u64)>, BanksClientError> {
+        self.inner
+            .get_latest_blockhash_with_commitment_and_context(ctx, commitment)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn get_fee_for_message(
         &self,
         message: Message,
-    ) -> impl Future<Output = Result<Option<u64>, BanksClientError>> + '_ {
+    ) -> Result<Option<u64>, BanksClientError> {
         self.get_fee_for_message_with_commitment_and_context(
             context::current(),
             message,
             CommitmentLevel::default(),
         )
+        .await
     }
 
-    pub fn get_fee_for_message_with_commitment(
+    pub async fn get_fee_for_message_with_commitment(
         &self,
         message: Message,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<Option<u64>, BanksClientError>> + '_ {
+    ) -> Result<Option<u64>, BanksClientError> {
         self.get_fee_for_message_with_commitment_and_context(
             context::current(),
             message,
             commitment,
         )
+        .await
     }
 
-    pub fn get_fee_for_message_with_commitment_and_context(
+    pub async fn get_fee_for_message_with_commitment_and_context(
         &self,
         ctx: Context,
         message: Message,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = Result<Option<u64>, BanksClientError>> + '_ {
+    ) -> Result<Option<u64>, BanksClientError> {
         self.inner
             .get_fee_for_message_with_commitment_and_context(ctx, message, commitment)
+            .await
             .map_err(Into::into)
     }
 }

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -59,7 +59,7 @@ impl BanksClient {
     }
 
     pub fn send_transaction_with_context(
-        &mut self,
+        &self,
         ctx: Context,
         transaction: impl Into<VersionedTransaction>,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
@@ -69,7 +69,7 @@ impl BanksClient {
     }
 
     pub fn get_transaction_status_with_context(
-        &mut self,
+        &self,
         ctx: Context,
         signature: Signature,
     ) -> impl Future<Output = Result<Option<TransactionStatus>, BanksClientError>> + '_ {
@@ -79,7 +79,7 @@ impl BanksClient {
     }
 
     pub fn get_slot_with_context(
-        &mut self,
+        &self,
         ctx: Context,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<Slot, BanksClientError>> + '_ {
@@ -89,7 +89,7 @@ impl BanksClient {
     }
 
     pub fn get_block_height_with_context(
-        &mut self,
+        &self,
         ctx: Context,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<Slot, BanksClientError>> + '_ {
@@ -99,7 +99,7 @@ impl BanksClient {
     }
 
     pub fn process_transaction_with_commitment_and_context(
-        &mut self,
+        &self,
         ctx: Context,
         transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
@@ -110,7 +110,7 @@ impl BanksClient {
     }
 
     pub fn process_transaction_with_preflight_and_commitment_and_context(
-        &mut self,
+        &self,
         ctx: Context,
         transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
@@ -126,7 +126,7 @@ impl BanksClient {
     }
 
     pub fn process_transaction_with_metadata_and_context(
-        &mut self,
+        &self,
         ctx: Context,
         transaction: impl Into<VersionedTransaction>,
     ) -> impl Future<Output = Result<BanksTransactionResultWithMetadata, BanksClientError>> + '_
@@ -137,7 +137,7 @@ impl BanksClient {
     }
 
     pub fn simulate_transaction_with_commitment_and_context(
-        &mut self,
+        &self,
         ctx: Context,
         transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
@@ -149,7 +149,7 @@ impl BanksClient {
     }
 
     pub fn get_account_with_commitment_and_context(
-        &mut self,
+        &self,
         ctx: Context,
         address: Pubkey,
         commitment: CommitmentLevel,
@@ -163,16 +163,14 @@ impl BanksClient {
     /// transaction until either it is accepted by the cluster or the transaction's
     /// blockhash expires.
     pub fn send_transaction(
-        &mut self,
+        &self,
         transaction: impl Into<VersionedTransaction>,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
         self.send_transaction_with_context(context::current(), transaction.into())
     }
 
     /// Return the cluster Sysvar
-    pub fn get_sysvar<T: Sysvar>(
-        &mut self,
-    ) -> impl Future<Output = Result<T, BanksClientError>> + '_ {
+    pub fn get_sysvar<T: Sysvar>(&self) -> impl Future<Output = Result<T, BanksClientError>> + '_ {
         self.get_account(T::id()).map(|result| {
             let sysvar = result?.ok_or(BanksClientError::ClientError("Sysvar not present"))?;
             from_account::<T, _>(&sysvar).ok_or(BanksClientError::ClientError(
@@ -182,14 +180,14 @@ impl BanksClient {
     }
 
     /// Return the cluster rent
-    pub fn get_rent(&mut self) -> impl Future<Output = Result<Rent, BanksClientError>> + '_ {
+    pub fn get_rent(&self) -> impl Future<Output = Result<Rent, BanksClientError>> + '_ {
         self.get_sysvar::<Rent>()
     }
 
     /// Send a transaction and return after the transaction has been rejected or
     /// reached the given level of commitment.
     pub fn process_transaction_with_commitment(
-        &mut self,
+        &self,
         transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
@@ -205,7 +203,7 @@ impl BanksClient {
 
     /// Process a transaction and return the result with metadata.
     pub fn process_transaction_with_metadata(
-        &mut self,
+        &self,
         transaction: impl Into<VersionedTransaction>,
     ) -> impl Future<Output = Result<BanksTransactionResultWithMetadata, BanksClientError>> + '_
     {
@@ -216,7 +214,7 @@ impl BanksClient {
     /// Send a transaction and return any preflight (sanitization or simulation) errors, or return
     /// after the transaction has been rejected or reached the given level of commitment.
     pub fn process_transaction_with_preflight_and_commitment(
-        &mut self,
+        &self,
         transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
@@ -252,7 +250,7 @@ impl BanksClient {
     /// Send a transaction and return any preflight (sanitization or simulation) errors, or return
     /// after the transaction has been finalized or rejected.
     pub fn process_transaction_with_preflight(
-        &mut self,
+        &self,
         transaction: impl Into<VersionedTransaction>,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
         self.process_transaction_with_preflight_and_commitment(
@@ -263,14 +261,14 @@ impl BanksClient {
 
     /// Send a transaction and return until the transaction has been finalized or rejected.
     pub fn process_transaction(
-        &mut self,
+        &self,
         transaction: impl Into<VersionedTransaction>,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
         self.process_transaction_with_commitment(transaction, CommitmentLevel::default())
     }
 
     pub async fn process_transactions_with_commitment<T: Into<VersionedTransaction>>(
-        &mut self,
+        &self,
         transactions: Vec<T>,
         commitment: CommitmentLevel,
     ) -> Result<(), BanksClientError> {
@@ -287,7 +285,7 @@ impl BanksClient {
 
     /// Send transactions and return until the transaction has been finalized or rejected.
     pub fn process_transactions<'a, T: Into<VersionedTransaction> + 'a>(
-        &'a mut self,
+        &'a self,
         transactions: Vec<T>,
     ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
         self.process_transactions_with_commitment(transactions, CommitmentLevel::default())
@@ -295,7 +293,7 @@ impl BanksClient {
 
     /// Simulate a transaction at the given commitment level
     pub fn simulate_transaction_with_commitment(
-        &mut self,
+        &self,
         transaction: impl Into<VersionedTransaction>,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<BanksTransactionResultWithSimulation, BanksClientError>> + '_
@@ -309,7 +307,7 @@ impl BanksClient {
 
     /// Simulate a transaction at the default commitment level
     pub fn simulate_transaction(
-        &mut self,
+        &self,
         transaction: impl Into<VersionedTransaction>,
     ) -> impl Future<Output = Result<BanksTransactionResultWithSimulation, BanksClientError>> + '_
     {
@@ -318,14 +316,14 @@ impl BanksClient {
 
     /// Return the most recent rooted slot. All transactions at or below this slot
     /// are said to be finalized. The cluster will not fork to a higher slot.
-    pub fn get_root_slot(&mut self) -> impl Future<Output = Result<Slot, BanksClientError>> + '_ {
+    pub fn get_root_slot(&self) -> impl Future<Output = Result<Slot, BanksClientError>> + '_ {
         self.get_slot_with_context(context::current(), CommitmentLevel::default())
     }
 
     /// Return the most recent rooted block height. All transactions at or below this height
     /// are said to be finalized. The cluster will not fork to a higher block height.
     pub fn get_root_block_height(
-        &mut self,
+        &self,
     ) -> impl Future<Output = Result<Slot, BanksClientError>> + '_ {
         self.get_block_height_with_context(context::current(), CommitmentLevel::default())
     }
@@ -333,7 +331,7 @@ impl BanksClient {
     /// Return the account at the given address at the slot corresponding to the given
     /// commitment level. If the account is not found, None is returned.
     pub fn get_account_with_commitment(
-        &mut self,
+        &self,
         address: Pubkey,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<Option<Account>, BanksClientError>> + '_ {
@@ -343,7 +341,7 @@ impl BanksClient {
     /// Return the account at the given address at the time of the most recent root slot.
     /// If the account is not found, None is returned.
     pub fn get_account(
-        &mut self,
+        &self,
         address: Pubkey,
     ) -> impl Future<Output = Result<Option<Account>, BanksClientError>> + '_ {
         self.get_account_with_commitment(address, CommitmentLevel::default())
@@ -352,7 +350,7 @@ impl BanksClient {
     /// Return the unpacked account data at the given address
     /// If the account is not found, an error is returned
     pub fn get_packed_account_data<T: Pack>(
-        &mut self,
+        &self,
         address: Pubkey,
     ) -> impl Future<Output = Result<T, BanksClientError>> + '_ {
         self.get_account(address).map(|result| {
@@ -365,7 +363,7 @@ impl BanksClient {
     /// Return the unpacked account data at the given address
     /// If the account is not found, an error is returned
     pub fn get_account_data_with_borsh<T: BorshDeserialize>(
-        &mut self,
+        &self,
         address: Pubkey,
     ) -> impl Future<Output = Result<T, BanksClientError>> + '_ {
         self.get_account(address).map(|result| {
@@ -377,7 +375,7 @@ impl BanksClient {
     /// Return the balance in lamports of an account at the given address at the slot
     /// corresponding to the given commitment level.
     pub fn get_balance_with_commitment(
-        &mut self,
+        &self,
         address: Pubkey,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<u64, BanksClientError>> + '_ {
@@ -388,7 +386,7 @@ impl BanksClient {
     /// Return the balance in lamports of an account at the given address at the time
     /// of the most recent root slot.
     pub fn get_balance(
-        &mut self,
+        &self,
         address: Pubkey,
     ) -> impl Future<Output = Result<u64, BanksClientError>> + '_ {
         self.get_balance_with_commitment(address, CommitmentLevel::default())
@@ -400,7 +398,7 @@ impl BanksClient {
     /// transaction fee. Note that servers rarely store the full transaction history. This
     /// method may return None if the transaction status has been discarded.
     pub fn get_transaction_status(
-        &mut self,
+        &self,
         signature: Signature,
     ) -> impl Future<Output = Result<Option<TransactionStatus>, BanksClientError>> + '_ {
         self.get_transaction_status_with_context(context::current(), signature)
@@ -408,7 +406,7 @@ impl BanksClient {
 
     /// Same as get_transaction_status, but for multiple transactions.
     pub async fn get_transaction_statuses(
-        &mut self,
+        &self,
         signatures: Vec<Signature>,
     ) -> Result<Vec<Option<TransactionStatus>>, BanksClientError> {
         // tarpc futures oddly hold a mutable reference back to the client so clone the client upfront
@@ -428,7 +426,7 @@ impl BanksClient {
     }
 
     pub fn get_latest_blockhash(
-        &mut self,
+        &self,
     ) -> impl Future<Output = Result<Hash, BanksClientError>> + '_ {
         self.get_latest_blockhash_with_commitment(CommitmentLevel::default())
             .map(|result| {
@@ -440,14 +438,14 @@ impl BanksClient {
     }
 
     pub fn get_latest_blockhash_with_commitment(
-        &mut self,
+        &self,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<Option<(Hash, u64)>, BanksClientError>> + '_ {
         self.get_latest_blockhash_with_commitment_and_context(context::current(), commitment)
     }
 
     pub fn get_latest_blockhash_with_commitment_and_context(
-        &mut self,
+        &self,
         ctx: Context,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<Option<(Hash, u64)>, BanksClientError>> + '_ {
@@ -457,7 +455,7 @@ impl BanksClient {
     }
 
     pub fn get_fee_for_message(
-        &mut self,
+        &self,
         message: Message,
     ) -> impl Future<Output = Result<Option<u64>, BanksClientError>> + '_ {
         self.get_fee_for_message_with_commitment_and_context(
@@ -468,7 +466,7 @@ impl BanksClient {
     }
 
     pub fn get_fee_for_message_with_commitment(
-        &mut self,
+        &self,
         message: Message,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = Result<Option<u64>, BanksClientError>> + '_ {
@@ -480,7 +478,7 @@ impl BanksClient {
     }
 
     pub fn get_fee_for_message_with_commitment_and_context(
-        &mut self,
+        &self,
         ctx: Context,
         message: Message,
         commitment: CommitmentLevel,
@@ -557,7 +555,7 @@ mod tests {
             let client_transport =
                 start_local_server(bank_forks, block_commitment_cache, Duration::from_millis(1))
                     .await;
-            let mut banks_client = start_client(client_transport).await?;
+            let banks_client = start_client(client_transport).await?;
 
             let recent_blockhash = banks_client.get_latest_blockhash().await?;
             let transaction = Transaction::new(&[&genesis.mint_keypair], message, recent_blockhash);
@@ -596,7 +594,7 @@ mod tests {
             let client_transport =
                 start_local_server(bank_forks, block_commitment_cache, Duration::from_millis(1))
                     .await;
-            let mut banks_client = start_client(client_transport).await?;
+            let banks_client = start_client(client_transport).await?;
             let (recent_blockhash, last_valid_block_height) = banks_client
                 .get_latest_blockhash_with_commitment(CommitmentLevel::default())
                 .await?

--- a/program-test/tests/bpf.rs
+++ b/program-test/tests/bpf.rs
@@ -14,7 +14,7 @@ async fn test_add_bpf_program() {
     program_test.prefer_bpf(true);
     program_test.add_program("noop_program", program_id, None);
 
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
 
     // Assert the program is a BPF Loader 2 program.
     let program_account = context

--- a/program-test/tests/builtins.rs
+++ b/program-test/tests/builtins.rs
@@ -13,7 +13,7 @@ use {
 #[tokio::test]
 async fn test_bpf_loader_upgradeable_present() {
     // Arrange
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::default().start().await;
+    let (banks_client, payer, recent_blockhash) = ProgramTest::default().start().await;
 
     let buffer_keypair = Keypair::new();
     let upgrade_authority_keypair = Keypair::new();
@@ -50,7 +50,7 @@ async fn test_bpf_loader_upgradeable_present() {
 #[tokio::test]
 async fn versioned_transaction() {
     let program_test = ProgramTest::default();
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
 
     let program_id = Pubkey::new_unique();
     let account = Keypair::new();

--- a/program-test/tests/compute_units.rs
+++ b/program-test/tests/compute_units.rs
@@ -20,7 +20,7 @@ fn overflow_compute_units() {
 async fn max_compute_units() {
     let mut program_test = ProgramTest::default();
     program_test.set_compute_max_units(i64::MAX as u64);
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
 
     // Invalid compute unit maximums are only triggered by BPF programs, so send
     // a valid instruction into a BPF program to make sure the issue doesn't

--- a/program-test/tests/core_bpf.rs
+++ b/program-test/tests/core_bpf.rs
@@ -14,7 +14,7 @@ async fn test_add_bpf_program() {
     let mut program_test = ProgramTest::default();
     program_test.add_upgradeable_program_to_genesis("noop_program", &program_id);
 
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
 
     // Assert the program is a BPF Loader Upgradeable program.
     let program_account = context

--- a/program-test/tests/cpi.rs
+++ b/program-test/tests/cpi.rs
@@ -129,7 +129,7 @@ async fn cpi() {
         processor!(invoked_process_instruction),
     );
 
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
     let instructions = vec![Instruction::new_with_bincode(
         invoker_program_id,
         &[0],
@@ -165,7 +165,7 @@ async fn cpi_dupes() {
         processor!(invoked_process_instruction),
     );
 
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
     let instructions = vec![Instruction::new_with_bincode(
         invoker_program_id,
         &[0],
@@ -201,7 +201,7 @@ async fn cpi_create_account() {
     );
 
     let create_account_keypair = Keypair::new();
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
     let instructions = vec![Instruction::new_with_bincode(
         create_account_program_id,
         &[0],
@@ -272,7 +272,7 @@ async fn stack_height() {
         processor!(invoked_stack_height),
     );
 
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
     let instructions = vec![Instruction::new_with_bytes(
         invoker_stack_height_program_id,
         &[],

--- a/program-test/tests/genesis_accounts.rs
+++ b/program-test/tests/genesis_accounts.rs
@@ -30,7 +30,7 @@ async fn genesis_accounts() {
         program_test.add_genesis_account(*pubkey, account.clone());
     }
 
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
 
     // Verify the accounts are present.
     for (pubkey, account) in my_genesis_accounts.iter() {

--- a/program-test/tests/lamports.rs
+++ b/program-test/tests/lamports.rs
@@ -42,7 +42,7 @@ async fn move_lamports() {
 
     let lamports = 1_000_000_000;
     let source = Keypair::new();
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
     let instructions = vec![
         system_instruction::create_account(
             &context.payer.pubkey(),

--- a/program-test/tests/realloc.rs
+++ b/program-test/tests/realloc.rs
@@ -50,7 +50,7 @@ async fn realloc_smaller_in_cpi() {
         program_id,
         processor!(process_instruction),
     );
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
 
     let token_2022_id = solana_inline_spl::token_2022::id();
     let mint = Keypair::new();

--- a/program-test/tests/return_data.rs
+++ b/program-test/tests/return_data.rs
@@ -69,7 +69,7 @@ async fn return_data() {
         processor!(set_return_data_process_instruction),
     );
 
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
     let instructions = vec![Instruction {
         program_id: get_return_data_program_id,
         accounts: vec![AccountMeta::new_readonly(set_return_data_program_id, false)],
@@ -109,7 +109,7 @@ async fn simulation_return_data() {
         processor!(error_set_return_data_process_instruction),
     );
 
-    let mut context = program_test.start_with_context().await;
+    let context = program_test.start_with_context().await;
     let expected_data = vec![240, 159, 166, 150];
     let instructions = vec![Instruction {
         program_id: error_set_return_data_program_id,

--- a/program-test/tests/spl.rs
+++ b/program-test/tests/spl.rs
@@ -14,7 +14,7 @@ use {
 
 #[tokio::test]
 async fn programs_present() {
-    let (mut banks_client, _, _) = ProgramTest::default().start().await;
+    let (banks_client, _, _) = ProgramTest::default().start().await;
     let rent = banks_client.get_rent().await.unwrap();
     let token_2022_id = solana_inline_spl::token_2022::id();
     let (token_2022_programdata_id, _) =
@@ -32,7 +32,7 @@ async fn programs_present() {
 
 #[tokio::test]
 async fn token_2022() {
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::default().start().await;
+    let (banks_client, payer, recent_blockhash) = ProgramTest::default().start().await;
 
     let token_2022_id = solana_inline_spl::token_2022::id();
     let mint = Keypair::new();

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -3,7 +3,7 @@ use {
     crate::tpu_client::{RecentLeaderSlots, TpuClientConfig, MAX_FANOUT_SLOTS},
     bincode::serialize,
     futures_util::{
-        future::{join_all, FutureExt, TryFutureExt},
+        future::{join_all, FutureExt},
         stream::StreamExt,
     },
     log::*,
@@ -308,11 +308,12 @@ where
 //
 // Useful for end-users who don't need a persistent connection to each validator,
 // and want to abort more quickly.
-fn timeout_future<'a, Fut: Future<Output = TransportResult<()>> + 'a>(
+async fn timeout_future<Fut: Future<Output = TransportResult<()>>>(
     timeout_duration: Duration,
     future: Fut,
-) -> impl Future<Output = TransportResult<()>> + 'a {
+) -> TransportResult<()> {
     timeout(timeout_duration, future)
+        .await
         .unwrap_or_else(|_| Err(TransportError::Custom("Timed out".to_string())))
 }
 


### PR DESCRIPTION
#### Problem
`BanksClient` has many methods which unnecessarily take a `&mut self` where a `&self` would be sufficient. The same methods also use explicit verbose `Future` types instead of the more concise `async-await` syntax.


#### Summary of Changes
- Converted all methods of `BanksClient` to receive `&self` instead of `&mut self`
- Re-wrote all methods signatures and bodies to use `async-await` syntax instead of explicit `Future`s and types from `futures` crate.
