### PR TITLE
Extract signer crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8269,7 +8269,6 @@ dependencies = [
  "solana-signer",
  "solana-transaction-error",
  "static_assertions",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7010,9 +7010,12 @@ version = "2.2.0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
+ "ed25519-dalek-bip32",
  "rand 0.7.3",
  "serde_json",
+ "solana-derivation-path",
  "solana-pubkey",
+ "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
@@ -8178,10 +8181,7 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 name = "solana-seed-derivable"
 version = "2.2.0"
 dependencies = [
- "ed25519-dalek",
- "ed25519-dalek-bip32",
  "solana-derivation-path",
- "solana-keypair",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7433,6 +7433,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-presigner"
+version = "2.2.0"
+dependencies = [
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
+]
+
+[[package]]
 name = "solana-program"
 version = "2.2.0"
 dependencies = [
@@ -8094,6 +8103,7 @@ dependencies = [
  "solana-native-token",
  "solana-packet",
  "solana-precompile-error",
+ "solana-presigner",
  "solana-program",
  "solana-program-memory",
  "solana-pubkey",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8261,7 +8261,6 @@ version = "2.2.0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
- "itertools 0.12.1",
  "rand 0.7.3",
  "serde_json",
  "solana-pubkey",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8266,6 +8266,7 @@ dependencies = [
  "serde_json",
  "solana-pubkey",
  "solana-signature",
+ "solana-signer",
  "solana-transaction-error",
  "static_assertions",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8102,6 +8102,7 @@ dependencies = [
  "solana-sdk-macro",
  "solana-secp256k1-recover",
  "solana-seed-derivable",
+ "solana-seed-phrase",
  "solana-serde-varint",
  "solana-short-vec",
  "solana-signature",
@@ -8151,7 +8152,19 @@ dependencies = [
  "ed25519-dalek",
  "ed25519-dalek-bip32",
  "solana-derivation-path",
+ "solana-seed-phrase",
  "solana-signer",
+]
+
+[[package]]
+name = "solana-seed-phrase"
+version = "2.2.0"
+dependencies = [
+ "hmac 0.12.1",
+ "pbkdf2 0.11.0",
+ "sha2 0.10.8",
+ "solana-signer",
+ "tiny-bip39",
 ]
 
 [[package]]
@@ -8238,18 +8251,14 @@ version = "2.2.0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
- "hmac 0.12.1",
  "itertools 0.12.1",
- "pbkdf2 0.11.0",
  "rand 0.7.3",
  "serde_json",
- "sha2 0.10.8",
  "solana-pubkey",
  "solana-signature",
  "solana-transaction-error",
  "static_assertions",
  "thiserror",
- "tiny-bip39",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8101,6 +8101,7 @@ dependencies = [
  "solana-sdk",
  "solana-sdk-macro",
  "solana-secp256k1-recover",
+ "solana-seed-derivable",
  "solana-serde-varint",
  "solana-short-vec",
  "solana-signature",
@@ -8142,6 +8143,16 @@ name = "solana-security-txt"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
+
+[[package]]
+name = "solana-seed-derivable"
+version = "2.2.0"
+dependencies = [
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "solana-derivation-path",
+ "solana-signer",
+]
 
 [[package]]
 name = "solana-send-transaction-service"
@@ -8227,14 +8238,12 @@ version = "2.2.0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
- "ed25519-dalek-bip32",
  "hmac 0.12.1",
  "itertools 0.12.1",
  "pbkdf2 0.11.0",
  "rand 0.7.3",
  "serde_json",
  "sha2 0.10.8",
- "solana-derivation-path",
  "solana-pubkey",
  "solana-signature",
  "solana-transaction-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8173,6 +8173,7 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "sha2 0.10.8",
+ "solana-seed-phrase",
  "solana-signer",
  "tiny-bip39",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8268,6 +8268,7 @@ dependencies = [
  "solana-signer",
  "solana-transaction-error",
  "static_assertions",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7005,6 +7005,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-keypair"
+version = "2.2.0"
+dependencies = [
+ "bs58",
+ "ed25519-dalek",
+ "rand 0.7.3",
+ "serde_json",
+ "solana-pubkey",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+ "solana-transaction-error",
+ "static_assertions",
+ "tiny-bip39",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "solana-last-restart-slot"
 version = "2.2.0"
 dependencies = [
@@ -7436,6 +7454,7 @@ dependencies = [
 name = "solana-presigner"
 version = "2.2.0"
 dependencies = [
+ "solana-keypair",
  "solana-pubkey",
  "solana-signature",
  "solana-signer",
@@ -8099,6 +8118,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-inflation",
  "solana-instruction",
+ "solana-keypair",
  "solana-logger",
  "solana-native-token",
  "solana-packet",
@@ -8162,8 +8182,7 @@ dependencies = [
  "ed25519-dalek",
  "ed25519-dalek-bip32",
  "solana-derivation-path",
- "solana-seed-phrase",
- "solana-signer",
+ "solana-keypair",
 ]
 
 [[package]]
@@ -8173,9 +8192,6 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "sha2 0.10.8",
- "solana-seed-phrase",
- "solana-signer",
- "tiny-bip39",
 ]
 
 [[package]]
@@ -8260,16 +8276,11 @@ dependencies = [
 name = "solana-signer"
 version = "2.2.0"
 dependencies = [
- "bs58",
- "ed25519-dalek",
- "rand 0.7.3",
  "serde_json",
  "solana-pubkey",
  "solana-signature",
- "solana-signer",
  "solana-transaction-error",
  "static_assertions",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8056,11 +8056,9 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "digest 0.10.7",
  "ed25519-dalek",
- "ed25519-dalek-bip32",
  "generic-array 0.14.7",
  "getrandom 0.1.16",
  "hex",
- "hmac 0.12.1",
  "itertools 0.12.1",
  "js-sys",
  "lazy_static",
@@ -8070,7 +8068,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "pbkdf2 0.11.0",
  "qualifier_attr",
  "rand 0.7.3",
  "rand 0.8.5",
@@ -8107,6 +8104,7 @@ dependencies = [
  "solana-serde-varint",
  "solana-short-vec",
  "solana-signature",
+ "solana-signer",
  "solana-time-utils",
  "solana-transaction-error",
  "static_assertions",
@@ -8221,6 +8219,28 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-program",
  "solana-sanitize",
+]
+
+[[package]]
+name = "solana-signer"
+version = "2.2.0"
+dependencies = [
+ "bs58",
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "hmac 0.12.1",
+ "itertools 0.12.1",
+ "pbkdf2 0.11.0",
+ "rand 0.7.3",
+ "serde_json",
+ "sha2 0.10.8",
+ "solana-derivation-path",
+ "solana-pubkey",
+ "solana-signature",
+ "solana-transaction-error",
+ "static_assertions",
+ "thiserror",
+ "tiny-bip39",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7016,7 +7016,6 @@ dependencies = [
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
- "solana-transaction-error",
  "static_assertions",
  "tiny-bip39",
  "wasm-bindgen",
@@ -8276,11 +8275,9 @@ dependencies = [
 name = "solana-signer"
 version = "2.2.0"
 dependencies = [
- "serde_json",
  "solana-pubkey",
  "solana-signature",
  "solana-transaction-error",
- "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ members = [
     "sdk/serialize-utils",
     "sdk/sha256-hasher",
     "sdk/signature",
+    "sdk/signer",
     "sdk/slot-hashes",
     "sdk/slot-history",
     "sdk/stable-layout",
@@ -359,6 +360,7 @@ quinn = "0.11.4"
 quinn-proto = "0.11.7"
 quote = "1.0"
 rand = "0.8.5"
+rand0-7 = { package = "rand", version = "0.7" }
 rand_chacha = "0.3.1"
 rayon = "1.10.0"
 reed-solomon-erasure = "6.0.0"
@@ -488,6 +490,7 @@ solana-serde-varint = { path = "sdk/serde-varint", version = "=2.2.0" }
 solana-serialize-utils = { path = "sdk/serialize-utils", version = "=2.2.0" }
 solana-sha256-hasher = { path = "sdk/sha256-hasher", version = "=2.2.0" }
 solana-signature = { path = "sdk/signature", version = "=2.2.0", default-features = false }
+solana-signer = { path = "sdk/signer", version = "=2.2.0" }
 solana-slot-hashes = { path = "sdk/slot-hashes", version = "=2.2.0" }
 solana-slot-history = { path = "sdk/slot-history", version = "=2.2.0" }
 solana-time-utils = { path = "sdk/time-utils", version = "=2.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ members = [
     "sdk/hash",
     "sdk/inflation",
     "sdk/instruction",
+    "sdk/keypair",
     "sdk/macro",
     "sdk/msg",
     "sdk/native-token",
@@ -452,6 +453,7 @@ solana-hash = { path = "sdk/hash", version = "=2.2.0", default-features = false 
 solana-inflation = { path = "sdk/inflation", version = "=2.2.0" }
 solana-inline-spl = { path = "inline-spl", version = "=2.2.0" }
 solana-instruction = { path = "sdk/instruction", version = "=2.2.0", default-features = false }
+solana-keypair = { path = "sdk/keypair", version = "=2.2.0" }
 solana-last-restart-slot = { path = "sdk/last-restart-slot", version = "=2.2.0" }
 solana-lattice-hash = { path = "lattice-hash", version = "=2.2.0" }
 solana-ledger = { path = "ledger", version = "=2.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ members = [
     "sdk/rent",
     "sdk/sanitize",
     "sdk/seed-derivable",
+    "sdk/seed-phrase",
     "sdk/serde-varint",
     "sdk/serialize-utils",
     "sdk/sha256-hasher",
@@ -488,6 +489,7 @@ solana-remote-wallet = { path = "remote-wallet", version = "=2.2.0", default-fea
 solana-rent = { path = "sdk/rent", version = "=2.2.0", default-features = false }
 solana-sanitize = { path = "sdk/sanitize", version = "=2.2.0" }
 solana-seed-derivable = { path = "sdk/seed-derivable", version = "=2.2.0" }
+solana-seed-phrase = { path = "sdk/seed-phrase", version = "=2.2.0" }
 solana-serde-varint = { path = "sdk/serde-varint", version = "=2.2.0" }
 solana-serialize-utils = { path = "sdk/serialize-utils", version = "=2.2.0" }
 solana-sha256-hasher = { path = "sdk/sha256-hasher", version = "=2.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ members = [
     "sdk/package-metadata-macro",
     "sdk/packet",
     "sdk/precompile-error",
+    "sdk/presigner",
     "sdk/program",
     "sdk/program-entrypoint",
     "sdk/program-error",
@@ -474,6 +475,7 @@ solana-perf = { path = "perf", version = "=2.2.0" }
 solana-poh = { path = "poh", version = "=2.2.0" }
 solana-poseidon = { path = "poseidon", version = "=2.2.0" }
 solana-precompile-error = { path = "sdk/precompile-error", version = "=2.2.0" }
+solana-presigner = { path = "sdk/presigner", version = "=2.2.0" }
 solana-program = { path = "sdk/program", version = "=2.2.0", default-features = false }
 solana-program-error = { path = "sdk/program-error", version = "=2.2.0" }
 solana-program-memory = { path = "sdk/program-memory", version = "=2.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ members = [
     "sdk/pubkey",
     "sdk/rent",
     "sdk/sanitize",
+    "sdk/seed-derivable",
     "sdk/serde-varint",
     "sdk/serialize-utils",
     "sdk/sha256-hasher",
@@ -486,6 +487,7 @@ solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.2.0" }
 solana-remote-wallet = { path = "remote-wallet", version = "=2.2.0", default-features = false }
 solana-rent = { path = "sdk/rent", version = "=2.2.0", default-features = false }
 solana-sanitize = { path = "sdk/sanitize", version = "=2.2.0" }
+solana-seed-derivable = { path = "sdk/seed-derivable", version = "=2.2.0" }
 solana-serde-varint = { path = "sdk/serde-varint", version = "=2.2.0" }
 solana-serialize-utils = { path = "sdk/serialize-utils", version = "=2.2.0" }
 solana-sha256-hasher = { path = "sdk/sha256-hasher", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6847,6 +6847,7 @@ dependencies = [
  "solana-sdk-macro",
  "solana-secp256k1-recover",
  "solana-seed-derivable",
+ "solana-seed-phrase",
  "solana-serde-varint",
  "solana-short-vec",
  "solana-signature",
@@ -6890,6 +6891,17 @@ dependencies = [
  "ed25519-dalek",
  "ed25519-dalek-bip32",
  "solana-derivation-path",
+ "solana-seed-phrase",
+ "solana-signer",
+]
+
+[[package]]
+name = "solana-seed-phrase"
+version = "2.2.0"
+dependencies = [
+ "hmac 0.12.1",
+ "pbkdf2 0.11.0",
+ "sha2 0.10.8",
  "solana-signer",
 ]
 
@@ -6959,12 +6971,9 @@ version = "2.2.0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
- "hmac 0.12.1",
  "itertools 0.12.1",
- "pbkdf2 0.11.0",
  "rand 0.7.3",
  "serde_json",
- "sha2 0.10.8",
  "solana-pubkey",
  "solana-signature",
  "solana-transaction-error",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5804,6 +5804,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-presigner"
+version = "2.2.0"
+dependencies = [
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
+]
+
+[[package]]
 name = "solana-program"
 version = "2.2.0"
 dependencies = [
@@ -6840,6 +6849,7 @@ dependencies = [
  "solana-native-token",
  "solana-packet",
  "solana-precompile-error",
+ "solana-presigner",
  "solana-program",
  "solana-program-memory",
  "solana-pubkey",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6985,6 +6985,7 @@ dependencies = [
  "solana-pubkey",
  "solana-signature",
  "solana-transaction-error",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6807,9 +6807,7 @@ dependencies = [
  "chrono",
  "digest 0.10.7",
  "ed25519-dalek",
- "ed25519-dalek-bip32",
  "getrandom 0.1.14",
- "hmac 0.12.1",
  "itertools 0.12.1",
  "js-sys",
  "lazy_static",
@@ -6819,7 +6817,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "pbkdf2 0.11.0",
  "qualifier_attr",
  "rand 0.7.3",
  "rand 0.8.5",
@@ -6852,6 +6849,7 @@ dependencies = [
  "solana-serde-varint",
  "solana-short-vec",
  "solana-signature",
+ "solana-signer",
  "solana-time-utils",
  "solana-transaction-error",
  "thiserror",
@@ -6942,6 +6940,26 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sanitize",
+]
+
+[[package]]
+name = "solana-signer"
+version = "2.2.0"
+dependencies = [
+ "bs58",
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "hmac 0.12.1",
+ "itertools 0.12.1",
+ "pbkdf2 0.11.0",
+ "rand 0.7.3",
+ "serde_json",
+ "sha2 0.10.8",
+ "solana-derivation-path",
+ "solana-pubkey",
+ "solana-signature",
+ "solana-transaction-error",
+ "thiserror",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6846,6 +6846,7 @@ dependencies = [
  "solana-sanitize",
  "solana-sdk-macro",
  "solana-secp256k1-recover",
+ "solana-seed-derivable",
  "solana-serde-varint",
  "solana-short-vec",
  "solana-signature",
@@ -6881,6 +6882,16 @@ name = "solana-security-txt"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
+
+[[package]]
+name = "solana-seed-derivable"
+version = "2.2.0"
+dependencies = [
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "solana-derivation-path",
+ "solana-signer",
+]
 
 [[package]]
 name = "solana-send-transaction-service"
@@ -6948,14 +6959,12 @@ version = "2.2.0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
- "ed25519-dalek-bip32",
  "hmac 0.12.1",
  "itertools 0.12.1",
  "pbkdf2 0.11.0",
  "rand 0.7.3",
  "serde_json",
  "sha2 0.10.8",
- "solana-derivation-path",
  "solana-pubkey",
  "solana-signature",
  "solana-transaction-error",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6981,7 +6981,6 @@ version = "2.2.0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
- "itertools 0.12.1",
  "rand 0.7.3",
  "solana-pubkey",
  "solana-signature",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6983,7 +6983,6 @@ dependencies = [
  "ed25519-dalek",
  "itertools 0.12.1",
  "rand 0.7.3",
- "serde_json",
  "solana-pubkey",
  "solana-signature",
  "solana-transaction-error",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5539,6 +5539,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-keypair"
+version = "2.2.0"
+dependencies = [
+ "bs58",
+ "ed25519-dalek",
+ "rand 0.7.3",
+ "solana-pubkey",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+ "solana-transaction-error",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "solana-last-restart-slot"
 version = "2.2.0"
 dependencies = [
@@ -6846,6 +6861,7 @@ dependencies = [
  "solana-fee-structure",
  "solana-inflation",
  "solana-instruction",
+ "solana-keypair",
  "solana-native-token",
  "solana-packet",
  "solana-precompile-error",
@@ -6901,8 +6917,7 @@ dependencies = [
  "ed25519-dalek",
  "ed25519-dalek-bip32",
  "solana-derivation-path",
- "solana-seed-phrase",
- "solana-signer",
+ "solana-keypair",
 ]
 
 [[package]]
@@ -6912,7 +6927,6 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "sha2 0.10.8",
- "solana-signer",
 ]
 
 [[package]]
@@ -6979,13 +6993,9 @@ dependencies = [
 name = "solana-signer"
 version = "2.2.0"
 dependencies = [
- "bs58",
- "ed25519-dalek",
- "rand 0.7.3",
  "solana-pubkey",
  "solana-signature",
  "solana-transaction-error",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5544,8 +5544,11 @@ version = "2.2.0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
+ "ed25519-dalek-bip32",
  "rand 0.7.3",
+ "solana-derivation-path",
  "solana-pubkey",
+ "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
@@ -6913,10 +6916,7 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 name = "solana-seed-derivable"
 version = "2.2.0"
 dependencies = [
- "ed25519-dalek",
- "ed25519-dalek-bip32",
  "solana-derivation-path",
- "solana-keypair",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6986,7 +6986,6 @@ dependencies = [
  "solana-pubkey",
  "solana-signature",
  "solana-transaction-error",
- "thiserror",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5549,7 +5549,6 @@ dependencies = [
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
- "solana-transaction-error",
  "wasm-bindgen",
 ]
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -36,6 +36,7 @@ full = [
     "digest",
     "solana-pubkey/rand",
     "dep:solana-precompile-error",
+    "dep:solana-presigner",
     "dep:solana-seed-derivable",
     "dep:solana-seed-phrase",
     "dep:solana-transaction-error"
@@ -108,6 +109,7 @@ solana-instruction = { workspace = true }
 solana-native-token = { workspace = true }
 solana-packet = { workspace = true, features = ["bincode", "serde"] }
 solana-precompile-error = { workspace = true, optional = true }
+solana-presigner = { workspace = true, optional = true }
 solana-program = { workspace = true }
 solana-program-memory = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false, features = ["std"] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -36,6 +36,7 @@ full = [
     "digest",
     "solana-pubkey/rand",
     "dep:solana-precompile-error",
+    "dep:solana-seed-derivable",
     "dep:solana-transaction-error"
 ]
 borsh = ["dep:borsh", "solana-program/borsh", "solana-secp256k1-recover/borsh"]
@@ -114,6 +115,7 @@ solana-sdk-macro = { workspace = true }
 solana-secp256k1-recover = { workspace = true }
 solana-serde-varint = { workspace = true }
 solana-short-vec = { workspace = true }
+solana-seed-derivable = { workspace = true, optional = true }
 solana-signer = { workspace = true, optional = true }
 solana-signature = { workspace = true, features = [
     "rand",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -107,7 +107,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-inflation = { workspace = true, features = ["serde"] }
 solana-instruction = { workspace = true }
-solana-keypair = { workspace = true, optional = true }
+solana-keypair = { workspace = true, optional = true, features = ["seed-derivable"] }
 solana-native-token = { workspace = true }
 solana-packet = { workspace = true, features = ["bincode", "serde"] }
 solana-precompile-error = { workspace = true, optional = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -37,6 +37,7 @@ full = [
     "solana-pubkey/rand",
     "dep:solana-precompile-error",
     "dep:solana-seed-derivable",
+    "dep:solana-seed-phrase",
     "dep:solana-transaction-error"
 ]
 borsh = ["dep:borsh", "solana-program/borsh", "solana-secp256k1-recover/borsh"]
@@ -116,6 +117,7 @@ solana-secp256k1-recover = { workspace = true }
 solana-serde-varint = { workspace = true }
 solana-short-vec = { workspace = true }
 solana-seed-derivable = { workspace = true, optional = true }
+solana-seed-phrase = { workspace = true, optional = true }
 solana-signer = { workspace = true, optional = true }
 solana-signature = { workspace = true, features = [
     "rand",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -116,17 +116,17 @@ solana-pubkey = { workspace = true, default-features = false, features = ["std"]
 solana-sanitize = { workspace = true }
 solana-sdk-macro = { workspace = true }
 solana-secp256k1-recover = { workspace = true }
-solana-serde-varint = { workspace = true }
-solana-short-vec = { workspace = true }
 solana-seed-derivable = { workspace = true, optional = true }
 solana-seed-phrase = { workspace = true, optional = true }
-solana-signer = { workspace = true, optional = true, features = ["keypair"] }
+solana-serde-varint = { workspace = true }
+solana-short-vec = { workspace = true }
 solana-signature = { workspace = true, features = [
     "rand",
     "serde",
     "std",
     "verify",
 ], optional = true }
+solana-signer = { workspace = true, optional = true, features = ["keypair"] }
 solana-time-utils = { workspace = true }
 solana-transaction-error = { workspace = true, features = ["serde"], optional = true }
 thiserror = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -28,17 +28,18 @@ full = [
     "rand0-7",
     "serde_json",
     "solana-signature",
-    "solana-signer",
     "ed25519-dalek",
     "libsecp256k1",
     "sha3",
     "solana-commitment-config",
     "digest",
     "solana-pubkey/rand",
+    "dep:solana-keypair",
     "dep:solana-precompile-error",
     "dep:solana-presigner",
     "dep:solana-seed-derivable",
     "dep:solana-seed-phrase",
+    "dep:solana-signer",
     "dep:solana-transaction-error"
 ]
 borsh = ["dep:borsh", "solana-program/borsh", "solana-secp256k1-recover/borsh"]
@@ -106,6 +107,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-inflation = { workspace = true, features = ["serde"] }
 solana-instruction = { workspace = true }
+solana-keypair = { workspace = true, optional = true }
 solana-native-token = { workspace = true }
 solana-packet = { workspace = true, features = ["bincode", "serde"] }
 solana-precompile-error = { workspace = true, optional = true }
@@ -126,7 +128,7 @@ solana-signature = { workspace = true, features = [
     "std",
     "verify",
 ], optional = true }
-solana-signer = { workspace = true, optional = true, features = ["keypair"] }
+solana-signer = { workspace = true, optional = true }
 solana-time-utils = { workspace = true }
 solana-transaction-error = { workspace = true, features = ["serde"], optional = true }
 thiserror = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -120,7 +120,7 @@ solana-serde-varint = { workspace = true }
 solana-short-vec = { workspace = true }
 solana-seed-derivable = { workspace = true, optional = true }
 solana-seed-phrase = { workspace = true, optional = true }
-solana-signer = { workspace = true, optional = true }
+solana-signer = { workspace = true, optional = true, features = ["keypair"] }
 solana-signature = { workspace = true, features = [
     "rand",
     "serde",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -28,8 +28,8 @@ full = [
     "rand0-7",
     "serde_json",
     "solana-signature",
+    "solana-signer",
     "ed25519-dalek",
-    "ed25519-dalek-bip32",
     "libsecp256k1",
     "sha3",
     "solana-commitment-config",
@@ -65,12 +65,10 @@ chrono = { workspace = true, features = ["alloc"], optional = true }
 curve25519-dalek = { workspace = true, optional = true }
 digest = { workspace = true, optional = true }
 ed25519-dalek = { workspace = true, optional = true }
-ed25519-dalek-bip32 = { workspace = true, optional = true }
 generic-array = { workspace = true, features = [
     "serde",
     "more_lengths",
 ], optional = true }
-hmac = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 libsecp256k1 = { workspace = true, optional = true, features = ["hmac"] }
@@ -79,10 +77,9 @@ memmap2 = { workspace = true, optional = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 num_enum = { workspace = true }
-pbkdf2 = { workspace = true }
 qualifier_attr = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
-rand0-7 = { package = "rand", version = "0.7", optional = true }
+rand0-7 = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_derive = { workspace = true }
@@ -117,6 +114,7 @@ solana-sdk-macro = { workspace = true }
 solana-secp256k1-recover = { workspace = true }
 solana-serde-varint = { workspace = true }
 solana-short-vec = { workspace = true }
+solana-signer = { workspace = true, optional = true }
 solana-signature = { workspace = true, features = [
     "rand",
     "serde",

--- a/sdk/keypair/Cargo.toml
+++ b/sdk/keypair/Cargo.toml
@@ -12,8 +12,11 @@ edition = { workspace = true }
 [dependencies]
 bs58 = { workspace = true, features = ["std"] }
 ed25519-dalek = { workspace = true }
+ed25519-dalek-bip32 = { workspace = true, optional = true }
 rand0-7 = { workspace = true }
+solana-derivation-path = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
+solana-seed-derivable = { workspace = true, optional = true }
 solana-seed-phrase = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
@@ -25,6 +28,9 @@ wasm-bindgen = { workspace = true }
 serde_json = { workspace = true }
 static_assertions = { workspace = true }
 tiny-bip39 = { workspace = true }
+
+[features]
+seed-derivable = ["dep:solana-derivation-path", "dep:solana-seed-derivable", "dep:ed25519-dalek-bip32"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/keypair/Cargo.toml
+++ b/sdk/keypair/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "solana-signer"
-description = "Abstractions for Solana transaction signers. See `solana-keypair` for a concrete implementation."
-documentation = "https://docs.rs/solana-signer"
+name = "solana-keypair"
+description = "Concrete implementation of a Solana `Signer`."
+documentation = "https://docs.rs/solana-keypair"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
@@ -10,13 +10,22 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bs58 = { workspace = true, features = ["std"] }
+ed25519-dalek = { workspace = true }
+rand0-7 = { workspace = true }
 solana-pubkey = { workspace = true }
+solana-seed-phrase = { workspace = true }
 solana-signature = { workspace = true }
+solana-signer = { workspace = true }
 solana-transaction-error = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
 static_assertions = { workspace = true }
+tiny-bip39 = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/keypair/Cargo.toml
+++ b/sdk/keypair/Cargo.toml
@@ -17,7 +17,6 @@ solana-pubkey = { workspace = true }
 solana-seed-phrase = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
-solana-transaction-error = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { workspace = true }

--- a/sdk/keypair/src/lib.rs
+++ b/sdk/keypair/src/lib.rs
@@ -1,3 +1,5 @@
+//! Concrete implementation of a Solana `Signer` from raw bytes
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 use {

--- a/sdk/keypair/src/lib.rs
+++ b/sdk/keypair/src/lib.rs
@@ -16,6 +16,9 @@ use {
     },
 };
 
+#[cfg(feature = "seed-derivable")]
+pub mod seed_derivable;
+
 /// A vanilla Ed25519 key pair
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[derive(Debug)]

--- a/sdk/keypair/src/seed_derivable.rs
+++ b/sdk/keypair/src/seed_derivable.rs
@@ -1,0 +1,53 @@
+//! Implementation of the SeedDerivable trait for Keypair
+
+use {
+    crate::{keypair_from_seed, keypair_from_seed_phrase_and_passphrase, Keypair},
+    ed25519_dalek_bip32::Error as Bip32Error,
+    solana_derivation_path::DerivationPath,
+    solana_seed_derivable::SeedDerivable,
+    std::error,
+};
+
+impl SeedDerivable for Keypair {
+    fn from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>> {
+        keypair_from_seed(seed)
+    }
+
+    fn from_seed_and_derivation_path(
+        seed: &[u8],
+        derivation_path: Option<DerivationPath>,
+    ) -> Result<Self, Box<dyn error::Error>> {
+        keypair_from_seed_and_derivation_path(seed, derivation_path)
+    }
+
+    fn from_seed_phrase_and_passphrase(
+        seed_phrase: &str,
+        passphrase: &str,
+    ) -> Result<Self, Box<dyn error::Error>> {
+        keypair_from_seed_phrase_and_passphrase(seed_phrase, passphrase)
+    }
+}
+
+/// Generates a Keypair using Bip32 Hierarchical Derivation if derivation-path is provided;
+/// otherwise generates the base Bip44 Solana keypair from the seed
+pub fn keypair_from_seed_and_derivation_path(
+    seed: &[u8],
+    derivation_path: Option<DerivationPath>,
+) -> Result<Keypair, Box<dyn error::Error>> {
+    let derivation_path = derivation_path.unwrap_or_default();
+    bip32_derived_keypair(seed, derivation_path).map_err(|err| err.to_string().into())
+}
+
+/// Generates a Keypair using Bip32 Hierarchical Derivation
+fn bip32_derived_keypair(
+    seed: &[u8],
+    derivation_path: DerivationPath,
+) -> Result<Keypair, Bip32Error> {
+    let extended = ed25519_dalek_bip32::ExtendedSecretKey::from_seed(seed)
+        .and_then(|extended| extended.derive(&derivation_path))?;
+    let extended_public_key = extended.public_key();
+    Ok(Keypair::from(ed25519_dalek::Keypair {
+        secret: extended.secret_key,
+        public: extended_public_key,
+    }))
+}

--- a/sdk/presigner/Cargo.toml
+++ b/sdk/presigner/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "solana-presigner"
+description = "A Solana  `Signer` implementation representing an externally-constructed `Signature`."
+documentation = "https://docs.rs/solana-presigner"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-pubkey = { workspace = true }
+solana-signature = { workspace = true, features = ["verify"] }
+solana-signer = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/presigner/Cargo.toml
+++ b/sdk/presigner/Cargo.toml
@@ -14,5 +14,8 @@ solana-pubkey = { workspace = true }
 solana-signature = { workspace = true, features = ["verify"] }
 solana-signer = { workspace = true }
 
+[dev-dependencies]
+solana-signer = { workspace = true, features = ["keypair"] }
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/presigner/Cargo.toml
+++ b/sdk/presigner/Cargo.toml
@@ -15,7 +15,7 @@ solana-signature = { workspace = true, features = ["verify"] }
 solana-signer = { workspace = true }
 
 [dev-dependencies]
-solana-signer = { workspace = true, features = ["keypair"] }
+solana-keypair = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/presigner/Cargo.toml
+++ b/sdk/presigner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-presigner"
-description = "A Solana  `Signer` implementation representing an externally-constructed `Signature`."
+description = "A Solana `Signer` implementation representing an externally-constructed `Signature`."
 documentation = "https://docs.rs/solana-presigner"
 version = { workspace = true }
 authors = { workspace = true }

--- a/sdk/presigner/src/lib.rs
+++ b/sdk/presigner/src/lib.rs
@@ -1,8 +1,8 @@
+pub use solana_signer::PresignerError;
 use {
-    crate::{Signer, SignerError},
     solana_pubkey::Pubkey,
     solana_signature::Signature,
-    thiserror::Error,
+    solana_signer::{Signer, SignerError},
 };
 
 /// A `Signer` implementation that represents a `Signature` that has been
@@ -22,12 +22,6 @@ impl Presigner {
             signature: *signature,
         }
     }
-}
-
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum PresignerError {
-    #[error("pre-generated signature cannot verify data")]
-    VerificationFailure,
 }
 
 impl Signer for Presigner {
@@ -59,7 +53,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::keypair::keypair_from_seed};
+    use {super::*, solana_signer::keypair::keypair_from_seed};
 
     #[test]
     fn test_presigner() {

--- a/sdk/presigner/src/lib.rs
+++ b/sdk/presigner/src/lib.rs
@@ -53,7 +53,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_signer::keypair::keypair_from_seed};
+    use {super::*, solana_keypair::keypair_from_seed};
 
     #[test]
     fn test_presigner() {

--- a/sdk/seed-derivable/Cargo.toml
+++ b/sdk/seed-derivable/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 ed25519-dalek = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 solana-derivation-path = { workspace = true }
+solana-seed-phrase = { workspace = true }
 solana-signer = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/sdk/seed-derivable/Cargo.toml
+++ b/sdk/seed-derivable/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 ed25519-dalek = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 solana-derivation-path = { workspace = true }
-solana-seed-phrase = { workspace = true }
+solana-seed-phrase = { workspace = true, features = ["keypair"] }
 solana-signer = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/sdk/seed-derivable/Cargo.toml
+++ b/sdk/seed-derivable/Cargo.toml
@@ -10,10 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-ed25519-dalek = { workspace = true }
-ed25519-dalek-bip32 = { workspace = true }
 solana-derivation-path = { workspace = true }
-solana-keypair = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/seed-derivable/Cargo.toml
+++ b/sdk/seed-derivable/Cargo.toml
@@ -13,8 +13,7 @@ edition = { workspace = true }
 ed25519-dalek = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 solana-derivation-path = { workspace = true }
-solana-seed-phrase = { workspace = true, features = ["keypair"] }
-solana-signer = { workspace = true }
+solana-keypair = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/seed-derivable/Cargo.toml
+++ b/sdk/seed-derivable/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-seed-derivable"
+description = "Solana trait defining the interface by which keys are derived."
+documentation = "https://docs.rs/solana-seed-derivable"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+ed25519-dalek = { workspace = true }
+ed25519-dalek-bip32 = { workspace = true }
+solana-derivation-path = { workspace = true }
+solana-signer = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/seed-derivable/src/lib.rs
+++ b/sdk/seed-derivable/src/lib.rs
@@ -1,0 +1,65 @@
+//! Abstractions and implementations for transaction signers.
+use {
+    ed25519_dalek_bip32::Error as Bip32Error,
+    solana_derivation_path::DerivationPath,
+    solana_signer::keypair::{keypair_from_seed, keypair_from_seed_phrase_and_passphrase, Keypair},
+    std::error,
+};
+
+/// The `SeedDerivable` trait defines the interface by which cryptographic keys/keypairs are
+/// derived from byte seeds, derivation paths, and passphrases.
+pub trait SeedDerivable: Sized {
+    fn from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>>;
+    fn from_seed_and_derivation_path(
+        seed: &[u8],
+        derivation_path: Option<DerivationPath>,
+    ) -> Result<Self, Box<dyn error::Error>>;
+    fn from_seed_phrase_and_passphrase(
+        seed_phrase: &str,
+        passphrase: &str,
+    ) -> Result<Self, Box<dyn error::Error>>;
+}
+
+impl SeedDerivable for Keypair {
+    fn from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>> {
+        keypair_from_seed(seed)
+    }
+
+    fn from_seed_and_derivation_path(
+        seed: &[u8],
+        derivation_path: Option<DerivationPath>,
+    ) -> Result<Self, Box<dyn error::Error>> {
+        keypair_from_seed_and_derivation_path(seed, derivation_path)
+    }
+
+    fn from_seed_phrase_and_passphrase(
+        seed_phrase: &str,
+        passphrase: &str,
+    ) -> Result<Self, Box<dyn error::Error>> {
+        keypair_from_seed_phrase_and_passphrase(seed_phrase, passphrase)
+    }
+}
+
+/// Generates a Keypair using Bip32 Hierarchical Derivation if derivation-path is provided;
+/// otherwise generates the base Bip44 Solana keypair from the seed
+pub fn keypair_from_seed_and_derivation_path(
+    seed: &[u8],
+    derivation_path: Option<DerivationPath>,
+) -> Result<Keypair, Box<dyn error::Error>> {
+    let derivation_path = derivation_path.unwrap_or_default();
+    bip32_derived_keypair(seed, derivation_path).map_err(|err| err.to_string().into())
+}
+
+/// Generates a Keypair using Bip32 Hierarchical Derivation
+fn bip32_derived_keypair(
+    seed: &[u8],
+    derivation_path: DerivationPath,
+) -> Result<Keypair, Bip32Error> {
+    let extended = ed25519_dalek_bip32::ExtendedSecretKey::from_seed(seed)
+        .and_then(|extended| extended.derive(&derivation_path))?;
+    let extended_public_key = extended.public_key();
+    Ok(Keypair::from(ed25519_dalek::Keypair {
+        secret: extended.secret_key,
+        public: extended_public_key,
+    }))
+}

--- a/sdk/seed-derivable/src/lib.rs
+++ b/sdk/seed-derivable/src/lib.rs
@@ -2,8 +2,7 @@
 use {
     ed25519_dalek_bip32::Error as Bip32Error,
     solana_derivation_path::DerivationPath,
-    solana_seed_phrase::keypair_from_seed_phrase_and_passphrase,
-    solana_signer::keypair::{keypair_from_seed, Keypair},
+    solana_keypair::{keypair_from_seed, keypair_from_seed_phrase_and_passphrase, Keypair},
     std::error,
 };
 

--- a/sdk/seed-derivable/src/lib.rs
+++ b/sdk/seed-derivable/src/lib.rs
@@ -2,7 +2,8 @@
 use {
     ed25519_dalek_bip32::Error as Bip32Error,
     solana_derivation_path::DerivationPath,
-    solana_signer::keypair::{keypair_from_seed, keypair_from_seed_phrase_and_passphrase, Keypair},
+    solana_seed_phrase::keypair_from_seed_phrase_and_passphrase,
+    solana_signer::keypair::{keypair_from_seed, Keypair},
     std::error,
 };
 

--- a/sdk/seed-derivable/src/lib.rs
+++ b/sdk/seed-derivable/src/lib.rs
@@ -1,10 +1,5 @@
 //! The interface by which keys are derived.
-use {
-    ed25519_dalek_bip32::Error as Bip32Error,
-    solana_derivation_path::DerivationPath,
-    solana_keypair::{keypair_from_seed, keypair_from_seed_phrase_and_passphrase, Keypair},
-    std::error,
-};
+use {solana_derivation_path::DerivationPath, std::error};
 
 /// The `SeedDerivable` trait defines the interface by which cryptographic keys/keypairs are
 /// derived from byte seeds, derivation paths, and passphrases.
@@ -18,48 +13,4 @@ pub trait SeedDerivable: Sized {
         seed_phrase: &str,
         passphrase: &str,
     ) -> Result<Self, Box<dyn error::Error>>;
-}
-
-impl SeedDerivable for Keypair {
-    fn from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>> {
-        keypair_from_seed(seed)
-    }
-
-    fn from_seed_and_derivation_path(
-        seed: &[u8],
-        derivation_path: Option<DerivationPath>,
-    ) -> Result<Self, Box<dyn error::Error>> {
-        keypair_from_seed_and_derivation_path(seed, derivation_path)
-    }
-
-    fn from_seed_phrase_and_passphrase(
-        seed_phrase: &str,
-        passphrase: &str,
-    ) -> Result<Self, Box<dyn error::Error>> {
-        keypair_from_seed_phrase_and_passphrase(seed_phrase, passphrase)
-    }
-}
-
-/// Generates a Keypair using Bip32 Hierarchical Derivation if derivation-path is provided;
-/// otherwise generates the base Bip44 Solana keypair from the seed
-pub fn keypair_from_seed_and_derivation_path(
-    seed: &[u8],
-    derivation_path: Option<DerivationPath>,
-) -> Result<Keypair, Box<dyn error::Error>> {
-    let derivation_path = derivation_path.unwrap_or_default();
-    bip32_derived_keypair(seed, derivation_path).map_err(|err| err.to_string().into())
-}
-
-/// Generates a Keypair using Bip32 Hierarchical Derivation
-fn bip32_derived_keypair(
-    seed: &[u8],
-    derivation_path: DerivationPath,
-) -> Result<Keypair, Bip32Error> {
-    let extended = ed25519_dalek_bip32::ExtendedSecretKey::from_seed(seed)
-        .and_then(|extended| extended.derive(&derivation_path))?;
-    let extended_public_key = extended.public_key();
-    Ok(Keypair::from(ed25519_dalek::Keypair {
-        secret: extended.secret_key,
-        public: extended_public_key,
-    }))
 }

--- a/sdk/seed-derivable/src/lib.rs
+++ b/sdk/seed-derivable/src/lib.rs
@@ -1,4 +1,4 @@
-//! Abstractions and implementations for transaction signers.
+//! The interface by which keys are derived.
 use {
     ed25519_dalek_bip32::Error as Bip32Error,
     solana_derivation_path::DerivationPath,

--- a/sdk/seed-phrase/Cargo.toml
+++ b/sdk/seed-phrase/Cargo.toml
@@ -13,10 +13,13 @@ edition = { workspace = true }
 hmac = { workspace = true }
 pbkdf2 = { workspace = true }
 sha2 = { workspace = true }
-solana-signer = { workspace = true, features = ["keypair"] }
+solana-signer = { workspace = true }
 
 [dev-dependencies]
 tiny-bip39 = { workspace = true }
+
+[features]
+keypair = ["solana-signer/keypair"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/seed-phrase/Cargo.toml
+++ b/sdk/seed-phrase/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "solana-seed-phrase"
+description = "Solana functions for generating keypairs from seed phrases."
+documentation = "https://docs.rs/solana-seed-phrase"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+pbkdf2 = { workspace = true }
+hmac = { workspace = true }
+sha2 = { workspace = true }
+solana-signer = { workspace = true }
+
+[dev-dependencies]
+tiny-bip39 = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/seed-phrase/Cargo.toml
+++ b/sdk/seed-phrase/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 pbkdf2 = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
-solana-signer = { workspace = true }
+solana-signer = { workspace = true, features = ["keypair"] }
 
 [dev-dependencies]
 tiny-bip39 = { workspace = true }

--- a/sdk/seed-phrase/Cargo.toml
+++ b/sdk/seed-phrase/Cargo.toml
@@ -13,15 +13,6 @@ edition = { workspace = true }
 hmac = { workspace = true }
 pbkdf2 = { workspace = true }
 sha2 = { workspace = true }
-solana-signer = { workspace = true }
-
-[dev-dependencies]
-solana-seed-phrase = { path = ".", features = ["dev-context-only-utils"] }
-tiny-bip39 = { workspace = true }
-
-[features]
-dev-context-only-utils = ["keypair"]
-keypair = ["solana-signer/keypair"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/seed-phrase/Cargo.toml
+++ b/sdk/seed-phrase/Cargo.toml
@@ -10,8 +10,8 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-pbkdf2 = { workspace = true }
 hmac = { workspace = true }
+pbkdf2 = { workspace = true }
 sha2 = { workspace = true }
 solana-signer = { workspace = true, features = ["keypair"] }
 

--- a/sdk/seed-phrase/Cargo.toml
+++ b/sdk/seed-phrase/Cargo.toml
@@ -16,9 +16,11 @@ sha2 = { workspace = true }
 solana-signer = { workspace = true }
 
 [dev-dependencies]
+solana-seed-phrase = { path = ".", features = ["dev-context-only-utils"] }
 tiny-bip39 = { workspace = true }
 
 [features]
+dev-context-only-utils = ["keypair"]
 keypair = ["solana-signer/keypair"]
 
 [package.metadata.docs.rs]

--- a/sdk/seed-phrase/src/lib.rs
+++ b/sdk/seed-phrase/src/lib.rs
@@ -1,0 +1,55 @@
+//! Functions for generating keypairs from seed phrases.
+use {
+    hmac::Hmac,
+    solana_signer::keypair::{keypair_from_seed, Keypair},
+    std::error,
+};
+
+pub fn generate_seed_from_seed_phrase_and_passphrase(
+    seed_phrase: &str,
+    passphrase: &str,
+) -> Vec<u8> {
+    const PBKDF2_ROUNDS: u32 = 2048;
+    const PBKDF2_BYTES: usize = 64;
+
+    let salt = format!("mnemonic{passphrase}");
+
+    let mut seed = vec![0u8; PBKDF2_BYTES];
+    pbkdf2::pbkdf2::<Hmac<sha2::Sha512>>(
+        seed_phrase.as_bytes(),
+        salt.as_bytes(),
+        PBKDF2_ROUNDS,
+        &mut seed,
+    );
+    seed
+}
+
+pub fn keypair_from_seed_phrase_and_passphrase(
+    seed_phrase: &str,
+    passphrase: &str,
+) -> Result<Keypair, Box<dyn error::Error>> {
+    keypair_from_seed(&generate_seed_from_seed_phrase_and_passphrase(
+        seed_phrase,
+        passphrase,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        bip39::{Language, Mnemonic, MnemonicType, Seed},
+        solana_signer::Signer,
+    };
+
+    #[test]
+    fn test_keypair_from_seed_phrase_and_passphrase() {
+        let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
+        let passphrase = "42";
+        let seed = Seed::new(&mnemonic, passphrase);
+        let expected_keypair = keypair_from_seed(seed.as_bytes()).unwrap();
+        let keypair =
+            keypair_from_seed_phrase_and_passphrase(mnemonic.phrase(), passphrase).unwrap();
+        assert_eq!(keypair.pubkey(), expected_keypair.pubkey());
+    }
+}

--- a/sdk/seed-phrase/src/lib.rs
+++ b/sdk/seed-phrase/src/lib.rs
@@ -1,9 +1,7 @@
 //! Functions for generating keypairs from seed phrases.
-use {
-    hmac::Hmac,
-    solana_signer::keypair::{keypair_from_seed, Keypair},
-    std::error,
-};
+use hmac::Hmac;
+#[cfg(feature = "keypair")]
+use solana_signer::keypair::{keypair_from_seed, Keypair};
 
 pub fn generate_seed_from_seed_phrase_and_passphrase(
     seed_phrase: &str,
@@ -28,7 +26,7 @@ pub fn generate_seed_from_seed_phrase_and_passphrase(
 pub fn keypair_from_seed_phrase_and_passphrase(
     seed_phrase: &str,
     passphrase: &str,
-) -> Result<Keypair, Box<dyn error::Error>> {
+) -> Result<Keypair, Box<dyn std::error::Error>> {
     keypair_from_seed(&generate_seed_from_seed_phrase_and_passphrase(
         seed_phrase,
         passphrase,

--- a/sdk/seed-phrase/src/lib.rs
+++ b/sdk/seed-phrase/src/lib.rs
@@ -24,6 +24,7 @@ pub fn generate_seed_from_seed_phrase_and_passphrase(
     seed
 }
 
+#[cfg(feature = "keypair")]
 pub fn keypair_from_seed_phrase_and_passphrase(
     seed_phrase: &str,
     passphrase: &str,

--- a/sdk/seed-phrase/src/lib.rs
+++ b/sdk/seed-phrase/src/lib.rs
@@ -1,7 +1,5 @@
 //! Functions for generating keypairs from seed phrases.
 use hmac::Hmac;
-#[cfg(feature = "keypair")]
-use solana_signer::keypair::{keypair_from_seed, Keypair};
 
 pub fn generate_seed_from_seed_phrase_and_passphrase(
     seed_phrase: &str,
@@ -20,35 +18,4 @@ pub fn generate_seed_from_seed_phrase_and_passphrase(
         &mut seed,
     );
     seed
-}
-
-#[cfg(feature = "keypair")]
-pub fn keypair_from_seed_phrase_and_passphrase(
-    seed_phrase: &str,
-    passphrase: &str,
-) -> Result<Keypair, Box<dyn std::error::Error>> {
-    keypair_from_seed(&generate_seed_from_seed_phrase_and_passphrase(
-        seed_phrase,
-        passphrase,
-    ))
-}
-
-#[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        bip39::{Language, Mnemonic, MnemonicType, Seed},
-        solana_signer::Signer,
-    };
-
-    #[test]
-    fn test_keypair_from_seed_phrase_and_passphrase() {
-        let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
-        let passphrase = "42";
-        let seed = Seed::new(&mnemonic, passphrase);
-        let expected_keypair = keypair_from_seed(seed.as_bytes()).unwrap();
-        let keypair =
-            keypair_from_seed_phrase_and_passphrase(mnemonic.phrase(), passphrase).unwrap();
-        assert_eq!(keypair.pubkey(), expected_keypair.pubkey());
-    }
 }

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -17,7 +17,6 @@ rand0-7 = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction-error = { workspace = true }
-thiserror = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -12,12 +12,9 @@ edition = { workspace = true }
 [dependencies]
 bs58 = { workspace = true, features = ["std"] }
 ed25519-dalek = { workspace = true }
-hmac = { workspace = true }
 itertools = { workspace = true }
-pbkdf2 = { workspace = true }
 rand0-7 = { workspace = true }
 serde_json = { workspace = true }
-sha2 = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true, features = ["verify"] }
 solana-transaction-error = { workspace = true }
@@ -25,7 +22,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 static_assertions = { workspace = true }
-tiny-bip39 = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -14,21 +14,22 @@ bs58 = { workspace = true, features = ["std"], optional = true }
 ed25519-dalek = { workspace = true, optional = true }
 itertools = { workspace = true }
 rand0-7 = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+serde_json = { workspace = true }
+solana-signer = { path = ".", features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 
 [features]
+dev-context-only-utils = ["keypair"]
 keypair = [
     "dep:bs58",
     "dep:ed25519-dalek",
     "dep:rand0-7",
-    "dep:serde_json"
 ]
 
 [package.metadata.docs.rs]

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -35,3 +35,5 @@ keypair = [
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "solana-signer"
+description = "Solana abstractions and implementations for transaction signers."
+documentation = "https://docs.rs/solana-signer"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+bs58 = { workspace = true }
+ed25519-dalek = { workspace = true }
+ed25519-dalek-bip32 = { workspace = true }
+hmac = { workspace = true }
+itertools = { workspace = true }
+pbkdf2 = { workspace = true }
+rand0-7 = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+solana-derivation-path = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-signature = { workspace = true, features = ["verify" ]}
+solana-transaction-error = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+static_assertions = { workspace = true }
+tiny-bip39 = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -10,7 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-bs58 = { workspace = true }
+bs58 = { workspace = true, features = ["std"] }
 ed25519-dalek = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 hmac = { workspace = true }

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -14,10 +14,6 @@ solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction-error = { workspace = true }
 
-[dev-dependencies]
-serde_json = { workspace = true }
-static_assertions = { workspace = true }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -16,7 +16,7 @@ itertools = { workspace = true }
 rand0-7 = { workspace = true }
 serde_json = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-signature = { workspace = true, features = ["verify"] }
+solana-signature = { workspace = true }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -12,14 +12,12 @@ edition = { workspace = true }
 [dependencies]
 bs58 = { workspace = true, features = ["std"] }
 ed25519-dalek = { workspace = true }
-ed25519-dalek-bip32 = { workspace = true }
 hmac = { workspace = true }
 itertools = { workspace = true }
 pbkdf2 = { workspace = true }
 rand0-7 = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-solana-derivation-path = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true, features = ["verify"] }
 solana-transaction-error = { workspace = true }

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 solana-derivation-path = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-signature = { workspace = true, features = ["verify" ]}
+solana-signature = { workspace = true, features = ["verify"] }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -17,6 +17,9 @@ solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction-error = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { workspace = true }
+
 [dev-dependencies]
 serde_json = { workspace = true }
 solana-signer = { path = ".", features = ["dev-context-only-utils"] }

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -12,7 +12,6 @@ edition = { workspace = true }
 [dependencies]
 bs58 = { workspace = true, features = ["std"], optional = true }
 ed25519-dalek = { workspace = true, optional = true }
-itertools = { workspace = true }
 rand0-7 = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }

--- a/sdk/signer/Cargo.toml
+++ b/sdk/signer/Cargo.toml
@@ -10,11 +10,11 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-bs58 = { workspace = true, features = ["std"] }
-ed25519-dalek = { workspace = true }
+bs58 = { workspace = true, features = ["std"], optional = true }
+ed25519-dalek = { workspace = true, optional = true }
 itertools = { workspace = true }
-rand0-7 = { workspace = true }
-serde_json = { workspace = true }
+rand0-7 = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction-error = { workspace = true }
@@ -22,6 +22,14 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 static_assertions = { workspace = true }
+
+[features]
+keypair = [
+    "dep:bs58",
+    "dep:ed25519-dalek",
+    "dep:rand0-7",
+    "dep:serde_json"
+]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/signer/src/keypair.rs
+++ b/sdk/signer/src/keypair.rs
@@ -1,12 +1,10 @@
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 use {
-    crate::{EncodableKey, EncodableKeypair, SeedDerivable, Signer, SignerError},
+    crate::{EncodableKey, EncodableKeypair, Signer, SignerError},
     ed25519_dalek::Signer as DalekSigner,
-    ed25519_dalek_bip32::Error as Bip32Error,
     hmac::Hmac,
     rand0_7::{rngs::OsRng, CryptoRng, RngCore},
-    solana_derivation_path::DerivationPath,
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     std::{
@@ -96,6 +94,12 @@ impl Keypair {
     }
 }
 
+impl From<ed25519_dalek::Keypair> for Keypair {
+    fn from(value: ed25519_dalek::Keypair) -> Self {
+        Self(value)
+    }
+}
+
 #[cfg(test)]
 static_assertions::const_assert_eq!(Keypair::SECRET_KEY_LENGTH, ed25519_dalek::SECRET_KEY_LENGTH);
 
@@ -138,26 +142,6 @@ impl EncodableKey for Keypair {
 
     fn write<W: Write>(&self, writer: &mut W) -> Result<String, Box<dyn error::Error>> {
         write_keypair(self, writer)
-    }
-}
-
-impl SeedDerivable for Keypair {
-    fn from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>> {
-        keypair_from_seed(seed)
-    }
-
-    fn from_seed_and_derivation_path(
-        seed: &[u8],
-        derivation_path: Option<DerivationPath>,
-    ) -> Result<Self, Box<dyn error::Error>> {
-        keypair_from_seed_and_derivation_path(seed, derivation_path)
-    }
-
-    fn from_seed_phrase_and_passphrase(
-        seed_phrase: &str,
-        passphrase: &str,
-    ) -> Result<Self, Box<dyn error::Error>> {
-        keypair_from_seed_phrase_and_passphrase(seed_phrase, passphrase)
     }
 }
 
@@ -212,30 +196,6 @@ pub fn keypair_from_seed(seed: &[u8]) -> Result<Keypair, Box<dyn error::Error>> 
     let public = ed25519_dalek::PublicKey::from(&secret);
     let dalek_keypair = ed25519_dalek::Keypair { secret, public };
     Ok(Keypair(dalek_keypair))
-}
-
-/// Generates a Keypair using Bip32 Hierarchical Derivation if derivation-path is provided;
-/// otherwise generates the base Bip44 Solana keypair from the seed
-pub fn keypair_from_seed_and_derivation_path(
-    seed: &[u8],
-    derivation_path: Option<DerivationPath>,
-) -> Result<Keypair, Box<dyn error::Error>> {
-    let derivation_path = derivation_path.unwrap_or_default();
-    bip32_derived_keypair(seed, derivation_path).map_err(|err| err.to_string().into())
-}
-
-/// Generates a Keypair using Bip32 Hierarchical Derivation
-fn bip32_derived_keypair(
-    seed: &[u8],
-    derivation_path: DerivationPath,
-) -> Result<Keypair, Bip32Error> {
-    let extended = ed25519_dalek_bip32::ExtendedSecretKey::from_seed(seed)
-        .and_then(|extended| extended.derive(&derivation_path))?;
-    let extended_public_key = extended.public_key();
-    Ok(Keypair(ed25519_dalek::Keypair {
-        secret: extended.secret_key,
-        public: extended_public_key,
-    }))
 }
 
 pub fn generate_seed_from_seed_phrase_and_passphrase(

--- a/sdk/signer/src/keypair.rs
+++ b/sdk/signer/src/keypair.rs
@@ -65,7 +65,9 @@ impl Keypair {
 
     /// Recovers a `Keypair` from a base58-encoded string
     pub fn from_base58_string(s: &str) -> Self {
-        Self::from_bytes(&bs58::decode(s).into_vec().unwrap()).unwrap()
+        let mut buf = [0u8; ed25519_dalek::KEYPAIR_LENGTH];
+        bs58::decode(s).onto(&mut buf).unwrap();
+        Self::from_bytes(&buf).unwrap()
     }
 
     /// Returns this `Keypair` as a base58-encoded string

--- a/sdk/signer/src/keypair.rs
+++ b/sdk/signer/src/keypair.rs
@@ -1,18 +1,14 @@
-#![cfg(feature = "full")]
-
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 use {
-    crate::{
-        pubkey::Pubkey,
-        signature::Signature,
-        signer::{EncodableKey, EncodableKeypair, SeedDerivable, Signer, SignerError},
-    },
+    crate::{EncodableKey, EncodableKeypair, SeedDerivable, Signer, SignerError},
     ed25519_dalek::Signer as DalekSigner,
     ed25519_dalek_bip32::Error as Bip32Error,
     hmac::Hmac,
     rand0_7::{rngs::OsRng, CryptoRng, RngCore},
     solana_derivation_path::DerivationPath,
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
     std::{
         error,
         io::{Read, Write},

--- a/sdk/signer/src/keypair.rs
+++ b/sdk/signer/src/keypair.rs
@@ -166,6 +166,9 @@ pub fn read_keypair<R: Read>(reader: &mut R) -> Result<Keypair, Box<dyn error::E
         )
         .into());
     }
+    // we already checked that the string has at least two chars,
+    // so 1..trimmed.len() - 1 won't be out of bounds
+    #[allow(clippy::arithmetic_side_effects)]
     let contents = &trimmed[1..trimmed.len() - 1];
     let elements_vec: Vec<&str> = contents.split(',').map(|s| s.trim()).collect();
     let len = elements_vec.len();

--- a/sdk/signer/src/keypair.rs
+++ b/sdk/signer/src/keypair.rs
@@ -93,6 +93,34 @@ impl Keypair {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+#[allow(non_snake_case)]
+#[wasm_bindgen]
+impl Keypair {
+    /// Create a new `Keypair `
+    #[wasm_bindgen(constructor)]
+    pub fn constructor() -> Keypair {
+        Keypair::new()
+    }
+
+    /// Convert a `Keypair` to a `Uint8Array`
+    pub fn toBytes(&self) -> Box<[u8]> {
+        self.to_bytes().into()
+    }
+
+    /// Recover a `Keypair` from a `Uint8Array`
+    pub fn fromBytes(bytes: &[u8]) -> Result<Keypair, JsValue> {
+        Keypair::from_bytes(bytes).map_err(|e| e.to_string().into())
+    }
+
+    /// Return the `Pubkey` for this `Keypair`
+    #[wasm_bindgen(js_name = pubkey)]
+    pub fn js_pubkey(&self) -> Pubkey {
+        // `wasm_bindgen` does not support traits (`Signer) yet
+        self.pubkey()
+    }
+}
+
 impl From<ed25519_dalek::Keypair> for Keypair {
     fn from(value: ed25519_dalek::Keypair) -> Self {
         Self(value)

--- a/sdk/signer/src/lib.rs
+++ b/sdk/signer/src/lib.rs
@@ -1,7 +1,6 @@
 //! Abstractions and implementations for transaction signers.
 use {
     core::fmt,
-    itertools::Itertools,
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_transaction_error::TransactionError,
@@ -164,7 +163,17 @@ impl std::fmt::Debug for dyn Signer {
 
 /// Removes duplicate signers while preserving order. O(n²)
 pub fn unique_signers(signers: Vec<&dyn Signer>) -> Vec<&dyn Signer> {
-    signers.into_iter().unique_by(|s| s.pubkey()).collect()
+    let capacity = signers.len();
+    let mut out = Vec::with_capacity(capacity);
+    let mut seen = std::collections::HashSet::with_capacity(capacity);
+    for signer in signers {
+        let pubkey = signer.pubkey();
+        if !seen.contains(&pubkey) {
+            seen.insert(pubkey);
+            out.push(signer);
+        }
+    }
+    out
 }
 
 /// The `EncodableKey` trait defines the interface by which cryptographic keys/keypairs are read,

--- a/sdk/signer/src/lib.rs
+++ b/sdk/signer/src/lib.rs
@@ -2,7 +2,6 @@
 use {
     crate::presigner::PresignerError,
     itertools::Itertools,
-    solana_derivation_path::DerivationPath,
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_transaction_error::TransactionError,
@@ -158,20 +157,6 @@ pub trait EncodableKey: Sized {
 
         self.write(&mut f)
     }
-}
-
-/// The `SeedDerivable` trait defines the interface by which cryptographic keys/keypairs are
-/// derived from byte seeds, derivation paths, and passphrases.
-pub trait SeedDerivable: Sized {
-    fn from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>>;
-    fn from_seed_and_derivation_path(
-        seed: &[u8],
-        derivation_path: Option<DerivationPath>,
-    ) -> Result<Self, Box<dyn error::Error>>;
-    fn from_seed_phrase_and_passphrase(
-        seed_phrase: &str,
-        passphrase: &str,
-    ) -> Result<Self, Box<dyn error::Error>>;
 }
 
 /// The `EncodableKeypair` trait extends `EncodableKey` for asymmetric keypairs, i.e. have

--- a/sdk/signer/src/lib.rs
+++ b/sdk/signer/src/lib.rs
@@ -1,4 +1,5 @@
 //! Abstractions and implementations for transaction signers.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {
     core::fmt,
     solana_pubkey::Pubkey,

--- a/sdk/signer/src/lib.rs
+++ b/sdk/signer/src/lib.rs
@@ -14,8 +14,6 @@ use {
     },
 };
 
-#[cfg(feature = "keypair")]
-pub mod keypair;
 pub mod null_signer;
 pub mod signers;
 
@@ -220,60 +218,4 @@ pub trait EncodableKeypair: EncodableKey {
 
     /// Returns an encodable representation of the associated public key.
     fn encodable_pubkey(&self) -> Self::Pubkey;
-}
-
-#[cfg(test)]
-mod tests {
-    use {super::*, crate::keypair::Keypair};
-
-    fn pubkeys(signers: &[&dyn Signer]) -> Vec<Pubkey> {
-        signers.iter().map(|x| x.pubkey()).collect()
-    }
-
-    #[test]
-    fn test_unique_signers() {
-        let alice = Keypair::new();
-        let bob = Keypair::new();
-        assert_eq!(
-            pubkeys(&unique_signers(vec![&alice, &bob, &alice])),
-            pubkeys(&[&alice, &bob])
-        );
-    }
-
-    #[test]
-    fn test_containers() {
-        use std::{rc::Rc, sync::Arc};
-
-        struct Foo<S: Signer> {
-            #[allow(unused)]
-            signer: S,
-        }
-
-        fn foo(_s: impl Signer) {}
-
-        let _arc_signer = Foo {
-            signer: Arc::new(Keypair::new()),
-        };
-        foo(Arc::new(Keypair::new()));
-
-        let _rc_signer = Foo {
-            signer: Rc::new(Keypair::new()),
-        };
-        foo(Rc::new(Keypair::new()));
-
-        let _ref_signer = Foo {
-            signer: &Keypair::new(),
-        };
-        foo(Keypair::new());
-
-        let _box_signer = Foo {
-            signer: Box::new(Keypair::new()),
-        };
-        foo(Box::new(Keypair::new()));
-
-        let _signer = Foo {
-            signer: Keypair::new(),
-        };
-        foo(Keypair::new());
-    }
 }

--- a/sdk/signer/src/lib.rs
+++ b/sdk/signer/src/lib.rs
@@ -14,6 +14,7 @@ use {
     thiserror::Error,
 };
 
+#[cfg(feature = "keypair")]
 pub mod keypair;
 pub mod null_signer;
 pub mod signers;

--- a/sdk/signer/src/lib.rs
+++ b/sdk/signer/src/lib.rs
@@ -1,6 +1,5 @@
 //! Abstractions and implementations for transaction signers.
 use {
-    crate::presigner::PresignerError,
     itertools::Itertools,
     solana_pubkey::Pubkey,
     solana_signature::Signature,
@@ -17,8 +16,13 @@ use {
 
 pub mod keypair;
 pub mod null_signer;
-pub mod presigner;
 pub mod signers;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PresignerError {
+    #[error("pre-generated signature cannot verify data")]
+    VerificationFailure,
+}
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum SignerError {

--- a/sdk/signer/src/lib.rs
+++ b/sdk/signer/src/lib.rs
@@ -73,9 +73,9 @@ impl fmt::Display for SignerError {
         match self {
             SignerError::KeypairPubkeyMismatch => f.write_str("keypair-pubkey mismatch"),
             SignerError::NotEnoughSigners => f.write_str("not enough signers"),
-            SignerError::TransactionError(_0) => f.write_str("transaction error"),
+            SignerError::TransactionError(_) => f.write_str("transaction error"),
             SignerError::Custom(e) => write!(f, "custom error: {e}",),
-            SignerError::PresignerError(_0) => f.write_str("presigner error"),
+            SignerError::PresignerError(_) => f.write_str("presigner error"),
             SignerError::Connection(e) => write!(f, "connection error: {e}",),
             SignerError::InvalidInput(s) => write!(f, "invalid input: {s}",),
             SignerError::NoDeviceFound => f.write_str("no device found"),

--- a/sdk/signer/src/lib.rs
+++ b/sdk/signer/src/lib.rs
@@ -1,14 +1,10 @@
 //! Abstractions and implementations for transaction signers.
-
-#![cfg(feature = "full")]
-
 use {
-    crate::{
-        pubkey::Pubkey,
-        signature::{PresignerError, Signature},
-    },
+    crate::presigner::PresignerError,
     itertools::Itertools,
     solana_derivation_path::DerivationPath,
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
     solana_transaction_error::TransactionError,
     std::{
         error,
@@ -189,7 +185,7 @@ pub trait EncodableKeypair: EncodableKey {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::signer::keypair::Keypair};
+    use {super::*, crate::keypair::Keypair};
 
     fn pubkeys(signers: &[&dyn Signer]) -> Vec<Pubkey> {
         signers.iter().map(|x| x.pubkey()).collect()

--- a/sdk/signer/src/null_signer.rs
+++ b/sdk/signer/src/null_signer.rs
@@ -1,9 +1,7 @@
-#![cfg(feature = "full")]
-
-use crate::{
-    pubkey::Pubkey,
-    signature::Signature,
-    signer::{Signer, SignerError},
+use {
+    crate::{Signer, SignerError},
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
 };
 
 /// NullSigner - A `Signer` implementation that always produces `Signature::default()`.

--- a/sdk/signer/src/presigner.rs
+++ b/sdk/signer/src/presigner.rs
@@ -1,11 +1,7 @@
-#![cfg(feature = "full")]
-
 use {
-    crate::{
-        pubkey::Pubkey,
-        signature::Signature,
-        signer::{Signer, SignerError},
-    },
+    crate::{Signer, SignerError},
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
     thiserror::Error,
 };
 
@@ -63,7 +59,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::signer::keypair::keypair_from_seed};
+    use {super::*, crate::keypair::keypair_from_seed};
 
     #[test]
     fn test_presigner() {

--- a/sdk/signer/src/signers.rs
+++ b/sdk/signer/src/signers.rs
@@ -1,8 +1,7 @@
-#![cfg(feature = "full")]
-
-use crate::{
-    pubkey::Pubkey,
-    signature::{Signature, Signer, SignerError},
+use {
+    crate::{Signer, SignerError},
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
 };
 
 /// Convenience trait for working with mixed collections of `Signer`s

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -36,9 +36,9 @@
 extern crate self as solana_sdk;
 
 #[cfg(feature = "full")]
-pub use signer::signers;
-#[cfg(feature = "full")]
 pub use solana_commitment_config as commitment_config;
+#[cfg(feature = "full")]
+pub use solana_signer::{self as signer, signers};
 #[cfg(not(target_os = "solana"))]
 pub use solana_program::program_stubs;
 // These solana_program imports could be *-imported, but that causes a bunch of
@@ -94,7 +94,6 @@ pub mod rpc_port;
 pub mod secp256k1_instruction;
 pub mod shred_version;
 pub mod signature;
-pub mod signer;
 pub mod simple_vote_transaction_checker;
 pub mod system_transaction;
 pub mod transaction;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -38,7 +38,7 @@ extern crate self as solana_sdk;
 #[cfg(feature = "full")]
 pub use solana_commitment_config as commitment_config;
 #[cfg(feature = "full")]
-pub use solana_signer::{self as signer, signers};
+pub use solana_signer::signers;
 #[cfg(not(target_os = "solana"))]
 pub use solana_program::program_stubs;
 // These solana_program imports could be *-imported, but that causes a bunch of
@@ -94,7 +94,6 @@ pub mod rpc_port;
 pub mod secp256k1_instruction;
 pub mod shred_version;
 pub mod signature;
-pub mod signer;
 pub mod simple_vote_transaction_checker;
 pub mod system_transaction;
 pub mod transaction;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -94,6 +94,7 @@ pub mod rpc_port;
 pub mod secp256k1_instruction;
 pub mod shred_version;
 pub mod signature;
+pub mod signer;
 pub mod simple_vote_transaction_checker;
 pub mod system_transaction;
 pub mod transaction;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -37,8 +37,6 @@ extern crate self as solana_sdk;
 
 #[cfg(feature = "full")]
 pub use solana_commitment_config as commitment_config;
-#[cfg(feature = "full")]
-pub use solana_signer::signers;
 #[cfg(not(target_os = "solana"))]
 pub use solana_program::program_stubs;
 // These solana_program imports could be *-imported, but that causes a bunch of
@@ -60,6 +58,8 @@ pub use solana_program::{
 };
 #[cfg(feature = "borsh")]
 pub use solana_program::{borsh, borsh0_10, borsh1};
+#[cfg(feature = "full")]
+pub use solana_signer::signers;
 pub mod client;
 pub mod compute_budget;
 pub mod deserialize_utils;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -59,6 +59,7 @@ pub use solana_program::{
 #[cfg(feature = "borsh")]
 pub use solana_program::{borsh, borsh0_10, borsh1};
 #[cfg(feature = "full")]
+#[deprecated(since = "2.2.0", note = "Use `solana-signer` crate instead")]
 pub use solana_signer::signers;
 pub mod client;
 pub mod compute_budget;

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -1,7 +1,4 @@
 pub use {
-    solana_seed_derivable::keypair_from_seed_and_derivation_path,
-    solana_seed_phrase::{
-        generate_seed_from_seed_phrase_and_passphrase, keypair_from_seed_phrase_and_passphrase,
-    },
-    solana_signer::keypair::*,
+    solana_keypair::*, solana_seed_derivable::keypair_from_seed_and_derivation_path,
+    solana_seed_phrase::generate_seed_from_seed_phrase_and_passphrase, solana_signer::*,
 };

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -1,4 +1,8 @@
-pub use {
-    solana_keypair::*, solana_seed_derivable::keypair_from_seed_and_derivation_path,
-    solana_seed_phrase::generate_seed_from_seed_phrase_and_passphrase, solana_signer::*,
-};
+#[deprecated(since = "2.2.0", note = "Use `solana-keypair` crate instead")]
+pub use solana_keypair::*;
+#[deprecated(since = "2.2.0", note = "Use `solana-seed-derivable` crate instead")]
+pub use solana_seed_derivable::keypair_from_seed_and_derivation_path;
+#[deprecated(since = "2.2.0", note = "Use `solana-seed-phrase` crate instead")]
+pub use solana_seed_phrase::generate_seed_from_seed_phrase_and_passphrase;
+#[deprecated(since = "2.2.0", note = "Use `solana-signer` crate instead")]
+pub use solana_signer::*;

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -1,7 +1,9 @@
 #[deprecated(since = "2.2.0", note = "Use `solana-keypair` crate instead")]
-pub use solana_keypair::*;
-#[deprecated(since = "2.2.0", note = "Use `solana-seed-derivable` crate instead")]
-pub use solana_seed_derivable::keypair_from_seed_and_derivation_path;
+pub use solana_keypair::{
+    keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair, read_keypair_file,
+    seed_derivable::keypair_from_seed_and_derivation_path, write_keypair, write_keypair_file,
+    Keypair,
+};
 #[deprecated(since = "2.2.0", note = "Use `solana-seed-phrase` crate instead")]
 pub use solana_seed_phrase::generate_seed_from_seed_phrase_and_passphrase;
 #[deprecated(since = "2.2.0", note = "Use `solana-signer` crate instead")]

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -1,0 +1,1 @@
+pub use {solana_seed_derivable::keypair_from_seed_and_derivation_path, solana_signer::keypair::*};

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -1,1 +1,7 @@
-pub use {solana_seed_derivable::keypair_from_seed_and_derivation_path, solana_signer::keypair::*};
+pub use {
+    solana_seed_derivable::keypair_from_seed_and_derivation_path,
+    solana_seed_phrase::{
+        generate_seed_from_seed_phrase_and_passphrase, keypair_from_seed_phrase_and_passphrase,
+    },
+    solana_signer::keypair::*,
+};

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -1,0 +1,9 @@
+#![cfg(feature = "full")]
+pub use {
+    solana_seed_derivable::SeedDerivable,
+    solana_signer::{
+        null_signer, presigner, signers, unique_signers, EncodableKey, EncodableKeypair, Signer,
+        SignerError,
+    },
+};
+pub mod keypair;

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "full")]
 pub use {
+    solana_presigner as presigner,
     solana_seed_derivable::SeedDerivable,
     solana_signer::{
-        null_signer, presigner, signers, unique_signers, EncodableKey, EncodableKeypair, Signer,
-        SignerError,
+        null_signer, signers, unique_signers, EncodableKey, EncodableKeypair, Signer, SignerError,
     },
 };
 pub mod keypair;

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -1,9 +1,10 @@
 #![cfg(feature = "full")]
-pub use {
-    solana_presigner as presigner,
-    solana_seed_derivable::SeedDerivable,
-    solana_signer::{
-        null_signer, signers, unique_signers, EncodableKey, EncodableKeypair, Signer, SignerError,
-    },
+#[deprecated(since = "2.2.0", note = "Use `solana-presigner` crate instead")]
+pub use solana_presigner as presigner;
+#[deprecated(since = "2.2.0", note = "Use `solana-seed-derivable` crate instead")]
+pub use solana_seed_derivable::SeedDerivable;
+#[deprecated(since = "2.2.0", note = "Use `solana-signer` crate instead")]
+pub use solana_signer::{
+    null_signer, signers, unique_signers, EncodableKey, EncodableKeypair, Signer, SignerError,
 };
 pub mod keypair;

--- a/sdk/src/wasm/keypair.rs
+++ b/sdk/src/wasm/keypair.rs
@@ -1,34 +1,3 @@
-//! `Keypair` Javascript interface
-#![cfg(target_arch = "wasm32")]
-#![allow(non_snake_case)]
-use {
-    crate::signer::{keypair::Keypair, Signer},
-    solana_program::{pubkey::Pubkey, wasm::display_to_jsvalue},
-    wasm_bindgen::prelude::*,
-};
-
-#[wasm_bindgen]
-impl Keypair {
-    /// Create a new `Keypair `
-    #[wasm_bindgen(constructor)]
-    pub fn constructor() -> Keypair {
-        Keypair::new()
-    }
-
-    /// Convert a `Keypair` to a `Uint8Array`
-    pub fn toBytes(&self) -> Box<[u8]> {
-        self.to_bytes().into()
-    }
-
-    /// Recover a `Keypair` from a `Uint8Array`
-    pub fn fromBytes(bytes: &[u8]) -> Result<Keypair, JsValue> {
-        Keypair::from_bytes(bytes).map_err(display_to_jsvalue)
-    }
-
-    /// Return the `Pubkey` for this `Keypair`
-    #[wasm_bindgen(js_name = pubkey)]
-    pub fn js_pubkey(&self) -> Pubkey {
-        // `wasm_bindgen` does not support traits (`Signer) yet
-        self.pubkey()
-    }
-}
+//! This module is empty but has not yet been removed because that would
+//! technically be a breaking change. There was never anything to import
+//! from here.


### PR DESCRIPTION
#### Problem
`solana_sdk::signer` needs to be made available outside `solana_sdk`

#### Summary of Changes
- Rip out the following crates (not putting them in one crate because each one has quite significant dependencies): solana-presigner, solana-seed-derivable, solana-seed-phrase, solana-signer
- Make the `keypair` module optional in solana-signer. This didn't go in its own crate because it seems it's not possible to do so without breaking the `Signers` trait
- replace serde_json usage in `keypair.rs` with a simple inline parser
- remove itertools from the `unique_signers` function

This branches off #2295 so that needs to be merged first