### PR TITLE
Aggressively shrink ancient storages when shrink isn't too busy.

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -12127,7 +12127,7 @@ pub mod tests {
         // The above check works only when the AppendVec storage is
         // used. More generally the pubkey of the smallest account
         // shouldn't be present in the shrunk storage, which is
-        // validated by the following scan ofthe storage accounts.
+        // validated by the following scan of the storage accounts.
         storage.accounts.scan_pubkeys(|pubkey| {
             assert_ne!(pubkey, &modified_account_pubkey);
         });

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4390,10 +4390,10 @@ impl AccountsDb {
         });
 
         // If there are too few slots to shrink, add an ancient slot
-        // for shrinking.
+        // for shrinking.  The best ancient slots to shrink are
+        // assumed to be in reverse order.
         if shrink_slots.len() < SHRINK_INSERT_ANCIENT_THRESHOLD {
             let mut ancients = self.best_ancient_slots_to_shrink.write().unwrap();
-            ancients.reverse();
             while let Some((slot, capacity)) = ancients.pop() {
                 if let Some(store) = self.storage.get_slot_storage_entry(slot) {
                     if !shrink_slots.contains(&slot)

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1469,9 +1469,12 @@ pub struct AccountsDb {
     /// (For R&D only; a feature-gate also exists to turn this on and make it a part of consensus.)
     pub is_experimental_accumulator_hash_enabled: AtomicBool,
 
-    /// These are the ancient storages that could be valuable to shrink.
-    /// sorted by largest dead bytes to smallest
-    /// Members are Slot and capacity. If capacity is smaller, then that means the storage was already shrunk.
+    /// These are the ancient storages that could be valuable to
+    /// shrink, sorted by amount of dead bytes. The elements
+    /// are popped from the end of the vector, hence the sorting is
+    /// expected to be from the smallest dead bytes to the largest.
+    /// Members are Slot and capacity. If capacity is smaller, then
+    /// that means the storage was already shrunk.
     pub(crate) best_ancient_slots_to_shrink: RwLock<Vec<(Slot, u64)>>,
 }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -12092,8 +12092,8 @@ pub mod tests {
             .pubkey;
         let modified_account_owner = *AccountSharedData::default().owner();
         let modified_account = AccountSharedData::new(223, 0, &modified_account_owner);
-        let offset = db.ancient_append_vec_offset.unwrap().abs() as u64;
-        let current_slot = epoch_schedule.slots_per_epoch + offset + 1;
+        let ancient_append_vec_offset = db.ancient_append_vec_offset.unwrap().abs();
+        let current_slot = epoch_schedule.slots_per_epoch + ancient_append_vec_offset as u64 + 1;
         // Simulate killing of the ancient account by overwriting it in the current slot.
         db.store_for_tests(
             current_slot,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1472,7 +1472,7 @@ pub struct AccountsDb {
     /// These are the ancient storages that could be valuable to shrink.
     /// sorted by largest dead bytes to smallest
     /// Members are Slot and capacity. If capacity is smaller, then that means the storage was already shrunk.
-    pub(crate) best_ancient_slots_to_shrink: RwLock<Vec<(Slot, u64)>>,
+    pub(crate) best_ancient_slots_to_shrink: RwLock<Vec<(Slot, u64, u64)>>,
 }
 
 /// results from 'split_storages_ancient'
@@ -4394,7 +4394,7 @@ impl AccountsDb {
         // assumed to be in reverse order.
         if shrink_slots.len() < SHRINK_INSERT_ANCIENT_THRESHOLD {
             let mut ancients = self.best_ancient_slots_to_shrink.write().unwrap();
-            while let Some((slot, capacity)) = ancients.pop() {
+            while let Some((slot, capacity, _dead_bytes)) = ancients.pop() {
                 if let Some(store) = self.storage.get_slot_storage_entry(slot) {
                     if !shrink_slots.contains(&slot)
                         && capacity == store.capacity()

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -12053,14 +12053,14 @@ pub mod tests {
         );
     }
 
-    /// This test creates an ancient storage with three live accounts
+    /// This test creates an ancient storage with three alive accounts
     /// of various sizes. It then simulates killing one the accounts
     /// in a more recent (non-ancient) slot by overwriting the account
     /// that has the smallest data size.  The dead account is expected
     /// to be deleted from its ancient storages in the process
     /// shrinking candidate slots.  The capacity of the updated new
     /// storage after shrinking is expected to be the sum of alive
-    /// bytes of the two remaining live ancient accounts.
+    /// bytes of the two remaining alive ancient accounts.
     #[test]
     fn test_shrink_candidate_slots_with_dead_ancient_account() {
         solana_logger::setup();
@@ -12083,7 +12083,7 @@ pub mod tests {
         // Check that three accounts are indeed present in the combined storage
         assert_eq!(ancient_accounts.stored_accounts.len(), 3);
         // Find an ancient account with smallest data length.
-        // This will be a dead account, overwrittent in the current slot.
+        // This will be a dead account, overwritten in the current slot.
         let modified_account_pubkey = ancient_accounts
             .stored_accounts
             .iter()
@@ -12107,14 +12107,14 @@ pub mod tests {
         let storage = db.get_storage_for_slot(starting_ancient_slot).unwrap();
         let created_accounts = db.get_unique_accounts_from_storage(&storage);
         // The dead account should still be in the ancient storage,
-        // because the storage wouldn't be shrunk with normal live to
+        // because the storage wouldn't be shrunk with normal alive to
         // capacity ratio.
         assert_eq!(created_accounts.stored_accounts.len(), 3);
         db.shrink_candidate_slots(&epoch_schedule);
         let storage = db.get_storage_for_slot(starting_ancient_slot).unwrap();
         let created_accounts = db.get_unique_accounts_from_storage(&storage);
         // At this point the dead ancient account should be removed
-        // and storage capacity shrunk to the sum of live bytes of
+        // and storage capacity shrunk to the sum of alive bytes of
         // accounts it holds.  This is the data lengths of the
         // accounts plus the length of their metadata.
         assert_eq!(created_accounts.capacity, 1000 + 2000 + 136 * 2);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1472,7 +1472,7 @@ pub struct AccountsDb {
     /// These are the ancient storages that could be valuable to shrink.
     /// sorted by largest dead bytes to smallest
     /// Members are Slot and capacity. If capacity is smaller, then that means the storage was already shrunk.
-    pub(crate) best_ancient_slots_to_shrink: RwLock<Vec<(Slot, u64, u64)>>,
+    pub(crate) best_ancient_slots_to_shrink: RwLock<Vec<(Slot, u64)>>,
 }
 
 /// results from 'split_storages_ancient'
@@ -4394,7 +4394,7 @@ impl AccountsDb {
         // assumed to be in reverse order.
         if shrink_slots.len() < SHRINK_INSERT_ANCIENT_THRESHOLD {
             let mut ancients = self.best_ancient_slots_to_shrink.write().unwrap();
-            while let Some((slot, capacity, _dead_bytes)) = ancients.pop() {
+            while let Some((slot, capacity)) = ancients.pop() {
                 if let Some(store) = self.storage.get_slot_storage_entry(slot) {
                     if !shrink_slots.contains(&slot)
                         && capacity == store.capacity()

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4401,18 +4401,18 @@ impl AccountsDb {
                             .ancient_bytes_added_to_shrink
                             .fetch_add(store.alive_bytes() as u64, Ordering::Relaxed);
                         shrink_slots.insert(*slot, store);
+                        log::debug!(
+                            "ancient_slots_added: {ancient_slots_added}, {}, avail: {}",
+                            shrink_slots.len(),
+                            ancients.len()
+                        );
+                        self.shrink_stats
+                            .ancient_slots_added_to_shrink
+                            .fetch_add(ancient_slots_added, Ordering::Relaxed);
                     }
                 }
             }
-            log::debug!(
-                "ancient_slots_added: {ancient_slots_added}, {}, avail: {}",
-                shrink_slots.len(),
-                ancients.len()
-            );
         }
-        self.shrink_stats
-            .ancient_slots_added_to_shrink
-            .fetch_add(ancient_slots_added, Ordering::Relaxed);
         if shrink_slots.is_empty()
             && shrink_slots_next_batch
                 .as_ref()

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4393,7 +4393,7 @@ impl AccountsDb {
         // for shrinking.
         if shrink_slots.len() < SHRINK_INSERT_ANCIENT_THRESHOLD {
             let ancients = self.best_ancient_slots_to_shrink.read().unwrap();
-            if let Some((slot, capacity)) = ancients.first() {
+            for (slot, capacity) in ancients.iter() {
                 if let Some(store) = self.storage.get_slot_storage_entry(*slot) {
                     if !shrink_slots.contains(slot)
                         && *capacity == store.capacity()
@@ -4407,6 +4407,7 @@ impl AccountsDb {
                         self.shrink_stats
                             .ancient_slots_added_to_shrink
                             .fetch_add(1, Ordering::Relaxed);
+                        break;
                     }
                 }
             }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -12054,11 +12054,11 @@ pub mod tests {
     }
 
     /// This test creates an ancient storage with three alive accounts
-    /// of various sizes. It then simulates killing one of the accounts
-    /// in a more recent (non-ancient) slot by overwriting the account
-    /// that has the smallest data size.  The dead account is expected
-    /// to be deleted from its ancient storages in the process
-    /// shrinking candidate slots.  The capacity of the updated new
+    /// of various sizes. It then simulates killing one of the
+    /// accounts in a more recent (non-ancient) slot by overwriting
+    /// the account that has the smallest data size.  The dead account
+    /// is expected to be deleted from its ancient storage in the
+    /// process of shrinking candidate slots.  The capacity of the
     /// storage after shrinking is expected to be the sum of alive
     /// bytes of the two remaining alive ancient accounts.
     #[test]
@@ -12080,7 +12080,7 @@ pub mod tests {
         db.combine_ancient_slots(slots_to_combine, CAN_RANDOMLY_SHRINK_FALSE);
         let storage = db.get_storage_for_slot(starting_ancient_slot).unwrap();
         let ancient_accounts = db.get_unique_accounts_from_storage(&storage);
-        // Check that three accounts are indeed present in the combined storage
+        // Check that three accounts are indeed present in the combined storage.
         assert_eq!(ancient_accounts.stored_accounts.len(), 3);
         // Find an ancient account with smallest data length.
         // This will be a dead account, overwritten in the current slot.
@@ -12101,7 +12101,7 @@ pub mod tests {
         );
         db.calculate_accounts_delta_hash(current_slot);
         db.add_root_and_flush_write_cache(current_slot);
-        // This should remove the dead ancient account from the index
+        // This should remove the dead ancient account from the index.
         db.clean_accounts_for_tests();
         db.shrink_ancient_slots(&epoch_schedule);
         let storage = db.get_storage_for_slot(starting_ancient_slot).unwrap();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -12054,7 +12054,7 @@ pub mod tests {
     }
 
     /// This test creates an ancient storage with three alive accounts
-    /// of various sizes. It then simulates killing one the accounts
+    /// of various sizes. It then simulates killing one of the accounts
     /// in a more recent (non-ancient) slot by overwriting the account
     /// that has the smallest data size.  The dead account is expected
     /// to be deleted from its ancient storages in the process

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -407,6 +407,18 @@ impl ShrinkStats {
             datapoint_info!(
                 "shrink_stats",
                 (
+                    "ancient_slots_added_to_shrink",
+                    self.ancient_slots_added_to_shrink
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "ancient_bytes_added_to_shrink",
+                    self.ancient_bytes_added_to_shrink
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
                     "num_slots_shrunk",
                     self.num_slots_shrunk.swap(0, Ordering::Relaxed) as i64,
                     i64
@@ -508,11 +520,6 @@ impl ShrinkStats {
                     i64
                 ),
                 (
-                    "initial_candidates_count",
-                    self.initial_candidates_count.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
                     "purged_zero_lamports_count",
                     self.purged_zero_lamports.swap(0, Ordering::Relaxed),
                     i64
@@ -528,15 +535,8 @@ impl ShrinkStats {
                     i64
                 ),
                 (
-                    "ancient_slots_added_to_shrink",
-                    self.ancient_slots_added_to_shrink
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "ancient_bytes_added_to_shrink",
-                    self.ancient_bytes_added_to_shrink
-                        .swap(0, Ordering::Relaxed),
+                    "initial_candidates_count",
+                    self.initial_candidates_count.swap(0, Ordering::Relaxed),
                     i64
                 ),
             );

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -407,18 +407,6 @@ impl ShrinkStats {
             datapoint_info!(
                 "shrink_stats",
                 (
-                    "ancient_slots_added_to_shrink",
-                    self.ancient_slots_added_to_shrink
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "ancient_bytes_added_to_shrink",
-                    self.ancient_bytes_added_to_shrink
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
                     "num_slots_shrunk",
                     self.num_slots_shrunk.swap(0, Ordering::Relaxed) as i64,
                     i64
@@ -520,6 +508,11 @@ impl ShrinkStats {
                     i64
                 ),
                 (
+                    "initial_candidates_count",
+                    self.initial_candidates_count.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
                     "purged_zero_lamports_count",
                     self.purged_zero_lamports.swap(0, Ordering::Relaxed),
                     i64
@@ -535,8 +528,15 @@ impl ShrinkStats {
                     i64
                 ),
                 (
-                    "initial_candidates_count",
-                    self.initial_candidates_count.swap(0, Ordering::Relaxed),
+                    "ancient_slots_added_to_shrink",
+                    self.ancient_slots_added_to_shrink
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "ancient_bytes_added_to_shrink",
+                    self.ancient_bytes_added_to_shrink
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
             );

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -407,7 +407,7 @@ impl AccountsDb {
             &mut ancient_slot_infos.best_slots_to_shrink,
         );
         // Reverse the vector so that the elements with the largest
-        // dead bytes are poped first when used to extend the
+        // dead bytes are popped first when used to extend the
         // shrinking candidates.
         self.best_ancient_slots_to_shrink.write().unwrap().reverse();
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -79,6 +79,8 @@ struct AncientSlotInfos {
     total_alive_bytes_shrink: Saturating<u64>,
     /// total alive bytes across all slots
     total_alive_bytes: Saturating<u64>,
+    /// best_slots_to_shrink
+    best_slots_to_shrink: Vec<(Slot, u64)>,
 }
 
 impl AncientSlotInfos {
@@ -177,8 +179,10 @@ impl AncientSlotInfos {
                     * tuning.percent_of_alive_shrunk_data
                     / 100,
             );
+        self.best_slots_to_shrink = Vec::with_capacity(self.shrink_indexes.len());
         for info_index in &self.shrink_indexes {
             let info = &mut self.all_infos[*info_index];
+            self.best_slots_to_shrink.push((info.slot, info.capacity));
             if bytes_to_shrink_due_to_ratio.0 >= threshold_bytes {
                 // we exceeded the amount to shrink due to alive ratio, so don't shrink this one just due to 'should_shrink'
                 // It MAY be shrunk based on total capacity still.
@@ -396,7 +400,12 @@ impl AccountsDb {
         self.shrink_ancient_stats
             .slots_considered
             .fetch_add(sorted_slots.len() as u64, Ordering::Relaxed);
-        let ancient_slot_infos = self.collect_sort_filter_ancient_slots(sorted_slots, &tuning);
+        let mut ancient_slot_infos = self.collect_sort_filter_ancient_slots(sorted_slots, &tuning);
+
+        std::mem::swap(
+            &mut *self.best_ancient_slots_to_shrink.write().unwrap(),
+            &mut ancient_slot_infos.best_slots_to_shrink,
+        );
 
         if ancient_slot_infos.all_infos.is_empty() {
             return; // nothing to do

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -184,7 +184,8 @@ impl AncientSlotInfos {
         for info_index in &self.shrink_indexes {
             let info = &mut self.all_infos[*info_index];
             let dead_bytes = info.capacity - info.alive_bytes;
-            self.best_slots_to_shrink.push((info.slot, info.capacity, dead_bytes));
+            self.best_slots_to_shrink
+                .push((info.slot, info.capacity, dead_bytes));
             if bytes_to_shrink_due_to_ratio.0 >= threshold_bytes {
                 // we exceeded the amount to shrink due to alive ratio, so don't shrink this one just due to 'should_shrink'
                 // It MAY be shrunk based on total capacity still.

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -182,12 +182,12 @@ impl AncientSlotInfos {
         self.best_slots_to_shrink = Vec::with_capacity(self.shrink_indexes.len());
         for info_index in &self.shrink_indexes {
             let info = &mut self.all_infos[*info_index];
-            self.best_slots_to_shrink.push((info.slot, info.capacity));
             if bytes_to_shrink_due_to_ratio.0 >= threshold_bytes {
                 // we exceeded the amount to shrink due to alive ratio, so don't shrink this one just due to 'should_shrink'
                 // It MAY be shrunk based on total capacity still.
                 // Mark it as false for 'should_shrink' so it gets evaluated solely based on # of files.
                 info.should_shrink = false;
+                self.best_slots_to_shrink.push((info.slot, info.capacity));
             } else {
                 bytes_to_shrink_due_to_ratio += info.alive_bytes;
             }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -81,7 +81,7 @@ struct AncientSlotInfos {
     total_alive_bytes: Saturating<u64>,
     /// slots that have dead accounts and thus the corresponding slot
     /// storages can be shrunk
-    best_slots_to_shrink: Vec<(Slot, u64, u64)>,
+    best_slots_to_shrink: Vec<(Slot, u64)>,
 }
 
 impl AncientSlotInfos {
@@ -180,12 +180,13 @@ impl AncientSlotInfos {
                     * tuning.percent_of_alive_shrunk_data
                     / 100,
             );
+        // At this point self.shrink_indexes have been sorted by the
+        // largest amount of dead bytes first in the corresponding
+        // storages.
         self.best_slots_to_shrink = Vec::with_capacity(self.shrink_indexes.len());
         for info_index in &self.shrink_indexes {
             let info = &mut self.all_infos[*info_index];
-            let dead_bytes = info.capacity - info.alive_bytes;
-            self.best_slots_to_shrink
-                .push((info.slot, info.capacity, dead_bytes));
+            self.best_slots_to_shrink.push((info.slot, info.capacity));
             if bytes_to_shrink_due_to_ratio.0 >= threshold_bytes {
                 // we exceeded the amount to shrink due to alive ratio, so don't shrink this one just due to 'should_shrink'
                 // It MAY be shrunk based on total capacity still.
@@ -195,10 +196,10 @@ impl AncientSlotInfos {
                 bytes_to_shrink_due_to_ratio += info.alive_bytes;
             }
         }
-        // Sort the vector so that the elements with the largest
+        // Reverse the vector so that the elements with the largest
         // dead bytes are popped first when used to extend the
         // shrinking candidates.
-        self.best_slots_to_shrink.sort_by(|a, b| b.2.cmp(&a.2));
+        self.best_slots_to_shrink.reverse();
     }
 
     /// after this function, only slots that were chosen to shrink are marked with

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -182,12 +182,12 @@ impl AncientSlotInfos {
         self.best_slots_to_shrink = Vec::with_capacity(self.shrink_indexes.len());
         for info_index in &self.shrink_indexes {
             let info = &mut self.all_infos[*info_index];
+            self.best_slots_to_shrink.push((info.slot, info.capacity));
             if bytes_to_shrink_due_to_ratio.0 >= threshold_bytes {
                 // we exceeded the amount to shrink due to alive ratio, so don't shrink this one just due to 'should_shrink'
                 // It MAY be shrunk based on total capacity still.
                 // Mark it as false for 'should_shrink' so it gets evaluated solely based on # of files.
                 info.should_shrink = false;
-                self.best_slots_to_shrink.push((info.slot, info.capacity));
             } else {
                 bytes_to_shrink_due_to_ratio += info.alive_bytes;
             }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -406,6 +406,10 @@ impl AccountsDb {
             &mut *self.best_ancient_slots_to_shrink.write().unwrap(),
             &mut ancient_slot_infos.best_slots_to_shrink,
         );
+        // Reverse the vector so that the elements with the largest
+        // dead bytes are poped first when used to extend the
+        // shrinking candidates.
+        self.best_ancient_slots_to_shrink.write().unwrap().reverse();
 
         if ancient_slot_infos.all_infos.is_empty() {
             return; // nothing to do


### PR DESCRIPTION
#### Problem

Ancient packing when skipping rewrites has some non-ideal behavior.
It can sometimes be true that an ancient storage might never meet the 90%(?) threshold for shrinking. However, every dead account that an ancient storage keeps present causes the account to remain in the index in memory and starts a chain reaction of other accounts, such as zero lamport accounts, that must be kept alive.

#### Summary of Changes

Add another slot for shrinking when the number of shrink candidate slots is too small (less than 10).  The additional slot's storage has the largest number of dead bytes. This aggressively shrinks ancient storages, even when they are below the normal threshold. This allows the system to keep itself towards the ideal of storing each non-zero account once and having no zero lamport accounts.

reworked #2849