### PR TITLE
Set zstd compression level to 1 as it offers fastest compression with small size tradeoff.

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1083,8 +1083,9 @@ fn archive_snapshot(
                 encoder.finish().map_err(E::FinishEncoder)?;
             }
             ArchiveFormat::TarZstd => {
+                // Compression level of 1 is optimized for speed.
                 let mut encoder =
-                    zstd::stream::Encoder::new(archive_file, 0).map_err(E::CreateEncoder)?;
+                    zstd::stream::Encoder::new(archive_file, 1).map_err(E::CreateEncoder)?;
                 do_archive_files(&mut encoder)?;
                 encoder.finish().map_err(E::FinishEncoder)?;
             }


### PR DESCRIPTION
As per https://github.com/facebook/zstd/tree/v1.5.2?tab=readme-ov-file#benchmarks compression levels can be tuned to our needs. Higher compression ratio typically take more time and vice versa. zstd has compression levels from 1..19 with default of 3 that zstd-rs uses. But zstd-rs provides a way to set compression level. We should set a level that is more suitable for our purposes.

For the context zstd compression runs continuously (for taking snapshots). `ZSTD_compressBlock_doubleFast_extDict_generic` is one of the hottest function consuming 2.54% of cycles, as per linux perf.

Based on the results [below](https://github.com/anza-xyz/agave/pull/2729#issuecomment-2322808901) going from level 3 to 1 can give us speed up of almost 60%.