### PR TITLE
PoC for removing check results

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -150,7 +150,7 @@ use {
         stake_state::StakeStateV2,
     },
     solana_svm::{
-        account_loader::{collect_rent_from_account, LoadedTransaction},
+        account_loader::{collect_rent_from_account, LoadedTransaction, TransactionCheckBatch},
         account_overrides::AccountOverrides,
         account_saver::collect_accounts_to_store,
         transaction_commit_result::{CommittedTransaction, TransactionCommitResult},
@@ -3486,12 +3486,13 @@ impl Bank {
             rent_collector: Some(&self.rent_collector),
         };
 
+        let mut transaction_check_batch = TransactionCheckBatch::new(check_results);
         let sanitized_output = self
             .transaction_processor
             .load_and_execute_sanitized_transactions(
                 self,
                 sanitized_txs,
-                check_results,
+                &mut transaction_check_batch,
                 &processing_environment,
                 &processing_config,
             );

--- a/svm/examples/paytube/src/lib.rs
+++ b/svm/examples/paytube/src/lib.rs
@@ -61,11 +61,10 @@ pub mod transaction;
 
 use {
     crate::{
-        loader::PayTubeAccountLoader, settler::PayTubeSettler, transaction::PayTubeTransaction,
+        loader::PayTubeAccountLoader, processor::PayTubeCheckResults, settler::PayTubeSettler,
+        transaction::PayTubeTransaction,
     },
-    processor::{
-        create_transaction_batch_processor, get_transaction_check_results, PayTubeForkGraph,
-    },
+    processor::{create_transaction_batch_processor, PayTubeForkGraph},
     solana_client::rpc_client::RpcClient,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_sdk::{
@@ -177,7 +176,7 @@ impl PayTubeChannel {
         let results = processor.load_and_execute_sanitized_transactions(
             &account_loader,
             &svm_transactions,
-            get_transaction_check_results(svm_transactions.len(), lamports_per_signature),
+            &mut PayTubeCheckResults::default(),
             &processing_environment,
             &processing_config,
         );

--- a/svm/examples/paytube/src/processor.rs
+++ b/svm/examples/paytube/src/processor.rs
@@ -6,9 +6,9 @@ use {
     solana_program_runtime::loaded_programs::{
         BlockRelation, ForkGraph, LoadProgramMetrics, ProgramCacheEntry,
     },
-    solana_sdk::{account::ReadableAccount, clock::Slot, feature_set::FeatureSet, transaction},
+    solana_sdk::{account::ReadableAccount, clock::Slot, feature_set::FeatureSet},
     solana_svm::{
-        account_loader::CheckedTransactionDetails,
+        account_loader::TransactionCheckResults,
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processor::TransactionBatchProcessor,
     },
@@ -105,18 +105,7 @@ pub(crate) fn create_transaction_batch_processor<CB: TransactionProcessingCallba
     processor
 }
 
-/// This function is also a mock. In the Agave validator, the bank pre-checks
-/// transactions before providing them to the SVM API. We mock this step in
-/// PayTube, since we don't need to perform such pre-checks.
-pub(crate) fn get_transaction_check_results(
-    len: usize,
-    lamports_per_signature: u64,
-) -> Vec<transaction::Result<CheckedTransactionDetails>> {
-    vec![
-        transaction::Result::Ok(CheckedTransactionDetails {
-            nonce: None,
-            lamports_per_signature,
-        });
-        len
-    ]
-}
+/// Use the default implementation of CheckResults
+#[derive(Default)]
+pub struct PayTubeCheckResults {}
+impl TransactionCheckResults for PayTubeCheckResults {}

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        mock_bank::{MockBankCallback, MockForkGraph},
+        mock_bank::{MockBankCallback, MockForkGraph, MockTransactionCheck},
         transaction_builder::SanitizedTransactionBuilder,
     },
     lazy_static::lazy_static,
@@ -33,7 +33,6 @@ use {
         },
     },
     solana_svm::{
-        account_loader::CheckedTransactionDetails,
         program_loader,
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processing_result::TransactionProcessingResultExtensions,
@@ -230,10 +229,6 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
     };
 
     let transactions = vec![transaction];
-    let transaction_check = vec![Ok(CheckedTransactionDetails {
-        nonce: None,
-        lamports_per_signature: 30,
-    })];
 
     let compute_budget = ComputeBudget {
         compute_unit_limit: input.cu_avail,
@@ -302,7 +297,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
     let result = batch_processor.load_and_execute_sanitized_transactions(
         &mock_bank,
         &transactions,
-        transaction_check,
+        &mut MockTransactionCheck::default(),
         &TransactionProcessingEnvironment {
             blockhash,
             lamports_per_signature,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -19,7 +19,9 @@ use {
         transaction::{SanitizedTransaction, TransactionError},
     },
     solana_svm::{
-        account_loader::{CheckedTransactionDetails, TransactionCheckResult},
+        account_loader::{
+            CheckedTransactionDetails, TransactionCheckBatch, TransactionCheckResult,
+        },
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processing_result::TransactionProcessingResultExtensions,
         transaction_processor::{
@@ -242,6 +244,8 @@ fn svm_integration() {
         HashSet::new(),
     );
 
+    let mut batch_check_results = TransactionCheckBatch::new(check_results);
+
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
 
     create_executable_environment(
@@ -266,7 +270,7 @@ fn svm_integration() {
     let result = batch_processor.load_and_execute_sanitized_transactions(
         &mock_bank,
         &transactions,
-        check_results,
+        &mut batch_check_results,
         &TransactionProcessingEnvironment::default(),
         &processing_config,
     );

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -25,6 +25,7 @@ use {
         sysvar::SysvarId,
     },
     solana_svm::{
+        account_loader::TransactionCheckResults,
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processor::TransactionBatchProcessor,
     },
@@ -40,6 +41,11 @@ use {
 };
 
 pub struct MockForkGraph {}
+
+#[derive(Default)]
+pub struct MockTransactionCheck {}
+
+impl TransactionCheckResults for MockTransactionCheck {}
 
 impl ForkGraph for MockForkGraph {
     fn relationship(&self, a: Slot, b: Slot) -> BlockRelation {


### PR DESCRIPTION
#### Problem

SVM's entry point requires a check result for each transaction. For external users, this may be a burden because it may hinder creating a standard behavior for all executed transactions.

#### Summary of Changes

I abstracted the check results in a trait `TransactionCheckResults` that allows a custom implementation to fetch the check result. Such a setting allows external users to customize the behavior or set a default for every transaction in the batch.

This PR is a proof of concept and is not ready to be merged. It is supposed to kickstart a discussion about the solution and possibly devise other changes.