### PR TITLE
Simplify RPC partitioned_epoch_reward_enabled determination

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -660,8 +660,8 @@ impl JsonRpcRequestProcessor {
         // rewards is enabled
         if partitioned_epoch_reward_enabled {
             let num_partitions = epoch_boundary_block.num_reward_partitions.expect(
-                "epoch-boundary block should have num_reward_partitions after partitioned epoch \
-                 rewards enabled",
+                "epoch-boundary block should have num_reward_partitions for epochs with \
+                 partitioned rewards enabled",
             );
 
             let num_partitions = usize::try_from(num_partitions)

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -638,7 +638,7 @@ impl JsonRpcRequestProcessor {
             .into());
         }
 
-        let partitioned_epoch_reward_enabled = epoch_boundary_block.num_reward_partitions.is_some();
+        let epoch_has_partitioned_rewards = epoch_boundary_block.num_reward_partitions.is_some();
 
         // Collect rewards from first block in the epoch if partitioned epoch
         // rewards not enabled, or address is a vote account
@@ -651,14 +651,14 @@ impl JsonRpcRequestProcessor {
                 &addresses,
                 &|reward_type| -> bool {
                     reward_type == RewardType::Voting
-                        || (!partitioned_epoch_reward_enabled && reward_type == RewardType::Staking)
+                        || (!epoch_has_partitioned_rewards && reward_type == RewardType::Staking)
                 },
             )
         };
 
         // Append stake account rewards from partitions if partitions epoch
         // rewards is enabled
-        if partitioned_epoch_reward_enabled {
+        if epoch_has_partitioned_rewards {
             let num_partitions = epoch_boundary_block.num_reward_partitions.expect(
                 "epoch-boundary block should have num_reward_partitions for epochs with \
                  partitioned rewards enabled",


### PR DESCRIPTION
#### Problem
RPC's `getInflationReward` currently does some gymnastics to determine if partitioned epoch rewards (PER) were enabled for a particular epoch (to do the right thing to find stake rewards). But `UiConfirmedBlock::num_reward_partitions` can offer a simple indicator whether the feature was active.
`num_partitions` is populated  for the RewardsRecorderService here: https://github.com/anza-xyz/agave/blob/b9c9ecccbb05d9da774d600bdbef2cf210c57fa8/runtime/src/bank/partitioned_epoch_rewards/mod.rs#L187-L188

#### Summary of Changes
Set `partitioned_epoch_reward_enabled` if `UiConfirmedBlock::num_reward_partitions.is_some()`

`UiConfirmedBlock::num_reward_partitions.is_none()` cases are:
- `!partitioned_epoch_reward_enabled` for the given epoch/epoch_boundary_block
- There was an issue with the RPC server such that rewards were not recorded, it is not clear whether PER was active -- in this case, `get_inflation_reward()` will return an empty Vec which matches the current behavior.
- The block indicated as the epoch_boundary_block is not actually the at the epoch boundary -- should be caught by the case at L634
