### PR TITLE
clean scan optimization: scan disk index only for zero lamport

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3173,7 +3173,7 @@ impl AccountsDb {
                 .take(num_bins)
                 .collect();
 
-        let insert_candidate = |pubkey, is_zero| {
+        let insert_candidate = |pubkey, is_zero_lamport| {
             let index = self.accounts_index.bin_calculator.bin_from_pubkey(&pubkey);
             let mut candidates_bin = candidates[index].write().unwrap();
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3207,7 +3207,7 @@ impl AccountsDb {
 
                         store.accounts.scan_index(|index| {
                             let pubkey = index.index_info.pubkey;
-                            let is_zero = index.index_info.lamports == 0;
+                            let is_zero_lamport = index.index_info.is_zero_lamport();
                             insert_candidate(pubkey, is_zero);
                         });
                     });

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1352,8 +1352,10 @@ impl StoreAccountsTiming {
 struct CleaningInfo {
     slot_list: SlotList<AccountInfo>,
     ref_count: u64,
-    /// True for pubkeys which can contain zero accounts
-    can_contain_zero: bool,
+    /// Indicates if this account might have a zero lamport index entry.
+    /// If false, the account *shall* not have zero lamport index entries.
+    /// If true, the account *might* have zero lamport index entries.
+    might_contain_zero_lamport_entry: bool,
 }
 
 /// This is the return type of AccountsDb::construct_candidate_clean_keys.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3197,7 +3197,7 @@ impl AccountsDb {
 
                         store.accounts.scan_index(|index| {
                             let pubkey = index.index_info.pubkey;
-                            let is_zero_lamport = index.index_info.is_zero_lamport();
+                            let is_zero_lamport = index.index_info.lamports == 0;
                             insert_candidate(pubkey, is_zero_lamport);
                         });
                     });

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3110,10 +3110,10 @@ impl AccountsDb {
                             candidates_bin = candidates[curr_bin].write().unwrap();
                             prev_bin = curr_bin;
                         }
-                        // Conservatively mark the candidate to be zero for
+                        // Conservatively mark the candidate might have a zero lamport entry for
                         // correctness so that scan WILL try to look in disk if it is
                         // not in-mem. These keys are from 1) recently processed
-                        // slots, 2) zeros found in shrink. Therefore, they are very likely
+                        // slots, 2) zero lamports found in shrink. Therefore, they are very likely
                         // to be in-memory, and seldomly do we need to look them up in disk.
                         candidates_bin.insert(
                             removed_pubkey,

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -209,6 +209,12 @@ pub(crate) struct IndexInfoInner {
     pub data_len: u64,
 }
 
+impl ZeroLamport for IndexInfoInner {
+    fn is_zero_lamport(&self) -> bool {
+        self.lamports == 0
+    }
+}
+
 /// offsets to help navigate the persisted format of `AppendVec`
 #[derive(Debug)]
 struct AccountOffsets {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -209,12 +209,6 @@ pub(crate) struct IndexInfoInner {
     pub data_len: u64,
 }
 
-impl ZeroLamport for IndexInfoInner {
-    fn is_zero_lamport(&self) -> bool {
-        self.lamports == 0
-    }
-}
-
 /// offsets to help navigate the persisted format of `AppendVec`
 #[derive(Debug)]
 struct AccountOffsets {


### PR DESCRIPTION
#### Problem



Generally, we don't need to scan disk index for clean because disk index only contains single ref single entry account index, which is *nearly* always "alive" and shouldn't be cleaned, except for one special case - single ref zero accounts (single ref zero accounts need to be cleaned). 

Currently, we scan disk index for every candidate, which can be optimized to only scan disk index for zeros.


#### Summary of Changes

optimize clean scan. 
1. add is_zero mark on cleaning info.
2. only scan disk index for is_zero candidate.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
