### PR TITLE
impl Deref for RuntimeTransaction

### DIFF
--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -14,6 +14,7 @@ use {
         compute_budget_instruction_details::*,
         transaction_meta::{DynamicMeta, StaticMeta, TransactionMeta},
     },
+    core::ops::Deref,
     solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_sdk::{
         feature_set::FeatureSet,
@@ -62,7 +63,15 @@ impl<T: StaticMetaAccess> StaticMeta for RuntimeTransaction<T> {
     }
 }
 
-impl<M: DynamicMetaAccess> DynamicMeta for RuntimeTransaction<M> {}
+impl<T: DynamicMetaAccess> DynamicMeta for RuntimeTransaction<T> {}
+
+impl<T> Deref for RuntimeTransaction<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.transaction
+    }
+}
 
 impl RuntimeTransaction<SanitizedVersionedTransaction> {
     pub fn try_from(


### PR DESCRIPTION
#### Problem
- See https://github.com/anza-xyz/agave/pull/2672/files#r1723646709
- `Deref` is the more appropriate trait since we want `RuntimeTransaction` to directly be able to call functions of `T`. Not having to call `.as_ref()` everywhere.

#### Summary of Changes
- implement `Deref` for `RuntimeTransaction<T>` so that `RuntimeTransaction` is able to access transaction information

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
