### PR TITLE
Adds inspect_account() to TransactionProcessingCallback

### DIFF
--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -7,4 +7,16 @@ pub trait TransactionProcessingCallback {
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
 
     fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {}
+
+    fn inspect_account(&self, _address: &Pubkey, _account_state: AccountState, _is_writable: bool) {
+    }
+}
+
+/// The state the account is in initially, before transaction processing
+#[derive(Debug)]
+pub enum AccountState<'a> {
+    /// This account is dead, and will be created by this transaction
+    Dead,
+    /// This account is alive, and already existed prior to this transaction
+    Alive(&'a AccountSharedData),
 }


### PR DESCRIPTION
#### Problem

For the upcoming accounts accumulator hash, we will need a way to get the initial state of an account *before* transactions update it.

A generic way to inspect accounts prior to transaction processing would solve this.


#### Summary of Changes

Add a new method to TransactionProcessingCallback, `inspect_account()`, that will provide a callback for the loaded accounts in a transaction.