### PR TITLE
store-histogram: skip not found file meta

### DIFF
--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -249,7 +249,9 @@ fn main() {
             for entry in dir.flatten() {
                 if let Some(name) = entry.path().file_name() {
                     let name = name.to_str().unwrap().split_once(".").unwrap().0;
-                    let len = fs::metadata(entry.path()).unwrap().len();
+                    let len = fs::metadata(entry.path())
+                        .unwrap_or_else(|_| panic!("{:?} not found!", entry.path()))
+                        .len();
                     info.push((name.parse::<usize>().unwrap(), len as usize));
                     // eprintln!("{name}, {len}");
                 }

--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -249,12 +249,16 @@ fn main() {
             for entry in dir.flatten() {
                 if let Some(name) = entry.path().file_name() {
                     let name = name.to_str().unwrap().split_once(".").unwrap().0;
-                    let len = fs::metadata(entry.path())
-                        .unwrap_or_else(|err| {
-                            panic!("failed to get metadata '{}': {err}", entry.path().display())
-                        })
-                        .len();
-                    info.push((name.parse::<usize>().unwrap(), len as usize));
+                    match fs::metadata(entry.path()) {
+                        Ok(meta) => {
+                            info.push((name.parse::<usize>().unwrap(), meta.len() as usize));
+                        }
+                        Err(_) => {
+                            // skip when metadata fails. This can happen when you are running this tool while a validator is running.
+                            // It could clean something away and delete it after getting the dir but before opening the file.
+                            continue;
+                        }
+                    }
                     // eprintln!("{name}, {len}");
                 }
             }

--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -250,7 +250,7 @@ fn main() {
                 if let Some(name) = entry.path().file_name() {
                     let name = name.to_str().unwrap().split_once(".").unwrap().0;
                     let len = fs::metadata(entry.path())
-                        .unwrap_or_else(|_| panic!("{:?} not found!", entry.path()))
+                        .unwrap_or_else(|err| panic!("failed to get metadata '{}': {err}", entry.path().display()))
                         .len();
                     info.push((name.parse::<usize>().unwrap(), len as usize));
                     // eprintln!("{name}, {len}");

--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -250,7 +250,9 @@ fn main() {
                 if let Some(name) = entry.path().file_name() {
                     let name = name.to_str().unwrap().split_once(".").unwrap().0;
                     let len = fs::metadata(entry.path())
-                        .unwrap_or_else(|err| panic!("failed to get metadata '{}': {err}", entry.path().display()))
+                        .unwrap_or_else(|err| {
+                            panic!("failed to get metadata '{}': {err}", entry.path().display())
+                        })
                         .len();
                     info.push((name.parse::<usize>().unwrap(), len as usize));
                     // eprintln!("{name}, {len}");


### PR DESCRIPTION
#### Problem

store-histogram crash on not found file meta. 

```
thread 'main' panicked at accounts-db/store-histogram/src/main.rs:252:58:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

this can actually happen.
https://github.com/anza-xyz/agave/pull/2906#issuecomment-2347401279


#### Summary of Changes

instead of crash when file meta is not found, we skip them and continue.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
