### PR TITLE
svm: advance nonce for fee-only transactions sooner

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -12,7 +12,7 @@ use {
         transaction_batch::TransactionBatch,
         vote_sender_types::ReplayVoteSender,
     },
-    solana_sdk::{hash::Hash, pubkey::Pubkey, saturating_add_assign},
+    solana_sdk::{pubkey::Pubkey, saturating_add_assign},
     solana_svm::{
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
         transaction_processing_result::{
@@ -65,13 +65,10 @@ impl Committer {
         self.transaction_status_sender.is_some()
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn commit_transactions(
         &self,
         batch: &TransactionBatch,
         processing_results: Vec<TransactionProcessingResult>,
-        last_blockhash: Hash,
-        lamports_per_signature: u64,
         starting_transaction_index: Option<usize>,
         bank: &Arc<Bank>,
         pre_balance_info: &mut PreBalanceInfo,
@@ -87,8 +84,6 @@ impl Committer {
         let (commit_results, commit_time_us) = measure_us!(bank.commit_transactions(
             batch.sanitized_transactions(),
             processing_results,
-            last_blockhash,
-            lamports_per_signature,
             processed_counts,
             &mut execute_and_commit_timings.execute_timings,
         ));

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -275,7 +275,6 @@ impl ConsumeWorkerMetrics {
             collect_balances_us,
             load_execute_us,
             freeze_lock_us,
-            last_blockhash_us,
             record_us,
             commit_us,
             find_and_send_votes_us,
@@ -291,9 +290,6 @@ impl ConsumeWorkerMetrics {
         self.timing_metrics
             .freeze_lock_us
             .fetch_add(*freeze_lock_us, Ordering::Relaxed);
-        self.timing_metrics
-            .last_blockhash_us
-            .fetch_add(*last_blockhash_us, Ordering::Relaxed);
         self.timing_metrics
             .record_us
             .fetch_add(*record_us, Ordering::Relaxed);
@@ -494,7 +490,6 @@ struct ConsumeWorkerTimingMetrics {
     collect_balances_us: AtomicU64,
     load_execute_us: AtomicU64,
     freeze_lock_us: AtomicU64,
-    last_blockhash_us: AtomicU64,
     record_us: AtomicU64,
     commit_us: AtomicU64,
     find_and_send_votes_us: AtomicU64,
@@ -525,11 +520,6 @@ impl ConsumeWorkerTimingMetrics {
             (
                 "freeze_lock_us",
                 self.freeze_lock_us.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "last_blockhash_us",
-                self.last_blockhash_us.swap(0, Ordering::Relaxed),
                 i64
             ),
             ("record_us", self.record_us.swap(0, Ordering::Relaxed), i64),

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -665,7 +665,6 @@ impl Consumer {
 
         let (freeze_lock, freeze_lock_us) = measure_us!(bank.freeze_lock());
         execute_and_commit_timings.freeze_lock_us = freeze_lock_us;
-        execute_and_commit_timings.last_blockhash_us = 0;
 
         let (record_transactions_summary, record_us) = measure_us!(self
             .transaction_recorder

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -665,17 +665,7 @@ impl Consumer {
 
         let (freeze_lock, freeze_lock_us) = measure_us!(bank.freeze_lock());
         execute_and_commit_timings.freeze_lock_us = freeze_lock_us;
-
-        // In order to avoid a race condition, leaders must get the last
-        // blockhash *before* recording transactions because recording
-        // transactions will only succeed if the block max tick height hasn't
-        // been reached yet. If they get the last blockhash *after* recording
-        // transactions, the block max tick height could have already been
-        // reached and the blockhash queue could have already been updated with
-        // a new blockhash.
-        let ((last_blockhash, lamports_per_signature), last_blockhash_us) =
-            measure_us!(bank.last_blockhash_and_lamports_per_signature());
-        execute_and_commit_timings.last_blockhash_us = last_blockhash_us;
+        execute_and_commit_timings.last_blockhash_us = 0;
 
         let (record_transactions_summary, record_us) = measure_us!(self
             .transaction_recorder
@@ -713,8 +703,6 @@ impl Consumer {
                 self.committer.commit_transactions(
                     batch,
                     processing_results,
-                    last_blockhash,
-                    lamports_per_signature,
                     starting_transaction_index,
                     bank,
                     &mut pre_balance_info,

--- a/core/src/banking_stage/leader_slot_timing_metrics.rs
+++ b/core/src/banking_stage/leader_slot_timing_metrics.rs
@@ -10,7 +10,6 @@ pub struct LeaderExecuteAndCommitTimings {
     pub collect_balances_us: u64,
     pub load_execute_us: u64,
     pub freeze_lock_us: u64,
-    pub last_blockhash_us: u64,
     pub record_us: u64,
     pub commit_us: u64,
     pub find_and_send_votes_us: u64,
@@ -23,7 +22,6 @@ impl LeaderExecuteAndCommitTimings {
         saturating_add_assign!(self.collect_balances_us, other.collect_balances_us);
         saturating_add_assign!(self.load_execute_us, other.load_execute_us);
         saturating_add_assign!(self.freeze_lock_us, other.freeze_lock_us);
-        saturating_add_assign!(self.last_blockhash_us, other.last_blockhash_us);
         saturating_add_assign!(self.record_us, other.record_us);
         saturating_add_assign!(self.commit_us, other.commit_us);
         saturating_add_assign!(self.find_and_send_votes_us, other.find_and_send_votes_us);
@@ -40,7 +38,6 @@ impl LeaderExecuteAndCommitTimings {
             ("collect_balances_us", self.collect_balances_us as i64, i64),
             ("load_execute_us", self.load_execute_us as i64, i64),
             ("freeze_lock_us", self.freeze_lock_us as i64, i64),
-            ("last_blockhash_us", self.last_blockhash_us as i64, i64),
             ("record_us", self.record_us as i64, i64),
             ("commit_us", self.commit_us as i64, i64),
             (

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -1,8 +1,12 @@
 use {
     core::borrow::Borrow,
     solana_sdk::{
+<<<<<<< HEAD
         account::AccountSharedData, nonce::state::DurableNonce, pubkey::Pubkey,
         transaction::SanitizedTransaction, transaction_context::TransactionAccount,
+=======
+        account::AccountSharedData, pubkey::Pubkey, transaction_context::TransactionAccount,
+>>>>>>> adb1a4159c (fix merge issues)
     },
     solana_svm::{
         rollback_accounts::RollbackAccounts,
@@ -309,9 +313,7 @@ mod tests {
             let (collected_accounts, transactions) = collect_accounts_to_store(
                 &txs,
                 &transaction_refs,
-                &mut processing_results,
-                &DurableNonce::default(),
-                0,
+                &processing_results,
             );
             assert_eq!(collected_accounts.len(), 2);
             assert!(collected_accounts
@@ -374,16 +376,13 @@ mod tests {
         )];
         let max_collected_accounts = max_number_of_accounts_to_collect(&txs, &processing_results);
         assert_eq!(max_collected_accounts, 1);
-        let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
 
         for collect_transactions in [false, true] {
             let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
             let (collected_accounts, transactions) = collect_accounts_to_store(
                 &txs,
                 &transaction_refs,
-                &mut processing_results,
-                &durable_nonce,
-                0,
+                &processing_results,
             );
             assert_eq!(collected_accounts.len(), 1);
             assert_eq!(
@@ -481,9 +480,7 @@ mod tests {
             let (collected_accounts, transactions) = collect_accounts_to_store(
                 &txs,
                 &transaction_refs,
-                &mut processing_results,
-                &durable_nonce,
-                0,
+                &processing_results,
             );
             assert_eq!(collected_accounts.len(), 2);
             assert_eq!(
@@ -594,9 +591,7 @@ mod tests {
             let (collected_accounts, transactions) = collect_accounts_to_store(
                 &txs,
                 &transaction_refs,
-                &mut processing_results,
-                &durable_nonce,
-                0,
+                &processing_results,
             );
             assert_eq!(collected_accounts.len(), 1);
             let collected_nonce_account = collected_accounts
@@ -649,16 +644,13 @@ mod tests {
         )))];
         let max_collected_accounts = max_number_of_accounts_to_collect(&txs, &processing_results);
         assert_eq!(max_collected_accounts, 1);
-        let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
 
         for collect_transactions in [false, true] {
             let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
             let (collected_accounts, transactions) = collect_accounts_to_store(
                 &txs,
                 &transaction_refs,
-                &mut processing_results,
-                &durable_nonce,
-                0,
+                &processing_results,
             );
             assert_eq!(collected_accounts.len(), 1);
             assert_eq!(

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -186,7 +186,7 @@ mod tests {
             message::Message,
             native_loader,
             nonce::{
-                state::{Data as NonceData, Versions as NonceVersions},
+                state::{Data as NonceData, DurableNonce, Versions as NonceVersions},
                 State as NonceState,
             },
             nonce_account,
@@ -297,7 +297,7 @@ mod tests {
         };
 
         let txs = vec![tx0.clone(), tx1.clone()];
-        let mut processing_results = vec![
+        let processing_results = vec![
             new_executed_processing_result(Ok(()), loaded0),
             new_executed_processing_result(Ok(()), loaded1),
         ];
@@ -365,7 +365,7 @@ mod tests {
         };
 
         let txs = vec![tx];
-        let mut processing_results = vec![new_executed_processing_result(
+        let processing_results = vec![new_executed_processing_result(
             Err(TransactionError::InstructionError(
                 1,
                 InstructionError::InvalidArgument,
@@ -465,9 +465,8 @@ mod tests {
             loaded_accounts_data_size: 0,
         };
 
-        let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
         let txs = vec![tx];
-        let mut processing_results = vec![new_executed_processing_result(
+        let processing_results = vec![new_executed_processing_result(
             Err(TransactionError::InstructionError(
                 1,
                 InstructionError::InvalidArgument,
@@ -579,9 +578,8 @@ mod tests {
             loaded_accounts_data_size: 0,
         };
 
-        let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
         let txs = vec![tx];
-        let mut processing_results = vec![new_executed_processing_result(
+        let processing_results = vec![new_executed_processing_result(
             Err(TransactionError::InstructionError(
                 1,
                 InstructionError::InvalidArgument,
@@ -640,7 +638,7 @@ mod tests {
         let from_account_pre = AccountSharedData::new(4242, 0, &Pubkey::default());
 
         let txs = vec![tx];
-        let mut processing_results = vec![Ok(ProcessedTransaction::FeesOnly(Box::new(
+        let processing_results = vec![Ok(ProcessedTransaction::FeesOnly(Box::new(
             FeesOnlyTransaction {
                 load_error: TransactionError::InvalidProgramForExecution,
                 fee_details: FeeDetails::default(),

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -1,12 +1,8 @@
 use {
     core::borrow::Borrow,
     solana_sdk::{
-<<<<<<< HEAD
-        account::AccountSharedData, nonce::state::DurableNonce, pubkey::Pubkey,
-        transaction::SanitizedTransaction, transaction_context::TransactionAccount,
-=======
-        account::AccountSharedData, pubkey::Pubkey, transaction_context::TransactionAccount,
->>>>>>> adb1a4159c (fix merge issues)
+        account::AccountSharedData, pubkey::Pubkey, transaction::SanitizedTransaction,
+        transaction_context::TransactionAccount,
     },
     solana_svm::{
         rollback_accounts::RollbackAccounts,
@@ -55,7 +51,7 @@ fn max_number_of_accounts_to_collect(
 pub fn collect_accounts_to_store<'a, T: SVMMessage>(
     txs: &'a [T],
     txs_refs: &'a Option<Vec<impl Borrow<SanitizedTransaction>>>,
-    processing_results: &'a mut [TransactionProcessingResult],
+    processing_results: &'a [TransactionProcessingResult],
 ) -> (
     Vec<(&'a Pubkey, &'a AccountSharedData)>,
     Option<Vec<&'a SanitizedTransaction>>,
@@ -65,8 +61,7 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
     let mut transactions = txs_refs
         .is_some()
         .then(|| Vec::with_capacity(collect_capacity));
-    for (index, (processing_result, transaction)) in
-        processing_results.iter_mut().zip(txs).enumerate()
+    for (index, (processing_result, transaction)) in processing_results.iter().zip(txs).enumerate()
     {
         let Some(processed_tx) = processing_result.processed_transaction() else {
             // Don't store any accounts if tx wasn't executed
@@ -310,11 +305,8 @@ mod tests {
 
         for collect_transactions in [false, true] {
             let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
-            let (collected_accounts, transactions) = collect_accounts_to_store(
-                &txs,
-                &transaction_refs,
-                &processing_results,
-            );
+            let (collected_accounts, transactions) =
+                collect_accounts_to_store(&txs, &transaction_refs, &processing_results);
             assert_eq!(collected_accounts.len(), 2);
             assert!(collected_accounts
                 .iter()
@@ -379,11 +371,8 @@ mod tests {
 
         for collect_transactions in [false, true] {
             let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
-            let (collected_accounts, transactions) = collect_accounts_to_store(
-                &txs,
-                &transaction_refs,
-                &processing_results,
-            );
+            let (collected_accounts, transactions) =
+                collect_accounts_to_store(&txs, &transaction_refs, &processing_results);
             assert_eq!(collected_accounts.len(), 1);
             assert_eq!(
                 collected_accounts
@@ -477,11 +466,8 @@ mod tests {
 
         for collect_transactions in [false, true] {
             let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
-            let (collected_accounts, transactions) = collect_accounts_to_store(
-                &txs,
-                &transaction_refs,
-                &processing_results,
-            );
+            let (collected_accounts, transactions) =
+                collect_accounts_to_store(&txs, &transaction_refs, &processing_results);
             assert_eq!(collected_accounts.len(), 2);
             assert_eq!(
                 collected_accounts
@@ -588,11 +574,8 @@ mod tests {
 
         for collect_transactions in [false, true] {
             let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
-            let (collected_accounts, transactions) = collect_accounts_to_store(
-                &txs,
-                &transaction_refs,
-                &processing_results,
-            );
+            let (collected_accounts, transactions) =
+                collect_accounts_to_store(&txs, &transaction_refs, &processing_results);
             assert_eq!(collected_accounts.len(), 1);
             let collected_nonce_account = collected_accounts
                 .iter()
@@ -647,11 +630,8 @@ mod tests {
 
         for collect_transactions in [false, true] {
             let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
-            let (collected_accounts, transactions) = collect_accounts_to_store(
-                &txs,
-                &transaction_refs,
-                &processing_results,
-            );
+            let (collected_accounts, transactions) =
+                collect_accounts_to_store(&txs, &transaction_refs, &processing_results);
             assert_eq!(collected_accounts.len(), 1);
             assert_eq!(
                 collected_accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -127,7 +127,6 @@ use {
         message::{AccountKeys, SanitizedMessage},
         native_loader,
         native_token::LAMPORTS_PER_SOL,
-        nonce::state::DurableNonce,
         packet::PACKET_DATA_SIZE,
         precompiles::get_precompiles,
         pubkey::Pubkey,
@@ -3761,9 +3760,7 @@ impl Bank {
     pub fn commit_transactions(
         &self,
         sanitized_txs: &[SanitizedTransaction],
-        mut processing_results: Vec<TransactionProcessingResult>,
-        last_blockhash: Hash,
-        lamports_per_signature: u64,
+        processing_results: Vec<TransactionProcessingResult>,
         processed_counts: &ProcessedTransactionCounts,
         timings: &mut ExecuteTimings,
     ) -> Vec<TransactionCommitResult> {
@@ -3812,9 +3809,7 @@ impl Bank {
             let (accounts_to_store, transactions) = collect_accounts_to_store(
                 sanitized_txs,
                 &maybe_transaction_refs,
-                &mut processing_results,
-                &durable_nonce,
-                lamports_per_signature,
+                &processing_results,
             );
             self.rc.accounts.store_cached(
                 (self.slot(), accounts_to_store.as_slice()),
@@ -4633,13 +4628,9 @@ impl Bank {
             },
         );
 
-        let (last_blockhash, lamports_per_signature) =
-            self.last_blockhash_and_lamports_per_signature();
         let commit_results = self.commit_transactions(
             batch.sanitized_transactions(),
             processing_results,
-            last_blockhash,
-            lamports_per_signature,
             &processed_counts,
             timings,
         );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3015,8 +3015,11 @@ impl Bank {
             blockhash_queue.get_lamports_per_signature(message.recent_blockhash())
         }
         .or_else(|| {
-            self.load_message_nonce_account(message)
-                .map(|(_nonce, nonce_data)| nonce_data.get_lamports_per_signature())
+            self.load_message_nonce_account(message).map(
+                |(_nonce_address, _nonce_account, nonce_data)| {
+                    nonce_data.get_lamports_per_signature()
+                },
+            )
         })?;
         Some(self.get_fee_for_message_with_lamports_per_signature(message, lamports_per_signature))
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3798,8 +3798,6 @@ impl Bank {
         }
 
         let ((), store_accounts_us) = measure_us!({
-            let durable_nonce = DurableNonce::from_blockhash(&last_blockhash);
-
             // If geyser is present, we must collect `SanitizedTransaction`
             // references in order to comply with that interface - until it
             // is changed.

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -250,9 +250,16 @@ mod tests {
         ));
         let nonce_account = bank.get_account(&nonce_pubkey).unwrap();
         let nonce_data = get_nonce_data_from_account(&nonce_account).unwrap();
+
+        let lamports_per_signature = nonce_data.get_lamports_per_signature();
+        let mut expected_nonce_info = NonceInfo::new(nonce_pubkey, nonce_account);
+        expected_nonce_info
+            .try_advance_nonce(bank.next_durable_nonce(), lamports_per_signature)
+            .unwrap();
+
         assert_eq!(
-            bank.check_and_load_message_nonce_account(&message, &bank.next_durable_nonce()),
-            Some((NonceInfo::new(nonce_pubkey, nonce_account), nonce_data))
+            bank.check_load_and_advance_message_nonce_account(&message, &bank.next_durable_nonce()),
+            Some((expected_nonce_info, lamports_per_signature)),
         );
     }
 
@@ -280,7 +287,7 @@ mod tests {
             &nonce_hash,
         ));
         assert!(bank
-            .check_and_load_message_nonce_account(&message, &bank.next_durable_nonce())
+            .check_load_and_advance_message_nonce_account(&message, &bank.next_durable_nonce())
             .is_none());
     }
 
@@ -309,7 +316,7 @@ mod tests {
         );
         message.instructions[0].accounts.clear();
         assert!(bank
-            .check_and_load_message_nonce_account(
+            .check_load_and_advance_message_nonce_account(
                 &new_sanitized_message(message),
                 &bank.next_durable_nonce(),
             )
@@ -342,7 +349,7 @@ mod tests {
             &nonce_hash,
         ));
         assert!(bank
-            .check_and_load_message_nonce_account(&message, &bank.next_durable_nonce())
+            .check_load_and_advance_message_nonce_account(&message, &bank.next_durable_nonce())
             .is_none());
     }
 
@@ -369,7 +376,7 @@ mod tests {
             &Hash::default(),
         ));
         assert!(bank
-            .check_and_load_message_nonce_account(&message, &bank.next_durable_nonce())
+            .check_load_and_advance_message_nonce_account(&message, &bank.next_durable_nonce())
             .is_none());
     }
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5733,7 +5733,7 @@ fn test_check_ro_durable_nonce_fails() {
         Err(TransactionError::BlockhashNotFound)
     );
     assert_eq!(
-        bank.check_and_load_message_nonce_account(
+        bank.check_load_and_advance_message_nonce_account(
             &new_sanitized_message(tx.message().clone()),
             &bank.next_durable_nonce(),
         ),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5732,10 +5732,12 @@ fn test_check_ro_durable_nonce_fails() {
         bank.process_transaction(&tx),
         Err(TransactionError::BlockhashNotFound)
     );
+    let (_, lamports_per_signature) = bank.last_blockhash_and_lamports_per_signature();
     assert_eq!(
         bank.check_load_and_advance_message_nonce_account(
             &new_sanitized_message(tx.message().clone()),
             &bank.next_durable_nonce(),
+            lamports_per_signature,
         ),
         None
     );

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -51,9 +51,7 @@ impl RollbackAccounts {
 
         if let Some(nonce) = nonce {
             if &fee_payer_address == nonce.address() {
-                fee_payer_account
-                    .data_as_mut_slice()
-                    .copy_from_slice(nonce.account().data());
+                fee_payer_account.set_data_from_slice(nonce.account().data());
 
                 RollbackAccounts::SameNonceAndFeePayer {
                     nonce: NonceInfo::new(fee_payer_address, fee_payer_account),

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -51,6 +51,10 @@ impl RollbackAccounts {
 
         if let Some(nonce) = nonce {
             if &fee_payer_address == nonce.address() {
+                fee_payer_account
+                    .data_as_mut_slice()
+                    .copy_from_slice(nonce.account().data());
+
                 RollbackAccounts::SameNonceAndFeePayer {
                     nonce: NonceInfo::new(fee_payer_address, fee_payer_account),
                 }

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -51,6 +51,10 @@ impl RollbackAccounts {
 
         if let Some(nonce) = nonce {
             if &fee_payer_address == nonce.address() {
+                // `nonce` contains an AccountSharedData which has already been advanced to the current DurableNonce
+                // `fee_payer_account` is an AccountSharedData as it currently exists on-chain
+                // thus if the nonce account is being used as the fee payer, we need to update that data here
+                // so we capture both the data change for the nonce and the lamports/rent epoch change for the fee payer
                 fee_payer_account.set_data_from_slice(nonce.account().data());
 
                 RollbackAccounts::SameNonceAndFeePayer {
@@ -65,7 +69,7 @@ impl RollbackAccounts {
         } else {
             // When rolling back failed transactions which don't use nonces, the
             // runtime should not update the fee payer's rent epoch so reset the
-            // rollback fee payer acocunt's rent epoch to its originally loaded
+            // rollback fee payer account's rent epoch to its originally loaded
             // rent epoch value. In the future, a feature gate could be used to
             // alter this behavior such that rent epoch updates are handled the
             // same for both nonce and non-nonce failed transactions.

--- a/svm/src/transaction_processing_result.rs
+++ b/svm/src/transaction_processing_result.rs
@@ -15,7 +15,6 @@ pub trait TransactionProcessingResultExtensions {
     fn was_processed(&self) -> bool;
     fn was_processed_with_successful_result(&self) -> bool;
     fn processed_transaction(&self) -> Option<&ProcessedTransaction>;
-    fn processed_transaction_mut(&mut self) -> Option<&mut ProcessedTransaction>;
     fn flattened_result(&self) -> TransactionResult<()>;
 }
 
@@ -42,13 +41,6 @@ impl TransactionProcessingResultExtensions for TransactionProcessingResult {
     }
 
     fn processed_transaction(&self) -> Option<&ProcessedTransaction> {
-        match self {
-            Ok(processed_tx) => Some(processed_tx),
-            Err(_) => None,
-        }
-    }
-
-    fn processed_transaction_mut(&mut self) -> Option<&mut ProcessedTransaction> {
         match self {
             Ok(processed_tx) => Some(processed_tx),
             Err(_) => None,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -224,6 +224,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         self.sysvar_cache.read().unwrap()
     }
 
+    // XXX OK WHEN BACK need to fix svm integration and bank tests
+
     /// Main entrypoint to the SVM.
     pub fn load_and_execute_sanitized_transactions<CB: TransactionProcessingCallback>(
         &self,
@@ -1010,7 +1012,7 @@ mod tests {
             fee_calculator::FeeCalculator,
             hash::Hash,
             message::{LegacyMessage, Message, MessageHeader, SanitizedMessage},
-            nonce,
+            nonce::{self, state::DurableNonce},
             rent_collector::{RentCollector, RENT_EXEMPT_RENT_EPOCH},
             rent_debits::RentDebits,
             reserved_account_keys::ReservedAccountKeys,
@@ -1896,7 +1898,6 @@ mod tests {
             &FeatureSet::default(),
             &FeeStructure::default(),
             &rent_collector,
-            &DurableNonce::default(),
             &mut error_counters,
         );
 
@@ -1975,7 +1976,6 @@ mod tests {
             &FeatureSet::default(),
             &FeeStructure::default(),
             &rent_collector,
-            &DurableNonce::default(),
             &mut error_counters,
         );
 
@@ -2027,7 +2027,6 @@ mod tests {
             &FeatureSet::default(),
             &FeeStructure::default(),
             &RentCollector::default(),
-            &DurableNonce::default(),
             &mut error_counters,
         );
 
@@ -2062,7 +2061,6 @@ mod tests {
             &FeatureSet::default(),
             &FeeStructure::default(),
             &RentCollector::default(),
-            &DurableNonce::default(),
             &mut error_counters,
         );
 
@@ -2101,7 +2099,6 @@ mod tests {
             &FeatureSet::default(),
             &FeeStructure::default(),
             &rent_collector,
-            &DurableNonce::default(),
             &mut error_counters,
         );
 
@@ -2138,7 +2135,6 @@ mod tests {
             &FeatureSet::default(),
             &FeeStructure::default(),
             &RentCollector::default(),
-            &DurableNonce::default(),
             &mut error_counters,
         );
 
@@ -2171,7 +2167,6 @@ mod tests {
             &FeatureSet::default(),
             &FeeStructure::default(),
             &RentCollector::default(),
-            &DurableNonce::default(),
             &mut error_counters,
         );
 
@@ -2241,7 +2236,6 @@ mod tests {
                 &feature_set,
                 &FeeStructure::default(),
                 &rent_collector,
-                &durable_nonce,
                 &mut error_counters,
             );
 
@@ -2304,7 +2298,6 @@ mod tests {
                 &feature_set,
                 &FeeStructure::default(),
                 &rent_collector,
-                &DurableNonce::default(),
                 &mut error_counters,
             );
 
@@ -2359,7 +2352,6 @@ mod tests {
             &FeatureSet::default(),
             &FeeStructure::default(),
             &rent_collector,
-            &DurableNonce::default(),
             &mut error_counters,
         );
         assert!(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1010,7 +1010,7 @@ mod tests {
             fee_calculator::FeeCalculator,
             hash::Hash,
             message::{LegacyMessage, Message, MessageHeader, SanitizedMessage},
-            nonce::{self, state::DurableNonce},
+            nonce,
             rent_collector::{RentCollector, RENT_EXEMPT_RENT_EPOCH},
             rent_debits::RentDebits,
             reserved_account_keys::ReservedAccountKeys,
@@ -2216,12 +2216,10 @@ mod tests {
             let mut error_counters = TransactionErrorMetrics::default();
             let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
-            let durable_nonce = DurableNonce::from_blockhash(&last_blockhash);
-            let mut nonce_info = NonceInfo::new(*fee_payer_address, fee_payer_account.clone());
-            nonce_info
-                .try_advance_nonce(durable_nonce, lamports_per_signature)
-                .unwrap();
-            let nonce = Some(nonce_info);
+            let nonce = Some(NonceInfo::new(
+                *fee_payer_address,
+                fee_payer_account.clone(),
+            ));
 
             let result = batch_processor.validate_transaction_fee_payer(
                 &mock_bank,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -224,8 +224,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         self.sysvar_cache.read().unwrap()
     }
 
-    // XXX OK WHEN BACK need to fix svm integration and bank tests
-
     /// Main entrypoint to the SVM.
     pub fn load_and_execute_sanitized_transactions<CB: TransactionProcessingCallback>(
         &self,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -6,20 +6,25 @@ use {
         MockBankCallback, MockForkGraph, WALLCLOCK_TIME,
     },
     solana_sdk::{
-        account::{AccountSharedData, WritableAccount},
+        account::{AccountSharedData, ReadableAccount, WritableAccount},
         clock::Slot,
+        feature_set::{self, FeatureSet},
         hash::Hash,
         instruction::{AccountMeta, Instruction},
         native_token::LAMPORTS_PER_SOL,
+        nonce::{self, state::DurableNonce},
         pubkey::Pubkey,
         signature::Signer,
         signer::keypair::Keypair,
         system_instruction, system_program, system_transaction,
+        sysvar::rent::Rent,
         transaction::{SanitizedTransaction, Transaction, TransactionError},
         transaction_context::TransactionReturnData,
     },
     solana_svm::{
         account_loader::{CheckedTransactionDetails, TransactionCheckResult},
+        nonce_info::NonceInfo,
+        rollback_accounts::RollbackAccounts,
         transaction_execution_result::TransactionExecutionDetails,
         transaction_processing_result::ProcessedTransaction,
         transaction_processor::{
@@ -27,6 +32,7 @@ use {
             TransactionProcessingEnvironment,
         },
     },
+    solana_svm_transaction::svm_message::SVMMessage,
     solana_type_overrides::sync::{Arc, RwLock},
     std::collections::{HashMap, HashSet},
     test_case::test_case,
@@ -40,22 +46,25 @@ const EXECUTION_SLOT: u64 = 5; // The execution slot must be greater than the de
 const EXECUTION_EPOCH: u64 = 2; // The execution epoch must be greater than the deployment epoch
 const LAMPORTS_PER_SIGNATURE: u64 = 5000;
 
-pub type AccountMap = HashMap<Pubkey, AccountSharedData>;
+pub type AccountsMap = HashMap<Pubkey, AccountSharedData>;
 
 // container for a transaction batch and all data needed to run and verify it against svm
 #[derive(Debug, Default)]
 pub struct SvmTestEntry {
+    // features are disabled by default; these will be enabled
+    pub enabled_features: Vec<Pubkey>,
+
     // programs to deploy to the new svm before transaction execution
     pub initial_programs: Vec<(String, Slot)>,
 
     // accounts to deploy to the new svm before transaction execution
-    pub initial_accounts: AccountMap,
+    pub initial_accounts: AccountsMap,
 
     // transactions to execute and transaction-specific checks to perform on the results from svm
     pub transaction_batch: Vec<TransactionBatchItem>,
 
     // expected final account states, checked after transaction execution
-    pub final_accounts: AccountMap,
+    pub final_accounts: AccountsMap,
 }
 
 impl SvmTestEntry {
@@ -123,6 +132,27 @@ impl SvmTestEntry {
         });
     }
 
+    // convenience function that adds a nonce transaction that is expected to succeed
+    pub fn push_nonce_transaction(&mut self, transaction: Transaction, nonce_info: NonceInfo) {
+        self.transaction_batch.push(TransactionBatchItem {
+            transaction,
+            ..TransactionBatchItem::with_nonce(nonce_info)
+        });
+    }
+
+    // convenience function that adds a nonce transaction that is expected to execute but fail
+    pub fn push_failed_nonce_transaction(
+        &mut self,
+        transaction: Transaction,
+        nonce_info: NonceInfo,
+    ) {
+        self.transaction_batch.push(TransactionBatchItem {
+            transaction,
+            asserts: TransactionBatchItemAsserts::failed(),
+            ..TransactionBatchItem::with_nonce(nonce_info)
+        });
+    }
+
     // internal helper to gather SanitizedTransaction objects for execution
     fn prepare_transactions(&self) -> (Vec<SanitizedTransaction>, Vec<TransactionCheckResult>) {
         self.transaction_batch
@@ -153,6 +183,18 @@ pub struct TransactionBatchItem {
     pub transaction: Transaction,
     pub check_result: TransactionCheckResult,
     pub asserts: TransactionBatchItemAsserts,
+}
+
+impl TransactionBatchItem {
+    fn with_nonce(nonce_info: NonceInfo) -> Self {
+        Self {
+            check_result: Ok(CheckedTransactionDetails {
+                nonce: Some(nonce_info),
+                lamports_per_signature: LAMPORTS_PER_SIGNATURE,
+            }),
+            ..Self::default()
+        }
+    }
 }
 
 impl Default for TransactionBatchItem {
@@ -546,8 +588,182 @@ fn simple_transfer() -> Vec<SvmTestEntry> {
     vec![test_entry]
 }
 
+fn simple_nonce_fee_only(enable_fee_only_transactions: bool) -> Vec<SvmTestEntry> {
+    let mut test_entry = SvmTestEntry::default();
+    if enable_fee_only_transactions {
+        test_entry
+            .enabled_features
+            .push(feature_set::enable_transaction_loading_failure_fees::id());
+    }
+
+    let program_name = "hello-solana".to_string();
+    let real_program_id = program_address(&program_name);
+    test_entry
+        .initial_programs
+        .push((program_name, DEPLOYMENT_SLOT));
+
+    // create and return a transaction, fee payer, and nonce info
+    // sets up initial account states but not final ones
+    let mk_nonce_transaction = |test_entry: &mut SvmTestEntry, program_id, fake_fee_payer: bool| {
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+
+        if !fake_fee_payer {
+            let mut fee_payer_data = AccountSharedData::default();
+            fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+            test_entry.add_initial_account(fee_payer, &fee_payer_data);
+        }
+
+        let nonce_size = nonce::State::size();
+        let nonce_balance = Rent::default().minimum_balance(nonce_size);
+        let nonce_pubkey = Pubkey::new_unique();
+        let nonce_initial_hash = DurableNonce::from_blockhash(&Hash::new_unique());
+        let nonce_data =
+            nonce::state::Data::new(fee_payer, nonce_initial_hash, LAMPORTS_PER_SIGNATURE);
+        let nonce_account = AccountSharedData::new_data(
+            nonce_balance,
+            &nonce::state::Versions::new(nonce::State::Initialized(nonce_data.clone())),
+            &system_program::id(),
+        )
+        .unwrap();
+        let nonce_info = NonceInfo::new(nonce_pubkey, nonce_account.clone());
+
+        test_entry.add_initial_account(nonce_pubkey, &nonce_account);
+
+        let instructions = vec![
+            system_instruction::advance_nonce_account(&nonce_pubkey, &fee_payer),
+            Instruction::new_with_bytes(program_id, &[], vec![]),
+        ];
+
+        let transaction = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            nonce_data.blockhash(),
+        );
+
+        (transaction, fee_payer, nonce_info)
+    };
+
+    // successful nonce transaction, regardless of features
+    {
+        let (transaction, fee_payer, mut nonce_info) =
+            mk_nonce_transaction(&mut test_entry, real_program_id, false);
+        test_entry.push_nonce_transaction(transaction, nonce_info.clone());
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        nonce_info
+            .try_advance_nonce(
+                DurableNonce::from_blockhash(&Hash::default()),
+                LAMPORTS_PER_SIGNATURE,
+            )
+            .unwrap();
+        test_entry
+            .final_accounts
+            .get_mut(nonce_info.address())
+            .unwrap()
+            .data_as_mut_slice()
+            .copy_from_slice(nonce_info.account().data());
+    }
+
+    // non-executing nonce transaction (fee payer doesnt exist) regardless of features
+    {
+        let (transaction, _fee_payer, nonce_info) =
+            mk_nonce_transaction(&mut test_entry, real_program_id, true);
+
+        test_entry
+            .final_accounts
+            .get_mut(nonce_info.address())
+            .unwrap()
+            .set_rent_epoch(0);
+
+        test_entry.transaction_batch.push(TransactionBatchItem {
+            transaction,
+            asserts: TransactionBatchItemAsserts::not_executed(),
+            ..TransactionBatchItem::with_nonce(nonce_info)
+        });
+    }
+
+    // failing nonce transaction (bad system instruction) regardless of features
+    {
+        let (transaction, fee_payer, mut nonce_info) =
+            mk_nonce_transaction(&mut test_entry, system_program::id(), false);
+        test_entry.push_failed_nonce_transaction(transaction, nonce_info.clone());
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        nonce_info
+            .try_advance_nonce(
+                DurableNonce::from_blockhash(&Hash::default()),
+                LAMPORTS_PER_SIGNATURE,
+            )
+            .unwrap();
+        test_entry
+            .final_accounts
+            .get_mut(nonce_info.address())
+            .unwrap()
+            .data_as_mut_slice()
+            .copy_from_slice(nonce_info.account().data());
+    }
+
+    // and this (program doesnt exist) will be a non-executing transaction without the feature
+    // or a fee-only transaction with it. which is identical to failed *except* rent is not updated
+    // HANA and i need to update my verbiage to include this new strange creature
+    {
+        let (transaction, fee_payer, mut nonce_info) =
+            mk_nonce_transaction(&mut test_entry, Pubkey::new_unique(), false);
+
+        if enable_fee_only_transactions {
+            test_entry.push_failed_nonce_transaction(transaction, nonce_info.clone());
+
+            test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+
+            nonce_info
+                .try_advance_nonce(
+                    DurableNonce::from_blockhash(&Hash::default()),
+                    LAMPORTS_PER_SIGNATURE,
+                )
+                .unwrap();
+            test_entry
+                .final_accounts
+                .get_mut(nonce_info.address())
+                .unwrap()
+                .data_as_mut_slice()
+                .copy_from_slice(nonce_info.account().data());
+            test_entry
+                .final_accounts
+                .get_mut(nonce_info.address())
+                .unwrap()
+                .set_rent_epoch(0);
+        } else {
+            test_entry
+                .final_accounts
+                .get_mut(&fee_payer)
+                .unwrap()
+                .set_rent_epoch(0);
+
+            test_entry
+                .final_accounts
+                .get_mut(nonce_info.address())
+                .unwrap()
+                .set_rent_epoch(0);
+
+            test_entry.transaction_batch.push(TransactionBatchItem {
+                transaction,
+                asserts: TransactionBatchItemAsserts::not_executed(),
+                ..TransactionBatchItem::with_nonce(nonce_info)
+            });
+        }
+    }
+
+    vec![test_entry]
+}
+
 #[test_case(program_medley())]
 #[test_case(simple_transfer())]
+#[test_case(simple_nonce_fee_only(false))]
+#[test_case(simple_nonce_fee_only(true))]
 fn svm_integration(test_entries: Vec<SvmTestEntry>) {
     for test_entry in test_entries {
         execute_test_entry(test_entry);
@@ -596,37 +812,79 @@ fn execute_test_entry(test_entry: SvmTestEntry) {
         ..Default::default()
     };
 
+    let mut feature_set = FeatureSet::default();
+    for feature_id in &test_entry.enabled_features {
+        feature_set.activate(feature_id, 0);
+    }
+
+    let processing_environment = TransactionProcessingEnvironment {
+        feature_set: feature_set.into(),
+        lamports_per_signature: LAMPORTS_PER_SIGNATURE,
+        ..TransactionProcessingEnvironment::default()
+    };
+
     // execute transaction batch
     let (transactions, check_results) = test_entry.prepare_transactions();
     let batch_output = batch_processor.load_and_execute_sanitized_transactions(
         &mock_bank,
         &transactions,
         check_results,
-        &TransactionProcessingEnvironment::default(),
+        &processing_environment,
         &processing_config,
     );
 
     // build a hashmap of final account states incrementally, starting with all initial states, updating to all final states
     // NOTE with SIMD-83 an account may appear multiple times in the same batch
     let mut final_accounts_actual = test_entry.initial_accounts.clone();
-    for processed_transaction in batch_output
-        .processing_results
-        .iter()
-        .filter_map(|r| r.as_ref().ok())
-    {
+
+    for (index, processed_transaction) in batch_output.processing_results.iter().enumerate() {
         match processed_transaction {
-            ProcessedTransaction::Executed(executed_transaction) => {
+            Ok(ProcessedTransaction::Executed(executed_transaction)) => {
                 for (pubkey, account_data) in
                     executed_transaction.loaded_transaction.accounts.clone()
                 {
                     final_accounts_actual.insert(pubkey, account_data);
                 }
             }
-            // NOTE this is a possible state with `feature_set::enable_transaction_loading_failure_fees` enabled
-            // by using `TransactionProcessingEnvironment::default()` we have all features disabled
-            // in other words, this will be unreachable until we are ready to test fee-only transactions
-            // (or the feature is activated on mainnet and removed... but we should do it before then!)
-            ProcessedTransaction::FeesOnly(_) => unreachable!(),
+            Ok(ProcessedTransaction::FeesOnly(fees_only_transaction)) => {
+                let fee_payer = transactions[index].fee_payer();
+
+                match fees_only_transaction.rollback_accounts.clone() {
+                    RollbackAccounts::FeePayerOnly { fee_payer_account } => {
+                        final_accounts_actual.insert(*fee_payer, fee_payer_account);
+                    }
+                    RollbackAccounts::SameNonceAndFeePayer { nonce } => {
+                        let mut new_nonce = nonce.clone();
+                        new_nonce
+                            .try_advance_nonce(
+                                DurableNonce::from_blockhash(&Hash::default()),
+                                LAMPORTS_PER_SIGNATURE,
+                            )
+                            .unwrap();
+
+                        final_accounts_actual
+                            .insert(*new_nonce.address(), new_nonce.account().clone());
+                    }
+                    RollbackAccounts::SeparateNonceAndFeePayer {
+                        nonce,
+                        fee_payer_account,
+                    } => {
+                        final_accounts_actual.insert(*fee_payer, fee_payer_account);
+
+                        let mut new_nonce = nonce.clone();
+                        new_nonce
+                            .try_advance_nonce(
+                                DurableNonce::from_blockhash(&Hash::default()),
+                                LAMPORTS_PER_SIGNATURE,
+                            )
+                            .unwrap();
+
+                        final_accounts_actual
+                            .insert(*new_nonce.address(), new_nonce.account().clone());
+                    }
+                }
+            }
+            Err(_) => {}
         }
     }
 
@@ -650,7 +908,9 @@ fn execute_test_entry(test_entry: SvmTestEntry) {
         match processing_result {
             Ok(ProcessedTransaction::Executed(executed_transaction)) => test_item_asserts
                 .check_executed_transaction(&executed_transaction.execution_details),
-            Ok(ProcessedTransaction::FeesOnly(_)) => unreachable!(),
+            // HANA we have to expand our semantics, there are four cases now
+            // succeeded, failed-executed, failed-processed, no-op
+            Ok(ProcessedTransaction::FeesOnly(_)) => assert!(!test_item_asserts.succeeded),
             Err(_) => assert!(!test_item_asserts.executed),
         }
     }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -854,33 +854,14 @@ fn execute_test_entry(test_entry: SvmTestEntry) {
                         final_accounts_actual.insert(*fee_payer, fee_payer_account);
                     }
                     RollbackAccounts::SameNonceAndFeePayer { nonce } => {
-                        let mut new_nonce = nonce.clone();
-                        new_nonce
-                            .try_advance_nonce(
-                                DurableNonce::from_blockhash(&Hash::default()),
-                                LAMPORTS_PER_SIGNATURE,
-                            )
-                            .unwrap();
-
-                        final_accounts_actual
-                            .insert(*new_nonce.address(), new_nonce.account().clone());
+                        final_accounts_actual.insert(*nonce.address(), nonce.account().clone());
                     }
                     RollbackAccounts::SeparateNonceAndFeePayer {
                         nonce,
                         fee_payer_account,
                     } => {
                         final_accounts_actual.insert(*fee_payer, fee_payer_account);
-
-                        let mut new_nonce = nonce.clone();
-                        new_nonce
-                            .try_advance_nonce(
-                                DurableNonce::from_blockhash(&Hash::default()),
-                                LAMPORTS_PER_SIGNATURE,
-                            )
-                            .unwrap();
-
-                        final_accounts_actual
-                            .insert(*new_nonce.address(), new_nonce.account().clone());
+                        final_accounts_actual.insert(*nonce.address(), nonce.account().clone());
                     }
                 }
             }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -680,7 +680,7 @@ fn simple_nonce_fee_only(
             fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
             test_entry.add_initial_account(fee_payer, &fee_payer_data);
         } else if fee_paying_nonce {
-            nonce_balance += LAMPORTS_PER_SOL;
+            nonce_balance = nonce_balance.saturating_add(LAMPORTS_PER_SOL);
         }
 
         let nonce_initial_hash = DurableNonce::from_blockhash(&Hash::new_unique());
@@ -743,8 +743,8 @@ fn simple_nonce_fee_only(
 
         test_entry
             .final_accounts
-            .get_mut(nonce_info.address())
-            .map(|a| a.set_rent_epoch(0));
+            .entry(*nonce_info.address())
+            .and_modify(|account| account.set_rent_epoch(0));
 
         test_entry.push_nonce_transaction_with_status(
             transaction,

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -233,7 +233,8 @@ pub fn create_executable_environment(
         .unwrap()
         .insert(Rent::id(), account_data);
 
-    // advance nonce asserts recent blockhashes is non-empty but then just gets the blockhash from ic
+    // SystemInstruction::AdvanceNonceAccount asserts RecentBlockhashes is non-empty
+    // but then just gets the blockhash from InvokeContext. so the sysvar doesnt need real entries
     #[allow(deprecated)]
     let recent_blockhashes = vec![BlockhashesEntry::default()];
 

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -1,7 +1,9 @@
+#[allow(deprecated)]
+use solana_sdk::sysvar::recent_blockhashes::{Entry as BlockhashesEntry, RecentBlockhashes};
 use {
     solana_bpf_loader_program::syscalls::{
-        SyscallAbort, SyscallGetClockSysvar, SyscallInvokeSignedRust, SyscallLog, SyscallMemcpy,
-        SyscallMemset, SyscallSetReturnData,
+        SyscallAbort, SyscallGetClockSysvar, SyscallGetRentSysvar, SyscallInvokeSignedRust,
+        SyscallLog, SyscallMemcpy, SyscallMemset, SyscallSetReturnData,
     },
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_program_runtime::{
@@ -21,6 +23,7 @@ use {
         feature_set::FeatureSet,
         native_loader,
         pubkey::Pubkey,
+        rent::Rent,
         slot_hashes::Slot,
         sysvar::SysvarId,
     },
@@ -201,6 +204,8 @@ pub fn create_executable_environment(
     program_cache.fork_graph = Some(Arc::downgrade(&fork_graph));
 
     // We must fill in the sysvar cache entries
+
+    // clock contents are important because we use them for a sysvar loading test
     let clock = Clock {
         slot: DEPLOYMENT_SLOT,
         epoch_start_timestamp: WALLCLOCK_TIME.saturating_sub(10) as UnixTimestamp,
@@ -216,6 +221,30 @@ pub fn create_executable_environment(
         .write()
         .unwrap()
         .insert(Clock::id(), account_data);
+
+    // default rent is fine
+    let rent = Rent::default();
+
+    let mut account_data = AccountSharedData::default();
+    account_data.set_data(bincode::serialize(&rent).unwrap());
+    mock_bank
+        .account_shared_data
+        .write()
+        .unwrap()
+        .insert(Rent::id(), account_data);
+
+    // advance nonce asserts recent blockhashes is non-empty but then just gets the blockhash from ic
+    #[allow(deprecated)]
+    let recent_blockhashes = vec![BlockhashesEntry::default()];
+
+    let mut account_data = AccountSharedData::default();
+    account_data.set_data(bincode::serialize(&recent_blockhashes).unwrap());
+    #[allow(deprecated)]
+    mock_bank
+        .account_shared_data
+        .write()
+        .unwrap()
+        .insert(RecentBlockhashes::id(), account_data);
 }
 
 #[allow(unused)]
@@ -302,6 +331,10 @@ fn create_custom_environment<'a>() -> BuiltinProgram<InvokeContext<'a>> {
 
     function_registry
         .register_function_hashed(*b"sol_get_clock_sysvar", SyscallGetClockSysvar::vm)
+        .expect("Registration failed");
+
+    function_registry
+        .register_function_hashed(*b"sol_get_rent_sysvar", SyscallGetRentSysvar::vm)
         .expect("Registration failed");
 
     BuiltinProgram::new_loader(vm_config, function_registry)


### PR DESCRIPTION
#### Problem
as part of SIMD-83, transaction loading needs to track state changes made by previous transactions in the same batch. `RollbackAccounts` is a struct used to manage state changes that must be committed in the case of transaction processing failure. successful transactions, on the other hand, hold the data to be committed on their loaded transaction accounts struct

presently, `RollbackAccounts` is set up with the prior nonce account state and the expected fee-payer account state. for failed transactions, the nonce data here is not advanced until state changes are being committed, necessitating that the account saver mutate `TransactionProcessingResult` objects

#### Summary of Changes
store the already advanced nonce data in `RollbackAccounts`, in line with how the fee-payer is handled. this means transaction post-processing can reuse the account saver method `collect_accounts_to_store` without cloning `TransactionProcessingResult` because the account saver will no longer need mutable references to them