### PR TITLE
adds ContactInfo socket for TPU votes over QUIC

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -855,7 +855,7 @@ impl ClusterInfo {
                             "-".to_string()
                         },
                         self.addr_to_string(&ip_addr, &node.gossip().ok()),
-                        self.addr_to_string(&ip_addr, &node.tpu_vote().ok()),
+                        self.addr_to_string(&ip_addr, &node.tpu_vote(contact_info::Protocol::UDP).ok()),
                         self.addr_to_string(&ip_addr, &node.tpu(contact_info::Protocol::UDP).ok()),
                         self.addr_to_string(&ip_addr, &node.tpu_forwards(contact_info::Protocol::UDP).ok()),
                         self.addr_to_string(&ip_addr, &node.tvu(contact_info::Protocol::UDP).ok()),

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -199,7 +199,7 @@ impl TryFrom<&ContactInfo> for LegacyContactInfo {
             serve_repair_quic: unwrap_socket!(serve_repair, Protocol::QUIC),
             tpu: unwrap_socket!(tpu, Protocol::UDP),
             tpu_forwards: unwrap_socket!(tpu_forwards, Protocol::UDP),
-            tpu_vote: unwrap_socket!(tpu_vote),
+            tpu_vote: unwrap_socket!(tpu_vote, Protocol::UDP),
             rpc: unwrap_socket!(rpc),
             rpc_pubsub: unwrap_socket!(rpc_pubsub),
             serve_repair: unwrap_socket!(serve_repair, Protocol::UDP),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3528,7 +3528,7 @@ pub mod rpc_full {
                                 .ok()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             tpu_vote: contact_info
-                                .tpu_vote()
+                                .tpu_vote(Protocol::UDP)
                                 .ok()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             serve_repair: contact_info

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -108,7 +108,7 @@ impl From<ContactInfo> for AdminRpcContactInfo {
             serve_repair_quic: unwrap_socket!(serve_repair, Protocol::QUIC),
             tpu: unwrap_socket!(tpu, Protocol::UDP),
             tpu_forwards: unwrap_socket!(tpu_forwards, Protocol::UDP),
-            tpu_vote: unwrap_socket!(tpu_vote),
+            tpu_vote: unwrap_socket!(tpu_vote, Protocol::UDP),
             rpc: unwrap_socket!(rpc),
             rpc_pubsub: unwrap_socket!(rpc_pubsub),
             serve_repair: unwrap_socket!(serve_repair, Protocol::UDP),

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -91,7 +91,7 @@ fn verify_reachable_ports(
         udp_sockets.extend(node.sockets.tpu_forwards.iter());
         udp_sockets.extend(&node.sockets.tpu_forwards_quic);
     }
-    if verify_address(&node.info.tpu_vote().ok()) {
+    if verify_address(&node.info.tpu_vote(Protocol::UDP).ok()) {
         udp_sockets.extend(node.sockets.tpu_vote.iter());
     }
     if verify_address(&node.info.tvu(Protocol::UDP).ok()) {


### PR DESCRIPTION
#### Problem
Prerequisite for implementing TPU path for votes over QUIC.

#### Summary of Changes
Added `ContactInfo` socket for TPU votes over QUIC