### PR TITLE
perf: replace vote state tuples with named structs and improve deser

### DIFF
--- a/ci/test-miri.sh
+++ b/ci/test-miri.sh
@@ -11,7 +11,9 @@ _ cargo "+${rust_nightly}" miri test -p solana-program -- hash:: account_info::
 _ cargo "+${rust_nightly}" miri test -p solana-unified-scheduler-logic
 
 # test big endian branch
-_ cargo "+${rust_nightly}" miri test --target s390x-unknown-linux-gnu -p solana-program  -- "vote::state::tests::test_deserialize_vote_state" --exact
+_ cargo "+${rust_nightly}" miri test --target s390x-unknown-linux-gnu -p solana-program -- "vote::state::tests::test_deserialize_vote_state" --exact
+# test little endian branch for UB
+_ cargo "+${rust_nightly}" miri test -p solana-program -- "vote::state::tests::test_deserialize_vote_state" --exact
 
 # run intentionally-#[ignored] ub triggering tests for each to make sure they fail
 (! _ cargo "+${rust_nightly}" miri test -p solana-unified-scheduler-logic -- \

--- a/ci/test-miri.sh
+++ b/ci/test-miri.sh
@@ -10,6 +10,9 @@ _ cargo "+${rust_nightly}" miri test -p solana-program -- hash:: account_info::
 
 _ cargo "+${rust_nightly}" miri test -p solana-unified-scheduler-logic
 
+# test big endian branch
+_ cargo "+${rust_nightly}" miri test --target s390x-unknown-linux-gnu -p solana-program  -- "vote::state::tests::test_deserialize_vote_state" --exact
+
 # run intentionally-#[ignored] ub triggering tests for each to make sure they fail
 (! _ cargo "+${rust_nightly}" miri test -p solana-unified-scheduler-logic -- \
   --ignored --exact "utils::tests::test_ub_illegally_created_multiple_tokens")

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -60,6 +60,7 @@ use {
         system_program,
         sysvar::{clock, stake_history},
         transaction::Transaction,
+        vote::state::EpochCreditsItem,
     },
     std::{ops::Deref, rc::Rc},
 };
