### PR TITLE
ci: only upload the integer part for the benchmark

### DIFF
--- a/ci/upload-benchmark.sh
+++ b/ci/upload-benchmark.sh
@@ -69,13 +69,13 @@ fi
 
 while IFS= read -r line; do
 
-  if [[ $line =~ ^test\ (.*)\ \.\.\.\ bench:\ *([0-9,]+)\ ns\/iter\ \(\+\/-\ *([0-9,]+)\) ]]; then
+  if [[ $line =~ ^test\ (.*)\ \.\.\.\ bench:\ *([0-9,\.]+)\ ns\/iter\ \(\+\/-\ *([0-9,\.]+)\) ]]; then
     test_name="${BASH_REMATCH[1]}"
     ns_iter="${BASH_REMATCH[2]}"
     plus_minus="${BASH_REMATCH[3]}"
 
-    ns_iter=$(echo "$ns_iter" | tr -d ',')
-    plus_minus=$(echo "$plus_minus" | tr -d ',')
+    ns_iter=$(echo "$ns_iter" | tr -d ',' | cut -d'.' -f1)
+    plus_minus=$(echo "$plus_minus" | tr -d ',' | cut -d'.' -f1)
 
     datapoint="${INFLUX_MEASUREMENT},commit=${COMMIT_HASH},test_suite=${TEST_SUITE},name=${test_name} median=${ns_iter}i,deviation=${plus_minus}i"
     echo "datapoint: $datapoint"


### PR DESCRIPTION
#### Problem

the new nightly version `2024-08-08` reports the decimal portion

```
running 6 tests
test bench_arc_mutex_poh_batched_hash            ... bench:   2,133,981.70 ns/iter (+/- 66,242.26)
test bench_arc_mutex_poh_hash                    ... bench:   2,220,412.20 ns/iter (+/- 51,310.34)
test bench_poh_hash                              ... bench:   2,072,839.70 ns/iter (+/- 42,045.04)
test bench_poh_lock_time_per_batch               ... bench:       4,413.65 ns/iter (+/- 68.52)
test bench_poh_recorder_record_transaction_index ... bench:       1,948.15 ns/iter (+/- 78.79)
test bench_poh_recorder_set_bank                 ... bench:   5,468,743.20 ns/iter (+/- 13.91)
```

it broke the benchmark uploading process 🫠 

#### Summary of Changes

only upload the integer part