### PR TITLE
metric: report estimated_mem_bytes for in-mem index

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -981,7 +981,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     }
 
     /// assumes 1 entry in the slot list. Ignores overhead of the HashMap and such
-    pub(crate) fn approx_size_of_one_entry() -> usize {
+    pub const fn approx_size_of_one_entry() -> usize {
         std::mem::size_of::<T>()
             + std::mem::size_of::<Pubkey>()
             + std::mem::size_of::<AccountMapEntry<T>>()

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -980,6 +980,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         thread_rng().gen_range(0..N) == 0
     }
 
+    /// assumes 1 entry in the slot list. Ignores overhead of the HashMap and such
+    pub(crate) fn approx_size_of_one_entry() -> usize {
+        std::mem::size_of::<T>()
+            + std::mem::size_of::<Pubkey>()
+            + std::mem::size_of::<AccountMapEntry<T>>()
+    }
+
     fn should_evict_based_on_age(
         current_age: Age,
         entry: &AccountMapEntry<T>,

--- a/accounts-db/src/bucket_map_holder_stats.rs
+++ b/accounts-db/src/bucket_map_holder_stats.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        accounts_index::{DiskIndexValue, IndexValue},
+        accounts_index::{in_mem_accounts_index::InMemAccountsIndex, DiskIndexValue, IndexValue},
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
     },
     solana_sdk::timing::AtomicInterval,
@@ -262,7 +262,8 @@ impl BucketMapHolderStats {
                 },
                 (
                     "estimate_mem_bytes",
-                    self.count_in_mem.load(Ordering::Relaxed) * 48, // each index entry in memory takes approx 48 bytes.
+                    self.count_in_mem.load(Ordering::Relaxed)
+                        * InMemAccountsIndex::<T, U>::approx_size_of_one_entry(),
                     i64
                 ),
                 (

--- a/accounts-db/src/bucket_map_holder_stats.rs
+++ b/accounts-db/src/bucket_map_holder_stats.rs
@@ -61,7 +61,6 @@ pub struct BucketMapHolderStats {
     last_was_startup: AtomicBool,
     last_time: AtomicInterval,
     bins: u64,
-    pub estimate_mem: AtomicU64,
     pub flush_should_evict_us: AtomicU64,
 }
 
@@ -263,7 +262,7 @@ impl BucketMapHolderStats {
                 },
                 (
                     "estimate_mem_bytes",
-                    self.estimate_mem.load(Ordering::Relaxed),
+                    self.count_in_mem.load(Ordering::Relaxed) * 48, // each index entry in memory takes approx 48 bytes.
                     i64
                 ),
                 (


### PR DESCRIPTION
#### Problem

It is nice to report bytes usage for in-memory index.


#### Summary of Changes

report estimated memory bytes for in-memory index.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
