### PR TITLE
RuntimeTransactions: implement SVM traits

### DIFF
--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -20,12 +20,16 @@ use {
     solana_sdk::{
         feature_set::FeatureSet,
         hash::Hash,
-        message::{AddressLoader, TransactionSignatureDetails},
+        message::{AccountKeys, AddressLoader, TransactionSignatureDetails},
         pubkey::Pubkey,
+        signature::Signature,
         simple_vote_transaction_checker::is_simple_vote_transaction,
         transaction::{Result, SanitizedTransaction, SanitizedVersionedTransaction},
     },
-    solana_svm_transaction::instruction::SVMInstruction,
+    solana_svm_transaction::{
+        instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
+        svm_message::SVMMessage, svm_transaction::SVMTransaction,
+    },
     std::collections::HashSet,
 };
 
@@ -150,6 +154,71 @@ impl RuntimeTransaction<SanitizedTransaction> {
 
     fn load_dynamic_metadata(&mut self) -> Result<()> {
         Ok(())
+    }
+}
+
+impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
+    // override to access from the cached meta instead of re-calculating
+    fn num_total_signatures(&self) -> u64 {
+        self.meta.signature_details.total_signatures()
+    }
+
+    fn num_write_locks(&self) -> u64 {
+        self.transaction.num_write_locks()
+    }
+
+    fn recent_blockhash(&self) -> &Hash {
+        self.transaction.recent_blockhash()
+    }
+
+    fn num_instructions(&self) -> usize {
+        self.transaction.num_instructions()
+    }
+
+    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction> {
+        self.transaction.instructions_iter()
+    }
+
+    fn program_instructions_iter(&self) -> impl Iterator<Item = (&Pubkey, SVMInstruction)> {
+        self.transaction.program_instructions_iter()
+    }
+
+    fn account_keys(&self) -> AccountKeys {
+        self.transaction.account_keys()
+    }
+
+    fn fee_payer(&self) -> &Pubkey {
+        self.transaction.fee_payer()
+    }
+
+    fn is_writable(&self, index: usize) -> bool {
+        self.transaction.is_writable(index)
+    }
+
+    fn is_signer(&self, index: usize) -> bool {
+        self.transaction.is_signer(index)
+    }
+
+    fn is_invoked(&self, key_index: usize) -> bool {
+        self.transaction.is_invoked(key_index)
+    }
+
+    fn num_lookup_tables(&self) -> usize {
+        self.transaction.num_lookup_tables()
+    }
+
+    fn message_address_table_lookups(&self) -> impl Iterator<Item = SVMMessageAddressTableLookup> {
+        self.transaction.message_address_table_lookups()
+    }
+}
+
+impl<T: SVMTransaction> SVMTransaction for RuntimeTransaction<T> {
+    fn signature(&self) -> &Signature {
+        self.transaction.signature()
+    }
+
+    fn signatures(&self) -> &[Signature] {
+        self.transaction.signatures()
     }
 }
 


### PR DESCRIPTION
#### Problem
- Many of internal functions are generic over `SVMMessage` or `SVMTransaction`
- If we have a `RuntimeTransaction` wrapped transaction to cache metadata, then it cannot be passed

#### Summary of Changes
- Implement the traits for `RuntimeTransaction` if the inner type implements

Blocked by #2983,#2986 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
