### PR TITLE
Add popcnt target feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(any(target_arch="x86", target_arch="x86_64"))']
+rustflags = ["-C", "target-feature=+popcnt"]

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ target/
 /test-ledger/
 
 **/*.rs.bk
-.cargo
 
 /config/
 


### PR DESCRIPTION
#### Problem
Without popcnt feature the bitwise operations will use the standard library implementation instead of the hardware supported popcnt instruction.

Instances where it will affect:
```
bloom/src/bloom.rs:223:        let num_bits_set = bits.iter().map(|x| x.count_ones() as u64).sum();
core/src/banking_stage/transaction_scheduler/thread_aware_account_locks.rs:394:        self.0.count_ones()
core/src/banking_stage/transaction_scheduler/thread_aware_account_locks.rs:399:        (self.num_threads() == 1).then_some(self.0.trailing_zeros() as ThreadId)
```

On x86 [popcnt](https://en.wikipedia.org/wiki/X86_Bit_manipulation_instruction_set) is a single instruction but without this target-feature rustc will generate something like this: (https://godbolt.org/z/69oc98chW)

```asm
; Without the patch
example::count1::h62041e16c115ac6a:
        mov     eax, edi
        shr     eax
        and     eax, 1431655765
        sub     edi, eax
        mov     eax, edi
        and     eax, 858993459
        shr     edi, 2
        and     edi, 858993459
        add     edi, eax
        mov     eax, edi
        shr     eax, 4
        add     eax, edi
        and     eax, 252645135
        imul    eax, eax, 16843009
        shr     eax, 24
        ret

; With the patch
example::count1:
 popcnt eax,edi
 ret
```

#### Summary of Changes

Add target-feature popcnt to generate single instruction for popcnt, count leading zeros etc.

