### PR TITLE
Ensure to build release binaries without dcou

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -165,6 +165,7 @@ mkdir -p "$installDir/bin"
   # Make sure dcou is really disabled by peeking the (unstable) build plan
   # output after turning rustc into the nightly mode with RUSTC_BOOTSTRAP=1.
   # In this way, additional requirement of nightly rustc toolchian is avoided.
+  # Note that `cargo tree` can't be used, because it doesn't support `--bin`.
   # shellcheck disable=SC2086 # Don't want to double quote $maybeRustVersion
   if (RUSTC_BOOTSTRAP=1 \
       "$cargo" $maybeRustVersion build \

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -96,22 +96,25 @@ if [[ $CI_OS_NAME = windows ]]; then
     solana-test-validator
     solana-tokens
   )
+  DCOU_BINS=()
 else
   ./fetch-perf-libs.sh
 
   BINS=(
     solana
-    solana-bench-tps
     solana-faucet
     solana-genesis
     solana-gossip
     agave-install
     solana-keygen
-    agave-ledger-tool
     solana-log-analyzer
     solana-net-shaper
     agave-validator
     rbpf-cli
+  )
+  DCOU_BINS=(
+    agave-ledger-tool
+    solana-bench-tps
   )
 
   # Speed up net.sh deploys by excluding unused binaries
@@ -119,12 +122,14 @@ else
     BINS+=(
       cargo-build-sbf
       cargo-test-sbf
-      solana-dos
       agave-install-init
       solana-stake-accounts
       solana-test-validator
       solana-tokens
       agave-watchtower
+    )
+    DCOU_BINS+=(
+      solana-dos
     )
   fi
 fi
@@ -134,12 +139,50 @@ for bin in "${BINS[@]}"; do
   binArgs+=(--bin "$bin")
 done
 
+dcouBinArgs=()
+for bin in "${DCOU_BINS[@]}"; do
+  dcouBinArgs+=(--bin "$bin")
+done
+
+source "$SOLANA_ROOT"/scripts/dcou-tainted-packages.sh
+
+excludeArgs=()
+for package in "${dcou_tainted_packages[@]}"; do
+  excludeArgs+=(--exclude "$package")
+done
+
 mkdir -p "$installDir/bin"
 
+# Some binaries (like the notable agave-ledger-tool) need to acitivate
+# the dev-context-only-utils feature flag to build.
+# Build those binaries separately to avoid the unwanted feature unification.
+# Note that `--workspace --exclude <dcou tainted packages>` is needed to really
+# inhibit the feature unification due to a cargo bug. Otherwise, feature
+# unification happens even if cargo build is run only with `--bin` targets
+# which don't depend on dcou as part of dependencies at all.
 (
   set -x
-  # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  "$cargo" $maybeRustVersion build $buildProfileArg "${binArgs[@]}"
+  # Make sure dcou is really disabled by peeking the (unstable) build plan
+  # output after making rustc the nightly mode with RUSTC_BOOTSTRAP=1
+  # shellcheck disable=SC2086 # Don't want to double quote $maybeRustVersion
+  if (RUSTC_BOOTSTRAP=1 \
+      "$cargo" $maybeRustVersion build \
+      -Z unstable-options --build-plan \
+      $buildProfileArg "${binArgs[@]}" --workspace "${excludeArgs[@]}" | \
+      grep -q -F '"feature=\"dev-context-only-utils\""'); then
+     echo 'dcou feature activation is incorrctly activated!' && \
+     exit 1
+  fi
+
+  # Build our production binaries without dcou.
+  # shellcheck disable=SC2086 # Don't want to double quote $maybeRustVersion
+  "$cargo" $maybeRustVersion build \
+     $buildProfileArg "${binArgs[@]}" --workspace "${excludeArgs[@]}"
+
+  # Finally, build the remaining dev tools with dcou.
+  # shellcheck disable=SC2086 # Don't want to double quote $maybeRustVersion
+  "$cargo" $maybeRustVersion build \
+     $buildProfileArg "${dcouBinArgs[@]}"
 
   # Exclude `spl-token` binary for net.sh builds
   if [[ -z "$validatorOnly" ]]; then
@@ -155,7 +198,7 @@ mkdir -p "$installDir/bin"
   fi
 )
 
