### PR TITLE
Plumb errors through TransactionStatusService instead of panicking

### DIFF
--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -3,7 +3,7 @@ use {
     crossbeam_channel::{Receiver, RecvTimeoutError},
     itertools::izip,
     solana_ledger::{
-        blockstore::Blockstore,
+        blockstore::{Blockstore, BlockstoreError},
         blockstore_processor::{TransactionStatusBatch, TransactionStatusMessage},
     },
     solana_svm::transaction_commit_result::CommittedTransaction,
@@ -41,15 +41,30 @@ impl TransactionStatusService {
                     break;
                 }
 
-                if let Err(RecvTimeoutError::Disconnected) = Self::write_transaction_status_batch(
-                    &write_transaction_status_receiver,
+                let message =
+                    match write_transaction_status_receiver.recv_timeout(Duration::from_secs(1)) {
+                        Ok(message) => message,
+                        Err(RecvTimeoutError::Disconnected) => {
+                            break;
+                        }
+                        Err(RecvTimeoutError::Timeout) => {
+                            continue;
+                        }
+                    };
+
+                match Self::write_transaction_status_batch(
+                    message,
                     &max_complete_transaction_status_slot,
                     enable_rpc_transaction_history,
                     transaction_notifier.clone(),
                     &blockstore,
                     enable_extended_tx_metadata_storage,
                 ) {
-                    break;
+                    Ok(_) => {}
+                    Err(_err) => {
+                        exit.store(true, Ordering::Relaxed);
+                        break;
+                    }
                 }
             })
             .unwrap();
