### PR TITLE
extract serialize-utils crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7229,6 +7229,7 @@ dependencies = [
  "solana-sdk-macro",
  "solana-secp256k1-recover",
  "solana-serde-varint",
+ "solana-serialize-utils",
  "solana-sha256-hasher",
  "solana-short-vec",
  "static_assertions",
@@ -7837,6 +7838,19 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-short-vec",
+]
+
+[[package]]
+name = "solana-serialize-utils"
+version = "2.1.0"
+dependencies = [
+ "bincode",
+ "borsh 0.10.3",
+ "rand 0.8.5",
+ "serde",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sanitize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7845,7 +7845,7 @@ name = "solana-serialize-utils"
 version = "2.1.0"
 dependencies = [
  "bincode",
- "borsh 0.10.3",
+ "borsh 1.5.1",
  "rand 0.8.5",
  "serde",
  "solana-instruction",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ members = [
     "sdk/program-option",
     "sdk/pubkey",
     "sdk/serde-varint",
+    "sdk/serialize-utils",
     "sdk/sha256-hasher",
     "sdk/signature",
     "send-transaction-service",
@@ -207,6 +208,7 @@ bincode = "1.3.3"
 bitflags = { version = "2.6.0" }
 blake3 = "1.5.4"
 borsh = { version = "1.5.1", features = ["derive", "unstable__schema"] }
+borsh0-10 = { package = "borsh", version = "0.10.3" }
 bs58 = { version = "0.5.1", default-features = false }
 bv = "0.11.1"
 byte-unit = "4.0.19"
@@ -433,6 +435,7 @@ solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.1.0" }
 solana-remote-wallet = { path = "remote-wallet", version = "=2.1.0", default-features = false }
 solana-sanitize = { path = "sanitize", version = "=2.1.0" }
 solana-serde-varint = { path = "sdk/serde-varint", version = "=2.1.0" }
+solana-serialize-utils = { path = "sdk/serialize-utils", version = "=2.1.0" }
 solana-sha256-hasher = { path = "sdk/sha256-hasher", version = "=2.1.0" }
 solana-signature = { path = "sdk/signature", version = "=2.1.0", default-features = false }
 solana-timings = { path = "timings", version = "=2.1.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5640,6 +5640,7 @@ dependencies = [
  "solana-sdk-macro",
  "solana-secp256k1-recover",
  "solana-serde-varint",
+ "solana-serialize-utils",
  "solana-sha256-hasher",
  "solana-short-vec",
  "thiserror",
@@ -6619,6 +6620,15 @@ name = "solana-serde-varint"
 version = "2.1.0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "solana-serialize-utils"
+version = "2.1.0"
+dependencies = [
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sanitize",
 ]
 
 [[package]]

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.79.0"                          # solana platform-tools rust ve
 bincode = { workspace = true }
 blake3 = { workspace = true, features = ["traits-preview"] }
 borsh = { workspace = true, optional = true }
-borsh0-10 = { package = "borsh", version = "0.10.3", optional = true }
+borsh0-10 = { workspace = true, optional = true }
 bs58 = { workspace = true, features = ["alloc"] }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true }
@@ -55,6 +55,7 @@ solana-sanitize = { workspace = true }
 solana-sdk-macro = { workspace = true }
 solana-secp256k1-recover = { workspace = true }
 solana-serde-varint = { workspace = true }
+solana-serialize-utils = { workspace = true }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-short-vec = { workspace = true }
 thiserror = { workspace = true }

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -513,7 +513,6 @@ pub mod program_stubs;
 pub mod program_utils;
 pub mod rent;
 pub mod secp256k1_program;
-pub mod serialize_utils;
 pub mod slot_hashes;
 pub mod slot_history;
 pub mod stable_layout;
@@ -534,6 +533,8 @@ pub use solana_sanitize as sanitize;
 pub use solana_secp256k1_recover as secp256k1_recover;
 #[deprecated(since = "2.1.0", note = "Use `solana-serde-varint` crate instead")]
 pub use solana_serde_varint as serde_varint;
+#[deprecated(since = "2.1.0", note = "Use `solana-serialize-utils` crate instead")]
+pub use solana_serialize_utils as serialize_utils;
 #[deprecated(since = "2.1.0", note = "Use `solana-short-vec` crate instead")]
 pub use solana_short_vec as short_vec;
 #[cfg(target_arch = "wasm32")]

--- a/sdk/serialize-utils/Cargo.toml
+++ b/sdk/serialize-utils/Cargo.toml
@@ -18,7 +18,7 @@ solana-sanitize = { workspace = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
-borsh0-10 = { workspace = true }
+borsh = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false, features = [

--- a/sdk/serialize-utils/Cargo.toml
+++ b/sdk/serialize-utils/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "solana-serialize-utils"
+description = "Solana helpers for reading and writing bytes."
+documentation = "https://docs.rs/solana-serialize-utils"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-instruction = { workspace = true, default-features = false, features = [
+    "std",
+] }
+solana-pubkey = { workspace = true, default-features = false }
+solana-sanitize = { workspace = true }
+
+[dev-dependencies]
+bincode = { workspace = true }
+borsh0-10 = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+solana-pubkey = { workspace = true, default-features = false, features = [
+    "borsh",
+    "serde",
+] }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/serialize-utils/src/cursor.rs
+++ b/sdk/serialize-utils/src/cursor.rs
@@ -1,15 +1,13 @@
 use {
-    crate::{
-        instruction::InstructionError,
-        pubkey::{Pubkey, PUBKEY_BYTES},
-    },
+    solana_instruction::error::InstructionError,
+    solana_pubkey::{Pubkey, PUBKEY_BYTES},
     std::{
         io::{BufRead as _, Cursor, Read},
         ptr,
     },
 };
 
-pub(crate) fn read_u8<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<u8, InstructionError> {
+pub fn read_u8<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<u8, InstructionError> {
     let mut buf = [0; 1];
     cursor
         .read_exact(&mut buf)
@@ -18,7 +16,7 @@ pub(crate) fn read_u8<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<u8, Inst
     Ok(buf[0])
 }
 
-pub(crate) fn read_u32<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<u32, InstructionError> {
+pub fn read_u32<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<u32, InstructionError> {
     let mut buf = [0; 4];
     cursor
         .read_exact(&mut buf)
@@ -27,7 +25,7 @@ pub(crate) fn read_u32<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<u32, In
     Ok(u32::from_le_bytes(buf))
 }
 
-pub(crate) fn read_u64<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<u64, InstructionError> {
+pub fn read_u64<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<u64, InstructionError> {
     let mut buf = [0; 8];
     cursor
         .read_exact(&mut buf)
@@ -36,7 +34,7 @@ pub(crate) fn read_u64<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<u64, In
     Ok(u64::from_le_bytes(buf))
 }
 
-pub(crate) fn read_option_u64<T: AsRef<[u8]>>(
+pub fn read_option_u64<T: AsRef<[u8]>>(
     cursor: &mut Cursor<T>,
 ) -> Result<Option<u64>, InstructionError> {
     let variant = read_u8(cursor)?;
@@ -47,7 +45,7 @@ pub(crate) fn read_option_u64<T: AsRef<[u8]>>(
     }
 }
 
-pub(crate) fn read_i64<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<i64, InstructionError> {
+pub fn read_i64<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<i64, InstructionError> {
     let mut buf = [0; 8];
     cursor
         .read_exact(&mut buf)
@@ -56,7 +54,7 @@ pub(crate) fn read_i64<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<i64, In
     Ok(i64::from_le_bytes(buf))
 }
 
-pub(crate) fn read_pubkey_into(
+pub fn read_pubkey_into(
     cursor: &mut Cursor<&[u8]>,
     pubkey: *mut Pubkey,
 ) -> Result<(), InstructionError> {
@@ -77,9 +75,7 @@ pub(crate) fn read_pubkey_into(
     Ok(())
 }
 
-pub(crate) fn read_pubkey<T: AsRef<[u8]>>(
-    cursor: &mut Cursor<T>,
-) -> Result<Pubkey, InstructionError> {
+pub fn read_pubkey<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<Pubkey, InstructionError> {
     let mut buf = [0; 32];
     cursor
         .read_exact(&mut buf)
@@ -88,7 +84,7 @@ pub(crate) fn read_pubkey<T: AsRef<[u8]>>(
     Ok(Pubkey::from(buf))
 }
 
-pub(crate) fn read_bool<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<bool, InstructionError> {
+pub fn read_bool<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<bool, InstructionError> {
     let byte = read_u8(cursor)?;
     match byte {
         0 => Ok(false),
@@ -97,7 +93,6 @@ pub(crate) fn read_bool<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<bool, 
     }
 }
 
-#[cfg(feature = "borsh")]
 #[cfg(test)]
 mod test {
     use {super::*, rand::Rng, std::fmt::Debug};

--- a/sdk/serialize-utils/src/cursor.rs
+++ b/sdk/serialize-utils/src/cursor.rs
@@ -153,7 +153,7 @@ mod test {
         test_read(read_bool, true);
     }
 
-    fn test_read<T: Debug + PartialEq + serde::Serialize + borsh0_10::BorshSerialize>(
+    fn test_read<T: Debug + PartialEq + serde::Serialize + borsh::BorshSerialize>(
         reader: fn(&mut Cursor<Vec<u8>>) -> Result<T, InstructionError>,
         test_value: T,
     ) {
@@ -161,7 +161,7 @@ mod test {
         let mut cursor = Cursor::new(bincode_bytes);
         let bincode_read = reader(&mut cursor).unwrap();
 
-        let borsh_bytes = borsh0_10::to_vec(&test_value).unwrap();
+        let borsh_bytes = borsh::to_vec(&test_value).unwrap();
         let mut cursor = Cursor::new(borsh_bytes);
         let borsh_read = reader(&mut cursor).unwrap();
 

--- a/sdk/serialize-utils/src/lib.rs
+++ b/sdk/serialize-utils/src/lib.rs
@@ -1,7 +1,7 @@
 //! Helpers for reading and writing bytes.
 
 #![allow(clippy::arithmetic_side_effects)]
-use {crate::pubkey::Pubkey, solana_sanitize::SanitizeError};
+use {solana_pubkey::Pubkey, solana_sanitize::SanitizeError};
 
 pub mod cursor;
 


### PR DESCRIPTION
#### Problem
`solana_program::serialize_utils` is a blocker for pulling out `solana_program::sysvar` and `solana_program::vote`

#### Summary of Changes
Move it to its own crate and re-export with deprecation
