### PR TITLE
Use parameter struct for configuring QUIC streamer

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -201,13 +201,9 @@ mod tests {
         super::*,
         crate::connection_cache::ConnectionCache,
         crossbeam_channel::unbounded,
-        solana_sdk::{net::DEFAULT_TPU_COALESCE, signature::Keypair},
+        solana_sdk::signature::Keypair,
         solana_streamer::{
-            nonblocking::quic::{
-                DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_STREAMS_PER_MS,
-                DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-            },
-            quic::SpawnServerResult,
+            quic::{QuicServerParams, SpawnServerResult},
             streamer::StakedNodes,
         },
         std::{
@@ -246,14 +242,13 @@ mod tests {
             &keypair2,
             sender2,
             response_recv_exit.clone(),
-            1,
             staked_nodes,
-            10,
-            10,
-            DEFAULT_MAX_STREAMS_PER_MS,
-            DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-            DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-            DEFAULT_TPU_COALESCE,
+            QuicServerParams {
+                max_connections_per_peer: 1,
+                max_staked_connections: 10,
+                max_unstaked_connections: 10,
+                ..QuicServerParams::default()
+            },
         )
         .unwrap();
 

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -8,13 +8,9 @@ mod tests {
         solana_quic_client::nonblocking::quic_client::{
             QuicClientCertificate, QuicLazyInitializedEndpoint,
         },
-        solana_sdk::{net::DEFAULT_TPU_COALESCE, packet::PACKET_DATA_SIZE, signature::Keypair},
+        solana_sdk::{packet::PACKET_DATA_SIZE, signature::Keypair},
         solana_streamer::{
-            nonblocking::quic::{
-                DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_STREAMS_PER_MS,
-                DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-            },
-            quic::SpawnServerResult,
+            quic::{QuicServerParams, SpawnServerResult},
             streamer::StakedNodes,
             tls_certificates::new_dummy_x509_certificate,
         },
@@ -83,14 +79,13 @@ mod tests {
             &keypair,
             sender,
             exit.clone(),
-            1,
             staked_nodes,
-            10,
-            10,
-            DEFAULT_MAX_STREAMS_PER_MS,
-            DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-            DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-            DEFAULT_TPU_COALESCE,
+            QuicServerParams {
+                max_connections_per_peer: 1,
+                max_staked_connections: 10,
+                max_unstaked_connections: 10,
+                ..QuicServerParams::default()
+            },
         )
         .unwrap();
 
@@ -169,14 +164,14 @@ mod tests {
             &keypair,
             sender,
             exit.clone(),
-            1,
             staked_nodes,
-            10,
-            10,
-            DEFAULT_MAX_STREAMS_PER_MS,
-            DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-            Duration::from_secs(1), // wait_for_chunk_timeout
-            DEFAULT_TPU_COALESCE,
+            QuicServerParams {
+                max_connections_per_peer: 1,
+                max_staked_connections: 10,
+                max_unstaked_connections: 10,
+                wait_for_chunk_timeout: Duration::from_secs(1),
+                ..QuicServerParams::default()
+            },
         )
         .unwrap();
 
@@ -233,14 +228,13 @@ mod tests {
             &keypair,
             sender,
             request_recv_exit.clone(),
-            1,
             staked_nodes.clone(),
-            10,
-            10,
-            DEFAULT_MAX_STREAMS_PER_MS,
-            DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-            DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-            DEFAULT_TPU_COALESCE,
+            QuicServerParams {
+                max_connections_per_peer: 1,
+                max_staked_connections: 10,
+                max_unstaked_connections: 10,
+                ..QuicServerParams::default()
+            },
         )
         .unwrap();
 
@@ -263,14 +257,13 @@ mod tests {
             &keypair2,
             sender2,
             response_recv_exit.clone(),
-            1,
             staked_nodes,
-            10,
-            10,
-            DEFAULT_MAX_STREAMS_PER_MS,
-            DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-            DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-            DEFAULT_TPU_COALESCE,
+            QuicServerParams {
+                max_connections_per_peer: 1,
+                max_staked_connections: 10,
+                max_unstaked_connections: 10,
+                ..QuicServerParams::default()
+            },
         )
         .unwrap();
 

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -7,7 +7,7 @@ use {
                 STREAM_THROTTLING_INTERVAL_MS,
             },
         },
-        quic::{configure_server, QuicServerError, StreamerStats},
+        quic::{configure_server, QuicServerError, QuicServerParams, StreamerStats},
         streamer::StakedNodes,
         tls_certificates::get_pubkey_from_tls_certificate,
     },
@@ -132,21 +132,14 @@ pub struct SpawnNonBlockingServerResult {
     pub max_concurrent_connections: usize,
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn spawn_server(
     name: &'static str,
     sock: UdpSocket,
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
     exit: Arc<AtomicBool>,
-    max_connections_per_peer: usize,
     staked_nodes: Arc<RwLock<StakedNodes>>,
-    max_staked_connections: usize,
-    max_unstaked_connections: usize,
-    max_streams_per_ms: u64,
-    max_connections_per_ipaddr_per_min: u64,
-    wait_for_chunk_timeout: Duration,
-    coalesce: Duration,
+    quic_server_params: QuicServerParams,
 ) -> Result<SpawnNonBlockingServerResult, QuicServerError> {
     spawn_server_multi(
         name,
@@ -154,34 +147,30 @@ pub fn spawn_server(
         keypair,
         packet_sender,
         exit,
-        max_connections_per_peer,
         staked_nodes,
-        max_staked_connections,
-        max_unstaked_connections,
-        max_streams_per_ms,
-        max_connections_per_ipaddr_per_min,
-        wait_for_chunk_timeout,
-        coalesce,
+        quic_server_params,
     )
 }
 
-#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn spawn_server_multi(
     name: &'static str,
     sockets: Vec<UdpSocket>,
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
     exit: Arc<AtomicBool>,
-    max_connections_per_peer: usize,
     staked_nodes: Arc<RwLock<StakedNodes>>,
-    max_staked_connections: usize,
-    max_unstaked_connections: usize,
-    max_streams_per_ms: u64,
-    max_connections_per_ipaddr_per_min: u64,
-    wait_for_chunk_timeout: Duration,
-    coalesce: Duration,
+    quic_server_params: QuicServerParams,
 ) -> Result<SpawnNonBlockingServerResult, QuicServerError> {
     info!("Start {name} quic server on {sockets:?}");
+    let QuicServerParams {
+        max_unstaked_connections,
+        max_staked_connections,
+        max_connections_per_peer,
+        max_streams_per_ms,
+        max_connections_per_ipaddr_per_min,
+        wait_for_chunk_timeout,
+        coalesce,
+    } = quic_server_params;
     let concurrent_connections = max_staked_connections + max_unstaked_connections;
     let max_concurrent_connections = concurrent_connections + concurrent_connections / 4;
     let (config, _) = configure_server(keypair)?;
@@ -1491,15 +1480,12 @@ impl<'a> Future for EndpointAccept<'a> {
 pub mod test {
     use {
         super::*,
-        crate::{
-            nonblocking::{
-                quic::compute_max_allowed_uni_streams,
-                testing_utilities::{
-                    get_client_config, make_client_endpoint, setup_quic_server,
-                    SpawnTestServerResult, TestServerConfig,
-                },
+        crate::nonblocking::{
+            quic::compute_max_allowed_uni_streams,
+            testing_utilities::{
+                get_client_config, make_client_endpoint, setup_quic_server, SpawnTestServerResult,
+                TestServerConfig,
             },
-            quic::{MAX_STAKED_CONNECTIONS, MAX_UNSTAKED_CONNECTIONS},
         },
         assert_matches::assert_matches,
         async_channel::unbounded as async_unbounded,
@@ -1975,14 +1961,11 @@ pub mod test {
             &keypair,
             sender,
             exit.clone(),
-            1,
             staked_nodes,
-            MAX_STAKED_CONNECTIONS,
-            0, // Do not allow any connection from unstaked clients/nodes
-            DEFAULT_MAX_STREAMS_PER_MS,
-            DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-            DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-            DEFAULT_TPU_COALESCE,
+            QuicServerParams {
+                max_unstaked_connections: 0, // Do not allow any connection from unstaked clients/nodes
+                ..QuicServerParams::default()
+            },
         )
         .unwrap();
 
@@ -2011,14 +1994,11 @@ pub mod test {
             &keypair,
             sender,
             exit.clone(),
-            2,
             staked_nodes,
-            MAX_STAKED_CONNECTIONS,
-            MAX_UNSTAKED_CONNECTIONS,
-            DEFAULT_MAX_STREAMS_PER_MS,
-            DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-            DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-            DEFAULT_TPU_COALESCE,
+            QuicServerParams {
+                max_connections_per_peer: 2,
+                ..QuicServerParams::default()
+            },
         )
         .unwrap();
 

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -552,7 +552,7 @@ async fn test_rate_limiting() {
         None,
         TestServerConfig {
             max_connections_per_peer: 100,
-            max_connections_per_ipaddr_per_minute: 1,
+            max_connections_per_ipaddr_per_min: 1,
             ..Default::default()
         },
     );
@@ -610,7 +610,7 @@ async fn test_rate_limiting_establish_connection() {
         None,
         TestServerConfig {
             max_connections_per_peer: 100,
-            max_connections_per_ipaddr_per_minute: 1,
+            max_connections_per_ipaddr_per_min: 1,
             ..Default::default()
         },
     );


### PR DESCRIPTION
#### Problem

Methods with too many complicated parameters and duplication of parameterizing the quic server.

#### Summary of Changes

Add a parameter struct to pass the QUIC server parameters.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
