### PR TITLE
Extract transaction-context crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8338,6 +8338,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-time-utils",
+ "solana-transaction-context",
  "solana-transaction-error",
  "static_assertions",
  "thiserror",
@@ -8945,6 +8946,24 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util 0.7.12",
+]
+
+[[package]]
+name = "solana-transaction-context"
+version = "2.2.0"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-program",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-signature",
+ "solana-transaction-context",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ members = [
     "sdk/stable-layout",
     "sdk/sysvar-id",
     "sdk/time-utils",
+    "sdk/transaction-context",
     "sdk/transaction-error",
     "send-transaction-service",
     "stake-accounts",
@@ -540,6 +541,7 @@ solana-thin-client = { path = "thin-client", version = "=2.2.0" }
 solana-transaction-error = { path = "sdk/transaction-error", version = "=2.2.0" }
 solana-tpu-client = { path = "tpu-client", version = "=2.2.0", default-features = false }
 solana-tpu-client-next = { path = "tpu-client-next", version = "=2.2.0" }
+solana-transaction-context = { path = "sdk/transaction-context", version = "=2.2.0" }
 solana-transaction-status = { path = "transaction-status", version = "=2.2.0" }
 solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=2.2.0" }
 solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7070,6 +7070,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-time-utils",
+ "solana-transaction-context",
  "solana-transaction-error",
  "thiserror",
  "wasm-bindgen",
@@ -7463,6 +7464,21 @@ dependencies = [
  "solana-sdk",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "solana-transaction-context"
+version = "2.2.0"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-signature",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7474,7 +7474,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-account",
- "solana-account-info",
  "solana-instruction",
  "solana-pubkey",
  "solana-rent",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -28,7 +28,7 @@ full = [
     "rand0-7",
     "serde_json",
     "solana-signature",
-    "solana-transaction-context/debug_signature",
+    "solana-transaction-context/debug-signature",
     "ed25519-dalek",
     "libsecp256k1",
     "sha3",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -44,7 +44,11 @@ full = [
     "dep:solana-transaction-error"
 ]
 borsh = ["dep:borsh", "solana-program/borsh", "solana-secp256k1-recover/borsh"]
-dev-context-only-utils = ["qualifier_attr", "solana-account/dev-context-only-utils"]
+dev-context-only-utils = [
+    "qualifier_attr",
+    "solana-account/dev-context-only-utils",
+    "solana-transaction-context/dev-context-only-utils",
+]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -28,7 +28,7 @@ full = [
     "rand0-7",
     "serde_json",
     "solana-signature",
-    "solana-transaction-context/debug_assertions",
+    "solana-transaction-context/debug_signature",
     "ed25519-dalek",
     "libsecp256k1",
     "sha3",
@@ -141,7 +141,7 @@ solana-signer = { workspace = true, optional = true }
 solana-time-utils = { workspace = true }
 solana-transaction-context = { workspace = true, features = [
     "bincode",
-    "debug_assertions",
+    "debug_signature",
 ] }
 solana-transaction-error = { workspace = true, features = ["serde"], optional = true }
 thiserror = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -28,6 +28,7 @@ full = [
     "rand0-7",
     "serde_json",
     "solana-signature",
+    "solana-transaction-context/debug_assertions",
     "ed25519-dalek",
     "libsecp256k1",
     "sha3",
@@ -134,6 +135,10 @@ solana-signature = { workspace = true, features = [
 ], optional = true }
 solana-signer = { workspace = true, optional = true }
 solana-time-utils = { workspace = true }
+solana-transaction-context = { workspace = true, features = [
+    "bincode",
+    "debug_assertions",
+] }
 solana-transaction-error = { workspace = true, features = ["serde"], optional = true }
 thiserror = { workspace = true }
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -141,7 +141,6 @@ solana-signer = { workspace = true, optional = true }
 solana-time-utils = { workspace = true }
 solana-transaction-context = { workspace = true, features = [
     "bincode",
-    "debug_signature",
 ] }
 solana-transaction-error = { workspace = true, features = ["serde"], optional = true }
 thiserror = { workspace = true }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -104,7 +104,6 @@ pub mod signer;
 pub mod simple_vote_transaction_checker;
 pub mod system_transaction;
 pub mod transaction;
-pub mod transaction_context;
 pub mod transport;
 pub mod wasm;
 
@@ -190,6 +189,11 @@ pub use solana_serde_varint as serde_varint;
 pub use solana_short_vec as short_vec;
 #[deprecated(since = "2.2.0", note = "Use `solana-time-utils` crate instead")]
 pub use solana_time_utils as timing;
+#[deprecated(
+    since = "2.2.0",
+    note = "Use `solana-transaction-context` crate instead"
+)]
+pub use solana_transaction_context as transaction_context;
 
 /// Convenience macro for `AddAssign` with saturating arithmetic.
 /// Replace by `std::num::Saturating` once stable

--- a/sdk/transaction-context/Cargo.toml
+++ b/sdk/transaction-context/Cargo.toml
@@ -36,10 +36,10 @@ static_assertions = { workspace = true }
 
 [features]
 bincode = ["dep:bincode", "serde", "solana-account/bincode"]
-debug_assertions = ["dep:solana-signature"]
+debug_signature = ["dep:solana-signature"]
 dev-context-only-utils = [
     "bincode",
-    "debug_assertions",
+    "debug_signature",
     "solana-account/dev-context-only-utils"
 ]
 serde = ["dep:serde", "dep:serde_derive"]

--- a/sdk/transaction-context/Cargo.toml
+++ b/sdk/transaction-context/Cargo.toml
@@ -36,12 +36,12 @@ static_assertions = { workspace = true }
 
 [features]
 bincode = ["dep:bincode", "serde", "solana-account/bincode"]
+debug_assertions = ["dep:solana-signature"]
 dev-context-only-utils = [
     "bincode",
     "debug_assertions",
-    "solana-account/dev-context-only-utils",
+    "solana-account/dev-context-only-utils"
 ]
-debug_assertions = ["dep:solana-signature"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [lints]

--- a/sdk/transaction-context/Cargo.toml
+++ b/sdk/transaction-context/Cargo.toml
@@ -21,11 +21,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 bincode = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-account-info = { workspace = true }
 solana-rent = { workspace = true }
 solana-signature = { workspace = true, optional = true }
 
 [dev-dependencies]
+solana-account-info = { workspace = true }
 solana-program = { workspace = true }
 solana-transaction-context = { path = ".", features = [
     "dev-context-only-utils",

--- a/sdk/transaction-context/Cargo.toml
+++ b/sdk/transaction-context/Cargo.toml
@@ -36,10 +36,10 @@ static_assertions = { workspace = true }
 
 [features]
 bincode = ["dep:bincode", "serde", "solana-account/bincode"]
-debug_signature = ["dep:solana-signature"]
+debug-signature = ["dep:solana-signature"]
 dev-context-only-utils = [
     "bincode",
-    "debug_signature",
+    "debug-signature",
     "solana-account/dev-context-only-utils"
 ]
 serde = ["dep:serde", "dep:serde_derive"]

--- a/sdk/transaction-context/Cargo.toml
+++ b/sdk/transaction-context/Cargo.toml
@@ -10,6 +10,8 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
 solana-account = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-pubkey = { workspace = true }
@@ -21,8 +23,6 @@ rustdoc-args = ["--cfg=docsrs"]
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 bincode = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
 solana-rent = { workspace = true }
 solana-signature = { workspace = true, optional = true }
 

--- a/sdk/transaction-context/Cargo.toml
+++ b/sdk/transaction-context/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "solana-transaction-context"
+description = "Solana data shared between program runtime and built-in programs as well as SBF programs."
+documentation = "https://docs.rs/solana-transaction-context"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-account = { workspace = true }
+solana-instruction = { workspace = true, features = ["std"] }
+solana-pubkey = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[target.'cfg(not(target_os = "solana"))'.dependencies]
+bincode = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-account-info = { workspace = true }
+solana-rent = { workspace = true }
+solana-signature = { workspace = true, optional = true }
+
+[dev-dependencies]
+solana-program = { workspace = true }
+solana-transaction-context = { path = ".", features = [
+    "dev-context-only-utils",
+] }
+static_assertions = { workspace = true }
+
+[features]
+bincode = ["dep:bincode", "serde", "solana-account/bincode"]
+dev-context-only-utils = [
+    "bincode",
+    "debug_assertions",
+    "solana-account/dev-context-only-utils",
+]
+debug_assertions = ["dep:solana-signature"]
+serde = ["dep:serde", "dep:serde_derive"]
+
+[lints]
+workspace = true

--- a/sdk/transaction-context/Cargo.toml
+++ b/sdk/transaction-context/Cargo.toml
@@ -16,6 +16,8 @@ solana-pubkey = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 bincode = { workspace = true, optional = true }

--- a/sdk/transaction-context/src/lib.rs
+++ b/sdk/transaction-context/src/lib.rs
@@ -31,6 +31,7 @@ static_assertions::const_assert_eq!(
 );
 
 // Inlined to avoid solana_program dep
+#[cfg(not(target_os = "solana"))]
 const MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION: i64 =
     MAX_PERMITTED_DATA_LENGTH as i64 * 2;
 #[cfg(test)]
@@ -40,6 +41,7 @@ static_assertions::const_assert_eq!(
 );
 
 // Inlined to avoid solana_account_info dep
+#[cfg(not(target_os = "solana"))]
 const MAX_PERMITTED_DATA_INCREASE: usize = 1_024 * 10;
 #[cfg(test)]
 static_assertions::const_assert_eq!(

--- a/sdk/transaction-context/src/lib.rs
+++ b/sdk/transaction-context/src/lib.rs
@@ -4,7 +4,7 @@
 
 #[cfg(all(
     not(target_os = "solana"),
-    feature = "debug_assertions",
+    feature = "debug_signature",
     debug_assertions
 ))]
 use solana_signature::Signature;
@@ -170,7 +170,7 @@ pub struct TransactionContext {
     /// Useful for debugging to filter by or to look it up on the explorer
     #[cfg(all(
         not(target_os = "solana"),
-        feature = "debug_assertions",
+        feature = "debug_signature",
         debug_assertions
     ))]
     signature: Signature,
@@ -202,7 +202,7 @@ impl TransactionContext {
             rent,
             #[cfg(all(
                 not(target_os = "solana"),
-                feature = "debug_assertions",
+                feature = "debug_signature",
                 debug_assertions
             ))]
             signature: Signature::default(),
