### PR TITLE
Uses real stored count in tests

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9935,7 +9935,7 @@ pub mod tests {
             assert_eq!(append_vec.alive_bytes(), expected_alive_bytes);
         }
         // total # accounts in append vec
-        assert_eq!(append_vec.approx_stored_count(), 2);
+        assert_eq!(append_vec.accounts_count(), 2);
         // # alive accounts
         assert_eq!(append_vec.count(), 1);
         // all account data alive
@@ -10775,8 +10775,8 @@ pub mod tests {
             let slot_1_store = &db.storage.get_slot_storage_entry(1).unwrap();
             assert_eq!(slot_0_store.count(), 2);
             assert_eq!(slot_1_store.count(), 2);
-            assert_eq!(slot_0_store.approx_stored_count(), 2);
-            assert_eq!(slot_1_store.approx_stored_count(), 2);
+            assert_eq!(slot_0_store.accounts_count(), 2);
+            assert_eq!(slot_1_store.accounts_count(), 2);
         }
 
         // overwrite old rooted account version; only the r_slot_0_stores.count() should be
@@ -10789,8 +10789,8 @@ pub mod tests {
             let slot_1_store = &db.storage.get_slot_storage_entry(1).unwrap();
             assert_eq!(slot_0_store.count(), 1);
             assert_eq!(slot_1_store.count(), 2);
-            assert_eq!(slot_0_store.approx_stored_count(), 2);
-            assert_eq!(slot_1_store.approx_stored_count(), 2);
+            assert_eq!(slot_0_store.accounts_count(), 2);
+            assert_eq!(slot_1_store.accounts_count(), 2);
         }
     });
 


### PR DESCRIPTION
#### Problem

Some tests use the approximate store count to get the total number of accounts stored in an append vec. There's already a better dcou fn for getting the total number of accounts: `accounts_count()`.


#### Summary of Changes

Use `accounts_count()` in tests.