### PR TITLE
don't ignore doc examples in secp256k1-recover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7963,6 +7963,7 @@ dependencies = [
  "solana-define-syscall",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-program",
  "thiserror",
 ]
 

--- a/curves/secp256k1-recover/Cargo.toml
+++ b/curves/secp256k1-recover/Cargo.toml
@@ -28,6 +28,7 @@ libsecp256k1 = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true }
+solana-program = { path = "../../sdk/program" }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 libsecp256k1 = { workspace = true, features = ["hmac"] }

--- a/curves/secp256k1-recover/src/lib.rs
+++ b/curves/secp256k1-recover/src/lib.rs
@@ -165,7 +165,7 @@ solana_define_syscall::define_syscall!(fn sol_secp256k1_recover(hash: *const u8,
 /// signatures with high-order `S` values. The following code will accomplish
 /// this:
 ///
-/// ```rust,ignore
+/// ```rust
 /// # use solana_program::program_error::ProgramError;
 /// # let signature_bytes = [
 /// #     0x83, 0x55, 0x81, 0xDF, 0xB1, 0x02, 0xA7, 0xD2,
@@ -261,7 +261,7 @@ solana_define_syscall::define_syscall!(fn sol_secp256k1_recover(hash: *const u8,
 /// The Solana program. Note that it uses `libsecp256k1` version 0.7.0 to parse
 /// the secp256k1 signature to prevent malleability.
 ///
-/// ```rust,ignore
+/// ```rust,no_run
 /// use solana_program::{
 ///     entrypoint::ProgramResult,
 ///     keccak, msg,
@@ -331,7 +331,7 @@ solana_define_syscall::define_syscall!(fn sol_secp256k1_recover(hash: *const u8,
 ///
 /// The RPC client program:
 ///
-/// ```rust,ignore
+/// ```rust,no_run
 /// # use solana_program::example_mocks::solana_rpc_client;
 /// # use solana_program::example_mocks::solana_sdk;
 /// use anyhow::Result;


### PR DESCRIPTION
#### Problem
In #1656 I added `ignore` to some doc examples because the CI at the time didn't allow us to have a `solana_program` dev dep in this crate. Now it does allow this.

#### Summary of Changes
Remove one `ignore` and replace the other two with `no_run` so the examples are tested/compiled as before

