### PR TITLE
extract fee-calculator crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6676,6 +6676,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-fee-calculator"
+version = "2.1.0"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+ "solana-clock",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-logger",
+ "static_assertions",
+]
+
+[[package]]
 name = "solana-frozen-abi"
 version = "2.1.0"
 dependencies = [
@@ -7316,6 +7330,7 @@ dependencies = [
  "solana-decode-error",
  "solana-define-syscall",
  "solana-epoch-schedule",
+ "solana-fee-calculator",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ members = [
     "sdk/derivation-path",
     "sdk/epoch-schedule",
     "sdk/feature-set",
+    "sdk/fee-calculator",
     "sdk/gen-headers",
     "sdk/hash",
     "sdk/instruction",
@@ -413,6 +414,7 @@ solana-program-entrypoint = { path = "sdk/program-entrypoint", version = "=2.1.0
 solana-epoch-schedule = { path = "sdk/epoch-schedule", version = "=2.1.0" }
 solana-faucet = { path = "faucet", version = "=2.1.0" }
 solana-feature-set = { path = "sdk/feature-set", version = "=2.1.0" }
+solana-fee-calculator = { path = "sdk/fee-calculator", version = "=2.1.0" }
 solana-fee = { path = "fee", version = "=2.1.0" }
 solana-frozen-abi = { path = "frozen-abi", version = "=2.1.0" }
 solana-frozen-abi-macro = { path = "frozen-abi/macro", version = "=2.1.0" }

--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -26,7 +26,7 @@ impl HashInfo {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "BxykY65dC2NCcDm17rHQPjEY8wK55sKAhfhKVFGc5T1u")
+    frozen_abi(digest = "2GFWjonjAdte2KsJthPzFdSvVKJ4viKYTPzUHB8dzjtE")
 )]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockhashQueue {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5315,6 +5315,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-fee-calculator"
+version = "2.1.0"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "solana-genesis-utils"
 version = "2.1.0"
 dependencies = [
@@ -5702,6 +5711,7 @@ dependencies = [
  "solana-decode-error",
  "solana-define-syscall",
  "solana-epoch-schedule",
+ "solana-fee-calculator",
  "solana-hash",
  "solana-instruction",
  "solana-msg",

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -546,7 +546,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "D7zx9HfzJa1cqhNariHYufgyLUVLR64iPoMFzRYqs8rZ")
+            frozen_abi(digest = "2G3gi9LAN7w45KNu4GffLfUUCTQLcChzrvSp7ah3Awbv")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapper {

--- a/sdk/fee-calculator/Cargo.toml
+++ b/sdk/fee-calculator/Cargo.toml
@@ -27,3 +27,5 @@ serde = ["dep:serde", "dep:serde_derive"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]

--- a/sdk/fee-calculator/Cargo.toml
+++ b/sdk/fee-calculator/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "solana-fee-calculator"
+description = "Solana transaction fee calculation"
+documentation = "https://docs.rs/solana-fee-calculator"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+log = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
+
+[dev-dependencies]
+solana-clock = { workspace = true }
+solana-logger = { workspace = true }
+static_assertions = { workspace = true }
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = ["dep:serde", "dep:serde_derive"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/fee-calculator/src/lib.rs
+++ b/sdk/fee-calculator/src/lib.rs
@@ -1,12 +1,18 @@
 //! Calculation of transaction fees.
-
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
-use {log::*, solana_clock::DEFAULT_MS_PER_SLOT};
+#![no_std]
+
+use log::*;
 
 #[repr(C)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Clone, Copy, Debug)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
+#[derive(Default, PartialEq, Eq, Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct FeeCalculator {
     /// The current cost of a signature.
     ///
@@ -23,13 +29,17 @@ impl FeeCalculator {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
+#[derive(PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct FeeRateGovernor {
     // The current cost of a signature  This amount may increase/decrease over time based on
     // cluster processing load.
-    #[serde(skip)]
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub lamports_per_signature: u64,
 
     // The target cost of a signature when the cluster is operating around target_signatures_per_slot
@@ -49,6 +59,9 @@ pub struct FeeRateGovernor {
 }
 
 pub const DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE: u64 = 10_000;
+const DEFAULT_MS_PER_SLOT: u64 = 400;
+#[cfg(test)]
+static_assertions::const_assert_eq!(DEFAULT_MS_PER_SLOT, solana_clock::DEFAULT_MS_PER_SLOT);
 pub const DEFAULT_TARGET_SIGNATURES_PER_SLOT: u64 = 50 * DEFAULT_MS_PER_SLOT;
 
 // Percentage of tx fees to burn
@@ -88,7 +101,7 @@ impl FeeRateGovernor {
         if me.target_signatures_per_slot > 0 {
             // lamports_per_signature can range from 50% to 1000% of
             // target_lamports_per_signature
-            me.min_lamports_per_signature = std::cmp::max(1, me.target_lamports_per_signature / 2);
+            me.min_lamports_per_signature = core::cmp::max(1, me.target_lamports_per_signature / 2);
             me.max_lamports_per_signature = me.target_lamports_per_signature * 10;
 
             // What the cluster should charge at `latest_signatures_per_slot`
@@ -96,7 +109,7 @@ impl FeeRateGovernor {
                 me.max_lamports_per_signature
                     .min(me.min_lamports_per_signature.max(
                         me.target_lamports_per_signature
-                            * std::cmp::min(latest_signatures_per_slot, u32::MAX as u64)
+                            * core::cmp::min(latest_signatures_per_slot, u32::MAX as u64)
                             / me.target_signatures_per_slot,
                     ));
 
@@ -114,7 +127,7 @@ impl FeeRateGovernor {
                 // Adjust fee by 5% of target_lamports_per_signature to produce a smooth
                 // increase/decrease in fees over time.
                 let gap_adjust =
-                    std::cmp::max(1, me.target_lamports_per_signature / 20) as i64 * gap.signum();
+                    core::cmp::max(1, me.target_lamports_per_signature / 20) as i64 * gap.signum();
 
                 trace!(
                     "lamports_per_signature gap is {}, adjusting by {}",

--- a/sdk/fee-calculator/src/lib.rs
+++ b/sdk/fee-calculator/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 #![no_std]
-
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use log::*;
 #[cfg(feature = "frozen-abi")]
 extern crate std;

--- a/sdk/fee-calculator/src/lib.rs
+++ b/sdk/fee-calculator/src/lib.rs
@@ -4,6 +4,8 @@
 #![no_std]
 
 use log::*;
+#[cfg(feature = "frozen-abi")]
+extern crate std;
 
 #[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -38,6 +38,7 @@ solana-bincode = { workspace = true }
 solana-clock = { workspace = true, features = ["serde"] }
 solana-decode-error = { workspace = true }
 solana-epoch-schedule = { workspace = true, features = ["serde"] }
+solana-fee-calculator = { workspace = true, features = ["serde"] }
 solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-hash = { workspace = true, features = [
@@ -133,6 +134,7 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-epoch-schedule/frozen-abi",
+    "solana-fee-calculator/frozen-abi",
     "solana-hash/frozen-abi",
     "solana-instruction/frozen-abi",
     "solana-pubkey/frozen-abi",

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -488,7 +488,6 @@ pub mod epoch_rewards;
 pub mod epoch_schedule;
 pub mod epoch_stake;
 pub mod feature;
-pub mod fee_calculator;
 pub mod hash;
 pub mod incinerator;
 pub mod instruction;
@@ -519,6 +518,8 @@ pub mod sysvar;
 pub mod vote;
 pub mod wasm;
 
+#[deprecated(since = "2.1.0", note = "Use `solana-fee-calculator` crate instead")]
+pub use solana_fee_calculator as fee_calculator;
 #[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]
 pub use solana_program_memory as program_memory;
 #[deprecated(since = "2.1.0", note = "Use `solana-program-pack` crate instead")]

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -87,7 +87,7 @@ impl FromStr for ClusterType {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "7kinRF6sWtJWxz9Wt8Zu4CB4SxaiFsNW2y9wnZH1FkNM")
+    frozen_abi(digest = "3GwiwngfwuPnrUyCcnTDYEWfQQzWGuBWR9RRyf9YYgif")
 )]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct GenesisConfig {


### PR DESCRIPTION
#### Problem
`solana_program::fee_calculator` imposes a `solana-program` dependency on many useful crates, including `solana-account-decoder`

#### Summary of Changes
- Move it to a new `solana-fee-calculator` crate
- Re-export with deprecation notice
- Make the new crate no_std (no material changes here)
- Make serde optional in the new crate
- Inline `DEFAULT_MS_PER_SLOT` in the new crate to avoid a `solana-clock` dependency. Use `static_assertions` to test that the inline const matches `solana-clock`

