### PR TITLE
Add offset command line option to store-histogram

### DIFF
--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -53,7 +53,7 @@ fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>, offset: i64) {
     eprintln!("highest slot: {max_inclusive}");
     eprintln!("slot range: {}", max_inclusive - min + 1);
     eprintln!(
-        "outside of epoch: {}",
+        "ancient boundary: {}",
         info.iter()
             .filter(|x| x.0 < max_inclusive - outside_slot)
             .count()

--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -142,9 +142,6 @@ fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>, offset: i64) {
             eprintln!("...");
         }
         let bin = &bins[i];
-        if bin.slot_min == outside_slot {
-            eprintln!("{}", String::from_utf8(vec![b'-'; 168]).unwrap());
-        }
         let offset = format!("{:8}", bin.slot_min);
 
         if i == 0 {
@@ -202,6 +199,9 @@ fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>, offset: i64) {
             s2 = format!("{s2}{s}");
         });
         eprintln!("{s2}");
+        if bin.slot_min < outside_slot && outside_slot <= bin.slot_max {
+            eprintln!("{}", String::from_utf8(vec![b'-'; 168]).unwrap());
+        }
     }
 }
 

--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -52,8 +52,9 @@ fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>, offset: i64) {
     eprintln!("lowest slot: {min}");
     eprintln!("highest slot: {max_inclusive}");
     eprintln!("slot range: {}", max_inclusive - min + 1);
+    eprintln!("ancient boundary: {}", outside_slot);
     eprintln!(
-        "ancient boundary: {}",
+        "number of slots beyond ancient bondary: {}",
         info.iter()
             .filter(|x| x.0 < max_inclusive - outside_slot)
             .count()

--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
-    clap::{crate_description, crate_name, value_t_or_exit, App, Arg},
-    std::{fs, path::PathBuf},
+    clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg},
+    std::{fmt::Display, fs, path::PathBuf, str::FromStr},
 };
 
 struct Bin {
@@ -31,11 +31,23 @@ fn get_stars(x: usize, max: usize, width: usize) -> String {
     s
 }
 
-fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>) {
+fn is_parsable<T>(string: String) -> Result<(), String>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    string
+        .parse::<T>()
+        .map(|_| ())
+        .map_err(|err| format!("error parsing '{string}': {err}"))
+}
+
+fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>, offset: i64) {
     let mut info = info.to_owned();
     info.sort();
     let min = info.first().unwrap().0;
     let max_inclusive = info.last().unwrap().0;
+    let outside_slot = 432_000 - offset as usize;
     eprintln!("storages: {}", info.len());
     eprintln!("lowest slot: {min}");
     eprintln!("highest slot: {max_inclusive}");
@@ -43,7 +55,7 @@ fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>) {
     eprintln!(
         "outside of epoch: {}",
         info.iter()
-            .filter(|x| x.0 < max_inclusive - 432_000)
+            .filter(|x| x.0 < max_inclusive - outside_slot)
             .count()
     );
 
@@ -130,7 +142,7 @@ fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>) {
             eprintln!("...");
         }
         let bin = &bins[i];
