### PR TITLE
accounts-index: remove in-memory account index limit

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -50,7 +50,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndex
     bins: Some(BINS_FOR_TESTING),
     flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: IndexLimitMb::Unspecified,
+    index_limit_mb: IndexLimitMb::Unlimited,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
     started_from_validator: false,
@@ -59,7 +59,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
     bins: Some(BINS_FOR_BENCHMARKS),
     flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: IndexLimitMb::Unspecified,
+    index_limit_mb: IndexLimitMb::Unlimited,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
     started_from_validator: false,
@@ -191,17 +191,16 @@ pub struct AccountSecondaryIndexesIncludeExclude {
 /// specification of how much memory in-mem portion of account index can use
 #[derive(Debug, Clone)]
 pub enum IndexLimitMb {
-    /// nothing explicit specified, so default
-    Unspecified,
-    /// limit was specified, use disk index for rest
-    Limit(usize),
+    /// use disk index while allowing to use as much memory as available for
+    /// in-memory index.
+    Unlimited,
     /// in-mem-only was specified, no disk index
     InMemOnly,
 }
 
 impl Default for IndexLimitMb {
     fn default() -> Self {
-        Self::Unspecified
+        Self::Unlimited
     }
 }
 
@@ -2487,7 +2486,7 @@ pub mod tests {
 
         let mut config = ACCOUNTS_INDEX_CONFIG_FOR_TESTING;
         config.index_limit_mb = if use_disk {
-            IndexLimitMb::Limit(10_000)
+            IndexLimitMb::Unlimited
         } else {
             IndexLimitMb::InMemOnly // in-mem only
         };

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -189,7 +189,7 @@ pub struct AccountSecondaryIndexesIncludeExclude {
 }
 
 /// specification of how much memory in-mem portion of account index can use
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default)]
 pub enum IndexLimitMb {
     /// use disk index while allowing to use as much memory as available for
     /// in-memory index.

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -189,19 +189,14 @@ pub struct AccountSecondaryIndexesIncludeExclude {
 }
 
 /// specification of how much memory in-mem portion of account index can use
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum IndexLimitMb {
     /// use disk index while allowing to use as much memory as available for
     /// in-memory index.
+    #[default]
     Unlimited,
     /// in-mem-only was specified, no disk index
     InMemOnly,
-}
-
-impl Default for IndexLimitMb {
-    fn default() -> Self {
-        Self::Unlimited
-    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1188,7 +1188,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             if !evictions_age_possible.is_empty() || !evictions_random.is_empty() {
                 let disk = self.bucket.as_ref().unwrap();
                 let mut flush_entries_updated_on_disk = 0;
-
                 let mut flush_should_evict_us = 0;
                 // we don't care about lock time in this metric - bg threads can wait
                 let m = Measure::start("flush_update");

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -213,7 +213,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         let disk = match config
             .as_ref()
             .map(|config| &config.index_limit_mb)
-            .unwrap_or(&IndexLimitMb::Unlimited)
+            .unwrap_or(&IndexLimitMb::default())
         {
             IndexLimitMb::InMemOnly => None,
             IndexLimitMb::Unlimited => Some(BucketMap::new(bucket_config)),
@@ -477,10 +477,7 @@ pub mod tests {
     #[test]
     fn test_disk_index_enabled() {
         let bins = 1;
-        let config = AccountsIndexConfig {
-            index_limit_mb: IndexLimitMb::Unlimited,
-            ..AccountsIndexConfig::default()
-        };
+        let config = AccountsIndexConfig::default();
         let test = BucketMapHolder::<u64, u64>::new(bins, &Some(config), 1);
         assert!(test.is_disk_index_enabled());
     }

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -212,8 +212,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
 
         let disk = match config
             .as_ref()
-            .map(|config| &config.index_limit_mb)
-            .unwrap_or(&IndexLimitMb::default())
+            .map(|config| config.index_limit_mb)
+            .unwrap_or_default()
         {
             IndexLimitMb::InMemOnly => None,
             IndexLimitMb::Unlimited => Some(BucketMap::new(bucket_config)),

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -29,9 +29,6 @@ const _: () = assert!(std::mem::size_of::<Age>() == std::mem::size_of::<AtomicAg
 
 const AGE_MS: u64 = DEFAULT_MS_PER_SLOT; // match one age per slot time
 
-// 10 GB limit for in-mem idx. In practice, we don't get this high. This tunes how aggressively to save items we expect to use soon.
-pub const DEFAULT_DISK_INDEX: Option<usize> = Some(10_000);
-
 pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     pub disk: Option<BucketMap<(Slot, U)>>,
 
@@ -58,10 +55,6 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     bins: usize,
 
     pub threads: usize,
-
-    // how much mb are we allowed to keep in the in-mem index?
-    // Rest goes to disk.
-    pub mem_budget_mb: Option<usize>,
 
     /// how many ages should elapse from the last time an item is used where the item will remain in the cache
     pub ages_to_stay_in_cache: Age,
@@ -217,43 +210,15 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             config.drives.clone()
         });
 
-        let mem_budget_mb = match config
+        let disk = match config
             .as_ref()
             .map(|config| &config.index_limit_mb)
-            .unwrap_or(&IndexLimitMb::Unspecified)
+            .unwrap_or(&IndexLimitMb::Unlimited)
         {
-            // creator said to use disk idx with a specific limit
-            IndexLimitMb::Limit(mb) => Some(*mb),
-            // creator said InMemOnly, so no disk index
             IndexLimitMb::InMemOnly => None,
-            // whatever started us didn't specify whether to use the acct idx
-            IndexLimitMb::Unspecified => {
-                // check env var if we were not started from a validator
-                let mut use_default = true;
-                if !config
-                    .as_ref()
-                    .map(|config| config.started_from_validator)
-                    .unwrap_or_default()
-                {
-                    if let Ok(_limit) = std::env::var("SOLANA_TEST_ACCOUNTS_INDEX_MEMORY_LIMIT_MB")
-                    {
-                        // Note this env var means the opposite of the default. The default now is disk index is on.
-                        // So, if this env var is set, DO NOT allocate with disk buckets if mem budget was not set, we were NOT started from validator, and env var was set
-                        // we do not want the env var to have an effect when running the validator (only tests, benches, etc.)
-                        use_default = false;
-                    }
-                }
-                if use_default {
-                    // if validator does not specify disk index limit or specify in mem only, then this is the default
-                    DEFAULT_DISK_INDEX
-                } else {
-                    None
-                }
-            }
+            IndexLimitMb::Unlimited => Some(BucketMap::new(bucket_config)),
         };
 
-        // only allocate if mem_budget_mb is Some
-        let disk = mem_budget_mb.map(|_| BucketMap::new(bucket_config));
         Self {
             disk,
             ages_to_stay_in_cache,
@@ -270,7 +235,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             age_timer: AtomicInterval::default(),
             bins,
             startup: AtomicBool::default(),
-            mem_budget_mb,
+
             threads,
             _phantom: PhantomData,
             startup_stats: Arc::default(),
@@ -513,7 +478,7 @@ pub mod tests {
     fn test_disk_index_enabled() {
         let bins = 1;
         let config = AccountsIndexConfig {
-            index_limit_mb: IndexLimitMb::Limit(0),
+            index_limit_mb: IndexLimitMb::Unlimited,
             ..AccountsIndexConfig::default()
         };
         let test = BucketMapHolder::<u64, u64>::new(bins, &Some(config), 1);

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -59,22 +59,12 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .validator(is_pow2)
             .takes_value(true)
             .help("Number of bins to divide the accounts index into"),
-        Arg::with_name("accounts_index_memory_limit_mb")
-            .long("accounts-index-memory-limit-mb")
-            .value_name("MEGABYTES")
-            .validator(is_parsable::<usize>)
-            .takes_value(true)
-            .help(
-                "How much memory the accounts index can consume. If this is exceeded, some \
-                 account index entries will be stored on disk.",
-            ),
         Arg::with_name("disable_accounts_disk_index")
             .long("disable-accounts-disk-index")
             .help(
                 "Disable the disk-based accounts index. It is enabled by default. The entire \
                  accounts index will be kept in memory.",
-            )
-            .conflicts_with("accounts_index_memory_limit_mb"),
+            ),
         Arg::with_name("accounts_db_skip_shrink")
             .long("accounts-db-skip-shrink")
             .help(
@@ -241,14 +231,11 @@ pub fn get_accounts_db_config(
     let ledger_tool_ledger_path = ledger_path.join(LEDGER_TOOL_DIRECTORY);
 
     let accounts_index_bins = value_t!(arg_matches, "accounts_index_bins", usize).ok();
-    let accounts_index_index_limit_mb =
-        if let Ok(limit) = value_t!(arg_matches, "accounts_index_memory_limit_mb", usize) {
-            IndexLimitMb::Limit(limit)
-        } else if arg_matches.is_present("disable_accounts_disk_index") {
-            IndexLimitMb::InMemOnly
-        } else {
-            IndexLimitMb::Unspecified
-        };
+    let accounts_index_index_limit_mb = if arg_matches.is_present("disable_accounts_disk_index") {
+        IndexLimitMb::InMemOnly
+    } else {
+        IndexLimitMb::Unlimited
+    };
     let accounts_index_drives = values_t!(arg_matches, "accounts_index_path", String)
         .ok()
         .map(|drives| drives.into_iter().map(PathBuf::from).collect())

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2121,6 +2121,17 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .help("Skip ledger verification at validator bootup."),
         replaced_by: "skip-startup-ledger-verification",
     );
+    add_arg!(Arg::with_name("accounts_index_memory_limit_mb")
+        .long("accounts-index-memory-limit-mb")
+        .value_name("MEGABYTES")
+        .validator(is_parsable::<usize>)
+        .takes_value(true)
+        .help(
+            "How much memory the accounts index can consume. If this is exceeded, some \
+         account index entries will be stored on disk.",
+        ),
+        usage_warning: "index memory limit has been deprecated. The limit arg has no effect now.",
+    );
 
     res
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1999,6 +1999,7 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
                 Ok(())
             }
         }));
+    // deprecated in v2.1 by PR #2721
     add_arg!(Arg::with_name("accounts_index_memory_limit_mb")
         .long("accounts-index-memory-limit-mb")
         .value_name("MEGABYTES")
@@ -2033,7 +2034,8 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         .help("Number of threads to use for servicing AccountsDb Replication requests"));
     add_arg!(Arg::with_name("disable_accounts_disk_index")
         .long("disable-accounts-disk-index")
-        .help("Disable the disk-based accounts index if it is enabled by default."));
+        .help("Disable the disk-based accounts index if it is enabled by default.")
+        .conflicts_with("accounts_index_memory_limit_mb"));
     add_arg!(
         Arg::with_name("disable_quic_servers")
             .long("disable-quic-servers")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1393,17 +1393,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 ),
         )
         .arg(
-            Arg::with_name("accounts_index_memory_limit_mb")
-                .long("accounts-index-memory-limit-mb")
-                .value_name("MEGABYTES")
-                .validator(is_parsable::<usize>)
-                .takes_value(true)
-                .help(
-                    "How much memory the accounts index can consume. If this is exceeded, some \
-                     account index entries will be stored on disk.",
-                ),
-        )
-        .arg(
             Arg::with_name("accounts_index_bins")
                 .long("accounts-index-bins")
                 .value_name("BINS")
@@ -2033,8 +2022,7 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         .help("Number of threads to use for servicing AccountsDb Replication requests"));
     add_arg!(Arg::with_name("disable_accounts_disk_index")
         .long("disable-accounts-disk-index")
-        .help("Disable the disk-based accounts index if it is enabled by default.")
-        .conflicts_with("accounts_index_memory_limit_mb"));
+        .help("Disable the disk-based accounts index if it is enabled by default."));
     add_arg!(
         Arg::with_name("disable_quic_servers")
             .long("disable-quic-servers")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1999,6 +1999,17 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
                 Ok(())
             }
         }));
