### PR TITLE
feat: configurable faucet address for test-validator

### DIFF
--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -52,7 +52,11 @@ macro_rules! socketaddr {
 const ERROR_RESPONSE: [u8; 2] = 0u16.to_le_bytes();
 
 pub const TIME_SLICE: u64 = 60;
+/// The default faucet port: `9900`
 pub const FAUCET_PORT: u16 = 9900;
+/// The default faucet socket: `127.0.0.1:9900`
+pub const FAUCET_SOCKET: SocketAddr =
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), FAUCET_PORT);
 
 #[derive(Error, Debug)]
 pub enum FaucetError {

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -11,7 +11,7 @@ use {
         program::ProgramCliCommand,
     },
     solana_client::transaction_executor::TransactionExecutor,
-    solana_faucet::faucet::{request_airdrop_transaction, FAUCET_PORT},
+    solana_faucet::faucet::{request_airdrop_transaction, FAUCET_SOCKET},
     solana_gossip::gossip_service::discover,
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{
@@ -550,7 +550,7 @@ fn main() {
             exit(1)
         });
     }
-    let mut faucet_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, FAUCET_PORT));
+    let mut faucet_addr = FAUCET_SOCKET;
     if let Some(addr) = matches.value_of("faucet_addr") {
         faucet_addr = solana_net_utils::parse_host_port(addr).unwrap_or_else(|e| {
             eprintln!("failed to parse entrypoint address: {e}");

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -23,7 +23,7 @@ use {
         banking_trace::{DirByteLimit, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
         validator::{BlockProductionMethod, BlockVerificationMethod},
     },
-    solana_faucet::faucet::{self, FAUCET_PORT},
+    solana_faucet::faucet::{self, FAUCET_SOCKET},
     solana_ledger::use_snapshot_archives_at_startup,
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
     solana_rayon_threadlimit::get_thread_count,
@@ -2856,7 +2856,7 @@ impl DefaultTestArgs {
     pub fn new() -> Self {
         DefaultTestArgs {
             rpc_port: rpc_port::DEFAULT_RPC_PORT.to_string(),
-            faucet_addr: format!("127.0.0.1:{FAUCET_PORT}"),
+            faucet_addr: format!("{}", FAUCET_SOCKET),
             /* 10,000 was derived empirically by watching the size
              * of the rocksdb/ directory self-limit itself to the
              * 40MB-150MB range when running `solana-test-validator`

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2472,13 +2472,16 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .help("Enable an accounts index, indexed by the selected account field"),
         )
         .arg(
-            Arg::with_name("faucet_port")
-                .long("faucet-port")
-                .value_name("PORT")
+            Arg::with_name("rpc_faucet_addr")
+                .long("rpc-faucet-address")
+                .value_name("HOST:PORT")
                 .takes_value(true)
-                .default_value(&default_args.faucet_port)
-                .validator(port_validator)
-                .help("Enable the faucet on this port"),
+                .default_value(&default_args.faucet_addr)
+                .validator(solana_net_utils::is_host_port)
+                .help(
+                    "Enable the JSON RPC 'requestAirdrop' API with this faucet address + port.\
+                    Defaults to 127.0.0.1:9900",
+                ),
         )
         .arg(
             Arg::with_name("rpc_port")
@@ -2843,7 +2846,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
 
 pub struct DefaultTestArgs {
     pub rpc_port: String,
-    pub faucet_port: String,
+    pub faucet_addr: String,
     pub limit_ledger_size: String,
     pub faucet_sol: String,
     pub faucet_time_slice_secs: String,
@@ -2853,7 +2856,7 @@ impl DefaultTestArgs {
     pub fn new() -> Self {
         DefaultTestArgs {
             rpc_port: rpc_port::DEFAULT_RPC_PORT.to_string(),
-            faucet_port: FAUCET_PORT.to_string(),
+            faucet_addr: format!("127.0.0.1:{FAUCET_PORT}"),
             /* 10,000 was derived empirically by watching the size
              * of the rocksdb/ directory self-limit itself to the
              * 40MB-150MB range when running `solana-test-validator`


### PR DESCRIPTION
#### Problem

When using the solana-test-validator, it should be possible to run this entirely within the localhost space.
Currently there are a few services which listen on `0.0.0.0` by default, and have no option to configure to another address.

#### Summary of Changes
This PR fixes the faucet config in the test-validator, so that it runs on localhost + port 9900 (`FAUCET_PORT` constant from the faucet crate).

If additional configuration is required, the flag `--rpc-faucet-address` can be used, which is the same as the flag used in the main validator crate. 

Example usage if it was required to make the faucet available to other hosts on port 9500:

`solana-test-validator --rpc-faucet-address=0.0.0.0:9500`

The clap arg validator ensures that any value passed will parse into a SocketAddr, otherwise an error is displayed to the user. If the flag isn't used, then the default value mentioned above is used.

