### PR TITLE
sign `PruneData` with prefix

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -280,8 +280,7 @@ impl Signable for PruneData {
     }
 
     fn signable_data(&self) -> Cow<[u8]> {
-        // Continue to return signable data without a prefix until cluster has upgraded
-        self.signable_data_without_prefix()
+        self.signable_data_with_prefix()
     }
 
     fn get_signature(&self) -> Signature {


### PR DESCRIPTION
#### Problem
Validators have upgraded to accept `PruneData` with and without the `xffSOLANA_PRUNE_DATA` prefix. Now the `PruneData` struct needs to be signed.

#### Summary of Changes
Sign `PruneData`
