### PR TITLE
remove disable_block_production_forwarding cli flag

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1554,16 +1554,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help(BlockProductionMethod::cli_message()),
         )
         .arg(
-            Arg::with_name("disable_block_production_forwarding")
-            .long("disable-block-production-forwarding")
-            .requires("staked_nodes_overrides")
-            .takes_value(false)
-            .help("Disable forwarding of non-vote transactions in block production. \
-                   By default, forwarding is already disabled, it is enabled by setting \
-                   \"staked-nodes-overrides\". This flag can be used to disable forwarding \
-                   even when \"staked-nodes-overrides\" is set."),
-        )
-        .arg(
             Arg::with_name("unified_scheduler_handler_threads")
                 .long("unified-scheduler-handler-threads")
                 .value_name("COUNT")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1783,10 +1783,7 @@ pub fn main() {
         BlockProductionMethod
     )
     .unwrap_or_default();
-    validator_config.enable_block_production_forwarding = staked_nodes_overrides_path
-        .as_ref()
-        .map(|_| !matches.is_present("disable_block_production_forwarding"))
-        .unwrap_or_default();
+    validator_config.enable_block_production_forwarding = staked_nodes_overrides_path.is_some();
     validator_config.unified_scheduler_handler_threads =
         value_t!(matches, "unified_scheduler_handler_threads", usize).ok();
 


### PR DESCRIPTION
#### Problem
- Flag adds operational complexity
- If operators see issue(s) with staked partner forwarding, they should remove staked-partner configuration.

#### Summary of Changes
- Remove `disable-block-production-forwarding` cli flag from validator

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
