### PR TITLE
fix some args name in the wen restart log

### DIFF
--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -971,8 +971,8 @@ pub fn wait_for_wen_restart(config: WenRestartConfig) -> Result<()> {
             } => {
                 error!(
                     "Wen start finished, please remove --wen_restart and restart with \
-                    --wait-for-supermajority {} --expected-bank-hash {} --shred-version {}\
-                    --hard-fork {} --no-snapshot-fetchsnapshot",
+                    --wait-for-supermajority {} --expected-bank-hash {} --expected-shred-version {} \
+                    --hard-fork {} --no-snapshot-fetch",
                     slot, hash, shred_version, slot
                 );
                 return Ok(());

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -972,8 +972,8 @@ pub fn wait_for_wen_restart(config: WenRestartConfig) -> Result<()> {
                 error!(
                     "Wen start finished, please remove --wen_restart and restart with \
                     --wait-for-supermajority {} --expected-bank-hash {} --expected-shred-version {} \
-                    --hard-fork {} --no-snapshot-fetch",
-                    slot, hash, shred_version, slot
+                    --no-snapshot-fetch",
+                    slot, hash, shred_version,
                 );
                 return Ok(());
             }


### PR DESCRIPTION
#### Problem

I guess we mistype some validator args in the wen restart log.

#### Summary of Changes

try to fix them.