### PR TITLE
replay: populate block_id and send as part of TowerSync tx

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -590,11 +590,20 @@ impl Tower {
     pub fn record_bank_vote(&mut self, bank: &Bank) -> Option<Slot> {
         // Returns the new root if one is made after applying a vote for the given bank to
         // `self.vote_state`
+        let block_id = bank.block_id().unwrap_or_else(|| {
+            // This can only happen for our leader bank
+            assert!(
+                *bank.collector_id() == self.node_pubkey,
+                "block_id must not be None for a frozen non-leader bank"
+            );
+            Hash::default()
+        });
         self.record_bank_vote_and_update_lockouts(
             bank.slot(),
             bank.hash(),
             bank.feature_set
                 .is_active(&solana_feature_set::enable_tower_sync_ix::id()),
+            block_id,
         )
     }
 
@@ -604,6 +613,7 @@ impl Tower {
         &mut self,
         vote_hash: Hash,
         enable_tower_sync_ix: bool,
+        block_id: Hash,
     ) {
         let mut new_vote = if enable_tower_sync_ix {
             VoteTransaction::from(TowerSync::new(
@@ -614,7 +624,7 @@ impl Tower {
                     .collect(),
                 self.vote_state.root_slot,
                 vote_hash,
-                Hash::default(), // TODO: block_id will fill in upcoming pr
+                block_id,
             ))
         } else {
             VoteTransaction::from(VoteStateUpdate::new(
@@ -637,6 +647,7 @@ impl Tower {
         vote_slot: Slot,
         vote_hash: Hash,
         enable_tower_sync_ix: bool,
+        block_id: Hash,
     ) -> Option<Slot> {
         trace!("{} record_vote for {}", self.node_pubkey, vote_slot);
         let old_root = self.root();
@@ -649,7 +660,7 @@ impl Tower {
                 vote_slot, vote_hash, result
             );
         }
-        self.update_last_vote_from_vote_state(vote_hash, enable_tower_sync_ix);
+        self.update_last_vote_from_vote_state(vote_hash, enable_tower_sync_ix, block_id);
 
         let new_root = self.root();
 
@@ -667,7 +678,7 @@ impl Tower {
 
     #[cfg(feature = "dev-context-only-utils")]
     pub fn record_vote(&mut self, slot: Slot, hash: Hash) -> Option<Slot> {
-        self.record_bank_vote_and_update_lockouts(slot, hash, true)
+        self.record_bank_vote_and_update_lockouts(slot, hash, true, Hash::default())
     }
 
     /// Used for tests

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -150,6 +150,7 @@ impl VoteSimulator {
                 new_bank.register_unique_tick();
             }
             if !visit.node().has_no_child() || is_frozen {
+                new_bank.set_block_id(Some(Hash::new_unique()));
                 new_bank.freeze();
                 self.progress
                     .get_fork_stats_mut(new_bank.slot())
@@ -396,6 +397,7 @@ pub fn initialize_state(
 
     genesis_config.poh_config.hashes_per_tick = Some(2);
     let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    bank0.set_block_id(Some(Hash::new_unique()));
 
     for pubkey in validator_keypairs_map.keys() {
         bank0.transfer(10_000, &mint_keypair, pubkey).unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -582,6 +582,7 @@ impl PartialEq for Bank {
             transaction_account_lock_limit: _,
             fee_structure: _,
             cache_for_accounts_lt_hash: _,
+            block_id,
             // Ignore new fields explicitly if they do not impact PartialEq.
             // Adding ".." will remove compile-time checks that if a new field
             // is added to the struct, this PartialEq is accordingly updated.
@@ -621,6 +622,7 @@ impl PartialEq for Bank {
                 *hash_overrides.lock().unwrap() == *other.hash_overrides.lock().unwrap())
             && !(self.is_accounts_lt_hash_enabled() && other.is_accounts_lt_hash_enabled()
                 && *accounts_lt_hash.lock().unwrap() != *other.accounts_lt_hash.lock().unwrap())
+            && *block_id.read().unwrap() == *other.block_id.read().unwrap()
     }
 }
 
@@ -925,6 +927,11 @@ pub struct Bank {
     /// The accounts lt hash needs both the initial and final state of each
     /// account that was modified in this slot.  Cache the initial state here.
     cache_for_accounts_lt_hash: RwLock<AHashMap<Pubkey, InitialStateOfAccount>>,
+
+    /// The unique identifier for the corresponding block for this bank.
+    /// None for banks that have not yet completed replay or for leader banks as we cannot populate block_id
+    /// until bankless leader. Can be computed directly from shreds without needing to execute transactions.
+    block_id: RwLock<Option<Hash>>,
 }
 
 struct VoteWithStakeDelegations {
@@ -1047,6 +1054,7 @@ impl Bank {
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
             accounts_lt_hash: Mutex::new(AccountsLtHash(LtHash([0xBAD1; LtHash::NUM_ELEMENTS]))),
             cache_for_accounts_lt_hash: RwLock::new(AHashMap::new()),
+            block_id: RwLock::new(None),
         };
 
         bank.transaction_processor =
@@ -1321,6 +1329,7 @@ impl Bank {
             hash_overrides: parent.hash_overrides.clone(),
             accounts_lt_hash: Mutex::new(parent.accounts_lt_hash.lock().unwrap().clone()),
             cache_for_accounts_lt_hash: RwLock::new(AHashMap::new()),
+            block_id: RwLock::new(None),
         };
 
         let (_, ancestors_time_us) = measure_us!({
@@ -1701,6 +1710,7 @@ impl Bank {
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
             accounts_lt_hash: Mutex::new(AccountsLtHash(LtHash([0xBAD2; LtHash::NUM_ELEMENTS]))),
             cache_for_accounts_lt_hash: RwLock::new(AHashMap::new()),
+            block_id: RwLock::new(None),
         };
 
         bank.transaction_processor =
@@ -6853,6 +6863,14 @@ impl Bank {
 
     pub fn fee_structure(&self) -> &FeeStructure {
         &self.fee_structure
+    }
+
+    pub fn block_id(&self) -> Option<Hash> {
+        *self.block_id.read().unwrap()
+    }
+
+    pub fn set_block_id(&self, block_id: Option<Hash>) {
+        *self.block_id.write().unwrap() = block_id;
     }
 
     pub fn compute_budget(&self) -> Option<ComputeBudget> {


### PR DESCRIPTION
#### Problem
The block_id returned after completing the final fec set checks is unused.

#### Summary of Changes
Add the block_id to the bank (not yet serialized / deserialized) in order to be populated on the TowerSync vote.
Note that this block_id will be None in the case that the bank is our leader bank. This is because we cannot guarantee the shred will be ready.

We can adjust this approach to hold the vote until the last shred is finished, or to simply resend the vote once the last shred is finished (this would involve messing with the timestamp or deduplication code).