-for bin in "${BINS[@]}"; do
+for bin in "${BINS[@]}" "${DCOU_BINS[@]}"; do
   cp -fv "target/$buildProfile/$bin" "$installDir"/bin
 done
 

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -163,7 +163,8 @@ mkdir -p "$installDir/bin"
 (
   set -x
   # Make sure dcou is really disabled by peeking the (unstable) build plan
-  # output after making rustc the nightly mode with RUSTC_BOOTSTRAP=1
+  # output after turning rustc into the nightly mode with RUSTC_BOOTSTRAP=1.
+  # In this way, additional requirement of nightly rustc toolchian is avoided.
   # shellcheck disable=SC2086 # Don't want to double quote $maybeRustVersion
   if (RUSTC_BOOTSTRAP=1 \
       "$cargo" $maybeRustVersion build \

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -28,18 +28,10 @@ source ci/rust-version.sh nightly
 # as normal (not dev) dependencies, only if you're sure that there's good
 # reason to bend dev-context-only-utils's original intention and that listed
 # package isn't part of released binaries.
-declare tainted_packages=(
-  solana-accounts-bench
-  solana-banking-bench
-  agave-ledger-tool
-  solana-bench-tps
-  agave-store-tool
-  agave-store-histogram
-  agave-accounts-hash-cache-tool
-)
+source scripts/dcou-tainted-packages.sh
 
 # convert to comma separeted (ref: https://stackoverflow.com/a/53839433)
-printf -v allowed '"%s",' "${tainted_packages[@]}"
+printf -v allowed '"%s",' "${dcou_tainted_packages[@]}"
 allowed="${allowed%,}"
 
 mode=${1:-full}

--- a/scripts/dcou-tainted-packages.sh
+++ b/scripts/dcou-tainted-packages.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2034 # This file is intended to be `source`d
+declare dcou_tainted_packages=(
+  solana-accounts-bench
+  solana-banking-bench
+  agave-ledger-tool
+  solana-bench-tps
+  agave-store-tool
+  agave-store-histogram
+  agave-accounts-hash-cache-tool
+  solana-dos
+)


### PR DESCRIPTION
#### Problem

It turned out dcou is enabled when building our release binaries.

#### Summary of Changes

Ensure to disable it. note that some hackery is needed...

This makes our binary size reduced and some dev-purpose (i.e. dangerous) function bodies not shipped.

Further more, this makes sure it's totally safe to add some conditional dcou code on important code-path.

context: #2733 adds some dcou code when freezing banks.

#### Before

```
$ ls --full-time -l ./path/to/bin/
total 472744
-rwxr-xr-x 1 sol users 18794632 2024-09-06 07:20:59.123785989 +0000 agave-install
-rwxr-xr-x 1 sol users 18086496 2024-09-06 07:20:59.403793602 +0000 agave-install-init
-rwxr-xr-x 1 sol users 51809064 2024-09-06 07:20:59.199788056 +0000 agave-ledger-tool
-rwxr-xr-x 1 sol users 69616360 2024-09-06 07:20:59.307790992 +0000 agave-validator
-rwxr-xr-x 1 sol users 17022408 2024-09-06 07:20:59.567798061 +0000 agave-watchtower
-rwxr-xr-x 1 sol users 16007080 2024-09-06 07:20:59.335791754 +0000 cargo-build-sbf
-rwxr-xr-x 1 sol users  3863040 2024-09-06 07:20:59.339791863 +0000 cargo-test-sbf
drwxr-xr-x 2 sol users     4096 2024-09-06 07:21:04.999945749 +0000 deps
drwxr-xr-x 5 sol users     4096 2024-09-06 07:17:40.598386096 +0000 perf-libs
-rwxr-xr-x 1 sol users   398344 2024-09-06 07:20:59.311791101 +0000 rbpf-cli
drwxr-xr-x 3 sol users     4096 2024-09-06 07:21:04.967944880 +0000 sdk
-rwxr-xr-x 1 sol users 33735344 2024-09-06 07:20:59.003782726 +0000 solana
-rwxr-xr-x 1 sol users 27081288 2024-09-06 07:20:59.043783815 +0000 solana-bench-tps
-rwxr-xr-x 1 sol users 27782056 2024-09-06 07:20:59.379792950 +0000 solana-dos
-rwxr-xr-x 1 sol users 15727904 2024-09-06 07:20:59.063784358 +0000 solana-faucet
-rwxr-xr-x 1 sol users 27970736 2024-09-06 07:20:59.607799149 +0000 solana-genesis
-rwxr-xr-x 1 sol users 22599480 2024-09-06 07:20:59.095785229 +0000 solana-gossip
-rwxr-xr-x 1 sol users  2750320 2024-09-06 07:20:59.131786207 +0000 solana-keygen
-rwxr-xr-x 1 sol users  3584736 2024-09-06 07:20:59.207788274 +0000 solana-log-analyzer
-rwxr-xr-x 1 sol users  3594704 2024-09-06 07:20:59.215788491 +0000 solana-net-shaper
-rwxr-xr-x 1 sol users 16002216 2024-09-06 07:20:59.427794255 +0000 solana-stake-accounts
-rwxr-xr-x 1 sol users 67689416 2024-09-06 07:20:59.519796757 +0000 solana-test-validator
-rwxr-xr-x 1 sol users 16778112 2024-09-06 07:20:59.543797408 +0000 solana-tokens
-rwxr-xr-x 1 sol users 23062472 2024-09-06 07:20:58.379765762 +0000 spl-token
```

#### After

notice that `agave-validator` got smaller by 70608 bytes (`69616360` vs `69545752`), while `agave-ledger-tool` remained the same basically (`51809072` vs `51809064`):

```
$ ls --full-time -l ./path/to/bin/
total 472540
-rwxr-xr-x 1 sol users 18793904 2024-09-07 05:25:14.129415848 +0000 agave-install
-rwxr-xr-x 1 sol users 18085784 2024-09-07 05:25:14.301420549 +0000 agave-install-init
-rwxr-xr-x 1 sol users 51809072 2024-09-07 05:25:14.573427984 +0000 agave-ledger-tool
-rwxr-xr-x 1 sol users 69545752 2024-09-07 05:25:14.241418909 +0000 agave-validator
-rwxr-xr-x 1 sol users 17022024 2024-09-07 05:25:14.465425032 +0000 agave-watchtower
-rwxr-xr-x 1 sol users 16006288 2024-09-07 05:25:14.269419674 +0000 cargo-build-sbf
-rwxr-xr-x 1 sol users  3863040 2024-09-07 05:25:14.277419893 +0000 cargo-test-sbf
drwxr-xr-x 2 sol users     4096 2024-09-07 05:25:15.737459801 +0000 deps
drwxr-xr-x 5 sol users     4096 2024-09-06 07:17:40.598386096 +0000 perf-libs
-rwxr-xr-x 1 sol users   398344 2024-09-07 05:25:14.245419018 +0000 rbpf-cli
drwxr-xr-x 3 sol users     4096 2024-09-07 05:25:15.709459036 +0000 sdk
-rwxr-xr-x 1 sol users 33743696 2024-09-07 05:25:14.049413660 +0000 solana
-rwxr-xr-x 1 sol users 27081288 2024-09-07 05:25:14.613429077 +0000 solana-bench-tps
-rwxr-xr-x 1 sol users 27782056 2024-09-07 05:25:14.653430170 +0000 solana-dos
-rwxr-xr-x 1 sol users 15727904 2024-09-07 05:25:14.069414208 +0000 solana-faucet
-rwxr-xr-x 1 sol users 27968992 2024-09-07 05:25:14.505426125 +0000 solana-genesis
-rwxr-xr-x 1 sol users 22592512 2024-09-07 05:25:14.101415083 +0000 solana-gossip
-rwxr-xr-x 1 sol users  2750320 2024-09-07 05:25:14.137416066 +0000 solana-keygen
-rwxr-xr-x 1 sol users  3584736 2024-09-07 05:25:14.141416176 +0000 solana-log-analyzer
-rwxr-xr-x 1 sol users  3594704 2024-09-07 05:25:14.149416394 +0000 solana-net-shaper
-rwxr-xr-x 1 sol users 16001928 2024-09-07 05:25:14.325421205 +0000 solana-stake-accounts
-rwxr-xr-x 1 sol users 67625144 2024-09-07 05:25:14.417423720 +0000 solana-test-validator
-rwxr-xr-x 1 sol users 16786288 2024-09-07 05:25:14.441424376 +0000 solana-tokens
-rwxr-xr-x 1 sol users 23062472 2024-09-07 05:25:13.461397588 +0000 spl-token
```
