### PR TITLE
perf: use ahash for reserved keys set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6829,6 +6829,7 @@ dependencies = [
 name = "solana-ledger"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "assert_matches",
  "bincode",
  "bitflags 2.6.0",
@@ -7185,6 +7186,7 @@ dependencies = [
 name = "solana-program"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "anyhow",
  "arbitrary",
  "array-bytes",
@@ -7460,6 +7462,7 @@ dependencies = [
 name = "solana-rpc"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "base64 0.22.1",
  "bincode",
  "bs58",
@@ -7621,6 +7624,7 @@ name = "solana-runtime"
 version = "2.1.0"
 dependencies = [
  "agave-transaction-view",
+ "ahash 0.8.10",
  "aquamarine",
  "arrayref",
  "assert_matches",
@@ -7716,6 +7720,7 @@ name = "solana-runtime-transaction"
 version = "2.1.0"
 dependencies = [
  "agave-transaction-view",
+ "ahash 0.8.10",
  "bincode",
  "criterion",
  "log",
@@ -7737,6 +7742,7 @@ version = "2.1.0"
 name = "solana-sdk"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "anyhow",
  "assert_matches",
  "bincode",

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -1,5 +1,6 @@
 use {
     super::packet_filter::PacketFilterFailure,
+    ahash::RandomState,
     solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_perf::packet::Packet,
     solana_runtime_transaction::instructions_processor::process_compute_budget_instructions,
@@ -115,7 +116,7 @@ impl ImmutableDeserializedPacket {
         &self,
         votes_only: bool,
         address_loader: impl AddressLoader,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, RandomState>,
     ) -> Option<SanitizedTransaction> {
         if votes_only && !self.is_simple_vote() {
             return None;

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true, features = ["serde"] }

--- a/ledger/src/transaction_address_lookup_table_scanner.rs
+++ b/ledger/src/transaction_address_lookup_table_scanner.rs
@@ -1,4 +1,5 @@
 use {
+    ahash::RandomState,
     bincode::deserialize,
     lazy_static::lazy_static,
     solana_sdk::{
@@ -11,7 +12,8 @@ use {
 };
 
 lazy_static! {
-    static ref RESERVED_IDS_SET: HashSet<Pubkey> = ReservedAccountKeys::new_all_activated().active;
+    static ref RESERVED_IDS_SET: HashSet<Pubkey, RandomState> =
+        ReservedAccountKeys::new_all_activated().active;
 }
 
 pub struct ScannedLookupTableExtensions {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5398,6 +5398,7 @@ dependencies = [
 name = "solana-ledger"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "assert_matches",
  "bincode",
  "bitflags 2.6.0",
@@ -5609,6 +5610,7 @@ dependencies = [
 name = "solana-program"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "base64 0.22.1",
  "bincode",
  "bitflags 2.6.0",
@@ -5848,6 +5850,7 @@ dependencies = [
 name = "solana-rpc"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "base64 0.22.1",
  "bincode",
  "bs58",
@@ -5962,6 +5965,7 @@ dependencies = [
 name = "solana-runtime"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "aquamarine",
  "arrayref",
  "base64 0.22.1",
@@ -6047,6 +6051,7 @@ name = "solana-runtime-transaction"
 version = "2.1.0"
 dependencies = [
  "agave-transaction-view",
+ "ahash 0.8.10",
  "log",
  "solana-builtins-default-costs",
  "solana-compute-budget",
@@ -6539,6 +6544,7 @@ dependencies = [
 name = "solana-sdk"
 version = "2.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "bincode",
  "bitflags 2.6.0",
  "borsh 1.5.1",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
 bs58 = { workspace = true }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5,6 +5,7 @@ use {
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
         parsed_token_accounts::*, rpc_cache::LargestAccountsCache, rpc_health::*,
     },
+    ahash::RandomState,
     base64::{prelude::BASE64_STANDARD, Engine},
     bincode::{config::Options, serialize},
     crossbeam_channel::{unbounded, Receiver, Sender},
@@ -4209,7 +4210,7 @@ where
 fn sanitize_transaction(
     transaction: VersionedTransaction,
     address_loader: impl AddressLoader,
-    reserved_account_keys: &HashSet<Pubkey>,
+    reserved_account_keys: &HashSet<Pubkey, RandomState>,
 ) -> Result<SanitizedTransaction> {
     SanitizedTransaction::try_create(
         transaction,

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 agave-transaction-view = { workspace = true }
+ahash = { workspace = true }
 log = { workspace = true }
 solana-builtins-default-costs = { workspace = true }
 solana-compute-budget = { workspace = true }

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -14,6 +14,7 @@ use {
         compute_budget_instruction_details::*,
         transaction_meta::{DynamicMeta, StaticMeta, TransactionMeta},
     },
+    ahash::RandomState,
     core::ops::Deref,
     solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_sdk::{
@@ -105,7 +106,7 @@ impl RuntimeTransaction<SanitizedTransaction> {
     pub fn try_from(
         statically_loaded_runtime_tx: RuntimeTransaction<SanitizedVersionedTransaction>,
         address_loader: impl AddressLoader,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, RandomState>,
     ) -> Result<Self> {
         let hash = *statically_loaded_runtime_tx.message_hash();
         let is_simple_vote_tx = statically_loaded_runtime_tx.is_simple_vote_tx();

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 aquamarine = { workspace = true }
 arrayref = { workspace = true }
 base64 = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -58,6 +58,7 @@ use {
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
+    ahash::RandomState,
     byteorder::{ByteOrder, LittleEndian},
     dashmap::{DashMap, DashSet},
     log::*,
@@ -6272,7 +6273,7 @@ impl Bank {
 
     /// Get a set of all actively reserved account keys that are not allowed to
     /// be write-locked during transaction processing.
-    pub fn get_reserved_account_keys(&self) -> &HashSet<Pubkey> {
+    pub fn get_reserved_account_keys(&self) -> &HashSet<Pubkey, RandomState> {
         &self.reserved_account_keys.active
     }
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -46,6 +46,7 @@ frozen-abi = [
 ]
 
 [dependencies]
+ahash = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true, features = ["serde"] }
 borsh = { workspace = true, optional = true }

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 rust-version = "1.79.0"                          # solana platform-tools rust version
 
 [dependencies]
+ahash = { workspace = true }
 bincode = { workspace = true }
 blake3 = { workspace = true, features = ["traits-preview"] }
 borsh = { workspace = true, optional = true }

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -24,6 +24,7 @@ use {
         pubkey::Pubkey,
         system_instruction, system_program, sysvar,
     },
+    ahash::RandomState,
     solana_sanitize::{Sanitize, SanitizeError},
     solana_short_vec as short_vec,
     std::{collections::HashSet, convert::TryFrom, str::FromStr},
@@ -637,7 +638,7 @@ impl Message {
     pub fn is_maybe_writable(
         &self,
         i: usize,
-        reserved_account_keys: Option<&HashSet<Pubkey>>,
+        reserved_account_keys: Option<&HashSet<Pubkey, RandomState>>,
     ) -> bool {
         (self.is_writable_index(i))
             && !self.is_account_maybe_reserved(i, reserved_account_keys)
@@ -649,7 +650,7 @@ impl Message {
     fn is_account_maybe_reserved(
         &self,
         key_index: usize,
-        reserved_account_keys: Option<&HashSet<Pubkey>>,
+        reserved_account_keys: Option<&HashSet<Pubkey, RandomState>>,
     ) -> bool {
         let mut is_maybe_reserved = false;
         if let Some(reserved_account_keys) = reserved_account_keys {

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -16,6 +16,7 @@ use {
         solana_program::{system_instruction::SystemInstruction, system_program},
         sysvar::instructions::{BorrowedAccountMeta, BorrowedInstruction},
     },
+    ahash::RandomState,
     solana_sanitize::{Sanitize, SanitizeError},
     std::{borrow::Cow, collections::HashSet, convert::TryFrom},
     thiserror::Error,
@@ -31,7 +32,10 @@ pub struct LegacyMessage<'a> {
 }
 
 impl<'a> LegacyMessage<'a> {
-    pub fn new(message: legacy::Message, reserved_account_keys: &HashSet<Pubkey>) -> Self {
+    pub fn new(
+        message: legacy::Message,
+        reserved_account_keys: &HashSet<Pubkey, RandomState>,
+    ) -> Self {
         let is_writable_account_cache = message
             .account_keys
             .iter()
@@ -109,7 +113,7 @@ impl SanitizedMessage {
     pub fn try_new(
         sanitized_msg: SanitizedVersionedMessage,
         address_loader: impl AddressLoader,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, RandomState>,
     ) -> Result<Self, SanitizeMessageError> {
         Ok(match sanitized_msg.message {
             VersionedMessage::Legacy(message) => {
@@ -130,7 +134,7 @@ impl SanitizedMessage {
     /// Create a sanitized legacy message
     pub fn try_from_legacy_message(
         message: legacy::Message,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, RandomState>,
     ) -> Result<Self, SanitizeMessageError> {
         message.sanitize()?;
         Ok(Self::Legacy(LegacyMessage::new(

--- a/sdk/program/src/message/versions/mod.rs
+++ b/sdk/program/src/message/versions/mod.rs
@@ -5,6 +5,7 @@ use {
         message::{legacy::Message as LegacyMessage, v0::MessageAddressTableLookup, MessageHeader},
         pubkey::Pubkey,
     },
+    ahash::RandomState,
     serde::{
         de::{self, Deserializer, SeqAccess, Unexpected, Visitor},
         ser::{SerializeTuple, Serializer},
@@ -85,7 +86,7 @@ impl VersionedMessage {
     pub fn is_maybe_writable(
         &self,
         index: usize,
-        reserved_account_keys: Option<&HashSet<Pubkey>>,
+        reserved_account_keys: Option<&HashSet<Pubkey, RandomState>>,
     ) -> bool {
         match self {
             Self::Legacy(message) => message.is_maybe_writable(index, reserved_account_keys),

--- a/sdk/program/src/message/versions/v0/loaded.rs
+++ b/sdk/program/src/message/versions/v0/loaded.rs
@@ -4,6 +4,7 @@ use {
         message::{v0, AccountKeys},
         pubkey::Pubkey,
     },
+    ahash::RandomState,
     std::{borrow::Cow, collections::HashSet},
 };
 
@@ -58,7 +59,7 @@ impl<'a> LoadedMessage<'a> {
     pub fn new(
         message: v0::Message,
         loaded_addresses: LoadedAddresses,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, RandomState>,
     ) -> Self {
         let mut loaded_message = Self {
             message: Cow::Owned(message),
@@ -72,7 +73,7 @@ impl<'a> LoadedMessage<'a> {
     pub fn new_borrowed(
         message: &'a v0::Message,
         loaded_addresses: &'a LoadedAddresses,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, RandomState>,
     ) -> Self {
         let mut loaded_message = Self {
             message: Cow::Borrowed(message),
@@ -83,7 +84,10 @@ impl<'a> LoadedMessage<'a> {
         loaded_message
     }
 
-    fn set_is_writable_account_cache(&mut self, reserved_account_keys: &HashSet<Pubkey>) {
+    fn set_is_writable_account_cache(
+        &mut self,
+        reserved_account_keys: &HashSet<Pubkey, RandomState>,
+    ) {
         let is_writable_account_cache = self
             .account_keys()
             .iter()
@@ -138,7 +142,7 @@ impl<'a> LoadedMessage<'a> {
     fn is_writable_internal(
         &self,
         key_index: usize,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, RandomState>,
     ) -> bool {
         if self.is_writable_index(key_index) {
             if let Some(key) = self.account_keys().get(key_index) {

--- a/sdk/program/src/message/versions/v0/mod.rs
+++ b/sdk/program/src/message/versions/v0/mod.rs
@@ -22,6 +22,7 @@ use {
         },
         pubkey::Pubkey,
     },
+    ahash::RandomState,
     solana_sanitize::SanitizeError,
     solana_short_vec as short_vec,
     std::collections::HashSet,
@@ -346,7 +347,7 @@ impl Message {
     pub fn is_maybe_writable(
         &self,
         key_index: usize,
-        reserved_account_keys: Option<&HashSet<Pubkey>>,
+        reserved_account_keys: Option<&HashSet<Pubkey, RandomState>>,
     ) -> bool {
         self.is_writable_index(key_index)
             && !self.is_account_maybe_reserved(key_index, reserved_account_keys)
@@ -363,7 +364,7 @@ impl Message {
     fn is_account_maybe_reserved(
         &self,
         key_index: usize,
-        reserved_account_keys: Option<&HashSet<Pubkey>>,
+        reserved_account_keys: Option<&HashSet<Pubkey, RandomState>>,
     ) -> bool {
         let mut is_maybe_reserved = false;
         if let Some(reserved_account_keys) = reserved_account_keys {

--- a/sdk/src/reserved_account_keys.rs
+++ b/sdk/src/reserved_account_keys.rs
@@ -10,6 +10,7 @@ use {
         compute_budget, config, ed25519_program, feature, loader_v4, native_loader, pubkey::Pubkey,
         secp256k1_program, stake, system_program, sysvar, vote,
     },
+    ahash::RandomState,
     lazy_static::lazy_static,
     solana_feature_set::{self as feature_set, FeatureSet},
     std::collections::{HashMap, HashSet},
@@ -41,7 +42,7 @@ impl ::solana_frozen_abi::abi_example::AbiExample for ReservedAccountKeys {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReservedAccountKeys {
     /// Set of currently active reserved account keys
-    pub active: HashSet<Pubkey>,
+    pub active: HashSet<Pubkey, RandomState>,
     /// Set of currently inactive reserved account keys that will be moved to the
     /// active set when their feature id is activated
     inactive: HashMap<Pubkey, Pubkey>,
@@ -114,7 +115,7 @@ impl ReservedAccountKeys {
 
     /// Return an empty set of reserved keys for visibility when using in
     /// tests where the dynamic reserved key set is not available
-    pub fn empty_key_set() -> HashSet<Pubkey> {
+    pub fn empty_key_set() -> HashSet<Pubkey, RandomState> {
         HashSet::default()
     }
 }

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -17,6 +17,7 @@ use {
         simple_vote_transaction_checker::is_simple_vote_transaction,
         transaction::{Result, Transaction, TransactionError, VersionedTransaction},
     },
+    ahash::RandomState,
     solana_feature_set as feature_set,
     solana_program::message::SanitizedVersionedMessage,
     solana_sanitize::Sanitize,
@@ -68,7 +69,7 @@ impl SanitizedTransaction {
         message_hash: Hash,
         is_simple_vote_tx: bool,
         address_loader: impl AddressLoader,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, RandomState>,
     ) -> Result<Self> {
         let signatures = tx.signatures;
         let SanitizedVersionedMessage { message } = tx.message;
@@ -103,7 +104,7 @@ impl SanitizedTransaction {
         message_hash: impl Into<MessageHash>,
         is_simple_vote_tx: Option<bool>,
         address_loader: impl AddressLoader,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, RandomState>,
     ) -> Result<Self> {
         let sanitized_versioned_tx = SanitizedVersionedTransaction::try_from(tx)?;
         let is_simple_vote_tx = is_simple_vote_tx
@@ -124,7 +125,7 @@ impl SanitizedTransaction {
     /// Create a sanitized transaction from a legacy transaction
     pub fn try_from_legacy_transaction(
         tx: Transaction,
-        reserved_account_keys: &HashSet<Pubkey>,
+        reserved_account_keys: &HashSet<Pubkey, RandomState>,
     ) -> Result<Self> {
         tx.sanitize()?;
 

--- a/svm/examples/paytube/src/transaction.rs
+++ b/svm/examples/paytube/src/transaction.rs
@@ -65,7 +65,7 @@ impl From<&PayTubeTransaction> for SolanaSanitizedTransaction {
     fn from(value: &PayTubeTransaction) -> Self {
         SolanaSanitizedTransaction::try_from_legacy_transaction(
             SolanaTransaction::from(value),
-            &HashSet::new(),
+            &HashSet::default(),
         )
         .unwrap()
     }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -766,7 +766,7 @@ impl Encodable for v0::Message {
             let account_keys = AccountKeys::new(&self.account_keys, None);
             let loaded_addresses = LoadedAddresses::default();
             let loaded_message =
-                LoadedMessage::new_borrowed(self, &loaded_addresses, &HashSet::new());
+                LoadedMessage::new_borrowed(self, &loaded_addresses, &HashSet::default());
             UiMessage::Parsed(UiParsedMessage {
                 account_keys: parse_v0_message_accounts(&loaded_message),
                 recent_blockhash: self.recent_blockhash.to_string(),


### PR DESCRIPTION
#### Problem
The reserved keys set introduced in https://github.com/anza-xyz/agave/pull/84 for [SIMD-0105](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0105-dynamic-reserved-accounts-set.md) uses the default cryptographically secure siphash algorithm used by `HashSet`. The reserved keys set implementation doesn't require a cryptographically secure hash algorithm so it should use a faster hash algorithm.

#### Summary of Changes
- Use `ahash` for the reserved keys set

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
