### PR TITLE
account_saver: optionally collect txs

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2708,6 +2708,11 @@ impl AccountsDb {
         self.base_working_path.clone()
     }
 
+    /// Returns true if there is an accounts update notifier.
+    pub fn has_accounts_update_notifier(&self) -> bool {
+        self.accounts_update_notifier.is_some()
+    }
+
     fn next_id(&self) -> AccountsFileId {
         let next_id = self.next_id.fetch_add(1, Ordering::AcqRel);
         assert!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3804,6 +3804,7 @@ impl Bank {
                 &mut processing_results,
                 &durable_nonce,
                 lamports_per_signature,
+                self.accounts().accounts_db.has_accounts_update_notifier(),
             );
             self.rc.accounts.store_cached(
                 (self.slot(), accounts_to_store.as_slice()),


### PR DESCRIPTION
#### Problem
- transactions are only used for the account update notifier (geyser)
- we should not waste our time collecting them if there is no notifier

#### Summary of Changes
- optionally collect transactions

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
