### PR TITLE
Consistent TransactionPriorityId ordering/equality

### DIFF
--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -21,7 +21,7 @@ impl Display for TransactionBatchId {
 }
 
 /// A unique identifier for a transaction.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionId(u64);
 
 impl TransactionId {

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -858,7 +858,7 @@ mod tests {
             &Keypair::new(),
             &Pubkey::new_unique(),
             1,
-            1,
+            1000,
             bank.last_blockhash(),
         );
         let tx2 = create_and_fund_prioritized_transfer(
@@ -867,7 +867,7 @@ mod tests {
             &Keypair::new(),
             &Pubkey::new_unique(),
             1,
-            2,
+            2000,
             bank.last_blockhash(),
         );
         let tx1_hash = tx1.message().hash();
@@ -914,7 +914,7 @@ mod tests {
             &Keypair::new(),
             &pk,
             1,
-            1,
+            1000,
             bank.last_blockhash(),
         );
         let tx2 = create_and_fund_prioritized_transfer(
@@ -923,7 +923,7 @@ mod tests {
             &Keypair::new(),
             &pk,
             1,
-            2,
+            2000,
             bank.last_blockhash(),
         );
         let tx1_hash = tx1.message().hash();
@@ -1105,7 +1105,7 @@ mod tests {
             &Keypair::new(),
             &Pubkey::new_unique(),
             1,
-            1,
+            1000,
             bank.last_blockhash(),
         );
         let tx2 = create_and_fund_prioritized_transfer(
@@ -1114,7 +1114,7 @@ mod tests {
             &Keypair::new(),
             &Pubkey::new_unique(),
             1,
-            2,
+            2000,
             bank.last_blockhash(),
         );
         let tx1_hash = tx1.message().hash();

--- a/core/src/banking_stage/transaction_scheduler/transaction_id_generator.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_id_generator.rs
@@ -1,16 +1,21 @@
 use crate::banking_stage::scheduler_messages::TransactionId;
 
-/// Simple sequential ID generator for `TransactionId`s.
+/// Simple reverse-sequential ID generator for `TransactionId`s.
 /// These IDs uniquely identify transactions during the scheduling process.
-#[derive(Default)]
 pub struct TransactionIdGenerator {
     next_id: u64,
+}
+
+impl Default for TransactionIdGenerator {
+    fn default() -> Self {
+        Self { next_id: u64::MAX }
+    }
 }
 
 impl TransactionIdGenerator {
     pub fn next(&mut self) -> TransactionId {
         let id = self.next_id;
-        self.next_id = self.next_id.wrapping_add(1);
+        self.next_id = self.next_id.wrapping_sub(1);
         TransactionId::new(id)
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/transaction_priority_id.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_priority_id.rs
@@ -5,7 +5,7 @@ use {
 };
 
 /// A unique identifier tied with priority ordering for a transaction/packet:
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct TransactionPriorityId {
     pub(crate) priority: u64,
     pub(crate) id: TransactionId,
@@ -14,20 +14,6 @@ pub(crate) struct TransactionPriorityId {
 impl TransactionPriorityId {
     pub(crate) fn new(priority: u64, id: TransactionId) -> Self {
         Self { priority, id }
-    }
-}
-
-impl Ord for TransactionPriorityId {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.priority
-            .cmp(&other.priority)
-            .then_with(|| self.id.cmp(&other.id))
-    }
-}
-
-impl PartialOrd for TransactionPriorityId {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
#### Problem
- Rust 1.81 may panic if we sort types with ordering that is inconsistent with equality.
- The `TransactionPriorityId` currently does not consider `id` when ordering, but does for equality. 

#### Summary of Changes
- Make `TransactionPriorityId` ordering consistent with equality + tests
- Make `TransactionIdGenerator` generate in reverse order - to explicitly favor earlier arrived packets

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
