### PR TITLE
Add workflow and script to add security-incident-response to GHSAs 

### DIFF
--- a/.github/scripts/add-team-to-ghsa.sh
+++ b/.github/scripts/add-team-to-ghsa.sh
@@ -23,7 +23,7 @@ while IFS= read -r ghsa_id; do
     # added to this GHSA and format them as parameters for gh api like:
     #    -f collaborating_teams[]=ghsa-testing-1
     original_collaborating_team_slugs=$( jq -r '[ .[] | select(.ghsa_id == "'$ghsa_id'") | .collaborating_teams ] | "-f collaborating_teams[]=" + .[][].slug ' <<< "$ghsa_json" )
-    
+
     # Update the team list
     gh api \
         --method PATCH \

--- a/.github/scripts/add-team-to-ghsa.sh
+++ b/.github/scripts/add-team-to-ghsa.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euof pipefail
 
 team_to_add_slug="security-incident-response"
 github_org="anza-xyz"
@@ -25,11 +25,12 @@ while IFS= read -r ghsa_id; do
     original_collaborating_team_slugs=$( jq -r '[ .[] | select(.ghsa_id == "'"$ghsa_id"'") | .collaborating_teams ] | "-f collaborating_teams[]=" + .[][].slug ' <<< "$ghsa_json" )
 
     # Update the team list
+    # shellcheck disable=SC2086
     gh api \
         --method PATCH \
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
         "/repos/$github_org/$github_repo/security-advisories/$ghsa_id" \
-        -f "collaborating_teams[]=$team_to_add_slug" "$original_collaborating_team_slugs" \
+        -f "collaborating_teams[]=$team_to_add_slug" $original_collaborating_team_slugs \
         > /dev/null 2>&1
 done <<< "$ghsa_without_team"

--- a/.github/scripts/add-team-to-ghsa.sh
+++ b/.github/scripts/add-team-to-ghsa.sh
@@ -5,8 +5,6 @@ team_to_add_slug="security-incident-response"
 github_org="anza-xyz"
 github_repo="agave"
 
-echo "Adding $team_to_add_slug"
-
 # Note: This will get all the GHSAs even if there are more than the per_page value
 # from gh api --help
 # --paginate    Make additional HTTP requests to fetch all pages of results
