### PR TITLE
ancient shrink bug fix - remove skip slots

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1761,7 +1761,14 @@ pub mod tests {
                             &tuning,
                             many_ref_slots,
                         );
-                        let expected_accounts_to_combine = num_slots;
+                        let expected_accounts_to_combine = if num_slots >= 3
+                            && two_refs
+                            && many_ref_slots == IncludeManyRefSlots::Skip
+                        {
+                            0
+                        } else {
+                            num_slots
+                        };
                         (0..accounts_to_combine
                             .target_slots_sorted
                             .len()
@@ -1864,7 +1871,8 @@ pub mod tests {
                                 assert_eq!(
                                     accounts_to_combine.accounts_to_combine.len(),
                                     // if we are only trying to pack a single slot of multi-refs, it will succeed
-                                    if !two_refs || many_ref_slots == IncludeManyRefSlots::Include || num_slots == 1 || num_slots == 2 {num_slots} else {0},
+                                    // if num_slots = 2 and skip multi-ref slots, accounts_to_combine should be empty.
+                                    if !two_refs || many_ref_slots == IncludeManyRefSlots::Include || num_slots == 1 || (num_slots == 2 && many_ref_slots != IncludeManyRefSlots::Skip) {num_slots} else {0},
                                     "method: {method:?}, num_slots: {num_slots}, two_refs: {two_refs}, many_refs: {many_ref_slots:?}"
                                 );
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1765,6 +1765,12 @@ pub mod tests {
                             && two_refs
                             && many_ref_slots == IncludeManyRefSlots::Skip
                         {
+                            // In this test setup, 2.5 regular slots fits into 1 ancient slot.
+                            // When there are two_refs and when slots < 3, all regular slots can fit into one ancient slots.
+                            // Therefore, we should have all slots that can be combined for slots < 3.
+                            // However, when slots >=3, we need more than one ancient slots. The pack algorithm will need to first
+                            // find at least [ceiling(num_slots/2.5) - 1] slots that's doesn't have many_refs before we can pack slots with many_refs.
+                            // Since all the slots have many_refs, we can't find any eligible slot to combine.
                             0
                         } else {
                             num_slots

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -851,6 +851,12 @@ impl AccountsDb {
             }
         }
         let unpackable_slots_count = remove.len();
+
+        // Remove skipped slots
+        for i in remove.iter().rev() {
+            accounts_to_combine.remove(*i);
+        }
+
         target_slots_sorted.sort_unstable();
         self.shrink_ancient_stats
             .slots_cannot_move_count


### PR DESCRIPTION
#### Problem

There is a bug in ancient shrinking - not removing skipped slots from actual shrinking. 


#### Summary of Changes

remove skipped slots from actual shrinking. 

- validated from ledger tool run:

before the fix (num_slots_shrunk=0): 
`[2024-09-13T17:17:36.603654713Z INFO  solana_metrics::metrics] datapoint: shrink_ancient_stats num_slots_shrunk=0i index_scan_returned_none=0i index_scan_returned_some=3854447i storage_read_elapsed=2570935i num_duplicated_accounts=0i index_read_elapsed=8062383i create_and_insert_store_elapsed=0i store_accounts_elapsed=0i update_index_elapsed=0i handle_reclaims_elapsed=0i remove_old_stores_shrink_us=0i rewrite_elapsed=0i unpackable_slots_count=70i newest_alive_packed_count=228941i drop_storage_entries_elapsed=0i accounts_removed=574179i bytes_removed=224574008i bytes_written=1303311744i alive_accounts=3280268i dead_accounts=288404i accounts_loaded=3854447i ancient_append_vecs_shrunk=0i random=25i slots_eligible_to_shrink=116326i total_dead_bytes=3194867160i total_alive_bytes=24936296088i slots_considered=349305i ancient_scanned=0i total_us=12413822i bytes_ancient_created=0i bytes_from_must_shrink=794468832i bytes_from_smallest_storages=547390160i bytes_from_newest_storages=318152i many_ref_slots_skipped=70i slots_cannot_move_count=20i many_refs_old_alive=24i purged_zero_lamports_count=0i accounts_not_found_in_index=0i`

after the fix (num_slots_shrunk=143688i): 
`[2024-09-14T01:41:36.336810701Z INFO  solana_metrics::metrics] datapoint: shrink_ancient_stats num_slots_shrunk=143688i index_scan_returned_none=0i index_scan_returned_some=6624140i storage_read_elapsed=37268722i num_duplicated_accounts=0i index_read_elapsed=172293636i create_and_insert_store_elapsed=9091913i store_accounts_elapsed=354280809i update_index_elapsed=64029479i handle_reclaims_elapsed=0i remove_old_stores_shrink_us=41921345i rewrite_elapsed=418431086i unpackable_slots_count=83i newest_alive_packed_count=281390i drop_storage_entries_elapsed=1000i accounts_removed=3040391i bytes_removed=427606104i bytes_written=956024832i alive_accounts=3583749i dead_accounts=201141i accounts_loaded=6624140i ancient_append_vecs_shrunk=182761i random=38i slots_eligible_to_shrink=16790i total_dead_bytes=17117208i total_alive_bytes=119581136i slots_considered=355591i ancient_scanned=0i total_us=405999472i bytes_ancient_created=955343832i bytes_from_must_shrink=65777712i bytes_from_smallest_storages=1275587248i bytes_from_newest_storages=797872i many_ref_slots_skipped=78i slots_cannot_move_count=143681i many_refs_old_alive=381509i purged_zero_lamports_count=2838313i accounts_not_found_in_index=0i`




Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
