### PR TITLE
SVM: Clarify usage of `lamports_per_signature`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -150,27 +150,27 @@ impl BpfAllocator {
 
 pub struct EnvironmentConfig<'a> {
     pub blockhash: Hash,
+    pub blockhash_lamports_per_signature: u64,
     epoch_total_stake: Option<u64>,
     epoch_vote_accounts: Option<&'a VoteAccountsHashMap>,
     pub feature_set: Arc<FeatureSet>,
-    pub lamports_per_signature: u64,
     sysvar_cache: &'a SysvarCache,
 }
 impl<'a> EnvironmentConfig<'a> {
     pub fn new(
         blockhash: Hash,
+        blockhash_lamports_per_signature: u64,
         epoch_total_stake: Option<u64>,
         epoch_vote_accounts: Option<&'a VoteAccountsHashMap>,
         feature_set: Arc<FeatureSet>,
-        lamports_per_signature: u64,
         sysvar_cache: &'a SysvarCache,
     ) -> Self {
         Self {
             blockhash,
+            blockhash_lamports_per_signature,
             epoch_total_stake,
             epoch_vote_accounts,
             feature_set,
-            lamports_per_signature,
             sysvar_cache,
         }
     }
@@ -764,10 +764,10 @@ macro_rules! with_mock_invoke_context {
         });
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            0,
             None,
             None,
             Arc::new(FeatureSet::all_enabled()),
-            0,
             &sysvar_cache,
         );
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -4800,10 +4800,10 @@ mod tests {
         with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
+            0,
             Some(expected_total_stake),
             None, // Vote accounts are not needed for this test.
             Arc::<FeatureSet>::default(),
-            0,
             &sysvar_cache,
         );
 
@@ -4854,10 +4854,10 @@ mod tests {
         with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
+            0,
             None, // Total stake is not needed for this test.
             Some(&vote_accounts_map),
             Arc::<FeatureSet>::default(),
-            0,
             &sysvar_cache,
         );
 

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -56,7 +56,9 @@ pub fn advance_nonce_account(
             let new_data = nonce::state::Data::new(
                 data.authority,
                 next_durable_nonce,
-                invoke_context.environment_config.lamports_per_signature,
+                invoke_context
+                    .environment_config
+                    .blockhash_lamports_per_signature,
             );
             account.set_state(&Versions::new(State::Initialized(new_data)))
         }
