### PR TITLE
TransactionBatch - hold RuntimeTransaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-rpc",
  "solana-runtime",
+ "solana-runtime-transaction",
  "solana-sdk",
  "solana-stake-program",
  "solana-storage-bigtable",
@@ -5928,6 +5929,7 @@ dependencies = [
  "solana-client",
  "solana-feature-set",
  "solana-runtime",
+ "solana-runtime-transaction",
  "solana-sdk",
  "solana-send-transaction-service",
  "solana-svm",
@@ -6672,6 +6674,7 @@ dependencies = [
  "solana-metrics",
  "solana-perf",
  "solana-rayon-threadlimit",
+ "solana-runtime-transaction",
  "solana-sdk",
 ]
 
@@ -7045,6 +7048,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime",
+ "solana-runtime-transaction",
  "solana-sdk",
  "solana-stake-program",
  "solana-storage-bigtable",
@@ -7748,6 +7752,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-rpc-client-api",
  "solana-runtime",
+ "solana-runtime-transaction",
  "solana-sdk",
  "solana-send-transaction-service",
  "solana-stake-program",
@@ -8787,6 +8792,7 @@ name = "solana-unified-scheduler-logic"
 version = "2.2.0"
 dependencies = [
  "assert_matches",
+ "solana-runtime-transaction",
  "solana-sdk",
  "static_assertions",
 ]
@@ -8806,6 +8812,7 @@ dependencies = [
  "solana-ledger",
  "solana-logger",
  "solana-runtime",
+ "solana-runtime-transaction",
  "solana-sdk",
  "solana-timings",
  "solana-unified-scheduler-logic",

--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -17,6 +17,7 @@ solana-banks-interface = { workspace = true }
 solana-client = { workspace = true }
 solana-feature-set = { workspace = true }
 solana-runtime = { workspace = true }
+solana-runtime-transaction = { workspace = true }
 solana-sdk = { workspace = true }
 solana-send-transaction-service = { workspace = true }
 solana-svm = { workspace = true }

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -181,7 +181,7 @@ fn simulate_transaction(
 ) -> BanksTransactionResultWithSimulation {
     let sanitized_transaction = match RuntimeTransaction::try_create(
         transaction,
-        None,        // message_hash
+        MessageHash::Compute,
         Some(false), // is_simple_vote_tx
         bank,
         bank.get_reserved_account_keys(),

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -15,6 +15,7 @@ use {
         commitment::BlockCommitmentCache,
         verify_precompiles::verify_precompiles,
     },
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         account::Account,
         clock::Slot,
@@ -178,9 +179,9 @@ fn simulate_transaction(
     bank: &Bank,
     transaction: VersionedTransaction,
 ) -> BanksTransactionResultWithSimulation {
-    let sanitized_transaction = match SanitizedTransaction::try_create(
+    let sanitized_transaction = match RuntimeTransaction::try_create(
         transaction,
-        MessageHash::Compute,
+        None,        // message_hash
         Some(false), // is_simple_vote_tx
         bank,
         bank.get_reserved_account_keys(),

--- a/core/benches/consumer.rs
+++ b/core/benches/consumer.rs
@@ -20,6 +20,7 @@ use {
         poh_service::PohService,
     },
     solana_runtime::{bank::Bank, bank_forks::BankForks},
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         account::{Account, ReadableAccount},
         signature::Keypair,
@@ -66,7 +67,7 @@ fn create_funded_accounts(bank: &Bank, num: usize) -> Vec<Keypair> {
     accounts
 }
 
-fn create_transactions(bank: &Bank, num: usize) -> Vec<SanitizedTransaction> {
+fn create_transactions(bank: &Bank, num: usize) -> Vec<RuntimeTransaction<SanitizedTransaction>> {
     let funded_accounts = create_funded_accounts(bank, 2 * num);
     funded_accounts
         .into_par_iter()
@@ -76,7 +77,7 @@ fn create_transactions(bank: &Bank, num: usize) -> Vec<SanitizedTransaction> {
             let to = &chunk[1];
             system_transaction::transfer(from, &to.pubkey(), 1, bank.last_blockhash())
         })
-        .map(SanitizedTransaction::from_transaction_for_tests)
+        .map(RuntimeTransaction::from_transaction_for_tests)
         .collect()
 }
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -841,6 +841,7 @@ mod tests {
             poh_service::PohService,
         },
         solana_runtime::{bank::Bank, genesis_utils::bootstrap_validator_stake_lamports},
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk::{
             hash::Hash,
             poh_config::PohConfig,
@@ -867,9 +868,11 @@ mod tests {
         (node, cluster_info)
     }
 
-    pub(crate) fn sanitize_transactions(txs: Vec<Transaction>) -> Vec<SanitizedTransaction> {
+    pub(crate) fn sanitize_transactions(
+        txs: Vec<Transaction>,
+    ) -> Vec<RuntimeTransaction<SanitizedTransaction>> {
         txs.into_iter()
-            .map(SanitizedTransaction::from_transaction_for_tests)
+            .map(RuntimeTransaction::from_transaction_for_tests)
             .collect()
     }
 

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -12,6 +12,7 @@ use {
         transaction_batch::TransactionBatch,
         vote_sender_types::ReplayVoteSender,
     },
+    solana_runtime_transaction::svm_transaction_adapter::SVMTransactionAdapter,
     solana_sdk::{pubkey::Pubkey, saturating_add_assign, transaction::SanitizedTransaction},
     solana_svm::{
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
@@ -22,7 +23,7 @@ use {
     solana_transaction_status::{
         token_balances::TransactionTokenBalancesSet, TransactionTokenBalance,
     },
-    std::{collections::HashMap, ops::Deref, sync::Arc},
+    std::{borrow::Borrow, collections::HashMap, sync::Arc},
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -139,7 +140,7 @@ impl Committer {
             let txs = batch
                 .sanitized_transactions()
                 .iter()
-                .map(|tx| tx.deref().clone())
+                .map(|tx| tx.as_sanitized_transaction().borrow().clone())
                 .collect_vec();
             let post_balances = bank.collect_balances(batch);
             let post_token_balances =

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -724,6 +724,7 @@ mod tests {
             tests::{create_slow_genesis_config, sanitize_transactions, simulate_poh},
         },
         crossbeam_channel::unbounded,
+        itertools::Itertools,
         solana_ledger::{
             blockstore::Blockstore, genesis_utils::GenesisConfigInfo,
             get_tmp_ledger_path_auto_delete, leader_schedule_cache::LeaderScheduleCache,
@@ -733,9 +734,10 @@ mod tests {
             bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
             vote_sender_types::ReplayVoteReceiver,
         },
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk::{
             address_lookup_table::AddressLookupTableAccount,
-            clock::{Slot, MAX_PROCESSING_AGE},
+            clock::Slot,
             genesis_config::GenesisConfig,
             message::{
                 v0::{self, LoadedAddresses},
@@ -746,9 +748,7 @@ mod tests {
             signature::Keypair,
             signer::Signer,
             system_instruction, system_transaction,
-            transaction::{
-                MessageHash, SanitizedTransaction, TransactionError, VersionedTransaction,
-            },
+            transaction::VersionedTransaction,
         },
         solana_svm_transaction::svm_message::SVMMessage,
         std::{
@@ -1101,7 +1101,7 @@ mod tests {
                 readonly: vec![],
             };
             let loader = SimpleAddressLoader::Enabled(loaded_addresses);
-            SanitizedTransaction::try_create(
+            RuntimeTransaction::try_create(
                 VersionedTransaction::try_new(
                     VersionedMessage::V0(
                         v0::Message::try_compile(
@@ -1118,7 +1118,7 @@ mod tests {
                     &[&payer],
                 )
                 .unwrap(),
-                MessageHash::Compute,
+                None,
                 None,
                 loader,
                 &HashSet::default(),
@@ -1134,7 +1134,8 @@ mod tests {
         txs.push(simple_v0_transfer());
         txs.push(simple_v0_transfer());
         txs.push(simple_v0_transfer());
-        let sanitized_txs = txs.clone();
+
+        let signatures = txs.iter().map(|tx| *tx.signature()).collect::<Vec<_>>();
 
         // Fund the keypairs.
         for tx in &txs {
@@ -1193,30 +1194,11 @@ mod tests {
         // all but one succeed. 6 for initial funding
         assert_eq!(bank.transaction_count(), 6 + 5);
 
-        let already_processed_results = bank
-            .check_transactions(
-                &sanitized_txs,
-                &vec![Ok(()); sanitized_txs.len()],
-                MAX_PROCESSING_AGE,
-                &mut TransactionErrorMetrics::default(),
-            )
-            .into_iter()
-            .map(|r| match r {
-                Ok(_) => Ok(()),
-                Err(err) => Err(err),
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(
-            already_processed_results,
-            vec![
-                Err(TransactionError::AlreadyProcessed),
-                Err(TransactionError::AlreadyProcessed),
-                Err(TransactionError::AlreadyProcessed),
-                Ok(()), // <--- this transaction was not processed
-                Err(TransactionError::AlreadyProcessed),
-                Err(TransactionError::AlreadyProcessed)
-            ]
-        );
+        let is_processed = signatures
+            .iter()
+            .map(|signature| bank.get_signature_status(signature).is_some())
+            .collect_vec();
+        assert_eq!(is_processed, [true, true, true, false, true, true]);
 
         drop(test_frame);
         let _ = worker_thread.join().unwrap();

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -748,7 +748,7 @@ mod tests {
             signature::Keypair,
             signer::Signer,
             system_instruction, system_transaction,
-            transaction::VersionedTransaction,
+            transaction::{MessageHash, VersionedTransaction},
         },
         solana_svm_transaction::svm_message::SVMMessage,
         std::{
@@ -1118,7 +1118,7 @@ mod tests {
                     &[&payer],
                 )
                 .unwrap(),
-                None,
+                MessageHash::Compute,
                 None,
                 loader,
                 &HashSet::default(),

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -24,7 +24,10 @@ use {
         transaction_batch::TransactionBatch,
         verify_precompiles::verify_precompiles,
     },
-    solana_runtime_transaction::instructions_processor::process_compute_budget_instructions,
+    solana_runtime_transaction::{
+        instructions_processor::process_compute_budget_instructions,
+        runtime_transaction::RuntimeTransaction,
+    },
     solana_sdk::{
         clock::{FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, MAX_PROCESSING_AGE},
         fee::FeeBudgetLimits,
@@ -228,7 +231,7 @@ impl Consumer {
         &self,
         bank: &Arc<Bank>,
         bank_creation_time: &Instant,
-        sanitized_transactions: &[SanitizedTransaction],
+        sanitized_transactions: &[RuntimeTransaction<SanitizedTransaction>],
         banking_stage_stats: &BankingStageStats,
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
     ) -> ProcessTransactionsSummary {
@@ -284,7 +287,7 @@ impl Consumer {
         &self,
         bank: &Arc<Bank>,
         bank_creation_time: &Instant,
-        transactions: &[SanitizedTransaction],
+        transactions: &[RuntimeTransaction<SanitizedTransaction>],
     ) -> ProcessTransactionsSummary {
         let mut chunk_start = 0;
         let mut all_retryable_tx_indexes = vec![];
@@ -386,7 +389,7 @@ impl Consumer {
     pub fn process_and_record_transactions(
         &self,
         bank: &Arc<Bank>,
-        txs: &[SanitizedTransaction],
+        txs: &[RuntimeTransaction<SanitizedTransaction>],
         chunk_offset: usize,
     ) -> ProcessTransactionBatchOutput {
         let mut error_counters = TransactionErrorMetrics::default();
@@ -429,7 +432,7 @@ impl Consumer {
     pub fn process_and_record_aged_transactions(
         &self,
         bank: &Arc<Bank>,
-        txs: &[SanitizedTransaction],
+        txs: &[RuntimeTransaction<SanitizedTransaction>],
         max_ages: &[MaxAge],
     ) -> ProcessTransactionBatchOutput {
         let move_precompile_verification_to_svm = bank
@@ -473,7 +476,7 @@ impl Consumer {
     fn process_and_record_transactions_with_pre_results(
         &self,
         bank: &Arc<Bank>,
-        txs: &[SanitizedTransaction],
+        txs: &[RuntimeTransaction<SanitizedTransaction>],
         chunk_offset: usize,
         pre_results: impl Iterator<Item = Result<(), TransactionError>>,
     ) -> ProcessTransactionBatchOutput {
@@ -803,7 +806,7 @@ impl Consumer {
     /// * `pending_indexes` - identifies which indexes in the `transactions` list are still pending
     fn filter_pending_packets_from_pending_txs(
         bank: &Bank,
-        transactions: &[SanitizedTransaction],
+        transactions: &[RuntimeTransaction<SanitizedTransaction>],
         pending_indexes: &[usize],
     ) -> Vec<usize> {
         let filter =
@@ -887,7 +890,7 @@ mod tests {
             signature::Keypair,
             signer::Signer,
             system_instruction, system_program, system_transaction,
-            transaction::{MessageHash, Transaction, VersionedTransaction},
+            transaction::{Transaction, VersionedTransaction},
         },
         solana_svm::account_loader::CheckedTransactionDetails,
         solana_timings::ProgramTiming,
@@ -2059,14 +2062,15 @@ mod tests {
         });
 
         let tx = VersionedTransaction::try_new(message, &[&keypair]).unwrap();
-        let sanitized_tx = SanitizedTransaction::try_create(
+        let sanitized_tx = RuntimeTransaction::try_create(
             tx.clone(),
-            MessageHash::Compute,
+            None,
             Some(false),
             bank.as_ref(),
             &ReservedAccountKeys::empty_key_set(),
         )
         .unwrap();
+        let loaded_addresses = sanitized_tx.get_loaded_addresses();
 
         let entry = next_versioned_entry(&genesis_config.hash(), 1, vec![tx]);
         let entries = vec![entry];
@@ -2131,7 +2135,7 @@ mod tests {
             );
             let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-            let _ = consumer.process_and_record_transactions(&bank, &[sanitized_tx.clone()], 0);
+            let _ = consumer.process_and_record_transactions(&bank, &[sanitized_tx], 0);
 
             drop(consumer); // drop/disconnect transaction_status_sender
             transaction_status_service.join().unwrap();
@@ -2149,7 +2153,7 @@ mod tests {
                     pre_token_balances: Some(vec![]),
                     post_token_balances: Some(vec![]),
                     rewards: Some(vec![]),
-                    loaded_addresses: sanitized_tx.get_loaded_addresses(),
+                    loaded_addresses,
                     compute_units_consumed: Some(0),
                     ..TransactionStatusMeta::default()
                 }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -2071,7 +2071,6 @@ mod tests {
             &ReservedAccountKeys::empty_key_set(),
         )
         .unwrap();
-        let loaded_addresses = sanitized_tx.get_loaded_addresses();
 
         let entry = next_versioned_entry(&genesis_config.hash(), 1, vec![tx]);
         let entries = vec![entry];
@@ -2136,7 +2135,7 @@ mod tests {
             );
             let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-            let _ = consumer.process_and_record_transactions(&bank, &[sanitized_tx], 0);
+            let _ = consumer.process_and_record_transactions(&bank, &[sanitized_tx.clone()], 0);
 
             drop(consumer); // drop/disconnect transaction_status_sender
             transaction_status_service.join().unwrap();
@@ -2154,7 +2153,7 @@ mod tests {
                     pre_token_balances: Some(vec![]),
                     post_token_balances: Some(vec![]),
                     rewards: Some(vec![]),
-                    loaded_addresses,
+                    loaded_addresses: sanitized_tx.get_loaded_addresses(),
                     compute_units_consumed: Some(0),
                     ..TransactionStatusMeta::default()
                 }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -905,6 +905,7 @@ mod tests {
             thread::{Builder, JoinHandle},
             time::Duration,
         },
+        transaction::MessageHash,
     };
 
     fn execute_transactions_with_dummy_poh_service(
@@ -2064,7 +2065,7 @@ mod tests {
         let tx = VersionedTransaction::try_new(message, &[&keypair]).unwrap();
         let sanitized_tx = RuntimeTransaction::try_create(
             tx.clone(),
-            None,
+            MessageHash::Compute,
             Some(false),
             bank.as_ref(),
             &ReservedAccountKeys::empty_key_set(),

--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -19,8 +19,10 @@ use {
     solana_perf::{data_budget::DataBudget, packet::Packet},
     solana_poh::poh_recorder::PohRecorder,
     solana_runtime::bank_forks::BankForks,
-    solana_sdk::{pubkey::Pubkey, transaction::SanitizedTransaction, transport::TransportError},
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_sdk::{pubkey::Pubkey, transport::TransportError},
     solana_streamer::sendmmsg::batch_send,
+    solana_svm_transaction::svm_message::SVMMessage,
     std::{
         iter::repeat,
         net::{SocketAddr, UdpSocket},
@@ -64,7 +66,7 @@ impl<T: LikeClusterInfo> Forwarder<T> {
 
     pub fn try_add_packet(
         &mut self,
-        sanitized_transaction: &SanitizedTransaction,
+        sanitized_transaction: &RuntimeTransaction<impl SVMMessage>,
         immutable_packet: Arc<ImmutableDeserializedPacket>,
         feature_set: &FeatureSet,
     ) -> bool {

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -14,7 +14,9 @@ use {
         message::{v0::LoadedAddresses, AddressLoaderError, Message, SimpleAddressLoader},
         pubkey::Pubkey,
         signature::Signature,
-        transaction::{SanitizedTransaction, SanitizedVersionedTransaction, VersionedTransaction},
+        transaction::{
+            MessageHash, SanitizedTransaction, SanitizedVersionedTransaction, VersionedTransaction,
+        },
     },
     solana_short_vec::decode_shortu16_len,
     solana_svm_transaction::{
@@ -132,7 +134,7 @@ impl ImmutableDeserializedPacket {
         let address_loader = SimpleAddressLoader::Enabled(loaded_addresses);
         let tx = RuntimeTransaction::<SanitizedVersionedTransaction>::try_from(
             self.transaction.clone(),
-            Some(self.message_hash),
+            MessageHash::Precomputed(self.message_hash),
             Some(self.is_simple_vote),
         )
         .and_then(|tx| {

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -11,6 +11,7 @@ use {
     solana_feature_set::FeatureSet,
     solana_measure::measure::Measure,
     solana_runtime::bank::Bank,
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         clock::Slot,
         saturating_add_assign,
@@ -43,7 +44,7 @@ impl QosService {
     pub fn select_and_accumulate_transaction_costs<'a>(
         &self,
         bank: &Bank,
-        transactions: &'a [SanitizedTransaction],
+        transactions: &'a [RuntimeTransaction<SanitizedTransaction>],
         pre_results: impl Iterator<Item = transaction::Result<()>>,
     ) -> (
         Vec<transaction::Result<TransactionCost<'a, SanitizedTransaction>>>,
@@ -73,7 +74,7 @@ impl QosService {
     fn compute_transaction_costs<'a>(
         &self,
         feature_set: &FeatureSet,
-        transactions: impl Iterator<Item = &'a SanitizedTransaction>,
+        transactions: impl Iterator<Item = &'a RuntimeTransaction<SanitizedTransaction>>,
         pre_results: impl Iterator<Item = transaction::Result<()>>,
     ) -> Vec<transaction::Result<TransactionCost<'a, SanitizedTransaction>>> {
         let mut compute_cost_time = Measure::start("compute_cost_time");
@@ -98,7 +99,7 @@ impl QosService {
     /// and a count of the number of transactions that would fit in the block
     fn select_transactions_per_cost<'a>(
         &self,
-        transactions: impl Iterator<Item = &'a SanitizedTransaction>,
+        transactions: impl Iterator<Item = &'a RuntimeTransaction<SanitizedTransaction>>,
         transactions_costs: impl Iterator<
             Item = transaction::Result<TransactionCost<'a, SanitizedTransaction>>,
         >,
@@ -628,7 +629,6 @@ mod tests {
         solana_runtime::genesis_utils::{create_genesis_config, GenesisConfigInfo},
         solana_sdk::{
             hash::Hash,
-            message::TransactionSignatureDetails,
             signature::{Keypair, Signer},
             system_transaction,
         },
@@ -642,20 +642,27 @@ mod tests {
 
         // make a vec of txs
         let keypair = Keypair::new();
-        let transfer_tx = SanitizedTransaction::from_transaction_for_tests(
-            system_transaction::transfer(&keypair, &keypair.pubkey(), 1, Hash::default()),
-        );
-        let vote_tx = SanitizedTransaction::from_transaction_for_tests(
-            vote_transaction::new_tower_sync_transaction(
-                TowerSync::from(vec![(42, 1)]),
+        let transfer_tx = || {
+            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+                &keypair,
+                &keypair.pubkey(),
+                1,
                 Hash::default(),
-                &keypair,
-                &keypair,
-                &keypair,
-                None,
-            ),
-        );
-        let txs = vec![transfer_tx.clone(), vote_tx.clone(), vote_tx, transfer_tx];
+            ))
+        };
+        let vote_tx = || {
+            RuntimeTransaction::from_transaction_for_tests(
+                vote_transaction::new_tower_sync_transaction(
+                    TowerSync::from(vec![(42, 1)]),
+                    Hash::default(),
+                    &keypair,
+                    &keypair,
+                    &keypair,
+                    None,
+                ),
+            )
+        };
+        let txs = vec![transfer_tx(), vote_tx(), vote_tx(), transfer_tx()];
 
         let qos_service = QosService::new(1);
         let txs_costs = qos_service.compute_transaction_costs(
@@ -685,25 +692,30 @@ mod tests {
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let keypair = Keypair::new();
-        let transfer_tx = SanitizedTransaction::from_transaction_for_tests(
-            system_transaction::transfer(&keypair, &keypair.pubkey(), 1, Hash::default()),
-        );
-        let vote_tx = SanitizedTransaction::from_transaction_for_tests(
-            vote_transaction::new_tower_sync_transaction(
-                TowerSync::from(vec![(42, 1)]),
+        let transfer_tx = || {
+            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+                &keypair,
+                &keypair.pubkey(),
+                1,
                 Hash::default(),
-                &keypair,
-                &keypair,
-                &keypair,
-                None,
-            ),
-        );
-        let transfer_tx_cost =
-            CostModel::calculate_cost(&transfer_tx, &FeatureSet::all_enabled()).sum();
-        let vote_tx_cost = CostModel::calculate_cost(&vote_tx, &FeatureSet::all_enabled()).sum();
-
+            ))
+        };
+        let vote_tx = || {
+            RuntimeTransaction::from_transaction_for_tests(
+                vote_transaction::new_tower_sync_transaction(
+                    TowerSync::from(vec![(42, 1)]),
+                    Hash::default(),
+                    &keypair,
+                    &keypair,
+                    &keypair,
+                    None,
+                ),
+            )
+        };
         // make a vec of txs
-        let txs = vec![transfer_tx.clone(), vote_tx.clone(), transfer_tx, vote_tx];
+        let txs = vec![transfer_tx(), vote_tx(), transfer_tx(), vote_tx()];
+        let transfer_tx_cost = CostModel::calculate_cost(&txs[0], &FeatureSet::all_enabled()).sum();
+        let vote_tx_cost = CostModel::calculate_cost(&txs[1], &FeatureSet::all_enabled()).sum();
 
         let qos_service = QosService::new(1);
         let txs_costs = qos_service.compute_transaction_costs(
@@ -747,9 +759,8 @@ mod tests {
             ],
             Some(&keypair.pubkey()),
         ));
-        let transfer_tx = SanitizedTransaction::from_transaction_for_tests(transaction.clone());
-        let txs: Vec<SanitizedTransaction> = (0..transaction_count)
-            .map(|_| transfer_tx.clone())
+        let txs: Vec<_> = (0..transaction_count)
+            .map(|_| RuntimeTransaction::from_transaction_for_tests(transaction.clone()))
             .collect();
         let execute_units_adjustment: u64 = 10;
         let loaded_accounts_data_size_adjustment: u32 = 32000;
@@ -817,11 +828,15 @@ mod tests {
         // calculate their costs, apply to cost_tracker
         let transaction_count = 5;
         let keypair = Keypair::new();
-        let transfer_tx = SanitizedTransaction::from_transaction_for_tests(
-            system_transaction::transfer(&keypair, &keypair.pubkey(), 1, Hash::default()),
-        );
-        let txs: Vec<SanitizedTransaction> = (0..transaction_count)
-            .map(|_| transfer_tx.clone())
+        let txs: Vec<_> = (0..transaction_count)
+            .map(|_| {
+                RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+                    &keypair,
+                    &keypair.pubkey(),
+                    1,
+                    Hash::default(),
+                ))
+            })
             .collect();
 
         // assert all tx_costs should be removed from cost_tracker if all execution_results are all Not Committed
@@ -867,9 +882,8 @@ mod tests {
             ],
             Some(&keypair.pubkey()),
         ));
-        let transfer_tx = SanitizedTransaction::from_transaction_for_tests(transaction.clone());
-        let txs: Vec<SanitizedTransaction> = (0..transaction_count)
-            .map(|_| transfer_tx.clone())
+        let txs: Vec<_> = (0..transaction_count)
+            .map(|_| RuntimeTransaction::from_transaction_for_tests(transaction.clone()))
             .collect();
         let execute_units_adjustment: u64 = 10;
         let loaded_accounts_data_size_adjustment: u32 = 32000;
@@ -951,7 +965,7 @@ mod tests {
         let programs_execution_cost = 10;
         let num_txs = 4;
 
-        let dummy_transaction = WritableKeysTransaction(vec![]);
+        let dummy_transaction = RuntimeTransaction::new_for_tests(WritableKeysTransaction(vec![]));
         let tx_cost_results: Vec<_> = (0..num_txs)
             .map(|n| {
                 if n % 2 == 0 {
@@ -963,7 +977,6 @@ mod tests {
                         programs_execution_cost,
                         loaded_accounts_data_size_cost: 0,
                         allocated_accounts_data_size: 0,
-                        signature_details: TransactionSignatureDetails::new(0, 0, 0),
                     }))
                 } else {
                     Err(TransactionError::WouldExceedMaxBlockCostLimit)

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -1,4 +1,5 @@
 use {
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{clock::Slot, transaction::SanitizedTransaction},
     std::fmt::Display,
 };
@@ -46,7 +47,7 @@ pub struct MaxAge {
 pub struct ConsumeWork {
     pub batch_id: TransactionBatchId,
     pub ids: Vec<TransactionId>,
-    pub transactions: Vec<SanitizedTransaction>,
+    pub transactions: Vec<RuntimeTransaction<SanitizedTransaction>>,
     pub max_ages: Vec<MaxAge>,
 }
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -28,7 +28,10 @@ use {
     solana_cost_model::cost_model::CostModel,
     solana_measure::measure_us,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
-    solana_runtime_transaction::instructions_processor::process_compute_budget_instructions,
+    solana_runtime_transaction::{
+        instructions_processor::process_compute_budget_instructions,
+        runtime_transaction::RuntimeTransaction,
+    },
     solana_sdk::{
         self,
         address_lookup_table::state::estimate_last_valid_slot,
@@ -223,7 +226,7 @@ impl<T: LikeClusterInfo> SchedulerController<T> {
     }
 
     fn pre_graph_filter(
-        transactions: &[&SanitizedTransaction],
+        transactions: &[&RuntimeTransaction<SanitizedTransaction>],
         results: &mut [bool],
         bank: &Bank,
         max_age: usize,
@@ -661,7 +664,7 @@ impl<T: LikeClusterInfo> SchedulerController<T> {
     /// Any difference in the prioritization is negligible for
     /// the current transaction costs.
     fn calculate_priority_and_cost(
-        transaction: &SanitizedTransaction,
+        transaction: &RuntimeTransaction<SanitizedTransaction>,
         fee_budget_limits: &FeeBudgetLimits,
         bank: &Bank,
     ) -> (u64, u64) {

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -274,9 +274,16 @@ mod tests {
     #[should_panic(expected = "already unprocessed")]
     fn test_transition_to_unprocessed_panic() {
         let mut transaction_state = create_transaction_state(0);
-        let mut other_state = create_transaction_state(1);
 
-        let transaction_ttl = other_state.transition_to_pending();
+        // Manually clone `SanitizedTransactionTTL`
+        let SanitizedTransactionTTL {
+            transaction,
+            max_age,
+        } = transaction_state.transaction_ttl();
+        let transaction_ttl = SanitizedTransactionTTL {
+            transaction: transaction.clone(),
+            max_age: *max_age,
+        };
         transaction_state.transition_to_unprocessed(transaction_ttl); // invalid transition
     }
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -154,16 +154,11 @@ mod tests {
     use {
         super::*,
         crate::banking_stage::scheduler_messages::MaxAge,
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk::{
-            compute_budget::ComputeBudgetInstruction,
-            hash::Hash,
-            message::Message,
-            packet::Packet,
-            signature::Keypair,
-            signer::Signer,
-            slot_history::Slot,
-            system_instruction,
-            transaction::{SanitizedTransaction, Transaction},
+            compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message, packet::Packet,
+            signature::Keypair, signer::Signer, slot_history::Slot, system_instruction,
+            transaction::Transaction,
         },
     };
 
@@ -186,7 +181,7 @@ mod tests {
             ComputeBudgetInstruction::set_compute_unit_price(priority),
         ];
         let message = Message::new(&ixs, Some(&from_keypair.pubkey()));
-        let tx = SanitizedTransaction::from_transaction_for_tests(Transaction::new(
+        let tx = RuntimeTransaction::from_transaction_for_tests(Transaction::new(
             &[&from_keypair],
             message,
             Hash::default(),

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -19,6 +19,7 @@ use {
         accounts_background_service::AbsRequestSender, bank::Bank, bank_forks::BankForks,
         genesis_utils::GenesisConfigInfo, prioritization_fee_cache::PrioritizationFeeCache,
     },
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         hash::Hash,
         pubkey::Pubkey,
@@ -48,7 +49,7 @@ fn test_scheduler_waited_by_drop_bank_service() {
             result: &mut Result<()>,
             timings: &mut ExecuteTimings,
             bank: &Arc<Bank>,
-            transaction: &SanitizedTransaction,
+            transaction: &RuntimeTransaction<SanitizedTransaction>,
             index: usize,
             handler_context: &HandlerContext,
         ) {
@@ -97,7 +98,7 @@ fn test_scheduler_waited_by_drop_bank_service() {
     let root_hash = root_bank.hash();
     bank_forks.write().unwrap().insert(root_bank);
 
-    let tx = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+    let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
         &mint_keypair,
         &solana_sdk::pubkey::new_rand(),
         2,

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -38,6 +38,9 @@ rand = "0.8.5"
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-cost-model = { path = ".", features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
+solana-runtime-transaction = { workspace = true, features = [
+    "dev-context-only-utils",
+] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 solana-system-program = { workspace = true }
 static_assertions = { workspace = true }

--- a/cost-model/benches/cost_model.rs
+++ b/cost-model/benches/cost_model.rs
@@ -2,6 +2,7 @@
 extern crate test;
 use {
     solana_cost_model::cost_model::CostModel,
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         feature_set::FeatureSet,
         hash::Hash,
@@ -16,7 +17,7 @@ use {
 };
 
 struct BenchSetup {
-    transactions: Vec<SanitizedTransaction>,
+    transactions: Vec<RuntimeTransaction<SanitizedTransaction>>,
     feature_set: FeatureSet,
 }
 
@@ -32,7 +33,7 @@ fn setup(num_transactions: usize) -> BenchSetup {
             let ixs = system_instruction::transfer_many(&from_keypair.pubkey(), &to_lamports);
             let message = Message::new(&ixs, Some(&from_keypair.pubkey()));
             let transaction = Transaction::new(&[from_keypair], message, Hash::default());
-            SanitizedTransaction::from_transaction_for_tests(transaction)
+            RuntimeTransaction::from_transaction_for_tests(transaction)
         })
         .collect();
 

--- a/cost-model/benches/cost_tracker.rs
+++ b/cost-model/benches/cost_tracker.rs
@@ -6,13 +6,14 @@ use {
         cost_tracker::CostTracker,
         transaction_cost::{TransactionCost, UsageCostDetails, WritableKeysTransaction},
     },
-    solana_sdk::{message::TransactionSignatureDetails, pubkey::Pubkey},
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_sdk::pubkey::Pubkey,
     test::Bencher,
 };
 
 struct BenchSetup {
     cost_tracker: CostTracker,
-    transactions: Vec<WritableKeysTransaction>,
+    transactions: Vec<RuntimeTransaction<WritableKeysTransaction>>,
 }
 
 fn setup(num_transactions: usize, contentious_transactions: bool) -> BenchSetup {
@@ -33,7 +34,7 @@ fn setup(num_transactions: usize, contentious_transactions: bool) -> BenchSetup 
                 };
                 writable_accounts.push(writable_account_key)
             });
-            WritableKeysTransaction(writable_accounts)
+            RuntimeTransaction::new_for_tests(WritableKeysTransaction(writable_accounts))
         })
         .collect_vec();
 
@@ -44,7 +45,7 @@ fn setup(num_transactions: usize, contentious_transactions: bool) -> BenchSetup 
 }
 
 fn get_costs(
-    transactions: &[WritableKeysTransaction],
+    transactions: &[RuntimeTransaction<WritableKeysTransaction>],
 ) -> Vec<TransactionCost<WritableKeysTransaction>> {
     transactions
         .iter()
@@ -57,7 +58,6 @@ fn get_costs(
                 programs_execution_cost: 9999,
                 loaded_accounts_data_size_cost: 0,
                 allocated_accounts_data_size: 0,
-                signature_details: TransactionSignatureDetails::new(0, 0, 0),
             })
         })
         .collect_vec()

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -617,45 +617,6 @@ mod tests {
     }
 
     #[test]
-    fn test_cost_model_with_failed_compute_budget_transaction() {
-        let (mint_keypair, start_hash) = test_setup();
-
-        let instructions = vec![
-            CompiledInstruction::new(3, &(), vec![1, 2, 0]),
-            CompiledInstruction::new_from_raw_parts(
-                4,
-                ComputeBudgetInstruction::SetComputeUnitLimit(12_345)
-                    .pack()
-                    .unwrap(),
-                vec![],
-            ),
-            // to trigger `duplicate_instruction_error` error
-            CompiledInstruction::new_from_raw_parts(
-                4,
-                ComputeBudgetInstruction::SetComputeUnitLimit(1_000)
-                    .pack()
-                    .unwrap(),
-                vec![],
-            ),
-        ];
-        let tx = Transaction::new_with_compiled_instructions(
-            &[&mint_keypair],
-            &[
-                solana_sdk::pubkey::new_rand(),
-                solana_sdk::pubkey::new_rand(),
-            ],
-            start_hash,
-            vec![Pubkey::new_unique(), compute_budget::id()],
-            instructions,
-        );
-        let token_transaction = RuntimeTransaction::from_transaction_for_tests(tx);
-
-        let (program_execution_cost, _loaded_accounts_data_size_cost, _data_bytes_cost) =
-            CostModel::get_transaction_cost(&token_transaction, &FeatureSet::all_enabled());
-        assert_eq!(0, program_execution_cost);
-    }
-
-    #[test]
     fn test_cost_model_transaction_many_transfer_instructions() {
         let (mint_keypair, start_hash) = test_setup();
 

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -1,6 +1,9 @@
 use {
     crate::block_cost_limits,
-    solana_sdk::{message::TransactionSignatureDetails, pubkey::Pubkey},
+    solana_runtime_transaction::{
+        runtime_transaction::RuntimeTransaction, transaction_meta::StaticMeta,
+    },
+    solana_sdk::pubkey::Pubkey,
     solana_svm_transaction::svm_message::SVMMessage,
 };
 
@@ -16,8 +19,10 @@ const SIMPLE_VOTE_USAGE_COST: u64 = 3428;
 
 #[derive(Debug)]
 pub enum TransactionCost<'a, Tx: SVMMessage> {
-    SimpleVote { transaction: &'a Tx },
-    Transaction(UsageCostDetails<'a, Tx>),
+    SimpleVote {
+        transaction: &'a RuntimeTransaction<Tx>,
+    },
+    Transaction(UsageCostDetails<'a, RuntimeTransaction<Tx>>),
 }
 
 impl<'a, Tx: SVMMessage> TransactionCost<'a, Tx> {
@@ -104,9 +109,10 @@ impl<'a, Tx: SVMMessage> TransactionCost<'a, Tx> {
     pub fn num_transaction_signatures(&self) -> u64 {
         match self {
             Self::SimpleVote { .. } => 1,
-            Self::Transaction(usage_cost) => {
-                usage_cost.signature_details.num_transaction_signatures()
-            }
+            Self::Transaction(usage_cost) => usage_cost
+                .transaction
+                .signature_details()
+                .num_transaction_signatures(),
         }
     }
 
@@ -114,7 +120,8 @@ impl<'a, Tx: SVMMessage> TransactionCost<'a, Tx> {
         match self {
             Self::SimpleVote { .. } => 0,
             Self::Transaction(usage_cost) => usage_cost
-                .signature_details
+                .transaction
+                .signature_details()
                 .num_secp256k1_instruction_signatures(),
         }
     }
@@ -123,7 +130,8 @@ impl<'a, Tx: SVMMessage> TransactionCost<'a, Tx> {
         match self {
             Self::SimpleVote { .. } => 0,
             Self::Transaction(usage_cost) => usage_cost
-                .signature_details
+                .transaction
+                .signature_details()
                 .num_ed25519_instruction_signatures(),
         }
     }
@@ -139,7 +147,6 @@ pub struct UsageCostDetails<'a, Tx: SVMMessage> {
     pub programs_execution_cost: u64,
     pub loaded_accounts_data_size_cost: u64,
     pub allocated_accounts_data_size: u64,
-    pub signature_details: TransactionSignatureDetails,
 }
 
 impl<'a, Tx: SVMMessage> UsageCostDetails<'a, Tx> {
@@ -225,12 +232,10 @@ mod tests {
         super::*,
         crate::cost_model::CostModel,
         solana_feature_set::FeatureSet,
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk::{
-            hash::Hash,
-            message::SimpleAddressLoader,
-            reserved_account_keys::ReservedAccountKeys,
-            signer::keypair::Keypair,
-            transaction::{MessageHash, SanitizedTransaction, VersionedTransaction},
+            hash::Hash, message::SimpleAddressLoader, reserved_account_keys::ReservedAccountKeys,
+            signer::keypair::Keypair, transaction::VersionedTransaction,
         },
         solana_vote_program::{vote_state::TowerSync, vote_transaction},
     };
@@ -251,9 +256,9 @@ mod tests {
         );
 
         // create a sanitized vote transaction
-        let vote_transaction = SanitizedTransaction::try_create(
+        let vote_transaction = RuntimeTransaction::try_create(
             VersionedTransaction::from(transaction.clone()),
-            MessageHash::Compute,
+            None,
             Some(true),
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
@@ -261,9 +266,9 @@ mod tests {
         .unwrap();
 
         // create a identical sanitized transaction, but identified as non-vote
-        let none_vote_transaction = SanitizedTransaction::try_create(
+        let none_vote_transaction = RuntimeTransaction::try_create(
             VersionedTransaction::from(transaction),
-            MessageHash::Compute,
+            None,
             Some(false),
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -234,8 +234,11 @@ mod tests {
         solana_feature_set::FeatureSet,
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk::{
-            hash::Hash, message::SimpleAddressLoader, reserved_account_keys::ReservedAccountKeys,
-            signer::keypair::Keypair, transaction::VersionedTransaction,
+            hash::Hash,
+            message::SimpleAddressLoader,
+            reserved_account_keys::ReservedAccountKeys,
+            signer::keypair::Keypair,
+            transaction::{MessageHash, VersionedTransaction},
         },
         solana_vote_program::{vote_state::TowerSync, vote_transaction},
     };
@@ -258,7 +261,7 @@ mod tests {
         // create a sanitized vote transaction
         let vote_transaction = RuntimeTransaction::try_create(
             VersionedTransaction::from(transaction.clone()),
-            None,
+            MessageHash::Compute,
             Some(true),
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
@@ -268,7 +271,7 @@ mod tests {
         // create a identical sanitized transaction, but identified as non-vote
         let none_vote_transaction = RuntimeTransaction::try_create(
             VersionedTransaction::from(transaction),
-            None,
+            MessageHash::Compute,
             Some(false),
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -23,6 +23,7 @@ solana-merkle-tree = { workspace = true }
 solana-metrics = { workspace = true }
 solana-perf = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
+solana-runtime-transaction = { workspace = true }
 solana-sdk = { workspace = true }
 
 [dev-dependencies]

--- a/entry/benches/entry_sigverify.rs
+++ b/entry/benches/entry_sigverify.rs
@@ -3,6 +3,7 @@ extern crate test;
 use {
     solana_entry::entry::{self, VerifyRecyclers},
     solana_perf::test_tx::test_tx,
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         hash::Hash,
         reserved_account_keys::ReservedAccountKeys,
@@ -28,7 +29,7 @@ fn bench_gpusigverify(bencher: &mut Bencher) {
     let verify_transaction = {
         move |versioned_tx: VersionedTransaction,
               verification_mode: TransactionVerificationMode|
-              -> Result<SanitizedTransaction> {
+              -> Result<RuntimeTransaction<SanitizedTransaction>> {
             let sanitized_tx = {
                 let message_hash =
                     if verification_mode == TransactionVerificationMode::FullVerification {
@@ -37,9 +38,9 @@ fn bench_gpusigverify(bencher: &mut Bencher) {
                         versioned_tx.message.hash()
                     };
 
-                SanitizedTransaction::try_create(
+                RuntimeTransaction::try_create(
                     versioned_tx,
-                    message_hash,
+                    Some(message_hash),
                     None,
                     SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),
@@ -78,12 +79,12 @@ fn bench_cpusigverify(bencher: &mut Bencher) {
         .collect::<Vec<_>>();
 
     let verify_transaction = {
-        move |versioned_tx: VersionedTransaction| -> Result<SanitizedTransaction> {
+        move |versioned_tx: VersionedTransaction| -> Result<RuntimeTransaction<SanitizedTransaction>> {
             let sanitized_tx = {
                 let message_hash = versioned_tx.verify_and_hash_message()?;
-                SanitizedTransaction::try_create(
+                RuntimeTransaction::try_create(
                     versioned_tx,
-                    message_hash,
+                    Some(message_hash),
                     None,
                     SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),

--- a/entry/benches/entry_sigverify.rs
+++ b/entry/benches/entry_sigverify.rs
@@ -8,8 +8,8 @@ use {
         hash::Hash,
         reserved_account_keys::ReservedAccountKeys,
         transaction::{
-            Result, SanitizedTransaction, SimpleAddressLoader, TransactionVerificationMode,
-            VersionedTransaction,
+            MessageHash, Result, SanitizedTransaction, SimpleAddressLoader,
+            TransactionVerificationMode, VersionedTransaction,
         },
     },
     std::sync::Arc,
@@ -40,7 +40,7 @@ fn bench_gpusigverify(bencher: &mut Bencher) {
 
                 RuntimeTransaction::try_create(
                     versioned_tx,
-                    Some(message_hash),
+                    MessageHash::Precomputed(message_hash),
                     None,
                     SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),
@@ -84,7 +84,7 @@ fn bench_cpusigverify(bencher: &mut Bencher) {
                 let message_hash = versioned_tx.verify_and_hash_message()?;
                 RuntimeTransaction::try_create(
                     versioned_tx,
-                    Some(message_hash),
+                    MessageHash::Precomputed(message_hash),
                     None,
                     SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -1001,7 +1001,8 @@ mod tests {
             signature::{Keypair, Signer},
             system_transaction,
             transaction::{
-                Result, SanitizedTransaction, SimpleAddressLoader, VersionedTransaction,
+                MessageHash, Result, SanitizedTransaction, SimpleAddressLoader,
+                VersionedTransaction,
             },
         },
     };
@@ -1097,7 +1098,7 @@ mod tests {
 
                     RuntimeTransaction::try_create(
                         versioned_tx,
-                        Some(message_hash),
+                        MessageHash::Precomputed(message_hash),
                         None,
                         SimpleAddressLoader::Disabled,
                         &ReservedAccountKeys::empty_key_set(),

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -21,6 +21,7 @@ use {
         sigverify,
     },
     solana_rayon_threadlimit::get_max_thread_count,
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         hash::Hash,
         packet::Meta,
@@ -151,7 +152,7 @@ impl From<&Entry> for EntrySummary {
 
 /// Typed entry to distinguish between transaction and tick entries
 pub enum EntryType {
-    Transactions(Vec<SanitizedTransaction>),
+    Transactions(Vec<RuntimeTransaction<SanitizedTransaction>>),
     Tick(Hash),
 }
 
@@ -394,7 +395,11 @@ impl EntryVerificationState {
 pub fn verify_transactions(
     entries: Vec<Entry>,
     thread_pool: &ThreadPool,
-    verify: Arc<dyn Fn(VersionedTransaction) -> Result<SanitizedTransaction> + Send + Sync>,
+    verify: Arc<
+        dyn Fn(VersionedTransaction) -> Result<RuntimeTransaction<SanitizedTransaction>>
+            + Send
+            + Sync,
+    >,
 ) -> Result<Vec<EntryType>> {
     thread_pool.install(|| {
         entries
@@ -422,7 +427,10 @@ pub fn start_verify_transactions(
     thread_pool: &ThreadPool,
     verify_recyclers: VerifyRecyclers,
     verify: Arc<
-        dyn Fn(VersionedTransaction, TransactionVerificationMode) -> Result<SanitizedTransaction>
+        dyn Fn(
+                VersionedTransaction,
+                TransactionVerificationMode,
+            ) -> Result<RuntimeTransaction<SanitizedTransaction>>
             + Send
             + Sync,
     >,
@@ -460,7 +468,10 @@ fn start_verify_transactions_cpu(
     skip_verification: bool,
     thread_pool: &ThreadPool,
     verify: Arc<
-        dyn Fn(VersionedTransaction, TransactionVerificationMode) -> Result<SanitizedTransaction>
+        dyn Fn(
+                VersionedTransaction,
+                TransactionVerificationMode,
+            ) -> Result<RuntimeTransaction<SanitizedTransaction>>
             + Send
             + Sync,
     >,
@@ -490,13 +501,16 @@ fn start_verify_transactions_gpu(
     verify_recyclers: VerifyRecyclers,
     thread_pool: &ThreadPool,
     verify: Arc<
-        dyn Fn(VersionedTransaction, TransactionVerificationMode) -> Result<SanitizedTransaction>
+        dyn Fn(
+                VersionedTransaction,
+                TransactionVerificationMode,
+            ) -> Result<RuntimeTransaction<SanitizedTransaction>>
             + Send
             + Sync,
     >,
 ) -> Result<EntrySigVerificationState> {
     let verify_func = {
-        move |versioned_tx: VersionedTransaction| -> Result<SanitizedTransaction> {
+        move |versioned_tx: VersionedTransaction| -> Result<RuntimeTransaction<SanitizedTransaction>> {
             verify(
                 versioned_tx,
                 TransactionVerificationMode::HashAndVerifyPrecompiles,
@@ -506,7 +520,7 @@ fn start_verify_transactions_gpu(
 
     let entries = verify_transactions(entries, thread_pool, Arc::new(verify_func))?;
 
-    let transactions: Vec<&SanitizedTransaction> = entries
+    let transactions = entries
         .iter()
         .filter_map(|entry_type| match entry_type {
             EntryType::Tick(_) => None,
@@ -1011,7 +1025,7 @@ mod tests {
             dyn Fn(
                     VersionedTransaction,
                     TransactionVerificationMode,
-                ) -> Result<SanitizedTransaction>
+                ) -> Result<RuntimeTransaction<SanitizedTransaction>>
                 + Send
                 + Sync,
         >,
@@ -1023,7 +1037,7 @@ mod tests {
             } else {
                 TransactionVerificationMode::FullVerification
             };
-            move |versioned_tx: VersionedTransaction| -> Result<SanitizedTransaction> {
+            move |versioned_tx: VersionedTransaction| -> Result<RuntimeTransaction<SanitizedTransaction>> {
                 verify(versioned_tx, verification_mode)
             }
         };
@@ -1072,7 +1086,7 @@ mod tests {
         let verify_transaction = {
             move |versioned_tx: VersionedTransaction,
                   verification_mode: TransactionVerificationMode|
-                  -> Result<SanitizedTransaction> {
+                  -> Result<RuntimeTransaction<SanitizedTransaction>> {
                 let sanitized_tx = {
                     let message_hash =
                         if verification_mode == TransactionVerificationMode::FullVerification {
@@ -1081,9 +1095,9 @@ mod tests {
                             versioned_tx.message.hash()
                         };
 
-                    SanitizedTransaction::try_create(
+                    RuntimeTransaction::try_create(
                         versioned_tx,
-                        message_hash,
+                        Some(message_hash),
                         None,
                         SimpleAddressLoader::Disabled,
                         &ReservedAccountKeys::empty_key_set(),

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -45,6 +45,7 @@ solana-measure = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-rpc = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime-transaction = { workspace = true }
 solana-sdk = { workspace = true }
 solana-stake-program = { workspace = true }
 solana-storage-bigtable = { workspace = true }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -59,6 +59,7 @@ use {
             SUPPORTED_ARCHIVE_COMPRESSION,
         },
     },
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         account_utils::StateMut,
@@ -73,7 +74,7 @@ use {
         shred_version::compute_shred_version,
         stake::{self, state::StakeStateV2},
         system_program,
-        transaction::{MessageHash, SanitizedTransaction, SimpleAddressLoader},
+        transaction::SimpleAddressLoader,
     },
     solana_stake_program::{points::PointValue, stake_state},
     solana_transaction_status::parse_ui_instruction,
@@ -472,9 +473,9 @@ fn compute_slot_cost(
             .transactions
             .into_iter()
             .filter_map(|transaction| {
-                SanitizedTransaction::try_create(
+                RuntimeTransaction::try_create(
                     transaction,
-                    MessageHash::Compute,
+                    None,
                     None,
                     SimpleAddressLoader::Disabled,
                     &reserved_account_keys.active,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -74,7 +74,7 @@ use {
         shred_version::compute_shred_version,
         stake::{self, state::StakeStateV2},
         system_program,
-        transaction::SimpleAddressLoader,
+        transaction::{MessageHash, SimpleAddressLoader},
     },
     solana_stake_program::{points::PointValue, stake_state},
     solana_transaction_status::parse_ui_instruction,
@@ -475,7 +475,7 @@ fn compute_slot_cost(
             .filter_map(|transaction| {
                 RuntimeTransaction::try_create(
                     transaction,
-                    None,
+                    MessageHash::Compute,
                     None,
                     SimpleAddressLoader::Disabled,
                     &reserved_account_keys.active,

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -59,6 +59,7 @@ solana-perf = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-runtime = { workspace = true }
+solana-runtime-transaction = { workspace = true }
 solana-sdk = { workspace = true }
 solana-stake-program = { workspace = true }
 solana-storage-bigtable = { workspace = true }

--- a/ledger/benches/blockstore_processor.rs
+++ b/ledger/benches/blockstore_processor.rs
@@ -17,6 +17,7 @@ use {
         prioritization_fee_cache::PrioritizationFeeCache,
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         account::{Account, ReadableAccount},
         signature::Keypair,
@@ -60,7 +61,7 @@ fn create_funded_accounts(bank: &Bank, num: usize) -> Vec<Keypair> {
     accounts
 }
 
-fn create_transactions(bank: &Bank, num: usize) -> Vec<SanitizedTransaction> {
+fn create_transactions(bank: &Bank, num: usize) -> Vec<RuntimeTransaction<SanitizedTransaction>> {
     let funded_accounts = create_funded_accounts(bank, 2 * num);
     funded_accounts
         .into_par_iter()
@@ -70,7 +71,7 @@ fn create_transactions(bank: &Bank, num: usize) -> Vec<SanitizedTransaction> {
             let to = &chunk[1];
             system_transaction::transfer(from, &to.pubkey(), 1, bank.last_blockhash())
         })
-        .map(SanitizedTransaction::from_transaction_for_tests)
+        .map(RuntimeTransaction::from_transaction_for_tests)
         .collect()
 }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -38,7 +38,9 @@ use {
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
         vote_sender_types::ReplayVoteSender,
     },
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::{
+        runtime_transaction::RuntimeTransaction, svm_transaction_adapter::SVMTransactionAdapter,
+    },
     solana_sdk::{
         clock::{Slot, MAX_PROCESSING_AGE},
         genesis_config::GenesisConfig,
@@ -60,8 +62,9 @@ use {
     solana_transaction_status::token_balances::TransactionTokenBalancesSet,
     solana_vote::vote_account::VoteAccountsHashMap,
     std::{
+        borrow::Borrow,
         collections::{HashMap, HashSet},
-        ops::{Deref, Index, Range},
+        ops::{Index, Range},
         path::PathBuf,
         result,
         sync::{
@@ -205,7 +208,7 @@ pub fn execute_batch(
         let transactions: Vec<SanitizedTransaction> = batch
             .sanitized_transactions()
             .iter()
-            .map(|tx| tx.deref().clone())
+            .map(|tx| tx.as_sanitized_transaction().borrow().clone())
             .collect();
         let post_token_balances = if record_token_balances {
             collect_token_balances(bank, batch, &mut mint_decimals)

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4883,6 +4883,7 @@ dependencies = [
  "solana-client",
  "solana-feature-set",
  "solana-runtime",
+ "solana-runtime-transaction",
  "solana-sdk",
  "solana-send-transaction-service",
  "solana-svm",
@@ -5311,6 +5312,7 @@ dependencies = [
  "solana-metrics",
  "solana-perf",
  "solana-rayon-threadlimit",
+ "solana-runtime-transaction",
  "solana-sdk",
 ]
 
@@ -5576,6 +5578,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime",
+ "solana-runtime-transaction",
  "solana-sdk",
  "solana-stake-program",
  "solana-storage-bigtable",
@@ -6084,6 +6087,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-rpc-client-api",
  "solana-runtime",
+ "solana-runtime-transaction",
  "solana-sdk",
  "solana-send-transaction-service",
  "solana-stake-program",
@@ -7291,6 +7295,7 @@ name = "solana-unified-scheduler-logic"
 version = "2.2.0"
 dependencies = [
  "assert_matches",
+ "solana-runtime-transaction",
  "solana-sdk",
  "static_assertions",
 ]
@@ -7308,6 +7313,7 @@ dependencies = [
  "scopeguard",
  "solana-ledger",
  "solana-runtime",
+ "solana-runtime-transaction",
  "solana-sdk",
  "solana-timings",
  "solana-unified-scheduler-logic",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -120,7 +120,9 @@ solana-measure = { workspace = true }
 solana-program = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-runtime-transaction = { workspace = true }
+solana-runtime-transaction = { workspace = true, features = [
+    "dev-context-only-utils",
+] }
 solana-sbf-rust-invoke-dep = { workspace = true }
 solana-sbf-rust-realloc-dep = { workspace = true }
 solana-sbf-rust-realloc-invoke-dep = { workspace = true }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -33,7 +33,10 @@ use {
             load_upgradeable_program_wrapper, set_upgrade_authority, upgrade_program,
         },
     },
-    solana_runtime_transaction::instructions_processor::process_compute_budget_instructions,
+    solana_runtime_transaction::{
+        instructions_processor::process_compute_budget_instructions,
+        runtime_transaction::RuntimeTransaction,
+    },
     solana_sbf_rust_invoke_dep::*,
     solana_sbf_rust_realloc_dep::*,
     solana_sbf_rust_realloc_invoke_dep::*,
@@ -59,7 +62,7 @@ use {
         system_instruction::{self, MAX_PERMITTED_DATA_LENGTH},
         system_program,
         sysvar::{self, clock},
-        transaction::{SanitizedTransaction, Transaction, TransactionError, VersionedTransaction},
+        transaction::{Transaction, TransactionError, VersionedTransaction},
     },
     solana_svm::{
         transaction_commit_result::{CommittedTransaction, TransactionCommitResult},
@@ -652,7 +655,7 @@ fn test_return_data_and_log_data_syscall() {
         let blockhash = bank.last_blockhash();
         let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
         let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
-        let sanitized_tx = SanitizedTransaction::from_transaction_for_tests(transaction);
+        let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
 
         let result = bank.simulate_transaction(&sanitized_tx, false);
 

--- a/programs/sbf/tests/simulation.rs
+++ b/programs/sbf/tests/simulation.rs
@@ -8,13 +8,14 @@ use {
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         loader_utils::load_upgradeable_program_and_advance_slot,
     },
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         instruction::{AccountMeta, Instruction},
         message::Message,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         sysvar::{clock, slot_history},
-        transaction::{SanitizedTransaction, Transaction},
+        transaction::Transaction,
     },
 };
 
@@ -50,7 +51,7 @@ fn test_no_panic_banks_client() {
     let blockhash = bank.last_blockhash();
     let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
     let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
-    let sanitized_tx = SanitizedTransaction::from_transaction_for_tests(transaction);
+    let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
     let result = bank.simulate_transaction(&sanitized_tx, false);
     assert!(result.result.is_ok());
 }

--- a/programs/sbf/tests/syscall_get_epoch_stake.rs
+++ b/programs/sbf/tests/syscall_get_epoch_stake.rs
@@ -10,11 +10,12 @@ use {
         },
         loader_utils::load_upgradeable_program_and_advance_slot,
     },
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         instruction::{AccountMeta, Instruction},
         message::Message,
         signature::{Keypair, Signer},
-        transaction::{SanitizedTransaction, Transaction},
+        transaction::Transaction,
     },
     solana_vote::vote_account::VoteAccount,
     solana_vote_program::vote_state::create_account_with_authorized,
@@ -90,7 +91,7 @@ fn test_syscall_get_epoch_stake() {
     let blockhash = bank.last_blockhash();
     let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
     let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
-    let sanitized_tx = SanitizedTransaction::from_transaction_for_tests(transaction);
+    let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
 
     let result = bank.simulate_transaction(&sanitized_tx, false);
 

--- a/programs/sbf/tests/sysvar.rs
+++ b/programs/sbf/tests/sysvar.rs
@@ -8,6 +8,7 @@ use {
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         loader_utils::load_upgradeable_program_and_advance_slot,
     },
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         instruction::{AccountMeta, Instruction},
         message::Message,
@@ -18,7 +19,7 @@ use {
             clock, epoch_rewards, epoch_schedule, instructions, recent_blockhashes, rent,
             slot_hashes, slot_history, stake_history,
         },
-        transaction::{SanitizedTransaction, Transaction},
+        transaction::Transaction,
     },
 };
 
@@ -92,7 +93,7 @@ fn test_sysvar_syscalls() {
         let blockhash = bank.last_blockhash();
         let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
         let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
-        let sanitized_tx = SanitizedTransaction::from_transaction_for_tests(transaction);
+        let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
         let result = bank.simulate_transaction(&sanitized_tx, false);
         assert!(result.result.is_ok());
     }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -45,6 +45,7 @@ solana-poh = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
+solana-runtime-transaction = { workspace = true }
 solana-sdk = { workspace = true }
 solana-send-transaction-service = { workspace = true }
 solana-stake-program = { workspace = true }
@@ -67,6 +68,9 @@ tokio-util = { workspace = true, features = ["codec", "compat"] }
 serial_test = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime-transaction = { workspace = true, features = [
+    "dev-context-only-utils",
+] }
 solana-stake-program = { workspace = true }
 spl-pod = { workspace = true }
 symlink = { workspace = true }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -77,8 +77,8 @@ use {
         signature::{Keypair, Signature, Signer},
         system_instruction,
         transaction::{
-            self, AddressLoader, SanitizedTransaction, TransactionError, VersionedTransaction,
-            MAX_TX_ACCOUNT_LOCKS,
+            self, AddressLoader, MessageHash, SanitizedTransaction, TransactionError,
+            VersionedTransaction, MAX_TX_ACCOUNT_LOCKS,
         },
     },
     solana_send_transaction_service::{
@@ -4216,7 +4216,7 @@ fn sanitize_transaction(
 ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
     RuntimeTransaction::try_create(
         transaction,
-        None,
+        MessageHash::Compute,
         None,
         address_loader,
         reserved_account_keys,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -62,6 +62,7 @@ use {
         snapshot_utils,
         verify_precompiles::verify_precompiles,
     },
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::{Slot, UnixTimestamp, MAX_PROCESSING_AGE},
@@ -76,8 +77,8 @@ use {
         signature::{Keypair, Signature, Signer},
         system_instruction,
         transaction::{
-            self, AddressLoader, MessageHash, SanitizedTransaction, TransactionError,
-            VersionedTransaction, MAX_TX_ACCOUNT_LOCKS,
+            self, AddressLoader, SanitizedTransaction, TransactionError, VersionedTransaction,
+            MAX_TX_ACCOUNT_LOCKS,
         },
     },
     solana_send_transaction_service::{
@@ -4212,10 +4213,10 @@ fn sanitize_transaction(
     transaction: VersionedTransaction,
     address_loader: impl AddressLoader,
     reserved_account_keys: &HashSet<Pubkey>,
-) -> Result<SanitizedTransaction> {
-    SanitizedTransaction::try_create(
+) -> Result<RuntimeTransaction<SanitizedTransaction>> {
+    RuntimeTransaction::try_create(
         transaction,
-        MessageHash::Compute,
+        None,
         None,
         address_loader,
         reserved_account_keys,
@@ -4737,7 +4738,7 @@ pub mod tests {
             let prioritization_fee_cache = &self.meta.prioritization_fee_cache;
             let transactions: Vec<_> = transactions
                 .into_iter()
-                .map(SanitizedTransaction::from_transaction_for_tests)
+                .map(RuntimeTransaction::from_transaction_for_tests)
                 .collect();
             prioritization_fee_cache.update(&bank, transactions.iter());
         }

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -32,6 +32,9 @@ solana-program = { workspace = true }
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[features]
+dev-context-only-utils = []
+
 [[bench]]
 name = "process_compute_budget_instructions"
 harness = false

--- a/runtime-transaction/src/compute_budget_instruction_details.rs
+++ b/runtime-transaction/src/compute_budget_instruction_details.rs
@@ -14,6 +14,7 @@ use {
 };
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
+#[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
 #[derive(Default, Debug)]
 pub(crate) struct ComputeBudgetInstructionDetails {
     // compute-budget instruction details:

--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -6,4 +6,5 @@ mod compute_budget_program_id_filter;
 pub mod instructions_processor;
 pub mod runtime_transaction;
 pub mod signature_details;
+pub mod svm_transaction_adapter;
 pub mod transaction_meta;

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -36,6 +36,7 @@ use {
     std::collections::HashSet,
 };
 
+#[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
 #[derive(Debug)]
 pub struct RuntimeTransaction<T> {
     transaction: T,

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -172,6 +172,38 @@ impl RuntimeTransaction<SanitizedTransaction> {
     }
 }
 
+#[cfg(feature = "dev-context-only-utils")]
+impl RuntimeTransaction<SanitizedTransaction> {
+    pub fn from_transaction_for_tests(transaction: solana_sdk::transaction::Transaction) -> Self {
+        let versioned_transaction = VersionedTransaction::from(transaction);
+        Self::try_create(
+            versioned_transaction,
+            None,
+            None,
+            solana_sdk::message::SimpleAddressLoader::Disabled,
+            &HashSet::new(),
+        )
+        .expect("failed to create RuntimeTransaction from Transaction")
+    }
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl<Tx: SVMMessage> RuntimeTransaction<Tx> {
+    /// Create simply wrapped transaction with a `TransactionMeta` for testing.
+    /// The `TransactionMeta` is default initialized.
+    pub fn new_for_tests(transaction: Tx) -> Self {
+        Self {
+            transaction,
+            meta: TransactionMeta {
+                message_hash: Hash::default(),
+                is_simple_vote_transaction: false,
+                signature_details: TransactionSignatureDetails::new(0, 0, 0),
+                compute_budget_instruction_details: ComputeBudgetInstructionDetails::default(),
+            },
+        }
+    }
+}
+
 impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
     // override to access from the cached meta instead of re-calculating
     fn num_total_signatures(&self) -> u64 {

--- a/runtime-transaction/src/svm_transaction_adapter.rs
+++ b/runtime-transaction/src/svm_transaction_adapter.rs
@@ -1,0 +1,25 @@
+use {
+    core::borrow::Borrow,
+    solana_sdk::transaction::{SanitizedTransaction, VersionedTransaction},
+    solana_svm_transaction::svm_transaction::SVMTransaction,
+};
+
+/// Adapter trait to allow for conversion to legacy transaction types
+/// that are required by some outside interfaces.
+/// Eventually this trait should go away, but for now it is necessary.
+pub trait SVMTransactionAdapter: SVMTransaction {
+    fn as_sanitized_transaction(&self) -> impl Borrow<SanitizedTransaction>;
+    fn to_versioned_transaction(&self) -> VersionedTransaction;
+}
+
+impl SVMTransactionAdapter for SanitizedTransaction {
+    #[inline]
+    fn as_sanitized_transaction(&self) -> impl Borrow<SanitizedTransaction> {
+        self
+    }
+
+    #[inline]
+    fn to_versioned_transaction(&self) -> VersionedTransaction {
+        self.to_versioned_transaction()
+    }
+}

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -36,6 +36,7 @@ pub trait StaticMeta {
 /// on-chain ALT, examples are: transaction usage costs, nonce account.
 pub trait DynamicMeta: StaticMeta {}
 
+#[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
 #[derive(Debug)]
 pub struct TransactionMeta {
     pub(crate) message_hash: Hash,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -114,6 +114,9 @@ solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-runtime = { path = ".", features = ["dev-context-only-utils"] }
+solana-runtime-transaction = { workspace = true, features = [
+    "dev-context-only-utils",
+] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 solana-svm = { workspace = true, features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
@@ -123,7 +126,10 @@ test-case = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-dev-context-only-utils = ["solana-svm/dev-context-only-utils"]
+dev-context-only-utils = [
+    "solana-svm/dev-context-only-utils",
+    "solana-runtime-transaction/dev-context-only-utils",
+]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/runtime/benches/prioritization_fee_cache.rs
+++ b/runtime/benches/prioritization_fee_cache.rs
@@ -9,6 +9,7 @@ use {
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         prioritization_fee_cache::*,
     },
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         compute_budget::ComputeBudgetInstruction,
         message::Message,
@@ -25,7 +26,7 @@ fn build_sanitized_transaction(
     compute_unit_price: u64,
     signer_account: &Pubkey,
     write_account: &Pubkey,
-) -> SanitizedTransaction {
+) -> RuntimeTransaction<SanitizedTransaction> {
     let transfer_lamports = 1;
     let transaction = Transaction::new_unsigned(Message::new(
         &[
@@ -36,7 +37,7 @@ fn build_sanitized_transaction(
         Some(signer_account),
     ));
 
-    SanitizedTransaction::from_transaction_for_tests(transaction)
+    RuntimeTransaction::from_transaction_for_tests(transaction)
 }
 
 #[bench]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -151,7 +151,7 @@ use {
         sysvar::{self, last_restart_slot::LastRestartSlot, Sysvar, SysvarId},
         timing::years_as_slots,
         transaction::{
-            Result, SanitizedTransaction, Transaction, TransactionError,
+            MessageHash, Result, SanitizedTransaction, Transaction, TransactionError,
             TransactionVerificationMode, VersionedTransaction, MAX_TX_ACCOUNT_LOCKS,
         },
         transaction_context::{TransactionAccount, TransactionReturnData},
@@ -3463,7 +3463,7 @@ impl Bank {
             .map(|tx| {
                 RuntimeTransaction::try_create(
                     tx,
-                    None,
+                    MessageHash::Compute,
                     None,
                     self,
                     self.get_reserved_account_keys(),
@@ -5920,7 +5920,7 @@ impl Bank {
 
             RuntimeTransaction::try_create(
                 tx,
-                Some(message_hash),
+                MessageHash::Precomputed(message_hash),
                 None,
                 self,
                 self.get_reserved_account_keys(),

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -2,6 +2,7 @@ use {
     super::{Bank, BankStatusCache},
     solana_accounts_db::blockhash_queue::BlockhashQueue,
     solana_perf::perf_libs,
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         account::AccountSharedData,
         account_utils::StateMut,
@@ -31,7 +32,7 @@ impl Bank {
     /// Checks a batch of sanitized transactions again bank for age and status
     pub fn check_transactions_with_forwarding_delay(
         &self,
-        transactions: &[SanitizedTransaction],
+        transactions: &[RuntimeTransaction<SanitizedTransaction>],
         filter: &[TransactionResult<()>],
         forward_transactions_to_leader_at_slot_offset: u64,
     ) -> Vec<TransactionCheckResult> {
@@ -60,7 +61,7 @@ impl Bank {
 
     pub fn check_transactions(
         &self,
-        sanitized_txs: &[impl core::borrow::Borrow<SanitizedTransaction>],
+        sanitized_txs: &[impl core::borrow::Borrow<RuntimeTransaction<SanitizedTransaction>>],
         lock_results: &[TransactionResult<()>],
         max_age: usize,
         error_counters: &mut TransactionErrorMetrics,
@@ -71,7 +72,7 @@ impl Bank {
 
     fn check_age(
         &self,
-        sanitized_txs: &[impl core::borrow::Borrow<SanitizedTransaction>],
+        sanitized_txs: &[impl core::borrow::Borrow<RuntimeTransaction<SanitizedTransaction>>],
         lock_results: &[TransactionResult<()>],
         max_age: usize,
         error_counters: &mut TransactionErrorMetrics,
@@ -184,7 +185,7 @@ impl Bank {
 
     fn check_status_cache(
         &self,
-        sanitized_txs: &[impl core::borrow::Borrow<SanitizedTransaction>],
+        sanitized_txs: &[impl core::borrow::Borrow<RuntimeTransaction<SanitizedTransaction>>],
         lock_results: Vec<TransactionCheckResult>,
         error_counters: &mut TransactionErrorMetrics,
     ) -> Vec<TransactionCheckResult> {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9912,17 +9912,17 @@ fn test_verify_and_hash_transaction_sig_len() {
     // Too few signatures: Sanitization failure
     {
         let tx = make_transaction(TestCase::RemoveSignature);
-        assert_eq!(
+        assert_matches!(
             bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
-            Err(TransactionError::SanitizeFailure),
+            Err(TransactionError::SanitizeFailure)
         );
     }
     // Too many signatures: Sanitization failure
     {
         let tx = make_transaction(TestCase::AddSignature);
-        assert_eq!(
+        assert_matches!(
             bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
-            Err(TransactionError::SanitizeFailure),
+            Err(TransactionError::SanitizeFailure)
         );
     }
 }
@@ -9957,9 +9957,9 @@ fn test_verify_transactions_packet_data_size() {
     {
         let tx = make_transaction(25);
         assert!(bincode::serialized_size(&tx).unwrap() > PACKET_DATA_SIZE as u64);
-        assert_eq!(
+        assert_matches!(
             bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
-            Err(TransactionError::SanitizeFailure),
+            Err(TransactionError::SanitizeFailure)
         );
     }
     // Assert that verify fails as soon as serialized
@@ -12852,7 +12852,7 @@ fn test_failed_simulation_compute_units() {
     let transaction = Transaction::new(&[&mint_keypair], message, bank.last_blockhash());
 
     bank.freeze();
-    let sanitized = SanitizedTransaction::from_transaction_for_tests(transaction);
+    let sanitized = RuntimeTransaction::from_transaction_for_tests(transaction);
     let simulation = bank.simulate_transaction(&sanitized, false);
     assert_eq!(expected_consumed_units, simulation.units_consumed);
 }
@@ -12875,7 +12875,7 @@ fn test_failed_simulation_load_error() {
     let transaction = Transaction::new(&[&mint_keypair], message, bank.last_blockhash());
 
     bank.freeze();
-    let sanitized = SanitizedTransaction::from_transaction_for_tests(transaction);
+    let sanitized = RuntimeTransaction::from_transaction_for_tests(transaction);
     let simulation = bank.simulate_transaction(&sanitized, false);
     assert_eq!(
         simulation,

--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -1,5 +1,6 @@
 use {
     crate::vote_sender_types::ReplayVoteSender,
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::transaction::SanitizedTransaction,
     solana_svm::transaction_commit_result::{
         TransactionCommitResult, TransactionCommitResultExtensions,
@@ -40,7 +41,7 @@ pub fn setup_bank_and_vote_pubkeys_for_tests(
 }
 
 pub fn find_and_send_votes(
-    sanitized_txs: &[SanitizedTransaction],
+    sanitized_txs: &[RuntimeTransaction<SanitizedTransaction>],
     commit_results: &[TransactionCommitResult],
     vote_sender: Option<&ReplayVoteSender>,
 ) {

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -407,6 +407,7 @@ impl SanitizedMessage {
 /// Transaction signature details including the number of transaction signatures
 /// and precompile signatures.
 #[derive(Debug, Default)]
+#[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
 pub struct TransactionSignatureDetails {
     num_transaction_signatures: u64,
     num_secp256k1_instruction_signatures: u64,

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -406,8 +406,7 @@ impl SanitizedMessage {
 
 /// Transaction signature details including the number of transaction signatures
 /// and precompile signatures.
-#[derive(Debug, Default)]
-#[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
+#[derive(Clone, Debug, Default)]
 pub struct TransactionSignatureDetails {
     num_transaction_signatures: u64,
     num_secp256k1_instruction_signatures: u64,

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -11,5 +11,11 @@ edition = { workspace = true }
 
 [dependencies]
 assert_matches = { workspace = true }
+solana-runtime-transaction = { workspace = true }
 solana-sdk = { workspace = true }
 static_assertions = { workspace = true }
+
+[dev-dependencies]
+solana-runtime-transaction = { workspace = true, features = [
+    "dev-context-only-utils",
+] }

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -1001,23 +1001,11 @@ mod tests {
 
     #[test]
     fn test_conflicting_task_related_counts() {
+        let sanitized = simplest_transaction();
         let address_loader = &mut create_address_loader(None);
-        let conflicting_address = Pubkey::new_unique();
-        let task1 = SchedulingStateMachine::create_task(
-            transaction_with_writable_address(conflicting_address),
-            101,
-            address_loader,
-        );
-        let task2 = SchedulingStateMachine::create_task(
-            transaction_with_writable_address(conflicting_address),
-            102,
-            address_loader,
-        );
-        let task3 = SchedulingStateMachine::create_task(
-            transaction_with_writable_address(conflicting_address),
-            103,
-            address_loader,
-        );
+        let task1 = SchedulingStateMachine::create_task(sanitized.clone(), 101, address_loader);
+        let task2 = SchedulingStateMachine::create_task(sanitized.clone(), 102, address_loader);
+        let task3 = SchedulingStateMachine::create_task(sanitized.clone(), 103, address_loader);
 
         let mut state_machine = unsafe {
             SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling()
@@ -1065,23 +1053,11 @@ mod tests {
 
     #[test]
     fn test_existing_blocking_task_then_newly_scheduled_task() {
+        let sanitized = simplest_transaction();
         let address_loader = &mut create_address_loader(None);
-        let conflicting_address = Pubkey::new_unique();
-        let task1 = SchedulingStateMachine::create_task(
-            transaction_with_writable_address(conflicting_address),
-            101,
-            address_loader,
-        );
-        let task2 = SchedulingStateMachine::create_task(
-            transaction_with_writable_address(conflicting_address),
-            102,
-            address_loader,
-        );
-        let task3 = SchedulingStateMachine::create_task(
-            transaction_with_writable_address(conflicting_address),
-            103,
-            address_loader,
-        );
+        let task1 = SchedulingStateMachine::create_task(sanitized.clone(), 101, address_loader);
+        let task2 = SchedulingStateMachine::create_task(sanitized.clone(), 102, address_loader);
+        let task3 = SchedulingStateMachine::create_task(sanitized.clone(), 103, address_loader);
 
         let mut state_machine = unsafe {
             SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling()

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -98,6 +98,7 @@
 use {
     crate::utils::{ShortCounter, Token, TokenCell},
     assert_matches::assert_matches,
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{pubkey::Pubkey, transaction::SanitizedTransaction},
     static_assertions::const_assert_eq,
     std::{collections::VecDeque, mem, sync::Arc},
@@ -413,7 +414,7 @@ const_assert_eq!(mem::size_of::<BlockedUsageCountToken>(), 0);
 /// Internal scheduling data about a particular task.
 #[derive(Debug)]
 pub struct TaskInner {
-    transaction: SanitizedTransaction,
+    transaction: RuntimeTransaction<SanitizedTransaction>,
     /// The index of a transaction in ledger entries; not used by SchedulingStateMachine by itself.
     /// Carrying this along with the transaction is needed to properly record the execution result
     /// of it.
@@ -427,7 +428,7 @@ impl TaskInner {
         self.index
     }
 
-    pub fn transaction(&self) -> &SanitizedTransaction {
+    pub fn transaction(&self) -> &RuntimeTransaction<SanitizedTransaction> {
         &self.transaction
     }
 
@@ -754,8 +755,8 @@ impl SchedulingStateMachine {
         }
     }
 
-    /// Creates a new task with [`SanitizedTransaction`] with all of its corresponding
-    /// [`UsageQueue`]s preloaded.
+    /// Creates a new task with [`RuntimeTransaction<SanitizedTransaction>`] with all of
+    /// its corresponding [`UsageQueue`]s preloaded.
     ///
     /// Closure (`usage_queue_loader`) is used to delegate the (possibly multi-threaded)
     /// implementation of [`UsageQueue`] look-up by [`pubkey`](Pubkey) to callers. It's the
@@ -768,7 +769,7 @@ impl SchedulingStateMachine {
     /// after created, if `has_no_active_task()` is `true`. Also note that this is desired for
     /// separation of concern.
     pub fn create_task(
-        transaction: SanitizedTransaction,
+        transaction: RuntimeTransaction<SanitizedTransaction>,
         index: usize,
         usage_queue_loader: &mut impl FnMut(Pubkey) -> UsageQueue,
     ) -> Task {
@@ -887,21 +888,20 @@ mod tests {
             instruction::{AccountMeta, Instruction},
             message::Message,
             pubkey::Pubkey,
-            signature::Signer,
-            signer::keypair::Keypair,
             transaction::{SanitizedTransaction, Transaction},
         },
         std::{cell::RefCell, collections::HashMap, rc::Rc},
     };
 
-    fn simplest_transaction() -> SanitizedTransaction {
-        let payer = Keypair::new();
-        let message = Message::new(&[], Some(&payer.pubkey()));
+    fn simplest_transaction() -> RuntimeTransaction<SanitizedTransaction> {
+        let message = Message::new(&[], Some(&Pubkey::new_unique()));
         let unsigned = Transaction::new_unsigned(message);
-        SanitizedTransaction::from_transaction_for_tests(unsigned)
+        RuntimeTransaction::from_transaction_for_tests(unsigned)
     }
 
-    fn transaction_with_readonly_address(address: Pubkey) -> SanitizedTransaction {
+    fn transaction_with_readonly_address(
+        address: Pubkey,
+    ) -> RuntimeTransaction<SanitizedTransaction> {
         let instruction = Instruction {
             program_id: Pubkey::default(),
             accounts: vec![AccountMeta::new_readonly(address, false)],
@@ -909,10 +909,12 @@ mod tests {
         };
         let message = Message::new(&[instruction], Some(&Pubkey::new_unique()));
         let unsigned = Transaction::new_unsigned(message);
-        SanitizedTransaction::from_transaction_for_tests(unsigned)
+        RuntimeTransaction::from_transaction_for_tests(unsigned)
     }
 
-    fn transaction_with_writable_address(address: Pubkey) -> SanitizedTransaction {
+    fn transaction_with_writable_address(
+        address: Pubkey,
+    ) -> RuntimeTransaction<SanitizedTransaction> {
         let instruction = Instruction {
             program_id: Pubkey::default(),
             accounts: vec![AccountMeta::new(address, false)],
@@ -920,7 +922,7 @@ mod tests {
         };
         let message = Message::new(&[instruction], Some(&Pubkey::new_unique()));
         let unsigned = Transaction::new_unsigned(message);
-        SanitizedTransaction::from_transaction_for_tests(unsigned)
+        RuntimeTransaction::from_transaction_for_tests(unsigned)
     }
 
     fn create_address_loader(
@@ -972,18 +974,18 @@ mod tests {
     #[test]
     fn test_create_task() {
         let sanitized = simplest_transaction();
-        let task = SchedulingStateMachine::create_task(sanitized.clone(), 3, &mut |_| {
-            UsageQueue::default()
-        });
+        let signature = *sanitized.signature();
+        let task =
+            SchedulingStateMachine::create_task(sanitized, 3, &mut |_| UsageQueue::default());
         assert_eq!(task.task_index(), 3);
-        assert_eq!(task.transaction(), &sanitized);
+        assert_eq!(task.transaction().signature(), &signature);
     }
 
     #[test]
     fn test_non_conflicting_task_related_counts() {
         let sanitized = simplest_transaction();
         let address_loader = &mut create_address_loader(None);
-        let task = SchedulingStateMachine::create_task(sanitized.clone(), 3, address_loader);
+        let task = SchedulingStateMachine::create_task(sanitized, 3, address_loader);
 
         let mut state_machine = unsafe {
             SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling()
@@ -999,11 +1001,23 @@ mod tests {
 
     #[test]
     fn test_conflicting_task_related_counts() {
-        let sanitized = simplest_transaction();
         let address_loader = &mut create_address_loader(None);
-        let task1 = SchedulingStateMachine::create_task(sanitized.clone(), 101, address_loader);
-        let task2 = SchedulingStateMachine::create_task(sanitized.clone(), 102, address_loader);
-        let task3 = SchedulingStateMachine::create_task(sanitized.clone(), 103, address_loader);
+        let conflicting_address = Pubkey::new_unique();
+        let task1 = SchedulingStateMachine::create_task(
+            transaction_with_writable_address(conflicting_address),
+            101,
+            address_loader,
+        );
+        let task2 = SchedulingStateMachine::create_task(
+            transaction_with_writable_address(conflicting_address),
+            102,
+            address_loader,
+        );
+        let task3 = SchedulingStateMachine::create_task(
+            transaction_with_writable_address(conflicting_address),
+            103,
+            address_loader,
+        );
 
         let mut state_machine = unsafe {
             SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling()
@@ -1051,11 +1065,23 @@ mod tests {
 
     #[test]
     fn test_existing_blocking_task_then_newly_scheduled_task() {
-        let sanitized = simplest_transaction();
         let address_loader = &mut create_address_loader(None);
-        let task1 = SchedulingStateMachine::create_task(sanitized.clone(), 101, address_loader);
-        let task2 = SchedulingStateMachine::create_task(sanitized.clone(), 102, address_loader);
-        let task3 = SchedulingStateMachine::create_task(sanitized.clone(), 103, address_loader);
+        let conflicting_address = Pubkey::new_unique();
+        let task1 = SchedulingStateMachine::create_task(
+            transaction_with_writable_address(conflicting_address),
+            101,
+            address_loader,
+        );
+        let task2 = SchedulingStateMachine::create_task(
+            transaction_with_writable_address(conflicting_address),
+            102,
+            address_loader,
+        );
+        let task3 = SchedulingStateMachine::create_task(
+            transaction_with_writable_address(conflicting_address),
+            103,
+            address_loader,
+        );
 
         let mut state_machine = unsafe {
             SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling()

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -19,6 +19,7 @@ qualifier_attr = { workspace = true }
 scopeguard = { workspace = true }
 solana-ledger = { workspace = true }
 solana-runtime = { workspace = true }
+solana-runtime-transaction = { workspace = true }
 solana-sdk = { workspace = true }
 solana-timings = { workspace = true }
 solana-unified-scheduler-logic = { workspace = true }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -2652,7 +2652,14 @@ mod tests {
             ignored_prioritization_fee_cache,
         );
 
-        // Create two contexts
+        // Create a dummy tx and two contexts
+        let dummy_tx =
+            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+                &mint_keypair,
+                &solana_sdk::pubkey::new_rand(),
+                2,
+                genesis_config.hash(),
+            ));
         let context0 = &SchedulingContext::new(bank0.clone());
         let context1 = &SchedulingContext::new(bank1.clone());
 
@@ -2662,16 +2669,10 @@ mod tests {
             .cycle()
             .take(10000)
         {
-            let dummy_tx =
-                RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
-                    &mint_keypair,
-                    &solana_sdk::pubkey::new_rand(),
-                    2,
-                    genesis_config.hash(),
-                ));
-
             let scheduler = pool.take_scheduler(context.clone());
-            scheduler.schedule_execution(dummy_tx, index).unwrap();
+            scheduler
+                .schedule_execution(dummy_tx.clone(), index)
+                .unwrap();
             scheduler.wait_for_termination(false).1.return_to_pool();
         }
     }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -31,6 +31,7 @@ use {
         prioritization_fee_cache::PrioritizationFeeCache,
         vote_sender_types::ReplayVoteSender,
     },
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
         pubkey::Pubkey,
         transaction::{Result, SanitizedTransaction, TransactionError},
@@ -411,7 +412,7 @@ pub trait TaskHandler: Send + Sync + Debug + Sized + 'static {
         result: &mut Result<()>,
         timings: &mut ExecuteTimings,
         bank: &Arc<Bank>,
-        transaction: &SanitizedTransaction,
+        transaction: &RuntimeTransaction<SanitizedTransaction>,
         index: usize,
         handler_context: &HandlerContext,
     );
@@ -425,7 +426,7 @@ impl TaskHandler for DefaultTaskHandler {
         result: &mut Result<()>,
         timings: &mut ExecuteTimings,
         bank: &Arc<Bank>,
-        transaction: &SanitizedTransaction,
+        transaction: &RuntimeTransaction<SanitizedTransaction>,
         index: usize,
         handler_context: &HandlerContext,
     ) {
@@ -1411,7 +1412,7 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
 
     fn schedule_execution(
         &self,
-        transaction: SanitizedTransaction,
+        transaction: RuntimeTransaction<SanitizedTransaction>,
         index: usize,
     ) -> ScheduleResult {
         let task = SchedulingStateMachine::create_task(transaction, index, &mut |pubkey| {
@@ -1753,7 +1754,7 @@ mod tests {
                 _result: &mut Result<()>,
                 timings: &mut ExecuteTimings,
                 _bank: &Arc<Bank>,
-                _transaction: &SanitizedTransaction,
+                _transaction: &RuntimeTransaction<SanitizedTransaction>,
                 _index: usize,
                 _handler_context: &HandlerContext,
             ) {
@@ -1777,7 +1778,7 @@ mod tests {
         pool.register_timeout_listener(bank.create_timeout_listener());
 
         let tx_before_stale =
-            SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
                 &mint_keypair,
                 &solana_sdk::pubkey::new_rand(),
                 2,
@@ -1789,7 +1790,7 @@ mod tests {
 
         sleepless_testing::at(TestCheckPoint::AfterTimeoutListenerTriggered);
         let tx_after_stale =
-            SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
                 &mint_keypair,
                 &solana_sdk::pubkey::new_rand(),
                 2,
@@ -1897,7 +1898,7 @@ mod tests {
         pool.register_timeout_listener(bank.create_timeout_listener());
 
         let tx_before_stale =
-            SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
                 &mint_keypair,
                 &solana_sdk::pubkey::new_rand(),
                 2,
@@ -1910,7 +1911,7 @@ mod tests {
 
         sleepless_testing::at(TestCheckPoint::AfterTimeoutListenerTriggered);
         let tx_after_stale =
-            SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
                 &mint_keypair,
                 &solana_sdk::pubkey::new_rand(),
                 2,
@@ -1936,7 +1937,7 @@ mod tests {
             result: &mut Result<()>,
             _timings: &mut ExecuteTimings,
             _bank: &Arc<Bank>,
-            _transaction: &SanitizedTransaction,
+            _transaction: &RuntimeTransaction<SanitizedTransaction>,
             _index: usize,
             _handler_context: &HandlerContext,
         ) {
@@ -1961,7 +1962,7 @@ mod tests {
             ..
         } = create_genesis_config(10_000);
 
-        let tx = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+        let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
             &mint_keypair,
             &solana_sdk::pubkey::new_rand(),
             2,
@@ -2047,7 +2048,7 @@ mod tests {
                 _result: &mut Result<()>,
                 _timings: &mut ExecuteTimings,
                 _bank: &Arc<Bank>,
-                _transaction: &SanitizedTransaction,
+                _transaction: &RuntimeTransaction<SanitizedTransaction>,
                 _index: usize,
                 _handler_context: &HandlerContext,
             ) {
@@ -2082,13 +2083,12 @@ mod tests {
         const MAX_TASK_COUNT: usize = 100;
 
         for i in 0..MAX_TASK_COUNT {
-            let tx =
-                SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
-                    &mint_keypair,
-                    &solana_sdk::pubkey::new_rand(),
-                    2,
-                    genesis_config.hash(),
-                ));
+            let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+                &mint_keypair,
+                &solana_sdk::pubkey::new_rand(),
+                2,
+                genesis_config.hash(),
+            ));
             scheduler.schedule_execution(tx, i).unwrap();
         }
 
@@ -2234,7 +2234,7 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        let tx0 = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+        let tx0 = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
             &mint_keypair,
             &solana_sdk::pubkey::new_rand(),
             2,
@@ -2294,20 +2294,19 @@ mod tests {
         let scheduler = pool.take_scheduler(context);
 
         let unfunded_keypair = Keypair::new();
-        let bad_tx =
-            SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
-                &unfunded_keypair,
-                &solana_sdk::pubkey::new_rand(),
-                2,
-                genesis_config.hash(),
-            ));
+        let bad_tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+            &unfunded_keypair,
+            &solana_sdk::pubkey::new_rand(),
+            2,
+            genesis_config.hash(),
+        ));
         assert_eq!(bank.transaction_count(), 0);
         scheduler.schedule_execution(bad_tx, 0).unwrap();
         sleepless_testing::at(TestCheckPoint::AfterTaskHandled);
         assert_eq!(bank.transaction_count(), 0);
 
         let good_tx_after_bad_tx =
-            SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
                 &mint_keypair,
                 &solana_sdk::pubkey::new_rand(),
                 3,
@@ -2386,7 +2385,7 @@ mod tests {
                 _result: &mut Result<()>,
                 _timings: &mut ExecuteTimings,
                 _bank: &Arc<Bank>,
-                _transaction: &SanitizedTransaction,
+                _transaction: &RuntimeTransaction<SanitizedTransaction>,
                 index: usize,
                 _handler_context: &HandlerContext,
             ) {
@@ -2425,13 +2424,12 @@ mod tests {
 
         for index in 0..TX_COUNT {
             // Use 2 non-conflicting txes to exercise the channel disconnected case as well.
-            let tx =
-                SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
-                    &Keypair::new(),
-                    &solana_sdk::pubkey::new_rand(),
-                    1,
-                    genesis_config.hash(),
-                ));
+            let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+                &Keypair::new(),
+                &solana_sdk::pubkey::new_rand(),
+                1,
+                genesis_config.hash(),
+            ));
             scheduler.schedule_execution(tx, index).unwrap();
         }
         // finally unblock the scheduler thread; otherwise the above schedule_execution could
@@ -2467,7 +2465,7 @@ mod tests {
                 result: &mut Result<()>,
                 _timings: &mut ExecuteTimings,
                 _bank: &Arc<Bank>,
-                _transaction: &SanitizedTransaction,
+                _transaction: &RuntimeTransaction<SanitizedTransaction>,
                 index: usize,
                 _handler_context: &HandlerContext,
             ) {
@@ -2499,13 +2497,12 @@ mod tests {
         let scheduler = pool.do_take_scheduler(context);
 
         for i in 0..10 {
-            let tx =
-                SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
-                    &mint_keypair,
-                    &solana_sdk::pubkey::new_rand(),
-                    2,
-                    genesis_config.hash(),
-                ));
+            let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+                &mint_keypair,
+                &solana_sdk::pubkey::new_rand(),
+                2,
+                genesis_config.hash(),
+            ));
             scheduler.schedule_execution(tx, i).unwrap();
         }
         // finally unblock the scheduler thread; otherwise the above schedule_execution could
@@ -2537,7 +2534,7 @@ mod tests {
                 result: &mut Result<()>,
                 timings: &mut ExecuteTimings,
                 bank: &Arc<Bank>,
-                transaction: &SanitizedTransaction,
+                transaction: &RuntimeTransaction<SanitizedTransaction>,
                 index: usize,
                 handler_context: &HandlerContext,
             ) {
@@ -2564,13 +2561,13 @@ mod tests {
         } = create_genesis_config(10_000);
 
         // tx0 and tx1 is definitely conflicting to write-lock the mint address
-        let tx0 = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+        let tx0 = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
             &mint_keypair,
             &solana_sdk::pubkey::new_rand(),
             2,
             genesis_config.hash(),
         ));
-        let tx1 = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+        let tx1 = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
             &mint_keypair,
             &solana_sdk::pubkey::new_rand(),
             2,
@@ -2622,7 +2619,7 @@ mod tests {
                 _result: &mut Result<()>,
                 _timings: &mut ExecuteTimings,
                 bank: &Arc<Bank>,
-                _transaction: &SanitizedTransaction,
+                _transaction: &RuntimeTransaction<SanitizedTransaction>,
                 index: usize,
                 _handler_context: &HandlerContext,
             ) {
@@ -2655,14 +2652,7 @@ mod tests {
             ignored_prioritization_fee_cache,
         );
 
-        // Create a dummy tx and two contexts
-        let dummy_tx =
-            SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
-                &mint_keypair,
-                &solana_sdk::pubkey::new_rand(),
-                2,
-                genesis_config.hash(),
-            ));
+        // Create two contexts
         let context0 = &SchedulingContext::new(bank0.clone());
         let context1 = &SchedulingContext::new(bank1.clone());
 
@@ -2672,10 +2662,16 @@ mod tests {
             .cycle()
             .take(10000)
         {
+            let dummy_tx =
+                RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+                    &mint_keypair,
+                    &solana_sdk::pubkey::new_rand(),
+                    2,
+                    genesis_config.hash(),
+                ));
+
             let scheduler = pool.take_scheduler(context.clone());
-            scheduler
-                .schedule_execution(dummy_tx.clone(), index)
-                .unwrap();
+            scheduler.schedule_execution(dummy_tx, index).unwrap();
             scheduler.wait_for_termination(false).1.return_to_pool();
         }
     }
@@ -2717,7 +2713,7 @@ mod tests {
 
         fn schedule_execution(
             &self,
-            transaction: SanitizedTransaction,
+            transaction: RuntimeTransaction<SanitizedTransaction>,
             index: usize,
         ) -> ScheduleResult {
             let transaction_and_index = (transaction, index);
@@ -2823,7 +2819,7 @@ mod tests {
             ..
         } = create_genesis_config(10_000);
         let very_old_valid_tx =
-            SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
                 &mint_keypair,
                 &solana_sdk::pubkey::new_rand(),
                 2,
@@ -2921,7 +2917,7 @@ mod tests {
         );
         // mangle the transfer tx to try to lock fee_payer (= mint_keypair) address twice!
         tx.message.account_keys.push(tx.message.account_keys[0]);
-        let tx = SanitizedTransaction::from_transaction_for_tests(tx);
+        let tx = RuntimeTransaction::from_transaction_for_tests(tx);
 
         // this internally should call SanitizedTransaction::get_account_locks().
         let result = &mut Ok(());


### PR DESCRIPTION
#### Problem
- `RuntimeTransaction` helps us in multiple ways:
	- caches metadata so we do not re-calculate later in pipeline
	- easier transition to new transaction type (fields not present on new tx type are cached) 

#### Summary of Changes
- Use `RuntimeTransaction` wherever required by forcing it in `TransactionBatch`
- `RuntimeTransaction` implements `Deref` for the wrapped transaction type, so in many places this does not require any changes in function implementation
- This PR is a near minimum of changes required to get `TransactionBatch` to use `RuntimeTransaction`. This makes the type available wherever we may need it in our processing pipeline, and we can optimize some of the processing to use the meta in the pipeline in subsequent PRs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
