### PR TITLE
Restrict QUIC crypto algorithms, switch to Dalek for {X,Ed}25519

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7995,6 +7995,7 @@ dependencies = [
  "bytes",
  "crossbeam-channel",
  "dashmap",
+ "ed25519-dalek",
  "futures 0.3.30",
  "futures-util",
  "governor",
@@ -8020,6 +8021,7 @@ dependencies = [
  "solana-transaction-metrics-tracker",
  "thiserror",
  "tokio",
+ "x25519-dalek",
  "x509-parser",
 ]
 
@@ -10269,6 +10271,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -520,6 +520,7 @@ vec_extract_if_polyfill = "0.1.0"
 wasm-bindgen = "0.2"
 winapi = "0.3.8"
 winreg = "0.50"
+x25519-dalek = "2.0.1"
 x509-parser = "0.14.0"
 # See "zeroize versioning issues" below if you are updating this version.
 zeroize = { version = "1.7", default-features = false }

--- a/core/src/repair/quic_endpoint.rs
+++ b/core/src/repair/quic_endpoint.rs
@@ -12,13 +12,12 @@ use {
     },
     rustls::{
         pki_types::{CertificateDer, PrivateKeyDer},
-        CertificateError, KeyLogFile,
+        CertificateError,
     },
     serde_bytes::ByteBuf,
-    solana_quic_client::nonblocking::quic_client::SkipServerVerification,
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{packet::PACKET_DATA_SIZE, pubkey::Pubkey, signature::Keypair},
-    solana_streamer::{quic::SkipClientVerification, tls_certificates::new_dummy_x509_certificate},
+    solana_streamer::tls_certificates::new_dummy_x509_certificate,
     std::{
         cmp::Reverse,
         collections::{hash_map::Entry, HashMap},
@@ -178,11 +177,7 @@ fn new_server_config(
     cert: CertificateDer<'static>,
     key: PrivateKeyDer<'static>,
 ) -> Result<ServerConfig, rustls::Error> {
-    let mut config = rustls::ServerConfig::builder()
-        .with_client_cert_verifier(SkipClientVerification::new())
-        .with_single_cert(vec![cert], key)?;
-    config.alpn_protocols = vec![ALPN_REPAIR_PROTOCOL_ID.to_vec()];
-    config.key_log = Arc::new(KeyLogFile::new());
+    let config = solana_streamer::tls::new_server_config(cert, key, ALPN_REPAIR_PROTOCOL_ID)?;
     let quic_server_config = QuicServerConfig::try_from(config)
         .map_err(|_err| rustls::Error::InvalidCertificate(CertificateError::BadSignature))?;
 
@@ -197,12 +192,7 @@ fn new_client_config(
     cert: CertificateDer<'static>,
     key: PrivateKeyDer<'static>,
 ) -> Result<ClientConfig, rustls::Error> {
-    let mut config = rustls::ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(SkipServerVerification::new())
-        .with_client_auth_cert(vec![cert], key)?;
-    config.enable_early_data = true;
-    config.alpn_protocols = vec![ALPN_REPAIR_PROTOCOL_ID.to_vec()];
+    let config = solana_streamer::tls::new_client_config(cert, key, ALPN_REPAIR_PROTOCOL_ID)?;
     let mut config = ClientConfig::new(Arc::new(QuicClientConfig::try_from(config).unwrap()));
     config.transport_config(Arc::new(new_transport_config()));
     Ok(config)

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6705,6 +6705,7 @@ dependencies = [
  "bytes",
  "crossbeam-channel",
  "dashmap",
+ "ed25519-dalek",
  "futures 0.3.30",
  "futures-util",
  "governor",
@@ -6729,6 +6730,7 @@ dependencies = [
  "solana-transaction-metrics-tracker",
  "thiserror",
  "tokio",
+ "x25519-dalek",
  "x509-parser",
 ]
 
@@ -8597,6 +8599,18 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if 1.0.0",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 async-channel = { workspace = true }
 bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
+ed25519-dalek = { workspace = true }
 dashmap = { workspace = true }
 futures  = { workspace = true }
 futures-util = { workspace = true }
@@ -38,6 +39,7 @@ solana-sdk = { workspace = true }
 solana-transaction-metrics-tracker = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+x25519-dalek = { workspace = true }
 x509-parser = { workspace = true }
 
 [dev-dependencies]

--- a/streamer/src/lib.rs
+++ b/streamer/src/lib.rs
@@ -6,6 +6,7 @@ pub mod recvmmsg;
 pub mod sendmmsg;
 pub mod socket;
 pub mod streamer;
+pub mod tls;
 pub mod tls_certificates;
 
 #[macro_use]

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -28,72 +28,11 @@ use {
     tokio::task::JoinHandle,
 };
 
-#[derive(Debug)]
-pub struct SkipServerVerification(Arc<rustls::crypto::CryptoProvider>);
-
-impl SkipServerVerification {
-    pub fn new() -> Arc<Self> {
-        Arc::new(Self(Arc::new(rustls::crypto::ring::default_provider())))
-    }
-}
-
-impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
-    fn verify_tls12_signature(
-        &self,
-        message: &[u8],
-        cert: &rustls::pki_types::CertificateDer<'_>,
-        dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        rustls::crypto::verify_tls12_signature(
-            message,
-            cert,
-            dss,
-            &self.0.signature_verification_algorithms,
-        )
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        message: &[u8],
-        cert: &rustls::pki_types::CertificateDer<'_>,
-        dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        rustls::crypto::verify_tls13_signature(
-            message,
-            cert,
-            dss,
-            &self.0.signature_verification_algorithms,
-        )
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        self.0.signature_verification_algorithms.supported_schemes()
-    }
-
-    fn verify_server_cert(
-        &self,
-        _end_entity: &rustls::pki_types::CertificateDer<'_>,
-        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
-        _server_name: &rustls::pki_types::ServerName<'_>,
-        _ocsp_response: &[u8],
-        _now: rustls::pki_types::UnixTime,
-    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        Ok(rustls::client::danger::ServerCertVerified::assertion())
-    }
-}
-
 pub fn get_client_config(keypair: &Keypair) -> ClientConfig {
     let (cert, key) = new_dummy_x509_certificate(keypair);
 
-    let mut crypto = rustls::ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(SkipServerVerification::new())
-        .with_client_auth_cert(vec![cert], key)
-        .expect("Failed to use client certificate");
-
-    crypto.enable_early_data = true;
-    crypto.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
-
+    let crypto = crate::tls::new_client_config(cert, key, ALPN_TPU_PROTOCOL_ID)
+        .expect("Failed to create TLS client config");
     let mut config = ClientConfig::new(Arc::new(QuicClientConfig::try_from(crypto).unwrap()));
 
     let mut transport_config = TransportConfig::default();

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -9,11 +9,6 @@ use {
         crypto::rustls::{NoInitialCipherSuite, QuicServerConfig},
         Endpoint, IdleTimeout, ServerConfig,
     },
-    rustls::{
-        pki_types::{CertificateDer, UnixTime},
-        server::danger::ClientCertVerified,
-        DistinguishedName, KeyLogFile,
-    },
     solana_perf::packet::PacketBatch,
     solana_sdk::{
         packet::PACKET_DATA_SIZE,
@@ -38,74 +33,10 @@ pub const MAX_UNSTAKED_CONNECTIONS: usize = 500;
 // This will be adjusted and parameterized in follow-on PRs.
 pub const DEFAULT_QUIC_ENDPOINTS: usize = 1;
 
-#[derive(Debug)]
-pub struct SkipClientVerification(Arc<rustls::crypto::CryptoProvider>);
-
-impl SkipClientVerification {
-    pub fn new() -> Arc<Self> {
-        Arc::new(Self(Arc::new(rustls::crypto::ring::default_provider())))
-    }
-}
-
 pub struct SpawnServerResult {
     pub endpoints: Vec<Endpoint>,
     pub thread: thread::JoinHandle<()>,
     pub key_updater: Arc<EndpointKeyUpdater>,
-}
-
-impl rustls::server::danger::ClientCertVerifier for SkipClientVerification {
-    fn verify_client_cert(
-        &self,
-        _end_entity: &CertificateDer,
-        _intermediates: &[CertificateDer],
-        _now: UnixTime,
-    ) -> Result<ClientCertVerified, rustls::Error> {
-        Ok(rustls::server::danger::ClientCertVerified::assertion())
-    }
-
-    fn root_hint_subjects(&self) -> &[DistinguishedName] {
-        &[]
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        message: &[u8],
-        cert: &rustls::pki_types::CertificateDer<'_>,
-        dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        rustls::crypto::verify_tls12_signature(
-            message,
-            cert,
-            dss,
-            &self.0.signature_verification_algorithms,
-        )
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        message: &[u8],
-        cert: &rustls::pki_types::CertificateDer<'_>,
-        dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        rustls::crypto::verify_tls13_signature(
-            message,
-            cert,
-            dss,
-            &self.0.signature_verification_algorithms,
-        )
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        self.0.signature_verification_algorithms.supported_schemes()
-    }
-
-    fn offer_client_auth(&self) -> bool {
-        true
-    }
-
-    fn client_auth_mandatory(&self) -> bool {
-        self.offer_client_auth()
-    }
 }
 
 /// Returns default server configuration along with its PEM certificate chain.
@@ -120,11 +51,7 @@ pub(crate) fn configure_server(
     }];
     let cert_chain_pem = pem::encode_many(&cert_chain_pem_parts);
 
-    let mut server_tls_config = rustls::ServerConfig::builder()
-        .with_client_cert_verifier(SkipClientVerification::new())
-        .with_single_cert(vec![cert], priv_key)?;
-    server_tls_config.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
-    server_tls_config.key_log = Arc::new(KeyLogFile::new());
+    let server_tls_config = crate::tls::new_server_config(cert, priv_key, ALPN_TPU_PROTOCOL_ID)?;
     let quic_server_config = QuicServerConfig::try_from(server_tls_config)?;
 
     let mut server_config = ServerConfig::with_crypto(Arc::new(quic_server_config));

--- a/streamer/src/tls.rs
+++ b/streamer/src/tls.rs
@@ -1,0 +1,268 @@
+use {
+    ed25519_dalek::Verifier,
+    rustls::{
+        client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+        crypto::{
+            SharedSecret, SupportedKxGroup,
+            verify_tls13_signature, ActiveKeyExchange, CryptoProvider, WebPkiSupportedAlgorithms,
+        },
+        PeerMisbehaved,
+        pki_types::{
+            AlgorithmIdentifier, CertificateDer, InvalidSignature, PrivateKeyDer, ServerName,
+            SignatureVerificationAlgorithm, UnixTime,
+        },
+        server::danger::{ClientCertVerified, ClientCertVerifier},
+        version::TLS13,
+        CipherSuite, ClientConfig, DigitallySignedStruct, DistinguishedName, KeyLogFile,
+        PeerIncompatible, ServerConfig, SignatureScheme,
+    },
+    std::sync::Arc,
+    rand::rngs::OsRng,
+};
+
+// Boilerplate required to use ed25519_dalek for signature verification.
+
+#[derive(Debug)]
+struct DalekEd25519;
+static DALEK_ED25519: &dyn SignatureVerificationAlgorithm = &DalekEd25519;
+const ED25519_ALG_ID: AlgorithmIdentifier =
+    AlgorithmIdentifier::from_slice(&[0x06, 0x03, 0x2b, 0x65, 0x70]);
+impl SignatureVerificationAlgorithm for DalekEd25519 {
+    fn public_key_alg_id(&self) -> AlgorithmIdentifier {
+        ED25519_ALG_ID
+    }
+
+    fn signature_alg_id(&self) -> AlgorithmIdentifier {
+        ED25519_ALG_ID
+    }
+
+    fn verify_signature(
+        &self,
+        public_key: &[u8],
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), InvalidSignature> {
+        let publickey =
+            ed25519_dalek::PublicKey::from_bytes(public_key).map_err(|_| InvalidSignature)?;
+        let signature =
+            ed25519_dalek::Signature::try_from(signature).map_err(|_| InvalidSignature)?;
+        publickey
+            .verify(message, &signature)
+            .map_err(|_| InvalidSignature)
+    }
+}
+
+pub static TLS_SIGVERIFY_SCHEMES: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
+    all: &[DALEK_ED25519],
+    mapping: &[(SignatureScheme::ED25519, &[DALEK_ED25519])],
+};
+
+// Boilerplate required to use x25519_dalek for key exchange.
+
+struct X25519State {
+    secret: x25519_dalek::EphemeralSecret,
+    pubkey: x25519_dalek::PublicKey,
+}
+
+impl ActiveKeyExchange for X25519State {
+    fn complete(self: Box<Self>, peer: &[u8]) -> Result<SharedSecret, rustls::Error> {
+        let peer_array: [u8; 32] = peer
+            .try_into()
+            .map_err(|_| rustls::Error::from(PeerMisbehaved::InvalidKeyShare))?;
+        let their_pub = x25519_dalek::PublicKey::from(peer_array);
+        let shared_secret = self.secret.diffie_hellman(&their_pub);
+        Ok(SharedSecret::from(&shared_secret.as_bytes()[..]))
+    }
+
+    fn pub_key(&self) -> &[u8] {
+        self.pubkey.as_bytes()
+    }
+
+    fn group(&self) -> rustls::NamedGroup {
+        X25519.name()
+    }
+}
+
+#[derive(Debug)]
+pub struct X25519Group;
+
+impl SupportedKxGroup for X25519Group {
+    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, rustls::Error> {
+        let secret = x25519_dalek::EphemeralSecret::random_from_rng(OsRng);
+        Ok(Box::new(X25519State {
+            pubkey: (&secret).into(),
+            secret,
+        }))
+    }
+
+    fn name(&self) -> rustls::NamedGroup {
+        rustls::NamedGroup::X25519
+    }
+}
+
+pub static X25519: X25519Group = X25519Group;
+
+// Assemble a CryptoProvider using ring and dalek
+
+fn new_crypto_provider() -> CryptoProvider {
+    let ring_provider = rustls::crypto::ring::default_provider();
+
+    // Create minimal cipher suite list
+    let mut aes128gcm = None;
+    let mut chacha20poly1305 = None;
+    for cipher_suite in ring_provider.cipher_suites {
+        match cipher_suite.suite() {
+            CipherSuite::TLS13_AES_128_GCM_SHA256 => aes128gcm = Some(cipher_suite),
+            CipherSuite::TLS13_CHACHA20_POLY1305_SHA256 => chacha20poly1305 = Some(cipher_suite),
+            _ => {}
+        }
+    }
+    let mut cipher_suites = Vec::with_capacity(2);
+    if let Some(suite) = aes128gcm {
+        cipher_suites.push(suite);
+    }
+    if let Some(suite) = chacha20poly1305 {
+        cipher_suites.push(suite);
+    }
+
+    CryptoProvider {
+        cipher_suites,
+        kx_groups: vec![&X25519],
+        key_provider: ring_provider.key_provider,
+        secure_random: ring_provider.secure_random,
+        signature_verification_algorithms: TLS_SIGVERIFY_SCHEMES,
+    }
+}
+
+// Declare TLS 1.3 cert validation rules for p2p
+
+#[derive(Debug)]
+struct SkipServerVerification;
+
+impl SkipServerVerification {
+    fn new() -> Arc<Self> {
+        Arc::new(Self)
+    }
+}
+
+impl ServerCertVerifier for SkipServerVerification {
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Err(rustls::Error::PeerIncompatible(
+            PeerIncompatible::Tls13RequiredForQuic,
+        ))
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls13_signature(message, cert, dss, &TLS_SIGVERIFY_SCHEMES)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        TLS_SIGVERIFY_SCHEMES.supported_schemes()
+    }
+
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+}
+
+#[derive(Debug)]
+struct SkipClientVerification;
+
+impl SkipClientVerification {
+    fn new() -> Arc<Self> {
+        Arc::new(Self)
+    }
+}
+
+impl ClientCertVerifier for SkipClientVerification {
+    fn verify_client_cert(
+        &self,
+        _end_entity: &CertificateDer,
+        _intermediates: &[CertificateDer],
+        _now: UnixTime,
+    ) -> Result<ClientCertVerified, rustls::Error> {
+        Ok(ClientCertVerified::assertion())
+    }
+
+    fn root_hint_subjects(&self) -> &[DistinguishedName] {
+        &[]
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Err(rustls::Error::PeerIncompatible(
+            PeerIncompatible::Tls13RequiredForQuic,
+        ))
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls13_signature(message, cert, dss, &TLS_SIGVERIFY_SCHEMES)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        TLS_SIGVERIFY_SCHEMES.supported_schemes()
+    }
+
+    fn offer_client_auth(&self) -> bool {
+        true
+    }
+
+    fn client_auth_mandatory(&self) -> bool {
+        true
+    }
+}
+
+pub fn new_server_config(
+    cert: CertificateDer<'static>,
+    key: PrivateKeyDer<'static>,
+    alpn: &[u8],
+) -> Result<ServerConfig, rustls::Error> {
+    let mut config = ServerConfig::builder_with_provider(Arc::new(new_crypto_provider()))
+        .with_protocol_versions(&[&TLS13])?
+        .with_client_cert_verifier(SkipClientVerification::new())
+        .with_single_cert(vec![cert], key)?;
+    config.alpn_protocols = vec![alpn.to_vec()];
+    config.key_log = Arc::new(KeyLogFile::new());
+    Ok(config)
+}
+
+pub fn new_client_config(
+    cert: CertificateDer<'static>,
+    key: PrivateKeyDer<'static>,
+    alpn: &[u8],
+) -> Result<ClientConfig, rustls::Error> {
+    let mut config = ClientConfig::builder_with_provider(Arc::new(new_crypto_provider()))
+        .with_protocol_versions(&[&TLS13])?
+        .dangerous()
+        .with_custom_certificate_verifier(SkipServerVerification::new())
+        .with_client_auth_cert(vec![cert], key)?;
+    config.enable_early_data = true;
+    config.alpn_protocols = vec![alpn.to_vec()];
+    Ok(config)
+}


### PR DESCRIPTION
#### Problem

The Agave QUIC server allows a lot of QUIC-TLS protocol options that are unused.

#### Summary of Changes

Hardens the list of crypto algorithms imported for QUIC-TLS.
Switch QUIC server to same Curve25519 backend as transaction and shred sigverify.

Nodes running this PR can connect to and accept connections from older nodes without any config change.

- Only support TLS certs with an Ed25519 public key (remove support for RSA, ECDSA, etc)
- Only support the X25519 key exchange algorithm
- Only support TLS13_AES_128_GCM_SHA256 and TLS13_CHACHA20_POLY1305_SHA256 cipher suites
- Add custom rustls crypto provider
- Add public API for creating TLS configs for QUIC endpoints
- Use ed25519-dalek instead of ring for Ed25519
- Use x25519-dalek instead of ring for X25519

Relates to https://github.com/lijunwangs/solana/pull/3

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
