### PR TITLE
Verifies accounts lt hash at startup

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -80,7 +80,7 @@ use {
     seqlock::SeqLock,
     smallvec::SmallVec,
     solana_lattice_hash::lt_hash::LtHash,
-    solana_measure::{measure::Measure, measure_us},
+    solana_measure::{meas_dur, measure::Measure, measure_us},
     solana_nohash_hasher::{IntMap, IntSet},
     solana_rayon_threadlimit::get_thread_count,
     solana_sdk::{
@@ -654,6 +654,9 @@ pub enum ScanStorageResult<R, B> {
 pub struct IndexGenerationInfo {
     pub accounts_data_len: u64,
     pub rent_paying_accounts_by_partition: RentPayingAccountsByPartition,
+    /// The lt hash of the old/duplicate accounts identified during index generation.
+    /// Will be used when verifying the accounts lt hash, after rebuilding a Bank.
+    pub duplicates_lt_hash: Box<DuplicatesLtHash>,
 }
 
 #[derive(Debug, Default)]
@@ -664,6 +667,21 @@ struct SlotIndexGenerationInfo {
     accounts_data_len: u64,
     amount_to_top_off_rent: u64,
     rent_paying_accounts_by_partition: Vec<Pubkey>,
+}
+
+/// The lt hash of old/duplicate accounts
+///
+/// Accumulation of all the duplicate accounts found during index generation.
+/// These accounts need to have their lt hashes mixed *out*.
+/// This is the final value, that when applied to all the storages at startup,
+/// will produce the correct accounts lt hash.
+#[derive(Debug, Clone)]
+pub struct DuplicatesLtHash(pub LtHash);
+
+impl Default for DuplicatesLtHash {
+    fn default() -> Self {
+        Self(LtHash::identity())
+    }
 }
 
 #[derive(Default, Debug)]
@@ -687,6 +705,7 @@ struct GenerateIndexTimings {
     pub populate_duplicate_keys_us: u64,
     pub total_slots: u64,
     pub slots_to_clean: u64,
+    pub par_duplicates_lt_hash_us: AtomicU64,
 }
 
 #[derive(Default, Debug, PartialEq, Eq)]
@@ -761,6 +780,11 @@ impl GenerateIndexTimings {
             (
                 "copy_data_us",
                 startup_stats.copy_data_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "par_duplicates_lt_hash_us",
+                self.par_duplicates_lt_hash_us.load(Ordering::Relaxed),
                 i64
             ),
         );
@@ -6467,7 +6491,7 @@ impl AccountsDb {
     ///
     /// Only intended to be called at startup (or by tests).
     /// Only intended to be used while testing the experimental accumulator hash.
-    pub fn calculate_accounts_lt_hash_at_startup(
+    pub fn calculate_accounts_lt_hash_at_startup_from_index(
         &self,
         ancestors: &Ancestors,
         startup_slot: Slot,
@@ -6524,6 +6548,39 @@ impl AccountsDb {
                 accum.mix_in(&elem);
                 accum
             });
+
+        AccountsLtHash(lt_hash)
+    }
+
+    /// Calculates the accounts lt hash
+    ///
+    /// Intended to be used to verify the accounts lt hash at startup.
+    ///
+    /// The `duplicates_lt_hash` is the old/duplicate accounts to mix *out* of the storages.
+    /// This value comes from index generation.
+    pub fn calculate_accounts_lt_hash_at_startup_from_storages(
+        &self,
+        storages: &[Arc<AccountStorageEntry>],
+        duplicates_lt_hash: &DuplicatesLtHash,
+    ) -> AccountsLtHash {
+        debug_assert!(self.is_experimental_accumulator_hash_enabled());
+
+        let mut lt_hash = storages
+            .par_iter()
+            .fold(LtHash::identity, |mut accum, storage| {
+                storage.accounts.scan_accounts(|stored_account_meta| {
+                    let account_lt_hash =
+                        Self::lt_hash_account(&stored_account_meta, stored_account_meta.pubkey());
+                    accum.mix_in(&account_lt_hash.0);
+                });
+                accum
+            })
+            .reduce(LtHash::identity, |mut accum, elem| {
+                accum.mix_in(&elem);
+                accum
+            });
+
+        lt_hash.mix_out(&duplicates_lt_hash.0);
 
         AccountsLtHash(lt_hash)
     }
@@ -8351,6 +8408,7 @@ impl AccountsDb {
 
         let rent_paying_accounts_by_partition =
             Mutex::new(RentPayingAccountsByPartition::new(schedule));
+        let mut outer_duplicates_lt_hash = None;
 
         // pass == 0 always runs and generates the index
         // pass == 1 only runs if verify == true.
@@ -8554,6 +8612,7 @@ impl AccountsDb {
                     accounts_data_len_from_duplicates: u64,
                     num_duplicate_accounts: u64,
                     uncleaned_roots: IntSet<Slot>,
+                    duplicates_lt_hash: DuplicatesLtHash,
                 }
                 impl DuplicatePubkeysVisitedInfo {
                     fn reduce(mut a: Self, mut b: Self) -> Self {
@@ -8570,6 +8629,9 @@ impl AccountsDb {
                             other.accounts_data_len_from_duplicates;
                         self.num_duplicate_accounts += other.num_duplicate_accounts;
                         self.uncleaned_roots.extend(other.uncleaned_roots);
+                        self.duplicates_lt_hash
+                            .0
+                            .mix_in(&other.duplicates_lt_hash.0);
                     }
                 }
 
@@ -8580,6 +8642,7 @@ impl AccountsDb {
                     accounts_data_len_from_duplicates,
                     num_duplicate_accounts,
                     uncleaned_roots,
+                    duplicates_lt_hash,
                 } = unique_pubkeys_by_bin
                     .par_iter()
                     .fold(
@@ -8592,6 +8655,7 @@ impl AccountsDb {
                                         accounts_data_len_from_duplicates,
                                         accounts_duplicates_num,
                                         uncleaned_roots,
+                                        duplicates_lt_hash,
                                     ) = self.visit_duplicate_pubkeys_during_startup(
                                         pubkeys,
                                         &rent_collector,
@@ -8601,6 +8665,7 @@ impl AccountsDb {
                                         accounts_data_len_from_duplicates,
                                         num_duplicate_accounts: accounts_duplicates_num,
                                         uncleaned_roots,
+                                        duplicates_lt_hash,
                                     };
                                     DuplicatePubkeysVisitedInfo::reduce(accum, intermediate)
                                 })
@@ -8623,6 +8688,8 @@ impl AccountsDb {
                 self.accounts_index
                     .add_uncleaned_roots(uncleaned_roots.into_iter());
                 accounts_data_len.fetch_sub(accounts_data_len_from_duplicates, Ordering::Relaxed);
+                let old_val = outer_duplicates_lt_hash.replace(duplicates_lt_hash);
+                assert!(old_val.is_none());
                 info!(
                     "accounts data len: {}",
                     accounts_data_len.load(Ordering::Relaxed)
@@ -8649,6 +8716,7 @@ impl AccountsDb {
             rent_paying_accounts_by_partition: rent_paying_accounts_by_partition
                 .into_inner()
                 .unwrap(),
+            duplicates_lt_hash: Box::new(outer_duplicates_lt_hash.unwrap()),
         }
     }
 
@@ -8678,20 +8746,28 @@ impl AccountsDb {
     /// 1. get the _duplicate_ accounts data len from the given pubkeys
     /// 2. get the slots that contained duplicate pubkeys
     /// 3. update rent stats
+    /// 4. build up the duplicates lt hash
     ///
     /// Note this should only be used when ALL entries in the accounts index are roots.
-    /// returns (data len sum of all older duplicates, number of duplicate accounts, slots that contained duplicate pubkeys)
+    ///
+    /// returns tuple of:
+    /// - data len sum of all older duplicates
+    /// - number of duplicate accounts
+    /// - slots that contained duplicate pubkeys
+    /// - lt hash of duplicates
     fn visit_duplicate_pubkeys_during_startup(
         &self,
         pubkeys: &[Pubkey],
         rent_collector: &RentCollector,
         timings: &GenerateIndexTimings,
-    ) -> (u64, u64, IntSet<Slot>) {
+    ) -> (u64, u64, IntSet<Slot>, DuplicatesLtHash) {
         let mut accounts_data_len_from_duplicates = 0;
         let mut num_duplicate_accounts = 0_u64;
         let mut uncleaned_slots = IntSet::default();
+        let mut duplicates_lt_hash = DuplicatesLtHash::default();
         let mut removed_rent_paying = 0;
         let mut removed_top_off = 0;
+        let mut lt_hash_time = Duration::default();
         self.accounts_index.scan(
             pubkeys.iter(),
             |pubkey, slots_refs, _entry| {
@@ -8730,6 +8806,14 @@ impl AccountsDb {
                                     removed_rent_paying += 1;
                                     removed_top_off += lamports_to_top_off;
                                 }
+                                if self.is_experimental_accumulator_hash_enabled() {
+                                    let (_, duration) = meas_dur!({
+                                        let account_lt_hash =
+                                            Self::lt_hash_account(&loaded_account, pubkey);
+                                        duplicates_lt_hash.0.mix_in(&account_lt_hash.0);
+                                    });
+                                    lt_hash_time += duration;
+                                }
                             });
                         });
                     }
@@ -8746,10 +8830,14 @@ impl AccountsDb {
         timings
             .amount_to_top_off_rent
             .fetch_sub(removed_top_off, Ordering::Relaxed);
+        timings
+            .par_duplicates_lt_hash_us
+            .fetch_add(lt_hash_time.as_micros() as u64, Ordering::Relaxed);
         (
             accounts_data_len_from_duplicates as u64,
             num_duplicate_accounts,
             uncleaned_slots,
+            duplicates_lt_hash,
         )
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8612,7 +8612,7 @@ impl AccountsDb {
                     accounts_data_len_from_duplicates: u64,
                     num_duplicate_accounts: u64,
                     uncleaned_roots: IntSet<Slot>,
-                    duplicates_lt_hash: DuplicatesLtHash,
+                    duplicates_lt_hash: Box<DuplicatesLtHash>,
                 }
                 impl DuplicatePubkeysVisitedInfo {
                     fn reduce(mut a: Self, mut b: Self) -> Self {
@@ -8716,7 +8716,7 @@ impl AccountsDb {
             rent_paying_accounts_by_partition: rent_paying_accounts_by_partition
                 .into_inner()
                 .unwrap(),
-            duplicates_lt_hash: Box::new(outer_duplicates_lt_hash.unwrap()),
+            duplicates_lt_hash: outer_duplicates_lt_hash.unwrap(),
         }
     }
 
@@ -8760,11 +8760,11 @@ impl AccountsDb {
         pubkeys: &[Pubkey],
         rent_collector: &RentCollector,
         timings: &GenerateIndexTimings,
-    ) -> (u64, u64, IntSet<Slot>, DuplicatesLtHash) {
+    ) -> (u64, u64, IntSet<Slot>, Box<DuplicatesLtHash>) {
         let mut accounts_data_len_from_duplicates = 0;
         let mut num_duplicate_accounts = 0_u64;
         let mut uncleaned_slots = IntSet::default();
-        let mut duplicates_lt_hash = DuplicatesLtHash::default();
+        let mut duplicates_lt_hash = Box::new(DuplicatesLtHash::default());
         let mut removed_rent_paying = 0;
         let mut removed_top_off = 0;
         let mut lt_hash_time = Duration::default();

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -210,10 +210,7 @@ impl AccountsFile {
     }
 
     /// Iterate over all accounts and call `callback` with each account.
-    pub(crate) fn scan_accounts(
-        &self,
-        callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
-    ) {
+    pub fn scan_accounts(&self, callback: impl for<'local> FnMut(StoredAccountMeta<'local>)) {
         match self {
             Self::AppendVec(av) => av.scan_accounts(callback),
             Self::TieredStorage(ts) => {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -75,7 +75,8 @@ use {
         accounts::{AccountAddressFilter, Accounts, PubkeyAccountSlot},
         accounts_db::{
             AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig,
-            CalcAccountsHashDataSource, PubkeyHashAccount, VerifyAccountsHashAndLamportsConfig,
+            CalcAccountsHashDataSource, DuplicatesLtHash, PubkeyHashAccount,
+            VerifyAccountsHashAndLamportsConfig,
         },
         accounts_hash::{
             AccountHash, AccountsHash, AccountsLtHash, CalcAccountsHashConfig, HashStats,
@@ -1724,7 +1725,7 @@ impl Bank {
                     .rc
                     .accounts
                     .accounts_db
-                    .calculate_accounts_lt_hash_at_startup(&bank.ancestors, bank.slot());
+                    .calculate_accounts_lt_hash_at_startup_from_index(&bank.ancestors, bank.slot());
             });
             duration
         });
@@ -5548,6 +5549,7 @@ impl Bank {
                 run_in_background: false,
                 store_hash_raw_data_for_debug: on_halt_store_hash_raw_data_for_debug,
             },
+            None,
         );
     }
 
@@ -5558,7 +5560,8 @@ impl Bank {
     fn verify_accounts_hash(
         &self,
         base: Option<(Slot, /*capitalization*/ u64)>,
-        config: VerifyAccountsHashConfig,
+        mut config: VerifyAccountsHashConfig,
+        duplicates_lt_hash: Option<&DuplicatesLtHash>,
     ) -> bool {
         let accounts = &self.rc.accounts;
         // Wait until initial hash calc is complete before starting a new hash calc.
@@ -5569,19 +5572,36 @@ impl Bank {
             .wait_for_complete();
 
         let slot = self.slot();
+        let is_accounts_lt_hash_enabled = self.is_accounts_lt_hash_enabled();
         if config.require_rooted_bank && !accounts.accounts_db.accounts_index.is_alive_root(slot) {
             if let Some(parent) = self.parent() {
                 info!(
                     "slot {slot} is not a root, so verify accounts hash on parent bank at slot {}",
                     parent.slot(),
                 );
-                return parent.verify_accounts_hash(base, config);
+                if is_accounts_lt_hash_enabled {
+                    // The duplicates_lt_hash is only valid for the current slot, so we must fall
+                    // back to verifying the accounts lt hash with the index (which also means we
+                    // cannot run in the background).
+                    config.run_in_background = false;
+                }
+                return parent.verify_accounts_hash(base, config, None);
             } else {
                 // this will result in mismatch errors
                 // accounts hash calc doesn't include unrooted slots
                 panic!("cannot verify accounts hash because slot {slot} is not a root");
             }
         }
+
+        if is_accounts_lt_hash_enabled {
+            // Calculating the accounts lt hash from storages *requires* a duplicates_lt_hash.
+            // If it is None here, then we must use the index instead, which also means we
+            // cannot run in the background.
+            if duplicates_lt_hash.is_none() {
+                config.run_in_background = false;
+            }
+        }
+
         // The snapshot storages must be captured *before* starting the background verification.
         // Otherwise, it is possible that a delayed call to `get_snapshot_storages()` will *not*
         // get the correct storages required to calculate and verify the accounts hashes.
@@ -5600,17 +5620,43 @@ impl Bank {
             store_detailed_debug_info: config.store_hash_raw_data_for_debug,
             use_bg_thread_pool: config.run_in_background,
         };
+
         if config.run_in_background {
             let accounts = Arc::clone(accounts);
             let accounts_ = Arc::clone(&accounts);
             let ancestors = self.ancestors.clone();
             let epoch_schedule = self.epoch_schedule().clone();
             let rent_collector = self.rent_collector().clone();
+            let expected_accounts_lt_hash = self.accounts_lt_hash.lock().unwrap().clone();
+            let duplicates_lt_hash = duplicates_lt_hash.cloned();
             accounts.accounts_db.verify_accounts_hash_in_bg.start(|| {
                 Builder::new()
                     .name("solBgHashVerify".into())
                     .spawn(move || {
                         info!("Initial background accounts hash verification has started");
+                        if is_accounts_lt_hash_enabled {
+                            let accounts_db = &accounts_.accounts_db;
+                            let (calculated_accounts_lt_hash, duration) = meas_dur!(accounts_db.thread_pool_hash.install(|| {
+                                    accounts_db
+                                    .calculate_accounts_lt_hash_at_startup_from_storages(
+                                        snapshot_storages.0.as_slice(),
+                                        &duplicates_lt_hash.unwrap(),
+                                    )
+                            }));
+                            if calculated_accounts_lt_hash != expected_accounts_lt_hash {
+                                error!(
+                                    "Verifying accounts lt hash failed: hashes do not match, expected: {}, calculated: {}",
+                                    expected_accounts_lt_hash.0.checksum(),
+                                    calculated_accounts_lt_hash.0.checksum(),
+                                );
+                                return false;
+                            }
+                            datapoint_info!(
+                                "startup_verify_accounts",
+                                ("verify_accounts_lt_hash_us", duration.as_micros(), i64)
+                            );
+                        }
+
                         let snapshot_storages_and_slots = (
                             snapshot_storages.0.as_slice(),
                             snapshot_storages.1.as_slice(),
@@ -5638,6 +5684,32 @@ impl Bank {
             });
             true // initial result is true. We haven't failed yet. If verification fails, we'll panic from bg thread.
         } else {
+            if is_accounts_lt_hash_enabled {
+                let expected_accounts_lt_hash = self.accounts_lt_hash.lock().unwrap().clone();
+                let calculated_accounts_lt_hash =
+                    if let Some(duplicates_lt_hash) = duplicates_lt_hash {
+                        accounts
+                            .accounts_db
+                            .calculate_accounts_lt_hash_at_startup_from_storages(
+                                snapshot_storages.0.as_slice(),
+                                duplicates_lt_hash,
+                            )
+                    } else {
+                        accounts
+                            .accounts_db
+                            .calculate_accounts_lt_hash_at_startup_from_index(&self.ancestors, slot)
+                    };
+                if calculated_accounts_lt_hash != expected_accounts_lt_hash {
+                    error!(
+                        "Verifying accounts lt hash failed: hashes do not match, expected: {}, calculated: {}",
+                        expected_accounts_lt_hash.0.checksum(),
+                        calculated_accounts_lt_hash.0.checksum(),
+                    );
+                    return false;
+                }
+                // if we get here then the accounts lt hash is correct
+            }
+
             let snapshot_storages_and_slots = (
                 snapshot_storages.0.as_slice(),
                 snapshot_storages.1.as_slice(),
@@ -5953,6 +6025,7 @@ impl Bank {
         force_clean: bool,
         latest_full_snapshot_slot: Slot,
         base: Option<(Slot, /*capitalization*/ u64)>,
+        duplicates_lt_hash: Option<&DuplicatesLtHash>,
     ) -> bool {
         let (_, clean_time_us) = measure_us!({
             let should_clean = force_clean || (!skip_shrink && self.slot() > 0);
@@ -6002,6 +6075,7 @@ impl Bank {
                         run_in_background: true,
                         store_hash_raw_data_for_debug: false,
                     },
+                    duplicates_lt_hash,
                 );
                 info!("Verifying accounts... In background.");
                 verified

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -238,7 +238,7 @@ mod tests {
                 full_snapshot_stream: &mut reader,
                 incremental_snapshot_stream: None,
             };
-            let dbank = serde_snapshot::bank_from_streams(
+            let (dbank, _) = serde_snapshot::bank_from_streams(
                 &mut snapshot_streams,
                 &dbank_paths,
                 storage_and_next_append_vec_id,
@@ -352,7 +352,7 @@ mod tests {
             storage_access,
         )
         .unwrap();
-        let dbank = crate::serde_snapshot::bank_from_streams(
+        let (dbank, _) = crate::serde_snapshot::bank_from_streams(
             &mut snapshot_streams,
             &dbank_paths,
             storage_and_next_append_vec_id,
@@ -487,7 +487,7 @@ mod tests {
             storage_access,
         )
         .unwrap();
-        let dbank = crate::serde_snapshot::bank_from_streams(
+        let (dbank, _) = crate::serde_snapshot::bank_from_streams(
             &mut snapshot_streams,
             &dbank_paths,
             storage_and_next_append_vec_id,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2220,7 +2220,11 @@ fn test_purge_empty_accounts() {
 
         if pass == 0 {
             add_root_and_flush_write_cache(&bank0);
-            assert!(bank0.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
+            assert!(bank0.verify_accounts_hash(
+                None,
+                VerifyAccountsHashConfig::default_for_test(),
+                None,
+            ));
             continue;
         }
 
@@ -2229,7 +2233,11 @@ fn test_purge_empty_accounts() {
         bank0.squash();
         add_root_and_flush_write_cache(&bank0);
         if pass == 1 {
-            assert!(bank0.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
+            assert!(bank0.verify_accounts_hash(
+                None,
+                VerifyAccountsHashConfig::default_for_test(),
+                None,
+            ));
             continue;
         }
 
@@ -2237,7 +2245,11 @@ fn test_purge_empty_accounts() {
         bank1.squash();
         add_root_and_flush_write_cache(&bank1);
         bank1.update_accounts_hash_for_tests();
-        assert!(bank1.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
+        assert!(bank1.verify_accounts_hash(
+            None,
+            VerifyAccountsHashConfig::default_for_test(),
+            None,
+        ));
 
         // keypair should have 0 tokens on both forks
         assert_eq!(bank0.get_account(&keypair.pubkey()), None);
@@ -2245,7 +2257,11 @@ fn test_purge_empty_accounts() {
 
         bank1.clean_accounts_for_tests();
 
-        assert!(bank1.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
+        assert!(bank1.verify_accounts_hash(
+            None,
+            VerifyAccountsHashConfig::default_for_test(),
+            None,
+        ));
     }
 }
 
@@ -3440,7 +3456,7 @@ fn test_bank_hash_internal_state() {
     add_root_and_flush_write_cache(&bank1);
     add_root_and_flush_write_cache(&bank2);
     bank2.update_accounts_hash_for_tests();
-    assert!(bank2.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
+    assert!(bank2.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test(), None,));
 }
 
 #[test]
@@ -3475,7 +3491,11 @@ fn test_bank_hash_internal_state_verify() {
             // we later modify bank 2, so this flush is destructive to the test
             add_root_and_flush_write_cache(&bank2);
             bank2.update_accounts_hash_for_tests();
-            assert!(bank2.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
+            assert!(bank2.verify_accounts_hash(
+                None,
+                VerifyAccountsHashConfig::default_for_test(),
+                None,
+            ));
         }
         let bank3 = new_bank_from_parent_with_bank_forks(
             bank_forks.as_ref(),
@@ -3486,7 +3506,11 @@ fn test_bank_hash_internal_state_verify() {
         assert_eq!(bank0_state, bank0.hash_internal_state());
         if pass == 0 {
             // this relies on us having set the bank hash in the pass==0 if above
-            assert!(bank2.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
+            assert!(bank2.verify_accounts_hash(
+                None,
+                VerifyAccountsHashConfig::default_for_test(),
+                None,
+            ));
             continue;
         }
         if pass == 1 {
@@ -3495,7 +3519,11 @@ fn test_bank_hash_internal_state_verify() {
             // Doing so throws an assert. So, we can't flush 3 until 2 is flushed.
             add_root_and_flush_write_cache(&bank3);
             bank3.update_accounts_hash_for_tests();
-            assert!(bank3.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
+            assert!(bank3.verify_accounts_hash(
+                None,
+                VerifyAccountsHashConfig::default_for_test(),
+                None,
+            ));
             continue;
         }
 
@@ -3504,10 +3532,18 @@ fn test_bank_hash_internal_state_verify() {
         bank2.transfer(amount, &mint_keypair, &pubkey2).unwrap();
         add_root_and_flush_write_cache(&bank2);
         bank2.update_accounts_hash_for_tests();
-        assert!(bank2.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
+        assert!(bank2.verify_accounts_hash(
+            None,
+            VerifyAccountsHashConfig::default_for_test(),
+            None,
+        ));
         add_root_and_flush_write_cache(&bank3);
         bank3.update_accounts_hash_for_tests();
-        assert!(bank3.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
+        assert!(bank3.verify_accounts_hash(
+            None,
+            VerifyAccountsHashConfig::default_for_test(),
+            None,
+        ));
     }
 }
 
@@ -3533,11 +3569,11 @@ fn test_verify_snapshot_bank() {
     bank.freeze();
     add_root_and_flush_write_cache(&bank);
     bank.update_accounts_hash_for_tests();
-    assert!(bank.verify_snapshot_bank(true, false, false, bank.slot(), None));
+    assert!(bank.verify_snapshot_bank(true, false, false, bank.slot(), None, None,));
 
     // tamper the bank after freeze!
     bank.increment_signature_count(1);
-    assert!(!bank.verify_snapshot_bank(true, false, false, bank.slot(), None));
+    assert!(!bank.verify_snapshot_bank(true, false, false, bank.slot(), None, None,));
 }
 
 // Test that two bank forks with the same accounts should not hash to the same value.
@@ -12157,6 +12193,7 @@ fn test_bank_verify_accounts_hash_with_base() {
             test_hash_calculation: false,
             ..VerifyAccountsHashConfig::default_for_test()
         },
+        None,
     ));
 }
 


### PR DESCRIPTION
#### Problem

Eventually, the accounts lt hash will not be recalculated at startup. Instead, we'll get the initial accounts lt hash from the snapshot (or equivalent). When that happens, we will still want to verify the accounts, and we'll want that to happen in the background, similar to today with the full accounts hash calculation. Currently there is not a way to verify the accounts lt hash that is suitable for running in the background.


#### Summary of Changes

Add a function to calculate the accounts lt hash from storages. Use that to verify the accounts lt hash at startup in the background.


#### Additional Testing

In addition to the tests in the PR, I ran this code against mnb on a dev box. This calculates the accounts lt hash from the index first, then verifies from storages second. This was successful (hashes matched). The verification step took approximately the same amount of time as the normal accounts hash verification (full + incremental).