### PR TITLE
Uses actual number of items in generate_index_for_slot()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8860,6 +8860,7 @@ impl AccountsDb {
                 }
                 items_local.push(info.index_info);
             });
+            let items_len = items_local.len();
             let items = items_local.into_iter().map(|info| {
                 if let Some(amount_to_top_off_rent_this_account) = Self::stats_for_rent_payers(
                     &info.pubkey,
@@ -8884,11 +8885,7 @@ impl AccountsDb {
                 )
             });
             self.accounts_index
-                .insert_new_if_missing_into_primary_index(
-                    slot,
-                    storage.approx_stored_count(),
-                    items,
-                )
+                .insert_new_if_missing_into_primary_index(slot, items_len, items)
         };
         if secondary {
             // scan storage a second time to update the secondary index


### PR DESCRIPTION
#### Problem

When generating the index, we call `insert_new_if_missing_into_primary_index()`. It takes an iterator of items, and a count of items. The count only needs to be approximate. Since we make the iterator from a Vec, we know the actual number of items, so we can use that directly.


#### Summary of Changes

Use the actual number of items.