### PR TITLE
Tune ideal storage size based on total alive bytes and max ancient slots

### DIFF
--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -347,6 +347,7 @@ pub struct ShrinkAncientStats {
     pub slots_eligible_to_shrink: AtomicU64,
     pub total_dead_bytes: AtomicU64,
     pub total_alive_bytes: AtomicU64,
+    pub ideal_storage_size: AtomicU64,
 }
 
 #[derive(Debug, Default)]
@@ -770,6 +771,11 @@ impl ShrinkAncientStats {
                 self.shrink_stats
                     .accounts_not_found_in_index
                     .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "ideal_storage_size",
+                self.ideal_storage_size.swap(0, Ordering::Relaxed),
                 i64
             ),
         );

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -415,6 +415,9 @@ impl AccountsDb {
                 .max(MINUMAL_IDEAL_STORAGE_SIZE),
         )
         .unwrap();
+        self.shrink_ancient_stats
+            .ideal_storage_size
+            .store(tuning.ideal_storage_size.into(), Ordering::Relaxed);
 
         std::mem::swap(
             &mut *self.best_ancient_slots_to_shrink.write().unwrap(),
@@ -595,9 +598,6 @@ impl AccountsDb {
             })
             .count()
             .saturating_sub(randoms as usize);
-        self.shrink_ancient_stats
-            .ideal_storage_size
-            .store(tuning.ideal_storage_size.into(), Ordering::Relaxed);
         self.shrink_ancient_stats
             .slots_eligible_to_shrink
             .fetch_add(should_shrink_count as u64, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem

The size of storage files affects validator's performance.

#### Summary of Changes

Set the `ideal_storage_size` shrinking tuning parameter based on the total amount of alive bytes and the number of ancient storages, so that the size of each storage file is approximately 5M.

Adjust unit tests.