### PR TITLE
Deprecate Legacy BlockProductionMethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Release channels have their own copy of this changelog:
   * `solana-test-validator`: Add `--clone-feature-set` flag to mimic features from a target cluster (#2480)
   * `solana-genesis`: the `--cluster-type` parameter now clones the feature set from the target cluster (#2587)
   * `unified-scheduler` as default option for `--block-verification-method` (#2653)
+  * warn that `thread-local-multi-iterator` option for `--block-production-method` is deprecated (#3113)
 
 ## [2.0.0]
 * Breaking

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -844,6 +844,16 @@ impl Validator {
             "Using: block-verification-method: {}, block-production-method: {}",
             config.block_verification_method, config.block_production_method
         );
+        if matches!(
+            config.block_production_method,
+            BlockProductionMethod::ThreadLocalMultiIterator
+        ) {
+            warn!(
+                "--block-production-method thread-local-multi-iterator is deprecated \
+                   and will be removed in a future release. Please use \
+                   --block-production-method=central-scheduler instead."
+            );
+        }
 
         let (replay_vote_sender, replay_vote_receiver) = unbounded();
 


### PR DESCRIPTION
#### Problem
- Legacy banking stage is worse in most ways and causes maintainence burden

#### Summary of Changes
- Add a warning in v2.1 that `--block-production-method thread-local-multi-iterator` will be removed in future version (2.2)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
