### PR TITLE
Support notifying bank created slot status in geyser

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4022,7 +4022,7 @@ impl ReplayStage {
                     forks.root(),
                     &leader,
                     rpc_subscriptions,
-                    &slot_status_notifier,
+                    slot_status_notifier,
                     NewBankOptions::default(),
                 );
                 let empty: Vec<Pubkey> = vec![];

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -54,7 +54,7 @@ use {
     solana_rpc::{
         optimistically_confirmed_bank_tracker::{BankNotification, BankNotificationSenderConfig},
         rpc_subscriptions::RpcSubscriptions,
-        slot_status_notifier::{self, SlotStatusNotifier},
+        slot_status_notifier::SlotStatusNotifier,
     },
     solana_rpc_client_api::response::SlotUpdate,
     solana_runtime::{
@@ -1126,6 +1126,7 @@ impl ReplayStage {
                         &poh_recorder,
                         &leader_schedule_cache,
                         &rpc_subscriptions,
+                        &slot_status_notifier,
                         &mut progress,
                         &retransmit_slots_sender,
                         &mut skipped_slots_info,
@@ -2056,7 +2057,7 @@ impl ReplayStage {
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         rpc_subscriptions: &Arc<RpcSubscriptions>,
-        slot_status_notifier: Option<SlotStatusNotifier>,
+        slot_status_notifier: &Option<SlotStatusNotifier>,
         progress_map: &mut ProgressMap,
         retransmit_slots_sender: &Sender<Slot>,
         skipped_slots_info: &mut SkippedSlotsInfo,
@@ -4077,7 +4078,7 @@ impl ReplayStage {
             slot_status_notifier
                 .read()
                 .unwrap()
-                .notify_bank_created(slot, parent);
+                .notify_created_bank(slot, parent.slot());
         }
         Bank::new_from_parent_with_options(parent, leader, slot, new_bank_options)
     }
@@ -4425,6 +4426,7 @@ pub(crate) mod tests {
             &bank_forks,
             &leader_schedule_cache,
             &rpc_subscriptions,
+            &None,
             &mut progress,
             &mut replay_timing,
         );
@@ -4453,6 +4455,7 @@ pub(crate) mod tests {
             &bank_forks,
             &leader_schedule_cache,
             &rpc_subscriptions,
+            &None,
             &mut progress,
             &mut replay_timing,
         );
@@ -6322,6 +6325,7 @@ pub(crate) mod tests {
             &bank_forks,
             &leader_schedule_cache,
             &rpc_subscriptions,
+            &None,
             &mut progress,
             &mut replay_timing,
         );
@@ -6351,6 +6355,7 @@ pub(crate) mod tests {
             &bank_forks,
             &leader_schedule_cache,
             &rpc_subscriptions,
+            &None,
             &mut progress,
             &mut replay_timing,
         );
@@ -6381,6 +6386,7 @@ pub(crate) mod tests {
             &bank_forks,
             &leader_schedule_cache,
             &rpc_subscriptions,
+            &None,
             &mut progress,
             &mut replay_timing,
         );
@@ -6410,6 +6416,7 @@ pub(crate) mod tests {
             &bank_forks,
             &leader_schedule_cache,
             &rpc_subscriptions,
+            &None,
             &mut progress,
             &mut replay_timing,
         );
@@ -8344,6 +8351,7 @@ pub(crate) mod tests {
             &poh_recorder,
             &leader_schedule_cache,
             &rpc_subscriptions,
+            &None,
             &mut progress,
             &retransmit_slots_sender,
             &mut SkippedSlotsInfo::default(),
@@ -9012,6 +9020,7 @@ pub(crate) mod tests {
             &poh_recorder,
             &leader_schedule_cache,
             &rpc_subscriptions,
+            &None,
             &mut progress,
             &retransmit_slots_sender,
             &mut SkippedSlotsInfo::default(),
@@ -9038,6 +9047,7 @@ pub(crate) mod tests {
             &poh_recorder,
             &leader_schedule_cache,
             &rpc_subscriptions,
+            &None,
             &mut progress,
             &retransmit_slots_sender,
             &mut SkippedSlotsInfo::default(),

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -211,7 +211,7 @@ impl Tvu {
             retransmit_receiver,
             max_slots.clone(),
             Some(rpc_subscriptions.clone()),
-            slot_status_notifier,
+            slot_status_notifier.clone(),
         );
 
         let (ancestor_duplicate_slots_sender, ancestor_duplicate_slots_receiver) = unbounded();
@@ -274,6 +274,7 @@ impl Tvu {
             authorized_voter_keypairs,
             exit: exit.clone(),
             rpc_subscriptions: rpc_subscriptions.clone(),
+            slot_status_notifier,
             leader_schedule_cache: leader_schedule_cache.clone(),
             accounts_background_request_sender,
             block_commitment_cache,

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -338,7 +338,7 @@ impl SlotStatus {
             SlotStatus::Rooted => "rooted",
             SlotStatus::FirstShredReceived => "first_shread_received",
             SlotStatus::Completed => "completed",
-            Self::CreatedBank => "created_bank",
+            SlotStatus::CreatedBank => "created_bank",
         }
     }
 }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -325,6 +325,9 @@ pub enum SlotStatus {
 
     /// All shreds for the slot have been received.
     Completed,
+
+    /// A new bank is created with the slot
+    CreatedBank,
 }
 
 impl SlotStatus {
@@ -335,6 +338,7 @@ impl SlotStatus {
             SlotStatus::Rooted => "rooted",
             SlotStatus::FirstShredReceived => "first_shread_received",
             SlotStatus::Completed => "completed",
+            Self::CreatedBank => "created_bank",
         }
     }
 }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -326,7 +326,7 @@ pub enum SlotStatus {
     /// All shreds for the slot have been received.
     Completed,
 
-    /// A new bank is created with the slot
+    /// A new bank fork is created with the slot
     CreatedBank,
 }
 

--- a/geyser-plugin-manager/src/slot_status_notifier.rs
+++ b/geyser-plugin-manager/src/slot_status_notifier.rs
@@ -33,6 +33,10 @@ impl SlotStatusNotifierInterface for SlotStatusNotifierImpl {
     fn notify_completed(&self, slot: Slot) {
         self.notify_slot_status(slot, None, SlotStatus::Completed);
     }
+
+    fn notify_created_bank(&self, slot: Slot, parent: Slot) {
+        self.notify_slot_status(slot, Some(parent), SlotStatus::CreatedBank);
+    }
 }
 
 impl SlotStatusNotifierImpl {

--- a/rpc/src/slot_status_notifier.rs
+++ b/rpc/src/slot_status_notifier.rs
@@ -18,6 +18,9 @@ pub trait SlotStatusNotifierInterface {
 
     /// Notified when the slot is completed.
     fn notify_completed(&self, slot: Slot);
+
+    /// Notified when the slot has bank created.
+    fn notify_bank_created(&self, slot: Slot, parent: Slot);
 }
 
 pub type SlotStatusNotifier = Arc<RwLock<dyn SlotStatusNotifierInterface + Sync + Send>>;

--- a/rpc/src/slot_status_notifier.rs
+++ b/rpc/src/slot_status_notifier.rs
@@ -20,7 +20,7 @@ pub trait SlotStatusNotifierInterface {
     fn notify_completed(&self, slot: Slot);
 
     /// Notified when the slot has bank created.
-    fn notify_bank_created(&self, slot: Slot, parent: Slot);
+    fn notify_created_bank(&self, slot: Slot, parent: Slot);
 }
 
 pub type SlotStatusNotifier = Arc<RwLock<dyn SlotStatusNotifierInterface + Sync + Send>>;


### PR DESCRIPTION
Problem

This is the 3rd part to support more slot status notification type in geyser. CreatedBank on new fork creation.

Summary of Changes

Link SlotStatusNotifier in replay stage on CreatedBank.

Tests: tested change with Postgres geyser plugin and confirming the CreatedBank being received.

Fixes #

https://github.com/anza-xyz/agave/issues/2957