### PR TITLE
Fix frozen_abi for not-Bytes serde_with::serde_as

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6617,6 +6617,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
+ "serde_with",
  "sha2 0.10.8",
  "solana-frozen-abi-macro",
  "solana-logger",

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -15,6 +15,7 @@ bv = { workspace = true, features = ["serde"] }
 log = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
+serde_with = { workspace = true }
 sha2 = { workspace = true }
 solana-frozen-abi-macro = { workspace = true }
 thiserror = { workspace = true }
@@ -28,6 +29,7 @@ memmap2 = { workspace = true }
 bitflags = { workspace = true, features = ["serde"] }
 serde_bytes = { workspace = true }
 solana-logger = { workspace = true }
+serde_with = { workspace = true, features = ["macros"] }
 
 [features]
 default = []

--- a/frozen-abi/src/abi_digester.rs
+++ b/frozen-abi/src/abi_digester.rs
@@ -684,6 +684,36 @@ mod tests {
         }
     }
 
+    mod serde_with_abi {
+        use serde_with::{serde_as, Bytes};
+
+        // This is a minimized testcase based on solana_sdk::packet::Packet
+        #[serde_as]
+        #[derive(serde_derive::Serialize, AbiExample)]
+        #[frozen_abi(digest = "DcR9EB87D4uQBjUrsendvcFgS5KSF7okjnxGx8ZaDE8Z")]
+        struct U8ArrayWithBytes {
+            #[serde_as(as = "Bytes")]
+            foo: [u8; 42],
+        }
+
+        #[serde_as]
+        #[derive(serde_derive::Serialize, AbiExample)]
+        #[frozen_abi(digest = "CVqaXh4pWCiUyAuZ6dZPCmbCEtJyNH3e6uwUpJzymT6b")]
+        struct U8ArrayWithGenericAs {
+            #[serde_as(as = "[_; 42]")]
+            foo: [u8; 42],
+        }
+
+        // This is a minimized testcase based on solana_lattice_hash::lt_hash::LtHash
+        #[serde_as]
+        #[derive(serde_derive::Serialize, AbiExample)]
+        #[frozen_abi(digest = "A1J57qgtrhpqk6vD4tjV1CHLPagacBKsXJBBUB5mdp5W")]
+        struct NotU8ArrayWithGenericAs {
+            #[serde_as(as = "[_; 42]")]
+            bar: [u16; 42],
+        }
+    }
+
     mod skip_should_be_same {
         #[frozen_abi(digest = "4LbuvQLX78XPbm4hqqZcHFHpseDJcw4qZL9EUZXSi2Ss")]
         #[derive(serde_derive::Serialize, AbiExample)]

--- a/frozen-abi/src/abi_example.rs
+++ b/frozen-abi/src/abi_example.rs
@@ -245,6 +245,14 @@ impl<T: BlockType> EvenAsOpaque for BitVec<T> {
     const TYPE_NAME_MATCHER: &'static str = "bv::bit_vec::inner::";
 }
 
+use serde_with::ser::SerializeAsWrap;
+impl<'a, T: ?Sized, U: ?Sized> TransparentAsHelper for SerializeAsWrap<'a, T, U> {}
+// This (EvenAsOpaque) marker trait is needed for serde_with's serde_as(...) because this struct is
+// basically a wrapper struct.
+impl<'a, T: ?Sized, U: ?Sized> EvenAsOpaque for SerializeAsWrap<'a, T, U> {
+    const TYPE_NAME_MATCHER: &'static str = "serde_with::ser::SerializeAsWrap<";
+}
+
 pub(crate) fn normalize_type_name(type_name: &str) -> String {
     type_name.chars().filter(|c| *c != '&').collect()
 }


### PR DESCRIPTION
#### Problem

`serde_with::serde_as` is a convenient work-around for the lack of direct support of serializing/deserializing rust arrays with elements > 32.

However, frozen abi needed some tweak in order to work with it due to some internal implementation magic of `serde_with::serde_as`. 

#### Summary of Changes

Fix it.