### PR TITLE
Extract fee-structure crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6749,6 +6749,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-fee-structure"
+version = "2.2.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-native-token",
+ "solana-program",
+]
+
+[[package]]
 name = "solana-frozen-abi"
 version = "2.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8062,6 +8062,7 @@ dependencies = [
  "solana-decode-error",
  "solana-derivation-path",
  "solana-feature-set",
+ "solana-fee-structure",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-inflation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6754,6 +6754,7 @@ version = "2.2.0"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-frozen-abi",
  "solana-native-token",
  "solana-program",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ members = [
     "sdk/epoch-schedule",
     "sdk/feature-set",
     "sdk/fee-calculator",
+    "sdk/fee-structure",
     "sdk/gen-headers",
     "sdk/hash",
     "sdk/inflation",
@@ -429,6 +430,7 @@ solana-faucet = { path = "faucet", version = "=2.2.0" }
 solana-feature-set = { path = "sdk/feature-set", version = "=2.2.0" }
 solana-fee-calculator = { path = "sdk/fee-calculator", version = "=2.2.0" }
 solana-fee = { path = "fee", version = "=2.2.0" }
+solana-fee-structure = { path = "sdk/fee-structure", version = "=2.2.0" }
 solana-frozen-abi = { path = "frozen-abi", version = "=2.2.0" }
 solana-frozen-abi-macro = { path = "frozen-abi/macro", version = "=2.2.0" }
 solana-tps-client = { path = "tps-client", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5376,6 +5376,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-fee-structure"
+version = "2.2.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-native-token",
+ "solana-program",
+]
+
+[[package]]
 name = "solana-genesis-utils"
 version = "2.2.0"
 dependencies = [
@@ -6805,6 +6815,7 @@ dependencies = [
  "solana-decode-error",
  "solana-derivation-path",
  "solana-feature-set",
+ "solana-fee-structure",
  "solana-inflation",
  "solana-instruction",
  "solana-native-token",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -43,6 +43,7 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-feature-set/frozen-abi",
+    "solana-fee-structure/frozen-abi",
     "solana-account/frozen-abi",
     "solana-inflation/frozen-abi",
     "solana-program/frozen-abi",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -94,6 +94,7 @@ solana-bn254 = { workspace = true }
 solana-decode-error = { workspace = true }
 solana-derivation-path = { workspace = true }
 solana-feature-set = { workspace = true }
+solana-fee-structure = { workspace = true, features = ["serde"] }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }

--- a/sdk/fee-structure/Cargo.toml
+++ b/sdk/fee-structure/Cargo.toml
@@ -12,6 +12,9 @@ edition = { workspace = true }
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = [
+    "frozen-abi",
+] }
 solana-native-token = { workspace = true }
 
 [package.metadata.docs.rs]
@@ -23,6 +26,7 @@ rustdoc-args = ["--cfg=docsrs"]
 solana-program = { workspace = true, default-features = false }
 
 [features]
+frozen-abi = ["dep:solana-frozen-abi"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [lints]

--- a/sdk/fee-structure/Cargo.toml
+++ b/sdk/fee-structure/Cargo.toml
@@ -16,6 +16,8 @@ solana-native-token = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 solana-program = { workspace = true, default-features = false }

--- a/sdk/fee-structure/Cargo.toml
+++ b/sdk/fee-structure/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "solana-fee-structure"
+description = "Solana fee structures."
+documentation = "https://docs.rs/solana-fee-structure"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-native-token = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[target.'cfg(not(target_os = "solana"))'.dependencies]
+solana-program = { workspace = true, default-features = false }
+
+[features]
+serde = ["dep:serde", "dep:serde_derive"]
+
+[lints]
+workspace = true

--- a/sdk/fee-structure/src/lib.rs
+++ b/sdk/fee-structure/src/lib.rs
@@ -1,5 +1,6 @@
 //! Fee structures.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 #[cfg(not(target_os = "solana"))]
 use solana_program::message::SanitizedMessage;

--- a/sdk/fee-structure/src/lib.rs
+++ b/sdk/fee-structure/src/lib.rs
@@ -31,7 +31,11 @@ pub struct FeeStructure {
     pub compute_fee_bins: Vec<FeeBin>,
 }
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct FeeDetails {
     transaction_fee: u64,
     prioritization_fee: u64,

--- a/sdk/fee-structure/src/lib.rs
+++ b/sdk/fee-structure/src/lib.rs
@@ -1,4 +1,5 @@
 //! Fee structures.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(not(target_os = "solana"))]
 use solana_program::message::SanitizedMessage;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -70,7 +70,6 @@ pub mod epoch_rewards_hasher;
 pub mod example_mocks;
 pub mod exit;
 pub mod feature;
-pub mod fee;
 pub mod genesis_config;
 pub mod hard_forks;
 pub mod hash;
@@ -117,6 +116,8 @@ pub use solana_decode_error as decode_error;
 pub use solana_derivation_path as derivation_path;
 #[deprecated(since = "2.1.0", note = "Use `solana-feature-set` crate instead")]
 pub use solana_feature_set as feature_set;
+#[deprecated(since = "2.2.0", note = "Use `solana-fee-structure` crate instead")]
+pub use solana_fee_structure as fee;
 #[deprecated(since = "2.1.0", note = "Use `solana-inflation` crate instead")]
 pub use solana_inflation as inflation;
 #[deprecated(since = "2.1.0", note = "Use `solana-packet` crate instead")]


### PR DESCRIPTION
#### Problem
`solana_sdk::fee` imposes a `solana_sdk` dependency on `solana_svm` and `solana_compute_budget`

#### Summary of Changes
- Move to its own crate and re-export with deprecation in `solana_sdk`. I've named the new crate `solana-fee-structure` based on the top level doc comment for fee.rs. `solana-fee` is already taken.
- Make serde optional in the new crate
- Add doc_auto_cfg