### PR TITLE
cli: Use a better amount during transaction simulation

### DIFF
--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -445,7 +445,7 @@ pub fn process_create_nonce_account(
     seed: Option<String>,
     nonce_authority: Option<Pubkey>,
     memo: Option<&String>,
-    amount: SpendAmount,
+    mut amount: SpendAmount,
     compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let nonce_account_pubkey = config.signers[nonce_account].pubkey();
@@ -459,6 +459,11 @@ pub fn process_create_nonce_account(
         (&config.signers[0].pubkey(), "cli keypair".to_string()),
         (&nonce_account_address, "nonce_account".to_string()),
     )?;
+
+    let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(State::size())?;
+    if amount == SpendAmount::All {
+        amount = SpendAmount::AllWithMinimum(minimum_balance);
+    }
 
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.signers[0].pubkey());
 
@@ -516,7 +521,6 @@ pub fn process_create_nonce_account(
         return Err(CliError::BadParameter(err_msg).into());
     }
 
-    let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(State::size())?;
     if lamports < minimum_balance {
         return Err(CliError::BadParameter(format!(
             "need at least {minimum_balance} lamports for nonce account to be rent exempt, \

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -462,7 +462,9 @@ pub fn process_create_nonce_account(
 
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(State::size())?;
     if amount == SpendAmount::All {
-        amount = SpendAmount::AllWithMinimum(minimum_balance);
+        amount = SpendAmount::AllForAccountCreation {
+            create_account_min_balance: minimum_balance,
+        };
     }
 
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.signers[0].pubkey());

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1457,7 +1457,9 @@ pub fn process_create_stake_account(
     if !sign_only && amount == SpendAmount::All {
         let minimum_balance =
             rpc_client.get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
-        amount = SpendAmount::AllWithMinimum(minimum_balance);
+        amount = SpendAmount::AllForAccountCreation {
+            create_account_min_balance: minimum_balance,
+        };
     }
 
     let (message, lamports) = resolve_spend_tx_and_check_account_balances(

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1368,7 +1368,7 @@ pub fn process_create_stake_account(
     withdrawer: &Option<Pubkey>,
     withdrawer_signer: Option<SignerIndex>,
     lockup: &Lockup,
-    amount: SpendAmount,
+    mut amount: SpendAmount,
     sign_only: bool,
     dump_transaction_message: bool,
     blockhash_query: &BlockhashQuery,
@@ -1454,6 +1454,12 @@ pub fn process_create_stake_account(
 
     let recent_blockhash = blockhash_query.get_blockhash(rpc_client, config.commitment)?;
 
+    if !sign_only && amount == SpendAmount::All {
+        let minimum_balance =
+            rpc_client.get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
+        amount = SpendAmount::AllWithMinimum(minimum_balance);
+    }
+
     let (message, lamports) = resolve_spend_tx_and_check_account_balances(
         rpc_client,
         sign_only,
@@ -1478,7 +1484,6 @@ pub fn process_create_stake_account(
 
         let minimum_balance =
             rpc_client.get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
-
         if lamports < minimum_balance {
             return Err(CliError::BadParameter(format!(
                 "need at least {minimum_balance} lamports for stake account to be rent exempt, \


### PR DESCRIPTION
#### Problem

There are issues with the current strategy of simulating a test transaction in the `resolve_spend_message`. If the transaction is creating an account, the test transaction will fail because not enough lamports are sent to the destination.

#### Summary of changes

It's a tricky situation in which we can't always be correct, since there's a chicken-and-egg situation with calculating the fee for spend variants of `All` and `RentExempt` if the sender and the fee payer are the same account.

To get the simulation correct in almost all situations, we simulate with the real transfer amount. But if the fee payer is the sender, we simulate with `0`. But we also add a new variant on `SpendAmount` to cover some minimum amount required that must be transferred. Currently, the only situations in which we have an issue are:

* creating a nonce account
* creating a stake account
* transferring SOL

Those first two have a minimum requirement, so use that. The third works fine with a 0 amount, since it's just a SOL transfer.