### PR TITLE
svm: test account loader edge cases

### DIFF
--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1417,6 +1417,13 @@ mod tests {
 
     #[test]
     fn test_load_transaction_accounts_program_account_executable_bypass() {
+        // currently, the account loader retrieves read-only non-instruction accounts from the program cache
+        // it creates a mock AccountSharedData with the executable flag set to true
+        // however, it does not check whether these accounts are actually executable before doing so
+        // this affects consensus: a transaction that uses a cached non-executable program executes and fails
+        // but if the transaction gets the program from accounts-db, it will be dropped during account loading
+        // this test enforces the current behavior, so that future account loader changes do not break consensus
+
         let mut mock_bank = TestCallbacks::default();
         let account_keypair = Keypair::new();
         let program_keypair = Keypair::new();


### PR DESCRIPTION
#### Problem
the existing account loader has a few unique edge cases:
* if a program can be found in the cache, the executable flag on the program account retrevied from accounts-db is never checked, unless it is writable or an instruction account
* if native loader is an instruction account, it is counted against the transaction data size limit, otherwise it is not
* if any other required loader is also an instruction account, it is counted against the transaction data size limit twice
* an upgradeable program retrieved from cache has a loaded size that includes its programdata, so size totals differ if the cache is used or skipped

all of these affect consensus because they may determine whether the transaction is executed. as we are implementing a new loader without a feature gate, we must test that the new loader preserves these behaviors

#### Summary of Changes
add tests for them. we do this as a separate pr from the new loader so we are sure they pass for the old loader