### PR TITLE
runtime: use leader schedule epoch to serve `sol_get_epoch_stake`

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6229,6 +6229,8 @@ dependencies = [
  "solana-timings",
  "solana-transaction-status",
  "solana-type-overrides",
+ "solana-vote",
+ "solana-vote-program",
  "solana_rbpf",
 ]
 
@@ -6662,6 +6664,13 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-upgraded"
+version = "2.1.0"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
+name = "solana-sbf-syscall-get-epoch-stake"
 version = "2.1.0"
 dependencies = [
  "solana-program",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -64,6 +64,8 @@ solana-svm-transaction = { path = "../../svm-transaction", version = "=2.1.0" }
 solana-timings = { path = "../../timings", version = "=2.1.0" }
 solana-transaction-status = { path = "../../transaction-status", version = "=2.1.0" }
 solana-type-overrides = { path = "../../type-overrides", version = "=2.1.0" }
+solana-vote = { path = "../../vote", version = "=2.1.0" }
+solana-vote-program = { path = "../../programs/vote", version = "=2.1.0" }
 agave-validator = { path = "../../validator", version = "=2.1.0" }
 solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=2.1.0" }
 solana_rbpf = "=0.8.5"
@@ -128,6 +130,8 @@ solana-svm-transaction = { workspace = true }
 solana-timings = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-type-overrides = { workspace = true }
+solana-vote = { workspace = true }
+solana-vote-program = { workspace = true }
 solana_rbpf = { workspace = true }
 
 [[bench]]
@@ -186,6 +190,7 @@ members = [
     "rust/simulation",
     "rust/spoof1",
     "rust/spoof1_system",
+    "rust/syscall-get-epoch-stake",
     "rust/sysvar",
     "rust/upgradeable",
     "rust/upgraded",

--- a/programs/sbf/rust/syscall-get-epoch-stake/Cargo.toml
+++ b/programs/sbf/rust/syscall-get-epoch-stake/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "solana-sbf-syscall-get-epoch-stake"
+version = { workspace = true }
+description = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-program = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]

--- a/programs/sbf/rust/syscall-get-epoch-stake/src/lib.rs
+++ b/programs/sbf/rust/syscall-get-epoch-stake/src/lib.rs
@@ -1,0 +1,39 @@
+//! Example Rust-based SBF program that tests the `sol_get_epoch_stake`
+//! syscall.
+
+extern crate solana_program;
+use solana_program::{
+    account_info::AccountInfo,
+    entrypoint::ProgramResult,
+    epoch_stake::{get_epoch_stake_for_vote_account, get_epoch_total_stake},
+    msg,
+    program::set_return_data,
+    pubkey::Pubkey,
+};
+
+solana_program::entrypoint_no_alloc!(process_instruction);
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    // Total stake.
+    let total_stake = get_epoch_total_stake();
+    assert_ne!(total_stake, 0);
+    msg!("Total Stake: {}", total_stake);
+
+    // Vote accounts.
+    let check_vote_account_stake = |i: usize| {
+        let vote_address = accounts[i].key;
+        let vote_stake = get_epoch_stake_for_vote_account(vote_address);
+        assert_ne!(vote_stake, 0);
+        msg!("Vote Stake for account {}: {}", i, vote_stake);
+    };
+    check_vote_account_stake(0);
+    check_vote_account_stake(1);
+
+    // For good measure, set the return data to total stake.
+    set_return_data(&total_stake.to_le_bytes());
+
+    Ok(())
+}

