### PR TITLE
Bump platform tools version

### DIFF
--- a/programs/sbf/rust/ro_modify/src/lib.rs
+++ b/programs/sbf/rust/ro_modify/src/lib.rs
@@ -39,22 +39,6 @@ struct SolAccountInfo {
     executable: bool,
 }
 
-/// Rust representation of C's SolSignerSeed
-#[derive(Debug)]
-#[repr(C)]
-struct SolSignerSeedC {
-    addr: u64,
-    len: u64,
-}
-
-/// Rust representation of C's SolSignerSeeds
-#[derive(Debug)]
-#[repr(C)]
-struct SolSignerSeedsC {
-    addr: u64,
-    len: u64,
-}
-
 const READONLY_ACCOUNTS: &[SolAccountInfo] = &[
     SolAccountInfo {
         is_signer: false,

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -913,7 +913,7 @@ fn main() {
 
     // The following line is scanned by CI configuration script to
     // separate cargo caches according to the version of platform-tools.
-    let platform_tools_version = String::from("v1.42");
+    let platform_tools_version = String::from("v1.43");
     let rust_base_version = get_base_rust_version(platform_tools_version.as_str());
     let version = format!(
         "{}\nplatform-tools {}\n{}",

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-rust-version = "1.75.0"                          # solana platform-tools rust version
+rust-version = "1.79.0"                          # solana platform-tools rust version
 
 [dependencies]
 bincode = { workspace = true }

--- a/sdk/sbf/scripts/install.sh
+++ b/sdk/sbf/scripts/install.sh
@@ -109,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install platform tools
-version=v1.42
+version=v1.43
 if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
   (
     set -e


### PR DESCRIPTION
#### Problem

Platform tools v1.42 is dated and still brings Rust 1.75.

#### Summary of Changes

Bump the tools version to v1.43, which brings Rust 1.79.
