### PR TITLE
Fix calculation of packed slots minimum when calculating accounts to combine

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1795,9 +1795,11 @@ pub mod tests {
                             // When there are two_refs and when slots < 3, all regular slots can fit into one ancient slots.
                             // Therefore, we should have all slots that can be combined for slots < 3.
                             // However, when slots >=3, we need more than one ancient slots. The pack algorithm will need to first
-                            // find at least [ceiling(num_slots/2.5) - 1] slots that's doesn't have many_refs before we can pack slots with many_refs.
-                            // Since all the slots have many_refs, we can't find any eligible slot to combine.
-                            0
+                            // find at least [ceiling(num_slots/2.5) - 1] slots that's don't have many_refs before we can pack slots with many_refs.
+                            // Since we decrease the number of alive bytes we'll be writing, when we encounter slots that can't be packed,
+                            // we now reduce the number required ideal packed storages. As a result, the last
+                            // slot can be packed, and the number of accounts to combine should be 2.
+                            2
                         } else {
                             num_slots
                         };
@@ -1901,7 +1903,9 @@ pub mod tests {
                                     many_ref_slots,
                                 );
                                 // if we are only trying to pack a single slot of multi-refs, it will succeed
-                                // if num_slots = 2 and skip multi-ref slots, accounts_to_combine should be empty.
+                                // if num_slots = 2 and skip multi-ref slots, accounts_to_combine should contain
+                                // one element (storage), because we don't count alive bytes of skipped accounts
+                                // when we compute required target storages, and the second slot can be combined.
                                 let expected_number_accounts_to_combine = if !two_refs
                                     || many_ref_slots == IncludeManyRefSlots::Include
                                     || num_slots == 1


### PR DESCRIPTION
#### Problem

In ancient pack, we can encounter storages which can't be safely moved to new slots. One example is when a storage contains an alive account whose refcount > 1. In that case, we can only move the alive account to a slot that is newer than the current slot. Otherwise, we risk moving the alive account to a slot older than the currently dead account. If we restarted from a snapshot, we would have the wrong alive version of an account.
When determining whether individual storages can be packed, when we encounter a storage with a multi ref account and we determine we can't pack it this time, we have now decreased the # of alive bytes we'll be writing. As a result, we now reduce the # required ideal packed storages. As a result, this makes it easier for multi ref storages we encounter later in this pack to succeed.
 
#### Summary of Changes

If we determine a storage cannot be packed, reduce the # alive bytes so we can reduce the # ideal storages we'll be creating. This allows the algorithm to make progress.