### PR TITLE
Extract quic-definitions crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7917,6 +7917,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-quic-definitions"
+version = "2.2.0"
+dependencies = [
+ "solana-keypair",
+]
+
+[[package]]
 name = "solana-rayon-threadlimit"
 version = "2.2.0"
 dependencies = [
@@ -8325,6 +8332,7 @@ dependencies = [
  "solana-program",
  "solana-program-memory",
  "solana-pubkey",
+ "solana-quic-definitions",
  "solana-reserved-account-keys",
  "solana-reward-info",
  "solana-sanitize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ members = [
     "sdk/program-option",
     "sdk/program-pack",
     "sdk/pubkey",
+    "sdk/quic-definitions",
     "sdk/rent",
     "sdk/reserved-account-keys",
     "sdk/sanitize",
@@ -492,6 +493,7 @@ solana-program-test = { path = "program-test", version = "=2.2.0" }
 solana-pubkey = { path = "sdk/pubkey", version = "=2.2.0", default-features = false }
 solana-pubsub-client = { path = "pubsub-client", version = "=2.2.0" }
 solana-quic-client = { path = "quic-client", version = "=2.2.0" }
+solana-quic-definitions = { path = "sdk/quic-definitions", version = "=2.2.0" }
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.2.0" }
 solana-remote-wallet = { path = "remote-wallet", version = "=2.2.0", default-features = false }
 solana-rent = { path = "sdk/rent", version = "=2.2.0", default-features = false }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6247,6 +6247,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-quic-definitions"
+version = "2.2.0"
+dependencies = [
+ "solana-keypair",
+]
+
+[[package]]
 name = "solana-rayon-threadlimit"
 version = "2.2.0"
 dependencies = [
@@ -7058,6 +7065,7 @@ dependencies = [
  "solana-program",
  "solana-program-memory",
  "solana-pubkey",
+ "solana-quic-definitions",
  "solana-reserved-account-keys",
  "solana-reward-info",
  "solana-sanitize",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -37,6 +37,7 @@ full = [
     "dep:solana-keypair",
     "dep:solana-precompile-error",
     "dep:solana-presigner",
+    "dep:solana-quic-definitions",
     "dep:solana-seed-derivable",
     "dep:solana-seed-phrase",
     "dep:solana-signer",
@@ -116,7 +117,7 @@ solana-presigner = { workspace = true, optional = true }
 solana-program = { workspace = true }
 solana-program-memory = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false, features = ["std"] }
-solana-quic-definitions = { workspace = true }
+solana-quic-definitions = { workspace = true, optional = true }
 solana-reserved-account-keys = { workspace = true }
 solana-reward-info = { workspace = true, features = ["serde"] }
 solana-sanitize = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -116,6 +116,7 @@ solana-presigner = { workspace = true, optional = true }
 solana-program = { workspace = true }
 solana-program-memory = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false, features = ["std"] }
+solana-quic-definitions = { workspace = true }
 solana-reserved-account-keys = { workspace = true }
 solana-reward-info = { workspace = true, features = ["serde"] }
 solana-sanitize = { workspace = true }

--- a/sdk/quic-definitions/Cargo.toml
+++ b/sdk/quic-definitions/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-quic-definitions"
+description = "Definitions related to Solana over QUIC."
+documentation = "https://docs.rs/solana-quic-definitions"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-keypair = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/sdk/quic-definitions/src/lib.rs
+++ b/sdk/quic-definitions/src/lib.rs
@@ -1,6 +1,5 @@
-#![cfg(feature = "full")]
 //! Definitions related to Solana over QUIC.
-use {crate::signer::keypair::Keypair, std::time::Duration};
+use {solana_keypair::Keypair, std::time::Duration};
 
 pub const QUIC_PORT_OFFSET: u16 = 6;
 // Empirically found max number of concurrent streams
@@ -27,14 +26,20 @@ pub const QUIC_CONNECTION_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// The receive window for QUIC connection from unstaked nodes is
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
+///
+/// [`solana_sdk::packet::PACKET_DATA_SIZE`]: https://docs.rs/solana-sdk/latest/solana_sdk/packet/constant.PACKET_DATA_SIZE.html
 pub const QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO: u64 = 128;
 
 /// The receive window for QUIC connection from minimum staked nodes is
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
+///
+/// [`solana_sdk::packet::PACKET_DATA_SIZE`]: https://docs.rs/solana-sdk/latest/solana_sdk/packet/constant.PACKET_DATA_SIZE.html
 pub const QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO: u64 = 128;
 
 /// The receive window for QUIC connection from maximum staked nodes is
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
+///
+/// [`solana_sdk::packet::PACKET_DATA_SIZE`]: https://docs.rs/solana-sdk/latest/solana_sdk/packet/constant.PACKET_DATA_SIZE.html
 pub const QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO: u64 = 512;
 
 pub trait NotifyKeyUpdate {

--- a/sdk/quic-definitions/src/lib.rs
+++ b/sdk/quic-definitions/src/lib.rs
@@ -31,15 +31,15 @@ pub const QUIC_CONNECTION_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(60);
 pub const QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO: u64 = 128;
 
 /// The receive window for QUIC connection from minimum staked nodes is
-/// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
+/// set to this ratio times [`solana_packet::PACKET_DATA_SIZE`]
 ///
-/// [`solana_sdk::packet::PACKET_DATA_SIZE`]: https://docs.rs/solana-sdk/latest/solana_sdk/packet/constant.PACKET_DATA_SIZE.html
+/// [`solana_packet::PACKET_DATA_SIZE`]: https://docs.rs/solana-packet/latest/solana_packet/constant.PACKET_DATA_SIZE.html
 pub const QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO: u64 = 128;
 
 /// The receive window for QUIC connection from maximum staked nodes is
-/// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
+/// set to this ratio times [`solana_packet::PACKET_DATA_SIZE`]
 ///
-/// [`solana_sdk::packet::PACKET_DATA_SIZE`]: https://docs.rs/solana-sdk/latest/solana_sdk/packet/constant.PACKET_DATA_SIZE.html
+/// [`solana_packet::PACKET_DATA_SIZE`]: https://docs.rs/solana-packet/latest/solana_packet/constant.PACKET_DATA_SIZE.html
 pub const QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO: u64 = 512;
 
 pub trait NotifyKeyUpdate {

--- a/sdk/quic-definitions/src/lib.rs
+++ b/sdk/quic-definitions/src/lib.rs
@@ -25,9 +25,9 @@ pub const QUIC_KEEP_ALIVE: Duration = Duration::from_secs(1);
 pub const QUIC_CONNECTION_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// The receive window for QUIC connection from unstaked nodes is
-/// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
+/// set to this ratio times [`solana_packet::PACKET_DATA_SIZE`]
 ///
-/// [`solana_sdk::packet::PACKET_DATA_SIZE`]: https://docs.rs/solana-sdk/latest/solana_sdk/packet/constant.PACKET_DATA_SIZE.html
+/// [`solana_packet::PACKET_DATA_SIZE`]: https://docs.rs/solana-packet/latest/solana_packet/constant.PACKET_DATA_SIZE.html
 pub const QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO: u64 = 128;
 
 /// The receive window for QUIC connection from minimum staked nodes is

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -85,7 +85,6 @@ pub mod poh_config;
 pub mod precompiles;
 pub mod program_utils;
 pub mod pubkey;
-pub mod quic;
 pub mod rent_collector;
 pub mod rent_debits;
 #[deprecated(since = "2.2.0", note = "Use `solana-reward-info` crate instead")]
@@ -148,6 +147,9 @@ pub use solana_program_memory as program_memory;
 /// assert_eq!(ID, my_id);
 /// ```
 pub use solana_pubkey::pubkey;
+#[cfg(feature = "full")]
+#[deprecated(since = "2.2.0", note = "Use `solana-quic-definitions` crate instead")]
+pub use solana_quic_definitions as quic;
 #[cfg(feature = "full")]
 #[deprecated(
     since = "2.2.0",


### PR DESCRIPTION
#### Problem
`solana_sdk::quic` imposes a `solana_sdk` dep on `solana_quic_client` and `solana_streamer`

#### Summary of Changes
- Move to its own crate and re-export with deprecation

This branches off #3087 so that needs to be merged first
