### PR TITLE
ci: increase timeout for dcou

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -181,9 +181,9 @@ wait_step() {
 
 all_test_steps() {
   command_step checks1 "ci/docker-run-default-image.sh ci/test-checks.sh" 20 check
-  command_step dcou-1-of-3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh --partition 1/3" 15 check
-  command_step dcou-2-of-3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh --partition 2/3" 15 check
-  command_step dcou-3-of-3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh --partition 3/3" 15 check
+  command_step dcou-1-of-3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh --partition 1/3" 20 check
+  command_step dcou-2-of-3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh --partition 2/3" 20 check
+  command_step dcou-3-of-3 "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh --partition 3/3" 20 check
   command_step miri "ci/docker-run-default-image.sh ci/test-miri.sh" 5 check
   command_step frozen-abi "ci/docker-run-default-image.sh ./test-abi.sh" 15 check
   wait_step


### PR DESCRIPTION
#### Problem

our project is growing with more and more crates being added. (10/1: 158, today: 173) and I see some timeout in dcou tests

https://buildkite.com/anza/agave/builds/12575
<img width="1464" alt="Screenshot 2024-10-25 at 00 17 47" src="https://github.com/user-attachments/assets/24332466-10e5-46de-9394-781bc5d2cbc4">

they are almost done, just need a little bit more time.

#### Summary of Changes

increase the timeout for dcou tests by 5 minutes.