### PR TITLE
Address Resolved TransactionView

### DIFF
--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -90,11 +90,11 @@ impl CostModel {
         feature_set: &FeatureSet,
     ) {
         let signatures_count_detail = transaction.message().get_signature_details();
-        tx_cost.num_transaction_signatures = signatures_count_detail.num_transaction_signatures;
+        tx_cost.num_transaction_signatures = signatures_count_detail.num_transaction_signatures();
         tx_cost.num_secp256k1_instruction_signatures =
-            signatures_count_detail.num_secp256k1_instruction_signatures;
+            signatures_count_detail.num_secp256k1_instruction_signatures();
         tx_cost.num_ed25519_instruction_signatures =
-            signatures_count_detail.num_ed25519_instruction_signatures;
+            signatures_count_detail.num_ed25519_instruction_signatures();
 
         let ed25519_verify_cost =
             if feature_set.is_active(&feature_set::ed25519_precompile_verify_strict::id()) {
@@ -104,16 +104,16 @@ impl CostModel {
             };
 
         tx_cost.signature_cost = signatures_count_detail
-            .num_transaction_signatures
+            .num_transaction_signatures()
             .saturating_mul(SIGNATURE_COST)
             .saturating_add(
                 signatures_count_detail
-                    .num_secp256k1_instruction_signatures
+                    .num_secp256k1_instruction_signatures()
                     .saturating_mul(SECP256K1_VERIFY_COST),
             )
             .saturating_add(
                 signatures_count_detail
-                    .num_ed25519_instruction_signatures
+                    .num_ed25519_instruction_signatures()
                     .saturating_mul(ed25519_verify_cost),
             );
     }

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -90,11 +90,11 @@ impl CostModel {
         feature_set: &FeatureSet,
     ) {
         let signatures_count_detail = transaction.message().get_signature_details();
-        tx_cost.num_transaction_signatures = signatures_count_detail.num_transaction_signatures();
+        tx_cost.num_transaction_signatures = signatures_count_detail.num_transaction_signatures;
         tx_cost.num_secp256k1_instruction_signatures =
-            signatures_count_detail.num_secp256k1_instruction_signatures();
+            signatures_count_detail.num_secp256k1_instruction_signatures;
         tx_cost.num_ed25519_instruction_signatures =
-            signatures_count_detail.num_ed25519_instruction_signatures();
+            signatures_count_detail.num_ed25519_instruction_signatures;
 
         let ed25519_verify_cost =
             if feature_set.is_active(&feature_set::ed25519_precompile_verify_strict::id()) {
@@ -104,16 +104,16 @@ impl CostModel {
             };
 
         tx_cost.signature_cost = signatures_count_detail
-            .num_transaction_signatures()
+            .num_transaction_signatures
             .saturating_mul(SIGNATURE_COST)
             .saturating_add(
                 signatures_count_detail
-                    .num_secp256k1_instruction_signatures()
+                    .num_secp256k1_instruction_signatures
                     .saturating_mul(SECP256K1_VERIFY_COST),
             )
             .saturating_add(
                 signatures_count_detail
-                    .num_ed25519_instruction_signatures()
+                    .num_ed25519_instruction_signatures
                     .saturating_mul(ed25519_verify_cost),
             );
     }

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -427,32 +427,17 @@ impl SanitizedMessage {
 /// Transaction signature details including the number of transaction signatures
 /// and precompile signatures.
 pub struct TransactionSignatureDetails {
-    num_transaction_signatures: u64,
-    num_secp256k1_instruction_signatures: u64,
-    num_ed25519_instruction_signatures: u64,
+    pub num_transaction_signatures: u64,
+    pub num_secp256k1_instruction_signatures: u64,
+    pub num_ed25519_instruction_signatures: u64,
 }
 
 impl TransactionSignatureDetails {
     /// return total number of signature, treating pre-processor operations as signature
-    pub(crate) fn total_signatures(&self) -> u64 {
+    pub fn total_signatures(&self) -> u64 {
         self.num_transaction_signatures
             .saturating_add(self.num_secp256k1_instruction_signatures)
             .saturating_add(self.num_ed25519_instruction_signatures)
-    }
-
-    /// return the number of transaction signatures
-    pub fn num_transaction_signatures(&self) -> u64 {
-        self.num_transaction_signatures
-    }
-
-    /// return the number of secp256k1 instruction signatures
-    pub fn num_secp256k1_instruction_signatures(&self) -> u64 {
-        self.num_secp256k1_instruction_signatures
-    }
-
-    /// return the number of ed25519 instruction signatures
-    pub fn num_ed25519_instruction_signatures(&self) -> u64 {
-        self.num_ed25519_instruction_signatures
     }
 }
 

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -427,17 +427,44 @@ impl SanitizedMessage {
 /// Transaction signature details including the number of transaction signatures
 /// and precompile signatures.
 pub struct TransactionSignatureDetails {
-    pub num_transaction_signatures: u64,
-    pub num_secp256k1_instruction_signatures: u64,
-    pub num_ed25519_instruction_signatures: u64,
+    num_transaction_signatures: u64,
+    num_secp256k1_instruction_signatures: u64,
+    num_ed25519_instruction_signatures: u64,
 }
 
 impl TransactionSignatureDetails {
+    pub fn new(
+        num_transaction_signatures: u64,
+        num_secp256k1_instruction_signatures: u64,
+        num_ed25519_instruction_signatures: u64,
+    ) -> Self {
+        Self {
+            num_transaction_signatures,
+            num_secp256k1_instruction_signatures,
+            num_ed25519_instruction_signatures,
+        }
+    }
+
     /// return total number of signature, treating pre-processor operations as signature
     pub fn total_signatures(&self) -> u64 {
         self.num_transaction_signatures
             .saturating_add(self.num_secp256k1_instruction_signatures)
             .saturating_add(self.num_ed25519_instruction_signatures)
+    }
+
+    /// return the number of transaction signatures
+    pub fn num_transaction_signatures(&self) -> u64 {
+        self.num_transaction_signatures
+    }
+
+    /// return the number of secp256k1 instruction signatures
+    pub fn num_secp256k1_instruction_signatures(&self) -> u64 {
+        self.num_secp256k1_instruction_signatures
+    }
+
+    /// return the number of ed25519 instruction signatures
+    pub fn num_ed25519_instruction_signatures(&self) -> u64 {
+        self.num_ed25519_instruction_signatures
     }
 }
 

--- a/transaction-view/src/address_table_lookup_frame.rs
+++ b/transaction-view/src/address_table_lookup_frame.rs
@@ -6,6 +6,7 @@ use {
         },
         result::{Result, TransactionViewError},
     },
+    core::fmt::{Debug, Formatter},
     solana_sdk::{hash::Hash, packet::PACKET_DATA_SIZE, pubkey::Pubkey, signature::Signature},
     solana_svm_transaction::message_address_table_lookup::SVMMessageAddressTableLookup,
 };
@@ -128,6 +129,7 @@ impl AddressTableLookupFrame {
     }
 }
 
+#[derive(Clone)]
 pub struct AddressTableLookupIterator<'a> {
     pub(crate) bytes: &'a [u8],
     pub(crate) offset: usize,
@@ -198,6 +200,12 @@ impl<'a> Iterator for AddressTableLookupIterator<'a> {
 impl ExactSizeIterator for AddressTableLookupIterator<'_> {
     fn len(&self) -> usize {
         usize::from(self.num_address_table_lookups.wrapping_sub(self.index))
+    }
+}
+
+impl Debug for AddressTableLookupIterator<'_> {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
     }
 }
 

