### PR TITLE
fix: reduce max packet receive time during leader window

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -438,7 +438,7 @@ impl SchedulerController {
     fn receive_and_buffer_packets(&mut self, decision: &BufferedPacketsDecision) -> bool {
         let remaining_queue_capacity = self.container.remaining_queue_capacity();
 
-        const MAX_PACKET_RECEIVE_TIME: Duration = Duration::from_millis(100);
+        const MAX_PACKET_RECEIVE_TIME: Duration = Duration::from_millis(10);
         let (recv_timeout, should_buffer) = match decision {
             BufferedPacketsDecision::Consume(_) => (
                 if self.container.is_empty() {


### PR DESCRIPTION
#### Problem
<img width="605" alt="image" src="https://github.com/user-attachments/assets/afbcb472-0853-4b58-abfd-016e5d0366bd">

In certain cases (if the transaction container is emptied during a leader's window), the scheduler controller may wait up to 100 milliseconds for incoming packets.

#### Summary of Changes
Reduce the constant max wait from 100 ms to 10 ms.
