### PR TITLE
Format string literals in solana_rpc_client_api

### DIFF
--- a/rpc-client-api/src/custom_error.rs
+++ b/rpc-client-api/src/custom_error.rs
@@ -115,7 +115,8 @@ impl From<RpcCustomError> for Error {
             } => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_BLOCK_CLEANED_UP),
                 message: format!(
-                    "Block {slot} cleaned up, does not exist on node. First available block: {first_available_block}",
+                    "Block {slot} cleaned up, does not exist on node. First available block: \
+                     {first_available_block}",
                 ),
                 data: None,
             },
@@ -178,8 +179,8 @@ impl From<RpcCustomError> for Error {
                     JSON_RPC_SERVER_ERROR_KEY_EXCLUDED_FROM_SECONDARY_INDEX,
                 ),
                 message: format!(
-                    "{index_key} excluded from account secondary indexes; \
-                    this RPC method unavailable for key"
+                    "{index_key} excluded from account secondary indexes; this RPC method \
+                     unavailable for key"
                 ),
                 data: None,
             },
@@ -211,8 +212,8 @@ impl From<RpcCustomError> for Error {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION),
                 message: format!(
                     "Transaction version ({version}) is not supported by the requesting client. \
-                    Please try the request again with the following configuration parameter: \
-                    \"maxSupportedTransactionVersion\": {version}"
+                     Please try the request again with the following configuration parameter: \
+                     \"maxSupportedTransactionVersion\": {version}"
                 ),
                 data: None,
             },
@@ -223,7 +224,11 @@ impl From<RpcCustomError> for Error {
                     context_slot,
                 })),
             },
-            RpcCustomError::EpochRewardsPeriodActive { slot, current_block_height, rewards_complete_block_height } => Self {
+            RpcCustomError::EpochRewardsPeriodActive {
+                slot,
+                current_block_height,
+                rewards_complete_block_height,
+            } => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_EPOCH_REWARDS_PERIOD_ACTIVE),
                 message: format!("Epoch rewards period still active at slot {slot}"),
                 data: Some(serde_json::json!(EpochRewardsPeriodActiveErrorData {


### PR DESCRIPTION
#### Problem
Long string literals are preventing rustfmt formatting the match statement in `solana_rpc_client_api::custom_error`

#### Summary of Changes
Format strings (via temporary add of `format_strings = true` to rustfmt.toml and running nightly fmt)
