### PR TITLE
bank::(un)lock_accounts generic

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -514,9 +514,9 @@ impl Accounts {
     /// This function will prevent multiple threads from modifying the same account state at the
     /// same time
     #[must_use]
-    pub fn lock_accounts<'a>(
+    pub fn lock_accounts<'a, Tx: SVMMessage + 'a>(
         &self,
-        txs: impl Iterator<Item = &'a SanitizedTransaction>,
+        txs: impl Iterator<Item = &'a Tx>,
         tx_account_lock_limit: usize,
     ) -> Vec<Result<()>> {
         // Validate the account locks, then get iterator if successful validation.

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -566,9 +566,9 @@ impl Accounts {
     }
 
     /// Once accounts are unlocked, new transactions that modify that state can enter the pipeline
-    pub fn unlock_accounts<'a>(
+    pub fn unlock_accounts<'a, Tx: SVMMessage + 'a>(
         &self,
-        txs_and_results: impl Iterator<Item = (&'a SanitizedTransaction, &'a Result<()>)> + Clone,
+        txs_and_results: impl Iterator<Item = (&'a Tx, &'a Result<()>)> + Clone,
     ) {
         if !txs_and_results.clone().any(|(_, res)| res.is_ok()) {
             return;
@@ -578,7 +578,7 @@ impl Accounts {
         debug!("bank unlock accounts");
         for (tx, res) in txs_and_results {
             if res.is_ok() {
-                let tx_account_locks = TransactionAccountLocksIterator::new(tx.message());
+                let tx_account_locks = TransactionAccountLocksIterator::new(tx);
                 account_locks.unlock_accounts(tx_account_locks.accounts_with_is_writable());
             }
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3425,9 +3425,9 @@ impl Bank {
         account_overrides
     }
 
-    pub fn unlock_accounts<'a>(
+    pub fn unlock_accounts<'a, Tx: SVMMessage + 'a>(
         &self,
-        txs_and_results: impl Iterator<Item = (&'a SanitizedTransaction, &'a Result<()>)> + Clone,
+        txs_and_results: impl Iterator<Item = (&'a Tx, &'a Result<()>)> + Clone,
     ) {
         self.rc.accounts.unlock_accounts(txs_and_results)
     }


### PR DESCRIPTION
#### Problem
- Locking and Unlocking accounts currently forces `SanitizedTransaction`, need to transition to allowing new transaction type(s)

#### Summary of Changes
- Make `lock_accounts` and `unlock_accounts` generic
- Step towards allowing `TransactionBatch` to be generic.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