-        if bin.slot_min == 432_000 {
+        if bin.slot_min == outside_slot {
             eprintln!("------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
         }
         let offset = format!("{:8}", bin.slot_min);
@@ -237,9 +249,18 @@ fn main() {
                 .value_name("PATH")
                 .help("ledger path"),
         )
+        .arg(
+            Arg::with_name("offset")
+                .long("offset")
+                .takes_value(true)
+                .value_name("SLOT-OFFSET")
+                .validator(is_parsable::<i64>)
+                .help("ancient offset"),
+        )
         .get_matches();
 
     let ledger = value_t_or_exit!(matches, "ledger", String);
+    let offset = value_t!(matches, "offset", i64).unwrap_or(100_000);
     let path: PathBuf = [&ledger, "accounts", "run"].iter().collect();
 
     if path.is_dir() {
@@ -263,15 +284,15 @@ fn main() {
                 }
             }
             eprintln!("======== Normal Histogram");
-            calc(&info, normal_bin_widths());
+            calc(&info, normal_bin_widths(), offset);
             eprintln!("========");
 
             eprintln!("\n======== Normal Ancient Histogram");
-            calc(&info, normal_ancient());
+            calc(&info, normal_ancient(), offset);
             eprintln!("========");
 
             eprintln!("\n======== Normal Ancient 10K Histogram");
-            calc(&info, normal_10k());
+            calc(&info, normal_10k(), offset);
             eprintln!("========");
         } else {
             panic!("couldn't read folder: {path:?}, {:?}", dir);
@@ -302,8 +323,9 @@ pub mod tests {
             .into_iter()
             .map(|(slot, size)| (max - slot + base, size))
             .collect::<Vec<_>>();
-        calc(&info, normal_bin_widths());
-        calc(&info, normal_ancient());
-        calc(&info, normal_10k());
+        let offset = 100_000i64;
+        calc(&info, normal_bin_widths(), offset);
+        calc(&info, normal_ancient(), offset);
+        calc(&info, normal_10k(), offset);
     }
 }

--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -143,7 +143,7 @@ fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>, offset: i64) {
         }
         let bin = &bins[i];
         if bin.slot_min == outside_slot {
-            eprintln!("------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+            eprintln!("{}", String::from_utf8(vec![b'-'; 168]).unwrap());
         }
         let offset = format!("{:8}", bin.slot_min);
 

--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -254,12 +254,6 @@ fn normal_ancient() -> Vec<usize> {
     bin_widths.push(432_000);
     bin_widths
 }
-fn normal_10k() -> Vec<usize> {
-    let mut bin_widths = vec![0];
-    bin_widths.push(432_000);
-    bin_widths.push(442_000);
-    bin_widths
-}
 
 fn main() {
     let matches = App::new(crate_name!())
@@ -312,10 +306,6 @@ fn main() {
 
             eprintln!("\n======== Normal Ancient Histogram");
             calc(&info, normal_ancient(), offset);
-            eprintln!("========");
-
-            eprintln!("\n======== Normal Ancient 10K Histogram");
-            calc(&info, normal_10k(), offset);
             eprintln!("========");
         } else {
             panic!("couldn't read folder: {path:?}, {:?}", dir);

--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -249,9 +249,9 @@ fn normal_bin_widths() -> Vec<usize> {
     bin_widths
 }
 
-fn normal_ancient() -> Vec<usize> {
+fn normal_ancient(offset: i64) -> Vec<usize> {
     let mut bin_widths = vec![0];
-    bin_widths.push(432_000);
+    bin_widths.push((432_000 - offset) as usize);
     bin_widths
 }
 
@@ -305,7 +305,7 @@ fn main() {
             eprintln!("========");
 
             eprintln!("\n======== Normal Ancient Histogram");
-            calc(&info, normal_ancient(), offset);
+            calc(&info, normal_ancient(offset), offset);
             eprintln!("========");
         } else {
             panic!("couldn't read folder: {path:?}, {:?}", dir);
@@ -338,7 +338,6 @@ pub mod tests {
             .collect::<Vec<_>>();
         let offset = 100_000i64;
         calc(&info, normal_bin_widths(), offset);
-        calc(&info, normal_ancient(), offset);
-        calc(&info, normal_10k(), offset);
+        calc(&info, normal_ancient(offset), offset);
     }
 }

--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -67,14 +67,36 @@ fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>, offset: i64) {
         } else {
             bin_widths[i + 1]
         };
-        let abin = Bin {
-            slot_min: bin_widths[i],
-            slot_max: next,
-            count: 0,
-            min_size: usize::MAX,
-            max_size: 0,
-            sum_size: 0,
-            avg: 0,
+        let abin = if bin_widths[i] < outside_slot && outside_slot < next {
+            let abin = Bin {
+                slot_min: bin_widths[i],
+                slot_max: outside_slot,
+                count: 0,
+                min_size: usize::MAX,
+                max_size: 0,
+                sum_size: 0,
+                avg: 0,
+            };
+            bins.push(abin);
+            Bin {
+                slot_min: outside_slot,
+                slot_max: next,
+                count: 0,
+                min_size: usize::MAX,
+                max_size: 0,
+                sum_size: 0,
+                avg: 0,
+            }
+        } else {
+            Bin {
+                slot_min: bin_widths[i],
+                slot_max: next,
+                count: 0,
+                min_size: usize::MAX,
+                max_size: 0,
+                sum_size: 0,
+                avg: 0,
+            }
         };
         bins.push(abin);
     }
@@ -143,6 +165,9 @@ fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>, offset: i64) {
             eprintln!("...");
         }
         let bin = &bins[i];
+        if bin.slot_min == outside_slot {
+            eprintln!("{}", String::from_utf8(vec![b'-'; 168]).unwrap());
+        }
         let offset = format!("{:8}", bin.slot_min);
 
         if i == 0 {
@@ -200,9 +225,6 @@ fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>, offset: i64) {
             s2 = format!("{s2}{s}");
         });
         eprintln!("{s2}");
-        if bin.slot_min < outside_slot && outside_slot <= bin.slot_max {
-            eprintln!("{}", String::from_utf8(vec![b'-'; 168]).unwrap());
-        }
     }
 }
 


### PR DESCRIPTION
#### Problem

Boundary of ancient slots is hard-coded and not configurable.

Recent mnb changes make the offset 100k by default. Would be great if histogram allowed specifying the boundary between ancient and non-ancient.

#### Summary of Changes

Add a command line option to pass a value of offset from which the epoch boundary should be computed.