### PR TITLE
extract epoch-info crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6871,6 +6871,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-epoch-info"
+version = "2.2.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "solana-epoch-rewards"
 version = "2.2.0"
 dependencies = [
@@ -8360,6 +8368,7 @@ dependencies = [
  "solana-decode-error",
  "solana-derivation-path",
  "solana-ed25519-program",
+ "solana-epoch-info",
  "solana-feature-set",
  "solana-fee-structure",
  "solana-frozen-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ members = [
     "sdk/define-syscall",
     "sdk/derivation-path",
     "sdk/ed25519-program",
+    "sdk/epoch-info",
     "sdk/epoch-rewards",
     "sdk/epoch-schedule",
     "sdk/feature-set",
@@ -443,6 +444,7 @@ solana-download-utils = { path = "download-utils", version = "=2.2.0" }
 solana-ed25519-program = { path = "sdk/ed25519-program", version = "=2.2.0" }
 solana-entry = { path = "entry", version = "=2.2.0" }
 solana-program-entrypoint = { path = "sdk/program-entrypoint", version = "=2.2.0" }
+solana-epoch-info = { path = "sdk/epoch-info", version = "=2.2.0" }
 solana-epoch-rewards = { path = "sdk/epoch-rewards", version = "=2.2.0" }
 solana-epoch-schedule = { path = "sdk/epoch-schedule", version = "=2.2.0" }
 solana-faucet = { path = "faucet", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5500,6 +5500,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-epoch-info"
+version = "2.2.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "solana-epoch-rewards"
 version = "2.2.0"
 dependencies = [
@@ -7086,6 +7094,7 @@ dependencies = [
  "solana-decode-error",
  "solana-derivation-path",
  "solana-ed25519-program",
+ "solana-epoch-info",
  "solana-feature-set",
  "solana-fee-structure",
  "solana-inflation",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -106,6 +106,7 @@ solana-commitment-config = { workspace = true, optional = true, features = ["ser
 solana-decode-error = { workspace = true }
 solana-derivation-path = { workspace = true }
 solana-ed25519-program = { workspace = true, optional = true }
+solana-epoch-info = { workspace = true, features = ["serde"] }
 solana-feature-set = { workspace = true }
 solana-fee-structure = { workspace = true, features = ["serde"] }
 solana-frozen-abi = { workspace = true, optional = true, features = [

--- a/sdk/epoch-info/Cargo.toml
+++ b/sdk/epoch-info/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "solana-epoch-info"
+description = "Information about the current Solana epoch."
+documentation = "https://docs.rs/solana-epoch-info"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+
+[features]
+serde = ["dep:serde", "dep:serde_derive"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/sdk/epoch-info/Cargo.toml
+++ b/sdk/epoch-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-epoch-info"
-description = "Information about the current Solana epoch."
+description = "Information about a Solana epoch."
 documentation = "https://docs.rs/solana-epoch-info"
 version = { workspace = true }
 authors = { workspace = true }

--- a/sdk/epoch-info/src/lib.rs
+++ b/sdk/epoch-info/src/lib.rs
@@ -4,13 +4,15 @@
 //!
 //! [`getEpochInfo`]: https://solana.com/docs/rpc/http/getepochinfo
 
-use crate::clock::{Epoch, Slot};
-
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize),
+    serde(rename_all = "camelCase")
+)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EpochInfo {
     /// The current epoch
-    pub epoch: Epoch,
+    pub epoch: u64,
 
     /// The current slot, relative to the start of the current epoch
     pub slot_index: u64,
@@ -19,7 +21,7 @@ pub struct EpochInfo {
     pub slots_in_epoch: u64,
 
     /// The absolute current slot
-    pub absolute_slot: Slot,
+    pub absolute_slot: u64,
 
     /// The current block height
     pub block_height: u64,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -65,7 +65,6 @@ pub mod client;
 pub mod compute_budget;
 pub mod entrypoint;
 pub mod entrypoint_deprecated;
-pub mod epoch_info;
 pub mod epoch_rewards_hasher;
 pub mod example_mocks;
 pub mod exit;
@@ -121,6 +120,8 @@ pub use solana_derivation_path as derivation_path;
 #[cfg(feature = "full")]
 #[deprecated(since = "2.2.0", note = "Use `solana-ed25519-program` crate instead")]
 pub use solana_ed25519_program as ed25519_instruction;
+#[deprecated(since = "2.2.0", note = "Use `solana-epoch-info` crate instead")]
+pub use solana_epoch_info as epoch_info;
 #[deprecated(since = "2.1.0", note = "Use `solana-feature-set` crate instead")]
 pub use solana_feature_set as feature_set;
 #[deprecated(since = "2.2.0", note = "Use `solana-fee-structure` crate instead")]


### PR DESCRIPTION
#### Problem
`solana_sdk::epoch_info` imposes a `solana_sdk` dependency on `solana_rpc_client`

#### Summary of Changes
- Move to its own crate
- Re-export with deprecation
- Make serde optional in the new crate
