### PR TITLE
bank: add current_epoch_staked_nodes()

### DIFF
--- a/core/src/repair/quic_endpoint.rs
+++ b/core/src/repair/quic_endpoint.rs
@@ -724,7 +724,7 @@ async fn prune_connection_cache(
     debug_assert!(prune_cache_pending.load(Ordering::Relaxed));
     let staked_nodes = {
         let root_bank = bank_forks.read().unwrap().root_bank();
-        root_bank.staked_nodes()
+        root_bank.current_epoch_staked_nodes()
     };
     {
         let mut cache = cache.lock().await;

--- a/core/src/staked_nodes_updater_service.rs
+++ b/core/src/staked_nodes_updater_service.rs
@@ -32,7 +32,7 @@ impl StakedNodesUpdaterService {
                 while !exit.load(Ordering::Relaxed) {
                     let stakes = {
                         let root_bank = bank_forks.read().unwrap().root_bank();
-                        root_bank.staked_nodes()
+                        root_bank.current_epoch_staked_nodes()
                     };
                     let overrides = staked_nodes_overrides.read().unwrap().clone();
                     *staked_nodes.write().unwrap() = StakedNodes::new(stakes, overrides);

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1895,7 +1895,7 @@ impl ClusterInfo {
                         Some(ref bank_forks) => {
                             let root_bank = bank_forks.read().unwrap().root_bank();
                             (
-                                root_bank.staked_nodes(),
+                                root_bank.current_epoch_staked_nodes(),
                                 Some(root_bank.feature_set.clone()),
                             )
                         }
@@ -2704,7 +2704,7 @@ impl ClusterInfo {
             Some(bank_forks) => {
                 let bank = bank_forks.read().unwrap().root_bank();
                 let feature_set = bank.feature_set.clone();
-                (Some(feature_set), bank.staked_nodes())
+                (Some(feature_set), bank.current_epoch_staked_nodes())
             }
         };
         self.process_packets(

--- a/ledger/src/leader_schedule_utils.rs
+++ b/ledger/src/leader_schedule_utils.rs
@@ -99,7 +99,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
 
         let pubkeys_and_stakes: Vec<_> = bank
-            .staked_nodes()
+            .current_epoch_staked_nodes()
             .iter()
             .map(|(pubkey, stake)| (*pubkey, *stake))
             .collect();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5921,6 +5921,8 @@ impl Bank {
 
     /// Get the EpochStakes for the current Bank::epoch
     pub fn current_epoch_stakes(&self) -> &EpochStakes {
+        // The stakes for a given epoch (E) in self.epoch_stakes are keyed by leader schedule epoch
+        // (E + 1) so the stakes for the current epoch are stored at self.epoch_stakes[E + 1]
         self.epoch_stakes
             .get(&self.epoch.saturating_add(1))
             .expect("Current epoch stakes must exist")

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5905,10 +5905,6 @@ impl Bank {
             });
     }
 
-    pub fn staked_nodes(&self) -> Arc<HashMap<Pubkey, u64>> {
-        self.stakes_cache.stakes().staked_nodes()
-    }
-
     /// current vote accounts for this bank along with the stake
     ///   attributed to each account
     pub fn vote_accounts(&self) -> Arc<VoteAccountsHashMap> {
@@ -5923,6 +5919,13 @@ impl Bank {
         Some(vote_account.clone())
     }
 
+    /// Get the EpochStakes for the current Bank::epoch
+    pub fn current_epoch_stakes(&self) -> &EpochStakes {
+        self.epoch_stakes
+            .get(&self.epoch.saturating_add(1))
+            .expect("Current epoch stakes must exist")
+    }
+
     /// Get the EpochStakes for a given epoch
     pub fn epoch_stakes(&self, epoch: Epoch) -> Option<&EpochStakes> {
         self.epoch_stakes.get(&epoch)
@@ -5930,6 +5933,11 @@ impl Bank {
 
     pub fn epoch_stakes_map(&self) -> &HashMap<Epoch, EpochStakes> {
         &self.epoch_stakes
+    }
+
+    /// Get the staked nodes map for the current Bank::epoch
+    pub fn current_epoch_staked_nodes(&self) -> Arc<HashMap<Pubkey, u64>> {
+        self.current_epoch_stakes().stakes().staked_nodes()
     }
 
     pub fn epoch_staked_nodes(&self, epoch: Epoch) -> Option<Arc<HashMap<Pubkey, u64>>> {

--- a/turbine/src/quic_endpoint.rs
+++ b/turbine/src/quic_endpoint.rs
@@ -575,7 +575,7 @@ async fn prune_connection_cache(
     debug_assert!(prune_cache_pending.load(Ordering::Relaxed));
     let staked_nodes = {
         let root_bank = bank_forks.read().unwrap().root_bank();
-        root_bank.staked_nodes()
+        root_bank.current_epoch_staked_nodes()
     };
     {
         let mut cache = cache.lock().await;


### PR DESCRIPTION
Add current_epoch_staked_nodes() which returns the staked nodes for the current epoch and remove Bank::staked_nodes() which used to return the bank's view of staked nodes updated to the last vote processed.

The updated call sites don't really need super up to date stake info, and with this change we can stop updating the staked nodes hash map on every bank for every vote. Instead we now build the hash map once per epoch and then never touch it.
