### PR TITLE
generalize support for bin range of accounts hash tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "clap 2.33.3",
  "memmap2",
  "rayon",
+ "regex",
  "solana-accounts-db",
  "solana-program",
  "solana-version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,8 +72,8 @@ dependencies = [
  "clap 2.33.3",
  "memmap2",
  "rayon",
- "regex",
  "solana-accounts-db",
+ "solana-clap-utils",
  "solana-program",
  "solana-version",
 ]

--- a/accounts-db/accounts-hash-cache-tool/Cargo.toml
+++ b/accounts-db/accounts-hash-cache-tool/Cargo.toml
@@ -14,8 +14,8 @@ ahash = { workspace = true }
 bytemuck = { workspace = true }
 clap = { workspace = true }
 memmap2 = { workspace = true }
-regex = {workspace = true }
 rayon = { workspace = true }
+regex = {workspace = true }
 solana-accounts-db = { workspace = true }
 solana-program = { workspace = true }
 solana-version = { workspace = true }

--- a/accounts-db/accounts-hash-cache-tool/Cargo.toml
+++ b/accounts-db/accounts-hash-cache-tool/Cargo.toml
@@ -14,6 +14,7 @@ ahash = { workspace = true }
 bytemuck = { workspace = true }
 clap = { workspace = true }
 memmap2 = { workspace = true }
+regex = {workspace = true }
 rayon = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-program = { workspace = true }

--- a/accounts-db/accounts-hash-cache-tool/Cargo.toml
+++ b/accounts-db/accounts-hash-cache-tool/Cargo.toml
@@ -15,8 +15,8 @@ bytemuck = { workspace = true }
 clap = { workspace = true }
 memmap2 = { workspace = true }
 rayon = { workspace = true }
-regex = { workspace = true }
 solana-accounts-db = { workspace = true }
+solana-clap-utils = { workspace = true }
 solana-program = { workspace = true }
 solana-version = { workspace = true }
 

--- a/accounts-db/accounts-hash-cache-tool/Cargo.toml
+++ b/accounts-db/accounts-hash-cache-tool/Cargo.toml
@@ -15,7 +15,7 @@ bytemuck = { workspace = true }
 clap = { workspace = true }
 memmap2 = { workspace = true }
 rayon = { workspace = true }
-regex = {workspace = true }
+regex = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-program = { workspace = true }
 solana-version = { workspace = true }

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -157,7 +157,7 @@ fn main() {
                                      When diffing large state that does not fit in memory, \
                                      it may be necessary to diff a subset at a time. \
                                      Use this arg to limit the state to bin range. \
-                                     The BIN_RANGE is specified with start-end, which contains bin with start <= bin < end." 
+                                     The BIN_RANGE is specified with start-end, which contains bin with start <= bin < end."
                                 ),
                         ),
                 ),

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -151,7 +151,7 @@ fn main() {
                             Arg::with_name("bins_of_interest")
                                 .long("bins-of-interest")
                                 .takes_value(true)
-                                .value_name("BIN_RANGE")
+                                .value_name("BINS")
                                 .min_values(1)
                                 .max_values(2)
                                 .value_delimiter("-")

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -157,7 +157,7 @@ fn main() {
                                      When diffing large state that does not fit in memory, \
                                      it may be necessary to diff a subset at a time. \
                                      Use this arg to limit the state to bin range. \
-                                     The BIN_RANGE is specified with start-end, which contains bin with start < bin < end." 
+                                     The BIN_RANGE is specified with start-end, which contains bin with start <= bin < end." 
                                 ),
                         ),
                 ),

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -163,9 +163,9 @@ fn main() {
                                      When diffing large state that does not fit in memory, \
                                      it may be necessary to diff a subset at a time. \
                                      Use this arg to limit the state to bins of interest. \
-                                     This arg takes either a single bin or a bin_range. bin_range \
-                                     can be specified as \"start-end\", which contains bin with \
-                                     start <= bin < end."
+                                     This arg takes either a single bin or a bin range. \
+                                     A bin range is specified as \"start-end\", where \
+                                     \"start\" is inclusive, and \"end\" is exclusive."
                                 ),
                         ),
                 ),

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -241,7 +241,7 @@ fn cmd_diff_state(
                 1 => bins[0]..bins[0].saturating_add(1),
                 2 => bins[0]..bins[1],
                 _ => {
-                    unreachable!("invalid argument are given to bins_of_interest.")
+                    unreachable!("invalid number of values given to bins_of_interest.")
                 }
             }
         } else {


### PR DESCRIPTION
#### Problem

Currently, accounts hash tool only supports extracting single bin of entries. It will be useful to support extracting a range of bins.

#### Summary of Changes

Generalize support of bin range for accounts hash tool

Example usage:

```
$ accounts-hash-cache-tool diff state --bins-of-interest 0-1024 <hash_cache_dir1> <hash_cache_dir2>
```
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
