### PR TITLE
svm: better testing for transaction batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7717,6 +7717,7 @@ dependencies = [
  "solana-timings",
  "solana-type-overrides",
  "solana-vote",
+ "test-case",
  "thiserror",
 ]
 

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -54,6 +54,7 @@ solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-svm = { path = ".", features = ["dev-context-only-utils"] }
 solana-svm-conformance = { workspace = true }
+test-case = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -1,27 +1,27 @@
 #![cfg(test)]
 
 use {
-    crate::{
-        mock_bank::{
-            create_executable_environment, deploy_program, register_builtins, MockBankCallback,
-            MockForkGraph,
-        },
-        transaction_builder::SanitizedTransactionBuilder,
+    crate::mock_bank::{
+        create_executable_environment, deploy_program, program_address, register_builtins,
+        MockBankCallback, MockForkGraph, WALLCLOCK_TIME,
     },
     solana_sdk::{
-        account::{AccountSharedData, ReadableAccount, WritableAccount},
-        clock::Clock,
+        account::{AccountSharedData, WritableAccount},
+        clock::Slot,
         hash::Hash,
-        instruction::AccountMeta,
+        instruction::{AccountMeta, Instruction},
+        native_token::LAMPORTS_PER_SOL,
         pubkey::Pubkey,
-        signature::Signature,
-        sysvar::SysvarId,
-        transaction::{SanitizedTransaction, TransactionError},
+        signature::Signer,
+        signer::keypair::Keypair,
+        system_program, system_transaction,
+        transaction::{SanitizedTransaction, Transaction, TransactionError},
+        transaction_context::TransactionReturnData,
     },
     solana_svm::{
         account_loader::{CheckedTransactionDetails, TransactionCheckResult},
-        transaction_processing_callback::TransactionProcessingCallback,
-        transaction_processing_result::TransactionProcessingResultExtensions,
+        transaction_execution_result::TransactionExecutionDetails,
+        transaction_processing_result::ProcessedTransaction,
         transaction_processor::{
             ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingConfig,
             TransactionProcessingEnvironment,
@@ -29,213 +29,511 @@ use {
     },
     solana_type_overrides::sync::{Arc, RwLock},
     std::collections::{HashMap, HashSet},
+    test_case::test_case,
 };
 
 // This module contains the implementation of TransactionProcessingCallback
 mod mock_bank;
-mod transaction_builder;
 
 const DEPLOYMENT_SLOT: u64 = 0;
 const EXECUTION_SLOT: u64 = 5; // The execution slot must be greater than the deployment slot
 const EXECUTION_EPOCH: u64 = 2; // The execution epoch must be greater than the deployment epoch
+const LAMPORTS_PER_SIGNATURE: u64 = 5000;
 
-fn prepare_transactions(
-    mock_bank: &MockBankCallback,
-) -> (Vec<SanitizedTransaction>, Vec<TransactionCheckResult>) {
-    let mut transaction_builder = SanitizedTransactionBuilder::default();
-    let mut all_transactions = Vec::new();
-    let mut transaction_checks = Vec::new();
+pub type AccountMap = HashMap<Pubkey, AccountSharedData>;
 
-    // A transaction that works without any account
-    let hello_program = deploy_program("hello-solana".to_string(), DEPLOYMENT_SLOT, mock_bank);
-    let fee_payer = Pubkey::new_unique();
-    transaction_builder.create_instruction(hello_program, Vec::new(), HashMap::new(), Vec::new());
+// container for a transaction batch and all data needed to run and verify it against svm
+#[derive(Debug, Default)]
+pub struct SvmTestEntry {
+    // programs to deploy to the new svm before transaction execution
+    pub initial_programs: Vec<(String, Slot)>,
 
-    let sanitized_transaction =
-        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), false);
+    // accounts to deploy to the new svm before transaction execution
+    pub initial_accounts: AccountMap,
 
-    all_transactions.push(sanitized_transaction.unwrap());
-    transaction_checks.push(Ok(CheckedTransactionDetails {
-        nonce: None,
-        lamports_per_signature: 20,
-    }));
+    // transactions to execute and transaction-specific checks to perform on the results from svm
+    pub transaction_batch: Vec<TransactionBatchItem>,
 
-    // The transaction fee payer must have enough funds
-    let mut account_data = AccountSharedData::default();
-    account_data.set_lamports(80000);
-    mock_bank
-        .account_shared_data
-        .write()
-        .unwrap()
-        .insert(fee_payer, account_data);
-
-    // A simple funds transfer between accounts
-    let transfer_program_account =
-        deploy_program("simple-transfer".to_string(), DEPLOYMENT_SLOT, mock_bank);
-    let sender = Pubkey::new_unique();
-    let recipient = Pubkey::new_unique();
-    let fee_payer = Pubkey::new_unique();
-    let system_account = Pubkey::from([0u8; 32]);
-
-    transaction_builder.create_instruction(
-        transfer_program_account,
-        vec![
-            AccountMeta {
-                pubkey: sender,
-                is_signer: true,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: recipient,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: system_account,
-                is_signer: false,
-                is_writable: false,
-            },
-        ],
-        HashMap::from([(sender, Signature::new_unique())]),
-        vec![0, 0, 0, 0, 0, 0, 0, 10],
-    );
-
-    let sanitized_transaction =
-        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), true);
-    all_transactions.push(sanitized_transaction.unwrap());
-    transaction_checks.push(Ok(CheckedTransactionDetails {
-        nonce: None,
-        lamports_per_signature: 20,
-    }));
-
-    // Setting up the accounts for the transfer
-
-    // fee payer
-    let mut account_data = AccountSharedData::default();
-    account_data.set_lamports(80000);
-    mock_bank
-        .account_shared_data
-        .write()
-        .unwrap()
-        .insert(fee_payer, account_data);
-
-    // sender
-    let mut account_data = AccountSharedData::default();
-    account_data.set_lamports(900000);
-    mock_bank
-        .account_shared_data
-        .write()
-        .unwrap()
-        .insert(sender, account_data);
-
-    // recipient
-    let mut account_data = AccountSharedData::default();
-    account_data.set_lamports(900000);
-    mock_bank
-        .account_shared_data
-        .write()
-        .unwrap()
-        .insert(recipient, account_data);
-
-    // The system account is set in `create_executable_environment`
-
-    // A program that utilizes a Sysvar
-    let program_account = deploy_program("clock-sysvar".to_string(), DEPLOYMENT_SLOT, mock_bank);
-    let fee_payer = Pubkey::new_unique();
-    transaction_builder.create_instruction(program_account, Vec::new(), HashMap::new(), Vec::new());
-
-    let sanitized_transaction =
-        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), false);
-
-    all_transactions.push(sanitized_transaction.unwrap());
-    transaction_checks.push(Ok(CheckedTransactionDetails {
-        nonce: None,
-        lamports_per_signature: 20,
-    }));
-
-    let mut account_data = AccountSharedData::default();
-    account_data.set_lamports(80000);
-    mock_bank
-        .account_shared_data
-        .write()
-        .unwrap()
-        .insert(fee_payer, account_data);
-
-    // A transaction that fails
-    let sender = Pubkey::new_unique();
-    let recipient = Pubkey::new_unique();
-    let fee_payer = Pubkey::new_unique();
-    let system_account = Pubkey::new_from_array([0; 32]);
-    let data = 900050u64.to_be_bytes().to_vec();
-    transaction_builder.create_instruction(
-        transfer_program_account,
-        vec![
-            AccountMeta {
-                pubkey: sender,
-                is_signer: true,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: recipient,
-                is_signer: false,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: system_account,
-                is_signer: false,
-                is_writable: false,
-            },
-        ],
-        HashMap::from([(sender, Signature::new_unique())]),
-        data,
-    );
-
-    let sanitized_transaction =
-        transaction_builder.build(Hash::default(), (fee_payer, Signature::new_unique()), true);
-    all_transactions.push(sanitized_transaction.clone().unwrap());
-    transaction_checks.push(Ok(CheckedTransactionDetails {
-        nonce: None,
-        lamports_per_signature: 20,
-    }));
-
-    // fee payer
-    let mut account_data = AccountSharedData::default();
-    account_data.set_lamports(80000);
-    mock_bank
-        .account_shared_data
-        .write()
-        .unwrap()
-        .insert(fee_payer, account_data);
-
-    // Sender without enough funds
-    let mut account_data = AccountSharedData::default();
-    account_data.set_lamports(900000);
-    mock_bank
-        .account_shared_data
-        .write()
-        .unwrap()
-        .insert(sender, account_data);
-
-    // recipient
-    let mut account_data = AccountSharedData::default();
-    account_data.set_lamports(900000);
-    mock_bank
-        .account_shared_data
-        .write()
-        .unwrap()
-        .insert(recipient, account_data);
-
-    // A transaction whose verification has already failed
-    all_transactions.push(sanitized_transaction.unwrap());
-    transaction_checks.push(Err(TransactionError::BlockhashNotFound));
-
-    (all_transactions, transaction_checks)
+    // expected final account states, checked after transaction execution
+    pub final_accounts: AccountMap,
 }
 
