### PR TITLE
accounts-db: use smaller thread pool for hash scan

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1659,10 +1659,6 @@ pub fn quarter_thread_count() -> usize {
     std::cmp::max(2, num_cpus::get() / 4)
 }
 
-pub fn one_eighth_thread_count() -> usize {
-    std::cmp::max(2, num_cpus::get() / 8)
-}
-
 pub fn make_min_priority_thread_pool() -> ThreadPool {
     // Use lower thread count to reduce priority.
     let num_threads = quarter_thread_count();
@@ -1674,9 +1670,10 @@ pub fn make_min_priority_thread_pool() -> ThreadPool {
 }
 
 pub fn make_hash_thread_pool() -> ThreadPool {
-    let num_threads = one_eighth_thread_count();
+    // Up to 8 threads gives good balance for the system.
+    let num_threads = std::cmp::min(8, std::cmp::max(2, num_cpus::get() / 8));
     rayon::ThreadPoolBuilder::new()
-        .thread_name(|i| format!("solAccountsHash{i:02}"))
+        .thread_name(|i| format!("solAccHash{i:02}"))
         .num_threads(num_threads)
         .build()
         .unwrap()

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1673,7 +1673,7 @@ pub fn make_hash_thread_pool() -> ThreadPool {
     // 1/8 of the number of cpus and up to 6 threads gives good balance for the system.
     let num_threads = (num_cpus::get() / 8).clamp(2, 6);
     rayon::ThreadPoolBuilder::new()
-        .thread_name(|i| format!("solAccHash{i:02}"))
+        .thread_name(|i| format!("solAcctHash{i:02}"))
         .num_threads(num_threads)
         .build()
         .unwrap()

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1670,8 +1670,8 @@ pub fn make_min_priority_thread_pool() -> ThreadPool {
 }
 
 pub fn make_hash_thread_pool() -> ThreadPool {
-    // 1/8 of the number of cpus and up to 8 threads gives good balance for the system.
-    let num_threads = (num_cpus::get() / 8).clamp(2, 8);
+    // 1/8 of the number of cpus and up to 6 threads gives good balance for the system.
+    let num_threads = (num_cpus::get() / 8).clamp(2, 6);
     rayon::ThreadPoolBuilder::new()
         .thread_name(|i| format!("solAccHash{i:02}"))
         .num_threads(num_threads)

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1670,8 +1670,8 @@ pub fn make_min_priority_thread_pool() -> ThreadPool {
 }
 
 pub fn make_hash_thread_pool() -> ThreadPool {
-    // Up to 8 threads gives good balance for the system.
-    let num_threads = std::cmp::min(8, std::cmp::max(2, num_cpus::get() / 8));
+    // 1/8 of the number of cpus and up to 8 threads gives good balance for the system.
+    let num_threads = (num_cpus::get() / 8).clamp(2, 8);
     rayon::ThreadPoolBuilder::new()
         .thread_name(|i| format!("solAccHash{i:02}"))
         .num_threads(num_threads)


### PR DESCRIPTION
#### Problem

During account's hash calculation, we are seeing slower block production. 

Currently, calculating hash use accounts db clean threadpool to scan and compute account's hash cache. 

Accounts-db clean thread pool uses 1/4 of cpus as the number of thread. For a 64 core machine that's 16 threads. 16 parallel threads scanning accounts storage and writing accounts' hash cache causes very heavy disk/io load, which affects foreground block producing process.    

#### Summary of Changes

- use a separate smaller thread pool for hash cache scan

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
