### PR TITLE
sdk: Extract `solana-sysvar-id` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6368,7 +6368,7 @@ dependencies = [
  "serde_derive",
  "solana-clock",
  "solana-sdk-macro",
- "solana-sysvar",
+ "solana-sysvar-id",
  "static_assertions",
 ]
 
@@ -6686,7 +6686,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-sdk-macro",
- "solana-sysvar",
+ "solana-sysvar-id",
  "static_assertions",
 ]
 
@@ -6977,6 +6977,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk-macro",
+ "solana-sysvar-id",
 ]
 
 [[package]]
@@ -7460,7 +7461,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stable-layout",
- "solana-sysvar",
+ "solana-sysvar-id",
  "solana-transaction-error",
  "static_assertions",
  "test-case",
@@ -7702,7 +7703,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-sdk-macro",
- "solana-sysvar",
+ "solana-sysvar-id",
  "static_assertions",
 ]
 
@@ -8177,7 +8178,7 @@ dependencies = [
  "serde_derive",
  "solana-hash",
  "solana-sha256-hasher",
- "solana-sysvar",
+ "solana-sysvar-id",
 ]
 
 [[package]]
@@ -8187,6 +8188,7 @@ dependencies = [
  "bv",
  "serde",
  "serde_derive",
+ "solana-sysvar-id",
 ]
 
 [[package]]
@@ -8461,7 +8463,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-sysvar"
+name = "solana-sysvar-id"
 version = "2.1.0"
 dependencies = [
  "solana-program-entrypoint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8464,7 +8464,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sysvar-id"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "solana-pubkey",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6366,7 +6366,9 @@ version = "2.2.0"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-clock",
  "solana-sdk-macro",
+ "solana-sysvar",
  "static_assertions",
 ]
 
@@ -6680,9 +6682,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-clock",
+ "solana-epoch-schedule",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-sdk-macro",
+ "solana-sysvar",
  "static_assertions",
 ]
 
@@ -7456,6 +7460,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stable-layout",
+ "solana-sysvar",
  "solana-transaction-error",
  "static_assertions",
  "test-case",
@@ -7697,6 +7702,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-sdk-macro",
+ "solana-sysvar",
  "static_assertions",
 ]
 
@@ -8171,6 +8177,7 @@ dependencies = [
  "serde_derive",
  "solana-hash",
  "solana-sha256-hasher",
+ "solana-sysvar",
 ]
 
 [[package]]
@@ -8451,6 +8458,16 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk",
  "solana-type-overrides",
+]
+
+[[package]]
+name = "solana-sysvar"
+version = "2.1.0"
+dependencies = [
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8466,10 +8466,7 @@ dependencies = [
 name = "solana-sysvar-id"
 version = "2.1.0"
 dependencies = [
- "solana-program-entrypoint",
- "solana-program-error",
  "solana-pubkey",
- "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ members = [
     "sdk/slot-hashes",
     "sdk/slot-history",
     "sdk/stable-layout",
+    "sdk/sysvar",
     "sdk/transaction-error",
     "send-transaction-service",
     "short-vec",
@@ -505,6 +506,7 @@ solana-svm-example-paytube = { path = "svm/examples/paytube", version = "=2.2.0"
 solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.2.0" }
 solana-svm-transaction = { path = "svm-transaction", version = "=2.2.0" }
 solana-system-program = { path = "programs/system", version = "=2.2.0" }
+solana-sysvar = { path = "sdk/sysvar", version = "=2.2.0" }
 solana-test-validator = { path = "test-validator", version = "=2.2.0" }
 solana-thin-client = { path = "thin-client", version = "=2.2.0" }
 solana-transaction-error = { path = "sdk/transaction-error", version = "=2.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ members = [
     "sdk/slot-hashes",
     "sdk/slot-history",
     "sdk/stable-layout",
-    "sdk/sysvar",
+    "sdk/sysvar-id",
     "sdk/transaction-error",
     "send-transaction-service",
     "short-vec",
@@ -506,7 +506,7 @@ solana-svm-example-paytube = { path = "svm/examples/paytube", version = "=2.2.0"
 solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.2.0" }
 solana-svm-transaction = { path = "svm-transaction", version = "=2.2.0" }
 solana-system-program = { path = "programs/system", version = "=2.2.0" }
-solana-sysvar = { path = "sdk/sysvar", version = "=2.2.0" }
+solana-sysvar-id = { path = "sdk/sysvar-id", version = "=2.2.0" }
 solana-test-validator = { path = "test-validator", version = "=2.2.0" }
 solana-thin-client = { path = "thin-client", version = "=2.2.0" }
 solana-transaction-error = { path = "sdk/transaction-error", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5087,7 +5087,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk-macro",
- "solana-sysvar",
+ "solana-sysvar-id",
 ]
 
 [[package]]
@@ -5321,7 +5321,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk-macro",
- "solana-sysvar",
+ "solana-sysvar-id",
 ]
 
 [[package]]
@@ -5515,6 +5515,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk-macro",
+ "solana-sysvar-id",
 ]
 
 [[package]]
@@ -5825,7 +5826,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stable-layout",
- "solana-sysvar",
+ "solana-sysvar-id",
  "solana-transaction-error",
  "thiserror",
  "wasm-bindgen",
@@ -6041,7 +6042,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk-macro",
- "solana-sysvar",
+ "solana-sysvar-id",
 ]
 
 [[package]]
@@ -6903,7 +6904,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-hash",
- "solana-sysvar",
+ "solana-sysvar-id",
 ]
 
 [[package]]
@@ -6913,6 +6914,7 @@ dependencies = [
  "bv",
  "serde",
  "serde_derive",
+ "solana-sysvar-id",
 ]
 
 [[package]]
@@ -7079,7 +7081,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-sysvar"
+name = "solana-sysvar-id"
 version = "2.1.0"
 dependencies = [
  "solana-program-error",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5087,6 +5087,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk-macro",
+ "solana-sysvar",
 ]
 
 [[package]]
@@ -5320,6 +5321,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk-macro",
+ "solana-sysvar",
 ]
 
 [[package]]
@@ -5823,6 +5825,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stable-layout",
+ "solana-sysvar",
  "solana-transaction-error",
  "thiserror",
  "wasm-bindgen",
@@ -6038,6 +6041,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk-macro",
+ "solana-sysvar",
 ]
 
 [[package]]
@@ -6899,6 +6903,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-hash",
+ "solana-sysvar",
 ]
 
 [[package]]
@@ -7071,6 +7076,14 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk",
  "solana-type-overrides",
