### PR TITLE
ci: bump softprops/action-gh-release to v2

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -102,7 +102,7 @@ jobs:
           path: ./windows-release/
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.windows-build.outputs.tag }}
           draft: true


### PR DESCRIPTION
split from the #2928

#### Summary of Changes

bump softprops/action-gh-release to v2