### PR TITLE
Publish Agave docs

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -15,3 +15,14 @@ source ../ci/rust-version.sh
 # Build from /src into /build
 npm run build
 echo $?
+
+# Publish only from merge commits and beta release tags
+if [[ -n $CI ]]; then
+  if [[ -z $CI_PULL_REQUEST ]]; then
+    if [[ -n $CI_TAG ]] && [[ $CI_TAG != $BETA_CHANNEL* ]]; then
+      echo "not a beta tag"
+      exit 0
+    fi
+    ./publish-docs.sh
+  fi
+fi

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -18,6 +18,7 @@ echo "build.sh starting npm run build"
 npm run build
 echo $?
 echo "build.sh checking if publish"
+CI="TODO remove"
 # Publish only from merge commits and beta release tags
 if [[ -n $CI ]]; then
   if [[ -z $CI_PULL_REQUEST ]]; then

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -7,15 +7,17 @@ cd "$(dirname "$0")"
 source ../ci/env.sh
 
 # shellcheck source=ci/rust-version.sh
+echo "build.sh starting build cli usage"
 source ../ci/rust-version.sh
 ../ci/docker-run-default-image.sh docs/build-cli-usage.sh
+echo "build.sh starting convert ascii to svg"
 ../ci/docker-run-default-image.sh docs/convert-ascii-to-svg.sh
 ./set-solana-release-tag.sh
-
+echo "build.sh starting npm run build"
 # Build from /src into /build
 npm run build
 echo $?
-
+echo "build.sh checking if publish"
 # Publish only from merge commits and beta release tags
 if [[ -n $CI ]]; then
   if [[ -z $CI_PULL_REQUEST ]]; then

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -7,18 +7,15 @@ cd "$(dirname "$0")"
 source ../ci/env.sh
 
 # shellcheck source=ci/rust-version.sh
-echo "build.sh starting build cli usage"
 source ../ci/rust-version.sh
 ../ci/docker-run-default-image.sh docs/build-cli-usage.sh
-echo "build.sh starting convert ascii to svg"
 ../ci/docker-run-default-image.sh docs/convert-ascii-to-svg.sh
 ./set-solana-release-tag.sh
-echo "build.sh starting npm run build"
+
 # Build from /src into /build
 npm run build
 echo $?
-echo "build.sh checking if publish"
-CI="TODO remove"
+
 # Publish only from merge commits and beta release tags
 if [[ -n $CI ]]; then
   if [[ -z $CI_PULL_REQUEST ]]; then

--- a/docs/publish-docs.sh
+++ b/docs/publish-docs.sh
@@ -9,15 +9,15 @@ fi
 CONFIG_FILE=vercel.json
 
 if [[ -n $CI_TAG ]]; then
-  PROJECT_NAME=docs-solana-com
+  PROJECT_NAME=docs-anza-xyz
 else
   eval "$(../ci/channel-info.sh)"
   case $CHANNEL in
   edge)
-    PROJECT_NAME=edge-docs-solana-com
+    PROJECT_NAME=edge-docs-anza-xyz
     ;;
   beta)
-    PROJECT_NAME=beta-docs-solana-com
+    PROJECT_NAME=beta-docs-anza-xyz
     ;;
   *)
     PROJECT_NAME=docs
@@ -151,4 +151,4 @@ EOF
   echo "VERCEL_TOKEN is undefined.  Needed for Vercel authentication."
   exit 1
 }
-vercel deploy . --local-config="$CONFIG_FILE" --confirm --token "$VERCEL_TOKEN" --prod
+vercel deploy . --local-config="$CONFIG_FILE" --yes --token "$VERCEL_TOKEN" --prod


### PR DESCRIPTION
#### Problem
Agave docs don't publish anywhere

#### Summary of Changes
Turn the docs publishing pipeline back on.

This is tricky to test properly without merging first. I've tested it from my dev server by running this:

```bash
#!/usr/bin/env bash

export VERCEL_TOKEN="***"
export VERCEL_SCOPE="***"
echo "Starting npm install"
npm install
echo "Starting ./build.sh"
./build.sh
```

Which produces builds here:
https://vercel.com/anza-tech/docs/deployments

Looking through `.github/workflows/docs.yml`, `docs/build.sh`, and `docs/publish-docs.sh` I think the old logic logic should still work. I'd like to merge this and test it in production. Once it's publishing correctly I can setup a DNS record for: edge.docs.anza.xyz

And then backport this PR (plus any follow ups) before setting up DNS records for:
beta.docs.anza.xyz
docs.anza.xyz