### PR TITLE
SVM: add `new` bootstrap method

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5141,23 +5141,22 @@ impl Bank {
             }
         }
 
-        let mut program_cache = self.transaction_processor.program_cache.write().unwrap();
-        program_cache.latest_root_slot = self.slot();
-        program_cache.latest_root_epoch = self.epoch();
-        program_cache.environments.program_runtime_v1 = Arc::new(
-            create_program_runtime_environment_v1(
-                &self.feature_set,
-                &self.compute_budget().unwrap_or_default(),
-                false, /* deployment */
-                false, /* debugging_features */
-            )
-            .unwrap(),
-        );
-        program_cache.environments.program_runtime_v2 =
-            Arc::new(create_program_runtime_environment_v2(
-                &self.compute_budget().unwrap_or_default(),
-                false, /* debugging_features */
-            ));
+        self.transaction_processor
+            .configure_program_runtime_environments(
+                Some(Arc::new(
+                    create_program_runtime_environment_v1(
+                        &self.feature_set,
+                        &self.compute_budget().unwrap_or_default(),
+                        false, /* deployment */
+                        false, /* debugging_features */
+                    )
+                    .unwrap(),
+                )),
+                Some(Arc::new(create_program_runtime_environment_v2(
+                    &self.compute_budget().unwrap_or_default(),
+                    false, /* debugging_features */
+                ))),
+            );
     }
 
     pub fn set_inflation(&self, inflation: Inflation) {

--- a/svm/examples/paytube/src/processor.rs
+++ b/svm/examples/paytube/src/processor.rs
@@ -47,23 +47,16 @@ pub(crate) fn create_transaction_batch_processor<CB: TransactionProcessingCallba
     // marked as "depoyed" in slot 0.
     // See `solana_svm::program_loader::load_program_with_pubkey` for more
     // details.
-    let processor = TransactionBatchProcessor::<PayTubeForkGraph>::new_uninitialized(
-        /* slot */ 1, /* epoch */ 1,
-    );
-
-    {
-        let mut cache = processor.program_cache.write().unwrap();
-
-        // Initialize the mocked fork graph.
-        cache.fork_graph = Some(Arc::downgrade(&fork_graph));
-
-        // Initialize a proper cache environment.
-        // (Use Loader v4 program to initialize runtime v2 if desired)
-        cache.environments.program_runtime_v1 = Arc::new(
+    let processor = TransactionBatchProcessor::<PayTubeForkGraph>::new(
+        /* slot */ 1,
+        /* epoch */ 1,
+        Arc::downgrade(&fork_graph),
+        Some(Arc::new(
             create_program_runtime_environment_v1(feature_set, compute_budget, false, false)
                 .unwrap(),
-        );
-    }
+        )),
+        None,
+    );
 
     // Add the system program builtin.
     processor.add_builtin(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -34,7 +34,11 @@ use {
         invoke_context::{EnvironmentConfig, InvokeContext},
         loaded_programs::{
             ForkGraph, ProgramCache, ProgramCacheEntry, ProgramCacheForTxBatch,
-            ProgramCacheMatchCriteria,
+            ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
+        },
+        solana_rbpf::{
+            program::{BuiltinProgram, FunctionRegistry},
+            vm::Config as VmConfig,
         },
         sysvar_cache::SysvarCache,
     },
@@ -61,6 +65,7 @@ use {
         collections::{hash_map::Entry, HashMap, HashSet},
         fmt::{Debug, Formatter},
         rc::Rc,
+        sync::Weak,
     },
 };
 
@@ -206,6 +211,42 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             program_cache: Arc::new(RwLock::new(ProgramCache::new(slot, epoch))),
             ..Self::default()
         }