@@ -185,7 +187,9 @@ pub fn initialize_nonce_account(
             let data = nonce::state::Data::new(
                 *nonce_authority,
                 durable_nonce,
-                invoke_context.environment_config.lamports_per_signature,
+                invoke_context
+                    .environment_config
+                    .blockhash_lamports_per_signature,
             );
             let state = State::Initialized(data);
             account.set_state(&Versions::new(state))
@@ -312,8 +316,9 @@ mod test {
         ($invoke_context:expr, $seed:expr) => {
             $invoke_context.environment_config.blockhash =
                 hash(&bincode::serialize(&$seed).unwrap());
-            $invoke_context.environment_config.lamports_per_signature =
-                ($seed as u64).saturating_mul(100);
+            $invoke_context
+                .environment_config
+                .blockhash_lamports_per_signature = ($seed as u64).saturating_mul(100);
         };
     }
 
@@ -350,7 +355,9 @@ mod test {
         let data = nonce::state::Data::new(
             data.authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.environment_config.lamports_per_signature,
+            invoke_context
+                .environment_config
+                .blockhash_lamports_per_signature,
         );
         // First nonce instruction drives state from Uninitialized to Initialized
         assert_eq!(versions.state(), &State::Initialized(data.clone()));
@@ -360,7 +367,9 @@ mod test {
         let data = nonce::state::Data::new(
             data.authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.environment_config.lamports_per_signature,
+            invoke_context
+                .environment_config
+                .blockhash_lamports_per_signature,
         );
         // Second nonce instruction consumes and replaces stored nonce
         assert_eq!(versions.state(), &State::Initialized(data.clone()));
@@ -370,7 +379,9 @@ mod test {
         let data = nonce::state::Data::new(
             data.authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.environment_config.lamports_per_signature,
+            invoke_context
+                .environment_config
+                .blockhash_lamports_per_signature,
         );
         // Third nonce instruction for fun and profit
         assert_eq!(versions.state(), &State::Initialized(data));
@@ -429,7 +440,9 @@ mod test {
         let data = nonce::state::Data::new(
             authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.environment_config.lamports_per_signature,
+            invoke_context
+                .environment_config
+                .blockhash_lamports_per_signature,
         );
         assert_eq!(versions.state(), &State::Initialized(data));
         // Nonce account did not sign
@@ -741,7 +754,9 @@ mod test {
         let data = nonce::state::Data::new(
             authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.environment_config.lamports_per_signature,
+            invoke_context
+                .environment_config
+                .blockhash_lamports_per_signature,
         );
         assert_eq!(versions.state(), &State::Initialized(data.clone()));
         let withdraw_lamports = 42;
@@ -770,7 +785,9 @@ mod test {
         let data = nonce::state::Data::new(
             data.authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.environment_config.lamports_per_signature,
+            invoke_context
+                .environment_config
+                .blockhash_lamports_per_signature,
         );
         assert_eq!(versions.state(), &State::Initialized(data));
         assert_eq!(nonce_account.get_lamports(), from_expect_lamports);
@@ -962,7 +979,9 @@ mod test {
         let data = nonce::state::Data::new(
             authorized,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.environment_config.lamports_per_signature,
+            invoke_context
+                .environment_config
+                .blockhash_lamports_per_signature,
         );
         assert_eq!(result, Ok(()));
         let versions = nonce_account.get_state::<Versions>().unwrap();
@@ -1031,7 +1050,9 @@ mod test {
         let data = nonce::state::Data::new(
             authority,
             DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash),
-            invoke_context.environment_config.lamports_per_signature,
+            invoke_context
+                .environment_config
+                .blockhash_lamports_per_signature,
         );
         authorize_nonce_account(&mut nonce_account, &authority, &signers, &invoke_context).unwrap();
         let versions = nonce_account.get_state::<Versions>().unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3716,7 +3716,7 @@ impl Bank {
             epoch_total_stake: Some(self.get_current_epoch_total_stake()),
             epoch_vote_accounts: Some(self.get_current_epoch_vote_accounts()),
             feature_set: Arc::clone(&self.feature_set),
-            fee_structure: Some(&self.fee_structure),
+            fee_lamports_per_signature: self.fee_structure.lamports_per_signature,
             lamports_per_signature,
             rent_collector: Some(&rent_collector_with_metrics),
         };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3708,16 +3708,17 @@ impl Bank {
         ));
         timings.saturating_add_in_place(ExecuteTimingType::CheckUs, check_us);
 
-        let (blockhash, lamports_per_signature) = self.last_blockhash_and_lamports_per_signature();
+        let (blockhash, blockhash_lamports_per_signature) =
+            self.last_blockhash_and_lamports_per_signature();
         let rent_collector_with_metrics =
             RentCollectorWithMetrics::new(self.rent_collector.clone());
         let processing_environment = TransactionProcessingEnvironment {
             blockhash,
+            blockhash_lamports_per_signature,
             epoch_total_stake: Some(self.get_current_epoch_total_stake()),
             epoch_vote_accounts: Some(self.get_current_epoch_vote_accounts()),
             feature_set: Arc::clone(&self.feature_set),
             fee_lamports_per_signature: self.fee_structure.lamports_per_signature,
-            lamports_per_signature,
             rent_collector: Some(&rent_collector_with_metrics),
         };
 

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -201,10 +201,10 @@ impl Bank {
                 &mut program_cache_for_tx_batch,
                 EnvironmentConfig::new(
                     Hash::default(),
+                    0,
                     None,
                     None,
                     self.feature_set.clone(),
-                    0,
                     &sysvar_cache,
                 ),
                 None,

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -546,11 +546,11 @@ impl JsonRpcRequestProcessor {
         let (blockhash, lamports_per_signature) = self.last_blockhash_and_lamports_per_signature();
         let processing_environment = TransactionProcessingEnvironment {
             blockhash,
+            blockhash_lamports_per_signature: lamports_per_signature,
             epoch_total_stake: self.epoch_total_stake(Epoch::default()),
             epoch_vote_accounts: self.epoch_vote_accounts(Epoch::default()),
             feature_set: Arc::clone(&bank.feature_set),
             fee_lamports_per_signature: lamports_per_signature,
-            lamports_per_signature,
             rent_collector: None,
         };
 

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -549,7 +549,7 @@ impl JsonRpcRequestProcessor {
             epoch_total_stake: self.epoch_total_stake(Epoch::default()),
             epoch_vote_accounts: self.epoch_vote_accounts(Epoch::default()),
             feature_set: Arc::clone(&bank.feature_set),
-            fee_structure: None,
+            fee_lamports_per_signature: lamports_per_signature,
             lamports_per_signature,
             rent_collector: None,
         };

--- a/svm/examples/paytube/src/lib.rs
+++ b/svm/examples/paytube/src/lib.rs
@@ -151,7 +151,7 @@ impl PayTubeChannel {
             epoch_total_stake: None,
             epoch_vote_accounts: None,
             feature_set: Arc::new(feature_set),
-            fee_structure: Some(&fee_structure),
+            fee_lamports_per_signature: fee_structure.lamports_per_signature,
             lamports_per_signature,
             rent_collector: Some(&rent_collector),
         };

--- a/svm/examples/paytube/src/lib.rs
+++ b/svm/examples/paytube/src/lib.rs
@@ -117,7 +117,6 @@ impl PayTubeChannel {
         let compute_budget = ComputeBudget::default();
         let feature_set = FeatureSet::all_enabled();
         let fee_structure = FeeStructure::default();
-        let lamports_per_signature = fee_structure.lamports_per_signature;
         let rent_collector = RentCollector::default();
 
         // PayTube loader/callback implementation.
@@ -148,11 +147,11 @@ impl PayTubeChannel {
         // Again, these can be configurable or hoisted from the cluster.
         let processing_environment = TransactionProcessingEnvironment {
             blockhash: Hash::default(),
+            blockhash_lamports_per_signature: fee_structure.lamports_per_signature,
             epoch_total_stake: None,
             epoch_vote_accounts: None,
             feature_set: Arc::new(feature_set),
             fee_lamports_per_signature: fee_structure.lamports_per_signature,
-            lamports_per_signature,
             rent_collector: Some(&rent_collector),
         };
 
@@ -177,7 +176,10 @@ impl PayTubeChannel {
         let results = processor.load_and_execute_sanitized_transactions(
             &account_loader,
             &svm_transactions,
-            get_transaction_check_results(svm_transactions.len(), lamports_per_signature),
+            get_transaction_check_results(
+                svm_transactions.len(),
+                fee_structure.lamports_per_signature,
+            ),
             &processing_environment,
             &processing_config,
         );

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -257,10 +257,10 @@ mod tests {
         let sysvar_cache = SysvarCache::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            0,
             None,
             None,
             Arc::new(FeatureSet::all_enabled()),
-            0,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -311,10 +311,10 @@ mod tests {
         ));
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            0,
             None,
             None,
             Arc::new(FeatureSet::all_enabled()),
-            0,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -355,10 +355,10 @@ mod tests {
         ));
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            0,
             None,
             None,
             Arc::new(FeatureSet::all_enabled()),
-            0,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -490,10 +490,10 @@ mod tests {
         let sysvar_cache = SysvarCache::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            0,
             None,
             None,
             Arc::new(FeatureSet::all_enabled()),
-            0,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -529,10 +529,10 @@ mod tests {
         ));
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            0,
             None,
             None,
             Arc::new(FeatureSet::all_enabled()),
-            0,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -565,10 +565,10 @@ mod tests {
         ));
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            0,
             None,
             None,
             Arc::new(FeatureSet::all_enabled()),
-            0,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -662,10 +662,10 @@ mod tests {
         );
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
+            0,
             None,
             None,
             Arc::new(FeatureSet::all_enabled()),
-            0,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -831,10 +831,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             program_cache_for_tx_batch,
             EnvironmentConfig::new(
                 environment.blockhash,
+                environment.blockhash_lamports_per_signature,
                 environment.epoch_total_stake,
                 environment.epoch_vote_accounts,
                 Arc::clone(&environment.feature_set),
-                environment.blockhash_lamports_per_signature,
                 sysvar_cache,
             ),
             log_collector.clone(),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -121,7 +121,6 @@ pub struct TransactionProcessingConfig<'a> {
 }
 
 /// Runtime environment for transaction batch processing.
-#[derive(Default)]
 pub struct TransactionProcessingEnvironment<'a> {
     /// The blockhash to use for the transaction batch.
     pub blockhash: Hash,
@@ -131,12 +130,26 @@ pub struct TransactionProcessingEnvironment<'a> {
     pub epoch_vote_accounts: Option<&'a VoteAccountsHashMap>,
     /// Runtime feature set to use for the transaction batch.
     pub feature_set: Arc<FeatureSet>,
-    /// Fee structure to use for assessing transaction fees.
-    pub fee_structure: Option<&'a FeeStructure>,
+    /// Transaction fee to charge per signature, in lamports.
+    pub fee_lamports_per_signature: u64,
     /// Lamports per signature to charge per transaction.
     pub lamports_per_signature: u64,
     /// Rent collector to use for the transaction batch.
     pub rent_collector: Option<&'a dyn SVMRentCollector>,
+}
+
+impl Default for TransactionProcessingEnvironment<'_> {
+    fn default() -> Self {
+        Self {
+            blockhash: Hash::default(),
+            epoch_total_stake: None,
+            epoch_vote_accounts: None,
+            feature_set: Arc::<FeatureSet>::default(),
+            fee_lamports_per_signature: FeeStructure::default().lamports_per_signature, // <-- Default fee.
+            lamports_per_signature: 0,
+            rent_collector: None,
+        }
+    }
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
@@ -270,9 +283,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             sanitized_txs,
             check_results,
             &environment.feature_set,
-            environment
-                .fee_structure
-                .unwrap_or(&FeeStructure::default()),
+            environment.fee_lamports_per_signature,
             environment
                 .rent_collector
                 .unwrap_or(&RentCollector::default()),
@@ -408,7 +419,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         sanitized_txs: &[impl core::borrow::Borrow<T>],
         check_results: Vec<TransactionCheckResult>,
         feature_set: &FeatureSet,
-        fee_structure: &FeeStructure,
+        fee_lamports_per_signature: u64,
         rent_collector: &dyn SVMRentCollector,
         error_counters: &mut TransactionErrorMetrics,
     ) -> Vec<TransactionValidationResult> {
@@ -424,7 +435,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         message,
                         checked_details,
                         feature_set,
-                        fee_structure,
+                        fee_lamports_per_signature,
                         rent_collector,
                         error_counters,
                     )
@@ -443,7 +454,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         message: &impl SVMMessage,
         checked_details: CheckedTransactionDetails,
         feature_set: &FeatureSet,
-        fee_structure: &FeeStructure,
+        fee_lamports_per_signature: u64,
         rent_collector: &dyn SVMRentCollector,
         error_counters: &mut TransactionErrorMetrics,
     ) -> transaction::Result<ValidatedTransactionDetails> {
@@ -491,7 +502,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let fee_details = solana_fee::calculate_fee_details(
             message,
             lamports_per_signature == 0,
-            fee_structure.lamports_per_signature,
+            fee_lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             feature_set.is_active(&remove_rounding_in_fee_calculation::id()),
         );
@@ -1044,7 +1055,7 @@ mod tests {
             bpf_loader,
             compute_budget::ComputeBudgetInstruction,
             epoch_schedule::EpochSchedule,
-            fee::FeeDetails,
+            fee::{FeeDetails, FeeStructure},
             fee_calculator::FeeCalculator,
             hash::Hash,
             message::{LegacyMessage, Message, MessageHeader, SanitizedMessage},
@@ -1978,7 +1989,7 @@ mod tests {
                 lamports_per_signature,
             },
             &FeatureSet::default(),
-            &FeeStructure::default(),
+            FeeStructure::default().lamports_per_signature,
             &rent_collector,
             &mut error_counters,
         );
@@ -2056,7 +2067,7 @@ mod tests {
                 lamports_per_signature,
             },
             &FeatureSet::default(),
-            &FeeStructure::default(),
+            FeeStructure::default().lamports_per_signature,
             &rent_collector,
             &mut error_counters,
         );
@@ -2107,7 +2118,7 @@ mod tests {
                 lamports_per_signature,
             },
             &FeatureSet::default(),
-            &FeeStructure::default(),
+            FeeStructure::default().lamports_per_signature,
             &RentCollector::default(),
             &mut error_counters,
         );
@@ -2141,7 +2152,7 @@ mod tests {
                 lamports_per_signature,
             },
             &FeatureSet::default(),
-            &FeeStructure::default(),
+            FeeStructure::default().lamports_per_signature,
             &RentCollector::default(),
             &mut error_counters,
         );
@@ -2179,7 +2190,7 @@ mod tests {
                 lamports_per_signature,
             },
             &FeatureSet::default(),
-            &FeeStructure::default(),
+            FeeStructure::default().lamports_per_signature,
             &rent_collector,
             &mut error_counters,
         );
@@ -2215,7 +2226,7 @@ mod tests {
                 lamports_per_signature,
             },
             &FeatureSet::default(),
-            &FeeStructure::default(),
+            FeeStructure::default().lamports_per_signature,
             &RentCollector::default(),
             &mut error_counters,
         );
@@ -2247,7 +2258,7 @@ mod tests {
                 lamports_per_signature,
             },
             &FeatureSet::default(),
-            &FeeStructure::default(),
+            FeeStructure::default().lamports_per_signature,
             &RentCollector::default(),
             &mut error_counters,
         );
@@ -2314,7 +2325,7 @@ mod tests {
                     lamports_per_signature,
                 },
                 &feature_set,
-                &FeeStructure::default(),
+                FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
             );