--- a/transaction-view/src/address_table_lookup_frame.rs
+++ b/transaction-view/src/address_table_lookup_frame.rs
@@ -46,6 +46,7 @@ const MAX_ATLS_PER_PACKET: u8 =
     ((PACKET_DATA_SIZE - MIN_SIZED_PACKET_WITH_ATLS) / MIN_SIZED_ATL) as u8;
 
 /// Contains metadata about the address table lookups in a transaction packet.
+#[derive(Debug)]
 pub(crate) struct AddressTableLookupFrame {
     /// The number of address table lookups in the transaction.
     pub(crate) num_address_table_lookups: u8,

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -10,7 +10,7 @@ use {
 };
 
 /// Contains metadata about the instructions in a transaction packet.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct InstructionsFrame {
     /// The number of instructions in the transaction.
     pub(crate) num_instructions: u16,

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -6,6 +6,7 @@ use {
         },
         result::Result,
     },
+    core::fmt::{Debug, Formatter},
     solana_svm_transaction::instruction::SVMInstruction,
 };
 
@@ -71,6 +72,7 @@ impl InstructionsFrame {
     }
 }
 
+#[derive(Clone)]
 pub struct InstructionsIterator<'a> {
     pub(crate) bytes: &'a [u8],
     pub(crate) offset: usize,
