### PR TITLE
switch to ContactInfo propagation in PullRequests

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1605,11 +1605,7 @@ impl ClusterInfo {
             .map(|(_, filters)| filters.len())
             .sum::<usize>() as u64;
         self.stats.new_pull_requests_count.add_relaxed(num_requests);
-        // TODO: Use new ContactInfo once the cluster has upgraded to:
-        // https://github.com/anza-xyz/agave/pull/803
-        let self_info = LegacyContactInfo::try_from(&self.my_contact_info())
-            .map(CrdsData::LegacyContactInfo)
-            .expect("Operator must spin up node with valid contact-info");
+        let self_info = CrdsData::ContactInfo(self.my_contact_info());
         let self_info = CrdsValue::new_signed(self_info, &self.keypair());
         let pulls = pulls
             .into_iter()
@@ -4386,10 +4382,7 @@ mod tests {
     }
 
     fn check_pull_request_size(filter: CrdsFilter) {
-        // TODO: Use new ContactInfo once the cluster has upgraded to:
-        // https://github.com/anza-xyz/agave/pull/803
-        let value =
-            CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(LegacyContactInfo::default()));
+        let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::default()));
         let protocol = Protocol::PullRequest(filter, value);
         assert!(serialized_size(&protocol).unwrap() <= PACKET_DATA_SIZE as u64);
     }
@@ -4557,11 +4550,9 @@ mod tests {
     fn max_bloom_size() -> usize {
         let filter_size = serialized_size(&CrdsFilter::default())
             .expect("unable to serialize default filter") as usize;
-        // TODO: Use new ContactInfo once the cluster has upgraded to:
-        // https://github.com/anza-xyz/agave/pull/803
         let protocol = Protocol::PullRequest(
             CrdsFilter::default(),
-            CrdsValue::new_unsigned(CrdsData::LegacyContactInfo(LegacyContactInfo::default())),
+            CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::default())),
         );
         let protocol_size =
             serialized_size(&protocol).expect("unable to serialize gossip protocol") as usize;

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -5738,7 +5738,6 @@ fn test_randomly_mixed_block_verification_methods_between_bootstrap_and_not() {
 
 /// Forks previous marked invalid should be marked as such in fork choice on restart
 #[test]
-#[ignore]
 #[serial]
 fn test_invalid_forks_persisted_on_restart() {
     solana_logger::setup_with("info,solana_metrics=off,solana_ledger=off");


### PR DESCRIPTION
#### Problem
1) unstaked nodes are having a difficult time catching up and acquiring shreds via repair: https://discord.com/channels/428295358100013066/1282690942616211526/1282691964558643221
2) `tvu_peers` set of unstaked nodes is unreliable and keeps changing, causing nodes to appear offline or out of gossip

#### Cause
In v2.0.8, `self.nodes` in `crds` only stores `ContactInfo`, it does not store `LegacyContactInfo` , but v1.18.23 stores `LegacyContactInfo` in `crds.nodes`.  
master: https://github.com/anza-xyz/agave/blob/37671df9fd654e9da453cb094ce32e3ea181c536/gossip/src/crds.rs#L254-L255
v1.18.23: https://github.com/anza-xyz/agave/blob/8c42fa8a3ae3b11c2a223762d368ccfff0d22340/gossip/src/crds.rs#L246-L247
self.nodes aka crds.nodes: https://github.com/anza-xyz/agave/blob/37671df9fd654e9da453cb094ce32e3ea181c536/gossip/src/crds.rs#L74

In both versions, we send our `LegacyContactInfo` in every `PullRequest` sent. However, in v2.0.8, this `LegacyContactInfo`, no longer gets stored in `crds.nodes` even though it is sent. So when unstaked nodes are sending pull requests, their `LegacyContactInfo` is not getting propagated. 

It seems that unstaked nodes are relying heavily on pull requests to propagated their `ContactInfo`. But with the update to v2.0.8, receiving nodes are no longer registering `LegacyContactInfo` in their set of `tvu_peer`s because `crds.nodes` doesn't hold them anymore.

#### Summary of Changes
Since mb has upgraded to v1.18.23 and can handle `ContactInfo` in a `PullRequest`, we can switch over to propagating `ContactInfo` in `PullRequest`. We can also remove the `[ignore]` on the previously flaky test caused by this same issue.

#### Data
@steviez applied this patch to `tw2NAkBpTwST2c4NDW9xFmWgqSL5ErPy5QYbfYa3KXi`, which was previously experiencing repair issues as mentioned above and got the following result:
From Steve:
<img width="1418" alt="pr-contact-info-repair" src="https://github.com/user-attachments/assets/35dbdda1-9c51-4b26-88ad-10263785ed16">
^ Shred percentages through turbine/recovery/repair over the last hour:
Vertical white line is where process came back online with patch
Orange = turbine
Blue = recovery
Purple = repair

Almost entirely repair previously and now almost no repair / all turbine + recovery (recovery technically under turbine too)

This patch also causes `tw2NAkBpTwST2c4NDW9xFmWgqSL5ErPy5QYbfYa3KXi` to consistently and immediately appear in `tvu_peers`.

PR made with @steviez 

