### PR TITLE
Avoid combining older slots with newer ones in ancient shrinking

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -34,9 +34,11 @@ const HIGH_SLOT_OFFSET: u64 = 100;
 /// ancient packing algorithm tuning per pass
 #[derive(Debug)]
 struct PackedAncientStorageTuning {
-    /// shrink enough of these ancient append vecs to realize this% of the total dead data that needs to be shrunk
-    /// Doing too much burns too much time and disk i/o.
-    /// Doing too little could cause us to never catch up and have old data accumulate.
+    /// Shrink enough of these ancient append vecs to realize this
+    /// percentage of the total dead data that needs to be shrunk
+    /// - shrinking too much, burns too much time and disk i/o,
+    /// - shrinking too little could cause us to never catch up,
+    ///   and have old data accumulate.
     percent_of_alive_shrunk_data: u64,
     /// number of ancient slots we should aim to have. If we have more than this, combine further.
     max_ancient_slots: usize,
@@ -340,8 +342,9 @@ impl AccountsDb {
         let tuning = PackedAncientStorageTuning {
             // only allow 10k slots old enough to be ancient
             max_ancient_slots: 10_000,
-            // re-combine/shrink 55% of the data savings this pass
-            percent_of_alive_shrunk_data: 55,
+            // Don't re-pack anything just to shrink.
+            // shrink_candidate_slots will handle these old storages.
+            percent_of_alive_shrunk_data: 0,
             ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
             can_randomly_shrink,
             max_resulting_storages: NonZeroU64::new(10).unwrap(),
@@ -3596,7 +3599,7 @@ pub mod tests {
         let tuning = PackedAncientStorageTuning {
             max_ancient_slots: 0,
             // re-combine/shrink 55% of the data savings this pass
-            percent_of_alive_shrunk_data: 55,
+            percent_of_alive_shrunk_data: 0,
             ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
             can_randomly_shrink: CAN_RANDOMLY_SHRINK_FALSE,
             ..default_tuning()
@@ -3786,7 +3789,7 @@ pub mod tests {
             // only allow 10k slots old enough to be ancient
             max_ancient_slots: 10_000,
             // re-combine/shrink 55% of the data savings this pass
-            percent_of_alive_shrunk_data: 55,
+            percent_of_alive_shrunk_data: 0,
             ideal_storage_size: NonZeroU64::new(1000).unwrap(),
             can_randomly_shrink: false,
             ..default_tuning()

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -3598,7 +3598,6 @@ pub mod tests {
         // combine normal append vec(s) into packed ancient append vec
         let tuning = PackedAncientStorageTuning {
             max_ancient_slots: 0,
-            // re-combine/shrink 55% of the data savings this pass
             percent_of_alive_shrunk_data: 0,
             ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
             can_randomly_shrink: CAN_RANDOMLY_SHRINK_FALSE,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -3787,7 +3787,6 @@ pub mod tests {
         let tuning = PackedAncientStorageTuning {
             // only allow 10k slots old enough to be ancient
             max_ancient_slots: 10_000,
-            // re-combine/shrink 55% of the data savings this pass
             percent_of_alive_shrunk_data: 0,
             ideal_storage_size: NonZeroU64::new(1000).unwrap(),
             can_randomly_shrink: false,


### PR DESCRIPTION
#### Problem

shrink_ancient_slots bundles ancient storages together without considering the relative age of slots for which they contain account data. The combined storage can contain account data for very old slots along with the data for more recent slots, thus making it more likely that the combined storage will have to be updated soon. More uniform storages w.r.t. to the age of slots they contain would less likely have to be updated when account data is overwritten in newer slots.

#### Summary of Changes

This change tweaks a tuning parameter that determines which ancient slots are eligible for shrinking, and, in the process, for combining into a larger storage.  Setting the `percent_of_alive_shrunk_data` parameter to 0, we effectively disable selecting old ancient slots for shrinking based only on their contribution of alive bytes to the combined storage alive bytes. These slots can still be picked up for shrinking when `shrink_candidate_slots` is called, but their storages won't be combined with the storages containing newer slots account data unless these older storages become small.