### PR TITLE
updates ContactInfo.outset when hot-swapping identity

### DIFF
--- a/core/src/cluster_slots_service/cluster_slots.rs
+++ b/core/src/cluster_slots_service/cluster_slots.rs
@@ -278,8 +278,6 @@ mod tests {
     #[test]
     fn test_best_peer_2() {
         let cs = ClusterSlots::default();
-        let mut c1 = ContactInfo::default();
-        let mut c2 = ContactInfo::default();
         let mut map = HashMap::new();
         let k1 = solana_sdk::pubkey::new_rand();
         let k2 = solana_sdk::pubkey::new_rand();
@@ -289,16 +287,14 @@ mod tests {
             .write()
             .unwrap()
             .insert(0, Arc::new(RwLock::new(map)));
-        c1.set_pubkey(k1);
-        c2.set_pubkey(k2);
+        let c1 = ContactInfo::new(k1, /*wallclock:*/ 0, /*shred_version:*/ 0);
+        let c2 = ContactInfo::new(k2, /*wallclock:*/ 0, /*shred_version:*/ 0);
         assert_eq!(cs.compute_weights(0, &[c1, c2]), vec![u64::MAX / 4, 1]);
     }
 
     #[test]
     fn test_best_peer_3() {
         let cs = ClusterSlots::default();
-        let mut c1 = ContactInfo::default();
-        let mut c2 = ContactInfo::default();
         let mut map = HashMap::new();
         let k1 = solana_sdk::pubkey::new_rand();
         let k2 = solana_sdk::pubkey::new_rand();
@@ -318,18 +314,23 @@ mod tests {
         .into_iter()
         .collect();
         *cs.validator_stakes.write().unwrap() = Arc::new(validator_stakes);
-        c1.set_pubkey(k1);
-        c2.set_pubkey(k2);
+        let c1 = ContactInfo::new(k1, /*wallclock:*/ 0, /*shred_version:*/ 0);
+        let c2 = ContactInfo::new(k2, /*wallclock:*/ 0, /*shred_version:*/ 0);
         assert_eq!(cs.compute_weights(0, &[c1, c2]), vec![u64::MAX / 4 + 1, 1]);
     }
 
     #[test]
     fn test_best_completed_slot_peer() {
         let cs = ClusterSlots::default();
-        let mut contact_infos = vec![ContactInfo::default(); 2];
-        for ci in contact_infos.iter_mut() {
-            ci.set_pubkey(solana_sdk::pubkey::new_rand());
-        }
+        let contact_infos: Vec<_> = std::iter::repeat_with(|| {
+            ContactInfo::new(
+                solana_sdk::pubkey::new_rand(),
+                0, // wallclock
+                0, // shred_version
+            )
+        })
+        .take(2)
+        .collect();
         let slot = 9;
 
         // None of these validators have completed slot 9, so should

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -679,7 +679,7 @@ impl ClusterInfo {
             *instance = NodeInstance::new(&mut thread_rng(), id, timestamp());
         }
         *self.keypair.write().unwrap() = new_keypair;
-        self.my_contact_info.write().unwrap().set_pubkey(id);
+        self.my_contact_info.write().unwrap().hot_swap_pubkey(id);
 
         self.refresh_my_gossip_contact_info();
         self.push_message(CrdsValue::new_signed(

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -536,7 +536,7 @@ pub fn make_test_cluster<R: Rng>(
     .collect();
     nodes.shuffle(rng);
     let keypair = Arc::new(Keypair::new());
-    nodes[0].set_pubkey(keypair.pubkey());
+    nodes[0] = ContactInfo::new_localhost(&keypair.pubkey(), /*wallclock:*/ timestamp());
     let this_node = nodes[0].clone();
     let mut stakes: HashMap<Pubkey, u64> = nodes
         .iter()


### PR DESCRIPTION

#### Problem
When hot-swapping identity, `ContactInfo.outset` should be updated so that the new `ContactInfo` overrides older node with the same pubkey.


#### Summary of Changes
updates `ContactInfo.outset` when hot-swapping identity