+]
+
+[[package]]
+name = "solana-sysvar"
+version = "2.1.0"
+dependencies = [
+ "solana-program-error",
+ "solana-pubkey",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7084,7 +7084,6 @@ dependencies = [
 name = "solana-sysvar-id"
 version = "2.1.0"
 dependencies = [
- "solana-program-error",
  "solana-pubkey",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7082,7 +7082,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sysvar-id"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "solana-pubkey",
 ]

--- a/sdk/clock/Cargo.toml
+++ b/sdk/clock/Cargo.toml
@@ -13,12 +13,17 @@ edition = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
+solana-sysvar = { workspace = true, optional = true }
 
 [dev-dependencies]
+solana-clock = { path = ".", features = ["sysvar"] }
 static_assertions = { workspace = true }
 
 [features]
 serde = ["dep:serde", "dep:serde_derive"]
+sysvar = ["dep:solana-sysvar"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]

--- a/sdk/clock/Cargo.toml
+++ b/sdk/clock/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
-solana-sysvar = { workspace = true, optional = true }
+solana-sysvar-id = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-clock = { path = ".", features = ["sysvar"] }
@@ -21,7 +21,7 @@ static_assertions = { workspace = true }
 
 [features]
 serde = ["dep:serde", "dep:serde_derive"]
-sysvar = ["dep:solana-sysvar"]
+sysvar = ["dep:solana-sysvar-id"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/clock/src/lib.rs
+++ b/sdk/clock/src/lib.rs
@@ -20,6 +20,10 @@
 //!
 //! [oracle]: https://docs.solanalabs.com/implemented-proposals/validator-timestamp-oracle
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+#[cfg(feature = "sysvar")]
+pub mod sysvar;
 
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};

--- a/sdk/clock/src/sysvar.rs
+++ b/sdk/clock/src/sysvar.rs
@@ -1,3 +1,3 @@
-use {crate::Clock, solana_sysvar::declare_sysvar_id};
+use {crate::Clock, solana_sysvar_id::declare_sysvar_id};
 
 declare_sysvar_id!("SysvarC1ock11111111111111111111111111111111", Clock);

--- a/sdk/clock/src/sysvar.rs
+++ b/sdk/clock/src/sysvar.rs
@@ -1,0 +1,3 @@
+use {crate::Clock, solana_sysvar::declare_sysvar_id};
+
+declare_sysvar_id!("SysvarC1ock11111111111111111111111111111111", Clock);

--- a/sdk/epoch-schedule/Cargo.toml
+++ b/sdk/epoch-schedule/Cargo.toml
@@ -15,7 +15,7 @@ serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
-solana-sysvar = { workspace = true, optional = true }
+solana-sysvar-id = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -28,7 +28,7 @@ static_assertions = { workspace = true }
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]
-sysvar = ["dep:solana-sysvar"]
+sysvar = ["dep:solana-sysvar-id"]
 
 [lints]
 workspace = true

--- a/sdk/epoch-schedule/Cargo.toml
+++ b/sdk/epoch-schedule/Cargo.toml
@@ -15,17 +15,20 @@ serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
+solana-sysvar = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
 solana-clock = { workspace = true }
+solana-epoch-schedule = { path = ".", features = ["sysvar"] }
 static_assertions = { workspace = true }
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]
+sysvar = ["dep:solana-sysvar"]
 
 [lints]
 workspace = true

--- a/sdk/epoch-schedule/src/lib.rs
+++ b/sdk/epoch-schedule/src/lib.rs
@@ -17,6 +17,9 @@
 #[cfg(feature = "frozen-abi")]
 extern crate std;
 
+#[cfg(feature = "sysvar")]
+pub mod sysvar;
+
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk_macro::CloneZeroed;

--- a/sdk/epoch-schedule/src/sysvar.rs
+++ b/sdk/epoch-schedule/src/sysvar.rs
@@ -1,3 +1,3 @@
-use {crate::EpochSchedule, solana_sysvar::declare_sysvar_id};
+use {crate::EpochSchedule, solana_sysvar_id::declare_sysvar_id};
 
 declare_sysvar_id!("SysvarEpochSchedu1e111111111111111111111111", EpochSchedule);

--- a/sdk/epoch-schedule/src/sysvar.rs
+++ b/sdk/epoch-schedule/src/sysvar.rs
@@ -1,0 +1,3 @@
+use {crate::EpochSchedule, solana_sysvar::declare_sysvar_id};
+
+declare_sysvar_id!("SysvarEpochSchedu1e111111111111111111111111", EpochSchedule);

--- a/sdk/last-restart-slot/Cargo.toml
+++ b/sdk/last-restart-slot/Cargo.toml
@@ -13,9 +13,11 @@ edition = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
+solana-sysvar-id = { workspace = true, optional = true }
 
 [features]
 serde = ["dep:serde", "dep:serde_derive"]
