### PR TITLE
cli: Use simulated compute units in nonce interactions

### DIFF
--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -5,7 +5,9 @@ use {
             log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError,
             ProcessResult,
         },
-        compute_budget::{ComputeUnitConfig, WithComputeUnitConfig},
+        compute_budget::{
+            simulate_and_update_compute_unit_limit, ComputeUnitConfig, WithComputeUnitConfig,
+        },
         memo::WithMemo,
         spend_utils::{resolve_spend_tx_and_check_account_balance, SpendAmount},
     },
@@ -423,7 +425,8 @@ pub fn process_authorize_nonce_account(
         compute_unit_price,
         compute_unit_limit: ComputeUnitLimit::Simulated,
     });
-    let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
+    let mut message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
+    simulate_and_update_compute_unit_limit(&rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
 
@@ -582,7 +585,8 @@ pub fn process_new_nonce(
         compute_unit_limit: ComputeUnitLimit::Simulated,
     });
     let latest_blockhash = rpc_client.get_latest_blockhash()?;
-    let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
+    let mut message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
+    simulate_and_update_compute_unit_limit(&rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
     check_account_for_fee_with_commitment(
@@ -650,7 +654,8 @@ pub fn process_withdraw_from_nonce_account(
         compute_unit_price,
         compute_unit_limit: ComputeUnitLimit::Simulated,
     });
-    let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
+    let mut message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
+    simulate_and_update_compute_unit_limit(&rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
     check_account_for_fee_with_commitment(
@@ -678,7 +683,8 @@ pub(crate) fn process_upgrade_nonce_account(
             compute_unit_price,
             compute_unit_limit: ComputeUnitLimit::Simulated,
         });
-    let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
+    let mut message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
+    simulate_and_update_compute_unit_limit(&rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
     check_account_for_fee_with_commitment(

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -426,7 +426,7 @@ pub fn process_authorize_nonce_account(
         compute_unit_limit: ComputeUnitLimit::Simulated,
     });
     let mut message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
-    simulate_and_update_compute_unit_limit(&rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
 
@@ -586,7 +586,7 @@ pub fn process_new_nonce(
     });
     let latest_blockhash = rpc_client.get_latest_blockhash()?;
     let mut message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
-    simulate_and_update_compute_unit_limit(&rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
     check_account_for_fee_with_commitment(
@@ -655,7 +655,7 @@ pub fn process_withdraw_from_nonce_account(
         compute_unit_limit: ComputeUnitLimit::Simulated,
     });
     let mut message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
-    simulate_and_update_compute_unit_limit(&rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
     check_account_for_fee_with_commitment(
@@ -684,7 +684,7 @@ pub(crate) fn process_upgrade_nonce_account(
             compute_unit_limit: ComputeUnitLimit::Simulated,
         });
     let mut message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
-    simulate_and_update_compute_unit_limit(&rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
     check_account_for_fee_with_commitment(

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -421,7 +421,7 @@ pub fn process_authorize_nonce_account(
     .with_memo(memo)
     .with_compute_unit_config(&ComputeUnitConfig {
         compute_unit_price,
-        compute_unit_limit: ComputeUnitLimit::Default,
+        compute_unit_limit: ComputeUnitLimit::Simulated,
     });
     let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
@@ -469,7 +469,7 @@ pub fn process_create_nonce_account(
 
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.signers[0].pubkey());
 
-    let compute_unit_limit = ComputeUnitLimit::Default;
+    let compute_unit_limit = ComputeUnitLimit::Simulated;
     let build_message = |lamports| {
         let ixs = if let Some(seed) = seed.clone() {
             create_nonce_account_with_seed(
@@ -579,7 +579,7 @@ pub fn process_new_nonce(
     .with_memo(memo)
     .with_compute_unit_config(&ComputeUnitConfig {
         compute_unit_price,
-        compute_unit_limit: ComputeUnitLimit::Default,
+        compute_unit_limit: ComputeUnitLimit::Simulated,
     });
     let latest_blockhash = rpc_client.get_latest_blockhash()?;
     let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
@@ -648,7 +648,7 @@ pub fn process_withdraw_from_nonce_account(
     .with_memo(memo)
     .with_compute_unit_config(&ComputeUnitConfig {
         compute_unit_price,
-        compute_unit_limit: ComputeUnitLimit::Default,
+        compute_unit_limit: ComputeUnitLimit::Simulated,
     });
     let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
@@ -676,7 +676,7 @@ pub(crate) fn process_upgrade_nonce_account(
         .with_memo(memo)
         .with_compute_unit_config(&ComputeUnitConfig {
             compute_unit_price,
-            compute_unit_limit: ComputeUnitLimit::Default,
+            compute_unit_limit: ComputeUnitLimit::Simulated,
         });
     let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -23,10 +23,11 @@ use {
     test_case::test_case,
 };
 
-#[test_case(None, false; "base")]
-#[test_case(Some(String::from("seed")), false; "with_seed")]
-#[test_case(None, true; "with_authority")]
-fn test_nonce(seed: Option<String>, use_nonce_authority: bool) {
+#[test_case(None, false, None; "base")]
+#[test_case(Some(String::from("seed")), false, None; "with_seed")]
+#[test_case(None, true, None; "with_authority")]
+#[test_case(None, false, Some(1_000_000); "with_compute_unit_price")]
+fn test_nonce(seed: Option<String>, use_nonce_authority: bool, compute_unit_price: Option<u64>) {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
@@ -86,7 +87,7 @@ fn test_nonce(seed: Option<String>, use_nonce_authority: bool) {
         nonce_authority: optional_authority,
         memo: None,
         amount: SpendAmount::Some(sol_to_lamports(1000.0)),
-        compute_unit_price: None,
+        compute_unit_price,
     };
 
     process_command(&config_payer).unwrap();
@@ -124,7 +125,7 @@ fn test_nonce(seed: Option<String>, use_nonce_authority: bool) {
         nonce_account,
         nonce_authority: index,
         memo: None,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_payer).unwrap();
 
@@ -145,7 +146,7 @@ fn test_nonce(seed: Option<String>, use_nonce_authority: bool) {
         memo: None,
         destination_account_pubkey: payee_pubkey,
         lamports: sol_to_lamports(100.0),
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_payer).unwrap();
     check_balance!(
@@ -170,7 +171,7 @@ fn test_nonce(seed: Option<String>, use_nonce_authority: bool) {
         nonce_authority: index,
         memo: None,
         new_authority: new_authority.pubkey(),
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_payer).unwrap();
 
@@ -179,7 +180,7 @@ fn test_nonce(seed: Option<String>, use_nonce_authority: bool) {
         nonce_account,
         nonce_authority: index,
         memo: None,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_payer).unwrap_err();
 
@@ -189,7 +190,7 @@ fn test_nonce(seed: Option<String>, use_nonce_authority: bool) {
         nonce_account,
         nonce_authority: 1,
         memo: None,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_payer).unwrap();
 
@@ -200,7 +201,7 @@ fn test_nonce(seed: Option<String>, use_nonce_authority: bool) {
         memo: None,
         destination_account_pubkey: payee_pubkey,
         lamports: sol_to_lamports(100.0),
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_payer).unwrap();
     check_balance!(

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -20,46 +20,19 @@ use {
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_test_validator::TestValidator,
+    test_case::test_case,
 };
 
-#[test]
-fn test_nonce() {
+#[test_case(None, false; "base")]
+#[test_case(Some(String::from("seed")), false; "with_seed")]
+#[test_case(None, true; "with_authority")]
+fn test_nonce(seed: Option<String>, use_nonce_authority: bool) {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
     let test_validator =
         TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
-    full_battery_tests(test_validator, None, false);
-}
-
-#[test]
-fn test_nonce_with_seed() {
-    let mint_keypair = Keypair::new();
-    let mint_pubkey = mint_keypair.pubkey();
-    let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator =
-        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
-
-    full_battery_tests(test_validator, Some(String::from("seed")), false);
-}
-
-#[test]
-fn test_nonce_with_authority() {
-    let mint_keypair = Keypair::new();
-    let mint_pubkey = mint_keypair.pubkey();
-    let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator =
-        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
-
-    full_battery_tests(test_validator, None, true);
-}
-
-fn full_battery_tests(
-    test_validator: TestValidator,
-    seed: Option<String>,
-    use_nonce_authority: bool,
-) {
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
     let json_rpc_url = test_validator.rpc_url();


### PR DESCRIPTION
#### Problem

The CLI can simulate to get the compute budget used by a transaction, but nonce interactions are still using the default compute unit limit.

#### Summary of changes

Refactor the tests into `test_case`s, add tests for setting a compute unit price, and then change compute unit limit to `Simulated`.