### PR TITLE
Extract program-pack crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7233,6 +7233,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-memory",
  "solana-program-option",
+ "solana-program-pack",
  "solana-pubkey",
  "solana-sanitize",
  "solana-sdk-macro",
@@ -7272,6 +7273,13 @@ dependencies = [
 [[package]]
 name = "solana-program-option"
 version = "2.1.0"
+
+[[package]]
+name = "solana-program-pack"
+version = "2.1.0"
+dependencies = [
+ "solana-program-error",
+]
 
 [[package]]
 name = "solana-program-runtime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ members = [
     "sdk/program-error",
     "sdk/program-memory",
     "sdk/program-option",
+    "sdk/program-pack",
     "sdk/pubkey",
     "sdk/serde-varint",
     "sdk/serialize-utils",
@@ -428,6 +429,7 @@ solana-program = { path = "sdk/program", version = "=2.1.0", default-features = 
 solana-program-error = { path = "sdk/program-error", version = "=2.1.0" }
 solana-program-memory = { path = "sdk/program-memory", version = "=2.1.0" }
 solana-program-option = { path = "sdk/program-option", version = "=2.1.0" }
+solana-program-pack = { path = "sdk/program-pack", version = "=2.1.0" }
 solana-program-runtime = { path = "program-runtime", version = "=2.1.0" }
 solana-program-test = { path = "program-test", version = "=2.1.0" }
 solana-pubkey = { path = "sdk/pubkey", version = "=2.1.0", default-features = false }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5644,6 +5644,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-memory",
  "solana-program-option",
+ "solana-program-pack",
  "solana-pubkey",
  "solana-sanitize",
  "solana-sdk-macro",
@@ -5681,6 +5682,13 @@ dependencies = [
 [[package]]
 name = "solana-program-option"
 version = "2.1.0"
+
+[[package]]
+name = "solana-program-pack"
+version = "2.1.0"
+dependencies = [
+ "solana-program-error",
+]
 
 [[package]]
 name = "solana-program-runtime"

--- a/sdk/program-pack/Cargo.toml
+++ b/sdk/program-pack/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "solana-program-pack"
+description = "Solana The Pack serialization trait."
+documentation = "https://docs.rs/solana-program-pack"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-program-error = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/program-pack/Cargo.toml
+++ b/sdk/program-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-program-pack"
-description = "Solana The Pack serialization trait."
+description = "Solana Pack serialization trait."
 documentation = "https://docs.rs/solana-program-pack"
 version = { workspace = true }
 authors = { workspace = true }

--- a/sdk/program-pack/src/lib.rs
+++ b/sdk/program-pack/src/lib.rs
@@ -1,6 +1,6 @@
 //! The [`Pack`] serialization trait
 //! This is a specific serialization API that is used by many older programs in
-//! the [Solana Program Library][spl] to manage account state. It is not generally 
+//! the [Solana Program Library][spl] to manage account state. It is not generally
 //! recommended for new code since it does not define a language-independent
 //! serialization format.
 //!

--- a/sdk/program-pack/src/lib.rs
+++ b/sdk/program-pack/src/lib.rs
@@ -1,9 +1,8 @@
 //! The [`Pack`] serialization trait
-//! This is a Solana-specific serialization API that is used by many
-//! older programs in the [Solana Program Library][spl] to define their
-//! account format. It is difficult to implement and does not define a
-//! language-independent serialization format. It is not generally recommended
-//! for new code.
+//! This is a specific serialization API that is used by many older programs in
+//! the [Solana Program Library][spl] to manage account state. It is not generally 
+//! recommended for new code since it does not define a language-independent
+//! serialization format.
 //!
 //! [spl]: https://github.com/solana-labs/solana-program-library
 

--- a/sdk/program-pack/src/lib.rs
+++ b/sdk/program-pack/src/lib.rs
@@ -1,6 +1,13 @@
-//! The [`Pack`] serialization trait.
+//! The [`Pack`] serialization trait
+//! This is a Solana-specific serialization API that is used by many
+//! older programs in the [Solana Program Library][spl] to define their
+//! account format. It is difficult to implement and does not define a
+//! language-independent serialization format. It is not generally recommended
+//! for new code.
+//!
+//! [spl]: https://github.com/solana-labs/solana-program-library
 
-use crate::program_error::ProgramError;
+use solana_program_error::ProgramError;
 
 /// Check if a program account state is initialized
 pub trait IsInitialized {

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -51,6 +51,7 @@ solana-msg = { workspace = true }
 solana-program-error = { workspace = true, features = ["serde"] }
 solana-program-memory = { workspace = true }
 solana-program-option = { workspace = true }
+solana-program-pack = { workspace = true }
 solana-pubkey = { workspace = true, features = ["bytemuck", "curve25519", "serde", "std"] }
 solana-sanitize = { workspace = true }
 solana-sdk-macro = { workspace = true }

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -248,7 +248,7 @@
 //!   language-independent serialization format. It is not generally recommended
 //!   for new code.
 //!
-//!   [`Pack`]: program_pack::Pack
+//!   [`Pack`]: https://docs.rs/solana-program-pack/latest/trait.Pack.html
 //!
 //! Developers should carefully consider the CPU cost of serialization, balanced
 //! against the need for correctness and ease of use: off-the-shelf
@@ -506,7 +506,6 @@ pub mod native_token;
 pub mod nonce;
 pub mod program;
 pub mod program_error;
-pub mod program_pack;
 pub mod program_stubs;
 pub mod program_utils;
 pub mod rent;
@@ -525,6 +524,8 @@ pub mod wasm;
 
 #[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]
 pub use solana_program_memory as program_memory;
+#[deprecated(since = "2.1.0", note = "Use `solana-program-pack` crate instead")]
+pub use solana_program_pack as program_pack;
 #[deprecated(since = "2.1.0", note = "Use `solana-sanitize` crate instead")]
 pub use solana_sanitize as sanitize;
 #[deprecated(since = "2.1.0", note = "Use `solana-secp256k1-recover` crate instead")]


### PR DESCRIPTION
#### Problem
The `Pack` trait imposes a `solana_program` requirement on many programs, most notably in the SPL

#### Summary of Changes
Move `program_pack.rs` to its own crate and re-export with deprecation

This branches off #2413 so that needs to be merged first