### PR TITLE
Sigverify wraps each PacketBatch with Arc

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -19,7 +19,7 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
     },
     solana_measure::measure::Measure,
-    solana_perf::packet::{to_packet_batches, PacketBatch},
+    solana_perf::packet::{to_arc_packet_batches, PacketBatch},
     solana_poh::poh_recorder::{create_test_recorder, PohRecorder, WorkingBankEntry},
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
@@ -185,7 +185,7 @@ fn make_transfer_transaction_with_compute_unit_price(
 }
 
 struct PacketsPerIteration {
-    packet_batches: Vec<PacketBatch>,
+    packet_batches: Vec<Arc<PacketBatch>>,
     transactions: Vec<Transaction>,
     packets_per_batch: usize,
 }
@@ -209,7 +209,7 @@ impl PacketsPerIteration {
             mint_txs_percentage,
         );
 
-        let packet_batches: Vec<PacketBatch> = to_packet_batches(&transactions, packets_per_batch);
+        let packet_batches = to_arc_packet_batches(&transactions, packets_per_batch);
         assert_eq!(packet_batches.len(), batches_per_iteration);
         Self {
             packet_batches,
@@ -224,7 +224,7 @@ impl PacketsPerIteration {
             let sig: [u8; 64] = std::array::from_fn(|_| thread_rng().gen::<u8>());
             tx.signatures[0] = Signature::from(sig);
         }
-        self.packet_batches = to_packet_batches(&self.transactions, self.packets_per_batch);
+        self.packet_batches = to_arc_packet_batches(&self.transactions, self.packets_per_batch);
     }
 }
 

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -29,6 +29,7 @@ use {
         get_tmp_ledger_path_auto_delete,
     },
     solana_perf::{
+        mutable_packet_batch::MutablePacketBatch,
         packet::{to_arc_packet_batches, Packet},
         test_tx::test_tx,
     },
