### PR TITLE
Extract rent-debits crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8107,6 +8107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-rent-debits"
+version = "2.2.0"
+dependencies = [
+ "solana-define-syscall",
+ "solana-pubkey",
+ "solana-reward-info",
+]
+
+[[package]]
 name = "solana-reserved-account-keys"
 version = "2.2.0"
 dependencies = [
@@ -8477,6 +8486,7 @@ dependencies = [
  "solana-program-memory",
  "solana-pubkey",
  "solana-quic-definitions",
+ "solana-rent-debits",
  "solana-reserved-account-keys",
  "solana-reward-info",
  "solana-sanitize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8110,7 +8110,6 @@ dependencies = [
 name = "solana-rent-debits"
 version = "2.2.0"
 dependencies = [
- "solana-define-syscall",
  "solana-pubkey",
  "solana-reward-info",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,9 @@ members = [
     "sdk/pubkey",
     "sdk/quic-definitions",
     "sdk/rent",
+    "sdk/rent-debits",
     "sdk/reserved-account-keys",
+    "sdk/reward-info",
     "sdk/sanitize",
     "sdk/sdk-ids",
     "sdk/secp256k1-program",
@@ -515,6 +517,7 @@ solana-quic-definitions = { path = "sdk/quic-definitions", version = "=2.2.0" }
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.2.0" }
 solana-remote-wallet = { path = "remote-wallet", version = "=2.2.0", default-features = false }
 solana-rent = { path = "sdk/rent", version = "=2.2.0", default-features = false }
+solana-rent-debits = { path = "sdk/rent-debits", version = "=2.2.0" }
 solana-reserved-account-keys = { path = "sdk/reserved-account-keys", version = "=2.2.0", default-features = false }
 solana-reward-info = { path = "sdk/reward-info", version = "=2.2.0" }
 solana-secp256r1-program = { path = "sdk/secp256r1-program", version = "=2.2.0", default-features = false }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6409,6 +6409,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-rent-debits"
+version = "2.2.0"
+dependencies = [
+ "solana-define-syscall",
+ "solana-pubkey",
+ "solana-reward-info",
+]
+
+[[package]]
 name = "solana-reserved-account-keys"
 version = "2.2.0"
 dependencies = [
@@ -7188,6 +7197,7 @@ dependencies = [
  "solana-program-memory",
  "solana-pubkey",
  "solana-quic-definitions",
+ "solana-rent-debits",
  "solana-reserved-account-keys",
  "solana-reward-info",
  "solana-sanitize",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6412,7 +6412,6 @@ dependencies = [
 name = "solana-rent-debits"
 version = "2.2.0"
 dependencies = [
- "solana-define-syscall",
  "solana-pubkey",
  "solana-reward-info",
 ]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -144,6 +144,7 @@ solana-pubkey = { workspace = true, default-features = false, features = ["std"]
 solana-quic-definitions = { workspace = true, optional = true }
 solana-reserved-account-keys = { workspace = true }
 solana-reward-info = { workspace = true, features = ["serde"] }
+solana-rent-debits = { workspace = true }
 solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sdk-macro = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -59,6 +59,7 @@ dev-context-only-utils = [
     "qualifier_attr",
     "solana-account/dev-context-only-utils",
     "solana-compute-budget-interface/dev-context-only-utils",
+    "solana-rent-debits/dev-context-only-utils",
     "solana-transaction-context/dev-context-only-utils",
 ]
 frozen-abi = [

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -143,8 +143,8 @@ solana-program = { workspace = true }
 solana-program-memory = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false, features = ["std"] }
 solana-quic-definitions = { workspace = true, optional = true }
-solana-reserved-account-keys = { workspace = true }
 solana-rent-debits = { workspace = true }
+solana-reserved-account-keys = { workspace = true }
 solana-reward-info = { workspace = true, features = ["serde"] }
 solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -144,8 +144,8 @@ solana-program-memory = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false, features = ["std"] }
 solana-quic-definitions = { workspace = true, optional = true }
 solana-reserved-account-keys = { workspace = true }
-solana-reward-info = { workspace = true, features = ["serde"] }
 solana-rent-debits = { workspace = true }
+solana-reward-info = { workspace = true, features = ["serde"] }
 solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sdk-macro = { workspace = true }

--- a/sdk/rent-debits/Cargo.toml
+++ b/sdk/rent-debits/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "solana-rent-debits"
+description = "Solana rent debit types."
+documentation = "https://docs.rs/solana-rent-debits"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-pubkey = { workspace = true }
+solana-reward-info = { workspace = true }
+
+[features]
+dev-context-only-utils = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[target.'cfg(target_os = "solana")'.dependencies]
+solana-define-syscall = { workspace = true }
+
+[lints]
+workspace = true

--- a/sdk/rent-debits/Cargo.toml
+++ b/sdk/rent-debits/Cargo.toml
@@ -18,6 +18,8 @@ dev-context-only-utils = []
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = { workspace = true }

--- a/sdk/rent-debits/Cargo.toml
+++ b/sdk/rent-debits/Cargo.toml
@@ -21,8 +21,5 @@ targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = { workspace = true }
-
 [lints]
 workspace = true

--- a/sdk/rent-debits/src/lib.rs
+++ b/sdk/rent-debits/src/lib.rs
@@ -1,5 +1,6 @@
 use {
-    solana_sdk::{pubkey::Pubkey, reward_info::RewardInfo, reward_type::RewardType},
+    solana_pubkey::Pubkey,
+    solana_reward_info::{RewardInfo, RewardType},
     std::collections::HashMap,
 };
 

--- a/sdk/rent-debits/src/lib.rs
+++ b/sdk/rent-debits/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {
     solana_pubkey::Pubkey,
     solana_reward_info::{RewardInfo, RewardType},

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -83,6 +83,7 @@ pub mod program_utils;
 pub mod pubkey;
 pub mod rent_collector;
 pub mod rent_debits;
+pub mod reserved_account_keys;
 #[deprecated(since = "2.2.0", note = "Use `solana-reward-info` crate instead")]
 pub mod reward_info {
     pub use solana_reward_info::RewardInfo;
@@ -161,6 +162,8 @@ pub use solana_quic_definitions as quic;
     note = "Use `solana-reserved-account-keys` crate instead"
 )]
 pub use solana_reserved_account_keys as reserved_account_keys;
+#[deprecated(since = "2.2.0", note = "Use `solana-rent-debits` crate instead")]
+pub use solana_rent_debits as rent_debits;
 #[deprecated(since = "2.1.0", note = "Use `solana-sanitize` crate instead")]
 pub use solana_sanitize as sanitize;
 /// Same as `declare_id` except report that this id has been deprecated.

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -151,6 +151,8 @@ pub use solana_program_memory as program_memory;
 /// assert_eq!(ID, my_id);
 /// ```
 pub use solana_pubkey::pubkey;
+#[deprecated(since = "2.2.0", note = "Use `solana-rent-debits` crate instead")]
+pub use solana_rent_debits as rent_debits;
 #[cfg(feature = "full")]
 #[deprecated(since = "2.2.0", note = "Use `solana-quic-definitions` crate instead")]
 pub use solana_quic_definitions as quic;
@@ -160,8 +162,6 @@ pub use solana_quic_definitions as quic;
     note = "Use `solana-reserved-account-keys` crate instead"
 )]
 pub use solana_reserved_account_keys as reserved_account_keys;
-#[deprecated(since = "2.2.0", note = "Use `solana-rent-debits` crate instead")]
-pub use solana_rent_debits as rent_debits;
 #[deprecated(since = "2.1.0", note = "Use `solana-sanitize` crate instead")]
 pub use solana_sanitize as sanitize;
 /// Same as `declare_id` except report that this id has been deprecated.

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -151,11 +151,11 @@ pub use solana_program_memory as program_memory;
 /// assert_eq!(ID, my_id);
 /// ```
 pub use solana_pubkey::pubkey;
-#[deprecated(since = "2.2.0", note = "Use `solana-rent-debits` crate instead")]
-pub use solana_rent_debits as rent_debits;
 #[cfg(feature = "full")]
 #[deprecated(since = "2.2.0", note = "Use `solana-quic-definitions` crate instead")]
 pub use solana_quic_definitions as quic;
+#[deprecated(since = "2.2.0", note = "Use `solana-rent-debits` crate instead")]
+pub use solana_rent_debits as rent_debits;
 #[cfg(feature = "full")]
 #[deprecated(
     since = "2.2.0",

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -82,8 +82,6 @@ pub mod precompiles;
 pub mod program_utils;
 pub mod pubkey;
 pub mod rent_collector;
-pub mod rent_debits;
-pub mod reserved_account_keys;
 #[deprecated(since = "2.2.0", note = "Use `solana-reward-info` crate instead")]
 pub mod reward_info {
     pub use solana_reward_info::RewardInfo;

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6229,6 +6229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-rent-debits"
+version = "2.2.0"
+dependencies = [
+ "solana-define-syscall",
+ "solana-pubkey",
+ "solana-reward-info",
+]
+
+[[package]]
 name = "solana-reserved-account-keys"
 version = "2.2.0"
 dependencies = [
@@ -6523,6 +6532,7 @@ dependencies = [
  "solana-program-memory",
  "solana-pubkey",
  "solana-quic-definitions",
+ "solana-rent-debits",
  "solana-reserved-account-keys",
  "solana-reward-info",
  "solana-sanitize",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6232,7 +6232,6 @@ dependencies = [
 name = "solana-rent-debits"
 version = "2.2.0"
 dependencies = [
- "solana-define-syscall",
  "solana-pubkey",
  "solana-reward-info",
 ]


### PR DESCRIPTION
#### Problem
`solana_sdk::rent_debits` imposes a `solana_sdk` dep on `solana_svm`

#### Summary of Changes
Move to its own crate and re-export with deprecation

This branches off #2971 so that needs to be merged first