### PR TITLE
Cleanup - `external_internal_function_hash_collision`

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -24,9 +24,9 @@ use {
         disable_deploy_of_alloc_free_syscall, disable_fees_sysvar, disable_sbpf_v1_execution,
         enable_alt_bn128_compression_syscall, enable_alt_bn128_syscall, enable_big_mod_exp_syscall,
         enable_get_epoch_stake_syscall, enable_partitioned_epoch_reward, enable_poseidon_syscall,
-        error_on_syscall_bpf_function_hash_collisions, get_sysvar_syscall_enabled,
-        last_restart_slot_sysvar, partitioned_epoch_rewards_superfeature,
-        reenable_sbpf_v1_execution, remaining_compute_units_syscall_enabled, FeatureSet,
+        get_sysvar_syscall_enabled, last_restart_slot_sysvar,
+        partitioned_epoch_rewards_superfeature, reenable_sbpf_v1_execution,
+        remaining_compute_units_syscall_enabled, FeatureSet,
     },
     solana_log_collector::{ic_logger_msg, ic_msg},
     solana_poseidon as poseidon,
@@ -297,8 +297,7 @@ pub fn create_program_runtime_environment_v1<'a>(
         reject_broken_elfs: reject_deployment_of_broken_elfs,
         noop_instruction_rate: 256,
         sanitize_user_provided_values: true,
-        external_internal_function_hash_collision: feature_set
-            .is_active(&error_on_syscall_bpf_function_hash_collisions::id()),
+        external_internal_function_hash_collision: true,
         reject_callx_r10: true,
         enable_sbpf_v1: !feature_set.is_active(&disable_sbpf_v1_execution::id())
             || feature_set.is_active(&reenable_sbpf_v1_execution::id()),


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/24261 has been activated on all clusters.

#### Summary of Changes
Hard-codes the RBPF config to `true` until further cleanup.