### PR TITLE
[syscalls] Update mod exp compute cost

### DIFF
--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -105,8 +105,10 @@ pub struct ComputeBudget {
     pub alt_bn128_pairing_one_pair_cost_other: u64,
     /// Big integer modular exponentiation base cost
     pub big_modular_exponentiation_base_cost: u64,
-    /// Big integer moduler exponentiation cost multiplicative factor
-    pub big_modular_exponentiation_cost_multiplicative_factor: u64,
+    /// Big integer moduler exponentiation cost divisor
+    /// The modular exponentiation cost is computed as
+    /// `input_length`/`big_modular_exponentiation_cost_divisor` + `big_modular_exponentiation_base_cost`
+    pub big_modular_exponentiation_cost_divisor: u64,
     /// Coefficient `a` of the quadratic function which determines the number
     /// of compute units consumed to call poseidon syscall for a given number
     /// of inputs.
@@ -183,7 +185,7 @@ impl ComputeBudget {
             alt_bn128_pairing_one_pair_cost_first: 36_364,
             alt_bn128_pairing_one_pair_cost_other: 12_121,
             big_modular_exponentiation_base_cost: 190,
-            big_modular_exponentiation_cost_multiplicative_factor: 2,
+            big_modular_exponentiation_cost_divisor: 2,
             poseidon_cost_coefficient_a: 61,
             poseidon_cost_coefficient_c: 542,
             get_remaining_compute_units_cost: 100,

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -180,7 +180,7 @@ impl ComputeBudget {
             alt_bn128_multiplication_cost: 3_840,
             alt_bn128_pairing_one_pair_cost_first: 36_364,
             alt_bn128_pairing_one_pair_cost_other: 12_121,
-            big_modular_exponentiation_cost: 33,
+            big_modular_exponentiation_cost: 190,
             poseidon_cost_coefficient_a: 61,
             poseidon_cost_coefficient_c: 542,
             get_remaining_compute_units_cost: 100,

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -103,8 +103,10 @@ pub struct ComputeBudget {
     /// + alt_bn128_pairing_one_pair_cost_other * (num_elems - 1)
     pub alt_bn128_pairing_one_pair_cost_first: u64,
     pub alt_bn128_pairing_one_pair_cost_other: u64,
-    /// Big integer modular exponentiation cost
-    pub big_modular_exponentiation_cost: u64,
+    /// Big integer modular exponentiation base cost
+    pub big_modular_exponentiation_base_cost: u64,
+    /// Big integer moduler exponentiation cost multiplicative factor
+    pub big_modular_exponentiation_cost_multiplicative_factor: u64,
     /// Coefficient `a` of the quadratic function which determines the number
     /// of compute units consumed to call poseidon syscall for a given number
     /// of inputs.
@@ -180,7 +182,8 @@ impl ComputeBudget {
             alt_bn128_multiplication_cost: 3_840,
             alt_bn128_pairing_one_pair_cost_first: 36_364,
             alt_bn128_pairing_one_pair_cost_other: 12_121,
-            big_modular_exponentiation_cost: 190,
+            big_modular_exponentiation_base_cost: 190,
+            big_modular_exponentiation_cost_multiplicative_factor: 2,
             poseidon_cost_coefficient_a: 61,
             poseidon_cost_coefficient_c: 542,
             get_remaining_compute_units_cost: 100,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1710,13 +1710,15 @@ declare_builtin_function!(
         let input_len: u64 = std::cmp::max(input_len, params.modulus_len);
 
         let budget = invoke_context.get_compute_budget();
+        // the compute units are calculated by the quadratic equation `0.5 input_len^2 + 190`
         consume_compute_meter(
             invoke_context,
             budget.syscall_base_cost.saturating_add(
                 input_len
                     .saturating_mul(input_len)
-                    .checked_div(budget.big_modular_exponentiation_cost)
-                    .unwrap_or(u64::MAX),
+                    .checked_div(2)
+                    .unwrap_or(u64::MAX)
+                    .saturating_add(budget.big_modular_exponentiation_cost),
             ),
         )?;
 
@@ -4719,7 +4721,8 @@ mod tests {
             let budget = invoke_context.get_compute_budget();
             invoke_context.mock_set_remaining(
                 budget.syscall_base_cost
-                    + (MAX_LEN * MAX_LEN) / budget.big_modular_exponentiation_cost,
+                    + (MAX_LEN * MAX_LEN) / 2
+                    + budget.big_modular_exponentiation_cost,
             );
 
             let result = SyscallBigModExp::rust(
@@ -4760,7 +4763,8 @@ mod tests {
             let budget = invoke_context.get_compute_budget();
             invoke_context.mock_set_remaining(
                 budget.syscall_base_cost
-                    + (INV_LEN * INV_LEN) / budget.big_modular_exponentiation_cost,
+                    + (INV_LEN * INV_LEN) / 2
+                    + budget.big_modular_exponentiation_cost,
             );
 
             let result = SyscallBigModExp::rust(

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1716,7 +1716,7 @@ declare_builtin_function!(
             budget.syscall_base_cost.saturating_add(
                 input_len
                     .saturating_mul(input_len)
-                    .checked_div(budget.big_modular_exponentiation_cost_multiplicative_factor)
+                    .checked_div(budget.big_modular_exponentiation_cost_divisor)
                     .unwrap_or(u64::MAX)
                     .saturating_add(budget.big_modular_exponentiation_base_cost),
             ),
@@ -4721,8 +4721,7 @@ mod tests {
             let budget = invoke_context.get_compute_budget();
             invoke_context.mock_set_remaining(
                 budget.syscall_base_cost
-                    + (MAX_LEN * MAX_LEN)
-                        / budget.big_modular_exponentiation_cost_multiplicative_factor
+                    + (MAX_LEN * MAX_LEN) / budget.big_modular_exponentiation_cost_divisor
                     + budget.big_modular_exponentiation_base_cost,
             );
 
@@ -4764,8 +4763,7 @@ mod tests {
             let budget = invoke_context.get_compute_budget();
             invoke_context.mock_set_remaining(
                 budget.syscall_base_cost
-                    + (INV_LEN * INV_LEN)
-                        / budget.big_modular_exponentiation_cost_multiplicative_factor
+                    + (INV_LEN * INV_LEN) / budget.big_modular_exponentiation_cost_divisor
                     + budget.big_modular_exponentiation_base_cost,
             );
 

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1716,9 +1716,9 @@ declare_builtin_function!(
             budget.syscall_base_cost.saturating_add(
                 input_len
                     .saturating_mul(input_len)
-                    .checked_div(2)
+                    .checked_div(budget.big_modular_exponentiation_cost_multiplicative_factor)
                     .unwrap_or(u64::MAX)
-                    .saturating_add(budget.big_modular_exponentiation_cost),
+                    .saturating_add(budget.big_modular_exponentiation_base_cost),
             ),
         )?;
 
@@ -4721,8 +4721,9 @@ mod tests {
             let budget = invoke_context.get_compute_budget();
             invoke_context.mock_set_remaining(
                 budget.syscall_base_cost
-                    + (MAX_LEN * MAX_LEN) / 2
-                    + budget.big_modular_exponentiation_cost,
+                    + (MAX_LEN * MAX_LEN)
+                        / budget.big_modular_exponentiation_cost_multiplicative_factor
+                    + budget.big_modular_exponentiation_base_cost,
             );
 
             let result = SyscallBigModExp::rust(
@@ -4763,8 +4764,9 @@ mod tests {
             let budget = invoke_context.get_compute_budget();
             invoke_context.mock_set_remaining(
                 budget.syscall_base_cost
-                    + (INV_LEN * INV_LEN) / 2
-                    + budget.big_modular_exponentiation_cost,
+                    + (INV_LEN * INV_LEN)
+                        / budget.big_modular_exponentiation_cost_multiplicative_factor
+                    + budget.big_modular_exponentiation_base_cost,
             );
 
             let result = SyscallBigModExp::rust(


### PR DESCRIPTION
#### Problem
The big integer modular exponentiation (EIP-198) syscall was added in https://github.com/solana-labs/solana/pull/28503. However, the compute units were significantly under-assigned and there is currently a security advisory regarding this.

The syscalls are feature-gated (on the blocked list) and not activated on any of the networks. There are currently no projects that are actively waiting for these syscalls to land so these syscalls are not at the top priority especially given the current active development of firedancer. However, there are project that plans to use these syscalls in the future, so it would be best to address the compute-unit issue and close the security advisory even if the feature gate remain in the blocked list for some time.

#### Summary of Changes
I updated the compute cost.

The initial compute unit was assigned by benching the modular exponentiation and dividing the time by 33ns per CU. The initial bench not only failed to represent an average cluster performance in executing these modular exponentiation functions, but also failed to take into account certain edge cases in the modular exponentiation algorithm that performs significantly slower.

The modular exponentiation syscall implementation uses the rust `num_bigint` crate. In this crate, the modular exponentiation is implemented with the following logic:
- If the modulus is odd, then use the montgomery arithmetic to do the exponentiation
- If the modulus is even, then use regular modular arithmetic to do the exponentiation

The initial bench of the syscalls only took into account the case when the modulus is odd even though the performance is much slower when the modulus is even due to the unsuitability of the montgomery arithmetic.

I re-ran the benches in my devserver for the cases when the modulus is even (power-of-two) and re-calculated the compute units (33ns per CU). I interpolated the CUs in relation to the input size (`N`) and it seems that the function `N^2/2 + 190` suitably approximates the CUs. This function does slightly over-assigns the CUs for small inputs (up to ~32 bytes), but given that most uses of these syscalls will be on much higher numbers, I think this is okay.

Note: There is actually a better algorithm for computing modular exponentiation that takes advantage of the Chinese remainder theorem (https://www.people.vcu.edu/~jwang3/CMSC691/j34monex.pdf). I tested the Aurora implementation of this algorithm (https://github.com/aurora-is-near/aurora-engine/tree/develop/engine-modexp), but it seems that this specific implementation actually performs slower than the `num_bigint` implementation.

Since this syscall is currently not at the top-priority list and will remain in the blocked list for some time, I think we can just bump-up the compute units to address and close the security advisory for now. In the future, we should revisit this to use the better algorithm to improve the syscall performance.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
