### PR TITLE
transaction_view::*Meta rename to *Frame

### DIFF
--- a/runtime-transaction/src/compute_budget_program_id_filter.rs
+++ b/runtime-transaction/src/compute_budget_program_id_filter.rs
@@ -1,6 +1,6 @@
 // static account keys has max
 use {
-    agave_transaction_view::static_account_keys_meta::MAX_STATIC_ACCOUNTS_PER_PACKET as FILTER_SIZE,
+    agave_transaction_view::static_account_keys_frame::MAX_STATIC_ACCOUNTS_PER_PACKET as FILTER_SIZE,
     solana_builtins_default_costs::MAYBE_BUILTIN_KEY, solana_sdk::pubkey::Pubkey,
 };
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -16,7 +16,7 @@ use {
         snapshot_bank_utils, snapshot_utils,
         status_cache::MAX_CACHE_ENTRIES,
     },
-    agave_transaction_view::static_account_keys_meta::MAX_STATIC_ACCOUNTS_PER_PACKET,
+    agave_transaction_view::static_account_keys_frame::MAX_STATIC_ACCOUNTS_PER_PACKET,
     assert_matches::assert_matches,
     crossbeam_channel::{bounded, unbounded},
     itertools::Itertools,

--- a/transaction-view/src/address_table_lookup_frame.rs
+++ b/transaction-view/src/address_table_lookup_frame.rs
@@ -46,7 +46,7 @@ const MAX_ATLS_PER_PACKET: u8 =
     ((PACKET_DATA_SIZE - MIN_SIZED_PACKET_WITH_ATLS) / MIN_SIZED_ATL) as u8;
 
 /// Contains metadata about the address table lookups in a transaction packet.
-pub(crate) struct AddressTableLookupMeta {
+pub(crate) struct AddressTableLookupFrame {
     /// The number of address table lookups in the transaction.
     pub(crate) num_address_table_lookups: u8,
     /// The offset to the first address table lookup in the transaction.
@@ -57,7 +57,7 @@ pub(crate) struct AddressTableLookupMeta {
     pub(crate) total_readonly_lookup_accounts: u16,
 }
 
-impl AddressTableLookupMeta {
+impl AddressTableLookupFrame {
     /// Get the number of address table lookups (ATL) and offset to the first.
     /// The offset will be updated to point to the first byte after the last
     /// ATL.
@@ -211,12 +211,12 @@ mod tests {
     fn test_zero_atls() {
         let bytes = bincode::serialize(&ShortVec::<MessageAddressTableLookup>(vec![])).unwrap();
         let mut offset = 0;
-        let meta = AddressTableLookupMeta::try_new(&bytes, &mut offset).unwrap();
-        assert_eq!(meta.num_address_table_lookups, 0);
-        assert_eq!(meta.offset, 1);
+        let frame = AddressTableLookupFrame::try_new(&bytes, &mut offset).unwrap();
+        assert_eq!(frame.num_address_table_lookups, 0);
+        assert_eq!(frame.offset, 1);
         assert_eq!(offset, bytes.len());
-        assert_eq!(meta.total_writable_lookup_accounts, 0);
-        assert_eq!(meta.total_readonly_lookup_accounts, 0);
+        assert_eq!(frame.total_writable_lookup_accounts, 0);
+        assert_eq!(frame.total_readonly_lookup_accounts, 0);
     }
 
     #[test]
@@ -225,7 +225,7 @@ mod tests {
         let mut offset = 0;
         // modify the number of atls to be too high
         bytes[0] = 5;
-        assert!(AddressTableLookupMeta::try_new(&bytes, &mut offset).is_err());
+        assert!(AddressTableLookupFrame::try_new(&bytes, &mut offset).is_err());
     }
 
     #[test]
@@ -239,12 +239,12 @@ mod tests {
         ]))
         .unwrap();
         let mut offset = 0;
-        let meta = AddressTableLookupMeta::try_new(&bytes, &mut offset).unwrap();
-        assert_eq!(meta.num_address_table_lookups, 1);
-        assert_eq!(meta.offset, 1);
+        let frame = AddressTableLookupFrame::try_new(&bytes, &mut offset).unwrap();
+        assert_eq!(frame.num_address_table_lookups, 1);
+        assert_eq!(frame.offset, 1);
         assert_eq!(offset, bytes.len());
-        assert_eq!(meta.total_writable_lookup_accounts, 3);
-        assert_eq!(meta.total_readonly_lookup_accounts, 3);
+        assert_eq!(frame.total_writable_lookup_accounts, 3);
+        assert_eq!(frame.total_readonly_lookup_accounts, 3);
     }
 
     #[test]
@@ -263,12 +263,12 @@ mod tests {
         ]))
         .unwrap();
         let mut offset = 0;
