### PR TITLE
wip: check for all zeros on startup

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8869,6 +8869,7 @@ impl AccountsDb {
                 // this whole slot can likely be marked dead and dropped. Clean has to determine that. There could be an older non-zero account for any of these zero lamport accounts.
                 self.dirty_stores.insert(slot, Arc::clone(storage));
                 self.accounts_index.add_uncleaned_roots([slot].into_iter());
+                self.shrink_candidate_slots.lock().unwrap().insert(slot);
             }
             let items = items_local.into_iter().map(|info| {
                 if let Some(amount_to_top_off_rent_this_account) = Self::stats_for_rent_payers(

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8836,7 +8836,7 @@ impl AccountsDb {
 
     fn generate_index_for_slot(
         &self,
-        storage: &AccountStorageEntry,
+        storage: &Arc<AccountStorageEntry>,
         slot: Slot,
         store_id: AccountsFileId,
         rent_collector: &RentCollector,
@@ -8853,15 +8853,22 @@ impl AccountsDb {
         let mut amount_to_top_off_rent = 0;
         let mut stored_size_alive = 0;
 
+        let mut all_accounts_are_zero_lamports = true;
+
         let (dirty_pubkeys, insert_time_us, mut generate_index_results) = {
             let mut items_local = Vec::default();
             storage.accounts.scan_index(|info| {
                 stored_size_alive += info.stored_size_aligned;
                 if info.index_info.lamports > 0 {
                     accounts_data_len += info.index_info.data_len;
+                    all_accounts_are_zero_lamports = false;
                 }
                 items_local.push(info.index_info);
             });
+            if all_accounts_are_zero_lamports {
+                self.dirty_stores.insert(slot, Arc::clone(storage));
+                log::error!("all zeros: {slot}");
+            }
             let items = items_local.into_iter().map(|info| {
                 if let Some(amount_to_top_off_rent_this_account) = Self::stats_for_rent_payers(
                     &info.pubkey,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8866,8 +8866,9 @@ impl AccountsDb {
                 items_local.push(info.index_info);
             });
             if all_accounts_are_zero_lamports {
+                // this whole slot can likely be marked dead and dropped. Clean has to determine that. There could be an older non-zero account for any of these zero lamport accounts.
                 self.dirty_stores.insert(slot, Arc::clone(storage));
-                log::error!("all zeros: {slot}");
+                self.accounts_index.add_uncleaned_roots([slot].into_iter());
             }
             let items = items_local.into_iter().map(|info| {
                 if let Some(amount_to_top_off_rent_this_account) = Self::stats_for_rent_payers(


### PR DESCRIPTION
#### Problem
On startup, we can identify storages that have all zero lamport accounts. Perhaps the whole slot can be marked dead.

#### Summary of Changes
In generating index, we can find storages with all zeros and add them to clean.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