@@ -17,17 +15,14 @@ ghsa_json=$(gh api \
 
 # Get a list of GHSAs that don't have the $team_to_add_slug in collaborating_teams
 ghsa_without_team=$( jq -r '[ .[] | select(all(.collaborating_teams.[]; .slug != "'$team_to_add_slug'")) | .ghsa_id ] | sort | .[] ' <<< "$ghsa_json" )
-echo "ghsa_without_team: $ghsa_without_team"
 
 # Iterate through the teams
 while IFS= read -r ghsa_id; do
-    echo "ghsa_id: $ghsa_id"
     # PATCH updates the value. If we just set -f "collaborating_teams[]=$team_to_add_slug" it
     # will overwrite any existing collaborating_teams. So we get the list of teams that are already
     # added to this GHSA and format them as parameters for gh api like:
     #    -f collaborating_teams[]=ghsa-testing-1
     original_collaborating_team_slugs=$( jq -r '[ .[] | select(.ghsa_id == "'$ghsa_id'") | .collaborating_teams ] | "-f collaborating_teams[]=" + .[][].slug ' <<< "$ghsa_json" )
-    echo "original_collaborating_team_slugs: $original_collaborating_team_slugs"
     
     # Update the team list
     gh api \

--- a/.github/scripts/add-team-to-ghsa.sh
+++ b/.github/scripts/add-team-to-ghsa.sh
@@ -30,5 +30,6 @@ while IFS= read -r ghsa_id; do
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
         "/repos/$github_org/$github_repo/security-advisories/$ghsa_id" \
-        -f "collaborating_teams[]=$team_to_add_slug" $original_collaborating_team_slugs
+        -f "collaborating_teams[]=$team_to_add_slug" $original_collaborating_team_slugs \
+        > /dev/null 2>&1
 done <<< "$ghsa_without_team"

--- a/.github/scripts/add-team-to-ghsa.sh
+++ b/.github/scripts/add-team-to-ghsa.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+team_to_add_slug="security-incident-response"
+github_org="anza-xyz"
+github_repo="agave"
+
+echo "Adding $team_to_add_slug"
+
+# Note: This will get all the GHSAs even if there are more than the per_page value
+# from gh api --help
+# --paginate    Make additional HTTP requests to fetch all pages of results
+ghsa_json=$(gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28"   \
+    /repos/$github_org/$github_repo/security-advisories?per_page=100 --paginate )
+
+# Get a list of GHSAs that don't have the $team_to_add_slug in collaborating_teams
+ghsa_without_team=$( jq -r '[ .[] | select(all(.collaborating_teams.[]; .slug != "'$team_to_add_slug'")) | .ghsa_id ] | sort | .[] ' <<< "$ghsa_json" )
+echo "ghsa_without_team: $ghsa_without_team"
+
+# Iterate through the teams
+while IFS= read -r ghsa_id; do
+    echo "ghsa_id: $ghsa_id"
+    # PATCH updates the value. If we just set -f "collaborating_teams[]=$team_to_add_slug" it
+    # will overwrite any existing collaborating_teams. So we get the list of teams that are already
+    # added to this GHSA and format them as parameters for gh api like:
+    #    -f collaborating_teams[]=ghsa-testing-1
+    original_collaborating_team_slugs=$( jq -r '[ .[] | select(.ghsa_id == "'$ghsa_id'") | .collaborating_teams ] | "-f collaborating_teams[]=" + .[][].slug ' <<< "$ghsa_json" )
+    echo "original_collaborating_team_slugs: $original_collaborating_team_slugs"
+    
+    # Update the team list
+    gh api \
+        --method PATCH \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "/repos/$github_org/$github_repo/security-advisories/$ghsa_id" \
+        -f "collaborating_teams[]=$team_to_add_slug" $original_collaborating_team_slugs
+done <<< "$ghsa_without_team"

--- a/.github/scripts/add-team-to-ghsa.sh
+++ b/.github/scripts/add-team-to-ghsa.sh
@@ -14,7 +14,7 @@ ghsa_json=$(gh api \
     /repos/$github_org/$github_repo/security-advisories?per_page=100 --paginate )
 
 # Get a list of GHSAs that don't have the $team_to_add_slug in collaborating_teams
-ghsa_without_team=$( jq -r '[ .[] | select(all(.collaborating_teams.[]; .slug != "'$team_to_add_slug'")) | .ghsa_id ] | sort | .[] ' <<< "$ghsa_json" )
+ghsa_without_team=$( jq -r '[ .[] | select(all(.collaborating_teams.[]; .slug != "'"$team_to_add_slug"'")) | .ghsa_id ] | sort | .[] ' <<< "$ghsa_json" )
 
 # Iterate through the teams
 while IFS= read -r ghsa_id; do
@@ -22,7 +22,7 @@ while IFS= read -r ghsa_id; do
     # will overwrite any existing collaborating_teams. So we get the list of teams that are already
     # added to this GHSA and format them as parameters for gh api like:
     #    -f collaborating_teams[]=ghsa-testing-1
-    original_collaborating_team_slugs=$( jq -r '[ .[] | select(.ghsa_id == "'$ghsa_id'") | .collaborating_teams ] | "-f collaborating_teams[]=" + .[][].slug ' <<< "$ghsa_json" )
+    original_collaborating_team_slugs=$( jq -r '[ .[] | select(.ghsa_id == "'"$ghsa_id"'") | .collaborating_teams ] | "-f collaborating_teams[]=" + .[][].slug ' <<< "$ghsa_json" )
 
     # Update the team list
     gh api \
@@ -30,6 +30,6 @@ while IFS= read -r ghsa_id; do
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
         "/repos/$github_org/$github_repo/security-advisories/$ghsa_id" \
-        -f "collaborating_teams[]=$team_to_add_slug" $original_collaborating_team_slugs \
+        -f "collaborating_teams[]=$team_to_add_slug" "$original_collaborating_team_slugs" \
         > /dev/null 2>&1
 done <<< "$ghsa_without_team"

--- a/.github/workflows/add-team-to-ghsa.yml
+++ b/.github/workflows/add-team-to-ghsa.yml
@@ -1,0 +1,22 @@
+name: Add Security Team to GHSAs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  add-team-to-ghsa:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Run script
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GHSA_ADD_SECURITY_INCIDENT_RESPONSE }}
+        run: |
+          .github/scripts/add-team-to-ghsa.sh

--- a/.github/workflows/add-team-to-ghsa.yml
+++ b/.github/workflows/add-team-to-ghsa.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   add-team-to-ghsa:
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/add-team-to-ghsa.yml
+++ b/.github/workflows/add-team-to-ghsa.yml
@@ -12,8 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
-          fetch-depth: 0
+          ref: master
       - name: Run script
         shell: bash
         env:


### PR DESCRIPTION
#### Problem
Github doesn't have a default way to add a specific team to all GHSAs without also giving that team admin access. We would like to be able to include non-Anza people in the `security-incident-response` team without making them org admins.

#### Summary of Changes
This creates a Github action that runs a script hourly. The script gets a list of all GHSAs and checks if any of them don't have `security-incident-response` in the collaborating_teams list. For any GHSAs that don't already have the team it is added.

As far as I can tell it's necessary to do this with polling because  [security_adisory.reported won't fire for advisories created via draft](https://github.com/orgs/community/discussions/67518).

The workflow uses `runs-on: macos-latest` because the jq commands don't work correctly in ubuntu. I'm not sure why, but don't want to spend more time debugging it.

The GH_TOKEN has `repo` access and is already added to secrets.

