### PR TITLE
Box NewTaskPayload to reduce size greatly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8186,6 +8186,7 @@ dependencies = [
  "solana-sdk",
  "solana-timings",
  "solana-unified-scheduler-logic",
+ "static_assertions",
  "vec_extract_if_polyfill",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6772,6 +6772,7 @@ dependencies = [
  "solana-sdk",
  "solana-timings",
  "solana-unified-scheduler-logic",
+ "static_assertions",
  "vec_extract_if_polyfill",
 ]
 

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -22,6 +22,7 @@ solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 solana-timings = { workspace = true }
 solana-unified-scheduler-logic = { workspace = true }
+static_assertions = { workspace = true }
 vec_extract_if_polyfill = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
#### Problem

`NewTaskPayload` is large (more than 200 bytes) due to its direct inclusion of `ExecuteTimings`. In turn, this causes large mem writes/reads around crossbeam channel even for `NewTaskPayload::Task`.

Note that this is particularly problematic for block production mode (senders are multi-threaded whereas block verification is currently single-threaded) because those writes are inside crossbeam channel's linearization point, creating a source of contention.

#### Summary of Changes

Box the rare variant, which only occurs once per bank, benefiting the other variant channel transmission (99.9% of time). Overall, extra indirection for access and mem alloc/dealloc for the `NewTaskPayload::OpenSubchannel` variant pays off.


#### before

```
ledger processed in 13 seconds, 977 ms
ledger processed in 13 seconds, 777 ms
ledger processed in 13 seconds, 905 ms
```

#### after

maybe 1-2% gain.

```
ledger processed in 13 seconds, 678 ms
ledger processed in 13 seconds, 512 ms
ledger processed in 13 seconds, 856 ms
```

Extracted from: #2325 