### PR TITLE
add clean metric for # slots cleaned

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1961,6 +1961,7 @@ struct CleanAccountsStats {
     clean_stored_dead_slots_us: AtomicU64,
     uncleaned_roots_slot_list_1: AtomicU64,
     get_account_sizes_us: AtomicU64,
+    slots_cleaned: AtomicU64,
 }
 
 impl CleanAccountsStats {
@@ -3599,6 +3600,13 @@ impl AccountsDb {
                 "get_account_sizes_us",
                 self.clean_accounts_stats
                     .get_account_sizes_us
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "slots_cleaned",
+                self.clean_accounts_stats
+                    .slots_cleaned
                     .swap(0, Ordering::Relaxed),
                 i64
             ),
@@ -8018,6 +8026,10 @@ impl AccountsDb {
             assert_eq!(reclaimed_offsets.len(), 1);
             assert!(reclaimed_offsets.contains_key(&expected_slot));
         }
+
+        self.clean_accounts_stats
+            .slots_cleaned
+            .fetch_add(reclaimed_offsets.len() as u64, Ordering::Relaxed);
 
         reclaimed_offsets.iter().for_each(|(slot, offsets)| {
             if let Some(store) = self


### PR DESCRIPTION
#### Problem
clean is often slow. Useful to know how many slots we are cleaning when clean runs

#### Summary of Changes
add a metric

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
