### PR TITLE
Replace unbounded with bounded as single channel is used

### DIFF
--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -14,7 +14,9 @@
 use solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo};
 use {
     crate::{leader_bank_notifier::LeaderBankNotifier, poh_service::PohService},
-    crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, SendError, Sender, TrySendError},
+    crossbeam_channel::{
+        bounded, unbounded, Receiver, RecvTimeoutError, SendError, Sender, TrySendError,
+    },
     log::*,
     solana_entry::{
         entry::{hash_transactions, Entry},
@@ -207,7 +209,7 @@ impl TransactionRecorder {
         transactions: Vec<VersionedTransaction>,
     ) -> Result<Option<usize>> {
         // create a new channel so that there is only 1 sender and when it goes out of scope, the receiver fails
-        let (result_sender, result_receiver) = unbounded();
+        let (result_sender, result_receiver) = bounded(1);
         let res =
             self.record_sender
                 .send(Record::new(mixin, transactions, bank_slot, result_sender));


### PR DESCRIPTION
We need the receiver to hold just one message so there is no need to have an unbounded channel.
