### PR TITLE
remove cu price rounding

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -507,7 +507,6 @@ impl BankingStage {
                 Self::spawn_thread_local_multi_iterator_thread(
                     id,
                     packet_receiver,
-                    bank_forks.clone(),
                     decision_maker.clone(),
                     committer.clone(),
                     transaction_recorder.clone(),
@@ -566,7 +565,6 @@ impl BankingStage {
             bank_thread_hdls.push(Self::spawn_thread_local_multi_iterator_thread(
                 id,
                 packet_receiver,
-                bank_forks.clone(),
                 decision_maker.clone(),
                 committer.clone(),
                 transaction_recorder.clone(),
@@ -631,8 +629,7 @@ impl BankingStage {
 
         // Spawn the central scheduler thread
         bank_thread_hdls.push({
-            let packet_deserializer =
-                PacketDeserializer::new(non_vote_receiver, bank_forks.clone());
+            let packet_deserializer = PacketDeserializer::new(non_vote_receiver);
             let scheduler = PrioGraphScheduler::new(work_senders, finished_work_receiver);
             let scheduler_controller = SchedulerController::new(
                 decision_maker.clone(),
@@ -660,7 +657,6 @@ impl BankingStage {
     fn spawn_thread_local_multi_iterator_thread<T: LikeClusterInfo>(
         id: u32,
         packet_receiver: BankingPacketReceiver,
-        bank_forks: Arc<RwLock<BankForks>>,
         decision_maker: DecisionMaker,
         committer: Committer,
         transaction_recorder: TransactionRecorder,
@@ -668,7 +664,7 @@ impl BankingStage {
         mut forwarder: Forwarder<T>,
         unprocessed_transaction_storage: UnprocessedTransactionStorage,
     ) -> JoinHandle<()> {
-        let mut packet_receiver = PacketReceiver::new(id, packet_receiver, bank_forks);
+        let mut packet_receiver = PacketReceiver::new(id, packet_receiver);
         let consumer = Consumer::new(
             committer,
             transaction_recorder,

--- a/core/src/banking_stage/packet_receiver.rs
+++ b/core/src/banking_stage/packet_receiver.rs
@@ -9,12 +9,8 @@ use {
     crate::{banking_trace::BankingPacketReceiver, tracer_packet_stats::TracerPacketStats},
     crossbeam_channel::RecvTimeoutError,
     solana_measure::{measure::Measure, measure_us},
-    solana_runtime::bank_forks::BankForks,
     solana_sdk::{saturating_add_assign, timing::timestamp},
-    std::{
-        sync::{atomic::Ordering, Arc, RwLock},
-        time::Duration,
-    },
+    std::{sync::atomic::Ordering, time::Duration},
 };
 
 pub struct PacketReceiver {
@@ -23,14 +19,10 @@ pub struct PacketReceiver {
 }
 
 impl PacketReceiver {
-    pub fn new(
-        id: u32,
-        banking_packet_receiver: BankingPacketReceiver,
-        bank_forks: Arc<RwLock<BankForks>>,
-    ) -> Self {
+    pub fn new(id: u32, banking_packet_receiver: BankingPacketReceiver) -> Self {
         Self {
             id,
-            packet_deserializer: PacketDeserializer::new(banking_packet_receiver, bank_forks),
+            packet_deserializer: PacketDeserializer::new(banking_packet_receiver),
         }
     }
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -733,8 +733,7 @@ mod tests {
         let decision_maker = DecisionMaker::new(Pubkey::new_unique(), poh_recorder.clone());
 
         let (banking_packet_sender, banking_packet_receiver) = unbounded();
-        let packet_deserializer =
-            PacketDeserializer::new(banking_packet_receiver, bank_forks.clone());
+        let packet_deserializer = PacketDeserializer::new(banking_packet_receiver);
 
         let (consume_work_senders, consume_work_receivers) = create_channels(num_threads);
         let (finished_consume_work_sender, finished_consume_work_receiver) = unbounded();

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -29,10 +29,6 @@ bitflags! {
         const REPAIR         = 0b0000_0100;
         const SIMPLE_VOTE_TX = 0b0000_1000;
         const TRACER_PACKET  = 0b0001_0000;
-        /// to be set by bank.feature_set.is_active(round_compute_unit_price::id()) at the moment
-        /// the packet is built.
-        /// This field can be removed when the above feature gate is adopted by mainnet-beta.
-        const ROUND_COMPUTE_UNIT_PRICE = 0b0010_0000;
         /// For tracking performance
         const PERF_TRACK_PACKET  = 0b0100_0000;
         /// For marking packets from staked nodes
@@ -251,14 +247,6 @@ impl Meta {
     }
 
     #[inline]
-    pub fn set_round_compute_unit_price(&mut self, round_compute_unit_price: bool) {
-        self.flags.set(
-            PacketFlags::ROUND_COMPUTE_UNIT_PRICE,
-            round_compute_unit_price,
-        );
-    }
-
-    #[inline]
     pub fn forwarded(&self) -> bool {
         self.flags.contains(PacketFlags::FORWARDED)
     }
@@ -281,11 +269,6 @@ impl Meta {
     #[inline]
     pub fn is_perf_track_packet(&self) -> bool {
         self.flags.contains(PacketFlags::PERF_TRACK_PACKET)
-    }
-
-    #[inline]
-    pub fn round_compute_unit_price(&self) -> bool {
-        self.flags.contains(PacketFlags::ROUND_COMPUTE_UNIT_PRICE)
     }
 
     #[inline]

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -29,6 +29,8 @@ bitflags! {
         const REPAIR         = 0b0000_0100;
         const SIMPLE_VOTE_TX = 0b0000_1000;
         const TRACER_PACKET  = 0b0001_0000;
+        // Previously used - this can now be re-used for something else.
+        const UNUSED = 0b0010_0000;
         /// For tracking performance
         const PERF_TRACK_PACKET  = 0b0100_0000;
         /// For marking packets from staked nodes


### PR DESCRIPTION
#### Problem
- Code added in https://github.com/solana-labs/solana/pull/31469 for rounding cu price down
- That code added a mutation of `Packet` inside `BankingStage` which is bad for us moving to zero-copy approach
- Feature for rounding down has no plans to ever be used

#### Summary of Changes
- Remove all code related to that feature
- Remove all the now unused variables/fields

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
