### PR TITLE
runtime-transaction: get_signature_details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7722,6 +7722,7 @@ dependencies = [
  "solana-builtins-default-costs",
  "solana-compute-budget",
  "solana-program",
+ "solana-pubkey",
  "solana-sdk",
  "solana-svm-transaction",
  "thiserror",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6049,6 +6049,7 @@ dependencies = [
  "log",
  "solana-builtins-default-costs",
  "solana-compute-budget",
+ "solana-pubkey",
  "solana-sdk",
  "solana-svm-transaction",
  "thiserror",

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -35,5 +35,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 name = "process_compute_budget_instructions"
 harness = false
 
+[[bench]]
+name = "get_signature_details"
+harness = false
+
 [lints]
 workspace = true

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -14,6 +14,7 @@ agave-transaction-view = { workspace = true }
 log = { workspace = true }
 solana-builtins-default-costs = { workspace = true }
 solana-compute-budget = { workspace = true }
+solana-pubkey = { workspace = true }
 solana-sdk = { workspace = true }
 solana-svm-transaction = { workspace = true }
 thiserror = { workspace = true }

--- a/runtime-transaction/benches/get_signature_details.rs
+++ b/runtime-transaction/benches/get_signature_details.rs
@@ -1,0 +1,132 @@
+use {
+    criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput},
+    solana_runtime_transaction::signature_details::get_signature_details,
+    solana_sdk::{instruction::CompiledInstruction, pubkey::Pubkey},
+    solana_svm_transaction::instruction::SVMInstruction,
+};
+
+fn bench_get_signature_details_empty(c: &mut Criterion) {
+    let instructions = std::iter::empty();
+
+    c.benchmark_group("bench_get_signature_details_empty")
+        .throughput(Throughput::Elements(1))
+        .bench_function("0 instructions", |bencher| {
+            bencher.iter(|| {
+                let instructions = black_box(instructions.clone());
+                let _ = get_signature_details(0, instructions);
+            });
+        });
+}
+
+fn bench_get_signature_details_no_sigs_unique(c: &mut Criterion) {
+    let program_ids = vec![Pubkey::new_unique(); 32];
+    for num_instructions in [4, 32] {
+        let instructions = (0..num_instructions)
+            .map(|i| {
+                let program_id = &program_ids[i];
+                (
+                    program_id,
+                    CompiledInstruction {
+                        program_id_index: i as u8,
+                        accounts: vec![],
+                        data: vec![],
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+
+        c.benchmark_group("bench_get_signature_details_no_sigs_unique")
+            .throughput(Throughput::Elements(1))
+            .bench_function(&format!("{num_instructions} instructions"), |bencher| {
+                bencher.iter(|| {
+                    let instructions =
+                        black_box(instructions.iter().map(|(program_id, instruction)| {
+                            (*program_id, SVMInstruction::from(instruction))
+                        }));
+                    let _ = get_signature_details(0, instructions);
+                });
+            });
+    }
+}
+
+fn bench_get_signature_details_packed_sigs(c: &mut Criterion) {
+    let program_ids = vec![
+        solana_sdk::secp256k1_program::id(),
+        solana_sdk::ed25519_program::id(),
+    ];
+    for num_instructions in [4, 64] {
+        let instructions = (0..num_instructions)
+            .map(|i| {
+                let index = i % 2;
+                let program_id = &program_ids[index];
+                (
+                    program_id,
+                    CompiledInstruction {
+                        program_id_index: index as u8,
+                        accounts: vec![],
+                        data: vec![4], // some dummy number of signatures
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+
+        c.benchmark_group("bench_get_signature_details_packed_sigs")
+            .throughput(Throughput::Elements(1))
+            .bench_function(&format!("{num_instructions} instructions"), |bencher| {
+                bencher.iter(|| {
+                    let instructions =
+                        black_box(instructions.iter().map(|(program_id, instruction)| {
+                            (*program_id, SVMInstruction::from(instruction))
+                        }));
+                    let _ = get_signature_details(0, instructions);
+                });
+            });
+    }
+}
+
+fn bench_get_signature_details_mixed_sigs(c: &mut Criterion) {
+    let program_ids = [
+        solana_sdk::secp256k1_program::id(),
+        solana_sdk::ed25519_program::id(),
+    ]
+    .into_iter()
+    .chain((0..6).map(|_| Pubkey::new_unique()))
+    .collect::<Vec<_>>();
+    for num_instructions in [4, 64] {
+        let instructions = (0..num_instructions)
+            .map(|i| {
+                let index = i % 8;
+                let program_id = &program_ids[index];
+                (
+                    program_id,
+                    CompiledInstruction {
+                        program_id_index: index as u8,
+                        accounts: vec![],
+                        data: vec![4], // some dummy number of signatures
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+
+        c.benchmark_group("bench_get_signature_details_mixed_sigs")
+            .throughput(Throughput::Elements(1))
+            .bench_function(&format!("{num_instructions} instructions"), |bencher| {
+                bencher.iter(|| {
+                    let instructions =
+                        black_box(instructions.iter().map(|(program_id, instruction)| {
+                            (*program_id, SVMInstruction::from(instruction))
+                        }));
+                    let _ = get_signature_details(0, instructions);
+                });
+            });
+    }
+}
+
+criterion_group!(
+    benches,
+    bench_get_signature_details_empty,
+    bench_get_signature_details_no_sigs_unique,
+    bench_get_signature_details_packed_sigs,
+    bench_get_signature_details_mixed_sigs
+);
+criterion_main!(benches);

--- a/runtime-transaction/benches/get_signature_details.rs
+++ b/runtime-transaction/benches/get_signature_details.rs
@@ -1,6 +1,6 @@
 use {
     criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput},
-    solana_runtime_transaction::signature_details::get_signature_details,
+    solana_runtime_transaction::signature_details::get_precompile_signature_details,
     solana_sdk::{instruction::CompiledInstruction, pubkey::Pubkey},
     solana_svm_transaction::instruction::SVMInstruction,
 };
@@ -13,7 +13,7 @@ fn bench_get_signature_details_empty(c: &mut Criterion) {
         .bench_function("0 instructions", |bencher| {
             bencher.iter(|| {
                 let instructions = black_box(instructions.clone());
-                let _ = get_signature_details(0, instructions);
+                let _ = get_precompile_signature_details(instructions);
             });
         });
 }
@@ -43,7 +43,7 @@ fn bench_get_signature_details_no_sigs_unique(c: &mut Criterion) {
                         black_box(instructions.iter().map(|(program_id, instruction)| {
                             (*program_id, SVMInstruction::from(instruction))
                         }));
-                    let _ = get_signature_details(0, instructions);
+                    let _ = get_precompile_signature_details(instructions);
                 });
             });
     }
@@ -78,7 +78,7 @@ fn bench_get_signature_details_packed_sigs(c: &mut Criterion) {
                         black_box(instructions.iter().map(|(program_id, instruction)| {
                             (*program_id, SVMInstruction::from(instruction))
                         }));
-                    let _ = get_signature_details(0, instructions);
+                    let _ = get_precompile_signature_details(instructions);
                 });
             });
     }
@@ -116,7 +116,7 @@ fn bench_get_signature_details_mixed_sigs(c: &mut Criterion) {
                         black_box(instructions.iter().map(|(program_id, instruction)| {
                             (*program_id, SVMInstruction::from(instruction))
                         }));
-                    let _ = get_signature_details(0, instructions);
+                    let _ = get_precompile_signature_details(instructions);
                 });
             });
     }

