### PR TITLE
AddressTableLookupMeta::try_new fix variable names

### DIFF
--- a/transaction-view/src/address_table_lookup_meta.rs
+++ b/transaction-view/src/address_table_lookup_meta.rs
@@ -87,12 +87,12 @@ impl AddressTableLookupMeta {
             advance_offset_for_type::<Pubkey>(bytes, offset)?;
 
             // Read the number of write indexes, and then update the offset.
-            let num_accounts = optimized_read_compressed_u16(bytes, offset)?;
-            advance_offset_for_array::<u8>(bytes, offset, num_accounts)?;
+            let num_write_accounts = optimized_read_compressed_u16(bytes, offset)?;
+            advance_offset_for_array::<u8>(bytes, offset, num_write_accounts)?;
 
             // Read the number of read indexes, and then update the offset.
-            let data_len = optimized_read_compressed_u16(bytes, offset)?;
-            advance_offset_for_array::<u8>(bytes, offset, data_len)?
+            let num_read_accounts = optimized_read_compressed_u16(bytes, offset)?;
+            advance_offset_for_array::<u8>(bytes, offset, num_read_accounts)?
         }
 
         Ok(Self {


### PR DESCRIPTION
#### Problem
- Variable names were copied from the instructions parsing

#### Summary of Changes
- Fix the names

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
