### PR TITLE
fix doc link in solana-epoch-schedule

### DIFF
--- a/sdk/epoch-schedule/src/lib.rs
+++ b/sdk/epoch-schedule/src/lib.rs
@@ -10,6 +10,8 @@
 //! though the length of an epoch does &mdash; during the initial launch of
 //! the chain there is a "warmup" period, where epochs are short, with subsequent
 //! epochs increasing in slots until they last for [`DEFAULT_SLOTS_PER_EPOCH`].
+//! 
+//! [`DEFAULT_SLOTS_PER_EPOCH`]: https://docs.rs/solana-clock/latest/solana_clock/constant.DEFAULT_SLOTS_PER_EPOCH.html
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![no_std]
 #[cfg(feature = "frozen-abi")]

--- a/sdk/epoch-schedule/src/lib.rs
+++ b/sdk/epoch-schedule/src/lib.rs
@@ -10,7 +10,7 @@
 //! though the length of an epoch does &mdash; during the initial launch of
 //! the chain there is a "warmup" period, where epochs are short, with subsequent
 //! epochs increasing in slots until they last for [`DEFAULT_SLOTS_PER_EPOCH`].
-//! 
+//!
 //! [`DEFAULT_SLOTS_PER_EPOCH`]: https://docs.rs/solana-clock/latest/solana_clock/constant.DEFAULT_SLOTS_PER_EPOCH.html
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![no_std]


### PR DESCRIPTION
Fixing this warning:

```
warning: public documentation for `solana_epoch_schedule` links to private item `DEFAULT_SLOTS_PER_EPOCH`
  --> sdk/epoch-schedule/src/lib.rs:12:54
   |
12 | //! epochs increasing in slots until they last for [`DEFAULT_SLOTS_PER_EPOCH`].
   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^ this item is private
   |
   = note: this link will resolve properly if you pass `--document-private-items`
   = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default
```