### PR TITLE
Fix: Corrected the derivation command format

### DIFF
--- a/docs/src/cli/wallets/paper.md
+++ b/docs/src/cli/wallets/paper.md
@@ -150,14 +150,14 @@ By default, `prompt:` will derive solana's base derivation path `m/44'/501'`. To
 derive a child key, supply the `?key=<ACCOUNT>/<CHANGE>` query string.
 
 ```bash
-solana-keygen pubkey prompt://?key=0/1
+solana-keygen pubkey 'prompt://?key=0/1'
 ```
 
 To use a derivation path other than solana's standard BIP44, you can supply
 `?full-path=m/<PURPOSE>/<COIN_TYPE>/<ACCOUNT>/<CHANGE>`.
 
 ```bash
-solana-keygen pubkey prompt://?full-path=m/44/2017/0/1
+solana-keygen pubkey 'prompt://?full-path=m/44/2017/0/1'
 ```
 
 Because Solana uses Ed25519 keypairs, as per


### PR DESCRIPTION
#### Problem

The command for generating a public key is incorrectly formatted, leading to errors when users try to generate keys using the provided syntax.

Here is what I got when execute that example command on Mac terminal:

```
solana-keygen pubkey prompt://?key=0/1
zsh: no matches found: prompt://?key=0/1
```

#### Summary of Changes

Corrected the command syntax.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
