### PR TITLE
Cleanup entry threadpool usage in GPU case

### DIFF
--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -506,7 +506,7 @@ fn start_verify_transactions_gpu(
 
     let entries = verify_transactions(entries, thread_pool, Arc::new(verify_func))?;
 
-    let entry_txs: Vec<&SanitizedTransaction> = entries
+    let transactions: Vec<&SanitizedTransaction> = entries
         .iter()
         .filter_map(|entry_type| match entry_type {
             EntryType::Tick(_) => None,
@@ -515,7 +515,7 @@ fn start_verify_transactions_gpu(
         .flatten()
         .collect::<Vec<_>>();
 
-    if entry_txs.is_empty() {
+    if transactions.is_empty() {
         return Ok(EntrySigVerificationState {
             verification_status: EntryVerificationStatus::Success,
             entries: Some(entries),
@@ -525,29 +525,31 @@ fn start_verify_transactions_gpu(
     }
 
     let packet_batches = thread_pool.install(|| {
-        entry_txs
+        transactions
             .par_iter()
             .chunks(PACKETS_PER_BATCH)
-            .map(|slice| {
-                let vec_size = slice.len();
+            .map(|transaction_chunk| {
+                let num_transactions = transaction_chunk.len();
                 let mut packet_batch = PacketBatch::new_with_recycler(
                     &verify_recyclers.packet_recycler,
-                    vec_size,
+                    num_transactions,
                     "entry-sig-verify",
                 );
-                // We use set_len here instead of resize(vec_size, Packet::default()), to save
+                // We use set_len here instead of resize(num_txs, Packet::default()), to save
                 // memory bandwidth and avoid writing a large amount of data that will be overwritten
                 // soon afterwards. As well, Packet::default() actually leaves the packet data
                 // uninitialized, so the initialization would simply write junk into
                 // the vector anyway.
                 unsafe {
-                    packet_batch.set_len(vec_size);
+                    packet_batch.set_len(num_transactions);
                 }
-                let entry_tx_iter = slice.into_iter().map(|tx| tx.to_versioned_transaction());
+                let transaction_iter = transaction_chunk
+                    .into_iter()
+                    .map(|tx| tx.to_versioned_transaction());
 
                 let res = packet_batch
                     .iter_mut()
-                    .zip(entry_tx_iter)
+                    .zip(transaction_iter)
                     .all(|(packet, tx)| {
                         *packet.meta_mut() = Meta::default();
                         Packet::populate_packet(packet, None, &tx).is_ok()
@@ -564,7 +566,7 @@ fn start_verify_transactions_gpu(
 
     let tx_offset_recycler = verify_recyclers.tx_offset_recycler;
     let out_recycler = verify_recyclers.out_recycler;
-    let num_packets = entry_txs.len();
+    let num_packets = transactions.len();
     let gpu_verify_thread = thread::Builder::new()
         .name("solGpuSigVerify".into())
         .spawn(move || {

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -525,42 +525,43 @@ fn start_verify_transactions_gpu(
     }
 
     let packet_batches = thread_pool.install(|| {
-    entry_txs
-        .par_iter()
-        .chunks(PACKETS_PER_BATCH)
-        .map(|slice| {
-            let vec_size = slice.len();
-            let mut packet_batch = PacketBatch::new_with_recycler(
-                &verify_recyclers.packet_recycler,
-                vec_size,
-                "entry-sig-verify",
-            );
-            // We use set_len here instead of resize(vec_size, Packet::default()), to save
-            // memory bandwidth and avoid writing a large amount of data that will be overwritten
-            // soon afterwards. As well, Packet::default() actually leaves the packet data
-            // uninitialized, so the initialization would simply write junk into
-            // the vector anyway.
-            unsafe {
-                packet_batch.set_len(vec_size);
-            }
-            let entry_tx_iter = slice
-                .into_par_iter()
-                .map(|tx| tx.to_versioned_transaction());
+        entry_txs
+            .par_iter()
+            .chunks(PACKETS_PER_BATCH)
+            .map(|slice| {
+                let vec_size = slice.len();
+                let mut packet_batch = PacketBatch::new_with_recycler(
+                    &verify_recyclers.packet_recycler,
+                    vec_size,
+                    "entry-sig-verify",
+                );
+                // We use set_len here instead of resize(vec_size, Packet::default()), to save
+                // memory bandwidth and avoid writing a large amount of data that will be overwritten
+                // soon afterwards. As well, Packet::default() actually leaves the packet data
+                // uninitialized, so the initialization would simply write junk into
+                // the vector anyway.
+                unsafe {
+                    packet_batch.set_len(vec_size);
+                }
+                let entry_tx_iter = slice
+                    .into_par_iter()
+                    .map(|tx| tx.to_versioned_transaction());
 
-            let res = packet_batch
-                .par_iter_mut()
-                .zip(entry_tx_iter)
-                .all(|(packet, tx)| {
-                    *packet.meta_mut() = Meta::default();
-                    Packet::populate_packet(packet, None, &tx).is_ok()
-                });
-            if res {
-                Ok(packet_batch)
-            } else {
-                Err(TransactionError::SanitizeFailure)
-            }
-        })
-        .collect::<Result<Vec<_>>>()});
+                let res = packet_batch
+                    .par_iter_mut()
+                    .zip(entry_tx_iter)
+                    .all(|(packet, tx)| {
+                        *packet.meta_mut() = Meta::default();
+                        Packet::populate_packet(packet, None, &tx).is_ok()
+                    });
+                if res {
+                    Ok(packet_batch)
+                } else {
+                    Err(TransactionError::SanitizeFailure)
+                }
+            })
+            .collect::<Result<Vec<_>>>()
+    });
     let mut packet_batches = packet_batches?;
 
     let tx_offset_recycler = verify_recyclers.tx_offset_recycler;

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -524,7 +524,8 @@ fn start_verify_transactions_gpu(
         });
     }
 
-    let mut packet_batches = entry_txs
+    let packet_batches = thread_pool.install(|| {
+    entry_txs
         .par_iter()
         .chunks(PACKETS_PER_BATCH)
         .map(|slice| {
@@ -559,7 +560,8 @@ fn start_verify_transactions_gpu(
                 Err(TransactionError::SanitizeFailure)
             }
         })
-        .collect::<Result<Vec<_>>>()?;
+        .collect::<Result<Vec<_>>>()});
+    let mut packet_batches = packet_batches?;
 
     let tx_offset_recycler = verify_recyclers.tx_offset_recycler;
     let out_recycler = verify_recyclers.out_recycler;

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -543,12 +543,10 @@ fn start_verify_transactions_gpu(
                 unsafe {
                     packet_batch.set_len(vec_size);
                 }
-                let entry_tx_iter = slice
-                    .into_par_iter()
-                    .map(|tx| tx.to_versioned_transaction());
+                let entry_tx_iter = slice.into_iter().map(|tx| tx.to_versioned_transaction());
 
                 let res = packet_batch
-                    .par_iter_mut()
+                    .iter_mut()
                     .zip(entry_tx_iter)
                     .all(|(packet, tx)| {
                         *packet.meta_mut() = Meta::default();

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -526,8 +526,7 @@ fn start_verify_transactions_gpu(
 
     let packet_batches = thread_pool.install(|| {
         transactions
-            .par_iter()
-            .chunks(PACKETS_PER_BATCH)
+            .par_chunks(PACKETS_PER_BATCH)
             .map(|transaction_chunk| {
                 let num_transactions = transaction_chunk.len();
                 let mut packet_batch = PacketBatch::new_with_recycler(
@@ -544,7 +543,7 @@ fn start_verify_transactions_gpu(
                     packet_batch.set_len(num_transactions);
                 }
                 let transaction_iter = transaction_chunk
-                    .into_iter()
+                    .iter()
                     .map(|tx| tx.to_versioned_transaction());
 
                 let res = packet_batch


### PR DESCRIPTION
#### Problem
Entry verification can use CPU or GPU (if one is available). In the GPU case, there is still some "prep" work to be done to assemble data in a format the GPU can work with. There are several issues with current code:
- We pass a threadpool into the function, but use `par_iter()` in global scope which will result in the global Rayon threadpool being utilized. We should use the one that is already "allocated"
- Within the threadpool, there are nested parallel iterators. The top level layer intentionally chunks transactions to a smallest amount of work we'd want to do per thread. But, the tested iterators then break that up.

#### Summary of Changes
- Use the passed in threadpool instead of global threadpool
- Remove the nested parallel iterators to keep our parallelism at the "per-batch" level instead of "per-packet"
- Use `.par_chunks` instead of `.par_iter().chunks()` [to avoid intermediate allocations](https://docs.rs/rayon/latest/rayon/iter/trait.IndexedParallelIterator.html#method.chunks)
- Variable rename