### PR TITLE
Bank::check_reserved_keys

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -440,26 +440,29 @@ impl Consumer {
         // This means that the transaction may cross and epoch boundary (not allowed),
         //  or account lookup tables may have been closed.
         let pre_results = txs.iter().zip(max_ages).map(|(tx, max_age)| {
+            // If the transaction was sanitized before this bank's epoch,
+            // additional checks are necessary.
             if bank.slot() > max_age.epoch_invalidation_slot {
-                // Epoch has rolled over. Need to re-verify the transaction.
-                bank.reverify_transaction(tx)?;
-            } else {
-                if bank.slot() > max_age.alt_invalidation_slot {
-                    // The address table lookup **may** have expired, but the
-                    // expiration is not guaranteed since there may have been
-                    // skipped slot.
-                    // If the addresses still resolve here, then the transaction is still
-                    // valid, and we can continue with processing.
-                    // If they do not, then the ATL has expired and the transaction
-                    // can be dropped.
-                    let (_addresses, _deactivation_slot) =
-                        bank.load_addresses_from_ref(tx.message_address_table_lookups())?;
-                }
+                // Reserved key set may have cahnged, so we must verify that
+                // no writable keys are reserved.
+                bank.check_reserved_keys(tx)?;
+            }
 
-                // Verify pre-compiles.
-                if !move_precompile_verification_to_svm {
-                    verify_precompiles(tx, &bank.feature_set)?;
-                }
+            if bank.slot() > max_age.alt_invalidation_slot {
+                // The address table lookup **may** have expired, but the
+                // expiration is not guaranteed since there may have been
+                // skipped slot.
+                // If the addresses still resolve here, then the transaction is still
+                // valid, and we can continue with processing.
+                // If they do not, then the ATL has expired and the transaction
+                // can be dropped.
+                let (_addresses, _deactivation_slot) =
+                    bank.load_addresses_from_ref(tx.message_address_table_lookups())?;
+            }
+
+            // Verify pre-compiles.
+            if !move_precompile_verification_to_svm {
+                verify_precompiles(tx, &bank.feature_set)?;
             }
 
             Ok(())

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5868,6 +5868,35 @@ impl Bank {
         self.verify_transaction(tx, TransactionVerificationMode::FullVerification)
     }
 
+    /// Re-performs **feature** or state dependent verification on the transaction.
+    pub fn reverify_transaction(&self, tx: &impl SVMMessage) -> Result<()> {
+        // Loaded addresses depend on address table account state.
+        // We need only verify that loading works correctly.
+        // Since the address table is append only there is no chance addresses
+        // are different than the first time this was resolved.
+        let _loaded_addresses = self.load_addresses_from_ref(tx.message_address_table_lookups())?;
+
+        // Precompiles may be verified at this time if feature is not activated.
+        // Precompile verification can be dependent on features of the bank.
+        let move_precompile_verification_to_svm = self
+            .feature_set
+            .is_active(&feature_set::move_precompile_verification_to_svm::id());
+        if !move_precompile_verification_to_svm {
+            verify_precompiles(tx, &self.feature_set)?;
+        }
+
+        // Check keys against the reserved set - these failures simply require us
+        // to re-sanitize the transaction. We do not need to drop the transaction.
+        let reserved_keys = self.get_reserved_account_keys();
+        for (index, key) in tx.account_keys().iter().enumerate() {
+            if tx.is_writable(index) && reserved_keys.contains(key) {
+                return Err(TransactionError::ResanitizationNeeded);
+            }
+        }
+
+        Ok(())
+    }
+
     /// only called from ledger-tool or tests
     fn calculate_capitalization(&self, debug_verify: bool) -> u64 {
         let is_startup = true;

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -51,11 +51,6 @@ use {
             Account, AccountSharedData, ReadableAccount, WritableAccount,
         },
         account_utils::StateMut,
-        address_lookup_table::{
-            self,
-            state::{AddressLookupTable, LookupTableMeta},
-            AddressLookupTableAccount,
-        },
         bpf_loader,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         client::SyncClient,
@@ -76,10 +71,7 @@ use {
         incinerator,
         instruction::{AccountMeta, CompiledInstruction, Instruction, InstructionError},
         loader_upgradeable_instruction::UpgradeableLoaderInstruction,
-        message::{
-            v0::{self, LoadedAddresses},
-            Message, MessageHeader, SanitizedMessage, SimpleAddressLoader, VersionedMessage,
-        },
+        message::{Message, MessageHeader, SanitizedMessage},
         native_loader,
         native_token::{sol_to_lamports, LAMPORTS_PER_SOL},
         nonce::{self, state::DurableNonce},
@@ -125,7 +117,6 @@ use {
         },
     },
     std::{
-        borrow::Cow,
         collections::{HashMap, HashSet},
         convert::TryInto,
         fs::File,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -51,6 +51,11 @@ use {
             Account, AccountSharedData, ReadableAccount, WritableAccount,
         },
         account_utils::StateMut,
+        address_lookup_table::{
+            self,
+            state::{AddressLookupTable, LookupTableMeta},
+            AddressLookupTableAccount,
+        },
         bpf_loader,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         client::SyncClient,
@@ -71,7 +76,10 @@ use {
         incinerator,
         instruction::{AccountMeta, CompiledInstruction, Instruction, InstructionError},
         loader_upgradeable_instruction::UpgradeableLoaderInstruction,
-        message::{Message, MessageHeader, SanitizedMessage},
+        message::{
+            v0::{self, LoadedAddresses},
+            Message, MessageHeader, SanitizedMessage, SimpleAddressLoader, VersionedMessage,
+        },
         native_loader,
         native_token::{sol_to_lamports, LAMPORTS_PER_SOL},
         nonce::{self, state::DurableNonce},
@@ -117,6 +125,7 @@ use {
         },
     },
     std::{
+        borrow::Cow,
         collections::{HashMap, HashSet},
         convert::TryInto,
         fs::File,
@@ -10044,6 +10053,103 @@ fn test_verify_transactions_packet_data_size() {
                 .is_ok(),
         );
     }
+}
+
+#[test]
+fn test_reverify_transaction_alts() {
+    let (genesis_config, _mint_keypair) = create_genesis_config(1);
+    let bank = Bank::new_for_tests(&genesis_config);
+    let bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::new_unique(), 1);
+
+    // Handcraft a v0 transaction that will fail to re-resolve.
+    let simple_v0_transfer = |to_pubkey: Pubkey, alt: Option<Pubkey>| {
+        let payer = Keypair::new();
+        let loaded_addresses = LoadedAddresses {
+            writable: vec![to_pubkey],
+            readonly: vec![],
+        };
+        let loader = SimpleAddressLoader::Enabled(loaded_addresses);
+        let alts = match alt {
+            Some(alt) => &[AddressLookupTableAccount {
+                key: alt,
+                addresses: vec![to_pubkey],
+            }][..],
+            None => &[],
+        };
+        SanitizedTransaction::try_create(
+            VersionedTransaction::try_new(
+                VersionedMessage::V0(
+                    v0::Message::try_compile(
+                        &payer.pubkey(),
+                        &[system_instruction::transfer(&payer.pubkey(), &to_pubkey, 1)],
+                        alts,
+                        genesis_config.hash(),
+                    )
+                    .unwrap(),
+                ),
+                &[&payer],
+            )
+            .unwrap(),
+            MessageHash::Compute,
+            None,
+            loader,
+            &HashSet::default(),
+        )
+        .unwrap()
+    };
+
+    // No ALT. Transaction succeeds to reverify.
+    let tx1 = simple_v0_transfer(Pubkey::new_unique(), None);
+    assert_eq!(bank.reverify_transaction(&tx1), Ok(()));
+
+    // ALT that actually exists.
+    let to_pubkey = Pubkey::new_unique();
+    let alt_pubkey = Pubkey::new_unique();
+    let alt_data = AddressLookupTable {
+        meta: LookupTableMeta::default(),
+        addresses: Cow::Owned(vec![to_pubkey]),
+    }
+    .serialize_for_tests()
+    .unwrap();
+    let mut alt_account =
+        AccountSharedData::new(1, alt_data.len(), &address_lookup_table::program::id());
+    alt_account.set_data(alt_data);
+    bank.store_account(&alt_pubkey, &alt_account);
+    let tx2 = simple_v0_transfer(to_pubkey, Some(alt_pubkey));
+    assert_eq!(bank.reverify_transaction(&tx2), Ok(()));
+
+    // ALT that doesn't actually exist.
+    // Manually create to emulate resolving earlier but ALT has since expired.
+    let tx3 = simple_v0_transfer(Pubkey::new_unique(), Some(Pubkey::new_unique()));
+    assert_eq!(
+        bank.reverify_transaction(&tx3),
+        Err(TransactionError::AddressLookupTableNotFound)
+    );
+}
+
+#[test]
+fn test_reverify_transaction_reserved() {
+    let (genesis_config, _mint_keypair) = create_genesis_config(1);
+    let bank = Bank::new_for_tests(&genesis_config);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::new_unique(), 1);
+
+    let transaction =
+        SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            &Keypair::new(),
+            &Pubkey::new_unique(),
+            1,
+            genesis_config.hash(),
+        ));
+
+    assert_eq!(bank.reverify_transaction(&transaction), Ok(()));
+
+    Arc::make_mut(&mut bank.reserved_account_keys)
+        .active
+        .insert(transaction.account_keys()[1]);
+    assert_eq!(
+        bank.reverify_transaction(&transaction),
+        Err(TransactionError::ResanitizationNeeded)
+    );
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
- We need a generic way to re-verify some transaction state that depends on features/state

#### Summary of Changes
- Add `Bank::check_reserved_keys`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
