### PR TITLE
Update latest release variable for agave docs

### DIFF
--- a/docs/set-solana-release-tag.sh
+++ b/docs/set-solana-release-tag.sh
@@ -6,15 +6,15 @@ cd "$(dirname "$0")"
 eval "$(../ci/channel-info.sh)"
 
 if [[ -n $BETA_CHANNEL_LATEST_TAG ]]; then
-  LATEST_SOLANA_RELEASE_VERSION=$BETA_CHANNEL_LATEST_TAG
+  LATEST_AGAVE_RELEASE_VERSION=$BETA_CHANNEL_LATEST_TAG
 else
-  LATEST_SOLANA_RELEASE_VERSION=$STABLE_CHANNEL_LATEST_TAG
+  LATEST_AGAVE_RELEASE_VERSION=$STABLE_CHANNEL_LATEST_TAG
 fi
-VERSION_FOR_DOCS_RS="${LATEST_SOLANA_RELEASE_VERSION:1}"
+VERSION_FOR_DOCS_RS="${LATEST_AGAVE_RELEASE_VERSION:1}"
 
 set -x
 if [[ -n $CI ]]; then
   sed --version || { echo "Error: Incompatible version of sed, use gnu sed"; exit 1; }
-  find src/ -name \*.md -exec sed -i "s/LATEST_SOLANA_RELEASE_VERSION/$LATEST_SOLANA_RELEASE_VERSION/g" {} \;
+  find src/ -name \*.md -exec sed -i "s/LATEST_AGAVE_RELEASE_VERSION/$LATEST_AGAVE_RELEASE_VERSION/g" {} \;
   find src/ -name \*.md -exec sed -i "s/VERSION_FOR_DOCS_RS/$VERSION_FOR_DOCS_RS/g" {} \;
 fi


### PR DESCRIPTION
#### Problem
On the [Agave install docs](https://docs.anza.xyz/cli/install) the version number isn't interpolating:

`sh -c "$(curl -sSfL https://release.anza.xyz/LATEST_AGAVE_RELEASE_VERSION/install)"`

The variable name in the docs is updated, but not in the script that sets it. 

#### Summary of Changes
Update the variable name