### PR TITLE
Reduce QUIC crypto buffer size to 2kB

### DIFF
--- a/core/src/repair/quic_endpoint.rs
+++ b/core/src/repair/quic_endpoint.rs
@@ -203,7 +203,8 @@ fn new_transport_config() -> TransportConfig {
         .keep_alive_interval(Some(KEEP_ALIVE_INTERVAL))
         .max_concurrent_bidi_streams(MAX_CONCURRENT_BIDI_STREAMS)
         .max_concurrent_uni_streams(VarInt::from(0u8))
-        .max_idle_timeout(Some(max_idle_timeout));
+        .max_idle_timeout(Some(max_idle_timeout))
+        .crypto_buffer_size(2048);
     config
 }
 


### PR DESCRIPTION
quinn-proto's default crypto buffer size is 16kB.
This can comfortably be reduced to 2048 bytes to limit large
allocations early on in the handshake sequence.  A typical QUIC
handshake is about 1153 bytes of CRYPTO frames in total.

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
