### PR TITLE
add doc_auto_cfg to relevant sdk crates

### DIFF
--- a/sdk/account-info/Cargo.toml
+++ b/sdk/account-info/Cargo.toml
@@ -21,3 +21,5 @@ bincode = ["dep:bincode", "dep:serde"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]

--- a/sdk/account-info/src/lib.rs
+++ b/sdk/account-info/src/lib.rs
@@ -1,5 +1,5 @@
 //! Account information.
-
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {
     solana_program_error::ProgramError,
     solana_program_memory::sol_memset,

--- a/sdk/account/Cargo.toml
+++ b/sdk/account/Cargo.toml
@@ -36,3 +36,5 @@ serde = ["dep:serde", "dep:serde_bytes", "dep:serde_derive"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]

--- a/sdk/account/src/lib.rs
+++ b/sdk/account/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 //! The Solana [`Account`] type.
 
 #[cfg(feature = "dev-context-only-utils")]

--- a/sdk/hash/Cargo.toml
+++ b/sdk/hash/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 borsh = { workspace = true, optional = true }

--- a/sdk/hash/src/lib.rs
+++ b/sdk/hash/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};

--- a/sdk/instruction/Cargo.toml
+++ b/sdk/instruction/Cargo.toml
@@ -49,6 +49,8 @@ std = []
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/sdk/instruction/src/error.rs
+++ b/sdk/instruction/src/error.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
 #[cfg(feature = "std")]

--- a/sdk/instruction/src/error.rs
+++ b/sdk/instruction/src/error.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
 #[cfg(feature = "std")]

--- a/sdk/instruction/src/lib.rs
+++ b/sdk/instruction/src/lib.rs
@@ -10,6 +10,7 @@
 //! while executing a given instruction is also included in `Instruction`, as
 //! [`AccountMeta`] values. The runtime uses this information to efficiently
 //! schedule execution of transactions.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 #![no_std]

--- a/sdk/program-error/Cargo.toml
+++ b/sdk/program-error/Cargo.toml
@@ -27,3 +27,5 @@ serde = ["dep:serde", "dep:serde_derive"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]

--- a/sdk/program-error/src/lib.rs
+++ b/sdk/program-error/src/lib.rs
@@ -1,6 +1,7 @@
 //! The [`ProgramError`] type and related definitions.
 
 #![allow(clippy::arithmetic_side_effects)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #[cfg(feature = "borsh")]
 use borsh::io::Error as BorshIoError;
 #[cfg(feature = "serde")]

--- a/sdk/pubkey/Cargo.toml
+++ b/sdk/pubkey/Cargo.toml
@@ -75,6 +75,8 @@ std = []
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/sdk/pubkey/src/lib.rs
+++ b/sdk/pubkey/src/lib.rs
@@ -1,5 +1,6 @@
 //! Solana account addresses.
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 

--- a/sdk/signature/Cargo.toml
+++ b/sdk/signature/Cargo.toml
@@ -43,6 +43,8 @@ verify = ["dep:ed25519-dalek"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/sdk/signature/src/lib.rs
+++ b/sdk/signature/src/lib.rs
@@ -1,5 +1,6 @@
 //! 64-byte signature type.
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(any(test, feature = "verify"))]
 use core::convert::TryInto;


### PR DESCRIPTION
#### Problem
The new SDK crates put a bunch of code behind feature gates, which means those items won't be visible on docs.rs. This wasn't a big issue with `solana_sdk` and `solana_program` because those crates enable almost all their features by default.

#### Summary of Changes
For each crate in `sdk/` where this is an issue, add 
```
all-features = true
rustdoc-args = ["--cfg=docsrs"]
```
to `[package.metadata.docs.rs]`
and add `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` to each module that contains feature-gated public items.

This makes docs.rs show these items with a note that they require certain features (or targets etc). This solution is fairly common: [tokio](https://docs.rs/tokio/latest/tokio/) is a prominent crate that does this.

To emulate what docs.rs generates, you can cd to the individual crate directory and run `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps`

I published a toy example crate to demonstrate that this works on docs.rs: https://docs.rs/doc-feature-examples/latest/doc_feature_examples/

