### PR TITLE
rolls out chained Merkle shreds to ~50% of testnet slots

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -508,8 +508,8 @@ fn should_chain_merkle_shreds(slot: Slot, cluster_type: ClusterType) -> bool {
         ClusterType::Development => true,
         ClusterType::Devnet => false,
         ClusterType::MainnetBeta => false,
-        // Roll out chained Merkle shreds to ~21% of testnet.
-        ClusterType::Testnet => slot % 19 < 4,
+        // Roll out chained Merkle shreds to ~53% of testnet slots.
+        ClusterType::Testnet => slot % 19 < 10,
     }
 }
 


### PR DESCRIPTION
#### Problem
Rolling out chained Merkle shreds to testnet.

#### Summary of Changes
The commit rolls out chained Merkle shreds to ~50% of testnet slots.