### PR TITLE
perf: improve efficiency on processing instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7402,6 +7402,7 @@ dependencies = [
 name = "solana-runtime-transaction"
 version = "2.1.0"
 dependencies = [
+ "agave-transaction-view",
  "bincode",
  "criterion",
  "log",

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -40,3 +40,17 @@ lazy_static! {
     .cloned()
     .collect();
 }
+
+lazy_static! {
+    /// A table of 256 booleans indicates whether the first `u8` of a Pubkey exists in
+    /// BUILTIN_INSTRUCTION_COSTS. If the value is true, the Pubkey might be a builtin key;
+    /// if false, it cannot be a builtin key. This table allows for quick filtering of
+    /// builtin program IDs without the need for hashing.
+    pub static ref MAYBE_BUILTIN_KEY: [bool; 256] = {
+        let mut temp_table: [bool; 256] = [false; 256];
+        BUILTIN_INSTRUCTION_COSTS
+            .keys()
+            .for_each(|key| temp_table[key.as_ref()[0] as usize] = true);
+        temp_table
+    };
+}

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5737,6 +5737,7 @@ name = "solana-runtime-transaction"
 version = "2.1.0"
 dependencies = [
  "log",
+ "solana-builtins-default-costs",
  "solana-compute-budget",
  "solana-sdk",
  "solana-svm-transaction",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -74,6 +74,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-transaction-view"
+version = "2.1.0"
+dependencies = [
+ "solana-sdk",
+ "solana-svm-transaction",
+]
+
+[[package]]
 name = "agave-validator"
 version = "2.1.0"
 dependencies = [
@@ -5736,6 +5744,7 @@ dependencies = [
 name = "solana-runtime-transaction"
 version = "2.1.0"
 dependencies = [
+ "agave-transaction-view",
  "log",
  "solana-builtins-default-costs",
  "solana-compute-budget",

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 log = { workspace = true }
+solana-builtins-default-costs = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-sdk = { workspace = true }
 solana-svm-transaction = { workspace = true }

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+agave-transaction-view = { workspace = true }
 log = { workspace = true }
 solana-builtins-default-costs = { workspace = true }
 solana-compute-budget = { workspace = true }
@@ -25,7 +26,6 @@ name = "solana_runtime_transaction"
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-builtins-default-costs = { workspace = true }
 solana-program = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/runtime-transaction/src/compute_budget_program_id_filter.rs
+++ b/runtime-transaction/src/compute_budget_program_id_filter.rs
@@ -1,20 +1,30 @@
-use {solana_builtins_default_costs::MAYBE_BUILTIN_KEY, solana_sdk::pubkey::Pubkey};
+// static account keys has max
+use {
+    agave_transaction_view::static_account_keys_meta::MAX_STATIC_ACCOUNTS_PER_PACKET as FILTER_SIZE,
+    solana_builtins_default_costs::MAYBE_BUILTIN_KEY, solana_sdk::pubkey::Pubkey,
+};
 
 pub(crate) struct ComputeBudgetProgramIdFilter {
-    // array of 256 slots for all possible program_id_index (as u8),
+    // array of slots for all possible static and sanitized program_id_index,
     // each slot indicates if a program_id_index has not been checked (eg, None),
     // or already checked with result (eg, Some(result)) that can be reused.
-    flags: [Option<bool>; 256],
+    flags: [Option<bool>; FILTER_SIZE as usize],
 }
 
 impl ComputeBudgetProgramIdFilter {
     pub(crate) fn new() -> Self {
-        ComputeBudgetProgramIdFilter { flags: [None; 256] }
+        ComputeBudgetProgramIdFilter {
+            flags: [None; FILTER_SIZE as usize],
+        }
     }
 
     #[inline]
     pub(crate) fn is_compute_budget_program(&mut self, index: usize, program_id: &Pubkey) -> bool {
-        *self.flags[index].get_or_insert_with(|| Self::check_program_id(program_id))
+        *self
+            .flags
+            .get_mut(index)
+            .expect("program id index is sanitized")
+            .get_or_insert_with(|| Self::check_program_id(program_id))
     }
 
     #[inline]

--- a/runtime-transaction/src/compute_budget_program_id_filter.rs
+++ b/runtime-transaction/src/compute_budget_program_id_filter.rs
@@ -1,0 +1,27 @@
+use {solana_builtins_default_costs::MAYBE_BUILTIN_KEY, solana_sdk::pubkey::Pubkey};
+
+pub(crate) struct ComputeBudgetProgramIdFilter {
+    // array of 256 slots for all possible program_id_index (as u8),
+    // each slot indicates if a program_id_index has not been checked (eg, None),
+    // or already checked with result (eg, Some(result)) that can be reused.
+    flags: [Option<bool>; 256],
+}
+
+impl ComputeBudgetProgramIdFilter {
+    pub(crate) fn new() -> Self {
+        ComputeBudgetProgramIdFilter { flags: [None; 256] }
+    }
+
+    #[inline]
+    pub(crate) fn is_compute_budget_program(&mut self, index: usize, program_id: &Pubkey) -> bool {
+        *self.flags[index].get_or_insert_with(|| Self::check_program_id(program_id))
+    }
+
+    #[inline]
+    fn check_program_id(program_id: &Pubkey) -> bool {
+        if !MAYBE_BUILTIN_KEY[program_id.as_ref()[0] as usize] {
+            return false;
+        }
+        solana_sdk::compute_budget::check_id(program_id)
+    }
+}

--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 mod compute_budget_instruction_details;
+mod compute_budget_program_id_filter;
 pub mod instructions_processor;
 pub mod runtime_transaction;
 pub mod transaction_meta;

--- a/transaction-view/src/lib.rs
+++ b/transaction-view/src/lib.rs
@@ -14,6 +14,6 @@ pub mod result;
 #[allow(dead_code)]
 mod signature_meta;
 #[allow(dead_code)]
-mod static_account_keys_meta;
+pub mod static_account_keys_meta;
 #[allow(dead_code)]
 pub mod transaction_meta;

--- a/transaction-view/src/static_account_keys_meta.rs
+++ b/transaction-view/src/static_account_keys_meta.rs
@@ -15,7 +15,7 @@ pub const MAX_STATIC_ACCOUNTS_PER_PACKET: u8 =
 
 /// Contains meta-data about the static account keys in a transaction packet.
 #[derive(Default)]
-pub struct StaticAccountKeysMeta {
+pub(crate) struct StaticAccountKeysMeta {
     /// The number of static accounts in the transaction.
     pub(crate) num_static_accounts: u8,
     /// The offset to the first static account in the transaction.

--- a/transaction-view/src/static_account_keys_meta.rs
+++ b/transaction-view/src/static_account_keys_meta.rs
@@ -10,7 +10,7 @@ use {
 // This means the maximum number of 32 byte keys is 38.
 // 38 as an min-sized encoded u16 is 1 byte.
 // We can simply read this byte, if it's >38 we can return None.
-const MAX_STATIC_ACCOUNTS_PER_PACKET: u8 =
+pub const MAX_STATIC_ACCOUNTS_PER_PACKET: u8 =
     (PACKET_DATA_SIZE / core::mem::size_of::<Pubkey>()) as u8;
 
 /// Contains meta-data about the static account keys in a transaction packet.


### PR DESCRIPTION
#### Problem
#2560 

#### Summary of Changes
1. add filter to avoid duplicated process of same program_id_index;
2. add static filter to filter out non-builtin programs early;


Fixes #2560 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
