### PR TITLE
assert refcount = 0 for zero lamport 1 refcount deletes

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4258,7 +4258,7 @@ impl AccountsDb {
         self.accounts_index.scan(
             zero_lamport_single_ref_pubkeys.iter().cloned(),
             |_pubkey, _slots_refs, _entry| AccountsIndexScanResult::Unref,
-            Some(AccountsIndexScanResult::Unref),
+            Some(AccountsIndexScanResult::UnrefAssert0),
             false,
             ScanFilter::All,
         );

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -11158,9 +11158,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi, [(1, AccountInfo { store_id: 0, account_offset_and_flags: AccountOffsetAndFlags { packed_offset_and_flags: PackedOffsetAndFlags { offset_reduced: 0, is_zero_lamport: false } } }), (2, AccountInfo { store_id: 1, account_offset_and_flags: AccountOffsetAndFlags { packed_offset_and_flags: PackedOffsetAndFlags { offset_reduced: 0, is_zero_lamport: true } } })]"
-    )]
+    #[should_panic(expected = "ref count expected to be zero")]
     fn test_remove_zero_lamport_multi_ref_accounts_panic() {
         let accounts = AccountsDb::new_single_for_tests();
         let pubkey_zero = Pubkey::from([1; 32]);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -11151,7 +11151,9 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi, [(1, AccountInfo { store_id: 0, account_offset_and_flags: AccountOffsetAndFlags { packed_offset_and_flags: PackedOffsetAndFlags { offset_reduced: 0, is_zero_lamport: false } } }), (2, AccountInfo { store_id: 1, account_offset_and_flags: AccountOffsetAndFlags { packed_offset_and_flags: PackedOffsetAndFlags { offset_reduced: 0, is_zero_lamport: true } } })]"
+    )]
     fn test_remove_zero_lamport_multi_ref_accounts_panic() {
         let accounts = AccountsDb::new_single_for_tests();
         let pubkey_zero = Pubkey::from([1; 32]);
@@ -11273,7 +11275,6 @@ pub mod tests {
                             .cloned()
                             .collect::<Vec<_>>();
                         assert_eq!(slots, vec![slot, slot + 1]);
-                        // refcount = 1 if we flushed the write cache for slot + 1
                         let expected_ref_count = 2;
                         assert_eq!(
                             entry.map(|e| e.ref_count()),
@@ -11282,7 +11283,7 @@ pub mod tests {
                         );
                     }
                     _ => {
-                        panic!("Shouldn't reach here.")
+                        unreachable!("Shouldn't reach here.")
                     }
                 }
                 (false, ())

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -11170,7 +11170,7 @@ pub mod tests {
         accounts.calculate_accounts_delta_hash(slot + 1);
         accounts.add_root_and_flush_write_cache(slot + 1);
 
-        // This should panic because there are ref for pubkey_zero.
+        // This should panic because there are 2 refs for pubkey_zero.
         accounts.remove_zero_lamport_single_ref_accounts_after_shrink(
             &[&pubkey_zero],
             slot,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -11151,6 +11151,35 @@ pub mod tests {
     }
 
     #[test]
+    #[should_panic]
+
+    fn test_remove_zero_lamport_multi_ref_accounts_panic() {
+        let accounts = AccountsDb::new_single_for_tests();
+        let pubkey_zero = Pubkey::from([1; 32]);
+        let one_lamport_account =
+            AccountSharedData::new(1, 0, AccountSharedData::default().owner());
+
+        let zero_lamport_account =
+            AccountSharedData::new(0, 0, AccountSharedData::default().owner());
+        let slot = 1;
+
+        accounts.store_for_tests(slot, &[(&pubkey_zero, &one_lamport_account)]);
+        accounts.calculate_accounts_delta_hash(slot);
+        accounts.add_root_and_flush_write_cache(slot);
+
+        accounts.store_for_tests(slot + 1, &[(&pubkey_zero, &zero_lamport_account)]);
+        accounts.calculate_accounts_delta_hash(slot + 1);
+        accounts.add_root_and_flush_write_cache(slot + 1);
+
+        // This should panic because there are ref for pubkey_zero.
+        accounts.remove_zero_lamport_single_ref_accounts_after_shrink(
+            &[&pubkey_zero],
+            slot,
+            &ShrinkStats::default(),
+        );
+    }
+
+    #[test]
     fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
         for pass in 0..3 {
             let accounts = AccountsDb::new_single_for_tests();

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1468,18 +1468,19 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                                 assert_eq!(
                                     locked_entry.unref(),
                                     1,
-                                    "{pubkey}, {:?}",
-                                    locked_entry.slot_list.read().unwrap()
+                                    "ref count expected to be zero, but is {}! {pubkey}, {:?}",
+                                    locked_entry.ref_count(),
+                                    locked_entry.slot_list.read().unwrap(),
                                 );
                                 true
                             }
                             AccountsIndexScanResult::UnrefLog0 => {
                                 let old_ref = locked_entry.unref();
                                 if old_ref != 1 {
-                                    info!("Unexpected unref {pubkey} with {old_ref} {:?}, expect ref to be 1", locked_entry.slot_list.read().unwrap());
+                                    info!("Unexpected unref {pubkey} with {old_ref} {:?}, expect old_ref to be 1", locked_entry.slot_list.read().unwrap());
                                     datapoint_warn!(
                                         "accounts_db-unexpected-unref-zero",
-                                        ("ref", old_ref, i64),
+                                        ("old_ref", old_ref, i64),
                                         ("pubkey", pubkey.to_string(), String),
                                     );
                                 }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1463,7 +1463,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                                 true
                             }
                             AccountsIndexScanResult::UnrefAssert0 => {
-                                assert_eq!(locked_entry.unref(), 1);
+                                assert_eq!(
+                                    locked_entry.unref(),
+                                    1,
+                                    "{pubkey}, {:?}",
+                                    locked_entry.slot_list.read().unwrap()
+                                );
                                 true
                             }
                             AccountsIndexScanResult::KeepInMemory => true,

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -648,7 +648,7 @@ pub enum AccountsIndexScanResult {
     KeepInMemory,
     /// reduce refcount by 1
     Unref,
-    /// reduce refcount by 1 and assert that ref_count = 0
+    /// reduce refcount by 1 and assert that ref_count = 0 after unref
     UnrefAssert0,
 }
 

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -650,7 +650,7 @@ pub enum AccountsIndexScanResult {
     Unref,
     /// reduce refcount by 1 and assert that ref_count = 0 after unref
     UnrefAssert0,
-    /// reduce refcount by 1 and log if ref_count = 0 after unref
+    /// reduce refcount by 1 and log if ref_count != 0 after unref
     UnrefLog0,
 }
 

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -311,14 +311,15 @@ impl<T: IndexValue> AccountMapEntryInner<T> {
     }
 
     /// decrement the ref count
-    /// return true if the old refcount was already 0. This indicates an under refcounting error in the system.
-    pub fn unref(&self) -> bool {
+    /// return the refcount prior to subtracting 1
+    /// 0 indicates an under refcounting error in the system.
+    pub fn unref(&self) -> RefCount {
         let previous = self.ref_count.fetch_sub(1, Ordering::Release);
         self.set_dirty(true);
         if previous == 0 {
             inc_new_counter_info!("accounts_index-deref_from_0", 1);
         }
-        previous == 0
+        previous
     }
 
     pub fn dirty(&self) -> bool {
@@ -647,6 +648,8 @@ pub enum AccountsIndexScanResult {
     KeepInMemory,
     /// reduce refcount by 1
     Unref,
+    /// reduce refcount by 1 and assert that ref_count = 0
+    UnrefAssert0,
 }
 
 #[derive(Debug)]
@@ -1453,10 +1456,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                         };
                         cache = match result {
                             AccountsIndexScanResult::Unref => {
-                                if locked_entry.unref() {
+                                if locked_entry.unref() == 0 {
                                     info!("scan: refcount of item already at 0: {pubkey}");
                                     self.unref_zero_count.fetch_add(1, Ordering::Relaxed);
                                 }
+                                true
+                            }
+                            AccountsIndexScanResult::UnrefAssert0 => {
+                                assert_eq!(locked_entry.unref(), 1);
                                 true
                             }
                             AccountsIndexScanResult::KeepInMemory => true,
@@ -4065,9 +4072,9 @@ pub mod tests {
             assert!(map.get_internal_inner(&key, |entry| {
                 // check refcount BEFORE the unref
                 assert_eq!(u64::from(!expected), entry.unwrap().ref_count());
-                // first time, ref count was at 1, we can unref once. Unref should return false.
-                // second time, ref count was at 0, it is an error to unref. Unref should return true
-                assert_eq!(expected, entry.unwrap().unref());
+                // first time, ref count was at 1, we can unref once. Unref should return 1.
+                // second time, ref count was at 0, it is an error to unref. Unref should return 0
+                assert_eq!(u64::from(!expected), entry.unwrap().unref());
                 // check refcount AFTER the unref
                 assert_eq!(
                     if expected {


### PR DESCRIPTION
#### Problem
Getting ancient append vecs and skipping rewrites correct has been quite tricky. We recently tracked down bugs related to race conditions connected to unref'ing accounts.

#### Summary of Changes
Assert when we unref a zero lamport 1 refcount account that the refcount always goes to 0. Otherwise, there is a refcounting bug. Note that a tx thread can write to the account and that would add slot list entries, but the refcount will remain unchanged until we flush. shrink and pack code runs serially with write cache flushing, so refcounting should never change while shrink/pack is running apart from what shrink/pack do.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
