### PR TITLE
stop requesting entry on scan

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4021,7 +4021,7 @@ impl AccountsDb {
                 result
             },
             None,
-            true,
+            false,
             self.scan_filter_for_shrinking,
         );
         assert_eq!(index, std::cmp::min(accounts.len(), count));


### PR DESCRIPTION
#### Problem
we don't need to populate `entry` when we scan. This costs something and isn't used.

#### Summary of Changes
pass `false`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