@@ -234,7 +234,7 @@ impl TransactionContext {
     /// Stores the signature of the current transaction
     #[cfg(all(
         not(target_os = "solana"),
-        feature = "debug_assertions",
+        feature = "debug_signature",
         debug_assertions
     ))]
     pub fn set_signature(&mut self, signature: &Signature) {
@@ -244,7 +244,7 @@ impl TransactionContext {
     /// Returns the signature of the current transaction
     #[cfg(all(
         not(target_os = "solana"),
-        feature = "debug_assertions",
+        feature = "debug_signature",
         debug_assertions
     ))]
     pub fn get_signature(&self) -> &Signature {

--- a/sdk/transaction-context/src/lib.rs
+++ b/sdk/transaction-context/src/lib.rs
@@ -23,6 +23,7 @@ use {
 };
 
 // Inlined to avoid solana_program dep
+#[cfg(not(target_os = "solana"))]
 const MAX_PERMITTED_DATA_LENGTH: u64 = 10 * 1024 * 1024;
 #[cfg(test)]
 static_assertions::const_assert_eq!(

--- a/sdk/transaction-context/src/lib.rs
+++ b/sdk/transaction-context/src/lib.rs
@@ -1,5 +1,6 @@
 //! Data shared between program runtime and built-in programs as well as SBF programs.
 #![deny(clippy::indexing_slicing)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(all(
     not(target_os = "solana"),

--- a/sdk/transaction-context/src/lib.rs
+++ b/sdk/transaction-context/src/lib.rs
@@ -4,7 +4,7 @@
 
 #[cfg(all(
     not(target_os = "solana"),
-    feature = "debug_signature",
+    feature = "debug-signature",
     debug_assertions
 ))]
 use solana_signature::Signature;
