### PR TITLE
svm: allow conflicting transactions in entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8355,6 +8355,7 @@ dependencies = [
 name = "solana-svm"
 version = "2.2.0"
 dependencies = [
+ "ahash 0.8.11",
  "assert_matches",
  "base64 0.22.1",
  "bincode",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7041,6 +7041,7 @@ dependencies = [
 name = "solana-svm"
 version = "2.2.0"
 dependencies = [
+ "ahash 0.8.11",
  "itertools 0.12.1",
  "log",
  "percentage",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 percentage = { workspace = true }

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -152,6 +152,7 @@ fn svm_concurrent() {
     let mut check_data = vec![Vec::new(); THREADS];
     let read_account = Pubkey::new_unique();
     let mut account_data = AccountSharedData::default();
+    account_data.set_lamports(BALANCE);
     account_data.set_data(AMOUNT.to_le_bytes().to_vec());
     mock_bank
         .account_shared_data

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -4,13 +4,14 @@
 use {
     crate::mock_bank::{
         create_executable_environment, deploy_program_with_upgrade_authority, program_address,
-        register_builtins, MockBankCallback, MockForkGraph, EXECUTION_EPOCH, EXECUTION_SLOT,
-        WALLCLOCK_TIME,
+        program_data_size, register_builtins, MockBankCallback, MockForkGraph, EXECUTION_EPOCH,
+        EXECUTION_SLOT, WALLCLOCK_TIME,
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         clock::Slot,
         compute_budget::ComputeBudgetInstruction,
+        entrypoint::MAX_PERMITTED_DATA_INCREASE,
         feature_set::{self, FeatureSet},
         hash::Hash,
         instruction::{AccountMeta, Instruction},
@@ -1085,7 +1086,692 @@ fn simple_nonce(enable_fee_only_transactions: bool, fee_paying_nonce: bool) -> V
     vec![test_entry]
 }
 
-#[allow(unused)]
+fn intrabatch_account_reuse(enable_fee_only_transactions: bool) -> Vec<SvmTestEntry> {
+    let mut test_entries = vec![];
+    let transfer_amount = LAMPORTS_PER_SOL;
+    let wallet_rent = Rent::default().minimum_balance(0);
+
+    // batch 0: two successful transfers from the same source
+    {
+        let mut test_entry = SvmTestEntry::default();
+
+        let source_keypair = Keypair::new();
+        let source = source_keypair.pubkey();
+        let destination1 = Pubkey::new_unique();
+        let destination2 = Pubkey::new_unique();
+
+        let mut source_data = AccountSharedData::default();
+        let destination1_data = AccountSharedData::default();
+        let destination2_data = AccountSharedData::default();
+
+        source_data.set_lamports(LAMPORTS_PER_SOL * 10);
+        test_entry.add_initial_account(source, &source_data);
+
+        for (destination, mut destination_data) in [
+            (destination1, destination1_data),
+            (destination2, destination2_data),
+        ] {
+            test_entry.push_transaction(system_transaction::transfer(
+                &source_keypair,
+                &destination,
+                transfer_amount,
+                Hash::default(),
+            ));
+
+            destination_data
+                .checked_add_lamports(transfer_amount)
+                .unwrap();
+            test_entry.create_expected_account(destination, &destination_data);
+
+            test_entry
+                .decrease_expected_lamports(&source, transfer_amount + LAMPORTS_PER_SIGNATURE);
+        }
+
+        test_entries.push(test_entry);
+    }
+
+    // batch 1:
+    // * successful transfer, source left with rent-exempt minimum
+    // * non-processable transfer due to underfunded fee-payer
+    {
+        let mut test_entry = SvmTestEntry::default();
+
+        let source_keypair = Keypair::new();
+        let source = source_keypair.pubkey();
+        let destination = Pubkey::new_unique();
+
+        let mut source_data = AccountSharedData::default();
+        let mut destination_data = AccountSharedData::default();
+
+        source_data.set_lamports(transfer_amount + LAMPORTS_PER_SIGNATURE + wallet_rent);
+        test_entry.add_initial_account(source, &source_data);
+
+        test_entry.push_transaction(system_transaction::transfer(
+            &source_keypair,
+            &destination,
+            transfer_amount,
+            Hash::default(),
+        ));
+
+        destination_data
+            .checked_add_lamports(transfer_amount)
+            .unwrap();
+        test_entry.create_expected_account(destination, &destination_data);
+
+        test_entry.decrease_expected_lamports(&source, transfer_amount + LAMPORTS_PER_SIGNATURE);
+
+        test_entry.push_transaction_with_status(
+            system_transaction::transfer(
+                &source_keypair,
+                &destination,
+                transfer_amount,
+                Hash::default(),
+            ),
+            ExecutionStatus::Discarded,
+        );
+
+        test_entries.push(test_entry);
+    }
+
+    // batch 2:
+    // * successful transfer to a previously unfunded account
+    // * successful transfer using the new account as a fee-payer in the same batch
+    {
+        let mut test_entry = SvmTestEntry::default();
+        let first_transfer_amount = transfer_amount + LAMPORTS_PER_SIGNATURE + wallet_rent;
+        let second_transfer_amount = transfer_amount;
+
+        let grandparent_keypair = Keypair::new();
+        let grandparent = grandparent_keypair.pubkey();
+        let parent_keypair = Keypair::new();
+        let parent = parent_keypair.pubkey();
+        let child = Pubkey::new_unique();
+
+        let mut grandparent_data = AccountSharedData::default();
+        let mut parent_data = AccountSharedData::default();
+        let mut child_data = AccountSharedData::default();
+
+        grandparent_data.set_lamports(LAMPORTS_PER_SOL * 10);
+        test_entry.add_initial_account(grandparent, &grandparent_data);
+
+        test_entry.push_transaction(system_transaction::transfer(
+            &grandparent_keypair,
+            &parent,
+            first_transfer_amount,
+            Hash::default(),
+        ));
+
+        parent_data
+            .checked_add_lamports(first_transfer_amount)
+            .unwrap();
+        test_entry.create_expected_account(parent, &parent_data);
+
+        test_entry.decrease_expected_lamports(
+            &grandparent,
+            first_transfer_amount + LAMPORTS_PER_SIGNATURE,
+        );
+
+        test_entry.push_transaction(system_transaction::transfer(
+            &parent_keypair,
+            &child,
+            second_transfer_amount,
+            Hash::default(),
+        ));
+
+        child_data
+            .checked_add_lamports(second_transfer_amount)
+            .unwrap();
+        test_entry.create_expected_account(child, &child_data);
+
+        test_entry
+            .decrease_expected_lamports(&parent, second_transfer_amount + LAMPORTS_PER_SIGNATURE);
+
+        test_entries.push(test_entry);
+    }
+
+    // batch 3:
+    // * non-processable transfer due to underfunded fee-payer (two signatures)
+    // * successful transfer with the same fee-payer (one signature)
+    {
+        let mut test_entry = SvmTestEntry::default();
+
+        let feepayer_keypair = Keypair::new();
+        let feepayer = feepayer_keypair.pubkey();
+        let separate_source_keypair = Keypair::new();
+        let separate_source = separate_source_keypair.pubkey();
+        let destination = Pubkey::new_unique();
+
+        let mut feepayer_data = AccountSharedData::default();
+        let mut separate_source_data = AccountSharedData::default();
+        let mut destination_data = AccountSharedData::default();
+
+        feepayer_data.set_lamports(1 + LAMPORTS_PER_SIGNATURE + wallet_rent);
+        test_entry.add_initial_account(feepayer, &feepayer_data);
+
+        separate_source_data.set_lamports(LAMPORTS_PER_SOL * 10);
+        test_entry.add_initial_account(separate_source, &separate_source_data);
+
+        test_entry.push_transaction_with_status(
+            Transaction::new_signed_with_payer(
+                &[system_instruction::transfer(
+                    &separate_source,
+                    &destination,
+                    1,
+                )],
+                Some(&feepayer),
+                &[&feepayer_keypair, &separate_source_keypair],
+                Hash::default(),
+            ),
+            ExecutionStatus::Discarded,
+        );
+
+        test_entry.push_transaction(system_transaction::transfer(
+            &feepayer_keypair,
+            &destination,
+            1,
+            Hash::default(),
+        ));
+
+        destination_data.checked_add_lamports(1).unwrap();
+        test_entry.create_expected_account(destination, &destination_data);
+
+        test_entry.decrease_expected_lamports(&feepayer, 1 + LAMPORTS_PER_SIGNATURE);
+    }
+
+    // batch 4:
+    // * processable non-executable transaction
+    // * successful transfer
+    // this confirms we update the AccountsMap from RollbackAccounts intrabatch
+    if enable_fee_only_transactions {
+        let mut test_entry = SvmTestEntry::default();
+
+        let source_keypair = Keypair::new();
+        let source = source_keypair.pubkey();
+        let destination = Pubkey::new_unique();
+
+        let mut source_data = AccountSharedData::default();
+        let mut destination_data = AccountSharedData::default();
+
+        source_data.set_lamports(LAMPORTS_PER_SOL * 10);
+        test_entry.add_initial_account(source, &source_data);
+
+        let mut load_program_fail_instruction =
+            system_instruction::transfer(&source, &Pubkey::new_unique(), transfer_amount);
+        load_program_fail_instruction.program_id = Pubkey::new_unique();
+
+        test_entry.push_transaction_with_status(
+            Transaction::new_signed_with_payer(
+                &[load_program_fail_instruction],
+                Some(&source),
+                &[&source_keypair],
+                Hash::default(),
+            ),
+            ExecutionStatus::ProcessedFailed,
+        );
+
+        test_entry.push_transaction(system_transaction::transfer(
+            &source_keypair,
+            &destination,
+            transfer_amount,
+            Hash::default(),
+        ));
+
+        destination_data
+            .checked_add_lamports(transfer_amount)
+            .unwrap();
+        test_entry.create_expected_account(destination, &destination_data);
+
+        test_entry
+            .decrease_expected_lamports(&source, transfer_amount + LAMPORTS_PER_SIGNATURE * 2);
+
+        test_entries.push(test_entry);
+    }
+
+    if enable_fee_only_transactions {
+        for test_entry in &mut test_entries {
+            test_entry
+                .enabled_features
+                .push(feature_set::enable_transaction_loading_failure_fees::id());
+        }
+    }
+
+    test_entries
+}
+
+fn nonce_reuse(enable_fee_only_transactions: bool, fee_paying_nonce: bool) -> Vec<SvmTestEntry> {
+    let mut test_entries = vec![];
+
+    let program_name = "hello-solana";
+    let program_id = program_address(program_name);
+
+    let fee_payer_keypair = Keypair::new();
+    let non_fee_nonce_keypair = Keypair::new();
+    let fee_payer = fee_payer_keypair.pubkey();
+    let nonce_pubkey = if fee_paying_nonce {
+        fee_payer
+    } else {
+        non_fee_nonce_keypair.pubkey()
+    };
+
+    let nonce_size = nonce::State::size();
+    let initial_durable = DurableNonce::from_blockhash(&Hash::new_unique());
+    let initial_nonce_data =
+        nonce::state::Data::new(fee_payer, initial_durable, LAMPORTS_PER_SIGNATURE);
+    let initial_nonce_account = AccountSharedData::new_data(
+        LAMPORTS_PER_SOL,
+        &nonce::state::Versions::new(nonce::State::Initialized(initial_nonce_data.clone())),
+        &system_program::id(),
+    )
+    .unwrap();
+    let initial_nonce_info = NonceInfo::new(nonce_pubkey, initial_nonce_account.clone());
+
+    let advanced_durable = DurableNonce::from_blockhash(&LAST_BLOCKHASH);
+    let mut advanced_nonce_info = initial_nonce_info.clone();
+    advanced_nonce_info
+        .try_advance_nonce(advanced_durable, LAMPORTS_PER_SIGNATURE)
+        .unwrap();
+
+    let advance_instruction = system_instruction::advance_nonce_account(&nonce_pubkey, &fee_payer);
+    let withdraw_instruction = system_instruction::withdraw_nonce_account(
+        &nonce_pubkey,
+        &fee_payer,
+        &fee_payer,
+        LAMPORTS_PER_SOL,
+    );
+
+    let successful_noop_instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
+    let failing_noop_instruction = Instruction::new_with_bytes(system_program::id(), &[], vec![]);
+    let fee_only_noop_instruction = Instruction::new_with_bytes(Pubkey::new_unique(), &[], vec![]);
+
+    let second_transaction = Transaction::new_signed_with_payer(
+        &[
+            advance_instruction.clone(),
+            successful_noop_instruction.clone(),
+        ],
+        Some(&fee_payer),
+        &[&fee_payer_keypair],
+        *advanced_durable.as_hash(),
+    );
+
+    let mut common_test_entry = SvmTestEntry::default();
+
+    common_test_entry.add_initial_account(nonce_pubkey, &initial_nonce_account);
+
+    if !fee_paying_nonce {
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        common_test_entry.add_initial_account(fee_payer, &fee_payer_data);
+    }
+
+    common_test_entry
+        .final_accounts
+        .get_mut(&nonce_pubkey)
+        .unwrap()
+        .data_as_mut_slice()
+        .copy_from_slice(advanced_nonce_info.account().data());
+
+    common_test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+
+    let common_test_entry = common_test_entry;
+
+    // batch 0: one transaction that advances the nonce twice
+    {
+        let mut test_entry = common_test_entry.clone();
+
+        let transaction = Transaction::new_signed_with_payer(
+            &[advance_instruction.clone(), advance_instruction.clone()],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            *initial_durable.as_hash(),
+        );
+
+        test_entry.push_nonce_transaction_with_status(
+            transaction,
+            initial_nonce_info.clone(),
+            ExecutionStatus::ExecutedFailed,
+        );
+
+        test_entries.push(test_entry);
+    }
+
+    // batch 1:
+    // * a successful nonce transaction
+    // * a nonce transaction that reuses the same nonce; this transaction must be dropped
+    {
+        let mut test_entry = common_test_entry.clone();
+
+        let first_transaction = Transaction::new_signed_with_payer(
+            &[
+                advance_instruction.clone(),
+                successful_noop_instruction.clone(),
+            ],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            *initial_durable.as_hash(),
+        );
+
+        test_entry.push_nonce_transaction(first_transaction, initial_nonce_info.clone());
+        test_entry.push_nonce_transaction_with_status(
+            second_transaction.clone(),
+            advanced_nonce_info.clone(),
+            ExecutionStatus::Discarded,
+        );
+
+        test_entries.push(test_entry);
+    }
+
+    // batch 2:
+    // * an executable failed nonce transaction
+    // * a nonce transaction that reuses the same nonce; this transaction must be dropped
+    {
+        let mut test_entry = common_test_entry.clone();
+
+        let first_transaction = Transaction::new_signed_with_payer(
+            &[advance_instruction.clone(), failing_noop_instruction],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            *initial_durable.as_hash(),
+        );
+
+        test_entry.push_nonce_transaction_with_status(
+            first_transaction,
+            initial_nonce_info.clone(),
+            ExecutionStatus::ExecutedFailed,
+        );
+
+        test_entry.push_nonce_transaction_with_status(
+            second_transaction.clone(),
+            advanced_nonce_info.clone(),
+            ExecutionStatus::Discarded,
+        );
+
+        test_entries.push(test_entry);
+    }
+
+    // batch 3:
+    // * a processable non-executable nonce transaction, if fee-only transactions are enabled
+    // * a nonce transaction that reuses the same nonce; this transaction must be dropped
+    if enable_fee_only_transactions {
+        let mut test_entry = common_test_entry.clone();
+
+        let first_transaction = Transaction::new_signed_with_payer(
+            &[advance_instruction.clone(), fee_only_noop_instruction],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            *initial_durable.as_hash(),
+        );
+
+        test_entry.push_nonce_transaction_with_status(
+            first_transaction,
+            initial_nonce_info.clone(),
+            ExecutionStatus::ProcessedFailed,
+        );
+
+        test_entry.push_nonce_transaction_with_status(
+            second_transaction.clone(),
+            advanced_nonce_info.clone(),
+            ExecutionStatus::Discarded,
+        );
+
+        // if the nonce account pays fees, it keeps its new rent epoch, otherwise it resets
+        if !fee_paying_nonce {
+            test_entry
+                .final_accounts
+                .get_mut(&nonce_pubkey)
+                .unwrap()
+                .set_rent_epoch(0);
+        }
+
+        test_entries.push(test_entry);
+    }
+
+    // batch 4:
+    // * a successful blockhash transaction that also advances the nonce
+    // * a nonce transaction that reuses the same nonce; this transaction must be dropped
+    {
+        let mut test_entry = common_test_entry.clone();
+
+        let first_transaction = Transaction::new_signed_with_payer(
+            &[
+                successful_noop_instruction.clone(),
+                advance_instruction.clone(),
+            ],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            Hash::default(),
+        );
+
+        test_entry.push_nonce_transaction(first_transaction, initial_nonce_info.clone());
+        test_entry.push_nonce_transaction_with_status(
+            second_transaction.clone(),
+            advanced_nonce_info.clone(),
+            ExecutionStatus::Discarded,
+        );
+
+        test_entries.push(test_entry);
+    }
+
+    for test_entry in &mut test_entries {
+        test_entry.add_initial_program(program_name);
+
+        if enable_fee_only_transactions {
+            test_entry
+                .enabled_features
+                .push(feature_set::enable_transaction_loading_failure_fees::id());
+        }
+    }
+
+    // batch 5:
+    // * a successful blockhash transaction that closes the nonce
+    // * a nonce transaction that uses the nonce; this transaction must be dropped
+    // * a successful blockhash noop transaction that touches the nonce, convenience to see state update
+    if !fee_paying_nonce {
+        let mut test_entry = common_test_entry.clone();
+
+        let first_transaction = Transaction::new_signed_with_payer(
+            &[withdraw_instruction.clone()],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            Hash::default(),
+        );
+
+        test_entry.push_transaction(first_transaction);
+        test_entry.push_nonce_transaction_with_status(
+            second_transaction.clone(),
+            advanced_nonce_info.clone(),
+            ExecutionStatus::Discarded,
+        );
+        test_entry.push_transaction(Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                program_id,
+                &[],
+                vec![AccountMeta::new_readonly(nonce_pubkey, false)],
+            )],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            Hash::default(),
+        ));
+
+        test_entry
+            .increase_expected_lamports(&fee_payer, LAMPORTS_PER_SOL - LAMPORTS_PER_SIGNATURE);
+
+        test_entry.update_expected_account_data(nonce_pubkey, &AccountSharedData::default());
+
+        test_entries.push(test_entry);
+    }
+
+    // batch 6:
+    // * a successful blockhash transaction that closes the nonce
+    // * a successful blockhash transaction that funds the closed account
+    // * a nonce transaction that uses the account; this transaction must be dropped
+    if !fee_paying_nonce {
+        let mut test_entry = common_test_entry.clone();
+
+        let first_transaction = Transaction::new_signed_with_payer(
+            &[withdraw_instruction.clone()],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            Hash::default(),
+        );
+
+        let middle_transaction = system_transaction::transfer(
+            &fee_payer_keypair,
+            &nonce_pubkey,
+            LAMPORTS_PER_SOL,
+            Hash::default(),
+        );
+
+        test_entry.push_transaction(first_transaction);
+        test_entry.push_transaction(middle_transaction);
+        test_entry.push_nonce_transaction_with_status(
+            second_transaction.clone(),
+            advanced_nonce_info.clone(),
+            ExecutionStatus::Discarded,
+        );
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        let mut new_nonce_state = AccountSharedData::default();
+        new_nonce_state.set_lamports(LAMPORTS_PER_SOL);
+
+        test_entry.update_expected_account_data(nonce_pubkey, &new_nonce_state);
+
+        test_entries.push(test_entry);
+    }
+
+    // batch 7:
+    // * a successful blockhash transaction that closes the nonce
+    // * a successful blockhash transaction that reopens the account with proper nonce size
+    // * a nonce transaction that uses the account; this transaction must be dropped
+    if !fee_paying_nonce {
+        let mut test_entry = common_test_entry.clone();
+
+        let first_transaction = Transaction::new_signed_with_payer(
+            &[withdraw_instruction.clone()],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            Hash::default(),
+        );
+
+        let middle_transaction = system_transaction::create_account(
+            &fee_payer_keypair,
+            &non_fee_nonce_keypair,
+            Hash::default(),
+            LAMPORTS_PER_SOL,
+            nonce_size as u64,
+            &system_program::id(),
+        );
+
+        test_entry.push_transaction(first_transaction);
+        test_entry.push_transaction(middle_transaction);
+        test_entry.push_nonce_transaction_with_status(
+            second_transaction.clone(),
+            advanced_nonce_info.clone(),
+            ExecutionStatus::Discarded,
+        );
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE * 2);
+
+        let new_nonce_state = AccountSharedData::create(
+            LAMPORTS_PER_SOL,
+            vec![0; nonce_size],
+            system_program::id(),
+            false,
+            u64::MAX,
+        );
+
+        test_entry.update_expected_account_data(nonce_pubkey, &new_nonce_state);
+
+        test_entries.push(test_entry);
+    }
+
+    // batch 8:
+    // * a successful blockhash transaction that closes the nonce
+    // * a successful blockhash transaction that reopens the nonce
+    // * a nonce transaction that uses the nonce; this transaction must be dropped
+    if !fee_paying_nonce {
+        let mut test_entry = common_test_entry.clone();
+
+        let first_transaction = Transaction::new_signed_with_payer(
+            &[withdraw_instruction.clone()],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            Hash::default(),
+        );
+
+        let create_instructions = system_instruction::create_nonce_account(
+            &fee_payer,
+            &nonce_pubkey,
+            &fee_payer,
+            LAMPORTS_PER_SOL,
+        );
+
+        let middle_transaction = Transaction::new_signed_with_payer(
+            &create_instructions,
+            Some(&fee_payer),
+            &[&fee_payer_keypair, &non_fee_nonce_keypair],
+            Hash::default(),
+        );
+
+        test_entry.push_transaction(first_transaction);
+        test_entry.push_transaction(middle_transaction);
+        test_entry.push_nonce_transaction_with_status(
+            second_transaction.clone(),
+            advanced_nonce_info.clone(),
+            ExecutionStatus::Discarded,
+        );
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE * 2);
+
+        test_entries.push(test_entry);
+    }
+
+    // batch 9:
+    // * a successful blockhash noop transaction
+    // * a nonce transaction that uses a spoofed nonce account; this transaction must be dropped
+    // check_age would never let such a transaction through validation
+    // this simulates the case where someone closes a nonce account, then reuses the address in the same batch
+    // but as a non-system account that parses as an initialized nonce account
+    if !fee_paying_nonce {
+        let mut test_entry = common_test_entry.clone();
+        test_entry.initial_accounts.remove(&nonce_pubkey);
+        test_entry.final_accounts.remove(&nonce_pubkey);
+
+        let mut fake_nonce_account = initial_nonce_account.clone();
+        fake_nonce_account.set_rent_epoch(u64::MAX);
+        fake_nonce_account.set_owner(Pubkey::new_unique());
+        test_entry.add_initial_account(nonce_pubkey, &fake_nonce_account);
+
+        let first_transaction = Transaction::new_signed_with_payer(
+            &[successful_noop_instruction.clone()],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            Hash::default(),
+        );
+
+        test_entry.push_transaction(first_transaction);
+        test_entry.push_nonce_transaction_with_status(
+            second_transaction.clone(),
+            advanced_nonce_info.clone(),
+            ExecutionStatus::Discarded,
+        );
+
+        test_entries.push(test_entry);
+    }
+
+    for test_entry in &mut test_entries {
+        test_entry.add_initial_program(program_name);
+
+        if enable_fee_only_transactions {
+            test_entry
+                .enabled_features
+                .push(feature_set::enable_transaction_loading_failure_fees::id());
+        }
+    }
+
+    test_entries
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum WriteProgramInstruction {
     Print,
@@ -1094,7 +1780,7 @@ enum WriteProgramInstruction {
     Realloc(usize),
 }
 impl WriteProgramInstruction {
-    fn _create_transaction(
+    fn create_transaction(
         self,
         program_id: Pubkey,
         fee_payer: &Keypair,
@@ -1139,6 +1825,339 @@ impl WriteProgramInstruction {
     }
 }
 
+fn account_deallocate() -> Vec<SvmTestEntry> {
+    let mut test_entries = vec![];
+
+    // batch 0: sanity check, the program actually sets data
+    // batch 1: removing lamports from account hides it from subsequent in-batch transactions
+    for remove_lamports in [false, true] {
+        let mut test_entry = SvmTestEntry::default();
+
+        let program_name = "write-to-account";
+        let program_id = program_address(program_name);
+        test_entry.add_initial_program(program_name);
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let target = Pubkey::new_unique();
+
+        let mut target_data = AccountSharedData::create(
+            Rent::default().minimum_balance(1),
+            vec![0],
+            program_id,
+            false,
+            u64::MAX,
+        );
+        test_entry.add_initial_account(target, &target_data);
+
+        let set_data_transaction = WriteProgramInstruction::Set.create_transaction(
+            program_id,
+            &fee_payer_keypair,
+            target,
+            None,
+        );
+        test_entry.push_transaction(set_data_transaction);
+
+        target_data.data_as_mut_slice()[0] = 100;
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+        test_entry.update_expected_account_data(target, &target_data);
+
+        if remove_lamports {
+            let dealloc_transaction = WriteProgramInstruction::Dealloc.create_transaction(
+                program_id,
+                &fee_payer_keypair,
+                target,
+                None,
+            );
+            test_entry.push_transaction(dealloc_transaction);
+
+            let print_transaction = WriteProgramInstruction::Print.create_transaction(
+                program_id,
+                &fee_payer_keypair,
+                target,
+                None,
+            );
+            test_entry.push_transaction(print_transaction);
+            test_entry.transaction_batch[2]
+                .asserts
+                .logs
+                .push("Program log: account size 0".to_string());
+
+            test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE * 2);
+
+            test_entry.update_expected_account_data(target, &AccountSharedData::default());
+        }
+
+        test_entries.push(test_entry);
+    }
+
+    test_entries
+}
+
+fn fee_payer_deallocate(enable_fee_only_transactions: bool) -> Vec<SvmTestEntry> {
+    let mut test_entry = SvmTestEntry::default();
+    if enable_fee_only_transactions {
+        test_entry
+            .enabled_features
+            .push(feature_set::enable_transaction_loading_failure_fees::id());
+    }
+
+    let program_name = "hello-solana";
+    let real_program_id = program_address(program_name);
+    test_entry.add_initial_program(program_name);
+
+    // 0/1: a rent-paying fee-payer goes to zero lamports on an executed transaction, the batch sees it as deallocated
+    // 2/3: the same, except if fee-only transactions are enabled, it goes to zero lamports from a a fee-only transaction
+    for do_fee_only_transaction in if enable_fee_only_transactions {
+        vec![false, true]
+    } else {
+        vec![false]
+    } {
+        let dealloc_fee_payer_keypair = Keypair::new();
+        let dealloc_fee_payer = dealloc_fee_payer_keypair.pubkey();
+
+        let mut dealloc_fee_payer_data = AccountSharedData::default();
+        dealloc_fee_payer_data.set_lamports(LAMPORTS_PER_SIGNATURE);
+        dealloc_fee_payer_data.set_rent_epoch(u64::MAX - 1);
+        test_entry.add_initial_account(dealloc_fee_payer, &dealloc_fee_payer_data);
+
+        let stable_fee_payer_keypair = Keypair::new();
+        let stable_fee_payer = stable_fee_payer_keypair.pubkey();
+
+        let mut stable_fee_payer_data = AccountSharedData::default();
+        stable_fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        test_entry.add_initial_account(stable_fee_payer, &stable_fee_payer_data);
+
+        // transaction which drains a fee-payer
+        let instruction = Instruction::new_with_bytes(
+            if do_fee_only_transaction {
+                Pubkey::new_unique()
+            } else {
+                real_program_id
+            },
+            &[],
+            vec![],
+        );
+
+        let transaction = Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&dealloc_fee_payer),
+            &[&dealloc_fee_payer_keypair],
+            Hash::default(),
+        );
+
+        test_entry.push_transaction_with_status(
+            transaction,
+            if do_fee_only_transaction {
+                ExecutionStatus::ProcessedFailed
+            } else {
+                ExecutionStatus::Succeeded
+            },
+        );
+
+        test_entry.decrease_expected_lamports(&dealloc_fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        // as noted in `account_deallocate()` we must touch the account to see if anything actually happened
+        let instruction = Instruction::new_with_bytes(
+            real_program_id,
+            &[],
+            vec![AccountMeta::new_readonly(dealloc_fee_payer, false)],
+        );
+        test_entry.push_transaction(Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&stable_fee_payer),
+            &[&stable_fee_payer_keypair],
+            Hash::default(),
+        ));
+
+        test_entry.decrease_expected_lamports(&stable_fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        test_entry.update_expected_account_data(dealloc_fee_payer, &AccountSharedData::default());
+    }
+
+    // 4: a rent-paying non-nonce fee-payer goes to zero on a fee-only nonce transaction, the batch sees it as deallocated
+    // we test in `simple_nonce()` that nonce fee-payers cannot as a rule be brought below rent-exemption
+    if enable_fee_only_transactions {
+        let dealloc_fee_payer_keypair = Keypair::new();
+        let dealloc_fee_payer = dealloc_fee_payer_keypair.pubkey();
+
+        let mut dealloc_fee_payer_data = AccountSharedData::default();
+        dealloc_fee_payer_data.set_lamports(LAMPORTS_PER_SIGNATURE);
+        dealloc_fee_payer_data.set_rent_epoch(u64::MAX - 1);
+        test_entry.add_initial_account(dealloc_fee_payer, &dealloc_fee_payer_data);
+
+        let stable_fee_payer_keypair = Keypair::new();
+        let stable_fee_payer = stable_fee_payer_keypair.pubkey();
+
+        let mut stable_fee_payer_data = AccountSharedData::default();
+        stable_fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        test_entry.add_initial_account(stable_fee_payer, &stable_fee_payer_data);
+
+        let nonce_pubkey = Pubkey::new_unique();
+        let initial_durable = DurableNonce::from_blockhash(&Hash::new_unique());
+        let initial_nonce_data =
+            nonce::state::Data::new(dealloc_fee_payer, initial_durable, LAMPORTS_PER_SIGNATURE);
+        let initial_nonce_account = AccountSharedData::new_data(
+            LAMPORTS_PER_SOL,
+            &nonce::state::Versions::new(nonce::State::Initialized(initial_nonce_data.clone())),
+            &system_program::id(),
+        )
+        .unwrap();
+        let initial_nonce_info = NonceInfo::new(nonce_pubkey, initial_nonce_account.clone());
+
+        let advanced_durable = DurableNonce::from_blockhash(&LAST_BLOCKHASH);
+        let mut advanced_nonce_info = initial_nonce_info.clone();
+        advanced_nonce_info
+            .try_advance_nonce(advanced_durable, LAMPORTS_PER_SIGNATURE)
+            .unwrap();
+
+        let advance_instruction =
+            system_instruction::advance_nonce_account(&nonce_pubkey, &dealloc_fee_payer);
+        let fee_only_noop_instruction =
+            Instruction::new_with_bytes(Pubkey::new_unique(), &[], vec![]);
+
+        // fee-only nonce transaction which drains a fee-payer
+        let transaction = Transaction::new_signed_with_payer(
+            &[advance_instruction, fee_only_noop_instruction],
+            Some(&dealloc_fee_payer),
+            &[&dealloc_fee_payer_keypair],
+            Hash::default(),
+        );
+        test_entry.push_transaction_with_status(transaction, ExecutionStatus::ProcessedFailed);
+
+        test_entry.decrease_expected_lamports(&dealloc_fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        // as noted in `account_deallocate()` we must touch the account to see if anything actually happened
+        let instruction = Instruction::new_with_bytes(
+            real_program_id,
+            &[],
+            vec![AccountMeta::new_readonly(dealloc_fee_payer, false)],
+        );
+        test_entry.push_transaction(Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&stable_fee_payer),
+            &[&stable_fee_payer_keypair],
+            Hash::default(),
+        ));
+
+        test_entry.decrease_expected_lamports(&stable_fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        test_entry.update_expected_account_data(dealloc_fee_payer, &AccountSharedData::default());
+    }
+
+    vec![test_entry]
+}
+
+fn account_reallocate(enable_fee_only_transactions: bool) -> Vec<SvmTestEntry> {
+    let mut test_entries = vec![];
+
+    let program_name = "write-to-account";
+    let program_id = program_address(program_name);
+    let program_size = program_data_size(program_name);
+
+    let mut common_test_entry = SvmTestEntry::default();
+
+    let fee_payer_keypair = Keypair::new();
+    let fee_payer = fee_payer_keypair.pubkey();
+
+    let mut fee_payer_data = AccountSharedData::default();
+    fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+    common_test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+    let mk_target = |size| {
+        AccountSharedData::create(
+            LAMPORTS_PER_SOL * 10,
+            vec![0; size],
+            program_id,
+            false,
+            u64::MAX,
+        )
+    };
+
+    let target = Pubkey::new_unique();
+    let target_start_size = 100;
+    common_test_entry.add_initial_account(target, &mk_target(target_start_size));
+
+    let print_transaction = WriteProgramInstruction::Print.create_transaction(
+        program_id,
+        &fee_payer_keypair,
+        target,
+        Some(
+            (program_size + MAX_PERMITTED_DATA_INCREASE)
+                .try_into()
+                .unwrap(),
+        ),
+    );
+
+    common_test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE * 2);
+
+    let common_test_entry = common_test_entry;
+
+    // batch 0/1:
+    // * successful realloc up/down
+    // * change reflected in same batch
+    for new_target_size in [target_start_size + 1, target_start_size - 1] {
+        let mut test_entry = common_test_entry.clone();
+
+        let realloc_transaction = WriteProgramInstruction::Realloc(new_target_size)
+            .create_transaction(program_id, &fee_payer_keypair, target, None);
+        test_entry.push_transaction(realloc_transaction);
+
+        test_entry.push_transaction(print_transaction.clone());
+        test_entry.transaction_batch[1]
+            .asserts
+            .logs
+            .push(format!("Program log: account size {}", new_target_size));
+
+        test_entry.update_expected_account_data(target, &mk_target(new_target_size));
+
+        test_entries.push(test_entry);
+    }
+
+    // batch 2:
+    // * successful large realloc up
+    // * transaction is aborted based on the new transaction data size post-realloc
+    {
+        let mut test_entry = common_test_entry.clone();
+
+        let new_target_size = target_start_size + MAX_PERMITTED_DATA_INCREASE;
+        let expected_print_status = if enable_fee_only_transactions {
+            ExecutionStatus::ProcessedFailed
+        } else {
+            test_entry.increase_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+            ExecutionStatus::Discarded
+        };
+
+        let realloc_transaction = WriteProgramInstruction::Realloc(new_target_size)
+            .create_transaction(program_id, &fee_payer_keypair, target, None);
+        test_entry.push_transaction(realloc_transaction);
+
+        test_entry.push_transaction_with_status(print_transaction.clone(), expected_print_status);
+
+        test_entry.update_expected_account_data(target, &mk_target(new_target_size));
+
+        test_entries.push(test_entry);
+    }
+
+    for test_entry in &mut test_entries {
+        test_entry.add_initial_program(program_name);
+
+        if enable_fee_only_transactions {
+            test_entry
+                .enabled_features
+                .push(feature_set::enable_transaction_loading_failure_fees::id());
+        }
+    }
+
+    test_entries
+}
+
 #[test_case(program_medley())]
 #[test_case(simple_transfer(false))]
 #[test_case(simple_transfer(true))]
@@ -1146,6 +2165,17 @@ impl WriteProgramInstruction {
 #[test_case(simple_nonce(true, false))]
 #[test_case(simple_nonce(false, true))]
 #[test_case(simple_nonce(true, true))]
+#[test_case(intrabatch_account_reuse(false))]
+#[test_case(intrabatch_account_reuse(true))]
+#[test_case(nonce_reuse(false, false))]
+#[test_case(nonce_reuse(true, false))]
+#[test_case(nonce_reuse(false, true))]
+#[test_case(nonce_reuse(true, true))]
+#[test_case(account_deallocate())]
+#[test_case(fee_payer_deallocate(false))]
+#[test_case(fee_payer_deallocate(true))]
+#[test_case(account_reallocate(false))]
+#[test_case(account_reallocate(true))]
 fn svm_integration(test_entries: Vec<SvmTestEntry>) {
     for test_entry in test_entries {
         let env = SvmTestEnvironment::create(test_entry);


### PR DESCRIPTION
#### Problem
[simd83](https://github.com/solana-foundation/solana-improvement-documents/pull/83) intends to relax entry-level constraints, namely that a transaction which takes a write lock on an account cannot be batched with any other transaction which takes a read or write lock on it

before the locking code can be changed, however, svm must be able to support such batches. presently, if one transaction were to write to an account, and a subsequent transaction read from or wrote to that account, svm would not pass the updated account state to the second transaction; it gets them from accounts-db, which is not updated until after all transaction execution finishes

#### Summary of Changes
improve the account loader to cache intermediate account states after each transaction execution, and pass that updated state to any subsequent transaction which uses it. rework the transaction batch processor so that fee-payer validation and account loading for each transaction happens after the previous transaction executes

we accomplish this using a just-in-time account loading strategy. we previously experimented with a batched loading strategy, but this had some fundamental drawbacks related to transaction size accounting

transaction batch processing proceeds as follows:
* create program cache for batch
* create account loader
* for each transaction:
  * validate fee-payer and nonce
  * load transaction accounts
  * if executable, execute transaction
  * if successful, update local program cache and update account loader with all writable accounts; if failed, or if fee-only, update nonce and fee-payer; if non-processable, do nothing
* update global program cache from local program cache, record timings

account loading now happens for one transaction at a time, interleaved with transaction execution, but the high-level flow for an individual transaction is largely unchanged. the crucial difference is that we now maintain a cache of account states local to svm, in addition to the program cache. this allows us to transparently provide transactions with updated account states that previous transactions produced. as a side effect, it should improve performance for batches where multiple transactions read from the same account, since these accounts only need to be fetched from accounts-db once

this change does not affect consensus rules. it updates svm to handle blocks that have write contention, but no such blocks can be produced, because account locking remains unchanged

there are also several consensus-affecting bugs in the old account loader related to the program cache and to transaction data size (see #3045). these have been preserved: the new account loader should in all cases produce identical execution results. we intend to fix the program cache in a subsequent (feature-gated) pr, and to present a simd to explicitly define transaction data size semantics

~~all code changes are contained in the first commit, for ease of review. the large majority of this pr (all its other commits) are tests~~ (this is presently not true but could be made true again easily)