### PR TITLE
Report ConsumeWorkerMetrics at slot transitions

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -183,8 +183,8 @@ impl ConsumeWorkerMetrics {
     /// a) (when a leader) Previous slot is not the same as current.
     /// b) (when not a leader) report the metrics accumulated so far.
     pub fn maybe_report_and_reset(&self, slot: Option<Slot>) {
+        let prev_slot_id: u64 = self.slot.load(Ordering::Relaxed);
         if let Some(slot) = slot {
-            let prev_slot_id: u64 = self.slot.load(Ordering::Relaxed);
             if slot != prev_slot_id {
                 if !self.has_data.swap(false, Ordering::Relaxed) {
                     return;
@@ -194,7 +194,7 @@ impl ConsumeWorkerMetrics {
                 self.error_metrics.report_and_reset(&self.id);
                 self.slot.swap(slot, Ordering::Relaxed);
             }
-        } else {
+        } else if prev_slot_id != 0 {
             self.count_metrics.report_and_reset(&self.id);
             self.timing_metrics.report_and_reset(&self.id);
             self.error_metrics.report_and_reset(&self.id);

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -425,6 +425,7 @@ struct ConsumeWorkerCountMetrics {
     cost_model_throttled_transactions_count: AtomicU64,
     min_prioritization_fees: AtomicU64,
     max_prioritization_fees: AtomicU64,
+    slot: AtomicU64,
 }
 
 impl Default for ConsumeWorkerCountMetrics {
@@ -438,6 +439,7 @@ impl Default for ConsumeWorkerCountMetrics {
             cost_model_throttled_transactions_count: AtomicU64::default(),
             min_prioritization_fees: AtomicU64::new(u64::MAX),
             max_prioritization_fees: AtomicU64::default(),
+            slot: AtomicU64::default(),
         }
     }
 }
@@ -491,6 +493,11 @@ impl ConsumeWorkerCountMetrics {
                 self.max_prioritization_fees.swap(0, Ordering::Relaxed),
                 i64
             ),
+            (
+                "slot",
+                self.slot.swap(0, Ordering::Relaxed),
+                i64
+            ),
         );
     }
 }
@@ -506,6 +513,7 @@ struct ConsumeWorkerTimingMetrics {
     find_and_send_votes_us: AtomicU64,
     wait_for_bank_success_us: AtomicU64,
     wait_for_bank_failure_us: AtomicU64,
+    slot: AtomicU64,
 }
 
 impl ConsumeWorkerTimingMetrics {
@@ -550,6 +558,11 @@ impl ConsumeWorkerTimingMetrics {
                 self.wait_for_bank_failure_us.swap(0, Ordering::Relaxed),
                 i64
             ),
+            (
+                "slot",
+                self.slot.swap(0, Ordering::Relaxed),
+                i64
+            ),
         );
     }
 }
@@ -580,6 +593,7 @@ struct ConsumeWorkerTransactionErrorMetrics {
     would_exceed_account_data_block_limit: AtomicUsize,
     max_loaded_accounts_data_size_exceeded: AtomicUsize,
     program_execution_temporarily_restricted: AtomicUsize,
+    slot: AtomicU64,
 }
 
 impl ConsumeWorkerTransactionErrorMetrics {
@@ -692,6 +706,11 @@ impl ConsumeWorkerTransactionErrorMetrics {
                 "would_exceed_max_vote_cost_limit",
                 self.would_exceed_max_vote_cost_limit
                     .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "slot",
+                self.slot.swap(0, Ordering::Relaxed),
                 i64
             ),
         );

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -198,6 +198,7 @@ impl ConsumeWorkerMetrics {
             self.count_metrics.report_and_reset(&self.id);
             self.timing_metrics.report_and_reset(&self.id);
             self.error_metrics.report_and_reset(&self.id);
+            self.slot.swap(0, Ordering::Relaxed);
         }
     }
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -140,7 +140,7 @@ impl<T: LikeClusterInfo> SchedulerController<T> {
                 .maybe_report_and_reset_interval(should_report);
             self.worker_metrics
                 .iter()
-                .for_each(|metrics| metrics.maybe_report_and_reset());
+                .for_each(|metrics| metrics.maybe_report_and_reset(new_leader_slot));
         }
 
         Ok(())


### PR DESCRIPTION
#### Problem
ConsumeWorkerMetrics are reported every 1s mostly for convenience. Having these metrics at
slot transitions is desirable.

#### Summary of Changes
- Save the slot# while reporting in order to track slot transitions.
- Remove the interval as it is not needed anymore.

```
Log from test-validator with solana airdrop

[2024-10-24T15:03:34.588387000Z INFO  solana_metrics::metrics] datapoint: banking_stage_worker_counts,id=2 transactions_attempted_processing_count=1i processed_transactions_count=1i processed_with_successful_result_count=1i retryable_transaction_count=0i retryable_expired_bank_count=0i cost_model_throttled_transactions_count=0i min_prioritization_fees=-1i max_prioritization_fees=0i slot=169i
[2024-10-24T15:03:34.588413000Z INFO  solana_metrics::metrics] datapoint: banking_stage_worker_timing,id=2 cost_model_us=28i collect_balances_us=48i load_execute_us=244i freeze_lock_us=0i record_us=58i commit_us=63i find_and_send_votes_us=44i wait_for_bank_success_us=2i wait_for_bank_failure_us=0i slot=169i
[2024-10-24T15:03:34.588430000Z INFO  solana_metrics::metrics] datapoint: banking_stage_worker_error_metrics,id=2 total=0i account_in_use=0i too_many_account_locks=0i account_loaded_twice=0i account_not_found=0i blockhash_not_found=0i blockhash_too_old=0i call_chain_too_deep=0i already_processed=0i instruction_error=0i insufficient_funds=0i invalid_account_for_fee=0i invalid_account_index=0i invalid_program_for_execution=0i invalid_compute_budget=0i not_allowed_during_cluster_maintenance=0i invalid_writable_account=0i invalid_rent_paying_account=0i would_exceed_max_block_cost_limit=0i would_exceed_max_account_cost_limit=0i would_exceed_max_vote_cost_limit=0i slot=169i
```

Fixes: #478