### PR TITLE
Report mean,min,max ConsumeWorkerMetrics::timing_metrics

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -296,6 +296,12 @@ impl ConsumeWorkerMetrics {
             .collect_balances_us
             .fetch_add(*collect_balances_us, Ordering::Relaxed);
         self.timing_metrics
+            .load_execute_us_min
+            .fetch_min(*load_execute_us, Ordering::Relaxed);
+        self.timing_metrics
+            .load_execute_us_max
+            .fetch_max(*load_execute_us, Ordering::Relaxed);
+        self.timing_metrics
             .load_execute_us
             .fetch_add(*load_execute_us, Ordering::Relaxed);
         self.timing_metrics
@@ -310,6 +316,7 @@ impl ConsumeWorkerMetrics {
         self.timing_metrics
             .find_and_send_votes_us
             .fetch_add(*find_and_send_votes_us, Ordering::Relaxed);
+        self.timing_metrics.count.fetch_add(1, Ordering::Relaxed);
     }
 
     fn update_on_error_counters(
@@ -505,12 +512,15 @@ struct ConsumeWorkerTimingMetrics {
     cost_model_us: AtomicU64,
     collect_balances_us: AtomicU64,
     load_execute_us: AtomicU64,
+    load_execute_us_min: AtomicU64,
+    load_execute_us_max: AtomicU64,
     freeze_lock_us: AtomicU64,
     record_us: AtomicU64,
     commit_us: AtomicU64,
     find_and_send_votes_us: AtomicU64,
     wait_for_bank_success_us: AtomicU64,
     wait_for_bank_failure_us: AtomicU64,
+    count: AtomicU64,
 }
 
 impl ConsumeWorkerTimingMetrics {
@@ -531,6 +541,21 @@ impl ConsumeWorkerTimingMetrics {
             (
                 "load_execute_us",
                 self.load_execute_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "load_execute_us_min",
+                self.load_execute_us_min.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "load_execute_us_max",
+                self.load_execute_us_max.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "load_execute_us_mean",
+                self.load_execute_us.swap(0, Ordering::Relaxed)/self.count.swap(0, Ordering::Relaxed),
                 i64
             ),
             (

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -316,7 +316,9 @@ impl ConsumeWorkerMetrics {
         self.timing_metrics
             .find_and_send_votes_us
             .fetch_add(*find_and_send_votes_us, Ordering::Relaxed);
-        self.timing_metrics.count.fetch_add(1, Ordering::Relaxed);
+        self.timing_metrics
+            .commit_count
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     fn update_on_error_counters(
@@ -520,7 +522,7 @@ struct ConsumeWorkerTimingMetrics {
     find_and_send_votes_us: AtomicU64,
     wait_for_bank_success_us: AtomicU64,
     wait_for_bank_failure_us: AtomicU64,
-    count: AtomicU64,
+    commit_count: AtomicU64,
 }
 
 impl ConsumeWorkerTimingMetrics {
@@ -554,8 +556,8 @@ impl ConsumeWorkerTimingMetrics {
                 i64
             ),
             (
-                "load_execute_us_mean",
-                self.load_execute_us.swap(0, Ordering::Relaxed)/self.count.swap(0, Ordering::Relaxed),
+                "commit_count",
+                self.commit_count.swap(0, Ordering::Relaxed),
                 i64
             ),
             (

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -317,7 +317,7 @@ impl ConsumeWorkerMetrics {
             .find_and_send_votes_us
             .fetch_add(*find_and_send_votes_us, Ordering::Relaxed);
         self.timing_metrics
-            .commit_count
+            .num_batches_processed
             .fetch_add(1, Ordering::Relaxed);
     }
 
@@ -522,7 +522,7 @@ struct ConsumeWorkerTimingMetrics {
     find_and_send_votes_us: AtomicU64,
     wait_for_bank_success_us: AtomicU64,
     wait_for_bank_failure_us: AtomicU64,
-    commit_count: AtomicU64,
+    num_batches_processed: AtomicU64,
 }
 
 impl ConsumeWorkerTimingMetrics {
@@ -556,8 +556,8 @@ impl ConsumeWorkerTimingMetrics {
                 i64
             ),
             (
-                "commit_count",
-                self.commit_count.swap(0, Ordering::Relaxed),
+                "num_batches_processed",
+                self.num_batches_processed.swap(0, Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem
Only total time is reported for load_execute

#### Summary of Changes
Report mean, min, max metrics.

Testing:
$ solana airdrop -u http://127.0.0.1:8899 10 An8CLJA36yAivbBCo3dneq9rQz4h5MqM2exXEre4yheu

> solana_metrics::metrics datapoint: banking_stage_worker_timing,id=2 cost_model_us=17i collect_balances_us=30i load_execute_us=188i load_execute_us_min=0i load_execute_us_max=188i commit_count=1i freeze_lock_us=0i record_us=42i commit_us=45i find_and_send_votes_us=35i wait_for_bank_success_us=1i wait_for_bank_failure_us=0i slot=6547i

Fixes #467