### PR TITLE
extract packet crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cfg_eval"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7191,6 +7202,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-packet"
+version = "2.1.0"
+dependencies = [
+ "bincode",
+ "bitflags 2.6.0",
+ "cfg_eval",
+ "serde",
+ "serde_derive",
+ "serde_with",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-packet",
+ "static_assertions",
+]
+
+[[package]]
 name = "solana-perf"
 version = "2.1.0"
 dependencies = [
@@ -7925,6 +7952,7 @@ dependencies = [
  "solana-instruction",
  "solana-logger",
  "solana-native-token",
+ "solana-packet",
  "solana-precompile-error",
  "solana-program",
  "solana-program-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ members = [
     "sdk/native-token",
     "sdk/package-metadata",
     "sdk/package-metadata-macro",
+    "sdk/packet",
     "sdk/precompile-error",
     "sdk/program",
     "sdk/program-entrypoint",
@@ -235,6 +236,7 @@ bytes = "1.7"
 bzip2 = "0.4.4"
 caps = "0.5.5"
 cargo_metadata = "0.15.4"
+cfg_eval = "0.1.2"
 chrono = { version = "0.4.38", default-features = false }
 chrono-humanize = "0.2.3"
 clap = "2.33.1"
@@ -442,6 +444,7 @@ solana-nohash-hasher = "0.2.1"
 solana-notifier = { path = "notifier", version = "=2.1.0" }
 solana-package-metadata = { path = "sdk/package-metadata", version = "=2.1.0" }
 solana-package-metadata-macro = { path = "sdk/package-metadata-macro", version = "=2.1.0" }
+solana-packet = { path = "sdk/packet", version = "=2.1.0" }
 solana-perf = { path = "perf", version = "=2.1.0" }
 solana-poh = { path = "poh", version = "=2.1.0" }
 solana-poseidon = { path = "poseidon", version = "=2.1.0" }

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -65,7 +65,7 @@ pub struct BankingTracer {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "F5GH1poHbPqipU4DB3MczhSxHZw4o27f3C7QnMVirFci")
+    frozen_abi(digest = "6PCDw6YSEivfbwhbPmE4NAsXb88ZX6hkFnruP8B38nma")
 )]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TimedTracedEvent(pub std::time::SystemTime, pub TracedEvent);

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -962,6 +962,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cfg_eval"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5613,6 +5624,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 
 [[package]]
+name = "solana-packet"
+version = "2.1.0"
+dependencies = [
+ "bincode",
+ "bitflags 2.6.0",
+ "cfg_eval",
+ "serde",
+ "serde_derive",
+ "serde_with",
+]
+
+[[package]]
 name = "solana-perf"
 version = "2.1.0"
 dependencies = [
@@ -6685,6 +6708,7 @@ dependencies = [
  "solana-feature-set",
  "solana-instruction",
  "solana-native-token",
+ "solana-packet",
  "solana-precompile-error",
  "solana-program",
  "solana-program-memory",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -99,6 +99,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-instruction = { workspace = true }
 solana-native-token = { workspace = true }
+solana-packet = { workspace = true, features = ["bincode", "serde"] }
 solana-precompile-error = { workspace = true, optional = true }
 solana-program = { workspace = true }
 solana-program-memory = { workspace = true }

--- a/sdk/packet/Cargo.toml
+++ b/sdk/packet/Cargo.toml
@@ -37,6 +37,8 @@ frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/sdk/packet/Cargo.toml
+++ b/sdk/packet/Cargo.toml
@@ -16,8 +16,8 @@ cfg_eval = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true, features = ["macros"] }
-solana-frozen-abi = { workspace = true, optional = true }
-solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
 
 [dev-dependencies]
 solana-packet = { path = ".", features = ["dev-context-only-utils"] }

--- a/sdk/packet/Cargo.toml
+++ b/sdk/packet/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "solana-packet"
+description = "The definition of a Solana network packet."
+documentation = "https://docs.rs/solana-packet"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+bincode = { workspace = true, optional = true }
+bitflags = { workspace = true }
+cfg_eval = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+serde_with = { workspace = true, optional = true, features = ["macros"] }
+
+[dev-dependencies]
+solana-packet = { path = ".", features = ["dev-context-only-utils"] }
+static_assertions = { workspace = true }
+
+[features]
+bincode = ["dep:bincode", "serde"]
+dev-context-only-utils = ["bincode"]
+serde = [
+    "bitflags/serde",
+    "dep:cfg_eval",
+    "dep:serde",
+    "dep:serde_derive",
+    "dep:serde_with",
+]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/sdk/packet/Cargo.toml
+++ b/sdk/packet/Cargo.toml
@@ -13,11 +13,11 @@ edition = { workspace = true }
 bincode = { workspace = true, optional = true }
 bitflags = { workspace = true }
 cfg_eval = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
-solana-frozen-abi-macro = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true, features = ["macros"] }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-packet = { path = ".", features = ["dev-context-only-utils"] }
@@ -31,7 +31,7 @@ serde = [
     "dep:cfg_eval",
     "dep:serde",
     "dep:serde_derive",
-    "dep:serde_with",
+    "dep:serde_with"
 ]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 

