### PR TITLE
rpc: improve latency by not blocking worker threads polling IO notifications

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1940,13 +1940,9 @@ impl JsonRpcRequestProcessor {
 
     pub async fn get_first_available_block(&self) -> Slot {
         let slot = self
-            .runtime
-            .spawn_blocking({
-                let blockstore = Arc::clone(&self.blockstore);
-                move || blockstore.get_first_available_block().unwrap_or_default()
-            })
-            .await
-            .expect("Failed to spawn blocking task");
+            .blockstore
+            .get_first_available_block()
+            .unwrap_or_default();
 
         if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
             let bigtable_slot = bigtable_ledger_storage

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1914,9 +1914,13 @@ impl JsonRpcRequestProcessor {
 
     pub async fn get_first_available_block(&self) -> Slot {
         let slot = self
-            .blockstore
-            .get_first_available_block()
-            .unwrap_or_default();
+            .runtime
+            .spawn_blocking({
+                let blockstore = Arc::clone(&self.blockstore);
+                move || blockstore.get_first_available_block().unwrap_or_default()
+            })
+            .await
+            .expect("Failed to spawn blocking task");
 
         if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
             let bigtable_slot = bigtable_ledger_storage

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -161,6 +161,7 @@ pub struct JsonRpcConfig {
     pub max_multiple_accounts: Option<usize>,
     pub account_indexes: AccountSecondaryIndexes,
     pub rpc_threads: usize,
+    pub rpc_blocking_threads: usize,
     pub rpc_niceness_adj: i8,
     pub full_api: bool,
     pub rpc_scan_and_fix_roots: bool,

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -362,6 +362,7 @@ impl JsonRpcService {
         info!("rpc bound to {:?}", rpc_addr);
         info!("rpc configuration: {:?}", config);
         let rpc_threads = 1.max(config.rpc_threads);
+        let rpc_blocking_threads = 1.max(config.rpc_blocking_threads);
         let rpc_niceness_adj = config.rpc_niceness_adj;
 
         let health = Arc::new(RpcHealth::new(
@@ -381,15 +382,26 @@ impl JsonRpcService {
             .tpu(connection_cache.protocol())
             .map_err(|err| format!("{err}"))?;
 
-        // sadly, some parts of our current rpc implemention block the jsonrpc's
-        // _socket-listening_ event loop for too long, due to (blocking) long IO or intesive CPU,
-        // causing no further processing of incoming requests and ultimatily innocent clients timing-out.
-        // So create a (shared) multi-threaded event_loop for jsonrpc and set its .threads() to 1,
-        // so that we avoid the single-threaded event loops from being created automatically by
-        // jsonrpc for threads when .threads(N > 1) is given.
+        // The jsonrpc_http_server crate supports two execution models:
+        //
+        // - By default, it spawns a number of threads - configured with .threads(N) - and runs a
+        //   single-threaded futures executor in each thread.
+        // - Alternatively when configured with .event_loop_executor(executor) and .threads(1),
+        //   it executes all the tasks on the given executor, not spawning any extra internal threads.
+        //
+        // We use the latter configuration, using a multi threaded tokio runtime as the executor. We
+        // do this so we can configure the number of worker threads, the number of blocking threads
+        // and then use tokio::task::spawn_blocking() to avoid blocking the worker threads on CPU
+        // bound operations like getMultipleAccounts. This results in reduced latency, since fast
+        // rpc calls (the majority) are not blocked by slow CPU bound ones.
+        //
+        // NB: `rpc_blocking_threads` shouldn't be set too high (defaults to num_cpus / 2). Too many
+        // (busy) blocking threads could compete with CPU time with other validator threads and
+        // negatively impact performance.
         let runtime = Arc::new(
             tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(rpc_threads)
+                .max_blocking_threads(rpc_blocking_threads)
                 .on_thread_start(move || renice_this_thread(rpc_niceness_adj).unwrap())
                 .thread_name("solRpcEl")
                 .enable_all()

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -382,32 +382,7 @@ impl JsonRpcService {
             .tpu(connection_cache.protocol())
             .map_err(|err| format!("{err}"))?;
 
-        // The jsonrpc_http_server crate supports two execution models:
-        //
-        // - By default, it spawns a number of threads - configured with .threads(N) - and runs a
-        //   single-threaded futures executor in each thread.
-        // - Alternatively when configured with .event_loop_executor(executor) and .threads(1),
-        //   it executes all the tasks on the given executor, not spawning any extra internal threads.
-        //
-        // We use the latter configuration, using a multi threaded tokio runtime as the executor. We
-        // do this so we can configure the number of worker threads, the number of blocking threads
-        // and then use tokio::task::spawn_blocking() to avoid blocking the worker threads on CPU
-        // bound operations like getMultipleAccounts. This results in reduced latency, since fast
-        // rpc calls (the majority) are not blocked by slow CPU bound ones.
-        //
-        // NB: `rpc_blocking_threads` shouldn't be set too high (defaults to num_cpus / 2). Too many
-        // (busy) blocking threads could compete with CPU time with other validator threads and
-        // negatively impact performance.
-        let runtime = Arc::new(
-            tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(rpc_threads)
-                .max_blocking_threads(rpc_blocking_threads)
-                .on_thread_start(move || renice_this_thread(rpc_niceness_adj).unwrap())
-                .thread_name("solRpcEl")
-                .enable_all()
-                .build()
-                .expect("Runtime"),
-        );
+        let runtime = service_runtime(rpc_threads, rpc_blocking_threads, rpc_niceness_adj);
 
         let exit_bigtable_ledger_upload_service = Arc::new(AtomicBool::new(false));
 
@@ -485,6 +460,7 @@ impl JsonRpcService {
             max_complete_transaction_status_slot,
             max_complete_rewards_slot,
             prioritization_fee_cache,
+            Arc::clone(&runtime),
         );
 
         let leader_info =
@@ -596,6 +572,40 @@ impl JsonRpcService {
         self.exit();
         self.thread_hdl.join()
     }
+}
+
+pub fn service_runtime(
+    rpc_threads: usize,
+    rpc_blocking_threads: usize,
+    rpc_niceness_adj: i8,
+) -> Arc<tokio::runtime::Runtime> {
+    // The jsonrpc_http_server crate supports two execution models:
+    //
+    // - By default, it spawns a number of threads - configured with .threads(N) - and runs a
+    //   single-threaded futures executor in each thread.
+    // - Alternatively when configured with .event_loop_executor(executor) and .threads(1),
+    //   it executes all the tasks on the given executor, not spawning any extra internal threads.
+    //
+    // We use the latter configuration, using a multi threaded tokio runtime as the executor. We
+    // do this so we can configure the number of worker threads, the number of blocking threads
+    // and then use tokio::task::spawn_blocking() to avoid blocking the worker threads on CPU
+    // bound operations like getMultipleAccounts. This results in reduced latency, since fast
+    // rpc calls (the majority) are not blocked by slow CPU bound ones.
+    //
+    // NB: `rpc_blocking_threads` shouldn't be set too high (defaults to num_cpus / 2). Too many
+    // (busy) blocking threads could compete with CPU time with other validator threads and
+    // negatively impact performance.
+    let runtime = Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(rpc_threads)
+            .max_blocking_threads(rpc_blocking_threads)
+            .on_thread_start(move || renice_this_thread(rpc_niceness_adj).unwrap())
+            .thread_name("solRpcEl")
+            .enable_all()
+            .build()
+            .expect("Runtime"),
+    );
+    runtime
 }
 
 #[cfg(test)]

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -960,6 +960,27 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Number of threads to use for servicing RPC requests"),
         )
         .arg(
+            Arg::with_name("rpc_blocking_threads")
+                .long("rpc-blocking-threads")
+                .value_name("NUMBER")
+                .validator(is_parsable::<usize>)
+                .validator(|value| {
+                    value
+                        .parse::<u64>()
+                        .map_err(|err| format!("error parsing '{value}': {err}"))
+                        .and_then(|threads| {
+                            if threads > 0 {
+                                Ok(())
+                            } else {
+                                Err("value must be >= 1".to_string())
+                            }
+                        })
+                })
+                .takes_value(true)
+                .default_value(&default_args.rpc_blocking_threads)
+                .help("Number of blocking threads to use for servicing CPU bound RPC requests (eg getMultipleAccounts)"),
+        )
+        .arg(
             Arg::with_name("rpc_niceness_adj")
                 .long("rpc-niceness-adjustment")
                 .value_name("ADJUSTMENT")
@@ -2270,6 +2291,7 @@ pub struct DefaultArgs {
     pub rpc_send_transaction_batch_size: String,
     pub rpc_send_transaction_retry_pool_max_size: String,
     pub rpc_threads: String,
+    pub rpc_blocking_threads: String,
     pub rpc_niceness_adjustment: String,
     pub rpc_bigtable_timeout: String,
     pub rpc_bigtable_instance_name: String,
@@ -2362,6 +2384,7 @@ impl DefaultArgs {
                 .retry_pool_max_size
                 .to_string(),
             rpc_threads: num_cpus::get().to_string(),
+            rpc_blocking_threads: 1.max(num_cpus::get() / 2).to_string(),
             rpc_niceness_adjustment: "0".to_string(),
             rpc_bigtable_timeout: "30".to_string(),
             rpc_bigtable_instance_name: solana_storage_bigtable::DEFAULT_INSTANCE_NAME.to_string(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2384,7 +2384,7 @@ impl DefaultArgs {
                 .retry_pool_max_size
                 .to_string(),
             rpc_threads: num_cpus::get().to_string(),
-            rpc_blocking_threads: 1.max(num_cpus::get() / 2).to_string(),
+            rpc_blocking_threads: 1.max(num_cpus::get() / 4).to_string(),
             rpc_niceness_adjustment: "0".to_string(),
             rpc_bigtable_timeout: "30".to_string(),
             rpc_bigtable_instance_name: solana_storage_bigtable::DEFAULT_INSTANCE_NAME.to_string(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1492,6 +1492,7 @@ pub fn main() {
             ),
             disable_health_check: false,
             rpc_threads: value_t_or_exit!(matches, "rpc_threads", usize),
+            rpc_blocking_threads: value_t_or_exit!(matches, "rpc_blocking_threads", usize),
             rpc_niceness_adj: value_t_or_exit!(matches, "rpc_niceness_adj", i8),
             account_indexes: account_indexes.clone(),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),


### PR DESCRIPTION
#### Problem

Some RPC operations are CPU bound and run for a significant amount of time. Those operations end up blocking worker threads that are also used to handle IO notifications, leading to notifications not being polled often enough and so for the whole RPC server to potentially become slow and exhibit high latency. When latency gets high enough it can exceed request timeouts, leading to failed requests.

#### Summary of Changes

This PR makes some of the most CPU expensive RPC methods use `tokio::task::spawn_blocking` to run cpu hungry code. This way the worker threads doing IO don't get blocked and latency is improved.

The methods changed so far include:
- `getMultipleAccounts`
- `getProgramAccounts`
- `getAccountInfo`
- `getTokenAccountsByDelegate`
- `getTokenAccountsByOwner`

I'm not super familiar with RPC so I've changed what looking at the code seems to be loading/copying a lot of data around. Please feel free to suggest more!

## Test plan

### Methodolgy for selection of CPU defaults

Run [this `blocks` benchmark script](https://gist.github.com/steveluscher/3eedefeab65217d980d8c80e3b860635) while tweaking CPU params. This was run on a 48 CPU machine.

| `rpc_threads` | `rpc_blocking_threads` | Average | Median | p90 | p99 |
|---|---|---|---|---|---|
| cpus | cpus / 2 | 21880 | 22136 | 22546 | 22572 |
| cpus | cpus / 4 | 20617 ($${\color{green}-5.7\\%}$$) | 20627 ($${\color{green}-6.8\\%}$$) | 21040 ($${\color{green}-6.7\\%}$$) | 21149 ($${\color{green}-6.3\\%}$$) |
| cpus | cpus / 8 | 21366 ($${\color{green}-2.4\\%}$$) | 21367 ($${\color{green}-3.8\\%}$$) | 21434 ($${\color{green}-4.9\\%}$$) | 21477 ($${\color{green}-4.9\\%}$$) |
| cpus / 2 | cpus / 2 | 21642 ($${\color{green}-1.1\\%}$$) | 21525 ($${\color{green}-2.8\\%}$$) | 23202 ($${\color{red}+2.9\\%}$$) | 23235 ($${\color{red}+2.9\\%}$$) |
| cpus / 2 | cpus / 4 | 20033 ($${\color{green}-8.4\\%}$$) | 20044 ($${\color{green}-9.4\\%}$$) | 20430 ($${\color{green}-9.4\\%}$$) | 20598 ($${\color{green}-8.7\\%}$$) |

### Methodology

Using this script for computing metrics: https://gist.github.com/steveluscher/b4959b9601093b0009f1d7646217b030, ran each of these `account-cluster-bench` suites before and after this PR:

* `account-info`
* `block`
* `blocks`
* `first-available-block`
* `multiple-accounts`
* `slot`
* `supply`
* `token-accounts-by-delegate`
* `token-accounts-by-owner`
* `token-supply`
* `transaction`
* `transaction-parsed`
* `version`

Using a command similar to this:

```shell
 % (
       bash -c 'while ! curl -s localhost:8899/health | grep -q "ok"; do echo "Waiting for validator" && sleep 1; done;' \
           ${IFS# Set this higher if you want the test to run with more blocks having been committed } \
           && sleep 15 \
           && echo "Running bench" \
           && cd accounts-cluster-bench \
           && cargo run --release -- \
               -u l \
               --identity ~/.config/solana/id.json \
               ${IFS# Optional for benches that require token accounts} \
               ${IFS# https://gist.github.com/steveluscher/19261b5321f56a89dc75804070b61dc4} \
               ${IFS# --mint UhrKsjtPJJ8ndhSdrcCbQaiw8L8a6gH1FbmtJ4XpVJR } \
               --iterations 100 \
               --num-rpc-bench-threads 100 \
               --rpc-bench supply 2>&1 \
           | grep -Po "Supply average success_time: \K(\d+)" \
           | ~/stats.sh 
   ) \
       & (
           (cd accounts-cluster-bench && cargo build --release) \
           && (
               cd validator \
                   && rm -rf test-ledger/ \
                   && cargo run --release \
                       --manifest-path=./Cargo.toml \
                       --bin solana-test-validator -- \
                           ${IFS# Put this in ~/fixtures/ } \
                           ${IFS# https://gist.github.com/steveluscher/19261b5321f56a89dc75804070b61dc4 } \
                           --account-dir ~/fixtures \
                           --quiet
               ) \
       )
Average: 34293.3
Median: 31708.5
90th Percentile: 44640
99th Percentile: 45166
```

> [!NOTE]
> You can adjust the `sleep 15` if you want the validator to stack up more slots before starting the bench.

> [!WARNING]
> When running benches that require token accounts, supply a `mint`, `space`, and actually create the token account using the fixture found [here](https://gist.github.com/steveluscher/19261b5321f56a89dc75804070b61dc4).

#### Results

> [!WARNING]
> These results are a little messed up, because what's _actually_ happening here is that the benchmark script is spitting out averages in 3s windows. The avg/p50/p90/p99 of _those_ numbers is what you're seeing in this table. Not correct, but directionally correct.

> [!NOTE]
> Filling in this grid would take a _long_ time, especially if run against a mainnet RPC with production traffic. We may just choose to land this as ‘certainly better, how much we can't say exactly.’

| Suite | Average | Median | p90 | p99|
|---|---|---|---|---|
| `account-info` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |
| `block` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |
| `blocks` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |
| `first-available-block` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |
| `multiple-accounts` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |
| `slot` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |
| `supply` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |
| `token-accounts-by-delegate` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |
| `token-accounts-by-owner` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |
| `token-supply` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |
| `transaction` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |
| `transaction-parsed` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |
| `version` | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) | TBD ($${\color{green}-99\\%}$$) |