### PR TITLE
Tweaks for transaction-level fuzzing

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -865,6 +865,7 @@ pub(crate) fn process_blockstore_for_bank_0(
         None,
         exit,
         None,
+        None,
     );
     let bank0_slot = bank0.slot();
     let bank_forks = BankForks::new_rw_arc(bank0);

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -867,6 +867,7 @@ impl ProgramTest {
             None,
             Arc::default(),
             None,
+            None,
         );
 
         // Add commonly-used SPL programs as a convenience to the user

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -987,6 +987,7 @@ impl Bank {
         #[allow(unused)] collector_id_for_tests: Option<Pubkey>,
         exit: Arc<AtomicBool>,
         #[allow(unused)] genesis_hash: Option<Hash>,
+        #[allow(unused)] feature_set: Option<FeatureSet>,
     ) -> Self {
         let accounts_db = AccountsDb::new_with_config(
             paths,
@@ -1004,6 +1005,11 @@ impl Bank {
         bank.transaction_account_lock_limit = runtime_config.transaction_account_lock_limit;
         bank.transaction_debug_keys = debug_keys;
         bank.cluster_type = Some(genesis_config.cluster_type);
+
+        #[cfg(feature = "dev-context-only-utils")]
+        {
+            bank.feature_set = Arc::new(feature_set.unwrap_or_default());
+        }
 
         #[cfg(not(feature = "dev-context-only-utils"))]
         bank.process_genesis_config(genesis_config);
@@ -3157,7 +3163,6 @@ impl Bank {
             w_blockhash_queue
                 .register_hash(blockhash, self.fee_rate_governor.lamports_per_signature);
         }
-        self.update_recent_blockhashes_locked(&w_blockhash_queue);
     }
 
     /// Tell the bank which Entry IDs exist on the ledger. This function assumes subsequent calls
@@ -6631,6 +6636,7 @@ impl Bank {
             Some(Pubkey::new_unique()),
             Arc::default(),
             None,
+            None,
         )
     }
 
@@ -6654,6 +6660,7 @@ impl Bank {
             None,
             Some(Pubkey::new_unique()),
             Arc::default(),
+            None,
             None,
         )
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -380,6 +380,7 @@ mod tests {
             Some(Pubkey::new_unique()),
             Arc::default(),
             None,
+            None,
         );
 
         // Fill bank_forks with banks with votes landing in the next slot
@@ -487,6 +488,7 @@ mod tests {
             None,
             Some(Pubkey::new_unique()),
             Arc::default(),
+            None,
             None,
         );
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9010,6 +9010,7 @@ fn test_epoch_schedule_from_genesis_config() {
         None,
         Arc::default(),
         None,
+        None,
     ));
 
     assert_eq!(bank.epoch_schedule(), &genesis_config.epoch_schedule);
@@ -9040,6 +9041,7 @@ where
         None,
         None,
         Arc::default(),
+        None,
         None,
     ));
     let vote_and_stake_accounts =
@@ -12645,6 +12647,7 @@ fn test_rehash_with_skipped_rewrites() {
         Some(Pubkey::new_unique()),
         Arc::new(AtomicBool::new(false)),
         None,
+        None,
     ));
     // This test is only meaningful while the bank hash contains rewrites.
     // Once this feature is enabled, it may be possible to remove this test entirely.
@@ -12706,6 +12709,7 @@ fn test_rebuild_skipped_rewrites() {
         None,
         Some(Pubkey::new_unique()),
         Arc::new(AtomicBool::new(false)),
+        None,
         None,
     ));
     // This test is only meaningful while the bank hash contains rewrites.
@@ -12817,6 +12821,7 @@ fn test_get_accounts_for_bank_hash_details(skip_rewrites: bool) {
         None,
         Some(Pubkey::new_unique()),
         Arc::new(AtomicBool::new(false)),
+        None,
         None,
     ));
     // This test is only meaningful while the bank hash contains rewrites.


### PR DESCRIPTION


#### Problem
Working from [solfuzz-agave](https://github.com/firedancer-io/solfuzz-agave) to be able to fuzz transactions. `register_recent_blockhash_for_test` previously updated the recent blockhashes sysvar account on every single insertion, which would slow down fuzzing significantly. Instead, we can register all of the blockhashes, and then update the sysvar account at once. 

Additionally, the bank's feature set is not registered when calling `new_with_paths`. This results in some precompiles not being loaded within `finish_init`. 

#### Summary of Changes
* Remove sysvar setting within `register_recent_blockhash_for_test` - this will be the caller's task.
* Add an optional feature set parameter into `new_with_paths` 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
