### PR TITLE
account_saver: Remove nested options

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -588,7 +588,7 @@ impl Accounts {
     pub fn store_cached<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
-        transactions: &'a [Option<&'a SanitizedTransaction>],
+        transactions: &'a [&'a SanitizedTransaction],
     ) {
         self.accounts_db
             .store_cached_inline_update_index(accounts, Some(transactions));

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -588,10 +588,10 @@ impl Accounts {
     pub fn store_cached<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
-        transactions: &'a [&'a SanitizedTransaction],
+        transactions: Option<&'a [&'a SanitizedTransaction]>,
     ) {
         self.accounts_db
-            .store_cached_inline_update_index(accounts, Some(transactions));
+            .store_cached_inline_update_index(accounts, transactions);
     }
 
     pub fn store_accounts_cached<'a>(&self, accounts: impl StorableAccounts<'a>) {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6812,9 +6812,12 @@ impl AccountsDb {
         accounts_and_meta_to_store: &impl StorableAccounts<'b>,
         txs: Option<&[&SanitizedTransaction]>,
     ) -> Vec<AccountInfo> {
-        let mut current_write_version = self
-            .write_version
-            .fetch_add(accounts_and_meta_to_store.len() as u64, Ordering::AcqRel);
+        let mut current_write_version = if self.accounts_update_notifier.is_some() {
+            self.write_version
+                .fetch_add(accounts_and_meta_to_store.len() as u64, Ordering::AcqRel)
+        } else {
+            0
+        };
 
         let (account_infos, cached_accounts) = (0..accounts_and_meta_to_store.len())
             .map(|index| {

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -57,23 +57,21 @@ impl AccountsDb {
         notify_stats.report();
     }
 
-    pub fn notify_account_at_accounts_update<P>(
+    pub fn notify_account_at_accounts_update(
         &self,
         slot: Slot,
         account: &AccountSharedData,
         txn: &Option<&SanitizedTransaction>,
         pubkey: &Pubkey,
-        write_version_producer: &mut P,
-    ) where
-        P: Iterator<Item = u64>,
-    {
+        write_version: u64,
+    ) {
         if let Some(accounts_update_notifier) = &self.accounts_update_notifier {
             accounts_update_notifier.notify_account_update(
                 slot,
                 account,
                 txn,
                 pubkey,
-                write_version_producer.next().unwrap(),
+                write_version,
             );
         }
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3801,9 +3801,10 @@ impl Bank {
                 &durable_nonce,
                 lamports_per_signature,
             );
-            self.rc
-                .accounts
-                .store_cached((self.slot(), accounts_to_store.as_slice()), &transactions);
+            self.rc.accounts.store_cached(
+                (self.slot(), accounts_to_store.as_slice()),
+                transactions.as_deref(),
+            );
         });
 
         self.collect_rent(&processing_results);

--- a/svm/src/account_saver.rs
+++ b/svm/src/account_saver.rs
@@ -45,7 +45,7 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
     processing_results: &'a mut [TransactionProcessingResult],
     durable_nonce: &DurableNonce,
     lamports_per_signature: u64,
-) -> (Vec<(&'a Pubkey, &'a AccountSharedData)>, Vec<&'a T>) {
+) -> (Vec<(&'a Pubkey, &'a AccountSharedData)>, Option<Vec<&'a T>>) {
     let collect_capacity = max_number_of_accounts_to_collect(txs, processing_results);
     let mut accounts = Vec::with_capacity(collect_capacity);
     let mut transactions = Vec::with_capacity(collect_capacity);
@@ -87,7 +87,7 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
             }
         }
     }
-    (accounts, transactions)
+    (accounts, Some(transactions))
 }
 
 fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
@@ -294,6 +294,7 @@ mod tests {
             .iter()
             .any(|(pubkey, _account)| *pubkey == &keypair1.pubkey()));
 
+        let transactions = transactions.unwrap();
         assert_eq!(transactions.len(), 2);
         assert!(transactions.iter().any(|txn| (*txn).eq(&tx0)));
         assert!(transactions.iter().any(|txn| (*txn).eq(&tx1)));

