### PR TITLE
Add a new client implementation targeting TPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8395,10 +8395,11 @@ version = "2.1.0"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
+ "futures 0.3.31",
  "log",
  "lru",
  "quinn",
- "rustls",
+ "rustls 0.23.14",
  "solana-cli-config",
  "solana-connection-cache",
  "solana-logger",
@@ -8409,6 +8410,7 @@ dependencies = [
  "solana-tpu-client",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8390,6 +8390,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-tpu-client-next"
+version = "2.1.0"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "log",
+ "lru",
+ "quinn",
+ "rustls",
+ "solana-cli-config",
+ "solana-connection-cache",
+ "solana-logger",
+ "solana-measure",
+ "solana-rpc-client",
+ "solana-sdk",
+ "solana-streamer",
+ "solana-tpu-client",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "solana-transaction-dos"
 version = "2.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ members = [
     "tokens",
     "tps-client",
     "tpu-client",
+    "tpu-client-next",
     "transaction-dos",
     "transaction-metrics-tracker",
     "transaction-status",

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -23,10 +23,12 @@ solana-streamer = { workspace = true }
 solana-tpu-client = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 
 [dev-dependencies]
 crossbeam-channel = { workspace = true }
 solana-cli-config = { workspace = true }
+futures = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "solana-tpu-client-next"
+description = "Client code to send transaction to TPU."
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+async-trait = { workspace = true }
+log = { workspace = true }
+lru = { workspace = true }
+quinn = { workspace = true }
+rustls = { workspace = true }
+solana-connection-cache = { workspace = true }
+solana-logger = { workspace = true }
+solana-measure = { workspace = true }
+solana-rpc-client = { workspace = true }
+solana-sdk = { workspace = true }
+solana-streamer = { workspace = true }
+solana-tpu-client = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+crossbeam-channel = { workspace = true }
+solana-cli-config = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -27,8 +27,8 @@ tokio-util = { workspace = true }
 
 [dev-dependencies]
 crossbeam-channel = { workspace = true }
-solana-cli-config = { workspace = true }
 futures = { workspace = true }
+solana-cli-config = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -141,7 +141,7 @@ impl ConnectionWorker {
     }
 
     /// Retrieves the statistics for transactions sent by this worker.
-    pub fn get_transaction_stats(&self) -> &SendTransactionStats {
+    pub fn transaction_stats(&self) -> &SendTransactionStats {
         &self.send_txs_stats
     }
 
@@ -154,7 +154,7 @@ impl ConnectionWorker {
     async fn send_transactions(&mut self, connection: Connection, transactions: TransactionBatch) {
         let now = timestamp();
         if !self.skip_check_transaction_age
-            && now.saturating_sub(transactions.get_timestamp()) > MAX_PROCESSING_AGE_MS
+            && now.saturating_sub(transactions.timestamp()) > MAX_PROCESSING_AGE_MS
         {
             debug!("Drop outdated transaction batch.");
             return;

--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -183,7 +183,7 @@ impl ConnectionWorker {
     /// the connection is successful, the state is updated to `Active`. If an
     /// error occurs, the state may transition to `Retry` or `Closing`,
     /// depending on the nature of the error.
-    async fn create_connection(&mut self, num_reconnects: usize) {
+    async fn create_connection(&mut self, max_retries_attempt: usize) {
         let connecting = self.endpoint.connect(self.peer, "connect");
         match connecting {
             Ok(connecting) => {
@@ -202,7 +202,8 @@ impl ConnectionWorker {
                     Err(err) => {
                         warn!("Connection error {}: {}", self.peer, err);
                         record_error(err.into(), &mut self.send_txs_stats);
-                        self.connection = ConnectionState::Retry(num_reconnects.saturating_add(1));
+                        self.connection =
+                            ConnectionState::Retry(max_retries_attempt.saturating_add(1));
                     }
                 }
             }

--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -158,6 +158,7 @@ impl ConnectionWorker {
             let result = send_data_over_stream(&connection, &data).await;
 
             if let Err(error) = result {
+                trace!("Failed to send transaction over stream with error: {error}.");
                 record_error(error, &mut self.send_txs_stats);
                 self.connection = ConnectionState::Retry(0);
             } else {

--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -1,0 +1,220 @@
+//! This module defines `ConnectionWorker` which encapsulates the
+//! functionality needed to handle one connection within the scope of task.
+use {
+    super::SendTransactionStats,
+    crate::{
+        quic_networking::send_data_over_stream, send_transaction_stats::record_error,
+        transaction_batch::TransactionBatch,
+    },
+    log::*,
+    quinn::{ConnectError, Connection, Endpoint},
+    solana_measure::measure::Measure,
+    solana_sdk::{
+        clock::{DEFAULT_MS_PER_SLOT, MAX_PROCESSING_AGE, NUM_CONSECUTIVE_LEADER_SLOTS},
+        timing::timestamp,
+    },
+    std::net::SocketAddr,
+    tokio::{
+        sync::mpsc,
+        time::{sleep, Duration},
+    },
+};
+
+/// Maximum number of reconnection attempts in case the connection errors out.
+const MAX_RECONNECT_ATTEMPTS: usize = 4;
+
+/// Interval between retry attempts for creating a new connection. This value is
+/// a best-effort estimate, based on current network conditions.
+const RETRY_SLEEP_INTERVAL: Duration =
+    Duration::from_millis(NUM_CONSECUTIVE_LEADER_SLOTS * DEFAULT_MS_PER_SLOT);
+
+/// Maximum age (in milliseconds) of a blockhash, beyond which transaction
+/// batches are dropped.
+const MAX_PROCESSING_AGE_MS: u64 = MAX_PROCESSING_AGE as u64 * DEFAULT_MS_PER_SLOT;
+
+/// [`ConnectionState`] represents the current state of a quic connection. This
+/// enum tracks the lifecycle of connection from initial setup to closing phase.
+/// The transition function between states is defined in `ConnectionWorker`
+/// implementation.
+enum ConnectionState {
+    NotSetup,
+    Active(Connection),
+    Retry(usize),
+    Closing,
+}
+
+impl Drop for ConnectionState {
+    fn drop(&mut self) {
+        if let Self::Active(connection) = self {
+            info!(
+                "Close connection with {:?}, stats: {:?}. All pending streams will be dropped.",
+                connection.remote_address(),
+                connection.stats()
+            );
+            // no guarantee that all the streams will finish
+            connection.close(0u32.into(), b"done");
+        }
+    }
+}
+
+/// [`ConnectionWorker`] holds connection to the validator with address `peer`. If
+/// connection has been closed, [`ConnectionWorker`] tries to reconnect
+/// [`MAX_RECONNECT_ATTEMPTS`] times. If connection is in `Active` state, it sends
+/// transactions received from `transactions_receiver`. Additionally, it
+/// accumulates statistics about connections and streams failures.
+pub(crate) struct ConnectionWorker {
+    endpoint: Endpoint,
+    peer: SocketAddr,
+    transactions_receiver: mpsc::Receiver<TransactionBatch>,
+    connection: ConnectionState,
+    send_txs_stats: SendTransactionStats,
+}
+
+impl ConnectionWorker {
+    pub fn new(
+        endpoint: Endpoint,
+        peer: SocketAddr,
+        command_receiver: mpsc::Receiver<TransactionBatch>,
+    ) -> Self {
+        Self {
+            endpoint,
+            peer,
+            transactions_receiver: command_receiver,
+            connection: ConnectionState::NotSetup,
+            send_txs_stats: SendTransactionStats::default(),
+        }
+    }
+
+    /// Starts the main loop of the [`ConnectionWorker`]. This method manages the
+    /// connection to the peer and handles state transitions. It runs
+    /// indefinitely until the connection is closed or an unrecoverable error
+    /// occurs.
+    pub async fn run(&mut self) {
+        loop {
+            match &self.connection {
+                ConnectionState::Closing => {
+                    break;
+                }
+                ConnectionState::NotSetup => {
+                    self.create_connection(0).await;
+                }
+                ConnectionState::Active(connection) => {
+                    let Some(transactions) = self.transactions_receiver.recv().await else {
+                        info!("Transactions sender has been dropped.");
+                        self.connection = ConnectionState::Closing;
+                        continue;
+                    };
+                    self.send_transactions(connection.clone(), transactions)
+                        .await;
+                }
+                ConnectionState::Retry(num_reconnects) => {
+                    if *num_reconnects > MAX_RECONNECT_ATTEMPTS {
+                        error!(
+                            "Didn't manage to establish connection: reach max reconnect attempts."
+                        );
+                        self.connection = ConnectionState::Closing;
+                        continue;
+                    }
+                    sleep(RETRY_SLEEP_INTERVAL).await;
+                    self.reconnect(*num_reconnects).await;
+                }
+            }
+        }
+    }
+
+    /// Retrieves the statistics for transactions sent by this worker.
+    pub fn get_transaction_stats(&self) -> &SendTransactionStats {
+        &self.send_txs_stats
+    }
+
+    /// Sends a batch of transactions using the provided `connection`. Each
+    /// transaction in the batch is sent over the QUIC streams one at the time,
+    /// which prevents traffic fragmentation and shows better TPS in comparison
+    /// with multistream send. If the batch is determined to be outdated, it
+    /// will be dropped without being sent. In case of error, it doesn't retry
+    /// to send the same transactions again.
+    async fn send_transactions(&mut self, connection: Connection, transactions: TransactionBatch) {
+        let now = timestamp();
+        if now.saturating_sub(transactions.get_timestamp()) > MAX_PROCESSING_AGE_MS {
+            info!("Drop outdated transaction batch.");
+            return;
+        }
+        let mut measure_send = Measure::start("send transaction batch");
+        for data in transactions.into_iter() {
+            let result = send_data_over_stream(&connection, &data).await;
+
+            if let Err(error) = result {
+                record_error(error, &mut self.send_txs_stats);
+                self.connection = ConnectionState::Retry(0);
+            } else {
+                self.send_txs_stats.successfully_sent =
+                    self.send_txs_stats.successfully_sent.saturating_add(1);
+            }
+        }
+        measure_send.stop();
+        info!(
+            "Time to send transactions batch: {} us",
+            measure_send.as_us()
+        );
+    }
+
+    /// Attempts to create a new connection to the specified `peer` address. If
+    /// the connection is successful, the state is updated to `Active`. If an
+    /// error occurs, the state may transition to `Retry` or `Closing`,
+    /// depending on the nature of the error.
+    async fn create_connection(&mut self, num_reconnects: usize) {
+        let connecting = self.endpoint.connect(self.peer, "connect");
+        match connecting {
+            Ok(connecting) => {
+                let mut measure_connection = Measure::start("establish connection");
+                let res = connecting.await;
+                measure_connection.stop();
+                info!(
+                    "Establishing connection with {} took: {} us",
+                    self.peer,
+                    measure_connection.as_us()
+                );
+                match res {
+                    Ok(connection) => {
+                        self.connection = ConnectionState::Active(connection);
+                    }
+                    Err(err) => {
+                        warn!("Connection error {}: {}", self.peer, err);
+                        record_error(err.into(), &mut self.send_txs_stats);
+                        self.connection = ConnectionState::Retry(num_reconnects.saturating_add(1));
+                    }
+                }
+            }
+            Err(connecting_error) => {
+                record_error(connecting_error.clone().into(), &mut self.send_txs_stats);
+                match connecting_error {
+                    ConnectError::EndpointStopping => {
+                        info!("Endpoint stopping, exit connection worker.");
+                        self.connection = ConnectionState::Closing;
+                    }
+                    ConnectError::InvalidRemoteAddress(_) => {
+                        warn!("Invalid remote address.");
+                        self.connection = ConnectionState::Closing;
+                    }
+                    ConnectError::TooManyConnections => {
+                        warn!("Too many connections have been opened. Wait.");
+                        self.connection = ConnectionState::Retry(num_reconnects.saturating_add(1));
+                    }
+                    e => {
+                        error!("Unexpected error has happen while trying to create connection {e}");
+                        self.connection = ConnectionState::Closing;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Attempts to reconnect to the peer after a connection failure.
+    async fn reconnect(&mut self, num_reconnects: usize) {
+        info!("Trying to reconnect. Reopen connection, 0rtt is not implemented yet.");
+        // We can reconnect using 0rtt, but not a priority for now. Check if we
+        // need to call config.enable_0rtt() on the client side and where
+        // session tickets are stored.
+        self.create_connection(num_reconnects).await;
+    }
+}

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -68,7 +68,7 @@ impl ConnectionWorkersScheduler {
                 break;
                 }
             };
-            let updated_leaders = leader_updater.get_leaders();
+            let updated_leaders = leader_updater.next_num_lookahead_slots_leaders();
             let new_leader = &updated_leaders[0];
             let future_leaders = &updated_leaders[1..];
             if !workers.contains(new_leader) {

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -1,0 +1,121 @@
+//! This module defines [`ConnectionWorkersScheduler`] which creates and
+//! orchestrates `ConnectionWorker` instances.
+use {
+    super::{leader_updater::LeaderUpdater, SendTransactionStatsPerAddr},
+    crate::{
+        connection_worker::ConnectionWorker,
+        quic_networking::{
+            create_client_config, create_client_endpoint, QuicClientCertificate, QuicError,
+        },
+        transaction_batch::TransactionBatch,
+        workers_cache::{WorkerInfo, WorkersCache, WorkersCacheError},
+    },
+    log::*,
+    quinn::Endpoint,
+    solana_sdk::signature::Keypair,
+    std::{net::SocketAddr, sync::Arc},
+    thiserror::Error,
+    tokio::sync::mpsc,
+};
+
+/// Size of the channel to transmit transaction batches to the target workers.
+const WORKER_CHANNEL_SIZE: usize = 2;
+
+/// [`ConnectionWorkersScheduler`] is responsible for managing and scheduling
+/// connection workers that handle transactions over the network.
+pub struct ConnectionWorkersScheduler;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum ConnectionWorkersSchedulerError {
+    #[error(transparent)]
+    QuicError(#[from] QuicError),
+    #[error(transparent)]
+    WorkersCacheError(#[from] WorkersCacheError),
+    #[error("Leader receiver unexpectedly dropped.")]
+    LeaderReceiverDropped,
+}
+
+impl ConnectionWorkersScheduler {
+    /// Runs the main loop that handles worker scheduling and management for
+    /// connections. Returns the error quic statistics per connection address or
+    /// an error if something goes wrong. Importantly, if some transactions were
+    /// not delivered due to network problems, they will not be retried when the
+    /// problem is resolved.
+    pub async fn run(
+        bind: SocketAddr,
+        validator_identity: Option<Keypair>,
+        mut leader_updater: Box<dyn LeaderUpdater>,
+        mut transaction_receiver: mpsc::Receiver<TransactionBatch>,
+        num_connections: usize,
+    ) -> Result<SendTransactionStatsPerAddr, ConnectionWorkersSchedulerError> {
+        let endpoint = Self::setup_endpoint(bind, validator_identity)?;
+        debug!("Client endpoint bind address: {:?}", endpoint.local_addr());
+        let mut workers = WorkersCache::new(num_connections);
+        loop {
+            let Some(transaction_batch) = transaction_receiver.recv().await else {
+                info!("Transaction generator has stopped, stopping ConnectionWorkersScheduler.");
+                break;
+            };
+            let updated_leaders = leader_updater.get_leaders();
+            let new_leader = &updated_leaders[0];
+            let future_leaders = &updated_leaders[1..];
+            if !workers.contains(new_leader) {
+                debug!("Could not find pre-fetch leader worker for {new_leader:?}.");
+                let worker = Self::spawn_worker(&endpoint, new_leader).await;
+                workers.push(*new_leader, worker).await;
+            }
+
+            if let Err(error) = workers
+                .send_txs_to_worker(new_leader, transaction_batch)
+                .await
+            {
+                warn!(
+                    "Connection to the leader {new_leader} has been closed, worker error: {error}",
+                );
+                // if we has failed to send batch, it will be dropped.
+            }
+
+            // regardless of who is leader, add future leaders to the cache to
+            // hide the latency of opening the connection.
+            for peer in future_leaders {
+                if !workers.contains(peer) {
+                    let worker = Self::spawn_worker(&endpoint, peer).await;
+                    workers.push(*peer, worker).await;
+                }
+            }
+        }
+        workers.close().await;
+
+        endpoint.close(0u32.into(), b"Closing connection");
+        leader_updater.stop_and_join().await;
+        Ok(workers.get_transaction_stats().clone())
+    }
+
+    /// Sets up the QUIC endpoint for the scheduler to handle connections.
+    fn setup_endpoint(
+        bind: SocketAddr,
+        validator_identity: Option<Keypair>,
+    ) -> Result<Endpoint, ConnectionWorkersSchedulerError> {
+        let client_certificate = if let Some(validator_identity) = validator_identity {
+            Arc::new(QuicClientCertificate::new(&validator_identity))
+        } else {
+            Arc::new(QuicClientCertificate::default())
+        };
+        let client_config = create_client_config(client_certificate);
+        let endpoint = create_client_endpoint(bind, client_config)?;
+        Ok(endpoint)
+    }
+
+    /// Spawns a worker to handle communication with a given peer.
+    async fn spawn_worker(endpoint: &Endpoint, peer: &SocketAddr) -> WorkerInfo {
+        let (txs_sender, txs_receiver) = mpsc::channel(WORKER_CHANNEL_SIZE);
+        let endpoint = endpoint.clone();
+        let peer = *peer;
+        let handle = tokio::spawn(async move {
+            let mut new_connection_worker = ConnectionWorker::new(endpoint, peer, txs_receiver);
+            new_connection_worker.run().await;
+            new_connection_worker.get_transaction_stats().clone()
+        });
+        WorkerInfo::new(txs_sender, handle)
+    }
+}

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -128,7 +128,7 @@ impl ConnectionWorkersScheduler {
 
         endpoint.close(0u32.into(), b"Closing connection");
         leader_updater.stop_and_join().await;
-        Ok(workers.get_transaction_stats().clone())
+        Ok(workers.transaction_stats().clone())
     }
 
     /// Sets up the QUIC endpoint for the scheduler to handle connections.
@@ -139,7 +139,7 @@ impl ConnectionWorkersScheduler {
         let client_certificate = if let Some(validator_identity) = validator_identity {
             Arc::new(QuicClientCertificate::new(&validator_identity))
         } else {
-            Arc::new(QuicClientCertificate::default())
+            Arc::new(QuicClientCertificate::new(&Keypair::new()))
         };
         let client_config = create_client_config(client_certificate);
         let endpoint = create_client_endpoint(bind, client_config)?;
@@ -161,7 +161,7 @@ impl ConnectionWorkersScheduler {
             ConnectionWorker::new(endpoint, peer, txs_receiver, skip_check_transaction_age);
         let handle = tokio::spawn(async move {
             worker.run().await;
-            worker.get_transaction_stats().clone()
+            worker.transaction_stats().clone()
         });
 
         WorkerInfo::new(txs_sender, handle, cancel)

--- a/tpu-client-next/src/leader_updater.rs
+++ b/tpu-client-next/src/leader_updater.rs
@@ -1,0 +1,117 @@
+//! This module provides [`LeaderUpdater`] trait along with it's implementations
+//! `LeaderUpdaterService` and `PinnedLeaderUpdater`. Currently, the main
+//! purpose of [`LeaderUpdater`] is to abstract over leader updates, hiding the
+//! details of how leaders are retrieved and which structures are used.
+//! Specifically, `LeaderUpdaterService` keeps [`LeaderTpuService`] internal to
+//! this module. Yet, it also allows to implement custom leader estimation.
+use {
+    async_trait::async_trait,
+    log::*,
+    solana_connection_cache::connection_cache::Protocol,
+    solana_rpc_client::nonblocking::rpc_client::RpcClient,
+    solana_tpu_client::nonblocking::tpu_client::LeaderTpuService,
+    std::{
+        fmt,
+        net::SocketAddr,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+    },
+};
+
+/// [`LeaderUpdater`] trait abstracts out functionality required for the
+/// [`ConnectionWorkersScheduler`](crate::network::ConnectionWorkersScheduler)
+/// to identify next leaders to send transactions to.
+#[async_trait]
+pub trait LeaderUpdater: Send {
+    fn get_leaders(&self) -> Vec<SocketAddr>;
+    async fn stop_and_join(&mut self);
+}
+
+pub struct LeaderUpdaterError;
+
+impl fmt::Display for LeaderUpdaterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Leader updater encountered an error")
+    }
+}
+
+impl fmt::Debug for LeaderUpdaterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "LeaderUpdaterError")
+    }
+}
+
+/// Creates a [`LeaderUpdater`] based on the configuration provided by the
+/// caller. If a pinned address is provided, it will return a
+/// `PinnedLeaderUpdater` that always returns the provided address instead of
+/// checking leader schedule. Otherwise, it creates a `LeaderUpdaterService`
+/// which dynamically updates the leaders by connecting to the network via the
+/// [`LeaderTpuService`].
+pub async fn create_leader_updater(
+    rpc_client: Arc<RpcClient>,
+    websocket_url: String,
+    lookahead_slots: u64,
+    pinned_address: Option<SocketAddr>,
+) -> Result<Box<dyn LeaderUpdater>, LeaderUpdaterError> {
+    if let Some(pinned_address) = pinned_address {
+        return Ok(Box::new(PinnedLeaderUpdater {
+            address: vec![pinned_address],
+        }));
+    }
+
+    let exit = Arc::new(AtomicBool::new(false));
+    let leader_tpu_service =
+        LeaderTpuService::new(rpc_client, &websocket_url, Protocol::QUIC, exit.clone())
+            .await
+            .map_err(|error| {
+                error!("Failed to create a LeaderTpuService: {error}");
+                LeaderUpdaterError
+            })?;
+    Ok(Box::new(LeaderUpdaterService {
+        leader_tpu_service,
+        exit,
+        lookahead_slots,
+    }))
+}
+
+/// `LeaderUpdaterService` is an implementation of the [`LeaderUpdater`] trait
+/// that dynamically retrieves the current and upcoming leaders by communicating
+/// with the Solana network using [`LeaderTpuService`].
+struct LeaderUpdaterService {
+    leader_tpu_service: LeaderTpuService,
+    exit: Arc<AtomicBool>,
+    /// Number of *estimated* next leaders. If the estimation for the current
+    /// leader is wrong and we have sent to only one leader, we may lose all the
+    /// txs (depends on the forwarding policy).
+    lookahead_slots: u64,
+}
+
+#[async_trait]
+impl LeaderUpdater for LeaderUpdaterService {
+    fn get_leaders(&self) -> Vec<SocketAddr> {
+        self.leader_tpu_service
+            .leader_tpu_sockets(self.lookahead_slots)
+    }
+
+    async fn stop_and_join(&mut self) {
+        self.exit.store(true, Ordering::Relaxed);
+        self.leader_tpu_service.join().await;
+    }
+}
+
+/// `PinnedLeaderUpdater` is an implementation of [`LeaderUpdater`] that always
+/// returns a fixed, "pinned" leader address. It is mainly used for testing.
+struct PinnedLeaderUpdater {
+    address: Vec<SocketAddr>,
+}
+
+#[async_trait]
+impl LeaderUpdater for PinnedLeaderUpdater {
+    fn get_leaders(&self) -> Vec<SocketAddr> {
+        self.address.clone()
+    }
+
+    async fn stop_and_join(&mut self) {}
+}

--- a/tpu-client-next/src/leader_updater.rs
+++ b/tpu-client-next/src/leader_updater.rs
@@ -25,7 +25,7 @@ use {
 /// to identify next leaders to send transactions to.
 #[async_trait]
 pub trait LeaderUpdater: Send {
-    fn get_leaders(&self) -> Vec<SocketAddr>;
+    fn next_num_lookahead_slots_leaders(&self) -> Vec<SocketAddr>;
     async fn stop_and_join(&mut self);
 }
 
@@ -90,7 +90,7 @@ struct LeaderUpdaterService {
 
 #[async_trait]
 impl LeaderUpdater for LeaderUpdaterService {
-    fn get_leaders(&self) -> Vec<SocketAddr> {
+    fn next_num_lookahead_slots_leaders(&self) -> Vec<SocketAddr> {
         self.leader_tpu_service
             .leader_tpu_sockets(self.lookahead_slots)
     }
@@ -109,7 +109,7 @@ struct PinnedLeaderUpdater {
 
 #[async_trait]
 impl LeaderUpdater for PinnedLeaderUpdater {
-    fn get_leaders(&self) -> Vec<SocketAddr> {
+    fn next_num_lookahead_slots_leaders(&self) -> Vec<SocketAddr> {
         self.address.clone()
     }
 

--- a/tpu-client-next/src/leader_updater.rs
+++ b/tpu-client-next/src/leader_updater.rs
@@ -26,7 +26,7 @@ use {
 #[async_trait]
 pub trait LeaderUpdater: Send {
     fn next_num_lookahead_slots_leaders(&self) -> Vec<SocketAddr>;
-    async fn stop_and_join(&mut self);
+    async fn stop(&mut self);
 }
 
 pub struct LeaderUpdaterError;
@@ -95,7 +95,7 @@ impl LeaderUpdater for LeaderUpdaterService {
             .leader_tpu_sockets(self.lookahead_slots)
     }
 
-    async fn stop_and_join(&mut self) {
+    async fn stop(&mut self) {
         self.exit.store(true, Ordering::Relaxed);
         self.leader_tpu_service.join().await;
     }
@@ -113,5 +113,5 @@ impl LeaderUpdater for PinnedLeaderUpdater {
         self.address.clone()
     }
 
-    async fn stop_and_join(&mut self) {}
+    async fn stop(&mut self) {}
 }

--- a/tpu-client-next/src/lib.rs
+++ b/tpu-client-next/src/lib.rs
@@ -1,12 +1,12 @@
-pub mod connection_worker;
+pub(crate) mod connection_worker;
 pub mod connection_workers_scheduler;
 pub mod send_transaction_stats;
-pub mod workers_cache;
+pub(crate) mod workers_cache;
 pub use crate::{
     connection_workers_scheduler::{ConnectionWorkersScheduler, ConnectionWorkersSchedulerError},
     send_transaction_stats::{SendTransactionStats, SendTransactionStatsPerAddr},
 };
-pub mod quic_networking;
-pub use crate::quic_networking::QuicError;
+pub(crate) mod quic_networking;
+pub(crate) use crate::quic_networking::QuicError;
 pub mod leader_updater;
 pub mod transaction_batch;

--- a/tpu-client-next/src/lib.rs
+++ b/tpu-client-next/src/lib.rs
@@ -1,0 +1,12 @@
+pub mod connection_worker;
+pub mod connection_workers_scheduler;
+pub mod send_transaction_stats;
+pub mod workers_cache;
+pub use crate::{
+    connection_workers_scheduler::{ConnectionWorkersScheduler, ConnectionWorkersSchedulerError},
+    send_transaction_stats::{SendTransactionStats, SendTransactionStatsPerAddr},
+};
+pub mod quic_networking;
+pub use crate::quic_networking::QuicError;
+pub mod leader_updater;
+pub mod transaction_batch;

--- a/tpu-client-next/src/quic_networking.rs
+++ b/tpu-client-next/src/quic_networking.rs
@@ -20,7 +20,7 @@ pub use {
     quic_client_certificate::QuicClientCertificate,
 };
 
-pub fn create_client_config(client_certificate: Arc<QuicClientCertificate>) -> ClientConfig {
+pub(crate) fn create_client_config(client_certificate: Arc<QuicClientCertificate>) -> ClientConfig {
     // adapted from QuicLazyInitializedEndpoint::create_endpoint
     let mut crypto = rustls::ClientConfig::builder()
         .dangerous()

--- a/tpu-client-next/src/quic_networking.rs
+++ b/tpu-client-next/src/quic_networking.rs
@@ -5,6 +5,7 @@ use {
         crypto::rustls::QuicClientConfig, ClientConfig, Connection, Endpoint, IdleTimeout,
         TransportConfig,
     },
+    skip_server_verification::SkipServerVerification,
     solana_sdk::quic::{QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT},
     solana_streamer::nonblocking::quic::ALPN_TPU_PROTOCOL_ID,
     std::{net::SocketAddr, sync::Arc},
@@ -17,7 +18,6 @@ pub mod skip_server_verification;
 pub use {
     error::{IoErrorWithPartialEq, QuicError},
     quic_client_certificate::QuicClientCertificate,
-    skip_server_verification::SkipServerVerification,
 };
 
 pub fn create_client_config(client_certificate: Arc<QuicClientCertificate>) -> ClientConfig {

--- a/tpu-client-next/src/quic_networking.rs
+++ b/tpu-client-next/src/quic_networking.rs
@@ -1,120 +1,49 @@
 //! Utility code to handle quic networking.
+
 use {
     quinn::{
-        ClientConfig, ConnectError, Connection, ConnectionError, Endpoint, IdleTimeout,
-        TransportConfig, WriteError,
+        crypto::rustls::QuicClientConfig, ClientConfig, Connection, Endpoint, IdleTimeout,
+        TransportConfig,
     },
-    solana_sdk::{
-        quic::{QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT},
-        signature::Keypair,
-    },
-    solana_streamer::{
-        nonblocking::quic::ALPN_TPU_PROTOCOL_ID, tls_certificates::new_dummy_x509_certificate,
-    },
-    std::{fmt, io, net::SocketAddr, sync::Arc},
-    thiserror::Error,
+    solana_sdk::quic::{QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT},
+    solana_streamer::nonblocking::quic::ALPN_TPU_PROTOCOL_ID,
+    std::{net::SocketAddr, sync::Arc},
 };
 
-/// Wrapper for [`std::io::Error`] implementing [`PartialEq`] to simplify error
-/// checking for [`QuicError`] type. The reasons why [`std::io::Error`] doesn't
-/// implement [`PartialEq`] are discussed in
-/// <https://github.com/rust-lang/rust/issues/34158>
-#[derive(Debug, Error)]
-pub struct IoErrorWithPartialEq(pub io::Error);
+pub mod error;
+pub mod quic_client_certificate;
+pub mod skip_server_verification;
 
-impl PartialEq for IoErrorWithPartialEq {
-    fn eq(&self, other: &Self) -> bool {
-        let formatted_self = format!("{self:?}");
-        let formatted_other = format!("{other:?}");
-        formatted_self == formatted_other
-    }
-}
+pub use {
+    error::{IoErrorWithPartialEq, QuicError},
+    quic_client_certificate::QuicClientCertificate,
+    skip_server_verification::SkipServerVerification,
+};
 
-impl fmt::Display for IoErrorWithPartialEq {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl From<io::Error> for IoErrorWithPartialEq {
-    fn from(err: io::Error) -> Self {
-        IoErrorWithPartialEq(err)
-    }
-}
-
-/// Error types that can occur when dealing with QUIC connections or
-/// transmissions.
-#[derive(Error, Debug, PartialEq)]
-pub enum QuicError {
-    #[error(transparent)]
-    WriteError(#[from] WriteError),
-    #[error(transparent)]
-    ConnectionError(#[from] ConnectionError),
-    #[error(transparent)]
-    ConnectError(#[from] ConnectError),
-    #[error(transparent)]
-    EndpointError(#[from] IoErrorWithPartialEq),
-}
-
-// Implementation of [`ServerCertVerifier`] that verifies everything as
-// trustworthy.
-struct SkipServerVerification;
-
-impl SkipServerVerification {
-    pub fn new() -> Arc<Self> {
-        Arc::new(Self)
-    }
-}
-impl rustls::client::ServerCertVerifier for SkipServerVerification {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &rustls::Certificate,
-        _intermediates: &[rustls::Certificate],
-        _server_name: &rustls::ServerName,
-        _scts: &mut dyn Iterator<Item = &[u8]>,
-        _ocsp_response: &[u8],
-        _now: std::time::SystemTime,
-    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
-        Ok(rustls::client::ServerCertVerified::assertion())
-    }
-}
-pub(crate) struct QuicClientCertificate {
-    pub certificate: rustls::Certificate,
-    pub key: rustls::PrivateKey,
-}
-
-impl Default for QuicClientCertificate {
-    fn default() -> Self {
-        QuicClientCertificate::new(&Keypair::new())
-    }
-}
-
-impl QuicClientCertificate {
-    pub fn new(keypair: &Keypair) -> Self {
-        let (certificate, key) = new_dummy_x509_certificate(keypair);
-        Self { certificate, key }
-    }
-}
-
-pub(crate) fn create_client_config(client_certificate: Arc<QuicClientCertificate>) -> ClientConfig {
+pub fn create_client_config(client_certificate: Arc<QuicClientCertificate>) -> ClientConfig {
     // adapted from QuicLazyInitializedEndpoint::create_endpoint
     let mut crypto = rustls::ClientConfig::builder()
-        .with_safe_defaults()
+        .dangerous()
         .with_custom_certificate_verifier(SkipServerVerification::new())
         .with_client_auth_cert(
             vec![client_certificate.certificate.clone()],
-            client_certificate.key.clone(),
+            client_certificate.key.clone_key(),
         )
         .expect("Failed to set QUIC client certificates");
     crypto.enable_early_data = true;
     crypto.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
 
-    let mut config = ClientConfig::new(Arc::new(crypto));
-    let mut transport_config = TransportConfig::default();
+    let transport_config = {
+        let mut res = TransportConfig::default();
 
-    let timeout = IdleTimeout::try_from(QUIC_MAX_TIMEOUT).unwrap();
-    transport_config.max_idle_timeout(Some(timeout));
-    transport_config.keep_alive_interval(Some(QUIC_KEEP_ALIVE));
+        let timeout = IdleTimeout::try_from(QUIC_MAX_TIMEOUT).unwrap();
+        res.max_idle_timeout(Some(timeout));
+        res.keep_alive_interval(Some(QUIC_KEEP_ALIVE));
+
+        res
+    };
+
+    let mut config = ClientConfig::new(Arc::new(QuicClientConfig::try_from(crypto).unwrap()));
     config.transport_config(Arc::new(transport_config));
 
     config
@@ -134,8 +63,8 @@ pub(crate) async fn send_data_over_stream(
     data: &[u8],
 ) -> Result<(), QuicError> {
     let mut send_stream = connection.open_uni().await?;
-    send_stream.write_all(data).await?;
-    // stream will be finished when dropped. Finishing here explicitly would
-    // lead to blocking.
+    send_stream.write_all(data).await.map_err(QuicError::from)?;
+
+    // Stream will be finished when dropped. Finishing here explicitly is a noop.
     Ok(())
 }

--- a/tpu-client-next/src/quic_networking.rs
+++ b/tpu-client-next/src/quic_networking.rs
@@ -1,0 +1,141 @@
+//! Utility code to handle quic networking.
+use {
+    quinn::{
+        ClientConfig, ConnectError, Connection, ConnectionError, Endpoint, IdleTimeout,
+        TransportConfig, WriteError,
+    },
+    solana_sdk::{
+        quic::{QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT},
+        signature::Keypair,
+    },
+    solana_streamer::{
+        nonblocking::quic::ALPN_TPU_PROTOCOL_ID, tls_certificates::new_dummy_x509_certificate,
+    },
+    std::{fmt, io, net::SocketAddr, sync::Arc},
+    thiserror::Error,
+};
+
+/// Wrapper for [`std::io::Error`] implementing [`PartialEq`] to simplify error
+/// checking for [`QuicError`] type. The reasons why [`std::io::Error`] doesn't
+/// implement [`PartialEq`] are discussed in
+/// <https://github.com/rust-lang/rust/issues/34158>
+#[derive(Debug, Error)]
+pub struct IoErrorWithPartialEq(pub io::Error);
+
+impl PartialEq for IoErrorWithPartialEq {
+    fn eq(&self, other: &Self) -> bool {
+        let formatted_self = format!("{self:?}");
+        let formatted_other = format!("{other:?}");
+        formatted_self == formatted_other
+    }
+}
+
+impl fmt::Display for IoErrorWithPartialEq {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<io::Error> for IoErrorWithPartialEq {
+    fn from(err: io::Error) -> Self {
+        IoErrorWithPartialEq(err)
+    }
+}
+
+/// Error types that can occur when dealing with QUIC connections or
+/// transmissions.
+#[derive(Error, Debug, PartialEq)]
+pub enum QuicError {
+    #[error(transparent)]
+    WriteError(#[from] WriteError),
+    #[error(transparent)]
+    ConnectionError(#[from] ConnectionError),
+    #[error(transparent)]
+    ConnectError(#[from] ConnectError),
+    #[error(transparent)]
+    EndpointError(#[from] IoErrorWithPartialEq),
+}
+
+// Implementation of [`ServerCertVerifier`] that verifies everything as
+// trustworthy.
+struct SkipServerVerification;
+
+impl SkipServerVerification {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self)
+    }
+}
+impl rustls::client::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &rustls::ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: std::time::SystemTime,
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::ServerCertVerified::assertion())
+    }
+}
+pub(crate) struct QuicClientCertificate {
+    pub certificate: rustls::Certificate,
+    pub key: rustls::PrivateKey,
+}
+
+impl Default for QuicClientCertificate {
+    fn default() -> Self {
+        QuicClientCertificate::new(&Keypair::new())
+    }
+}
+
+impl QuicClientCertificate {
+    pub fn new(keypair: &Keypair) -> Self {
+        let (certificate, key) = new_dummy_x509_certificate(keypair);
+        Self { certificate, key }
+    }
+}
+
+pub(crate) fn create_client_config(client_certificate: Arc<QuicClientCertificate>) -> ClientConfig {
+    // adapted from QuicLazyInitializedEndpoint::create_endpoint
+    let mut crypto = rustls::ClientConfig::builder()
+        .with_safe_defaults()
+        .with_custom_certificate_verifier(SkipServerVerification::new())
+        .with_client_auth_cert(
+            vec![client_certificate.certificate.clone()],
+            client_certificate.key.clone(),
+        )
+        .expect("Failed to set QUIC client certificates");
+    crypto.enable_early_data = true;
+    crypto.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
+
+    let mut config = ClientConfig::new(Arc::new(crypto));
+    let mut transport_config = TransportConfig::default();
+
+    let timeout = IdleTimeout::try_from(QUIC_MAX_TIMEOUT).unwrap();
+    transport_config.max_idle_timeout(Some(timeout));
+    transport_config.keep_alive_interval(Some(QUIC_KEEP_ALIVE));
+    config.transport_config(Arc::new(transport_config));
+
+    config
+}
+
+pub(crate) fn create_client_endpoint(
+    bind_addr: SocketAddr,
+    client_config: ClientConfig,
+) -> Result<Endpoint, QuicError> {
+    let mut endpoint = Endpoint::client(bind_addr).map_err(IoErrorWithPartialEq::from)?;
+    endpoint.set_default_client_config(client_config);
+    Ok(endpoint)
+}
+
+pub(crate) async fn send_data_over_stream(
+    connection: &Connection,
+    data: &[u8],
+) -> Result<(), QuicError> {
+    let mut send_stream = connection.open_uni().await?;
+    send_stream.write_all(data).await?;
+    // stream will be finished when dropped. Finishing here explicitly would
+    // lead to blocking.
+    Ok(())
+}

--- a/tpu-client-next/src/quic_networking/error.rs
+++ b/tpu-client-next/src/quic_networking/error.rs
@@ -39,11 +39,11 @@ impl From<io::Error> for IoErrorWithPartialEq {
 #[derive(Error, Debug, PartialEq)]
 pub enum QuicError {
     #[error(transparent)]
-    WriteError(#[from] WriteError),
+    StreamWrite(#[from] WriteError),
     #[error(transparent)]
-    ConnectionError(#[from] ConnectionError),
+    Connection(#[from] ConnectionError),
     #[error(transparent)]
-    ConnectError(#[from] ConnectError),
+    Connect(#[from] ConnectError),
     #[error(transparent)]
-    EndpointError(#[from] IoErrorWithPartialEq),
+    Endpoint(#[from] IoErrorWithPartialEq),
 }

--- a/tpu-client-next/src/quic_networking/error.rs
+++ b/tpu-client-next/src/quic_networking/error.rs
@@ -1,0 +1,48 @@
+use {
+    quinn::{ConnectError, ConnectionError, WriteError},
+    std::{
+        fmt::{self, Formatter},
+        io,
+    },
+    thiserror::Error,
+};
+
+/// Wrapper for [`io::Error`] implementing [`PartialEq`] to simplify error checking for the
+/// [`QuicError`] type.
+/// The reasons why [`io::Error`] doesn't implement [`PartialEq`] are discusses in
+/// <https://github.com/rust-lang/rust/issues/34158>.
+#[derive(Debug, Error)]
+pub struct IoErrorWithPartialEq(pub io::Error);
+
+impl PartialEq for IoErrorWithPartialEq {
+    fn eq(&self, other: &Self) -> bool {
+        let formatted_self = format!("{self:?}");
+        let formatted_other = format!("{other:?}");
+        formatted_self == formatted_other
+    }
+}
+
+impl fmt::Display for IoErrorWithPartialEq {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<io::Error> for IoErrorWithPartialEq {
+    fn from(err: io::Error) -> Self {
+        IoErrorWithPartialEq(err)
+    }
+}
+
+/// Error types that can occur when dealing with QUIC connections or transmissions.
+#[derive(Error, Debug, PartialEq)]
+pub enum QuicError {
+    #[error(transparent)]
+    WriteError(#[from] WriteError),
+    #[error(transparent)]
+    ConnectionError(#[from] ConnectionError),
+    #[error(transparent)]
+    ConnectError(#[from] ConnectError),
+    #[error(transparent)]
+    EndpointError(#[from] IoErrorWithPartialEq),
+}

--- a/tpu-client-next/src/quic_networking/error.rs
+++ b/tpu-client-next/src/quic_networking/error.rs
@@ -7,9 +7,9 @@ use {
     thiserror::Error,
 };
 
-/// Wrapper for [`io::Error`] implementing [`PartialEq`] to simplify error checking for the
-/// [`QuicError`] type.
-/// The reasons why [`io::Error`] doesn't implement [`PartialEq`] are discusses in
+/// Wrapper for [`io::Error`] implementing [`PartialEq`] to simplify error
+/// checking for the [`QuicError`] type. The reasons why [`io::Error`] doesn't
+/// implement [`PartialEq`] are discusses in
 /// <https://github.com/rust-lang/rust/issues/34158>.
 #[derive(Debug, Error)]
 pub struct IoErrorWithPartialEq(pub io::Error);
@@ -34,7 +34,8 @@ impl From<io::Error> for IoErrorWithPartialEq {
     }
 }
 
-/// Error types that can occur when dealing with QUIC connections or transmissions.
+/// Error types that can occur when dealing with QUIC connections or
+/// transmissions.
 #[derive(Error, Debug, PartialEq)]
 pub enum QuicError {
     #[error(transparent)]

--- a/tpu-client-next/src/quic_networking/quic_client_certificate.rs
+++ b/tpu-client-next/src/quic_networking/quic_client_certificate.rs
@@ -1,0 +1,23 @@
+use {
+    rustls::pki_types::{CertificateDer, PrivateKeyDer},
+    solana_sdk::signature::Keypair,
+    solana_streamer::tls_certificates::new_dummy_x509_certificate,
+};
+
+pub struct QuicClientCertificate {
+    pub certificate: CertificateDer<'static>,
+    pub key: PrivateKeyDer<'static>,
+}
+
+impl Default for QuicClientCertificate {
+    fn default() -> Self {
+        QuicClientCertificate::new(&Keypair::new())
+    }
+}
+
+impl QuicClientCertificate {
+    pub fn new(keypair: &Keypair) -> Self {
+        let (certificate, key) = new_dummy_x509_certificate(keypair);
+        Self { certificate, key }
+    }
+}

--- a/tpu-client-next/src/quic_networking/quic_client_certificate.rs
+++ b/tpu-client-next/src/quic_networking/quic_client_certificate.rs
@@ -9,12 +9,6 @@ pub struct QuicClientCertificate {
     pub key: PrivateKeyDer<'static>,
 }
 
-impl Default for QuicClientCertificate {
-    fn default() -> Self {
-        QuicClientCertificate::new(&Keypair::new())
-    }
-}
-
 impl QuicClientCertificate {
     pub fn new(keypair: &Keypair) -> Self {
         let (certificate, key) = new_dummy_x509_certificate(keypair);

--- a/tpu-client-next/src/quic_networking/skip_server_verification.rs
+++ b/tpu-client-next/src/quic_networking/skip_server_verification.rs
@@ -1,0 +1,76 @@
+use {
+    rustls::{
+        client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+        crypto::{ring, verify_tls12_signature, verify_tls13_signature, CryptoProvider},
+        pki_types::{CertificateDer, ServerName, UnixTime},
+        DigitallySignedStruct, Error, SignatureScheme,
+    },
+    std::{
+        fmt::{self, Debug, Formatter},
+        sync::Arc,
+    },
+};
+
+/// Implementation of [`ServerCertVerifier`] that ignores the server certificate.  But still checks
+/// the TLS signatures.
+///
+/// This is a duplicate of `solana_quic_client::nonblocking::quic_client::SkipServerVerification`.
+pub struct SkipServerVerification(Arc<CryptoProvider>);
+
+impl SkipServerVerification {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self(Arc::new(ring::default_provider())))
+    }
+}
+
+impl ServerCertVerifier for SkipServerVerification {
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+}
+
+impl Debug for SkipServerVerification {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SkipServerVerification")
+            .finish_non_exhaustive()
+    }
+}

--- a/tpu-client-next/src/quic_networking/skip_server_verification.rs
+++ b/tpu-client-next/src/quic_networking/skip_server_verification.rs
@@ -11,11 +11,9 @@ use {
     },
 };
 
-/// Implementation of [`ServerCertVerifier`] that ignores the server certificate.  But still checks
-/// the TLS signatures.
-///
-/// This is a duplicate of `solana_quic_client::nonblocking::quic_client::SkipServerVerification`.
-pub struct SkipServerVerification(Arc<CryptoProvider>);
+/// Implementation of [`ServerCertVerifier`] that ignores the server
+/// certificate. Yet still checks the TLS signatures.
+pub(crate) struct SkipServerVerification(Arc<CryptoProvider>);
 
 impl SkipServerVerification {
     pub fn new() -> Arc<Self> {

--- a/tpu-client-next/src/send_transaction_stats.rs
+++ b/tpu-client-next/src/send_transaction_stats.rs
@@ -1,0 +1,158 @@
+//! This module defines [`SendTransactionStats`] which is used to collect per IP
+//! statistics about relevant network errors.
+use {
+    super::QuicError,
+    quinn::{ConnectError, ConnectionError, WriteError},
+    std::{collections::HashMap, fmt, net::IpAddr},
+};
+
+/// [`SendTransactionStats`] aggregates counters related to sending transactions.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SendTransactionStats {
+    pub successfully_sent: u64,
+    pub connect_error_invalid_remote_address: u64,
+    pub connect_error_other: u64,
+    pub connect_error_too_many_connections: u64,
+    pub connection_error_application_closed: u64,
+    pub connection_error_connection_closed: u64,
+    pub connection_error_locally_closed: u64,
+    pub connection_error_reset: u64,
+    pub connection_error_timed_out: u64,
+    pub connection_error_transport_error: u64,
+    pub connection_error_version_mismatch: u64,
+    pub write_error_connection_lost: u64,
+    pub write_error_stopped: u64,
+    pub write_error_unknown_stream: u64,
+    pub write_error_zero_rtt_rejected: u64,
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+pub fn record_error(err: QuicError, stats: &mut SendTransactionStats) {
+    match err {
+        QuicError::ConnectError(ConnectError::EndpointStopping) => {
+            stats.connect_error_other += 1;
+        }
+        QuicError::ConnectError(ConnectError::TooManyConnections) => {
+            stats.connect_error_too_many_connections += 1;
+        }
+        QuicError::ConnectError(ConnectError::InvalidDnsName(_)) => {
+            stats.connect_error_other += 1;
+        }
+        QuicError::ConnectError(ConnectError::InvalidRemoteAddress(_)) => {
+            stats.connect_error_invalid_remote_address += 1;
+        }
+        QuicError::ConnectError(ConnectError::NoDefaultClientConfig) => {
+            stats.connect_error_other += 1;
+        }
+        QuicError::ConnectError(ConnectError::UnsupportedVersion) => {
+            stats.connect_error_other += 1;
+        }
+        QuicError::ConnectionError(ConnectionError::VersionMismatch) => {
+            stats.connection_error_version_mismatch += 1;
+        }
+        QuicError::ConnectionError(ConnectionError::TransportError(_)) => {
+            stats.connection_error_transport_error += 1;
+        }
+        QuicError::ConnectionError(ConnectionError::ConnectionClosed(_)) => {
+            stats.connection_error_connection_closed += 1;
+        }
+        QuicError::ConnectionError(ConnectionError::ApplicationClosed(_)) => {
+            stats.connection_error_application_closed += 1;
+        }
+        QuicError::ConnectionError(ConnectionError::Reset) => {
+            stats.connection_error_reset += 1;
+        }
+        QuicError::ConnectionError(ConnectionError::TimedOut) => {
+            stats.connection_error_timed_out += 1;
+        }
+        QuicError::ConnectionError(ConnectionError::LocallyClosed) => {
+            stats.connection_error_locally_closed += 1;
+        }
+        QuicError::WriteError(WriteError::Stopped(_)) => {
+            stats.write_error_stopped += 1;
+        }
+        QuicError::WriteError(WriteError::ConnectionLost(_)) => {
+            stats.write_error_connection_lost += 1;
+        }
+        QuicError::WriteError(WriteError::UnknownStream) => {
+            stats.write_error_unknown_stream += 1;
+        }
+        QuicError::WriteError(WriteError::ZeroRttRejected) => {
+            stats.write_error_zero_rtt_rejected += 1;
+        }
+        // Endpoint is created on the scheduler level and handled separately
+        // No counters are used for this case.
+        QuicError::EndpointError(_) => (),
+    }
+}
+
+pub type SendTransactionStatsPerAddr = HashMap<IpAddr, SendTransactionStats>;
+
+macro_rules! add_fields {
+    ($self:ident, $other:ident, $( $field:ident ),* ) => {
+        $(
+            $self.$field = $self.$field.saturating_add($other.$field);
+        )*
+    };
+}
+
+impl SendTransactionStats {
+    pub fn add(&mut self, other: &SendTransactionStats) {
+        add_fields!(
+            self,
+            other,
+            successfully_sent,
+            connect_error_invalid_remote_address,
+            connect_error_other,
+            connect_error_too_many_connections,
+            connection_error_application_closed,
+            connection_error_connection_closed,
+            connection_error_locally_closed,
+            connection_error_reset,
+            connection_error_timed_out,
+            connection_error_transport_error,
+            connection_error_version_mismatch,
+            write_error_connection_lost,
+            write_error_stopped,
+            write_error_unknown_stream,
+            write_error_zero_rtt_rejected
+        );
+    }
+}
+
+macro_rules! display_send_transaction_stats {
+    ($($field:ident),*) => {
+        impl fmt::Display for SendTransactionStats {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(
+                    f,
+                    concat!(
+                        "SendTransactionStats:\n",
+                        $(
+                            "\x20   ", stringify!($field), ": {},\n",
+                        )*
+                    ),
+                    $(self.$field),*
+                )
+            }
+        }
+    };
+}
+
+display_send_transaction_stats!(
+    successfully_sent,
+    connect_error_invalid_remote_address,
+    connect_error_other,
+    connect_error_too_many_connections,
+    connection_error_application_closed,
+    connection_error_connection_closed,
+    connection_error_locally_closed,
+    connection_error_reset,
+    connection_error_timed_out,
+    connection_error_transport_error,
+    connection_error_version_mismatch,
+    write_error_connection_lost,
+    write_error_stopped,
+    write_error_unknown_stream,
+    write_error_zero_rtt_rejected
+);

--- a/tpu-client-next/src/send_transaction_stats.rs
+++ b/tpu-client-next/src/send_transaction_stats.rs
@@ -31,63 +31,63 @@ pub struct SendTransactionStats {
 #[allow(clippy::arithmetic_side_effects)]
 pub fn record_error(err: QuicError, stats: &mut SendTransactionStats) {
     match err {
-        QuicError::ConnectError(ConnectError::EndpointStopping) => {
+        QuicError::Connect(ConnectError::EndpointStopping) => {
             stats.connect_error_other += 1;
         }
-        QuicError::ConnectError(ConnectError::CidsExhausted) => {
+        QuicError::Connect(ConnectError::CidsExhausted) => {
             stats.connect_error_cids_exhausted += 1;
         }
-        QuicError::ConnectError(ConnectError::InvalidServerName(_)) => {
+        QuicError::Connect(ConnectError::InvalidServerName(_)) => {
             stats.connect_error_other += 1;
         }
-        QuicError::ConnectError(ConnectError::InvalidRemoteAddress(_)) => {
+        QuicError::Connect(ConnectError::InvalidRemoteAddress(_)) => {
             stats.connect_error_invalid_remote_address += 1;
         }
-        QuicError::ConnectError(ConnectError::NoDefaultClientConfig) => {
+        QuicError::Connect(ConnectError::NoDefaultClientConfig) => {
             stats.connect_error_other += 1;
         }
-        QuicError::ConnectError(ConnectError::UnsupportedVersion) => {
+        QuicError::Connect(ConnectError::UnsupportedVersion) => {
             stats.connect_error_other += 1;
         }
-        QuicError::ConnectionError(ConnectionError::VersionMismatch) => {
+        QuicError::Connection(ConnectionError::VersionMismatch) => {
             stats.connection_error_version_mismatch += 1;
         }
-        QuicError::ConnectionError(ConnectionError::TransportError(_)) => {
+        QuicError::Connection(ConnectionError::TransportError(_)) => {
             stats.connection_error_transport_error += 1;
         }
-        QuicError::ConnectionError(ConnectionError::ConnectionClosed(_)) => {
+        QuicError::Connection(ConnectionError::ConnectionClosed(_)) => {
             stats.connection_error_connection_closed += 1;
         }
-        QuicError::ConnectionError(ConnectionError::ApplicationClosed(_)) => {
+        QuicError::Connection(ConnectionError::ApplicationClosed(_)) => {
             stats.connection_error_application_closed += 1;
         }
-        QuicError::ConnectionError(ConnectionError::Reset) => {
+        QuicError::Connection(ConnectionError::Reset) => {
             stats.connection_error_reset += 1;
         }
-        QuicError::ConnectionError(ConnectionError::TimedOut) => {
+        QuicError::Connection(ConnectionError::TimedOut) => {
             stats.connection_error_timed_out += 1;
         }
-        QuicError::ConnectionError(ConnectionError::LocallyClosed) => {
+        QuicError::Connection(ConnectionError::LocallyClosed) => {
             stats.connection_error_locally_closed += 1;
         }
-        QuicError::ConnectionError(ConnectionError::CidsExhausted) => {
+        QuicError::Connection(ConnectionError::CidsExhausted) => {
             stats.connection_error_cids_exhausted += 1;
         }
-        QuicError::WriteError(WriteError::Stopped(_)) => {
+        QuicError::StreamWrite(WriteError::Stopped(_)) => {
             stats.write_error_stopped += 1;
         }
-        QuicError::WriteError(WriteError::ConnectionLost(_)) => {
+        QuicError::StreamWrite(WriteError::ConnectionLost(_)) => {
             stats.write_error_connection_lost += 1;
         }
-        QuicError::WriteError(WriteError::ClosedStream) => {
+        QuicError::StreamWrite(WriteError::ClosedStream) => {
             stats.write_error_closed_stream += 1;
         }
-        QuicError::WriteError(WriteError::ZeroRttRejected) => {
+        QuicError::StreamWrite(WriteError::ZeroRttRejected) => {
             stats.write_error_zero_rtt_rejected += 1;
         }
         // Endpoint is created on the scheduler level and handled separately
         // No counters are used for this case.
-        QuicError::EndpointError(_) => (),
+        QuicError::Endpoint(_) => (),
     }
 }
 

--- a/tpu-client-next/src/send_transaction_stats.rs
+++ b/tpu-client-next/src/send_transaction_stats.rs
@@ -127,16 +127,16 @@ impl SendTransactionStats {
 
 macro_rules! display_send_transaction_stats_body {
     ($self:ident, $f:ident, $($field:ident),* $(,)?) => {
-                write!(
+        write!(
             $f,
-                    concat!(
-                        "SendTransactionStats:\n",
-                        $(
-                            "\x20   ", stringify!($field), ": {},\n",
-                        )*
-                    ),
+            concat!(
+                "SendTransactionStats:\n",
+                $(
+                    "\x20   ", stringify!($field), ": {},\n",
+                )*
+            ),
             $($self.$field),*
-                )
+        )
     };
 }
 

--- a/tpu-client-next/src/send_transaction_stats.rs
+++ b/tpu-client-next/src/send_transaction_stats.rs
@@ -1,5 +1,6 @@
 //! This module defines [`SendTransactionStats`] which is used to collect per IP
 //! statistics about relevant network errors.
+
 use {
     super::QuicError,
     quinn::{ConnectError, ConnectionError, WriteError},
@@ -10,19 +11,20 @@ use {
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct SendTransactionStats {
     pub successfully_sent: u64,
+    pub connect_error_cids_exhausted: u64,
     pub connect_error_invalid_remote_address: u64,
     pub connect_error_other: u64,
-    pub connect_error_too_many_connections: u64,
     pub connection_error_application_closed: u64,
+    pub connection_error_cids_exhausted: u64,
     pub connection_error_connection_closed: u64,
     pub connection_error_locally_closed: u64,
     pub connection_error_reset: u64,
     pub connection_error_timed_out: u64,
     pub connection_error_transport_error: u64,
     pub connection_error_version_mismatch: u64,
+    pub write_error_closed_stream: u64,
     pub write_error_connection_lost: u64,
     pub write_error_stopped: u64,
-    pub write_error_unknown_stream: u64,
     pub write_error_zero_rtt_rejected: u64,
 }
 
@@ -32,10 +34,10 @@ pub fn record_error(err: QuicError, stats: &mut SendTransactionStats) {
         QuicError::ConnectError(ConnectError::EndpointStopping) => {
             stats.connect_error_other += 1;
         }
-        QuicError::ConnectError(ConnectError::TooManyConnections) => {
-            stats.connect_error_too_many_connections += 1;
+        QuicError::ConnectError(ConnectError::CidsExhausted) => {
+            stats.connect_error_cids_exhausted += 1;
         }
-        QuicError::ConnectError(ConnectError::InvalidDnsName(_)) => {
+        QuicError::ConnectError(ConnectError::InvalidServerName(_)) => {
             stats.connect_error_other += 1;
         }
         QuicError::ConnectError(ConnectError::InvalidRemoteAddress(_)) => {
@@ -68,14 +70,17 @@ pub fn record_error(err: QuicError, stats: &mut SendTransactionStats) {
         QuicError::ConnectionError(ConnectionError::LocallyClosed) => {
             stats.connection_error_locally_closed += 1;
         }
+        QuicError::ConnectionError(ConnectionError::CidsExhausted) => {
+            stats.connection_error_cids_exhausted += 1;
+        }
         QuicError::WriteError(WriteError::Stopped(_)) => {
             stats.write_error_stopped += 1;
         }
         QuicError::WriteError(WriteError::ConnectionLost(_)) => {
             stats.write_error_connection_lost += 1;
         }
-        QuicError::WriteError(WriteError::UnknownStream) => {
-            stats.write_error_unknown_stream += 1;
+        QuicError::WriteError(WriteError::ClosedStream) => {
+            stats.write_error_closed_stream += 1;
         }
         QuicError::WriteError(WriteError::ZeroRttRejected) => {
             stats.write_error_zero_rtt_rejected += 1;
@@ -89,7 +94,7 @@ pub fn record_error(err: QuicError, stats: &mut SendTransactionStats) {
 pub type SendTransactionStatsPerAddr = HashMap<IpAddr, SendTransactionStats>;
 
 macro_rules! add_fields {
-    ($self:ident, $other:ident, $( $field:ident ),* ) => {
+    ($self:ident += $other:ident for: $( $field:ident ),* $(,)? ) => {
         $(
             $self.$field = $self.$field.saturating_add($other.$field);
         )*
@@ -99,60 +104,63 @@ macro_rules! add_fields {
 impl SendTransactionStats {
     pub fn add(&mut self, other: &SendTransactionStats) {
         add_fields!(
-            self,
-            other,
+            self += other for:
             successfully_sent,
+            connect_error_cids_exhausted,
             connect_error_invalid_remote_address,
             connect_error_other,
-            connect_error_too_many_connections,
             connection_error_application_closed,
+            connection_error_cids_exhausted,
             connection_error_connection_closed,
             connection_error_locally_closed,
             connection_error_reset,
             connection_error_timed_out,
             connection_error_transport_error,
             connection_error_version_mismatch,
+            write_error_closed_stream,
             write_error_connection_lost,
             write_error_stopped,
-            write_error_unknown_stream,
-            write_error_zero_rtt_rejected
+            write_error_zero_rtt_rejected,
         );
     }
 }
 
-macro_rules! display_send_transaction_stats {
-    ($($field:ident),*) => {
-        impl fmt::Display for SendTransactionStats {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+macro_rules! display_send_transaction_stats_body {
+    ($self:ident, $f:ident, $($field:ident),* $(,)?) => {
                 write!(
-                    f,
+            $f,
                     concat!(
                         "SendTransactionStats:\n",
                         $(
                             "\x20   ", stringify!($field), ": {},\n",
                         )*
                     ),
-                    $(self.$field),*
+            $($self.$field),*
                 )
-            }
-        }
     };
 }
 
-display_send_transaction_stats!(
-    successfully_sent,
-    connect_error_invalid_remote_address,
-    connect_error_other,
-    connect_error_too_many_connections,
-    connection_error_application_closed,
-    connection_error_connection_closed,
-    connection_error_locally_closed,
-    connection_error_reset,
-    connection_error_timed_out,
-    connection_error_transport_error,
-    connection_error_version_mismatch,
-    write_error_connection_lost,
-    write_error_stopped,
-    write_error_unknown_stream,
-    write_error_zero_rtt_rejected
-);
+impl fmt::Display for SendTransactionStats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        display_send_transaction_stats_body!(
+            self,
+            f,
+            successfully_sent,
+            connect_error_cids_exhausted,
+            connect_error_invalid_remote_address,
+            connect_error_other,
+            connection_error_application_closed,
+            connection_error_cids_exhausted,
+            connection_error_connection_closed,
+            connection_error_locally_closed,
+            connection_error_reset,
+            connection_error_timed_out,
+            connection_error_transport_error,
+            connection_error_version_mismatch,
+            write_error_closed_stream,
+            write_error_connection_lost,
+            write_error_stopped,
+            write_error_zero_rtt_rejected,
+        )
+    }
+}

--- a/tpu-client-next/src/transaction_batch.rs
+++ b/tpu-client-next/src/transaction_batch.rs
@@ -1,0 +1,33 @@
+//! This module holds [`TransactionBatch`] structure.
+use solana_sdk::timing::timestamp;
+
+/// Batch of generated transactions
+/// timestamp is used to discard batches which are too old
+/// to have valid blockhash.
+#[derive(Clone, PartialEq)]
+pub struct TransactionBatch {
+    wired_transactions: Vec<WiredTransaction>,
+    timestamp: u64,
+}
+
+type WiredTransaction = Vec<u8>;
+
+impl IntoIterator for TransactionBatch {
+    type Item = Vec<u8>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.wired_transactions.into_iter()
+    }
+}
+
+impl TransactionBatch {
+    pub fn new(wired_transactions: Vec<WiredTransaction>) -> Self {
+        Self {
+            wired_transactions,
+            timestamp: timestamp(),
+        }
+    }
+    pub fn get_timestamp(&self) -> u64 {
+        self.timestamp
+    }
+}

--- a/tpu-client-next/src/transaction_batch.rs
+++ b/tpu-client-next/src/transaction_batch.rs
@@ -1,9 +1,9 @@
 //! This module holds [`TransactionBatch`] structure.
+
 use solana_sdk::timing::timestamp;
 
-/// Batch of generated transactions
-/// timestamp is used to discard batches which are too old
-/// to have valid blockhash.
+/// Batch of generated transactions timestamp is used to discard batches which
+/// are too old to have valid blockhash.
 #[derive(Clone, PartialEq)]
 pub struct TransactionBatch {
     wired_transactions: Vec<WiredTransaction>,

--- a/tpu-client-next/src/transaction_batch.rs
+++ b/tpu-client-next/src/transaction_batch.rs
@@ -27,7 +27,7 @@ impl TransactionBatch {
             timestamp: timestamp(),
         }
     }
-    pub fn get_timestamp(&self) -> u64 {
+    pub fn timestamp(&self) -> u64 {
         self.timestamp
     }
 }

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -37,7 +37,10 @@ impl WorkerInfo {
         }
     }
 
-    async fn send_txs(&self, txs_batch: TransactionBatch) -> Result<(), WorkersCacheError> {
+    async fn send_transactions(
+        &self,
+        txs_batch: TransactionBatch,
+    ) -> Result<(), WorkersCacheError> {
         self.sender
             .send(txs_batch)
             .await
@@ -45,7 +48,8 @@ impl WorkerInfo {
         Ok(())
     }
 
-    /// Closes the worker by dropping the sender and awaiting the worker's statistics.
+    /// Closes the worker by dropping the sender and awaiting the worker's
+    /// statistics.
     async fn shutdown(self) -> Result<SendTransactionStats, WorkersCacheError> {
         self.cancel.cancel();
         drop(self.sender);
@@ -121,7 +125,7 @@ impl WorkersCache {
                 "Failed to fetch worker for peer {peer}.\n\
              Peer existence must be checked before this call using `contains` method.",
             );
-            let send_res = current_worker.send_txs(txs_batch).await;
+            let send_res = current_worker.send_transactions(txs_batch).await;
 
             if let Err(WorkersCacheError::ReceiverDropped) = send_res {
                 // Remove the worker from the cache, if the peer has disconnected.

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -107,7 +107,7 @@ impl WorkersCache {
     /// Sends a batch of transactions to the worker for a given peer. If the
     /// worker for the peer is disconnected or fails, it is removed from the
     /// cache.
-    pub async fn send_txs_to_worker(
+    pub async fn send_transactions_to_address(
         &mut self,
         peer: &SocketAddr,
         txs_batch: TransactionBatch,

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -1,0 +1,147 @@
+//! This module defines `WorkersCache` along with aux struct `WorkerInfo`. These
+//! structures provide mechanisms for caching workers, sending transaction
+//! batches, and gathering send transaction statistics.
+use {
+    super::SendTransactionStats,
+    crate::transaction_batch::TransactionBatch,
+    log::*,
+    lru::LruCache,
+    std::{
+        collections::HashMap,
+        net::{IpAddr, SocketAddr},
+    },
+    thiserror::Error,
+    tokio::{sync::mpsc, task::JoinHandle},
+};
+
+/// [`WorkerInfo`] holds information about a worker responsible for sending
+/// transaction batches.
+pub(crate) struct WorkerInfo {
+    pub sender: mpsc::Sender<TransactionBatch>,
+    pub handle: JoinHandle<SendTransactionStats>,
+}
+
+impl WorkerInfo {
+    pub fn new(
+        sender: mpsc::Sender<TransactionBatch>,
+        handle: JoinHandle<SendTransactionStats>,
+    ) -> Self {
+        Self { sender, handle }
+    }
+
+    async fn queue_txs(&self, txs_batch: TransactionBatch) -> Result<(), WorkersCacheError> {
+        self.sender
+            .send(txs_batch)
+            .await
+            .map_err(|_| WorkersCacheError::ReceiverDropped)?;
+        Ok(())
+    }
+
+    /// Closes the worker by dropping the sender and awaiting the worker's statistics.
+    async fn close(self) -> Result<SendTransactionStats, WorkersCacheError> {
+        drop(self.sender);
+        let stats = self
+            .handle
+            .await
+            .map_err(|_| WorkersCacheError::TaskJoinFailure)?;
+        Ok(stats)
+    }
+}
+
+/// [`WorkersCache`] manages and caches workers. It uses an LRU cache to store and
+/// manage workers. It also tracks transaction statistics for each peer.
+pub(crate) struct WorkersCache {
+    workers: LruCache<SocketAddr, WorkerInfo>,
+    send_stats_per_addr: HashMap<IpAddr, SendTransactionStats>,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum WorkersCacheError {
+    /// typically happens when the client could not establish the connection.
+    #[error("Work receiver has been dropped unexpectedly.")]
+    ReceiverDropped,
+
+    #[error("Task failed to join.")]
+    TaskJoinFailure,
+}
+
+impl WorkersCache {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            workers: LruCache::new(capacity),
+            send_stats_per_addr: HashMap::new(),
+        }
+    }
+
+    pub fn contains(&self, peer: &SocketAddr) -> bool {
+        self.workers.contains(peer)
+    }
+
+    pub async fn push(&mut self, peer: SocketAddr, peer_worker: WorkerInfo) {
+        // Although there might be concerns about the performance implications
+        // of waiting for the worker to be closed when trying to add a new
+        // worker, the idea is that these workers are almost always created in
+        // advance so the latency is hidden.
+        if let Some((leader, popped_worker)) = self.workers.push(peer, peer_worker) {
+            self.shutdown_worker(leader, popped_worker).await;
+        }
+    }
+
+    /// Sends a batch of transactions to the worker for a given peer. If the
+    /// worker for the peer is disconnected or fails, it is removed from the
+    /// cache.
+    pub async fn send_txs_to_worker(
+        &mut self,
+        peer: &SocketAddr,
+        txs_batch: TransactionBatch,
+    ) -> Result<(), WorkersCacheError> {
+        let current_worker = self.workers.get(peer).expect(
+            "Failed to fetch worker for peer {peer}.\n\
+             Peer existence must be checked before this call using `contains` method.",
+        );
+        let send_res = current_worker.queue_txs(txs_batch).await;
+        if let Err(WorkersCacheError::ReceiverDropped) = send_res {
+            // Remove the worker from the cache, if the peer has disconnected.
+            if let Some(current_worker) = self.workers.pop(peer) {
+                // to avoid obscuring the error from send, ignore possible
+                // TaskJoinFailure
+                let close_result = current_worker.close().await;
+                if let Err(error) = close_result {
+                    error!("Error while closing worker: {error}.");
+                }
+            }
+        }
+        send_res
+    }
+
+    pub fn get_transaction_stats(&self) -> &HashMap<IpAddr, SendTransactionStats> {
+        &self.send_stats_per_addr
+    }
+
+    /// Closes and removes all workers in the cache. This is typically done when
+    /// shutting down the system.
+    pub async fn close(&mut self) {
+        let leaders: Vec<SocketAddr> = self.workers.iter().map(|(key, _value)| *key).collect();
+        for leader in leaders {
+            if let Some(worker) = self.workers.pop(&leader) {
+                self.shutdown_worker(leader, worker).await;
+            }
+        }
+    }
+
+    /// Shuts down a worker for a given peer by closing the worker and gathering
+    /// its transaction statistics.
+    async fn shutdown_worker(&mut self, leader: SocketAddr, worker: WorkerInfo) {
+        let worker_stats = worker.close().await;
+
+        match worker_stats {
+            Ok(worker_stats) => {
+                self.send_stats_per_addr
+                    .entry(leader.ip())
+                    .and_modify(|e| e.add(&worker_stats))
+                    .or_insert(worker_stats);
+            }
+            Err(err) => debug!("Error while shutting down worker for {leader}: {err}"),
+        }
+    }
+}

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -1,6 +1,7 @@
 //! This module defines `WorkersCache` along with aux struct `WorkerInfo`. These
 //! structures provide mechanisms for caching workers, sending transaction
 //! batches, and gathering send transaction statistics.
+
 use {
     super::SendTransactionStats,
     crate::transaction_batch::TransactionBatch,
@@ -12,6 +13,7 @@ use {
     },
     thiserror::Error,
     tokio::{sync::mpsc, task::JoinHandle},
+    tokio_util::sync::CancellationToken,
 };
 
 /// [`WorkerInfo`] holds information about a worker responsible for sending
@@ -19,17 +21,23 @@ use {
 pub(crate) struct WorkerInfo {
     pub sender: mpsc::Sender<TransactionBatch>,
     pub handle: JoinHandle<SendTransactionStats>,
+    pub cancel: CancellationToken,
 }
 
 impl WorkerInfo {
     pub fn new(
         sender: mpsc::Sender<TransactionBatch>,
         handle: JoinHandle<SendTransactionStats>,
+        cancel: CancellationToken,
     ) -> Self {
-        Self { sender, handle }
+        Self {
+            sender,
+            handle,
+            cancel,
+        }
     }
 
-    async fn queue_txs(&self, txs_batch: TransactionBatch) -> Result<(), WorkersCacheError> {
+    async fn send_txs(&self, txs_batch: TransactionBatch) -> Result<(), WorkersCacheError> {
         self.sender
             .send(txs_batch)
             .await
@@ -38,7 +46,8 @@ impl WorkerInfo {
     }
 
     /// Closes the worker by dropping the sender and awaiting the worker's statistics.
-    async fn close(self) -> Result<SendTransactionStats, WorkersCacheError> {
+    async fn shutdown(self) -> Result<SendTransactionStats, WorkersCacheError> {
+        self.cancel.cancel();
         drop(self.sender);
         let stats = self
             .handle
@@ -53,6 +62,10 @@ impl WorkerInfo {
 pub(crate) struct WorkersCache {
     workers: LruCache<SocketAddr, WorkerInfo>,
     send_stats_per_addr: HashMap<IpAddr, SendTransactionStats>,
+
+    /// Indicates that the `WorkersCache` is been `shutdown()`, interrupting any outstanding
+    /// `send_txs()` invocations.
+    cancel: CancellationToken,
 }
 
 #[derive(Debug, Error, PartialEq)]
@@ -63,13 +76,17 @@ pub enum WorkersCacheError {
 
     #[error("Task failed to join.")]
     TaskJoinFailure,
+
+    #[error("The WorkersCache is being shutdown.")]
+    ShutdownError,
 }
 
 impl WorkersCache {
-    pub fn new(capacity: usize) -> Self {
+    pub fn new(capacity: usize, cancel: CancellationToken) -> Self {
         Self {
             workers: LruCache::new(capacity),
             send_stats_per_addr: HashMap::new(),
+            cancel,
         }
     }
 
@@ -95,23 +112,36 @@ impl WorkersCache {
         peer: &SocketAddr,
         txs_batch: TransactionBatch,
     ) -> Result<(), WorkersCacheError> {
-        let current_worker = self.workers.get(peer).expect(
-            "Failed to fetch worker for peer {peer}.\n\
+        let Self {
+            workers, cancel, ..
+        } = self;
+
+        let body = async move {
+            let current_worker = workers.get(peer).expect(
+                "Failed to fetch worker for peer {peer}.\n\
              Peer existence must be checked before this call using `contains` method.",
-        );
-        let send_res = current_worker.queue_txs(txs_batch).await;
-        if let Err(WorkersCacheError::ReceiverDropped) = send_res {
-            // Remove the worker from the cache, if the peer has disconnected.
-            if let Some(current_worker) = self.workers.pop(peer) {
-                // to avoid obscuring the error from send, ignore possible
-                // TaskJoinFailure
-                let close_result = current_worker.close().await;
-                if let Err(error) = close_result {
-                    error!("Error while closing worker: {error}.");
+            );
+            let send_res = current_worker.send_txs(txs_batch).await;
+
+            if let Err(WorkersCacheError::ReceiverDropped) = send_res {
+                // Remove the worker from the cache, if the peer has disconnected.
+                if let Some(current_worker) = workers.pop(peer) {
+                    // To avoid obscuring the error from send, ignore a possible
+                    // `TaskJoinFailure`.
+                    let close_result = current_worker.shutdown().await;
+                    if let Err(error) = close_result {
+                        error!("Error while closing worker: {error}.");
+                    }
                 }
             }
+
+            send_res
+        };
+
+        tokio::select! {
+            send_res = body => send_res,
+            () = cancel.cancelled() => Err(WorkersCacheError::ShutdownError),
         }
-        send_res
     }
 
     pub fn get_transaction_stats(&self) -> &HashMap<IpAddr, SendTransactionStats> {
@@ -120,28 +150,31 @@ impl WorkersCache {
 
     /// Closes and removes all workers in the cache. This is typically done when
     /// shutting down the system.
-    pub async fn close(&mut self) {
-        let leaders: Vec<SocketAddr> = self.workers.iter().map(|(key, _value)| *key).collect();
-        for leader in leaders {
-            if let Some(worker) = self.workers.pop(&leader) {
-                self.shutdown_worker(leader, worker).await;
-            }
+    pub async fn shutdown(&mut self) {
+        // Interrupt any outstanding `send_txs()` calls.
+        self.cancel.cancel();
+
+        while let Some((leader, worker)) = self.workers.pop_lru() {
+            self.shutdown_worker(leader, worker).await;
         }
     }
 
     /// Shuts down a worker for a given peer by closing the worker and gathering
     /// its transaction statistics.
     async fn shutdown_worker(&mut self, leader: SocketAddr, worker: WorkerInfo) {
-        let worker_stats = worker.close().await;
+        let res = worker.shutdown().await;
 
-        match worker_stats {
-            Ok(worker_stats) => {
-                self.send_stats_per_addr
-                    .entry(leader.ip())
-                    .and_modify(|e| e.add(&worker_stats))
-                    .or_insert(worker_stats);
+        let stats = match res {
+            Ok(stats) => stats,
+            Err(err) => {
+                debug!("Error while shutting down worker for {leader}: {err}");
+                return;
             }
-            Err(err) => debug!("Error while shutting down worker for {leader}: {err}"),
-        }
+        };
+
+        self.send_stats_per_addr
+            .entry(leader.ip())
+            .and_modify(|e| e.add(&stats))
+            .or_insert(stats);
     }
 }

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -144,7 +144,7 @@ impl WorkersCache {
         }
     }
 
-    pub fn get_transaction_stats(&self) -> &HashMap<IpAddr, SendTransactionStats> {
+    pub fn transaction_stats(&self) -> &HashMap<IpAddr, SendTransactionStats> {
         &self.send_stats_per_addr
     }
 

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -65,7 +65,7 @@ async fn setup_connection_worker_scheduler(
     let cancel = CancellationToken::new();
     let config = ConnectionWorkersSchedulerConfig {
         bind,
-        validator_identity,
+        stake_identity: validator_identity,
         num_connections: 1,
         skip_check_transaction_age: false,
         worker_channel_size: 2,

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -69,6 +69,7 @@ async fn setup_connection_worker_scheduler(
         num_connections: 1,
         skip_check_transaction_age: false,
         worker_channel_size: 2,
+        max_reconnect_attempts: 4,
     };
     let scheduler = tokio::spawn(ConnectionWorkersScheduler::run(
         config,

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -16,6 +16,7 @@ use {
         streamer::StakedNodes,
     },
     solana_tpu_client_next::{
+        connection_workers_scheduler::ConnectionWorkersSchedulerConfig,
         leader_updater::create_leader_updater, transaction_batch::TransactionBatch,
         ConnectionWorkersScheduler, ConnectionWorkersSchedulerError, SendTransactionStats,
         SendTransactionStatsPerAddr,
@@ -62,13 +63,18 @@ async fn setup_connection_worker_scheduler(
 
     let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();
     let cancel = CancellationToken::new();
-    let scheduler = tokio::spawn(ConnectionWorkersScheduler::run(
+    let config = ConnectionWorkersSchedulerConfig {
         bind,
         validator_identity,
+        num_connections: 1,
+        skip_check_transaction_age: false,
+        worker_channel_size: 2,
+    };
+    let scheduler = tokio::spawn(ConnectionWorkersScheduler::run(
+        config,
         leader_updater,
-        cancel.clone(),
         transaction_receiver,
-        1,
+        cancel.clone(),
     ));
 
     (scheduler, cancel)

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -1,0 +1,582 @@
+use {
+    crossbeam_channel::Receiver as CrossbeamReceiver,
+    solana_cli_config::ConfigInput,
+    solana_rpc_client::nonblocking::rpc_client::RpcClient,
+    solana_sdk::{
+        commitment_config::CommitmentConfig,
+        pubkey::Pubkey,
+        signer::{keypair::Keypair, Signer},
+    },
+    solana_streamer::{
+        nonblocking::testing_utilities::{
+            make_client_endpoint, setup_quic_server, SpawnTestServerResult, TestServerConfig,
+        },
+        packet::PacketBatch,
+        streamer::StakedNodes,
+    },
+    solana_tpu_client_next::{
+        leader_updater::create_leader_updater, transaction_batch::TransactionBatch,
+        ConnectionWorkersScheduler, ConnectionWorkersSchedulerError, SendTransactionStats,
+        SendTransactionStatsPerAddr,
+    },
+    std::{
+        collections::HashMap,
+        net::{IpAddr, Ipv6Addr, SocketAddr},
+        str::FromStr,
+        sync::{atomic::Ordering, Arc},
+        time::Duration,
+    },
+    tokio::{
+        sync::mpsc::{channel, Receiver, Sender},
+        task::JoinHandle,
+        time::{sleep, Instant},
+    },
+};
+
+async fn setup_connection_worker_scheduler(
+    tpu_address: SocketAddr,
+    transaction_receiver: Receiver<TransactionBatch>,
+    validator_identity: Option<Keypair>,
+) -> JoinHandle<Result<SendTransactionStatsPerAddr, ConnectionWorkersSchedulerError>> {
+    let json_rpc_url = "http://127.0.0.1:8899";
+    let (_, websocket_url) = ConfigInput::compute_websocket_url_setting("", "", json_rpc_url, "");
+
+    let rpc_client = Arc::new(RpcClient::new_with_commitment(
+        json_rpc_url.to_string(),
+        CommitmentConfig::confirmed(),
+    ));
+
+    // Setup sending txs
+    let leader_updater =
+        create_leader_updater(rpc_client, websocket_url, 1, Some(tpu_address)).await;
+    assert!(leader_updater.is_ok());
+
+    let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    tokio::spawn(async move {
+        ConnectionWorkersScheduler::run(
+            bind,
+            validator_identity,
+            leader_updater.unwrap(),
+            transaction_receiver,
+            1,
+        )
+        .await
+    })
+}
+
+async fn join_scheduler(
+    scheduler_handle: JoinHandle<
+        Result<SendTransactionStatsPerAddr, ConnectionWorkersSchedulerError>,
+    >,
+) -> SendTransactionStats {
+    let stats_per_ip = scheduler_handle
+        .await
+        .unwrap()
+        .expect("Scheduler should stop successfully.");
+    stats_per_ip
+        .get(&IpAddr::from_str("127.0.0.1").unwrap())
+        .expect("setup_connection_worker_scheduler() connected to a leader at 127.0.0.1")
+        .clone()
+}
+
+// The unstaked connection rate is 100tps.
+const SEND_EACH: Duration = Duration::from_millis(10);
+// Specify the pessimistic time to finish generation and result checks.
+const TEST_MAX_TIME: Duration = Duration::from_millis(2000);
+
+async fn spawn_generator(
+    transaction_sender: Sender<TransactionBatch>,
+    tx_size: usize,
+    num_txs: usize,
+    send_each_interval: Duration,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        for i in 0..num_txs {
+            let wire_txs_batch = vec![vec![i as u8; tx_size]; 1];
+            let res = transaction_sender
+                .send(TransactionBatch::new(wire_txs_batch))
+                .await;
+            assert_eq!(res, Ok(()));
+            // to avoid throttling sleep the duration of the throttling period
+            sleep(send_each_interval).await;
+        }
+        // We need to wait until all the packets have landed. Since we send here
+        // a few bytes, all the packets will end up in receive window. Hence,
+        // sending will be fast but it doesn't mean that they have been
+        // delivered. If we drop sender too early, the connection will be closed
+        // and all the pending packets will be lost. Since we already slept for
+        // send_each_interval * num_txs, sleep the rest.
+        sleep(TEST_MAX_TIME.saturating_sub(send_each_interval.saturating_mul(num_txs as u32)))
+            .await;
+    })
+}
+
+#[tokio::test]
+async fn test_basic_transactions_sending() {
+    let SpawnTestServerResult {
+        join_handle: server_handle,
+        exit,
+        receiver,
+        server_address,
+        stats: _stats,
+    } = setup_quic_server(None, TestServerConfig::default());
+    let (transaction_sender, transaction_receiver) = channel(1);
+    let scheduler_handle =
+        setup_connection_worker_scheduler(server_address, transaction_receiver, None).await;
+
+    // Setup sending txs
+    let tx_size = 1;
+    let expected_num_txs: usize = 100;
+    let generator_handle =
+        spawn_generator(transaction_sender, tx_size, expected_num_txs, SEND_EACH).await;
+
+    // Check results
+    let mut received_data = Vec::with_capacity(expected_num_txs);
+    let now = Instant::now();
+    let mut actual_num_packets = 0;
+    while actual_num_packets < expected_num_txs && now.elapsed() < TEST_MAX_TIME {
+        if let Ok(packets) = receiver.try_recv() {
+            actual_num_packets += packets.len();
+            for p in packets.iter() {
+                let packet_id = p.data(0).expect("Data should not be lost by server.");
+                received_data.push(*packet_id);
+                assert_eq!(p.meta().size, tx_size);
+            }
+        } else {
+            sleep(Duration::from_millis(10)).await;
+        }
+    }
+    // check that we received what we have sent.
+    assert_eq!(actual_num_packets, expected_num_txs);
+    received_data.sort_unstable();
+    for i in 1..received_data.len() {
+        assert_eq!(received_data[i - 1] + 1, received_data[i]);
+    }
+
+    // Stop sending
+    generator_handle.await.unwrap();
+    let localhost_stats = join_scheduler(scheduler_handle).await;
+    assert_eq!(
+        localhost_stats,
+        SendTransactionStats {
+            successfully_sent: expected_num_txs as u64,
+            ..Default::default()
+        }
+    );
+
+    // Stop server
+    exit.store(true, Ordering::Relaxed);
+    server_handle.await.unwrap();
+}
+
+async fn count_server_received_packets(
+    receiver: CrossbeamReceiver<PacketBatch>,
+    expected_tx_size: usize,
+) -> usize {
+    let now = Instant::now();
+    let mut num_packets_received: usize = 0;
+    while now.elapsed() < TEST_MAX_TIME {
+        if let Ok(packets) = receiver.try_recv() {
+            num_packets_received = num_packets_received.saturating_add(packets.len());
+            for p in packets.iter() {
+                assert_eq!(p.meta().size, expected_tx_size);
+            }
+        } else {
+            sleep(Duration::from_millis(100)).await;
+        }
+    }
+    num_packets_received
+}
+
+// Check that client can create connection even if the first several attempts
+// were unsuccessful. To prevent server from accepting a new connection, we use
+// the following observation: since max_connections_per_peer == 1 (<
+// max_unstaked_connections == 500), if we create a first connection and later
+// try another one, the second connection will be immediately closed. Since
+// client is not retrying sending failed transactions, this leads to the packets
+// loss: the connection has been created and closed when we already have sent
+// the data.
+#[tokio::test]
+async fn test_connection_denied_until_allowed() {
+    let SpawnTestServerResult {
+        join_handle: server_handle,
+        exit,
+        receiver,
+        server_address,
+        stats: _stats,
+    } = setup_quic_server(None, TestServerConfig::default());
+
+    let connection = make_client_endpoint(&server_address, None).await;
+
+    let (transaction_sender, transaction_receiver) = channel(1);
+    let scheduler_handle =
+        setup_connection_worker_scheduler(server_address, transaction_receiver, None).await;
+
+    // Setup sending txs
+    let tx_size = 1;
+    let expected_num_txs: usize = 10;
+    let generator_handle = spawn_generator(
+        transaction_sender,
+        tx_size,
+        expected_num_txs,
+        Duration::from_millis(100),
+    )
+    .await;
+
+    sleep(Duration::from_millis(1000)).await;
+    drop(connection);
+
+    // Check results
+    let actual_num_packets = count_server_received_packets(receiver, tx_size).await;
+    assert!(actual_num_packets > 0 && actual_num_packets < expected_num_txs);
+
+    // Stop sending
+    generator_handle.await.unwrap();
+    let localhost_stats = join_scheduler(scheduler_handle).await;
+    assert_eq!(
+        localhost_stats.write_error_connection_lost
+            + localhost_stats.connection_error_application_closed,
+        1
+    );
+
+    // Exit server
+    exit.store(true, Ordering::Relaxed);
+    server_handle.await.unwrap();
+}
+
+// Check that if the client connection has been pruned, client manages to
+// reestablish it. Pruning will lead to 1 packet loss, because when we send the
+// next packet we will reestablish connection.
+#[tokio::test]
+async fn test_connection_pruned_and_reopened() {
+    let SpawnTestServerResult {
+        join_handle: server_handle,
+        exit,
+        receiver,
+        server_address,
+        stats: _stats,
+    } = setup_quic_server(
+        None,
+        TestServerConfig {
+            max_connections_per_peer: 100,
+            max_unstaked_connections: 1,
+            ..Default::default()
+        },
+    );
+
+    let (transaction_sender, transaction_receiver) = channel(1);
+    let scheduler_handle =
+        setup_connection_worker_scheduler(server_address, transaction_receiver, None).await;
+
+    // Setup sending txs
+    let tx_size = 1;
+    let expected_num_txs: usize = 16;
+    let generator_handle = spawn_generator(
+        transaction_sender,
+        tx_size,
+        expected_num_txs,
+        Duration::from_millis(100),
+    )
+    .await;
+
+    sleep(Duration::from_millis(400)).await;
+    let _connection_to_prune_client = make_client_endpoint(&server_address, None).await;
+
+    // Check results
+    let actual_num_packets = count_server_received_packets(receiver, tx_size).await;
+    assert!(actual_num_packets < expected_num_txs);
+
+    // Stop sending
+    generator_handle.await.unwrap();
+    let localhost_stats = join_scheduler(scheduler_handle).await;
+    // in case of pruning, server closes the connection with code 1 and error
+    // message b"dropped". This might lead to connection error
+    // (ApplicationClosed::ApplicationClose) or to stream error
+    // (ConnectionLost::ApplicationClosed::ApplicationClose).
+    assert_eq!(
+        localhost_stats.connection_error_application_closed
+            + localhost_stats.write_error_connection_lost,
+        1,
+    );
+
+    // Exit server
+    exit.store(true, Ordering::Relaxed);
+    server_handle.await.unwrap();
+}
+
+/// Check that client creates staked connection. To do that prohibit unstaked
+/// connection and verify that all the txs has been received.
+#[tokio::test]
+async fn test_staked_connection() {
+    let validator_identity = Keypair::new();
+    let stakes = HashMap::from([(validator_identity.pubkey(), 100_000)]);
+    let staked_nodes = StakedNodes::new(Arc::new(stakes), HashMap::<Pubkey, u64>::default());
+
+    let SpawnTestServerResult {
+        join_handle: server_handle,
+        exit,
+        receiver,
+        server_address,
+        stats: _stats,
+    } = setup_quic_server(
+        Some(staked_nodes),
+        TestServerConfig {
+            // Must use at least the number of endpoints (10) because
+            // `max_staked_connections` and `max_unstaked_connections` are
+            // cumulative for all the endpoints.
+            max_staked_connections: 10,
+            max_unstaked_connections: 0,
+            ..Default::default()
+        },
+    );
+
+    let (transaction_sender, transaction_receiver) = channel(1);
+    let scheduler_handle = setup_connection_worker_scheduler(
+        server_address,
+        transaction_receiver,
+        Some(validator_identity),
+    )
+    .await;
+
+    // Setup sending txs
+    let tx_size = 1;
+    let expected_num_txs: usize = 10;
+    let generator_handle = spawn_generator(
+        transaction_sender,
+        tx_size,
+        expected_num_txs,
+        Duration::from_millis(100),
+    )
+    .await;
+
+    // Check results
+    let actual_num_packets = count_server_received_packets(receiver, tx_size).await;
+    assert_eq!(actual_num_packets, expected_num_txs);
+
+    // Stop sending
+    generator_handle.await.unwrap();
+    let localhost_stats = join_scheduler(scheduler_handle).await;
+    assert_eq!(
+        localhost_stats,
+        SendTransactionStats {
+            successfully_sent: expected_num_txs as u64,
+            ..Default::default()
+        }
+    );
+
+    // Exit server
+    exit.store(true, Ordering::Relaxed);
+    server_handle.await.unwrap();
+}
+
+// Check that if client sends transactions at a reasonably high rate that is
+// higher than what the server accepts, nevertheless all the transactions are
+// delivered and there are no errors on the client side.
+#[tokio::test]
+async fn test_connection_throttling() {
+    let SpawnTestServerResult {
+        join_handle: server_handle,
+        exit,
+        receiver,
+        server_address,
+        stats: _stats,
+    } = setup_quic_server(None, TestServerConfig::default());
+
+    let (transaction_sender, transaction_receiver) = channel(1);
+    let scheduler_handle =
+        setup_connection_worker_scheduler(server_address, transaction_receiver, None).await;
+
+    // Setup sending txs
+    let tx_size = 1;
+    let expected_num_txs: usize = 100;
+    let generator_handle = spawn_generator(
+        transaction_sender,
+        tx_size,
+        expected_num_txs,
+        // send x10 more than the the throttling interval (10ms) allows
+        Duration::from_millis(1),
+    )
+    .await;
+
+    // Check results
+    let actual_num_packets = count_server_received_packets(receiver, tx_size).await;
+    assert_eq!(actual_num_packets, expected_num_txs);
+
+    // Stop sending
+    let localhost_stats = join_scheduler(scheduler_handle).await;
+    assert_eq!(
+        localhost_stats,
+        SendTransactionStats {
+            successfully_sent: expected_num_txs as u64,
+            ..Default::default()
+        }
+    );
+
+    // Exit server
+    assert!(generator_handle.await.is_ok());
+    exit.store(true, Ordering::Relaxed);
+    server_handle.await.unwrap();
+}
+
+// Check that when the host cannot be reached, the client exits gracefully.
+#[tokio::test]
+async fn test_no_host() {
+    // A "black hole" address for the TPU.
+    let tpu_address = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0x100, 0, 0, 0, 0, 0, 0, 1)), 49151);
+
+    let (transaction_sender, transaction_receiver) = channel(1);
+    let scheduler_handle =
+        setup_connection_worker_scheduler(tpu_address, transaction_receiver, None).await;
+
+    // Setup sending txs
+    let tx_size = 1;
+    let expected_num_txs: usize = 10;
+    let generator_handle: JoinHandle<()> = tokio::spawn(async move {
+        for i in 0..expected_num_txs {
+            let wire_txs_batch = vec![vec![i as u8; tx_size]; 1];
+            let res = transaction_sender
+                .send(TransactionBatch::new(wire_txs_batch.clone()))
+                .await;
+            if res.is_err() {
+                // Scheduler consumes transactions from the channel and tries to
+                // create connection and send them. After several attempts, it
+                // will fail and will decide to drop receiver on it's end. This
+                // will trigger Err on send side.
+                break;
+            }
+            // to avoid throttling sleep the duration of the throttling period
+            sleep(Duration::from_millis(100)).await;
+        }
+    });
+
+    // Stop sending
+    generator_handle.await.unwrap();
+    // While attempting to establish a connection with a nonexistent host, we
+    // fill the worker's channel. Transactions from this channel will never be
+    // sent and will eventually be dropped without increasing the
+    // SendTransactionStats counters.
+    let result = scheduler_handle.await.unwrap();
+    assert_eq!(result.unwrap(), HashMap::default());
+}
+
+// Check that when the client is rate-limited by server, we update counters
+// accordingly. To implement it we:
+// * set the connection limit per minute to 1
+// * create a dummy connection to reach the limit and immediately close it
+// * set up client which will try to create a new connection which it will be
+// rate-limited. This test doesn't check what happens when the rate-limiting
+// period ends because it too long for test (1min).
+#[tokio::test]
+async fn test_rate_limiting() {
+    let SpawnTestServerResult {
+        join_handle: server_handle,
+        exit,
+        receiver,
+        server_address,
+        stats: _stats,
+    } = setup_quic_server(
+        None,
+        TestServerConfig {
+            max_connections_per_peer: 100,
+            max_connections_per_ipaddr_per_minute: 1,
+            ..Default::default()
+        },
+    );
+
+    let connection_to_reach_limit = make_client_endpoint(&server_address, None).await;
+    drop(connection_to_reach_limit);
+    // give more time to endpoint to avoid failing test when several tests are
+    // running in parallel.
+    sleep(Duration::from_millis(100)).await;
+
+    let (transaction_sender, transaction_receiver) = channel(1);
+    let scheduler_handle =
+        setup_connection_worker_scheduler(server_address, transaction_receiver, None).await;
+
+    // Setup sending txs
+    let tx_size = 1;
+    let expected_num_txs: usize = 16;
+    let generator_handle = spawn_generator(
+        transaction_sender,
+        tx_size,
+        expected_num_txs,
+        Duration::from_millis(100),
+    )
+    .await;
+
+    // Stop sending
+    let localhost_stats = join_scheduler(scheduler_handle).await;
+    assert_eq!(
+        localhost_stats.write_error_connection_lost
+            + localhost_stats.connection_error_application_closed,
+        expected_num_txs as u64
+    );
+    assert!(generator_handle.await.is_ok());
+
+    // Check results
+    let actual_num_packets = count_server_received_packets(receiver, tx_size).await;
+    assert_eq!(actual_num_packets, 0);
+
+    // Exit server
+    exit.store(true, Ordering::Relaxed);
+    server_handle.await.unwrap();
+}
+
+// The same as test_rate_limiting but here we wait for 1 min to check that the
+// connection has been established.
+#[tokio::test]
+// Ignore because it takes more than 1 minute
+#[ignore]
+async fn test_rate_limiting_establish_connection() {
+    let SpawnTestServerResult {
+        join_handle: server_handle,
+        exit,
+        receiver,
+        server_address,
+        stats: _stats,
+    } = setup_quic_server(
+        None,
+        TestServerConfig {
+            max_connections_per_peer: 100,
+            max_connections_per_ipaddr_per_minute: 1,
+            ..Default::default()
+        },
+    );
+
+    let connection_to_reach_limit = make_client_endpoint(&server_address, None).await;
+    drop(connection_to_reach_limit);
+
+    let (transaction_sender, transaction_receiver) = channel(1);
+    let scheduler_handle =
+        setup_connection_worker_scheduler(server_address, transaction_receiver, None).await;
+
+    // Setup sending txs
+    let tx_size = 1;
+    let num_txs: usize = 65;
+    let generator_handle = spawn_generator(
+        transaction_sender,
+        tx_size,
+        num_txs,
+        Duration::from_millis(1000),
+    )
+    .await;
+
+    sleep(Duration::from_secs(60)).await;
+
+    // Stop sending
+    let localhost_stats = join_scheduler(scheduler_handle).await;
+    assert!(
+        localhost_stats.write_error_connection_lost
+            + localhost_stats.connection_error_application_closed
+            > 0
+    );
+    assert!(generator_handle.await.is_ok());
+
+    // Check results
+    let actual_num_packets = count_server_received_packets(receiver, tx_size).await;
+    assert!(actual_num_packets > 0);
+
+    // Exit server
+    exit.store(true, Ordering::Relaxed);
+    server_handle.await.unwrap();
+}


### PR DESCRIPTION
#### Problem

Although `tpu-client`, component which is currently used for sending transactions over TPU, suited for bulk transaction sent, it was not designed for handling the stream of transactions. Additionally, the call stack for sending transactions using tpu-client has grown too deep, making the code difficult to maintain.. This motivated us to create a new client implementation that is optimized for handling transaction streams and is built using Tokio from the start.

Initially, this implementation was part of the `transaction-bench` crate in the Invalidator repository, which is a client application for sending transactions that execute a program with a specified number of accounts. We now plan to move the networking component of this implementation to the Agave repository, making it reusable for different client applications and accessible to other parties.

The design was proposed by @alessandrod, who also used the `transaction-bench` tool for his testing activities. This component has been actively developed over the past several months and has undergone extensive review by @ilya-bobyr and @bw-solana. Documentation PRs were reviewed by @sam0x17.

Test results using `transaction-bench` will be added soon.

#### Summary of Changes

The main structure that is introduced in this PR is `ConnectionWorkersScheduler`.
Most of other components are private.

Key Components:

1. `ConnectionWorker`
* Represents a task that handles single connection to a peer
* Receives transactions from its own transaction receiver
* If a connection is closed or errors occur, it attempts to reconnect up to a maximum number of retries
* Tracks connection and transaction statistics, such as failed transaction attempts.

2. `WorkerInfo`
* Stores information about worker to allow other task to communicate with `ConnectionWorker` (including the transaction sender and the handle to the worker’s task).

3. `ConnectionWorkersScheduler`
* Manages workers scheduling
* Receives transaction  from a channel and distributes them to workers
* The scheduler runs in its own task, ensuring non-blocking performance

4. `WorkersCache`
* A cache that manages the lifecycle of workers using an LRU (Least Recently Used) cache
* Tracks transaction statistics for each worker
* Handles worker creation and retrieval, ensuring workers are reused efficiently to reduce overhead
	
#### Workflow

1. `ConnectionWorkersScheduler` receives transactions from channel receiver.
2. It fetches future leaders.
2. It checks if the task handling connection for the next leader is already in the `WorkersCache`. If not, creates a new worker.
3. Each worker (`ConnectionWorker`) handles a connection to a peer and processes transactions received through it's channel.
4. Workers run in their own tasks, ensuring that each connection is managed asynchronously.
5. The system is resilient to network failures, but does not retry undelivered transactions once the connection is restored.
6. Workers report statistics back to the scheduler, such as successful/failed transaction attempts and connection errors.

#### Future work

There are some features that are not included in this PR:
1. Send transactions to the next several leaders (fanout). Experiments show that this enhancement increases tps for both private cluster and testnet. Will be added in a separate PR.
2. Use several endpoints with different stake for the same node. The server limits receive window and number of concurrent streams per connection to `512*PACKET_SIZE` and `512` at most. These limits doesn't allow to use the full potential of the client. Will be added in a separate PR.
