### PR TITLE
patches bug causing false duplicate nodes error

### DIFF
--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -212,7 +212,7 @@ impl ContactInfo {
         &self.version
     }
 
-    pub(crate) fn hot_swap_pubkey(&mut self, pubkey: Pubkey) {
+    pub fn hot_swap_pubkey(&mut self, pubkey: Pubkey) {
         self.pubkey = pubkey;
         // Need to update ContactInfo.outset so that this node's contact-info
         // will override older node with the same pubkey.

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2038,6 +2038,13 @@ pub fn main() {
         return;
     }
 
+    // Bootstrap code above pushes a contact-info with more recent timestamp to
+    // gossip. If the node is staked the contact-info lingers in gossip causing
+    // false duplicate nodes error.
+    // Below line refreshes the timestamp on contact-info so that it overrides
+    // the one pushed by bootstrap.
+    node.info.hot_swap_pubkey(identity_keypair.pubkey());
+
     let validator = Validator::new(
         node,
         identity_keypair,


### PR DESCRIPTION

#### Problem
The bootstrap code during the validator start pushes a contact-info with more recent timestamp to gossip. If the node is staked the contact-info lingers in gossip causing false duplicate node instances when the fully initialized node joins gossip later on.



#### Summary of Changes
The commit refreshes the timestamp on contact-info so that it overrides the one pushed by bootstrap and avoid false duplicates error.