+sysvar = ["dep:solana-sysvar-id"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/last-restart-slot/src/lib.rs
+++ b/sdk/last-restart-slot/src/lib.rs
@@ -1,6 +1,9 @@
 //! Information about the last restart slot (hard fork).
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+#[cfg(feature = "sysvar")]
+pub mod sysvar;
+
 use solana_sdk_macro::CloneZeroed;
 
 #[repr(C)]

--- a/sdk/last-restart-slot/src/sysvar.rs
+++ b/sdk/last-restart-slot/src/sysvar.rs
@@ -1,0 +1,6 @@
+use {crate::LastRestartSlot, solana_sysvar_id::declare_sysvar_id};
+
+declare_sysvar_id!(
+    "SysvarLastRestartS1ot1111111111111111111111",
+    LastRestartSlot
+);

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -35,14 +35,8 @@ sha3 = { workspace = true }
 solana-account-info = { workspace = true, features = ["bincode"] }
 solana-atomic-u64 = { workspace = true }
 solana-bincode = { workspace = true }
-<<<<<<< HEAD
 solana-borsh = { workspace = true, optional = true }
-solana-clock = { workspace = true, features = ["serde"] }
-||||||| parent of 702bf288f8 (sdk: Extract `solana-sysvar` crate)
-solana-clock = { workspace = true, features = ["serde"] }
-=======
 solana-clock = { workspace = true, features = ["serde", "sysvar"] }
->>>>>>> 702bf288f8 (sdk: Extract `solana-sysvar` crate)
 solana-cpi = { workspace = true }
 solana-decode-error = { workspace = true }
 solana-epoch-schedule = { workspace = true, features = ["serde", "sysvar"] }
@@ -59,7 +53,7 @@ solana-instruction = { workspace = true, default-features = false, features = [
     "serde",
     "std",
 ] }
-solana-last-restart-slot = { workspace = true, features = ["serde"] }
+solana-last-restart-slot = { workspace = true, features = ["serde", "sysvar"] }
 solana-msg = { workspace = true }
 solana-native-token = { workspace = true }
 solana-program-entrypoint = { workspace = true }
@@ -77,9 +71,9 @@ solana-serialize-utils = { workspace = true }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-short-vec = { workspace = true }
 solana-slot-hashes = { workspace = true, features = ["serde", "sysvar"] }
-solana-slot-history = { workspace = true, features = ["serde"] }
+solana-slot-history = { workspace = true, features = ["serde", "sysvar"] }
 solana-stable-layout = { workspace = true }
-solana-sysvar = { workspace = true }
+solana-sysvar-id = { workspace = true }
 thiserror = { workspace = true }
 
 # This is currently needed to build on-chain programs reliably.

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -35,11 +35,17 @@ sha3 = { workspace = true }
 solana-account-info = { workspace = true, features = ["bincode"] }
 solana-atomic-u64 = { workspace = true }
 solana-bincode = { workspace = true }
+<<<<<<< HEAD
 solana-borsh = { workspace = true, optional = true }
 solana-clock = { workspace = true, features = ["serde"] }
+||||||| parent of 702bf288f8 (sdk: Extract `solana-sysvar` crate)
+solana-clock = { workspace = true, features = ["serde"] }
+=======
+solana-clock = { workspace = true, features = ["serde", "sysvar"] }
+>>>>>>> 702bf288f8 (sdk: Extract `solana-sysvar` crate)
 solana-cpi = { workspace = true }
 solana-decode-error = { workspace = true }
-solana-epoch-schedule = { workspace = true, features = ["serde"] }
+solana-epoch-schedule = { workspace = true, features = ["serde", "sysvar"] }
 solana-fee-calculator = { workspace = true, features = ["serde"] }
 solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
@@ -62,7 +68,7 @@ solana-program-memory = { workspace = true }
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-pubkey = { workspace = true, features = ["bytemuck", "curve25519", "serde", "std"] }
-solana-rent = { workspace = true, features = ["serde"] }
+solana-rent = { workspace = true, features = ["serde", "sysvar"] }
 solana-sanitize = { workspace = true }
 solana-sdk-macro = { workspace = true }
 solana-secp256k1-recover = { workspace = true }
@@ -70,9 +76,10 @@ solana-serde-varint = { workspace = true }
 solana-serialize-utils = { workspace = true }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-short-vec = { workspace = true }
-solana-slot-hashes = { workspace = true, features = ["serde"] }
+solana-slot-hashes = { workspace = true, features = ["serde", "sysvar"] }
 solana-slot-history = { workspace = true, features = ["serde"] }
 solana-stable-layout = { workspace = true }
+solana-sysvar = { workspace = true }
 thiserror = { workspace = true }
 
 # This is currently needed to build on-chain programs reliably.

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -606,8 +606,8 @@ pub mod sdk_ids {
 #[deprecated(since = "2.1.0", note = "Use `solana-decode-error` crate instead")]
 pub use solana_decode_error as decode_error;
 pub use solana_pubkey::{declare_deprecated_id, declare_id, pubkey};
-#[deprecated(since = "2.1.0", note = "Use `solana-sysvar` crate instead")]
-pub use solana_sysvar::{declare_deprecated_sysvar_id, declare_sysvar_id};
+#[deprecated(since = "2.1.0", note = "Use `solana-sysvar-id` crate instead")]
+pub use solana_sysvar_id::{declare_deprecated_sysvar_id, declare_sysvar_id};
 
 #[macro_use]
 extern crate serde_derive;

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -606,6 +606,8 @@ pub mod sdk_ids {
 #[deprecated(since = "2.1.0", note = "Use `solana-decode-error` crate instead")]
 pub use solana_decode_error as decode_error;
 pub use solana_pubkey::{declare_deprecated_id, declare_id, pubkey};
+#[deprecated(since = "2.1.0", note = "Use `solana-sysvar` crate instead")]
+pub use solana_sysvar::{declare_deprecated_sysvar_id, declare_sysvar_id};
 
 #[macro_use]
 extern crate serde_derive;

--- a/sdk/program/src/sysvar/clock.rs
+++ b/sdk/program/src/sysvar/clock.rs
@@ -38,7 +38,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_program::sysvar::SysvarId;
+//! # use solana_sysvar::SysvarId;
 //! # let p = Clock::id();
 //! # let l = &mut 1169280;
 //! # let d = &mut vec![240, 153, 233, 7, 0, 0, 0, 0, 11, 115, 118, 98, 0, 0, 0, 0, 51, 1, 0, 0, 0, 0, 0, 0, 52, 1, 0, 0, 0, 0, 0, 0, 121, 50, 119, 98, 0, 0, 0, 0];
@@ -81,7 +81,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_program::sysvar::SysvarId;
+//! # use solana_sysvar::SysvarId;
 //! # let p = Clock::id();
 //! # let l = &mut 1169280;
 //! # let d = &mut vec![240, 153, 233, 7, 0, 0, 0, 0, 11, 115, 118, 98, 0, 0, 0, 0, 51, 1, 0, 0, 0, 0, 0, 0, 52, 1, 0, 0, 0, 0, 0, 0, 121, 50, 119, 98, 0, 0, 0, 0];
@@ -127,9 +127,10 @@
 //! ```
 
 use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
-pub use solana_clock::Clock;
-
-crate::declare_sysvar_id!("SysvarC1ock11111111111111111111111111111111", Clock);
+pub use solana_clock::{
+    sysvar::{check_id, id, ID},
+    Clock,
+};
 
 impl Sysvar for Clock {
     impl_sysvar_get!(sol_get_clock_sysvar);

--- a/sdk/program/src/sysvar/clock.rs
+++ b/sdk/program/src/sysvar/clock.rs
@@ -38,7 +38,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_sysvar::SysvarId;
+//! # use solana_sysvar_id::SysvarId;
 //! # let p = Clock::id();
 //! # let l = &mut 1169280;
 //! # let d = &mut vec![240, 153, 233, 7, 0, 0, 0, 0, 11, 115, 118, 98, 0, 0, 0, 0, 51, 1, 0, 0, 0, 0, 0, 0, 52, 1, 0, 0, 0, 0, 0, 0, 121, 50, 119, 98, 0, 0, 0, 0];
@@ -81,7 +81,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_sysvar::SysvarId;
+//! # use solana_sysvar_id::SysvarId;
 //! # let p = Clock::id();
 //! # let l = &mut 1169280;
 //! # let d = &mut vec![240, 153, 233, 7, 0, 0, 0, 0, 11, 115, 118, 98, 0, 0, 0, 0, 51, 1, 0, 0, 0, 0, 0, 0, 52, 1, 0, 0, 0, 0, 0, 0, 121, 50, 119, 98, 0, 0, 0, 0];

--- a/sdk/program/src/sysvar/epoch_rewards.rs
+++ b/sdk/program/src/sysvar/epoch_rewards.rs
@@ -49,7 +49,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_program::sysvar::SysvarId;
+//! # use solana_sysvar::SysvarId;
 //! # let p = EpochRewards::id();
 //! # let l = &mut 1559040;
 //! # let epoch_rewards = EpochRewards {
@@ -99,7 +99,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_program::sysvar::SysvarId;
+//! # use solana_sysvar::SysvarId;
 //! # let p = EpochRewards::id();
 //! # let l = &mut 1559040;
 //! # let epoch_rewards = EpochRewards {
@@ -160,9 +160,12 @@
 //! ```
 
 pub use crate::epoch_rewards::EpochRewards;
-use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
+use {
+    crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar},
+    solana_sysvar::declare_sysvar_id,
+};
 
-crate::declare_sysvar_id!("SysvarEpochRewards1111111111111111111111111", EpochRewards);
+declare_sysvar_id!("SysvarEpochRewards1111111111111111111111111", EpochRewards);
 
 impl Sysvar for EpochRewards {
     impl_sysvar_get!(sol_get_epoch_rewards_sysvar);

--- a/sdk/program/src/sysvar/epoch_rewards.rs
+++ b/sdk/program/src/sysvar/epoch_rewards.rs
@@ -49,7 +49,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_sysvar::SysvarId;
+//! # use solana_sysvar_id::SysvarId;
 //! # let p = EpochRewards::id();
 //! # let l = &mut 1559040;
 //! # let epoch_rewards = EpochRewards {
@@ -99,7 +99,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_sysvar::SysvarId;
+//! # use solana_sysvar_id::SysvarId;
 //! # let p = EpochRewards::id();
 //! # let l = &mut 1559040;
 //! # let epoch_rewards = EpochRewards {
@@ -162,7 +162,7 @@
 pub use crate::epoch_rewards::EpochRewards;
 use {
     crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar},
-    solana_sysvar::declare_sysvar_id,
+    solana_sysvar_id::declare_sysvar_id,
 };
 
 declare_sysvar_id!("SysvarEpochRewards1111111111111111111111111", EpochRewards);

--- a/sdk/program/src/sysvar/epoch_schedule.rs
+++ b/sdk/program/src/sysvar/epoch_schedule.rs
@@ -38,7 +38,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_sysvar::SysvarId;
+//! # use solana_sysvar_id::SysvarId;
 //! # let p = EpochSchedule::id();
 //! # let l = &mut 1120560;
 //! # let d = &mut vec![0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -81,7 +81,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_sysvar::SysvarId;
+//! # use solana_sysvar_id::SysvarId;
 //! # let p = EpochSchedule::id();
 //! # let l = &mut 1120560;
 //! # let d = &mut vec![0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];

--- a/sdk/program/src/sysvar/epoch_schedule.rs
+++ b/sdk/program/src/sysvar/epoch_schedule.rs
@@ -38,7 +38,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_program::sysvar::SysvarId;
+//! # use solana_sysvar::SysvarId;
 //! # let p = EpochSchedule::id();
 //! # let l = &mut 1120560;
 //! # let d = &mut vec![0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -81,7 +81,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_program::sysvar::SysvarId;
+//! # use solana_sysvar::SysvarId;
 //! # let p = EpochSchedule::id();
 //! # let l = &mut 1120560;
 //! # let d = &mut vec![0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -125,10 +125,11 @@
 //! #
 //! # Ok::<(), anyhow::Error>(())
 //! ```
-pub use crate::epoch_schedule::EpochSchedule;
 use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
-
-crate::declare_sysvar_id!("SysvarEpochSchedu1e111111111111111111111111", EpochSchedule);
+pub use solana_epoch_schedule::{
+    sysvar::{check_id, id, ID},
+    EpochSchedule,
+};
 
 impl Sysvar for EpochSchedule {
     impl_sysvar_get!(sol_get_epoch_schedule_sysvar);

--- a/sdk/program/src/sysvar/fees.rs
+++ b/sdk/program/src/sysvar/fees.rs
@@ -25,7 +25,7 @@ use {
         fee_calculator::FeeCalculator, impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar,
     },
     solana_sdk_macro::CloneZeroed,
-    solana_sysvar::declare_deprecated_sysvar_id,
+    solana_sysvar_id::declare_deprecated_sysvar_id,
 };
 
 declare_deprecated_sysvar_id!("SysvarFees111111111111111111111111111111111", Fees);

--- a/sdk/program/src/sysvar/fees.rs
+++ b/sdk/program/src/sysvar/fees.rs
@@ -25,9 +25,10 @@ use {
         fee_calculator::FeeCalculator, impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar,
     },
     solana_sdk_macro::CloneZeroed,
+    solana_sysvar::declare_deprecated_sysvar_id,
 };
 
-crate::declare_deprecated_sysvar_id!("SysvarFees111111111111111111111111111111111", Fees);
+declare_deprecated_sysvar_id!("SysvarFees111111111111111111111111111111111", Fees);
 
 /// Transaction fees.
 #[deprecated(

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -45,6 +45,7 @@ use {
         serialize_utils::{read_pubkey, read_slice, read_u16, read_u8},
     },
     solana_sanitize::SanitizeError,
+    solana_sysvar::declare_sysvar_id,
 };
 
 /// Instructions sysvar, dummy type.
@@ -59,7 +60,7 @@ use {
 /// Use the free functions in this module to access the instructions sysvar.
 pub struct Instructions();
 
-crate::declare_sysvar_id!("Sysvar1nstructions1111111111111111111111111", Instructions);
+declare_sysvar_id!("Sysvar1nstructions1111111111111111111111111", Instructions);
 
 /// Construct the account data for the instructions sysvar.
 ///

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -45,7 +45,7 @@ use {
         serialize_utils::{read_pubkey, read_slice, read_u16, read_u8},
     },
     solana_sanitize::SanitizeError,
-    solana_sysvar::declare_sysvar_id,
+    solana_sysvar_id::declare_sysvar_id,
 };
 
 /// Instructions sysvar, dummy type.

--- a/sdk/program/src/sysvar/last_restart_slot.rs
+++ b/sdk/program/src/sysvar/last_restart_slot.rs
@@ -39,16 +39,11 @@
 //! ```
 //!
 
-pub use crate::last_restart_slot::LastRestartSlot;
-use {
-    crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar},
-    solana_sysvar::declare_sysvar_id,
+use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
+pub use solana_last_restart_slot::{
+    sysvar::{check_id, id, ID},
+    LastRestartSlot,
 };
-
-declare_sysvar_id!(
-    "SysvarLastRestartS1ot1111111111111111111111",
-    LastRestartSlot
-);
 
 impl Sysvar for LastRestartSlot {
     impl_sysvar_get!(sol_get_last_restart_slot);

--- a/sdk/program/src/sysvar/last_restart_slot.rs
+++ b/sdk/program/src/sysvar/last_restart_slot.rs
@@ -40,9 +40,12 @@
 //!
 
 pub use crate::last_restart_slot::LastRestartSlot;
-use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
+use {
+    crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar},
+    solana_sysvar::declare_sysvar_id,
+};
 
-crate::declare_sysvar_id!(
+declare_sysvar_id!(
     "SysvarLastRestartS1ot1111111111111111111111",
     LastRestartSlot
 );

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -82,8 +82,8 @@
 //! [sysvardoc]: https://docs.solanalabs.com/runtime/sysvars
 
 use crate::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
-#[deprecated(since = "2.1.0", note = "Use `solana-sysvar` crate instead")]
-pub use solana_sysvar::{
+#[deprecated(since = "2.1.0", note = "Use `solana-sysvar-id` crate instead")]
+pub use solana_sysvar_id::{
     check_id, declare_deprecated_sysvar_id, declare_sysvar_id, get_sysvar, id, SysvarId, ID,
 };
 #[allow(deprecated)]

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -84,7 +84,7 @@
 use crate::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
 #[deprecated(since = "2.1.0", note = "Use `solana-sysvar-id` crate instead")]
 pub use solana_sysvar_id::{
-    check_id, declare_deprecated_sysvar_id, declare_sysvar_id, get_sysvar, id, SysvarId, ID,
+    check_id, declare_deprecated_sysvar_id, declare_sysvar_id, id, SysvarId, ID,
 };
 #[allow(deprecated)]
 pub use sysvar_ids::ALL_IDS;
@@ -201,6 +201,35 @@ macro_rules! impl_sysvar_get {
             }
         }
     };
+}
+
+/// Handler for retrieving a slice of sysvar data from the `sol_get_sysvar`
+/// syscall.
+fn get_sysvar(
+    dst: &mut [u8],
+    sysvar_id: &Pubkey,
+    offset: u64,
+    length: u64,
+) -> Result<(), ProgramError> {
+    // Check that the provided destination buffer is large enough to hold the
+    // requested data.
+    if dst.len() < length as usize {
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    let sysvar_id = sysvar_id as *const _ as *const u8;
+    let var_addr = dst as *mut _ as *mut u8;
+
+    #[cfg(target_os = "solana")]
+    let result = unsafe { crate::syscalls::sol_get_sysvar(sysvar_id, var_addr, offset, length) };
+
+    #[cfg(not(target_os = "solana"))]
+    let result = crate::program_stubs::sol_get_sysvar(sysvar_id, var_addr, offset, length);
+
+    match result {
+        crate::entrypoint::SUCCESS => Ok(()),
+        e => Err(e.into()),
+    }
 }
 
 #[cfg(test)]

--- a/sdk/program/src/sysvar/recent_blockhashes.rs
+++ b/sdk/program/src/sysvar/recent_blockhashes.rs
@@ -20,7 +20,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
     crate::{fee_calculator::FeeCalculator, hash::Hash, sysvar::Sysvar},
-    solana_sysvar::declare_deprecated_sysvar_id,
+    solana_sysvar_id::declare_deprecated_sysvar_id,
     std::{cmp::Ordering, collections::BinaryHeap, iter::FromIterator, ops::Deref},
 };
 

