### PR TITLE
add ancient.total_alive_bytes metric

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1990,6 +1990,7 @@ pub(crate) struct ShrinkAncientStats {
     pub(crate) many_refs_old_alive: AtomicU64,
     pub(crate) slots_eligible_to_shrink: AtomicU64,
     pub(crate) total_dead_bytes: AtomicU64,
+    pub(crate) total_alive_bytes: AtomicU64,
 }
 
 #[derive(Debug, Default)]

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2322,6 +2322,11 @@ impl ShrinkAncientStats {
                 i64
             ),
             (
+                "total_alive_bytes",
+                self.total_alive_bytes.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
                 "slots_considered",
                 self.slots_considered.swap(0, Ordering::Relaxed) as i64,
                 i64


### PR DESCRIPTION
#### Problem
ancient packing needs to know the # of alive bytes across all ancient storages for future optimizations, such as a dynamic ideal size.

#### Summary of Changes
Calculate and add a metric for all alive bytes across all ancient storages.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
