### PR TITLE
Support dead slot notification in geyser

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4230,6 +4230,7 @@ pub(crate) mod tests {
         solana_rpc::{
             optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
             rpc::{create_test_transaction_entries, populate_blockstore_for_tests},
+            slot_status_notifier::SlotStatusNotifierInterface,
         },
         solana_runtime::{
             accounts_background_service::AbsRequestSender,
@@ -4255,7 +4256,7 @@ pub(crate) mod tests {
         std::{
             fs::remove_dir_all,
             iter,
-            sync::{atomic::AtomicU64, Arc, RwLock},
+            sync::{atomic::AtomicU64, Arc, Mutex, RwLock},
         },
         tempfile::tempdir,
         test_case::test_case,
@@ -4900,6 +4901,37 @@ pub(crate) mod tests {
         );
     }
 
+    struct SlotStatusNotifierForTest<'a> {
+        dead_slots: &'a std::sync::LazyLock<Mutex<HashSet<Slot>>>,
+    }
+
+    impl<'a> SlotStatusNotifierForTest<'a> {
+        pub fn new(dead_slots: &'a std::sync::LazyLock<Mutex<HashSet<Slot>>>) -> Self {
+            Self { dead_slots }
+        }
+    }
+
+    impl<'a> SlotStatusNotifierInterface for SlotStatusNotifierForTest<'a> {
+        fn notify_slot_confirmed(&self, _slot: Slot, _parent: Option<Slot>) {}
+
+        fn notify_slot_processed(&self, _slot: Slot, _parent: Option<Slot>) {}
+
+        fn notify_slot_rooted(&self, _slot: Slot, _parent: Option<Slot>) {}
+
+        fn notify_first_shred_received(&self, _slot: Slot) {}
+
+        fn notify_completed(&self, _slot: Slot) {}
+
+        fn notify_created_bank(&self, _slot: Slot, _parent: Slot) {}
+
+        fn notify_slot_dead(&self, slot: Slot, _error: String) {
+            self.dead_slots.lock().unwrap().insert(slot);
+        }
+    }
+
+    static DEAD_SLOTS: std::sync::LazyLock<Mutex<HashSet<Slot>>> =
+        std::sync::LazyLock::new(|| Mutex::new(HashSet::new()));
+
     // Given a shred and a fatal expected error, check that replaying that shred causes causes the fork to be
     // marked as dead. Returns the error for caller to verify.
     fn check_dead_fork<F>(shred_to_insert: F) -> result::Result<(), BlockstoreProcessorError>
@@ -4968,6 +5000,11 @@ pub(crate) mod tests {
             ));
             let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
                 unbounded();
