### PR TITLE
cli: Use simulated compute unit limit in stake interactions 

### DIFF
--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -415,6 +415,7 @@ pub fn process_authorize_nonce_account(
     let latest_blockhash = rpc_client.get_latest_blockhash()?;
 
     let nonce_authority = config.signers[nonce_authority];
+    let compute_unit_limit = ComputeUnitLimit::Simulated;
     let ixs = vec![authorize_nonce_account(
         nonce_account,
         &nonce_authority.pubkey(),
@@ -423,10 +424,10 @@ pub fn process_authorize_nonce_account(
     .with_memo(memo)
     .with_compute_unit_config(&ComputeUnitConfig {
         compute_unit_price,
-        compute_unit_limit: ComputeUnitLimit::Simulated,
+        compute_unit_limit,
     });
     let mut message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
-    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(&compute_unit_limit, rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
 
@@ -575,6 +576,7 @@ pub fn process_new_nonce(
     }
 
     let nonce_authority = config.signers[nonce_authority];
+    let compute_unit_limit = ComputeUnitLimit::Simulated;
     let ixs = vec![advance_nonce_account(
         nonce_account,
         &nonce_authority.pubkey(),
@@ -582,11 +584,11 @@ pub fn process_new_nonce(
     .with_memo(memo)
     .with_compute_unit_config(&ComputeUnitConfig {
         compute_unit_price,
-        compute_unit_limit: ComputeUnitLimit::Simulated,
+        compute_unit_limit,
     });
     let latest_blockhash = rpc_client.get_latest_blockhash()?;
     let mut message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
-    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(&compute_unit_limit, rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
     check_account_for_fee_with_commitment(
@@ -643,6 +645,7 @@ pub fn process_withdraw_from_nonce_account(
     let latest_blockhash = rpc_client.get_latest_blockhash()?;
 
     let nonce_authority = config.signers[nonce_authority];
+    let compute_unit_limit = ComputeUnitLimit::Simulated;
     let ixs = vec![withdraw_nonce_account(
         nonce_account,
         &nonce_authority.pubkey(),
@@ -652,10 +655,10 @@ pub fn process_withdraw_from_nonce_account(
     .with_memo(memo)
     .with_compute_unit_config(&ComputeUnitConfig {
         compute_unit_price,
-        compute_unit_limit: ComputeUnitLimit::Simulated,
+        compute_unit_limit,
     });
     let mut message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
-    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(&compute_unit_limit, rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
     check_account_for_fee_with_commitment(
@@ -677,14 +680,15 @@ pub(crate) fn process_upgrade_nonce_account(
     compute_unit_price: Option<u64>,
 ) -> ProcessResult {
     let latest_blockhash = rpc_client.get_latest_blockhash()?;
+    let compute_unit_limit = ComputeUnitLimit::Simulated;
     let ixs = vec![upgrade_nonce_account(nonce_account)]
         .with_memo(memo)
         .with_compute_unit_config(&ComputeUnitConfig {
             compute_unit_price,
-            compute_unit_limit: ComputeUnitLimit::Simulated,
+            compute_unit_limit,
         });
     let mut message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
-    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(&compute_unit_limit, rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
     check_account_for_fee_with_commitment(

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -197,18 +197,18 @@ where
             let mut dummy_message = build_message(lamports);
 
             dummy_message.recent_blockhash = *blockhash;
-            let compute_unit_info = if compute_unit_limit == ComputeUnitLimit::Simulated {
-                // Simulate for correct compute units
+            let compute_unit_info =
                 if let UpdateComputeUnitLimitResult::UpdatedInstructionIndex(ix_index) =
-                    simulate_and_update_compute_unit_limit(rpc_client, &mut dummy_message)?
+                    simulate_and_update_compute_unit_limit(
+                        &compute_unit_limit,
+                        rpc_client,
+                        &mut dummy_message,
+                    )?
                 {
                     Some((ix_index, dummy_message.instructions[ix_index].data.clone()))
                 } else {
                     None
-                }
-            } else {
-                None
-            };
+                };
             (
                 get_fee_for_messages(rpc_client, &[&dummy_message])?,
                 compute_unit_info,

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1633,7 +1633,7 @@ pub fn process_stake_authorize(
     } else {
         Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
-    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(&compute_unit_limit, rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
 
     if sign_only {
@@ -1784,7 +1784,7 @@ pub fn process_deactivate_stake_account(
     } else {
         Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
-    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(&compute_unit_limit, rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
 
     if sign_only {
@@ -2083,7 +2083,7 @@ pub fn process_split_stake(
     } else {
         Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
-    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(&compute_unit_limit, rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
 
     if sign_only {
@@ -2197,7 +2197,7 @@ pub fn process_merge_stake(
     } else {
         Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
-    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(&compute_unit_limit, rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
 
     if sign_only {
@@ -2300,7 +2300,7 @@ pub fn process_stake_set_lockup(
     } else {
         Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
-    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(&compute_unit_limit, rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
 
     if sign_only {
@@ -2769,7 +2769,7 @@ pub fn process_delegate_stake(
     } else {
         Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
-    simulate_and_update_compute_unit_limit(rpc_client, &mut message)?;
+    simulate_and_update_compute_unit_limit(&compute_unit_limit, rpc_client, &mut message)?;
     let mut tx = Transaction::new_unsigned(message);
 
     if sign_only {

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -31,6 +31,7 @@ use {
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_test_validator::{TestValidator, TestValidatorGenesis},
+    test_case::test_case,
 };
 
 #[test]
@@ -196,8 +197,9 @@ fn test_stake_delegation_force() {
     process_command(&config).unwrap();
 }
 
-#[test]
-fn test_seed_stake_delegation_and_deactivation() {
+#[test_case(None; "base")]
+#[test_case(Some(1_000_000); "with_compute_unit_price")]
+fn test_seed_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
     solana_logger::setup();
 
     let mint_keypair = Keypair::new();
@@ -252,7 +254,7 @@ fn test_seed_stake_delegation_and_deactivation() {
         memo: None,
         fee_payer: 0,
         from: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_validator).unwrap();
 
@@ -269,7 +271,7 @@ fn test_seed_stake_delegation_and_deactivation() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_validator).unwrap();
 
@@ -286,13 +288,14 @@ fn test_seed_stake_delegation_and_deactivation() {
         memo: None,
         seed: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_validator).unwrap();
 }
 
-#[test]
-fn test_stake_delegation_and_deactivation() {
+#[test_case(None; "base")]
+#[test_case(Some(1_000_000); "with_compute_unit_price")]
+fn test_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
     solana_logger::setup();
 
     let mint_keypair = Keypair::new();
@@ -342,7 +345,7 @@ fn test_stake_delegation_and_deactivation() {
         memo: None,
         fee_payer: 0,
         from: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_validator).unwrap();
 
@@ -360,7 +363,7 @@ fn test_stake_delegation_and_deactivation() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_validator).unwrap();
 
@@ -377,13 +380,14 @@ fn test_stake_delegation_and_deactivation() {
         memo: None,
         seed: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_validator).unwrap();
 }
 
-#[test]
-fn test_offline_stake_delegation_and_deactivation() {
+#[test_case(None; "base")]
+#[test_case(Some(1_000_000); "with_compute_unit_price")]
+fn test_offline_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
     solana_logger::setup();
 
     let mint_keypair = Keypair::new();
@@ -457,7 +461,7 @@ fn test_offline_stake_delegation_and_deactivation() {
         memo: None,
         fee_payer: 0,
         from: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_validator).unwrap();
 
@@ -475,7 +479,7 @@ fn test_offline_stake_delegation_and_deactivation() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     config_offline.output_format = OutputFormat::JsonCompact;
     let sig_response = process_command(&config_offline).unwrap();
@@ -497,7 +501,7 @@ fn test_offline_stake_delegation_and_deactivation() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_payer).unwrap();
 
@@ -515,7 +519,7 @@ fn test_offline_stake_delegation_and_deactivation() {
         memo: None,
         seed: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     let sig_response = process_command(&config_offline).unwrap();
     let sign_only = parse_sign_only_reply_string(&sig_response);
@@ -536,13 +540,14 @@ fn test_offline_stake_delegation_and_deactivation() {
         memo: None,
         seed: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config_payer).unwrap();
 }
 
-#[test]
-fn test_nonced_stake_delegation_and_deactivation() {
+#[test_case(None; "base")]
+#[test_case(Some(1_000_000); "with_compute_unit_price")]
+fn test_nonced_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
     solana_logger::setup();
 
     let mint_keypair = Keypair::new();
@@ -590,7 +595,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
         memo: None,
         fee_payer: 0,
         from: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
 
@@ -603,7 +608,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
         nonce_authority: Some(config.signers[0].pubkey()),
         memo: None,
         amount: SpendAmount::Some(minimum_nonce_balance),
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
 
@@ -634,7 +639,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
 
@@ -664,13 +669,14 @@ fn test_nonced_stake_delegation_and_deactivation() {
         memo: None,
         seed: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
 }
 
-#[test]
-fn test_stake_authorize() {
+#[test_case(None; "base")]
+#[test_case(Some(1_000_000); "with_compute_unit_price")]
+fn test_stake_authorize(compute_unit_price: Option<u64>) {
     solana_logger::setup();
 
     let mint_keypair = Keypair::new();
@@ -732,7 +738,7 @@ fn test_stake_authorize() {
         memo: None,
         fee_payer: 0,
         from: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
 
@@ -757,7 +763,7 @@ fn test_stake_authorize() {
         fee_payer: 0,
         custodian: None,
         no_wait: false,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -799,7 +805,7 @@ fn test_stake_authorize() {
         fee_payer: 0,
         custodian: None,
         no_wait: false,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -831,7 +837,7 @@ fn test_stake_authorize() {
         fee_payer: 0,
         custodian: None,
         no_wait: false,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -863,7 +869,7 @@ fn test_stake_authorize() {
         fee_payer: 0,
         custodian: None,
         no_wait: false,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     config_offline.output_format = OutputFormat::JsonCompact;
     let sign_reply = process_command(&config_offline).unwrap();
@@ -888,7 +894,7 @@ fn test_stake_authorize() {
         fee_payer: 0,
         custodian: None,
         no_wait: false,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -911,7 +917,7 @@ fn test_stake_authorize() {
         nonce_authority: Some(offline_authority_pubkey),
         memo: None,
         amount: SpendAmount::Some(minimum_nonce_balance),
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
 
@@ -946,7 +952,7 @@ fn test_stake_authorize() {
         fee_payer: 0,
         custodian: None,
         no_wait: false,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     let sign_reply = process_command(&config_offline).unwrap();
     let sign_only = parse_sign_only_reply_string(&sign_reply);
@@ -975,7 +981,7 @@ fn test_stake_authorize() {
         fee_payer: 0,
         custodian: None,
         no_wait: false,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -1178,8 +1184,9 @@ fn test_stake_authorize_with_fee_payer() {
     );
 }
 
-#[test]
-fn test_stake_split() {
+#[test_case(None; "base")]
+#[test_case(Some(1_000_000); "with_compute_unit_price")]
+fn test_stake_split(compute_unit_price: Option<u64>) {
     solana_logger::setup();
 
     let mint_keypair = Keypair::new();
@@ -1252,7 +1259,7 @@ fn test_stake_split() {
         memo: None,
         fee_payer: 0,
         from: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     check_balance!(10 * stake_balance, &rpc_client, &stake_account_pubkey,);
@@ -1269,7 +1276,7 @@ fn test_stake_split() {
         nonce_authority: Some(offline_pubkey),
         memo: None,
         amount: SpendAmount::Some(minimum_nonce_balance),
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     check_balance!(minimum_nonce_balance, &rpc_client, &nonce_account.pubkey());
@@ -1301,7 +1308,7 @@ fn test_stake_split() {
         seed: None,
         lamports: 2 * stake_balance,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
         rent_exempt_reserve: Some(minimum_balance),
     };
     config_offline.output_format = OutputFormat::JsonCompact;
@@ -1326,7 +1333,7 @@ fn test_stake_split() {
         seed: None,
         lamports: 2 * stake_balance,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
         rent_exempt_reserve: None,
     };
     process_command(&config).unwrap();
@@ -1338,8 +1345,9 @@ fn test_stake_split() {
     );
 }
 
-#[test]
-fn test_stake_set_lockup() {
+#[test_case(None; "base")]
+#[test_case(Some(1_000_000); "with_compute_unit_price")]
+fn test_stake_set_lockup(compute_unit_price: Option<u64>) {
     solana_logger::setup();
 
     let mint_keypair = Keypair::new();
@@ -1418,7 +1426,7 @@ fn test_stake_set_lockup() {
         memo: None,
         fee_payer: 0,
         from: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     check_balance!(10 * stake_balance, &rpc_client, &stake_account_pubkey,);
@@ -1443,7 +1451,7 @@ fn test_stake_set_lockup() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -1480,7 +1488,7 @@ fn test_stake_set_lockup() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
 
@@ -1502,7 +1510,7 @@ fn test_stake_set_lockup() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -1536,7 +1544,7 @@ fn test_stake_set_lockup() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
 
@@ -1553,7 +1561,7 @@ fn test_stake_set_lockup() {
         nonce_authority: Some(offline_pubkey),
         memo: None,
         amount: SpendAmount::Some(minimum_nonce_balance),
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     check_balance!(minimum_nonce_balance, &rpc_client, &nonce_account_pubkey);
@@ -1586,7 +1594,7 @@ fn test_stake_set_lockup() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     config_offline.output_format = OutputFormat::JsonCompact;
     let sig_response = process_command(&config_offline).unwrap();
@@ -1609,7 +1617,7 @@ fn test_stake_set_lockup() {
         nonce_authority: 0,
         memo: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -1626,8 +1634,9 @@ fn test_stake_set_lockup() {
     assert_eq!(current_lockup.custodian, offline_pubkey);
 }
 
-#[test]
-fn test_offline_nonced_create_stake_account_and_withdraw() {
+#[test_case(None; "base")]
+#[test_case(Some(1_000_000); "with_compute_unit_price")]
+fn test_offline_nonced_create_stake_account_and_withdraw(compute_unit_price: Option<u64>) {
     solana_logger::setup();
 
     let mint_keypair = Keypair::new();
@@ -1683,7 +1692,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         nonce_authority: Some(offline_pubkey),
         memo: None,
         amount: SpendAmount::Some(minimum_nonce_balance),
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
 
@@ -1717,7 +1726,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         memo: None,
         fee_payer: 0,
         from: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     config_offline.output_format = OutputFormat::JsonCompact;
     let sig_response = process_command(&config_offline).unwrap();
@@ -1745,7 +1754,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         memo: None,
         fee_payer: 0,
         from: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     check_balance!(50_000_000_000, &rpc_client, &stake_pubkey);
@@ -1778,7 +1787,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         memo: None,
         seed: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     let sig_response = process_command(&config_offline).unwrap();
     let sign_only = parse_sign_only_reply_string(&sig_response);
@@ -1801,7 +1810,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         memo: None,
         seed: None,
         fee_payer: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     check_balance!(50_000_000_000, &rpc_client, &recipient_pubkey);
@@ -1835,7 +1844,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         memo: None,
         fee_payer: 0,
         from: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     let sig_response = process_command(&config_offline).unwrap();
     let sign_only = parse_sign_only_reply_string(&sig_response);
@@ -1861,7 +1870,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         memo: None,
         fee_payer: 0,
         from: 0,
-        compute_unit_price: None,
+        compute_unit_price,
     };
     process_command(&config).unwrap();
     let seed_address =

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -1430,7 +1430,6 @@ fn test_stake_set_lockup(compute_unit_price: Option<u64>) {
     };
     process_command(&config).unwrap();
     check_balance!(10 * stake_balance, &rpc_client, &stake_account_pubkey,);
-    check_balance!(10 * stake_balance, &rpc_client, &stake_account_pubkey,);
 
     // Online set lockup
     let lockup = LockupArgs {


### PR DESCRIPTION
#### Problem

The CLI has the ability to simulate transactions before sending to use the correct number of compute units, but stake commands are still using the default compute unit limit.

#### Summary of changes

Update tests to use a compute unit limit, and then update the stake commands to use the simulated compute unit limit.