### PR TITLE
vote: allow block_id to be None until new shred format is rolled out

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -592,10 +592,9 @@ impl Tower {
         // `self.vote_state`
         let block_id = bank.block_id().unwrap_or_else(|| {
             // This can only happen for our leader bank
-            assert!(
-                *bank.collector_id() == self.node_pubkey,
-                "block_id must not be None for a frozen non-leader bank"
-            );
+            // Note: since the new shred format is yet to be rolled out to all clusters,
+            // this can also happen for non-leader banks. Once rolled out we can assert
+            // here that this is our leader bank.
             Hash::default()
         });
         self.record_bank_vote_and_update_lockouts(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3599,8 +3599,8 @@ impl ReplayStage {
             // Here we don't have to check if this is our leader bank, as since we are adopting this bank,
             // that means that it was created from a different instance (hot spare setup or a previous restart),
             // and thus we must have replayed and set the block_id from the shreds.
-            bank.block_id()
-                .expect("block_id for an adopted bank cannot be None")
+            // Note: since the new shred format is not rolled out everywhere, we have to provide a default
+            bank.block_id().unwrap_or_default()
         };
         tower.update_last_vote_from_vote_state(
             progress


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/2776 populates the `block_id` for all `TowerSync` instructions.

Normally this can only be `None` if we are voting on our own leader block, however for mainnet and 1.18 clusters, the new shred format is yet to be rolled out, also causing this value to be None.

#### Summary of Changes
Restore compatibility of master to mainnet by removing these assertions. These assertions can be added back in once the new shred format is fully rolled out. The feature flag that enables `TowerSync` is not planned to be activated until after the new shred format is fully rolled out.