### PR TITLE
Simplify program loading error handling

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1656,7 +1656,7 @@ fn test_program_sbf_invoke_stable_genesis_and_bank() {
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction.clone());
     assert_eq!(
         result.unwrap_err().unwrap(),
-        TransactionError::ProgramAccountNotFound
+        TransactionError::InvalidProgramForExecution
     );
 
     load_upgradeable_program(
@@ -1882,7 +1882,7 @@ fn test_program_sbf_invoke_in_same_tx_as_deployment() {
             let results = execute_transactions(&bank, vec![tx]);
             assert_eq!(
                 results[0].as_ref().unwrap_err(),
-                &TransactionError::ProgramAccountNotFound,
+                &TransactionError::InvalidProgramForExecution,
             );
         } else {
             let (result, _, _) = process_transaction_and_record_inner(&bank, tx);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6921,7 +6921,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     );
     assert_eq!(
         bank.process_transaction(&transaction),
-        Err(TransactionError::ProgramAccountNotFound),
+        Err(TransactionError::InvalidProgramForExecution),
     );
     {
         // Make sure it is not in the cache because the account owner is not a loader

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1383,7 +1383,7 @@ mod tests {
         let validation_results = vec![
             Ok(ValidatedTransactionDetails::default()),
             Ok(ValidatedTransactionDetails::default()),
-            Err(TransactionError::ProgramAccountNotFound),
+            Err(TransactionError::InvalidProgramForExecution),
         ];
         let owners = vec![owner1, owner2];
 


### PR DESCRIPTION
#### Problem
It's redundant to try to return an error for when programs are not found versus when they are not executable because there are no cases in which a program is not found and is somehow executable.

#### Summary of Changes
Simplify program loading so that we don't need to track whether accounts existed during loading. We can instead rely on whether the program account is executable.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
