### PR TITLE
refreshes ContactInfo.outset before initializing validator

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -666,7 +666,7 @@ impl ClusterInfo {
             *instance = NodeInstance::new(&mut thread_rng(), id, timestamp());
         }
         *self.keypair.write().unwrap() = new_keypair;
-        self.my_contact_info.write().unwrap().set_pubkey(id);
+        self.my_contact_info.write().unwrap().hot_swap_pubkey(id);
 
         self.insert_self();
         self.push_message(CrdsValue::new_signed(

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -547,7 +547,7 @@ pub fn make_test_cluster<R: Rng>(
     .collect();
     nodes.shuffle(rng);
     let keypair = Arc::new(Keypair::new());
-    nodes[0].set_pubkey(keypair.pubkey());
+    nodes[0] = ContactInfo::new_localhost(&keypair.pubkey(), /*wallclock:*/ timestamp());
     let this_node = nodes[0].clone();
     let mut stakes: HashMap<Pubkey, u64> = nodes
         .iter()

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1901,6 +1901,13 @@ pub fn main() {
         return;
     }
 
+    // Bootstrap code above pushes a contact-info with more recent timestamp to
+    // gossip. If the node is staked the contact-info lingers in gossip causing
+    // false duplicate nodes error.
+    // Below line refreshes the timestamp on contact-info so that it overrides
+    // the one pushed by bootstrap.
+    node.info.hot_swap_pubkey(identity_keypair.pubkey());
+
     let validator = Validator::new(
         node,
         identity_keypair,


### PR DESCRIPTION

#### Problem
Nodes join gossip during bootstrap process with a stub contact-info which in particular has invalid TVU socket address.

Once the bootstrap is done they re-join gossip a 2nd time with a fully populated contact-info, but this contact-info has an outset timestamp older than the 1st one because it was initiated earlier.

In v2.0, the outset timestamp determines which contact-info overrides the other, so the v2.0 nodes refrain from updating their CRDS table with the fully initialized contact-info.



#### Summary of Changes
The commit refreshes `ContactInfo.outset` before initializing validator so that it overrides the one pushed to gossip by the bootstrap stage.
