### PR TITLE
Replace bool field by a more compact bitvec one per cleaning bin

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3311,8 +3311,11 @@ impl AccountsDb {
 
         // parallel scan the index.
         let do_clean_scan = || {
-            candidates.bins.par_iter().zip(candidates.should_purge.par_iter()).for_each(
-                |(candidates_bin, should_purge_bin)| {
+            candidates
+                .bins
+                .par_iter()
+                .zip(candidates.should_purge.par_iter())
+                .for_each(|(candidates_bin, should_purge_bin)| {
                     let mut found_not_zero = 0;
                     let mut not_found_on_fork = 0;
                     let mut missing = 0;
@@ -3410,8 +3413,7 @@ impl AccountsDb {
                     useful_accum.fetch_add(useful, Ordering::Relaxed);
                     purges_old_accounts_count
                         .fetch_add(purges_old_accounts_local, Ordering::Relaxed);
-                },
-            );
+                });
         };
         if is_startup {
             do_clean_scan();

--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -1,6 +1,6 @@
 use solana_sdk::pubkey::Pubkey;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PubkeyBinCalculator24 {
     // how many bits from the first 2 bytes to shift away to ignore when calculating bin
     shift_bits: u32,


### PR DESCRIPTION
#### Problem

Cleaning accounts from accounts-db accounts index consumes too much memory.  We previously replaced a vector of pubkeys of accounts that should be purged from the index by a boolean field in `CleaningInfo` struct, which added 4 bytes for each cleaning candidate. We can further reduce the memory consumption by using a bit vector with one bit per candidate instead of a 4-byte boolean field per candidate.

#### Summary of Changes

- remove the `should_purge` field from CleaningInfo
- encapsulate the bins of hash maps of pubkeys to `CleaningInfo` in a new struct `CleaningMap`
- add `should_purge` as slice of bitvecs one per candidate bin as a field in `CleaningMap`
- encapsulate helper functions that operate on `CleaningInfo` data in `CleaningMap` implementation