### PR TITLE
ledger-tool: Fix create-snapshot default value for output_directory

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1923,11 +1923,11 @@ fn main() {
                     let is_minimized = arg_matches.is_present("minimized");
                     let output_directory = value_t!(arg_matches, "output_directory", PathBuf)
                         .unwrap_or_else(|_| {
-                            let snapshot_archive_path = value_t!(matches, "snapshots", String)
+                            let snapshot_archive_path = value_t!(arg_matches, "snapshots", String)
                                 .ok()
                                 .map(PathBuf::from);
                             let incremental_snapshot_archive_path =
-                                value_t!(matches, "incremental_snapshot_archive_path", String)
+                                value_t!(arg_matches, "incremental_snapshot_archive_path", String)
                                     .ok()
                                     .map(PathBuf::from);
                             match (


### PR DESCRIPTION
#### Problem
The arguments to specify full and incremental snapshot archives paths used to be a global argument; these were moved to only be instantiated on commands that needed them in #1773.

But, when the arguments were moved from app-level to subcommand-level, the code that matches the arguments was not updated to look at subcommand-matches instead of app-matches.

#### Summary of Changes
Examine the correct matches

Fixes #3117 