--- a/sdk/program/src/sysvar/recent_blockhashes.rs
+++ b/sdk/program/src/sysvar/recent_blockhashes.rs
@@ -19,9 +19,8 @@
 #![allow(deprecated)]
 #![allow(clippy::arithmetic_side_effects)]
 use {
-    crate::{
-        declare_deprecated_sysvar_id, fee_calculator::FeeCalculator, hash::Hash, sysvar::Sysvar,
-    },
+    crate::{fee_calculator::FeeCalculator, hash::Hash, sysvar::Sysvar},
+    solana_sysvar::declare_deprecated_sysvar_id,
     std::{cmp::Ordering, collections::BinaryHeap, iter::FromIterator, ops::Deref},
 };
 

--- a/sdk/program/src/sysvar/rent.rs
+++ b/sdk/program/src/sysvar/rent.rs
@@ -39,7 +39,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_program::sysvar::SysvarId;
+//! # use solana_sysvar::SysvarId;
 //! # let p = Rent::id();
 //! # let l = &mut 1009200;
 //! # let d = &mut vec![152, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 100];
@@ -82,7 +82,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_program::sysvar::SysvarId;
+//! # use solana_sysvar::SysvarId;
 //! # let p = Rent::id();
 //! # let l = &mut 1009200;
 //! # let d = &mut vec![152, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 100];
