### PR TITLE
Consistent ImmutableDeserializedPacket::PartialEq

### DIFF
--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -39,7 +39,7 @@ pub enum DeserializedPacketError {
     FailedFilter(#[from] PacketFilterFailure),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Eq)]
 pub struct ImmutableDeserializedPacket {
     original_packet: Packet,
     transaction: SanitizedVersionedTransaction,
@@ -129,6 +129,13 @@ impl ImmutableDeserializedPacket {
         )
         .ok()?;
         Some(tx)
+    }
+}
+
+// PartialEq MUST be consistent with PartialOrd and Ord
+impl PartialEq for ImmutableDeserializedPacket {
+    fn eq(&self, other: &Self) -> bool {
+        self.compute_unit_price() == other.compute_unit_price()
     }
 }
 


### PR DESCRIPTION
#### Problem
- `ImmutableDeserializedPacket`'s equality comparison is inconsistent with `PartialOrd`
- Newer version of `rust` may panic with inconsistencies if we sort (do not see we are)
- Similar change was made in #2832

#### Summary of Changes
- equality comparison uses just `compute_unit_price`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