@@ -57,14 +72,14 @@ impl TransactionStatusService {
     }
 
     fn write_transaction_status_batch(
-        write_transaction_status_receiver: &Receiver<TransactionStatusMessage>,
+        transaction_status_message: TransactionStatusMessage,
         max_complete_transaction_status_slot: &Arc<AtomicU64>,
         enable_rpc_transaction_history: bool,
         transaction_notifier: Option<TransactionNotifierArc>,
         blockstore: &Blockstore,
         enable_extended_tx_metadata_storage: bool,
-    ) -> Result<(), RecvTimeoutError> {
-        match write_transaction_status_receiver.recv_timeout(Duration::from_secs(1))? {
+    ) -> Result<(), BlockstoreError> {
+        match transaction_status_message {
             TransactionStatusMessage::Batch(TransactionStatusBatch {
                 slot,
                 transactions,
@@ -73,7 +88,7 @@ impl TransactionStatusService {
                 token_balances,
                 transaction_indexes,
             }) => {
-                let mut status_and_memos_batch = blockstore.get_write_batch().unwrap();
+                let mut status_and_memos_batch = blockstore.get_write_batch()?;
 
                 for (
                     transaction,
@@ -160,16 +175,12 @@ impl TransactionStatusService {
 
                     if enable_rpc_transaction_history {
                         if let Some(memos) = extract_and_fmt_memos(transaction.message()) {
-                            blockstore
-                                .add_transaction_memos_to_batch(
-                                    transaction.signature(),
-                                    slot,
-                                    memos,
-                                    &mut status_and_memos_batch,
-                                )
-                                .expect(
-                                    "Expect database batch accumulation to succeed: TransactionMemos",
-                                );
+                            blockstore.add_transaction_memos_to_batch(
+                                transaction.signature(),
+                                slot,
+                                memos,
+                                &mut status_and_memos_batch,
+                            )?;
                         }
 
                         let message = transaction.message();
@@ -179,24 +190,19 @@ impl TransactionStatusService {
                             .enumerate()
                             .map(|(index, key)| (key, message.is_writable(index)));
 
-                        blockstore
-                            .add_transaction_status_to_batch(
-                                slot,
-                                *transaction.signature(),
-                                keys_with_writable,
-                                transaction_status_meta,
-                                transaction_index,
-                                &mut status_and_memos_batch,
-                            )
-                            .expect(
-                                "Expect database batch accumulation to succeed: TransactionStatus",
-                            );
+                        blockstore.add_transaction_status_to_batch(
+                            slot,
+                            *transaction.signature(),
+                            keys_with_writable,
+                            transaction_status_meta,
+                            transaction_index,
+                            &mut status_and_memos_batch,
+                        )?;
                     }
                 }
 
                 if enable_rpc_transaction_history {
-                    blockstore.write_batch(status_and_memos_batch)
-                        .expect("Expect database batched writes to succeed: TransactionStatus + TransactionMemos");
+                    blockstore.write_batch(status_and_memos_batch)?;
                 }
             }
             TransactionStatusMessage::Freeze(slot) => {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -39,12 +39,13 @@ impl TransactionStatusService {
             .spawn(move || {
                 info!("TransactionStatusService has started");
                 loop {
-                if exit.load(Ordering::Relaxed) {
-                    break;
-                }
+                    if exit.load(Ordering::Relaxed) {
+                        break;
+                    }
 
-                let message =
-                    match write_transaction_status_receiver.recv_timeout(Duration::from_secs(1)) {
+                    let message = match write_transaction_status_receiver
+                        .recv_timeout(Duration::from_secs(1))
+                    {
                         Ok(message) => message,
                         Err(RecvTimeoutError::Disconnected) => {
                             break;
@@ -54,22 +55,22 @@ impl TransactionStatusService {
                         }
                     };
 
-                match Self::write_transaction_status_batch(
-                    message,
-                    &max_complete_transaction_status_slot,
-                    enable_rpc_transaction_history,
-                    transaction_notifier.clone(),
-                    &blockstore,
-                    enable_extended_tx_metadata_storage,
-                ) {
-                    Ok(_) => {}
-                    Err(_err) => {
-                        exit.store(true, Ordering::Relaxed);
-                        break;
+                    match Self::write_transaction_status_batch(
+                        message,
+                        &max_complete_transaction_status_slot,
+                        enable_rpc_transaction_history,
+                        transaction_notifier.clone(),
+                        &blockstore,
+                        enable_extended_tx_metadata_storage,
+                    ) {
+                        Ok(_) => {}
+                        Err(_err) => {
+                            exit.store(true, Ordering::Relaxed);
+                            break;
+                        }
                     }
                 }
-            }
-            info!("TransactionStatusService has stopped");
+                info!("TransactionStatusService has stopped");
             })
             .unwrap();
         Self { thread_hdl }

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -36,7 +36,9 @@ impl TransactionStatusService {
     ) -> Self {
         let thread_hdl = Builder::new()
             .name("solTxStatusWrtr".to_string())
-            .spawn(move || loop {
+            .spawn(move || {
+                info!("TransactionStatusService has started");
+                loop {
                 if exit.load(Ordering::Relaxed) {
                     break;
                 }
@@ -66,6 +68,8 @@ impl TransactionStatusService {
                         break;
                     }
                 }
+            }
+            info!("TransactionStatusService has stopped");
             })
             .unwrap();
         Self { thread_hdl }

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -64,7 +64,8 @@ impl TransactionStatusService {
                         enable_extended_tx_metadata_storage,
                     ) {
                         Ok(_) => {}
-                        Err(_err) => {
+                        Err(err) => {
+                            error!("TransactionStatusService stopping due to error: {err}");
                             exit.store(true, Ordering::Relaxed);
                             break;
                         }


### PR DESCRIPTION
#### Problem
I was reviewing https://github.com/anza-xyz/agave/pull/3026 post-merge and noticed we had a handful of `.expect()` and `.unwrap()` in `TransactionStatusService`. These do not allow for graceful teardown of the process, so try to be nicer to other threads by initiating a more graceful teardown

#### Summary of Changes
- Rework TransactionStatusService to raise/handle errors instead of `.expect()` and `.unwrap()`
- Set validator exit flag if fatal error encountered
- Add logs for service start/stop/error encountered

One additional item I'll call out is that the panic hook pretty quickly kills the entire process via this:
https://github.com/anza-xyz/agave/blob/7b05e29f4eb275bf884b18351b2d5ad13dc48bf0/metrics/src/metrics.rs#L538-L539

The sentiment behind that comment is still valid. However, enough threads respect the exit flag such that the process will still come down fairly quickly so I think setting the flag is ok in this scenario