### PR TITLE
fix flaky test

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1961,7 +1961,7 @@ pub fn process_wait_for_max_stake(
     max_stake_percent: f32,
 ) -> ProcessResult {
     let now = std::time::Instant::now();
-    rpc_client.wait_for_max_stake(config.commitment, max_stake_percent, None)?;
+    rpc_client.wait_for_max_stake(config.commitment, max_stake_percent)?;
     Ok(format!("Done waiting, took: {}s", now.elapsed().as_secs()))
 }
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1961,7 +1961,7 @@ pub fn process_wait_for_max_stake(
     max_stake_percent: f32,
 ) -> ProcessResult {
     let now = std::time::Instant::now();
-    rpc_client.wait_for_max_stake(config.commitment, max_stake_percent)?;
+    rpc_client.wait_for_max_stake(config.commitment, max_stake_percent, None)?;
     Ok(format!("Done waiting, took: {}s", now.elapsed().as_secs()))
 }
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1566,7 +1566,7 @@ fn test_wait_for_max_stake() {
         * num_expected_epochs;
     // Make the timeout double the expected duration to provide some margin.
     // Especially considering tests may be running in parallel.
-    let timeout = Some(expected_test_duration * 2);
+    let timeout = expected_test_duration * 2;
     if let Err(err) = client.wait_for_max_stake_below_threshold_with_timeout(
         CommitmentConfig::default(),
         33.0f32,

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -2179,6 +2179,15 @@ impl RpcClient {
         &self,
         commitment: CommitmentConfig,
         max_stake_percent: f32,
+    ) -> ClientResult<()> {
+        self.wait_for_max_stake_below_threshold_with_timeout(commitment, max_stake_percent, None)
+            .await
+    }
+
+    pub async fn wait_for_max_stake_below_threshold_with_timeout(
+        &self,
+        commitment: CommitmentConfig,
+        max_stake_percent: f32,
         timeout: Option<Duration>,
     ) -> ClientResult<()> {
         let mut current_percent;

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -2180,11 +2180,29 @@ impl RpcClient {
         commitment: CommitmentConfig,
         max_stake_percent: f32,
     ) -> ClientResult<()> {
-        self.wait_for_max_stake_below_threshold_with_timeout(commitment, max_stake_percent, None)
-            .await
+        self.wait_for_max_stake_below_threshold_with_timeout_helper(
+            commitment,
+            max_stake_percent,
+            None,
+        )
+        .await
     }
 
     pub async fn wait_for_max_stake_below_threshold_with_timeout(
+        &self,
+        commitment: CommitmentConfig,
+        max_stake_percent: f32,
+        timeout: Duration,
+    ) -> ClientResult<()> {
+        self.wait_for_max_stake_below_threshold_with_timeout_helper(
+            commitment,
+            max_stake_percent,
+            Some(timeout),
+        )
+        .await
+    }
+
+    async fn wait_for_max_stake_below_threshold_with_timeout_helper(
         &self,
         commitment: CommitmentConfig,
         max_stake_percent: f32,

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -1904,7 +1904,7 @@ impl RpcClient {
         &self,
         commitment: CommitmentConfig,
         max_stake_percent: f32,
-        timeout: Option<Duration>,
+        timeout: Duration,
     ) -> ClientResult<()> {
         self.invoke(
             (self.rpc_client.as_ref()).wait_for_max_stake_below_threshold_with_timeout(

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -1896,13 +1896,23 @@ impl RpcClient {
         &self,
         commitment: CommitmentConfig,
         max_stake_percent: f32,
+    ) -> ClientResult<()> {
+        self.invoke((self.rpc_client.as_ref()).wait_for_max_stake(commitment, max_stake_percent))
+    }
+
+    pub fn wait_for_max_stake_below_threshold_with_timeout(
+        &self,
+        commitment: CommitmentConfig,
+        max_stake_percent: f32,
         timeout: Option<Duration>,
     ) -> ClientResult<()> {
-        self.invoke((self.rpc_client.as_ref()).wait_for_max_stake(
-            commitment,
-            max_stake_percent,
-            timeout,
-        ))
+        self.invoke(
+            (self.rpc_client.as_ref()).wait_for_max_stake_below_threshold_with_timeout(
+                commitment,
+                max_stake_percent,
+                timeout,
+            ),
+        )
     }
 
     /// Returns information about all the nodes participating in the cluster.

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -1896,8 +1896,13 @@ impl RpcClient {
         &self,
         commitment: CommitmentConfig,
         max_stake_percent: f32,
+        timeout: Option<Duration>,
     ) -> ClientResult<()> {
-        self.invoke((self.rpc_client.as_ref()).wait_for_max_stake(commitment, max_stake_percent))
+        self.invoke((self.rpc_client.as_ref()).wait_for_max_stake(
+            commitment,
+            max_stake_percent,
+            timeout,
+        ))
     }
 
     /// Returns information about all the nodes participating in the cluster.


### PR DESCRIPTION
#### Problem
`test_wait_for_max_stake` is notoriously flaky. Even worse, when it fails, it takes an hour to timeout.

The following is observed when the test fails:

1. Stake of the highest staked validator gets stuck, usually around 71%
2. Stake is stuck because stake from the other 3 validators is not activating
3. Stake is not activating because epochs are not advancing
4. Epochs are not advancing because nobody thinks they are leader
5. Nobody thinks they are leader because the new leader schedule is not generated
6. New leader schedule is not generated because we have not rooted a new slot in the current epoch
7. We haven't rooted a new slot in the new epoch because we have skipped at least one slot and have zero margin
8. We have zero margin because tower height is 32, slots per epoch is 32 (so we can advance epochs quickly), and we only compute the leader slot 1 epoch worth of slots ahead of time
9. It's not 100% clear why we skip slots, but it may be partially due to running 4 validators on one set of HW. We see replay thread not executing in time and PoH ticking past the leader slot.

#### Summary of Changes

1. Compute the leader schedule 3 epochs worth of slots ahead of time. This will provide margin where we can skip a slot here and there and still not get stuck.
2. Reduce ticks per slot to 16. This isn't necessary to fix the issue (in fact, it potentially makes us skip more slots), but it will reduce the test time by a factor of 4.
3. Add a 5 minute timout to the test. This will prevent hanging CI for an hour if we still fail.