### PR TITLE
clippy: Fixes blocks_in_conditions warning

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1436,9 +1436,10 @@ pub fn process_ping(
     rpc_client: &RpcClient,
 ) -> ProcessResult {
     let (signal_sender, signal_receiver) = unbounded();
-    match ctrlc::try_set_handler(move || {
+    let handler = move || {
         let _ = signal_sender.send(());
-    }) {
+    };
+    match ctrlc::try_set_handler(handler) {
         // It's possible to set the ctrl-c handler more than once in testing
         // situations, so let that case through
         Err(ctrlc::Error::MultipleHandlers) => {}


### PR DESCRIPTION
#### Problem

Clippy throws this warning when I run locally:

```
warning: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
    --> cli/src/cluster_query.rs:1440:42
     |
1440 |       match ctrlc::try_set_handler(move || {
     |  __________________________________________^
1441 | |         let _ = signal_sender.send(());
1442 | |     }) {
     | |_____^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_conditions
     = note: `#[warn(clippy::blocks_in_conditions)]` on by default
```


#### Summary of Changes

Move the closure out of the scrutinee.