+    add_arg!(Arg::with_name("accounts_index_memory_limit_mb")
+        .long("accounts-index-memory-limit-mb")
+        .value_name("MEGABYTES")
+        .validator(is_parsable::<usize>)
+        .takes_value(true)
+        .help(
+            "How much memory the accounts index can consume. If this is exceeded, some \
+         account index entries will be stored on disk.",
+        ),
+        usage_warning: "index memory limit has been deprecated. The limit arg has no effect now.",
+    );
     add_arg!(Arg::with_name("accountsdb_repl_bind_address")
         .long("accountsdb-repl-bind-address")
         .value_name("HOST")
@@ -2120,17 +2131,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .takes_value(false)
             .help("Skip ledger verification at validator bootup."),
         replaced_by: "skip-startup-ledger-verification",
-    );
-    add_arg!(Arg::with_name("accounts_index_memory_limit_mb")
-        .long("accounts-index-memory-limit-mb")
-        .value_name("MEGABYTES")
-        .validator(is_parsable::<usize>)
-        .takes_value(true)
-        .help(
-            "How much memory the accounts index can consume. If this is exceeded, some \
-         account index entries will be stored on disk.",
-        ),
-        usage_warning: "index memory limit has been deprecated. The limit arg has no effect now.",
     );
 
     res

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1187,14 +1187,11 @@ pub fn main() {
             TestPartitionedEpochRewards::None
         };
 
