### PR TITLE
Revert "Advises kernel to use random access for disk bucket mmaps (#2140)"

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -433,10 +433,6 @@ impl<O: BucketOccupied> BucketStorage<O> {
                 std::env::current_dir(),
             );
         });
-        // Access to the disk bucket files are random (excluding the linear search on collisions),
-        // so advise the kernel to treat the mmaps as such.
-        #[cfg(unix)]
-        mmap.advise(memmap2::Advice::Random).unwrap();
         measure_mmap.stop();
         stats
             .new_file_us


### PR DESCRIPTION
#### Problem

Disk I/O time is elevated, around the same time as PR #2140 was merged. 
First reported here: https://discord.com/channels/428295358100013066/1027231858565586985/1298749291254382673

More testing/investigation is needed; putting up this PR so that it can go through CI and be all ready, if it turns out to be needed.


#### Summary of Changes

Revert PR #2140

This reverts commit 72963e1469031fbc72d3d87a1f5e568e98f734ce.