### PR TITLE
Remove explicit stream finish

### DIFF
--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -274,7 +274,6 @@ impl QuicClient {
         let mut send_stream = connection.open_uni().await?;
 
         send_stream.write_all(data).await?;
-        // send_stream.finish().await?;
         Ok(())
     }
 

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -274,7 +274,7 @@ impl QuicClient {
         let mut send_stream = connection.open_uni().await?;
 
         send_stream.write_all(data).await?;
-        send_stream.finish().await?;
+        // send_stream.finish().await?;
         Ok(())
     }
 


### PR DESCRIPTION
#### Problem

stream finish is redundant as StreamDrop is already doing that.
Removing that will allow next call to be made faster without waiting for the stream to be finished.

#### Summary of Changes

removed explicit stream finish

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
