### PR TITLE
increase writeable accounts cost hashmap size

### DIFF
--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -12,7 +12,7 @@ use {
     std::{cmp::Ordering, collections::HashMap},
 };
 
-const WRITABLE_ACCOUNTS_PER_BLOCK: usize = 512;
+const WRITABLE_ACCOUNTS_PER_BLOCK: usize = 4096;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CostTrackerError {


### PR DESCRIPTION
#### Problem
During block packing, we maintain a hashmap that tracks the CUs for each writeable account. We constrain this to 12M CUs for a given account because we know accessing the same account restricts parallelism, and serializing too many operations may inflate slot times beyond 400ms.

We currently pre-allocate this hashmap with a capacity of 512. Not sure where exactly this number came from, but looks like it was chosen ~3 years ago.

Looking at mainnet over the last 7 days, we can see that we touch an average of 2.5-3k accounts and a max of ~5k (w/ spikes beyond 8k):
![image](https://github.com/user-attachments/assets/fe7d1572-634a-4143-b0eb-d59fec0d8840)

As soon as we go beyond the 512 pre-allocation, we have to resize the hashmap, which is costly.

#### Summary of Changes
Increase the default allocation to 4k so that we don't have to resize most of the time. Even at this size, the hashmap should be only 128kB or so. It might make sense to go even larger so we almost never have to resize (maybe 6k or 8k)