### PR TITLE
fix: fix shell generation panic due to unnecessary 'conflicts_with'

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2721,4 +2721,25 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn test_cli_completions() {
+        let mut clap_app = get_clap_app("test", "desc", "version");
+
+        let shells = [
+            Shell::Bash,
+            Shell::Fish,
+            Shell::Zsh,
+            Shell::PowerShell,
+            Shell::Elvish,
+        ];
+
+        for shell in shells {
+            let mut buf: Vec<u8> = vec![];
+
+            clap_app.gen_completions_to("solana", shell, &mut buf);
+
+            assert!(!buf.is_empty());
+        }
+    }
 }

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -278,7 +278,6 @@ impl ProgramV4SubCommands for App<'_, '_> {
                             Arg::with_name("all")
                                 .long("all")
                                 .conflicts_with("account")
-                                .conflicts_with("buffer_authority")
                                 .help("Show accounts for all authorities"),
                         )
                         .arg(pubkey!(

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -278,6 +278,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                             Arg::with_name("all")
                                 .long("all")
                                 .conflicts_with("account")
+                                .conflicts_with("authority")
                                 .help("Show accounts for all authorities"),
                         )
                         .arg(pubkey!(


### PR DESCRIPTION
#### Problem

`solana completions -s zsh` currently panics when trying to generate zsh completions.

The root cause is the below code which defines a conflicting arg `buffer_authority` for `solana program-v4 show`, however `buffer_authority` is not an argument in `program-v4 show`:

https://github.com/anza-xyz/agave/blob/fc0183d73477fc24ee4b7c46b80efdd44d4b9cf1/cli/src/program_v4.rs#L277-L283

This results in clap panicking due to `find_any_arg` returning `None`, but the calling macro uses `expect()`

https://github.com/clap-rs/clap/blob/v2.33.3/src/completions/macros.rs#L15
https://github.com/clap-rs/clap/blob/v2.33.3/src/app/parser.rs#L2168-L2179


#### Summary of Changes

- Replaced `.conflicts_with("buffer_authority")` with `.conflicts_with("authority")` in `program-v4 show`
- Added a unit test that ensures CLI completion works for all supported shells.

Fixes https://github.com/anza-xyz/agave/issues/2929
