### PR TITLE
Bank main processing functions generic over transaction type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7403,6 +7403,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-perf",
+ "solana-program",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6665,6 +6665,7 @@ dependencies = [
  "solana-storage-bigtable",
  "solana-storage-proto",
  "solana-svm",
+ "solana-svm-transaction",
  "solana-timings",
  "solana-transaction-status",
  "solana-vote",

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -514,9 +514,9 @@ impl Accounts {
     /// This function will prevent multiple threads from modifying the same account state at the
     /// same time
     #[must_use]
-    pub fn lock_accounts<'a>(
+    pub fn lock_accounts<'a, Tx: SVMMessage + 'a>(
         &self,
-        txs: impl Iterator<Item = &'a SanitizedTransaction>,
+        txs: impl Iterator<Item = &'a Tx>,
         tx_account_lock_limit: usize,
     ) -> Vec<Result<()>> {
         // Validate the account locks, then get iterator if successful validation.

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -566,9 +566,9 @@ impl Accounts {
     }
 
     /// Once accounts are unlocked, new transactions that modify that state can enter the pipeline
-    pub fn unlock_accounts<'a>(
+    pub fn unlock_accounts<'a, Tx: SVMMessage + 'a>(
         &self,
-        txs_and_results: impl Iterator<Item = (&'a SanitizedTransaction, &'a Result<()>)> + Clone,
+        txs_and_results: impl Iterator<Item = (&'a Tx, &'a Result<()>)> + Clone,
     ) {
         if !txs_and_results.clone().any(|(_, res)| res.is_ok()) {
             return;
@@ -578,7 +578,7 @@ impl Accounts {
         debug!("bank unlock accounts");
         for (tx, res) in txs_and_results {
             if res.is_ok() {
-                let tx_account_locks = TransactionAccountLocksIterator::new(tx.message());
+                let tx_account_locks = TransactionAccountLocksIterator::new(tx);
                 account_locks.unlock_accounts(tx_account_locks.accounts_with_is_writable());
             }
         }

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -12,7 +12,9 @@ use {
         transaction_batch::TransactionBatch,
         vote_sender_types::ReplayVoteSender,
     },
-    solana_sdk::{hash::Hash, pubkey::Pubkey, saturating_add_assign},
+    solana_sdk::{
+        hash::Hash, pubkey::Pubkey, saturating_add_assign, transaction::SanitizedTransaction,
+    },
     solana_svm::{
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
         transaction_processing_result::{
@@ -68,7 +70,7 @@ impl Committer {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn commit_transactions(
         &self,
-        batch: &TransactionBatch,
+        batch: &TransactionBatch<SanitizedTransaction>,
         processing_results: Vec<TransactionProcessingResult>,
         last_blockhash: Hash,
         lamports_per_signature: u64,
@@ -134,7 +136,7 @@ impl Committer {
         &self,
         commit_results: Vec<TransactionCommitResult>,
         bank: &Arc<Bank>,
-        batch: &TransactionBatch,
+        batch: &TransactionBatch<SanitizedTransaction>,
         pre_balance_info: &mut PreBalanceInfo,
         starting_transaction_index: Option<usize>,
     ) {

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -550,7 +550,7 @@ impl Consumer {
     fn execute_and_commit_transactions_locked(
         &self,
         bank: &Arc<Bank>,
-        batch: &TransactionBatch,
+        batch: &TransactionBatch<SanitizedTransaction>,
     ) -> ExecuteAndCommitTransactionsOutput {
         let transaction_status_sender_enabled = self.committer.transaction_status_sender_enabled();
         let mut execute_and_commit_timings = LeaderExecuteAndCommitTimings::default();

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -228,8 +228,12 @@ impl SchedulerController {
     ) {
         let lock_results = vec![Ok(()); transactions.len()];
         let mut error_counters = TransactionErrorMetrics::default();
-        let check_results =
-            bank.check_transactions(transactions, &lock_results, max_age, &mut error_counters);
+        let check_results = bank.check_transactions::<SanitizedTransaction>(
+            transactions,
+            &lock_results,
+            max_age,
+            &mut error_counters,
+        );
 
         let fee_check_results: Vec<_> = check_results
             .into_iter()
@@ -390,7 +394,7 @@ impl SchedulerController {
                 })
                 .collect();
 
-            let check_results = bank.check_transactions(
+            let check_results = bank.check_transactions::<SanitizedTransaction>(
                 &sanitized_txs,
                 &lock_results,
                 MAX_PROCESSING_AGE,

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -58,6 +58,7 @@ solana-stake-program = { workspace = true }
 solana-storage-bigtable = { workspace = true }
 solana-storage-proto = { workspace = true }
 solana-svm = { workspace = true }
+solana-svm-transaction = { workspace = true }
 solana-timings = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-vote = { workspace = true }

--- a/ledger/benches/blockstore_processor.rs
+++ b/ledger/benches/blockstore_processor.rs
@@ -11,8 +11,10 @@ use {
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
     },
     solana_runtime::{
-        bank::Bank, bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
-        transaction_batch::TransactionBatch,
+        bank::Bank,
+        bank_forks::BankForks,
+        prioritization_fee_cache::PrioritizationFeeCache,
+        transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
     solana_sdk::{
         account::{Account, ReadableAccount},
@@ -24,10 +26,7 @@ use {
         transaction::SanitizedTransaction,
     },
     solana_timings::ExecuteTimings,
-    std::{
-        borrow::Cow,
-        sync::{Arc, RwLock},
-    },
+    std::sync::{Arc, RwLock},
     test::Bencher,
 };
 
@@ -136,8 +135,11 @@ fn bench_execute_batch(
     let batches: Vec<_> = transactions
         .chunks(batch_size)
         .map(|txs| {
-            let mut batch =
-                TransactionBatch::new(vec![Ok(()); txs.len()], &bank, Cow::Borrowed(txs));
+            let mut batch = TransactionBatch::new(
+                vec![Ok(()); txs.len()],
+                &bank,
+                OwnedOrBorrowed::Borrowed(txs),
+            );
             batch.set_needs_unlock(false);
             TransactionBatchWithIndexes {
                 batch,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -39,7 +39,7 @@ use {
         installed_scheduler_pool::BankWithScheduler,
         prioritization_fee_cache::PrioritizationFeeCache,
         runtime_config::RuntimeConfig,
-        transaction_batch::TransactionBatch,
+        transaction_batch::{OwnedOrBorrowed, TransactionBatch},
         vote_sender_types::ReplayVoteSender,
     },
     solana_sdk::{
@@ -64,7 +64,6 @@ use {
     solana_transaction_status::token_balances::TransactionTokenBalancesSet,
     solana_vote::vote_account::VoteAccountsHashMap,
     std::{
-        borrow::Cow,
         collections::{HashMap, HashSet},
         ops::Index,
         path::PathBuf,
@@ -444,7 +443,8 @@ fn rebatch_transactions<'a>(
 ) -> TransactionBatchWithIndexes<'a, 'a, SanitizedTransaction> {
     let txs = &sanitized_txs[start..=end];
     let results = &lock_results[start..=end];
-    let mut tx_batch = TransactionBatch::new(results.to_vec(), bank, Cow::from(txs));
+    let mut tx_batch =
+        TransactionBatch::new(results.to_vec(), bank, OwnedOrBorrowed::Borrowed(txs));
     tx_batch.set_needs_unlock(false);
 
     let transaction_indexes = transaction_indexes[start..=end].to_vec();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -59,6 +59,7 @@ use {
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
         transaction_processor::ExecutionRecordingConfig,
     },
+    solana_svm_transaction::svm_transaction::SVMTransaction,
     solana_timings::{report_execute_timings, ExecuteTimingType, ExecuteTimings},
     solana_transaction_status::token_balances::TransactionTokenBalancesSet,
     solana_vote::vote_account::VoteAccountsHashMap,
@@ -78,8 +79,8 @@ use {
     ExecuteTimingType::{NumExecuteBatches, TotalBatchesLen},
 };
 
-pub struct TransactionBatchWithIndexes<'a, 'b> {
-    pub batch: TransactionBatch<'a, 'b>,
+pub struct TransactionBatchWithIndexes<'a, 'b, Tx: SVMTransaction + Clone> {
+    pub batch: TransactionBatch<'a, 'b, Tx>,
     pub transaction_indexes: Vec<usize>,
 }
 
@@ -99,7 +100,7 @@ fn first_err(results: &[Result<()>]) -> Result<()> {
 
 // Includes transaction signature for unit-testing
 fn get_first_error(
-    batch: &TransactionBatch,
+    batch: &TransactionBatch<SanitizedTransaction>,
     commit_results: &[TransactionCommitResult],
 ) -> Option<(Result<()>, Signature)> {
     let mut first_err = None;
@@ -134,7 +135,7 @@ fn create_thread_pool(num_threads: usize) -> ThreadPool {
 }
 
 pub fn execute_batch(
-    batch: &TransactionBatchWithIndexes,
+    batch: &TransactionBatchWithIndexes<SanitizedTransaction>,
     bank: &Arc<Bank>,
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
@@ -283,7 +284,7 @@ impl ExecuteBatchesInternalMetrics {
 fn execute_batches_internal(
     bank: &Arc<Bank>,
     replay_tx_thread_pool: &ThreadPool,
-    batches: &[TransactionBatchWithIndexes],
+    batches: &[TransactionBatchWithIndexes<SanitizedTransaction>],
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
     log_messages_bytes_limit: Option<usize>,
@@ -361,7 +362,7 @@ fn execute_batches_internal(
 fn process_batches(
     bank: &BankWithScheduler,
     replay_tx_thread_pool: &ThreadPool,
-    batches: &[TransactionBatchWithIndexes],
+    batches: &[TransactionBatchWithIndexes<SanitizedTransaction>],
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
     batch_execution_timing: &mut BatchExecutionTiming,
@@ -416,7 +417,7 @@ fn process_batches(
 
 fn schedule_batches_for_execution(
     bank: &BankWithScheduler,
-    batches: &[TransactionBatchWithIndexes],
+    batches: &[TransactionBatchWithIndexes<SanitizedTransaction>],
 ) -> Result<()> {
     for TransactionBatchWithIndexes {
         batch,
@@ -440,7 +441,7 @@ fn rebatch_transactions<'a>(
     start: usize,
     end: usize,
     transaction_indexes: &'a [usize],
-) -> TransactionBatchWithIndexes<'a, 'a> {
+) -> TransactionBatchWithIndexes<'a, 'a, SanitizedTransaction> {
     let txs = &sanitized_txs[start..=end];
     let results = &lock_results[start..=end];
     let mut tx_batch = TransactionBatch::new(results.to_vec(), bank, Cow::from(txs));
@@ -456,7 +457,7 @@ fn rebatch_transactions<'a>(
 fn rebatch_and_execute_batches(
     bank: &Arc<Bank>,
     replay_tx_thread_pool: &ThreadPool,
-    batches: &[TransactionBatchWithIndexes],
+    batches: &[TransactionBatchWithIndexes<SanitizedTransaction>],
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
     timing: &mut BatchExecutionTiming,
@@ -495,7 +496,7 @@ fn rebatch_and_execute_batches(
 
     let target_batch_count = get_thread_count() as u64;
 
-    let mut tx_batches: Vec<TransactionBatchWithIndexes> = vec![];
+    let mut tx_batches: Vec<TransactionBatchWithIndexes<SanitizedTransaction>> = vec![];
     let rebatched_txs = if total_cost > target_batch_count.saturating_mul(minimal_tx_cost) {
         let target_batch_cost = total_cost / target_batch_count;
         let mut batch_cost: u64 = 0;

--- a/ledger/src/token_balances.rs
+++ b/ledger/src/token_balances.rs
@@ -6,7 +6,7 @@ use {
     solana_measure::measure::Measure,
     solana_metrics::datapoint_debug,
     solana_runtime::{bank::Bank, transaction_batch::TransactionBatch},
-    solana_sdk::{account::ReadableAccount, pubkey::Pubkey},
+    solana_sdk::{account::ReadableAccount, pubkey::Pubkey, transaction::SanitizedTransaction},
     solana_transaction_status::{
         token_balances::TransactionTokenBalances, TransactionTokenBalance,
     },
@@ -37,7 +37,7 @@ fn get_mint_decimals(bank: &Bank, mint: &Pubkey) -> Option<u8> {
 
 pub fn collect_token_balances(
     bank: &Bank,
-    batch: &TransactionBatch,
+    batch: &TransactionBatch<SanitizedTransaction>,
     mint_decimals: &mut HashMap<Pubkey, u8>,
 ) -> TransactionTokenBalances {
     let mut balances: TransactionTokenBalances = vec![];

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5742,6 +5742,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-perf",
+ "solana-program",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime-transaction",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5231,6 +5231,7 @@ dependencies = [
  "solana-storage-bigtable",
  "solana-storage-proto",
  "solana-svm",
+ "solana-svm-transaction",
  "solana-timings",
  "solana-transaction-status",
  "solana-vote",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -62,6 +62,7 @@ solana-loader-v4-program = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-perf = { workspace = true }
+solana-program = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-runtime-transaction = { workspace = true }

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -1,4 +1,5 @@
 use {
+    core::borrow::Borrow,
     solana_sdk::{
         account::AccountSharedData, nonce::state::DurableNonce, pubkey::Pubkey,
         transaction::SanitizedTransaction, transaction_context::TransactionAccount,
@@ -49,7 +50,7 @@ fn max_number_of_accounts_to_collect(
 // be useless.
 pub fn collect_accounts_to_store<'a, T: SVMMessage>(
     txs: &'a [T],
-    txs_refs: &'a Option<Vec<impl core::borrow::Borrow<SanitizedTransaction>>>,
+    txs_refs: &'a Option<Vec<impl Borrow<SanitizedTransaction>>>,
     processing_results: &'a mut [TransactionProcessingResult],
     durable_nonce: &DurableNonce,
     lamports_per_signature: u64,

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -1,7 +1,7 @@
 use {
     solana_sdk::{
         account::AccountSharedData, nonce::state::DurableNonce, pubkey::Pubkey,
-        transaction_context::TransactionAccount,
+        transaction::SanitizedTransaction, transaction_context::TransactionAccount,
     },
     solana_svm::{
         rollback_accounts::RollbackAccounts,
@@ -40,22 +40,37 @@ fn max_number_of_accounts_to_collect(
         .sum()
 }
 
+// Due to the current geyser interface, we are forced to collect references to
+// `SanitizedTransaction` - even if that's not the type that we have.
+// Until that interface changes, this function takes in an additional
+// `txs_refs` parameter that collects references to `SanitizedTransaction`
+// if it's provided.
+// If geyser is not used, `txs_refs` should be `None`, since the work would
+// be useless.
 pub fn collect_accounts_to_store<'a, T: SVMMessage>(
     txs: &'a [T],
+    txs_refs: &'a Option<Vec<impl core::borrow::Borrow<SanitizedTransaction>>>,
     processing_results: &'a mut [TransactionProcessingResult],
     durable_nonce: &DurableNonce,
     lamports_per_signature: u64,
-    collect_transactions: bool,
-) -> (Vec<(&'a Pubkey, &'a AccountSharedData)>, Option<Vec<&'a T>>) {
+) -> (
+    Vec<(&'a Pubkey, &'a AccountSharedData)>,
+    Option<Vec<&'a SanitizedTransaction>>,
+) {
     let collect_capacity = max_number_of_accounts_to_collect(txs, processing_results);
     let mut accounts = Vec::with_capacity(collect_capacity);
-    let mut transactions = collect_transactions.then(|| Vec::with_capacity(collect_capacity));
-    for (processing_result, transaction) in processing_results.iter_mut().zip(txs) {
+    let mut transactions = txs_refs
+        .is_some()
+        .then(|| Vec::with_capacity(collect_capacity));
+    for (index, (processing_result, transaction)) in
+        processing_results.iter_mut().zip(txs).enumerate()
+    {
         let Some(processed_tx) = processing_result.processed_transaction_mut() else {
             // Don't store any accounts if tx wasn't executed
             continue;
         };
 
+        let transaction_ref = txs_refs.as_ref().map(|txs_refs| txs_refs[index].borrow());
         match processed_tx {
             ProcessedTransaction::Executed(executed_tx) => {
                 if executed_tx.execution_details.status.is_ok() {
@@ -63,6 +78,7 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
                         &mut accounts,
                         &mut transactions,
                         transaction,
+                        transaction_ref,
                         &executed_tx.loaded_transaction.accounts,
                     );
                 } else {
@@ -70,6 +86,7 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
                         &mut accounts,
                         &mut transactions,
                         transaction,
+                        transaction_ref,
                         &mut executed_tx.loaded_transaction.rollback_accounts,
                         durable_nonce,
                         lamports_per_signature,
@@ -81,6 +98,7 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
                     &mut accounts,
                     &mut transactions,
                     transaction,
+                    transaction_ref,
                     &mut fees_only_tx.rollback_accounts,
                     durable_nonce,
                     lamports_per_signature,
@@ -93,8 +111,9 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
 
 fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
     collected_accounts: &mut Vec<(&'a Pubkey, &'a AccountSharedData)>,
-    collected_account_transactions: &mut Option<Vec<&'a T>>,
+    collected_account_transactions: &mut Option<Vec<&'a SanitizedTransaction>>,
     transaction: &'a T,
+    transaction_ref: Option<&'a SanitizedTransaction>,
     transaction_accounts: &'a [TransactionAccount],
 ) {
     for (_, (address, account)) in (0..transaction.account_keys().len())
@@ -111,15 +130,17 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
     {
         collected_accounts.push((address, account));
         if let Some(collected_account_transactions) = collected_account_transactions {
-            collected_account_transactions.push(transaction);
+            collected_account_transactions
+                .push(transaction_ref.expect("transaction ref must exist if collecting"));
         }
     }
 }
 
 fn collect_accounts_for_failed_tx<'a, T: SVMMessage>(
     collected_accounts: &mut Vec<(&'a Pubkey, &'a AccountSharedData)>,
-    collected_account_transactions: &mut Option<Vec<&'a T>>,
+    collected_account_transactions: &mut Option<Vec<&'a SanitizedTransaction>>,
     transaction: &'a T,
+    transaction_ref: Option<&'a SanitizedTransaction>,
     rollback_accounts: &'a mut RollbackAccounts,
     durable_nonce: &DurableNonce,
     lamports_per_signature: u64,
@@ -129,7 +150,8 @@ fn collect_accounts_for_failed_tx<'a, T: SVMMessage>(
         RollbackAccounts::FeePayerOnly { fee_payer_account } => {
             collected_accounts.push((fee_payer_address, &*fee_payer_account));
             if let Some(collected_account_transactions) = collected_account_transactions {
-                collected_account_transactions.push(transaction);
+                collected_account_transactions
+                    .push(transaction_ref.expect("transaction ref must exist if collecting"));
             }
         }
         RollbackAccounts::SameNonceAndFeePayer { nonce } => {
@@ -140,7 +162,8 @@ fn collect_accounts_for_failed_tx<'a, T: SVMMessage>(
                 .unwrap();
             collected_accounts.push((nonce.address(), nonce.account()));
             if let Some(collected_account_transactions) = collected_account_transactions {
-                collected_account_transactions.push(transaction);
+                collected_account_transactions
+                    .push(transaction_ref.expect("transaction ref must exist if collecting"));
             }
         }
         RollbackAccounts::SeparateNonceAndFeePayer {
@@ -149,7 +172,8 @@ fn collect_accounts_for_failed_tx<'a, T: SVMMessage>(
         } => {
             collected_accounts.push((fee_payer_address, &*fee_payer_account));
             if let Some(collected_account_transactions) = collected_account_transactions {
-                collected_account_transactions.push(transaction);
+                collected_account_transactions
+                    .push(transaction_ref.expect("transaction ref must exist if collecting"));
             }
 
             // Since we know we are dealing with a valid nonce account,
@@ -159,7 +183,8 @@ fn collect_accounts_for_failed_tx<'a, T: SVMMessage>(
                 .unwrap();
             collected_accounts.push((nonce.address(), nonce.account()));
             if let Some(collected_account_transactions) = collected_account_transactions {
-                collected_account_transactions.push(transaction);
+                collected_account_transactions
+                    .push(transaction_ref.expect("transaction ref must exist if collecting"));
             }
         }
     }
@@ -297,12 +322,13 @@ mod tests {
         assert_eq!(max_collected_accounts, 2);
 
         for collect_transactions in [false, true] {
+            let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
             let (collected_accounts, transactions) = collect_accounts_to_store(
                 &txs,
+                &transaction_refs,
                 &mut processing_results,
                 &DurableNonce::default(),
                 0,
-                collect_transactions,
             );
             assert_eq!(collected_accounts.len(), 2);
             assert!(collected_accounts
@@ -368,12 +394,13 @@ mod tests {
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
 
         for collect_transactions in [false, true] {
+            let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
             let (collected_accounts, transactions) = collect_accounts_to_store(
                 &txs,
+                &transaction_refs,
                 &mut processing_results,
                 &durable_nonce,
                 0,
-                collect_transactions,
             );
             assert_eq!(collected_accounts.len(), 1);
             assert_eq!(
@@ -468,12 +495,13 @@ mod tests {
         assert_eq!(max_collected_accounts, 2);
 
         for collect_transactions in [false, true] {
+            let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
             let (collected_accounts, transactions) = collect_accounts_to_store(
                 &txs,
+                &transaction_refs,
                 &mut processing_results,
                 &durable_nonce,
                 0,
-                collect_transactions,
             );
             assert_eq!(collected_accounts.len(), 2);
             assert_eq!(
@@ -581,12 +609,13 @@ mod tests {
         assert_eq!(max_collected_accounts, 1);
 
         for collect_transactions in [false, true] {
+            let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
             let (collected_accounts, transactions) = collect_accounts_to_store(
                 &txs,
+                &transaction_refs,
                 &mut processing_results,
                 &durable_nonce,
                 0,
-                collect_transactions,
             );
             assert_eq!(collected_accounts.len(), 1);
             let collected_nonce_account = collected_accounts
@@ -642,12 +671,13 @@ mod tests {
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
 
         for collect_transactions in [false, true] {
+            let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
             let (collected_accounts, transactions) = collect_accounts_to_store(
                 &txs,
+                &transaction_refs,
                 &mut processing_results,
                 &durable_nonce,
                 0,
-                collect_transactions,
             );
             assert_eq!(collected_accounts.len(), 1);
             assert_eq!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3425,9 +3425,9 @@ impl Bank {
         account_overrides
     }
 
-    pub fn unlock_accounts<'a>(
+    pub fn unlock_accounts<'a, Tx: SVMMessage + 'a>(
         &self,
-        txs_and_results: impl Iterator<Item = (&'a SanitizedTransaction, &'a Result<()>)> + Clone,
+        txs_and_results: impl Iterator<Item = (&'a Tx, &'a Result<()>)> + Clone,
     ) {
         self.rc.accounts.unlock_accounts(txs_and_results)
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4612,7 +4612,7 @@ impl Bank {
     #[must_use]
     pub fn load_execute_and_commit_transactions(
         &self,
-        batch: &TransactionBatch<SanitizedTransaction>,
+        batch: &TransactionBatch<impl SVMTransactionAdapter>,
         max_age: usize,
         collect_balances: bool,
         recording_config: ExecutionRecordingConfig,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3451,12 +3451,12 @@ impl Bank {
 
     pub fn collect_balances(
         &self,
-        batch: &TransactionBatch<SanitizedTransaction>,
+        batch: &TransactionBatch<impl SVMMessage>,
     ) -> TransactionBalances {
         let mut balances: TransactionBalances = vec![];
         for transaction in batch.sanitized_transactions() {
             let mut transaction_balances: Vec<u64> = vec![];
-            for account_key in transaction.message().account_keys().iter() {
+            for account_key in transaction.account_keys().iter() {
                 transaction_balances.push(self.get_balance(account_key));
             }
             balances.push(transaction_balances);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3805,12 +3805,22 @@ impl Bank {
 
         let ((), store_accounts_us) = measure_us!({
             let durable_nonce = DurableNonce::from_blockhash(&last_blockhash);
+
+            // If geyser is present, we must collect `SanitizedTransaction`
+            // references in order to comply with that interface - until it
+            // is changed.
+            let maybe_transaction_refs = self
+                .accounts()
+                .accounts_db
+                .has_accounts_update_notifier()
+                .then(|| sanitized_txs.iter().collect::<Vec<_>>());
+
             let (accounts_to_store, transactions) = collect_accounts_to_store(
                 sanitized_txs,
+                &maybe_transaction_refs,
                 &mut processing_results,
                 &durable_nonce,
                 lamports_per_signature,
-                self.accounts().accounts_db.has_accounts_update_notifier(),
             );
             self.rc.accounts.store_cached(
                 (self.slot(), accounts_to_store.as_slice()),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -56,6 +56,7 @@ use {
         },
         stakes::{InvalidCacheEntryReason, Stakes, StakesCache, StakesEnum},
         status_cache::{SlotDelta, StatusCache},
+        svm_transaction_adapter::SVMTransactionAdapter,
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
     byteorder::{ByteOrder, LittleEndian},
@@ -3567,7 +3568,7 @@ impl Bank {
 
     fn collect_logs(
         &self,
-        transactions: &[SanitizedTransaction],
+        transactions: &[impl SVMTransactionAdapter],
         processing_results: &[TransactionProcessingResult],
     ) {
         let transaction_log_collector_config =
@@ -3610,7 +3611,7 @@ impl Bank {
 
     fn collect_transaction_logs(
         transaction_log_collector_config: &TransactionLogCollectorConfig,
-        transaction: &SanitizedTransaction,
+        transaction: &impl SVMTransactionAdapter,
         execution_details: &TransactionExecutionDetails,
     ) -> Option<(TransactionLogInfo, Vec<Pubkey>)> {
         // Skip log collection if no log messages were recorded
@@ -3621,7 +3622,7 @@ impl Bank {
             .mentioned_addresses
             .is_empty()
         {
-            for key in transaction.message().account_keys().iter() {
+            for key in transaction.account_keys().iter() {
                 if transaction_log_collector_config
                     .mentioned_addresses
                     .contains(key)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -56,7 +56,7 @@ use {
         },
         stakes::{InvalidCacheEntryReason, Stakes, StakesCache, StakesEnum},
         status_cache::{SlotDelta, StatusCache},
-        transaction_batch::TransactionBatch,
+        transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
     byteorder::{ByteOrder, LittleEndian},
     dashmap::{DashMap, DashSet},
@@ -175,7 +175,6 @@ use {
     solana_vote::vote_account::{VoteAccount, VoteAccountsHashMap},
     solana_vote_program::vote_state::VoteState,
     std::{
-        borrow::Cow,
         collections::{HashMap, HashSet},
         convert::TryFrom,
         fmt,
@@ -3254,7 +3253,7 @@ impl Bank {
         Ok(TransactionBatch::new(
             lock_results,
             self,
-            Cow::Owned(sanitized_txs),
+            OwnedOrBorrowed::Owned(sanitized_txs),
         ))
     }
 
@@ -3268,7 +3267,7 @@ impl Bank {
             .rc
             .accounts
             .lock_accounts(txs.iter(), tx_account_lock_limit);
-        TransactionBatch::new(lock_results, self, Cow::Borrowed(txs))
+        TransactionBatch::new(lock_results, self, OwnedOrBorrowed::Borrowed(txs))
     }
 
     /// Prepare a locked transaction batch from a list of sanitized transactions, and their cost
@@ -3285,7 +3284,7 @@ impl Bank {
             transaction_results,
             tx_account_lock_limit,
         );
-        TransactionBatch::new(lock_results, self, Cow::Borrowed(transactions))
+        TransactionBatch::new(lock_results, self, OwnedOrBorrowed::Borrowed(transactions))
     }
 
     /// Prepare a transaction batch from a single transaction without locking accounts
@@ -3299,7 +3298,7 @@ impl Bank {
         let mut batch = TransactionBatch::new(
             vec![lock_result],
             self,
-            Cow::Borrowed(slice::from_ref(transaction)),
+            OwnedOrBorrowed::Borrowed(slice::from_ref(transaction)),
         );
         batch.set_needs_unlock(false);
         batch
@@ -6708,7 +6707,7 @@ impl Bank {
             .rc
             .accounts
             .lock_accounts(sanitized_txs.iter(), transaction_account_lock_limit);
-        TransactionBatch::new(lock_results, self, Cow::Owned(sanitized_txs))
+        TransactionBatch::new(lock_results, self, OwnedOrBorrowed::Owned(sanitized_txs))
     }
 
     /// Set the initial accounts data size

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,6 +34,7 @@ pub mod stake_weighted_timestamp;
 pub mod stakes;
 pub mod static_ids;
 pub mod status_cache;
+pub mod svm_transaction_adapter;
 pub mod transaction_batch;
 pub mod vote_sender_types;
 

--- a/runtime/src/svm_transaction_adapter.rs
+++ b/runtime/src/svm_transaction_adapter.rs
@@ -1,0 +1,49 @@
+use {
+    solana_sdk::{
+        hash::Hash,
+        transaction::{SanitizedTransaction, VersionedTransaction},
+    },
+    solana_svm_transaction::svm_transaction::SVMTransaction,
+};
+
+/// This trait is intended to be temporary.
+/// It is required now because certain interfaces in `runtime` and `core`
+/// currently force the use of old/sdk transaction types.
+/// During the transition to a new transaction type, these interfaces will
+/// not yet be updated to have a more generic interface.
+/// As such this trait is used to bridge the gap between the old and new
+/// transaction types - the main processing pipelines can be updated
+/// to be generic over a transaction interface while still allowing the
+/// necessary conversions when the interfaces forcing old transaction types
+/// are invoked.
+pub trait SVMTransactionAdapter: SVMTransaction {
+    /// Convert to a `SanitizedTransaction`.
+    fn to_sanitized_transaction(&self) -> SanitizedTransaction;
+    /// Convert to a `VersionedTransaction`.
+    fn to_versioned_transaction(&self) -> VersionedTransaction;
+
+    // Below are temprorary methods that will be removed
+    // after transition to `RuntimeTransaction`.
+
+    /// Get the message hash.
+    fn message_hash(&self) -> &Hash;
+    fn is_simple_vote_transaction(&self) -> bool;
+}
+
+impl SVMTransactionAdapter for SanitizedTransaction {
+    fn to_sanitized_transaction(&self) -> SanitizedTransaction {
+        self.clone()
+    }
+
+    fn to_versioned_transaction(&self) -> VersionedTransaction {
+        self.to_versioned_transaction()
+    }
+
+    fn message_hash(&self) -> &Hash {
+        self.message_hash()
+    }
+
+    fn is_simple_vote_transaction(&self) -> bool {
+        self.is_simple_vote_transaction()
+    }
+}

--- a/runtime/src/svm_transaction_adapter.rs
+++ b/runtime/src/svm_transaction_adapter.rs
@@ -1,4 +1,5 @@
 use {
+    core::borrow::Borrow,
     solana_sdk::{
         hash::Hash,
         transaction::{SanitizedTransaction, VersionedTransaction},
@@ -17,8 +18,8 @@ use {
 /// necessary conversions when the interfaces forcing old transaction types
 /// are invoked.
 pub trait SVMTransactionAdapter: SVMTransaction {
-    /// Convert to a `SanitizedTransaction`.
-    fn to_sanitized_transaction(&self) -> SanitizedTransaction;
+    /// Convert to something that can be borrowed as a `SanitizedTransaction`.
+    fn to_sanitized_transaction(&self) -> impl Borrow<SanitizedTransaction>;
     /// Convert to a `VersionedTransaction`.
     fn to_versioned_transaction(&self) -> VersionedTransaction;
 
@@ -31,8 +32,8 @@ pub trait SVMTransactionAdapter: SVMTransaction {
 }
 
 impl SVMTransactionAdapter for SanitizedTransaction {
-    fn to_sanitized_transaction(&self) -> SanitizedTransaction {
-        self.clone()
+    fn to_sanitized_transaction(&self) -> impl Borrow<SanitizedTransaction> {
+        self
     }
 
     fn to_versioned_transaction(&self) -> VersionedTransaction {

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -1,6 +1,6 @@
 use {
     crate::bank::Bank, solana_sdk::transaction::Result,
-    solana_svm_transaction::svm_transaction::SVMTransaction,
+    solana_svm_transaction::svm_message::SVMMessage,
 };
 
 pub enum OwnedOrBorrowed<'a, T> {
@@ -20,14 +20,14 @@ impl<T> core::ops::Deref for OwnedOrBorrowed<'_, T> {
 }
 
 // Represents the results of trying to lock a set of accounts
-pub struct TransactionBatch<'a, 'b, Tx: SVMTransaction> {
+pub struct TransactionBatch<'a, 'b, Tx: SVMMessage> {
     lock_results: Vec<Result<()>>,
     bank: &'a Bank,
     sanitized_txs: OwnedOrBorrowed<'b, Tx>,
     needs_unlock: bool,
 }
 
-impl<'a, 'b, Tx: SVMTransaction> TransactionBatch<'a, 'b, Tx> {
+impl<'a, 'b, Tx: SVMMessage> TransactionBatch<'a, 'b, Tx> {
     pub fn new(
         lock_results: Vec<Result<()>>,
         bank: &'a Bank,
@@ -97,7 +97,7 @@ impl<'a, 'b, Tx: SVMTransaction> TransactionBatch<'a, 'b, Tx> {
 }
 
 // Unlock all locked accounts in destructor.
-impl<'a, 'b, Tx: SVMTransaction> Drop for TransactionBatch<'a, 'b, Tx> {
+impl<'a, 'b, Tx: SVMMessage> Drop for TransactionBatch<'a, 'b, Tx> {
     fn drop(&mut self) {
         if self.needs_unlock() {
             self.set_needs_unlock(false);

--- a/sdk/program/src/program_utils.rs
+++ b/sdk/program/src/program_utils.rs
@@ -25,7 +25,7 @@ pub mod tests {
     #[test]
     fn test_limited_deserialize_advance_nonce_account() {
         let item = SystemInstruction::AdvanceNonceAccount;
-        let serialized = bincode::serialize(&item).unwrap();
+        let mut serialized = bincode::serialize(&item).unwrap();
 
         assert_eq!(
             serialized.len(),
@@ -38,5 +38,11 @@ pub mod tests {
             Ok(&item)
         );
         assert!(limited_deserialize::<SystemInstruction>(&serialized, 3).is_err());
+
+        serialized.push(0);
+        assert_eq!(
+            limited_deserialize::<SystemInstruction>(&serialized, 4).as_ref(),
+            Ok(&item)
+        );
     }
 }


### PR DESCRIPTION
#### Problem
- In order to allow a new transaction type (see #2198) bank's processing functions must be able to handle the new and old transaction types

#### Summary of Changes
- Make bank generic over traits for the transaction type
- This PR is not meant to be merged. Series of smaller changes are being split out of this, but want to have a PR posted so I can reference the eventual usage

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