-        let meta = AddressTableLookupMeta::try_new(&bytes, &mut offset).unwrap();
-        assert_eq!(meta.num_address_table_lookups, 2);
-        assert_eq!(meta.offset, 1);
+        let frame = AddressTableLookupFrame::try_new(&bytes, &mut offset).unwrap();
+        assert_eq!(frame.num_address_table_lookups, 2);
+        assert_eq!(frame.offset, 1);
         assert_eq!(offset, bytes.len());
-        assert_eq!(meta.total_writable_lookup_accounts, 6);
-        assert_eq!(meta.total_readonly_lookup_accounts, 5);
+        assert_eq!(frame.total_writable_lookup_accounts, 6);
+        assert_eq!(frame.total_readonly_lookup_accounts, 5);
     }
 
     #[test]
@@ -284,7 +284,7 @@ mod tests {
         bytes[33] = 127;
 
         let mut offset = 0;
-        assert!(AddressTableLookupMeta::try_new(&bytes, &mut offset).is_err());
+        assert!(AddressTableLookupFrame::try_new(&bytes, &mut offset).is_err());
     }
 
     #[test]
@@ -300,6 +300,6 @@ mod tests {
         bytes[37] = 127;
 
         let mut offset = 0;
-        assert!(AddressTableLookupMeta::try_new(&bytes, &mut offset).is_err());
+        assert!(AddressTableLookupFrame::try_new(&bytes, &mut offset).is_err());
     }
 }

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -11,14 +11,14 @@ use {
 
 /// Contains metadata about the instructions in a transaction packet.
 #[derive(Default)]
-pub(crate) struct InstructionsMeta {
+pub(crate) struct InstructionsFrame {
     /// The number of instructions in the transaction.
     pub(crate) num_instructions: u16,
     /// The offset to the first instruction in the transaction.
     pub(crate) offset: u16,
 }
 
-impl InstructionsMeta {
+impl InstructionsFrame {
     /// Get the number of instructions and offset to the first instruction.
     /// The offset will be updated to point to the first byte after the last
     /// instruction.
@@ -149,10 +149,10 @@ mod tests {
     fn test_zero_instructions() {
         let bytes = bincode::serialize(&ShortVec(Vec::<CompiledInstruction>::new())).unwrap();
         let mut offset = 0;
-        let instructions_meta = InstructionsMeta::try_new(&bytes, &mut offset).unwrap();
+        let instructions_frame = InstructionsFrame::try_new(&bytes, &mut offset).unwrap();
 
-        assert_eq!(instructions_meta.num_instructions, 0);
-        assert_eq!(instructions_meta.offset, 1);
+        assert_eq!(instructions_frame.num_instructions, 0);
+        assert_eq!(instructions_frame.offset, 1);
         assert_eq!(offset, bytes.len());
     }
 
@@ -167,7 +167,7 @@ mod tests {
         // modify the number of instructions to be too high
         bytes[0] = 0x02;
         let mut offset = 0;
-        assert!(InstructionsMeta::try_new(&bytes, &mut offset).is_err());
+        assert!(InstructionsFrame::try_new(&bytes, &mut offset).is_err());
     }
 
     #[test]
@@ -179,9 +179,9 @@ mod tests {
         }]))
         .unwrap();
         let mut offset = 0;
-        let instructions_meta = InstructionsMeta::try_new(&bytes, &mut offset).unwrap();
-        assert_eq!(instructions_meta.num_instructions, 1);
-        assert_eq!(instructions_meta.offset, 1);
+        let instructions_frame = InstructionsFrame::try_new(&bytes, &mut offset).unwrap();
+        assert_eq!(instructions_frame.num_instructions, 1);
+        assert_eq!(instructions_frame.offset, 1);
         assert_eq!(offset, bytes.len());
     }
 
@@ -201,9 +201,9 @@ mod tests {
         ]))
         .unwrap();
         let mut offset = 0;
-        let instructions_meta = InstructionsMeta::try_new(&bytes, &mut offset).unwrap();
-        assert_eq!(instructions_meta.num_instructions, 2);
-        assert_eq!(instructions_meta.offset, 1);
+        let instructions_frame = InstructionsFrame::try_new(&bytes, &mut offset).unwrap();
+        assert_eq!(instructions_frame.num_instructions, 2);
+        assert_eq!(instructions_frame.offset, 1);
         assert_eq!(offset, bytes.len());
     }
 
