### PR TITLE
Adds "slot" to bank-hash_internal_state datapoint

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5475,6 +5475,7 @@ impl Bank {
         let total_us = measure_total.end_as_us();
         datapoint_info!(
             "bank-hash_internal_state",
+            ("slot", slot, i64),
             ("total_us", total_us, i64),
             ("accounts_delta_hash_us", accounts_delta_hash_us, i64),
         );


### PR DESCRIPTION
#### Problem

The bank metrics for hash_internal_state() are helpful, but when comparing across different machines it is not straight-forward. I'd like to just grep the log for the hash_internal_state metrics, but without the slot I don't know definitively which datapoints to compare (across machines).


#### Summary of Changes

Add the slot to the datapoint.