### PR TITLE
Revert "bump rust to 1.82.0 (#3308)"

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.81.0"


### PR DESCRIPTION
#### Problem

I'm experiencing SIGILL crashes due to invalid opcodes. Maybe it's related to the recent rust 1.82.0 upgrade? Getting a revert PR going so it'll be ready as needed.

I started up two nodes with master, just after the upgrade of rust to 1.82.0 (`f8b33755f6b08d03f020bbeae4fd9724f2a407d3`). Both nodes crashed. Upon investigating the syslog, both had:
```
Oct 25 20:20:00 localhost kernel: [6027386.359788] traps: solRspndrGossip[2670083] trap invalid opcode ip:5560731be7d7 sp:7ec4429bd840 error:0 in agave-validator[55607252e000+246e000]
Oct 25 20:20:24 localhost systemd[1]: sol.service: Main process exited, code=killed, status=4/ILL
```

I built the binaries locally on each machine. I retried on one of the machines three times, and got the same crash each time. I then kept the same commit checked out and built with rust 1.81.0 and there were no more crashes.


#### Summary of Changes

This reverts commit ed5e30da88ee2811d3bf0ec37cd47453418e89e1.