### PR TITLE
Use MaybeUninit more properly in streamer::batch_send()

### DIFF
--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -3,7 +3,7 @@
 #[cfg(target_os = "linux")]
 use {
     itertools::izip,
-    libc::{iovec, mmsghdr, sockaddr_in, sockaddr_in6, sockaddr_storage},
+    libc::{iovec, mmsghdr, sockaddr_in, sockaddr_in6, sockaddr_storage, socklen_t},
     std::mem::MaybeUninit,
     std::os::unix::io::AsRawFd,
 };
@@ -83,7 +83,7 @@ fn mmsghdr_for_packet(
                     *nix::sys::socket::SockaddrIn::from(*socket_addr_v4).as_ref(),
                 );
             }
-            hdr.msg_hdr.msg_namelen = SIZE_OF_SOCKADDR_IN as u32;
+            hdr.msg_hdr.msg_namelen = SIZE_OF_SOCKADDR_IN as socklen_t;
         }
         SocketAddr::V6(socket_addr_v6) => {
             unsafe {
@@ -92,7 +92,7 @@ fn mmsghdr_for_packet(
                     *nix::sys::socket::SockaddrIn6::from(*socket_addr_v6).as_ref(),
                 );
             }
-            hdr.msg_hdr.msg_namelen = SIZE_OF_SOCKADDR_IN6 as u32;
+            hdr.msg_hdr.msg_namelen = SIZE_OF_SOCKADDR_IN6 as socklen_t;
         }
     }
 }

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -149,9 +149,9 @@ where
     T: AsRef<[u8]>,
 {
     let size = packets.len();
-    let mut iovs = vec![MaybeUninit::<iovec>::uninit(); size];
-    let mut addrs = vec![MaybeUninit::<sockaddr_storage>::zeroed(); size];
-    let mut hdrs = vec![MaybeUninit::<mmsghdr>::uninit(); size];
+    let mut iovs = vec![MaybeUninit::uninit(); size];
+    let mut addrs = vec![MaybeUninit::zeroed(); size];
+    let mut hdrs = vec![MaybeUninit::uninit(); size];
     for ((pkt, dest), hdr, iov, addr) in izip!(packets, &mut hdrs, &mut iovs, &mut addrs) {
         mmsghdr_for_packet(pkt.as_ref(), dest.borrow(), iov, addr, hdr);
     }


### PR DESCRIPTION
#### Problem
`batch_send()` has undefined behavior. Some uninitialized data is marked as initialized with `assume_init()` even though it hasn't actually been initialized:
https://github.com/anza-xyz/agave/blob/10bebfaf422b8e09409cc5b56a35ec40defa27aa/streamer/src/sendmmsg.rs#L138-L140

This is problematic since the [iovec](https://docs.rs/libc/latest/libc/struct.iovec.html) struct has a pointer:
```rust
#[repr(C)]
pub struct iovec {
    pub iov_base: *mut c_void,
    pub iov_len: size_t,
}
```
With rust 1.82, this made the validator start crashing:
```
kernel: traps: solRspndrGossip[1514252] trap invalid opcode ip:561a11d83bb7 sp:7eb14c3a4830 error:0
sol.service: Main process exited, code=killed, status=4/ILL
```

#### Summary of Changes
- Use `MaybeUninit` interface to initialize `iovec`'s
- Use `MaybeUninit` interface to initialize `mmsghdr`'s
- Write every field in `mmsghdr` so that we no longer need to request zeroed data
- Use `MaybeUninit` interface to initialize `sockaddr_storage`'s
