### PR TITLE
Cleanup AccountsDb::new_with_config()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1933,26 +1933,10 @@ impl AccountsDb {
     ) -> Self {
         let accounts_db_config = accounts_db_config.unwrap_or_default();
         let accounts_index = AccountsIndex::new(accounts_db_config.index.clone(), exit);
-
         let base_working_path = accounts_db_config.base_working_path.clone();
-
         let accounts_hash_cache_path = accounts_db_config.accounts_hash_cache_path.clone();
 
-        let skip_initial_hash_calc = accounts_db_config.skip_initial_hash_calc;
-
-        let ancient_append_vec_offset = accounts_db_config
-            .ancient_append_vec_offset
-            .or(ANCIENT_APPEND_VEC_DEFAULT_OFFSET);
-
-        let exhaustively_verify_refcounts = accounts_db_config.exhaustively_verify_refcounts;
-
-        let create_ancient_storage = accounts_db_config.create_ancient_storage;
-
         let test_partitioned_epoch_rewards = accounts_db_config.test_partitioned_epoch_rewards;
-
-        let test_skip_rewrites_but_include_in_bank_hash =
-            accounts_db_config.test_skip_rewrites_but_include_in_bank_hash;
-
         let partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig =
             PartitionedEpochRewardsConfig::new(test_partitioned_epoch_rewards);
 
@@ -1961,24 +1945,18 @@ impl AccountsDb {
             Self::DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_HI,
         ));
 
