### PR TITLE
TransactionView - sanitization checks

### DIFF
--- a/transaction-view/benches/transaction_view.rs
+++ b/transaction-view/benches/transaction_view.rs
@@ -45,7 +45,7 @@ fn bench_transactions_parsing(
     group.bench_function("TransactionView", |c| {
         c.iter(|| {
             for bytes in serialized_transactions.iter() {
-                let _ = TransactionView::try_new(black_box(bytes.as_ref())).unwrap();
+                let _ = TransactionView::try_new_unsanitized(black_box(bytes.as_ref())).unwrap();
             }
         });
     });

--- a/transaction-view/benches/transaction_view.rs
+++ b/transaction-view/benches/transaction_view.rs
@@ -15,7 +15,7 @@ use {
         signature::Keypair,
         signer::Signer,
         system_instruction,
-        transaction::VersionedTransaction,
+        transaction::{SanitizedVersionedTransaction, VersionedTransaction},
     },
 };
 
@@ -41,11 +41,30 @@ fn bench_transactions_parsing(
         });
     });
 
+    // Legacy Transaction Parsing and Sanitize checks
+    group.bench_function("SanitizedVersionedTransaction", |c| {
+        c.iter(|| {
+            for bytes in serialized_transactions.iter() {
+                let tx = bincode::deserialize::<VersionedTransaction>(black_box(bytes)).unwrap();
+                let _ = SanitizedVersionedTransaction::try_new(tx).unwrap();
+            }
+        });
+    });
+
     // New Transaction Parsing
     group.bench_function("TransactionView", |c| {
         c.iter(|| {
             for bytes in serialized_transactions.iter() {
                 let _ = TransactionView::try_new_unsanitized(black_box(bytes.as_ref())).unwrap();
+            }
+        });
+    });
+
+    // New Transaction Parsing and Sanitize checks
+    group.bench_function("TransactionView (Sanitized)", |c| {
+        c.iter(|| {
+            for bytes in serialized_transactions.iter() {
+                let _ = TransactionView::try_new_sanitized(black_box(bytes.as_ref())).unwrap();
             }
         });
     });

--- a/transaction-view/src/address_table_lookup_meta.rs
+++ b/transaction-view/src/address_table_lookup_meta.rs
@@ -51,6 +51,10 @@ pub(crate) struct AddressTableLookupMeta {
     pub(crate) num_address_table_lookups: u8,
     /// The offset to the first address table lookup in the transaction.
     pub(crate) offset: u16,
+    /// The total number of writable lookup accounts in the transaction.
+    pub(crate) total_writable_lookup_accounts: u16,
+    /// The total number of readonly lookup accounts in the transaction.
+    pub(crate) total_readonly_lookup_accounts: u16,
 }
 
 impl AddressTableLookupMeta {
@@ -80,6 +84,13 @@ impl AddressTableLookupMeta {
         // length is less than u16::MAX, so we can safely cast to u16.
         let address_table_lookups_offset = *offset as u16;
 
+        // Check that there is no chance of overflow when calculating the total
+        // number of writable and readonly lookup accounts using a u32.
+        const _: () =
+            assert!(u16::MAX as usize * MAX_ATLS_PER_PACKET as usize <= u32::MAX as usize);
+        let mut total_writable_lookup_accounts: u32 = 0;
+        let mut total_readonly_lookup_accounts: u32 = 0;
+
         // The ATLs do not have a fixed size. So we must iterate over
         // each ATL to find the total size of the ATLs in the packet,
         // and check for any malformed ATLs or buffer overflows.
@@ -94,16 +105,24 @@ impl AddressTableLookupMeta {
 
             // Read the number of write indexes, and then update the offset.
             let num_write_accounts = optimized_read_compressed_u16(bytes, offset)?;
+            total_writable_lookup_accounts =
+                total_writable_lookup_accounts.wrapping_add(u32::from(num_write_accounts));
             advance_offset_for_array::<u8>(bytes, offset, num_write_accounts)?;
 
             // Read the number of read indexes, and then update the offset.
             let num_read_accounts = optimized_read_compressed_u16(bytes, offset)?;
+            total_readonly_lookup_accounts =
+                total_readonly_lookup_accounts.wrapping_add(u32::from(num_read_accounts));
             advance_offset_for_array::<u8>(bytes, offset, num_read_accounts)?
         }
 
         Ok(Self {
             num_address_table_lookups,
             offset: address_table_lookups_offset,
+            total_writable_lookup_accounts: u16::try_from(total_writable_lookup_accounts)
+                .map_err(|_| TransactionParsingError)?,
+            total_readonly_lookup_accounts: u16::try_from(total_readonly_lookup_accounts)
+                .map_err(|_| TransactionParsingError)?,
         })
     }
 }
