### PR TITLE
clean all zero storages at index generation time

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8771,12 +8771,7 @@ impl AccountsDb {
                     all_zero_slots_to_clean.len()
                 );
                 for (slot, storage) in all_zero_slots_to_clean {
-                    let old = self.dirty_stores.insert(slot, storage);
-                    if old.is_none() {
-                        warn!(
-                            "Expecting all zero slot {slot} exists in dirty_store, but it doesn't."
-                        );
-                    }
+                    self.dirty_stores.insert(slot, storage);
                     self.accounts_index.add_uncleaned_roots([slot]);
                 }
             }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8533,12 +8533,6 @@ impl AccountsDb {
                                         rent_paying_accounts_by_partition.add_account(k);
                                     });
                             }
-
-                            all_accounts_are_zero_lamports_slots.fetch_add(
-                                all_accounts_are_zero_lamports as u64,
-                                Ordering::Relaxed,
-                            );
-
                             total_including_duplicates_sum += total_this_slot;
                             accounts_data_len_sum += accounts_data_len_this_slot;
                             if all_accounts_are_zero_lamports {
@@ -8765,6 +8759,7 @@ impl AccountsDb {
                     accounts_data_len.load(Ordering::Relaxed)
                 );
 
+                // insert all zero lamport account storage into the dirty stores and add them into the uncleaned roots for clean to pick up
                 let all_zero_slots_to_clean = std::mem::take(all_zeros_slots.get_mut().unwrap());
                 info!(
                     "insert all zero slots to clean at startup {}",

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8301,7 +8301,7 @@ impl AccountsDb {
 
     fn generate_index_for_slot(
         &self,
-        storage: &AccountStorageEntry,
+        storage: &Arc<AccountStorageEntry>,
         slot: Slot,
         store_id: AccountsFileId,
         rent_collector: &RentCollector,
@@ -8317,6 +8317,7 @@ impl AccountsDb {
         let mut num_accounts_rent_paying = 0;
         let mut amount_to_top_off_rent = 0;
         let mut stored_size_alive = 0;
+        let mut all_accounts_are_zero_lamports = true;
 
         let (dirty_pubkeys, insert_time_us, mut generate_index_results) = {
             let mut items_local = Vec::default();
@@ -8324,9 +8325,18 @@ impl AccountsDb {
                 stored_size_alive += info.stored_size_aligned;
                 if info.index_info.lamports > 0 {
                     accounts_data_len += info.index_info.data_len;
+                    all_accounts_are_zero_lamports = false;
                 }
                 items_local.push(info.index_info);
             });
+
+            if all_accounts_are_zero_lamports {
+                // this whole slot can likely be marked dead and dropped. Clean
+                // has to determine that. There could be an older non-zero
+                // account for any of these zero lamport accounts.
+                self.dirty_stores.insert(slot, Arc::clone(storage));
+                self.accounts_index.add_uncleaned_roots([slot]);
+            }
             let items_len = items_local.len();
             let items = items_local.into_iter().map(|info| {
                 if let Some(amount_to_top_off_rent_this_account) = Self::stats_for_rent_payers(


### PR DESCRIPTION
#### Problem

Split from https://github.com/anza-xyz/agave/pull/3188

We notice there are all zero account storages when we generate index at startup. 

We should add them as candidates for "clean".


#### Summary of Changes

- Add all zero account storages to clean when we generate index.
- Add a stat for all zero account storages at start up.
- ~~Refactor to use local sum of stats before update the outer atomic stats~~


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