+
+            let slot_status_notifier: Option<SlotStatusNotifier> = Some(Arc::new(RwLock::new(
+                SlotStatusNotifierForTest::new(&DEAD_SLOTS),
+            )));
+
             if let Err(err) = &res {
                 ReplayStage::mark_dead_slot(
                     &blockstore,
@@ -4975,7 +5012,7 @@ pub(crate) mod tests {
                     0,
                     err,
                     &rpc_subscriptions,
-                    &None,
+                    &slot_status_notifier,
                     &mut DuplicateSlotsTracker::default(),
                     &DuplicateConfirmedSlots::new(),
                     &mut EpochSlotsFrozenSlots::default(),
@@ -4986,7 +5023,7 @@ pub(crate) mod tests {
                     &mut PurgeRepairSlotCounter::default(),
                 );
             }
-
+            assert!(DEAD_SLOTS.lock().unwrap().contains(&bank1.slot()));
             // Check that the erroring bank was marked as dead in the progress map
             assert!(progress
                 .get(&bank1.slot())

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -328,6 +328,9 @@ pub enum SlotStatus {
 
     /// A new bank fork is created with the slot
     CreatedBank,
+
+    /// A slot is marked dead
+    Dead,
 }
 
 impl SlotStatus {
@@ -339,6 +342,7 @@ impl SlotStatus {
             SlotStatus::FirstShredReceived => "first_shread_received",
             SlotStatus::Completed => "completed",
             SlotStatus::CreatedBank => "created_bank",
+            SlotStatus::Dead => "dead",
         }
     }
 }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -306,7 +306,7 @@ pub enum GeyserPluginError {
 }
 
 /// The current status of a slot
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[repr(u32)]
 pub enum SlotStatus {
     /// The highest slot of the heaviest fork processed by the node. Ledger state at this slot is
@@ -330,7 +330,7 @@ pub enum SlotStatus {
     CreatedBank,
 
     /// A slot is marked dead
-    Dead,
+    Dead(String),
 }
 
 impl SlotStatus {
@@ -342,7 +342,7 @@ impl SlotStatus {
             SlotStatus::FirstShredReceived => "first_shread_received",
             SlotStatus::Completed => "completed",
             SlotStatus::CreatedBank => "created_bank",
-            SlotStatus::Dead => "dead",
+            SlotStatus::Dead(_error) => "dead",
         }
     }
 }
@@ -423,7 +423,7 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         &self,
         slot: Slot,
         parent: Option<u64>,
-        status: SlotStatus,
+        status: &SlotStatus,
     ) -> Result<()> {
         Ok(())
     }

--- a/geyser-plugin-manager/src/slot_status_notifier.rs
+++ b/geyser-plugin-manager/src/slot_status_notifier.rs
@@ -37,6 +37,10 @@ impl SlotStatusNotifierInterface for SlotStatusNotifierImpl {
     fn notify_created_bank(&self, slot: Slot, parent: Slot) {
         self.notify_slot_status(slot, Some(parent), SlotStatus::CreatedBank);
     }
+
+    fn notify_slot_dead(&self, slot: Slot, _error: String) {
+        self.notify_slot_status(slot, None, SlotStatus::Dead);
+    }
 }
 
 impl SlotStatusNotifierImpl {

--- a/geyser-plugin-manager/src/slot_status_notifier.rs
+++ b/geyser-plugin-manager/src/slot_status_notifier.rs
@@ -38,8 +38,8 @@ impl SlotStatusNotifierInterface for SlotStatusNotifierImpl {
         self.notify_slot_status(slot, Some(parent), SlotStatus::CreatedBank);
     }
 
-    fn notify_slot_dead(&self, slot: Slot, _error: String) {
-        self.notify_slot_status(slot, None, SlotStatus::Dead);
+    fn notify_slot_dead(&self, slot: Slot, error: String) {
+        self.notify_slot_status(slot, None, SlotStatus::Dead(error));
     }
 }
 
@@ -56,7 +56,7 @@ impl SlotStatusNotifierImpl {
 
         for plugin in plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-update-slot");
-            match plugin.update_slot_status(slot, parent, slot_status) {
+            match plugin.update_slot_status(slot, parent, &slot_status) {
                 Err(err) => {
                     error!(
                         "Failed to update slot status at slot {}, error: {} to plugin {}",

--- a/rpc/src/slot_status_notifier.rs
+++ b/rpc/src/slot_status_notifier.rs
@@ -21,6 +21,9 @@ pub trait SlotStatusNotifierInterface {
 
     /// Notified when the slot has bank created.
     fn notify_created_bank(&self, slot: Slot, parent: Slot);
+
+    /// Notified when the slot is marked "Dead"
+    fn notify_slot_dead(&self, slot: Slot, error: String);
 }
 
 pub type SlotStatusNotifier = Arc<RwLock<dyn SlotStatusNotifierInterface + Sync + Send>>;


### PR DESCRIPTION
Problem

This is the 4th part to support more slot status notification type in geyser: Dead slot.

Summary of Changes

Link SlotStatusNotifier in replay stage on Dead slot.

Tests: tested change with Postgres geyser plugin and confirming the Dead slot being received.

Fixes #

https://github.com/anza-xyz/agave/issues/2957
