### PR TITLE
fix syn version mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -969,7 +969,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.85",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem

master ci is broken:

<img width="927" alt="Screenshot 2024-10-28 at 17 08 41" src="https://github.com/user-attachments/assets/bd7c54b1-f84c-4728-9d31-f96f99b1a738">

#### Summary of Changes

fix it