### PR TITLE
inline try_new for internal meta

### DIFF
--- a/transaction-view/src/address_table_lookup_meta.rs
+++ b/transaction-view/src/address_table_lookup_meta.rs
@@ -57,6 +57,7 @@ impl AddressTableLookupMeta {
     /// ATL.
     /// This function will parse each ATL to ensure the data is well-formed,
     /// but will not cache data related to these ATLs.
+    #[inline(always)]
     pub fn try_new(bytes: &[u8], offset: &mut usize) -> Result<Self> {
         // Maximum number of ATLs should be represented by a single byte,
         // thus the MSB should not be set.

--- a/transaction-view/src/instructions_meta.rs
+++ b/transaction-view/src/instructions_meta.rs
@@ -24,6 +24,7 @@ impl InstructionsMeta {
     /// This function will parse each individual instruction to ensure the
     /// instruction data is well-formed, but will not cache data related to
     /// these instructions.
+    #[inline(always)]
     pub fn try_new(bytes: &[u8], offset: &mut usize) -> Result<Self> {
         // Read the number of instructions at the current offset.
         // Each instruction needs at least 3 bytes, so do a sanity check here to

--- a/transaction-view/src/message_header_meta.rs
+++ b/transaction-view/src/message_header_meta.rs
@@ -33,6 +33,7 @@ pub(crate) struct MessageHeaderMeta {
 }
 
 impl MessageHeaderMeta {
+    #[inline(always)]
     pub fn try_new(bytes: &[u8], offset: &mut usize) -> Result<Self> {
         // Get the message offset.
         // We know the offset does not exceed packet length, and our packet

--- a/transaction-view/src/signature_meta.rs
+++ b/transaction-view/src/signature_meta.rs
@@ -27,6 +27,7 @@ pub(crate) struct SignatureMeta {
 impl SignatureMeta {
     /// Get the number of signatures and the offset to the first signature in
     /// the transaction packet, starting at the given `offset`.
+    #[inline(always)]
     pub(crate) fn try_new(bytes: &[u8], offset: &mut usize) -> Result<Self> {
         // Maximum number of signatures should be represented by a single byte,
         // thus the MSB should not be set.

--- a/transaction-view/src/static_account_keys_meta.rs
+++ b/transaction-view/src/static_account_keys_meta.rs
@@ -23,6 +23,7 @@ pub struct StaticAccountKeysMeta {
 }
 
 impl StaticAccountKeysMeta {
+    #[inline(always)]
     pub fn try_new(bytes: &[u8], offset: &mut usize) -> Result<Self> {
         // Max size must not have the MSB set so that it is size 1.
         const _: () = assert!(MAX_STATIC_ACCOUNTS_PER_PACKET & 0b1000_0000 == 0);


### PR DESCRIPTION
#### Problem
- Forcing inling of some internal functions can help us be more efficient

#### Summary of Changes
- Use `#[inline(always)]` to force inlining of the internal meta fields

<details>
<summary>Benchmark Results</summary>

```
min sized transactions/VersionedTransaction
                        time:   [213.43 µs 213.67 µs 213.91 µs]
                        thrpt:  [4.7872 Melem/s 4.7925 Melem/s 4.7979 Melem/s]
                 change:
                        time:   [-2.3018% -1.7559% -1.2321%] (p = 0.00 < 0.05)
                        thrpt:  [+1.2475% +1.7872% +2.3560%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  4 (4.00%) high severe
min sized transactions/TransactionMeta
                        time:   [4.3997 µs 4.4140 µs 4.4311 µs]
                        thrpt:  [231.09 Melem/s 231.99 Melem/s 232.74 Melem/s]
                 change:
                        time:   [-43.359% -42.350% -41.342%] (p = 0.00 < 0.05)
                        thrpt:  [+70.479% +73.461% +76.551%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

simple transfers/VersionedTransaction
                        time:   [475.89 µs 478.27 µs 480.71 µs]
                        thrpt:  [2.1302 Melem/s 2.1411 Melem/s 2.1518 Melem/s]
                 change:
                        time:   [+0.9812% +1.4468% +1.9634%] (p = 0.00 < 0.05)
                        thrpt:  [-1.9256% -1.4262% -0.9717%]
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  5 (5.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
simple transfers/TransactionMeta
                        time:   [5.4348 µs 5.5273 µs 5.6421 µs]
                        thrpt:  [181.49 Melem/s 185.26 Melem/s 188.42 Melem/s]
                 change:
                        time:   [-28.337% -27.022% -25.853%] (p = 0.00 < 0.05)
                        thrpt:  [+34.868% +37.027% +39.542%]
                        Performance has improved.

packed transfers/VersionedTransaction
                        time:   [6.4247 ms 6.4532 ms 6.4828 ms]
                        thrpt:  [157.96 Kelem/s 158.68 Kelem/s 159.39 Kelem/s]
                 change:
                        time:   [+2.6290% +3.0829% +3.5882%] (p = 0.00 < 0.05)
                        thrpt:  [-3.4639% -2.9907% -2.5616%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
packed transfers/TransactionMeta
                        time:   [230.79 µs 231.81 µs 233.01 µs]
                        thrpt:  [4.3946 Melem/s 4.4173 Melem/s 4.4369 Melem/s]
                 change:
                        time:   [+1.0039% +1.8200% +2.6821%] (p = 0.00 < 0.05)
                        thrpt:  [-2.6121% -1.7875% -0.9939%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

packed noops/VersionedTransaction
                        time:   [4.8608 ms 4.8638 ms 4.8672 ms]
                        thrpt:  [210.39 Kelem/s 210.54 Kelem/s 210.67 Kelem/s]
                 change:
                        time:   [+3.2611% +3.3808% +3.5023%] (p = 0.00 < 0.05)
                        thrpt:  [-3.3838% -3.2703% -3.1581%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
packed noops/TransactionMeta
                        time:   [1.3780 ms 1.3798 ms 1.3821 ms]
                        thrpt:  [740.90 Kelem/s 742.12 Kelem/s 743.11 Kelem/s]
                 change:
                        time:   [-1.0258% -0.4892% +0.0234%] (p = 0.07 > 0.05)
                        thrpt:  [-0.0234% +0.4916% +1.0364%]
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

packed atls/VersionedTransaction
                        time:   [3.4663 ms 3.4692 ms 3.4725 ms]
                        thrpt:  [294.89 Kelem/s 295.17 Kelem/s 295.42 Kelem/s]
                 change:
                        time:   [+0.0358% +0.1894% +0.3513%] (p = 0.02 < 0.05)
                        thrpt:  [-0.3501% -0.1891% -0.0358%]
                        Change within noise threshold.
Found 15 outliers among 100 measurements (15.00%)
  11 (11.00%) high mild
  4 (4.00%) high severe
packed atls/TransactionMeta
                        time:   [113.48 µs 113.73 µs 113.99 µs]
                        thrpt:  [8.9831 Melem/s 9.0037 Melem/s 9.0233 Melem/s]
                 change:
                        time:   [-6.7763% -6.2081% -5.6713%] (p = 0.00 < 0.05)
                        thrpt:  [+6.0122% +6.6190% +7.2689%]
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  8 (8.00%) high mild
  7 (7.00%) high severe

```

</details>



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
