### PR TITLE
RuntimeTransaction: cache TransactionSignatureDetails

### DIFF
--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -12,13 +12,14 @@
 use {
     crate::{
         compute_budget_instruction_details::*,
+        signature_details::get_precompile_signature_details,
         transaction_meta::{DynamicMeta, StaticMeta, TransactionMeta},
     },
     solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_sdk::{
         feature_set::FeatureSet,
         hash::Hash,
-        message::AddressLoader,
+        message::{AddressLoader, TransactionSignatureDetails},
         pubkey::Pubkey,
         simple_vote_transaction_checker::is_simple_vote_transaction,
         transaction::{Result, SanitizedTransaction, SanitizedVersionedTransaction},
@@ -27,7 +28,6 @@ use {
     std::collections::HashSet,
 };
 
-#[cfg_attr(test, derive(Eq, PartialEq))]
 #[derive(Debug)]
 pub struct RuntimeTransaction<T> {
     transaction: T,
@@ -55,6 +55,9 @@ impl<T: StaticMetaAccess> StaticMeta for RuntimeTransaction<T> {
     fn is_simple_vote_tx(&self) -> bool {
         self.meta.is_simple_vote_tx
     }
+    fn signature_details(&self) -> &TransactionSignatureDetails {
+        &self.meta.signature_details
+    }
     fn compute_budget_limits(&self, _feature_set: &FeatureSet) -> Result<ComputeBudgetLimits> {
         self.meta
             .compute_budget_instruction_details
@@ -74,6 +77,24 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
             .unwrap_or_else(|| is_simple_vote_transaction(&sanitized_versioned_tx));
         let message_hash =
             message_hash.unwrap_or_else(|| sanitized_versioned_tx.get_message().message.hash());
+
+        let precompile_signature_details = get_precompile_signature_details(
+            sanitized_versioned_tx
+                .get_message()
+                .program_instructions_iter()
+                .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix))),
+        );
+        let signature_details = TransactionSignatureDetails::new(
+            u64::from(
+                sanitized_versioned_tx
+                    .get_message()
+                    .message
+                    .header()
+                    .num_required_signatures,
+            ),
+            precompile_signature_details.num_secp256k1_instruction_signatures,
+            precompile_signature_details.num_ed25519_instruction_signatures,
+        );
         let compute_budget_instruction_details = ComputeBudgetInstructionDetails::try_from(
             sanitized_versioned_tx
                 .get_message()
@@ -86,6 +107,7 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
             meta: TransactionMeta {
                 message_hash,
                 is_simple_vote_tx,
+                signature_details,
                 compute_budget_instruction_details,
             },
         })
@@ -290,6 +312,12 @@ mod tests {
 
         assert_eq!(&hash, runtime_transaction_static.message_hash());
         assert!(!runtime_transaction_static.is_simple_vote_tx());
+
+        let signature_details = &runtime_transaction_static.meta.signature_details;
+        assert_eq!(1, signature_details.num_transaction_signatures());
+        assert_eq!(0, signature_details.num_secp256k1_instruction_signatures());
+        assert_eq!(0, signature_details.num_ed25519_instruction_signatures());
+
         let compute_budget_limits = runtime_transaction_static
             .compute_budget_limits(&FeatureSet::default())
             .unwrap();

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -14,7 +14,10 @@
 use {
     crate::compute_budget_instruction_details::ComputeBudgetInstructionDetails,
     solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
-    solana_sdk::{feature_set::FeatureSet, hash::Hash, transaction::Result},
+    solana_sdk::{
+        feature_set::FeatureSet, hash::Hash, message::TransactionSignatureDetails,
+        transaction::Result,
+    },
 };
 
 /// metadata can be extracted statically from sanitized transaction,
@@ -22,6 +25,7 @@ use {
 pub trait StaticMeta {
     fn message_hash(&self) -> &Hash;
     fn is_simple_vote_tx(&self) -> bool;
+    fn signature_details(&self) -> &TransactionSignatureDetails;
     fn compute_budget_limits(&self, feature_set: &FeatureSet) -> Result<ComputeBudgetLimits>;
 }
 
@@ -32,10 +36,10 @@ pub trait StaticMeta {
 /// on-chain ALT, examples are: transaction usage costs, nonce account.
 pub trait DynamicMeta: StaticMeta {}
 
-#[cfg_attr(test, derive(Eq, PartialEq))]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct TransactionMeta {
     pub(crate) message_hash: Hash,
     pub(crate) is_simple_vote_tx: bool,
+    pub(crate) signature_details: TransactionSignatureDetails,
     pub(crate) compute_budget_instruction_details: ComputeBudgetInstructionDetails,
 }

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -423,9 +423,9 @@ impl SanitizedMessage {
     }
 }
 
-#[derive(Default)]
 /// Transaction signature details including the number of transaction signatures
 /// and precompile signatures.
+#[derive(Debug, Default)]
 pub struct TransactionSignatureDetails {
     num_transaction_signatures: u64,
     num_secp256k1_instruction_signatures: u64,


### PR DESCRIPTION
#### Problem
- Follow-up to #2847 - cache the signature details on `RuntimeTransaction`

#### Summary of Changes
- cache the signature details on `RuntimeTransaction`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
