### PR TITLE
fix: send votes to the immediate next leader

### DIFF
--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -1,9 +1,39 @@
 use {
+    itertools::Itertools,
     solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
     solana_poh::poh_recorder::PohRecorder,
     solana_sdk::{clock::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, pubkey::Pubkey},
     std::{net::SocketAddr, sync::RwLock},
 };
+
+/// Returns a list of tpu vote sockets for the leaders of the next N fanout
+/// slots. Leaders are deduped but the resulting list could have duplicate
+/// sockets if two different leaders share the same tpu vote socket.
+pub(crate) fn upcoming_leader_tpu_vote_sockets(
+    cluster_info: &ClusterInfo,
+    poh_recorder: &RwLock<PohRecorder>,
+    fanout_slots: usize,
+) -> Vec<SocketAddr> {
+    let upcoming_leaders = {
+        let mut upcoming_leaders = Vec::with_capacity(fanout_slots);
+        let poh_recorder = poh_recorder.read().unwrap();
+        for n_slots in 1..=fanout_slots {
+            upcoming_leaders.push(poh_recorder.leader_after_n_slots(n_slots as u64));
+        }
+        upcoming_leaders
+    };
+
+    upcoming_leaders
+        .into_iter()
+        .flatten()
+        .unique()
+        .filter_map(|leader_pubkey| {
+            cluster_info
+                .lookup_contact_info(&leader_pubkey, ContactInfo::tpu_vote)?
+                .ok()
+        })
+        .collect()
+}
 
 pub(crate) fn next_leader_tpu_vote(
     cluster_info: &ClusterInfo,

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -7,7 +7,10 @@ use {
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure::Measure,
     solana_poh::poh_recorder::PohRecorder,
-    solana_sdk::{clock::Slot, transaction::Transaction},
+    solana_sdk::{
+        clock::{Slot, FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET},
+        transaction::Transaction,
+    },
     std::{
         sync::{Arc, RwLock},
         thread::{self, Builder, JoinHandle},
@@ -79,7 +82,9 @@ impl VotingService {
         }
 
         // Attempt to send our vote transaction to the leaders for the next few slots
-        const UPCOMING_LEADER_FANOUT_SLOTS: usize = 2;
+        const UPCOMING_LEADER_FANOUT_SLOTS: u64 = FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET;
+        #[cfg(test)]
+        static_assertions::const_assert_eq!(UPCOMING_LEADER_FANOUT_SLOTS, 2);
         let upcoming_leader_sockets = upcoming_leader_tpu_vote_sockets(
             cluster_info,
             poh_recorder,


### PR DESCRIPTION
#### Problem
Votes are always sent to the "forward leader" which is defined as the leader of the slot which is 2 slots beyond our latest poh clock slot. This means that a vote for the third slot of a given leader's slot span will always be sent to the following leader for inclusion in the first slot of that leader's slot span. This adds an unnecessary slot of latency to votes because the vote could potentially land in current leader's fourth slot.

#### Summary of Changes
- Send votes to the leaders of the next two slots to decrease vote latency

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
