### PR TITLE
docs: setup-a-validator.md  Add cluster specific note

### DIFF
--- a/docs/src/operations/setup-a-validator.md
+++ b/docs/src/operations/setup-a-validator.md
@@ -435,10 +435,8 @@ Refer to `agave-validator --help` for more information on what each flag is
 doing in this script. Also refer to the section on
 [best practices for operating a validator](./best-practices/general.md).
 
-This startup script is specifically intended for testnet. Other startup
-script examples are contained in 
-[the clusters section.](./../clusters/available.md).
-
+This startup script is specifically intended for testnet. For more startup script examples intended for other clusters, refer to the
+[clusters section.](./../clusters/available.md).
 ## Verifying Your Validator Is Working
 
 Test that your `validator.sh` file is running properly by executing the

--- a/docs/src/operations/setup-a-validator.md
+++ b/docs/src/operations/setup-a-validator.md
@@ -435,6 +435,10 @@ Refer to `agave-validator --help` for more information on what each flag is
 doing in this script. Also refer to the section on
 [best practices for operating a validator](./best-practices/general.md).
 
+This startup script is specifically intended for testnet. Other startup
+script examples are contained in 
+[the clusters section.](./../clusters/available.md).
+
 ## Verifying Your Validator Is Working
 
 Test that your `validator.sh` file is running properly by executing the


### PR DESCRIPTION
#### Problem
The setup a validator page doesn't make it clear that the startup script contained is specifically for testnet or mention where to find startup scripts for other clusters.

#### Summary of Changes
Added a link to the clusters/avaliable.md page for people to find more info easily.