@@ -126,10 +126,11 @@
 //! #
 //! # Ok::<(), anyhow::Error>(())
 //! ```
-pub use crate::rent::Rent;
 use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
-
-crate::declare_sysvar_id!("SysvarRent111111111111111111111111111111111", Rent);
+pub use solana_rent::{
+    sysvar::{check_id, id, ID},
+    Rent,
+};
 
 impl Sysvar for Rent {
     impl_sysvar_get!(sol_get_rent_sysvar);

--- a/sdk/program/src/sysvar/rent.rs
+++ b/sdk/program/src/sysvar/rent.rs
@@ -39,7 +39,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_sysvar::SysvarId;
+//! # use solana_sysvar_id::SysvarId;
 //! # let p = Rent::id();
 //! # let l = &mut 1009200;
 //! # let d = &mut vec![152, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 100];
@@ -82,7 +82,7 @@
 //!     Ok(())
 //! }
 //! #
-//! # use solana_sysvar::SysvarId;
+//! # use solana_sysvar_id::SysvarId;
 //! # let p = Rent::id();
 //! # let l = &mut 1009200;
 //! # let d = &mut vec![152, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 100];

--- a/sdk/program/src/sysvar/rewards.rs
+++ b/sdk/program/src/sysvar/rewards.rs
@@ -1,8 +1,8 @@
 //! This sysvar is deprecated and unused.
 
-use crate::sysvar::Sysvar;
+use {crate::sysvar::Sysvar, solana_sysvar::declare_sysvar_id};
 
-crate::declare_sysvar_id!("SysvarRewards111111111111111111111111111111", Rewards);
+declare_sysvar_id!("SysvarRewards111111111111111111111111111111", Rewards);
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]

