### PR TITLE
fix comments

### DIFF
--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -2,7 +2,7 @@ use solana_sdk::pubkey::Pubkey;
 
 #[derive(Debug)]
 pub struct PubkeyBinCalculator24 {
-    // how many bits from the first 2 bytes to shift away to ignore when calculating bin
+    // how many bits from the first 3 bytes to shift away to ignore when calculating bin
     shift_bits: u32,
 }
 


### PR DESCRIPTION
#### Problem

PubkeyBinCalculator24 use 3 bytes not 2 bytes. 

The code comments is wrong and confusing. 


#### Summary of Changes

Fix code comments


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
