### PR TITLE
Fix flaky fuzzer test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7312,6 +7312,7 @@ dependencies = [
 name = "solana-runtime"
 version = "2.1.0"
 dependencies = [
+ "agave-transaction-view",
  "aquamarine",
  "arrayref",
  "assert_matches",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -93,6 +93,7 @@ crate-type = ["lib"]
 name = "solana_runtime"
 
 [dev-dependencies]
+agave-transaction-view = { workspace = true }
 assert_matches = { workspace = true }
 ed25519-dalek = { workspace = true }
 libsecp256k1 = { workspace = true }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -16,6 +16,7 @@ use {
         snapshot_bank_utils, snapshot_utils,
         status_cache::MAX_CACHE_ENTRIES,
     },
+    agave_transaction_view::static_account_keys_meta::MAX_STATIC_ACCOUNTS_PER_PACKET,
     assert_matches::assert_matches,
     crossbeam_channel::{bounded, unbounded},
     itertools::Itertools,
@@ -6192,7 +6193,7 @@ fn test_fuzz_instructions() {
         })
         .collect();
     let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
-    let max_keys = 100;
+    let max_keys = MAX_STATIC_ACCOUNTS_PER_PACKET;
     let keys: Vec<_> = (0..max_keys)
         .enumerate()
         .map(|_| {


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/2645 introduced some test flakiness in the bank fuzzing test because it expects that program indexes are always less than the max number of static keys that can fit into a transaction. The bank fuzzer test allows program indexes to be much higher, despite this not being currently possible.

#### Summary of Changes
Decrease number of keys that are added to test fuzzer transactions

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
