### PR TITLE
accounts-index: allow evicting refcount=2 entries from in-memory index (wip)

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1036,9 +1036,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     } else {
                         // Evict when ref_count == 1 or slot is more than one epoch old when ref_count = 2
                         if slot_list.len() == 1
-                            && (ref_count == 2
-                                && current_slot.saturating_sub(oldest_slot)
-                                    > solana_sdk::epoch_schedule::DEFAULT_SLOTS_PER_EPOCH)
+                            && (ref_count == 1
+                                || (ref_count == 2
+                                    && current_slot.saturating_sub(oldest_slot)
+                                        > solana_sdk::epoch_schedule::DEFAULT_SLOTS_PER_EPOCH))
                         {
                             (true, Some(slot_list))
                         } else {

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1283,10 +1283,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                                     // If the entry *was* updated, re-mark it as dirty then
                                     // skip to the next pubkey/entry.
                                     let ref_count = v.ref_count();
-                                    if ref_count != 1 || slot_list.len() != 1 {
-                                        v.set_dirty(true);
-                                        break;
-                                    }
                                     disk.try_write(
                                         &k,
                                         (


### PR DESCRIPTION
#### Problem

When skip rewrites and ancient storage is on, we are seeing that there are much
more ref_count=2 entries in in-memory index.  

So instead of only flushing ref_count=1 index entries to disk, this PR allows
to flush ref-count=2 index entries, if they contains a slot that's more than
one epoch old.

#### Summary of Changes

- Evict ref_count=2 index entry if they contains a slot that's more than one
  epoch old.
- Change disk index to allow single_slot_ref_2 entry to be stored in index bucket.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
