### PR TITLE
metric: add unref_zero_count stat

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1,6 +1,7 @@
 pub(crate) mod in_mem_accounts_index;
 use {
     crate::{
+        accounts_db::ShrinkStats,
         accounts_index_storage::{AccountsIndexStorage, Startup},
         accounts_partition::RentPayingAccountsByPartition,
         ancestors::Ancestors,
@@ -1395,6 +1396,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     ///     None.
     pub(crate) fn scan<'a, F, I>(
         &self,
+        stat: &ShrinkStats,
         pubkeys: I,
         mut callback: F,
         avoid_callback_result: Option<AccountsIndexScanResult>,
@@ -1437,6 +1439,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                             AccountsIndexScanResult::Unref => {
                                 if locked_entry.unref() {
                                     info!("scan: refcount of item already at 0: {pubkey}");
+                                    stat.unref_zero_count.fetch_add(1, Ordering::Relaxed);
                                 }
                                 true
                             }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -491,7 +491,6 @@ impl AccountsDb {
         self.thread_pool_clean.install(|| {
             accounts_to_combine.into_par_iter().for_each(|combine| {
                 self.accounts_index.scan(
-                    &self.shrink_stats,
                     combine.unrefed_pubkeys.into_iter(),
                     |_pubkey, _slots_refs, entry| {
                         if let Some(entry) = entry {
@@ -3887,7 +3886,6 @@ pub mod tests {
             };
             db.addref_accounts_failed_to_shrink_ancient(accounts_to_combine.accounts_to_combine);
             db.accounts_index.scan(
-                &db.shrink_stats,
                 unrefed_pubkeys.iter(),
                 |k, slot_refs, _entry| {
                     assert_eq!(expected_ref_counts.remove(k).unwrap(), slot_refs.unwrap().1);

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -491,6 +491,7 @@ impl AccountsDb {
         self.thread_pool_clean.install(|| {
             accounts_to_combine.into_par_iter().for_each(|combine| {
                 self.accounts_index.scan(
+                    &self.shrink_stats,
                     combine.unrefed_pubkeys.into_iter(),
                     |_pubkey, _slots_refs, entry| {
                         if let Some(entry) = entry {
@@ -3886,6 +3887,7 @@ pub mod tests {
             };
             db.addref_accounts_failed_to_shrink_ancient(accounts_to_combine.accounts_to_combine);
             db.accounts_index.scan(
+                &db.shrink_stats,
                 unrefed_pubkeys.iter(),
                 |k, slot_refs, _entry| {
                     assert_eq!(expected_ref_counts.remove(k).unwrap(), slot_refs.unwrap().1);


### PR DESCRIPTION
#### Problem

Unref accounts with zero ref is an abnormal situation, likely there is a bug in
the code when this happens. 

We would like to track if this happens by reporting a stat for it.


#### Summary of Changes

Report unref zero counts in stat.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