@@ -220,7 +220,7 @@ mod tests {
         bytes[2] = 127;
 
         let mut offset = 0;
-        assert!(InstructionsMeta::try_new(&bytes, &mut offset).is_err());
+        assert!(InstructionsFrame::try_new(&bytes, &mut offset).is_err());
     }
 
     #[test]
@@ -236,6 +236,6 @@ mod tests {
         bytes[6] = 127;
 
         let mut offset = 0;
-        assert!(InstructionsMeta::try_new(&bytes, &mut offset).is_err());
+        assert!(InstructionsFrame::try_new(&bytes, &mut offset).is_err());
     }
 }

--- a/transaction-view/src/lib.rs
+++ b/transaction-view/src/lib.rs
@@ -4,13 +4,13 @@ pub mod bytes;
 #[cfg(not(feature = "dev-context-only-utils"))]
 mod bytes;
 
-mod address_table_lookup_meta;
-mod instructions_meta;
-mod message_header_meta;
+mod address_table_lookup_frame;
+mod instructions_frame;
+mod message_header_frame;
 pub mod result;
 mod sanitize;
-mod signature_meta;
-pub mod static_account_keys_meta;
+mod signature_frame;
+pub mod static_account_keys_frame;
 pub mod transaction_data;
-mod transaction_meta;
+mod transaction_frame;
 pub mod transaction_view;

--- a/transaction-view/src/message_header_frame.rs
+++ b/transaction-view/src/message_header_frame.rs
@@ -15,8 +15,8 @@ pub enum TransactionVersion {
     V0 = 0,
 }
 
-/// Meta data for accessing message header fields in a transaction view.
-pub(crate) struct MessageHeaderMeta {
+/// Metadata for accessing message header fields in a transaction view.
+pub(crate) struct MessageHeaderFrame {
     /// The offset to the first byte of the message in the transaction packet.
     pub(crate) offset: u16,
     /// The version of the transaction.
@@ -32,7 +32,7 @@ pub(crate) struct MessageHeaderMeta {
     pub(crate) num_readonly_unsigned_accounts: u8,
 }
 
-impl MessageHeaderMeta {
+impl MessageHeaderFrame {
     #[inline(always)]
     pub(crate) fn try_new(bytes: &[u8], offset: &mut usize) -> Result<Self> {
         // Get the message offset.
@@ -78,21 +78,21 @@ mod tests {
     fn test_invalid_version() {
         let bytes = [0b1000_0001];
         let mut offset = 0;
-        assert!(MessageHeaderMeta::try_new(&bytes, &mut offset).is_err());
+        assert!(MessageHeaderFrame::try_new(&bytes, &mut offset).is_err());
     }
 
     #[test]
     fn test_legacy_transaction_missing_header_byte() {
         let bytes = [5, 0];
         let mut offset = 0;
-        assert!(MessageHeaderMeta::try_new(&bytes, &mut offset).is_err());
+        assert!(MessageHeaderFrame::try_new(&bytes, &mut offset).is_err());
     }
 
     #[test]
     fn test_legacy_transaction_valid() {
         let bytes = [5, 1, 2];
         let mut offset = 0;
-        let header = MessageHeaderMeta::try_new(&bytes, &mut offset).unwrap();
+        let header = MessageHeaderFrame::try_new(&bytes, &mut offset).unwrap();
         assert!(matches!(header.version, TransactionVersion::Legacy));
         assert_eq!(header.num_required_signatures, 5);
         assert_eq!(header.num_readonly_signed_accounts, 1);
@@ -103,14 +103,14 @@ mod tests {
     fn test_v0_transaction_missing_header_byte() {
         let bytes = [MESSAGE_VERSION_PREFIX, 5, 1];
         let mut offset = 0;
-        assert!(MessageHeaderMeta::try_new(&bytes, &mut offset).is_err());
+        assert!(MessageHeaderFrame::try_new(&bytes, &mut offset).is_err());
     }
 
     #[test]
     fn test_v0_transaction_valid() {
         let bytes = [MESSAGE_VERSION_PREFIX, 5, 1, 2];
         let mut offset = 0;
-        let header = MessageHeaderMeta::try_new(&bytes, &mut offset).unwrap();
+        let header = MessageHeaderFrame::try_new(&bytes, &mut offset).unwrap();
         assert!(matches!(header.version, TransactionVersion::V0));
         assert_eq!(header.num_required_signatures, 5);
         assert_eq!(header.num_readonly_signed_accounts, 1);


### PR DESCRIPTION
#### Problem
- There is already a `TransactionMeta` in `runtime-transaction` which makes the `transaction_view::`TransactionMeta` confusing

#### Summary of Changes
- Rename the `transaction_view::*Meta` to `*Frame`
- Naming coming from:
     - Content (Data) + Frame = Complete Picture (View)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
