### PR TITLE
Invoke ancient slots shrinking only if skipping rewrites is enabled

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6445,10 +6445,21 @@ impl Bank {
     }
 
     pub(crate) fn shrink_ancient_slots(&self) {
-        self.rc
+        let can_skip_rewrites = self.bank_hash_skips_rent_rewrites();
+        let test_skip_rewrites_but_include_in_bank_hash = self
+            .rc
             .accounts
             .accounts_db
-            .shrink_ancient_slots(self.epoch_schedule())
+            .test_skip_rewrites_but_include_in_bank_hash;
+        // Invoke ancient slot shrinking only when the validator is
+        // explicitly configured to do so. This condition may be
+        // removed when the skip rewrites feature is enabled.
+        if can_skip_rewrites || test_skip_rewrites_but_include_in_bank_hash {
+            self.rc
+                .accounts
+                .accounts_db
+                .shrink_ancient_slots(self.epoch_schedule())
+        }
     }
 
     pub fn read_cost_tracker(&self) -> LockResult<RwLockReadGuard<CostTracker>> {


### PR DESCRIPTION
#### Problem

Ancient slots shrinking currently should be done only when skipping rewrites is enabled. However, the entry function to ancient slots shrinking is unconditionally invoked in ABS.

#### Summary of Changes

Add a guarding check that prevents invocation of ancient slots shrinking unless the skip rewrites is enabled from the command line or by the feature gate.

This allows us more flexibility in setting up the parameters of the ancient slots shrinking implementation, in particular the changes of #3205.