### PR TITLE
ci: use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload Artifacts
         if: ${{ steps.build.outputs.channel != '' || steps.build.outputs.tag != '' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-artifact
           path: windows-release/


### PR DESCRIPTION
#### Problem

deprecation notice for v1~v3 of `actions/upload-artifact`

<img width="1039" alt="Screenshot 2024-08-16 at 14 58 44" src="https://github.com/user-attachments/assets/08cf76a4-18ce-4677-89bf-626f3bae159d">

#### Summary of Changes

use `actions/upload-artifact@v4`