### PR TITLE
SIMD-0118: fix `total_rewards` for recalculation

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -42,7 +42,8 @@ use {
             enable_big_mod_exp_syscall, enable_get_epoch_stake_syscall,
             enable_partitioned_epoch_reward, enable_poseidon_syscall,
             error_on_syscall_bpf_function_hash_collisions, get_sysvar_syscall_enabled,
-            last_restart_slot_sysvar, reject_callx_r10, remaining_compute_units_syscall_enabled,
+            last_restart_slot_sysvar, partitioned_epoch_rewards_superfeature, reject_callx_r10,
+            remaining_compute_units_syscall_enabled,
         },
         hash::{Hash, Hasher},
         instruction::{AccountMeta, InstructionError, ProcessedSiblingInstruction},
@@ -273,8 +274,9 @@ pub fn create_program_runtime_environment_v1<'a>(
     let blake3_syscall_enabled = feature_set.is_active(&blake3_syscall_enabled::id());
     let curve25519_syscall_enabled = feature_set.is_active(&curve25519_syscall_enabled::id());
     let disable_fees_sysvar = feature_set.is_active(&disable_fees_sysvar::id());
-    let epoch_rewards_syscall_enabled =
-        feature_set.is_active(&enable_partitioned_epoch_reward::id());
+    let epoch_rewards_syscall_enabled = feature_set
+        .is_active(&enable_partitioned_epoch_reward::id())
+        || feature_set.is_active(&partitioned_epoch_rewards_superfeature::id());
     let disable_deploy_of_alloc_free_syscall = reject_deployment_of_broken_elfs
         && feature_set.is_active(&disable_deploy_of_alloc_free_syscall::id());
     let last_restart_slot_syscall_enabled = feature_set.is_active(&last_restart_slot_sysvar::id());

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -66,8 +66,8 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
     };
 
     // The EpochRewards sysvar only exists after the
