### PR TITLE
extract account-utils crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5678,6 +5678,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-account-utils"
+version = "2.1.0"
+dependencies = [
+ "bincode",
+ "serde",
+ "solana-account",
+ "solana-instruction",
+ "solana-pubkey",
+]
+
+[[package]]
 name = "solana-accounts-bench"
 version = "2.1.0"
 dependencies = [
@@ -7831,6 +7842,7 @@ dependencies = [
  "sha3",
  "siphasher",
  "solana-account",
+ "solana-account-utils",
  "solana-bn254",
  "solana-decode-error",
  "solana-derivation-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ members = [
     "sdk",
     "sdk/account",
     "sdk/account-info",
+    "sdk/account-utils",
     "sdk/atomic-u64",
     "sdk/cargo-build-sbf",
     "sdk/cargo-test-sbf",
@@ -368,6 +369,7 @@ soketto = "0.7"
 solana-account = { path = "sdk/account", version = "=2.1.0" }
 solana-account-decoder = { path = "account-decoder", version = "=2.1.0" }
 solana-account-info = { path = "sdk/account-info", version = "=2.1.0" }
+solana-account-utils = { path = "sdk/account-utils", version = "=2.1.0" }
 solana-accounts-db = { path = "accounts-db", version = "=2.1.0" }
 solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=2.1.0" }
 solana-atomic-u64 = { path = "sdk/atomic-u64", version = "=2.1.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4735,6 +4735,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-account-utils"
+version = "2.1.0"
+dependencies = [
+ "bincode",
+ "serde",
+ "solana-account",
+ "solana-instruction",
+]
+
+[[package]]
 name = "solana-accounts-db"
 version = "2.1.0"
 dependencies = [
@@ -6609,6 +6619,7 @@ dependencies = [
  "sha3",
  "siphasher",
  "solana-account",
+ "solana-account-utils",
  "solana-bn254",
  "solana-decode-error",
  "solana-derivation-path",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -85,6 +85,7 @@ sha2 = { workspace = true }
 sha3 = { workspace = true, optional = true }
 siphasher = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
+solana-account-utils = { workspace = true }
 solana-bn254 = { workspace = true }
 solana-decode-error = { workspace = true }
 solana-derivation-path = { workspace = true }

--- a/sdk/account-utils/Cargo.toml
+++ b/sdk/account-utils/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "solana-account-utils"
+description = "Useful extras for Solana `Account` state."
+documentation = "https://docs.rs/solana-account-utils"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+bincode = { workspace = true }
+serde = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
+solana-instruction = { workspace = true }
+
+[dev-dependencies]
+solana-pubkey = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/account-utils/src/lib.rs
+++ b/sdk/account-utils/src/lib.rs
@@ -1,9 +1,9 @@
 //! Useful extras for `Account` state.
 
 use {
-    crate::instruction::InstructionError,
     bincode::ErrorKind,
     solana_account::{Account, AccountSharedData},
+    solana_instruction::error::InstructionError,
     std::cell::Ref,
 };
 
@@ -64,7 +64,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::pubkey::Pubkey, solana_account::AccountSharedData};
+    use {super::*, solana_account::AccountSharedData, solana_pubkey::Pubkey};
 
     #[test]
     fn test_account_state() {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -58,7 +58,6 @@ pub use solana_program::{
 };
 #[cfg(feature = "borsh")]
 pub use solana_program::{borsh, borsh0_10, borsh1};
-pub mod account_utils;
 pub mod client;
 pub mod commitment_config;
 pub mod compute_budget;
@@ -108,6 +107,8 @@ pub mod wasm;
 
 #[deprecated(since = "2.1.0", note = "Use `solana-account` crate instead")]
 pub use solana_account as account;
+#[deprecated(since = "2.1.0", note = "Use `solana-account-utils` crate instead")]
+pub use solana_account_utils as account_utils;
 #[deprecated(since = "2.1.0", note = "Use `solana-bn254` crate instead")]
 pub use solana_bn254 as alt_bn128;
 #[deprecated(since = "2.1.0", note = "Use `solana-decode-error` crate instead")]


### PR DESCRIPTION
#### Problem
solana_sdk::account_utils imposes a solana_sdk dep on solana-rpc-client-nonce-utils

#### Summary of Changes
Move to its own crate and re-export with deprecation

This branches off #2294 so that needs to be merged first
