### PR TITLE
Allow rewrite to visit non-empty zero lamport account (WIP)

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -346,7 +346,9 @@ impl Accounts {
         some_account_tuple: Option<(&Pubkey, AccountSharedData, Slot)>,
     ) {
         if let Some(mapped_account_tuple) = some_account_tuple
-            .filter(|(_, account, _)| Self::is_loadable(account.lamports()))
+            .filter(|(_, account, _)| {
+                account.data().len() > 0 || Self::is_loadable(account.lamports())
+            })
             .map(|(pubkey, account, slot)| (*pubkey, account, slot))
         {
             collector.push(mapped_account_tuple)


### PR DESCRIPTION
DON'T MERGE. I REALIZED THIS CHANGE WILL BREAK THE CONSENSUS BECAUSE IT WILL
CHANGE THE ACCOUNT'S DELTA HASH. WE PROBABLY NEED A FEATURE GATE FOR THIS.

#### Problem

We notice that there are zombie zero lamport accounts with non-empty data,
which could be left over forever. 

We should fix our validator to clean them.


#### Summary of Changes

Allow rewrite to visit non-empty zero lamport accounts

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
