### PR TITLE
Bound default value for thread pool args

### DIFF
--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -18,10 +18,11 @@ pub struct DefaultThreadArgs {
 impl Default for DefaultThreadArgs {
     fn default() -> Self {
         Self {
-            ip_echo_server_threads: IpEchoServerThreadsArg::default().to_string(),
-            replay_forks_threads: ReplayForksThreadsArg::default().to_string(),
-            replay_transactions_threads: ReplayTransactionsThreadsArg::default().to_string(),
-            tvu_receive_threads: TvuReceiveThreadsArg::default().to_string(),
+            ip_echo_server_threads: IpEchoServerThreadsArg::bounded_default().to_string(),
+            replay_forks_threads: ReplayForksThreadsArg::bounded_default().to_string(),
+            replay_transactions_threads: ReplayTransactionsThreadsArg::bounded_default()
+                .to_string(),
+            tvu_receive_threads: TvuReceiveThreadsArg::bounded_default().to_string(),
         }
     }
 }
@@ -85,6 +86,12 @@ trait ThreadArg {
 
     /// The default number of threads
     fn default() -> usize;
+    /// The default number of threads, bounded by Self::max()
+    /// This prevents potential CLAP issues on low core count machines where
+    /// a fixed value in Self::default() could be greater than Self::max()
+    fn bounded_default() -> usize {
+        std::cmp::min(Self::default(), Self::max())
+    }
     /// The minimum allowed number of threads (inclusive)
     fn min() -> usize {
         1


### PR DESCRIPTION
#### Problem
The thread pool argument trait declares min/max/default functions. These functions are then called to provide a default as well as validation that any user set value on the CLI is within [min(), max()].

Some of the default values are fixed numbers. On a machine with few enough cores, the default could exceed the max. This would raise an error when the argument is parsed. This can be worked around by the user specifying a lower value; however, these flags are still very much experimental and intentionally hidden.

#### Summary of Changes
So, make the default value that is passed to CLAP the min of default() and max(). This will adjust the default on low core count machines while leaving settings on sufficient machines untouched.

Fixes https://github.com/anza-xyz/agave/issues/2103
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
