### PR TITLE
Uses IntMap in SlotOffsets

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -822,7 +822,7 @@ pub type AtomicAccountsFileId = AtomicU32;
 pub type AccountsFileId = u32;
 
 type AccountSlots = HashMap<Pubkey, IntSet<Slot>>;
-type SlotOffsets = HashMap<Slot, IntSet<usize>>;
+type SlotOffsets = IntMap<Slot, IntSet<usize>>;
 type ReclaimResult = (AccountSlots, SlotOffsets);
 type PubkeysRemovedFromAccountsIndex = HashSet<Pubkey>;
 type ShrinkCandidates = IntSet<Slot>;


### PR DESCRIPTION
#### Problem

SlotOffsets is a map of slot to offsets. It does not need cryptographic security, so it can use IntMap instead of HashMap for better performance.


#### Summary of Changes

Replace HashMap with IntMap