### PR TITLE
[accounts-db] remove unnecessary ed25519-dalek dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5695,7 +5695,6 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "dashmap",
- "ed25519-dalek",
  "index_list",
  "indexmap 2.5.0",
  "itertools 0.12.1",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -65,7 +65,6 @@ name = "solana_accounts_db"
 [dev-dependencies]
 assert_matches = { workspace = true }
 criterion = { workspace = true }
-ed25519-dalek = { workspace = true }
 libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }
 rand_chacha = { workspace = true }


### PR DESCRIPTION
#### Problem
It seems that the ed25519-dalek crate is declared as a developer dependency in accounts-db, but it is not actually used in the code.

#### Summary of Changes
Remove the ed25519-dalek crate dependency.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
