### PR TITLE
chore: Fix whitespace in error message

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1735,7 +1735,7 @@ impl Bank {
         // from the passed in genesis_config instead (as new()/new_with_paths() already do)
         assert_eq!(
             bank.genesis_creation_time, genesis_config.creation_time,
-            "Bank snapshot genesis creation time does not match genesis.bin creation time.\
+            "Bank snapshot genesis creation time does not match genesis.bin creation time. \
              The snapshot and genesis.bin might pertain to different clusters"
         );
         assert_eq!(bank.ticks_per_slot, genesis_config.ticks_per_slot);


### PR DESCRIPTION
#### Problem
Saw someone post this error message in Discord, and realized there is no space after the period. Their copy/paste:
> Bank snapshot genesis creation time does not match genesis.bin creation time.The snapshot and genesis.bin might pertain to different clusters

#### Summary of Changes
Add a space