### PR TITLE
generic verify_precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7652,6 +7652,7 @@ dependencies = [
  "num_enum",
  "percentage",
  "qualifier_attr",
+ "rand 0.7.3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -13,6 +13,7 @@ use {
         bank::{Bank, TransactionSimulationResult},
         bank_forks::BankForks,
         commitment::BlockCommitmentCache,
+        verify_precompiles::verify_precompiles,
     },
     solana_sdk::{
         account::Account,
@@ -167,7 +168,7 @@ fn verify_transaction(
     let move_precompile_verification_to_svm =
         feature_set.is_active(&move_precompile_verification_to_svm::id());
     if !move_precompile_verification_to_svm {
-        transaction.verify_precompiles(feature_set)?;
+        verify_precompiles(transaction, feature_set)?;
     }
 
     Ok(())

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -21,6 +21,7 @@ use {
     solana_runtime::{
         bank::{Bank, LoadAndExecuteTransactionsOutput},
         transaction_batch::TransactionBatch,
+        verify_precompiles::verify_precompiles,
     },
     solana_runtime_transaction::instructions_processor::process_compute_budget_instructions,
     solana_sdk::{
@@ -401,7 +402,7 @@ impl Consumer {
             .map(|(tx, result)| match result {
                 Ok(_) => {
                     if !move_precompile_verification_to_svm {
-                        tx.verify_precompiles(&bank.feature_set)
+                        verify_precompiles(tx, &bank.feature_set)
                     } else {
                         Ok(())
                     }
@@ -452,7 +453,7 @@ impl Consumer {
             } else {
                 // Verify pre-compiles.
                 if !move_precompile_verification_to_svm {
-                    tx.verify_precompiles(&bank.feature_set)?;
+                    verify_precompiles(tx, &bank.feature_set)?;
                 }
 
                 // Any transaction executed between sanitization time and now may have closed the lookup table(s).

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -59,6 +59,7 @@ use {
         prioritization_fee_cache::PrioritizationFeeCache,
         snapshot_config::SnapshotConfig,
         snapshot_utils,
+        verify_precompiles::verify_precompiles,
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
@@ -2260,7 +2261,7 @@ fn verify_transaction(
     let move_precompile_verification_to_svm =
         feature_set.is_active(&feature_set::move_precompile_verification_to_svm::id());
     if !move_precompile_verification_to_svm {
-        if let Err(e) = transaction.verify_precompiles(feature_set) {
+        if let Err(e) = verify_precompiles(transaction, feature_set) {
             return Err(RpcCustomError::TransactionPrecompileVerificationFailure(e).into());
         }
     }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -107,6 +107,7 @@ assert_matches = { workspace = true }
 ed25519-dalek = { workspace = true }
 libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }
+rand0-7 = { package = "rand", version = "0.7" }
 rand_chacha = { workspace = true }
 solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -57,6 +57,7 @@ use {
         stakes::{InvalidCacheEntryReason, Stakes, StakesCache, StakesEnum},
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
+        verify_precompiles::verify_precompiles,
     },
     byteorder::{ByteOrder, LittleEndian},
     dashmap::{DashMap, DashSet},
@@ -5664,7 +5665,7 @@ impl Bank {
             verification_mode == TransactionVerificationMode::HashAndVerifyPrecompiles
                 || verification_mode == TransactionVerificationMode::FullVerification
         } {
-            sanitized_tx.verify_precompiles(&self.feature_set)?;
+            verify_precompiles(&sanitized_tx, &self.feature_set)?;
         }
 
         Ok(sanitized_tx)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -36,7 +36,7 @@ pub mod stakes;
 pub mod static_ids;
 pub mod status_cache;
 pub mod transaction_batch;
-mod verify_precompiles;
+pub mod verify_precompiles;
 pub mod vote_sender_types;
 
 #[macro_use]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -36,6 +36,7 @@ pub mod stakes;
 pub mod static_ids;
 pub mod status_cache;
 pub mod transaction_batch;
+mod verify_precompiles;
 pub mod vote_sender_types;
 
 #[macro_use]

--- a/runtime/src/verify_precompiles.rs
+++ b/runtime/src/verify_precompiles.rs
@@ -26,3 +26,140 @@ pub fn verify_precompiles(message: &impl SVMMessage, feature_set: &FeatureSet) -
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        rand0_7::{thread_rng, Rng},
+        solana_sdk::{
+            ed25519_instruction::new_ed25519_instruction,
+            hash::Hash,
+            pubkey::Pubkey,
+            secp256k1_instruction::new_secp256k1_instruction,
+            signature::Keypair,
+            signer::Signer,
+            system_instruction, system_transaction,
+            transaction::{SanitizedTransaction, Transaction},
+        },
+    };
+
+    #[test]
+    fn test_verify_precompiles_simple_transaction() {
+        let tx = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            &Keypair::new(),
+            &Pubkey::new_unique(),
+            1,
+            Hash::default(),
+        ));
+        assert!(verify_precompiles(&tx, &FeatureSet::all_enabled()).is_ok());
+    }
+
+    #[test]
+    fn test_verify_precompiles_secp256k1() {
+        let secp_privkey = libsecp256k1::SecretKey::random(&mut thread_rng());
+        let message_arr = b"hello";
+        let mut secp_instruction = new_secp256k1_instruction(&secp_privkey, message_arr);
+        let mint_keypair = Keypair::new();
+        let feature_set = FeatureSet::all_enabled();
+
+        let tx =
+            SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
+                &[secp_instruction.clone()],
+                Some(&mint_keypair.pubkey()),
+                &[&mint_keypair],
+                Hash::default(),
+            ));
+
+        assert!(verify_precompiles(&tx, &feature_set).is_ok());
+
+        let index = thread_rng().gen_range(0, secp_instruction.data.len());
+        secp_instruction.data[index] = secp_instruction.data[index].wrapping_add(12);
+        let tx =
+            SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
+                &[secp_instruction],
+                Some(&mint_keypair.pubkey()),
+                &[&mint_keypair],
+                Hash::default(),
+            ));
+
+        assert!(verify_precompiles(&tx, &feature_set).is_err());
+    }
+
+    #[test]
+    fn test_verify_precompiles_ed25519() {
+        let privkey = ed25519_dalek::Keypair::generate(&mut thread_rng());
+        let message_arr = b"hello";
+        let mut instruction = new_ed25519_instruction(&privkey, message_arr);
+        let mint_keypair = Keypair::new();
+        let feature_set = FeatureSet::all_enabled();
+
+        let tx =
+            SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
+                &[instruction.clone()],
+                Some(&mint_keypair.pubkey()),
+                &[&mint_keypair],
+                Hash::default(),
+            ));
+
+        assert!(verify_precompiles(&tx, &feature_set).is_ok());
+
+        let index = loop {
+            let index = thread_rng().gen_range(0, instruction.data.len());
+            // byte 1 is not used, so this would not cause the verify to fail
+            if index != 1 {
+                break index;
+            }
+        };
+
+        instruction.data[index] = instruction.data[index].wrapping_add(12);
+        let tx =
+            SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
+                &[instruction],
+                Some(&mint_keypair.pubkey()),
+                &[&mint_keypair],
+                Hash::default(),
+            ));
+        assert!(verify_precompiles(&tx, &feature_set).is_err());
+    }
+
+    #[test]
+    fn test_verify_precompiles_mixed() {
+        let message_arr = b"hello";
+        let secp_privkey = libsecp256k1::SecretKey::random(&mut thread_rng());
+        let mut secp_instruction = new_secp256k1_instruction(&secp_privkey, message_arr);
+        let ed25519_privkey = ed25519_dalek::Keypair::generate(&mut thread_rng());
+        let ed25519_instruction = new_ed25519_instruction(&ed25519_privkey, message_arr);
+
+        let mint_keypair = Keypair::new();
+        let feature_set = FeatureSet::all_enabled();
+
+        let tx =
+            SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
+                &[
+                    secp_instruction.clone(),
+                    ed25519_instruction.clone(),
+                    system_instruction::transfer(&mint_keypair.pubkey(), &Pubkey::new_unique(), 1),
+                ],
+                Some(&mint_keypair.pubkey()),
+                &[&mint_keypair],
+                Hash::default(),
+            ));
+        assert!(verify_precompiles(&tx, &feature_set).is_ok());
+
+        let index = thread_rng().gen_range(0, secp_instruction.data.len());
+        secp_instruction.data[index] = secp_instruction.data[index].wrapping_add(12);
+        let tx =
+            SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
+                &[
+                    secp_instruction,
+                    ed25519_instruction,
+                    system_instruction::transfer(&mint_keypair.pubkey(), &Pubkey::new_unique(), 1),
+                ],
+                Some(&mint_keypair.pubkey()),
+                &[&mint_keypair],
+                Hash::default(),
+            ));
+        assert!(verify_precompiles(&tx, &feature_set).is_err());
+    }
+}