-        let storage_access = accounts_db_config.storage_access;
-
-        let scan_filter_for_shrinking = accounts_db_config.scan_filter_for_shrinking;
-
-        let enable_experimental_accumulator_hash = accounts_db_config
-            .enable_experimental_accumulator_hash
-            .into();
-
         let paths_is_empty = paths.is_empty();
         let mut new = Self {
             paths,
-            skip_initial_hash_calc,
-            ancient_append_vec_offset,
+            skip_initial_hash_calc: accounts_db_config.skip_initial_hash_calc,
+            ancient_append_vec_offset: accounts_db_config
+                .ancient_append_vec_offset
+                .or(ANCIENT_APPEND_VEC_DEFAULT_OFFSET),
             cluster_type: Some(*cluster_type),
             account_indexes,
             shrink_ratio,
             accounts_update_notifier,
-            create_ancient_storage,
+            create_ancient_storage: accounts_db_config.create_ancient_storage,
             read_only_accounts_cache: ReadOnlyAccountsCache::new(
                 read_cache_size.0,
                 read_cache_size.1,
@@ -1986,11 +1964,14 @@ impl AccountsDb {
             ),
             write_cache_limit_bytes: accounts_db_config.write_cache_limit_bytes,
             partitioned_epoch_rewards_config,
-            exhaustively_verify_refcounts,
-            test_skip_rewrites_but_include_in_bank_hash,
-            storage_access,
-            scan_filter_for_shrinking,
-            is_experimental_accumulator_hash_enabled: enable_experimental_accumulator_hash,
+            exhaustively_verify_refcounts: accounts_db_config.exhaustively_verify_refcounts,
+            test_skip_rewrites_but_include_in_bank_hash: accounts_db_config
+                .test_skip_rewrites_but_include_in_bank_hash,
+            storage_access: accounts_db_config.storage_access,
+            scan_filter_for_shrinking: accounts_db_config.scan_filter_for_shrinking,
+            is_experimental_accumulator_hash_enabled: accounts_db_config
+                .enable_experimental_accumulator_hash
+                .into(),
             ..Self::default_with_accounts_index(
                 accounts_index,
                 base_working_path,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1927,77 +1927,46 @@ impl AccountsDb {
         cluster_type: &ClusterType,
         account_indexes: AccountSecondaryIndexes,
         shrink_ratio: AccountShrinkThreshold,
-        mut accounts_db_config: Option<AccountsDbConfig>,
+        accounts_db_config: Option<AccountsDbConfig>,
         accounts_update_notifier: Option<AccountsUpdateNotifier>,
         exit: Arc<AtomicBool>,
     ) -> Self {
-        let default_accounts_db_config = AccountsDbConfig::default();
+        let accounts_db_config = accounts_db_config.unwrap_or_default();
+        let accounts_index = AccountsIndex::new(accounts_db_config.index.clone(), exit);
 
-        let accounts_index = AccountsIndex::new(
-            accounts_db_config.as_mut().and_then(|x| x.index.take()),
-            exit,
-        );
-        let base_working_path = accounts_db_config
-            .as_ref()
-            .and_then(|x| x.base_working_path.clone());
-        let accounts_hash_cache_path = accounts_db_config
-            .as_ref()
-            .and_then(|config| config.accounts_hash_cache_path.clone());
-        let skip_initial_hash_calc = accounts_db_config
-            .as_ref()
-            .map(|config| config.skip_initial_hash_calc)
-            .unwrap_or_default();
+        let base_working_path = accounts_db_config.base_working_path.clone();
+
+        let accounts_hash_cache_path = accounts_db_config.accounts_hash_cache_path.clone();
+
+        let skip_initial_hash_calc = accounts_db_config.skip_initial_hash_calc;
 
         let ancient_append_vec_offset = accounts_db_config
-            .as_ref()
-            .and_then(|config| config.ancient_append_vec_offset)
+            .ancient_append_vec_offset
             .or(ANCIENT_APPEND_VEC_DEFAULT_OFFSET);
 
-        let exhaustively_verify_refcounts = accounts_db_config
-            .as_ref()
-            .map(|config| config.exhaustively_verify_refcounts)
-            .unwrap_or_default();
+        let exhaustively_verify_refcounts = accounts_db_config.exhaustively_verify_refcounts;
 
-        let create_ancient_storage = accounts_db_config
-            .as_ref()
-            .map(|config| config.create_ancient_storage)
-            .unwrap_or_default();
+        let create_ancient_storage = accounts_db_config.create_ancient_storage;
 
-        let test_partitioned_epoch_rewards = accounts_db_config
-            .as_ref()
-            .map(|config| config.test_partitioned_epoch_rewards)
-            .unwrap_or_default();
+        let test_partitioned_epoch_rewards = accounts_db_config.test_partitioned_epoch_rewards;
 
-        let test_skip_rewrites_but_include_in_bank_hash = accounts_db_config
-            .as_ref()
-            .map(|config| config.test_skip_rewrites_but_include_in_bank_hash)
-            .unwrap_or_default();
+        let test_skip_rewrites_but_include_in_bank_hash =
+            accounts_db_config.test_skip_rewrites_but_include_in_bank_hash;
 
         let partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig =
             PartitionedEpochRewardsConfig::new(test_partitioned_epoch_rewards);
 
-        let read_cache_size = accounts_db_config
-            .as_ref()
-            .and_then(|config| config.read_cache_limit_bytes)
-            .unwrap_or((
-                Self::DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_LO,
-                Self::DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_HI,
-            ));
+        let read_cache_size = accounts_db_config.read_cache_limit_bytes.unwrap_or((
+            Self::DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_LO,
+            Self::DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_HI,
+        ));
 
-        let storage_access = accounts_db_config
-            .as_ref()
-            .map(|config| config.storage_access)
-            .unwrap_or_default();
+        let storage_access = accounts_db_config.storage_access;
 
-        let scan_filter_for_shrinking = accounts_db_config
-            .as_ref()
-            .map(|config| config.scan_filter_for_shrinking)
-            .unwrap_or_default();
+        let scan_filter_for_shrinking = accounts_db_config.scan_filter_for_shrinking;
 
         let enable_experimental_accumulator_hash = accounts_db_config
-            .as_ref()
-            .map(|config| config.enable_experimental_accumulator_hash)
-            .unwrap_or(default_accounts_db_config.enable_experimental_accumulator_hash)
+            .enable_experimental_accumulator_hash
             .into();
 
         let paths_is_empty = paths.is_empty();
@@ -2015,9 +1984,7 @@ impl AccountsDb {
                 read_cache_size.1,
                 Self::READ_ONLY_CACHE_MS_TO_SKIP_LRU_UPDATE,
             ),
-            write_cache_limit_bytes: accounts_db_config
-                .as_ref()
-                .and_then(|x| x.write_cache_limit_bytes),
+            write_cache_limit_bytes: accounts_db_config.write_cache_limit_bytes,
             partitioned_epoch_rewards_config,
             exhaustively_verify_refcounts,
             test_skip_rewrites_but_include_in_bank_hash,
@@ -2039,8 +2006,8 @@ impl AccountsDb {
             new.temp_paths = Some(temp_dirs);
         };
         new.shrink_paths = accounts_db_config
-            .as_ref()
-            .and_then(|config| config.shrink_paths.clone())
+            .shrink_paths
+            .clone()
             .unwrap_or_else(|| new.paths.clone());
 
         new.start_background_hasher();


### PR DESCRIPTION
~~This PR is built on top of https://github.com/anza-xyz/agave/pull/3268 and should be merged after it.~~ (done)

#### Problem
`AccountsDb::new_with_config()` takes an `Option<AccountsDbConfig>`. This parameter is repeatedly read to get values out, but doing so is tedious. This sequence `.as_ref().map(...).unwrap_or_default()` (or one very similar) is repeated numerous times in the function.

#### Summary of Changes
At the top of function, do:
```rust
let accounts_db_config = accounts_db_config.unwrap_or_default();
```
so that we can then operate on an `AccountsDbConfig` instead of `Option<AccountsDbConfig`. In addition to removing boilerplate code, I'd also argue this prevents a future footgun by removing the `unwrap_or_default()` in the function.

For example, supposed we had:
```rust
struct AccountsDbConfig {
    some_field_whose_default_value_is_true: bool,
    ...
}
```
And then following existing pattern in `AccountsDb::new_with_config()`
```rust
let some_field_whose_default_value_is_true =
    accounts_db_config.as_ref().map(|config| config.some_field_whose_default_value_is_true);
```
we'd get `false` instead of `true`. Granted, this currently won't happen because `AccountsDbConfig` just derives `Default`, but it is not unthinkable that a custom `Default` impl may be desired for this struct in the future