### PR TITLE
sigverify using TransactionMeta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6798,6 +6798,7 @@ dependencies = [
 name = "solana-perf"
 version = "2.1.0"
 dependencies = [
+ "agave-transaction-view",
  "ahash 0.8.10",
  "assert_matches",
  "bincode",

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+agave-transaction-view = { workspace = true }
 ahash = { workspace = true }
 bincode = { workspace = true }
 bv = { workspace = true, features = ["serde"] }

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -18,7 +18,6 @@ extern crate lazy_static;
 extern crate log;
 
 #[cfg(test)]
-#[macro_use]
 extern crate assert_matches;
 
 #[macro_use]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -74,6 +74,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-transaction-view"
+version = "2.1.0"
+dependencies = [
+ "solana-sdk",
+ "solana-svm-transaction",
+]
+
+[[package]]
 name = "agave-validator"
 version = "2.1.0"
 dependencies = [
@@ -5249,6 +5257,7 @@ checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 name = "solana-perf"
 version = "2.1.0"
 dependencies = [
+ "agave-transaction-view",
  "ahash 0.8.10",
  "bincode",
  "bv",

--- a/transaction-view/src/lib.rs
+++ b/transaction-view/src/lib.rs
@@ -9,7 +9,7 @@ mod address_table_lookup_meta;
 #[allow(dead_code)]
 mod instructions_meta;
 #[allow(dead_code)]
-mod message_header_meta;
+pub mod message_header_meta;
 pub mod result;
 #[allow(dead_code)]
 mod signature_meta;

--- a/transaction-view/src/message_header_meta.rs
+++ b/transaction-view/src/message_header_meta.rs
@@ -59,6 +59,11 @@ impl MessageHeaderMeta {
         let num_readonly_signed_accounts = read_byte(bytes, offset)?;
         let num_readonly_unsigned_accounts = read_byte(bytes, offset)?;
 
+        // there should be at least 1 RW fee-payer account.
+        if num_readonly_signed_accounts >= num_required_signatures {
+            return Err(TransactionParsingError);
+        }
+
         Ok(Self {
             offset: message_offset,
             version,

--- a/transaction-view/src/message_header_meta.rs
+++ b/transaction-view/src/message_header_meta.rs
@@ -120,4 +120,15 @@ mod tests {
         assert_eq!(header.num_readonly_signed_accounts, 1);
         assert_eq!(header.num_readonly_unsigned_accounts, 2);
     }
+
+    #[test]
+    fn test_no_rw_fee_payer() {
+        let bytes = [1, 1, 1];
+        let mut offset = 0;
+        assert!(MessageHeaderMeta::try_new(&bytes, &mut offset).is_err());
+
+        let bytes = [MESSAGE_VERSION_PREFIX, 1, 1, 1];
+        let mut offset = 0;
+        assert!(MessageHeaderMeta::try_new(&bytes, &mut offset).is_err());
+    }
 }

--- a/transaction-view/src/transaction_meta.rs
+++ b/transaction-view/src/transaction_meta.rs
@@ -155,6 +155,15 @@ impl TransactionMeta {
             index: 0,
         }
     }
+
+    /// Return slice of bytes that are in the `Message`.
+    /// This excludes signatures.
+    /// # Safety
+    /// - This function must be called with the same `bytes` slice that was
+    ///   used to create the `TransactionMeta` instance.
+    pub unsafe fn message_bytes<'a>(&self, bytes: &'a [u8]) -> &'a [u8] {
+        &bytes[usize::from(self.message_header.offset)..]
+    }
 }
 
 #[cfg(test)]

--- a/transaction-view/src/transaction_meta.rs
+++ b/transaction-view/src/transaction_meta.rs
@@ -173,14 +173,14 @@ impl TransactionMeta {
     /// This does **not** check if the index is valid.
     pub fn signature_offset(&self, signature_index: u32) -> u32 {
         u32::from(self.signature.offset)
-            + signature_index * (core::mem::size_of::<Signature>() as u32)
+            .wrapping_add(signature_index.wrapping_mul(core::mem::size_of::<Signature>() as u32))
     }
 
     /// Get the offset to a static account key at specific index.
     /// This does **not** check if the index is valid.
     pub fn static_account_key_offset(&self, account_index: u32) -> u32 {
         u32::from(self.static_account_keys.offset)
-            + account_index * (core::mem::size_of::<Pubkey>() as u32)
+            .wrapping_add(account_index.wrapping_mul(core::mem::size_of::<Pubkey>() as u32))
     }
 
     /// Get the offset to the message.

--- a/transaction-view/src/transaction_meta.rs
+++ b/transaction-view/src/transaction_meta.rs
@@ -166,6 +166,37 @@ impl TransactionMeta {
     }
 }
 
+// Functionality needed to support the generating of offset vectors for GPU
+// implementation of sigverify.
+impl TransactionMeta {
+    /// Get the offset to a signature at specific index.
+    /// This does **not** check if the index is valid.
+    pub fn signature_offset(&self, signature_index: u32) -> u32 {
+        u32::from(self.signature.offset)
+            + signature_index * (core::mem::size_of::<Signature>() as u32)
+    }
+
+    /// Get the offset to a static account key at specific index.
+    /// This does **not** check if the index is valid.
+    pub fn static_account_key_offset(&self, account_index: u32) -> u32 {
+        u32::from(self.static_account_keys.offset)
+            + account_index * (core::mem::size_of::<Pubkey>() as u32)
+    }
+
+    /// Get the offset to the message.
+    pub fn message_offset(&self) -> u32 {
+        u32::from(self.message_header.offset)
+    }
+
+    /// Get the length in bytes of the message.
+    /// # Safety
+    /// - This function must be called with the same `bytes` slice that was
+    ///   used to create the `TransactionMeta` instance.
+    pub unsafe fn message_length(&self, packet_bytes: &[u8]) -> u32 {
+        (packet_bytes.len() as u32).wrapping_sub(u32::from(self.message_header.offset))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {

--- a/transaction-view/src/transaction_meta.rs
+++ b/transaction-view/src/transaction_meta.rs
@@ -211,7 +211,7 @@ mod tests {
         },
     };
 
-    fn verify_transaction_view_meta(tx: &VersionedTransaction) {
+    fn verify_transaction_meta(tx: &VersionedTransaction) {
         let bytes = bincode::serialize(tx).unwrap();
         let meta = TransactionMeta::try_new(&bytes).unwrap();
 
@@ -321,22 +321,22 @@ mod tests {
 
     #[test]
     fn test_minimal_sized_transaction() {
-        verify_transaction_view_meta(&minimally_sized_transaction());
+        verify_transaction_meta(&minimally_sized_transaction());
     }
 
     #[test]
     fn test_simple_transfer() {
-        verify_transaction_view_meta(&simple_transfer());
+        verify_transaction_meta(&simple_transfer());
     }
 
     #[test]
     fn test_simple_transfer_v0() {
-        verify_transaction_view_meta(&simple_transfer_v0());
+        verify_transaction_meta(&simple_transfer_v0());
     }
 
     #[test]
     fn test_v0_with_lookup() {
-        verify_transaction_view_meta(&v0_with_lookup());
+        verify_transaction_meta(&v0_with_lookup());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
- Can re-use this parsing code and do some additional *simple* checks before signature verification
- This let's us reduce code duplication and also not waste time on malformed packets

#### Summary of Changes
- perf/sigverify using `TransactionMeta`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
