### PR TITLE
vote: make VoteAccount::try_from deserialize in place

### DIFF
--- a/vote/benches/vote_account.rs
+++ b/vote/benches/vote_account.rs
@@ -1,0 +1,52 @@
+#![feature(test)]
+extern crate test;
+
+use {
+    rand::Rng,
+    solana_sdk::{
+        account::AccountSharedData,
+        pubkey::Pubkey,
+        vote::state::{VoteInit, VoteState, VoteStateVersions},
+    },
+    solana_vote::vote_account::VoteAccount,
+    test::Bencher,
+};
+
+fn new_rand_vote_account<R: Rng>(
+    rng: &mut R,
+    node_pubkey: Option<Pubkey>,
+) -> (AccountSharedData, VoteState) {
+    let vote_init = VoteInit {
+        node_pubkey: node_pubkey.unwrap_or_else(Pubkey::new_unique),
+        authorized_voter: Pubkey::new_unique(),
+        authorized_withdrawer: Pubkey::new_unique(),
+        commission: rng.gen(),
+    };
+    let clock = solana_sdk::sysvar::clock::Clock {
+        slot: rng.gen(),
+        epoch_start_timestamp: rng.gen(),
+        epoch: rng.gen(),
+        leader_schedule_epoch: rng.gen(),
+        unix_timestamp: rng.gen(),
+    };
+    let vote_state = VoteState::new(&vote_init, &clock);
+    let account = AccountSharedData::new_data(
+        rng.gen(), // lamports
+        &VoteStateVersions::new_current(vote_state.clone()),
+        &solana_sdk::vote::program::id(), // owner
+    )
+    .unwrap();
+    (account, vote_state)
+}
+
+#[bench]
+fn bench_vote_account_try_from(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let (account, vote_state) = new_rand_vote_account(&mut rng, None);
+
+    b.iter(|| {
+        let vote_account = VoteAccount::try_from(account.clone()).unwrap();
+        let state = vote_account.vote_state();
+        assert_eq!(state, &vote_state);
+    });
+}

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -15,7 +15,8 @@ use {
         collections::{hash_map::Entry, HashMap},
         fmt,
         iter::FromIterator,
-        mem,
+        mem::{self, MaybeUninit},
+        ptr::addr_of_mut,
         sync::{Arc, OnceLock},
     },
     thiserror::Error,
@@ -311,21 +312,51 @@ impl From<VoteAccount> for AccountSharedData {
 impl TryFrom<AccountSharedData> for VoteAccount {
     type Error = Error;
     fn try_from(account: AccountSharedData) -> Result<Self, Self::Error> {
-        let vote_account = VoteAccountInner::try_from(account)?;
-        Ok(Self(Arc::new(vote_account)))
-    }
-}
-
-impl TryFrom<AccountSharedData> for VoteAccountInner {
-    type Error = Error;
-    fn try_from(account: AccountSharedData) -> Result<Self, Self::Error> {
         if !solana_sdk::vote::program::check_id(account.owner()) {
             return Err(Error::InvalidOwner(*account.owner()));
         }
-        Ok(Self {
-            vote_state: VoteState::deserialize(account.data()).map_err(Error::InstructionError)?,
-            account,
-        })
+
+        // Allocate as Arc<MaybeUninit<VoteAccountInner>> so we can initialize in place.
+        let mut inner = Arc::new(MaybeUninit::<VoteAccountInner>::uninit());
+        let inner_ptr = Arc::get_mut(&mut inner)
+            .expect("we're the only ref")
+            .as_mut_ptr();
+
+        // Safety:
+        // - All the addr_of_mut!(...).write(...) calls are valid since we just allocated and so
+        // the field pointers are valid.
+        // - We use write() so that the old values aren't dropped since they're still
+        // uninitialized.
+        unsafe {
+            let vote_state = addr_of_mut!((*inner_ptr).vote_state);
+            // Safety:
+            // - vote_state is non-null and MaybeUninit<VoteState> is guaranteed to have same layout
+            // and alignment as VoteState.
+            // - Here it is safe to create a reference to MaybeUninit<VoteState> since the value is
+            // aligned and MaybeUninit<T> is valid for all possible bit values.
+            let vote_state = &mut *(vote_state as *mut MaybeUninit<VoteState>);
+
+            // Try to deserialize in place
+            if let Err(e) = VoteState::deserialize_into_uninit(account.data(), vote_state) {
+                // Safety:
+                // - Deserialization failed so at this point vote_state is uninitialized and must
+                // not be dropped. We're ok since `vote_state` is a subfield of `inner`  which is
+                // still MaybeUninit - which isn't dropped by definition - and so neither are its
+                // subfields.
+                return Err(e.into());
+            }
+
+            // Write the account field which completes the initialization of VoteAccountInner.
+            addr_of_mut!((*inner_ptr).account).write(account);
+
+            // Safety:
+            // - At this point both `inner.vote_state` and `inner.account`` are initialized, so it's safe to
+            // transmute the MaybeUninit<VoteAccountInner> to VoteAccountInner.
+            Ok(VoteAccount(mem::transmute::<
+                Arc<MaybeUninit<VoteAccountInner>>,
+                Arc<VoteAccountInner>,
+            >(inner)))
+        }
     }
 }
 


### PR DESCRIPTION
There were two issues with the previous implementation:

- VoteState::deserialize is slow because serde is slow

- Arc::new(VoteAccountInner::try_from(account)) is not able to allocate
inner in place but is making a copy:

        mov edx, 1816
        mov rdi, rax
        call qword ptr [rip + memcpy@GOTPCREL]

The new implementation fixes both issues by using VoteState::deserialize_into_uninit() and by manually building VoteAccountInner in place inside the Arc allocation.

before:

        test bench_vote_account_try_from ... bench:       5,320.65 ns/iter (+/- 1,077.39)

after:

        test bench_vote_account_try_from ... bench:         383.44 ns/iter (+/- 156.15)