@@ -170,7 +170,7 @@ pub struct TransactionContext {
     /// Useful for debugging to filter by or to look it up on the explorer
     #[cfg(all(
         not(target_os = "solana"),
-        feature = "debug_signature",
+        feature = "debug-signature",
         debug_assertions
     ))]
     signature: Signature,
@@ -202,7 +202,7 @@ impl TransactionContext {
             rent,
             #[cfg(all(
                 not(target_os = "solana"),
-                feature = "debug_signature",
+                feature = "debug-signature",
                 debug_assertions
             ))]
             signature: Signature::default(),
@@ -234,7 +234,7 @@ impl TransactionContext {
     /// Stores the signature of the current transaction
     #[cfg(all(
         not(target_os = "solana"),
-        feature = "debug_signature",
+        feature = "debug-signature",
         debug_assertions
     ))]
     pub fn set_signature(&mut self, signature: &Signature) {
@@ -244,7 +244,7 @@ impl TransactionContext {
     /// Returns the signature of the current transaction
     #[cfg(all(
         not(target_os = "solana"),
-        feature = "debug_signature",
+        feature = "debug-signature",
         debug_assertions
     ))]
     pub fn get_signature(&self) -> &Signature {

--- a/sdk/transaction-context/src/lib.rs
+++ b/sdk/transaction-context/src/lib.rs
@@ -8,14 +8,7 @@
 ))]
 use solana_signature::Signature;
 #[cfg(not(target_os = "solana"))]
