### PR TITLE
Feature - `disable_sbpf_v1_execution` for tests

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -21,12 +21,13 @@ use {
     solana_feature_set::{
         self as feature_set, abort_on_invalid_curve, blake3_syscall_enabled,
         bpf_account_data_direct_mapping, curve25519_syscall_enabled,
-        disable_deploy_of_alloc_free_syscall, disable_fees_sysvar,
+        disable_deploy_of_alloc_free_syscall, disable_fees_sysvar, disable_sbpf_v1_execution,
         enable_alt_bn128_compression_syscall, enable_alt_bn128_syscall, enable_big_mod_exp_syscall,
         enable_get_epoch_stake_syscall, enable_partitioned_epoch_reward, enable_poseidon_syscall,
         error_on_syscall_bpf_function_hash_collisions, get_sysvar_syscall_enabled,
-        last_restart_slot_sysvar, partitioned_epoch_rewards_superfeature, reject_callx_r10,
-        remaining_compute_units_syscall_enabled, FeatureSet,
+        last_restart_slot_sysvar, partitioned_epoch_rewards_superfeature,
+        reenable_sbpf_v1_execution, reject_callx_r10, remaining_compute_units_syscall_enabled,
+        FeatureSet,
     },
     solana_log_collector::{ic_logger_msg, ic_msg},
     solana_poseidon as poseidon,
@@ -300,7 +301,8 @@ pub fn create_program_runtime_environment_v1<'a>(
         external_internal_function_hash_collision: feature_set
             .is_active(&error_on_syscall_bpf_function_hash_collisions::id()),
         reject_callx_r10: feature_set.is_active(&reject_callx_r10::id()),
-        enable_sbpf_v1: true,
+        enable_sbpf_v1: !feature_set.is_active(&disable_sbpf_v1_execution::id())
+            || feature_set.is_active(&reenable_sbpf_v1_execution::id()),
         enable_sbpf_v2: false,
         optimize_rodata: false,
         aligned_memory_mapping: !feature_set.is_active(&bpf_account_data_direct_mapping::id()),

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -26,8 +26,7 @@ use {
         enable_get_epoch_stake_syscall, enable_partitioned_epoch_reward, enable_poseidon_syscall,
         error_on_syscall_bpf_function_hash_collisions, get_sysvar_syscall_enabled,
         last_restart_slot_sysvar, partitioned_epoch_rewards_superfeature,
-        reenable_sbpf_v1_execution, reject_callx_r10, remaining_compute_units_syscall_enabled,
-        FeatureSet,
+        reenable_sbpf_v1_execution, remaining_compute_units_syscall_enabled, FeatureSet,
     },
     solana_log_collector::{ic_logger_msg, ic_msg},
     solana_poseidon as poseidon,
@@ -300,7 +299,7 @@ pub fn create_program_runtime_environment_v1<'a>(
         sanitize_user_provided_values: true,
         external_internal_function_hash_collision: feature_set
             .is_active(&error_on_syscall_bpf_function_hash_collisions::id()),
-        reject_callx_r10: feature_set.is_active(&reject_callx_r10::id()),
+        reject_callx_r10: true,
         enable_sbpf_v1: !feature_set.is_active(&disable_sbpf_v1_execution::id())
             || feature_set.is_active(&reenable_sbpf_v1_execution::id()),
         enable_sbpf_v2: false,

--- a/sdk/feature-set/src/lib.rs
+++ b/sdk/feature-set/src/lib.rs
@@ -863,6 +863,14 @@ pub mod deprecate_legacy_vote_ixs {
     solana_program::declare_id!("depVvnQ2UysGrhwdiwU42tCadZL8GcBb1i2GYhMopQv");
 }
 
+pub mod disable_sbpf_v1_execution {
+    solana_program::declare_id!("TestFeature11111111111111111111111111111111");
+}
+
+pub mod reenable_sbpf_v1_execution {
+    solana_program::declare_id!("TestFeature21111111111111111111111111111111");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -1073,6 +1081,8 @@ lazy_static! {
         (enable_turbine_extended_fanout_experiments::id(), "enable turbine extended fanout experiments #"),
         (deprecate_legacy_vote_ixs::id(), "Deprecate legacy vote instructions"),
         (partitioned_epoch_rewards_superfeature::id(), "replaces enable_partitioned_epoch_reward to enable partitioned rewards at epoch boundary SIMD-0118"),
+        (disable_sbpf_v1_execution::id(), "Disables execution of SBPFv1 programs"),
+        (reenable_sbpf_v1_execution::id(), "Re-enables execution of SBPFv1 programs"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -299,7 +299,7 @@ fn create_custom_environment<'a>() -> BuiltinProgram<InvokeContext<'a>> {
         noop_instruction_rate: 256,
         sanitize_user_provided_values: true,
         external_internal_function_hash_collision: false,
-        reject_callx_r10: false,
+        reject_callx_r10: true,
         enable_sbpf_v1: true,
         enable_sbpf_v2: false,
         optimize_rodata: false,


### PR DESCRIPTION
#### Problem
The feature `reject_callx_r10` can not be cleaned up because some tests rely on it (see #2414).

These tests require a feature to toggle the verification success of a program. Currently we use very specific properties of the programs to trigger the rejection logic. This however is cumbersome as these programs need to be manually crafted, so a more general approach would be nice.

#### Summary of Changes
Adds two dummy features `disable_sbpf_v1_execution` and `reenable_sbpf_v1_execution` for tests, which is can not be activated on any cluster (would require rekeying) and replaces `reject_callx_r10` with these features. Two features are required because we enable all features by default. Thus, any single test feature which breaks programs on purpose would break all unit tests and local test clusters.