@@ -195,6 +214,8 @@ mod tests {
         assert_eq!(meta.num_address_table_lookups, 0);
         assert_eq!(meta.offset, 1);
         assert_eq!(offset, bytes.len());
+        assert_eq!(meta.total_writable_lookup_accounts, 0);
+        assert_eq!(meta.total_readonly_lookup_accounts, 0);
     }
 
     #[test]
@@ -221,6 +242,8 @@ mod tests {
         assert_eq!(meta.num_address_table_lookups, 1);
         assert_eq!(meta.offset, 1);
         assert_eq!(offset, bytes.len());
+        assert_eq!(meta.total_writable_lookup_accounts, 3);
+        assert_eq!(meta.total_readonly_lookup_accounts, 3);
     }
 
     #[test]
@@ -234,7 +257,7 @@ mod tests {
             MessageAddressTableLookup {
                 account_key: Pubkey::new_unique(),
                 writable_indexes: vec![1, 2, 3],
-                readonly_indexes: vec![4, 5, 6],
+                readonly_indexes: vec![4, 5],
             },
         ]))
         .unwrap();
@@ -243,6 +266,8 @@ mod tests {
         assert_eq!(meta.num_address_table_lookups, 2);
         assert_eq!(meta.offset, 1);
         assert_eq!(offset, bytes.len());
+        assert_eq!(meta.total_writable_lookup_accounts, 6);
+        assert_eq!(meta.total_readonly_lookup_accounts, 5);
     }
 
     #[test]

--- a/transaction-view/src/address_table_lookup_meta.rs
+++ b/transaction-view/src/address_table_lookup_meta.rs
@@ -113,7 +113,7 @@ impl AddressTableLookupMeta {
             let num_read_accounts = optimized_read_compressed_u16(bytes, offset)?;
             total_readonly_lookup_accounts =
                 total_readonly_lookup_accounts.wrapping_add(u32::from(num_read_accounts));
-            advance_offset_for_array::<u8>(bytes, offset, num_read_accounts)?
+            advance_offset_for_array::<u8>(bytes, offset, num_read_accounts)?;
         }
 
         Ok(Self {

--- a/transaction-view/src/address_table_lookup_meta.rs
+++ b/transaction-view/src/address_table_lookup_meta.rs
@@ -4,7 +4,7 @@ use {
             advance_offset_for_array, advance_offset_for_type, check_remaining,
             optimized_read_compressed_u16, read_byte, read_slice_data, read_type,
         },
-        result::{Result, TransactionParsingError},
+        result::{Result, TransactionViewError},
     },
     solana_sdk::{hash::Hash, packet::PACKET_DATA_SIZE, pubkey::Pubkey, signature::Signature},
     solana_svm_transaction::message_address_table_lookup::SVMMessageAddressTableLookup,
@@ -70,7 +70,7 @@ impl AddressTableLookupMeta {
         const _: () = assert!(MAX_ATLS_PER_PACKET & 0b1000_0000 == 0);
         let num_address_table_lookups = read_byte(bytes, offset)?;
         if num_address_table_lookups > MAX_ATLS_PER_PACKET {
-            return Err(TransactionParsingError);
+            return Err(TransactionViewError::ParseError);
         }
 
         // Check that the remaining bytes are enough to hold the ATLs.
@@ -120,9 +120,9 @@ impl AddressTableLookupMeta {
             num_address_table_lookups,
             offset: address_table_lookups_offset,
             total_writable_lookup_accounts: u16::try_from(total_writable_lookup_accounts)
-                .map_err(|_| TransactionParsingError)?,
+                .map_err(|_| TransactionViewError::SanitizeError)?,
             total_readonly_lookup_accounts: u16::try_from(total_readonly_lookup_accounts)
-                .map_err(|_| TransactionParsingError)?,
+                .map_err(|_| TransactionViewError::SanitizeError)?,
         })
     }
 }

--- a/transaction-view/src/lib.rs
+++ b/transaction-view/src/lib.rs
@@ -8,6 +8,7 @@ mod address_table_lookup_meta;
 mod instructions_meta;
 mod message_header_meta;
 pub mod result;
+pub mod sanitize;
 mod signature_meta;
 pub mod static_account_keys_meta;
 pub mod transaction_data;

--- a/transaction-view/src/lib.rs
+++ b/transaction-view/src/lib.rs
@@ -4,13 +4,13 @@ pub mod bytes;
 #[cfg(not(feature = "dev-context-only-utils"))]
 mod bytes;
 
-pub(crate) mod address_table_lookup_meta;
-pub(crate) mod instructions_meta;
-pub(crate) mod message_header_meta;
+mod address_table_lookup_meta;
+mod instructions_meta;
+mod message_header_meta;
 pub mod result;
