### PR TITLE
SVM: refactor entrypoint around `check_results`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3708,7 +3708,7 @@ impl Bank {
 
         let sanitized_output = self
             .transaction_processor
-            .load_and_execute_sanitized_transactions(
+            .load_and_execute_batch_with_preprocessing_checks(
                 self,
                 sanitized_txs,
                 check_results,

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -562,7 +562,7 @@ impl JsonRpcRequestProcessor {
             .transaction_processor
             .read()
             .unwrap()
-            .load_and_execute_sanitized_transactions(
+            .load_and_execute_batch_with_preprocessing_checks(
                 bank,
                 sanitized_txs,
                 check_results,

--- a/svm/examples/paytube/src/lib.rs
+++ b/svm/examples/paytube/src/lib.rs
@@ -63,9 +63,7 @@ use {
     crate::{
         loader::PayTubeAccountLoader, settler::PayTubeSettler, transaction::PayTubeTransaction,
     },
-    processor::{
-        create_transaction_batch_processor, get_transaction_check_results, PayTubeForkGraph,
-    },
+    processor::{create_transaction_batch_processor, PayTubeForkGraph},
     solana_client::rpc_client::RpcClient,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_sdk::{
@@ -174,10 +172,9 @@ impl PayTubeChannel {
 
         // Step 2: Process the SVM-compatible transactions with the SVM API.
         log::processing_transactions(svm_transactions.len());
-        let results = processor.load_and_execute_sanitized_transactions(
+        let results = processor.load_and_execute_batch(
             &account_loader,
             &svm_transactions,
-            get_transaction_check_results(svm_transactions.len(), lamports_per_signature),
             &processing_environment,
             &processing_config,
         );

--- a/svm/examples/paytube/src/processor.rs
+++ b/svm/examples/paytube/src/processor.rs
@@ -4,9 +4,8 @@ use {
     solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_program_runtime::loaded_programs::{BlockRelation, ForkGraph, ProgramCacheEntry},
-    solana_sdk::{clock::Slot, feature_set::FeatureSet, transaction},
+    solana_sdk::{clock::Slot, feature_set::FeatureSet},
     solana_svm::{
-        account_loader::CheckedTransactionDetails,
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processor::TransactionBatchProcessor,
     },
@@ -90,20 +89,4 @@ pub(crate) fn create_transaction_batch_processor<CB: TransactionProcessingCallba
     );
 
     processor
-}
-
-/// This function is also a mock. In the Agave validator, the bank pre-checks
-/// transactions before providing them to the SVM API. We mock this step in
-/// PayTube, since we don't need to perform such pre-checks.
-pub(crate) fn get_transaction_check_results(
-    len: usize,
-    lamports_per_signature: u64,
-) -> Vec<transaction::Result<CheckedTransactionDetails>> {
-    vec![
-        transaction::Result::Ok(CheckedTransactionDetails {
-            nonce: None,
-            lamports_per_signature,
-        });
-        len
-    ]
 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -240,8 +240,64 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         self.sysvar_cache.read().unwrap()
     }
 
-    /// Main entrypoint to the SVM.
-    pub fn load_and_execute_sanitized_transactions<CB: TransactionProcessingCallback>(
+    /// Main entrypoint to the SVM. Load and execute a batch of sanitized
+    /// transactions.
+    ///
+    /// The behavior of the SVM is configurable entirely from this method's
+    /// parameters.
+    ///
+    /// * `callbacks`: Reference to an object that implements the
+    ///   `TransactionProcessingCallback` trait. This plugin is used by SVM
+    ///   to load accounts, check account ownership, and more.
+    /// * `sanitized_txs`: A slice of sanitized transactions to process.
+    /// * `environment`: Configures the SVM runtime environment to use when
+    ///   processing the transaction batch.
+    /// * `config`: Additional configurations for controlling the behavior of
+    ///   SVM during transaction processing.
+    ///
+    /// Note: SVM has built-in support for evaluating preprocessing checks that
+    /// may have occurred before invoking the SVM API. These could be useful
+    /// for architectures that may wish to stream batches, performing checks
+    /// on-the-fly that aren't supported by SVM directly.
+    ///
+    /// If you wish to involve pre-processing checks, you can use
+    /// `load_and_execute_batch_with_preprocessing_checks` instead.
+    pub fn load_and_execute_batch<CB: TransactionProcessingCallback>(
+        &self,
+        callbacks: &CB,
+        sanitized_txs: &[impl SVMTransaction],
+        environment: &TransactionProcessingEnvironment,
+        config: &TransactionProcessingConfig,
+    ) -> LoadAndExecuteSanitizedTransactionsOutput {
+        let check_results = vec![
+            Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: environment.lamports_per_signature
+            });
+            sanitized_txs.len()
+        ];
+        self.load_and_execute_batch_with_preprocessing_checks(
+            callbacks,
+            sanitized_txs,
+            check_results,
+            environment,
+            config,
+        )
+    }
+
+    /// Load and execute a batch of sanitized transactions, with pre-processing
+    /// checks.
+    ///
+    /// This method's behavior is exactly the same as the flagship
+    /// `load_and_execute_batch`, except pre-processing checks are considered
+    /// when processing the batch.
+    ///
+    /// The vector of `check_results` must have the same length as the provided
+    /// slice of `sanitized_txs`. If the lengths do not match, the method will
+    /// panic.
+    ///
+    /// Any transaction that has a check result of `Err` will not be processed.
+    pub fn load_and_execute_batch_with_preprocessing_checks<CB: TransactionProcessingCallback>(
         &self,
         callbacks: &CB,
         sanitized_txs: &[impl SVMTransaction],
@@ -259,6 +315,23 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             "Length of check_results does not match length of sanitized_txs"
         );
 
+        self.load_and_execute_batch_inner(
+            callbacks,
+            sanitized_txs,
+            check_results,
+            environment,
+            config,
+        )
+    }
+
+    fn load_and_execute_batch_inner<CB: TransactionProcessingCallback>(
+        &self,
+        callbacks: &CB,
+        sanitized_txs: &[impl SVMTransaction],
+        check_results: Vec<TransactionCheckResult>,
+        environment: &TransactionProcessingEnvironment,
+        config: &TransactionProcessingConfig,
+    ) -> LoadAndExecuteSanitizedTransactionsOutput {
         // Initialize metrics.
         let mut error_metrics = TransactionErrorMetrics::default();
         let mut execute_timings = ExecuteTimings::default();
@@ -1158,7 +1231,7 @@ mod tests {
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         let callback = MockBankCallback::default();
 
-        batch_processor.load_and_execute_sanitized_transactions(
+        batch_processor.load_and_execute_batch_with_preprocessing_checks(
             &callback,
             &sanitized_txs,
             check_results,

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -243,7 +243,7 @@ fn svm_concurrent() {
             let check_tx_data = std::mem::take(&mut check_data[idx]);
 
             thread::spawn(move || {
-                let result = local_batch.load_and_execute_sanitized_transactions(
+                let result = local_batch.load_and_execute_batch_with_preprocessing_checks(
                     &*local_bank,
                     &th_txs,
                     check_results,

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -33,7 +33,6 @@ use {
         },
     },
     solana_svm::{
-        account_loader::CheckedTransactionDetails,
         program_loader,
         transaction_processing_callback::TransactionProcessingCallback,
         transaction_processing_result::TransactionProcessingResultExtensions,
@@ -230,10 +229,6 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
     };
 
     let transactions = vec![transaction];
-    let transaction_check = vec![Ok(CheckedTransactionDetails {
-        nonce: None,
-        lamports_per_signature: 30,
-    })];
 
     let compute_budget = ComputeBudget {
         compute_unit_limit: input.cu_avail,
@@ -299,10 +294,9 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
         return;
     }
 
-    let result = batch_processor.load_and_execute_sanitized_transactions(
+    let result = batch_processor.load_and_execute_batch(
         &mock_bank,
         &transactions,
-        transaction_check,
         &TransactionProcessingEnvironment {
             blockhash,
             lamports_per_signature,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -130,7 +130,7 @@ impl SvmTestEnvironment<'_> {
         let (transactions, check_results) = self.test_entry.prepare_transactions();
         let batch_output = self
             .batch_processor
-            .load_and_execute_sanitized_transactions(
+            .load_and_execute_batch_with_preprocessing_checks(
                 &self.mock_bank,
                 &transactions,
                 check_results,


### PR DESCRIPTION
#### Problem

I hate this parameter with a burning passion. I'm not sure if this is the right 
approach, but it at least gives consumers of the SVM API a better devex for 
working around `check_results`, mainly omitting them.

The SVM API makes use of a parameter `check_results`, which is a vector of 
results from pre-processing a batch of transactions. It gets zipped against the 
slice of transactions immediately and then passed around in that zipped form for 
a few other checks.

The core idea behind the check results is to skip processing of any transactions 
whose check result is `Err`. 

We're kind of stuck with this architecture due to Bank's `lock_results`, which 
are evaluated on transaction locking before invoking the SVM API. We could 
either refactor the SVM API a bit, with documentation, to help clarify how to 
use this parameter or omit it, or we could introduce a pretty large and 
convoluted change surface to the runtime in order to make pre-processing a 
plugin instead.

#### Summary of Changes

Break the main entrypoint of the SVM API into two separate methods, each of 
which call into a common `load_and_execute_batch_inner` method, which contains 
the current functionality of SVM.

The first method - `load_and_execute_batch` - allows anyone consuming the API to 
never have to worry about configuring check results, and they can just provide a 
slice of transactions directly (with the other configs). The second - 
`load_and_execute_batch_with_preprocessing_checks` - is an intentionally verbose 
alternate method, which accept the infamous `check_results` parameter, to be 
used in active transaction processing.

The first method bakes the "stubbing out" of check results into the SVM API 
itself.