@@ -1733,7 +1734,16 @@ pub fn process_deactivate_stake_account(
             .current
             .into_iter()
             .find(|vote_account_info| {
-                acceptable_reference_epoch_credits(&vote_account_info.epoch_credits, current_epoch)
+                let epoch_credits: Vec<_> = vote_account_info
+                    .epoch_credits
+                    .iter()
+                    .map(|&(epoch, credits, prev_credits)| EpochCreditsItem {
+                        epoch,
+                        credits,
+                        prev_credits,
+                    })
+                    .collect();
+                acceptable_reference_epoch_credits(&epoch_credits, current_epoch)
             });
         let reference_vote_account_address = reference_vote_account_address
             .ok_or_else(|| {

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -38,7 +38,7 @@ use {
     solana_vote_program::{
         vote_error::VoteError,
         vote_instruction::{self, withdraw, CreateVoteAccountConfig},
-        vote_state::{VoteAuthorize, VoteInit, VoteState, VoteStateVersions},
+        vote_state::{EpochCreditsItem, VoteAuthorize, VoteInit, VoteState, VoteStateVersions},
     },
     std::rc::Rc,
 };
@@ -1252,7 +1252,12 @@ pub fn process_show_vote_account(
         for vote in &vote_state.votes {
             votes.push(vote.into());
         }
-        for (epoch, credits, prev_credits) in vote_state.epoch_credits().iter().copied() {
+        for EpochCreditsItem {
+            epoch,
+            credits,
+            prev_credits,
+        } in vote_state.epoch_credits().iter().copied()
+        {
             let credits_earned = credits.saturating_sub(prev_credits);
             let slots_in_epoch = epoch_schedule.get_slots_in_epoch(epoch);
             epoch_voting_history.push(CliEpochVotingHistory {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -237,7 +237,7 @@ pub(crate) enum BlockhashStatus {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "H6T5A66kgJYANFXVrUprxV76WD5ce7Gf62q9SiBC2uYk")
+    frozen_abi(digest = "4zfuTP36J5PPvh2TFDN6itrj9frAB6BUs4Ney1Tmyz5T")
 )]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower {

--- a/core/src/consensus/tower1_14_11.rs
+++ b/core/src/consensus/tower1_14_11.rs
@@ -9,7 +9,7 @@ use {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "EqYa8kwY9Z1Zbjxgs2aBbqKyCK4f7WAG8gJ7pVSQyKzk")
+    frozen_abi(digest = "8NUPdkZzc4NaaVLbubPruhgM5yEbwpqBYUGZ2uL2rrhL")
 )]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower1_14_11 {

--- a/core/src/consensus/tower1_7_14.rs
+++ b/core/src/consensus/tower1_7_14.rs
@@ -11,7 +11,7 @@ use {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "9Kc3Cpak93xdL8bCnEwMWA8ZLGCBNfqh9PLo1o5RiPyT")
+    frozen_abi(digest = "PDdpVJx8Foxb8eo9PbJZ7BfkVDSmJYyNDmAUe9cmTpk")
 )]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower1_7_14 {

--- a/programs/stake/src/points.rs
+++ b/programs/stake/src/points.rs
@@ -9,7 +9,7 @@ use {
         stake::state::{Delegation, Stake, StakeStateV2},
         stake_history::StakeHistory,
     },
-    solana_vote_program::vote_state::VoteState,
+    solana_vote_program::vote_state::{EpochCreditsItem, VoteState},
     std::cmp::Ordering,
 };
 
@@ -162,8 +162,11 @@ pub(crate) fn calculate_stake_points_and_credits(
     let mut points = 0;
     let mut new_credits_observed = credits_in_stake;
 
-    for (epoch, final_epoch_credits, initial_epoch_credits) in
-        new_vote_state.epoch_credits().iter().copied()
+    for EpochCreditsItem {
+        epoch,
+        credits: final_epoch_credits,
+        prev_credits: initial_epoch_credits,
+    } in new_vote_state.epoch_credits().iter().copied()
     {
         let stake_amount = u128::from(stake.delegation.stake(
             epoch,

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -7134,14 +7134,14 @@ mod tests {
             reference_vote_state.increment_credits(epoch, 1);
         }
         assert_eq!(
-            reference_vote_state.epoch_credits[current_epoch as usize - 2].0,
+            reference_vote_state.epoch_credits[current_epoch as usize - 2].epoch,
             current_epoch - 2
         );
         reference_vote_state
             .epoch_credits
             .remove(current_epoch as usize - 2);
         assert_eq!(
-            reference_vote_state.epoch_credits[current_epoch as usize - 2].0,
+            reference_vote_state.epoch_credits[current_epoch as usize - 2].epoch,
             current_epoch - 1
         );
         reference_vote_account

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -282,7 +282,10 @@ mod tests {
                 self, clock::Clock, epoch_schedule::EpochSchedule, rent::Rent,
                 slot_hashes::SlotHashes,
             },
-            vote::instruction::{tower_sync, tower_sync_switch},
+            vote::{
+                instruction::{tower_sync, tower_sync_switch},
+                state::EpochCreditsItem,
+            },
         },
         std::{collections::HashSet, str::FromStr},
     };
@@ -461,11 +464,11 @@ mod tests {
         let mut previous_epoch_credits = 0;
         for (epoch, credits) in credits_to_append.iter().enumerate() {
             current_epoch_credits = current_epoch_credits.saturating_add(*credits);
-            vote_state.epoch_credits.push((
-                u64::try_from(epoch).unwrap(),
-                current_epoch_credits,
-                previous_epoch_credits,
-            ));
+            vote_state.epoch_credits.push(EpochCreditsItem {
+                epoch: u64::try_from(epoch).unwrap(),
+                credits: current_epoch_credits,
+                prev_credits: previous_epoch_credits,
+            });
             previous_epoch_credits = current_epoch_credits;
         }
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -994,13 +994,18 @@ pub fn withdraw<S: std::hash::BuildHasher>(
         let reject_active_vote_account_close = vote_state
             .epoch_credits
             .last()
-            .map(|(last_epoch_with_credits, _, _)| {
-                let current_epoch = clock.epoch;
-                // if current_epoch - last_epoch_with_credits < 2 then the validator has received credits
-                // either in the current epoch or the previous epoch. If it's >= 2 then it has been at least
-                // one full epoch since the validator has received credits.
-                current_epoch.saturating_sub(*last_epoch_with_credits) < 2
-            })
+            .map(
+                |EpochCreditsItem {
+                     epoch: last_epoch_with_credits,
+                     ..
+                 }| {
+                    let current_epoch = clock.epoch;
+                    // if current_epoch - last_epoch_with_credits < 2 then the validator has received credits
+                    // either in the current epoch or the previous epoch. If it's >= 2 then it has been at least
+                    // one full epoch since the validator has received credits.
+                    current_epoch.saturating_sub(*last_epoch_with_credits) < 2
+                },
+            )
             .unwrap_or(false);
 
         if reject_active_vote_account_close {

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -1959,4 +1959,14 @@ mod tests {
         VoteState::deserialize_into(vote_bytes.as_slice(), &mut deserialized_vote_state).unwrap();
         assert_eq!(vote_state, deserialized_vote_state);
     }
+
+    #[test]
+    fn test_epoch_credits_item_size_of() {
+        assert_eq!(24, mem::size_of::<EpochCreditsItem>());
+    }
+
+    #[test]
+    fn test_prior_voter_item_size_of() {
+        assert_eq!(48, mem::size_of::<PriorVotersItem>());
+    }
 }

--- a/sdk/program/src/vote/state/vote_state_0_23_5.rs
+++ b/sdk/program/src/vote/state/vote_state_0_23_5.rs
@@ -30,8 +30,7 @@ pub struct VoteState0_23_5 {
     pub root_slot: Option<u64>,
 
     /// history of how many credits earned by the end of each epoch
-    ///  each tuple is (Epoch, credits, prev_credits)
-    pub epoch_credits: Vec<(Epoch, u64, u64)>,
+    pub epoch_credits: Vec<EpochCreditsItem>,
 
     /// most recent timestamp submitted with a vote
     pub last_timestamp: BlockTimestamp,

--- a/sdk/program/src/vote/state/vote_state_1_14_11.rs
+++ b/sdk/program/src/vote/state/vote_state_1_14_11.rs
@@ -7,7 +7,7 @@ const DEFAULT_PRIOR_VOTERS_OFFSET: usize = 82;
 
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(digest = "CZTgLymuevXjAx6tM8X8T5J3MCx9AkEsFSmu4FJrEpkG"),
+    frozen_abi(digest = "6io5iuPRfguxFPNLtu9uMCncSudPvShXUaLYnxqJxbQG"),
     derive(AbiExample)
 )]
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -34,11 +34,10 @@ pub struct VoteState1_14_11 {
     /// history of prior authorized voters and the epochs for which
     /// they were set, the bottom end of the range is inclusive,
     /// the top of the range is exclusive
-    pub prior_voters: CircBuf<(Pubkey, Epoch, Epoch)>,
+    pub prior_voters: CircBuf<PriorVotersItem>,
 
     /// history of how many credits earned by the end of each epoch
-    ///  each tuple is (Epoch, credits, prev_credits)
-    pub epoch_credits: Vec<(Epoch, u64, u64)>,
+    pub epoch_credits: Vec<EpochCreditsItem>,
 
     /// most recent timestamp submitted with a vote
     pub last_timestamp: BlockTimestamp,

--- a/vote/benches/vote_account.rs
+++ b/vote/benches/vote_account.rs
@@ -1,0 +1,52 @@
+#![feature(test)]
+extern crate test;
+
+use {
+    rand::Rng,
+    solana_sdk::{
+        account::AccountSharedData,
+        pubkey::Pubkey,
+        vote::state::{VoteInit, VoteState, VoteStateVersions},
+    },
+    solana_vote::vote_account::VoteAccount,
+    test::Bencher,
+};
+
+fn new_rand_vote_account<R: Rng>(
+    rng: &mut R,
+    node_pubkey: Option<Pubkey>,
+) -> (AccountSharedData, VoteState) {
+    let vote_init = VoteInit {
+        node_pubkey: node_pubkey.unwrap_or_else(Pubkey::new_unique),
+        authorized_voter: Pubkey::new_unique(),
+        authorized_withdrawer: Pubkey::new_unique(),
+        commission: rng.gen(),
+    };
+    let clock = solana_sdk::sysvar::clock::Clock {
+        slot: rng.gen(),
+        epoch_start_timestamp: rng.gen(),
+        epoch: rng.gen(),
+        leader_schedule_epoch: rng.gen(),
+        unix_timestamp: rng.gen(),
+    };
+    let vote_state = VoteState::new(&vote_init, &clock);
+    let account = AccountSharedData::new_data(
+        rng.gen(), // lamports
+        &VoteStateVersions::new_current(vote_state.clone()),
+        &solana_sdk::vote::program::id(), // owner
+    )
+    .unwrap();
+    (account, vote_state)
+}
+
+#[bench]
+fn bench_vote_account_try_from(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let (account, vote_state) = new_rand_vote_account(&mut rng, None);
+
+    b.iter(|| {
+        let vote_account = VoteAccount::try_from(account.clone()).unwrap();
+        let state = vote_account.vote_state();
+        assert_eq!(state, &vote_state);
+    });
+}


### PR DESCRIPTION
#### Problem
Currently we cannot improve performance of deserializing some vote state fields because they use tuples which use the rust repr which doesn't have a defined memory layout.

#### Summary of Changes
- Change vote state tuples to named structs with `#[repr(C)]`
- Improve deserialization performance of `VoteState::prior_voters` and `VoteState::epoch_credits` fields

Bench improvements when rebased on https://github.com/anza-xyz/agave/pull/2734
```
# before
test bench_vote_account_try_from ... bench:         332.30 ns/iter (+/- 1.87)

# after
test bench_vote_account_try_from ... bench:         225.46 ns/iter (+/- 1.74)
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
