### PR TITLE
cli: Simulate for compute units in `validator-info publish`

### DIFF
--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -349,7 +349,7 @@ pub fn process_set_validator_info(
         vec![config.signers[0]]
     };
 
-    let compute_unit_limit = ComputeUnitLimit::Default;
+    let compute_unit_limit = ComputeUnitLimit::Simulated;
     let build_message = |lamports| {
         let keys = keys.clone();
         if balance == 0 {

--- a/cli/tests/validator_info.rs
+++ b/cli/tests/validator_info.rs
@@ -1,0 +1,57 @@
+use {
+    serde_json::json,
+    solana_cli::{
+        check_balance,
+        cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig},
+    },
+    solana_faucet::faucet::run_local_faucet,
+    solana_rpc_client::rpc_client::RpcClient,
+    solana_sdk::{
+        commitment_config::CommitmentConfig,
+        signature::{keypair_from_seed, Keypair, Signer},
+    },
+    solana_streamer::socket::SocketAddrSpace,
+    solana_test_validator::TestValidator,
+    test_case::test_case,
+};
+
+#[test_case(None; "base")]
+#[test_case(Some(1_000_000); "with_compute_unit_price")]
+fn test_publish(compute_unit_price: Option<u64>) {
+    solana_logger::setup();
+
+    let mint_keypair = Keypair::new();
+    let mint_pubkey = mint_keypair.pubkey();
+    let faucet_addr = run_local_faucet(mint_keypair, None);
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
+
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+
+    let validator_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
+    let mut config_validator = CliConfig::recent_for_tests();
+    config_validator.json_rpc_url = test_validator.rpc_url();
+    config_validator.signers = vec![&validator_keypair];
+
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &config_validator,
+        &config_validator.signers[0].pubkey(),
+        100_000_000_000,
+    )
+    .unwrap();
+    check_balance!(
+        100_000_000_000,
+        &rpc_client,
+        &config_validator.signers[0].pubkey()
+    );
+
+    config_validator.command = CliCommand::SetValidatorInfo {
+        validator_info: json!({ "name": "test" }),
+        force_keybase: true,
+        info_pubkey: None,
+        compute_unit_price,
+    };
+    process_command(&config_validator).unwrap();
+}


### PR DESCRIPTION
#### Problem

Similar to the other PRs like #2710, we should simulate transactions to find out the CUs consumed before sending them out.

#### Summary of changes

Similar to #2710, use `Simulated` compute units and perform the simulation before sending out the transaction. Also, add a test.