### PR TITLE
gossip: reduce votes stored per validator from 31 to 2

### DIFF
--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -33,9 +33,10 @@ pub const MAX_WALLCLOCK: u64 = 1_000_000_000_000_000;
 pub const MAX_SLOT: u64 = 1_000_000_000_000_000;
 
 pub type VoteIndex = u8;
-// TODO: Remove this in favor of vote_state::MAX_LOCKOUT_HISTORY once
-// the fleet is updated to the new ClusterInfo::push_vote code.
-pub const MAX_VOTES: VoteIndex = 32;
+/// Number of votes per validator to store.
+/// TODO: update comment after testing
+/// Only need latest vote + potential refresh of that vote.
+pub const MAX_VOTES: VoteIndex = 2;
 
 pub type EpochSlotsIndex = u8;
 pub const MAX_EPOCH_SLOTS: EpochSlotsIndex = 255;


### PR DESCRIPTION
#### Problem
Now that votes are no longer incremental, it is not necessary for gossip to hold 31 votes per validator.

#### Summary of Changes
Instead store `MAX_VOTES = 2` votes per validator. With the improvement to OC tracking in https://github.com/anza-xyz/agave/pull/3136, I believe that we will be fine with only 1 vote, however 2 votes might be beneficial in the case of refreshed votes. 

Note: DO NOT MERGE until tested in sim clusters