### PR TITLE
Refactors startup verify with accounts lt hash

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -549,7 +549,7 @@ pub(crate) fn fields_from_streams(
 /// This struct contains side-info while reconstructing the bank from streams
 #[derive(Debug)]
 pub struct BankFromStreamsInfo {
-    pub duplicates_lt_hash: Box<DuplicatesLtHash>,
+    pub duplicates_lt_hash: Option<Box<DuplicatesLtHash>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -842,7 +842,7 @@ impl<'a> solana_frozen_abi::abi_example::TransparentAsHelper for SerializableAcc
 /// This struct contains side-info while reconstructing the bank from fields
 #[derive(Debug)]
 struct ReconstructedBankInfo {
-    duplicates_lt_hash: Box<DuplicatesLtHash>,
+    duplicates_lt_hash: Option<Box<DuplicatesLtHash>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1037,7 +1037,7 @@ pub(crate) fn remap_and_reconstruct_single_storage(
 #[derive(Debug, Default, Clone)]
 pub struct ReconstructedAccountsDbInfo {
     pub accounts_data_len: u64,
-    pub duplicates_lt_hash: Box<DuplicatesLtHash>,
+    pub duplicates_lt_hash: Option<Box<DuplicatesLtHash>>,
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -235,7 +235,7 @@ pub fn bank_from_snapshot_archives(
         accounts_db_force_initial_clean,
         full_snapshot_archive_info.slot(),
         base,
-        Some(&info.duplicates_lt_hash),
+        info.duplicates_lt_hash,
     ) && limit_load_slot_count_from_snapshot.is_none()
     {
         panic!("Snapshot bank for slot {} failed to verify", bank.slot());
@@ -548,7 +548,7 @@ fn deserialize_status_cache(
 /// This struct contains side-info from rebuilding the bank
 #[derive(Debug)]
 struct RebuiltBankInfo {
-    duplicates_lt_hash: Box<DuplicatesLtHash>,
+    duplicates_lt_hash: Option<Box<DuplicatesLtHash>>,
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
#### Problem

While working on a branch to feature-gate accounts lt hash changes, I ran into issues in tests around startup accounts verification.

When the feature was enabled, I would get startup account verification mismatches. This is because the code to compute the accounts lt hash at startup *from storages* relies on `generate_index()` finding the duplicates lt hash. Since generate_index() runs before there is a Bank instance, that function cannot check if the feature is enabled or not. Instead it relies on the accounts lt hash cli arg. So if the feature is enabled and the cli arg is not, then generate_index() would *not* compute the duplicates lt hash, yet verify_accounts_hash() would need it.


#### Summary of Changes

* Until we have snapshot support for the accounts lt hash, verify_accounts_hash() should only use the lattice verification when the cli arg is set.
* generate_index() returns an Option of the duplicates lt hash, based on the cli arg. This makes it explicit when this paramter is valid or not.
* Add test permutations to the snapshot integration tests to verify with lattice (and merkle) accounts hashing.