### PR TITLE
Remove unused ClusterType argument from AccountsDb

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -17,8 +17,7 @@ use {
     },
     solana_measure::measure::Measure,
     solana_sdk::{
-        genesis_config::ClusterType, pubkey::Pubkey, rent_collector::RentCollector,
-        sysvar::epoch_schedule::EpochSchedule,
+        pubkey::Pubkey, rent_collector::RentCollector, sysvar::epoch_schedule::EpochSchedule,
     },
     std::{env, fs, path::PathBuf, sync::Arc},
 };
@@ -72,7 +71,6 @@ fn main() {
     }
     let accounts_db = AccountsDb::new_with_config(
         vec![path],
-        &ClusterType::Testnet,
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
         Some(ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS),

--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -19,7 +19,6 @@ use {
     },
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount},
-        genesis_config::ClusterType,
         hash::Hash,
         pubkey::Pubkey,
         rent_collector::RentCollector,
@@ -37,7 +36,6 @@ use {
 fn new_accounts_db(account_paths: Vec<PathBuf>) -> AccountsDb {
     AccountsDb::new_with_config(
         account_paths,
-        &ClusterType::Development,
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
         Some(ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1085,7 +1085,6 @@ impl Bank {
     ) -> Self {
         let accounts_db = AccountsDb::new_with_config(
             paths,
-            &genesis_config.cluster_type,
             account_indexes,
             shrink_ratio,
             accounts_db_config,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1062,7 +1062,6 @@ where
 {
     let mut accounts_db = AccountsDb::new_with_config(
         account_paths.to_vec(),
-        &genesis_config.cluster_type,
         account_secondary_indexes,
         shrink_ratio,
         accounts_db_config,

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -225,7 +225,7 @@ mod serde_snapshot_tests {
     fn test_accounts_serialize(storage_access: StorageAccess) {
         solana_logger::setup();
         let (_accounts_dir, paths) = get_temp_accounts_paths(4).unwrap();
-        let accounts_db = AccountsDb::new_for_tests(paths, &ClusterType::Development);
+        let accounts_db = AccountsDb::new_for_tests(paths);
         let accounts = Accounts::new(Arc::new(accounts_db));
 
         let slot = 0;


### PR DESCRIPTION
#### Problem
ClusterType is plumbed through but unused. It looks like there used to be some cluster-specific behavior in computing account hash based on the diff where `expected_cluster_type()` was introduced (https://github.com/solana-labs/solana/pull/15615)

#### Summary of Changes
Rip the dead code