### PR TITLE
[secp256k1] Remove old `libsecp256k1_fail_on_bad_count` features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5079,7 +5079,7 @@ dependencies = [
  "rustls-webpki 0.102.8",
  "security-framework",
  "security-framework-sys",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
  "winapi 0.3.9",
 ]
 
@@ -9981,9 +9981,9 @@ checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.5"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/sdk/src/secp256k1_instruction.rs
+++ b/sdk/src/secp256k1_instruction.rs
@@ -791,9 +791,7 @@ use {
     crate::{instruction::Instruction, precompiles::PrecompileError},
     digest::Digest,
     serde_derive::{Deserialize, Serialize},
-    solana_feature_set::{
-        libsecp256k1_fail_on_bad_count, libsecp256k1_fail_on_bad_count2, FeatureSet,
-    },
+    solana_feature_set::FeatureSet,
 };
 
 pub const HASHED_PUBKEY_SERIALIZED_SIZE: usize = 20;
@@ -926,17 +924,13 @@ pub fn construct_eth_pubkey(
 pub fn verify(
     data: &[u8],
     instruction_datas: &[&[u8]],
-    feature_set: &FeatureSet,
+    _feature_set: &FeatureSet,
 ) -> Result<(), PrecompileError> {
     if data.is_empty() {
         return Err(PrecompileError::InvalidInstructionDataSize);
     }
     let count = data[0] as usize;
-    if (feature_set.is_active(&libsecp256k1_fail_on_bad_count::id())
-        || feature_set.is_active(&libsecp256k1_fail_on_bad_count2::id()))
-        && count == 0
-        && data.len() > 1
-    {
+    if count == 0 && data.len() > 1 {
         // count is zero but the instruction data indicates that is probably not
         // correct, fail the instruction to catch probable invalid secp256k1
         // instruction construction.


### PR DESCRIPTION
#### Problem
The `libsecp256k1_fail_on_bad_count` and `libsecp256k1_fail_on_bad_count2` features have been activated on all networks.

#### Summary of Changes
Clean up the feature checks.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
