### PR TITLE
accounts-db: silence false positive info in shrink

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4346,7 +4346,7 @@ impl AccountsDb {
                 // if all are zero lamports, then we expect that we would like to mark the whole slot dead, but we cannot. That's clean's job.
                 info!(
                     "Unexpected shrink for slot {} alive {} capacity {}, \
-                        All alive bytes are zero.",
+                        likely caused by a bug for calculating alive bytes.",
                     slot, shrink_collect.alive_total_bytes, shrink_collect.capacity
                 );
             }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4346,13 +4346,8 @@ impl AccountsDb {
                 // if all are zero lamports, then we expect that we would like to mark the whole slot dead, but we cannot. That's clean's job.
                 info!(
                     "Unexpected shrink for slot {} alive {} capacity {}, \
-                        likely caused by a bug for calculating alive bytes. \
-                        All alive bytes are zero: {}, {}",
-                    slot,
-                    shrink_collect.alive_total_bytes,
-                    shrink_collect.capacity,
-                    store.alive_bytes(),
-                    shrink_collect.zero_lamport_single_ref_pubkeys.len() * aligned_stored_size(0)
+                        All alive bytes are zero.",
+                    slot, shrink_collect.alive_total_bytes, shrink_collect.capacity
                 );
             }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4341,21 +4341,21 @@ impl AccountsDb {
                 // clean needs to take care of this dead slot
                 self.accounts_index.add_uncleaned_roots([slot]);
             }
-            info!(
+
+            let mut msg = format!(
                 "Unexpected shrink for slot {} alive {} capacity {}, \
-                likely caused by a bug for calculating alive bytes.",
+                    likely caused by a bug for calculating alive bytes.",
                 slot, shrink_collect.alive_total_bytes, shrink_collect.capacity
             );
-
             if !shrink_collect.all_are_zero_lamports {
                 // if all are zero lamports, then we expect that we would like to mark the whole slot dead, but we cannot. That's clean's job.
-                info!(
-                    "Unexpected shrink for slot {} alive {} capacity {}, \
-                    likely caused by a bug for calculating alive bytes. All alive bytes are zero: {}, {}",
-                    slot, shrink_collect.alive_total_bytes, shrink_collect.capacity,
-                    store.alive_bytes(), shrink_collect.zero_lamport_single_ref_pubkeys.len() * aligned_stored_size(0),
-                );
+                msg.push_str(&format!(
+                    "All alive bytes are zero: {}, {}",
+                    store.alive_bytes(),
+                    shrink_collect.zero_lamport_single_ref_pubkeys.len() * aligned_stored_size(0)
+                ));
             }
+            info!("{}", &msg);
 
             self.shrink_stats
                 .skipped_shrink

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4342,20 +4342,19 @@ impl AccountsDb {
                 self.accounts_index.add_uncleaned_roots([slot]);
             }
 
-            let mut msg = format!(
-                "Unexpected shrink for slot {} alive {} capacity {}, \
-                    likely caused by a bug for calculating alive bytes.",
-                slot, shrink_collect.alive_total_bytes, shrink_collect.capacity
-            );
             if !shrink_collect.all_are_zero_lamports {
                 // if all are zero lamports, then we expect that we would like to mark the whole slot dead, but we cannot. That's clean's job.
-                msg.push_str(&format!(
-                    "All alive bytes are zero: {}, {}",
+                info!(
+                    "Unexpected shrink for slot {} alive {} capacity {}, \
+                        likely caused by a bug for calculating alive bytes. \
+                        All alive bytes are zero: {}, {}",
+                    slot,
+                    shrink_collect.alive_total_bytes,
+                    shrink_collect.capacity,
                     store.alive_bytes(),
                     shrink_collect.zero_lamport_single_ref_pubkeys.len() * aligned_stored_size(0)
-                ));
+                );
             }
-            info!("{}", &msg);
 
             self.shrink_stats
                 .skipped_shrink

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4347,6 +4347,16 @@ impl AccountsDb {
                 slot, shrink_collect.alive_total_bytes, shrink_collect.capacity
             );
 
+            if !shrink_collect.all_are_zero_lamports {
+                // if all are zero lamports, then we expect that we would like to mark the whole slot dead, but we cannot. That's clean's job.
+                info!(
+                    "Unexpected shrink for slot {} alive {} capacity {}, \
+                    likely caused by a bug for calculating alive bytes. All alive bytes are zero: {}, {}",
+                    slot, shrink_collect.alive_total_bytes, shrink_collect.capacity,
+                    store.alive_bytes(), shrink_collect.zero_lamport_single_ref_pubkeys.len() * aligned_stored_size(0),
+                );
+            }
+
             self.shrink_stats
                 .skipped_shrink
                 .fetch_add(1, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem

We want to know if we find we have zero alive bytes, but all accounts are not zero lamports when shrinking,
which would inidate a bug somewhere in clean. 
Right now this log line is going off when a slot ONLY contains single ref zero lamport accounts. In that case, we need clean to mark the slot dead.

#### Summary of Changes

log when we find NOT all accounts are zero lamports when shrinking.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
