### PR TITLE
reduce banking capacity

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -81,7 +81,7 @@ mod transaction_scheduler;
 // Fixed thread size seems to be fastest on GCP setup
 pub const NUM_THREADS: u32 = 6;
 
-const TOTAL_BUFFERED_PACKETS: usize = 700_000;
+const TOTAL_BUFFERED_PACKETS: usize = 100_000;
 
 const NUM_VOTE_PROCESSING_THREADS: u32 = 2;
 const MIN_THREADS_BANKING: u32 = 1;


### PR DESCRIPTION
#### Problem
- BankingStage buffer capacity is much larger than necessary
- Once we start keeping packet batch references around (see #3035) the worst case scales with buffer capacity

#### Summary of Changes
- Reduce maximum banking stage capacity from 700k to 100k

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
