### PR TITLE
remove redundant local NodeInstance push on startup

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1859,16 +1859,9 @@ impl ClusterInfo {
                 let mut last_contact_info_save = timestamp();
                 let mut entrypoints_processed = false;
                 let recycler = PacketBatchRecycler::default();
-                let crds_data = vec![
-                    CrdsData::Version(Version::new(self.id())),
-                    CrdsData::NodeInstance(
-                        self.instance.read().unwrap().with_wallclock(timestamp()),
-                    ),
-                ];
-                for value in crds_data {
-                    let value = CrdsValue::new_signed(value, &self.keypair());
-                    self.push_message(value);
-                }
+                let version = CrdsData::Version(Version::new(self.id()));
+                let value = CrdsValue::new_signed(version, &self.keypair());
+                self.push_message(value);
                 let mut generate_pull_requests = true;
                 loop {
                     let start = timestamp();


### PR DESCRIPTION
#### Problem
Nodes boot up and immediately log an error in gossip:
```
[2024-08-23T23:20:13.461821775Z ERROR solana_gossip::cluster_info] Insert self failed: InsertFailed
```
1) Validator boots up, calls `ClusterInfo::new()` which creates a `NodeInstance` and inserts it into the `crds`
2) Spins up `gossip()` thread, creates and inserts a new `NodeInstance` with `timestamp()` and inserts it into the `crds`, overwriting the `NodeInstance` from (1)
3) Immediately after, the node calls `refresh_my_gossip_contact_info()` which creates a new `NodeInstance` with `timestamp()`. The problem is `timestamp()` has the granularity of `ms`. So the `timestamp()` in (1) and (2) are the same. So the node tries to insert the `NodeInstance` again but the timestamps are the same, so `crds.insert()` returns an error. 

I can pretty consistently reproduce this on a equinix monogon node, but I can't seem to reproduce on my local dev box running against testnet. The `timestamp()` produced on my devbox ends up being different but is the same on the equinix monogon node. Could be that the equinix node is just a low performance node (which it is, it's 8-10 years old), so the `timestamp()` granularity is bad.

#### Summary of Changes
Don't push `NodeInstance` into our push queue on initial call to `gossip()`
