### PR TITLE
fix: solana-test-validator error (#2838)

### DIFF
--- a/install/agave-install-init.sh
+++ b/install/agave-install-init.sh
@@ -41,6 +41,37 @@ OPTIONS:
 EOF
 }
 
+install_homebrew() {
+    # Check if Homebrew is installed; if not, install it
+    if [ "$(uname -s)" = "Darwin" ]; then
+        if ! check_cmd brew; then
+            printf 'Homebrew not found. Installing Homebrew...\n' 1>&2
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        fi
+    fi
+}
+
+install_gnu_tar() {
+    # Check if gnu-tar is installed via Homebrew; if not, install it
+    if [ "$(uname -s)" = "Darwin" ]; then
+        if ! brew list gnu-tar >/dev/null 2>&1; then
+            printf 'gnu-tar not found. Installing gnu-tar using Homebrew...\n' 1>&2
+            brew install gnu-tar
+        fi
+    fi
+}
+
+update_path_for_gnu_tar() {
+    # Check uname for macOS and arm64
+    if [ "$(uname -s)" = "Darwin" ]; then
+        if [ "$(uname -m)" = "arm64" ]; then
+            export PATH="/opt/homebrew/opt/gnu-tar/libexec/gnubin:$PATH"
+        else
+            export PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH"
+        fi
+    fi
+}
+
 main() {
     downloader --check
     need_cmd uname
@@ -50,6 +81,11 @@ main() {
     need_cmd rm
     need_cmd sed
     need_cmd grep
+
+    # install homebrew and gnu-tar if not present and update PATH for gnu-tar on macOS
+    install_homebrew
+    install_gnu_tar
+    update_path_for_gnu_tar 
 
     for arg in "$@"; do
       case "$arg" in


### PR DESCRIPTION
### This PR fixes the `solana-test-validator` error #2838 

#### Problem
running `solana-test-validator` on macOS fails with the following error:

```bash
Ledger location: test-ledger
Log: test-ledger/validator.log
Error: failed to start validator: Failed to create ledger at test-ledger: io error: Error checking to unpack genesis archive: Archive error: extra entry found: "._genesis.bin" Regular
```
#### Proposed Solution

added checks for homebrew and GNU `tar` installation for intel-based and apple silicon-based macs directly in the [agave install](https://github.com/anza-xyz/agave/blob/master/install/agave-install-init.sh) file and exporting the PATH accordingly.
