### PR TITLE
link openssl statically for Windows

### DIFF
--- a/.github/scripts/install-all-deps.sh
+++ b/.github/scripts/install-all-deps.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+os_name="$1"
+
+# shellcheck source=.github/scripts/install-openssl.sh
+source "$here/install-openssl.sh" "$os_name"
+# shellcheck source=.github/scripts/install-proto.sh
+source "$here/install-proto.sh" "$os_name"

--- a/.github/scripts/install-openssl.sh
+++ b/.github/scripts/install-openssl.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+os_name="$1"
+
+case "$os_name" in
+"Windows")
+  choco install openssl --version 3.3.2 --install-arguments="'/DIR=C:\OpenSSL'" -y
+  export OPENSSL_LIB_DIR="C:\OpenSSL\lib\VC\x64\MT"
+  export OPENSSL_INCLUDE_DIR="C:\OpenSSL\include"
+  ;;
+"macOS") ;;
+"Linux") ;;
+*)
+  echo "Unknown Operating System"
+  ;;
+esac

--- a/.github/scripts/install-proto.sh
+++ b/.github/scripts/install-proto.sh
@@ -6,8 +6,6 @@ os_name="$1"
 
 case "$os_name" in
 "Windows")
-  vcpkg install openssl:x64-windows-static-md
-  vcpkg integrate install
   choco install protoc
   export PROTOC='C:\ProgramData\chocolatey\lib\protoc\tools\bin\protoc.exe'
   ;;

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -41,6 +41,12 @@ jobs:
         with:
           version: "v0.8.1"
 
+      - name: Set Perl environment variables
+        if: runner.os == 'Windows'
+        run: |
+          echo "PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          echo "OPENSSL_SRC_PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       - shell: bash
         run: |
           source .github/scripts/install-all-deps.sh ${{ runner.os }}

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           version: "v0.8.1"
 
+      # took the workaround from https://github.com/sfackler/rust-openssl/issues/2149
       - name: Set Perl environment variables
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -42,10 +42,8 @@ jobs:
           version: "v0.8.1"
 
       - shell: bash
-        run: .github/scripts/cargo-clippy-before-script.sh ${{ runner.os }}
-
-      - shell: bash
         run: |
+          source .github/scripts/install-all-deps.sh ${{ runner.os }}
           source ci/rust-version.sh nightly
           rustup component add clippy --toolchain "$rust_nightly"
           scripts/cargo-clippy-nightly.sh

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -43,10 +43,7 @@ jobs:
         id: build
         shell: bash
         run: |
-          vcpkg install openssl:x64-windows-static-md
-          vcpkg integrate install
-          choco install protoc
-          export PROTOC="C:\ProgramData\chocolatey\lib\protoc\tools\bin\protoc.exe"
+          source .github/scripts/install-all-deps.sh ${{ runner.os }}
           source /tmp/env.sh
           echo "tag=$CI_TAG" >> $GITHUB_OUTPUT
           eval "$(ci/channel-info.sh)"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           git checkout ${{ inputs.commit }}
 
+      # took the workaround from https://github.com/sfackler/rust-openssl/issues/2149
       - name: Set Perl environment variables
         run: |
           echo "PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -39,11 +39,18 @@ jobs:
         run: |
           git checkout ${{ inputs.commit }}
 
+      - name: Set Perl environment variables
+        run: |
+          echo "PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          echo "OPENSSL_SRC_PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       - name: Build
         id: build
         shell: bash
         run: |
+          # install all deps
           source .github/scripts/install-all-deps.sh ${{ runner.os }}
+
           source /tmp/env.sh
           echo "tag=$CI_TAG" >> $GITHUB_OUTPUT
           eval "$(ci/channel-info.sh)"

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -22,6 +22,9 @@ http = { workspace = true }
 hyper = { workspace = true }
 hyper-proxy = { workspace = true }
 log = { workspace = true }
+# openssl is a dependency of the goauth and smpl_jwt crates, but explicitly
+# declare it here as well to activate the "vendored" feature that builds OpenSSL
+openssl = { workspace = true, features = ["vendored"] }
 prost = { workspace = true }
 prost-types = { workspace = true }
 serde = { workspace = true }
@@ -35,16 +38,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true, features = ["tls", "transport"] }
 zstd = { workspace = true }
