### PR TITLE
SVM: API: drop builtin IDs from `new_uninitialized`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1048,7 +1048,7 @@ impl Bank {
         };
 
         bank.transaction_processor =
-            TransactionBatchProcessor::new_uninitialized(bank.slot, bank.epoch, HashSet::default());
+            TransactionBatchProcessor::new_uninitialized(bank.slot, bank.epoch);
 
         let accounts_data_size_initial = bank.get_total_accounts_stats().unwrap().data_len as u64;
         bank.accounts_data_size_initial = accounts_data_size_initial;
@@ -1702,7 +1702,7 @@ impl Bank {
         };
 
         bank.transaction_processor =
-            TransactionBatchProcessor::new_uninitialized(bank.slot, bank.epoch, HashSet::default());
+            TransactionBatchProcessor::new_uninitialized(bank.slot, bank.epoch);
 
         let thread_pool = ThreadPoolBuilder::new()
             .thread_name(|i| format!("solBnkNewFlds{i:02}"))

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -211,7 +211,6 @@ impl JsonRpcRequestProcessor {
         let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(
             EXECUTION_SLOT,
             EXECUTION_EPOCH,
-            HashSet::new(),
         );
 
         Self {

--- a/svm/examples/paytube/src/processor.rs
+++ b/svm/examples/paytube/src/processor.rs
@@ -11,10 +11,7 @@ use {
         transaction_processor::TransactionBatchProcessor,
     },
     solana_system_program::system_processor,
-    std::{
-        collections::HashSet,
-        sync::{Arc, RwLock},
-    },
+    std::sync::{Arc, RwLock},
 };
 
 /// In order to use the `TransactionBatchProcessor`, another trait - Solana
@@ -51,9 +48,7 @@ pub(crate) fn create_transaction_batch_processor<CB: TransactionProcessingCallba
     // See `solana_svm::program_loader::load_program_with_pubkey` for more
     // details.
     let processor = TransactionBatchProcessor::<PayTubeForkGraph>::new_uninitialized(
-        /* slot */ 1,
-        /* epoch */ 1,
-        /* builtin_program_ids */ HashSet::new(),
+        /* slot */ 1, /* epoch */ 1,
     );
 
     {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -198,17 +198,12 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     ///
     /// When using this method, it's advisable to call `set_fork_graph_in_program_cache`
     /// as well as `add_builtin` to configure the cache before using the processor.
-    pub fn new_uninitialized(
-        slot: Slot,
-        epoch: Epoch,
-        builtin_program_ids: HashSet<Pubkey>,
-    ) -> Self {
+    pub fn new_uninitialized(slot: Slot, epoch: Epoch) -> Self {
         Self {
             slot,
             epoch,
-            sysvar_cache: RwLock::<SysvarCache>::default(),
             program_cache: Arc::new(RwLock::new(ProgramCache::new(slot, epoch))),
-            builtin_program_ids: RwLock::new(builtin_program_ids),
+            ..Self::default()
         }
     }
 

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -31,7 +31,7 @@ use {
             TransactionProcessingEnvironment,
         },
     },
-    std::collections::{HashMap, HashSet},
+    std::collections::HashMap,
 };
 
 mod mock_bank;
@@ -40,8 +40,7 @@ mod transaction_builder;
 
 fn program_cache_execution(threads: usize) {
     let mut mock_bank = MockBankCallback::default();
-    let batch_processor =
-        TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(5, 5, HashSet::new());
+    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(5, 5);
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
     batch_processor.program_cache.write().unwrap().fork_graph = Some(Arc::downgrade(&fork_graph));
 
@@ -127,9 +126,8 @@ fn test_program_cache_with_exhaustive_scheduler() {
 // correctly.
 fn svm_concurrent() {
     let mock_bank = Arc::new(MockBankCallback::default());
-    let batch_processor = Arc::new(
-        TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(5, 2, HashSet::new()),
-    );
+    let batch_processor =
+        Arc::new(TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(5, 2));
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
 
     create_executable_environment(

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -244,8 +244,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
         create_program_runtime_environment_v1(&feature_set, &compute_budget, false, false).unwrap();
 
     mock_bank.override_feature_set(feature_set);
-    let batch_processor =
-        TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(42, 2, HashSet::new());
+    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(42, 2);
 
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
     {

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -35,7 +35,7 @@ use {
     },
     solana_svm_transaction::svm_message::SVMMessage,
     solana_type_overrides::sync::{Arc, RwLock},
-    std::collections::{HashMap, HashSet},
+    std::collections::HashMap,
     test_case::test_case,
 };
 
@@ -875,7 +875,6 @@ fn execute_test_entry(test_entry: SvmTestEntry) {
     let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(
         EXECUTION_SLOT,
         EXECUTION_EPOCH,
-        HashSet::new(),
     );
 
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
@@ -1062,7 +1061,6 @@ fn svm_inspect_account() {
     let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(
         EXECUTION_SLOT,
         EXECUTION_EPOCH,
-        HashSet::new(),
     );
 
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));


### PR DESCRIPTION
#### Problem
The `builtin_ids` parameter of `TransactionBatchProcessor::new_uninitialized` is never used. Whenever a builtin program is added to a new `TransactionBatchProcessor` instance, the set of IDs is updated.

Therefore, when creating a new, uninitialized processor, this argument should not be required.

#### Summary of Changes
Drop `builtin_ids` from `TransactionBatchProcessor::new_uninitialized`.

Note: Builds on the back of #3170.
