### PR TITLE
Refine the condition for 'should shrink' decision

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7518,7 +7518,7 @@ impl AccountsDb {
         true
     }
 
-    fn is_candidate_for_shrink(&self, store: &AccountStorageEntry) -> bool {
+    pub(crate) fn is_candidate_for_shrink(&self, store: &AccountStorageEntry) -> bool {
         // appended ancient append vecs should not be shrunk by the normal shrink codepath.
         // It is not possible to identify ancient append vecs when we pack, so no check for ancient when we are not appending.
         let total_bytes = if self.create_ancient_storage == CreateAncientStorage::Append

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -2681,7 +2681,7 @@ pub mod tests {
                             .iter()
                             .zip(infos.all_infos.iter())
                             .for_each(|(storage, info)| {
-                                let should_shrink = db.is_candidate_for_shrink(&storage);
+                                let should_shrink = db.is_candidate_for_shrink(storage);
                                 assert_storage_info(info, storage, should_shrink);
                                 if should_shrink {
                                     // data size is so small compared to min aligned file size that the storage is marked as should_shrink
@@ -2779,7 +2779,7 @@ pub mod tests {
                     assert_eq!(infos.all_infos.len(), 1, "method: {method:?}");
                     alive_storages.iter().zip(infos.all_infos.iter()).for_each(
                         |(storage, info)| {
-                            let should_shrink = db.is_candidate_for_shrink(&storage);
+                            let should_shrink = db.is_candidate_for_shrink(storage);
                             assert_storage_info(info, storage, should_shrink);
                             if should_shrink {
                                 // data size is so small compared to min aligned file size that the storage is marked as should_shrink

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -98,20 +98,21 @@ impl AncientSlotInfos {
         can_randomly_shrink: bool,
         ideal_size: NonZeroU64,
         is_high_slot: bool,
+        db: &AccountsDb,
     ) -> bool {
         let mut was_randomly_shrunk = false;
         let alive_bytes = storage.alive_bytes() as u64;
         if alive_bytes > 0 {
             let capacity = storage.accounts.capacity();
             let should_shrink = if capacity > 0 {
-                let alive_ratio = alive_bytes * 100 / capacity;
-                alive_ratio < 90
-                    || if can_randomly_shrink && thread_rng().gen_range(0..10000) == 0 {
-                        was_randomly_shrunk = true;
-                        true
-                    } else {
-                        false
-                    }
+                if db.is_candidate_for_shrink(&storage) {
+                    true
+                } else if can_randomly_shrink && thread_rng().gen_range(0..10000) == 0 {
+                    was_randomly_shrunk = true;
+                    true
+                } else {
+                    false
+                }
             } else {
                 false
             };
@@ -584,6 +585,7 @@ impl AccountsDb {
                     tuning.can_randomly_shrink,
                     tuning.ideal_storage_size,
                     is_high_slot(*slot),
+                    self,
                 ) {
                     randoms += 1;
                 }
@@ -2568,6 +2570,7 @@ pub mod tests {
                             can_randomly_shrink,
                             NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
                             high_slot,
+                            &db,
                         );
                     }
                     TestCollectInfo::CalcAncientSlotInfo => {
@@ -2621,6 +2624,7 @@ pub mod tests {
                     can_randomly_shrink,
                     NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
                     high_slot,
+                    &db,
                 );
             } else {
                 let tuning = PackedAncientStorageTuning {


### PR DESCRIPTION
#### Problem
When the ancient packing algorithm was designed, the intention was for 'shrinking' to occur as part of packing. This was observed to cause cold and warm accounts to be continually mixed, resulting in lots of disk i/o churn. In the newer strategy, we don't combine previously packed ancient storages with newly ancient storages. We do, however, rely on shrinking to shrink ancient storages. An important concept is that older ancient storages are very cold. Thus, the accounts in them are not expected to change frequently. if we require a threshold, like < 90% accounts are alive, some of these storages will never fail the threshold and be eligible for shrinking. When shrinking is idle, it finds the ancient storage with the highest # dead bytes and shrinks it.

#### Summary of Changes
Ancient packing adds ALL storages with dead bytes to the list that shrink uses to determine which ancient storages to shrink when shrink is otherwise idle.
