### PR TITLE
vote: add ephemeral bankhash and slot to TowerSync

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -239,7 +239,7 @@ pub(crate) enum BlockhashStatus {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "9ziHa1vA7WG5RCvXiE3g1f2qjSTNa47FB7e2czo7en7a")
+    frozen_abi(digest = "Lbx8JWmgAWq4SSo1XyrXprAgPtp9ncRNJJPCKH1pZ3W")
 )]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -239,7 +239,7 @@ pub(crate) enum BlockhashStatus {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "Lbx8JWmgAWq4SSo1XyrXprAgPtp9ncRNJJPCKH1pZ3W")
+    frozen_abi(digest = "jq28RP4SJpNQ3tZJ88zUcrEShMzhiTrNajyTXHgE7vR")
 )]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower {

--- a/core/src/consensus/tower1_14_11.rs
+++ b/core/src/consensus/tower1_14_11.rs
@@ -9,7 +9,7 @@ use {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "FYKsZaj6MH3hqA4ksJWEG8LHQZF3Ty5PQgfbexnpAPtB")
+    frozen_abi(digest = "FiF3sSBJQFoKAcU4xz3vpSopBqu1XfS7GE9SxNHaTzCq")
 )]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower1_14_11 {

--- a/core/src/consensus/tower1_14_11.rs
+++ b/core/src/consensus/tower1_14_11.rs
@@ -9,7 +9,7 @@ use {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "6VhLW7DSHNzrcswtxbNo4cb47oGrKLcKuDmCWVpUMLLM")
+    frozen_abi(digest = "FYKsZaj6MH3hqA4ksJWEG8LHQZF3Ty5PQgfbexnpAPtB")
 )]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower1_14_11 {

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -248,7 +248,7 @@ mod tests {
         // expected vote tx cost: 2 write locks, 1 sig, 1 vote ix, 8cu of loaded accounts size,
         let expected_vote_cost = SIMPLE_VOTE_USAGE_COST;
         // expected non-vote tx cost would include default loaded accounts size cost (16384) additionally
-        let expected_none_vote_cost = 20553;
+        let expected_none_vote_cost = 20551;
 
         let vote_cost = CostModel::calculate_cost(&vote_transaction, &FeatureSet::all_enabled());
         let none_vote_cost =

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -248,7 +248,7 @@ mod tests {
         // expected vote tx cost: 2 write locks, 1 sig, 1 vote ix, 8cu of loaded accounts size,
         let expected_vote_cost = SIMPLE_VOTE_USAGE_COST;
         // expected non-vote tx cost would include default loaded accounts size cost (16384) additionally
-        let expected_none_vote_cost = 20543;
+        let expected_none_vote_cost = 20553;
 
         let vote_cost = CostModel::calculate_cost(&vote_transaction, &FeatureSet::all_enabled());
         let none_vote_cost =

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3967,7 +3967,7 @@ fn run_duplicate_shreds_broadcast_leader(vote_on_duplicate: bool) {
                         AncestorIterator::new_inclusive(latest_vote_slot, &leader_blockstore)
                             .nth(MAX_LOCKOUT_HISTORY);
                     vote.root = root;
-                    vote.hash = vote_hash;
+                    vote.replay_hash = vote_hash;
                     let vote_tx = vote_transaction::new_tower_sync_transaction(
                         vote,
                         leader_vote_tx.message.recent_blockhash,

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -192,7 +192,9 @@ fn bench_process_tower_sync(bencher: &mut Bencher) {
         ((num_initial_votes.saturating_add(1)..=last_vote_slot).zip((1u32..=31).rev())).collect();
     let mut tower_sync = TowerSync::from(slots_and_lockouts);
     tower_sync.root = Some(num_initial_votes);
-    tower_sync.hash = last_vote_hash;
+    tower_sync.vote_only_hash = Hash::default();
+    tower_sync.replay_slot = Some(last_vote_slot);
+    tower_sync.replay_hash = last_vote_hash;
     tower_sync.block_id = Hash::new_unique();
     let instruction_data = bincode::serialize(&VoteInstruction::TowerSync(tower_sync)).unwrap();
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -30,7 +30,7 @@ use {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample, AbiEnumVisitor),
-    frozen_abi(digest = "3dbyMxwfCN43orGKa5YiyY1EqN2K97pTicNhKYTZSUQH")
+    frozen_abi(digest = "5zYYafKxFiaQj4s1PUhK7bW2rKAXBBcnpHVxR8kfpZhQ")
 )]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum VoteTransaction {

--- a/sdk/feature-set/src/lib.rs
+++ b/sdk/feature-set/src/lib.rs
@@ -788,7 +788,7 @@ pub mod remove_rounding_in_fee_calculation {
 }
 
 pub mod enable_tower_sync_ix {
-    solana_program::declare_id!("tSynMCspg4xFiCj1v3TDb4c7crMR5tSBhLz4sF7rrNA");
+    solana_program::declare_id!("tsYNCXjuS3M2Bj1GMeXv1gRjdaKgMj5PwNnYdJMc3SK");
 }
 
 pub mod deprecate_unused_legacy_vote_plumbing {

--- a/sdk/program/src/vote/instruction.rs
+++ b/sdk/program/src/vote/instruction.rs
@@ -218,7 +218,9 @@ impl VoteInstruction {
             | Self::UpdateVoteStateSwitch(vote_state_update, _)
             | Self::CompactUpdateVoteState(vote_state_update)
             | Self::CompactUpdateVoteStateSwitch(vote_state_update, _) => vote_state_update.hash,
-            Self::TowerSync(tower_sync) | Self::TowerSyncSwitch(tower_sync, _) => tower_sync.hash,
+            Self::TowerSync(tower_sync) | Self::TowerSyncSwitch(tower_sync, _) => {
+                tower_sync.replay_hash
+            }
             _ => panic!("Tried to get hash on non simple vote instruction"),
         }
     }

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -232,15 +232,15 @@ pub struct TowerSync {
     pub root: Option<Slot>,
     /// signature of the VoteState's at the latest slot in `lockouts`
     pub yolo_hash: Hash,
-    /// the latest fully replayed slot, equal to the last
-    /// slot in `lockouts` until asynchronous execution.
+    /// the latest fully replayed slot. until asynchronous execution
+    /// is active this will be equal to the latest slot in `lockouts`
     pub replay_tip: Slot,
     /// signature of the bank's state at `replay_tip`
     pub hash: Hash,
     /// processing timestamp of last slot
     pub timestamp: Option<UnixTimestamp>,
     /// the unique identifier for the chain up to and
-    /// including this block. Does not require replaying
+    /// including this block. does not require replaying
     /// in order to compute.
     pub block_id: Hash,
 }

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -176,7 +176,9 @@ pub fn parse_vote(
             let tower_sync = json!({
                 "lockouts": tower_sync.lockouts,
                 "root": tower_sync.root,
-                "hash": tower_sync.hash.to_string(),
+                "vote_only_hash": tower_sync.vote_only_hash.to_string(),
+                "replay_slot": tower_sync.replay_slot,
+                "replay_hash": tower_sync.replay_hash.to_string(),
                 "timestamp": tower_sync.timestamp,
                 "blockId": tower_sync.block_id.to_string(),
             });
@@ -194,7 +196,9 @@ pub fn parse_vote(
             let tower_sync = json!({
                 "lockouts": tower_sync.lockouts,
                 "root": tower_sync.root,
-                "hash": tower_sync.hash.to_string(),
+                "vote_only_hash": tower_sync.vote_only_hash.to_string(),
+                "replay_slot": tower_sync.replay_slot,
+                "replay_hash": tower_sync.replay_hash.to_string(),
                 "timestamp": tower_sync.timestamp,
                 "blockId": tower_sync.block_id.to_string(),
             });
@@ -925,7 +929,9 @@ mod test {
                     "towerSync": {
                         "lockouts": tower_sync.lockouts,
                         "root": None::<u64>,
-                        "hash": Hash::default().to_string(),
+                        "vote_only_hash": Hash::default().to_string(),
+                        "replay_slot": None::<u64>,
+                        "replay_hash": Hash::default().to_string(),
                         "timestamp": None::<u64>,
                         "blockId": Hash::default().to_string(),
                     },
@@ -970,7 +976,9 @@ mod test {
                     "towerSync": {
                         "lockouts": tower_sync.lockouts,
                         "root": None::<u64>,
-                        "hash": Hash::default().to_string(),
+                        "vote_only_hash": Hash::default().to_string(),
+                        "replay_slot": None::<u64>,
+                        "replay_hash": Hash::default().to_string(),
                         "timestamp": None::<u64>,
                         "blockId": Hash::default().to_string(),
                     },

--- a/vote/src/vote_transaction.rs
+++ b/vote/src/vote_transaction.rs
@@ -38,7 +38,7 @@ impl VoteTransaction {
         match self {
             VoteTransaction::Vote(vote) => vote.hash,
             VoteTransaction::VoteStateUpdate(vote_state_update) => vote_state_update.hash,
-            VoteTransaction::TowerSync(tower_sync) => tower_sync.hash,
+            VoteTransaction::TowerSync(tower_sync) => tower_sync.replay_hash,
         }
     }
 

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -2120,7 +2120,7 @@ mod tests {
         assert!(remove_file(&test_state.wen_restart_proto_path).is_ok());
         // Test the case where the file is not found.
         let mut vote = TowerSync::from(vec![(test_state.last_voted_fork_slots[0], 1)]);
-        vote.hash = last_vote_bankhash;
+        vote.replay_hash = last_vote_bankhash;
         let last_vote = VoteTransaction::from(vote);
         assert_eq!(
             initialize(


### PR DESCRIPTION
#### Problem
[Asynchronous execution](https://github.com/solana-foundation/solana-improvement-documents/pull/165/files) needs to track the ephemeral bank hash separately from the latest replayed bank hash. Additionally we need a slot # to now go with the bank hash. This requires a new vote ix format.

#### Summary of Changes
Since we are already in the midst of a vote ix upgrade for block_id, add this now to avoid having to go through another migration.