### PR TITLE
TransactionView: Address Table Lookup Iterator

### DIFF
--- a/transaction-view/src/address_table_lookup_meta.rs
+++ b/transaction-view/src/address_table_lookup_meta.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         bytes::{
             advance_offset_for_array, advance_offset_for_type, check_remaining,
-            optimized_read_compressed_u16, read_array, read_byte, read_type,
+            optimized_read_compressed_u16, read_slice_data, read_byte, read_type,
         },
         result::Result,
     },
@@ -128,13 +128,13 @@ impl<'a> Iterator for AddressTableLookupIterator<'a> {
             let num_write_accounts =
                 optimized_read_compressed_u16(self.bytes, &mut self.offset).ok()?;
             let writable_indexes =
-                read_array::<u8>(self.bytes, &mut self.offset, num_write_accounts).ok()?;
+                read_slice_data::<u8>(self.bytes, &mut self.offset, num_write_accounts).ok()?;
 
             // Read the number of read indexes, and then update the offset.
             let num_read_accounts =
                 optimized_read_compressed_u16(self.bytes, &mut self.offset).ok()?;
             let readonly_indexes =
-                read_array::<u8>(self.bytes, &mut self.offset, num_read_accounts).ok()?;
+                read_slice_data::<u8>(self.bytes, &mut self.offset, num_read_accounts).ok()?;
 
             Some(SVMMessageAddressTableLookup {
                 account_key,

--- a/transaction-view/src/address_table_lookup_meta.rs
+++ b/transaction-view/src/address_table_lookup_meta.rs
@@ -116,6 +116,8 @@ impl<'a> Iterator for AddressTableLookupIterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.index < self.num_address_table_lookup {
+            self.index = self.index.wrapping_add(1);
+
             // Each ATL has 3 pieces:
             // 1. Address (Pubkey)
             // 2. write indexes ([u8])

--- a/transaction-view/src/address_table_lookup_meta.rs
+++ b/transaction-view/src/address_table_lookup_meta.rs
@@ -47,7 +47,7 @@ const MAX_ATLS_PER_PACKET: usize = (PACKET_DATA_SIZE - MIN_SIZED_PACKET_WITH_ATL
 /// Contains metadata about the address table lookups in a transaction packet.
 pub struct AddressTableLookupMeta {
     /// The number of address table lookups in the transaction.
-    pub(crate) num_address_table_lookup: u8,
+    pub(crate) num_address_table_lookups: u8,
     /// The offset to the first address table lookup in the transaction.
     pub(crate) offset: u16,
 }
@@ -98,7 +98,7 @@ impl AddressTableLookupMeta {
         }
 
         Ok(Self {
-            num_address_table_lookup: num_address_table_lookups,
+            num_address_table_lookups,
             offset: address_table_lookups_offset,
         })
     }
@@ -107,7 +107,7 @@ impl AddressTableLookupMeta {
 pub struct AddressTableLookupIterator<'a> {
     pub(crate) bytes: &'a [u8],
     pub(crate) offset: usize,
-    pub(crate) num_address_table_lookup: u8,
+    pub(crate) num_address_table_lookups: u8,
     pub(crate) index: u8,
 }
 
@@ -115,7 +115,7 @@ impl<'a> Iterator for AddressTableLookupIterator<'a> {
     type Item = SVMMessageAddressTableLookup<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.index < self.num_address_table_lookup {
+        if self.index < self.num_address_table_lookups {
             self.index = self.index.wrapping_add(1);
 
             // Each ATL has 3 pieces:
@@ -172,7 +172,7 @@ impl<'a> Iterator for AddressTableLookupIterator<'a> {
 
 impl ExactSizeIterator for AddressTableLookupIterator<'_> {
     fn len(&self) -> usize {
-        usize::from(self.num_address_table_lookup.wrapping_sub(self.index))
+        usize::from(self.num_address_table_lookups.wrapping_sub(self.index))
     }
 }
 
@@ -188,7 +188,7 @@ mod tests {
         let bytes = bincode::serialize(&ShortVec::<MessageAddressTableLookup>(vec![])).unwrap();
         let mut offset = 0;
         let meta = AddressTableLookupMeta::try_new(&bytes, &mut offset).unwrap();
-        assert_eq!(meta.num_address_table_lookup, 0);
+        assert_eq!(meta.num_address_table_lookups, 0);
         assert_eq!(meta.offset, 1);
         assert_eq!(offset, bytes.len());
     }
@@ -214,7 +214,7 @@ mod tests {
         .unwrap();
         let mut offset = 0;
         let meta = AddressTableLookupMeta::try_new(&bytes, &mut offset).unwrap();
-        assert_eq!(meta.num_address_table_lookup, 1);
+        assert_eq!(meta.num_address_table_lookups, 1);
         assert_eq!(meta.offset, 1);
         assert_eq!(offset, bytes.len());
     }
@@ -236,7 +236,7 @@ mod tests {
         .unwrap();
         let mut offset = 0;
         let meta = AddressTableLookupMeta::try_new(&bytes, &mut offset).unwrap();
-        assert_eq!(meta.num_address_table_lookup, 2);
+        assert_eq!(meta.num_address_table_lookups, 2);
         assert_eq!(meta.offset, 1);
         assert_eq!(offset, bytes.len());
     }

--- a/transaction-view/src/bytes.rs
+++ b/transaction-view/src/bytes.rs
@@ -137,7 +137,11 @@ pub fn advance_offset_for_type<T: Sized>(bytes: &[u8], offset: &mut usize) -> Re
 /// 2. The size of `T` is small enough such that a usize will not overflow if
 ///    given the maximum array size (u16::MAX).
 #[inline(always)]
-pub fn read_array<'a, T: Sized>(bytes: &'a [u8], offset: &mut usize, len: u16) -> Result<&'a [T]> {
+pub fn read_slice_data<'a, T: Sized>(
+    bytes: &'a [u8],
+    offset: &mut usize,
+    len: u16,
+) -> Result<&'a [T]> {
     let current_ptr = bytes.as_ptr().wrapping_add(*offset);
     advance_offset_for_array::<T>(bytes, offset, len)?;
     Ok(unsafe { core::slice::from_raw_parts(current_ptr as *const T, len as usize) })

--- a/transaction-view/src/bytes.rs
+++ b/transaction-view/src/bytes.rs
@@ -132,30 +132,35 @@ pub fn advance_offset_for_type<T: Sized>(bytes: &[u8], offset: &mut usize) -> Re
 /// and advancing the offset.
 /// If the buffer is too short, return Err.
 ///
-/// Assumptions:
-/// 1. The current offset is not greater than `bytes.len()`.
-/// 2. The size of `T` is small enough such that a usize will not overflow if
-///    given the maximum array size (u16::MAX).
+/// # Safety
+/// 1. `bytes` must be a valid slice of bytes.
+/// 2. `offset` must be a valid offset into `bytes`.
+/// 3. `bytes + offset` must be properly aligned for `T`.
+/// 4. `T` slice must be validly initialized.
+/// 5. The size of `T` is small enough such that a usize will not overflow if
+///    given the maximum slice size (u16::MAX).
 #[inline(always)]
-pub fn read_slice_data<'a, T: Sized>(
+pub unsafe fn read_slice_data<'a, T: Sized>(
     bytes: &'a [u8],
     offset: &mut usize,
     len: u16,
 ) -> Result<&'a [T]> {
     let current_ptr = bytes.as_ptr().wrapping_add(*offset);
     advance_offset_for_array::<T>(bytes, offset, len)?;
-    Ok(unsafe { core::slice::from_raw_parts(current_ptr as *const T, len as usize) })
+    Ok(unsafe { core::slice::from_raw_parts(current_ptr as *const T, usize::from(len)) })
 }
 
 /// Return a reference to the next `T` in the buffer, checking bounds and
 /// advancing the offset.
 /// If the buffer is too short, return Err.
 ///
-/// Assumptions:
-/// 1. The current offset is not greater than `bytes.len()`.
-/// 2. The size of `T` is small enough such that a usize will not overflow.
+/// # Safety
+/// 1. `bytes` must be a valid slice of bytes.
+/// 2. `offset` must be a valid offset into `bytes`.
+/// 3. `bytes + offset` must be properly aligned for `T`.
+/// 4. `T` must be validly initialized.
 #[inline(always)]
-pub fn read_type<'a, T: Sized>(bytes: &'a [u8], offset: &mut usize) -> Result<&'a T> {
+pub unsafe fn read_type<'a, T: Sized>(bytes: &'a [u8], offset: &mut usize) -> Result<&'a T> {
     let current_ptr = bytes.as_ptr().wrapping_add(*offset);
     advance_offset_for_type::<T>(bytes, offset)?;
     Ok(unsafe { &*(current_ptr as *const T) })

