### PR TITLE
RuntimeTransaction::is_simple_vote_transaction

### DIFF
--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -45,8 +45,8 @@ impl<T> StaticMeta for RuntimeTransaction<T> {
     fn message_hash(&self) -> &Hash {
         &self.meta.message_hash
     }
-    fn is_simple_vote_tx(&self) -> bool {
-        self.meta.is_simple_vote_tx
+    fn is_simple_vote_transaction(&self) -> bool {
+        self.meta.is_simple_vote_transaction
     }
     fn signature_details(&self) -> &TransactionSignatureDetails {
         &self.meta.signature_details
@@ -107,7 +107,7 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
             transaction: sanitized_versioned_tx,
             meta: TransactionMeta {
                 message_hash,
-                is_simple_vote_tx,
+                is_simple_vote_transaction: is_simple_vote_tx,
                 signature_details,
                 compute_budget_instruction_details,
             },
@@ -122,7 +122,7 @@ impl RuntimeTransaction<SanitizedTransaction> {
         reserved_account_keys: &HashSet<Pubkey>,
     ) -> Result<Self> {
         let hash = *statically_loaded_runtime_tx.message_hash();
-        let is_simple_vote_tx = statically_loaded_runtime_tx.is_simple_vote_tx();
+        let is_simple_vote_tx = statically_loaded_runtime_tx.is_simple_vote_transaction();
         let sanitized_transaction = SanitizedTransaction::try_new(
             statically_loaded_runtime_tx.transaction,
             hash,
@@ -305,7 +305,7 @@ mod tests {
             RuntimeTransaction::<SanitizedVersionedTransaction>::try_from(svt, None, is_simple_vote)
                 .unwrap()
                 .meta
-                .is_simple_vote_tx
+                .is_simple_vote_transaction
         }
 
         assert!(!get_is_simple_vote(
@@ -342,7 +342,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(hash, *statically_loaded_transaction.message_hash());
-        assert!(!statically_loaded_transaction.is_simple_vote_tx());
+        assert!(!statically_loaded_transaction.is_simple_vote_transaction());
 
         let dynamically_loaded_transaction = RuntimeTransaction::<SanitizedTransaction>::try_from(
             statically_loaded_transaction,
@@ -353,7 +353,7 @@ mod tests {
             dynamically_loaded_transaction.expect("created from statically loaded tx");
 
         assert_eq!(hash, *dynamically_loaded_transaction.message_hash());
-        assert!(!dynamically_loaded_transaction.is_simple_vote_tx());
+        assert!(!dynamically_loaded_transaction.is_simple_vote_transaction());
     }
 
     #[test]
@@ -377,7 +377,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(&hash, runtime_transaction_static.message_hash());
-        assert!(!runtime_transaction_static.is_simple_vote_tx());
+        assert!(!runtime_transaction_static.is_simple_vote_transaction());
 
         let signature_details = &runtime_transaction_static.meta.signature_details;
         assert_eq!(1, signature_details.num_transaction_signatures());

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -24,7 +24,7 @@ use {
 /// for example: message hash, simple-vote-tx flag, limits set by instructions
 pub trait StaticMeta {
     fn message_hash(&self) -> &Hash;
-    fn is_simple_vote_tx(&self) -> bool;
+    fn is_simple_vote_transaction(&self) -> bool;
     fn signature_details(&self) -> &TransactionSignatureDetails;
     fn compute_budget_limits(&self, feature_set: &FeatureSet) -> Result<ComputeBudgetLimits>;
 }
@@ -39,7 +39,7 @@ pub trait DynamicMeta: StaticMeta {}
 #[derive(Debug)]
 pub struct TransactionMeta {
     pub(crate) message_hash: Hash,
-    pub(crate) is_simple_vote_tx: bool,
+    pub(crate) is_simple_vote_transaction: bool,
     pub(crate) signature_details: TransactionSignatureDetails,
     pub(crate) compute_budget_instruction_details: ComputeBudgetInstructionDetails,
 }


### PR DESCRIPTION
#### Problem
- Separate simple refactor out of #3041 

#### Summary of Changes
- Rename `RuntimeTransaction::is_simple_vote_tx` to more explicit (and consistent with `SanitizedTransaction`) `is_simple_vote_transaction`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