@@ -2376,7 +2387,7 @@ mod tests {
                     lamports_per_signature,
                 },
                 &feature_set,
-                &FeeStructure::default(),
+                FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
             );
@@ -2430,7 +2441,7 @@ mod tests {
                 lamports_per_signature,
             },
             &FeatureSet::default(),
-            &FeeStructure::default(),
+            FeeStructure::default().lamports_per_signature,
             &rent_collector,
             &mut error_counters,
         );
@@ -2478,7 +2489,7 @@ mod tests {
                     lamports_per_signature: 5000,
                 },
                 &FeatureSet::default(),
-                &FeeStructure::default(),
+                FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut TransactionErrorMetrics::default(),
             )

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -124,6 +124,13 @@ pub struct TransactionProcessingConfig<'a> {
 pub struct TransactionProcessingEnvironment<'a> {
     /// The blockhash to use for the transaction batch.
     pub blockhash: Hash,
+    /// Lamports per signature that corresponds to this blockhash.
+    ///
+    /// Note: This value is primarily used for nonce accounts. If set to zero,
+    /// it will disable transaction fees. However, any non-zero value will not
+    /// change transaction fees. For this reason, it is recommended to use the
+    /// `fee_per_signature` field to adjust transaction fees.
+    pub blockhash_lamports_per_signature: u64,
     /// The total stake for the current epoch.
     pub epoch_total_stake: Option<u64>,
     /// The vote accounts for the current epoch.
