### PR TITLE
Supports accounts lt hash in ledger-tool

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -345,6 +345,8 @@ pub fn get_accounts_db_config(
         create_ancient_storage,
         storage_access,
         scan_filter_for_shrinking,
+        enable_experimental_accumulator_hash: arg_matches
+            .is_present("accounts_db_experimental_accumulator_hash"),
         ..AccountsDbConfig::default()
     }
 }


### PR DESCRIPTION
#### Problem

I added `--accounts-db-experimental-accumulator-hash` back in #3060, but forgot to actually wire it up in ledger-tool.


#### Summary of Changes

Actually *use* `--accounts-db-experimental-accumulator-hash` in ledger-tool.