--- a/svm/src/account_saver.rs
+++ b/svm/src/account_saver.rs
@@ -45,7 +45,7 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
     processing_results: &'a mut [TransactionProcessingResult],
     durable_nonce: &DurableNonce,
     lamports_per_signature: u64,
-) -> (Vec<(&'a Pubkey, &'a AccountSharedData)>, Vec<Option<&'a T>>) {
+) -> (Vec<(&'a Pubkey, &'a AccountSharedData)>, Vec<&'a T>) {
     let collect_capacity = max_number_of_accounts_to_collect(txs, processing_results);
     let mut accounts = Vec::with_capacity(collect_capacity);
     let mut transactions = Vec::with_capacity(collect_capacity);
@@ -92,7 +92,7 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
 
 fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
     collected_accounts: &mut Vec<(&'a Pubkey, &'a AccountSharedData)>,
-    collected_account_transactions: &mut Vec<Option<&'a T>>,
+    collected_account_transactions: &mut Vec<&'a T>,
     transaction: &'a T,
     transaction_accounts: &'a [TransactionAccount],
 ) {
@@ -109,13 +109,13 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
         })
     {
         collected_accounts.push((address, account));
-        collected_account_transactions.push(Some(transaction));
+        collected_account_transactions.push(transaction);
     }
 }
 
 fn collect_accounts_for_failed_tx<'a, T: SVMMessage>(
     collected_accounts: &mut Vec<(&'a Pubkey, &'a AccountSharedData)>,
-    collected_account_transactions: &mut Vec<Option<&'a T>>,
+    collected_account_transactions: &mut Vec<&'a T>,
     transaction: &'a T,
     rollback_accounts: &'a mut RollbackAccounts,
     durable_nonce: &DurableNonce,
@@ -125,7 +125,7 @@ fn collect_accounts_for_failed_tx<'a, T: SVMMessage>(
     match rollback_accounts {
         RollbackAccounts::FeePayerOnly { fee_payer_account } => {
             collected_accounts.push((fee_payer_address, &*fee_payer_account));
-            collected_account_transactions.push(Some(transaction));
+            collected_account_transactions.push(transaction);
         }
         RollbackAccounts::SameNonceAndFeePayer { nonce } => {
             // Since we know we are dealing with a valid nonce account,
@@ -134,14 +134,14 @@ fn collect_accounts_for_failed_tx<'a, T: SVMMessage>(
                 .try_advance_nonce(*durable_nonce, lamports_per_signature)
                 .unwrap();
             collected_accounts.push((nonce.address(), nonce.account()));
-            collected_account_transactions.push(Some(transaction));
+            collected_account_transactions.push(transaction);
         }
         RollbackAccounts::SeparateNonceAndFeePayer {
             nonce,
             fee_payer_account,
         } => {
             collected_accounts.push((fee_payer_address, &*fee_payer_account));
-            collected_account_transactions.push(Some(transaction));
+            collected_account_transactions.push(transaction);
 
             // Since we know we are dealing with a valid nonce account,
             // unwrap is safe here
@@ -149,7 +149,7 @@ fn collect_accounts_for_failed_tx<'a, T: SVMMessage>(
                 .try_advance_nonce(*durable_nonce, lamports_per_signature)
                 .unwrap();
             collected_accounts.push((nonce.address(), nonce.account()));
-            collected_account_transactions.push(Some(transaction));
+            collected_account_transactions.push(transaction);
         }
     }
 }
@@ -295,8 +295,8 @@ mod tests {
             .any(|(pubkey, _account)| *pubkey == &keypair1.pubkey()));
 
         assert_eq!(transactions.len(), 2);
-        assert!(transactions.iter().any(|txn| txn.unwrap().eq(&tx0)));
-        assert!(transactions.iter().any(|txn| txn.unwrap().eq(&tx1)));
+        assert!(transactions.iter().any(|txn| (*txn).eq(&tx0)));
+        assert!(transactions.iter().any(|txn| (*txn).eq(&tx1)));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
- Nested options here is confusing in the accounts_db code.
- In reality, they are either all Some or the outer is None

#### Summary of Changes
- Remove nested options
- Get rid of unneccessary Boxes

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
