### PR TITLE
add flag to bake non bootstrap validator stakes into genesis

### DIFF
--- a/genesis/README.md
+++ b/genesis/README.md
@@ -1,0 +1,75 @@
+# Genesis
+
+## There are a few ways to bake validator accounts and staked into genesis:
+### 1) Through bootstrap validator cli args:
+```
+--bootstrap-validator <IDENTITY_PUBKEY> <VOTE_PUBKEY> <STAKE_PUBKEY>
+--bootstrap-validator-lamports <LAMPORTS>
+--bootstrap-validator-stake-lamports <LAMPORTS>
+```
+Note: you can pass in `--bootstrap-validator ...` multiple times but the lamports associated with `--bootstrap-validator-lamports` and `--bootstrap-validator-stake-lamports` will apply to all `--bootstrap-validator` arguments.
+For example:
+```
+cargo run --bin solana-genesis --
+    --bootstrap-validator <IDENTITY_PUBKEY_0> <VOTE_PUBKEY_0> <STAKE_PUBKEY_0>
+    --bootstrap-validator <IDENTITY_PUBKEY_1> <VOTE_PUBKEY_1> <STAKE_PUBKEY_1>
+    ...
+    --bootstrap-validator <IDENTITY_PUBKEY_N> <VOTE_PUBKEY_N> <STAKE_PUBKEY_N>
+    --bootstrap-validator-stake-lamports 10000000000
+    --bootstrap-validator 100000000000
+```
+All validator accounts will receive the same number of stake and account lamports
+
+### 2) Through the primordial accounts file flag:
+```
+--primordial-accounts-file <PATH_TO_PRIMORDIAL_ACCOUNTS_YAML>
+```
+The primordial accounts file has the following format:
+```
+---
+<IDENTITY_PUBKEY_0>:
+  balance: <LAMPORTS_0>
+  owner: <OWNER_PUBKEY_0>
+  data: <BAS64_ENCODED_DATA_0>
+  executable: false
+<IDENTITY_PUBKEY_1>:
+  balance: <LAMPORTS_1>
+  owner: <OWNER_PUBKEY_1>
+  data: <BAS64_ENCODED_DATA_1>
+  executable: true
+...
+<IDENTITY_PUBKEY_N>:
+  balance: <LAMPORTS_N>
+  owner: <OWNER_PUBKEY_N>
+  data: <BAS64_ENCODED_DATA_N>
+  executable: true
+```
+The `data` portion of the yaml file holds BASE64 encoded data about the account. `data` can include both vote and stake account information.
+
+### 3) Through the validator accounts file flag:
+The validator accounts file is an alternative to the primordial accounts file. The main goal with the validator accounts file is to:
+- Bake validator stakes into genesis with different stake and acount distributions
+- Remove the overhead of forcing the user to serialize and deserialize validator stake and vote account state if they want varying stake distributions - as required by (2)
+```
+--validator-accounts-file <PATH_TO_VALIDATOR_ACCOUNTS_YAML>
+```
+The validator accounts file has the following format:
+```
+validator_accounts:
+- balance_lamports: <balance-lamports-0>
+  stake_lamports: <stake-lamports-0>
+  identity_account: <identity-pubkey-0>
+  vote_account: <vote-pubkey-0>
+  stake_account: <stake-pubkey-0>
+- balance_lamports: <balance-lamports-1>
+  stake_lamports: <stake-lamports-1>
+  identity_account: <identity-pubkey-1>
+  vote_account: <vote-pubkey-1>
+  stake_account: <stake-pubkey-1>
+...
+- balance_lamports: <balance-lamports-N>
+  stake_lamports: <stake-lamports-N>
+  identity_account: <identity-pubkey-N>
+  vote_account: <vote-pubkey-N>
+  stake_account: <stake-pubkey-N>
+```

--- a/genesis/README.md
+++ b/genesis/README.md
@@ -1,6 +1,6 @@
 # Genesis
 
