### PR TITLE
SVM: Hoist transaction error metrics reporting to banking stage

### DIFF
--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -398,6 +398,98 @@ impl LeaderSlotPacketCountMetrics {
     }
 }
 
+fn report_transaction_error_metrics(errors: &TransactionErrorMetrics, id: &str, slot: Slot) {
+    datapoint_info!(
+        "banking_stage-leader_slot_transaction_errors",
+        "id" => id,
+        ("slot", slot as i64, i64),
+        ("total", errors.total as i64, i64),
+        ("account_in_use", errors.account_in_use as i64, i64),
+        (
+            "too_many_account_locks",
+            errors.too_many_account_locks as i64,
+            i64
+        ),
+        (
+            "account_loaded_twice",
+            errors.account_loaded_twice as i64,
+            i64
+        ),
+        ("account_not_found", errors.account_not_found as i64, i64),
+        ("blockhash_not_found", errors.blockhash_not_found as i64, i64),
+        ("blockhash_too_old", errors.blockhash_too_old as i64, i64),
+        ("call_chain_too_deep", errors.call_chain_too_deep as i64, i64),
+        ("already_processed", errors.already_processed as i64, i64),
+        ("instruction_error", errors.instruction_error as i64, i64),
+        ("insufficient_funds", errors.insufficient_funds as i64, i64),
+        (
+            "invalid_account_for_fee",
+            errors.invalid_account_for_fee as i64,
+            i64
+        ),
+        (
+            "invalid_account_index",
+            errors.invalid_account_index as i64,
+            i64
+        ),
+        (
+            "invalid_program_for_execution",
+            errors.invalid_program_for_execution as i64,
+            i64
+        ),
+        (
+            "invalid_compute_budget",
+            errors.invalid_compute_budget as i64,
+            i64
+        ),
+        (
+            "not_allowed_during_cluster_maintenance",
+            errors.not_allowed_during_cluster_maintenance as i64,
+            i64
+        ),
+        (
+            "invalid_writable_account",
+            errors.invalid_writable_account as i64,
+            i64
+        ),
+        (
+            "invalid_rent_paying_account",
+            errors.invalid_rent_paying_account as i64,
+            i64
+        ),
+        (
+            "would_exceed_max_block_cost_limit",
+            errors.would_exceed_max_block_cost_limit as i64,
+            i64
+        ),
+        (
+            "would_exceed_max_account_cost_limit",
+            errors.would_exceed_max_account_cost_limit as i64,
+            i64
+        ),
+        (
+            "would_exceed_max_vote_cost_limit",
+            errors.would_exceed_max_vote_cost_limit as i64,
+            i64
+        ),
+        (
+            "would_exceed_account_data_block_limit",
+            errors.would_exceed_account_data_block_limit as i64,
+            i64
+        ),
+        (
+            "max_loaded_accounts_data_size_exceeded",
+            errors.max_loaded_accounts_data_size_exceeded as i64,
+            i64
+        ),
+        (
+            "program_execution_temporarily_restricted",
+            errors.program_execution_temporarily_restricted as i64,
+            i64
+        ),
+    );
+}
+
 #[derive(Debug)]
 pub(crate) struct LeaderSlotMetrics {
     // banking_stage creates one QosService instance per working threads, that is uniquely
@@ -447,7 +539,7 @@ impl LeaderSlotMetrics {
         self.is_reported = true;
 
         self.timing_metrics.report(&self.id, self.slot);
-        self.transaction_error_metrics.report(&self.id, self.slot);
+        report_transaction_error_metrics(&self.transaction_error_metrics, &self.id, self.slot);
         self.packet_count_metrics.report(&self.id, self.slot);
         self.vote_packet_count_metrics.report(&self.id, self.slot);
         self.prioritization_fees_metric.report(&self.id, self.slot);

--- a/svm/src/transaction_error_metrics.rs
+++ b/svm/src/transaction_error_metrics.rs
@@ -1,4 +1,4 @@
-use solana_sdk::{clock::Slot, saturating_add_assign};
+use solana_sdk::saturating_add_assign;
 
 #[derive(Debug, Default)]
 pub struct TransactionErrorMetrics {
@@ -87,98 +87,6 @@ impl TransactionErrorMetrics {
         saturating_add_assign!(
             self.program_execution_temporarily_restricted,
             other.program_execution_temporarily_restricted
-        );
-    }
-
-    pub fn report(&self, id: &str, slot: Slot) {
-        datapoint_info!(
-            "banking_stage-leader_slot_transaction_errors",
-            "id" => id,
-            ("slot", slot as i64, i64),
-            ("total", self.total as i64, i64),
-            ("account_in_use", self.account_in_use as i64, i64),
-            (
-                "too_many_account_locks",
-                self.too_many_account_locks as i64,
-                i64
-            ),
-            (
-                "account_loaded_twice",
-                self.account_loaded_twice as i64,
-                i64
-            ),
-            ("account_not_found", self.account_not_found as i64, i64),
-            ("blockhash_not_found", self.blockhash_not_found as i64, i64),
-            ("blockhash_too_old", self.blockhash_too_old as i64, i64),
-            ("call_chain_too_deep", self.call_chain_too_deep as i64, i64),
-            ("already_processed", self.already_processed as i64, i64),
-            ("instruction_error", self.instruction_error as i64, i64),
-            ("insufficient_funds", self.insufficient_funds as i64, i64),
-            (
-                "invalid_account_for_fee",
-                self.invalid_account_for_fee as i64,
-                i64
-            ),
-            (
-                "invalid_account_index",
-                self.invalid_account_index as i64,
-                i64
-            ),
-            (
-                "invalid_program_for_execution",
-                self.invalid_program_for_execution as i64,
-                i64
-            ),
-            (
-                "invalid_compute_budget",
-                self.invalid_compute_budget as i64,
-                i64
-            ),
-            (
-                "not_allowed_during_cluster_maintenance",
-                self.not_allowed_during_cluster_maintenance as i64,
-                i64
-            ),
-            (
-                "invalid_writable_account",
-                self.invalid_writable_account as i64,
-                i64
-            ),
-            (
-                "invalid_rent_paying_account",
-                self.invalid_rent_paying_account as i64,
-                i64
-            ),
-            (
-                "would_exceed_max_block_cost_limit",
-                self.would_exceed_max_block_cost_limit as i64,
-                i64
-            ),
-            (
-                "would_exceed_max_account_cost_limit",
-                self.would_exceed_max_account_cost_limit as i64,
-                i64
-            ),
-            (
-                "would_exceed_max_vote_cost_limit",
-                self.would_exceed_max_vote_cost_limit as i64,
-                i64
-            ),
-            (
-                "would_exceed_account_data_block_limit",
-                self.would_exceed_account_data_block_limit as i64,
-                i64
-            ),
-            (
-                "max_loaded_accounts_data_size_exceeded",
-                self.max_loaded_accounts_data_size_exceeded as i64,
-                i64
-            ),
-            (
-                "program_execution_temporarily_restricted",
-                self.program_execution_temporarily_restricted as i64,
-                i64
-            ),
         );
     }
 }


### PR DESCRIPTION
#### Problem

The goal is to eliminate the SVM's dependency on the `solana-metrics` crate. 
This is change 1 of 2 to achieve this goal.

The `TransactionErrorMetrics` struct has a method that allows callers to submit 
these metrics via `solana_metrics::datapoint_info!`. If this method was not 
defined on the struct itself, but instead defined elsewhere, we could elminate 
the dependecy on `solana-metrics` for this type.

#### Summary of Changes

Add a free function to `banking_stage` that specifically submits transaction 
error metrics. This is the only callsite in the validator where we submit these 
metrics, and the module (`leader_slot_metrics`) is entirely metrics-oriented, so 
it makes sense for any additional configurations for submitting metrics to live 
here.

The use of a free function in leader slot metrics eliminates the need for this 
function to exist as a method on `TransactionErrorMetrics`, so the method is 
removed.