-use {
-    solana_account::WritableAccount,
-    // not inlining MAX_PERMITTED_DATA_INCREASE because we already
-    // depend on solana_account_info indirectly
-    solana_account_info::MAX_PERMITTED_DATA_INCREASE,
-    solana_rent::Rent,
-    std::mem::MaybeUninit,
-};
+use {solana_account::WritableAccount, solana_rent::Rent, std::mem::MaybeUninit};
 use {
     solana_account::{AccountSharedData, ReadableAccount},
     solana_instruction::error::InstructionError,
@@ -43,6 +36,14 @@ const MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION: i64 =
 static_assertions::const_assert_eq!(
     MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION,
     solana_program::system_instruction::MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION
+);
+
+// Inlined to avoid solana_account_info dep
+const MAX_PERMITTED_DATA_INCREASE: usize = 1_024 * 10;
+#[cfg(test)]
+static_assertions::const_assert_eq!(
+    MAX_PERMITTED_DATA_INCREASE,
+    solana_account_info::MAX_PERMITTED_DATA_INCREASE
 );
 
 /// Index of an account inside of the TransactionContext or an InstructionContext.


### PR DESCRIPTION
#### Problem
`solana_sdk::transaction_context` imposes a `solana_sdk` dep on `solana_transaction_status_client_types`

#### Summary of Changes
- Move to its own crate and re-export with deprecation notice
- transaction_context.rs was making use of the `full` feature of solana-sdk for code using debug_assertions. Add a `debug_assertions` feature to the new crate to replace the `full` feature.
- Make serde and bincode optional in the new crate
- Add doc_auto_cfg like in #3121
