### PR TITLE
Replaces our GroupBy with rust's ChunkBy

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -487,8 +487,7 @@ impl PrunedBanksRequestHandler {
         let num_banks_to_purge = banks_to_purge.len();
 
         // Group the banks into slices with the same slot
-        let grouped_banks_to_purge: Vec<_> =
-            GroupBy::new(banks_to_purge.as_slice(), |a, b| a.0 == b.0).collect();
+        let grouped_banks_to_purge: Vec<_> = banks_to_purge.chunk_by(|a, b| a.0 == b.0).collect();
 
         // Log whenever we need to handle banks with the same slot.  Purposely do this *before* we
         // call `purge_slot()` to ensure we get the datapoint (in case there's an assert/panic).
@@ -786,56 +785,6 @@ fn cmp_requests_by_priority(
         accounts_package_kind_b,
     )
     .then(slot_a.cmp(&slot_b))
-}
-
-/// An iterator over a slice producing non-overlapping runs
-/// of elements using a predicate to separate them.
-///
-/// This can be used to extract sorted subslices.
-///
-/// (`Vec::group_by()`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.group_by)
-/// is currently a nightly-only experimental API.  Once the API is stablized, use it instead.
-///
-/// tracking issue: https://github.com/rust-lang/rust/issues/80552
-/// rust-lang PR: https://github.com/rust-lang/rust/pull/79895/
-/// implementation permalink: https://github.com/Kerollmops/rust/blob/8b53be660444d736bb6a6e1c6ba42c8180c968e7/library/core/src/slice/iter.rs#L2972-L3023
-struct GroupBy<'a, T: 'a, P> {
-    slice: &'a [T],
-    predicate: P,
-}
-impl<'a, T: 'a, P> GroupBy<'a, T, P>
-where
-    P: FnMut(&T, &T) -> bool,
-{
-    fn new(slice: &'a [T], predicate: P) -> Self {
-        GroupBy { slice, predicate }
-    }
-}
-impl<'a, T: 'a, P> Iterator for GroupBy<'a, T, P>
-where
-    P: FnMut(&T, &T) -> bool,
-{
-    type Item = &'a [T];
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.slice.is_empty() {
-            None
-        } else {
-            let mut len = 1;
-            let mut iter = self.slice.windows(2);
-            while let Some([l, r]) = iter.next() {
-                if (self.predicate)(l, r) {
-                    len += 1;
-                } else {
-                    break;
-                }
-            }
-            let (head, tail) = self.slice.split_at(len);
-            self.slice = tail;
-            Some(head)
-        }
-    }
 }
 
 #[cfg(test)]
@@ -1173,20 +1122,5 @@ mod test {
         drop(fork0_bank0);
         let num_banks_purged = pruned_banks_request_handler.handle_request(&fork0_bank3);
         assert_eq!(num_banks_purged, 7);
-    }
-
-    // This test is for our copied impl of GroupBy, above.
-    // When it is removed, this test can be removed.
-    #[test]
-    fn test_group_by() {
-        let slice = &[1, 1, 1, 3, 3, 2, 2, 2, 1, 0];
-
-        let mut iter = GroupBy::new(slice, |a, b| a == b);
-        assert_eq!(iter.next(), Some(&[1, 1, 1][..]));
-        assert_eq!(iter.next(), Some(&[3, 3][..]));
-        assert_eq!(iter.next(), Some(&[2, 2, 2][..]));
-        assert_eq!(iter.next(), Some(&[1][..]));
-        assert_eq!(iter.next(), Some(&[0][..]));
-        assert_eq!(iter.next(), None);
     }
 }


### PR DESCRIPTION
#### Problem

We manually implemented GroupBy because it was experimental and only available in rust-nightly. Rust 1.77.0 stabilized this feature, and it is now available in rust-stable as `ChunkBy`. We can replace our copy with rust std.


#### Summary of Changes

Replace our GroupBy with rust's ChunkBy.