### PR TITLE
Deduper: Fix Hash-dependent Tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7237,6 +7237,7 @@ dependencies = [
  "log",
  "nix",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rayon",
  "serde",
  "solana-frozen-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7237,7 +7237,6 @@ dependencies = [
  "log",
  "nix",
  "rand 0.8.5",
- "rand_chacha 0.3.1",
  "rayon",
  "serde",
  "solana-frozen-abi",

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -43,6 +43,7 @@ name = "solana_perf"
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+rand_chacha = { workspace = true }
 solana-logger = { workspace = true }
 test-case = { workspace = true }
 

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -43,7 +43,6 @@ name = "solana_perf"
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-rand_chacha = { workspace = true }
 solana-logger = { workspace = true }
 test-case = { workspace = true }
 
@@ -67,7 +66,4 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
-check-cfg = [
-    'cfg(build_target_feature_avx)',
-    'cfg(build_target_feature_avx2)',
-]
+check-cfg = ['cfg(build_target_feature_avx)', 'cfg(build_target_feature_avx2)']

--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -134,9 +134,6 @@ mod tests {
     use {
         super::*,
         crate::{packet::to_packet_batches, sigverify, test_tx::test_tx},
-        rand::SeedableRng,
-        rand_chacha::ChaChaRng,
-        solana_sdk::packet::{Meta, PACKET_DATA_SIZE},
         test_case::test_case,
     };
 

--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -64,7 +64,6 @@ impl<const K: usize, T: ?Sized + Hash> Deduper<K, T> {
 
     // Returns true if the data is duplicate.
     #[must_use]
-    #[allow(clippy::arithmetic_side_effects)]
     pub fn dedup(&self, data: &T) -> bool {
         let hashes = self
             .state
@@ -81,6 +80,7 @@ impl<const K: usize, T: ?Sized + Hash> Deduper<K, T> {
     // inconsistent between machines. This method allows tests to provide
     // consistent "hashed" values that get inserted into the data-structure,
     // so that they may assert the expected behavior
+    #[allow(clippy::arithmetic_side_effects)]
     fn dedup_hashed(&self, hashes: impl ExactSizeIterator<Item = u64>) -> bool {
         let mut out = true;
         for hash in hashes {


### PR DESCRIPTION
#### Problem
- #3254 upgraded the `prio-graph` library. 
- That library uses `ahash v0.8.11`.
- Cargo will use highest non-breaking version, in this case `0.8.11`
- Current `Deduper` tests depend on consistent hashing output, which is explicitly not guaranteed by the `ahash` crate

#### Summary of Changes
- Refactor `Deduper` to have a fn to operate on already hashed values
- Remove tests on `dedup` itself, instead testing `dedup_hashed`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
