### PR TITLE
gossip: reduce votes stored per validator from 32 to 12

### DIFF
--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -27,9 +27,10 @@ pub(crate) const MAX_SLOT: u64 = 1_000_000_000_000_000;
 const MAX_ACCOUNTS_HASHES: usize = 16;
 
 pub(crate) type VoteIndex = u8;
-// TODO: Remove this in favor of vote_state::MAX_LOCKOUT_HISTORY once
-// the fleet is updated to the new ClusterInfo::push_vote code.
-const MAX_VOTES: VoteIndex = 32;
+// Until the cluster upgrades we allow votes from higher indices
+const OLD_MAX_VOTES: VoteIndex = 32;
+/// Number of votes per validator to store.
+pub const MAX_VOTES: VoteIndex = 12;
 
 pub(crate) type EpochSlotsIndex = u8;
 pub(crate) const MAX_EPOCH_SLOTS: EpochSlotsIndex = 255;
@@ -68,7 +69,7 @@ impl Sanitize for CrdsData {
         match self {
             CrdsData::LegacyContactInfo(val) => val.sanitize(),
             CrdsData::Vote(ix, val) => {
-                if *ix >= MAX_VOTES {
+                if *ix >= OLD_MAX_VOTES {
                     return Err(SanitizeError::ValueOutOfBounds);
                 }
                 val.sanitize()
@@ -539,7 +540,7 @@ mod test {
         let mut rng = rand::thread_rng();
         let keypair = Keypair::new();
         let vote = Vote::new(keypair.pubkey(), new_test_vote_tx(&mut rng), timestamp()).unwrap();
-        let vote = CrdsValue::new(CrdsData::Vote(MAX_VOTES, vote), &keypair);
+        let vote = CrdsValue::new(CrdsData::Vote(OLD_MAX_VOTES, vote), &keypair);
         assert!(vote.sanitize().is_err());
     }
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -20,7 +20,7 @@ use {
     },
     solana_download_utils::download_snapshot_archive,
     solana_entry::entry::create_ticks,
-    solana_gossip::gossip_service::discover_cluster,
+    solana_gossip::{crds_data::MAX_VOTES, gossip_service::discover_cluster},
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         bank_forks_utils,
@@ -4072,8 +4072,8 @@ fn run_duplicate_shreds_broadcast_leader(vote_on_duplicate: bool) {
                         None,
                     );
                     gossip_vote_index += 1;
-                    gossip_vote_index %= MAX_LOCKOUT_HISTORY;
-                    cluster_info.push_vote_at_index(vote_tx, gossip_vote_index as u8)
+                    gossip_vote_index %= MAX_VOTES;
+                    cluster_info.push_vote_at_index(vote_tx, gossip_vote_index);
                 }
             }
         },


### PR DESCRIPTION
As part of a recent effort to lower gossip vote bandwidth, we are slowly rolling out a smaller crds size for votes.
This change builds upon #3136 and #3274 and lowers the buffer to 12.