@@ -135,6 +137,12 @@ impl<'a> Iterator for InstructionsIterator<'a> {
 impl ExactSizeIterator for InstructionsIterator<'_> {
     fn len(&self) -> usize {
         usize::from(self.num_instructions.wrapping_sub(self.index))
+    }
+}
+
+impl Debug for InstructionsIterator<'_> {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
     }
 }
 

--- a/transaction-view/src/lib.rs
+++ b/transaction-view/src/lib.rs
@@ -7,6 +7,7 @@ mod bytes;
 mod address_table_lookup_frame;
 mod instructions_frame;
 mod message_header_frame;
+pub mod resolved_transaction_view;
 pub mod result;
 mod sanitize;
 mod signature_frame;

--- a/transaction-view/src/message_header_frame.rs
+++ b/transaction-view/src/message_header_frame.rs
@@ -7,7 +7,7 @@ use {
 };
 
 /// A byte that represents the version of the transaction.
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Debug, Default)]
 #[repr(u8)]
 pub enum TransactionVersion {
     #[default]
@@ -16,6 +16,7 @@ pub enum TransactionVersion {
 }
 
 /// Metadata for accessing message header fields in a transaction view.
+#[derive(Debug)]
 pub(crate) struct MessageHeaderFrame {
     /// The offset to the first byte of the message in the transaction packet.
     pub(crate) offset: u16,

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -80,14 +80,13 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
         let account_keys = AccountKeys::new(view.static_account_keys(), Some(resolved_addresses));
 
         let mut is_writable_cache = Vec::with_capacity(account_keys.len());
-        let num_static_accounts = usize::from(view.num_static_account_keys());
+        let num_static_account_keys = usize::from(view.num_static_account_keys());
         let num_writable_lookup_accounts = usize::from(view.total_writable_lookup_accounts());
         let num_signed_accounts = usize::from(view.num_required_signatures());
-        let num_unsigned_accounts = num_static_accounts.wrapping_sub(num_signed_accounts);
-        let num_writable_unsigned_accounts =
-            num_unsigned_accounts.wrapping_sub(usize::from(view.num_readonly_unsigned_accounts()));
-        let num_writable_signed_accounts =
-            num_signed_accounts.wrapping_sub(usize::from(view.num_readonly_signed_accounts()));
+        let num_writable_unsigned_static_accounts =
+            usize::from(view.num_writable_unsigned_static_accounts());
+        let num_writable_signed_static_accounts =
+            usize::from(view.num_writable_signed_static_accounts());
 
         let is_upgradable_loader_present = account_keys
             .iter()
@@ -96,14 +95,14 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
         for (index, key) in account_keys.iter().enumerate() {
             let is_requested_write = {
                 // If the account is a resolved address, check if it is writable.
-                if index >= num_static_accounts {
-                    let loaded_address_index = index.wrapping_sub(num_static_accounts);
+                if index >= num_static_account_keys {
+                    let loaded_address_index = index.wrapping_sub(num_static_account_keys);
                     loaded_address_index < num_writable_lookup_accounts
                 } else if index >= num_signed_accounts {
                     let unsigned_account_index = index.wrapping_sub(num_signed_accounts);
-                    unsigned_account_index < num_writable_unsigned_accounts
+                    unsigned_account_index < num_writable_unsigned_static_accounts
                 } else {
-                    index < num_writable_signed_accounts
+                    index < num_writable_signed_static_accounts
                 }
             };
 
@@ -129,8 +128,8 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
         usize::from(
             self.view
                 .total_readonly_lookup_accounts()
-                .wrapping_add(u16::from(self.view.num_readonly_signed_accounts()))
-                .wrapping_add(u16::from(self.view.num_readonly_unsigned_accounts())),
+                .wrapping_add(u16::from(self.view.num_readonly_signed_static_accounts()))
+                .wrapping_add(u16::from(self.view.num_readonly_unsigned_static_accounts())),
         )
     }
 

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -47,7 +47,7 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
     pub fn try_new(
         view: TransactionView<true, D>,
         resolved_addresses: Option<LoadedAddresses>,
-        reserved_account_keys: &HashSet<Pubkey>, // why does this not use ahash at least?!
+        reserved_account_keys: &HashSet<Pubkey>,
     ) -> Result<Self> {
         let resolved_addresses_ref = resolved_addresses.as_ref();
 

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -1,0 +1,217 @@
+use {
+    crate::{transaction_data::TransactionData, transaction_view::TransactionView},
+    core::fmt::{Debug, Formatter},
+    solana_sdk::{
+        bpf_loader_upgradeable, ed25519_program,
+        hash::Hash,
+        message::{v0::LoadedAddresses, AccountKeys, TransactionSignatureDetails},
+        pubkey::Pubkey,
+        secp256k1_program,
+    },
+    solana_svm_transaction::{
+        instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
+        svm_message::SVMMessage,
+    },
+    std::collections::HashSet,
+};
+
+/// A parsed and sanitized transaction view that has had all address lookups
+/// resolved.
+pub struct ResolvedTransactionView<D: TransactionData> {
+    /// The parsed and sanitized transction view.
+    view: TransactionView<true, D>,
+    /// The resolved address lookups.
+    resolved_addresses: LoadedAddresses,
+    /// A cache for whether an address is writable.
+    writable_cache: Vec<bool>, // TODO: should this be a vec, bitset, or array[256].
+}
+
+impl<D: TransactionData> Debug for ResolvedTransactionView<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedTransactionView")
+            .field("view", &self.view)
+            .finish()
+    }
+}
+
+impl<D: TransactionData> ResolvedTransactionView<D> {
+    /// Given a parsed and sanitized transaction view, and a set of resolved
+    /// addresses, create a resolved transaction view.
+    pub fn new(
+        view: TransactionView<true, D>,
+        resolved_addresses: LoadedAddresses,
+        reserved_account_keys: &HashSet<Pubkey>, // why does this not use ahash at least?!
+    ) -> Self {
+        let writable_cache =
+            Self::cache_is_writable(&view, &resolved_addresses, reserved_account_keys);
+        Self {
+            view,
+            resolved_addresses,
+            writable_cache,
+        }
+    }
+
+    /// Helper function to check if an address is writable,
+    /// and cache the result.
+    /// This is done so we avoid recomputing the expensive checks each time we call
+    /// `is_writable` - since there is more to it than just checking index.
+    fn cache_is_writable(
+        view: &TransactionView<true, D>,
+        resolved_addresses: &LoadedAddresses,
+        reserved_account_keys: &HashSet<Pubkey>, // why does this not use ahash at least?!
+    ) -> Vec<bool> {
+        // Build account keys so that we can iterate over and check if
+        // an address is writable.
+        let account_keys = AccountKeys::new(view.static_account_keys(), Some(resolved_addresses));
+
+        let mut is_writable_cache = Vec::with_capacity(account_keys.len());
+        let num_static_accounts = usize::from(view.num_static_account_keys());
+        let num_writable_lookup_accounts = usize::from(view.total_writable_lookup_accounts());
+        let num_signed_accounts = usize::from(view.num_required_signatures());
+        let num_unsigned_accounts = num_static_accounts.wrapping_sub(num_signed_accounts);
+        let num_writable_unsigned_accounts =
+            num_unsigned_accounts.wrapping_sub(usize::from(view.num_readonly_unsigned_accounts()));
+        let num_writable_signed_accounts =
+            num_signed_accounts.wrapping_sub(usize::from(view.num_readonly_signed_accounts()));
+
+        let is_upgradable_loader_present = account_keys
+            .iter()
+            .any(|key| bpf_loader_upgradeable::ID == *key);
+
+        for (index, key) in account_keys.iter().enumerate() {
+            let is_requested_write = {
+                // If the account is a resolved address, check if it is writable.
+                if index >= num_static_accounts {
+                    let loaded_address_index = index.wrapping_sub(num_static_accounts);
+                    loaded_address_index < num_writable_lookup_accounts
+                } else if index >= num_signed_accounts {
+                    let unsigned_account_index = index.wrapping_sub(num_signed_accounts);
+                    unsigned_account_index < num_writable_unsigned_accounts
+                } else {
+                    index < num_writable_signed_accounts
+                }
+            };
+
+            // If the key is reserved it cannot be writable.
+            is_writable_cache[index] = is_requested_write && !reserved_account_keys.contains(key);
+        }
+
+        // If the upgradable loader is not present and a key is called as a program
+        // it is not writable.
+        // If the upgradable loader is present, then there is no point to loop.
+        // Looping over the instructions is more efficient than looping over each account
+        // and checking `is_invoked` which loops over each instruction internally.
+        if !is_upgradable_loader_present {
+            for ix in view.instructions_iter() {
+                is_writable_cache[usize::from(ix.program_id_index)] = false;
+            }
+        }
+
+        is_writable_cache
+    }
+
+    fn num_readonly_accounts(&self) -> usize {
+        usize::from(
+            self.view
+                .total_readonly_lookup_accounts()
+                .wrapping_add(u16::from(self.view.num_readonly_signed_accounts()))
+                .wrapping_add(u16::from(self.view.num_readonly_unsigned_accounts())),
+        )
+    }
+
+    fn signature_details(&self) -> TransactionSignatureDetails {
+        // counting the number of pre-processor operations separately
+        let mut num_secp256k1_instruction_signatures: u64 = 0;
+        let mut num_ed25519_instruction_signatures: u64 = 0;
+        for (program_id, instruction) in self.program_instructions_iter() {
+            if secp256k1_program::check_id(program_id) {
+                if let Some(num_verifies) = instruction.data.first() {
+                    num_secp256k1_instruction_signatures =
+                        num_secp256k1_instruction_signatures.wrapping_add(u64::from(*num_verifies));
+                }
+            } else if ed25519_program::check_id(program_id) {
+                if let Some(num_verifies) = instruction.data.first() {
+                    num_ed25519_instruction_signatures =
+                        num_ed25519_instruction_signatures.wrapping_add(u64::from(*num_verifies));
+                }
+            }
+        }
+
+        TransactionSignatureDetails {
+            num_transaction_signatures: u64::from(self.view.num_required_signatures()),
+            num_secp256k1_instruction_signatures,
+            num_ed25519_instruction_signatures,
+        }
+    }
+}
+
+impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {
+    fn num_total_signatures(&self) -> u64 {
+        self.signature_details().total_signatures()
+    }
+
+    fn num_write_locks(&self) -> u64 {
+        self.account_keys()
+            .len()
+            .wrapping_sub(self.num_readonly_accounts()) as u64
+    }
+
+    fn recent_blockhash(&self) -> &Hash {
+        self.view.recent_blockhash()
+    }
+
+    fn num_instructions(&self) -> usize {
+        usize::from(self.view.num_instructions())
+    }
+
+    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction> {
+        self.view.instructions_iter()
+    }
+
+    fn program_instructions_iter(
+        &self,
+    ) -> impl Iterator<
+        Item = (
+            &solana_sdk::pubkey::Pubkey,
+            solana_svm_transaction::instruction::SVMInstruction,
+        ),
+    > {
+        self.view.program_instructions_iter()
+    }
+
+    fn account_keys(&self) -> AccountKeys {
+        AccountKeys::new(
+            self.view.static_account_keys(),
+            Some(&self.resolved_addresses), // TODO: should this always be Some?
+        )
+    }
+
+    fn fee_payer(&self) -> &Pubkey {
+        &self.view.static_account_keys()[0]
+    }
+
+    fn is_writable(&self, index: usize) -> bool {
+        self.writable_cache[index]
+    }
+
+    fn is_signer(&self, index: usize) -> bool {
+        index < usize::from(self.view.num_required_signatures())
+    }
+
+    fn is_invoked(&self, key_index: usize) -> bool {
+        let Ok(index) = u8::try_from(key_index) else {
+            return false;
+        };
+        self.view
+            .instructions_iter()
+            .any(|ix| ix.program_id_index == index)
+    }
+
+    fn num_lookup_tables(&self) -> usize {
+        usize::from(self.view.num_address_table_lookups())
+    }
+
+    fn message_address_table_lookups(&self) -> impl Iterator<Item = SVMMessageAddressTableLookup> {
+        self.view.address_table_lookup_iter()
+    }
+}

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -37,14 +37,6 @@ impl<D: TransactionData> Deref for ResolvedTransactionView<D> {
     }
 }
 
-impl<D: TransactionData> Debug for ResolvedTransactionView<D> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ResolvedTransactionView")
-            .field("view", &self.view)
-            .finish()
-    }
-}
-
 impl<D: TransactionData> ResolvedTransactionView<D> {
     /// Given a parsed and sanitized transaction view, and a set of resolved
     /// addresses, create a resolved transaction view.
@@ -236,6 +228,14 @@ impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {
 
     fn message_address_table_lookups(&self) -> impl Iterator<Item = SVMMessageAddressTableLookup> {
         self.view.address_table_lookup_iter()
+    }
+}
+
+impl<D: TransactionData> Debug for ResolvedTransactionView<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedTransactionView")
+            .field("view", &self.view)
+            .finish()
     }
 }
 

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -1,6 +1,9 @@
 use {
     crate::{transaction_data::TransactionData, transaction_view::TransactionView},
-    core::fmt::{Debug, Formatter},
+    core::{
+        fmt::{Debug, Formatter},
+        ops::Deref,
+    },
     solana_sdk::{
         bpf_loader_upgradeable, ed25519_program,
         hash::Hash,
@@ -24,6 +27,14 @@ pub struct ResolvedTransactionView<D: TransactionData> {
     resolved_addresses: LoadedAddresses,
     /// A cache for whether an address is writable.
     writable_cache: Vec<bool>, // TODO: should this be a vec, bitset, or array[256].
+}
+
+impl<D: TransactionData> Deref for ResolvedTransactionView<D> {
+    type Target = TransactionView<true, D>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.view
+    }
 }
 
 impl<D: TransactionData> Debug for ResolvedTransactionView<D> {

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -73,7 +73,7 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
     fn cache_is_writable(
         view: &TransactionView<true, D>,
         resolved_addresses: &LoadedAddresses,
-        reserved_account_keys: &HashSet<Pubkey>, // why does this not use ahash at least?!
+        reserved_account_keys: &HashSet<Pubkey>,
     ) -> Vec<bool> {
         // Build account keys so that we can iterate over and check if
         // an address is writable.

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -129,12 +129,11 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
     }
 
     fn num_readonly_accounts(&self) -> usize {
-        usize::from(
-            self.view
-                .total_readonly_lookup_accounts()
-                .wrapping_add(u16::from(self.view.num_readonly_signed_static_accounts()))
-                .wrapping_add(u16::from(self.view.num_readonly_unsigned_static_accounts())),
-        )
+        usize::from(self.view.total_readonly_lookup_accounts())
+            .wrapping_add(usize::from(self.view.num_readonly_signed_static_accounts()))
+            .wrapping_add(usize::from(
+                self.view.num_readonly_unsigned_static_accounts(),
+            ))
     }
 
     fn signature_details(&self) -> TransactionSignatureDetails {

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -212,7 +212,7 @@ impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {
     }
 
     fn is_writable(&self, index: usize) -> bool {
-        self.writable_cache[index]
+        self.writable_cache.get(index).copied().unwrap_or(false)
     }
 
     fn is_signer(&self, index: usize) -> bool {

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -123,17 +123,17 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
         let mut is_upgradable_loader_present = None;
         for ix in view.instructions_iter() {
             let program_id_index = usize::from(ix.program_id_index);
-            if is_writable_cache[program_id_index] {
-                if !*is_upgradable_loader_present.get_or_insert_with(|| {
+            if is_writable_cache[program_id_index]
+                && !*is_upgradable_loader_present.get_or_insert_with(|| {
                     for key in account_keys.iter() {
                         if key == &bpf_loader_upgradeable::ID {
                             return true;
                         }
                     }
                     false
-                }) {
-                    is_writable_cache[program_id_index] = false;
-                }
+                })
+            {
+                is_writable_cache[program_id_index] = false;
             }
         }
 

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -160,11 +160,11 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
             }
         }
 
-        TransactionSignatureDetails {
-            num_transaction_signatures: u64::from(self.view.num_required_signatures()),
+        TransactionSignatureDetails::new(
+            u64::from(self.view.num_required_signatures()),
             num_secp256k1_instruction_signatures,
             num_ed25519_instruction_signatures,
-        }
+        )
     }
 }
 

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -88,11 +88,9 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
         let num_writable_signed_static_accounts =
             usize::from(view.num_writable_signed_static_accounts());
 
-        let is_upgradable_loader_present = account_keys
-            .iter()
-            .any(|key| bpf_loader_upgradeable::ID == *key);
-
+        let mut is_upgradable_loader_present = false;
         for (index, key) in account_keys.iter().enumerate() {
+            is_upgradable_loader_present |= key == &bpf_loader_upgradeable::ID;
             let is_requested_write = {
                 // If the account is a resolved address, check if it is writable.
                 if index >= num_static_account_keys {

--- a/transaction-view/src/result.rs
+++ b/transaction-view/src/result.rs
@@ -3,6 +3,7 @@
 pub enum TransactionViewError {
     ParseError,
     SanitizeError,
+    AddressLookupMismatch,
 }
 
 pub type Result<T> = core::result::Result<T, TransactionViewError>;

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -30,7 +30,7 @@ fn sanitize_account_access(view: &UnsanitizedTransactionView<impl TransactionDat
     // Check there is no overlap of signing area and readonly non-signing area.
     // We have already checked that `num_required_signatures` is less than or equal to `num_static_account_keys`,
     // so it is safe to use wrapping arithmetic.
-    if view.num_readonly_unsigned_accounts()
+    if view.num_readonly_unsigned_static_accounts()
         > view
             .num_static_account_keys()
             .wrapping_sub(view.num_required_signatures())
@@ -39,7 +39,7 @@ fn sanitize_account_access(view: &UnsanitizedTransactionView<impl TransactionDat
     }
 
     // Check there is at least 1 writable fee-payer account.
-    if view.num_readonly_signed_accounts() >= view.num_required_signatures() {
+    if view.num_readonly_signed_static_accounts() >= view.num_required_signatures() {
         return Err(TransactionViewError::SanitizeError);
     }
 

--- a/transaction-view/src/signature_frame.rs
+++ b/transaction-view/src/signature_frame.rs
@@ -17,6 +17,7 @@ const MAX_SIGNATURES_PER_PACKET: u8 =
     (PACKET_DATA_SIZE / (core::mem::size_of::<Signature>() + core::mem::size_of::<Pubkey>())) as u8;
 
 /// Metadata for accessing transaction-level signatures in a transaction view.
+#[derive(Debug)]
 pub(crate) struct SignatureFrame {
     /// The number of signatures in the transaction.
     pub(crate) num_signatures: u8,

--- a/transaction-view/src/static_account_keys_frame.rs
+++ b/transaction-view/src/static_account_keys_frame.rs
@@ -14,7 +14,7 @@ pub const MAX_STATIC_ACCOUNTS_PER_PACKET: u8 =
     (PACKET_DATA_SIZE / core::mem::size_of::<Pubkey>()) as u8;
 
 /// Contains metadata about the static account keys in a transaction packet.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct StaticAccountKeysFrame {
     /// The number of static accounts in the transaction.
     pub(crate) num_static_accounts: u8,

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -86,15 +86,15 @@ impl TransactionFrame {
         self.message_header.num_required_signatures
     }
 
-    /// Return the number of readonly signed accounts in the transaction.
+    /// Return the number of readonly signed static accounts in the transaction.
     #[inline]
-    pub(crate) fn num_readonly_signed_accounts(&self) -> u8 {
+    pub(crate) fn num_readonly_signed_static_accounts(&self) -> u8 {
         self.message_header.num_readonly_signed_accounts
     }
 
-    /// Return the number of readonly unsigned accounts in the transaction.
+    /// Return the number of readonly unsigned static accounts in the transaction.
     #[inline]
-    pub(crate) fn num_readonly_unsigned_accounts(&self) -> u8 {
+    pub(crate) fn num_readonly_unsigned_static_accounts(&self) -> u8 {
         self.message_header.num_readonly_unsigned_accounts
     }
 
@@ -526,8 +526,8 @@ mod tests {
         assert_eq!(frame.num_signatures(), 1);
         assert!(matches!(frame.version(), TransactionVersion::Legacy));
         assert_eq!(frame.num_required_signatures(), 1);
-        assert_eq!(frame.num_readonly_signed_accounts(), 0);
-        assert_eq!(frame.num_readonly_unsigned_accounts(), 1);
+        assert_eq!(frame.num_readonly_signed_static_accounts(), 0);
+        assert_eq!(frame.num_readonly_unsigned_static_accounts(), 1);
         assert_eq!(frame.num_static_account_keys(), 3);
         assert_eq!(frame.num_instructions(), 1);
         assert_eq!(frame.num_address_table_lookups(), 0);

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -11,6 +11,7 @@ use {
     solana_sdk::{hash::Hash, pubkey::Pubkey, signature::Signature},
 };
 
+#[derive(Debug)]
 pub(crate) struct TransactionFrame {
     /// Signature framing data.
     signature: SignatureFrame,

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -26,14 +26,6 @@ pub struct TransactionView<const SANITIZED: bool, D: TransactionData> {
     frame: TransactionFrame,
 }
 
-impl<const SANITIZED: bool, D: TransactionData> Debug for TransactionView<SANITIZED, D> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TransactionView")
-            .field("frame", &self.frame)
-            .finish()
-    }
-}
-
 impl<D: TransactionData> TransactionView<false, D> {
     /// Creates a new `TransactionView` without running sanitization checks.
     pub fn try_new_unsanitized(data: D) -> Result<Self> {
@@ -182,6 +174,21 @@ impl<D: TransactionData> TransactionView<true, D> {
             let program_id = &self.static_account_keys()[program_id_index];
             (program_id, ix)
         })
+    }
+}
+
+// Manual implementation of `Debug` - avoids bound on `D`.
+// Prints nicely formatted struct-ish fields even for the iterator fields.
+impl<const SANITIZED: bool, D: TransactionData> Debug for TransactionView<SANITIZED, D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TransactionView")
+            .field("frame", &self.frame)
+            .field("signatures", &self.signatures())
+            .field("static_account_keys", &self.static_account_keys())
+            .field("recent_blockhash", &self.recent_blockhash())
+            .field("instructions", &self.instructions_iter())
+            .field("address_table_lookups", &self.address_table_lookup_iter())
+            .finish()
     }
 }
 


### PR DESCRIPTION
#### Problem
- Need to resolve ATLs to eventually process transaction type `TransactionView`

#### Summary of Changes
- Add `ResolvedTransactionView` which wraps a `TransactionView` with loaded addresses and writable cache

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
