### PR TITLE
Retain only candidates that should be purged or with non-empty slot list

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3429,7 +3429,7 @@ impl AccountsDb {
                             (purged_account_slots_new, removed_accounts_new),
                             pubkeys_removed_from_accounts_index_new,
                         ) = self.clean_accounts_older_than_root(
-                            &candidate_pubkey,
+                            candidate_pubkey,
                             max_clean_root_inclusive,
                             &ancient_account_cleans,
                             epoch_schedule,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3463,6 +3463,7 @@ impl AccountsDb {
         }
 
         accounts_scan.stop();
+        let retained_keys_count = Self::count_pubkeys(&candidates);
         let purged_account_slots = purged_account_slots.into_inner().unwrap();
         let removed_accounts = removed_accounts.into_inner().unwrap();
         let mut pubkeys_removed_from_accounts_index =
@@ -3627,6 +3628,7 @@ impl AccountsDb {
             ("dirty_pubkeys_count", key_timings.dirty_pubkeys_count, i64),
             ("useful_keys", useful_accum.load(Ordering::Relaxed), i64),
             ("total_keys_count", num_candidates, i64),
+            ("retained_keys_count", retained_keys_count, i64),
             (
                 "scan_found_not_zero",
                 found_not_zero_accum.load(Ordering::Relaxed),

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2784,7 +2784,6 @@ impl AccountsDb {
             ancient_account_cleans.fetch_add(old_reclaims, Ordering::Relaxed);
         }
         clean_rooted.stop();
-        debug!("{}", clean_rooted);
         self.clean_accounts_stats
             .clean_old_root_us
             .fetch_add(clean_rooted.as_us(), Ordering::Relaxed);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3443,7 +3443,9 @@ impl AccountsDb {
                             epoch_schedule,
                             &pubkeys_removed_from_accounts_index,
                         );
-                        reclaims.lock().unwrap().extend(reclaims_new);
+                        if !reclaims_new.is_empty() {
+                            reclaims.lock().unwrap().extend(reclaims_new);
+                        }
                     }
                     !candidate_info.slot_list.is_empty()
                 });

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3485,6 +3485,7 @@ impl AccountsDb {
                 },
             ) in candidates_bin.write().unwrap().iter_mut()
             {
+                debug_assert!(!slot_list.is_empty(), "candidate slot_list can't be empty");
                 if purged_account_slots.contains_key(pubkey) {
                     *ref_count = self.accounts_index.ref_count_from_storage(pubkey);
                 }
@@ -3864,9 +3865,7 @@ impl AccountsDb {
                     slot_list,
                     ref_count: _,
                 } = cleaning_info;
-                if slot_list.is_empty() {
-                    return false;
-                }
+                debug_assert!(!slot_list.is_empty(), "candidate slot_list can't be empty");
                 // Only keep candidates where the entire history of the account in the root set
                 // can be purged. All AppendVecs for those updates are dead.
                 for (slot, _account_info) in slot_list.iter() {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2753,7 +2753,7 @@ impl AccountsDb {
     /// Reclaim older states of accounts older than max_clean_root_inclusive for AccountsDb bloat mitigation.
     /// Any accounts which are removed from the accounts index are returned in PubkeysRemovedFromAccountsIndex.
     /// These should NOT be unref'd later from the accounts index.
-    fn clean_accounts_older_than_root(
+    fn clean_account_older_than_root(
         &self,
         pubkey: &Pubkey,
         max_clean_root_inclusive: Option<Slot>,
@@ -3428,7 +3428,7 @@ impl AccountsDb {
                         let (
                             (purged_account_slots_new, removed_accounts_new),
                             pubkeys_removed_from_accounts_index_new,
-                        ) = self.clean_accounts_older_than_root(
+                        ) = self.clean_account_older_than_root(
                             candidate_pubkey,
                             max_clean_root_inclusive,
                             &ancient_account_cleans,
@@ -3499,7 +3499,7 @@ impl AccountsDb {
                         return false;
                     }
                     // Check if this update in `slot` to the account with `key` was reclaimed earlier by
-                    // `clean_accounts_older_than_root()`
+                    // `clean_account_older_than_root()`
                     let was_reclaimed = removed_accounts
                         .get(slot)
                         .map(|store_removed| store_removed.contains(&account_info.offset()))
@@ -5583,7 +5583,7 @@ impl AccountsDb {
         //          handle_reclaims()             | (removes storage entries)
         //      OR                                |
         //    clean_accounts()/                   |
-        //        clean_accounts_older_than_root()| (removes existing store_id, offset for stores)
+        //        clean_account_older_than_root() | (removes existing store_id, offset for stores)
         //                                        V
         //
         // Remarks for purger: So, for any reading operations, it's a race condition

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1352,8 +1352,6 @@ impl StoreAccountsTiming {
 struct CleaningInfo {
     slot_list: SlotList<AccountInfo>,
     ref_count: u64,
-    /// True for pubkeys mapping to older versions of accounts that should be purged.
-    should_purge: bool,
 }
 
 /// This is the return type of AccountsDb::construct_candidate_clean_keys.
@@ -2757,50 +2755,32 @@ impl AccountsDb {
     /// These should NOT be unref'd later from the accounts index.
     fn clean_accounts_older_than_root(
         &self,
-        candidates: &[RwLock<HashMap<Pubkey, CleaningInfo>>],
+        pubkey: &Pubkey,
         max_clean_root_inclusive: Option<Slot>,
         ancient_account_cleans: &AtomicU64,
         epoch_schedule: &EpochSchedule,
     ) -> (ReclaimResult, PubkeysRemovedFromAccountsIndex) {
-        let pubkeys_removed_from_accounts_index = HashSet::default();
+        let mut pubkeys_removed_from_accounts_index = HashSet::default();
         let one_epoch_old = self.get_oldest_non_ancient_slot(epoch_schedule);
-        let pubkeys_removed_from_accounts_index = Mutex::new(pubkeys_removed_from_accounts_index);
-
         let mut clean_rooted = Measure::start("clean_old_root-ms");
-        let reclaim_vecs = candidates
-            .par_iter()
-            .filter_map(|candidates_bin| {
-                let mut reclaims = Vec::new();
-                for (pubkey, cleaning_info) in candidates_bin.read().unwrap().iter() {
-                    if cleaning_info.should_purge {
-                        let removed_from_index = self.accounts_index.clean_rooted_entries(
-                            pubkey,
-                            &mut reclaims,
-                            max_clean_root_inclusive,
-                        );
-                        if removed_from_index {
-                            pubkeys_removed_from_accounts_index
-                                .lock()
-                                .unwrap()
-                                .insert(*pubkey);
-                        }
-                    }
-                }
-
-                (!reclaims.is_empty()).then(|| {
-                    // figure out how many ancient accounts have been reclaimed
-                    let old_reclaims = reclaims
-                        .iter()
-                        .filter_map(|(slot, _)| (slot < &one_epoch_old).then_some(1))
-                        .sum();
-                    ancient_account_cleans.fetch_add(old_reclaims, Ordering::Relaxed);
-                    reclaims
-                })
-            })
-            .collect::<Vec<_>>();
+        let mut reclaims = Vec::new();
+        let removed_from_index = self.accounts_index.clean_rooted_entries(
+            pubkey,
+            &mut reclaims,
+            max_clean_root_inclusive,
+        );
+        if removed_from_index {
+            pubkeys_removed_from_accounts_index.insert(*pubkey);
+        }
+        if !reclaims.is_empty() {
+            // figure out how many ancient accounts have been reclaimed
+            let old_reclaims = reclaims
+                .iter()
+                .filter_map(|(slot, _)| (slot < &one_epoch_old).then_some(1))
+                .sum();
+            ancient_account_cleans.fetch_add(old_reclaims, Ordering::Relaxed);
+        }
         clean_rooted.stop();
-        let pubkeys_removed_from_accounts_index =
-            pubkeys_removed_from_accounts_index.into_inner().unwrap();
         self.clean_accounts_stats
             .clean_old_root_us
             .fetch_add(clean_rooted.as_us(), Ordering::Relaxed);
@@ -2812,7 +2792,7 @@ impl AccountsDb {
         let reset_accounts = false;
 
         let reclaim_result = self.handle_reclaims(
-            (!reclaim_vecs.is_empty()).then(|| reclaim_vecs.iter().flatten()),
+            (!reclaims.is_empty()).then(|| reclaims.iter()),
             None,
             reset_accounts,
             &pubkeys_removed_from_accounts_index,
@@ -2856,9 +2836,8 @@ impl AccountsDb {
                 CleaningInfo {
                     slot_list,
                     ref_count,
-                    should_purge: _,
                 },
-            ) in bin.iter().filter(|x| !x.1.slot_list.is_empty())
+            ) in bin.iter()
             {
                 let mut failed_slot = None;
                 let all_stores_being_deleted = slot_list.len() as RefCount == *ref_count;
@@ -3349,7 +3328,12 @@ impl AccountsDb {
         let not_found_on_fork_accum = AtomicU64::new(0);
         let missing_accum = AtomicU64::new(0);
         let useful_accum = AtomicU64::new(0);
-
+        let purged_account_slots: AccountSlots = HashMap::new();
+        let purged_account_slots = Mutex::new(purged_account_slots);
+        let removed_accounts: SlotOffsets = HashMap::new();
+        let removed_accounts = Mutex::new(removed_accounts);
+        let pubkeys_removed_from_accounts_index: PubkeysRemovedFromAccountsIndex = HashSet::new();
+        let pubkeys_removed_from_accounts_index = Mutex::new(pubkeys_removed_from_accounts_index);
         // parallel scan the index.
         let do_clean_scan = || {
             candidates.par_iter().for_each(|candidates_bin| {
@@ -3364,6 +3348,7 @@ impl AccountsDb {
                 // closure passed to scan thus making
                 // conflicting read and write borrows.
                 candidates_bin.retain(|candidate_pubkey, candidate_info| {
+                    let mut should_purge = false;
                     self.accounts_index.scan(
                         [*candidate_pubkey].iter(),
                         |_candidate_pubkey, slot_list_and_ref_count, _entry| {
@@ -3404,7 +3389,7 @@ impl AccountsDb {
                                             }
                                             if slot_list.len() > 1 {
                                                 // no need to purge old accounts if there is only 1 slot in the slot list
-                                                candidate_info.should_purge = true;
+                                                should_purge = true;
                                                 purges_old_accounts_local += 1;
                                                 useless = false;
                                             } else {
@@ -3422,7 +3407,7 @@ impl AccountsDb {
                                         // it was in the dirty list, so we assume that the slot it was
                                         // touched in must be unrooted.
                                         not_found_on_fork += 1;
-                                        candidate_info.should_purge = true;
+                                        should_purge = true;
                                         purges_old_accounts_local += 1;
                                         useless = false;
                                     }
@@ -3439,7 +3424,30 @@ impl AccountsDb {
                         false,
                         ScanFilter::All,
                     );
-                    !candidate_info.slot_list.is_empty() || candidate_info.should_purge
+                    if should_purge {
+                        let (
+                            (purged_account_slots_new, removed_accounts_new),
+                            pubkeys_removed_from_accounts_index_new,
+                        ) = self.clean_accounts_older_than_root(
+                            &candidate_pubkey,
+                            max_clean_root_inclusive,
+                            &ancient_account_cleans,
+                            epoch_schedule,
+                        );
+                        purged_account_slots
+                            .lock()
+                            .unwrap()
+                            .extend(purged_account_slots_new);
+                        removed_accounts
+                            .lock()
+                            .unwrap()
+                            .extend(removed_accounts_new);
+                        pubkeys_removed_from_accounts_index
+                            .lock()
+                            .unwrap()
+                            .extend(pubkeys_removed_from_accounts_index_new);
+                    }
+                    !candidate_info.slot_list.is_empty()
                 });
                 found_not_zero_accum.fetch_add(found_not_zero, Ordering::Relaxed);
                 not_found_on_fork_accum.fetch_add(not_found_on_fork, Ordering::Relaxed);
@@ -3455,16 +3463,11 @@ impl AccountsDb {
         }
 
         accounts_scan.stop();
-
+        let purged_account_slots = purged_account_slots.into_inner().unwrap();
+        let removed_accounts = removed_accounts.into_inner().unwrap();
+        let mut pubkeys_removed_from_accounts_index =
+            pubkeys_removed_from_accounts_index.into_inner().unwrap();
         let mut clean_old_rooted = Measure::start("clean_old_roots");
-        let ((purged_account_slots, removed_accounts), mut pubkeys_removed_from_accounts_index) =
-            self.clean_accounts_older_than_root(
-                &candidates,
-                max_clean_root_inclusive,
-                &ancient_account_cleans,
-                epoch_schedule,
-            );
-
         self.do_reset_uncleaned_roots(max_clean_root_inclusive);
         clean_old_rooted.stop();
 
@@ -3479,13 +3482,9 @@ impl AccountsDb {
                 CleaningInfo {
                     slot_list,
                     ref_count,
-                    should_purge: _,
                 },
             ) in candidates_bin.write().unwrap().iter_mut()
             {
-                if slot_list.is_empty() {
-                    continue; // seems simpler than filtering. `candidates` contains all the pubkeys we original started with
-                }
                 if purged_account_slots.contains_key(pubkey) {
                     *ref_count = self.accounts_index.ref_count_from_storage(pubkey);
                 }
@@ -3561,7 +3560,6 @@ impl AccountsDb {
                     let CleaningInfo {
                         slot_list,
                         ref_count: _,
-                        should_purge: _,
                     } = cleaning_info;
                     (!slot_list.is_empty()).then_some((
                         *pubkey,
@@ -3864,7 +3862,6 @@ impl AccountsDb {
                 let CleaningInfo {
                     slot_list,
                     ref_count: _,
-                    should_purge: _,
                 } = cleaning_info;
                 if slot_list.is_empty() {
                     return false;
@@ -12891,7 +12888,6 @@ pub mod tests {
                 CleaningInfo {
                     slot_list: rooted_entries,
                     ref_count,
-                    should_purge: false,
                 },
             );
         }
@@ -12902,7 +12898,6 @@ pub mod tests {
                 CleaningInfo {
                     slot_list: list,
                     ref_count,
-                    should_purge: _,
                 },
             ) in candidates_bin.iter()
             {
@@ -15207,7 +15202,6 @@ pub mod tests {
                 CleaningInfo {
                     slot_list: vec![(slot, account_info)],
                     ref_count: 1,
-                    should_purge: false,
                 },
             );
             let accounts_db = AccountsDb::new_single_for_tests();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3363,86 +3363,84 @@ impl AccountsDb {
                 // avoid capturing the HashMap in the
                 // closure passed to scan thus making
                 // conflicting read and write borrows.
-                candidates_bin
-                    .iter_mut()
-                    .for_each(|(candidate_pubkey, candidate_info)| {
-                        self.accounts_index.scan(
-                            [*candidate_pubkey].iter(),
-                            |_candidate_pubkey, slot_list_and_ref_count, _entry| {
-                                let mut useless = true;
-                                if let Some((slot_list, ref_count)) = slot_list_and_ref_count {
-                                    // find the highest rooted slot in the slot list
-                                    let index_in_slot_list = self.accounts_index.latest_slot(
-                                        None,
-                                        slot_list,
-                                        max_clean_root_inclusive,
-                                    );
+                candidates_bin.retain(|candidate_pubkey, candidate_info| {
+                    self.accounts_index.scan(
+                        [*candidate_pubkey].iter(),
+                        |_candidate_pubkey, slot_list_and_ref_count, _entry| {
+                            let mut useless = true;
+                            if let Some((slot_list, ref_count)) = slot_list_and_ref_count {
+                                // find the highest rooted slot in the slot list
+                                let index_in_slot_list = self.accounts_index.latest_slot(
+                                    None,
+                                    slot_list,
+                                    max_clean_root_inclusive,
+                                );
 
-                                    match index_in_slot_list {
-                                        Some(index_in_slot_list) => {
-                                            // found info relative to max_clean_root
-                                            let (slot, account_info) =
-                                                &slot_list[index_in_slot_list];
-                                            if account_info.is_zero_lamport() {
-                                                useless = false;
-                                                // The latest one is zero lamports. We may be able to purge it.
-                                                // Add all the rooted entries that contain this pubkey.
-                                                // We know the highest rooted entry is zero lamports.
-                                                candidate_info.slot_list =
-                                                    self.accounts_index.get_rooted_entries(
-                                                        slot_list,
-                                                        max_clean_root_inclusive,
-                                                    );
-                                                candidate_info.ref_count = ref_count;
-                                            } else {
-                                                found_not_zero += 1;
-                                            }
-                                            if uncleaned_roots.contains(slot) {
-                                                // Assertion enforced by `accounts_index.get()`, the latest slot
-                                                // will not be greater than the given `max_clean_root`
-                                                if let Some(max_clean_root_inclusive) =
-                                                    max_clean_root_inclusive
-                                                {
-                                                    assert!(slot <= &max_clean_root_inclusive);
-                                                }
-                                                if slot_list.len() > 1 {
-                                                    // no need to purge old accounts if there is only 1 slot in the slot list
-                                                    candidate_info.should_purge = true;
-                                                    purges_old_accounts_local += 1;
-                                                    useless = false;
-                                                } else {
-                                                    self.clean_accounts_stats
-                                                        .uncleaned_roots_slot_list_1
-                                                        .fetch_add(1, Ordering::Relaxed);
-                                                }
-                                            }
-                                        }
-                                        None => {
-                                            // This pubkey is in the index but not in a root slot, so clean
-                                            // it up by adding it to the to-be-purged list.
-                                            //
-                                            // Also, this pubkey must have been touched by some slot since
-                                            // it was in the dirty list, so we assume that the slot it was
-                                            // touched in must be unrooted.
-                                            not_found_on_fork += 1;
-                                            candidate_info.should_purge = true;
-                                            purges_old_accounts_local += 1;
+                                match index_in_slot_list {
+                                    Some(index_in_slot_list) => {
+                                        // found info relative to max_clean_root
+                                        let (slot, account_info) = &slot_list[index_in_slot_list];
+                                        if account_info.is_zero_lamport() {
                                             useless = false;
+                                            // The latest one is zero lamports. We may be able to purge it.
+                                            // Add all the rooted entries that contain this pubkey.
+                                            // We know the highest rooted entry is zero lamports.
+                                            candidate_info.slot_list =
+                                                self.accounts_index.get_rooted_entries(
+                                                    slot_list,
+                                                    max_clean_root_inclusive,
+                                                );
+                                            candidate_info.ref_count = ref_count;
+                                        } else {
+                                            found_not_zero += 1;
+                                        }
+                                        if uncleaned_roots.contains(slot) {
+                                            // Assertion enforced by `accounts_index.get()`, the latest slot
+                                            // will not be greater than the given `max_clean_root`
+                                            if let Some(max_clean_root_inclusive) =
+                                                max_clean_root_inclusive
+                                            {
+                                                assert!(slot <= &max_clean_root_inclusive);
+                                            }
+                                            if slot_list.len() > 1 {
+                                                // no need to purge old accounts if there is only 1 slot in the slot list
+                                                candidate_info.should_purge = true;
+                                                purges_old_accounts_local += 1;
+                                                useless = false;
+                                            } else {
+                                                self.clean_accounts_stats
+                                                    .uncleaned_roots_slot_list_1
+                                                    .fetch_add(1, Ordering::Relaxed);
+                                            }
                                         }
                                     }
-                                } else {
-                                    missing += 1;
+                                    None => {
+                                        // This pubkey is in the index but not in a root slot, so clean
+                                        // it up by adding it to the to-be-purged list.
+                                        //
+                                        // Also, this pubkey must have been touched by some slot since
+                                        // it was in the dirty list, so we assume that the slot it was
+                                        // touched in must be unrooted.
+                                        not_found_on_fork += 1;
+                                        candidate_info.should_purge = true;
+                                        purges_old_accounts_local += 1;
+                                        useless = false;
+                                    }
                                 }
-                                if !useless {
-                                    useful += 1;
-                                }
-                                AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
-                            },
-                            None,
-                            false,
-                            ScanFilter::All,
-                        );
-                    });
+                            } else {
+                                missing += 1;
+                            }
+                            if !useless {
+                                useful += 1;
+                            }
+                            AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
+                        },
+                        None,
+                        false,
+                        ScanFilter::All,
+                    );
+                    !candidate_info.slot_list.is_empty() || candidate_info.should_purge
+                });
                 found_not_zero_accum.fetch_add(found_not_zero, Ordering::Relaxed);
                 not_found_on_fork_accum.fetch_add(not_found_on_fork, Ordering::Relaxed);
                 missing_accum.fetch_add(missing, Ordering::Relaxed);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2750,17 +2750,16 @@ impl AccountsDb {
             .expect("Cluster type must be set at initialization")
     }
 
-    /// Reclaim older states of accounts older than max_clean_root_inclusive for AccountsDb bloat mitigation.
-    /// Any accounts which are removed from the accounts index are returned in PubkeysRemovedFromAccountsIndex.
-    /// These should NOT be unref'd later from the accounts index.
-    fn clean_account_older_than_root(
+    /// While scanning cleaning candidates obtain slots that can be
+    /// reclaimed for each pubkey. In addition if the pubkey is
+    /// removed from the index, let the caller know this.
+    fn collect_reclaims(
         &self,
         pubkey: &Pubkey,
         max_clean_root_inclusive: Option<Slot>,
         ancient_account_cleans: &AtomicU64,
         epoch_schedule: &EpochSchedule,
-    ) -> (ReclaimResult, PubkeysRemovedFromAccountsIndex) {
-        let mut pubkeys_removed_from_accounts_index = HashSet::default();
+    ) -> (SlotList<AccountInfo>, bool) {
         let one_epoch_old = self.get_oldest_non_ancient_slot(epoch_schedule);
         let mut clean_rooted = Measure::start("clean_old_root-ms");
         let mut reclaims = Vec::new();
@@ -2769,9 +2768,6 @@ impl AccountsDb {
             &mut reclaims,
             max_clean_root_inclusive,
         );
-        if removed_from_index {
-            pubkeys_removed_from_accounts_index.insert(*pubkey);
-        }
         if !reclaims.is_empty() {
             // figure out how many ancient accounts have been reclaimed
             let old_reclaims = reclaims
@@ -2781,10 +2777,21 @@ impl AccountsDb {
             ancient_account_cleans.fetch_add(old_reclaims, Ordering::Relaxed);
         }
         clean_rooted.stop();
+        debug!("{}", clean_rooted);
         self.clean_accounts_stats
             .clean_old_root_us
             .fetch_add(clean_rooted.as_us(), Ordering::Relaxed);
+        (reclaims, removed_from_index)
+    }
 
+    /// Reclaim older states of accounts older than max_clean_root_inclusive for AccountsDb bloat mitigation.
+    /// Any accounts which are removed from the accounts index are returned in PubkeysRemovedFromAccountsIndex.
+    /// These should NOT be unref'd later from the accounts index.
+    fn clean_accounts_older_than_root(
+        &self,
+        reclaims: &SlotList<AccountInfo>,
+        pubkeys_removed_from_accounts_index: &HashSet<Pubkey>,
+    ) -> ReclaimResult {
         let mut measure = Measure::start("clean_old_root_reclaims");
 
         // Don't reset from clean, since the pubkeys in those stores may need to be unref'ed
@@ -2795,15 +2802,15 @@ impl AccountsDb {
             (!reclaims.is_empty()).then(|| reclaims.iter()),
             None,
             reset_accounts,
-            &pubkeys_removed_from_accounts_index,
+            pubkeys_removed_from_accounts_index,
             HandleReclaims::ProcessDeadSlots(&self.clean_accounts_stats.purge_stats),
         );
         measure.stop();
-        debug!("{} {}", clean_rooted, measure);
+        debug!("{}", measure);
         self.clean_accounts_stats
             .clean_old_root_reclaim_us
             .fetch_add(measure.as_us(), Ordering::Relaxed);
-        (reclaim_result, pubkeys_removed_from_accounts_index)
+        reclaim_result
     }
 
     fn do_reset_uncleaned_roots(&self, max_clean_root: Option<Slot>) {
@@ -3328,10 +3335,8 @@ impl AccountsDb {
         let not_found_on_fork_accum = AtomicU64::new(0);
         let missing_accum = AtomicU64::new(0);
         let useful_accum = AtomicU64::new(0);
-        let purged_account_slots: AccountSlots = HashMap::new();
-        let purged_account_slots = Mutex::new(purged_account_slots);
-        let removed_accounts: SlotOffsets = HashMap::new();
-        let removed_accounts = Mutex::new(removed_accounts);
+        let reclaims: SlotList<AccountInfo> = Vec::new();
+        let reclaims = Mutex::new(reclaims);
         let pubkeys_removed_from_accounts_index: PubkeysRemovedFromAccountsIndex = HashSet::new();
         let pubkeys_removed_from_accounts_index = Mutex::new(pubkeys_removed_from_accounts_index);
         // parallel scan the index.
@@ -3425,27 +3430,19 @@ impl AccountsDb {
                         ScanFilter::All,
                     );
                     if should_purge {
-                        let (
-                            (purged_account_slots_new, removed_accounts_new),
-                            pubkeys_removed_from_accounts_index_new,
-                        ) = self.clean_account_older_than_root(
+                        let (reclaims_new, removed_from_index) = self.collect_reclaims(
                             candidate_pubkey,
                             max_clean_root_inclusive,
                             &ancient_account_cleans,
                             epoch_schedule,
                         );
-                        purged_account_slots
-                            .lock()
-                            .unwrap()
-                            .extend(purged_account_slots_new);
-                        removed_accounts
-                            .lock()
-                            .unwrap()
-                            .extend(removed_accounts_new);
-                        pubkeys_removed_from_accounts_index
-                            .lock()
-                            .unwrap()
-                            .extend(pubkeys_removed_from_accounts_index_new);
+                        reclaims.lock().unwrap().extend(reclaims_new);
+                        if removed_from_index {
+                            pubkeys_removed_from_accounts_index
+                                .lock()
+                                .unwrap()
+                                .insert(*candidate_pubkey);
+                        }
                     }
                     !candidate_info.slot_list.is_empty()
                 });
@@ -3464,11 +3461,12 @@ impl AccountsDb {
 
         accounts_scan.stop();
         let retained_keys_count = Self::count_pubkeys(&candidates);
-        let purged_account_slots = purged_account_slots.into_inner().unwrap();
-        let removed_accounts = removed_accounts.into_inner().unwrap();
+        let reclaims = reclaims.into_inner().unwrap();
         let mut pubkeys_removed_from_accounts_index =
             pubkeys_removed_from_accounts_index.into_inner().unwrap();
         let mut clean_old_rooted = Measure::start("clean_old_roots");
+        let (purged_account_slots, removed_accounts) =
+            self.clean_accounts_older_than_root(&reclaims, &pubkeys_removed_from_accounts_index);
         self.do_reset_uncleaned_roots(max_clean_root_inclusive);
         clean_old_rooted.stop();
 
@@ -3500,7 +3498,7 @@ impl AccountsDb {
                         return false;
                     }
                     // Check if this update in `slot` to the account with `key` was reclaimed earlier by
-                    // `clean_account_older_than_root()`
+                    // `clean_accounts_older_than_root()`
                     let was_reclaimed = removed_accounts
                         .get(slot)
                         .map(|store_removed| store_removed.contains(&account_info.offset()))
@@ -5585,7 +5583,7 @@ impl AccountsDb {
         //          handle_reclaims()             | (removes storage entries)
         //      OR                                |
         //    clean_accounts()/                   |
-        //        clean_account_older_than_root() | (removes existing store_id, offset for stores)
+        //        clean_accounts_older_than_root()| (removes existing store_id, offset for stores)
         //                                        V
         //
         // Remarks for purger: So, for any reading operations, it's a race condition


### PR DESCRIPTION
#### Problem

The list of cleaning candidates can be reduced while scanning through it before removing any accounts from the account index. 

#### Summary of Changes

While scanning the list of candidate accounts for removing from the accounts-db index, retain only the candidates with non-empty slot_list or that explicitly marked for purging.