### PR TITLE
Wen restart: the argument is one proto file now instead of a directory.

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1578,7 +1578,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
             Arg::with_name("wen_restart")
                 .long("wen-restart")
                 .hidden(hidden_unless_forced())
-                .value_name("DIR")
+                .value_name("FILE")
                 .takes_value(true)
                 .required(false)
                 .conflicts_with("wait_for_supermajority")


### PR DESCRIPTION
In the early designs, we planned to write multiple files into a directory.

In the end we only need one proto file.

Change the argument from dir to file.