### PR TITLE
blockstore: store merkle root duplicate proofs immediately on detection

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -166,21 +166,8 @@ fn run_check_duplicate(
         );
         let (shred1, shred2) = match shred {
             PossibleDuplicateShred::LastIndexConflict(shred, conflict)
-            | PossibleDuplicateShred::ErasureConflict(shred, conflict) => (shred, conflict),
-            PossibleDuplicateShred::MerkleRootConflict(shred, conflict) => {
-                // Although this proof can be immediately stored on detection, we wait until
-                // here in order to check the feature flag, as storage in blockstore can
-                // preclude the detection of other duplicate proofs in this slot
-                if blockstore.has_duplicate_shreds_in_slot(shred_slot) {
-                    return Ok(());
-                }
-                blockstore.store_duplicate_slot(
-                    shred_slot,
-                    conflict.clone(),
-                    shred.clone().into_payload(),
-                )?;
-                (shred, conflict)
-            }
+            | PossibleDuplicateShred::ErasureConflict(shred, conflict)
+            | PossibleDuplicateShred::MerkleRootConflict(shred, conflict) => (shred, conflict),
             PossibleDuplicateShred::ChainedMerkleRootConflict(shred, conflict) => {
                 if chained_merkle_conflict_duplicate_proofs {
                     // Although this proof can be immediately stored on detection, we wait until

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1811,6 +1811,17 @@ impl Blockstore {
                 );
                 return true;
             };
+            if let Err(e) = self.store_duplicate_slot(
+                slot,
+                conflicting_shred.clone(),
+                shred.clone().into_payload(),
+            ) {
+                warn!(
+                    "Unable to store conflicting merkle root duplicate proof for {slot} \
+                     {:?} {e}",
+                    shred.erasure_set(),
+                );
+            }
             duplicate_shreds.push(PossibleDuplicateShred::MerkleRootConflict(
                 shred.clone(),
                 conflicting_shred,


### PR DESCRIPTION
#### Problem
Previously we did not store merkle root duplicate proofs immediately on detection, as we are unsure if the feature flag is yet active. Storing the duplicate proof would preclude any other duplicate proof from being stored, however if the feature flag was not active this duplicate proof would not have been gossip or acted on by the state machine.

#### Summary of Changes
Now that the feature flag is active, we can immediately store the duplicate proof on receival, saving us from checking the slot again for duplicates. 
