### PR TITLE
SVM: API: rename `new` to `new_uninitialized`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1048,7 +1048,7 @@ impl Bank {
         };
 
         bank.transaction_processor =
-            TransactionBatchProcessor::new(bank.slot, bank.epoch, HashSet::default());
+            TransactionBatchProcessor::new_uninitialized(bank.slot, bank.epoch, HashSet::default());
 
         let accounts_data_size_initial = bank.get_total_accounts_stats().unwrap().data_len as u64;
         bank.accounts_data_size_initial = accounts_data_size_initial;
@@ -1702,7 +1702,7 @@ impl Bank {
         };
 
         bank.transaction_processor =
-            TransactionBatchProcessor::new(bank.slot, bank.epoch, HashSet::default());
+            TransactionBatchProcessor::new_uninitialized(bank.slot, bank.epoch, HashSet::default());
 
         let thread_pool = ThreadPoolBuilder::new()
             .thread_name(|i| format!("solBnkNewFlds{i:02}"))

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -208,7 +208,7 @@ impl JsonRpcRequestProcessor {
                 (pubkey, acc_data)
             })
             .collect();
-        let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(
+        let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(
             EXECUTION_SLOT,
             EXECUTION_EPOCH,
             HashSet::new(),

--- a/svm/examples/paytube/src/processor.rs
+++ b/svm/examples/paytube/src/processor.rs
@@ -50,7 +50,7 @@ pub(crate) fn create_transaction_batch_processor<CB: TransactionProcessingCallba
     // marked as "depoyed" in slot 0.
     // See `solana_svm::program_loader::load_program_with_pubkey` for more
     // details.
-    let processor = TransactionBatchProcessor::<PayTubeForkGraph>::new(
+    let processor = TransactionBatchProcessor::<PayTubeForkGraph>::new_uninitialized(
         /* slot */ 1,
         /* epoch */ 1,
         /* builtin_program_ids */ HashSet::new(),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -189,7 +189,20 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
 }
 
 impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
-    pub fn new(slot: Slot, epoch: Epoch, builtin_program_ids: HashSet<Pubkey>) -> Self {
+    /// Create a new, uninitialized `TransactionBatchProcessor`.
+    ///
+    /// In this context, uninitialized means that the `TransactionBatchProcessor`
+    /// has been initialized with an empty program cache. The cache contains no
+    /// programs (including builtins) and has not been configured with a valid
+    /// fork graph.
+    ///
+    /// When using this method, it's advisable to call `set_fork_graph_in_program_cache`
+    /// as well as `add_builtin` to configure the cache before using the processor.
+    pub fn new_uninitialized(
+        slot: Slot,
+        epoch: Epoch,
+        builtin_program_ids: HashSet<Pubkey>,
+    ) -> Self {
         Self {
             slot,
             epoch,
@@ -199,6 +212,12 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         }
     }
 
+    /// Create a new `TransactionBatchProcessor` from the current instance, but
+    /// with the provided slot and epoch.
+    ///
+    /// * Inherits the program cache and builtin program ids from the current
+    ///   instance.
+    /// * Resets the sysvar cache.
     pub fn new_from(&self, slot: Slot, epoch: Epoch) -> Self {
         Self {
             slot,

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -40,7 +40,8 @@ mod transaction_builder;
 
 fn program_cache_execution(threads: usize) {
     let mut mock_bank = MockBankCallback::default();
-    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(5, 5, HashSet::new());
+    let batch_processor =
+        TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(5, 5, HashSet::new());
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
     batch_processor.program_cache.write().unwrap().fork_graph = Some(Arc::downgrade(&fork_graph));
 
@@ -126,11 +127,9 @@ fn test_program_cache_with_exhaustive_scheduler() {
 // correctly.
 fn svm_concurrent() {
     let mock_bank = Arc::new(MockBankCallback::default());
-    let batch_processor = Arc::new(TransactionBatchProcessor::<MockForkGraph>::new(
-        5,
-        2,
-        HashSet::new(),
-    ));
+    let batch_processor = Arc::new(
+        TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(5, 2, HashSet::new()),
+    );
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
 
     create_executable_environment(

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -244,7 +244,8 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
         create_program_runtime_environment_v1(&feature_set, &compute_budget, false, false).unwrap();
 
     mock_bank.override_feature_set(feature_set);
-    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(42, 2, HashSet::new());
+    let batch_processor =
+        TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(42, 2, HashSet::new());
 
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
     {

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -872,7 +872,7 @@ fn execute_test_entry(test_entry: SvmTestEntry) {
             .insert(*pubkey, account.clone());
     }
 
-    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(
+    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(
         EXECUTION_SLOT,
         EXECUTION_EPOCH,
         HashSet::new(),
@@ -1059,7 +1059,7 @@ fn svm_inspect_account() {
 
     // Load and execute the transaction
 
-    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(
+    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(
         EXECUTION_SLOT,
         EXECUTION_EPOCH,
         HashSet::new(),


### PR DESCRIPTION
#### Problem
In SVM land, the `TransactionBatchProcessor` method `new` is designed to, as it says, allow consumers to create a new instance of a `TransactionBatchProcessor`. However, what's not clear from this method is that fact that the program cache created within this method is completely useless, since it's missing:

- A fork graph.
- A valid program runtime environment (for either PR version).
- Any builtin programs.

This method should be renamed to reflect the nature of its behavior, and documented.


#### Summary of Changes
Rename the method to `new_uninitialized`, and add some documentation!
