### PR TITLE
Add slot to ancient shrink stats

### DIFF
--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -347,6 +347,7 @@ pub struct ShrinkAncientStats {
     pub slots_eligible_to_shrink: AtomicU64,
     pub total_dead_bytes: AtomicU64,
     pub total_alive_bytes: AtomicU64,
+    pub slot: AtomicU64,
     pub ideal_storage_size: AtomicU64,
 }
 
@@ -773,6 +774,7 @@ impl ShrinkAncientStats {
                     .swap(0, Ordering::Relaxed),
                 i64
             ),
+            ("slot", self.slot.swap(0, Ordering::Relaxed), i64),
             (
                 "ideal_storage_size",
                 self.ideal_storage_size.swap(0, Ordering::Relaxed),

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -774,7 +774,7 @@ impl ShrinkAncientStats {
                     .swap(0, Ordering::Relaxed),
                 i64
             ),
-            ("slot", self.slot.swap(0, Ordering::Relaxed), i64),
+            ("slot", self.slot.load(Ordering::Relaxed), i64),
             (
                 "ideal_storage_size",
                 self.ideal_storage_size.swap(0, Ordering::Relaxed),

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -410,6 +410,10 @@ impl AccountsDb {
         mut tuning: PackedAncientStorageTuning,
         metrics: &mut ShrinkStatsSub,
     ) {
+        self.shrink_ancient_stats.slot.store(
+            sorted_slots.first().cloned().unwrap_or_default(),
+            Ordering::Relaxed,
+        );
         self.shrink_ancient_stats
             .slots_considered
             .fetch_add(sorted_slots.len() as u64, Ordering::Relaxed);

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -410,10 +410,9 @@ impl AccountsDb {
         mut tuning: PackedAncientStorageTuning,
         metrics: &mut ShrinkStatsSub,
     ) {
-        self.shrink_ancient_stats.slot.store(
-            sorted_slots.first().cloned().unwrap_or_default(),
-            Ordering::Relaxed,
-        );
+        self.shrink_ancient_stats
+            .slot
+            .store(*sorted_slots.first().unwrap_or(&0), Ordering::Relaxed);
         self.shrink_ancient_stats
             .slots_considered
             .fetch_add(sorted_slots.len() as u64, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem

It is useful to know the beginning slot for shrinking ancient storages.


#### Summary of Changes

Add slot to ancient shrink stat.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
