### PR TITLE
gossip: demote invalid duplicate proof errors to info

### DIFF
--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -93,16 +93,27 @@ pub enum Error {
 impl Error {
     /// Errors indicating that the initial node submitted an invalid duplicate proof case
     pub(crate) fn is_non_critical(&self) -> bool {
-        matches!(
-            self,
+        match self {
             Self::SlotMismatch
-                | Self::InvalidShredVersion(_)
-                | Self::InvalidSignature
-                | Self::ShredTypeMismatch
-                | Self::InvalidDuplicateShreds
-                | Self::InvalidLastIndexConflict
-                | Self::InvalidErasureMetaConflict
-        )
+            | Self::InvalidShredVersion(_)
+            | Self::InvalidSignature
+            | Self::ShredTypeMismatch
+            | Self::InvalidDuplicateShreds
+            | Self::InvalidLastIndexConflict
+            | Self::InvalidErasureMetaConflict => true,
+            Self::BlockstoreInsertFailed(_)
+            | Self::DataChunkMismatch
+            | Self::DuplicateSlotSenderFailure
+            | Self::InvalidChunkIndex { .. }
+            | Self::InvalidDuplicateSlotProof
+            | Self::InvalidSizeLimit
+            | Self::InvalidShred(_)
+            | Self::NumChunksMismatch
+            | Self::MissingDataChunk
+            | Self::SerializationError(_)
+            | Self::TryFromIntError(_)
+            | Self::UnknownSlotLeader(_) => false,
+        }
     }
 }
 

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -90,6 +90,22 @@ pub enum Error {
     UnknownSlotLeader(Slot),
 }
 
+impl Error {
+    /// Errors indicating that the initial node submitted an invalid duplicate proof case
+    pub(crate) fn is_non_critical(&self) -> bool {
+        matches!(
+            self,
+            Self::SlotMismatch
+                | Self::InvalidShredVersion(_)
+                | Self::InvalidSignature
+                | Self::ShredTypeMismatch
+                | Self::InvalidDuplicateShreds
+                | Self::InvalidLastIndexConflict
+                | Self::InvalidErasureMetaConflict
+        )
+    }
+}
+
 /// Check that `shred1` and `shred2` indicate a valid duplicate proof
 ///     - Must be for the same slot
 ///     - Must match the expected shred version

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -56,8 +56,14 @@ impl DuplicateShredHandlerTrait for DuplicateShredHandler {
     fn handle(&mut self, shred_data: DuplicateShred) {
         self.cache_root_info();
         self.maybe_prune_buffer();
+        let slot = shred_data.slot;
+        let pubkey = shred_data.from;
         if let Err(error) = self.handle_shred_data(shred_data) {
-            error!("handle packet: {error:?}")
+            if error.is_non_critical() {
+                info!("Received invalid duplicate shred proof from {pubkey} for slot {slot}: {error:?}");
+            } else {
+                error!("Unable to process duplicate shred proof from {pubkey} for slot {slot}: {error:?}");
+            }
         }
     }
 }


### PR DESCRIPTION
#### Problem
Misconfigured or malicious nodes can send out duplicate proofs that are invalid.
This will result in a lot of ERROR log spam.

#### Summary of Changes
Separate out logging to use INFO for invalid duplicate proofs, and ERROR for errors in the processing pipeline.