-#[test]
-fn svm_integration() {
+impl SvmTestEntry {
+    // add a new a rent-exempt account that exists before the batch
+    // inserts it into both account maps, assuming it lives unchanged (except for svm fixing rent epoch)
+    // rent-paying accounts must be added by hand because svm will not set rent epoch to u64::MAX
+    pub fn add_initial_account(&mut self, pubkey: Pubkey, account: &AccountSharedData) {
+        assert!(self
+            .initial_accounts
+            .insert(pubkey, account.clone())
+            .is_none());
+
+        self.create_account(pubkey, account);
+    }
+
+    // add a new rent-exempt account that is created by the transaction
+    // inserts it only into the post account map
+    pub fn create_account(&mut self, pubkey: Pubkey, account: &AccountSharedData) {
+        let mut account = account.clone();
+        account.set_rent_epoch(u64::MAX);
+
+        assert!(self.final_accounts.insert(pubkey, account).is_none());
+    }
+
+    // edit an existing account to reflect changes you expect the transaction to make to it
+    pub fn update_account(&mut self, pubkey: Pubkey, account: &AccountSharedData) {
+        let mut account = account.clone();
+        account.set_rent_epoch(u64::MAX);
+
+        assert!(self.final_accounts.insert(pubkey, account).is_some());
+    }
+
+    // add lamports to an existing expected final account state
+    pub fn increase_expected_lamports(&mut self, pubkey: &Pubkey, lamports: u64) {
+        self.final_accounts
+            .get_mut(pubkey)
+            .unwrap()
+            .checked_add_lamports(lamports)
+            .unwrap();
+    }
+
+    // subtract lamports from an existing expected final account state
+    pub fn decrease_expected_lamports(&mut self, pubkey: &Pubkey, lamports: u64) {
+        self.final_accounts
+            .get_mut(pubkey)
+            .unwrap()
+            .checked_sub_lamports(lamports)
+            .unwrap();
+    }
+
+    // convenience function that adds a transaction that is expected to succeed
+    pub fn push_transaction(&mut self, transaction: Transaction) {
+        self.transaction_batch.push(TransactionBatchItem {
+            transaction,
+            ..TransactionBatchItem::default()
+        });
+    }
+
+    // convenience function that adds a transaction that is expected to execute but fail
+    pub fn push_failed_transaction(&mut self, transaction: Transaction) {
+        self.transaction_batch.push(TransactionBatchItem {
+            transaction,
+            asserts: TransactionBatchItemAsserts::failed(),
+            ..TransactionBatchItem::default()
+        });
+    }
+
+    // internal helper to gather SanitizedTransaction objects for execution
+    fn prepare_transactions(&self) -> (Vec<SanitizedTransaction>, Vec<TransactionCheckResult>) {
+        self.transaction_batch
+            .iter()
+            .cloned()
+            .map(|item| {
+                (
+                    SanitizedTransaction::from_transaction_for_tests(item.transaction),
+                    item.check_result,
+                )
+            })
+            .unzip()
+    }
+
+    // internal helper to gather test items for post-execution checks
+    fn asserts(&self) -> Vec<TransactionBatchItemAsserts> {
+        self.transaction_batch
+            .iter()
+            .cloned()
+            .map(|item| item.asserts)
+            .collect()
+    }
+}
+
+// one transaction in a batch plus check results for svm and asserts for tests
+#[derive(Clone, Debug)]
+pub struct TransactionBatchItem {
+    pub transaction: Transaction,
+    pub check_result: TransactionCheckResult,
+    pub asserts: TransactionBatchItemAsserts,
+}
+
+impl Default for TransactionBatchItem {
+    fn default() -> Self {
+        Self {
+            transaction: Transaction::default(),
+            check_result: Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: LAMPORTS_PER_SIGNATURE,
+            }),
+            asserts: TransactionBatchItemAsserts::succeeded(),
+        }
+    }
+}
+
+// asserts for a given transaction in a batch
+// we can automatically check whether it executed, whether it succeeded
+// log items we expect to see (exect match only), and rodata
+// rodata is a doubly-nested Option. None means no check is performed, Some(None) means we assert no rodata
+#[derive(Clone, Debug)]
+pub struct TransactionBatchItemAsserts {
+    pub executed: bool,
+    pub succeeded: bool,
+    pub logs: Vec<String>,
+    pub return_data: ReturnDataAssert,
+}
+
+impl TransactionBatchItemAsserts {
+    pub fn succeeded() -> Self {
+        Self {
+            executed: true,
+            succeeded: true,
+            logs: vec![],
+            return_data: ReturnDataAssert::Skip,
+        }
+    }
+
+    pub fn failed() -> Self {
+        Self {
+            executed: true,
+            succeeded: false,
+            logs: vec![],
+            return_data: ReturnDataAssert::Skip,
+        }
+    }
+
+    pub fn not_executed() -> Self {
+        Self {
+            executed: false,
+            succeeded: false,
+            logs: vec![],
+            return_data: ReturnDataAssert::Skip,
+        }
+    }
+
+    pub fn check_executed_transaction(&self, execution_details: &TransactionExecutionDetails) {
+        assert!(self.executed);
+        assert_eq!(self.succeeded, execution_details.status.is_ok());
+
+        if !self.logs.is_empty() {
+            let actual_logs = execution_details.log_messages.as_ref().unwrap();
+            for expected_log in &self.logs {
+                assert!(actual_logs.contains(expected_log));
+            }
+        }
+
+        match (&self.return_data, &execution_details.return_data) {
+            (ReturnDataAssert::Some(expected_ro_data), Some(actual_ro_data)) => {
+                assert_eq!(expected_ro_data, actual_ro_data)
+            }
+            (ReturnDataAssert::None, None) => {}
+            (ReturnDataAssert::Skip, _) => {}
+            (left, right) => panic!(
+                "assertion `left == right` failed\n  {:?}\n  {:?}",
+                left, right
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub enum ReturnDataAssert {
+    Some(TransactionReturnData),
+    None,
+    #[default]
+    Skip,
+}
+
+fn program_medley() -> Vec<SvmTestEntry> {
+    let mut test_entry = SvmTestEntry::default();
+
+    // 0: A transaction that works without any account
+    {
+        let program_name = "hello-solana".to_string();
+        let program_id = program_address(&program_name);
+        test_entry
+            .initial_programs
+            .push((program_name, DEPLOYMENT_SLOT));
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
+        test_entry.push_transaction(Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            Hash::default(),
+        ));
+
+        test_entry.transaction_batch[0]
+            .asserts
+            .logs
+            .push("Program log: Hello, Solana!".to_string());
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+    }
+
+    // 1: A simple funds transfer between accounts
+    {
+        let program_name = "simple-transfer".to_string();
+        let program_id = program_address(&program_name);
+        test_entry
+            .initial_programs
+            .push((program_name, DEPLOYMENT_SLOT));
+
+        let fee_payer_keypair = Keypair::new();
+        let sender_keypair = Keypair::new();
+
+        let fee_payer = fee_payer_keypair.pubkey();
+        let sender = sender_keypair.pubkey();
+        let recipient = Pubkey::new_unique();
+
+        let transfer_amount = 10;
+
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let mut sender_data = AccountSharedData::default();
+        sender_data.set_lamports(LAMPORTS_PER_SOL);
+        test_entry.add_initial_account(sender, &sender_data);
+
+        let mut recipient_data = AccountSharedData::default();
+        recipient_data.set_lamports(LAMPORTS_PER_SOL);
+        test_entry.add_initial_account(recipient, &recipient_data);
+
+        let instruction = Instruction::new_with_bytes(
+            program_id,
+            &u64::to_be_bytes(transfer_amount),
+            vec![
+                AccountMeta::new(sender, true),
+                AccountMeta::new(recipient, false),
+                AccountMeta::new_readonly(system_program::id(), false),
+            ],
+        );
+
+        test_entry.push_transaction(Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&fee_payer),
+            &[&fee_payer_keypair, &sender_keypair],
+            Hash::default(),
+        ));
+
+        test_entry.increase_expected_lamports(&recipient, transfer_amount);
+        test_entry.decrease_expected_lamports(&sender, transfer_amount);
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE * 2);
+    }
+
+    // 2: A program that utilizes a Sysvar
+    {
+        let program_name = "clock-sysvar".to_string();
+        let program_id = program_address(&program_name);
+        test_entry
+            .initial_programs
+            .push((program_name, DEPLOYMENT_SLOT));
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
+        test_entry.push_transaction(Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            Hash::default(),
+        ));
+
+        let ro_data = TransactionReturnData {
+            program_id,
+            data: i64::to_be_bytes(WALLCLOCK_TIME).to_vec(),
+        };
+        test_entry.transaction_batch[2].asserts.return_data = ReturnDataAssert::Some(ro_data);
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+    }
+
+    // 3: A transaction that fails
+    {
+        let program_id = program_address("simple-transfer");
+
+        let fee_payer_keypair = Keypair::new();
+        let sender_keypair = Keypair::new();
+
+        let fee_payer = fee_payer_keypair.pubkey();
+        let sender = sender_keypair.pubkey();
+        let recipient = Pubkey::new_unique();
+
+        let base_amount = 900_000;
+        let transfer_amount = base_amount + 50;
+
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let mut sender_data = AccountSharedData::default();
+        sender_data.set_lamports(base_amount);
+        test_entry.add_initial_account(sender, &sender_data);
+
+        let mut recipient_data = AccountSharedData::default();
+        recipient_data.set_lamports(base_amount);
+        test_entry.add_initial_account(recipient, &recipient_data);
+
+        let instruction = Instruction::new_with_bytes(
+            program_id,
+            &u64::to_be_bytes(transfer_amount),
+            vec![
+                AccountMeta::new(sender, true),
+                AccountMeta::new(recipient, false),
+                AccountMeta::new_readonly(system_program::id(), false),
+            ],
+        );
+
+        test_entry.push_failed_transaction(Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&fee_payer),
+            &[&fee_payer_keypair, &sender_keypair],
+            Hash::default(),
+        ));
+
+        test_entry.transaction_batch[3]
+            .asserts
+            .logs
+            .push("Transfer: insufficient lamports 900000, need 900050".to_string());
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE * 2);
+    }
+
+    // 4: A transaction whose verification has already failed
+    {
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+
+        test_entry.transaction_batch.push(TransactionBatchItem {
+            transaction: Transaction::new_signed_with_payer(
+                &[],
+                Some(&fee_payer),
+                &[&fee_payer_keypair],
+                Hash::default(),
+            ),
+            check_result: Err(TransactionError::BlockhashNotFound),
+            asserts: TransactionBatchItemAsserts::not_executed(),
+        });
+    }
+
+    vec![test_entry]
+}
+
+fn simple_transfer() -> Vec<SvmTestEntry> {
+    let mut test_entry = SvmTestEntry::default();
+    let transfer_amount = LAMPORTS_PER_SOL;
+
+    // 0: a transfer that succeeds
+    {
+        let source_keypair = Keypair::new();
+        let source = source_keypair.pubkey();
+        let destination = Pubkey::new_unique();
+
+        let mut source_data = AccountSharedData::default();
+        let mut destination_data = AccountSharedData::default();
+
+        source_data.set_lamports(LAMPORTS_PER_SOL * 10);
+        test_entry.add_initial_account(source, &source_data);
+
+        test_entry.push_transaction(system_transaction::transfer(
+            &source_keypair,
+            &destination,
+            transfer_amount,
+            Hash::default(),
+        ));
+
+        destination_data
+            .checked_add_lamports(transfer_amount)
+            .unwrap();
+        test_entry.create_account(destination, &destination_data);
+
+        test_entry.decrease_expected_lamports(&source, transfer_amount + LAMPORTS_PER_SIGNATURE);
+    }
+
+    // 1: an executable transfer that fails
+    {
+        let source_keypair = Keypair::new();
+        let source = source_keypair.pubkey();
+
+        let mut source_data = AccountSharedData::default();
+
+        source_data.set_lamports(transfer_amount - 1);
+        test_entry.add_initial_account(source, &source_data);
+
+        test_entry.push_failed_transaction(system_transaction::transfer(
+            &source_keypair,
+            &Pubkey::new_unique(),
+            transfer_amount,
+            Hash::default(),
+        ));
+
+        test_entry.decrease_expected_lamports(&source, LAMPORTS_PER_SIGNATURE);
+    }
+
+    // 2: a non-executable transfer that fails before loading
+    {
+        test_entry.transaction_batch.push(TransactionBatchItem {
+            transaction: system_transaction::transfer(
+                &Keypair::new(),
+                &Pubkey::new_unique(),
+                transfer_amount,
+                Hash::default(),
+            ),
+            check_result: Err(TransactionError::BlockhashNotFound),
+            asserts: TransactionBatchItemAsserts::not_executed(),
+        });
+    }
+
+    // 3: a non-executable transfer that fails during loading
+    {
+        test_entry.transaction_batch.push(TransactionBatchItem {
+            transaction: system_transaction::transfer(
+                &Keypair::new(),
+                &Pubkey::new_unique(),
+                transfer_amount,
+                Hash::default(),
+            ),
+            asserts: TransactionBatchItemAsserts::not_executed(),
+            ..TransactionBatchItem::default()
+        });
+    }
+
+    vec![test_entry]
+}
+
+#[test_case(program_medley())]
+#[test_case(simple_transfer())]
+fn svm_integration(test_entries: Vec<SvmTestEntry>) {
+    for test_entry in test_entries {
+        execute_test_entry(test_entry);
+    }
+}
+
+fn execute_test_entry(test_entry: SvmTestEntry) {
     let mock_bank = MockBankCallback::default();
-    let (transactions, check_results) = prepare_transactions(&mock_bank);
+
+    for (name, slot) in &test_entry.initial_programs {
+        deploy_program(name.to_string(), *slot, &mock_bank);
+    }
+
+    for (pubkey, account) in &test_entry.initial_accounts {
+        mock_bank
+            .account_shared_data
+            .write()
+            .unwrap()
+            .insert(*pubkey, account.clone());
+    }
+
     let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(
         EXECUTION_SLOT,
         EXECUTION_EPOCH,
@@ -263,7 +561,9 @@ fn svm_integration() {
         ..Default::default()
     };
 
-    let result = batch_processor.load_and_execute_sanitized_transactions(
+    // execute transaction batch
+    let (transactions, check_results) = test_entry.prepare_transactions();
+    let batch_output = batch_processor.load_and_execute_sanitized_transactions(
         &mock_bank,
         &transactions,
         check_results,
@@ -271,68 +571,47 @@ fn svm_integration() {
         &processing_config,
     );
 
-    assert_eq!(result.processing_results.len(), 5);
-
-    let executed_tx_0 = result.processing_results[0]
-        .processed_transaction()
-        .unwrap()
-        .executed_transaction()
-        .unwrap();
-    assert!(executed_tx_0.was_successful());
-    let logs = executed_tx_0
-        .execution_details
-        .log_messages
-        .as_ref()
-        .unwrap();
-    assert!(logs.contains(&"Program log: Hello, Solana!".to_string()));
-
-    let executed_tx_1 = result.processing_results[1]
-        .processed_transaction()
-        .unwrap()
-        .executed_transaction()
-        .unwrap();
-    assert!(executed_tx_1.was_successful());
-
-    // The SVM does not commit the account changes in MockBank
-    let recipient_key = transactions[1].message().account_keys()[2];
-    let recipient_data = executed_tx_1
-        .loaded_transaction
-        .accounts
+    // build a hashmap of final account states incrementally
+    // NOTE with SIMD-83 an account may appear multiple times, thus we need the final state
+    let mut final_accounts_actual = AccountMap::default();
+    for processed_transaction in batch_output
+        .processing_results
         .iter()
-        .find(|key| key.0 == recipient_key)
-        .unwrap();
-    assert_eq!(recipient_data.1.lamports(), 900010);
+        .filter_map(|r| r.as_ref().ok())
+    {
+        match processed_transaction {
+            ProcessedTransaction::Executed(executed_transaction) => {
+                for (pubkey, account_data) in
+                    executed_transaction.loaded_transaction.accounts.clone()
+                {
+                    final_accounts_actual.insert(pubkey, account_data);
+                }
+            }
+            // NOTE this is a possible state with `feature_set::enable_transaction_loading_failure_fees` enabled
+            // by using `TransactionProcessingEnvironment::default()` we have all features disabled
+            // in other words, this will be unreachable until we are ready to test fee-only transactions
+            // (or the feature is activated on mainnet and removed... but we should do it before then!)
+            ProcessedTransaction::FeesOnly(_) => unreachable!(),
+        }
+    }
 
-    let executed_tx_2 = result.processing_results[2]
-        .processed_transaction()
-        .unwrap()
-        .executed_transaction()
-        .unwrap();
-    let return_data = executed_tx_2
-        .execution_details
-        .return_data
-        .as_ref()
-        .unwrap();
-    let time = i64::from_be_bytes(return_data.data[0..8].try_into().unwrap());
-    let clock_data = mock_bank.get_account_shared_data(&Clock::id()).unwrap();
-    let clock_info: Clock = bincode::deserialize(clock_data.data()).unwrap();
-    assert_eq!(clock_info.unix_timestamp, time);
+    // check that all the account states we care about are present and correct
+    for (pubkey, expected_account_data) in test_entry.final_accounts.iter() {
+        let actual_account_data = final_accounts_actual.get(pubkey);
+        assert_eq!(Some(expected_account_data), actual_account_data);
+    }
 
-    let executed_tx_3 = result.processing_results[3]
-        .processed_transaction()
-        .unwrap()
-        .executed_transaction()
-        .unwrap();
-    assert!(executed_tx_3.execution_details.status.is_err());
-    assert!(executed_tx_3
-        .execution_details
-        .log_messages
-        .as_ref()
-        .unwrap()
-        .contains(&"Transfer: insufficient lamports 900000, need 900050".to_string()));
-
-    assert!(matches!(
-        result.processing_results[4],
-        Err(TransactionError::BlockhashNotFound)
-    ));
+    // now run our transaction-by-transaction checks
+    for (processing_result, test_item_asserts) in batch_output
+        .processing_results
+        .iter()
+        .zip(test_entry.asserts())
+    {
+        match processing_result {
+            Ok(ProcessedTransaction::Executed(executed_transaction)) => test_item_asserts
+                .check_executed_transaction(&executed_transaction.execution_details),
+            Ok(ProcessedTransaction::FeesOnly(_)) => unreachable!(),
+            Err(_) => assert!(!test_item_asserts.executed),
+        }
+    }
 }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -68,12 +68,12 @@ impl SvmTestEntry {
             .insert(pubkey, account.clone())
             .is_none());
 
-        self.create_account(pubkey, account);
+        self.create_expected_account(pubkey, account);
     }
 
     // add a new rent-exempt account that is created by the transaction
     // inserts it only into the post account map
-    pub fn create_account(&mut self, pubkey: Pubkey, account: &AccountSharedData) {
+    pub fn create_expected_account(&mut self, pubkey: Pubkey, account: &AccountSharedData) {
         let mut account = account.clone();
         account.set_rent_epoch(u64::MAX);
 
@@ -458,7 +458,7 @@ fn simple_transfer() -> Vec<SvmTestEntry> {
         destination_data
             .checked_add_lamports(transfer_amount)
             .unwrap();
-        test_entry.create_account(destination, &destination_data);
+        test_entry.create_expected_account(destination, &destination_data);
 
         test_entry.decrease_expected_lamports(&source, transfer_amount + LAMPORTS_PER_SIGNATURE);
     }

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -35,9 +35,10 @@ use {
         env,
         fs::{self, File},
         io::Read,
-        time::{SystemTime, UNIX_EPOCH},
     },
 };
+
+pub const WALLCLOCK_TIME: i64 = 1704067200; // Arbitrarily Jan 1, 2024
 
 pub struct MockForkGraph {}
 
@@ -116,9 +117,15 @@ fn load_program(name: String) -> Vec<u8> {
 }
 
 #[allow(unused)]
+pub fn program_address(program_name: &str) -> Pubkey {
+    Pubkey::create_with_seed(&Pubkey::default(), program_name, &Pubkey::default()).unwrap()
+}
+
+#[allow(unused)]
 pub fn deploy_program(name: String, deployment_slot: Slot, mock_bank: &MockBankCallback) -> Pubkey {
-    let program_account = Pubkey::new_unique();
-    let program_data_account = Pubkey::new_unique();
+    let program_account = program_address(&name);
+    let program_data_account = bpf_loader_upgradeable::get_program_data_address(&program_account);
+
     let state = UpgradeableLoaderState::Program {
         programdata_address: program_data_account,
     };
@@ -128,6 +135,7 @@ pub fn deploy_program(name: String, deployment_slot: Slot, mock_bank: &MockBankC
     account_data.set_data(bincode::serialize(&state).unwrap());
     account_data.set_lamports(25);
     account_data.set_owner(bpf_loader_upgradeable::id());
+    account_data.set_executable(true);
     mock_bank
         .account_shared_data
         .write()
@@ -181,16 +189,12 @@ pub fn create_executable_environment(
     program_cache.fork_graph = Some(Arc::downgrade(&fork_graph));
 
     // We must fill in the sysvar cache entries
-    let time_now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_secs() as i64;
     let clock = Clock {
         slot: DEPLOYMENT_SLOT,
-        epoch_start_timestamp: time_now.saturating_sub(10) as UnixTimestamp,
+        epoch_start_timestamp: WALLCLOCK_TIME.saturating_sub(10) as UnixTimestamp,
         epoch: DEPLOYMENT_EPOCH,
         leader_schedule_epoch: DEPLOYMENT_EPOCH,
-        unix_timestamp: time_now as UnixTimestamp,
+        unix_timestamp: WALLCLOCK_TIME as UnixTimestamp,
     };
 
     let mut account_data = AccountSharedData::default();


### PR DESCRIPTION
#### Problem
transaction loading is a part of the code with poor test coverage. this has recently become (more) problematic for two reasons:
* for SIMD83 (removal of entry-level constraints) we need to change how transaction loading works, and the new behavior will need appreciably more test coverage
* transaction loading is currently unspecified and has several "surprising edge cases" especially when it comes to unintended behaviors of the program cache. we want to fix and specify the exact conditions under which a transaction should or should not be executed. this is of particular concern for when we need to maintain consensus with firedancer

#### Summary of Changes
using the code in `integration_test.rs` as a basis, i abstracted out a basic framework for doing arbitrary integration tests starting at the transaction processor `load_and_execute_sanitized_transactions` entrypoint. `program_medley()` is largely identical to the previous tests (some numbers changed for convenience) including checking logs and return data. `simple_transfer()` is a simple example of how to add more tests that go through this

one thing im not sure about (other than names of some things, in particulat `TestData` is bad) is if this can easily be further abstracted to also support testing from the `bank.rs` `load_execute_and_commit_transactions` or `load_and_execute_transactions` level. however maybe we dont want to abstract this further and just want two different systems. basically we want to also be able to test locks with batches of transactions