### PR TITLE
extract inflation crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6911,6 +6911,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-inflation"
+version = "2.1.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+]
+
+[[package]]
 name = "solana-inline-spl"
 version = "2.1.0"
 dependencies = [
@@ -8021,6 +8031,7 @@ dependencies = [
  "solana-feature-set",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-inflation",
  "solana-instruction",
  "solana-logger",
  "solana-native-token",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ members = [
     "sdk/fee-calculator",
     "sdk/gen-headers",
     "sdk/hash",
+    "sdk/inflation",
     "sdk/instruction",
     "sdk/macro",
     "sdk/msg",
@@ -433,6 +434,7 @@ agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=
 solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.1.0" }
 solana-gossip = { path = "gossip", version = "=2.1.0" }
 solana-hash = { path = "sdk/hash", version = "=2.1.0", default-features = false }
+solana-inflation = { path = "sdk/inflation", version = "=2.1.0" }
 solana-inline-spl = { path = "inline-spl", version = "=2.1.0" }
 solana-instruction = { path = "sdk/instruction", version = "=2.1.0", default-features = false }
 solana-last-restart-slot = { path = "sdk/last-restart-slot", version = "=2.1.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5475,6 +5475,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-inflation"
+version = "2.1.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "solana-inline-spl"
 version = "2.1.0"
 dependencies = [
@@ -6778,6 +6786,7 @@ dependencies = [
  "solana-decode-error",
  "solana-derivation-path",
  "solana-feature-set",
+ "solana-inflation",
  "solana-instruction",
  "solana-native-token",
  "solana-packet",

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -546,7 +546,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "2G3gi9LAN7w45KNu4GffLfUUCTQLcChzrvSp7ah3Awbv")
+            frozen_abi(digest = "WZPdQsksD18CRLSPKbinaMU8uZ5zov3iHJMMNvcamMY")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapper {

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -44,6 +44,7 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "solana-feature-set/frozen-abi",
     "solana-account/frozen-abi",
+    "solana-inflation/frozen-abi",
     "solana-program/frozen-abi",
     "solana-short-vec/frozen-abi",
     "solana-signature/frozen-abi",
@@ -99,6 +100,7 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
+solana-inflation = { workspace = true, features = ["serde"] }
 solana-instruction = { workspace = true }
 solana-native-token = { workspace = true }
 solana-packet = { workspace = true, features = ["bincode", "serde"] }

--- a/sdk/inflation/Cargo.toml
+++ b/sdk/inflation/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "solana-inflation"
+description = "Configuration for Solana network inflation"
+documentation = "https://docs.rs/solana-inflation"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = ["dep:serde", "dep:serde_derive"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/inflation/src/lib.rs
+++ b/sdk/inflation/src/lib.rs
@@ -1,8 +1,11 @@
 //! configuration for network inflation
+#[cfg(feature = "serde")]
+use serde_derive::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Copy)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(PartialEq, Clone, Debug, Copy)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Inflation {
     /// Initial inflation percentage, from time=0
     pub initial: f64,

--- a/sdk/inflation/src/lib.rs
+++ b/sdk/inflation/src/lib.rs
@@ -1,4 +1,5 @@
 //! configuration for network inflation
+#[cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 

--- a/sdk/inflation/src/lib.rs
+++ b/sdk/inflation/src/lib.rs
@@ -1,5 +1,5 @@
 //! configuration for network inflation
-#[cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -87,7 +87,7 @@ impl FromStr for ClusterType {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "3GwiwngfwuPnrUyCcnTDYEWfQQzWGuBWR9RRyf9YYgif")
+    frozen_abi(digest = "41wPwgEZLhp9AS4tjTQebW7cvHnkbSSTN19vaKwVett6")
 )]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct GenesisConfig {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -74,7 +74,6 @@ pub mod fee;
 pub mod genesis_config;
 pub mod hard_forks;
 pub mod hash;
-pub mod inflation;
 pub mod inner_instruction;
 pub mod log;
 pub mod native_loader;
@@ -119,6 +118,8 @@ pub use solana_decode_error as decode_error;
 pub use solana_derivation_path as derivation_path;
 #[deprecated(since = "2.1.0", note = "Use `solana-feature-set` crate instead")]
 pub use solana_feature_set as feature_set;
+#[deprecated(since = "2.1.0", note = "Use `solana-inflation` crate instead")]
+pub use solana_inflation as inflation;
 #[deprecated(since = "2.1.0", note = "Use `solana-packet` crate instead")]
 pub use solana_packet as packet;
 #[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]


### PR DESCRIPTION
#### Problem
`solana_sdk::inflation` imposes a `solana-sdk` dependency on `solana-rpc-client-api` among other things.

#### Summary of Changes
- Move to its own crate
- Re-export with deprecation notice
- Make serde optional in the new crate
