### PR TITLE
move LamportsError to solana-instruction

### DIFF
--- a/sdk/instruction/src/error.rs
+++ b/sdk/instruction/src/error.rs
@@ -432,3 +432,32 @@ where
         }
     }
 }
+
+#[derive(Debug)]
+pub enum LamportsError {
+    /// arithmetic underflowed
+    ArithmeticUnderflow,
+    /// arithmetic overflowed
+    ArithmeticOverflow,
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for LamportsError {}
+
+impl fmt::Display for LamportsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::ArithmeticUnderflow => f.write_str("Arithmetic underflowed"),
+            Self::ArithmeticOverflow => f.write_str("Arithmetic overflowed"),
+        }
+    }
+}
+
+impl From<LamportsError> for InstructionError {
+    fn from(error: LamportsError) -> Self {
+        match error {
+            LamportsError::ArithmeticOverflow => InstructionError::ArithmeticOverflow,
+            LamportsError::ArithmeticUnderflow => InstructionError::ArithmeticOverflow,
+        }
+    }
+}

--- a/sdk/program/src/lamports.rs
+++ b/sdk/program/src/lamports.rs
@@ -1,2 +1,6 @@
-//! Defines the [`LamportsError`] type.
+//! Re-exports the [`LamportsError`] type for backwards compatibility.
+#[deprecated(
+    since = "2.1.0",
+    note = "Use solana_instruction::error::LamportsError instead"
+)]
 pub use solana_instruction::error::LamportsError;

--- a/sdk/program/src/lamports.rs
+++ b/sdk/program/src/lamports.rs
@@ -1,23 +1,2 @@
 //! Defines the [`LamportsError`] type.
-
-use {crate::instruction::InstructionError, thiserror::Error};
-
-#[derive(Debug, Error)]
-pub enum LamportsError {
-    /// arithmetic underflowed
-    #[error("Arithmetic underflowed")]
-    ArithmeticUnderflow,
-
-    /// arithmetic overflowed
-    #[error("Arithmetic overflowed")]
-    ArithmeticOverflow,
-}
-
-impl From<LamportsError> for InstructionError {
-    fn from(error: LamportsError) -> Self {
-        match error {
-            LamportsError::ArithmeticOverflow => InstructionError::ArithmeticOverflow,
-            LamportsError::ArithmeticUnderflow => InstructionError::ArithmeticOverflow,
-        }
-    }
-}
+pub use solana_instruction::error::LamportsError;


### PR DESCRIPTION
#### Problem
`solana_program::lamports` imposes a `solana_program` dependency on `solana_sdk::account` (to be pulled out in #2294) 

#### Summary of Changes
- Move `LamportsError` to `solana_instruction::error`, since it already depends on `InstructionError` because of `impl From<LamportsError> for InstructionError {`.
- Remove thiserror from LamportsError
- Re-export for backwards compatibility

There is no measurable increase in the `solana_instruction` build time
