### PR TITLE
Add CLI args for AccountsDb thread pools to validator

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -511,8 +511,8 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalWithVerify,
     enable_experimental_accumulator_hash: false,
     num_clean_threads: None,
-    num_hash_threads: None,
     num_foreground_threads: None,
+    num_hash_threads: None,
 };
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
@@ -531,8 +531,8 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalWithVerify,
     enable_experimental_accumulator_hash: false,
     num_clean_threads: None,
-    num_hash_threads: None,
     num_foreground_threads: None,
+    num_hash_threads: None,
 };
 
 pub type BinnedHashData = Vec<Vec<CalculateHashIntermediate>>;
@@ -646,10 +646,10 @@ pub struct AccountsDbConfig {
     pub enable_experimental_accumulator_hash: bool,
     /// Number of threads for background cleaning operations (`thread_pool_clean')
     pub num_clean_threads: Option<NonZeroUsize>,
-    /// Number of threads for background accounts hashing (`thread_pool_hash`)
-    pub num_hash_threads: Option<NonZeroUsize>,
     /// Number of threads for foreground operations (`thread_pool`)
     pub num_foreground_threads: Option<NonZeroUsize>,
+    /// Number of threads for background accounts hashing (`thread_pool_hash`)
+    pub num_hash_threads: Option<NonZeroUsize>,
 }
 
 #[cfg(not(test))]

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -648,7 +648,7 @@ pub struct AccountsDbConfig {
     pub num_clean_threads: Option<NonZeroUsize>,
     /// Number of threads for background accounts hashing (`thread_pool_hash`)
     pub num_hash_threads: Option<NonZeroUsize>,
-    /// Number of threads for foreground opeations (`thread_pool`)
+    /// Number of threads for foreground operations (`thread_pool`)
     pub num_process_threads: Option<NonZeroUsize>,
 }
 

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -12,6 +12,7 @@ use {
 pub struct DefaultThreadArgs {
     pub accounts_db_clean_threads: String,
     pub accounts_db_hash_threads: String,
+    pub accounts_db_process_threads: String,
     pub ip_echo_server_threads: String,
     pub replay_forks_threads: String,
     pub replay_transactions_threads: String,
@@ -24,6 +25,7 @@ impl Default for DefaultThreadArgs {
         Self {
             accounts_db_clean_threads: AccountsDbCleanThreadsArg::bounded_default().to_string(),
             accounts_db_hash_threads: AccountsDbHashThreadsArg::bounded_default().to_string(),
+            accounts_db_process_threads: AccountsDbProcessThreadsArg::bounded_default().to_string(),
             ip_echo_server_threads: IpEchoServerThreadsArg::bounded_default().to_string(),
             replay_forks_threads: ReplayForksThreadsArg::bounded_default().to_string(),
             replay_transactions_threads: ReplayTransactionsThreadsArg::bounded_default()
@@ -38,6 +40,7 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
     vec![
         new_thread_arg::<AccountsDbCleanThreadsArg>(&defaults.accounts_db_clean_threads),
         new_thread_arg::<AccountsDbHashThreadsArg>(&defaults.accounts_db_hash_threads),
+        new_thread_arg::<AccountsDbProcessThreadsArg>(&defaults.accounts_db_process_threads),
         new_thread_arg::<IpEchoServerThreadsArg>(&defaults.ip_echo_server_threads),
         new_thread_arg::<ReplayForksThreadsArg>(&defaults.replay_forks_threads),
         new_thread_arg::<ReplayTransactionsThreadsArg>(&defaults.replay_transactions_threads),
@@ -60,6 +63,7 @@ fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
 pub struct NumThreadConfig {
     pub accounts_db_clean_threads: NonZeroUsize,
     pub accounts_db_hash_threads: NonZeroUsize,
+    pub accounts_db_process_threads: NonZeroUsize,
     pub ip_echo_server_threads: NonZeroUsize,
     pub replay_forks_threads: NonZeroUsize,
     pub replay_transactions_threads: NonZeroUsize,
@@ -77,6 +81,11 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
         accounts_db_hash_threads: value_t_or_exit!(
             matches,
             AccountsDbHashThreadsArg::NAME,
+            NonZeroUsize
+        ),
+        accounts_db_process_threads: value_t_or_exit!(
+            matches,
+            AccountsDbProcessThreadsArg::NAME,
             NonZeroUsize
         ),
         ip_echo_server_threads: value_t_or_exit!(
@@ -154,6 +163,17 @@ impl ThreadArg for AccountsDbHashThreadsArg {
 
     fn default() -> usize {
         accounts_db::default_num_hash_threads().get()
+    }
+}
+
+struct AccountsDbProcessThreadsArg;
+impl ThreadArg for AccountsDbProcessThreadsArg {
+    const NAME: &'static str = "accounts_db_process_threads";
+    const LONG_NAME: &'static str = "accounts-db-process-threads";
+    const HELP: &'static str = "Number of threads to use for AccountsDb block processing";
+
+    fn default() -> usize {
+        accounts_db::default_num_foreground_threads()
     }
 }
 

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -11,8 +11,8 @@ use {
 // Need this struct to provide &str whose lifetime matches that of the CLAP Arg's
 pub struct DefaultThreadArgs {
     pub accounts_db_clean_threads: String,
-    pub accounts_db_hash_threads: String,
     pub accounts_db_foreground_threads: String,
+    pub accounts_db_hash_threads: String,
     pub accounts_index_flush_threads: String,
     pub ip_echo_server_threads: String,
     pub replay_forks_threads: String,
@@ -25,9 +25,9 @@ impl Default for DefaultThreadArgs {
     fn default() -> Self {
         Self {
             accounts_db_clean_threads: AccountsDbCleanThreadsArg::bounded_default().to_string(),
-            accounts_db_hash_threads: AccountsDbHashThreadsArg::bounded_default().to_string(),
             accounts_db_foreground_threads: AccountsDbForegroundThreadsArg::bounded_default()
                 .to_string(),
+            accounts_db_hash_threads: AccountsDbHashThreadsArg::bounded_default().to_string(),
             accounts_index_flush_threads: AccountsIndexFlushThreadsArg::bounded_default()
                 .to_string(),
             ip_echo_server_threads: IpEchoServerThreadsArg::bounded_default().to_string(),
@@ -43,8 +43,8 @@ impl Default for DefaultThreadArgs {
 pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
     vec![
         new_thread_arg::<AccountsDbCleanThreadsArg>(&defaults.accounts_db_clean_threads),
-        new_thread_arg::<AccountsDbHashThreadsArg>(&defaults.accounts_db_hash_threads),
         new_thread_arg::<AccountsDbForegroundThreadsArg>(&defaults.accounts_db_foreground_threads),
+        new_thread_arg::<AccountsDbHashThreadsArg>(&defaults.accounts_db_hash_threads),
         new_thread_arg::<AccountsIndexFlushThreadsArg>(&defaults.accounts_db_foreground_threads),
         new_thread_arg::<IpEchoServerThreadsArg>(&defaults.ip_echo_server_threads),
         new_thread_arg::<ReplayForksThreadsArg>(&defaults.replay_forks_threads),
@@ -67,8 +67,8 @@ fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
 
 pub struct NumThreadConfig {
     pub accounts_db_clean_threads: NonZeroUsize,
-    pub accounts_db_hash_threads: NonZeroUsize,
     pub accounts_db_foreground_threads: NonZeroUsize,
+    pub accounts_db_hash_threads: NonZeroUsize,
     pub accounts_index_flush_threads: NonZeroUsize,
     pub ip_echo_server_threads: NonZeroUsize,
     pub replay_forks_threads: NonZeroUsize,
@@ -84,14 +84,14 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
             AccountsDbCleanThreadsArg::NAME,
             NonZeroUsize
         ),
-        accounts_db_hash_threads: value_t_or_exit!(
-            matches,
-            AccountsDbHashThreadsArg::NAME,
-            NonZeroUsize
-        ),
         accounts_db_foreground_threads: value_t_or_exit!(
             matches,
             AccountsDbForegroundThreadsArg::NAME,
+            NonZeroUsize
+        ),
+        accounts_db_hash_threads: value_t_or_exit!(
+            matches,
+            AccountsDbHashThreadsArg::NAME,
             NonZeroUsize
         ),
         accounts_index_flush_threads: value_t_or_exit!(
@@ -166,17 +166,6 @@ impl ThreadArg for AccountsDbCleanThreadsArg {
     }
 }
 
-struct AccountsDbHashThreadsArg;
-impl ThreadArg for AccountsDbHashThreadsArg {
-    const NAME: &'static str = "accounts_db_hash_threads";
-    const LONG_NAME: &'static str = "accounts-db-hash-threads";
-    const HELP: &'static str = "Number of threads to use for background accounts hashing";
-
-    fn default() -> usize {
-        accounts_db::default_num_hash_threads().get()
-    }
-}
-
 struct AccountsDbForegroundThreadsArg;
 impl ThreadArg for AccountsDbForegroundThreadsArg {
     const NAME: &'static str = "accounts_db_foreground_threads";
@@ -185,6 +174,17 @@ impl ThreadArg for AccountsDbForegroundThreadsArg {
 
     fn default() -> usize {
         accounts_db::default_num_foreground_threads()
+    }
+}
+
+struct AccountsDbHashThreadsArg;
+impl ThreadArg for AccountsDbHashThreadsArg {
+    const NAME: &'static str = "accounts_db_hash_threads";
+    const LONG_NAME: &'static str = "accounts-db-hash-threads";
+    const HELP: &'static str = "Number of threads to use for background accounts hashing";
+
+    fn default() -> usize {
+        accounts_db::default_num_hash_threads().get()
     }
 }
 

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -10,6 +10,7 @@ use {
 
 // Need this struct to provide &str whose lifetime matches that of the CLAP Arg's
 pub struct DefaultThreadArgs {
+    pub accounts_db_clean_threads: String,
     pub accounts_db_hash_threads: String,
     pub ip_echo_server_threads: String,
     pub replay_forks_threads: String,
@@ -21,6 +22,7 @@ pub struct DefaultThreadArgs {
 impl Default for DefaultThreadArgs {
     fn default() -> Self {
         Self {
+            accounts_db_clean_threads: AccountsDbCleanThreadsArg::bounded_default().to_string(),
             accounts_db_hash_threads: AccountsDbHashThreadsArg::bounded_default().to_string(),
             ip_echo_server_threads: IpEchoServerThreadsArg::bounded_default().to_string(),
             replay_forks_threads: ReplayForksThreadsArg::bounded_default().to_string(),
@@ -34,6 +36,7 @@ impl Default for DefaultThreadArgs {
 
 pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
     vec![
+        new_thread_arg::<AccountsDbCleanThreadsArg>(&defaults.accounts_db_clean_threads),
         new_thread_arg::<AccountsDbHashThreadsArg>(&defaults.accounts_db_hash_threads),
         new_thread_arg::<IpEchoServerThreadsArg>(&defaults.ip_echo_server_threads),
         new_thread_arg::<ReplayForksThreadsArg>(&defaults.replay_forks_threads),
@@ -55,6 +58,7 @@ fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
 }
 
 pub struct NumThreadConfig {
+    pub accounts_db_clean_threads: NonZeroUsize,
     pub accounts_db_hash_threads: NonZeroUsize,
     pub ip_echo_server_threads: NonZeroUsize,
     pub replay_forks_threads: NonZeroUsize,
@@ -65,6 +69,11 @@ pub struct NumThreadConfig {
 
 pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
     NumThreadConfig {
+        accounts_db_clean_threads: value_t_or_exit!(
+            matches,
+            AccountsDbCleanThreadsArg::NAME,
+            NonZeroUsize
+        ),
         accounts_db_hash_threads: value_t_or_exit!(
             matches,
             AccountsDbHashThreadsArg::NAME,
@@ -123,6 +132,17 @@ trait ThreadArg {
     /// The range of allowed number of threads (inclusive on both ends)
     fn range() -> RangeInclusive<usize> {
         RangeInclusive::new(Self::min(), Self::max())
+    }
+}
+
+struct AccountsDbCleanThreadsArg;
+impl ThreadArg for AccountsDbCleanThreadsArg {
+    const NAME: &'static str = "accounts_db_clean_threads";
+    const LONG_NAME: &'static str = "accounts-db-clean-threads";
+    const HELP: &'static str = "Number of threads to use for cleaning AccountsDb";
+
+    fn default() -> usize {
+        accounts_db::quarter_thread_count()
     }
 }
 

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -12,7 +12,7 @@ use {
 pub struct DefaultThreadArgs {
     pub accounts_db_clean_threads: String,
     pub accounts_db_hash_threads: String,
-    pub accounts_db_process_threads: String,
+    pub accounts_db_foreground_threads: String,
     pub accounts_index_flush_threads: String,
     pub ip_echo_server_threads: String,
     pub replay_forks_threads: String,
@@ -26,7 +26,8 @@ impl Default for DefaultThreadArgs {
         Self {
             accounts_db_clean_threads: AccountsDbCleanThreadsArg::bounded_default().to_string(),
             accounts_db_hash_threads: AccountsDbHashThreadsArg::bounded_default().to_string(),
-            accounts_db_process_threads: AccountsDbProcessThreadsArg::bounded_default().to_string(),
+            accounts_db_foreground_threads: AccountsDbForegroundThreadsArg::bounded_default()
+                .to_string(),
             accounts_index_flush_threads: AccountsIndexFlushThreadsArg::bounded_default()
                 .to_string(),
             ip_echo_server_threads: IpEchoServerThreadsArg::bounded_default().to_string(),
@@ -43,8 +44,8 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
     vec![
         new_thread_arg::<AccountsDbCleanThreadsArg>(&defaults.accounts_db_clean_threads),
         new_thread_arg::<AccountsDbHashThreadsArg>(&defaults.accounts_db_hash_threads),
-        new_thread_arg::<AccountsDbProcessThreadsArg>(&defaults.accounts_db_process_threads),
-        new_thread_arg::<AccountsIndexFlushThreadsArg>(&defaults.accounts_db_process_threads),
+        new_thread_arg::<AccountsDbForegroundThreadsArg>(&defaults.accounts_db_foreground_threads),
+        new_thread_arg::<AccountsIndexFlushThreadsArg>(&defaults.accounts_db_foreground_threads),
         new_thread_arg::<IpEchoServerThreadsArg>(&defaults.ip_echo_server_threads),
         new_thread_arg::<ReplayForksThreadsArg>(&defaults.replay_forks_threads),
         new_thread_arg::<ReplayTransactionsThreadsArg>(&defaults.replay_transactions_threads),
@@ -67,7 +68,7 @@ fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
 pub struct NumThreadConfig {
     pub accounts_db_clean_threads: NonZeroUsize,
     pub accounts_db_hash_threads: NonZeroUsize,
-    pub accounts_db_process_threads: NonZeroUsize,
+    pub accounts_db_foreground_threads: NonZeroUsize,
     pub accounts_index_flush_threads: NonZeroUsize,
     pub ip_echo_server_threads: NonZeroUsize,
     pub replay_forks_threads: NonZeroUsize,
@@ -88,9 +89,9 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
             AccountsDbHashThreadsArg::NAME,
             NonZeroUsize
         ),
-        accounts_db_process_threads: value_t_or_exit!(
+        accounts_db_foreground_threads: value_t_or_exit!(
             matches,
-            AccountsDbProcessThreadsArg::NAME,
+            AccountsDbForegroundThreadsArg::NAME,
             NonZeroUsize
         ),
         accounts_index_flush_threads: value_t_or_exit!(
@@ -176,10 +177,10 @@ impl ThreadArg for AccountsDbHashThreadsArg {
     }
 }
 
-struct AccountsDbProcessThreadsArg;
-impl ThreadArg for AccountsDbProcessThreadsArg {
-    const NAME: &'static str = "accounts_db_process_threads";
-    const LONG_NAME: &'static str = "accounts-db-process-threads";
+struct AccountsDbForegroundThreadsArg;
+impl ThreadArg for AccountsDbForegroundThreadsArg {
+    const NAME: &'static str = "accounts_db_foreground_threads";
+    const LONG_NAME: &'static str = "accounts-db-foreground-threads";
     const HELP: &'static str = "Number of threads to use for AccountsDb block processing";
 
     fn default() -> usize {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -912,7 +912,7 @@ pub fn main() {
     let cli::thread_args::NumThreadConfig {
         accounts_db_clean_threads,
         accounts_db_hash_threads,
-        accounts_db_process_threads,
+        accounts_db_foreground_threads,
         accounts_index_flush_threads,
         ip_echo_server_threads,
         replay_forks_threads,
@@ -1318,7 +1318,7 @@ pub fn main() {
             .is_present("accounts_db_experimental_accumulator_hash"),
         num_clean_threads: Some(accounts_db_clean_threads),
         num_hash_threads: Some(accounts_db_hash_threads),
-        num_process_threads: Some(accounts_db_process_threads),
+        num_foreground_threads: Some(accounts_db_foreground_threads),
         ..AccountsDbConfig::default()
     };
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -913,6 +913,7 @@ pub fn main() {
         accounts_db_clean_threads,
         accounts_db_hash_threads,
         accounts_db_process_threads,
+        accounts_index_flush_threads,
         ip_echo_server_threads,
         replay_forks_threads,
         replay_transactions_threads,
@@ -1183,6 +1184,7 @@ pub fn main() {
 
     let mut accounts_index_config = AccountsIndexConfig {
         started_from_validator: true, // this is the only place this is set
+        num_flush_threads: Some(accounts_index_flush_threads),
         ..AccountsIndexConfig::default()
     };
     if let Ok(bins) = value_t!(matches, "accounts_index_bins", usize) {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -912,6 +912,7 @@ pub fn main() {
     let cli::thread_args::NumThreadConfig {
         accounts_db_clean_threads,
         accounts_db_hash_threads,
+        accounts_db_process_threads,
         ip_echo_server_threads,
         replay_forks_threads,
         replay_transactions_threads,
@@ -1315,6 +1316,7 @@ pub fn main() {
             .is_present("accounts_db_experimental_accumulator_hash"),
         num_clean_threads: Some(accounts_db_clean_threads),
         num_hash_threads: Some(accounts_db_hash_threads),
+        num_process_threads: Some(accounts_db_process_threads),
         ..AccountsDbConfig::default()
     };
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -910,6 +910,7 @@ pub fn main() {
     };
 
     let cli::thread_args::NumThreadConfig {
+        accounts_db_clean_threads,
         accounts_db_hash_threads,
         ip_echo_server_threads,
         replay_forks_threads,
@@ -1312,6 +1313,7 @@ pub fn main() {
         scan_filter_for_shrinking,
         enable_experimental_accumulator_hash: matches
             .is_present("accounts_db_experimental_accumulator_hash"),
+        num_clean_threads: Some(accounts_db_clean_threads),
         num_hash_threads: Some(accounts_db_hash_threads),
         ..AccountsDbConfig::default()
     };

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -911,8 +911,8 @@ pub fn main() {
 
     let cli::thread_args::NumThreadConfig {
         accounts_db_clean_threads,
-        accounts_db_hash_threads,
         accounts_db_foreground_threads,
+        accounts_db_hash_threads,
         accounts_index_flush_threads,
         ip_echo_server_threads,
         replay_forks_threads,
@@ -1317,8 +1317,8 @@ pub fn main() {
         enable_experimental_accumulator_hash: matches
             .is_present("accounts_db_experimental_accumulator_hash"),
         num_clean_threads: Some(accounts_db_clean_threads),
-        num_hash_threads: Some(accounts_db_hash_threads),
         num_foreground_threads: Some(accounts_db_foreground_threads),
+        num_hash_threads: Some(accounts_db_hash_threads),
         ..AccountsDbConfig::default()
     };
 


### PR DESCRIPTION
Done: ~~This PR is on top of https://github.com/anza-xyz/agave/pull/3270 and should ship after it.~~
Done: ~~Rebase on top of https://github.com/anza-xyz/agave/pull/3233 after it ships~~

#### Problem
See https://github.com/anza-xyz/agave/issues/105 - we want a way to control the size of all thread pools

#### Summary of Changes
- Add args for the following thread pools:
    - AccountsDb clean
    - AccountsDb "foreground"
    - Accounts Index