### PR TITLE
[zk-sdk] Instantiate `From<u8; LEN>` for elgamal pod types

### DIFF
--- a/zk-sdk/src/encryption/pod/auth_encryption.rs
+++ b/zk-sdk/src/encryption/pod/auth_encryption.rs
@@ -3,7 +3,10 @@
 #[cfg(not(target_os = "solana"))]
 use crate::{encryption::auth_encryption::AeCiphertext, errors::AuthenticatedEncryptionError};
 use {
-    crate::encryption::{pod::impl_from_str, AE_CIPHERTEXT_LEN},
+    crate::encryption::{
+        pod::{impl_from_bytes, impl_from_str},
+        AE_CIPHERTEXT_LEN,
+    },
     base64::{prelude::BASE64_STANDARD, Engine},
     bytemuck::{Pod, Zeroable},
     std::fmt,
@@ -40,6 +43,8 @@ impl_from_str!(
     BYTES_LEN = AE_CIPHERTEXT_LEN,
     BASE64_LEN = AE_CIPHERTEXT_MAX_BASE64_LEN
 );
+
+impl_from_bytes!(TYPE = PodAeCiphertext, BYTES_LEN = AE_CIPHERTEXT_LEN);
 
 impl Default for PodAeCiphertext {
     fn default() -> Self {

--- a/zk-sdk/src/encryption/pod/elgamal.rs
+++ b/zk-sdk/src/encryption/pod/elgamal.rs
@@ -2,7 +2,8 @@
 
 use {
     crate::encryption::{
-        pod::impl_from_str, DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN, ELGAMAL_PUBKEY_LEN,
+        pod::{impl_from_bytes, impl_from_str},
+        DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN, ELGAMAL_PUBKEY_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
     bytemuck::Zeroable,
@@ -52,6 +53,11 @@ impl_from_str!(
     BASE64_LEN = ELGAMAL_CIPHERTEXT_MAX_BASE64_LEN
 );
 
+impl_from_bytes!(
+    TYPE = PodElGamalCiphertext,
+    BYTES_LEN = ELGAMAL_CIPHERTEXT_LEN
+);
+
 #[cfg(not(target_os = "solana"))]
 impl From<ElGamalCiphertext> for PodElGamalCiphertext {
     fn from(decoded_ciphertext: ElGamalCiphertext) -> Self {
@@ -90,6 +96,8 @@ impl_from_str!(
     BYTES_LEN = ELGAMAL_PUBKEY_LEN,
     BASE64_LEN = ELGAMAL_PUBKEY_MAX_BASE64_LEN
 );
+
+impl_from_bytes!(TYPE = PodElGamalPubkey, BYTES_LEN = ELGAMAL_PUBKEY_LEN);
 
 #[cfg(not(target_os = "solana"))]
 impl From<ElGamalPubkey> for PodElGamalPubkey {

--- a/zk-sdk/src/encryption/pod/grouped_elgamal.rs
+++ b/zk-sdk/src/encryption/pod/grouped_elgamal.rs
@@ -5,14 +5,24 @@ use crate::encryption::grouped_elgamal::GroupedElGamalCiphertext;
 use {
     crate::{
         encryption::{
-            pod::{elgamal::PodElGamalCiphertext, pedersen::PodPedersenCommitment},
+            pod::{
+                elgamal::PodElGamalCiphertext, impl_from_bytes, impl_from_str,
+                pedersen::PodPedersenCommitment,
+            },
             DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN, PEDERSEN_COMMITMENT_LEN,
         },
         errors::ElGamalError,
     },
+    base64::{prelude::BASE64_STANDARD, Engine},
     bytemuck::Zeroable,
     std::fmt,
 };
+
+/// Maximum length of a base64 encoded grouped ElGamal ciphertext with 2 handles
+const GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES_MAX_BASE64_LEN: usize = 132;
+
+/// Maximum length of a base64 encoded grouped ElGamal ciphertext with 3 handles
+const GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES_MAX_BASE64_LEN: usize = 176;
 
 macro_rules! impl_extract {
     (TYPE = $type:ident) => {
@@ -78,6 +88,18 @@ impl Default for PodGroupedElGamalCiphertext2Handles {
         Self::zeroed()
     }
 }
+
+impl_from_str!(
+    TYPE = PodGroupedElGamalCiphertext2Handles,
+    BYTES_LEN = GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES,
+    BASE64_LEN = GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES_MAX_BASE64_LEN
+);
+
+impl_from_bytes!(
+    TYPE = PodGroupedElGamalCiphertext2Handles,
+    BYTES_LEN = GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES
+);
+
 #[cfg(not(target_os = "solana"))]
 impl From<GroupedElGamalCiphertext<2>> for PodGroupedElGamalCiphertext2Handles {
     fn from(decoded_ciphertext: GroupedElGamalCiphertext<2>) -> Self {
@@ -114,6 +136,17 @@ impl Default for PodGroupedElGamalCiphertext3Handles {
         Self::zeroed()
     }
 }
+
+impl_from_str!(
+    TYPE = PodGroupedElGamalCiphertext3Handles,
+    BYTES_LEN = GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES,
+    BASE64_LEN = GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES_MAX_BASE64_LEN
+);
+
+impl_from_bytes!(
+    TYPE = PodGroupedElGamalCiphertext3Handles,
+    BYTES_LEN = GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES
+);
 
 #[cfg(not(target_os = "solana"))]
 impl From<GroupedElGamalCiphertext<3>> for PodGroupedElGamalCiphertext3Handles {

--- a/zk-sdk/src/encryption/pod/mod.rs
+++ b/zk-sdk/src/encryption/pod/mod.rs
@@ -26,3 +26,14 @@ macro_rules! impl_from_str {
     };
 }
 pub(crate) use impl_from_str;
+
+macro_rules! impl_from_bytes {
+    (TYPE = $type:ident, BYTES_LEN = $bytes_len:expr) => {
+        impl std::convert::From<[u8; $bytes_len]> for $type {
+            fn from(bytes: [u8; $bytes_len]) -> Self {
+                Self(bytes)
+            }
+        }
+    };
+}
+pub(crate) use impl_from_bytes;

--- a/zk-sdk/src/encryption/pod/pedersen.rs
+++ b/zk-sdk/src/encryption/pod/pedersen.rs
@@ -1,7 +1,11 @@
 //! Plain Old Data type for the Pedersen commitment scheme.
 
 use {
-    crate::encryption::PEDERSEN_COMMITMENT_LEN,
+    crate::encryption::{
+        pod::{impl_from_bytes, impl_from_str},
+        PEDERSEN_COMMITMENT_LEN,
+    },
+    base64::{prelude::BASE64_STANDARD, Engine},
     bytemuck_derive::{Pod, Zeroable},
     std::fmt,
 };
@@ -10,6 +14,9 @@ use {
     crate::{encryption::pedersen::PedersenCommitment, errors::ElGamalError},
     curve25519_dalek::ristretto::CompressedRistretto,
 };
+
+/// Maximum length of a base64 encoded ElGamal public key
+const PEDERSEN_COMMITMENT_MAX_BASE64_LEN: usize = 44;
 
 /// The `PedersenCommitment` type as a `Pod`.
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
@@ -28,6 +35,17 @@ impl From<PedersenCommitment> for PodPedersenCommitment {
         Self(decoded_commitment.to_bytes())
     }
 }
+
+impl_from_str!(
+    TYPE = PodPedersenCommitment,
+    BYTES_LEN = PEDERSEN_COMMITMENT_LEN,
+    BASE64_LEN = PEDERSEN_COMMITMENT_MAX_BASE64_LEN
+);
+
+impl_from_bytes!(
+    TYPE = PodPedersenCommitment,
+    BYTES_LEN = PEDERSEN_COMMITMENT_LEN
+);
 
 // For proof verification, interpret pod::PedersenCommitment directly as CompressedRistretto
 #[cfg(not(target_os = "solana"))]


### PR DESCRIPTION
#### Problem
Currently, there is no clean way to construct the encryption pod types because the type's internal bytes are `pub(crate)`.

#### Summary of Changes
Instantiate `From<[u8; LEN]>` for the pod types. In the process I ended up instantiating `FromStr` for the grouped ElGamal ciphertext and Pedersen commitment pod types.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
