### PR TITLE
Add missing docummentation comment

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7562,6 +7562,8 @@ impl AccountsDb {
         true
     }
 
+    /// Determines whether a given AccountStorageEntry instance is a
+    /// candidate for shrinking.
     pub(crate) fn is_candidate_for_shrink(&self, store: &AccountStorageEntry) -> bool {
         // appended ancient append vecs should not be shrunk by the normal shrink codepath.
         // It is not possible to identify ancient append vecs when we pack, so no check for ancient when we are not appending.


### PR DESCRIPTION
#### Problem

A function was converted to a public method, but wasn't documented.

#### Summary of Changes

Add the missing documentation comment.
