### PR TITLE
Rewords BankFromSnapshotsDirectory error message

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -52,7 +52,7 @@ pub enum BankForksUtilsError {
     )]
     NoBankSnapshotDirectory { flag: String, value: String },
 
-    #[error("failed to load bank: {source}, snapshot: {path}")]
+    #[error("failed to load bank from snapshot '{path}': {source}")]
     BankFromSnapshotsDirectory {
         source: snapshot_utils::SnapshotError,
         path: PathBuf,


### PR DESCRIPTION
#### Problem

While debugging a startup issue, I was looking at the error log message:
```
[2024-09-08T14:23:53.672683740Z ERROR agave_validator] Failed to start validator: "failed to load bank: I/O error: failed to read account snapshot dir '/home/sol/ledger/accounts/snapshot/291692183': No such file or directory (os error 2), snapshot: /home/sol/ledger-snapshots/snapshots/291692183/291692183"
```
And the trailing `snapshot: /home/sol/ledger-snapshots/snapshots/291692183/291692183` part initially confused me, since the origin IoError does *not* include that part.

I traced it up the stack and found it is due to how the BankFromSnapshotsDirectory error is displayed. It does `text: source, more info`. Whereas convention puts the source at the very end: `text, more info: source`.


#### Summary of Changes

Reword the error message.