### PR TITLE
bump blake3 1.5.1 -> 1.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.1"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
 dependencies = [
  "arrayref",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ backoff = "0.4.0"
 base64 = "0.22.1"
 bincode = "1.3.3"
 bitflags = { version = "2.6.0" }
-blake3 = "1.5.1"
+blake3 = "1.5.4"
 borsh = { version = "1.5.1", features = ["derive", "unstable__schema"] }
 bs58 = { version = "0.5.1", default-features = false }
 bv = "0.11.1"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.1"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
 dependencies = [
  "arrayref",
  "arrayvec",

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.79.0"                          # solana platform-tools rust ve
 
 [dependencies]
 bincode = { workspace = true }
-blake3 = { workspace = true, features = ["digest", "traits-preview"] }
+blake3 = { workspace = true, features = ["traits-preview"] }
 borsh = { workspace = true, optional = true }
 borsh0-10 = { package = "borsh", version = "0.10.3", optional = true }
 bs58 = { workspace = true, features = ["alloc"] }


### PR DESCRIPTION
#### Problem
New Rust crates with `blake3` version greater than 1.5.1 cannot be used with solana-program crate due to the removal of the implicit `"digest"` feature in version 1.5.2 of `blake3`.
Also new version comes with perf improvements:
1.5.4
> Initial implementation of SIMD acceleration for the XOF (i.e.
> blake3::Hasher::finalize_xof). This brings long output performance
> into line with long input performance. Currently AVX-512-only and Unix-only.

#### Summary of Changes
1. Change `blake3 = "1.5.1"` to `blake3 = "1.5.4"` in root Cargo.toml
2. Remove redundant feature `"digest"`in blake3 in solana program Cargo.toml

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
