### PR TITLE
refactor cli-output large functions and add starting epoch for rewards

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1311,6 +1311,84 @@ impl VerboseDisplay for CliStakeState {
     }
 }
 
+fn show_inactive_stake(
+    me: &CliStakeState,
+    f: &mut fmt::Formatter,
+    delegated_stake: u64,
+) -> fmt::Result {
+    if let Some(deactivation_epoch) = me.deactivation_epoch {
+        if me.current_epoch > deactivation_epoch {
+            let deactivating_stake = me.deactivating_stake.or(me.active_stake);
+            if let Some(deactivating_stake) = deactivating_stake {
+                writeln!(
+                    f,
+                    "Inactive Stake: {}",
+                    build_balance_message(
+                        delegated_stake - deactivating_stake,
+                        me.use_lamports_unit,
+                        true
+                    ),
+                )?;
+                writeln!(
+                    f,
+                    "Deactivating Stake: {}",
+                    build_balance_message(deactivating_stake, me.use_lamports_unit, true),
+                )?;
+            }
+        }
+        writeln!(
+            f,
+            "Stake deactivates starting from epoch: {deactivation_epoch}"
+        )?;
+    }
+    if let Some(delegated_vote_account_address) = &me.delegated_vote_account_address {
+        writeln!(
+            f,
+            "Delegated Vote Account Address: {delegated_vote_account_address}"
+        )?;
+    }
+    Ok(())
+}
+
+fn show_active_stake(
+    me: &CliStakeState,
+    f: &mut fmt::Formatter,
+    delegated_stake: u64,
+) -> fmt::Result {
+    if me
+        .deactivation_epoch
+        .map(|d| me.current_epoch <= d)
+        .unwrap_or(true)
+    {
+        let active_stake = me.active_stake.unwrap_or(0);
+        writeln!(
+            f,
+            "Active Stake: {}",
+            build_balance_message(active_stake, me.use_lamports_unit, true),
+        )?;
+        let activating_stake = me.activating_stake.or_else(|| {
+            if me.active_stake.is_none() {
+                Some(delegated_stake)
+            } else {
+                None
+            }
+        });
+        if let Some(activating_stake) = activating_stake {
+            writeln!(
+                f,
+                "Activating Stake: {}",
+                build_balance_message(activating_stake, me.use_lamports_unit, true),
+            )?;
+            writeln!(
+                f,
+                "Stake activates starting from epoch: {}",
+                me.activation_epoch.unwrap()
+            )?;
+        }
+    }
+    Ok(())
+}
+
 impl fmt::Display for CliStakeState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fn show_authorized(f: &mut fmt::Formatter, authorized: &CliAuthorized) -> fmt::Result {
@@ -1374,79 +1452,8 @@ impl fmt::Display for CliStakeState {
                         "Delegated Stake: {}",
                         build_balance_message(delegated_stake, self.use_lamports_unit, true)
                     )?;
-                    if self
-                        .deactivation_epoch
-                        .map(|d| self.current_epoch <= d)
-                        .unwrap_or(true)
-                    {
-                        let active_stake = self.active_stake.unwrap_or(0);
-                        writeln!(
-                            f,
-                            "Active Stake: {}",
-                            build_balance_message(active_stake, self.use_lamports_unit, true),
-                        )?;
-                        let activating_stake = self.activating_stake.or_else(|| {
-                            if self.active_stake.is_none() {
-                                Some(delegated_stake)
-                            } else {
-                                None
-                            }
-                        });
-                        if let Some(activating_stake) = activating_stake {
-                            writeln!(
-                                f,
-                                "Activating Stake: {}",
-                                build_balance_message(
-                                    activating_stake,
-                                    self.use_lamports_unit,
-                                    true
-                                ),
-                            )?;
-                            writeln!(
-                                f,
-                                "Stake activates starting from epoch: {}",
-                                self.activation_epoch.unwrap()
-                            )?;
-                        }
-                    }
-
-                    if let Some(deactivation_epoch) = self.deactivation_epoch {
-                        if self.current_epoch > deactivation_epoch {
-                            let deactivating_stake = self.deactivating_stake.or(self.active_stake);
-                            if let Some(deactivating_stake) = deactivating_stake {
-                                writeln!(
-                                    f,
-                                    "Inactive Stake: {}",
-                                    build_balance_message(
-                                        delegated_stake - deactivating_stake,
-                                        self.use_lamports_unit,
-                                        true
-                                    ),
-                                )?;
-                                writeln!(
-                                    f,
-                                    "Deactivating Stake: {}",
-                                    build_balance_message(
-                                        deactivating_stake,
-                                        self.use_lamports_unit,
-                                        true
-                                    ),
-                                )?;
-                            }
-                        }
-                        writeln!(
-                            f,
-                            "Stake deactivates starting from epoch: {deactivation_epoch}"
-                        )?;
-                    }
-                    if let Some(delegated_vote_account_address) =
-                        &self.delegated_vote_account_address
-                    {
-                        writeln!(
-                            f,
-                            "Delegated Vote Account Address: {delegated_vote_account_address}"
-                        )?;
-                    }
+                    show_active_stake(self, f, delegated_stake)?;
+                    show_inactive_stake(self, f, delegated_stake)?;
                 } else {
                     writeln!(f, "Stake account is undelegated")?;
                 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -269,6 +269,7 @@ pub enum CliCommand {
         use_lamports_unit: bool,
         with_rewards: Option<usize>,
         use_csv: bool,
+        starting_epoch: Option<u64>,
     },
     StakeAuthorize {
         stake_account_pubkey: Pubkey,
@@ -344,6 +345,7 @@ pub enum CliCommand {
         use_lamports_unit: bool,
         use_csv: bool,
         with_rewards: Option<usize>,
+        starting_epoch: Option<u64>,
     },
     WithdrawFromVoteAccount {
         vote_account_pubkey: Pubkey,
@@ -1325,6 +1327,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             use_lamports_unit,
             with_rewards,
             use_csv,
+            starting_epoch,
         } => process_show_stake_account(
             &rpc_client,
             config,
@@ -1332,6 +1335,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *use_lamports_unit,
             *with_rewards,
             *use_csv,
+            *starting_epoch,
         ),
         CliCommand::ShowStakeHistory {
             use_lamports_unit,
@@ -1494,6 +1498,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             use_lamports_unit,
             use_csv,
             with_rewards,
+            starting_epoch,
         } => process_show_vote_account(
             &rpc_client,
             config,
@@ -1501,6 +1506,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *use_lamports_unit,
             *use_csv,
             *with_rewards,
+            *starting_epoch,
         ),
         CliCommand::WithdrawFromVoteAccount {
             vote_account_pubkey,


### PR DESCRIPTION
#### Problem

Large functions in cli-output make the code hard to read.
No way to offset into the stake and vote rewards in case the user wants past rewards

#### Summary of Changes

Refactor functions into smaller ones.
Add `--starting-epoch <EPOCH_NUM>` argument to `solana vote-account --with-rewards` or `stake-account` commands.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
