### PR TITLE
fix a link in the solana-instruction docs

### DIFF
--- a/sdk/instruction/src/account_meta.rs
+++ b/sdk/instruction/src/account_meta.rs
@@ -14,6 +14,8 @@ use solana_pubkey::Pubkey;
 /// default [`AccountMeta::new`] constructor creates writable accounts, this is
 /// a minor hazard: use [`AccountMeta::new_readonly`] to specify that an account
 /// is not writable.
+/// 
+/// [`Instruction`]: crate::Instruction
 #[repr(C)]
 #[cfg_attr(
     feature = "serde",

--- a/sdk/instruction/src/account_meta.rs
+++ b/sdk/instruction/src/account_meta.rs
@@ -14,7 +14,7 @@ use solana_pubkey::Pubkey;
 /// default [`AccountMeta::new`] constructor creates writable accounts, this is
 /// a minor hazard: use [`AccountMeta::new_readonly`] to specify that an account
 /// is not writable.
-/// 
+///
 /// [`Instruction`]: crate::Instruction
 #[repr(C)]
 #[cfg_attr(


### PR DESCRIPTION
#### Problem
`cargo doc` emits a warning because a doc comment refers to ``[`Instruction`]`` without providing a path to the Instruction type.

#### Summary of Changes
Add the missing path
