### PR TITLE
replay: do not early return when marking slots duplicate confirmed

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1831,7 +1831,7 @@ impl ReplayStage {
                 {
                     assert_eq!(
                         prev_hash, duplicate_confirmed_hash,
-                        "Additional duplicate confirmed notification for {confirmed_slot} with a different hash"
+                        "Additional duplicate confirmed notification for slot {confirmed_slot} with a different hash"
                     );
                     // Already processed this signal
                     continue;
@@ -4143,7 +4143,7 @@ impl ReplayStage {
             if let Some(prev_hash) = duplicate_confirmed_slots.insert(*slot, *frozen_hash) {
                 assert_eq!(
                     prev_hash, *frozen_hash,
-                    "Additional duplicate confirmed notification for {slot} with a different hash"
+                    "Additional duplicate confirmed notification for slot {slot} with a different hash"
                 );
                 // Already processed this signal
                 continue;
@@ -9378,7 +9378,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Additional duplicate confirmed notification for 6")]
+    #[should_panic(expected = "Additional duplicate confirmed notification for slot 6")]
     fn test_mark_slots_duplicate_confirmed() {
         let generate_votes = |pubkeys: Vec<Pubkey>| {
             pubkeys
@@ -9492,7 +9492,7 @@ pub(crate) mod tests {
 
     #[test_case(true ; "same_batch")]
     #[test_case(false ; "seperate_batches")]
-    #[should_panic(expected = "Additional duplicate confirmed notification for 6")]
+    #[should_panic(expected = "Additional duplicate confirmed notification for slot 6")]
     fn test_process_duplicate_confirmed_slots(same_batch: bool) {
         let generate_votes = |pubkeys: Vec<Pubkey>| {
             pubkeys

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1829,7 +1829,10 @@ impl ReplayStage {
                 } else if let Some(prev_hash) =
                     duplicate_confirmed_slots.insert(confirmed_slot, duplicate_confirmed_hash)
                 {
-                    assert_eq!(prev_hash, duplicate_confirmed_hash);
+                    assert_eq!(
+                        prev_hash, duplicate_confirmed_hash,
+                        "Additional duplicate confirmed notification with a different hash"
+                    );
                     // Already processed this signal
                     continue;
                 }
@@ -4138,7 +4141,10 @@ impl ReplayStage {
 
             progress.set_duplicate_confirmed_hash(*slot, *frozen_hash);
             if let Some(prev_hash) = duplicate_confirmed_slots.insert(*slot, *frozen_hash) {
-                assert_eq!(prev_hash, *frozen_hash);
+                assert_eq!(
+                    prev_hash, *frozen_hash,
+                    "Additional duplicate confirmed notification with a different hash"
+                );
                 // Already processed this signal
                 continue;
             }
@@ -9482,7 +9488,10 @@ pub(crate) mod tests {
                 &mut PurgeRepairSlotCounter::default(),
                 &mut duplicate_confirmed_slots,
             ))
-            .is_err()
+            .unwrap_err()
+            .downcast_ref::<String>()
+            .unwrap()
+            .starts_with("assertion `left == right` failed: Additional duplicate confirmed notification with a different hash")
         );
     }
 
@@ -9608,7 +9617,10 @@ pub(crate) mod tests {
                 &ancestor_hashes_replay_update_sender,
                 &mut PurgeRepairSlotCounter::default(),
             ))
-            .is_err()
+            .unwrap_err()
+            .downcast_ref::<String>()
+            .unwrap()
+            .starts_with("assertion `left == right` failed: Additional duplicate confirmed notification with a different hash")
         );
     }
 }


### PR DESCRIPTION
#### Problem
When processing duplicate confirmed slots from gossip or replay we early return if we have already duplicate confirmed this slot.

This can cause the following situation:
* Slot `S` is DC through gossip and marked as valid in fork choice.
* Later replay of a slot `S + 2` indicates that `S` and `S + 1` are DC.
* We see that we've already marked `S` as DC through gossip, so we early exit. 
* `S + 1` is never marked as valid in fork choice.

And vice versa if `S` is first marked DC through replay.

#### Summary of Changes
`continue` instead so we can process any new slots later in the queue.
