### PR TITLE
Support notify first shred received in geyser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8373,6 +8373,7 @@ dependencies = [
  "rustls 0.23.13",
  "solana-entry",
  "solana-feature-set",
+ "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-ledger",
  "solana-logger",

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -25,7 +25,7 @@ use {
     bytes::Bytes,
     crossbeam_channel::{unbounded, Receiver, Sender},
     solana_client::connection_cache::ConnectionCache,
-    solana_geyser_plugin_manager::block_metadata_notifier_interface::BlockMetadataNotifierArc,
+    solana_geyser_plugin_manager::{block_metadata_notifier_interface::BlockMetadataNotifierArc, slot_status_notifier::SlotStatusNotifier},
     solana_gossip::{
         cluster_info::ClusterInfo, duplicate_shred_handler::DuplicateShredHandler,
         duplicate_shred_listener::DuplicateShredListener,
@@ -161,6 +161,7 @@ impl Tvu {
         outstanding_repair_requests: Arc<RwLock<OutstandingShredRepairs>>,
         cluster_slots: Arc<ClusterSlots>,
         wen_restart_repair_slots: Option<Arc<RwLock<Vec<Slot>>>>,
+        slot_status_notifier: Option<SlotStatusNotifier>,
     ) -> Result<Self, String> {
         let in_wen_restart = wen_restart_repair_slots.is_some();
 
@@ -210,6 +211,7 @@ impl Tvu {
             retransmit_receiver,
             max_slots.clone(),
             Some(rpc_subscriptions.clone()),
+            slot_status_notifier,
         );
 
         let (ancestor_duplicate_slots_sender, ancestor_duplicate_slots_receiver) = unbounded();

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -25,7 +25,10 @@ use {
     bytes::Bytes,
     crossbeam_channel::{unbounded, Receiver, Sender},
     solana_client::connection_cache::ConnectionCache,
-    solana_geyser_plugin_manager::{block_metadata_notifier_interface::BlockMetadataNotifierArc, slot_status_notifier::SlotStatusNotifier},
+    solana_geyser_plugin_manager::{
+        block_metadata_notifier_interface::BlockMetadataNotifierArc,
+        slot_status_notifier::SlotStatusNotifier,
+    },
     solana_gossip::{
         cluster_info::ClusterInfo, duplicate_shred_handler::DuplicateShredHandler,
         duplicate_shred_listener::DuplicateShredListener,
@@ -544,6 +547,7 @@ pub mod tests {
             outstanding_repair_requests,
             cluster_slots,
             wen_restart_repair_slots,
+            None,
         )
         .expect("assume success");
         if enable_wen_restart {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -674,6 +674,10 @@ impl Validator {
             .as_ref()
             .and_then(|geyser_plugin_service| geyser_plugin_service.get_block_metadata_notifier());
 
+        let slot_status_notifier = geyser_plugin_service
+            .as_ref()
+            .and_then(|geyser_plugin_service| geyser_plugin_service.get_slot_status_notifier());
+
         info!(
             "Geyser plugin: accounts_update_notifier: {}, transaction_notifier: {}, \
              entry_notifier: {}",
@@ -1405,6 +1409,7 @@ impl Validator {
             outstanding_repair_requests.clone(),
             cluster_slots.clone(),
             wen_restart_repair_slots.clone(),
+            slot_status_notifier,
         )
         .map_err(ValidatorError::Other)?;
 

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -319,6 +319,9 @@ pub enum SlotStatus {
 
     /// The highest slot that has been voted on by supermajority of the cluster, ie. is confirmed.
     Confirmed,
+
+    /// First Shred Received
+    FirstShredReceived,
 }
 
 impl SlotStatus {
@@ -327,6 +330,7 @@ impl SlotStatus {
             SlotStatus::Confirmed => "confirmed",
             SlotStatus::Processed => "processed",
             SlotStatus::Rooted => "rooted",
+            SlotStatus::FirstShredReceived => "first_shread_received",
         }
     }
 }

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -111,7 +111,7 @@ impl GeyserPluginService {
         let (slot_status_observer, block_metadata_notifier, slot_status_notifier): (
             Option<SlotStatusObserver>,
             Option<BlockMetadataNotifierArc>,
-            Option<SlotStatusNotifier>
+            Option<SlotStatusNotifier>,
         ) = if account_data_notifications_enabled
             || transaction_notifications_enabled
             || entry_notifications_enabled

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -5,7 +5,7 @@ use {
         block_metadata_notifier_interface::BlockMetadataNotifierArc,
         entry_notifier::EntryNotifierImpl,
         geyser_plugin_manager::{GeyserPluginManager, GeyserPluginManagerRequest},
-        slot_status_notifier::SlotStatusNotifierImpl,
+        slot_status_notifier::{SlotStatusNotifier, SlotStatusNotifierImpl},
         slot_status_observer::SlotStatusObserver,
         transaction_notifier::TransactionNotifierImpl,
     },
@@ -37,6 +37,7 @@ pub struct GeyserPluginService {
     transaction_notifier: Option<TransactionNotifierArc>,
     entry_notifier: Option<EntryNotifierArc>,
     block_metadata_notifier: Option<BlockMetadataNotifierArc>,
+    slot_status_notifier: Option<SlotStatusNotifier>,
 }
 
 impl GeyserPluginService {
@@ -107,9 +108,10 @@ impl GeyserPluginService {
             None
         };
 
-        let (slot_status_observer, block_metadata_notifier): (
+        let (slot_status_observer, block_metadata_notifier, slot_status_notifier): (
             Option<SlotStatusObserver>,
             Option<BlockMetadataNotifierArc>,
+            Option<SlotStatusNotifier>
         ) = if account_data_notifications_enabled
             || transaction_notifications_enabled
             || entry_notifications_enabled
@@ -119,14 +121,15 @@ impl GeyserPluginService {
             (
                 Some(SlotStatusObserver::new(
                     confirmed_bank_receiver,
-                    slot_status_notifier,
+                    slot_status_notifier.clone(),
                 )),
                 Some(Arc::new(BlockMetadataNotifierImpl::new(
                     plugin_manager.clone(),
                 ))),
+                Some(slot_status_notifier),
             )
         } else {
-            (None, None)
+            (None, None, None)
         };
 
         // Initialize plugin manager rpc handler thread if needed
@@ -143,6 +146,7 @@ impl GeyserPluginService {
             transaction_notifier,
             entry_notifier,
             block_metadata_notifier,
+            slot_status_notifier,
         })
     }
 
@@ -170,6 +174,10 @@ impl GeyserPluginService {
 
     pub fn get_block_metadata_notifier(&self) -> Option<BlockMetadataNotifierArc> {
         self.block_metadata_notifier.clone()
+    }
+
+    pub fn get_slot_status_notifier(&self) -> Option<SlotStatusNotifier> {
+        self.slot_status_notifier.clone()
     }
 
     pub fn join(self) -> thread::Result<()> {

--- a/geyser-plugin-manager/src/slot_status_notifier.rs
+++ b/geyser-plugin-manager/src/slot_status_notifier.rs
@@ -17,6 +17,9 @@ pub trait SlotStatusNotifierInterface {
 
     /// Notified when a slot is rooted.
     fn notify_slot_rooted(&self, slot: Slot, parent: Option<Slot>);
+
+    /// Notified when the first shred is received for a slot.
+    fn notify_shred_received(&self, slot: Slot);
 }
 
 pub type SlotStatusNotifier = Arc<RwLock<dyn SlotStatusNotifierInterface + Sync + Send>>;
@@ -36,6 +39,10 @@ impl SlotStatusNotifierInterface for SlotStatusNotifierImpl {
 
     fn notify_slot_rooted(&self, slot: Slot, parent: Option<Slot>) {
         self.notify_slot_status(slot, parent, SlotStatus::Rooted);
+    }
+
+    fn notify_shred_received(&self, slot: Slot) {
+        self.notify_slot_status(slot, None, SlotStatus::FirstShredReceived);
     }
 }
 

--- a/geyser-plugin-manager/src/slot_status_notifier.rs
+++ b/geyser-plugin-manager/src/slot_status_notifier.rs
@@ -19,7 +19,7 @@ pub trait SlotStatusNotifierInterface {
     fn notify_slot_rooted(&self, slot: Slot, parent: Option<Slot>);
 
     /// Notified when the first shred is received for a slot.
-    fn notify_shred_received(&self, slot: Slot);
+    fn notify_first_shred_received(&self, slot: Slot);
 }
 
 pub type SlotStatusNotifier = Arc<RwLock<dyn SlotStatusNotifierInterface + Sync + Send>>;
@@ -41,7 +41,7 @@ impl SlotStatusNotifierInterface for SlotStatusNotifierImpl {
         self.notify_slot_status(slot, parent, SlotStatus::Rooted);
     }
 
-    fn notify_shred_received(&self, slot: Slot) {
+    fn notify_first_shred_received(&self, slot: Slot) {
         self.notify_slot_status(slot, None, SlotStatus::FirstShredReceived);
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6976,6 +6976,7 @@ dependencies = [
  "rustls 0.23.13",
  "solana-entry",
  "solana-feature-set",
+ "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-ledger",
  "solana-measure",

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -25,8 +25,8 @@ rayon = { workspace = true }
 rustls = { workspace = true }
 solana-entry = { workspace = true }
 solana-feature-set = { workspace = true }
-solana-gossip = { workspace = true }
 solana-geyser-plugin-manager = { workspace = true }
+solana-gossip = { workspace = true }
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -26,6 +26,7 @@ rustls = { workspace = true }
 solana-entry = { workspace = true }
 solana-feature-set = { workspace = true }
 solana-gossip = { workspace = true }
+solana-geyser-plugin-manager = { workspace = true }
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }

--- a/turbine/benches/retransmit_stage.rs
+++ b/turbine/benches/retransmit_stage.rs
@@ -126,6 +126,7 @@ fn bench_retransmitter(bencher: &mut Bencher) {
         shreds_receiver,
         Arc::default(), // solana_rpc::max_slots::MaxSlots
         None,
+        None,
     );
 
     let mut index = 0;

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -185,7 +185,7 @@ fn retransmit(
     shred_deduper: &mut ShredDeduper<2>,
     max_slots: &MaxSlots,
     rpc_subscriptions: Option<&RpcSubscriptions>,
-    slot_status_notifier: Option<SlotStatusNotifier>,
+    slot_status_notifier: Option<&SlotStatusNotifier>,
 ) -> Result<(), RecvTimeoutError> {
     const RECV_TIMEOUT: Duration = Duration::from_secs(1);
     let mut shreds = shreds_receiver.recv_timeout(RECV_TIMEOUT)?;
@@ -420,7 +420,7 @@ pub fn retransmitter(
                 &mut shred_deduper,
                 &max_slots,
                 rpc_subscriptions.as_deref(),
-                slot_status_notifier.clone(),
+                slot_status_notifier.as_ref(),
             ) {
                 Ok(()) => (),
                 Err(RecvTimeoutError::Timeout) => (),
@@ -518,7 +518,7 @@ impl RetransmitStats {
         feed: I,
         root: Slot,
         rpc_subscriptions: Option<&RpcSubscriptions>,
-        slot_status_notifier: Option<SlotStatusNotifier>,
+        slot_status_notifier: Option<&SlotStatusNotifier>,
     ) where
         I: IntoIterator<Item = (Slot, RetransmitSlotStats)>,
     {
@@ -536,7 +536,7 @@ impl RetransmitStats {
                         }
                     }
 
-                    if let Some(slot_status_notifier) = &slot_status_notifier {
+                    if let Some(slot_status_notifier) = slot_status_notifier {
                         if slot > root {
                             slot_status_notifier
                                 .read()

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -10,6 +10,7 @@ use {
     rand::Rng,
     rayon::{prelude::*, ThreadPool, ThreadPoolBuilder},
     solana_gossip::{cluster_info::ClusterInfo, contact_info::Protocol},
+    solana_geyser_plugin_manager::slot_status_notifier::SlotStatusNotifier,
     solana_ledger::{
         leader_schedule_cache::LeaderScheduleCache,
         shred::{self, ShredId},
@@ -184,6 +185,7 @@ fn retransmit(
     shred_deduper: &mut ShredDeduper<2>,
     max_slots: &MaxSlots,
     rpc_subscriptions: Option<&RpcSubscriptions>,
+    slot_status_notifier: Option<SlotStatusNotifier>,
 ) -> Result<(), RecvTimeoutError> {
     const RECV_TIMEOUT: Duration = Duration::from_secs(1);
     let mut shreds = shreds_receiver.recv_timeout(RECV_TIMEOUT)?;
@@ -299,7 +301,7 @@ fn retransmit(
                 .reduce(HashMap::new, RetransmitSlotStats::merge)
         })
     };
-    stats.upsert_slot_stats(slot_stats, root_bank.slot(), rpc_subscriptions);
+    stats.upsert_slot_stats(slot_stats, root_bank.slot(), rpc_subscriptions, slot_status_notifier);
     timer_start.stop();
     stats.total_time += timer_start.as_us();
     stats.maybe_submit(&root_bank, &working_bank, cluster_info, cluster_nodes_cache);
@@ -381,6 +383,7 @@ pub fn retransmitter(
     shreds_receiver: Receiver<Vec</*shred:*/ Vec<u8>>>,
     max_slots: Arc<MaxSlots>,
     rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
+    slot_status_notifier: Option<SlotStatusNotifier>,    
 ) -> JoinHandle<()> {
     let cluster_nodes_cache = ClusterNodesCache::<RetransmitStage>::new(
         CLUSTER_NODES_CACHE_NUM_EPOCH_CAP,
@@ -412,6 +415,7 @@ pub fn retransmitter(
                 &mut shred_deduper,
                 &max_slots,
                 rpc_subscriptions.as_deref(),
+                slot_status_notifier.clone(),
             ) {
                 Ok(()) => (),
                 Err(RecvTimeoutError::Timeout) => (),
@@ -435,6 +439,7 @@ impl RetransmitStage {
         retransmit_receiver: Receiver<Vec</*shred:*/ Vec<u8>>>,
         max_slots: Arc<MaxSlots>,
         rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
+        slot_status_notifier: Option<SlotStatusNotifier>,
     ) -> Self {
         let retransmit_thread_handle = retransmitter(
             retransmit_sockets,
@@ -445,6 +450,7 @@ impl RetransmitStage {
             retransmit_receiver,
             max_slots,
             rpc_subscriptions,
+            slot_status_notifier,
         );
 
         Self {
@@ -507,6 +513,7 @@ impl RetransmitStats {
         feed: I,
         root: Slot,
         rpc_subscriptions: Option<&RpcSubscriptions>,
+        slot_status_notifier: Option<SlotStatusNotifier>,
     ) where
         I: IntoIterator<Item = (Slot, RetransmitSlotStats)>,
     {
@@ -523,6 +530,13 @@ impl RetransmitStats {
                             datapoint_info!("retransmit-first-shred", ("slot", slot, i64));
                         }
                     }
+
+                    if let Some(slot_status_notifier) = &slot_status_notifier {
+                        if slot > root {
+                            slot_status_notifier.read().unwrap().notify_shred_received(slot);
+                        }
+                    }
+
                     self.slot_stats.put(slot, slot_stats);
                 }
                 Some(entry) => {


### PR DESCRIPTION
#### Problem
This is the first part to support more slot status notification type in geyser. FirstShredReceived.

#### Summary of Changes

Link SlotStatusNotifier in retransmit stage on FirstShredReceived.

Tests: tested change with Postgres geyser plugin and confirming the FirstShredReceived being received.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
https://github.com/anza-xyz/agave/issues/2957
