### PR TITLE
cli: make find-program-derived-address print bump seed in verbose display

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -3325,11 +3325,19 @@ impl fmt::Display for CliBalance {
 #[serde(rename_all = "camelCase")]
 pub struct CliFindProgramDerivedAddress {
     pub address: String,
+    pub seeds: Vec<Vec<u8>>,
     pub bump_seed: u8,
 }
 
 impl QuietDisplay for CliFindProgramDerivedAddress {}
-impl VerboseDisplay for CliFindProgramDerivedAddress {}
+impl VerboseDisplay for CliFindProgramDerivedAddress {
+    fn write_str(&self, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
+        writeln!(w, "Seeds: {:?}", self.seeds)?;
+        writeln!(w, "Bump: {}", self.bump_seed)?;
+        write!(w, "{}", self.address)?;
+        Ok(())
+    }
+}
 
 impl fmt::Display for CliFindProgramDerivedAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -855,13 +855,11 @@ pub fn process_find_program_derived_address(
     seeds: &Vec<Vec<u8>>,
     program_id: &Pubkey,
 ) -> ProcessResult {
-    if config.verbose {
-        println!("Seeds: {seeds:?}");
-    }
     let seeds_slice = seeds.iter().map(|x| &x[..]).collect::<Vec<_>>();
     let (address, bump_seed) = Pubkey::find_program_address(&seeds_slice[..], program_id);
     let result = CliFindProgramDerivedAddress {
         address: address.to_string(),
+        seeds: seeds.clone(),
         bump_seed,
     };
     Ok(config.output_format.formatted_string(&result))

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -852,14 +852,14 @@ pub fn process_create_address_with_seed(
 
 pub fn process_find_program_derived_address(
     config: &CliConfig<'_>,
-    seeds: &Vec<Vec<u8>>,
+    seeds: &[Vec<u8>],
     program_id: &Pubkey,
 ) -> ProcessResult {
     let seeds_slice = seeds.iter().map(|x| &x[..]).collect::<Vec<_>>();
     let (address, bump_seed) = Pubkey::find_program_address(&seeds_slice[..], program_id);
     let result = CliFindProgramDerivedAddress {
         address: address.to_string(),
-        seeds: seeds.clone(),
+        seeds: seeds.to_owned(),
         bump_seed,
     };
     Ok(config.output_format.formatted_string(&result))


### PR DESCRIPTION
#### Problem

The find-program-derived-address command doesn't print the bump seed, which could be useful.

```
$ solana find-program-derived-address -v 11111111111111111111111111111111 "string:HELLO"
Seeds: [[72, 69, 76, 76, 79]]
4U64rfZFeEwSRmQdsNtMNRZtCD6w9b2QhrXgZzUoCDi6
```

#### Summary of Changes

This commit make it prints bump seed in verbose mode.

```
$ solana find-program-derived-address -v 11111111111111111111111111111111 "string:HELLO"
Seeds: [[72, 69, 76, 76, 79]]
Bump: 255
4U64rfZFeEwSRmQdsNtMNRZtCD6w9b2QhrXgZzUoCDi6
```