--- a/runtime/src/verify_precompiles.rs
+++ b/runtime/src/verify_precompiles.rs
@@ -1,0 +1,28 @@
+use {
+    solana_feature_set::FeatureSet,
+    solana_sdk::{
+        precompiles::get_precompiles,
+        transaction::{Result, TransactionError},
+    },
+    solana_svm_transaction::svm_message::SVMMessage,
+};
+
+pub fn verify_precompiles(message: &impl SVMMessage, feature_set: &FeatureSet) -> Result<()> {
+    let mut all_instruction_data = None; // lazily collect this on first pre-compile
+
+    let precompiles = get_precompiles();
+    for (program_id, instruction) in message.program_instructions_iter() {
+        for precompile in precompiles {
+            if program_id == &precompile.program_id {
+                let all_instruction_data: &Vec<&[u8]> = all_instruction_data
+                    .get_or_insert_with(|| message.instructions_iter().map(|ix| ix.data).collect());
+                precompile
+                    .verify(instruction.data, all_instruction_data, feature_set)
+                    .map_err(|_| TransactionError::InvalidAccountIndex)?;
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/runtime/src/verify_precompiles.rs
+++ b/runtime/src/verify_precompiles.rs
@@ -13,7 +13,7 @@ pub fn verify_precompiles(message: &impl SVMMessage, feature_set: &FeatureSet) -
     let precompiles = get_precompiles();
     for (program_id, instruction) in message.program_instructions_iter() {
         for precompile in precompiles {
-            if program_id == &precompile.program_id {
+            if precompile.check_id(program_id, |id| feature_set.is_active(id)) {
                 let all_instruction_data: &Vec<&[u8]> = all_instruction_data
                     .get_or_insert_with(|| message.instructions_iter().map(|ix| ix.data).collect());
                 precompile


### PR DESCRIPTION
#### Problem
- `verify_precompiles` needs to have a generic counterpart so that new transaction type(s) can verify them

#### Summary of Changes
- add `solana_runtime::verify_precompiles::verify_precompiles` fn
- use the generic function in all places `SanitizedTransaction::verify_precompiles` was previously used
- optimization to lazily collect instruction datas 
- basic tests of precompile success/failure

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
