### PR TITLE
when generate index re-used existing disk index, stats were incorrect

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -158,11 +158,12 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
                     Arc::clone(&stats.index),
                     count,
                 );
-                stats.index.resize_grow(0, index.capacity_bytes());
                 let random = thread_rng().gen();
                 restartable_bucket.set_file(file_name, random);
                 (index, random, false /* true = reused file */)
             });
+
+        stats.index.resize_grow(0, index.capacity_bytes());
 
         Self {
             random,


### PR DESCRIPTION
#### Problem
index file size metric does not include size of index files that were re-used at validator startup. This makes the metric useless.

This is the variation of several validators. They should be similar sizes.
![image](https://github.com/user-attachments/assets/43888564-1523-40a6-a07b-8a9374935557)


#### Summary of Changes
Initialize the metrics always.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
