### PR TITLE
clippy: #[warn(clippy::single_match)]

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6321,11 +6321,8 @@ impl AccountsDb {
             .unzip();
 
         // hash this accounts in bg
-        match &self.sender_bg_hasher {
-            Some(ref sender) => {
-                let _ = sender.send(cached_accounts);
-            }
-            None => (),
+        if let Some(ref sender) = &self.sender_bg_hasher {
+            let _ = sender.send(cached_accounts);
         };
 
         account_infos

--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -375,13 +375,10 @@ where
         |parts, kind| {
             if is_valid_snapshot_archive_entry(parts, kind) {
                 i += 1;
-                match &parallel_selector {
-                    Some(parallel_selector) => {
-                        if !parallel_selector.select_index(i - 1) {
-                            return UnpackPath::Ignore;
-                        }
+                if let Some(parallel_selector) = &parallel_selector {
+                    if !parallel_selector.select_index(i - 1) {
+                        return UnpackPath::Ignore;
                     }
-                    None => {}
                 };
                 if let ["accounts", file] = parts {
                     // Randomly distribute the accounts files about the available `account_paths`,

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -679,12 +679,11 @@ impl ClusterInfoVoteListener {
         gossip_vote_slot_confirming_time.stop();
         let gossip_vote_slot_confirming_time_us = gossip_vote_slot_confirming_time.as_us();
 
-        match vote_processing_time {
-            Some(ref mut vote_processing_time) => vote_processing_time.update(
+        if let Some(ref mut vote_processing_time) = vote_processing_time {
+            vote_processing_time.update(
                 gossip_vote_txn_processing_time_us,
                 gossip_vote_slot_confirming_time_us,
-            ),
-            None => {}
+            )
         }
         new_optimistic_confirmed_slots
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3916,14 +3916,11 @@ impl Bank {
     ) {
         let mut fees = 0;
 
-        processing_results
-            .iter()
-            .for_each(|processing_result| match processing_result {
-                Ok(processed_tx) => {
-                    fees += processed_tx.fee_details().total_fee();
-                }
-                Err(_) => {}
-            });
+        processing_results.iter().for_each(|processing_result| {
+            if let Ok(processed_tx) = processing_result {
+                fees += processed_tx.fee_details().total_fee();
+            }
+        });
 
         self.collector_fees.fetch_add(fees, Relaxed);
     }
@@ -3935,14 +3932,11 @@ impl Bank {
     ) {
         let mut accumulated_fee_details = FeeDetails::default();
 
-        processing_results
-            .iter()
-            .for_each(|processing_result| match processing_result {
-                Ok(processed_tx) => {
-                    accumulated_fee_details.accumulate(&processed_tx.fee_details());
-                }
-                Err(_) => {}
-            });
+        processing_results.iter().for_each(|processing_result| {
+            if let Ok(processed_tx) = processing_result {
+                accumulated_fee_details.accumulate(&processed_tx.fee_details());
+            }
+        });
 
         self.collector_fee_details
             .write()


### PR DESCRIPTION
#### Problem

While working on upgrading Rust to v1.82.0, there are new clippy lints to resolve. One is `clippy::single_match`:

```
warning: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> core/src/cluster_info_vote_listener.rs:682:9
    |
682 | /         match vote_processing_time {
683 | |             Some(ref mut vote_processing_time) => vote_processing_time.update(
684 | |                 gossip_vote_txn_processing_time_us,
685 | |                 gossip_vote_slot_confirming_time_us,
686 | |             ),
687 | |             None => {}
688 | |         }
    | |_________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match
    = note: `#[warn(clippy::single_match)]` on by default
help: try
    |
682 ~         if let Some(ref mut vote_processing_time) = vote_processing_time { vote_processing_time.update(
683 +             gossip_vote_txn_processing_time_us,
684 +             gossip_vote_slot_confirming_time_us,
685 +         ) }
```


#### Summary of Changes

Replace the match with `if let`.