### PR TITLE
docs: fix tonic crates.io url

### DIFF
--- a/docs/src/implemented-proposals/rpc-transaction-history.md
+++ b/docs/src/implemented-proposals/rpc-transaction-history.md
@@ -61,7 +61,7 @@ all transactions to build up the necessary metadata.
 ## Accessing BigTable
 
 BigTable has a gRPC endpoint that can be accessed using the
-[tonic](https://crates.io/crates/crate) and the raw protobuf API, as currently
+[tonic](https://crates.io/crates/tonic) and the raw protobuf API, as currently
 no higher-level Rust crate for BigTable exists. Practically this makes parsing
 the results of BigTable queries more complicated but is not a significant issue.
 


### PR DESCRIPTION
#### Problem
Link to tonic crate is wrong in `implemented-proposals/rpc-transaction-history.md` doc

#### Summary of Changes
Updated tonic crates.io link

Fixes #
