### PR TITLE
removes early return if prune_messages are empty

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2397,9 +2397,6 @@ impl ClusterInfo {
                     .collect()
             })
         };
-        if prune_messages.is_empty() {
-            return;
-        }
         let mut packet_batch = PacketBatch::new_unpinned_with_recycler_data_and_dests(
             recycler,
             "handle_batch_push_messages",
@@ -2429,7 +2426,9 @@ impl ClusterInfo {
         self.stats
             .packets_sent_push_messages_count
             .add_relaxed((packet_batch.len() - num_prune_packets) as u64);
-        let _ = response_sender.send(packet_batch);
+        if !packet_batch.is_empty() {
+            let _ = response_sender.send(packet_batch);
+        }
     }
 
     fn require_stake_for_gossip(&self, stakes: &HashMap<Pubkey, u64>) -> bool {


### PR DESCRIPTION

#### Problem
Even if there are no outgoing prune messages we still need to generate outgoing push messages for packets just received, so the code should not early return here:
https://github.com/anza-xyz/agave/blob/d2cc71f0d/gossip/src/cluster_info.rs#L2400-L2402


#### Summary of Changes
removes early return if `prune_messages` are empty