-pub mod sanitize;
-pub(crate) mod signature_meta;
+mod sanitize;
+mod signature_meta;
 pub mod static_account_keys_meta;
 pub mod transaction_data;
-pub(crate) mod transaction_meta;
+mod transaction_meta;
 pub mod transaction_view;

--- a/transaction-view/src/lib.rs
+++ b/transaction-view/src/lib.rs
@@ -4,13 +4,13 @@ pub mod bytes;
 #[cfg(not(feature = "dev-context-only-utils"))]
 mod bytes;
 
-mod address_table_lookup_meta;
-mod instructions_meta;
-mod message_header_meta;
+pub(crate) mod address_table_lookup_meta;
+pub(crate) mod instructions_meta;
+pub(crate) mod message_header_meta;
 pub mod result;
 pub mod sanitize;
-mod signature_meta;
+pub(crate) mod signature_meta;
 pub mod static_account_keys_meta;
 pub mod transaction_data;
-mod transaction_meta;
+pub(crate) mod transaction_meta;
 pub mod transaction_view;

--- a/transaction-view/src/message_header_meta.rs
+++ b/transaction-view/src/message_header_meta.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         bytes::read_byte,
-        result::{Result, TransactionParsingError},
+        result::{Result, TransactionViewError},
     },
     solana_sdk::message::MESSAGE_VERSION_PREFIX,
 };