--- a/programs/sbf/tests/syscall_get_epoch_stake.rs
+++ b/programs/sbf/tests/syscall_get_epoch_stake.rs
@@ -1,0 +1,102 @@
+#![cfg(feature = "sbf_rust")]
+
+use {
+    solana_runtime::{
+        bank::Bank,
+        bank_client::BankClient,
+        epoch_stakes::EpochStakes,
+        genesis_utils::{
+            create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
+        },
+        loader_utils::load_upgradeable_program_and_advance_slot,
+    },
+    solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        message::Message,
+        signature::{Keypair, Signer},
+        transaction::{SanitizedTransaction, Transaction},
+    },
+    solana_vote::vote_account::VoteAccount,
+    solana_vote_program::vote_state::create_account_with_authorized,
+    std::collections::HashMap,
+};
+
+#[test]
+fn test_syscall_get_epoch_stake() {
+    solana_logger::setup();
+
+    // Two vote accounts with stake.
+    let stakes = vec![100_000_000, 500_000_000];
+    let voting_keypairs = vec![
+        ValidatorVoteKeypairs::new_rand(),
+        ValidatorVoteKeypairs::new_rand(),
+    ];
+    let total_stake: u64 = stakes.iter().sum();
+
+    let GenesisConfigInfo {
+        genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config_with_vote_accounts(1_000_000_000, &voting_keypairs, stakes.clone());
+
+    let mut bank = Bank::new_for_tests(&genesis_config);
+
+    // Intentionally overwrite the bank epoch with no stake, to ensure the
+    // syscall gets the _current_ epoch stake based on the leader schedule
+    // (N + 1).
+    let epoch_stakes_epoch_0 = EpochStakes::new_for_tests(
+        voting_keypairs
+            .iter()
+            .map(|keypair| {
+                let node_id = keypair.node_keypair.pubkey();
+                let authorized_voter = keypair.vote_keypair.pubkey();
+                let vote_account = VoteAccount::try_from(create_account_with_authorized(
+                    &node_id,
+                    &authorized_voter,
+                    &node_id,
+                    0,
+                    100,
+                ))
+                .unwrap();
+                (authorized_voter, (0, vote_account)) // No stake.
+            })
+            .collect::<HashMap<_, _>>(),
+        0, // Leader schedule epoch 0
+    );
+    bank.set_epoch_stakes_for_test(0, epoch_stakes_epoch_0);
+
+    let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+    let mut bank_client = BankClient::new_shared(bank);
+
+    let authority_keypair = Keypair::new();
+    let (bank, program_id) = load_upgradeable_program_and_advance_slot(
+        &mut bank_client,
+        bank_forks.as_ref(),
+        &mint_keypair,
+        &authority_keypair,
+        "solana_sbf_syscall_get_epoch_stake",
+    );
+    bank.freeze();
+
+    let instruction = Instruction::new_with_bytes(
+        program_id,
+        &[],
+        vec![
+            AccountMeta::new_readonly(voting_keypairs[0].vote_keypair.pubkey(), false),
+            AccountMeta::new_readonly(voting_keypairs[1].vote_keypair.pubkey(), false),
+        ],
+    );
+
+    let blockhash = bank.last_blockhash();
+    let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
+    let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
+    let sanitized_tx = SanitizedTransaction::from_transaction_for_tests(transaction);
+
+    let result = bank.simulate_transaction(&sanitized_tx, false);
+
+    assert!(result.result.is_ok());
+
+    let return_data_le_bytes: [u8; 8] = result.return_data.unwrap().data[0..8].try_into().unwrap();
+    let total_stake_from_return_data = u64::from_le_bytes(return_data_le_bytes);
+    assert_eq!(total_stake_from_return_data, total_stake);
+}

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3673,8 +3673,8 @@ impl Bank {
             RentCollectorWithMetrics::new(self.rent_collector.clone());
         let processing_environment = TransactionProcessingEnvironment {
             blockhash,
-            epoch_total_stake: self.epoch_total_stake(self.epoch()),
-            epoch_vote_accounts: self.epoch_vote_accounts(self.epoch()),
+            epoch_total_stake: self.get_current_epoch_total_stake(),
+            epoch_vote_accounts: self.get_current_epoch_vote_accounts(),
             feature_set: Arc::clone(&self.feature_set),
             fee_structure: Some(&self.fee_structure),
             lamports_per_signature,
@@ -6302,10 +6302,27 @@ impl Bank {
             .map(|epoch_stakes| epoch_stakes.total_stake())
     }
 
+    /// Get the total epoch stake for the current Bank::epoch
+    pub fn get_current_epoch_total_stake(&self) -> Option<u64> {
+        self.epoch_stakes
+            .get(&self.epoch.saturating_add(1))
+            .map(|epoch_stakes| epoch_stakes.total_stake())
+    }
+
     /// vote accounts for the specific epoch along with the stake
     ///   attributed to each account
     pub fn epoch_vote_accounts(&self, epoch: Epoch) -> Option<&VoteAccountsHashMap> {
         let epoch_stakes = self.epoch_stakes.get(&epoch)?.stakes();
+        Some(epoch_stakes.vote_accounts().as_ref())
+    }
+
+    /// Get the vote accounts along with the stake attributed to each account
+    /// for the current Bank::epoch
+    pub fn get_current_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
+        let epoch_stakes = self
+            .epoch_stakes
+            .get(&self.epoch.saturating_add(1))?
+            .stakes();
         Some(epoch_stakes.vote_accounts().as_ref())
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3673,8 +3673,8 @@ impl Bank {
             RentCollectorWithMetrics::new(self.rent_collector.clone());
         let processing_environment = TransactionProcessingEnvironment {
             blockhash,
-            epoch_total_stake: self.get_current_epoch_total_stake(),
-            epoch_vote_accounts: self.get_current_epoch_vote_accounts(),
+            epoch_total_stake: Some(self.get_current_epoch_total_stake()),
+            epoch_vote_accounts: Some(self.get_current_epoch_vote_accounts()),
             feature_set: Arc::clone(&self.feature_set),
             fee_structure: Some(&self.fee_structure),
             lamports_per_signature,
@@ -6303,10 +6303,8 @@ impl Bank {
     }
 
     /// Get the total epoch stake for the current Bank::epoch
-    pub fn get_current_epoch_total_stake(&self) -> Option<u64> {
-        self.epoch_stakes
-            .get(&self.epoch.saturating_add(1))
-            .map(|epoch_stakes| epoch_stakes.total_stake())
+    pub fn get_current_epoch_total_stake(&self) -> u64 {
+        self.current_epoch_stakes().total_stake()
     }
 
     /// vote accounts for the specific epoch along with the stake
@@ -6318,12 +6316,11 @@ impl Bank {
 
     /// Get the vote accounts along with the stake attributed to each account
     /// for the current Bank::epoch
-    pub fn get_current_epoch_vote_accounts(&self) -> Option<&VoteAccountsHashMap> {
-        let epoch_stakes = self
-            .epoch_stakes
-            .get(&self.epoch.saturating_add(1))?
-            .stakes();
-        Some(epoch_stakes.vote_accounts().as_ref())
+    pub fn get_current_epoch_vote_accounts(&self) -> &VoteAccountsHashMap {
+        self.current_epoch_stakes()
+            .stakes()
+            .vote_accounts()
+            .as_ref()
     }
 
     /// Get the fixed authorized voter for the given vote account for the

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13261,17 +13261,17 @@ fn test_bank_epoch_stakes() {
 
     // Note using bank's `current_epoch_stake_*` methods should return the
     // same values.
-    assert_eq!(bank0.get_current_epoch_total_stake(), Some(total_stake));
+    assert_eq!(bank0.get_current_epoch_total_stake(), total_stake);
     assert_eq!(
         bank0.get_current_epoch_total_stake(),
-        bank0.epoch_total_stake(1)
+        bank0.epoch_total_stake(1).unwrap(),
     );
     assert_eq!(
-        bank0.get_current_epoch_vote_accounts().unwrap().len(),
+        bank0.get_current_epoch_vote_accounts().len(),
         voting_keypairs.len()
     );
     assert_eq!(
-        bank0.epoch_vote_accounts(1),
+        bank0.epoch_vote_accounts(1).unwrap(),
         bank0.get_current_epoch_vote_accounts(),
     );
 
@@ -13301,17 +13301,17 @@ fn test_bank_epoch_stakes() {
 
     // Again, using bank's `current_epoch_stake_*` methods should return the
     // same values.
-    assert_eq!(bank1.get_current_epoch_total_stake(), Some(total_stake));
+    assert_eq!(bank1.get_current_epoch_total_stake(), total_stake);
     assert_eq!(
         bank1.get_current_epoch_total_stake(),
-        bank1.epoch_total_stake(2)
+        bank1.epoch_total_stake(2).unwrap(),
     );
     assert_eq!(
-        bank1.get_current_epoch_vote_accounts().unwrap().len(),
+        bank1.get_current_epoch_vote_accounts().len(),
         voting_keypairs.len()
     );
     assert_eq!(
-        bank1.epoch_vote_accounts(2),
+        bank1.epoch_vote_accounts(2).unwrap(),
         bank1.get_current_epoch_vote_accounts(),
     );
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13233,6 +13233,11 @@ fn test_bank_epoch_stakes() {
     let initial_epochs = bank0.epoch_stake_keys();
     assert_eq!(initial_epochs, vec![0, 1]);
 
+    // Bank 0:
+
+    // First query with bank's epoch. As noted by the above check, the epoch
+    // stakes cache actually contains values for the _leader schedule_ epoch
+    // (N + 1). Therefore, we should be able to query both.
     assert_eq!(bank0.epoch(), 0);
     assert_eq!(bank0.epoch_total_stake(0), Some(total_stake));
     assert_eq!(bank0.epoch_node_id_to_stake(0, &Pubkey::new_unique()), None);
@@ -13242,6 +13247,37 @@ fn test_bank_epoch_stakes() {
             Some(stakes[i])
         );
     }
+
+    // Now query for epoch 1 on bank 0.
+    assert_eq!(bank0.epoch().saturating_add(1), 1);
+    assert_eq!(bank0.epoch_total_stake(1), Some(total_stake));
+    assert_eq!(bank0.epoch_node_id_to_stake(1, &Pubkey::new_unique()), None);
+    for (i, keypair) in voting_keypairs.iter().enumerate() {
+        assert_eq!(
+            bank0.epoch_node_id_to_stake(1, &keypair.node_keypair.pubkey()),
+            Some(stakes[i])
+        );
+    }
+
+    // Note using bank's `current_epoch_stake_*` methods should return the
+    // same values.
+    assert_eq!(bank0.get_current_epoch_total_stake(), Some(total_stake));
+    assert_eq!(
+        bank0.get_current_epoch_total_stake(),
+        bank0.epoch_total_stake(1)
+    );
+    assert_eq!(
+        bank0.get_current_epoch_vote_accounts().unwrap().len(),
+        voting_keypairs.len()
+    );
+    assert_eq!(
+        bank0.epoch_vote_accounts(1),
+        bank0.get_current_epoch_vote_accounts(),
+    );
+
+    // Bank 1:
+
+    // Run the same exercise. First query the bank's epoch.
     assert_eq!(bank1.epoch(), 1);
     assert_eq!(bank1.epoch_total_stake(1), Some(total_stake));
     assert_eq!(bank1.epoch_node_id_to_stake(1, &Pubkey::new_unique()), None);
@@ -13252,32 +13288,85 @@ fn test_bank_epoch_stakes() {
         );
     }
 
-    let new_epoch_stakes = EpochStakes::new_for_tests(
-        voting_keypairs
-            .iter()
-            .map(|keypair| {
-                let node_id = keypair.node_keypair.pubkey();
-                let authorized_voter = keypair.vote_keypair.pubkey();
-                let vote_account = VoteAccount::try_from(create_account_with_authorized(
-                    &node_id,
-                    &authorized_voter,
-                    &node_id,
-                    0,
-                    100,
-                ))
-                .unwrap();
-                (authorized_voter, (100_u64, vote_account))
-            })
-            .collect::<HashMap<_, _>>(),
-        1,
+    // Now query for epoch 2 on bank 1.
+    assert_eq!(bank1.epoch().saturating_add(1), 2);
+    assert_eq!(bank1.epoch_total_stake(2), Some(total_stake));
+    assert_eq!(bank1.epoch_node_id_to_stake(2, &Pubkey::new_unique()), None);
+    for (i, keypair) in voting_keypairs.iter().enumerate() {
+        assert_eq!(
+            bank1.epoch_node_id_to_stake(2, &keypair.node_keypair.pubkey()),
+            Some(stakes[i])
+        );
+    }
+
+    // Again, using bank's `current_epoch_stake_*` methods should return the
+    // same values.
+    assert_eq!(bank1.get_current_epoch_total_stake(), Some(total_stake));
+    assert_eq!(
+        bank1.get_current_epoch_total_stake(),
+        bank1.epoch_total_stake(2)
     );
-    bank1.set_epoch_stakes_for_test(1, new_epoch_stakes);
-    assert_eq!(bank1.epoch_total_stake(1), Some(100 * num_of_nodes));
+    assert_eq!(
+        bank1.get_current_epoch_vote_accounts().unwrap().len(),
+        voting_keypairs.len()
+    );
+    assert_eq!(
+        bank1.epoch_vote_accounts(2),
+        bank1.get_current_epoch_vote_accounts(),
+    );
+
+    // Setup new epoch stakes on Bank 1 for both leader schedule epochs.
+    let make_new_epoch_stakes = |stake_coefficient: u64| {
+        EpochStakes::new_for_tests(
+            voting_keypairs
+                .iter()
+                .map(|keypair| {
+                    let node_id = keypair.node_keypair.pubkey();
+                    let authorized_voter = keypair.vote_keypair.pubkey();
+                    let vote_account = VoteAccount::try_from(create_account_with_authorized(
+                        &node_id,
+                        &authorized_voter,
+                        &node_id,
+                        0,
+                        100,
+                    ))
+                    .unwrap();
+                    (authorized_voter, (stake_coefficient, vote_account))
+                })
+                .collect::<HashMap<_, _>>(),
+            1,
+        )
+    };
+    let stake_coefficient_epoch_1 = 100;
+    let stake_coefficient_epoch_2 = 500;
+    bank1.set_epoch_stakes_for_test(1, make_new_epoch_stakes(stake_coefficient_epoch_1));
+    bank1.set_epoch_stakes_for_test(2, make_new_epoch_stakes(stake_coefficient_epoch_2));
+
+    // Run the exercise again with the new stake. Now epoch 1 should have the
+    // stake added for epoch 1 (`stake_coefficient_epoch_1`).
+    assert_eq!(
+        bank1.epoch_total_stake(1),
+        Some(stake_coefficient_epoch_1 * num_of_nodes)
+    );
     assert_eq!(bank1.epoch_node_id_to_stake(1, &Pubkey::new_unique()), None);
     for keypair in voting_keypairs.iter() {
         assert_eq!(
             bank1.epoch_node_id_to_stake(1, &keypair.node_keypair.pubkey()),
-            Some(100)
+            Some(stake_coefficient_epoch_1)
+        );
+    }
+
+    // Now query for epoch 2 on bank 1. Epoch 2 should have the stake added for
+    // epoch 2 (`stake_coefficient_epoch_2`).
+    assert_eq!(
+        bank1.epoch_total_stake(2),
+        Some(stake_coefficient_epoch_2 * num_of_nodes)
+    );
+    assert_eq!(bank1.epoch_node_id_to_stake(2, &Pubkey::new_unique()), None);
+    for keypair in voting_keypairs.iter() {
+        assert_eq!(
+            bank1.epoch_node_id_to_stake(2, &keypair.node_keypair.pubkey()),
+            Some(stake_coefficient_epoch_2)
         );
     }
 }


### PR DESCRIPTION
#### Problem
The bank epoch stakes cache stores stakes according to the _leader schedule epoch_, which means the epoch stake for a given epoch `N` actually corresponds to the `N + 1` epoch in the epoch stakes cache.

The `sol_get_epoch_stake` syscall is designed to vend to on-chain programs the epoch stakes for the current epoch, but the existing implementation is returning the epoch stakes for leader schedule epoch `N`, when it actually should return the epoch stakes for leader schedule epoch `N + 1`.

For example, if you activate stake in epoch `N`, it becomes active in epoch `N + 1`, but the existing bank implementation for serving the `sol_get_epoch_stakes` syscall actually wouldn't return this new stake until epoch `N + 2`.

#### Summary of Changes
Use Bank's `current_epoch_stakes` method - which fetches the leader schedule epoch `bank.epoch() + 1` - to serve the epoch stake information for `sol_get_epoch_stakes`, properly returning the current epoch stake.