### PR TITLE
[WIP] metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
  "clap 2.33.3",
  "flate2",
  "hex",
- "hyper",
+ "hyper 0.14.30",
  "log",
  "rustc_version 0.4.0",
  "serde",
@@ -210,6 +210,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-metrics"
+version = "2.1.0"
+dependencies = [
+ "axum 0.7.5",
+ "log",
+ "prometheus-client",
+ "tokio",
+]
+
+[[package]]
 name = "agave-store-tool"
 version = "2.1.0"
 dependencies = [
@@ -235,6 +245,7 @@ name = "agave-validator"
 version = "2.1.0"
 dependencies = [
  "agave-geyser-plugin-interface",
+ "agave-metrics",
  "assert_cmd",
  "chrono",
  "clap 2.33.3",
@@ -759,13 +770,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.5",
+ "hyper 0.14.30",
  "itoa",
  "matchit",
  "memchr",
@@ -774,10 +785,44 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding 2.3.1",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -789,12 +834,33 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.5",
  "mime",
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1989,6 +2055,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
 name = "eager"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,7 +2202,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4b0ea5ef6dc2388a4b1669fa32097249bc03a15417b97cb75e38afb309e4a89"
 dependencies = [
- "http",
+ "http 0.2.12",
  "prost",
  "tokio",
  "tokio-stream",
@@ -2573,7 +2645,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.4.0",
  "slab",
  "tokio",
@@ -2634,7 +2706,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "headers-core",
- "http",
+ "http 0.2.12",
  "httpdate",
  "mime",
  "sha-1 0.10.0",
@@ -2646,7 +2718,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.12",
 ]
 
 [[package]]
@@ -2737,13 +2809,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2776,8 +2882,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -2790,6 +2896,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-proxy"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2798,8 +2923,8 @@ dependencies = [
  "bytes",
  "futures 0.3.30",
  "headers",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "hyper-tls",
  "native-tls",
  "tokio",
@@ -2814,8 +2939,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -2827,7 +2952,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.30",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2840,10 +2965,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.30",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3118,7 +3258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
 dependencies = [
  "futures 0.3.30",
- "hyper",
+ "hyper 0.14.30",
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
@@ -4266,6 +4406,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot 0.12.3",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
 name = "proptest"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4719,9 +4882,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.5",
+ "hyper 0.14.30",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -4738,7 +4901,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -4761,7 +4924,7 @@ checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
 dependencies = [
  "anyhow",
  "async-trait",
- "http",
+ "http 0.2.12",
  "reqwest",
  "serde",
  "task-local-extensions",
@@ -5109,6 +5272,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -6148,6 +6321,7 @@ dependencies = [
 name = "solana-core"
 version = "2.1.0"
 dependencies = [
+ "agave-metrics",
  "ahash 0.8.10",
  "anyhow",
  "arrayvec",
@@ -7602,8 +7776,8 @@ dependencies = [
  "flate2",
  "futures 0.3.30",
  "goauth",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "hyper-proxy",
  "log",
  "openssl",
@@ -8623,6 +8797,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9140,15 +9320,15 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.5",
+ "hyper 0.14.30",
  "hyper-timeout",
  "percent-encoding 2.3.1",
  "pin-project",
@@ -9285,7 +9465,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "merkle-root-bench",
     "merkle-tree",
     "metrics",
+    "metrics-next",
     "net-shaper",
     "net-utils",
     "notifier",
@@ -171,6 +172,7 @@ check-cfg = [
 [workspace.dependencies]
 Inflector = "0.11.4"
 agave-transaction-view = { path = "transaction-view", version = "=2.1.0" }
+agave-metrics = { path = "metrics-next", version = "=2.1.0" }
 aquamarine = "0.3.3"
 aes-gcm-siv = "0.11.1"
 ahash = "0.8.10"
@@ -305,6 +307,7 @@ predicates = "2.1"
 pretty-hex = "0.3.0"
 prio-graph = "0.2.1"
 proc-macro2 = "1.0.86"
+prometheus-client = "0.22.3"
 proptest = "1.5"
 prost = "0.11.9"
 prost-build = "0.11.9"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ edition = { workspace = true }
 codecov = { repository = "solana-labs/solana", branch = "master", service = "github" }
 
 [dependencies]
+agave-metrics = { workspace = true }
 ahash = { workspace = true }
 anyhow = { workspace = true }
 arrayvec = { workspace = true }

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -85,6 +85,9 @@ impl OptimisticConfirmationVerifier {
                     );
                 }
                 datapoint_info!("optimistic_slot", ("slot", new_optimistic_slot, i64),);
+                if let Some(metrics) = agave_metrics::singleton_metrics::get_metrics() {
+                    metrics.core.optimistic_slot.set(new_optimistic_slot as i64);
+                }
                 self.unchecked_slots.insert((new_optimistic_slot, hash));
             }
         }

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -73,6 +73,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         replay_forks_threads: config.replay_forks_threads,
         replay_transactions_threads: config.replay_transactions_threads,
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
+        prometheus_addrs: config.prometheus_addrs,
     }
 }
 

--- a/metrics-next/Cargo.toml
+++ b/metrics-next/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "agave-metrics"
+description = "Agave Metrics"
+documentation = "https://docs.rs/agave-metrics"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+prometheus-client = { workspace = true }
+# metrics endpoint
+log = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+axum = "0.7.5"

--- a/metrics-next/src/core.rs
+++ b/metrics-next/src/core.rs
@@ -1,0 +1,27 @@
+use prometheus_client::{
+    encoding::{EncodeLabelSet, EncodeLabelValue},
+    metrics::{
+        counter::Counter,
+        family::Family,
+        gauge::Gauge,
+        histogram::{exponential_buckets, Histogram},
+    },
+    registry::{Registry, Unit},
+};
+
+pub struct Metrics {
+    pub optimistic_slot: Gauge,
+}
+
+impl Metrics {
+    pub fn new_with_registry(registry: &mut Registry) -> Self {
+        let optimistic_slot = Gauge::default();
+        registry.register(
+            "optimistic_slot",
+            "optimistic_slot",
+            optimistic_slot.clone(),
+        );
+
+        Self { optimistic_slot }
+    }
+}

--- a/metrics-next/src/lib.rs
+++ b/metrics-next/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod service;
+
+// metrics instance
+pub mod singleton_metrics;
+
+// metrics
+pub mod metrics;
+pub mod core;

--- a/metrics-next/src/metrics.rs
+++ b/metrics-next/src/metrics.rs
@@ -1,0 +1,29 @@
+use {
+    crate::core,
+    prometheus_client::{encoding::text::encode, registry::Registry},
+};
+
+pub struct Metrics {
+    pub registry: Registry,
+    pub core: core::Metrics,
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        let mut registry = Registry::with_prefix("agave");
+
+        let sub_registry = registry.sub_registry_with_prefix("core");
+        let core = core::Metrics::new_with_registry(sub_registry);
+
+        // more metrics ...
+
+        Self { registry, core }
+    }
+
+    // TODO: should rename to something meaningful
+    pub fn dump(&self) -> Result<String, std::fmt::Error> {
+        let mut buffer = String::new();
+        encode(&mut buffer, &self.registry)?;
+        Ok(buffer)
+    }
+}

--- a/metrics-next/src/service.rs
+++ b/metrics-next/src/service.rs
@@ -1,0 +1,57 @@
+use {
+    crate::metrics::Metrics,
+    axum::{http::StatusCode, routing::get, Router},
+    log::info,
+    std::{
+        net::SocketAddr,
+        sync::Arc,
+        thread::{self, JoinHandle},
+    },
+    tokio::{net::TcpListener, runtime::Runtime},
+};
+
+pub struct PrometheusMetricsService {
+    // thread handler
+    thread_hdl: JoinHandle<()>,
+}
+
+impl PrometheusMetricsService {
+    pub fn new(prometheus_addr: SocketAddr, metrics: Option<Arc<Metrics>>) -> Self {
+        info!("prometheus bound to {:?}", prometheus_addr);
+
+        let thread_hdl = thread::spawn(move || {
+            let runtime = Runtime::new().unwrap();
+            runtime.block_on(async move {
+                let app = Router::new()
+                    .route("/ping", get(|| async { "pong" }))
+                    .route(
+                        "/metrics",
+                        get(move || async move {
+                            match metrics {
+                                None => Err((
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                    "Internal Server Error".to_string(),
+                                )),
+                                Some(metrics) => match metrics.dump() {
+                                    Ok(message) => Ok(message),
+                                    Err(_e) => Err((
+                                        StatusCode::INTERNAL_SERVER_ERROR,
+                                        "Internal Server Error".to_string(),
+                                    )),
+                                },
+                            }
+                        }),
+                    );
+
+                let listener = TcpListener::bind(prometheus_addr).await.unwrap();
+                axum::serve(listener, app).await.unwrap();
+            });
+        });
+
+        Self { thread_hdl }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.thread_hdl.join()
+    }
+}

--- a/metrics-next/src/singleton_metrics.rs
+++ b/metrics-next/src/singleton_metrics.rs
@@ -1,0 +1,14 @@
+use {
+    crate::metrics::Metrics,
+    std::sync::{Arc, OnceLock},
+};
+
+static METRICS: OnceLock<Option<Arc<Metrics>>> = OnceLock::new();
+
+pub fn initialize_metrics(metrics: Option<Arc<Metrics>>) -> Result<(), Option<Arc<Metrics>>> {
+    METRICS.set(metrics)
+}
+
+pub fn get_metrics() -> Option<Arc<Metrics>> {
+    METRICS.get().and_then(|opt| opt.clone())
+}

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 
 [dependencies]
 agave-geyser-plugin-interface = { workspace = true }
+agave-metrics = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
 clap = { workspace = true }
 console = { workspace = true }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1600,6 +1600,24 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                     further debugging.",
                 ),
         )
+        .arg(
+            Arg::with_name("prometheus")
+                .long("prometheus")
+                .takes_value(false)
+                .help(
+                    "enable prometheus metrics"
+                ),
+        )
+        .arg(
+            Arg::with_name("prometheus_port")
+                .long("prometheus-port")
+                .value_name("PORT")
+                .takes_value(true)
+                .validator(port_validator)
+                .help(
+                    "expose prometheus metrics on this port"
+                ),
+        )
         .args(&thread_args(&default_args.thread_args))
         .args(&get_deprecated_arguments())
         .after_help("The default subcommand is run")


### PR DESCRIPTION
POC for prometheus metrics

#### Summary of Changes

- **New Crate**: created a `metrics-next` directory to manage prometheus infra and all related metrics
- **Singleton**: introduced a singleton instance as a stopgap. I tried to use dependency injection but it's really painful... 🫠  
- **Validator Args**: 
  - `prometheus` to enable prometheus
  - `prometheus_port` to expose metrics 
  - not included in this POC, we should implement a basic mechanism to prevent potential abuse of the metrics endpoint



