### PR TITLE
Extract solana-rent crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7237,6 +7237,7 @@ dependencies = [
  "solana-program-memory",
  "solana-program-option",
  "solana-pubkey",
+ "solana-rent",
  "solana-sanitize",
  "solana-sdk-macro",
  "solana-secp256k1-recover",
@@ -7454,6 +7455,17 @@ dependencies = [
  "solana-sdk",
  "thiserror",
  "uriparse",
+]
+
+[[package]]
+name = "solana-rent"
+version = "2.1.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-sdk-macro",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7463,9 +7463,11 @@ version = "2.1.0"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-sdk-macro",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ members = [
     "sdk/program-memory",
     "sdk/program-option",
     "sdk/pubkey",
+    "sdk/rent",
     "sdk/serde-varint",
     "sdk/serialize-utils",
     "sdk/sha256-hasher",
@@ -435,6 +436,7 @@ solana-pubsub-client = { path = "pubsub-client", version = "=2.1.0" }
 solana-quic-client = { path = "quic-client", version = "=2.1.0" }
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.1.0" }
 solana-remote-wallet = { path = "remote-wallet", version = "=2.1.0", default-features = false }
+solana-rent = { path = "sdk/rent", version = "=2.1.0", default-features = false }
 solana-sanitize = { path = "sanitize", version = "=2.1.0" }
 solana-serde-varint = { path = "sdk/serde-varint", version = "=2.1.0" }
 solana-serialize-utils = { path = "sdk/serialize-utils", version = "=2.1.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5649,6 +5649,7 @@ dependencies = [
  "solana-program-memory",
  "solana-program-option",
  "solana-pubkey",
+ "solana-rent",
  "solana-sanitize",
  "solana-sdk-macro",
  "solana-secp256k1-recover",
@@ -5842,6 +5843,15 @@ dependencies = [
  "solana-sdk",
  "thiserror",
  "uriparse",
+]
+
+[[package]]
+name = "solana-rent"
+version = "2.1.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-macro",
 ]
 
 [[package]]

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -535,7 +535,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "6d4H7gw1hSrspdTew8dAXZ5dZT1mwFc6VZdXnkuggJ8E")
+            frozen_abi(digest = "8hwm4YsQXJWGZdp762SkJnDok29LXKwFtmW9oQ2KSzrN")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapper {

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -319,7 +319,7 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
                 syn::Fields::Named(ref fields) => fields.named.iter().map(|f| {
                     let name = &f.ident;
                     quote! {
-                        std::ptr::addr_of_mut!((*ptr).#name).write(self.#name);
+                        core::ptr::addr_of_mut!((*ptr).#name).write(self.#name);
                     }
                 }),
                 _ => unimplemented!(),
@@ -332,9 +332,9 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
                     // This is not the case here, and intentionally so because we want to
                     // guarantee zeroed padding.
                     fn clone(&self) -> Self {
-                        let mut value = std::mem::MaybeUninit::<Self>::uninit();
+                        let mut value = core::mem::MaybeUninit::<Self>::uninit();
                         unsafe {
-                            std::ptr::write_bytes(&mut value, 0, 1);
+                            core::ptr::write_bytes(&mut value, 0, 1);
                             let ptr = value.as_mut_ptr();
                             #(#clone_statements)*
                             value.assume_init()

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -52,6 +52,7 @@ solana-program-error = { workspace = true, features = ["serde"] }
 solana-program-memory = { workspace = true }
 solana-program-option = { workspace = true }
 solana-pubkey = { workspace = true, features = ["bytemuck", "curve25519", "serde", "std"] }
+solana-rent = { workspace = true, features = ["serde"] }
 solana-sanitize = { workspace = true }
 solana-sdk-macro = { workspace = true }
 solana-secp256k1-recover = { workspace = true }
@@ -127,6 +128,7 @@ frozen-abi = [
     "solana-hash/frozen-abi",
     "solana-instruction/frozen-abi",
     "solana-pubkey/frozen-abi",
+    "solana-rent/frozen-abi",
     "solana-short-vec/frozen-abi"
 ]
 

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -509,7 +509,6 @@ pub mod program_error;
 pub mod program_pack;
 pub mod program_stubs;
 pub mod program_utils;
-pub mod rent;
 pub mod secp256k1_program;
 pub mod slot_hashes;
 pub mod slot_history;
@@ -541,7 +540,7 @@ pub use {
     solana_account_info::{self as account_info, debug_account_data},
     solana_clock as clock,
     solana_msg::msg,
-    solana_program_option as program_option, solana_pubkey as pubkey,
+    solana_program_option as program_option, solana_pubkey as pubkey, solana_rent as rent,
 };
 
 /// The [config native program][np].

--- a/sdk/rent/Cargo.toml
+++ b/sdk/rent/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "solana-rent"
+description = "Configuration for Solana network rent."
+documentation = "https://docs.rs/solana-rent"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-sdk-macro = { workspace = true }
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = ["dep:serde", "dep:serde_derive"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/sdk/rent/Cargo.toml
+++ b/sdk/rent/Cargo.toml
@@ -16,6 +16,10 @@ solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
 
+[dev-dependencies]
+solana-clock = { workspace = true }
+static_assertions = { workspace = true }
+
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]

--- a/sdk/rent/src/lib.rs
+++ b/sdk/rent/src/lib.rs
@@ -3,13 +3,26 @@
 //! [rent]: https://docs.solanalabs.com/implemented-proposals/rent
 
 #![allow(clippy::arithmetic_side_effects)]
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
-use {solana_clock::DEFAULT_SLOTS_PER_EPOCH, solana_sdk_macro::CloneZeroed};
+use solana_sdk_macro::CloneZeroed;
+
+// inlined to avoid solana_clock dep
+const DEFAULT_SLOTS_PER_EPOCH: u64 = 432_000;
+#[cfg(test)]
+static_assertions::const_assert_eq!(
+    DEFAULT_SLOTS_PER_EPOCH,
+    solana_clock::DEFAULT_SLOTS_PER_EPOCH
+);
 
 /// Configuration of network rent.
 #[repr(C)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, PartialEq, CloneZeroed, Debug)]
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(PartialEq, CloneZeroed, Debug)]
 pub struct Rent {
     /// Rental rate in lamports/byte-year.
     pub lamports_per_byte_year: u64,

--- a/sdk/rent/src/lib.rs
+++ b/sdk/rent/src/lib.rs
@@ -3,7 +3,10 @@
 //! [rent]: https://docs.solanalabs.com/implemented-proposals/rent
 
 #![allow(clippy::arithmetic_side_effects)]
+#![no_std]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#[cfg(feature = "frozen-abi")]
+extern crate std;
 
 use solana_sdk_macro::CloneZeroed;
 

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -87,7 +87,7 @@ impl FromStr for ClusterType {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "z6vuQfrTaknTiRs1giPFzG1Jcw8eReidFTNDTmaX6GN")
+    frozen_abi(digest = "GDkrvVXezJYuGHcKSK19wvPBUMfKsifKQtoBxH1RpriL")
 )]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct GenesisConfig {


### PR DESCRIPTION
#### Problem
`solana_program::rent` blocks ripping out `solana_program::sysvar` and `solana_sdk::transaction_context`

#### Summary of Changes
- Move to its own crate and re-export for backwards compatibility