### PR TITLE
Fixes spurious failures in test_bank_update_sysvar_account

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3897,7 +3897,11 @@ fn test_bank_update_sysvar_account() {
     for pass in 0..5 {
         use sysvar::clock::Clock;
 
-        let dummy_clock_id = solana_sdk::pubkey::new_rand();
+        // This pubkey was chosen empirically.
+        // The test requires that the dummy clock id *not* be loaded for rent collection
+        // (since rent collection will update the rent epoch, thus causing the
+        // subsequent checks to fail spuriously).
+        let dummy_clock_id = Pubkey::from_str_const("64jsX5hwtsjsKR7eNcNU4yhgwjuXoU9KR2MpnV47iXXz");
         let dummy_rent_epoch = 44;
         let (mut genesis_config, _mint_keypair) = create_genesis_config(500);
 


### PR DESCRIPTION
#### Problem

Spurious failures in test_bank_update_sysvar_account(). See #3002 for more information.


#### Summary of Changes

Hardcode the pubkey to *not* have rent collection during the test.

Fixes #3002