@@ -267,7 +268,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
     let vote_packets = vote_txs.map(|vote_txs| {
         let mut packet_batches = to_arc_packet_batches(&vote_txs, PACKETS_PER_BATCH);
         for batch in packet_batches.iter_mut() {
-            for packet in Arc::make_mut(batch).iter_mut() {
+            for packet in batch.as_mut().iter_mut() {
                 packet.meta_mut().set_simple_vote(true);
             }
         }

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -2,14 +2,6 @@
 #![feature(test)]
 
 use {
-    solana_core::validator::BlockProductionMethod,
-    solana_perf::packet::to_arc_packet_batches,
-    solana_vote_program::{vote_state::TowerSync, vote_transaction::new_tower_sync_transaction},
-};
-
-extern crate test;
-
-use {
     crossbeam_channel::{unbounded, Receiver},
     log::*,
     rand::{thread_rng, Rng},
@@ -26,6 +18,7 @@ use {
             BankingStage, BankingStageStats,
         },
         banking_trace::{BankingPacketBatch, BankingTracer},
+        validator::BlockProductionMethod,
     },
     solana_entry::entry::{next_hash, Entry},
     solana_gossip::cluster_info::{ClusterInfo, Node},
@@ -35,7 +28,10 @@ use {
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         get_tmp_ledger_path_auto_delete,
     },
-    solana_perf::{packet::Packet, test_tx::test_tx},
+    solana_perf::{
+        packet::{to_arc_packet_batches, Packet},
+        test_tx::test_tx,
+    },
     solana_poh::poh_recorder::{create_test_recorder, WorkingBankEntry},
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
@@ -51,6 +47,7 @@ use {
         transaction::{Transaction, VersionedTransaction},
     },
     solana_streamer::socket::SocketAddrSpace,
+    solana_vote_program::{vote_state::TowerSync, vote_transaction::new_tower_sync_transaction},
     std::{
         iter::repeat_with,
         sync::{atomic::Ordering, Arc},
@@ -58,6 +55,8 @@ use {
     },
     test::Bencher,
 };
+
+extern crate test;
 
 fn check_txs(receiver: &Arc<Receiver<WorkingBankEntry>>, ref_tx_count: usize) {
     let mut total = 0;

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -722,7 +722,6 @@ mod tests {
                 tests::create_slow_genesis_config,
             },
             banking_trace::BankingPacketBatch,
-            sigverify::SigverifyTracerPacketStats,
         },
         crossbeam_channel::{unbounded, Receiver, Sender},
         itertools::Itertools,
@@ -731,7 +730,7 @@ mod tests {
             blockstore::Blockstore, genesis_utils::GenesisConfigInfo,
             get_tmp_ledger_path_auto_delete, leader_schedule_cache::LeaderScheduleCache,
         },
-        solana_perf::packet::{to_packet_batches, PacketBatch, NUM_PACKETS},
+        solana_perf::packet::{to_arc_packet_batches, NUM_PACKETS},
         solana_poh::poh_recorder::{PohRecorder, Record, WorkingBankEntry},
         solana_runtime::bank::Bank,
         solana_sdk::{
@@ -756,7 +755,7 @@ mod tests {
         _entry_receiver: Receiver<WorkingBankEntry>,
         _record_receiver: Receiver<Record>,
         poh_recorder: Arc<RwLock<PohRecorder>>,
-        banking_packet_sender: Sender<Arc<(Vec<PacketBatch>, Option<SigverifyTracerPacketStats>)>>,
+        banking_packet_sender: Sender<BankingPacketBatch>,
 
         consume_work_receivers: Vec<Receiver<ConsumeWork>>,
         finished_consume_work_sender: Sender<FinishedConsumeWork>,
@@ -845,7 +844,7 @@ mod tests {
     }
 
     fn to_banking_packet_batch(txs: &[Transaction]) -> BankingPacketBatch {
-        let packet_batch = to_packet_batches(txs, NUM_PACKETS);
+        let packet_batch = to_arc_packet_batches(txs, NUM_PACKETS);
         Arc::new((packet_batch, None))
     }
 

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -65,7 +65,7 @@ pub struct BankingTracer {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "F5GH1poHbPqipU4DB3MczhSxHZw4o27f3C7QnMVirFci")
+    frozen_abi(digest = "GxZSv4cLjY97v6UospZnyfKurN6UciYqDvFgZJByP9KW")
 )]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TimedTracedEvent(pub std::time::SystemTime, pub TracedEvent);

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -20,7 +20,7 @@ use {
     thiserror::Error,
 };
 
-pub type BankingPacketBatch = Arc<(Vec<PacketBatch>, Option<SigverifyTracerPacketStats>)>;
+pub type BankingPacketBatch = Arc<(Vec<Arc<PacketBatch>>, Option<SigverifyTracerPacketStats>)>;
 pub type BankingPacketSender = TracedSender;
 pub type BankingPacketReceiver = Receiver<BankingPacketBatch>;
 pub type TracerThreadResult = Result<(), TraceError>;
@@ -373,12 +373,12 @@ impl TracedSender {
 pub mod for_test {
     use {
         super::*,
-        solana_perf::{packet::to_packet_batches, test_tx::test_tx},
+        solana_perf::{packet::to_arc_packet_batches, test_tx::test_tx},
         tempfile::TempDir,
     };
 
     pub fn sample_packet_batch() -> BankingPacketBatch {
-        BankingPacketBatch::new((to_packet_batches(&vec![test_tx(); 4], 10), None))
+        BankingPacketBatch::new((to_arc_packet_batches(&vec![test_tx(); 4], 10), None))
     }
 
     pub fn drop_and_clean_temp_dir_unless_suppressed(temp_dir: TempDir) {

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -270,7 +270,7 @@ impl ClusterInfoVoteListener {
     fn verify_votes(
         votes: Vec<Transaction>,
         root_bank_cache: &mut RootBankCache,
-    ) -> (Vec<Transaction>, Vec<PacketBatch>) {
+    ) -> (Vec<Transaction>, Vec<Arc<PacketBatch>>) {
         let mut packet_batches = packet::to_packet_batches(&votes, 1);
 
         // Votes should already be filtered by this point.
@@ -301,7 +301,7 @@ impl ClusterInfoVoteListener {
                 if !keys.any(|(i, key)| tx.message.is_signer(i) && key == authorized_voter) {
                     return None;
                 }
-                Some((tx, packet_batch))
+                Some((tx, Arc::new(packet_batch)))
             })
             .unzip()
     }
@@ -1451,7 +1451,7 @@ mod tests {
         assert!(packets.is_empty());
     }
 
-    fn verify_packets_len(packets: &[PacketBatch], ref_value: usize) {
+    fn verify_packets_len(packets: &[Arc<PacketBatch>], ref_value: usize) {
         let num_packets: usize = packets.iter().map(|pb| pb.len()).sum();
         assert_eq!(num_packets, ref_value);
     }

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -14,6 +14,7 @@ use {
     },
     solana_perf::{cuda_runtime::PinnedVec, packet::PacketBatch, recycler::Recycler, sigverify},
     solana_sdk::{packet::Packet, saturating_add_assign},
+    std::sync::Arc,
 };
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
@@ -128,7 +129,7 @@ impl SigVerifier for TransactionSigVerifier {
     ) -> Result<(), SigVerifyServiceError<Self::SendType>> {
         let tracer_packet_stats_to_send = std::mem::take(&mut self.tracer_packet_stats);
         self.packet_sender.send(BankingPacketBatch::new((
-            packet_batches,
+            packet_batches.into_iter().map(Arc::new).collect(),
             Some(tracer_packet_stats_to_send),
         )))?;
         Ok(())

--- a/perf/src/discard.rs
+++ b/perf/src/discard.rs
@@ -1,24 +1,27 @@
 use {
-    crate::packet::PacketBatch,
+    crate::mutable_packet_batch::MutablePacketBatch,
     rand::{thread_rng, Rng},
 };
 
 pub fn discard_batches_randomly(
-    batches: &mut Vec<PacketBatch>,
+    batches: &mut Vec<impl MutablePacketBatch>,
     max_packets: usize,
     mut total_packets: usize,
 ) -> usize {
     while total_packets > max_packets {
         let index = thread_rng().gen_range(0..batches.len());
         let removed = batches.swap_remove(index);
-        total_packets = total_packets.saturating_sub(removed.len());
+        total_packets = total_packets.saturating_sub(removed.borrow().len());
     }
     total_packets
 }
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::packet::Packet};
+    use {
+        super::*,
+        crate::packet::{Packet, PacketBatch},
+    };
 
     #[test]
     fn test_batch_discard_random() {

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cuda_runtime;
 pub mod data_budget;
 pub mod deduper;
 pub mod discard;
+pub mod mutable_packet_batch;
 pub mod packet;
 pub mod perf_libs;
 pub mod recycler;

--- a/perf/src/mutable_packet_batch.rs
+++ b/perf/src/mutable_packet_batch.rs
@@ -1,0 +1,20 @@
+use {crate::packet::PacketBatch, core::borrow::Borrow, std::sync::Arc};
+
+/// Helper trait to make it simple to work with:
+/// - `&mut [PacketBatch]` or
+/// - `&mut [Arc<PacketBatch>]`
+pub trait MutablePacketBatch: Borrow<PacketBatch> + Send + Sync {
+    fn as_mut(&mut self) -> &mut PacketBatch;
+}
+
+impl MutablePacketBatch for PacketBatch {
+    fn as_mut(&mut self) -> &mut PacketBatch {
+        self
+    }
+}
+
+impl MutablePacketBatch for Arc<PacketBatch> {
+    fn as_mut(&mut self) -> &mut PacketBatch {
+        Arc::make_mut(self)
+    }
+}

--- a/perf/src/mutable_packet_batch.rs
+++ b/perf/src/mutable_packet_batch.rs
@@ -3,7 +3,7 @@ use {crate::packet::PacketBatch, core::borrow::Borrow, std::sync::Arc};
 /// Helper trait to make it simple to work with:
 /// - `&mut [PacketBatch]` or
 /// - `&mut [Arc<PacketBatch>]`
-pub trait MutablePacketBatch: Borrow<PacketBatch> + Send + Sync {
+pub trait MutablePacketBatch: Borrow<PacketBatch> + Send {
     fn as_mut(&mut self) -> &mut PacketBatch;
 }
 

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -366,17 +366,17 @@ fn recv_send(
 
 pub fn recv_packet_batches(
     recvr: &PacketBatchReceiver,
-) -> Result<(Vec<PacketBatch>, usize, Duration)> {
+) -> Result<(Vec<Arc<PacketBatch>>, usize, Duration)> {
     let recv_start = Instant::now();
     let timer = Duration::new(1, 0);
     let packet_batch = recvr.recv_timeout(timer)?;
     trace!("got packets");
     let mut num_packets = packet_batch.len();
-    let mut packet_batches = vec![packet_batch];
+    let mut packet_batches = vec![Arc::new(packet_batch)];
     while let Ok(packet_batch) = recvr.try_recv() {
         trace!("got more packets");
         num_packets += packet_batch.len();
-        packet_batches.push(packet_batch);
+        packet_batches.push(Arc::new(packet_batch));
     }
     let recv_duration = recv_start.elapsed();
     trace!(


### PR DESCRIPTION
#### Problem
- Currently SigVerify stage passes `Arc<(Vec<PacketBatch>, Option<SigverifyTracerPacketStats>)>` to `banking_trace`/`banking_stage`.
- We want to support zero-copy for new transaction type
- If we `Arc::clone` the current `message` type, the worst-case overhead per packet (assuming only one packet per message is kept) is very large
- Wrapping each `PacketBatch` in an `Arc` reduces this worst-case overhead considerably

#### Summary of Changes
- Wrap each `PacketBatch` in an `Arc` before sending to `BankingStage`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
