### PR TITLE
move account_utils to account crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5652,8 +5652,10 @@ dependencies = [
  "solana-account",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-instruction",
  "solana-logger",
  "solana-program",
+ "solana-pubkey",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4712,6 +4712,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
+ "solana-instruction",
  "solana-program",
 ]
 

--- a/sdk/account/Cargo.toml
+++ b/sdk/account/Cargo.toml
@@ -17,14 +17,16 @@ serde_bytes = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-instruction = { workspace = true, optional = true }
 solana-logger = { workspace = true, optional = true }
 solana-program = { workspace = true }
 
 [dev-dependencies]
 solana-account = { path = ".", features = ["dev-context-only-utils"] }
+solana-pubkey = { workspace = true }
 
 [features]
-bincode = ["dep:bincode", "serde"]
+bincode = ["dep:bincode", "dep:solana-instruction", "serde"]
 dev-context-only-utils = ["bincode", "dep:qualifier_attr"]
 frozen-abi = [
     "dep:solana-frozen-abi",

--- a/sdk/account/src/lib.rs
+++ b/sdk/account/src/lib.rs
@@ -29,6 +29,8 @@ use {
         sync::Arc,
     },
 };
+#[cfg(feature = "bincode")]
+pub mod state_traits;
 
 /// An Account with data that is stored on chain
 #[repr(C)]

--- a/sdk/account/src/state_traits.rs
+++ b/sdk/account/src/state_traits.rs
@@ -1,9 +1,9 @@
 //! Useful extras for `Account` state.
 
 use {
-    crate::instruction::InstructionError,
+    crate::{Account, AccountSharedData},
     bincode::ErrorKind,
-    solana_account::{Account, AccountSharedData},
+    solana_instruction::error::InstructionError,
     std::cell::Ref,
 };
 
@@ -64,7 +64,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::pubkey::Pubkey, solana_account::AccountSharedData};
+    use {
+        super::*,
+        solana_account::{state_traits::StateMut, AccountSharedData},
+        solana_pubkey::Pubkey,
+    };
 
     #[test]
     fn test_account_state() {

--- a/sdk/account/src/state_traits.rs
+++ b/sdk/account/src/state_traits.rs
@@ -64,11 +64,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        solana_account::{state_traits::StateMut, AccountSharedData},
-        solana_pubkey::Pubkey,
-    };
+    use {super::*, solana_pubkey::Pubkey};
 
     #[test]
     fn test_account_state() {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -58,7 +58,6 @@ pub use solana_program::{
 };
 #[cfg(feature = "borsh")]
 pub use solana_program::{borsh, borsh0_10, borsh1};
-pub mod account_utils;
 pub mod client;
 pub mod commitment_config;
 pub mod compute_budget;
@@ -108,6 +107,11 @@ pub mod wasm;
 
 #[deprecated(since = "2.1.0", note = "Use `solana-account` crate instead")]
 pub use solana_account as account;
+#[deprecated(
+    since = "2.1.0",
+    note = "Use `solana_account::state_traits` crate instead"
+)]
+pub use solana_account::state_traits as account_utils;
 #[deprecated(since = "2.1.0", note = "Use `solana-bn254` crate instead")]
 pub use solana_bn254 as alt_bn128;
 #[deprecated(since = "2.1.0", note = "Use `solana-decode-error` crate instead")]


### PR DESCRIPTION
#### Problem
solana_sdk::account_utils imposes a solana_sdk dep on solana-rpc-client-nonce-utils

#### Summary of Changes
Move it to a a new module `state_traits` in solana-account under the "bincode" feature
