### PR TITLE
add #![no_std] to solana-clock

### DIFF
--- a/sdk/clock/src/lib.rs
+++ b/sdk/clock/src/lib.rs
@@ -19,6 +19,7 @@
 //! validator set][oracle].
 //!
 //! [oracle]: https://docs.solanalabs.com/implemented-proposals/validator-timestamp-oracle
+#![no_std]
 
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -319,7 +319,7 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
                 syn::Fields::Named(ref fields) => fields.named.iter().map(|f| {
                     let name = &f.ident;
                     quote! {
-                        std::ptr::addr_of_mut!((*ptr).#name).write(self.#name);
+                        core::ptr::addr_of_mut!((*ptr).#name).write(self.#name);
                     }
                 }),
                 _ => unimplemented!(),
@@ -332,9 +332,9 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
                     // This is not the case here, and intentionally so because we want to
                     // guarantee zeroed padding.
                     fn clone(&self) -> Self {
-                        let mut value = std::mem::MaybeUninit::<Self>::uninit();
+                        let mut value = core::mem::MaybeUninit::<Self>::uninit();
                         unsafe {
-                            std::ptr::write_bytes(&mut value, 0, 1);
+                            core::ptr::write_bytes(&mut value, 0, 1);
                             let ptr = value.as_mut_ptr();
                             #(#clone_statements)*
                             value.assume_init()


### PR DESCRIPTION
#### Problem
`solana-clock` can be no_std

#### Summary of Changes
- add `#![no_std]`
- replace `std` with `core` in the CloneZeroed macro