--- a/sdk/program/src/sysvar/rewards.rs
+++ b/sdk/program/src/sysvar/rewards.rs
@@ -1,6 +1,6 @@
 //! This sysvar is deprecated and unused.
 
-use {crate::sysvar::Sysvar, solana_sysvar::declare_sysvar_id};
+use {crate::sysvar::Sysvar, solana_sysvar_id::declare_sysvar_id};
 
 declare_sysvar_id!("SysvarRewards111111111111111111111111111111", Rewards);
 

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -9,8 +9,8 @@
 //! [`Sysvar::size_of`] methods in an on-chain program, and it can be accessed
 //! off-chain through RPC.
 //!
-//! [`SysvarId::id`]: https://docs.rs/solana-sysvar/latest/solana_sysvar/trait.SysvarId.html#tymethod.id
-//! [`SysvarId::check_id`]: https://docs.rs/solana-sysvar/latest/solana_sysvar/trait.SysvarId.html#tymethod.check_id
+//! [`SysvarId::id`]: https://docs.rs/solana-sysvar-id/latest/solana_sysvar_id/trait.SysvarId.html#tymethod.id
+//! [`SysvarId::check_id`]: https://docs.rs/solana-sysvar-id/latest/solana_sysvar_id/trait.SysvarId.html#tymethod.check_id
 //!
 //! # Examples
 //!
@@ -55,14 +55,16 @@ use {
     },
     bytemuck_derive::{Pod, Zeroable},
     solana_clock::Slot,
-    solana_sysvar::SysvarId,
 };
 
 const U64_SIZE: usize = std::mem::size_of::<u64>();
 