--- a/runtime-transaction/benches/get_signature_details.rs
+++ b/runtime-transaction/benches/get_signature_details.rs
@@ -37,7 +37,7 @@ fn bench_get_signature_details_no_sigs_unique(c: &mut Criterion) {
 
         c.benchmark_group("bench_get_signature_details_no_sigs_unique")
             .throughput(Throughput::Elements(1))
-            .bench_function(&format!("{num_instructions} instructions"), |bencher| {
+            .bench_function(format!("{num_instructions} instructions"), |bencher| {
                 bencher.iter(|| {
                     let instructions =
                         black_box(instructions.iter().map(|(program_id, instruction)| {
@@ -50,7 +50,7 @@ fn bench_get_signature_details_no_sigs_unique(c: &mut Criterion) {
 }
 
 fn bench_get_signature_details_packed_sigs(c: &mut Criterion) {
-    let program_ids = vec![
+    let program_ids = [
         solana_sdk::secp256k1_program::id(),
         solana_sdk::ed25519_program::id(),
     ];
@@ -72,7 +72,7 @@ fn bench_get_signature_details_packed_sigs(c: &mut Criterion) {
 
         c.benchmark_group("bench_get_signature_details_packed_sigs")
             .throughput(Throughput::Elements(1))
-            .bench_function(&format!("{num_instructions} instructions"), |bencher| {
+            .bench_function(format!("{num_instructions} instructions"), |bencher| {
                 bencher.iter(|| {
                     let instructions =
                         black_box(instructions.iter().map(|(program_id, instruction)| {
@@ -110,7 +110,7 @@ fn bench_get_signature_details_mixed_sigs(c: &mut Criterion) {
 
         c.benchmark_group("bench_get_signature_details_mixed_sigs")
             .throughput(Throughput::Elements(1))
-            .bench_function(&format!("{num_instructions} instructions"), |bencher| {
+            .bench_function(format!("{num_instructions} instructions"), |bencher| {
                 bencher.iter(|| {
                     let instructions =
                         black_box(instructions.iter().map(|(program_id, instruction)| {

--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -5,4 +5,5 @@ mod compute_budget_instruction_details;
 mod compute_budget_program_id_filter;
 pub mod instructions_processor;
 pub mod runtime_transaction;
+pub mod signature_details;
 pub mod transaction_meta;

--- a/runtime-transaction/src/signature_details.rs
+++ b/runtime-transaction/src/signature_details.rs
@@ -1,0 +1,91 @@
+// static account keys has max
+use {
+    agave_transaction_view::static_account_keys_frame::MAX_STATIC_ACCOUNTS_PER_PACKET as FILTER_SIZE,
+    solana_sdk::{message::TransactionSignatureDetails, pubkey::Pubkey},
+    solana_svm_transaction::instruction::SVMInstruction,
+};
+
+/// Get transaction signature details.
+pub fn get_signature_details<'a>(
+    num_transaction_signatures: u64,
+    instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
+) -> TransactionSignatureDetails {
+    let mut filter = SignatureDetailsFilter::new();
+
+    // Wrapping arithmetic is safe below because the maximum number of signatures
+    // per instruction is 255, and the maximum number of instructions per transaction
+    // is low enough that the sum of all signatures will not overflow a u64.
+    let mut num_secp256k1_instruction_signatures: u64 = 0;
+    let mut num_ed25519_instruction_signatures: u64 = 0;
+    for (program_id, instruction) in instructions {
+        let program_id_index = instruction.program_id_index;
+        match filter.is_signature(program_id_index, program_id) {
+            ProgramIdStatus::NotSignature => {}
+            ProgramIdStatus::Secp256k1 => {
+                num_secp256k1_instruction_signatures = num_secp256k1_instruction_signatures
+                    .wrapping_add(u64::from(get_num_signatures_in_instruction(&instruction)));
+            }
+            ProgramIdStatus::Ed25519 => {
+                num_ed25519_instruction_signatures = num_ed25519_instruction_signatures
+                    .wrapping_add(u64::from(get_num_signatures_in_instruction(&instruction)));
+            }
+        }
+    }
+
+    TransactionSignatureDetails::new(
+        num_transaction_signatures,
+        num_secp256k1_instruction_signatures,
+        num_ed25519_instruction_signatures,
+    )
+}
+
+#[inline]
+fn get_num_signatures_in_instruction(instruction: &SVMInstruction) -> u8 {
+    instruction.data.first().copied().unwrap_or(0)
+}
+
+#[derive(Copy, Clone)]
+enum ProgramIdStatus {
+    NotSignature,
+    Secp256k1,
+    Ed25519,
+}
+
+struct SignatureDetailsFilter {
+    // array of slots for all possible static and sanitized program_id_index,
+    // each slot indicates if a program_id_index has not been checked, or is
+    // already checked with result that can be reused.
+    flags: [Option<ProgramIdStatus>; FILTER_SIZE as usize],
+}
+
+impl SignatureDetailsFilter {
+    #[inline]
+    fn new() -> Self {
+        Self {
+            flags: [None; FILTER_SIZE as usize],
+        }
+    }
+
+    #[inline]
+    fn is_signature(&mut self, index: u8, program_id: &Pubkey) -> ProgramIdStatus {
+        let flag = &mut self.flags[usize::from(index)];
+        match flag {
+            Some(status) => *status,
+            None => {
+                *flag = Some(Self::check_program_id(program_id));
+                *flag.as_ref().unwrap()
+            }
+        }
+    }
+
+    #[inline]
+    fn check_program_id(program_id: &Pubkey) -> ProgramIdStatus {
+        if program_id == &solana_sdk::secp256k1_program::ID {
+            ProgramIdStatus::Secp256k1
+        } else if program_id == &solana_sdk::ed25519_program::ID {
+            ProgramIdStatus::Ed25519
+        } else {
+            ProgramIdStatus::NotSignature
+        }
+    }
+}

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -433,6 +433,18 @@ pub struct TransactionSignatureDetails {
 }
 
 impl TransactionSignatureDetails {
+    pub fn new(
+        num_transaction_signatures: u64,
+        num_secp256k1_instruction_signatures: u64,
+        num_ed25519_instruction_signatures: u64,
+    ) -> Self {
+        Self {
+            num_transaction_signatures,
+            num_secp256k1_instruction_signatures,
+            num_ed25519_instruction_signatures,
+        }
+    }
+
     /// return total number of signature, treating pre-processor operations as signature
     pub(crate) fn total_signatures(&self) -> u64 {
         self.num_transaction_signatures


### PR DESCRIPTION
#### Problem
- Cannot get signature details easily for non-SanitizedMessage types

#### Summary of Changes
- Add `get_signature_details` to `RuntimeTransaction` (eventually this will be stashed)
- Avoid re-checking already checked keys using similar approach to ComputeBudget
- eventually this will be cached as meta on the `RuntimeTransaction`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