+    }
+
+    /// Create a new `TransactionBatchProcessor`.
+    ///
+    /// The created processor's program cache is initialized with the provided
+    /// fork graph and loaders. If any loaders are omitted, a default "empty"
+    /// loader (no syscalls) will be used.
+    ///
+    /// The cache will still not contain any builtin programs. It's advisable to
+    /// call `add_builtin` to add the required builtins before using the processor.
+    pub fn new(
+        slot: Slot,
+        epoch: Epoch,
+        fork_graph: Weak<RwLock<FG>>,
+        program_runtime_environment_v1: Option<ProgramRuntimeEnvironment>,
+        program_runtime_environment_v2: Option<ProgramRuntimeEnvironment>,
+    ) -> Self {
+        let processor = Self::new_uninitialized(slot, epoch);
+        {
+            let empty_loader = || {
+                Arc::new(BuiltinProgram::new_loader(
+                    VmConfig::default(),
+                    FunctionRegistry::default(),
+                ))
+            };
+
+            let mut program_cache = processor.program_cache.write().unwrap();
+            program_cache.set_fork_graph(fork_graph);
+            program_cache.latest_root_slot = slot;
+            program_cache.latest_root_epoch = epoch;
+            program_cache.environments.program_runtime_v1 =
+                program_runtime_environment_v1.unwrap_or(empty_loader());
+            program_cache.environments.program_runtime_v2 =
+                program_runtime_environment_v2.unwrap_or(empty_loader());
+        }
+        processor
     }
 
     /// Create a new `TransactionBatchProcessor` from the current instance, but
@@ -1378,10 +1419,9 @@ mod tests {
     #[should_panic = "called load_program_with_pubkey() with nonexistent account"]
     fn test_replenish_program_cache_with_nonexistent_accounts() {
         let mock_bank = MockBankCallback::default();
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         let fork_graph = Arc::new(RwLock::new(TestForkGraph {}));
-        batch_processor.program_cache.write().unwrap().fork_graph =
-            Some(Arc::downgrade(&fork_graph));
+        let batch_processor =
+            TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None, None);
         let key = Pubkey::new_unique();
 
         let mut account_maps: HashMap<Pubkey, u64> = HashMap::new();
@@ -1393,10 +1433,9 @@ mod tests {
     #[test]
     fn test_replenish_program_cache() {
         let mock_bank = MockBankCallback::default();
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         let fork_graph = Arc::new(RwLock::new(TestForkGraph {}));
-        batch_processor.program_cache.write().unwrap().fork_graph =
-            Some(Arc::downgrade(&fork_graph));
+        let batch_processor =
+            TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None, None);
         let key = Pubkey::new_unique();
 
         let mut account_data = AccountSharedData::default();
@@ -1881,10 +1920,9 @@ mod tests {
     #[test]
     fn test_add_builtin() {
         let mock_bank = MockBankCallback::default();
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         let fork_graph = Arc::new(RwLock::new(TestForkGraph {}));
-        batch_processor.program_cache.write().unwrap().fork_graph =
-            Some(Arc::downgrade(&fork_graph));
+        let batch_processor =
+            TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None, None);
 
         let key = Pubkey::new_unique();
         let name = "a_builtin_name";

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -40,9 +40,9 @@ mod transaction_builder;
 
 fn program_cache_execution(threads: usize) {
     let mut mock_bank = MockBankCallback::default();
-    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(5, 5);
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
-    batch_processor.program_cache.write().unwrap().fork_graph = Some(Arc::downgrade(&fork_graph));
+    let batch_processor =
+        TransactionBatchProcessor::new(5, 5, Arc::downgrade(&fork_graph), None, None);
 
     let programs = vec![
         deploy_program("hello-solana".to_string(), 0, &mut mock_bank),


### PR DESCRIPTION
#### Problem
In order to properly configure a `TransactionBatchProcessor`, one must use the `new_unitialized` method to create a new batch processor whose program cache is uninitialized. Subsequently, users must obtain a write lock on the cache and update it with the necessary configs (fork graph, loaders).

It would be much easier and cleaner to offer a method on the `TransactionBatchProcessor` that can handle all of this setup in one go.

#### Summary of Changes
Introduce `TransactionBatchProcessor::new` for creating a new, fully initialized batch processor with the provided program-runtime configurations.