### PR TITLE
feat: reduce max cpi data size to packet size

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -960,7 +960,7 @@ fn test_program_sbf_invoke_sanity() {
                 format!("Program log: invoke {program_lang} program"),
                 "Program log: Test max instruction data len exceeded".into(),
                 "skip".into(), // don't compare compute consumption logs
-                format!("Program {invoke_program_id} failed: Invoked an instruction with data that is too large (10241 > 10240)"),
+                format!("Program {invoke_program_id} failed: Invoked an instruction with data that is too large (1233 > 1232)"),
             ]),
         );
 

--- a/sdk/program/src/syscalls/mod.rs
+++ b/sdk/program/src/syscalls/mod.rs
@@ -8,10 +8,10 @@ mod definitions;
 #[cfg(target_os = "solana")]
 pub use definitions::*;
 
-/// Maximum CPI instruction data size. 10 KiB was chosen to ensure that CPI
-/// instructions are not more limited than transaction instructions if the size
-/// of transactions is doubled in the future.
-pub const MAX_CPI_INSTRUCTION_DATA_LEN: u64 = 10 * 1024;
+/// Maximum CPI instruction data size. 1232 bytes was chosen so that CPI
+/// instructions are limited similarly to transaction instructions
+/// and use the same limit as `program_utils::limited_deserialize`.
+pub const MAX_CPI_INSTRUCTION_DATA_LEN: u64 = 1232;
 
 /// Maximum CPI instruction accounts. 255 was chosen to ensure that instruction
 /// accounts are always within the maximum instruction account limit for SBF

--- a/sdk/sbf/c/inc/sol/cpi.h
+++ b/sdk/sbf/c/inc/sol/cpi.h
@@ -12,11 +12,11 @@ extern "C" {
 #endif
 
 /**
- * Maximum CPI instruction data size. 10 KiB was chosen to ensure that CPI
- * instructions are not more limited than transaction instructions if the size
- * of transactions is doubled in the future.
+ * Maximum CPI instruction data size. 1232 bytes was chosen so that CPI
+ * instructions are limited similarly to transaction instructions
+ * and use the same limit as `program_utils::limited_deserialize`.
  */
-static const uint64_t MAX_CPI_INSTRUCTION_DATA_LEN = 10240;
+static const uint64_t MAX_CPI_INSTRUCTION_DATA_LEN = 1232;
 
 /**
  * Maximum CPI instruction accounts. 255 was chosen to ensure that instruction

--- a/sdk/sbf/c/inc/sol/inc/cpi.inc
+++ b/sdk/sbf/c/inc/sol/inc/cpi.inc
@@ -12,11 +12,11 @@ extern "C" {
 #endif
 
 /**
- * Maximum CPI instruction data size. 10 KiB was chosen to ensure that CPI
- * instructions are not more limited than transaction instructions if the size
- * of transactions is doubled in the future.
+ * Maximum CPI instruction data size. 1232 bytes was chosen so that CPI
+ * instructions are limited similarly to transaction instructions
+ * and use the same limit as `program_utils::limited_deserialize`.
  */
-static const uint64_t MAX_CPI_INSTRUCTION_DATA_LEN = 10240;
+static const uint64_t MAX_CPI_INSTRUCTION_DATA_LEN = 1232;
 
 /**
  * Maximum CPI instruction accounts. 255 was chosen to ensure that instruction


### PR DESCRIPTION
#### Problem
The new proposed CPI instruction data limit implemented in https://github.com/solana-labs/solana/issues/26641 can cause strange deserialization behavior in builtin programs and will adversely impact the performance of firedancer's builtin program implementations given the complexity of matching bincode's `with_limit` behavior.

#### Summary of Changes
Reduce the CPI instruction data limit to the max packet size of 1232 bytes rather than the current limit of 10KiB

Note that this feature was previously activated on the testnet cluster but is no longer active there so its behavior can be modified without adding a new feature

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
