### PR TITLE
Update SVM docs

### DIFF
--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -139,28 +139,25 @@ pub trait TransactionProcessingCallback {
 Consumers can customize this plug-in to use their own Solana account source,
 caching, and more.
 
-### `SanitizedTransaction`
+### `SVMTransaction`
 
-A "sanitized" Solana transaction is a transaction that has undergone the
+An SVM transaction is a transaction that has undergone the
 various checks required to evaluate a transaction against the Solana protocol
 ruleset. Some of these rules include signature verification and validation
 of account indices (`num_readonly_signers`, etc.).
 
-A `SanitizedTransaction` contains:
+A `SVMTransaction` is a trait that can access:
 
-- `SanitizedMessage`: Enum with two kinds of messages - `LegacyMessage` and
-  `LoadedMessage` - both of which contain:
-    - `MessageHeader`: Vector of `Pubkey` of accounts used in the transaction.
-    - `Hash` of recent block.
-    - Vector of `CompiledInstruction`.
-    - In addition, `LoadedMessage` contains a vector of
-      `MessageAddressTableLookup` - list of address table lookups to
-      load additional accounts for this transaction.
-- A Hash of the message
-- A boolean flag `is_simple_vote_tx` - shortcut for determining if the
-  transaction is merely a simple vote transaction produced by a validator.
-- A vector of `Signature` - the hash of the transaction message encrypted using
+- `signatures`: the hash of the transaction message encrypted using
   the signing key (for each signer in the transaction).
+- `static_account_keys`: Slice of `Pubkey` of accounts used in the transaction.
+- `account_keys`: Pubkeys of all accounts used in the transaction, including
+  those from address table lookups.
+- `recent_blockhash`: Hash of a recent block.
+- `instructions_iter`: An iterator over the transaction's instructions.
+- `message_address_table_lookups`: An iterator over the transaction's
+  address table lookups. These are only used in V0 transactions, for legacy
+  transactions the iterator is empty.
 
 ### `TransactionCheckResult`
 
@@ -245,10 +242,10 @@ Steps of `load_and_execute_sanitized_transactions`
         - Return the replenished local program cache.
 
 2. Load accounts (call to `load_accounts` function)
-   - For each `SanitizedTransaction` and `TransactionCheckResult`, we:
+   - For each `SVMTransaction` and `TransactionCheckResult`, we:
         - Calculate the number of signatures in transaction and its cost.
         - Call `load_transaction_accounts`
-            - The function is interwined with the struct `CompiledInstruction`
+            - The function is interwined with the struct `SVMInstruction`
             - Load accounts from accounts DB
             - Extract data from accounts
             - Verify if we've reached the maximum account data size


### PR DESCRIPTION
#### Problem
- in #2111 SVM's main entrypoint became abstracted over the `SVMTransaction` trait rather than `SanitizedTransaction`
- The spec/docs are now out of date with this change

#### Summary of Changes
- Update `spec.md` to reflect the new interface

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