-
-# openssl is a dependency of the goauth and smpl_jwt crates, but explicitly
-# declare it here as well to activate the "vendored" feature that builds OpenSSL
-# statically...
-[target."cfg(not(windows))".dependencies]
-openssl = { workspace = true, features = ["vendored"] }
-# ...except on Windows to avoid having to deal with getting CI past a build-time
-# Perl dependency
-[target."cfg(windows)".dependencies]
-openssl = { workspace = true, features = [] }
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
#### Problem

a refined version of the timeline for future reference:

- we applied the `vendored` feature on openssl for all platforms.
- it looks like we had some perl issues so we did `Unvendor OpenSSL for Windows to avoid CI troubles with perl.exe`https://github.com/anza-xyz/agave/commit/c9bfc99c720ed091c326c1cce58fcd8197306235
- we planed to vendor Windows binaries #73.
- the pipeline failed recently https://github.com/anza-xyz/agave/actions/runs/11163589550/job/31030913975 and I have this PR

#### Summary of Changes

- use `vendored` in openssl for all platforms (it should work. I verified by this pipeline https://github.com/yihau/solana/actions/runs/11241556386/job/31253379456#step:7:8654)
```
> ldd solana-test-validator
  	ntdll.dll => /c/Windows/SYSTEM32/ntdll.dll (0x7ffe8ccc0000)
  	KERNEL32.DLL => /c/Windows/System32/KERNEL32.DLL (0x7ffe8b580000)
  	KERNELBASE.dll => /c/Windows/System32/KERNELBASE.dll (0x7ffe8a240000)
  	apphelp.dll => /c/Windows/SYSTEM32/apphelp.dll (0x7ffe88280000)
  	bcryptprimitives.dll => /c/Windows/System32/bcryptprimitives.dll (0x7ffe8ab70000)
  	USER32.dll => /c/Windows/System32/USER32.dll (0x7ffe8b3d0000)
  	win32u.dll => /c/Windows/System32/win32u.dll (0x7ffe8ab40000)
  	POWRPROF.dll => /c/Windows/SYSTEM32/POWRPROF.dll (0x7ffe8a120000)
  	GDI32.dll => /c/Windows/System32/GDI32.dll (0x7ffe8c610000)
  	ucrtbase.dll => /c/Windows/System32/ucrtbase.dll (0x7ffe8a800000)
  	gdi32full.dll => /c/Windows/System32/gdi32full.dll (0x7ffe8a6e0000)
  	RPCRT4.dll => /c/Windows/System32/RPCRT4.dll (0x7ffe8c1f0000)
  	msvcp_win.dll => /c/Windows/System32/msvcp_win.dll (0x7ffe8aaa0000)
  	CRYPT32.dll => /c/Windows/System32/CRYPT32.dll (0x7ffe8a910000)
  	WS2_32.dll => /c/Windows/System32/WS2_32.dll (0x7ffe8b7d0000)
  	ADVAPI32.dll => /c/Windows/System32/ADVAPI32.dll (0x7ffe8b710000)
  	msvcrt.dll => /c/Windows/System32/msvcrt.dll (0x7ffe8b320000)
  	sechost.dll => /c/Windows/System32/sechost.dll (0x7ffe8c640000)
  	bcrypt.dll => /c/Windows/System32/bcrypt.dll (0x7ffe8aa70000)
  	SHLWAPI.dll => /c/Windows/System32/SHLWAPI.dll (0x7ffe8c5b0000)
  	shell32.dll => /c/Windows/System32/shell32.dll (0x7ffe8b8d0000)
  	secur32.dll => /c/Windows/SYSTEM32/secur32.dll (0x7ffe7db70000)
  	ole32.dll => /c/Windows/System32/ole32.dll (0x7ffe8b1e0000)
  	combase.dll => /c/Windows/System32/combase.dll (0x7ffe8c910000)
  	VCRUNTIME140.dll => /c/Windows/SYSTEM32/VCRUNTIME140.dll (0x7ffe7e9a0000)
  	MSVCP140.dll => /c/Windows/SYSTEM32/MSVCP140.dll (0x7ffe7e9c0000)
  	VCRUNTIME140_1.dll => /c/Windows/SYSTEM32/VCRUNTIME140_1.dll (0x7ffe7f450000)
  	CRYPTBASE.DLL => /c/Windows/SYSTEM32/CRYPTBASE.DLL (0x7ffe899b0000)
  	SSPICLI.DLL => /c/Windows/SYSTEM32/SSPICLI.DLL (0x7ffe89bf0000)
```
- fixed openssl version to 3.3.2
- update ci