--- a/sdk/packet/src/lib.rs
+++ b/sdk/packet/src/lib.rs
@@ -1,5 +1,6 @@
 //! The definition of a Solana network packet.
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "bincode")]
 use bincode::{Options, Result};

--- a/sdk/packet/src/lib.rs
+++ b/sdk/packet/src/lib.rs
@@ -1,15 +1,22 @@
 //! The definition of a Solana network packet.
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
+#[cfg(feature = "bincode")]
+use bincode::{Options, Result};
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi_macro::AbiEXample;
 use {
-    bincode::{Options, Result},
     bitflags::bitflags,
-    serde::{Deserialize, Serialize},
-    serde_with::{serde_as, Bytes},
     std::{
-        fmt, io,
+        fmt,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         slice::SliceIndex,
     },
+};
+#[cfg(feature = "serde")]
+use {
+    serde_derive::{Deserialize, Serialize},
+    serde_with::{serde_as, Bytes},
 };
 
 #[cfg(test)]
@@ -22,7 +29,8 @@ pub const PACKET_DATA_SIZE: usize = 1280 - 40 - 8;
 
 bitflags! {
     #[repr(C)]
-    #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct PacketFlags: u8 {
         const DISCARD        = 0b0000_0001;
         const FORWARDED      = 0b0000_0010;
@@ -39,7 +47,8 @@ bitflags! {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct Meta {
     pub size: usize,
@@ -88,14 +97,18 @@ impl ::solana_frozen_abi::abi_example::EvenAsOpaque for PacketFlags {
 //   https://github.com/serde-rs/serde/pull/1860
 // ryoqun's dirty experiments:
 //   https://github.com/ryoqun/serde-array-comparisons
-#[serde_as]
+//
+// We use the cfg_eval crate as advised by the serde_with guide:
+// https://docs.rs/serde_with/latest/serde_with/guide/serde_as/index.html#gating-serde_as-on-features
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Eq)]
 #[repr(C)]
 pub struct Packet {
     // Bytes past Packet.meta.size are not valid to read from.
     // Use Packet.data(index) to read from the buffer.
-    #[serde_as(as = "Bytes")]
+    #[cfg_attr(feature = "serde", serde_as(as = "Bytes"))]
     buffer: [u8; PACKET_DATA_SIZE],
     meta: Meta,
 }
@@ -144,19 +157,21 @@ impl Packet {
         &mut self.meta
     }
 
-    pub fn from_data<T: Serialize>(dest: Option<&SocketAddr>, data: T) -> Result<Self> {
+    #[cfg(feature = "bincode")]
+    pub fn from_data<T: serde::Serialize>(dest: Option<&SocketAddr>, data: T) -> Result<Self> {
         let mut packet = Self::default();
         Self::populate_packet(&mut packet, dest, &data)?;
         Ok(packet)
     }
 
-    pub fn populate_packet<T: Serialize>(
+    #[cfg(feature = "bincode")]
+    pub fn populate_packet<T: serde::Serialize>(
         &mut self,
         dest: Option<&SocketAddr>,
         data: &T,
     ) -> Result<()> {
         debug_assert!(!self.meta.discard());
-        let mut wr = io::Cursor::new(self.buffer_mut());
+        let mut wr = std::io::Cursor::new(self.buffer_mut());
         bincode::serialize_into(&mut wr, data)?;
         self.meta.size = wr.position() as usize;
         if let Some(dest) = dest {
@@ -165,6 +180,7 @@ impl Packet {
         Ok(())
     }
 
+    #[cfg(feature = "bincode")]
     pub fn deserialize_slice<T, I>(&self, index: I) -> Result<T>
     where
         T: serde::de::DeserializeOwned,

--- a/sdk/packet/src/lib.rs
+++ b/sdk/packet/src/lib.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "bincode")]
 use bincode::{Options, Result};
 #[cfg(feature = "frozen-abi")]
-use solana_frozen_abi_macro::AbiEXample;
+use solana_frozen_abi_macro::AbiExample;
 use {
     bitflags::bitflags,
     std::{

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -81,7 +81,6 @@ pub mod native_loader;
 pub mod net;
 pub mod nonce_account;
 pub mod offchain_message;
-pub mod packet;
 pub mod poh_config;
 pub mod precompiles;
 pub mod program_utils;
@@ -120,6 +119,8 @@ pub use solana_decode_error as decode_error;
 pub use solana_derivation_path as derivation_path;
 #[deprecated(since = "2.1.0", note = "Use `solana-feature-set` crate instead")]
 pub use solana_feature_set as feature_set;
+#[deprecated(since = "2.1.0", note = "Use `solana-packet` crate instead")]
+pub use solana_packet as packet;
 #[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]
 pub use solana_program_memory as program_memory;
 #[deprecated(since = "2.1.0", note = "Use `solana_pubkey::pubkey` instead")]


### PR DESCRIPTION
#### Problem
`solana_sdk::packet` imposes a `solana_sdk` dependency on `solana_client`

#### Summary of Changes
- Move to its own crate
- Re-export with deprecation
- Make serde and bincode optional in the new crate. This involves adding a new dependency `cfg_eval` as advised by the `serde_with` docs: https://docs.rs/serde_with/latest/serde_with/guide/serde_as/index.html#gating-serde_as-on-features

