### PR TITLE
Fix account data_len 

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8868,7 +8868,9 @@ impl AccountsDb {
                             );
                             accessor.check_and_get_loaded_account(|loaded_account| {
                                 let data_len = loaded_account.data_len();
-                                accounts_data_len_from_duplicates += data_len;
+                                if loaded_account.lamports() > 0 {
+                                    accounts_data_len_from_duplicates += data_len;
+                                }
                                 num_duplicate_accounts += 1;
                                 if let Some(lamports_to_top_off) = Self::stats_for_rent_payers(
                                     pubkey,


### PR DESCRIPTION
#### Problem

account data_len could to be wrong if we have zero lamports accounts in the storage.

When accounts_data_len was populated [here](https://github.com/anza-xyz/agave/blob/aa44dc87c5c0eb6a7d02d5306ace15c40baac9cb/accounts-db/src/accounts_db.rs#L8828), we exclude zero lamport accounts. But when we visit it in dups, we don't exclude zero lamports.


#### Summary of Changes

check for zero lamports before subtract when visit duplicated accounts.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