@@ -49,7 +49,7 @@ impl MessageHeaderMeta {
             let version = message_prefix & !MESSAGE_VERSION_PREFIX;
             match version {
                 0 => (TransactionVersion::V0, read_byte(bytes, offset)?),
-                _ => return Err(TransactionParsingError),
+                _ => return Err(TransactionViewError::ParseError),
             }
         } else {
             // Legacy transaction. The `message_prefix` that was just read is

--- a/transaction-view/src/result.rs
+++ b/transaction-view/src/result.rs
@@ -1,3 +1,8 @@
 #[derive(Debug, PartialEq, Eq)]
-pub struct TransactionParsingError;
-pub type Result<T> = core::result::Result<T, TransactionParsingError>; // no distinction between errors for now
+#[repr(u8)] // repr(u8) is used to ensure that the enum is represented as a single byte in memory.
+pub enum TransactionViewError {
+    ParseError,
+    SanitizeError,
+}
+
+pub type Result<T> = core::result::Result<T, TransactionViewError>;

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -1,0 +1,105 @@
+use crate::{transaction_data::TransactionData, transaction_view::TransactionView};
+
+pub struct SanitizeError;
+
+pub fn sanitize(view: &TransactionView<impl TransactionData>) -> Result<(), SanitizeError> {
+    sanitize_signatures(view)?;
+    sanitize_account_access(view)?;
+    sanitize_instructions(view)?;
+    sanitize_address_table_lookups(view)?;
+
+    Ok(())
+}
+
+fn sanitize_signatures(view: &TransactionView<impl TransactionData>) -> Result<(), SanitizeError> {
+    // Check the required number of signatures matches the number of signatures.
+    if view.num_signatures() != view.num_required_signatures() {
+        return Err(SanitizeError);
+    }
+
+    // Each signature is associated with a unique static public key.
+    // Check that there are at least as many static account keys as signatures.
+    if view.num_static_account_keys() < view.num_signatures() {
+        return Err(SanitizeError);
+    }
+
+    Ok(())
+}
+
+fn sanitize_account_access(
+    view: &TransactionView<impl TransactionData>,
+) -> Result<(), SanitizeError> {
+    // Check there is no overlap of signing area and readonly non-signing area.
+    // We have already checked that `num_required_signatures` is less than or equal to `num_static_account_keys`,
+    // so it is safe to use wrapping arithmetic.
+    if view.num_readonly_unsigned_accounts()
+        > view
+            .num_static_account_keys()
+            .wrapping_sub(view.num_required_signatures())
+    {
+        return Err(SanitizeError);
+    }
+
+    // Check there is at least 1 writable fee-payer account.
+    if view.num_readonly_signed_accounts() >= view.num_required_signatures() {
+        return Err(SanitizeError);
+    }
+
+    // Check there are not more than 256 accounts.
+    if total_number_of_accounts(view) > 256 {
+        return Err(SanitizeError);
+    }
+
+    Ok(())
+}
+
+fn sanitize_instructions(
+    view: &TransactionView<impl TransactionData>,
+) -> Result<(), SanitizeError> {
+    // already verified there is at least one static account.
+    let max_program_id_index = view.num_static_account_keys().wrapping_sub(1);
+    // verified that there are no more than 256 accounts in `sanitize_account_access`
+    let max_account_index = total_number_of_accounts(view).wrapping_sub(1) as u8;
+
+    for instruction in view.instructions_iter() {
+        // Check that program indexes are static account keys.
+        if instruction.program_id_index > max_program_id_index {
+            return Err(SanitizeError);
+        }
+
+        // Check that the program index is not the fee-payer.
+        if instruction.program_id_index == 0 {
+            return Err(SanitizeError);
+        }
+
+        // Check that all account indexes are valid.
+        for account_index in instruction.accounts.iter().copied() {
+            if account_index > max_account_index {
+                return Err(SanitizeError);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn sanitize_address_table_lookups(
+    view: &TransactionView<impl TransactionData>,
+) -> Result<(), SanitizeError> {
+    for address_table_lookup in view.address_table_lookup_iter() {
+        // Check that there is at least one account lookup.
+        if address_table_lookup.writable_indexes.is_empty()
+            && address_table_lookup.readonly_indexes.is_empty()
+        {
+            return Err(SanitizeError);
+        }
+    }
+
+    Ok(())
+}
+
+fn total_number_of_accounts(view: &TransactionView<impl TransactionData>) -> u16 {
+    u16::from(view.num_static_account_keys())
+        .saturating_add(view.total_writable_lookup_accounts())
+        .saturating_add(view.total_readonly_lookup_accounts())
+}

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -1,8 +1,10 @@
-use crate::{transaction_data::TransactionData, transaction_view::TransactionView};
+use crate::{
+    result::{Result, TransactionViewError},
+    transaction_data::TransactionData,
+    transaction_view::TransactionView,
+};
 
-pub struct SanitizeError;
-
-pub fn sanitize(view: &TransactionView<impl TransactionData>) -> Result<(), SanitizeError> {
+pub fn sanitize(view: &TransactionView<impl TransactionData>) -> Result<()> {
     sanitize_signatures(view)?;
     sanitize_account_access(view)?;
     sanitize_instructions(view)?;
@@ -11,24 +13,22 @@ pub fn sanitize(view: &TransactionView<impl TransactionData>) -> Result<(), Sani
     Ok(())
 }
 
-fn sanitize_signatures(view: &TransactionView<impl TransactionData>) -> Result<(), SanitizeError> {
+fn sanitize_signatures(view: &TransactionView<impl TransactionData>) -> Result<()> {
     // Check the required number of signatures matches the number of signatures.
     if view.num_signatures() != view.num_required_signatures() {
-        return Err(SanitizeError);
+        return Err(TransactionViewError::SanitizeError);
     }
 
     // Each signature is associated with a unique static public key.
     // Check that there are at least as many static account keys as signatures.
     if view.num_static_account_keys() < view.num_signatures() {
-        return Err(SanitizeError);
+        return Err(TransactionViewError::SanitizeError);
     }
 
     Ok(())
 }
 
-fn sanitize_account_access(
-    view: &TransactionView<impl TransactionData>,
-) -> Result<(), SanitizeError> {
+fn sanitize_account_access(view: &TransactionView<impl TransactionData>) -> Result<()> {
     // Check there is no overlap of signing area and readonly non-signing area.
     // We have already checked that `num_required_signatures` is less than or equal to `num_static_account_keys`,
     // so it is safe to use wrapping arithmetic.
@@ -37,25 +37,23 @@ fn sanitize_account_access(
             .num_static_account_keys()
             .wrapping_sub(view.num_required_signatures())
     {
-        return Err(SanitizeError);
+        return Err(TransactionViewError::SanitizeError);
     }
 
     // Check there is at least 1 writable fee-payer account.
     if view.num_readonly_signed_accounts() >= view.num_required_signatures() {
-        return Err(SanitizeError);
+        return Err(TransactionViewError::SanitizeError);
     }
 
     // Check there are not more than 256 accounts.
     if total_number_of_accounts(view) > 256 {
-        return Err(SanitizeError);
+        return Err(TransactionViewError::SanitizeError);
     }
 
     Ok(())
 }
 
-fn sanitize_instructions(
-    view: &TransactionView<impl TransactionData>,
-) -> Result<(), SanitizeError> {
+fn sanitize_instructions(view: &TransactionView<impl TransactionData>) -> Result<()> {
     // already verified there is at least one static account.
     let max_program_id_index = view.num_static_account_keys().wrapping_sub(1);
     // verified that there are no more than 256 accounts in `sanitize_account_access`
@@ -64,18 +62,18 @@ fn sanitize_instructions(
     for instruction in view.instructions_iter() {
         // Check that program indexes are static account keys.
         if instruction.program_id_index > max_program_id_index {
-            return Err(SanitizeError);
+            return Err(TransactionViewError::SanitizeError);
         }
 
         // Check that the program index is not the fee-payer.
         if instruction.program_id_index == 0 {
-            return Err(SanitizeError);
+            return Err(TransactionViewError::SanitizeError);
         }
 
         // Check that all account indexes are valid.
         for account_index in instruction.accounts.iter().copied() {
             if account_index > max_account_index {
-                return Err(SanitizeError);
+                return Err(TransactionViewError::SanitizeError);
             }
         }
     }
@@ -83,15 +81,13 @@ fn sanitize_instructions(
     Ok(())
 }
 
-fn sanitize_address_table_lookups(
-    view: &TransactionView<impl TransactionData>,
-) -> Result<(), SanitizeError> {
+fn sanitize_address_table_lookups(view: &TransactionView<impl TransactionData>) -> Result<()> {
     for address_table_lookup in view.address_table_lookup_iter() {
         // Check that there is at least one account lookup.
         if address_table_lookup.writable_indexes.is_empty()
             && address_table_lookup.readonly_indexes.is_empty()
         {
-            return Err(SanitizeError);
+            return Err(TransactionViewError::SanitizeError);
         }
     }
 

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -414,6 +414,25 @@ mod tests {
                 );
             }
 
+            // Invalid program index with lookups.
+            {
+                let mut instructions = valid_instructions.clone();
+                instructions[instruction_index].program_id_index = account_keys.len() as u8;
+                let transaction = create_v0_transaction(
+                    num_signatures,
+                    header,
+                    account_keys.clone(),
+                    instructions,
+                    atls.clone(),
+                );
+                let data = bincode::serialize(&transaction).unwrap();
+                let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
+                assert_eq!(
+                    sanitize_instructions(&view),
+                    Err(TransactionViewError::SanitizeError)
+                );
+            }
+
             // Program index is fee-payer.
             {
                 let mut instructions = valid_instructions.clone();

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -110,3 +110,287 @@ fn total_number_of_accounts(view: &UnsanitizedTransactionView<impl TransactionDa
         .saturating_add(view.total_writable_lookup_accounts())
         .saturating_add(view.total_readonly_lookup_accounts())
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            address_table_lookup_meta::AddressTableLookupMeta,
+            instructions_meta::InstructionsMeta,
+            message_header_meta::{MessageHeaderMeta, TransactionVersion},
+            signature_meta::SignatureMeta,
+            static_account_keys_meta::StaticAccountKeysMeta,
+            transaction_meta::TransactionMeta,
+        },
+        solana_sdk::{
+            hash::Hash,
+            message::{
+                v0::{self, MessageAddressTableLookup},
+                Message, MessageHeader, VersionedMessage,
+            },
+            pubkey::Pubkey,
+            signature::Signature,
+            system_instruction,
+            transaction::VersionedTransaction,
+        },
+    };
+
+    // Construct a dummy metadata object for testing.
+    // Most sanitization checks are based on the counts stored in this metadata
+    // rather than checking actual data. Using a mutable dummy object allows for
+    // far simpler testing.
+    fn dummy_metadata() -> TransactionMeta {
+        TransactionMeta {
+            signature: SignatureMeta {
+                num_signatures: 1,
+                offset: 1,
+            },
+            message_header: MessageHeaderMeta {
+                offset: 0,
+                version: TransactionVersion::Legacy,
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 0,
+            },
+            static_account_keys: StaticAccountKeysMeta {
+                num_static_accounts: 1,
+                offset: 2,
+            },
+            recent_blockhash_offset: 3,
+            instructions: InstructionsMeta {
+                num_instructions: 0,
+                offset: 4,
+            },
+            address_table_lookup: AddressTableLookupMeta {
+                num_address_table_lookups: 0,
+                offset: 5,
+                total_writable_lookup_accounts: 0,
+                total_readonly_lookup_accounts: 0,
+            },
+        }
+    }
+
+    fn multiple_transfers() -> VersionedTransaction {
+        let payer = Pubkey::new_unique();
+        VersionedTransaction {
+            signatures: vec![Signature::default()], // 1 signature to be valid.
+            message: VersionedMessage::Legacy(Message::new(
+                &[
+                    system_instruction::transfer(&payer, &Pubkey::new_unique(), 1),
+                    system_instruction::transfer(&payer, &Pubkey::new_unique(), 1),
+                ],
+                Some(&payer),
+            )),
+        }
+    }
+
+    #[test]
+    fn test_sanitize_dummy() {
+        // The dummy metadata object should pass all sanitization checks.
+        // Otherwise the tests which modify it are incorrect.
+        let view = UnsanitizedTransactionView {
+            data: &[][..],
+            meta: dummy_metadata(),
+        };
+        assert!(sanitize(view).is_ok());
+    }
+
+    #[test]
+    fn test_sanitize_multiple_transfers() {
+        let transaction = multiple_transfers();
+        let data = bincode::serialize(&transaction).unwrap();
+        let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
+        assert!(sanitize(view).is_ok());
+    }
+
+    #[test]
+    fn test_sanitize_signatures() {
+        // Too few signatures.
+        {
+            let mut meta = dummy_metadata();
+            meta.signature.num_signatures = 0;
+            let view = UnsanitizedTransactionView {
+                data: &[][..],
+                meta,
+            };
+            assert_eq!(
+                sanitize_signatures(&view),
+                Err(TransactionViewError::SanitizeError)
+            );
+        }
+
+        // Too many signatures.
+        {
+            let mut meta = dummy_metadata();
+            meta.signature.num_signatures = 2;
+            let view = UnsanitizedTransactionView {
+                data: &[][..],
+                meta,
+            };
+            assert_eq!(
+                sanitize_signatures(&view),
+                Err(TransactionViewError::SanitizeError)
+            );
+        }
+
+        // Not enough static accounts.
+        {
+            let mut meta = dummy_metadata();
+            meta.signature.num_signatures = 2;
+            meta.message_header.num_required_signatures = 2;
+            meta.static_account_keys.num_static_accounts = 1;
+            let view = UnsanitizedTransactionView {
+                data: &[][..],
+                meta,
+            };
+            assert_eq!(
+                sanitize_signatures(&view),
+                Err(TransactionViewError::SanitizeError)
+            );
+        }
+    }
+
+    #[test]
+    fn test_sanitize_account_access() {
+        // Overlap of signing and readonly non-signing accounts.
+        {
+            let mut meta = dummy_metadata();
+            meta.message_header.num_readonly_unsigned_accounts = 2;
+            meta.static_account_keys.num_static_accounts = 2;
+            let view = UnsanitizedTransactionView {
+                data: &[][..],
+                meta,
+            };
+            assert_eq!(
+                sanitize_account_access(&view),
+                Err(TransactionViewError::SanitizeError)
+            );
+        }
+
+        // Not enough writable accounts.
+        {
+            let mut meta = dummy_metadata();
+            meta.message_header.num_readonly_signed_accounts = 1;
+            meta.static_account_keys.num_static_accounts = 2;
+            let view = UnsanitizedTransactionView {
+                data: &[][..],
+                meta,
+            };
+            assert_eq!(
+                sanitize_account_access(&view),
+                Err(TransactionViewError::SanitizeError)
+            );
+        }
+
+        // Too many accounts.
+        {
+            let mut meta = dummy_metadata();
+            meta.static_account_keys.num_static_accounts = 1;
+            meta.address_table_lookup.total_writable_lookup_accounts = 200;
+            meta.address_table_lookup.total_readonly_lookup_accounts = 200;
+            let view = UnsanitizedTransactionView {
+                data: &[][..],
+                meta,
+            };
+            assert_eq!(
+                sanitize_account_access(&view),
+                Err(TransactionViewError::SanitizeError)
+            );
+        }
+    }
+
+    #[test]
+    fn test_sanitize_instructions() {
+        let transaction = multiple_transfers();
+        let data = bincode::serialize(&transaction).unwrap();
+        let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
+
+        let instruction_size =
+            bincode::serialized_size(&transaction.message.instructions()[0]).unwrap();
+        for instruction_index in 0..usize::from(view.num_instructions()) {
+            let instruction_offset = usize::from(view.meta.instructions.offset)
+                + instruction_index * instruction_size as usize;
+
+            // Invalid program index.
+            {
+                let mut data = data.clone();
+                data[instruction_offset] = 4;
+                let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
+                assert_eq!(
+                    sanitize_instructions(&view),
+                    Err(TransactionViewError::SanitizeError)
+                );
+            }
+
+            // Program index is fee-payer.
+            {
+                let mut data = data.clone();
+                data[instruction_offset] = 0;
+                let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
+                assert_eq!(
+                    sanitize_instructions(&view),
+                    Err(TransactionViewError::SanitizeError)
+                );
+            }
+
+            // Invalid account index.
+            {
+                let mut data = data.clone();
+                // one byte for program index, one byte for number of accounts
+                data[instruction_offset + 2] = 7;
+                let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
+                assert_eq!(
+                    sanitize_instructions(&view),
+                    Err(TransactionViewError::SanitizeError)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_sanitize_address_table_lookups() {
+        fn create_transaction(empty_index: usize) -> VersionedTransaction {
+            let payer = Pubkey::new_unique();
+            VersionedTransaction {
+                signatures: vec![Signature::default()], // 1 signature to be valid.
+                message: VersionedMessage::V0(v0::Message {
+                    header: MessageHeader {
+                        num_required_signatures: 1,
+                        num_readonly_signed_accounts: 0,
+                        num_readonly_unsigned_accounts: 0,
+                    },
+                    account_keys: vec![payer],
+                    recent_blockhash: Hash::default(),
+                    instructions: vec![],
+                    address_table_lookups: vec![
+                        MessageAddressTableLookup {
+                            account_key: Pubkey::new_unique(),
+                            writable_indexes: if empty_index == 0 { vec![] } else { vec![0, 1] },
+                            readonly_indexes: vec![],
+                        },
+                        MessageAddressTableLookup {
+                            account_key: Pubkey::new_unique(),
+                            writable_indexes: if empty_index == 1 { vec![] } else { vec![0, 1] },
+                            readonly_indexes: vec![],
+                        },
+                    ],
+                }),
+            }
+        }
+
+        for empty_index in 0..2 {
+            let transaction = create_transaction(empty_index);
+            assert_eq!(
+                transaction.message.address_table_lookups().unwrap().len(),
+                2
+            );
+            let data = bincode::serialize(&transaction).unwrap();
+            let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
+            assert_eq!(
+                sanitize_address_table_lookups(&view),
+                Err(TransactionViewError::SanitizeError)
+            );
+        }
+    }
+}

--- a/transaction-view/src/signature_meta.rs
+++ b/transaction-view/src/signature_meta.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         bytes::{advance_offset_for_array, read_byte},
-        result::{Result, TransactionParsingError},
+        result::{Result, TransactionViewError},
     },
     solana_sdk::{packet::PACKET_DATA_SIZE, pubkey::Pubkey, signature::Signature},
 };
@@ -35,7 +35,7 @@ impl SignatureMeta {
 
         let num_signatures = read_byte(bytes, offset)?;
         if num_signatures == 0 || num_signatures > MAX_SIGNATURES_PER_PACKET {
-            return Err(TransactionParsingError);
+            return Err(TransactionViewError::ParseError);
         }
 
         let signature_offset = *offset as u16;

--- a/transaction-view/src/static_account_keys_meta.rs
+++ b/transaction-view/src/static_account_keys_meta.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         bytes::{advance_offset_for_array, read_byte},
-        result::{Result, TransactionParsingError},
+        result::{Result, TransactionViewError},
     },
     solana_sdk::{packet::PACKET_DATA_SIZE, pubkey::Pubkey},
 };
@@ -30,7 +30,7 @@ impl StaticAccountKeysMeta {
 
         let num_static_accounts = read_byte(bytes, offset)?;
         if num_static_accounts == 0 || num_static_accounts > MAX_STATIC_ACCOUNTS_PER_PACKET {
-            return Err(TransactionParsingError);
+            return Err(TransactionViewError::ParseError);
         }
 
         // We also know that the offset must be less than 3 here, since the

--- a/transaction-view/src/transaction_meta.rs
+++ b/transaction-view/src/transaction_meta.rs
@@ -46,6 +46,8 @@ impl TransactionMeta {
             TransactionVersion::Legacy => AddressTableLookupMeta {
                 num_address_table_lookups: 0,
                 offset: 0,
+                total_writable_lookup_accounts: 0,
+                total_readonly_lookup_accounts: 0,
             },
             TransactionVersion::V0 => AddressTableLookupMeta::try_new(bytes, &mut offset)?,
         };
@@ -103,6 +105,16 @@ impl TransactionMeta {
     /// Return the number of address table lookups in the transaction.
     pub(crate) fn num_address_table_lookups(&self) -> u8 {
         self.address_table_lookup.num_address_table_lookups
+    }
+
+    /// Return the number of writable lookup accounts in the transaction.
+    pub(crate) fn total_writable_lookup_accounts(&self) -> u16 {
+        self.address_table_lookup.total_writable_lookup_accounts
+    }
+
+    /// Return the number of readonly lookup accounts in the transaction.
+    pub(crate) fn total_readonly_lookup_accounts(&self) -> u16 {
+        self.address_table_lookup.total_readonly_lookup_accounts
     }
 
     /// Return the offset to the message.

--- a/transaction-view/src/transaction_meta.rs
+++ b/transaction-view/src/transaction_meta.rs
@@ -13,17 +13,17 @@ use {
 
 pub(crate) struct TransactionMeta {
     /// Signature metadata.
-    signature: SignatureMeta,
+    pub(crate) signature: SignatureMeta,
     /// Message header metadata.
-    message_header: MessageHeaderMeta,
+    pub(crate) message_header: MessageHeaderMeta,
     /// Static account keys metadata.
-    static_account_keys: StaticAccountKeysMeta,
+    pub(crate) static_account_keys: StaticAccountKeysMeta,
     /// Recent blockhash offset.
-    recent_blockhash_offset: u16,
+    pub(crate) recent_blockhash_offset: u16,
     /// Instructions metadata.
-    instructions: InstructionsMeta,
+    pub(crate) instructions: InstructionsMeta,
     /// Address table lookup metadata.
-    address_table_lookup: AddressTableLookupMeta,
+    pub(crate) address_table_lookup: AddressTableLookupMeta,
 }
 
 impl TransactionMeta {

--- a/transaction-view/src/transaction_meta.rs
+++ b/transaction-view/src/transaction_meta.rs
@@ -13,17 +13,17 @@ use {
 
 pub(crate) struct TransactionMeta {
     /// Signature metadata.
-    pub(crate) signature: SignatureMeta,
+    signature: SignatureMeta,
     /// Message header metadata.
-    pub(crate) message_header: MessageHeaderMeta,
+    message_header: MessageHeaderMeta,
     /// Static account keys metadata.
-    pub(crate) static_account_keys: StaticAccountKeysMeta,
+    static_account_keys: StaticAccountKeysMeta,
     /// Recent blockhash offset.
-    pub(crate) recent_blockhash_offset: u16,
+    recent_blockhash_offset: u16,
     /// Instructions metadata.
-    pub(crate) instructions: InstructionsMeta,
+    instructions: InstructionsMeta,
     /// Address table lookup metadata.
-    pub(crate) address_table_lookup: AddressTableLookupMeta,
+    address_table_lookup: AddressTableLookupMeta,
 }
 
 impl TransactionMeta {

--- a/transaction-view/src/transaction_meta.rs
+++ b/transaction-view/src/transaction_meta.rs
@@ -4,7 +4,7 @@ use {
         bytes::advance_offset_for_type,
         instructions_meta::{InstructionsIterator, InstructionsMeta},
         message_header_meta::{MessageHeaderMeta, TransactionVersion},
-        result::{Result, TransactionParsingError},
+        result::{Result, TransactionViewError},
         signature_meta::SignatureMeta,
         static_account_keys_meta::StaticAccountKeysMeta,
     },
@@ -54,7 +54,7 @@ impl TransactionMeta {
 
         // Verify that the entire transaction was parsed.
         if offset != bytes.len() {
-            return Err(TransactionParsingError);
+            return Err(TransactionViewError::ParseError);
         }
 
         Ok(Self {

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -2,11 +2,14 @@ use {
     crate::{
         address_table_lookup_meta::AddressTableLookupIterator,
         instructions_meta::InstructionsIterator, message_header_meta::TransactionVersion,
-        result::Result, sanitize::sanitize, transaction_data::TransactionData,
-        transaction_meta::TransactionMeta,
+        result::Result, transaction_data::TransactionData, transaction_meta::TransactionMeta,
     },
     solana_sdk::{hash::Hash, pubkey::Pubkey, signature::Signature},
 };
+
+// alias for convenience
+pub type UnsanitizedTransactionView<D> = TransactionView<false, D>;
+pub type SanitizedTransactionView<D> = TransactionView<true, D>;
 
 /// A view into a serialized transaction.
 ///
@@ -32,7 +35,7 @@ impl<D: TransactionData> TransactionView<true, D> {
     /// Creates a new `TransactionView`, running sanitization checks.
     pub fn try_new_sanitized(data: D) -> Result<Self> {
         let unsanitized_view = TransactionView::try_new_unsanitized(data)?;
-        sanitize(unsanitized_view)
+        unsanitized_view.sanitize()
     }
 }
 

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -67,6 +67,16 @@ impl<D: TransactionData> TransactionView<D> {
         self.meta.num_address_table_lookups()
     }
 
+    /// Return the number of writable lookup accounts in the transaction.
+    pub fn total_writable_lookup_accounts(&self) -> u16 {
+        self.meta.total_writable_lookup_accounts()
+    }
+
+    /// Return the number of readonly lookup accounts in the transaction.
+    pub fn total_readonly_lookup_accounts(&self) -> u16 {
+        self.meta.total_readonly_lookup_accounts()
+    }
+
     /// Return the slice of signatures in the transaction.
     pub fn signatures(&self) -> &[Signature] {
         let data = self.data();


### PR DESCRIPTION
#### Problem
- Task in #2255
- Run and "encode" sanitization in the type

#### Summary of Changes
- Add generic `SANITIZED` on the `TransactionView` to indicate if sanitization checks have been run
- Add sanitize checks and tests

Since the structs are different, and we probably do not want some intermediate trait - sanitization checks are duplicated from `sdk`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
