### PR TITLE
SVMMessage::{get_durable_nonce, get_ix_signers}

### DIFF
--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -24,10 +24,7 @@ use {
         nonce_info::NonceInfo,
         transaction_error_metrics::TransactionErrorMetrics,
     },
-    solana_svm_transaction::{
-        nonce_extraction::{get_durable_nonce, get_ix_signers},
-        svm_message::SVMMessage,
-    },
+    solana_svm_transaction::svm_message::SVMMessage,
 };
 
 impl Bank {
@@ -170,12 +167,13 @@ impl Bank {
         &self,
         message: &impl SVMMessage,
     ) -> Option<(Pubkey, AccountSharedData, NonceData)> {
-        let nonce_address = get_durable_nonce(message)?;
+        let nonce_address = message.get_durable_nonce()?;
         let nonce_account = self.get_account_with_fixed_root(nonce_address)?;
         let nonce_data =
             nonce_account::verify_nonce_account(&nonce_account, message.recent_blockhash())?;
 
-        let nonce_is_authorized = get_ix_signers(message, NONCED_TX_MARKER_IX_INDEX as usize)
+        let nonce_is_authorized = message
+            .get_ix_signers(NONCED_TX_MARKER_IX_INDEX as usize)
             .any(|signer| signer == &nonce_data.authority);
         if !nonce_is_authorized {
             return None;

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -1,6 +1,5 @@
 use {
     super::{Bank, BankStatusCache},
-    crate::nonce_extraction::{get_durable_nonce, get_ix_signers},
     solana_accounts_db::blockhash_queue::BlockhashQueue,
     solana_perf::perf_libs,
     solana_sdk::{
@@ -25,7 +24,10 @@ use {
         nonce_info::NonceInfo,
         transaction_error_metrics::TransactionErrorMetrics,
     },
-    solana_svm_transaction::svm_message::SVMMessage,
+    solana_svm_transaction::{
+        nonce_extraction::{get_durable_nonce, get_ix_signers},
+        svm_message::SVMMessage,
+    },
 };
 
 impl Bank {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -16,7 +16,6 @@ pub mod genesis_utils;
 pub mod installed_scheduler_pool;
 pub mod loader_utils;
 pub mod non_circulating_supply;
-mod nonce_extraction;
 pub mod prioritization_fee;
 pub mod prioritization_fee_cache;
 pub mod rent_collector;

--- a/svm-transaction/src/lib.rs
+++ b/svm-transaction/src/lib.rs
@@ -3,4 +3,4 @@ pub mod message_address_table_lookup;
 pub mod svm_message;
 pub mod svm_transaction;
 
-mod nonce_extraction;
+mod tests;

--- a/svm-transaction/src/lib.rs
+++ b/svm-transaction/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod instruction;
 pub mod message_address_table_lookup;
-pub mod nonce_extraction;
 pub mod svm_message;
 pub mod svm_transaction;
+
+mod nonce_extraction;

--- a/svm-transaction/src/lib.rs
+++ b/svm-transaction/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod instruction;
 pub mod message_address_table_lookup;
+pub mod nonce_extraction;
 pub mod svm_message;
 pub mod svm_transaction;

--- a/svm-transaction/src/nonce_extraction.rs
+++ b/svm-transaction/src/nonce_extraction.rs
@@ -7,7 +7,7 @@ use {
 };
 
 /// If the message uses a durable nonce, return the pubkey of the nonce account
-pub fn get_durable_nonce(message: &impl SVMMessage) -> Option<&Pubkey> {
+pub fn get_durable_nonce(message: &(impl SVMMessage + ?Sized)) -> Option<&Pubkey> {
     let account_keys = message.account_keys();
     message
         .instructions_iter()
@@ -33,7 +33,10 @@ pub fn get_durable_nonce(message: &impl SVMMessage) -> Option<&Pubkey> {
 
 /// For the instruction at `index`, return an iterator over input accounts
 /// that are signers.
-pub fn get_ix_signers(message: &impl SVMMessage, index: usize) -> impl Iterator<Item = &Pubkey> {
+pub fn get_ix_signers(
+    message: &(impl SVMMessage + ?Sized),
+    index: usize,
+) -> impl Iterator<Item = &Pubkey> {
     message
         .instructions_iter()
         .nth(index)

--- a/svm-transaction/src/svm_message.rs
+++ b/svm-transaction/src/svm_message.rs
@@ -1,6 +1,8 @@
 use {
     crate::{
-        instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
+        instruction::SVMInstruction,
+        message_address_table_lookup::SVMMessageAddressTableLookup,
+        nonce_extraction::{get_durable_nonce, get_ix_signers},
     },
     core::fmt::Debug,
     solana_sdk::{hash::Hash, message::AccountKeys, pubkey::Pubkey},
@@ -58,6 +60,17 @@ pub trait SVMMessage: Debug {
         } else {
             false
         }
+    }
+
+    /// If the message uses a durable nonce, return the pubkey of the nonce account
+    fn get_durable_nonce(&self) -> Option<&Pubkey> {
+        get_durable_nonce(self)
+    }
+
+    /// For the instruction at `index`, return an iterator over input accounts
+    /// that are signers.
+    fn get_ix_signers(&self, index: usize) -> impl Iterator<Item = &Pubkey> {
+        get_ix_signers(self, index)
     }
 
     /// Get the number of lookup tables.

--- a/svm-transaction/src/tests.rs
+++ b/svm-transaction/src/tests.rs
@@ -1,294 +1,292 @@
-#[cfg(test)]
-mod tests {
-    use {
-        crate::svm_message::SVMMessage,
-        solana_sdk::{
-            hash::Hash,
-            instruction::CompiledInstruction,
-            message::{
-                legacy,
-                v0::{self, LoadedAddresses, MessageAddressTableLookup},
-                MessageHeader, SanitizedMessage, SanitizedVersionedMessage, SimpleAddressLoader,
-                VersionedMessage,
-            },
-            pubkey::Pubkey,
-            system_instruction::SystemInstruction,
-            system_program,
+#![cfg(test)]
+use {
+    crate::svm_message::SVMMessage,
+    solana_sdk::{
+        hash::Hash,
+        instruction::CompiledInstruction,
+        message::{
+            legacy,
+            v0::{self, LoadedAddresses, MessageAddressTableLookup},
+            MessageHeader, SanitizedMessage, SanitizedVersionedMessage, SimpleAddressLoader,
+            VersionedMessage,
         },
-        std::collections::HashSet,
-    };
+        pubkey::Pubkey,
+        system_instruction::SystemInstruction,
+        system_program,
+    },
+    std::collections::HashSet,
+};
 
-    #[test]
-    fn test_get_durable_nonce() {
-        fn create_message_for_test(
-            num_signers: u8,
-            num_writable: u8,
-            account_keys: Vec<Pubkey>,
-            instructions: Vec<CompiledInstruction>,
-            loaded_addresses: Option<LoadedAddresses>,
-        ) -> SanitizedMessage {
-            let header = MessageHeader {
-                num_required_signatures: num_signers,
-                num_readonly_signed_accounts: 0,
-                num_readonly_unsigned_accounts: u8::try_from(account_keys.len()).unwrap()
-                    - num_writable,
-            };
-            let (versioned_message, loader) = match loaded_addresses {
-                None => (
-                    VersionedMessage::Legacy(legacy::Message {
-                        header,
-                        account_keys,
-                        recent_blockhash: Hash::default(),
-                        instructions,
-                    }),
-                    SimpleAddressLoader::Disabled,
-                ),
-                Some(loaded_addresses) => (
-                    VersionedMessage::V0(v0::Message {
-                        header,
-                        account_keys,
-                        recent_blockhash: Hash::default(),
-                        instructions,
-                        address_table_lookups: vec![MessageAddressTableLookup {
-                            account_key: Pubkey::new_unique(),
-                            writable_indexes: (0..loaded_addresses.writable.len())
-                                .map(|x| x as u8)
-                                .collect(),
-                            readonly_indexes: (0..loaded_addresses.readonly.len())
-                                .map(|x| (loaded_addresses.writable.len() + x) as u8)
-                                .collect(),
-                        }],
-                    }),
-                    SimpleAddressLoader::Enabled(loaded_addresses),
-                ),
-            };
-            SanitizedMessage::try_new(
-                SanitizedVersionedMessage::try_new(versioned_message).unwrap(),
-                loader,
-                &HashSet::new(),
-            )
-            .unwrap()
-        }
-
-        // No instructions - no nonce
-        {
-            let message = create_message_for_test(1, 1, vec![Pubkey::new_unique()], vec![], None);
-            assert!(SanitizedMessage::get_durable_nonce(&message).is_none());
-            assert!(SVMMessage::get_durable_nonce(&message).is_none());
-        }
-
-        // system program id instruction - invalid
-        {
-            let message = create_message_for_test(
-                1,
-                1,
-                vec![Pubkey::new_unique(), system_program::id()],
-                vec![CompiledInstruction::new_from_raw_parts(1, vec![], vec![])],
-                None,
-            );
-            assert!(SanitizedMessage::get_durable_nonce(&message).is_none());
-            assert!(SVMMessage::get_durable_nonce(&message).is_none());
-        }
-
-        // system program id instruction - not nonce
-        {
-            let message = create_message_for_test(
-                1,
-                1,
-                vec![Pubkey::new_unique(), system_program::id()],
-                vec![CompiledInstruction::new(
-                    1,
-                    &SystemInstruction::Transfer { lamports: 1 },
-                    vec![0, 0],
-                )],
-                None,
-            );
-            assert!(SanitizedMessage::get_durable_nonce(&message).is_none());
-            assert!(SVMMessage::get_durable_nonce(&message).is_none());
-        }
-
-        // system program id - nonce instruction (no accounts)
-        {
-            let message = create_message_for_test(
-                1,
-                1,
-                vec![Pubkey::new_unique(), system_program::id()],
-                vec![CompiledInstruction::new(
-                    1,
-                    &SystemInstruction::AdvanceNonceAccount,
-                    vec![],
-                )],
-                None,
-            );
-            assert!(SanitizedMessage::get_durable_nonce(&message).is_none());
-            assert!(SVMMessage::get_durable_nonce(&message).is_none());
-        }
-
-        // system program id - nonce instruction (non-fee-payer, non-writable)
-        {
-            let payer = Pubkey::new_unique();
-            let nonce = Pubkey::new_unique();
-            let message = create_message_for_test(
-                1,
-                1,
-                vec![payer, nonce, system_program::id()],
-                vec![CompiledInstruction::new(
-                    1,
-                    &SystemInstruction::AdvanceNonceAccount,
-                    vec![1],
-                )],
-                None,
-            );
-            assert!(SanitizedMessage::get_durable_nonce(&message).is_none());
-            assert!(SVMMessage::get_durable_nonce(&message).is_none());
-        }
-
-        // system program id - nonce instruction fee-payer
-        {
-            let payer_nonce = Pubkey::new_unique();
-            let message = create_message_for_test(
-                1,
-                1,
-                vec![payer_nonce, system_program::id()],
-                vec![CompiledInstruction::new(
-                    1,
-                    &SystemInstruction::AdvanceNonceAccount,
-                    vec![0],
-                )],
-                None,
-            );
-            assert_eq!(
-                SanitizedMessage::get_durable_nonce(&message),
-                Some(&payer_nonce)
-            );
-            assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&payer_nonce));
-        }
-
-        // system program id - nonce instruction w/ trailing bytes fee-payer
-        {
-            let payer_nonce = Pubkey::new_unique();
-            let mut instruction_bytes = vec![4, 0, 0, 0];
-            instruction_bytes.push(0); // add a trailing byte
-            let message = create_message_for_test(
-                1,
-                1,
-                vec![payer_nonce, system_program::id()],
-                vec![CompiledInstruction::new_from_raw_parts(
-                    1,
-                    instruction_bytes,
-                    vec![0],
-                )],
-                None,
-            );
-            assert_eq!(
-                SanitizedMessage::get_durable_nonce(&message),
-                Some(&payer_nonce)
-            );
-            assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&payer_nonce));
-        }
-
-        // system program id - nonce instruction (non-fee-payer)
-        {
-            let payer = Pubkey::new_unique();
-            let nonce = Pubkey::new_unique();
-            let message = create_message_for_test(
-                1,
-                2,
-                vec![payer, nonce, system_program::id()],
-                vec![CompiledInstruction::new(
-                    2,
-                    &SystemInstruction::AdvanceNonceAccount,
-                    vec![1],
-                )],
-                None,
-            );
-            assert_eq!(SanitizedMessage::get_durable_nonce(&message), Some(&nonce));
-            assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&nonce));
-        }
-
-        // system program id - nonce instruction (non-fee-payer, multiple accounts)
-        {
-            let payer = Pubkey::new_unique();
-            let other = Pubkey::new_unique();
-            let nonce = Pubkey::new_unique();
-            let message = create_message_for_test(
-                1,
-                3,
-                vec![payer, other, nonce, system_program::id()],
-                vec![CompiledInstruction::new(
-                    3,
-                    &SystemInstruction::AdvanceNonceAccount,
-                    vec![2, 1, 0],
-                )],
-                None,
-            );
-            assert_eq!(SanitizedMessage::get_durable_nonce(&message), Some(&nonce));
-            assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&nonce));
-        }
-
-        // system program id - nonce instruction (non-fee-payer, loaded account)
-        {
-            let payer = Pubkey::new_unique();
-            let nonce = Pubkey::new_unique();
-            let message = create_message_for_test(
-                1,
-                1,
-                vec![payer, system_program::id()],
-                vec![CompiledInstruction::new(
-                    1,
-                    &SystemInstruction::AdvanceNonceAccount,
-                    vec![2, 0, 1],
-                )],
-                Some(LoadedAddresses {
-                    writable: vec![nonce],
-                    readonly: vec![],
+#[test]
+fn test_get_durable_nonce() {
+    fn create_message_for_test(
+        num_signers: u8,
+        num_writable: u8,
+        account_keys: Vec<Pubkey>,
+        instructions: Vec<CompiledInstruction>,
+        loaded_addresses: Option<LoadedAddresses>,
+    ) -> SanitizedMessage {
+        let header = MessageHeader {
+            num_required_signatures: num_signers,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: u8::try_from(account_keys.len()).unwrap()
+                - num_writable,
+        };
+        let (versioned_message, loader) = match loaded_addresses {
+            None => (
+                VersionedMessage::Legacy(legacy::Message {
+                    header,
+                    account_keys,
+                    recent_blockhash: Hash::default(),
+                    instructions,
                 }),
-            );
-            assert_eq!(SanitizedMessage::get_durable_nonce(&message), Some(&nonce));
-            assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&nonce));
-        }
-    }
-
-    #[test]
-    fn test_get_ix_signers() {
-        let signer0 = Pubkey::new_unique();
-        let signer1 = Pubkey::new_unique();
-        let non_signer = Pubkey::new_unique();
-        let loader_key = Pubkey::new_unique();
-        let instructions = vec![
-            CompiledInstruction::new(3, &(), vec![2, 0]),
-            CompiledInstruction::new(3, &(), vec![0, 1]),
-            CompiledInstruction::new(3, &(), vec![0, 0]),
-        ];
-
-        let message = SanitizedMessage::try_from_legacy_message(
-            legacy::Message::new_with_compiled_instructions(
-                2,
-                1,
-                2,
-                vec![signer0, signer1, non_signer, loader_key],
-                Hash::default(),
-                instructions,
+                SimpleAddressLoader::Disabled,
             ),
-            &HashSet::default(),
+            Some(loaded_addresses) => (
+                VersionedMessage::V0(v0::Message {
+                    header,
+                    account_keys,
+                    recent_blockhash: Hash::default(),
+                    instructions,
+                    address_table_lookups: vec![MessageAddressTableLookup {
+                        account_key: Pubkey::new_unique(),
+                        writable_indexes: (0..loaded_addresses.writable.len())
+                            .map(|x| x as u8)
+                            .collect(),
+                        readonly_indexes: (0..loaded_addresses.readonly.len())
+                            .map(|x| (loaded_addresses.writable.len() + x) as u8)
+                            .collect(),
+                    }],
+                }),
+                SimpleAddressLoader::Enabled(loaded_addresses),
+            ),
+        };
+        SanitizedMessage::try_new(
+            SanitizedVersionedMessage::try_new(versioned_message).unwrap(),
+            loader,
+            &HashSet::new(),
         )
-        .unwrap();
-
-        assert_eq!(
-            SVMMessage::get_ix_signers(&message, 0).collect::<HashSet<_>>(),
-            HashSet::from_iter([&signer0])
-        );
-        assert_eq!(
-            SVMMessage::get_ix_signers(&message, 1).collect::<HashSet<_>>(),
-            HashSet::from_iter([&signer0, &signer1])
-        );
-        assert_eq!(
-            SVMMessage::get_ix_signers(&message, 2).collect::<HashSet<_>>(),
-            HashSet::from_iter([&signer0])
-        );
-        assert_eq!(
-            SVMMessage::get_ix_signers(&message, 3).collect::<HashSet<_>>(),
-            HashSet::default()
-        );
+        .unwrap()
     }
+
+    // No instructions - no nonce
+    {
+        let message = create_message_for_test(1, 1, vec![Pubkey::new_unique()], vec![], None);
+        assert!(SanitizedMessage::get_durable_nonce(&message).is_none());
+        assert!(SVMMessage::get_durable_nonce(&message).is_none());
+    }
+
+    // system program id instruction - invalid
+    {
+        let message = create_message_for_test(
+            1,
+            1,
+            vec![Pubkey::new_unique(), system_program::id()],
+            vec![CompiledInstruction::new_from_raw_parts(1, vec![], vec![])],
+            None,
+        );
+        assert!(SanitizedMessage::get_durable_nonce(&message).is_none());
+        assert!(SVMMessage::get_durable_nonce(&message).is_none());
+    }
+
+    // system program id instruction - not nonce
+    {
+        let message = create_message_for_test(
+            1,
+            1,
+            vec![Pubkey::new_unique(), system_program::id()],
+            vec![CompiledInstruction::new(
+                1,
+                &SystemInstruction::Transfer { lamports: 1 },
+                vec![0, 0],
+            )],
+            None,
+        );
+        assert!(SanitizedMessage::get_durable_nonce(&message).is_none());
+        assert!(SVMMessage::get_durable_nonce(&message).is_none());
+    }
+
+    // system program id - nonce instruction (no accounts)
+    {
+        let message = create_message_for_test(
+            1,
+            1,
+            vec![Pubkey::new_unique(), system_program::id()],
+            vec![CompiledInstruction::new(
+                1,
+                &SystemInstruction::AdvanceNonceAccount,
+                vec![],
+            )],
+            None,
+        );
+        assert!(SanitizedMessage::get_durable_nonce(&message).is_none());
+        assert!(SVMMessage::get_durable_nonce(&message).is_none());
+    }
+
+    // system program id - nonce instruction (non-fee-payer, non-writable)
+    {
+        let payer = Pubkey::new_unique();
+        let nonce = Pubkey::new_unique();
+        let message = create_message_for_test(
+            1,
+            1,
+            vec![payer, nonce, system_program::id()],
+            vec![CompiledInstruction::new(
+                1,
+                &SystemInstruction::AdvanceNonceAccount,
+                vec![1],
+            )],
+            None,
+        );
+        assert!(SanitizedMessage::get_durable_nonce(&message).is_none());
+        assert!(SVMMessage::get_durable_nonce(&message).is_none());
+    }
+
+    // system program id - nonce instruction fee-payer
+    {
+        let payer_nonce = Pubkey::new_unique();
+        let message = create_message_for_test(
+            1,
+            1,
+            vec![payer_nonce, system_program::id()],
+            vec![CompiledInstruction::new(
+                1,
+                &SystemInstruction::AdvanceNonceAccount,
+                vec![0],
+            )],
+            None,
+        );
+        assert_eq!(
+            SanitizedMessage::get_durable_nonce(&message),
+            Some(&payer_nonce)
+        );
+        assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&payer_nonce));
+    }
+
+    // system program id - nonce instruction w/ trailing bytes fee-payer
+    {
+        let payer_nonce = Pubkey::new_unique();
+        let mut instruction_bytes = vec![4, 0, 0, 0];
+        instruction_bytes.push(0); // add a trailing byte
+        let message = create_message_for_test(
+            1,
+            1,
+            vec![payer_nonce, system_program::id()],
+            vec![CompiledInstruction::new_from_raw_parts(
+                1,
+                instruction_bytes,
+                vec![0],
+            )],
+            None,
+        );
+        assert_eq!(
+            SanitizedMessage::get_durable_nonce(&message),
+            Some(&payer_nonce)
+        );
+        assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&payer_nonce));
+    }
+
+    // system program id - nonce instruction (non-fee-payer)
+    {
+        let payer = Pubkey::new_unique();
+        let nonce = Pubkey::new_unique();
+        let message = create_message_for_test(
+            1,
+            2,
+            vec![payer, nonce, system_program::id()],
+            vec![CompiledInstruction::new(
+                2,
+                &SystemInstruction::AdvanceNonceAccount,
+                vec![1],
+            )],
+            None,
+        );
+        assert_eq!(SanitizedMessage::get_durable_nonce(&message), Some(&nonce));
+        assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&nonce));
+    }
+
+    // system program id - nonce instruction (non-fee-payer, multiple accounts)
+    {
+        let payer = Pubkey::new_unique();
+        let other = Pubkey::new_unique();
+        let nonce = Pubkey::new_unique();
+        let message = create_message_for_test(
+            1,
+            3,
+            vec![payer, other, nonce, system_program::id()],
+            vec![CompiledInstruction::new(
+                3,
+                &SystemInstruction::AdvanceNonceAccount,
+                vec![2, 1, 0],
+            )],
+            None,
+        );
+        assert_eq!(SanitizedMessage::get_durable_nonce(&message), Some(&nonce));
+        assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&nonce));
+    }
+
+    // system program id - nonce instruction (non-fee-payer, loaded account)
+    {
+        let payer = Pubkey::new_unique();
+        let nonce = Pubkey::new_unique();
+        let message = create_message_for_test(
+            1,
+            1,
+            vec![payer, system_program::id()],
+            vec![CompiledInstruction::new(
+                1,
+                &SystemInstruction::AdvanceNonceAccount,
+                vec![2, 0, 1],
+            )],
+            Some(LoadedAddresses {
+                writable: vec![nonce],
+                readonly: vec![],
+            }),
+        );
+        assert_eq!(SanitizedMessage::get_durable_nonce(&message), Some(&nonce));
+        assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&nonce));
+    }
+}
+
+#[test]
+fn test_get_ix_signers() {
+    let signer0 = Pubkey::new_unique();
+    let signer1 = Pubkey::new_unique();
+    let non_signer = Pubkey::new_unique();
+    let loader_key = Pubkey::new_unique();
+    let instructions = vec![
+        CompiledInstruction::new(3, &(), vec![2, 0]),
+        CompiledInstruction::new(3, &(), vec![0, 1]),
+        CompiledInstruction::new(3, &(), vec![0, 0]),
+    ];
+
+    let message = SanitizedMessage::try_from_legacy_message(
+        legacy::Message::new_with_compiled_instructions(
+            2,
+            1,
+            2,
+            vec![signer0, signer1, non_signer, loader_key],
+            Hash::default(),
+            instructions,
+        ),
+        &HashSet::default(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        SVMMessage::get_ix_signers(&message, 0).collect::<HashSet<_>>(),
+        HashSet::from_iter([&signer0])
+    );
+    assert_eq!(
+        SVMMessage::get_ix_signers(&message, 1).collect::<HashSet<_>>(),
+        HashSet::from_iter([&signer0, &signer1])
+    );
+    assert_eq!(
+        SVMMessage::get_ix_signers(&message, 2).collect::<HashSet<_>>(),
+        HashSet::from_iter([&signer0])
+    );
+    assert_eq!(
+        SVMMessage::get_ix_signers(&message, 3).collect::<HashSet<_>>(),
+        HashSet::default()
+    );
 }

--- a/svm-transaction/src/tests.rs
+++ b/svm-transaction/src/tests.rs
@@ -1,18 +1,6 @@
-/// Serialized value of [`SystemInstruction::AdvanceNonceAccount`].
-const SERIALIZED_ADVANCE_NONCE_ACCOUNT: [u8; 4] = 4u32.to_le_bytes();
-
-#[inline]
-pub(crate) fn is_advance_nonce_account_instruction(data: &[u8]) -> bool {
-    const SERIALIZED_SIZE: usize = 4;
-    data.get(..SERIALIZED_SIZE)
-        .map(|data| data == SERIALIZED_ADVANCE_NONCE_ACCOUNT)
-        .unwrap_or(false)
-}
-
 #[cfg(test)]
 mod tests {
     use {
-        super::*,
         crate::svm_message::SVMMessage,
         solana_sdk::{
             hash::Hash,
@@ -179,7 +167,7 @@ mod tests {
         // system program id - nonce instruction w/ trailing bytes fee-payer
         {
             let payer_nonce = Pubkey::new_unique();
-            let mut instruction_bytes = SERIALIZED_ADVANCE_NONCE_ACCOUNT.to_vec();
+            let mut instruction_bytes = vec![4, 0, 0, 0];
             instruction_bytes.push(0); // add a trailing byte
             let message = create_message_for_test(
                 1,


### PR DESCRIPTION
#### Problem
- Disccusing with @buffalojoec that after recent changes we will be able to remove `TransactionCheckResults` from the interface of `svm` 
- Removing that would require getting nonce information inside of `svm`
- Currently nonce extraction is inside `runtime` not `svm-transaction`

#### Summary of Changes
- move nonce extraction to `SVMMessage`. Providing a default implementation.
- remove bincode usage in default implementation

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
