### PR TITLE
CI: Disable downstream anchor builds

### DIFF
--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -42,6 +42,7 @@ jobs:
     strategy:
       matrix:
         version: ["master"]
+    if: false # Re-enable once new major versions for spl-token-2022 and spl-pod are out
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
#### Problem

With https://github.com/solana-labs/solana-program-library/pull/7148, spl-token-2022 has moved from using solana-zk-token-sdk to solana-zk-sdk, which is a major breaking change. Certain agave and anchor crates are depending on the re-export solana-zk-token-sdk in spl-token-2022, which is no longer present. This change is causing the downstream Anchor job to fail, since the patched version of spl-token-2022 is no longer compatible.

#### Summary of changes

Until new major versions of the SPL crates are available used by the Agave monorepo, disable the downstream anchor job.