### PR TITLE
v2.0: ci: increase timeout for check3

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -142,7 +142,7 @@ wait_step() {
 all_test_steps() {
   command_step checks1 "ci/docker-run-default-image.sh ci/test-checks.sh" 20 check
   command_step checks2 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-bins" 15 check
-  command_step checks3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-all-targets" 15 check
+  command_step checks3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh check-all-targets" 30 check
   command_step miri "ci/docker-run-default-image.sh ci/test-miri.sh" 5 check
   wait_step
 


### PR DESCRIPTION
#### Problem

see lots of check3 timeout issue like: https://buildkite.com/anza/agave/builds/11316#01923579-e540-4573-9988-894199975210

#### Summary of Changes

we solved this issue on master with https://github.com/anza-xyz/agave/pull/2127 (thank you Ryo ❤️) but I think simply increasing it for a channel branch will be sufficient