### PR TITLE
rename `num_nodes` to `num_pushes`

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1638,7 +1638,7 @@ impl ClusterInfo {
     }
     fn new_push_requests(&self, stakes: &HashMap<Pubkey, u64>) -> Vec<(SocketAddr, Protocol)> {
         let self_id = self.id();
-        let (mut push_messages, num_entries, num_nodes) = {
+        let (mut push_messages, num_entries, num_pushes) = {
             let _st = ScopedTimer::from(&self.stats.new_push_requests);
             self.flush_push_queue();
             self.gossip.new_push_messages(&self_id, timestamp(), stakes)
@@ -1647,8 +1647,8 @@ impl ClusterInfo {
             .push_fanout_num_entries
             .add_relaxed(num_entries as u64);
         self.stats
-            .push_fanout_num_nodes
-            .add_relaxed(num_nodes as u64);
+            .push_fanout_num_pushes
+            .add_relaxed(num_pushes as u64);
         if self.require_stake_for_gossip(stakes) {
             push_messages.retain(|_, data| {
                 retain_staked(data, stakes, /* drop_unstaked_node_instance */ false);

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -163,8 +163,8 @@ pub struct GossipStats {
     pub(crate) pull_requests_count: Counter,
     pub(crate) purge: Counter,
     pub(crate) purge_count: Counter,
-    pub(crate) push_fanout_num_entries: Counter,
-    pub(crate) push_fanout_num_nodes: Counter,
+    pub(crate) push_fanout_num_entries: Counter, // Number of distinct entries pushed to peers
+    pub(crate) push_fanout_num_pushes: Counter, // Total number of pushes across all entries and nodes.
     pub(crate) push_message_count: Counter,
     pub(crate) push_message_pushes: Counter,
     pub(crate) push_message_value_count: Counter,
@@ -440,8 +440,8 @@ pub(crate) fn submit_gossip_stats(
             i64
         ),
         (
-            "push_fanout_num_nodes",
-            stats.push_fanout_num_nodes.clear(),
+            "push_fanout_num_pushes",
+            stats.push_fanout_num_pushes.clear(),
             i64
         ),
         (

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -77,7 +77,7 @@ impl CrdsGossip {
     ) -> (
         HashMap<Pubkey, Vec<CrdsValue>>,
         usize, // number of values
-        usize, // number of push messages
+        usize, // number of values pushed across all peers
     ) {
         self.push.new_push_messages(pubkey, &self.crds, now, stakes)
     }

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -172,7 +172,7 @@ impl CrdsGossipPush {
     ) -> (
         HashMap<Pubkey, Vec<CrdsValue>>,
         usize, // number of values
-        usize, // number of push messages
+        usize, // number of values pushed across all peers
     ) {
         const MAX_NUM_PUSHES: usize = 1 << 12;
         let active_set = self.active_set.read().unwrap();


### PR DESCRIPTION
#### Problem
very small problem that has been bugging me for a while
`num_nodes` variable is not actually counting the number of nodes. It is counting the `total entries * nodes` the node is pushing to for this round of gossip

#### Summary of Changes
rename variable to `num_pushes` and add comment in metrics for clarification