### PR TITLE
generic cost_model

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1577,7 +1577,14 @@ mod tests {
                         }
                     };
 
-                let mut cost = CostModel::calculate_cost(&transactions[0], &bank.feature_set);
+                let is_simple_vote_transaction = transactions[0].is_simple_vote_transaction();
+                let signature_count_detail = transactions[0].message().get_signature_details();
+                let mut cost = CostModel::calculate_cost(
+                    &transactions[0],
+                    is_simple_vote_transaction,
+                    &signature_count_detail,
+                    &bank.feature_set,
+                );
                 if let TransactionCost::Transaction(ref mut usage_cost) = cost {
                     usage_cost.programs_execution_cost = actual_programs_execution_cost;
                     usage_cost.loaded_accounts_data_size_cost =

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -637,7 +637,16 @@ impl<T: LikeClusterInfo> SchedulerController<T> {
         fee_budget_limits: &FeeBudgetLimits,
         bank: &Bank,
     ) -> (u64, u64) {
-        let cost = CostModel::calculate_cost(transaction, &bank.feature_set).sum();
+        let is_simple_vote_tx = transaction.is_simple_vote_transaction();
+        let signature_count_detail = transaction.message().get_signature_details();
+
+        let cost = CostModel::calculate_cost(
+            transaction,
+            is_simple_vote_tx,
+            &signature_count_detail,
+            &bank.feature_set,
+        )
+        .sum();
         let reward = bank.calculate_reward_for_transaction(transaction, fee_budget_limits);
 
         // We need a multiplier here to avoid rounding down too aggressively.

--- a/cost-model/benches/cost_model.rs
+++ b/cost-model/benches/cost_model.rs
@@ -53,7 +53,15 @@ fn bench_cost_model(bencher: &mut Bencher) {
 
     bencher.iter(|| {
         for transaction in &transactions {
-            let _ = CostModel::calculate_cost(test::black_box(transaction), &feature_set);
+            let transaction = test::black_box(transaction);
+            let is_simple_vote_transaction = transaction.is_simple_vote_transaction();
+            let signature_count_detail = transaction.message().get_signature_details();
+            let _ = CostModel::calculate_cost(
+                transaction,
+                is_simple_vote_transaction,
+                &signature_count_detail,
+                &feature_set,
+            );
         }
     });
 }
@@ -71,7 +79,15 @@ fn bench_cost_model_requested_write_locks(bencher: &mut Bencher) {
 
     bencher.iter(|| {
         for transaction in &transactions {
-            let _ = CostModel::calculate_cost(test::black_box(transaction), &feature_set);
+            let transaction = test::black_box(transaction);
+            let is_simple_vote_transaction = transaction.is_simple_vote_transaction();
+            let signature_count_detail = transaction.message().get_signature_details();
+            let _ = CostModel::calculate_cost(
+                transaction,
+                is_simple_vote_transaction,
+                &signature_count_detail,
+                &feature_set,
+            );
         }
     });
 }

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -19,6 +19,7 @@ use {
         compute_budget::{self, ComputeBudgetInstruction},
         fee::FeeStructure,
         instruction::CompiledInstruction,
+        message::TransactionSignatureDetails,
         program_utils::limited_deserialize,
         pubkey::Pubkey,
         saturating_add_assign,
@@ -53,7 +54,11 @@ impl CostModel {
         } else {
             let mut tx_cost = UsageCostDetails::new_with_default_capacity();
 
-            Self::get_signature_cost(&mut tx_cost, transaction, feature_set);
+            Self::get_signature_cost(
+                &mut tx_cost,
+                &transaction.message().get_signature_details(),
+                feature_set,
+            );
             Self::get_write_lock_cost(&mut tx_cost, transaction, feature_set);
             Self::get_transaction_cost(&mut tx_cost, transaction, feature_set);
             tx_cost.allocated_accounts_data_size =
@@ -79,7 +84,11 @@ impl CostModel {
         } else {
             let mut tx_cost = UsageCostDetails::new_with_default_capacity();
 
-            Self::get_signature_cost(&mut tx_cost, transaction, feature_set);
+            Self::get_signature_cost(
+                &mut tx_cost,
+                &transaction.message().get_signature_details(),
+                feature_set,
+            );
             Self::get_write_lock_cost(&mut tx_cost, transaction, feature_set);
             Self::get_instructions_data_cost(&mut tx_cost, transaction);
             tx_cost.allocated_accounts_data_size =
@@ -97,10 +106,9 @@ impl CostModel {
 
     fn get_signature_cost(
         tx_cost: &mut UsageCostDetails,
-        transaction: &SanitizedTransaction,
+        signatures_count_detail: &TransactionSignatureDetails,
         feature_set: &FeatureSet,
     ) {
-        let signatures_count_detail = transaction.message().get_signature_details();
         tx_cost.num_transaction_signatures = signatures_count_detail.num_transaction_signatures();
         tx_cost.num_secp256k1_instruction_signatures =
             signatures_count_detail.num_secp256k1_instruction_signatures();

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -231,14 +231,9 @@ impl CostModel {
         tx_cost.data_bytes_cost = data_bytes_len_total / INSTRUCTION_DATA_BYTES_COST;
     }
 
-    fn get_instructions_data_cost(
-        tx_cost: &mut UsageCostDetails,
-        transaction: &SanitizedTransaction,
-    ) {
+    fn get_instructions_data_cost(tx_cost: &mut UsageCostDetails, transaction: &impl SVMMessage) {
         let ix_data_bytes_len_total: u64 = transaction
-            .message()
-            .instructions()
-            .iter()
+            .instructions_iter()
             .map(|instruction| instruction.data.len() as u64)
             .sum();
 

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -129,8 +129,7 @@ impl CostModel {
             );
     }
 
-    fn get_writable_accounts(transaction: &SanitizedTransaction) -> Vec<Pubkey> {
-        let message = transaction.message();
+    fn get_writable_accounts(message: &impl SVMMessage) -> Vec<Pubkey> {
         message
             .account_keys()
             .iter()

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -154,13 +154,13 @@ impl CostModel {
 
     fn get_write_lock_cost(
         tx_cost: &mut UsageCostDetails,
-        transaction: &SanitizedTransaction,
+        transaction: &impl SVMMessage,
         feature_set: &FeatureSet,
     ) {
         tx_cost.writable_accounts = Self::get_writable_accounts(transaction);
         let num_write_locks =
             if feature_set.is_active(&feature_set::cost_model_requested_write_lock_cost::id()) {
-                transaction.message().num_write_locks()
+                transaction.num_write_locks()
             } else {
                 tx_cost.writable_accounts.len() as u64
             };

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -236,7 +236,7 @@ mod tests {
         .unwrap();
 
         // create a identical sanitized transaction, but identified as non-vote
-        let none_vote_transaction = SanitizedTransaction::try_create(
+        let non_vote_transaction = SanitizedTransaction::try_create(
             VersionedTransaction::from(transaction),
             MessageHash::Compute,
             Some(false),
@@ -250,11 +250,20 @@ mod tests {
         // expected non-vote tx cost would include default loaded accounts size cost (16384) additionally
         let expected_none_vote_cost = 20543;
 
-        let vote_cost = CostModel::calculate_cost(&vote_transaction, &FeatureSet::all_enabled());
-        let none_vote_cost =
-            CostModel::calculate_cost(&none_vote_transaction, &FeatureSet::all_enabled());
+        let vote_cost = CostModel::calculate_cost(
+            &vote_transaction,
+            vote_transaction.is_simple_vote_transaction(),
+            &vote_transaction.message().get_signature_details(),
+            &FeatureSet::all_enabled(),
+        );
+        let non_vote_cost = CostModel::calculate_cost(
+            &non_vote_transaction,
+            non_vote_transaction.is_simple_vote_transaction(),
+            &non_vote_transaction.message().get_signature_details(),
+            &FeatureSet::all_enabled(),
+        );
 
         assert_eq!(expected_vote_cost, vote_cost.sum());
-        assert_eq!(expected_none_vote_cost, none_vote_cost.sum());
+        assert_eq!(expected_none_vote_cost, non_vote_cost.sum());
     }
 }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -487,7 +487,14 @@ fn compute_slot_cost(
             .for_each(|transaction| {
                 num_programs += transaction.message().instructions().len();
 
-                let tx_cost = CostModel::calculate_cost(&transaction, &feature_set);
+                let is_simple_vote_transaction = transaction.is_simple_vote_transaction();
+                let signature_count_detail = transaction.message().get_signature_details();
+                let tx_cost = CostModel::calculate_cost(
+                    &transaction,
+                    is_simple_vote_transaction,
+                    &signature_count_detail,
+                    &feature_set,
+                );
                 let result = cost_tracker.try_add(&tx_cost);
                 if result.is_err() {
                     println!(


### PR DESCRIPTION
#### Problem
- need cost-model to be generic over transaction type so we can use more efficient transaction type

#### Summary of Changes
- pass in `is_simple_vote_transaction` and `TransactionSignatureDetails` to `calculate_cost`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