-## There are a few ways to bake validator accounts and staked into genesis:
+## There are a few ways to bake validator accounts and delegated stake into genesis:
 ### 1) Through bootstrap validator cli args:
 ```
 --bootstrap-validator <IDENTITY_PUBKEY> <VOTE_PUBKEY> <STAKE_PUBKEY>
@@ -21,6 +21,7 @@ cargo run --bin solana-genesis --
 All validator accounts will receive the same number of stake and account lamports
 
 ### 2) Through the primordial accounts file flag:
+The primordial accounts file can be used to add accounts of any type to genesis. A user can define all account data and metadata. `data` field must be BASE64 encoded.
 ```
 --primordial-accounts-file <PATH_TO_PRIMORDIAL_ACCOUNTS_YAML>
 ```
@@ -44,32 +45,32 @@ The primordial accounts file has the following format:
   data: <BAS64_ENCODED_DATA_N>
   executable: true
 ```
-The `data` portion of the yaml file holds BASE64 encoded data about the account. `data` can include both vote and stake account information.
+The `data` portion of the yaml file holds BASE64 encoded data about the account, which can be vote or stake account information.
 
 ### 3) Through the validator accounts file flag:
-The validator accounts file is an alternative to the primordial accounts file. The main goal with the validator accounts file is to:
-- Bake validator stakes into genesis with different stake and acount distributions
-- Remove the overhead of forcing the user to serialize and deserialize validator stake and vote account state if they want varying stake distributions - as required by (2)
+The main goal with the validator accounts file is to:
+- Bake validator stakes into genesis with different stake and account distributions
+- Remove the overhead of forcing the user to serialize and deserialize validator stake and vote account state, as required by a primordial accounts file.
 ```
 --validator-accounts-file <PATH_TO_VALIDATOR_ACCOUNTS_YAML>
 ```
 The validator accounts file has the following format:
 ```
 validator_accounts:
-- balance_lamports: <balance-lamports-0>
-  stake_lamports: <stake-lamports-0>
-  identity_account: <identity-pubkey-0>
-  vote_account: <vote-pubkey-0>
-  stake_account: <stake-pubkey-0>
-- balance_lamports: <balance-lamports-1>
-  stake_lamports: <stake-lamports-1>
-  identity_account: <identity-pubkey-1>
-  vote_account: <vote-pubkey-1>
-  stake_account: <stake-pubkey-1>
+- balance_lamports: <BALANCE_LAMPORTS_0>
+  stake_lamports: <STAKE_LAMPORTS_0>
+  identity_account: <IDENTITY_PUBKEY_0>
+  vote_account: <VOTE_PUBKEY_0>
+  stake_account: <STAKE_PUBKEY_0>
+- balance_lamports: <BALANCE_LAMPORTS_1>
+  stake_lamports: <STAKE_LAMPORTS_1>
+  identity_account: <IDENTITY_PUBKEY_1>
+  vote_account: <VOTE_PUBKEY_1>
+  stake_account: <STAKE_PUBKEY_1>
 ...
-- balance_lamports: <balance-lamports-N>
-  stake_lamports: <stake-lamports-N>
-  identity_account: <identity-pubkey-N>
-  vote_account: <vote-pubkey-N>
-  stake_account: <stake-pubkey-N>
+- balance_lamports: <BALANCE_LAMPORTS_N>
+  stake_lamports: <STAKE_LAMPORTS_N>
+  identity_account: <IDENTITY_PUBKEY_N>
+  vote_account: <VOTE_PUBKEY_N>
+  stake_account: <STAKE_PUBKEY_N>
 ```

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -15,6 +15,11 @@ pub struct Base64Account {
     pub executable: bool,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ValidatorAccountsFile {
+    pub validator_accounts: Vec<Base64ValidatorAccount>,
+}
+
 /// A validator account where the data is encoded as a Base64 string.
 /// Includes the vote account and stake account.
 #[derive(Serialize, Deserialize, Debug)]

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -17,13 +17,13 @@ pub struct Base64Account {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ValidatorAccountsFile {
-    pub validator_accounts: Vec<Base64ValidatorAccount>,
+    pub validator_accounts: Vec<StakedValidatorAccountInfo>,
 }
 
-/// A validator account where the data is encoded as a Base64 string.
-/// Includes the vote account and stake account.
+/// Info needed to create a staked validator account,
+/// including relevant balances and vote- and stake-account addresses
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Base64ValidatorAccount {
+pub struct StakedValidatorAccountInfo {
     pub balance_lamports: u64,
     pub stake_lamports: u64,
     pub identity_account: String,

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -14,3 +14,14 @@ pub struct Base64Account {
     pub data: String,
     pub executable: bool,
 }
+
+/// A validator account where the data is encoded as a Base64 string.
+/// Includes the vote account and stake account.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Base64ValidatorAccount {
+    pub balance_lamports: u64,
+    pub stake_lamports: u64,
+    pub identity_account: String,
+    pub vote_account: String,
+    pub stake_account: String,
+}

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -17,7 +17,7 @@ use {
     },
     solana_entry::poh::compute_hashes_per_tick,
     solana_genesis::{
-        genesis_accounts::add_genesis_accounts, Base64Account, Base64ValidatorAccount,
+        genesis_accounts::add_genesis_accounts, Base64Account, StakedValidatorAccountInfo,
         ValidatorAccountsFile,
     },
     solana_ledger::{blockstore::create_new_ledger, blockstore_options::LedgerColumnOptions},
@@ -123,7 +123,7 @@ pub fn load_validator_accounts(
     genesis_config: &mut GenesisConfig,
 ) -> io::Result<()> {
     let accounts_file = File::open(file)?;
-    let validator_genesis_accounts: Vec<Base64ValidatorAccount> =
+    let validator_genesis_accounts: Vec<StakedValidatorAccountInfo> =
         serde_yaml::from_reader::<_, ValidatorAccountsFile>(accounts_file)
             .map_err(|err| io::Error::new(io::ErrorKind::Other, format!("{err:?}")))?
             .validator_accounts;
@@ -551,7 +551,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .value_name("FILENAME")
                 .takes_value(true)
                 .multiple(true)
-                .help("The location of identity, vote, and stake pubkeys and balances for validator accounts to bake into genesis")
+                .help("The location of a file containing a list of identity, vote, and stake pubkeys and balances for validator accounts to bake into genesis")
         )
         .arg(
             Arg::with_name("cluster_type")
@@ -1258,21 +1258,21 @@ mod tests {
         let mut genesis_config = GenesisConfig::default();
 
         let validator_accounts = vec![
-            Base64ValidatorAccount {
+            StakedValidatorAccountInfo {
                 identity_account: solana_sdk::pubkey::new_rand().to_string(),
                 vote_account: solana_sdk::pubkey::new_rand().to_string(),
                 stake_account: solana_sdk::pubkey::new_rand().to_string(),
                 balance_lamports: 100000000000,
                 stake_lamports: 10000000000,
             },
-            Base64ValidatorAccount {
+            StakedValidatorAccountInfo {
                 identity_account: solana_sdk::pubkey::new_rand().to_string(),
                 vote_account: solana_sdk::pubkey::new_rand().to_string(),
                 stake_account: solana_sdk::pubkey::new_rand().to_string(),
                 balance_lamports: 200000000000,
                 stake_lamports: 20000000000,
             },
-            Base64ValidatorAccount {
+            StakedValidatorAccountInfo {
                 identity_account: solana_sdk::pubkey::new_rand().to_string(),
                 vote_account: solana_sdk::pubkey::new_rand().to_string(),
                 stake_account: solana_sdk::pubkey::new_rand().to_string(),


### PR DESCRIPTION
#### Problem
There is currently no efficient way of to bake validator stakes into genesis without requiring the user to serialize and deserialize validator accounts into and out of a `primordial-accounts-file` file. 

#### Summary of Changes
add `--validator-accounts-file <path-to-file>` cli arg that reads in validator accounts from a yaml file. These accounts and associated lamports are then baked into genesis. 

validator-accounts-file format:
```
validator_accounts:
- balance_lamports: <balance-lamports-0>
  stake_lamports: <stake-lamports-0>
  identity_account: <identity-pubkey-0>
  vote_account: <vote-pubkey-0>
  stake_account: <stake-pubkey-0>
- balance_lamports: <balance-lamports-1>
  stake_lamports: <stake-lamports-1>
  identity_account: <identity-pubkey-1>
  vote_account: <vote-pubkey-1>
  stake_account: <stake-pubkey-1>
...
- balance_lamports: <balance-lamports-N>
  stake_lamports: <stake-lamports-N>
  identity_account: <identity-pubkey-N>
  vote_account: <vote-pubkey-N>
  stake_account: <stake-pubkey-N>
```