-    accounts_index_config.index_limit_mb =
-        if let Ok(limit) = value_t!(matches, "accounts_index_memory_limit_mb", usize) {
-            IndexLimitMb::Limit(limit)
-        } else if matches.is_present("disable_accounts_disk_index") {
-            IndexLimitMb::InMemOnly
-        } else {
-            IndexLimitMb::Unspecified
-        };
+    accounts_index_config.index_limit_mb = if matches.is_present("disable_accounts_disk_index") {
+        IndexLimitMb::InMemOnly
+    } else {
+        IndexLimitMb::Unlimited
+    };
 
     {
         let mut accounts_index_paths: Vec<PathBuf> = if matches.is_present("accounts_index_path") {


### PR DESCRIPTION
#### Problem

The current design to enforce in-mem index limit is *not* good.

When exceeding in-mem index budget, any entry can be flushed to disk. This means that abnormal index entries (i.e. ref_count > 1, slot_list.len > 1) can be flushed to disk. While this is correct, it hurts performance. 

1. "abnormal" index entries are written to data disk bucket, which has bad performance. 

2. By allowing writing "abnormal" index entries to disk prevent the other optimization, such as skip disk index look up for shrinking.  https://github.com/anza-xyz/agave/pull/2689/

Therefore, we want to avoid having in-mem index budget.

#### Summary of Changes

1. deprecate cli argument for `accounts_index_memory_limit_mb`.
2. remove code logic that checks and handles for in-mem index budget.
3. change `IndexLimitMb` enum to support `Unlimited` and `InMemOnly`.
4. allow in-memory index to use as much memory as available in the system. In practice, it will take less than 10G memory thanks to `flush`.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
