### PR TITLE
Marks Bank::unfreeze_for_ledger_tool() as dcou

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2911,6 +2911,7 @@ impl Bank {
     }
 
     // dangerous; don't use this; this is only needed for ledger-tool's special command
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn unfreeze_for_ledger_tool(&self) {
         self.freeze_started.store(false, Relaxed);
     }


### PR DESCRIPTION
#### Problem

The function Bank::unfreeze_for_ledger_tool() is not safe to call from a normal validator. It can only be called from tests/utils, like ledger-tool. But nothing currently prevents that.


#### Summary of Changes

Mark fn as dcou.