### PR TITLE
Scheduler: Improve TTL

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -81,12 +81,14 @@ impl Accounts {
         }
     }
 
+    /// Return loaded addresses and the deactivation slot.
+    /// If no tables are de-activating, the deactivation slot is `u64::MAX`.
     pub fn load_lookup_table_addresses(
         &self,
         ancestors: &Ancestors,
         address_table_lookup: SVMMessageAddressTableLookup,
         slot_hashes: &SlotHashes,
-    ) -> std::result::Result<LoadedAddresses, AddressLookupError> {
+    ) -> std::result::Result<(LoadedAddresses, Slot), AddressLookupError> {
         let table_account = self
             .accounts_db
             .load_with_fixed_root(ancestors, address_table_lookup.account_key)
@@ -98,18 +100,21 @@ impl Accounts {
             let lookup_table = AddressLookupTable::deserialize(table_account.data())
                 .map_err(|_ix_err| AddressLookupError::InvalidAccountData)?;
 
-            Ok(LoadedAddresses {
-                writable: lookup_table.lookup(
-                    current_slot,
-                    address_table_lookup.writable_indexes,
-                    slot_hashes,
-                )?,
-                readonly: lookup_table.lookup(
-                    current_slot,
-                    address_table_lookup.readonly_indexes,
-                    slot_hashes,
-                )?,
-            })
+            Ok((
+                LoadedAddresses {
+                    writable: lookup_table.lookup(
+                        current_slot,
+                        address_table_lookup.writable_indexes,
+                        slot_hashes,
+                    )?,
+                    readonly: lookup_table.lookup(
+                        current_slot,
+                        address_table_lookup.readonly_indexes,
+                        slot_hashes,
+                    )?,
+                },
+                lookup_table.meta.deactivation_slot,
+            ))
         } else {
             Err(AddressLookupError::InvalidAccountOwner)
         }
@@ -806,10 +811,13 @@ mod tests {
                 SVMMessageAddressTableLookup::from(&address_table_lookup),
                 &SlotHashes::default(),
             ),
-            Ok(LoadedAddresses {
-                writable: vec![table_addresses[0]],
-                readonly: vec![table_addresses[1]],
-            }),
+            Ok((
+                LoadedAddresses {
+                    writable: vec![table_addresses[0]],
+                    readonly: vec![table_addresses[1]],
+                },
+                u64::MAX
+            )),
         );
     }
 

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -82,7 +82,7 @@ impl Accounts {
     }
 
     /// Return loaded addresses and the deactivation slot.
