### PR TITLE
replay: do not refresh votes for hot spare validators

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -230,6 +230,8 @@ pub(crate) enum BlockhashStatus {
     Uninitialized,
     /// Non voting validator
     NonVoting,
+    /// Hot spare validator
+    HotSpare,
     /// Successfully generated vote tx with blockhash
     Blockhash(Hash),
 }
@@ -573,6 +575,10 @@ impl Tower {
 
     pub(crate) fn mark_last_vote_tx_blockhash_non_voting(&mut self) {
         self.last_vote_tx_blockhash = BlockhashStatus::NonVoting;
+    }
+
+    pub(crate) fn mark_last_vote_tx_blockhash_hot_spare(&mut self) {
+        self.last_vote_tx_blockhash = BlockhashStatus::HotSpare;
     }
 
     pub fn last_voted_slot_in_bank(bank: &Bank, vote_account_pubkey: &Pubkey) -> Option<Slot> {


### PR DESCRIPTION
#### Problem
Hot spares will attempt to refresh votes even though the identity keypair check will fail.
This results in a large amount of log spam.

#### Summary of Changes
https://github.com/solana-labs/solana/pull/34737#discussion_r1450894171 creates a distinction between failed vote generation and non-voting validators.
Add an additional case for hot spare validators and exclude them from the refresh vote check as well.

Contributes to #2768 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
