### PR TITLE
metrics: remove vote-account-close

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -4,7 +4,6 @@ pub use solana_program::vote::state::{vote_state_versions::*, *};
 use {
     log::*,
     serde_derive::{Deserialize, Serialize},
-    solana_metrics::datapoint_debug,
     solana_program::vote::{error::VoteError, program::id},
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
@@ -1006,11 +1005,9 @@ pub fn withdraw<S: std::hash::BuildHasher>(
             .unwrap_or(false);
 
         if reject_active_vote_account_close {
-            datapoint_debug!("vote-account-close", ("reject-active", 1, i64));
             return Err(VoteError::ActiveVoteAccountClose.into());
         } else {
             // Deinitialize upon zero-balance
-            datapoint_debug!("vote-account-close", ("allow", 1, i64));
             set_vote_account_state(&mut vote_account, VoteState::default())?;
         }
     } else {


### PR DESCRIPTION
#### Problem

we introduced this metric in https://github.com/solana-labs/solana/pull/25746 and looks like it's for a feature activation.
the feature has been activated: https://github.com/solana-labs/solana/issues/24488

maybe it's good for us to remove this temporary datapoint?

#### Summary of Changes

remove them