### PR TITLE
Displays LtHash's Checksum as base58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6874,6 +6874,7 @@ version = "2.1.0"
 dependencies = [
  "base64 0.22.1",
  "blake3",
+ "bs58",
  "bytemuck",
  "criterion",
  "rand 0.8.5",

--- a/lattice-hash/Cargo.toml
+++ b/lattice-hash/Cargo.toml
@@ -10,6 +10,7 @@ edition = { workspace = true }
 [dependencies]
 base64 = { workspace = true }
 blake3 = { workspace = true }
+bs58 = { workspace = true }
 bytemuck = { workspace = true, features = ["must_cast"] }
 
 [dev-dependencies]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5427,6 +5427,7 @@ version = "2.1.0"
 dependencies = [
  "base64 0.22.1",
  "blake3",
+ "bs58",
  "bytemuck",
 ]
 


### PR DESCRIPTION
#### Problem

The LtHash `Checksum` is currently displayed as base64. Firedancer would prefer base58.


#### Summary of Changes

Change the display to be base58.