-    /// If no tables are de-activating, the deactivation slot is `u64::MAX`.
+    /// If the table hasn't been deactivated, the deactivation slot is `u64::MAX`.
     pub fn load_lookup_table_addresses(
         &self,
         ancestors: &Ancestors,

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -2,20 +2,21 @@ use {
     super::packet_filter::PacketFilterFailure,
     solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_perf::packet::Packet,
+    solana_runtime::bank::Bank,
     solana_runtime_transaction::instructions_processor::process_compute_budget_instructions,
     solana_sanitize::SanitizeError,
     solana_sdk::{
+        clock::Slot,
         hash::Hash,
-        message::Message,
+        message::{v0::LoadedAddresses, AddressLoaderError, Message, SimpleAddressLoader},
         pubkey::Pubkey,
         signature::Signature,
-        transaction::{
-            AddressLoader, SanitizedTransaction, SanitizedVersionedTransaction,
-            VersionedTransaction,
-        },
+        transaction::{SanitizedTransaction, SanitizedVersionedTransaction, VersionedTransaction},
     },
     solana_short_vec::decode_shortu16_len,
-    solana_svm_transaction::instruction::SVMInstruction,
+    solana_svm_transaction::{
+        instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
+    },
     std::{cmp::Ordering, collections::HashSet, mem::size_of},
     thiserror::Error,
 };
@@ -111,15 +112,22 @@ impl ImmutableDeserializedPacket {
 
     // This function deserializes packets into transactions, computes the blake3 hash of transaction
     // messages.
+    // Additionally, this returns the minimum deactivation slot of the resolved addresses.
     pub fn build_sanitized_transaction(
         &self,
         votes_only: bool,
-        address_loader: impl AddressLoader,
+        bank: &Bank,
         reserved_account_keys: &HashSet<Pubkey>,
-    ) -> Option<SanitizedTransaction> {
+    ) -> Option<(SanitizedTransaction, Slot)> {
         if votes_only && !self.is_simple_vote() {
             return None;
         }
+
+        // Resolve the lookup addresses and retrieve the min deactivation slot
+        let (loaded_addresses, deactivation_slot) =
+            Self::resolve_addresses_with_deactivation(self.transaction(), bank).ok()?;
+        let address_loader = SimpleAddressLoader::Enabled(loaded_addresses);
+
         let tx = SanitizedTransaction::try_new(
             self.transaction().clone(),
             *self.message_hash(),
@@ -128,7 +136,23 @@ impl ImmutableDeserializedPacket {
             reserved_account_keys,
         )
         .ok()?;
-        Some(tx)
+        Some((tx, deactivation_slot))
+    }
+
+    fn resolve_addresses_with_deactivation(
+        transaction: &SanitizedVersionedTransaction,
+        bank: &Bank,
+    ) -> Result<(LoadedAddresses, Slot), AddressLoaderError> {
+        let Some(address_table_lookups) = transaction.get_message().message.address_table_lookups()
+        else {
+            return Ok((LoadedAddresses::default(), Slot::MAX));
+        };
+
+        bank.load_addresses_from_ref(
+            address_table_lookups
+                .iter()
+                .map(SVMMessageAddressTableLookup::from),
+        )
     }
 }
 

--- a/core/src/banking_stage/latest_unprocessed_votes.rs
+++ b/core/src/banking_stage/latest_unprocessed_votes.rs
@@ -420,7 +420,7 @@ impl LatestUnprocessedVotes {
             }
 
             let deserialized_vote_packet = vote.vote.as_ref().unwrap().clone();
-            let Some(sanitized_vote_transaction) = deserialized_vote_packet
+            let Some((sanitized_vote_transaction, _deactivation_slot)) = deserialized_vote_packet
                 .build_sanitized_transaction(
                     bank.vote_only_bank(),
                     bank.as_ref(),

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -35,13 +35,19 @@ impl Display for TransactionId {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct MaxAge {
+    pub epoch_invalidation_slot: Slot,
+    pub alt_invalidation_slot: Slot,
+}
+
 /// Message: [Scheduler -> Worker]
 /// Transactions to be consumed (i.e. executed, recorded, and committed)
 pub struct ConsumeWork {
     pub batch_id: TransactionBatchId,
     pub ids: Vec<TransactionId>,
     pub transactions: Vec<SanitizedTransaction>,
-    pub max_age_slots: Vec<Slot>,
+    pub max_ages: Vec<MaxAge>,
 }
 
 /// Message: [Worker -> Scheduler]

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -19,6 +19,7 @@ use {
         forwarder::Forwarder,
         immutable_deserialized_packet::ImmutableDeserializedPacket,
         packet_deserializer::PacketDeserializer,
+        scheduler_messages::MaxAge,
         ForwardOption, LikeClusterInfo, TOTAL_BUFFERED_PACKETS,
     },
     arrayvec::ArrayVec,
@@ -30,7 +31,8 @@ use {
     solana_runtime_transaction::instructions_processor::process_compute_budget_instructions,
     solana_sdk::{
         self,
-        clock::{FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, MAX_PROCESSING_AGE},
+        address_lookup_table::state::estimate_last_valid_slot,
+        clock::{Slot, FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, MAX_PROCESSING_AGE},
         fee::FeeBudgetLimits,
         saturating_add_assign,
         transaction::SanitizedTransaction,
@@ -500,16 +502,25 @@ impl<T: LikeClusterInfo> SchedulerController<T> {
         // Convert to Arcs
         let packets: Vec<_> = packets.into_iter().map(Arc::new).collect();
         // Sanitize packets, generate IDs, and insert into the container.
-        let bank = self.bank_forks.read().unwrap().working_bank();
-        let last_slot_in_epoch = bank.epoch_schedule().get_last_slot_in_epoch(bank.epoch());
-        let transaction_account_lock_limit = bank.get_transaction_account_lock_limit();
-        let vote_only = bank.vote_only_bank();
+        let (root_bank, working_bank) = {
+            let bank_forks = self.bank_forks.read().unwrap();
+            let root_bank = bank_forks.root_bank();
+            let working_bank = bank_forks.working_bank();
+            (root_bank, working_bank)
+        };
+        let alt_resolved_slot = root_bank.slot();
+        let last_slot_in_epoch = working_bank
+            .epoch_schedule()
+            .get_last_slot_in_epoch(working_bank.epoch());
+        let transaction_account_lock_limit = working_bank.get_transaction_account_lock_limit();
+        let vote_only = working_bank.vote_only_bank();
 
         const CHUNK_SIZE: usize = 128;
         let lock_results: [_; CHUNK_SIZE] = core::array::from_fn(|_| Ok(()));
 
         let mut arc_packets = ArrayVec::<_, CHUNK_SIZE>::new();
         let mut transactions = ArrayVec::<_, CHUNK_SIZE>::new();
+        let mut max_ages = ArrayVec::<_, CHUNK_SIZE>::new();
         let mut fee_budget_limits_vec = ArrayVec::<_, CHUNK_SIZE>::new();
 
         let mut error_counts = TransactionErrorMetrics::default();
@@ -521,31 +532,43 @@ impl<T: LikeClusterInfo> SchedulerController<T> {
                     packet
                         .build_sanitized_transaction(
                             vote_only,
-                            bank.as_ref(),
-                            bank.get_reserved_account_keys(),
+                            root_bank.as_ref(),
+                            working_bank.get_reserved_account_keys(),
                         )
-                        .map(|tx| (packet.clone(), tx))
+                        .map(|(tx, deactivation_slot)| (packet.clone(), tx, deactivation_slot))
                 })
                 .inspect(|_| saturating_add_assign!(post_sanitization_count, 1))
-                .filter(|(_packet, tx)| {
+                .filter(|(_packet, tx, _deactivation_slot)| {
                     validate_account_locks(
                         tx.message().account_keys(),
                         transaction_account_lock_limit,
                     )
                     .is_ok()
                 })
-                .filter_map(|(packet, tx)| {
+                .filter_map(|(packet, tx, deactivation_slot)| {
                     process_compute_budget_instructions(SVMMessage::program_instructions_iter(&tx))
-                        .map(|compute_budget| (packet, tx, compute_budget.into()))
+                        .map(|compute_budget| {
+                            (packet, tx, deactivation_slot, compute_budget.into())
+                        })
                         .ok()
                 })
-                .for_each(|(packet, tx, fee_budget_limits)| {
+                .for_each(|(packet, tx, deactivation_slot, fee_budget_limits)| {
                     arc_packets.push(packet);
                     transactions.push(tx);
+                    max_ages.push(calculate_max_age(
+                        last_slot_in_epoch,
+                        deactivation_slot,
+                        alt_resolved_slot,
+                    ));
                     fee_budget_limits_vec.push(fee_budget_limits);
                 });
 
-            let check_results = bank.check_transactions(
+            let check_results: Vec<
+                Result<
+                    solana_svm::account_loader::CheckedTransactionDetails,
+                    solana_sdk::transaction::TransactionError,
+                >,
+            > = working_bank.check_transactions(
                 &transactions,
                 &lock_results[..transactions.len()],
                 MAX_PROCESSING_AGE,
@@ -556,21 +579,26 @@ impl<T: LikeClusterInfo> SchedulerController<T> {
             let mut post_transaction_check_count: usize = 0;
             let mut num_dropped_on_capacity: usize = 0;
             let mut num_buffered: usize = 0;
-            for (((packet, transaction), fee_budget_limits), _check_result) in arc_packets
-                .drain(..)
-                .zip(transactions.drain(..))
-                .zip(fee_budget_limits_vec.drain(..))
-                .zip(check_results)
-                .filter(|(_, check_result)| check_result.is_ok())
+            for ((((packet, transaction), max_age), fee_budget_limits), _check_result) in
+                arc_packets
+                    .drain(..)
+                    .zip(transactions.drain(..))
+                    .zip(max_ages.drain(..))
+                    .zip(fee_budget_limits_vec.drain(..))
+                    .zip(check_results)
+                    .filter(|(_, check_result)| check_result.is_ok())
             {
                 saturating_add_assign!(post_transaction_check_count, 1);
                 let transaction_id = self.transaction_id_generator.next();
 
-                let (priority, cost) =
-                    Self::calculate_priority_and_cost(&transaction, &fee_budget_limits, &bank);
+                let (priority, cost) = Self::calculate_priority_and_cost(
+                    &transaction,
+                    &fee_budget_limits,
+                    &working_bank,
+                );
                 let transaction_ttl = SanitizedTransactionTTL {
                     transaction,
-                    max_age_slot: last_slot_in_epoch,
+                    max_age,
                 };
 
                 if self.container.insert_new_transaction(
@@ -652,6 +680,34 @@ impl<T: LikeClusterInfo> SchedulerController<T> {
                 .saturating_div(cost.saturating_add(1)),
             cost,
         )
+    }
+}
+
+/// Given the last slot in the epoch, the minimum deactivation slot,
+/// and the current slot, return the `MaxAge` that should be used for
+/// the transaction. This is used to determine the maximum slot that a
+/// transaction will be considered valid for, without re-resolving addresses
+/// or resanitizing.
+///
+/// This function considers the deactivation period of Address Table
+/// accounts. If the deactivation period runs past the end of the epoch,
+/// then the transaction is considered valid until the end of the epoch.
+/// Otherwise, the transaction is considered valid until the deactivation
+/// period.
+///
+/// Since the deactivation period technically uses blocks rather than
+/// slots, the value used here is the lower-bound on the deactivation
+/// period, i.e. the transaction's address lookups are valid until
+/// AT LEAST this slot.
+fn calculate_max_age(
+    last_slot_in_epoch: Slot,
+    deactivation_slot: Slot,
+    current_slot: Slot,
+) -> MaxAge {
+    let alt_min_expire_slot = estimate_last_valid_slot(deactivation_slot.min(current_slot));
+    MaxAge {
+        epoch_invalidation_slot: last_slot_in_epoch,
+        alt_invalidation_slot: alt_min_expire_slot,
     }
 }
 
@@ -827,7 +883,7 @@ mod tests {
                     batch_id: TransactionBatchId::new(0),
                     ids: vec![],
                     transactions: vec![],
-                    max_age_slots: vec![],
+                    max_ages: vec![],
                 },
                 retryable_indexes: vec![],
             })
@@ -1157,5 +1213,30 @@ mod tests {
             .map(|tx| tx.message_hash())
             .collect_vec();
         assert_eq!(message_hashes, vec![&tx1_hash]);
+    }
+
+    #[test]
+    fn test_calculate_max_age() {
+        let current_slot = 100;
+        let last_slot_in_epoch = 1000;
+
+        // ALT deactivation slot is delayed
+        assert_eq!(
+            calculate_max_age(last_slot_in_epoch, current_slot - 1, current_slot),
+            MaxAge {
+                epoch_invalidation_slot: last_slot_in_epoch,
+                alt_invalidation_slot: current_slot - 1
+                    + solana_sdk::slot_hashes::get_entries() as u64,
+            }
+        );
+
+        // no deactivation slot
+        assert_eq!(
+            calculate_max_age(last_slot_in_epoch, u64::MAX, current_slot),
+            MaxAge {
+                epoch_invalidation_slot: last_slot_in_epoch,
+                alt_invalidation_slot: current_slot + solana_sdk::slot_hashes::get_entries() as u64,
+            }
+        );
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -1,13 +1,15 @@
 use {
-    crate::banking_stage::immutable_deserialized_packet::ImmutableDeserializedPacket,
-    solana_sdk::{clock::Slot, transaction::SanitizedTransaction},
+    crate::banking_stage::{
+        immutable_deserialized_packet::ImmutableDeserializedPacket, scheduler_messages::MaxAge,
+    },
+    solana_sdk::transaction::SanitizedTransaction,
     std::sync::Arc,
 };
 
 /// Simple wrapper type to tie a sanitized transaction to max age slot.
 pub(crate) struct SanitizedTransactionTTL {
     pub(crate) transaction: SanitizedTransaction,
-    pub(crate) max_age_slot: Slot,
+    pub(crate) max_age: MaxAge,
 }
 
 /// TransactionState is used to track the state of a transaction in the transaction scheduler
@@ -207,8 +209,9 @@ mod tests {
     use {
         super::*,
         solana_sdk::{
-            compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message, packet::Packet,
-            signature::Keypair, signer::Signer, system_instruction, transaction::Transaction,
+            clock::Slot, compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message,
+            packet::Packet, signature::Keypair, signer::Signer, system_instruction,
+            transaction::Transaction,
         },
     };
 
@@ -230,7 +233,10 @@ mod tests {
         );
         let transaction_ttl = SanitizedTransactionTTL {
             transaction: SanitizedTransaction::from_transaction_for_tests(tx),
-            max_age_slot: Slot::MAX,
+            max_age: MaxAge {
+                epoch_invalidation_slot: Slot::MAX,
+                alt_invalidation_slot: Slot::MAX,
+            },
         };
         const TEST_TRANSACTION_COST: u64 = 5000;
         TransactionState::new(
@@ -271,11 +277,11 @@ mod tests {
         // Manually clone `SanitizedTransactionTTL`
         let SanitizedTransactionTTL {
             transaction,
-            max_age_slot,
+            max_age,
         } = transaction_state.transaction_ttl();
         let transaction_ttl = SanitizedTransactionTTL {
             transaction: transaction.clone(),
-            max_age_slot: *max_age_slot,
+            max_age: *max_age,
         };
         transaction_state.transition_to_unprocessed(transaction_ttl); // invalid transition
     }
@@ -321,7 +327,13 @@ mod tests {
             transaction_state,
             TransactionState::Unprocessed { .. }
         ));
-        assert_eq!(transaction_ttl.max_age_slot, Slot::MAX);
+        assert_eq!(
+            transaction_ttl.max_age,
+            MaxAge {
+                epoch_invalidation_slot: Slot::MAX,
+                alt_invalidation_slot: Slot::MAX,
+            }
+        );
 
         let _ = transaction_state.transition_to_pending();
         assert!(matches!(
@@ -339,7 +351,13 @@ mod tests {
             transaction_state,
             TransactionState::Unprocessed { .. }
         ));
-        assert_eq!(transaction_ttl.max_age_slot, Slot::MAX);
+        assert_eq!(
+            transaction_ttl.max_age,
+            MaxAge {
+                epoch_invalidation_slot: Slot::MAX,
+                alt_invalidation_slot: Slot::MAX,
+            }
+        );
 
         // ensure transaction_ttl is not lost through state transitions
         let transaction_ttl = transaction_state.transition_to_pending();
@@ -354,6 +372,12 @@ mod tests {
             transaction_state,
             TransactionState::Unprocessed { .. }
         ));
-        assert_eq!(transaction_ttl.max_age_slot, Slot::MAX);
+        assert_eq!(
+            transaction_ttl.max_age,
+            MaxAge {
+                epoch_invalidation_slot: Slot::MAX,
+                alt_invalidation_slot: Slot::MAX,
+            }
+        );
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -153,6 +153,7 @@ impl TransactionStateContainer {
 mod tests {
     use {
         super::*,
+        crate::banking_stage::scheduler_messages::MaxAge,
         solana_sdk::{
             compute_budget::ComputeBudgetInstruction,
             hash::Hash,
@@ -198,7 +199,10 @@ mod tests {
         );
         let transaction_ttl = SanitizedTransactionTTL {
             transaction: tx,
-            max_age_slot: Slot::MAX,
+            max_age: MaxAge {
+                epoch_invalidation_slot: Slot::MAX,
+                alt_invalidation_slot: Slot::MAX,
+            },
         };
         const TEST_TRANSACTION_COST: u64 = 5000;
         (transaction_ttl, packet, priority, TEST_TRANSACTION_COST)

--- a/core/src/banking_stage/unprocessed_packet_batches.rs
+++ b/core/src/banking_stage/unprocessed_packet_batches.rs
@@ -307,13 +307,14 @@ mod tests {
     use {
         super::*,
         solana_perf::packet::PacketFlags,
+        solana_runtime::bank::Bank,
         solana_sdk::{
             compute_budget::ComputeBudgetInstruction,
             message::Message,
             reserved_account_keys::ReservedAccountKeys,
             signature::{Keypair, Signer},
             system_instruction, system_transaction,
-            transaction::{SimpleAddressLoader, Transaction},
+            transaction::Transaction,
         },
         solana_vote_program::{vote_state::TowerSync, vote_transaction},
     };
@@ -475,6 +476,7 @@ mod tests {
             &keypair,
             None,
         );
+        let bank = Bank::default_for_tests();
 
         // packets with no votes
         {
@@ -486,7 +488,7 @@ mod tests {
             let txs = packet_vector.iter().filter_map(|tx| {
                 tx.immutable_section().build_sanitized_transaction(
                     votes_only,
-                    SimpleAddressLoader::Disabled,
+                    &bank,
                     &ReservedAccountKeys::empty_key_set(),
                 )
             });
@@ -496,7 +498,7 @@ mod tests {
             let txs = packet_vector.iter().filter_map(|tx| {
                 tx.immutable_section().build_sanitized_transaction(
                     votes_only,
-                    SimpleAddressLoader::Disabled,
+                    &bank,
                     &ReservedAccountKeys::empty_key_set(),
                 )
             });
@@ -515,7 +517,7 @@ mod tests {
             let txs = packet_vector.iter().filter_map(|tx| {
                 tx.immutable_section().build_sanitized_transaction(
                     votes_only,
-                    SimpleAddressLoader::Disabled,
+                    &bank,
                     &ReservedAccountKeys::empty_key_set(),
                 )
             });
@@ -525,7 +527,7 @@ mod tests {
             let txs = packet_vector.iter().filter_map(|tx| {
                 tx.immutable_section().build_sanitized_transaction(
                     votes_only,
-                    SimpleAddressLoader::Disabled,
+                    &bank,
                     &ReservedAccountKeys::empty_key_set(),
                 )
             });
@@ -544,7 +546,7 @@ mod tests {
             let txs = packet_vector.iter().filter_map(|tx| {
                 tx.immutable_section().build_sanitized_transaction(
                     votes_only,
-                    SimpleAddressLoader::Disabled,
+                    &bank,
                     &ReservedAccountKeys::empty_key_set(),
                 )
             });
@@ -554,7 +556,7 @@ mod tests {
             let txs = packet_vector.iter().filter_map(|tx| {
                 tx.immutable_section().build_sanitized_transaction(
                     votes_only,
-                    SimpleAddressLoader::Disabled,
+                    &bank,
                     &ReservedAccountKeys::empty_key_set(),
                 )
             });

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -154,13 +154,15 @@ fn consume_scan_should_process_packet(
         return ProcessingDecision::Now;
     }
 
-    // Try to sanitize the packet
+    // Try to sanitize the packet. Ignore deactivation slot since we are
+    // immediately attempting to process the transaction.
     let (maybe_sanitized_transaction, sanitization_time_us) = measure_us!(packet
         .build_sanitized_transaction(
             bank.vote_only_bank(),
             bank,
             bank.get_reserved_account_keys(),
-        ));
+        )
+        .map(|(tx, _deactivation_slot)| tx));
 
     payload
         .slot_metrics_tracker
@@ -799,7 +801,7 @@ impl ThreadLocalUnprocessedPackets {
                             bank,
                             bank.get_reserved_account_keys(),
                         )
-                        .map(|transaction| (transaction, packet_index))
+                        .map(|(transaction, _deactivation_slot)| (transaction, packet_index))
                 })
                 .unzip();
 

--- a/runtime/src/bank/address_lookup_table.rs
+++ b/runtime/src/bank/address_lookup_table.rs
@@ -2,6 +2,7 @@ use {
     super::Bank,
     solana_sdk::{
         address_lookup_table::error::AddressLookupError,
+        clock::Slot,
         message::{
             v0::{LoadedAddresses, MessageAddressTableLookup},
             AddressLoaderError,
@@ -32,22 +33,25 @@ impl AddressLoader for &Bank {
                 .iter()
                 .map(SVMMessageAddressTableLookup::from),
         )
+        .map(|(loaded_addresses, _deactivation_slot)| loaded_addresses)
     }
 }
 
 impl Bank {
-    /// Load addresses from an iterator of `SVMMessageAddressTableLookup`.
+    /// Load addresses from an iterator of `SVMMessageAddressTableLookup`,
+    /// additionally returning the deactivation slot
     pub fn load_addresses_from_ref<'a>(
         &self,
         address_table_lookups: impl Iterator<Item = SVMMessageAddressTableLookup<'a>>,
-    ) -> Result<LoadedAddresses, AddressLoaderError> {
+    ) -> Result<(LoadedAddresses, Slot), AddressLoaderError> {
         let slot_hashes = self
             .transaction_processor
             .sysvar_cache()
             .get_slot_hashes()
             .map_err(|_| AddressLoaderError::SlotHashesSysvarNotFound)?;
 
-        address_table_lookups
+        let mut deactivation_slot = u64::MAX;
+        let loaded_addresses = address_table_lookups
             .map(|address_table_lookup| {
                 self.rc
                     .accounts
@@ -56,8 +60,14 @@ impl Bank {
                         address_table_lookup,
                         &slot_hashes,
                     )
+                    .map(|(loaded_addresses, table_deactivation_slot)| {
+                        deactivation_slot = deactivation_slot.min(table_deactivation_slot);
+                        loaded_addresses
+                    })
                     .map_err(into_address_loader_error)
             })
-            .collect::<Result<_, _>>()
+            .collect::<Result<_, _>>()?;
+
+        Ok((loaded_addresses, deactivation_slot))
     }
 }

--- a/runtime/src/bank/address_lookup_table.rs
+++ b/runtime/src/bank/address_lookup_table.rs
@@ -39,7 +39,7 @@ impl AddressLoader for &Bank {
 
 impl Bank {
     /// Load addresses from an iterator of `SVMMessageAddressTableLookup`,
-    /// additionally returning the deactivation slot
+    /// additionally returning the minimum deactivation slot across all referenced ALTs
     pub fn load_addresses_from_ref<'a>(
         &self,
         address_table_lookups: impl Iterator<Item = SVMMessageAddressTableLookup<'a>>,

--- a/sdk/program/src/address_lookup_table/state.rs
+++ b/sdk/program/src/address_lookup_table/state.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
 use {
+    crate::slot_hashes::get_entries,
     serde_derive::{Deserialize, Serialize},
     solana_clock::Slot,
     solana_program::{
@@ -11,6 +12,19 @@ use {
     },
     std::borrow::Cow,
 };
+
+/// The lookup table may be in a deactivating state until
+/// the `deactivation_slot`` is no longer "recent".
+/// This function returns a conservative estimate for the
+/// last block that the table may be used for lookups.
+/// This estimate may be incorrect due to skipped blocks,
+/// however, if the current slot is lower than the returned
+/// value, the table is guaranteed to still be in the
+/// deactivating state.
+#[inline]
+pub fn estimate_last_valid_slot(deactivation_slot: Slot) -> Slot {
+    deactivation_slot.saturating_add(get_entries() as Slot)
+}
 
 /// The maximum number of addresses that a lookup table can hold
 pub const LOOKUP_TABLE_MAX_ADDRESSES: usize = 256;


### PR DESCRIPTION
#### Problem
- Scheduler tracks the end of epoch slot so that transactions are re-sanitized if the epoch rolls over
- Does not tell us when ALTs may expire

#### Summary of Changes
- track when ALTs expire to avoid re-checking ALT resolution every time
- re-resolve if the ALT expiration is hit 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
