### PR TITLE
Check poh_recorder.start_slot() hasn't been dumped previously before checking it in ProgressMap.

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2045,17 +2045,13 @@ impl ReplayStage {
 
         trace!("{} reached_leader_slot", my_pubkey);
 
-        let parent = bank_forks.read().unwrap().get(parent_slot);
-
-        if parent.is_none() {
+        let Some(parent) = bank_forks.read().unwrap().get(parent_slot) else {
             warn!(
                 "parent bank {} may have been dumped, unable to start leader",
                 parent_slot
             );
             return false;
-        }
-
-        let parent = parent.unwrap();
+        };
 
         assert!(parent.is_frozen());
 
@@ -2100,7 +2096,6 @@ impl ReplayStage {
             );
 
             if !Self::check_propagation_for_start_leader(poh_slot, parent_slot, progress_map) {
-                // We checked that parent_slot hasn't been dumped, so we should get it in the progress map.
                 let latest_unconfirmed_leader_slot = progress_map.get_latest_leader_slot_must_exist(parent_slot)
                     .expect("In order for propagated check to fail, latest leader must exist in progress map");
                 if poh_slot != skipped_slots_info.last_skipped_slot {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1310,7 +1310,7 @@ impl ReplayStage {
         // It is possible that bank corresponding to `start_slot` has been
         // dumped, so we need to double check it exists before proceeding
         if !progress.contains(&start_slot) {
-            debug!("Slot may have been dumped: start_slot={}", start_slot);
+            warn!("Poh start slot {start_slot}, is missing from progress map. This indicates that we are in the middle of a dump and repair. Skipping retransmission of unpropagated leader slots");
             return;
         }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2047,9 +2047,8 @@ impl ReplayStage {
 
         let Some(parent) = bank_forks.read().unwrap().get(parent_slot) else {
             warn!(
-                "parent bank {} may have been dumped, unable to start leader",
-                parent_slot
-            );
+                "Poh recorder parent slot {parent_slot} is missing from bank_forks. This indicates \
+                that we are in the middle of a dump and repair. Unable to start leader");
             return false;
         };
 


### PR DESCRIPTION
#### Problem
It's possible that poh_recorder.start_slot() has been dumped because of duplicate proof, in that case we would currently panic inside ProgressMap::get_propagated_stats_must_exist()

#### Summary of Changes
Check that start_slot still exists in ProgressMap before proceeding.