### PR TITLE
Rework the validator scan-for-incorrect-shred-version function

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2861,21 +2861,6 @@ mod tests {
             .unwrap(),
             None,
         );
-
-        // Emulate cluster restart at slot 40 (past blockstore bounds)
-        // Do check from new_hard_fork
-        let new_hard_fork = 40;
-        hard_forks.register(new_hard_fork);
-        assert_eq!(
-            should_cleanup_blockstore_incorrect_shred_versions(
-                &validator_config,
-                &blockstore,
-                root_slot,
-                &hard_forks
-            )
-            .unwrap(),
-            Some(new_hard_fork + 1),
-        );
     }
 
     #[test]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2864,7 +2864,7 @@ mod tests {
     }
 
     #[test]
-    fn test_check_blockstore_for_incorrect_shred_version() {
+    fn test_cleanup_blockstore_incorrect_shred_versions() {
         solana_logger::setup();
 
         let validator_config = ValidatorConfig::default_for_test();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2232,11 +2232,12 @@ fn should_check_blockstore_for_incorrect_shred_version(
     } else {
         // blockstore_min_slot <= blockstore_max_slot <= latest_hard_fork
         //
-        // This could be similar to the previous case of there being a cluster restart, except
-        // that the blockstore data is all older than latest hard fork (perhaps this node crashed
-        // before observing the slot chosen for cluster restart). Or, maybe there was a hard fork
-        // issued very far into the future. Regardless, perform the blockstore check for this case.
-        Ok(Some(latest_hard_fork + 1))
+        // All slots in the blockstore are older than the latest hard fork. The blockstore check
+        // would start from latest_hard_fork + 1; skip the check as there are no slots to check
+        //
+        // This is kind of an unusual case to hit, maybe a node has been offline for a long time
+        // and just restarted with a new downloaded snapshot but the old blockstore
+        Ok(None)
     }
 }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -758,6 +758,8 @@ impl Validator {
                 start_slot,
                 shred_version,
             )?;
+        } else {
+            info!("Skipping the blockstore check for shreds with incorrect version");
         }
 
         node.info.set_shred_version(shred_version);
@@ -2207,6 +2209,10 @@ fn should_cleanup_blockstore_incorrect_shred_versions(
         return Ok(None);
     };
     let blockstore_min_slot = blockstore.lowest_slot();
+    info!(
+        "Blockstore contains data from slot {blockstore_min_slot} to {blockstore_max_slot}, the \
+        latest hard fork is {latest_hard_fork}"
+    );
 
     if latest_hard_fork < blockstore_min_slot {
         // latest_hard_fork < blockstore_min_slot <= blockstore_max_slot
@@ -2253,7 +2259,7 @@ fn scan_blockstore_for_incorrect_shred_version(
     // Search for shreds with incompatible version in blockstore
     let slot_meta_iterator = blockstore.slot_meta_iterator(start_slot)?;
 
-    info!("Searching blockstore for shred with incorrect version..");
+    info!("Searching blockstore for shred with incorrect version from slot {start_slot}");
     for (slot, _meta) in slot_meta_iterator {
         let shreds = blockstore.get_data_shreds_for_slot(slot, 0)?;
         for shred in &shreds {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -596,24 +596,7 @@ impl Validator {
             ));
         }
         let genesis_config = load_genesis(config, ledger_path)?;
-
         metrics_config_sanity_check(genesis_config.cluster_type)?;
-
-        if let Some(expected_shred_version) = config.expected_shred_version {
-            if let Some(wait_for_supermajority_slot) = config.wait_for_supermajority {
-                *start_progress.write().unwrap() = ValidatorStartProgress::CleaningBlockStore;
-                backup_and_clear_blockstore(
-                    ledger_path,
-                    config,
-                    wait_for_supermajority_slot + 1,
-                    expected_shred_version,
-                )
-                .context(
-                    "Failed to backup and clear shreds with incorrect shred version from \
-                     blockstore",
-                )?;
-            }
-        }
 
         info!("Cleaning accounts paths..");
         *start_progress.write().unwrap() = ValidatorStartProgress::CleaningAccounts;
@@ -756,6 +739,20 @@ impl Validator {
                 }
                 .into());
             }
+        }
+
+        if let Some(wait_for_supermajority_slot) = config.wait_for_supermajority {
+            *start_progress.write().unwrap() = ValidatorStartProgress::CleaningBlockStore;
+            backup_and_clear_blockstore(
+                ledger_path,
+                config,
+                wait_for_supermajority_slot + 1,
+                shred_version,
+            )
+            .context(
+                "Failed to backup and clear shreds with incorrect shred version from \
+                 blockstore",
+            )?;
         }
 
         node.info.set_shred_version(shred_version);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -748,10 +748,6 @@ impl Validator {
                 config,
                 wait_for_supermajority_slot + 1,
                 shred_version,
-            )
-            .context(
-                "Failed to backup and clear shreds with incorrect shred version from \
-                 blockstore",
             )?;
         }
 
@@ -2337,6 +2333,9 @@ fn initialize_rpc_transaction_history_services(
 pub enum ValidatorError {
     #[error("Bad expected bank hash")]
     BadExpectedBankHash,
+
+    #[error("blockstore error: {0}")]
+    Blockstore(#[source] BlockstoreError),
 
     #[error("genesis hash mismatch: actual={0}, expected={1}")]
     GenesisHashMismatch(Hash, Hash),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -752,7 +752,12 @@ impl Validator {
             &hard_forks,
         )? {
             *start_progress.write().unwrap() = ValidatorStartProgress::CleaningBlockStore;
-            backup_and_clear_blockstore(&blockstore, config, start_slot, shred_version)?;
+            check_blockstore_for_incorrect_shred_version(
+                &blockstore,
+                config,
+                start_slot,
+                shred_version,
+            )?;
         }
 
         node.info.set_shred_version(shred_version);
@@ -2265,7 +2270,7 @@ fn blockstore_contains_incorrect_shred_version(
 
 /// If the blockstore contains any shreds with the incorrect shred version,
 /// copy them to a backup blockstore and purge them from the actual blockstore.
-fn backup_and_clear_blockstore(
+fn check_blockstore_for_incorrect_shred_version(
     blockstore: &Blockstore,
     config: &ValidatorConfig,
     start_slot: Slot,
@@ -2867,7 +2872,7 @@ mod tests {
     }
 
     #[test]
-    fn test_backup_and_clear_blockstore() {
+    fn test_check_blockstore_for_incorrect_shred_version() {
         solana_logger::setup();
 
         let validator_config = ValidatorConfig::default_for_test();
@@ -2888,7 +2893,7 @@ mod tests {
         }
 
         // this purges and compacts all slots greater than or equal to 5
-        backup_and_clear_blockstore(&blockstore, &validator_config, 5, 2).unwrap();
+        check_blockstore_for_incorrect_shred_version(&blockstore, &validator_config, 5, 2).unwrap();
         // assert that slots less than 5 aren't affected
         assert!(blockstore.meta(4).unwrap().unwrap().next_slots.is_empty());
         for i in 5..10 {


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/issues/2380 for much more context

#### Summary of Changes
The comments and unit test are much more descriptive, but at a high level:
- Remove the check from occurring only if `--expected-shred-version` and `--wait-for-supermajority` are set
- Be smarter about when we do the scan based on relevant state

Fixes https://github.com/anza-xyz/agave/issues/2380
