### PR TITLE
appropriate precompile failure error

### DIFF
--- a/programs/ed25519-tests/tests/process_transaction.rs
+++ b/programs/ed25519-tests/tests/process_transaction.rs
@@ -73,7 +73,7 @@ async fn test_failure_without_move_precompiles_feature() {
     assert_matches!(
         client.process_transaction(transaction).await,
         Err(BanksClientError::TransactionError(
-            TransactionError::InvalidAccountIndex
+            TransactionError::InstructionError(0, InstructionError::Custom(3))
         ))
     );
 }

--- a/runtime/src/verify_precompiles.rs
+++ b/runtime/src/verify_precompiles.rs
@@ -1,6 +1,7 @@
 use {
     solana_feature_set::FeatureSet,
     solana_sdk::{
+        instruction::InstructionError,
         precompiles::get_precompiles,
         transaction::{Result, TransactionError},
     },
@@ -11,14 +12,19 @@ pub fn verify_precompiles(message: &impl SVMMessage, feature_set: &FeatureSet) -
     let mut all_instruction_data = None; // lazily collect this on first pre-compile
 
     let precompiles = get_precompiles();
-    for (program_id, instruction) in message.program_instructions_iter() {
+    for (index, (program_id, instruction)) in message.program_instructions_iter().enumerate() {
         for precompile in precompiles {
             if precompile.check_id(program_id, |id| feature_set.is_active(id)) {
                 let all_instruction_data: &Vec<&[u8]> = all_instruction_data
                     .get_or_insert_with(|| message.instructions_iter().map(|ix| ix.data).collect());
                 precompile
                     .verify(instruction.data, all_instruction_data, feature_set)
-                    .map_err(|_| TransactionError::InvalidAccountIndex)?;
+                    .map_err(|_| {
+                        TransactionError::InstructionError(
+                            index as u8,
+                            InstructionError::InvalidInstructionData,
+                        )
+                    })?;
                 break;
             }
         }

--- a/runtime/src/verify_precompiles.rs
+++ b/runtime/src/verify_precompiles.rs
@@ -19,10 +19,10 @@ pub fn verify_precompiles(message: &impl SVMMessage, feature_set: &FeatureSet) -
                     .get_or_insert_with(|| message.instructions_iter().map(|ix| ix.data).collect());
                 precompile
                     .verify(instruction.data, all_instruction_data, feature_set)
-                    .map_err(|_| {
+                    .map_err(|err| {
                         TransactionError::InstructionError(
                             index as u8,
-                            InstructionError::InvalidInstructionData,
+                            InstructionError::Custom(err as u32),
                         )
                     })?;
                 break;

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -18,7 +18,7 @@ use {
         transaction::{Result, Transaction, TransactionError, VersionedTransaction},
     },
     solana_feature_set as feature_set,
-    solana_program::message::SanitizedVersionedMessage,
+    solana_program::{instruction::InstructionError, message::SanitizedVersionedMessage},
     solana_sanitize::Sanitize,
     std::collections::HashSet,
 };
@@ -262,14 +262,21 @@ impl SanitizedTransaction {
 
     /// Verify the precompiled programs in this transaction
     pub fn verify_precompiles(&self, feature_set: &feature_set::FeatureSet) -> Result<()> {
-        for (program_id, instruction) in self.message.program_instructions_iter() {
+        for (index, (program_id, instruction)) in
+            self.message.program_instructions_iter().enumerate()
+        {
             verify_if_precompile(
                 program_id,
                 instruction,
                 self.message().instructions(),
                 feature_set,
             )
-            .map_err(|_| TransactionError::InvalidAccountIndex)?;
+            .map_err(|_| {
+                TransactionError::InstructionError(
+                    index as u8,
+                    InstructionError::InvalidInstructionData,
+                )
+            })?;
         }
         Ok(())
     }

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -271,10 +271,10 @@ impl SanitizedTransaction {
                 self.message().instructions(),
                 feature_set,
             )
-            .map_err(|_| {
+            .map_err(|err| {
                 TransactionError::InstructionError(
                     index as u8,
-                    InstructionError::InvalidInstructionData,
+                    InstructionError::Custom(err as u32),
                 )
             })?;
         }


### PR DESCRIPTION
#### Problem
- precompile verification failure currently returns a `TransactionError::InvalidAccountIndex` which is not very clear 

#### Summary of Changes
- return `TransactionError::InstructionError` for a more descriptive error

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