-    // enable_partitioned_epoch_reward feature is activated. If it exists, check
-    // the `active` field
+    // partitioned_epoch_rewards_superfeature feature is activated. If it
+    // exists, check the `active` field
     let epoch_rewards_active = invoke_context
         .get_sysvar_cache()
         .get_epoch_rewards()

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -610,12 +610,20 @@ impl JsonRpcRequestProcessor {
         // epoch
         let bank = self.get_bank_with_config(context_config)?;
 
-        // DO NOT CLEAN UP with feature_set::enable_partitioned_epoch_reward
+        // DO NOT CLEAN UP with feature_set::partitioned_epoch_rewards_superfeature
         // This logic needs to be retained indefinitely to support historical
         // rewards before and after feature activation.
         let partitioned_epoch_reward_enabled_slot = bank
             .feature_set
-            .activated_slot(&feature_set::enable_partitioned_epoch_reward::id());
+            .activated_slot(&feature_set::partitioned_epoch_rewards_superfeature::id())
+            .or_else(|| {
+                // The order of these checks should not matter, since we will
+                // not ever have both features active on a live cluster. This
+                // check can be removed with
+                // feature_set::enable_partitioned_epoch_reward
+                bank.feature_set
+                    .activated_slot(&feature_set::enable_partitioned_epoch_reward::id())
+            });
         let partitioned_epoch_reward_enabled = partitioned_epoch_reward_enabled_slot
             .map(|slot| slot <= first_confirmed_block_in_epoch)
             .unwrap_or(false);

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -105,7 +105,6 @@ impl Bank {
             vote_account_rewards,
             stake_rewards_by_partition,
             old_vote_balance_and_staked,
-            validator_rewards,
             validator_rate,
             foundation_rate,
             prev_epoch_duration_in_years,
@@ -136,11 +135,11 @@ impl Bank {
         self.assert_validator_rewards_paid(validator_rewards_paid);
 
         // verify that we didn't pay any more than we expected to
-        assert!(validator_rewards >= validator_rewards_paid + total_stake_rewards_lamports);
+        assert!(point_value.rewards >= validator_rewards_paid + total_stake_rewards_lamports);
 
         info!(
             "distributed vote rewards: {} out of {}, remaining {}",
-            validator_rewards_paid, validator_rewards, total_stake_rewards_lamports
+            validator_rewards_paid, point_value.rewards, total_stake_rewards_lamports
         );
 
         let (num_stake_accounts, num_vote_accounts) = {
@@ -260,7 +259,6 @@ impl Bank {
                 total_stake_rewards_lamports: stake_rewards.total_stake_rewards_lamports,
             },
             old_vote_balance_and_staked,
-            validator_rewards,
             validator_rate,
             foundation_rate,
             prev_epoch_duration_in_years,
@@ -1015,7 +1013,7 @@ mod tests {
                     stake_rewards_by_partition: expected_stake_rewards,
                     ..
                 },
-            validator_rewards,
+            point_value,
             ..
         } = bank.calculate_rewards_for_partitioning(
             rewarded_epoch,
@@ -1040,7 +1038,7 @@ mod tests {
         compare_stake_rewards(&expected_stake_rewards, recalculated_rewards);
 
         let sysvar = bank.get_epoch_rewards_sysvar();
-        assert_eq!(validator_rewards, sysvar.total_rewards);
+        assert_eq!(point_value.rewards, sysvar.total_rewards);
 
         // Advance to first distribution slot
         let mut bank =

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -50,7 +50,7 @@ impl Bank {
         let CalculateRewardsAndDistributeVoteRewardsResult {
             total_rewards,
             distributed_rewards,
-            total_points,
+            point_value,
             stake_rewards_by_partition,
         } = self.calculate_rewards_and_distribute_vote_rewards(
             parent_epoch,
@@ -80,7 +80,7 @@ impl Bank {
             distributed_rewards,
             distribution_starting_block_height,
             num_partitions,
-            total_points,
+            point_value,
         );
 
         datapoint_info!(
@@ -110,7 +110,7 @@ impl Bank {
             foundation_rate,
             prev_epoch_duration_in_years,
             capitalization,
-            total_points,
+            point_value,
         } = self.calculate_rewards_for_partitioning(
             prev_epoch,
             reward_calc_tracer,
@@ -179,7 +179,7 @@ impl Bank {
         CalculateRewardsAndDistributeVoteRewardsResult {
             total_rewards: validator_rewards_paid + total_stake_rewards_lamports,
             distributed_rewards: validator_rewards_paid,
-            total_points,
+            point_value,
             stake_rewards_by_partition,
         }
     }
@@ -231,7 +231,7 @@ impl Bank {
         let CalculateValidatorRewardsResult {
             vote_rewards_accounts: vote_account_rewards,
             stake_reward_calculation: mut stake_rewards,
-            total_points,
+            point_value,
         } = self
             .calculate_validator_rewards(
                 prev_epoch,
@@ -265,7 +265,7 @@ impl Bank {
             foundation_rate,
             prev_epoch_duration_in_years,
             capitalization,
-            total_points,
+            point_value,
         }
     }
 
@@ -288,12 +288,11 @@ impl Bank {
             metrics,
         )
         .map(|point_value| {
-            let total_points = point_value.points;
             let (vote_rewards_accounts, stake_reward_calculation) = self
                 .calculate_stake_vote_rewards(
                     &reward_calculate_param,
                     rewarded_epoch,
-                    point_value,
+                    point_value.clone(),
                     thread_pool,
                     reward_calc_tracer,
                     metrics,
@@ -301,7 +300,7 @@ impl Bank {
             CalculateValidatorRewardsResult {
                 vote_rewards_accounts,
                 stake_reward_calculation,
-                total_points,
+                point_value,
             }
         })
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -349,7 +349,7 @@ mod tests {
             create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
         genesis_config.epoch_schedule = EpochSchedule::custom(432000, 432000, false);
         let mut bank = Bank::new_for_tests(&genesis_config);
-        bank.activate_feature(&feature_set::enable_partitioned_epoch_reward::id());
+        bank.activate_feature(&feature_set::partitioned_epoch_rewards_superfeature::id());
 
         // Set up epoch_rewards sysvar with rewards with 1e9 lamports to distribute.
         let total_rewards = 1_000_000_000;

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -255,7 +255,7 @@ mod tests {
             },
             sysvar,
         },
-        solana_stake_program::stake_state,
+        solana_stake_program::{points::PointValue, stake_state},
         solana_vote_program::vote_state,
     };
 
@@ -355,7 +355,16 @@ mod tests {
         let total_rewards = 1_000_000_000;
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
         let total_points = (total_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
-        bank.create_epoch_rewards_sysvar(total_rewards, 0, 42, num_partitions, total_points);
+        bank.create_epoch_rewards_sysvar(
+            total_rewards,
+            0,
+            42,
+            num_partitions,
+            PointValue {
+                rewards: total_rewards,
+                points: total_points,
+            },
+        );
         let pre_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
         let expected_balance =
             bank.get_minimum_balance_for_rent_exemption(pre_epoch_rewards_account.data().len());

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -180,6 +180,9 @@ impl Bank {
     pub(super) fn is_partitioned_rewards_feature_enabled(&self) -> bool {
         self.feature_set
             .is_active(&feature_set::enable_partitioned_epoch_reward::id())
+            || self
+                .feature_set
+                .is_active(&feature_set::partitioned_epoch_rewards_superfeature::id())
     }
 
     pub(crate) fn set_epoch_reward_status_active(
@@ -456,7 +459,7 @@ mod tests {
 
         let mut bank = Bank::new_for_tests(&genesis_config);
         assert!(!bank.is_partitioned_rewards_feature_enabled());
-        bank.activate_feature(&feature_set::enable_partitioned_epoch_reward::id());
+        bank.activate_feature(&feature_set::partitioned_epoch_rewards_superfeature::id());
         assert!(bank.is_partitioned_rewards_feature_enabled());
     }
 
@@ -950,6 +953,9 @@ mod tests {
         genesis_config
             .accounts
             .remove(&feature_set::enable_partitioned_epoch_reward::id());
+        genesis_config
+            .accounts
+            .remove(&feature_set::partitioned_epoch_rewards_superfeature::id());
 
         let bank = Bank::new_for_tests(&genesis_config);
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -130,7 +130,6 @@ pub(super) struct PartitionedRewardsCalculation {
     pub(super) vote_account_rewards: VoteRewardsAccounts,
     pub(super) stake_rewards_by_partition: StakeRewardCalculationPartitioned,
     pub(super) old_vote_balance_and_staked: u64,
-    pub(super) validator_rewards: u64,
     pub(super) validator_rate: f64,
     pub(super) foundation_rate: f64,
     pub(super) prev_epoch_duration_in_years: f64,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -350,17 +350,25 @@ mod tests {
         stake_account_stores_per_block: u64,
         advance_num_slots: u64,
     ) -> RewardBank {
-        let validator_keypairs = (0..expected_num_delegations)
+        create_reward_bank_with_specific_stakes(
+            vec![2_000_000_000; expected_num_delegations],
+            stake_account_stores_per_block,
+            advance_num_slots,
+        )
+    }
+
+    pub(super) fn create_reward_bank_with_specific_stakes(
+        stakes: Vec<u64>,
+        stake_account_stores_per_block: u64,
+        advance_num_slots: u64,
+    ) -> RewardBank {
+        let validator_keypairs = (0..stakes.len())
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
 
         let GenesisConfigInfo {
             mut genesis_config, ..
-        } = create_genesis_config_with_vote_accounts(
-            1_000_000_000,
-            &validator_keypairs,
-            vec![2_000_000_000; expected_num_delegations],
-        );
+        } = create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, stakes);
         genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
 
         let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING.clone();

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -150,9 +150,13 @@ mod tests {
         let mut bank = Bank::new_for_tests(&genesis_config);
         bank.activate_feature(&feature_set::partitioned_epoch_rewards_superfeature::id());
 
-        let total_rewards = 1_000_000_000; // a large rewards so that the sysvar account is rent-exempted.
+        let total_rewards = 1_000_000_000;
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
         let total_points = (total_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
+        let point_value = PointValue {
+            rewards: total_rewards,
+            points: total_points,
+        };
 
         // create epoch rewards sysvar
         let expected_epoch_rewards = sysvar::epoch_rewards::EpochRewards {
@@ -171,7 +175,13 @@ mod tests {
             sysvar::epoch_rewards::EpochRewards::default()
         );
 
-        bank.create_epoch_rewards_sysvar(total_rewards, 10, 42, num_partitions, total_points);
+        bank.create_epoch_rewards_sysvar(
+            total_rewards,
+            10,
+            42,
+            num_partitions,
+            point_value.clone(),
+        );
         let account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
         let expected_balance = bank.get_minimum_balance_for_rent_exemption(account.data().len());
         // Expected balance is the sysvar rent-exempt balance
@@ -185,7 +195,13 @@ mod tests {
         let bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), parent_slot + 1);
         // Also note that running `create_epoch_rewards_sysvar()` against a bank
         // with an existing EpochRewards sysvar clobbers the previous values
-        bank.create_epoch_rewards_sysvar(total_rewards, 10, 42, num_partitions, total_points);
+        bank.create_epoch_rewards_sysvar(
+            total_rewards,
+            10,
+            42,
+            num_partitions,
+            point_value.clone(),
+        );
 
         let expected_epoch_rewards = sysvar::epoch_rewards::EpochRewards {
             distribution_starting_block_height: 42,

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -132,7 +132,7 @@ mod tests {
             create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
         genesis_config.epoch_schedule = EpochSchedule::custom(432000, 432000, false);
         let mut bank = Bank::new_for_tests(&genesis_config);
-        bank.activate_feature(&feature_set::enable_partitioned_epoch_reward::id());
+        bank.activate_feature(&feature_set::partitioned_epoch_rewards_superfeature::id());
 
         let total_rewards = 1_000_000_000; // a large rewards so that the sysvar account is rent-exempted.
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -109,7 +109,7 @@ mod tests {
         drop(bank1_sysvar_cache);
 
         // inject a reward sysvar for test
-        bank1.activate_feature(&feature_set::enable_partitioned_epoch_reward::id());
+        bank1.activate_feature(&feature_set::partitioned_epoch_rewards_superfeature::id());
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
         let total_points = 42_000; // total_points is arbitrary for the purposes of this test
         let expected_epoch_rewards = EpochRewards {

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -9,6 +9,7 @@ mod tests {
             feature_set, genesis_config::create_genesis_config, pubkey::Pubkey,
             sysvar::epoch_rewards::EpochRewards,
         },
+        solana_stake_program::points::PointValue,
         std::sync::Arc,
     };
 
@@ -126,7 +127,10 @@ mod tests {
             expected_epoch_rewards.distributed_rewards,
             expected_epoch_rewards.distribution_starting_block_height,
             num_partitions,
-            total_points,
+            PointValue {
+                rewards: 100,
+                points: total_points,
+            },
         );
 
         bank1

--- a/sdk/program/src/epoch_rewards.rs
+++ b/sdk/program/src/epoch_rewards.rs
@@ -29,7 +29,9 @@ pub struct EpochRewards {
     /// delegations
     pub total_points: u128,
 
-    /// The total rewards for the current epoch, in lamports
+    /// The total rewards calculated for the current epoch. This may be greater
+    /// than the total `distributed_rewards` at the end of the rewards period,
+    /// due to rounding and inability to deliver rewards smaller than 1 lamport.
     pub total_rewards: u64,
 
     /// The rewards currently distributed for the current epoch, in lamports

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -369,6 +369,10 @@ pub mod enable_partitioned_epoch_reward {
     solana_sdk::declare_id!("9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK");
 }
 
+pub mod partitioned_epoch_rewards_superfeature {
+    solana_sdk::declare_id!("PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8");
+}
+
 pub mod spl_token_v3_4_0 {
     solana_sdk::declare_id!("Ftok4njE8b7tDffYkC5bAbCaQv5sL6jispYrprzatUwN");
 }
@@ -1066,6 +1070,7 @@ lazy_static! {
         (enable_transaction_loading_failure_fees::id(), "Enable fees for some additional transaction failures SIMD-0082"),
         (enable_turbine_extended_fanout_experiments::id(), "enable turbine extended fanout experiments #"),
         (deprecate_legacy_vote_ixs::id(), "Deprecate legacy vote instructions"),
+        (partitioned_epoch_rewards_superfeature::id(), "replaces enable_partitioned_epoch_reward to enable partitioned rewards at epoch boundary SIMD-0118"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
A node that reboots from a snapshot that was created during the partitioned epoch reward period may diverge from the cluster. This is because the total rewards value currently stashed in the EpochRewards sysvar and used to populate PointValue in recalculation is the total lamports to actually be distributed:
https://github.com/anza-xyz/agave/blob/7e6399ab7244f9947ac52baa9bcd3bceec5191d0/runtime/src/bank/partitioned_epoch_rewards/calculation.rs#L180
https://github.com/anza-xyz/agave/blob/fff6257b0d0ed2c929fb31c20413314b0a2f0b96/runtime/src/bank/partitioned_epoch_rewards/calculation.rs#L566
In the initial calculation, however, this part of the PointValue is the total lamports *available* to be split/distributed. In a cluster with a diverse collection of stake accounts (like testnet), the lamports actually distributed is likely to be less than what is available, due to rounding to whole lamports. Different `PointValue::rewards` values may yield different calculated rewards.

#### Summary of Changes
Populate `EpochRewards::total_rewards` from the calculated `PointValue::rewards`
