### PR TITLE
Remove `slot_epoch` from SVM

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -55,11 +55,6 @@ pub enum BlockRelation {
 pub trait ForkGraph {
     /// Returns the BlockRelation of A to B
     fn relationship(&self, a: Slot, b: Slot) -> BlockRelation;
-
-    /// Returns the epoch of the given slot
-    fn slot_epoch(&self, _slot: Slot) -> Option<Epoch> {
-        Some(0)
-    }
 }
 
 /// The owner of a programs accounts, thus the loader of a program

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -13,10 +13,7 @@ use {
     log::*,
     solana_measure::measure::Measure,
     solana_program_runtime::loaded_programs::{BlockRelation, ForkGraph},
-    solana_sdk::{
-        clock::{Epoch, Slot},
-        hash::Hash,
-    },
+    solana_sdk::{clock::Slot, hash::Hash},
     std::{
         collections::{hash_map::Entry, HashMap, HashSet},
         ops::Index,
@@ -720,10 +717,6 @@ impl ForkGraph for BankForks {
                     .unwrap_or(BlockRelation::Unrelated)
             })
             .unwrap_or(BlockRelation::Unknown)
-    }
-
-    fn slot_epoch(&self, slot: Slot) -> Option<Epoch> {
-        self.banks.get(&slot).map(|bank| bank.epoch())
     }
 }
 

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -17,7 +17,7 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
-        clock::{Clock, Epoch, UnixTimestamp},
+        clock::{Clock, UnixTimestamp},
         feature_set::FeatureSet,
         native_loader,
         pubkey::Pubkey,
@@ -48,10 +48,6 @@ impl ForkGraph for MockForkGraph {
             Ordering::Equal => BlockRelation::Equal,
             Ordering::Greater => BlockRelation::Descendant,
         }
-    }
-
-    fn slot_epoch(&self, _slot: Slot) -> Option<Epoch> {
-        Some(0)
     }
 }
 


### PR DESCRIPTION
#### Problem

`slot_epoch` was a trait function, but never used anywhere.

#### Summary of Changes

I removed it.