-pub use solana_slot_hashes::{
-    sysvar::{check_id, id, ID},
-    SlotHashes,
+pub use {
+    solana_slot_hashes::{
+        sysvar::{check_id, id, ID},
+        SlotHashes,
+    },
+    solana_sysvar_id::SysvarId,
 };
 
 impl Sysvar for SlotHashes {

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -9,8 +9,8 @@
 //! [`Sysvar::size_of`] methods in an on-chain program, and it can be accessed
 //! off-chain through RPC.
 //!
-//! [`SysvarId::id`]: crate::sysvar::SysvarId::id
-//! [`SysvarId::check_id`]: crate::sysvar::SysvarId::check_id
+//! [`SysvarId::id`]: https://docs.rs/solana-sysvar/latest/solana_sysvar/trait.SysvarId.html#tymethod.id
+//! [`SysvarId::check_id`]: https://docs.rs/solana-sysvar/latest/solana_sysvar/trait.SysvarId.html#tymethod.check_id
 //!
 //! # Examples
 //!
@@ -45,22 +45,25 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 
-pub use crate::slot_hashes::SlotHashes;
 use {
     crate::{
         account_info::AccountInfo,
         hash::Hash,
         program_error::ProgramError,
         slot_hashes::MAX_ENTRIES,
-        sysvar::{get_sysvar, Sysvar, SysvarId},
+        sysvar::{get_sysvar, Sysvar},
     },
     bytemuck_derive::{Pod, Zeroable},
     solana_clock::Slot,
+    solana_sysvar::SysvarId,
 };
 
 const U64_SIZE: usize = std::mem::size_of::<u64>();
 
-crate::declare_sysvar_id!("SysvarS1otHashes111111111111111111111111111", SlotHashes);
+pub use solana_slot_hashes::{
+    sysvar::{check_id, id, ID},
+    SlotHashes,
+};
 
 impl Sysvar for SlotHashes {
     // override

--- a/sdk/program/src/sysvar/slot_history.rs
+++ b/sdk/program/src/sysvar/slot_history.rs
@@ -9,8 +9,8 @@
 //! [`Sysvar::size_of`] methods in an on-chain program, and it can be accessed
 //! off-chain through RPC.
 //!
-//! [`SysvarId::id`]: crate::sysvar::SysvarId::id
-//! [`SysvarId::check_id`]: crate::sysvar::SysvarId::check_id
+//! [`SysvarId::id`]: https://docs.rs/solana-sysvar-id/latest/solana_sysvar_id/trait.SysvarId.html#tymethod.id
+//! [`SysvarId::check_id`]: https://docs.rs/solana-sysvar-id/latest/solana_sysvar_id/trait.SysvarId.html#tymethod.check_id
 //!
 //! # Examples
 //!
@@ -47,12 +47,14 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 
-pub use crate::{
-    account_info::AccountInfo, program_error::ProgramError, slot_history::SlotHistory,
+use crate::sysvar::Sysvar;
+pub use {
+    crate::{account_info::AccountInfo, program_error::ProgramError},
+    solana_slot_history::{
+        sysvar::{check_id, id, ID},
+        SlotHistory,
+    },
 };
-use {crate::sysvar::Sysvar, solana_sysvar::declare_sysvar_id};
-
-declare_sysvar_id!("SysvarS1otHistory11111111111111111111111111", SlotHistory);
 
 impl Sysvar for SlotHistory {
     // override

--- a/sdk/program/src/sysvar/slot_history.rs
+++ b/sdk/program/src/sysvar/slot_history.rs
@@ -47,12 +47,12 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 
-use crate::sysvar::Sysvar;
 pub use crate::{
     account_info::AccountInfo, program_error::ProgramError, slot_history::SlotHistory,
 };
+use {crate::sysvar::Sysvar, solana_sysvar::declare_sysvar_id};
 
-crate::declare_sysvar_id!("SysvarS1otHistory11111111111111111111111111", SlotHistory);
+declare_sysvar_id!("SysvarS1otHistory11111111111111111111111111", SlotHistory);
 
 impl Sysvar for SlotHistory {
     // override

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -52,9 +52,10 @@ use {
         sysvar::{get_sysvar, Sysvar, SysvarId},
     },
     solana_clock::Epoch,
+    solana_sysvar::declare_sysvar_id,
 };
 
-crate::declare_sysvar_id!("SysvarStakeHistory1111111111111111111111111", StakeHistory);
+declare_sysvar_id!("SysvarStakeHistory1111111111111111111111111", StakeHistory);
 
 impl Sysvar for StakeHistory {
     // override

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -52,7 +52,7 @@ use {
         sysvar::{get_sysvar, Sysvar, SysvarId},
     },
     solana_clock::Epoch,
-    solana_sysvar::declare_sysvar_id,
+    solana_sysvar_id::declare_sysvar_id,
 };
 
 declare_sysvar_id!("SysvarStakeHistory1111111111111111111111111", StakeHistory);

--- a/sdk/rent/Cargo.toml
+++ b/sdk/rent/Cargo.toml
@@ -15,6 +15,7 @@ serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
+solana-sysvar = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-clock = { workspace = true }
@@ -23,6 +24,7 @@ static_assertions = { workspace = true }
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]
+sysvar = ["dep:solana-sysvar"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/rent/Cargo.toml
+++ b/sdk/rent/Cargo.toml
@@ -15,7 +15,7 @@ serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
-solana-sysvar = { workspace = true, optional = true }
+solana-sysvar-id = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-clock = { workspace = true }
@@ -24,7 +24,7 @@ static_assertions = { workspace = true }
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]
-sysvar = ["dep:solana-sysvar"]
+sysvar = ["dep:solana-sysvar-id"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/rent/src/lib.rs
+++ b/sdk/rent/src/lib.rs
@@ -8,6 +8,9 @@
 #[cfg(feature = "frozen-abi")]
 extern crate std;
 
+#[cfg(feature = "sysvar")]
+pub mod sysvar;
+
 use solana_sdk_macro::CloneZeroed;
 
 // inlined to avoid solana_clock dep

--- a/sdk/rent/src/sysvar.rs
+++ b/sdk/rent/src/sysvar.rs
@@ -1,0 +1,3 @@
+use {crate::Rent, solana_sysvar::declare_sysvar_id};
+
+declare_sysvar_id!("SysvarRent111111111111111111111111111111111", Rent);

--- a/sdk/rent/src/sysvar.rs
+++ b/sdk/rent/src/sysvar.rs
@@ -1,3 +1,3 @@
-use {crate::Rent, solana_sysvar::declare_sysvar_id};
+use {crate::Rent, solana_sysvar_id::declare_sysvar_id};
 
 declare_sysvar_id!("SysvarRent111111111111111111111111111111111", Rent);

--- a/sdk/slot-hashes/Cargo.toml
+++ b/sdk/slot-hashes/Cargo.toml
@@ -13,14 +13,14 @@ edition = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-hash = { workspace = true, default-features = false }
-solana-sysvar = { workspace = true, optional = true }
+solana-sysvar-id = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-sha256-hasher = { workspace = true }
 
 [features]
 serde = ["dep:serde", "dep:serde_derive", "solana-hash/serde"]
-sysvar = ["dep:solana-sysvar"]
+sysvar = ["dep:solana-sysvar-id"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/slot-hashes/Cargo.toml
+++ b/sdk/slot-hashes/Cargo.toml
@@ -13,12 +13,14 @@ edition = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-hash = { workspace = true, default-features = false }
+solana-sysvar = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-sha256-hasher = { workspace = true }
 
 [features]
 serde = ["dep:serde", "dep:serde_derive", "solana-hash/serde"]
+sysvar = ["dep:solana-sysvar"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/slot-hashes/src/lib.rs
+++ b/sdk/slot-hashes/src/lib.rs
@@ -6,6 +6,9 @@
 //!
 //! [`solana_program::sysvar::slot_hashes`]: https://docs.rs/solana-program/latest/solana_program/sysvar/slot_hashes/index.html
 
+#[cfg(feature = "sysvar")]
+pub mod sysvar;
+
 use {
     solana_hash::Hash,
     std::{

--- a/sdk/slot-hashes/src/sysvar.rs
+++ b/sdk/slot-hashes/src/sysvar.rs
@@ -1,0 +1,3 @@
+use {crate::SlotHashes, solana_sysvar::declare_sysvar_id};
+
+declare_sysvar_id!("SysvarS1otHashes111111111111111111111111111", SlotHashes);

--- a/sdk/slot-hashes/src/sysvar.rs
+++ b/sdk/slot-hashes/src/sysvar.rs
@@ -1,3 +1,3 @@
-use {crate::SlotHashes, solana_sysvar::declare_sysvar_id};
+use {crate::SlotHashes, solana_sysvar_id::declare_sysvar_id};
 
 declare_sysvar_id!("SysvarS1otHashes111111111111111111111111111", SlotHashes);

--- a/sdk/slot-history/Cargo.toml
+++ b/sdk/slot-history/Cargo.toml
@@ -13,9 +13,11 @@ edition = { workspace = true }
 bv = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
+solana-sysvar-id = { workspace = true, optional = true }
 
 [features]
 serde = ["dep:serde", "dep:serde_derive", "bv/serde"]
+sysvar = ["dep:solana-sysvar-id"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/slot-history/src/lib.rs
+++ b/sdk/slot-history/src/lib.rs
@@ -9,6 +9,9 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+#[cfg(feature = "sysvar")]
+pub mod sysvar;
+
 use bv::{BitVec, BitsMut};
 
 /// A bitvector indicating which slots are present in the past epoch.

--- a/sdk/slot-history/src/sysvar.rs
+++ b/sdk/slot-history/src/sysvar.rs
@@ -1,0 +1,3 @@
+use {crate::SlotHistory, solana_sysvar_id::declare_sysvar_id};
+
+declare_sysvar_id!("SysvarS1otHistory11111111111111111111111111", SlotHistory);

--- a/sdk/sysvar-id/Cargo.toml
+++ b/sdk/sysvar-id/Cargo.toml
@@ -10,12 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false }
-
-[dev-dependencies]
-solana-program-entrypoint = { workspace = true }
-static_assertions = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/sysvar-id/Cargo.toml
+++ b/sdk/sysvar-id/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "solana-sysvar"
-description = "Definitions for the sysvar traits and macros."
-documentation = "https://docs.rs/solana-sysvar"
+name = "solana-sysvar-id"
+description = "Definition for the sysvar id trait and associated macros."
+documentation = "https://docs.rs/solana-sysvar-id"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
@@ -12,9 +12,6 @@ edition = { workspace = true }
 [dependencies]
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false }
-
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = { workspace = true }
 
 [dev-dependencies]
 solana-program-entrypoint = { workspace = true }

--- a/sdk/sysvar-id/src/lib.rs
+++ b/sdk/sysvar-id/src/lib.rs
@@ -18,9 +18,6 @@
 //!
 //! [sysvardoc]: https://docs.solanalabs.com/runtime/sysvars
 
-#[cfg(target_os = "solana")]
-pub mod syscalls;
-
 use solana_program_error::ProgramError;
 /// Re-export types required for macros
 pub use solana_pubkey::{declare_deprecated_id, declare_id, Pubkey};

--- a/sdk/sysvar/Cargo.toml
+++ b/sdk/sysvar/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "solana-sysvar"
+description = "Definitions for the sysvar traits and macros."
+documentation = "https://docs.rs/solana-sysvar"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-program-error = { workspace = true }
+solana-pubkey = { workspace = true, default-features = false }
+
+[dev-dependencies]
+solana-program-entrypoint = { workspace = true }
+static_assertions = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[lints]
+workspace = true

--- a/sdk/sysvar/Cargo.toml
+++ b/sdk/sysvar/Cargo.toml
@@ -13,6 +13,9 @@ edition = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false }
 
+[target.'cfg(target_os = "solana")'.dependencies]
+solana-define-syscall = { workspace = true }
+
 [dev-dependencies]
 solana-program-entrypoint = { workspace = true }
 static_assertions = { workspace = true }

--- a/sdk/sysvar/src/lib.rs
+++ b/sdk/sysvar/src/lib.rs
@@ -1,0 +1,123 @@
+//! Access to special accounts with dynamically-updated data.
+//!
+//! Sysvars are special accounts that contain dynamically-updated data about the
+//! network cluster, the blockchain history, and the executing transaction. Each
+//! sysvar is defined in its own crate. The [`clock`], [`epoch_schedule`],
+//! [`instructions`], and [`rent`] sysvars are most useful to on-chain programs.
+//!
+//! [`clock`]: https://docs.rs/solana-clock/latest
+//! [`epoch_schedule`]: https://docs.rs/solana-epoch-schedule/latest
+//! [`instructions`]: https://docs.rs/solana-program/latest/solana_program/sysvar/instructions
+//! [`rent`]: https://docs.rs/solana-rent/latest
+//!
+//! All sysvar accounts are owned by the account identified by [`solana_sysvar::ID`].
+//!
+//! [`solana_sysvar::ID`]: crate::ID
+//!
+//! For more details see the Solana [documentation on sysvars][sysvardoc].
+//!
+//! [sysvardoc]: https://docs.solanalabs.com/runtime/sysvars
+
+#[cfg(target_os = "solana")]
+pub mod syscalls;
+
+use solana_program_error::ProgramError;
+/// Re-export types required for macros
+pub use solana_pubkey::{declare_deprecated_id, declare_id, Pubkey};
+
+/// A type that holds sysvar data and has an associated sysvar `Pubkey`.
+pub trait SysvarId {
+    /// The `Pubkey` of the sysvar.
+    fn id() -> Pubkey;
+
+    /// Returns `true` if the given pubkey is the program ID.
+    fn check_id(pubkey: &Pubkey) -> bool;
+}
+
+/// Declares an ID that implements [`SysvarId`].
+#[macro_export]
+macro_rules! declare_sysvar_id(
+    ($name:expr, $type:ty) => (
+        $crate::declare_id!($name);
+
+        impl $crate::SysvarId for $type {
+            fn id() -> $crate::Pubkey {
+                id()
+            }
+
+            fn check_id(pubkey: &$crate::Pubkey) -> bool {
+                check_id(pubkey)
+            }
+        }
+    )
+);
+
+/// Same as [`declare_sysvar_id`] except that it reports that this ID has been deprecated.
+#[macro_export]
+macro_rules! declare_deprecated_sysvar_id(
+    ($name:expr, $type:ty) => (
+        $crate::declare_deprecated_id!($name);
+
+        impl $crate::SysvarId for $type {
+            fn id() -> $crate::Pubkey {
+                #[allow(deprecated)]
+                id()
+            }
+
+            fn check_id(pubkey: &$crate::Pubkey) -> bool {
+                #[allow(deprecated)]
+                check_id(pubkey)
+            }
+        }
+    )
+);
+
+const _SUCCESS: u64 = 0;
+#[cfg(test)]
+static_assertions::const_assert_eq!(_SUCCESS, solana_program_entrypoint::SUCCESS);
+
+// Owner pubkey for sysvar accounts
+solana_pubkey::declare_id!("Sysvar1111111111111111111111111111111111111");
+
+/// Handler for retrieving a slice of sysvar data from the `sol_get_sysvar`
+/// syscall.
+pub fn get_sysvar(
+    dst: &mut [u8],
+    sysvar_id: &Pubkey,
+    offset: u64,
+    length: u64,
+) -> Result<(), ProgramError> {
+    // Check that the provided destination buffer is large enough to hold the
+    // requested data.
+    if dst.len() < length as usize {
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    get_sysvar_unchecked(dst, sysvar_id, offset, length)
+}
+
+/// Handler for retrieving a slice of sysvar data from the `sol_get_sysvar`
+/// syscall, without a client-side length check
+#[allow(unused_variables)]
+pub fn get_sysvar_unchecked(
+    dst: &mut [u8],
+    sysvar_id: &Pubkey,
+    offset: u64,
+    length: u64,
+) -> Result<(), ProgramError> {
+    #[cfg(target_os = "solana")]
+    {
+        let sysvar_id = sysvar_id as *const _ as *const u8;
+        let var_addr = dst as *mut _ as *mut u8;
+
+        let result =
+            unsafe { crate::syscalls::sol_get_sysvar(sysvar_id, var_addr, offset, length) };
+
+        match result {
+            _SUCCESS => Ok(()),
+            e => Err(e.into()),
+        }
+    }
+    #[cfg(not(target_os = "solana"))]
+    Err(ProgramError::UnsupportedSysvar)
+}

--- a/sdk/sysvar/src/syscalls.rs
+++ b/sdk/sysvar/src/syscalls.rs
@@ -1,0 +1,3 @@
+use solana_define_syscall::define_syscall;
+
+define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, result: *mut u8, offset: u64, length: u64) -> u64);

--- a/sdk/sysvar/src/syscalls.rs
+++ b/sdk/sysvar/src/syscalls.rs
@@ -1,3 +1,0 @@
-use solana_define_syscall::define_syscall;
-
-define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, result: *mut u8, offset: u64, length: u64) -> u64);


### PR DESCRIPTION
#### Problem

The sysvars in `solana-program` are tightly coupled with types that exist in `solana-program`. For example, all of the special sysvar getters like `Rent::get()` are implemented through a macro that falls back to using `program_stubs`.

Because of this tight coupling, it's difficult to pull out bits for the sysvars.

#### Summary of changes

After numerous attempts, I've decided to keep it simple and only extract `SysvarId`, its helper macros, and `get_sysvar`.

To go along with that, all of the separated sysvar crates now implement the sysvar ids themselves under a new `sysvar` feature. This new feature might be overkill, so let me know if we should just include the sysvar ids by default. I went with a feature to include an implementation using the `sol_get_sysvar` syscall in the future.

It was really messy to include the `Sysvar` trait from `solana-program` because it falls back to using `bincode`, which we know performs poorly for on-chain programs. So the future idea is to create a new `Sysvar` trait in `solana-sysvar` which will require fewer bits to deserialize sysvars.

Let me know what you think about this PR and the future idea! Note that I'll need to rebase this on top of #3249 and #3272 when they land.