### PR TITLE
Add early exit to add-team-to-ghsa

### DIFF
--- a/.github/scripts/add-team-to-ghsa.sh
+++ b/.github/scripts/add-team-to-ghsa.sh
@@ -15,6 +15,10 @@ ghsa_json=$(gh api \
 
 # Get a list of GHSAs that don't have the $team_to_add_slug in collaborating_teams
 ghsa_without_team=$( jq -r '[ .[] | select(all(.collaborating_teams.[]; .slug != "'"$team_to_add_slug"'")) | .ghsa_id ] | sort | .[] ' <<< "$ghsa_json" )
+if [[ -z $ghsa_without_team ]]; then
+    echo "All GHSAs already have $team_to_add_slug. Exiting..."
+    exit 0
+fi
 
 # Iterate through the teams
 while IFS= read -r ghsa_id; do


### PR DESCRIPTION
#### Problem
The [Add Security Team to GHSAs](https://github.com/anza-xyz/agave/actions/workflows/add-team-to-ghsa.yml) workflow is failing because `while IFS= read -r ghsa_id; do` runs once even if the input is empty. The input is usually empty, since most runs won't find any new GHSAs that don't already have the team added.

#### Summary of Changes
Add an early exit if all the GHSAs already have the security team added.
