### PR TITLE
Supports rehashing with accounts lt hash

### DIFF
--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -2,7 +2,7 @@ use {
     super::Bank,
     rayon::prelude::*,
     solana_accounts_db::accounts_db::AccountsDb,
-    solana_lattice_hash::lt_hash::{Checksum as LtChecksum, LtHash},
+    solana_lattice_hash::lt_hash::LtHash,
     solana_measure::{meas_dur, measure::Measure},
     solana_sdk::{
         account::{accounts_equal, AccountSharedData},
@@ -29,12 +29,11 @@ impl Bank {
     /// - mix in its current state
     ///
     /// Since this function is non-idempotent, it should only be called once per bank.
-    pub fn update_accounts_lt_hash(&self) -> LtChecksum {
+    pub fn update_accounts_lt_hash(&self) {
         debug_assert!(self.is_accounts_lt_hash_enabled());
         let delta_lt_hash = self.calculate_delta_lt_hash();
         let mut accounts_lt_hash = self.accounts_lt_hash.lock().unwrap();
         accounts_lt_hash.0.mix_in(&delta_lt_hash);
-        accounts_lt_hash.0.checksum()
     }
 
     /// Calculates the lt hash *of only this slot*

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -930,19 +930,7 @@ fn bank_to_full_snapshot_archive_with(
         .accounts_db
         .set_latest_full_snapshot_slot(bank.slot());
     bank.squash(); // Bank may not be a root
-
-    // Rehashing is not currently supported when the accounts lt hash is enabled.
-    // This is because rehashing will *re-mix-in* all the accounts stored in this bank into the
-    // accounts lt hash!  This is incorrect, as the accounts lt hash would change, even if the bank
-    // was *not* manually modified by the caller.
-    // We can re-allow rehasing if we change the Bank to hold its parent's accounts lt hash plus a
-    // *delta* accounts lt hash, and then Bank::hash_internal_state() will only recalculate the
-    // delta accounts lt hash.
-    // Another option is to consider if manual modification should even be allowed in the first
-    // place. Disallowing it would solve these issues.
-    if !bank.is_accounts_lt_hash_enabled() {
-        bank.rehash(); // Bank accounts may have been manually modified by the caller
-    }
+    bank.rehash(); // Bank may have been manually modified by the caller
     bank.force_flush_accounts_cache();
     bank.clean_accounts();
     let calculated_accounts_hash =
@@ -1005,11 +993,7 @@ pub fn bank_to_incremental_snapshot_archive(
         .accounts_db
         .set_latest_full_snapshot_slot(full_snapshot_slot);
     bank.squash(); // Bank may not be a root
-
-    // See the comment in bank_to_full_snapshot_archive() when calling rehash()
-    if !bank.is_accounts_lt_hash_enabled() {
-        bank.rehash(); // Bank accounts may have been manually modified by the caller
-    }
+    bank.rehash(); // Bank may have been manually modified by the caller
     bank.force_flush_accounts_cache();
     bank.clean_accounts();
     let calculated_incremental_accounts_hash =


### PR DESCRIPTION
#### Problem

In #3123 we had to skip rehashing if the accounts lt hash was enabled. Now that #3180 is merged, we can remove this restriction.


#### Summary of Changes

Move updating the accounts lt hash *outside* of Bank::hash_internal_state(). Since rehash() calls hash_internal_state(), and we're guaranteed no accounts have been modified, then we are also guaranteed the already-computed accounts lt hash is still correct.