@@ -132,8 +139,6 @@ pub struct TransactionProcessingEnvironment<'a> {
     pub feature_set: Arc<FeatureSet>,
     /// Transaction fee to charge per signature, in lamports.
     pub fee_lamports_per_signature: u64,
-    /// Lamports per signature to charge per transaction.
-    pub lamports_per_signature: u64,
     /// Rent collector to use for the transaction batch.
     pub rent_collector: Option<&'a dyn SVMRentCollector>,
 }
@@ -142,11 +147,11 @@ impl Default for TransactionProcessingEnvironment<'_> {
     fn default() -> Self {
         Self {
             blockhash: Hash::default(),
+            blockhash_lamports_per_signature: 0,
             epoch_total_stake: None,
             epoch_vote_accounts: None,
             feature_set: Arc::<FeatureSet>::default(),
             fee_lamports_per_signature: FeeStructure::default().lamports_per_signature, // <-- Default fee.
-            lamports_per_signature: 0,
             rent_collector: None,
         }
     }
@@ -818,9 +823,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             None
         };
 
-        let blockhash = environment.blockhash;
-        let lamports_per_signature = environment.lamports_per_signature;
-
         let mut executed_units = 0u64;
         let sysvar_cache = &self.sysvar_cache.read().unwrap();
 
