### PR TITLE
[zk-sdk] Make `AeKey` be `Clone` and `AeCiphertext` be `Copy`

### DIFF
--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -88,7 +88,7 @@ impl AuthenticatedEncryption {
     }
 }
 
-#[derive(Debug, Zeroize, Eq, PartialEq)]
+#[derive(Clone, Debug, Zeroize, Eq, PartialEq)]
 pub struct AeKey([u8; AE_KEY_LEN]);
 impl AeKey {
     /// Generates a random authenticated encryption key.

--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -243,7 +243,7 @@ type Nonce = [u8; NONCE_LEN];
 type Ciphertext = [u8; CIPHERTEXT_LEN];
 
 /// Authenticated encryption nonce and ciphertext
-#[derive(Debug, Default, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AeCiphertext {
     nonce: Nonce,
     ciphertext: Ciphertext,


### PR DESCRIPTION
#### Problem
- There is no way to duplicate the `AeKey` type, so it would be nice to make it `Clone`.
- The `AeCiphertext` type is `Clone`, but not `Copy` making duplicates a bit more awkward and verbose. `AeCiphertext` type is 24 bytes and not key-material, so it would be nice to make it `Copy` so that duplicates can be created implicitly.

#### Summary of Changes
- Make `AeKey` satisfy `Clone`
- Make `AeCiphertext` satisfy `Copy`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
