### PR TITLE
Supports accounts lt hash in snapshots

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -884,6 +884,7 @@ fn serialize_snapshot(
                 incremental_snapshot_persistence: bank_incremental_snapshot_persistence,
                 epoch_accounts_hash,
                 versioned_epoch_stakes,
+                accounts_lt_hash: bank_fields.accounts_lt_hash.clone().map(Into::into),
             };
             serde_snapshot::serialize_bank_snapshot_into(
                 stream,


### PR DESCRIPTION
#### Problem

The accounts lt hash is not in snapshots, so it must always be regenerated. While testing, this is kinda OK, but when the real feature is enabled, that won't be sufficient.


#### Summary of Changes

Serialize and deserialize the accounts lt hash from snapshots. But only if the CLI arg is passed in (as there's not a feature-gate yet). This let's us get testing/runtime on startup asap.