### PR TITLE
track zero lamport accounts 

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -84,15 +84,6 @@ impl AccountStorage {
         self.get_slot_storage_entry_shrinking_in_progress_ok(slot)
     }
 
-    /// return the append vec for 'slot' if it exists.
-    ///
-    /// Warning: This is the 'unsafe' version of `get_slot_storage_entry`. It
-    /// means that you could get an old storage entry if a shrink is in
-    /// progress. Any update to the storage could by lost.
-    pub fn get_slot_storage_entry_no_check(&self, slot: Slot) -> Option<Arc<AccountStorageEntry>> {
-        self.get_slot_storage_entry_shrinking_in_progress_ok(slot)
-    }
-
     pub(crate) fn replace_storage_with_equivalent(
         &self,
         slot: Slot,

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -84,6 +84,15 @@ impl AccountStorage {
         self.get_slot_storage_entry_shrinking_in_progress_ok(slot)
     }
 
+    /// return the append vec for 'slot' if it exists.
+    ///
+    /// Warning: This is the 'unsafe' version of `get_slot_storage_entry`. It
+    /// means that you could get an old storage entry if a shrink is in
+    /// progress. Any update to the storage could by lost.
+    pub fn get_slot_storage_entry_no_check(&self, slot: Slot) -> Option<Arc<AccountStorageEntry>> {
+        self.get_slot_storage_entry_shrinking_in_progress_ok(slot)
+    }
+
     pub(crate) fn replace_storage_with_equivalent(
         &self,
         slot: Slot,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1268,19 +1268,19 @@ impl AccountStorageEntry {
 
     /// Return true if offset is "new" and inserted successfully. Otherwise,
     /// return false if the offset exits already.
-    pub fn insert_zero_lamport_single_ref_account_offset(&self, offset: usize) -> bool {
+    fn insert_zero_lamport_single_ref_account_offset(&self, offset: usize) -> bool {
         let mut zero_lamport_single_ref_offsets =
             self.zero_lamport_single_ref_offsets.write().unwrap();
         zero_lamport_single_ref_offsets.insert(offset)
     }
 
     /// Return the number of zero_lamport_single_ref accounts in the storage.
-    pub fn zero_lamport_single_ref_account_len(&self) -> usize {
+    fn zero_lamport_single_ref_account_len(&self) -> usize {
         self.zero_lamport_single_ref_offsets.read().unwrap().len()
     }
 
     /// Return the "alive_bytes" minus "zero_lamport_single_ref_accounts bytes".
-    pub fn alive_bytes_exclude_zero_lamport_single_ref_accounts(&self) -> usize {
+    fn alive_bytes_exclude_zero_lamport_single_ref_accounts(&self) -> usize {
         let zero_lamport_dead_bytes = self.accounts.dead_bytes_due_to_zero_lamport_single_ref(
             self.zero_lamport_single_ref_offsets.read().unwrap().len(),
         );

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1281,9 +1281,9 @@ impl AccountStorageEntry {
 
     /// Return the "alive_bytes" minus "zero_lamport_single_ref_accounts bytes".
     fn alive_bytes_exclude_zero_lamport_single_ref_accounts(&self) -> usize {
-        let zero_lamport_dead_bytes = self.accounts.dead_bytes_due_to_zero_lamport_single_ref(
-            self.zero_lamport_single_ref_offsets.read().unwrap().len(),
-        );
+        let zero_lamport_dead_bytes = self
+            .accounts
+            .dead_bytes_due_to_zero_lamport_single_ref(self.num_zero_lamport_single_ref_accounts());
         self.alive_bytes().saturating_sub(zero_lamport_dead_bytes)
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -13754,11 +13754,11 @@ pub mod tests {
                 pubkeys.iter(),
                 |_pubkey, slots_refs, _entry| {
                     let (slot_list, ref_count) = slots_refs.unwrap();
-                    assert!(slot_list.len() == 1);
-                    assert!(ref_count == 1);
+                    assert_eq!(slot_list.len(), 1);
+                    assert_eq!(ref_count, 1);
 
                     let (slot, acct_info) = slot_list.first().unwrap();
-                    assert!(*slot == 0);
+                    assert_eq!(*slot, 0);
                     accounts_db.zero_lamport_single_ref_found(*slot, acct_info.offset());
                     AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
                 },

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -14325,7 +14325,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_shrink_unref_handle_zero_single_ref_accounts() {
+    fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
         let db = AccountsDb::new_single_for_tests();
         let epoch_schedule = EpochSchedule::default();
         let account_key1 = Pubkey::new_unique();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8643,10 +8643,6 @@ impl AccountsDb {
                                     .for_each(|k| {
                                         rent_paying_accounts_by_partition.add_account(k);
                                     });
-                                let mut zero_pubkeys = zero_pubkeys.lock().unwrap();
-                                zero_pubkeys_this_slot.into_iter().for_each(|k| {
-                                    zero_pubkeys.insert(k);
-                                });
                             }
                             total_including_duplicates_sum += total_this_slot;
                             accounts_data_len_sum += accounts_data_len_this_slot;
@@ -8654,6 +8650,10 @@ impl AccountsDb {
                                 all_accounts_are_zero_lamports_slots_inner += 1;
                                 all_zeros_slots_inner.push((*slot, Arc::clone(&storage)));
                             }
+                            let mut zero_pubkeys = zero_pubkeys.lock().unwrap();
+                            zero_pubkeys_this_slot.into_iter().for_each(|k| {
+                                zero_pubkeys.insert(k);
+                            });
 
                             insert_us
                         } else {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -14283,7 +14283,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_clean_drop_dead_storage_handle_zero_single_ref_accounts() {
+    fn test_clean_drop_dead_storage_handle_zero_lamport_single_ref_accounts() {
         let db = AccountsDb::new_single_for_tests();
         let account_key1 = Pubkey::new_unique();
         let account_key2 = Pubkey::new_unique();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8437,8 +8437,10 @@ impl AccountsDb {
                 stored_size_alive += info.stored_size_aligned;
                 if info.index_info.lamports > 0 {
                     accounts_data_len += info.index_info.data_len;
-                    zero_pubkeys.push(info.index_info.pubkey);
                     all_accounts_are_zero_lamports = false;
+                } else {
+                    // zero lamport accounts
+                    zero_pubkeys.push(info.index_info.pubkey);
                 }
                 items_local.push(info.index_info);
             });

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -14262,7 +14262,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_clean_drop_dead_zero_single_ref_accounts() {
+    fn test_clean_drop_dead_zero_lamport_single_ref_accounts() {
         let accounts_db = AccountsDb::new_single_for_tests();
         let epoch_schedule = EpochSchedule::default();
         let key1 = Pubkey::new_unique();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8981,15 +8981,16 @@ impl AccountsDb {
         self.accounts_index.scan(
             pubkeys.iter(),
             |_pubkey, slots_refs, _entry| {
-                if let Some((slot_list, ref_count)) = slots_refs {
-                    if slot_list.len() == 1 && ref_count == 1 {
-                        if let Some((slot_alive, acct_info)) = slot_list.first() {
-                            if acct_info.is_zero_lamport() && !acct_info.is_cached() {
-                                count += 1;
-                                self.zero_lamport_single_ref_found(*slot_alive, acct_info.offset());
-                            }
-                        }
+                let (slot_list, ref_count) = slots_refs.unwrap();
+                if ref_count == 1 {
+                    assert_eq!(slot_list.len(), 1);
+                    let (slot_alive, acct_info) = slot_list.first().unwrap();
+                    assert!(!account_info.is_cached());
+                    if acct_info.is_zero_lamport() {
+                        count += 1;
+                        self.zero_lamport_single_ref_found(*slot_alive, acct_info.offset());
                     }
+                }
                 }
                 AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
             },

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1174,7 +1174,7 @@ pub struct AccountStorageEntry {
 
     /// offsets to accounts that are zero lamport single ref stored in this storage.
     /// These are still alive. But, shrink will be able to remove them.
-    zero_lamport_single_ref_offsets: RwLock<IntSet<usize>>,
+    zero_lamport_single_ref_offsets: RwLock<IntSet<Offset>>,
 }
 
 impl AccountStorageEntry {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -13775,7 +13775,7 @@ pub mod tests {
                 AccountsFileProvider::AppendVec => {
                     assert!(storage.alive_bytes_exclude_zero_lamport_single_ref_accounts() == 0);
                 }
-                _ => {
+                AccountsFileProvider::HotStorage => {
                     // For tired-storage, alive bytes are only an approximation.
                     // Therefore, it won't be zero.
                     assert!(

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -14365,7 +14365,7 @@ pub mod tests {
             1
         );
         // And now, slot 1 should be marked complete dead, which will be added
-        // to uncleaned slots, which handle dropping dead storage. And it WON"T
+        // to uncleaned slots, which handle dropping dead storage. And it WON'T
         // be participating shrinking in the next round.
         assert!(db.accounts_index.clone_uncleaned_roots().contains(&1));
         assert!(!db.shrink_candidate_slots.lock().unwrap().contains(&1));

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3800,6 +3800,10 @@ impl AccountsDb {
                             .num_slots_with_zero_lamport_accounts_added_to_shrink
                             .fetch_add(1, Ordering::Relaxed);
                     }
+                } else {
+                    self.shrink_stats
+                        .marking_zero_dead_accounts_in_non_shrinkable_store
+                        .fetch_add(1, Ordering::Relaxed);
                 }
             }
         }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -694,7 +694,7 @@ struct SlotIndexGenerationInfo {
     accounts_data_len: u64,
     amount_to_top_off_rent: u64,
     rent_paying_accounts_by_partition: Vec<Pubkey>,
-    zero_pubkeys: Vec<Pubkey>,
+    zero_lamport_pubkeys: Vec<Pubkey>,
     all_accounts_are_zero_lamports: bool,
 }
 
@@ -8428,7 +8428,7 @@ impl AccountsDb {
         let mut num_accounts_rent_paying = 0;
         let mut amount_to_top_off_rent = 0;
         let mut stored_size_alive = 0;
-        let mut zero_pubkeys = vec![];
+        let mut zero_lamport_pubkeys = vec![];
         let mut all_accounts_are_zero_lamports = true;
 
         let (dirty_pubkeys, insert_time_us, mut generate_index_results) = {
@@ -8440,7 +8440,7 @@ impl AccountsDb {
                     all_accounts_are_zero_lamports = false;
                 } else {
                     // zero lamport accounts
-                    zero_pubkeys.push(info.index_info.pubkey);
+                    zero_lamport_pubkeys.push(info.index_info.pubkey);
                 }
                 items_local.push(info.index_info);
             });
@@ -8525,7 +8525,7 @@ impl AccountsDb {
             accounts_data_len,
             amount_to_top_off_rent,
             rent_paying_accounts_by_partition,
-            zero_pubkeys,
+            zero_lamport_pubkeys,
             all_accounts_are_zero_lamports,
         }
     }
@@ -8621,7 +8621,7 @@ impl AccountsDb {
                                 amount_to_top_off_rent: amount_to_top_off_rent_this_slot,
                                 rent_paying_accounts_by_partition:
                                     rent_paying_accounts_by_partition_this_slot,
-                                zero_pubkeys: zero_pubkeys_this_slot,
+                                zero_lamport_pubkeys: zero_pubkeys_this_slot,
                                 all_accounts_are_zero_lamports,
                             } = self.generate_index_for_slot(
                                 &storage,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3764,7 +3764,7 @@ impl AccountsDb {
     }
 
     /// This function handles the case when zero lamport single ref accounts are found during shrink.
-    pub(crate) fn zero_lamport_single_ref_found(&self, slot: Slot, offset: usize) {
+    pub(crate) fn zero_lamport_single_ref_found(&self, slot: Slot, offset: Offset) {
         // This function can be called when a zero lamport single ref account is
         // found during shrink. Therefore, we can't use the safe version of
         // `get_slot_storage_entry` because shrink_in_progress map may not be

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -13773,7 +13773,10 @@ pub mod tests {
             // assert the "alive_bytes_exclude_zero_lamport_single_ref_accounts"
             match accounts_db.accounts_file_provider {
                 AccountsFileProvider::AppendVec => {
-                    assert!(storage.alive_bytes_exclude_zero_lamport_single_ref_accounts() == 0);
+                    assert_eq!(
+                        storage.alive_bytes_exclude_zero_lamport_single_ref_accounts(),
+                        0
+                    );
                 }
                 AccountsFileProvider::HotStorage => {
                     // For tired-storage, alive bytes are only an approximation.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8938,6 +8938,7 @@ impl AccountsDb {
 
     /// Visit zero lamport pubkeys and populate zero_lamport_single_ref info on
     /// storage.
+    /// Returns the number of zero lamport single ref accounts found.
     fn visit_zero_pubkeys_during_startup(&self, pubkeys: &HashSet<Pubkey>) -> u64 {
         let mut count = 0;
         self.accounts_index.scan(

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3772,7 +3772,7 @@ impl AccountsDb {
                     // all accounts in this storage can be dead
                     self.accounts_index.add_uncleaned_roots([slot]);
                     self.shrink_stats
-                        .adding_dead_slots_to_clean
+                        .num_dead_slots_added_to_clean
                         .fetch_add(1, Ordering::Relaxed);
                 } else if Self::is_shrinking_productive(&store)
                     && self.is_candidate_for_shrink(&store)
@@ -3780,7 +3780,7 @@ impl AccountsDb {
                     // this store might be eligible for shrinking now
                     self.shrink_candidate_slots.lock().unwrap().insert(slot);
                     self.shrink_stats
-                        .adding_shrink_slots_from_zeros
+                        .num_slots_with_zero_lamport_accounts_added_to_shrink
                         .fetch_add(1, Ordering::Relaxed);
                 } else {
                     self.shrink_stats

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8984,13 +8984,12 @@ impl AccountsDb {
                 let (slot_list, ref_count) = slots_refs.unwrap();
                 if ref_count == 1 {
                     assert_eq!(slot_list.len(), 1);
-                    let (slot_alive, acct_info) = slot_list.first().unwrap();
+                    let (slot_alive, account_info) = slot_list.first().unwrap();
                     assert!(!account_info.is_cached());
-                    if acct_info.is_zero_lamport() {
+                    if account_info.is_zero_lamport() {
                         count += 1;
-                        self.zero_lamport_single_ref_found(*slot_alive, acct_info.offset());
+                        self.zero_lamport_single_ref_found(*slot_alive, account_info.offset());
                     }
-                }
                 }
                 AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
             },

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9671,7 +9671,7 @@ pub mod tests {
         let append_vec = db.create_and_insert_store(slot0, 1000, "test");
         let account = AccountSharedData::default();
 
-        let data = vec![(&pubkey, &account)];
+        let data = [(&pubkey, &account)];
         let storable_accounts = (slot0, &data[..]);
         append_vec.accounts.append_accounts(&storable_accounts, 0);
         let genesis_config = GenesisConfig::default();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -13771,14 +13771,18 @@ pub mod tests {
             assert_eq!(storage.num_zero_lamport_single_ref_accounts(), num_keys);
 
             // assert the "alive_bytes_exclude_zero_lamport_single_ref_accounts"
-            if accounts_db.accounts_file_provider == AccountsFileProvider::AppendVec {
-                assert!(storage.alive_bytes_exclude_zero_lamport_single_ref_accounts() == 0);
-            } else {
-                // For tired-storage, alive bytes are only an approximation.
-                // Therefore, it won't be zero.
-                assert!(
-                    storage.alive_bytes_exclude_zero_lamport_single_ref_accounts() < alive_bytes
-                );
+            match accounts_db.accounts_file_provider {
+                AccountsFileProvider::AppendVec => {
+                    assert!(storage.alive_bytes_exclude_zero_lamport_single_ref_accounts() == 0);
+                }
+                _ => {
+                    // For tired-storage, alive bytes are only an approximation.
+                    // Therefore, it won't be zero.
+                    assert!(
+                        storage.alive_bytes_exclude_zero_lamport_single_ref_accounts()
+                            < alive_bytes
+                    );
+                }
             }
         }
     );

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1275,7 +1275,7 @@ impl AccountStorageEntry {
     }
 
     /// Return the number of zero_lamport_single_ref accounts in the storage.
-    fn zero_lamport_single_ref_account_len(&self) -> usize {
+    fn num_zero_lamport_single_ref_accounts(&self) -> usize {
         self.zero_lamport_single_ref_offsets.read().unwrap().len()
     }
 
@@ -3764,7 +3764,7 @@ impl AccountsDb {
         if let Some(store) = self.storage.get_slot_storage_entry(slot) {
             if store.insert_zero_lamport_single_ref_account_offset(offset) {
                 // this wasn't previously marked as zero lamport single ref
-                if store.zero_lamport_single_ref_account_len() == store.count() {
+                if store.num_zero_lamport_single_ref_accounts() == store.count() {
                     // all accounts in this storage can be dead
                     self.accounts_index.add_uncleaned_roots([slot]);
                     self.shrink_stats
@@ -9677,7 +9677,7 @@ pub mod tests {
         assert_eq!(append_vec.accounts_count(), 1);
         assert_eq!(append_vec.count(), 1);
         assert_eq!(result.accounts_data_len, 0);
-        assert_eq!(1, append_vec.zero_lamport_single_ref_account_len());
+        assert_eq!(1, append_vec.num_zero_lamport_single_ref_accounts());
         assert_eq!(
             0,
             append_vec.alive_bytes_exclude_zero_lamport_single_ref_accounts()
@@ -13733,7 +13733,7 @@ pub mod tests {
             );
 
             // assert the number of zlsr accounts
-            assert_eq!(storage.zero_lamport_single_ref_account_len(), num_keys);
+            assert_eq!(storage.num_zero_lamport_single_ref_accounts(), num_keys);
 
             // assert the "alive_bytes_exclude_zero_lamport_single_ref_accounts"
             if accounts_db.accounts_file_provider == AccountsFileProvider::AppendVec {
@@ -14294,7 +14294,7 @@ pub mod tests {
         assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 1);
         assert_eq!(
             db.get_and_assert_single_storage(1)
-                .zero_lamport_single_ref_account_len(),
+                .num_zero_lamport_single_ref_accounts(),
             1
         );
         assert!(db.shrink_candidate_slots.lock().unwrap().contains(&1));
@@ -14337,7 +14337,7 @@ pub mod tests {
         assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 1);
         assert_eq!(
             db.get_and_assert_single_storage(1)
-                .zero_lamport_single_ref_account_len(),
+                .num_zero_lamport_single_ref_accounts(),
             1
         );
         // And now, slot 1 should be marked complete dead, which will be added

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -14385,7 +14385,7 @@ pub mod tests {
 
         // No stores should exist for slot 0 after clean
         assert_no_storages_at_slot(&db, 0);
-        // No store should exit for slot 1 too as it has only a zerolamport single ref account.
+        // No store should exit for slot 1 too as it has only a zero lamport single ref account.
         assert_no_storages_at_slot(&db, 1);
         // Store 2 should have a single account.
         assert_eq!(db.accounts_index.ref_count_from_storage(&account_key2), 1);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1267,7 +1267,7 @@ impl AccountStorageEntry {
     }
 
     /// Return true if offset is "new" and inserted successfully. Otherwise,
-    /// return false if the offset exits already.
+    /// return false if the offset exists already.
     fn insert_zero_lamport_single_ref_account_offset(&self, offset: usize) -> bool {
         let mut zero_lamport_single_ref_offsets =
             self.zero_lamport_single_ref_offsets.write().unwrap();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9693,7 +9693,7 @@ pub mod tests {
     });
 
     #[test]
-    fn test_generate_index_for_single_ref_zero_slot() {
+    fn test_generate_index_for_single_ref_zero_lamport_slot() {
         let db = AccountsDb::new_single_for_tests();
         let slot0 = 0;
         let pubkey = Pubkey::from([1; 32]);

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -400,6 +400,9 @@ pub struct ShrinkStats {
     pub num_ancient_slots_shrunk: AtomicU64,
     pub ancient_slots_added_to_shrink: AtomicU64,
     pub ancient_bytes_added_to_shrink: AtomicU64,
+    pub adding_dead_slots_to_clean: AtomicU64,
+    pub adding_shrink_slots_from_zeros: AtomicU64,
+    pub marking_zero_dead_accounts: AtomicU64,
 }
 
 impl ShrinkStats {
@@ -538,6 +541,22 @@ impl ShrinkStats {
                 (
                     "initial_candidates_count",
                     self.initial_candidates_count.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "adding_dead_slots_to_clean",
+                    self.adding_dead_slots_to_clean.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "adding_shrink_slots_from_zeros",
+                    self.adding_shrink_slots_from_zeros
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "marking_zero_dead_accounts",
+                    self.marking_zero_dead_accounts.swap(0, Ordering::Relaxed),
                     i64
                 ),
             );

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -563,7 +563,7 @@ impl ShrinkStats {
                     i64
                 ),
                 (
-                    "marking_zero_dead_accounts",
+                    "num_zero_lamport_single_ref_accounts_found",
                     self.num_zero_lamport_single_ref_accounts_found
                         .swap(0, Ordering::Relaxed),
                     i64

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -403,7 +403,7 @@ pub struct ShrinkStats {
     pub num_dead_slots_added_to_clean: AtomicU64,
     pub num_slots_with_zero_lamport_accounts_added_to_shrink: AtomicU64,
     pub marking_zero_dead_accounts_in_non_shrinkable_store: AtomicU64,
-    pub marking_zero_dead_accounts: AtomicU64,
+    pub num_zero_lamport_single_ref_accounts_found: AtomicU64,
 }
 
 impl ShrinkStats {
@@ -564,7 +564,8 @@ impl ShrinkStats {
                 ),
                 (
                     "marking_zero_dead_accounts",
-                    self.marking_zero_dead_accounts.swap(0, Ordering::Relaxed),
+                    self.num_zero_lamport_single_ref_accounts_found
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
             );

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -402,6 +402,7 @@ pub struct ShrinkStats {
     pub ancient_bytes_added_to_shrink: AtomicU64,
     pub num_dead_slots_added_to_clean: AtomicU64,
     pub num_slots_with_zero_lamport_accounts_added_to_shrink: AtomicU64,
+    pub marking_zero_dead_accounts_in_non_shrinkable_store: AtomicU64,
     pub marking_zero_dead_accounts: AtomicU64,
 }
 
@@ -552,6 +553,12 @@ impl ShrinkStats {
                 (
                     "num_slots_with_zero_lamport_accounts_added_to_shrink",
                     self.num_slots_with_zero_lamport_accounts_added_to_shrink
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "marking_zero_dead_accounts_in_non_shrinkable_store",
+                    self.marking_zero_dead_accounts_in_non_shrinkable_store
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -400,8 +400,8 @@ pub struct ShrinkStats {
     pub num_ancient_slots_shrunk: AtomicU64,
     pub ancient_slots_added_to_shrink: AtomicU64,
     pub ancient_bytes_added_to_shrink: AtomicU64,
-    pub adding_dead_slots_to_clean: AtomicU64,
-    pub adding_shrink_slots_from_zeros: AtomicU64,
+    pub num_dead_slots_added_to_clean: AtomicU64,
+    pub num_slots_with_zero_lamport_accounts_added_to_shrink: AtomicU64,
     pub marking_zero_dead_accounts: AtomicU64,
 }
 
@@ -544,13 +544,14 @@ impl ShrinkStats {
                     i64
                 ),
                 (
-                    "adding_dead_slots_to_clean",
-                    self.adding_dead_slots_to_clean.swap(0, Ordering::Relaxed),
+                    "num_dead_slots_added_to_clean",
+                    self.num_dead_slots_added_to_clean
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
-                    "adding_shrink_slots_from_zeros",
-                    self.adding_shrink_slots_from_zeros
+                    "num_slots_with_zero_lamport_accounts_added_to_shrink",
+                    self.num_slots_with_zero_lamport_accounts_added_to_shrink
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -98,6 +98,13 @@ impl AccountsFile {
         }
     }
 
+    pub(crate) fn dead_bytes_due_to_zero_lamport_single_ref(&self, count: usize) -> usize {
+        match self {
+            Self::AppendVec(av) => av.dead_bytes_due_to_zero_lamport_single_ref(count),
+            Self::TieredStorage(ts) => ts.dead_bytes_due_to_zero_lamport_single_ref(count),
+        }
+    }
+
     pub fn flush(&self) -> Result<()> {
         match self {
             Self::AppendVec(av) => av.flush(),

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -98,6 +98,8 @@ impl AccountsFile {
         }
     }
 
+    /// Return the total number of bytes of the zero lamport single ref accounts in the storage.
+    /// Those bytes are "dead" and can be shrunk away.
     pub(crate) fn dead_bytes_due_to_zero_lamport_single_ref(&self, count: usize) -> usize {
         match self {
             Self::AppendVec(av) => av.dead_bytes_due_to_zero_lamport_single_ref(count),

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -409,6 +409,10 @@ impl AppendVec {
         }
     }
 
+    pub fn dead_bytes_due_to_zero_lamport_single_ref(&self, count: usize) -> usize {
+        aligned_stored_size(0) * count
+    }
+
     pub fn flush(&self) -> Result<()> {
         match &self.backing {
             AppendVecFileBacking::Mmap(mmap_only) => {

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -164,6 +164,11 @@ impl TieredStorage {
         self.reader()
             .map_or(MAX_TIERED_STORAGE_FILE_SIZE, |reader| reader.capacity())
     }
+
+    pub fn dead_bytes_due_to_zero_lamport_single_ref(&self, count: usize) -> usize {
+        const ZERO_LAMPORT_ACCOUNT_SIZE: usize = 42; // approximately 42 bytes per zero lamport account
+        count * ZERO_LAMPORT_ACCOUNT_SIZE
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem

Implement the idea from the prototype https://github.com/anza-xyz/agave/pull/2865

Single-ref zero lamport accounts are special from other single-ref accounts. They can be treated as dead accounts, and dropped during shrink (thanks to the recently improvement of shrink). 

However, currently, we have no way to know if there are single ref zero lamport accounts before we shrink. Therefore, shrinking underestimates the potential byte-saving by using just the "alive bytes" on storage. And we are missing the opportunities to drop them in shrinking.

In this PR, we add tracking of single ref zero lamport account, when we unref the accounts. This info is stored on the StorageEntry. We can use this info to select candidate storage for shrinking better. 

#### Summary of Changes

1. add a field to store zero lamport single ref accounts' offset per storage.
1. track single ref zero lamport accounts during unref from clean/shrink.
1. use live_bytes - zero_lamport_single_ref bytes to populate shrink candidate.
1. ~~add all zero lamport accounts storage to clean at start up.~~ split off to #3196


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
