### PR TITLE
SVM: API method for setting cache fork graph

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -399,7 +399,7 @@ fn simulate_process_entries(
     let bank_fork = BankForks::new_rw_arc(bank);
     let bank = bank_fork.read().unwrap().get_with_scheduler(slot).unwrap();
     bank.clone_without_scheduler()
-        .set_fork_graph_in_program_cache(Arc::downgrade(&bank_fork));
+        .set_fork_graph_in_program_cache(bank_fork);
 
     for i in 0..(num_accounts / 2) {
         bank.transfer(initial_lamports, mint_keypair, &keypairs[i * 2].pubkey())

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -83,7 +83,7 @@ fn test_scheduler_waited_by_drop_bank_service() {
     bank_forks.write().unwrap().install_scheduler_pool(pool);
     let genesis = 0;
     let genesis_bank = &bank_forks.read().unwrap().get(genesis).unwrap();
-    genesis_bank.set_fork_graph_in_program_cache(Arc::downgrade(&bank_forks));
+    genesis_bank.set_fork_graph_in_program_cache(Arc::clone(&bank_forks));
 
     // Create bank, which is pruned later
     let pruned = 2;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -192,7 +192,7 @@ use {
                 AtomicBool, AtomicI64, AtomicU64, AtomicUsize,
                 Ordering::{AcqRel, Acquire, Relaxed},
             },
-            Arc, LockResult, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak,
+            Arc, LockResult, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard,
         },
         thread::Builder,
         time::{Duration, Instant},
@@ -1420,12 +1420,9 @@ impl Bank {
         new
     }
 
-    pub fn set_fork_graph_in_program_cache(&self, fork_graph: Weak<RwLock<BankForks>>) {
+    pub fn set_fork_graph_in_program_cache(&self, fork_graph: Arc<RwLock<BankForks>>) {
         self.transaction_processor
-            .program_cache
-            .write()
-            .unwrap()
-            .set_fork_graph(fork_graph);
+            .set_fork_graph_in_program_cache(fork_graph);
     }
 
     pub fn prune_program_cache(&self, new_root_slot: Slot, new_root_epoch: Epoch) {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -130,7 +130,7 @@ impl BankForks {
             scheduler_pool: None,
         }));
 
-        root_bank.set_fork_graph_in_program_cache(Arc::downgrade(&bank_forks));
+        root_bank.set_fork_graph_in_program_cache(Arc::clone(&bank_forks));
         bank_forks
     }
 

--- a/svm/examples/json-rpc/server/src/svm_bridge.rs
+++ b/svm/examples/json-rpc/server/src/svm_bridge.rs
@@ -203,6 +203,8 @@ pub fn create_executable_environment(
     mock_bank: &mut MockBankCallback,
     transaction_processor: &TransactionBatchProcessor<MockForkGraph>,
 ) {
+    transaction_processor.set_fork_graph_in_program_cache(fork_graph);
+
     let mut program_cache = transaction_processor.program_cache.write().unwrap();
 
     program_cache.environments = ProgramRuntimeEnvironments {
@@ -214,7 +216,6 @@ pub fn create_executable_environment(
         )),
     };
 
-    program_cache.fork_graph = Some(Arc::downgrade(&fork_graph));
     // add programs to cache
     for key in account_keys.iter() {
         if let Some(account) = mock_bank.get_account_shared_data(key) {

--- a/svm/examples/paytube/src/lib.rs
+++ b/svm/examples/paytube/src/lib.rs
@@ -140,7 +140,7 @@ impl PayTubeChannel {
             &account_loader,
             &feature_set,
             &compute_budget,
-            Arc::clone(&fork_graph),
+            fork_graph,
         );
 
         // The PayTube transaction processing runtime environment.

--- a/svm/examples/paytube/src/processor.rs
+++ b/svm/examples/paytube/src/processor.rs
@@ -56,11 +56,11 @@ pub(crate) fn create_transaction_batch_processor<CB: TransactionProcessingCallba
         /* builtin_program_ids */ HashSet::new(),
     );
 
+    // Initialize the mocked fork graph.
+    processor.set_fork_graph_in_program_cache(fork_graph);
+
     {
         let mut cache = processor.program_cache.write().unwrap();
-
-        // Initialize the mocked fork graph.
-        cache.fork_graph = Some(Arc::downgrade(&fork_graph));
 
         // Initialize a proper cache environment.
         // (Use Loader v4 program to initialize runtime v2 if desired)

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -209,6 +209,18 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         }
     }
 
+    /// Sets the fork graph in the processor's program cache instance.
+    ///
+    /// For newly created batch processors, which aren't created using
+    /// `new_from`, this method should be called to set the fork graph
+    /// in the program cache before processing transactions.
+    pub fn set_fork_graph_in_program_cache(&self, fork_graph: Arc<RwLock<FG>>) {
+        self.program_cache
+            .write()
+            .unwrap()
+            .set_fork_graph(Arc::downgrade(&fork_graph));
+    }
+
     /// Returns the current environments depending on the given epoch
     /// Returns None if the call could result in a deadlock
     #[cfg(feature = "dev-context-only-utils")]
@@ -1300,8 +1312,8 @@ mod tests {
         let mock_bank = MockBankCallback::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         let fork_graph = Arc::new(RwLock::new(TestForkGraph {}));
-        batch_processor.program_cache.write().unwrap().fork_graph =
-            Some(Arc::downgrade(&fork_graph));
+        batch_processor.set_fork_graph_in_program_cache(fork_graph);
+
         let key = Pubkey::new_unique();
 
         let mut account_maps: HashMap<Pubkey, u64> = HashMap::new();
@@ -1315,8 +1327,8 @@ mod tests {
         let mock_bank = MockBankCallback::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         let fork_graph = Arc::new(RwLock::new(TestForkGraph {}));
-        batch_processor.program_cache.write().unwrap().fork_graph =
-            Some(Arc::downgrade(&fork_graph));
+        batch_processor.set_fork_graph_in_program_cache(fork_graph);
+
         let key = Pubkey::new_unique();
 
         let mut account_data = AccountSharedData::default();
@@ -1803,8 +1815,7 @@ mod tests {
         let mock_bank = MockBankCallback::default();
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         let fork_graph = Arc::new(RwLock::new(TestForkGraph {}));
-        batch_processor.program_cache.write().unwrap().fork_graph =
-            Some(Arc::downgrade(&fork_graph));
+        batch_processor.set_fork_graph_in_program_cache(fork_graph);
 
         let key = Pubkey::new_unique();
         let name = "a_builtin_name";

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -42,7 +42,7 @@ fn program_cache_execution(threads: usize) {
     let mut mock_bank = MockBankCallback::default();
     let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(5, 5, HashSet::new());
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
-    batch_processor.program_cache.write().unwrap().fork_graph = Some(Arc::downgrade(&fork_graph));
+    batch_processor.set_fork_graph_in_program_cache(fork_graph);
 
     let programs = vec![
         deploy_program("hello-solana".to_string(), 0, &mut mock_bank),
@@ -131,7 +131,7 @@ fn svm_concurrent() {
         2,
         HashSet::new(),
     ));
-    let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
+    batch_processor.set_fork_graph_in_program_cache(Arc::new(RwLock::new(MockForkGraph {})));
 
     create_executable_environment(
         fork_graph.clone(),

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -245,8 +245,8 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
 
     mock_bank.override_feature_set(feature_set);
     let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(42, 2, HashSet::new());
+    batch_processor.set_fork_graph_in_program_cache(Arc::new(RwLock::new(MockForkGraph {})));
 
-    let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
     {
         let mut program_cache = batch_processor.program_cache.write().unwrap();
         program_cache.environments = ProgramRuntimeEnvironments {
@@ -256,7 +256,6 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
                 FunctionRegistry::default(),
             )),
         };
-        program_cache.fork_graph = Some(Arc::downgrade(&fork_graph.clone()));
     }
 
     batch_processor.fill_missing_sysvar_cache_entries(&mock_bank);

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -877,11 +877,9 @@ fn execute_test_entry(test_entry: SvmTestEntry) {
         EXECUTION_EPOCH,
         HashSet::new(),
     );
-
-    let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
+    batch_processor.set_fork_graph_in_program_cache(Arc::new(RwLock::new(MockForkGraph {})));
 
     create_executable_environment(
-        fork_graph.clone(),
         &mock_bank,
         &mut batch_processor.program_cache.write().unwrap(),
     );
@@ -1064,11 +1062,9 @@ fn svm_inspect_account() {
         EXECUTION_EPOCH,
         HashSet::new(),
     );
-
-    let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
+    batch_processor.set_fork_graph_in_program_cache(Arc::new(RwLock::new(MockForkGraph {})));
 
     create_executable_environment(
-        fork_graph.clone(),
         &mock_bank,
         &mut batch_processor.program_cache.write().unwrap(),
     );

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -201,7 +201,6 @@ pub fn deploy_program_with_upgrade_authority(
 
 #[allow(unused)]
 pub fn create_executable_environment(
-    fork_graph: Arc<RwLock<MockForkGraph>>,
     mock_bank: &MockBankCallback,
     program_cache: &mut ProgramCache<MockForkGraph>,
 ) {
@@ -213,8 +212,6 @@ pub fn create_executable_environment(
             FunctionRegistry::default(),
         )),
     };
-
-    program_cache.fork_graph = Some(Arc::downgrade(&fork_graph));
 
     // We must fill in the sysvar cache entries
 

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -2221,7 +2221,7 @@ mod tests {
         let slot = bank.slot();
         let bank_fork = BankForks::new_rw_arc(bank);
         let bank = bank_fork.read().unwrap().get(slot).unwrap();
-        bank.set_fork_graph_in_program_cache(Arc::downgrade(&bank_fork));
+        bank.set_fork_graph_in_program_cache(Arc::clone(&bank_fork));
         (bank, bank_fork)
     }
 


### PR DESCRIPTION
#### Problem
When creating a new `TransactionBatchProcessor` instance, you must configure the fork graph of the program cache in order for the cache to work properly. This can trip up many consumers of the SVM API.

We typically set this value on the program cache manually through something like this...

```rust
let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
let program_cache = batch_processor.program_cache.write().unwrap();
program_cache.fork_graph = Arc::downgrade(&fork_graph);
```

... which is just, awful.

#### Summary of Changes
Add an API method for setting the cache's fork graph, and use it everywhere.
