### PR TITLE
ci: run Github Actions only in anza-xyz/agave

### DIFF
--- a/.github/workflows/add-team-to-ghsa.yml
+++ b/.github/workflows/add-team-to-ghsa.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   add-team-to-ghsa:
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   benchmark:
+    if: github.repository == 'anza-xyz/agave'
     name: benchmark
     runs-on: benchmark
     strategy:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -27,6 +27,7 @@ env:
 
 jobs:
   clippy-nightly:
+    if: github.repository == 'anza-xyz/agave'
     strategy:
       matrix:
         os:

--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   android:
+    if: github.repository == 'anza-xyz/agave'
     strategy:
       matrix:
         os:
@@ -44,6 +45,7 @@ jobs:
         run: ./cargo stable ndk --target ${{ matrix.target }} build -p solana-client
 
   ios:
+    if: github.repository == 'anza-xyz/agave'
     strategy:
       matrix:
         os:

--- a/.github/workflows/crate-check.yml
+++ b/.github/workflows/crate-check.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   check:
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   check:
+    if: github.repository == 'anza-xyz/agave'
     outputs:
       continue: ${{ steps.check.outputs.need_to_build }}
     runs-on: ubuntu-20.04

--- a/.github/workflows/downstream-project-spl-nightly.yml
+++ b/.github/workflows/downstream-project-spl-nightly.yml
@@ -6,13 +6,7 @@ on:
 
 jobs:
   main:
-    # As this is a cron job, it is better to avoid running it for all the forks.
-    # They are unlike to benefit from these executions, and they could easily
-    # eat up all the minutes GitHub allocation to free accounts.
-    if: >
-      github.event_name != 'schedule'
-      || github.repository == 'solana-labs/solana'
-
+    if: github.repository == 'anza-xyz/agave'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -37,6 +37,7 @@ env:
 
 jobs:
   check:
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   trigger-buildkite-pipeline:
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger a Buildkite Build
@@ -20,6 +21,7 @@ jobs:
           message: ":github: Triggered from a GitHub Action"
 
   draft-release:
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     steps:
       - name: Create Release
@@ -38,6 +40,7 @@ jobs:
             })
 
   version-bump:
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
#### Problem

it's better to avoid running Github Actions in personal forks.

https://discord.com/channels/428295358100013066/560503042458517505/1291452129575309332

#### Summary of Changes

added `if: github.repository == 'anza-xyz/agave'` all Github Actions