@@ -828,11 +830,11 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             &mut transaction_context,
             program_cache_for_tx_batch,
             EnvironmentConfig::new(
-                blockhash,
+                environment.blockhash,
                 environment.epoch_total_stake,
                 environment.epoch_vote_accounts,
                 Arc::clone(&environment.feature_set),
-                lamports_per_signature,
+                environment.blockhash_lamports_per_signature,
                 sysvar_cache,
             ),
             log_collector.clone(),

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -452,10 +452,10 @@ fn execute_fixture_as_instr(
     let sysvar_cache = &batch_processor.sysvar_cache();
     let env_config = EnvironmentConfig::new(
         Hash::default(),
+        0,
         None,
         None,
         mock_bank.feature_set.clone(),
-        0,
         sysvar_cache,
     );
 

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -305,7 +305,7 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
         transaction_check,
         &TransactionProcessingEnvironment {
             blockhash,
-            lamports_per_signature,
+            blockhash_lamports_per_signature: lamports_per_signature,
             ..Default::default()
         },
         &processor_config,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -112,7 +112,8 @@ impl SvmTestEnvironment<'_> {
         let processing_environment = TransactionProcessingEnvironment {
             blockhash: LAST_BLOCKHASH,
             feature_set: feature_set.into(),
-            lamports_per_signature: LAMPORTS_PER_SIGNATURE,
+            blockhash_lamports_per_signature: LAMPORTS_PER_SIGNATURE,
+            fee_lamports_per_signature: LAMPORTS_PER_SIGNATURE,
             ..TransactionProcessingEnvironment::default()
         };
 


### PR DESCRIPTION
#### Problem
SVM uses two values for `lamports_per_signature` - one from the `FeeStructure` and one from the blockhash queue (fee governor). The former is used to actually assess transaction fees.

The relationship between these two `lamports_per_signature` values is not clear from the SVM API's documentation or symbol names.

#### Summary of Changes
First remove the entire `FeeStructure` type and just use its `lamports_per_signature` value directly, since SVM has no need for the rest of the type.

Then, rename the `lamports_per_signature` that comes from the blockhash queue (fee governor) to `blockhash_lamports_per_signature` in both SVM and the program-runtime.