### PR TITLE
Vote Bug Fix: Include all valid votes

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -644,7 +644,7 @@ impl Tower {
         let old_root = self.root();
 
         let vote = Vote::new(vec![vote_slot], vote_hash);
-        let result = process_vote_unchecked(&mut self.vote_state, vote);
+        let result = process_vote_unchecked(&mut self.vote_state, vote, parent_slot);
         if result.is_err() {
             panic!(
                 "Error while recording vote {} {} in local tower {:?}",

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -595,6 +595,7 @@ impl Tower {
             bank.hash(),
             bank.feature_set
                 .is_active(&feature_set::enable_tower_sync_ix::id()),
+            0,
         )
     }
 
@@ -637,6 +638,7 @@ impl Tower {
         vote_slot: Slot,
         vote_hash: Hash,
         enable_tower_sync_ix: bool,
+        parent_slot: u64,
     ) -> Option<Slot> {
         trace!("{} record_vote for {}", self.node_pubkey, vote_slot);
         let old_root = self.root();
@@ -667,7 +669,7 @@ impl Tower {
 
     #[cfg(feature = "dev-context-only-utils")]
     pub fn record_vote(&mut self, slot: Slot, hash: Hash) -> Option<Slot> {
-        self.record_bank_vote_and_update_lockouts(slot, hash, true)
+        self.record_bank_vote_and_update_lockouts(slot, hash, true, 0)
     }
 
     /// Used for tests

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -111,6 +111,7 @@ impl VoteSimulator {
                                 vec![parent],
                                 parent_bank.hash(),
                             ),
+                            0,
                         )
                         .unwrap();
                         TowerSync::new(

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -49,7 +49,7 @@ fn create_accounts() -> (Slot, SlotHashes, Vec<TransactionAccount>, Vec<AccountM
         );
 
         for next_vote_slot in 0..num_initial_votes {
-            vote_state.process_next_vote_slot(next_vote_slot, 0, 0, true);
+            vote_state.process_next_vote_slot(next_vote_slot, 0, 0, true, 0);
         }
         let mut vote_account_data: Vec<u8> = vec![0; VoteState::size_of()];
         let versioned = VoteStateVersions::new_current(vote_state);

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -749,10 +749,11 @@ pub fn process_vote_unfiltered(
     epoch: Epoch,
     current_slot: Slot,
     timely_vote_credits: bool,
+    parent_slot: u64,
 ) -> Result<(), VoteError> {
     check_slots_are_valid(vote_state, vote_slots, &vote.hash, slot_hashes)?;
     vote_slots.iter().for_each(|s| {
-        vote_state.process_next_vote_slot(*s, epoch, current_slot, timely_vote_credits)
+        vote_state.process_next_vote_slot(*s, epoch, current_slot, timely_vote_credits, parent_slot)
     });
     Ok(())
 }
@@ -786,11 +787,16 @@ pub fn process_vote(
         epoch,
         current_slot,
         timely_vote_credits,
+        0,
     )
 }
 
 /// "unchecked" functions used by tests and Tower
-pub fn process_vote_unchecked(vote_state: &mut VoteState, vote: Vote) -> Result<(), VoteError> {
+pub fn process_vote_unchecked(
+    vote_state: &mut VoteState,
+    vote: Vote,
+    parent_slot: u64,
+) -> Result<(), VoteError> {
     if vote.slots.is_empty() {
         return Err(VoteError::EmptySlots);
     }
@@ -803,6 +809,7 @@ pub fn process_vote_unchecked(vote_state: &mut VoteState, vote: Vote) -> Result<
         vote_state.current_epoch(),
         0,
         true,
+        parent_slot,
     )
 }
 
@@ -814,7 +821,7 @@ pub fn process_slot_votes_unchecked(vote_state: &mut VoteState, slots: &[Slot]) 
 }
 
 pub fn process_slot_vote_unchecked(vote_state: &mut VoteState, slot: Slot) {
-    let _ = process_vote_unchecked(vote_state, Vote::new(vec![slot], Hash::default()));
+    let _ = process_vote_unchecked(vote_state, Vote::new(vec![slot], Hash::default()), 0);
 }
 
 /// Authorize the given pubkey to withdraw or sign votes. This may be called multiple times,
@@ -1320,7 +1327,7 @@ mod tests {
             134, 135,
         ]
         .into_iter()
-        .for_each(|v| vote_state.process_next_vote_slot(v, 4, 0, false));
+        .for_each(|v| vote_state.process_next_vote_slot(v, 4, 0, false, 0));
 
         let version1_14_11_serialized = bincode::serialize(&VoteStateVersions::V1_14_11(Box::new(
             VoteState1_14_11::from(vote_state.clone()),
@@ -2016,6 +2023,7 @@ mod tests {
                     hash: Hash::new_unique(),
                     timestamp: None,
                 },
+                0,
             )
             .unwrap();
 
@@ -3159,8 +3167,17 @@ mod tests {
                 .unwrap()
                 .1;
             let vote = Vote::new(vote_slots, vote_hash);
-            process_vote_unfiltered(&mut vote_state, &vote.slots, &vote, slot_hashes, 0, 0, true)
-                .unwrap();
+            process_vote_unfiltered(
+                &mut vote_state,
+                &vote.slots,
+                &vote,
+                slot_hashes,
+                0,
+                0,
+                true,
+                0,
+            )
+            .unwrap();
         }
 
         vote_state

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -698,6 +698,7 @@ impl VoteState {
         epoch: Epoch,
         current_slot: Slot,
         timely_vote_credits: bool,
+        parent_slot: u64,
     ) {
         // Ignore votes for slots earlier than we already have votes for
         if self
@@ -707,7 +708,7 @@ impl VoteState {
             return;
         }
 
-        self.pop_expired_votes(next_vote_slot);
+        self.pop_expired_votes(next_vote_slot, parent_slot);
 
         let landed_vote = LandedVote {
             latency: if timely_vote_credits {
@@ -927,9 +928,11 @@ impl VoteState {
     // allows validators to switch forks once their votes for another fork have
     // expired. This also allows validators continue voting on recent blocks in
     // the same fork without increasing lockouts.
-    pub fn pop_expired_votes(&mut self, next_vote_slot: Slot) {
+    pub fn pop_expired_votes(&mut self, next_vote_slot: Slot, parent_slot: u64) {
         while let Some(vote) = self.last_lockout() {
-            if !vote.is_locked_out_at_slot(next_vote_slot) {
+            if !vote.is_locked_out_at_slot(next_vote_slot)
+                && (parent_slot == 0 || vote.slot != parent_slot)
+            {
                 self.votes.pop_back();
             } else {
                 break;


### PR DESCRIPTION
#### Problem
Solana validators drop votes from their votes vector which they have already voted on, resulting in missed credits even though they voted on valid slots. This results in 1-2% lower vote credits.

Vote credits [are earned](https://github.com/anza-xyz/agave/blob/5716b7ea1eacf859a8769277fc6294717ba11398/sdk/program/src/vote/state/mod.rs#L721-L728) when `votes.len() == MAX_LOCKOUT_HISTORY`. Validators do not include all of their valid votes, effectively missing vote credits.

As an example, a validator votes on slots `100, 101, 102, .. 105, 106`. Without this fix, its vote vector will be missing `101 & 102` and not receive credit for that slot because the vote was popped when it did not need to be.

#### Summary of Changes

Modify `pop_expired_votes` to consider the parent slot `sdk/program/src/vote/state/mod.rs`. This prevents votes for a particular parent slot from being popped when that slot matches parent_slot of the current slot, which means it's a valid parent that was already voted on.

#### Credit

- Zantetsu / Shinobi Systems for pioneering and sharing high level information around the vote credit bug openly in discord. Zan's alternative solution is here: https://github.com/bji/solana/commit/915909fc8539d4df7cc11ba14226ad6247c53cdb
- Kiethy / Solstice Validator (https://github.com/Spud957) for ideating and working on the fix in this PR together.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
