### PR TITLE
Uses scan_pubkeys() in accounts_count()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9475,7 +9475,7 @@ pub(crate) enum UpdateIndexThreadSelection {
 impl AccountStorageEntry {
     fn accounts_count(&self) -> usize {
         let mut count = 0;
-        self.accounts.scan_accounts(|_| {
+        self.accounts.scan_pubkeys(|_| {
             count += 1;
         });
         count


### PR DESCRIPTION
#### Problem

`accounts_count()` calls `scan_accounts()` as its way to iterate the accounts in a storage. Since we do not need any account meta/data, we can do this faster/cheaper.


#### Summary of Changes

Use `scan_pubkeys()` instead of `scan_accounts()`.