--- a/transaction-view/src/bytes.rs
+++ b/transaction-view/src/bytes.rs
@@ -135,7 +135,7 @@ pub fn advance_offset_for_type<T: Sized>(bytes: &[u8], offset: &mut usize) -> Re
 /// Assumptions:
 /// 1. The current offset is not greater than `bytes.len()`.
 /// 2. The size of `T` is small enough such that a usize will not overflow if
-///   given the maximum array size (u16::MAX).
+///    given the maximum array size (u16::MAX).
 #[inline(always)]
 pub fn read_array<'a, T: Sized>(bytes: &'a [u8], offset: &mut usize, len: u16) -> Result<&'a [T]> {
     let current_ptr = bytes.as_ptr().wrapping_add(*offset);

--- a/transaction-view/src/instructions_meta.rs
+++ b/transaction-view/src/instructions_meta.rs
@@ -94,13 +94,29 @@ impl<'a> Iterator for InstructionsIterator<'a> {
             // Read the number of account indexes, and then update the offset
             // to skip over the account indexes.
             let num_accounts = optimized_read_compressed_u16(self.bytes, &mut self.offset).ok()?;
+
+            const _: () = assert!(core::mem::align_of::<u8>() == 1, "u8 alignment");
+            // SAFETY:
+            // - The offset is checked to be valid in the byte slice.
+            // - The alignment of u8 is 1.
+            // - The slice length is checked to be valid.
+            // - `u8` cannot be improperly initialized.
             let accounts =
-                read_slice_data::<u8>(self.bytes, &mut self.offset, num_accounts).ok()?;
+                unsafe { read_slice_data::<u8>(self.bytes, &mut self.offset, num_accounts) }
+                    .ok()?;
 
             // Read the length of the data, and then update the offset to skip
             // over the data.
             let data_len = optimized_read_compressed_u16(self.bytes, &mut self.offset).ok()?;
-            let data = read_slice_data::<u8>(self.bytes, &mut self.offset, data_len).ok()?;
+
+            const _: () = assert!(core::mem::align_of::<u8>() == 1, "u8 alignment");
+            // SAFETY:
+            // - The offset is checked to be valid in the byte slice.
+            // - The alignment of u8 is 1.
+            // - The slice length is checked to be valid.
+            // - `u8` cannot be improperly initialized.
+            let data =
+                unsafe { read_slice_data::<u8>(self.bytes, &mut self.offset, data_len) }.ok()?;
 
             // Update the index to point to the next instruction.
             self.index = self.index.wrapping_add(1);

--- a/transaction-view/src/instructions_meta.rs
+++ b/transaction-view/src/instructions_meta.rs
@@ -83,6 +83,8 @@ impl<'a> Iterator for InstructionsIterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.index < self.num_instructions {
+            self.index = self.index.wrapping_add(1);
+
             // Each instruction has 3 pieces:
             // 1. Program ID index (u8)
             // 2. Accounts indexes ([u8])
@@ -117,9 +119,6 @@ impl<'a> Iterator for InstructionsIterator<'a> {
             // - `u8` cannot be improperly initialized.
             let data =
                 unsafe { read_slice_data::<u8>(self.bytes, &mut self.offset, data_len) }.ok()?;
-
-            // Update the index to point to the next instruction.
-            self.index = self.index.wrapping_add(1);
 
             Some(SVMInstruction {
                 program_id_index,

--- a/transaction-view/src/instructions_meta.rs
+++ b/transaction-view/src/instructions_meta.rs
@@ -1,8 +1,8 @@
 use {
     crate::{
         bytes::{
-            advance_offset_for_array, check_remaining, optimized_read_compressed_u16, read_array,
-            read_byte,
+            advance_offset_for_array, check_remaining, optimized_read_compressed_u16, read_byte,
+            read_slice_data,
         },
         result::Result,
     },
@@ -94,12 +94,13 @@ impl<'a> Iterator for InstructionsIterator<'a> {
             // Read the number of account indexes, and then update the offset
             // to skip over the account indexes.
             let num_accounts = optimized_read_compressed_u16(self.bytes, &mut self.offset).ok()?;
-            let accounts = read_array::<u8>(self.bytes, &mut self.offset, num_accounts).ok()?;
+            let accounts =
+                read_slice_data::<u8>(self.bytes, &mut self.offset, num_accounts).ok()?;
 
             // Read the length of the data, and then update the offset to skip
             // over the data.
             let data_len = optimized_read_compressed_u16(self.bytes, &mut self.offset).ok()?;
-            let data = read_array::<u8>(self.bytes, &mut self.offset, data_len).ok()?;
+            let data = read_slice_data::<u8>(self.bytes, &mut self.offset, data_len).ok()?;
 
             // Update the index to point to the next instruction.
             self.index = self.index.wrapping_add(1);

--- a/transaction-view/src/transaction_meta.rs
+++ b/transaction-view/src/transaction_meta.rs
@@ -44,7 +44,7 @@ impl TransactionMeta {
         let instructions = InstructionsMeta::try_new(bytes, &mut offset)?;
         let address_table_lookup = match message_header.version {
             TransactionVersion::Legacy => AddressTableLookupMeta {
-                num_address_table_lookup: 0,
+                num_address_table_lookups: 0,
                 offset: 0,
             },
             TransactionVersion::V0 => AddressTableLookupMeta::try_new(bytes, &mut offset)?,
@@ -102,7 +102,7 @@ impl TransactionMeta {
 
     /// Return the number of address table lookups in the transaction.
     pub fn num_address_table_lookups(&self) -> u8 {
-        self.address_table_lookup.num_address_table_lookup
+        self.address_table_lookup.num_address_table_lookups
     }
 }
 
@@ -167,7 +167,7 @@ impl TransactionMeta {
         AddressTableLookupIterator {
             bytes,
             offset: usize::from(self.address_table_lookup.offset),
-            num_address_table_lookup: self.address_table_lookup.num_address_table_lookup,
+            num_address_table_lookups: self.address_table_lookup.num_address_table_lookups,
             index: 0,
         }
     }
@@ -216,7 +216,7 @@ mod tests {
             tx.message.instructions().len() as u16
         );
         assert_eq!(
-            meta.address_table_lookup.num_address_table_lookup,
+            meta.address_table_lookup.num_address_table_lookups,
             tx.message
                 .address_table_lookups()
                 .map(|x| x.len() as u8)


### PR DESCRIPTION
#### Problem
- #2255
- Need a way to access ATLs

#### Summary of Changes
- Add `TransactionMeta::address_table_lookup_iter`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
