### PR TITLE
ci: remove deprecated macos-12 image

### DIFF
--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-12
+          - macos-13
         target:
           - aarch64-apple-ios
           - x86_64-apple-ios


### PR DESCRIPTION
#### Problem

macos-12 is deprecated and will be removed soon: https://github.com/actions/runner-images/issues/10721

#### Summary of Changes

bump to macos-13