### PR TITLE
Extract ed25519-instructions crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6811,7 +6811,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-ed25519-instruction"
+name = "solana-ed25519-instructions"
 version = "2.2.0"
 dependencies = [
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6824,8 +6824,8 @@ dependencies = [
  "solana-instruction",
  "solana-logger",
  "solana-precompile-error",
- "solana-pubkey",
  "solana-sdk",
+ "solana-sdk-ids",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6817,9 +6817,15 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "ed25519-dalek",
+ "hex",
+ "rand 0.7.3",
  "solana-feature-set",
+ "solana-hash",
  "solana-instruction",
+ "solana-logger",
  "solana-precompile-error",
+ "solana-pubkey",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -8340,6 +8346,7 @@ dependencies = [
  "solana-commitment-config",
  "solana-decode-error",
  "solana-derivation-path",
+ "solana-ed25519-instructions",
  "solana-feature-set",
  "solana-fee-structure",
  "solana-frozen-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6811,6 +6811,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-ed25519-instruction"
+version = "2.2.0"
+dependencies = [
+ "bytemuck",
+ "bytemuck_derive",
+ "ed25519-dalek",
+ "solana-feature-set",
+ "solana-instruction",
+ "solana-precompile-error",
+]
+
+[[package]]
 name = "solana-ed25519-program-tests"
 version = "2.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6822,10 +6822,12 @@ dependencies = [
  "solana-feature-set",
  "solana-hash",
  "solana-instruction",
+ "solana-keypair",
  "solana-logger",
  "solana-precompile-error",
  "solana-sdk",
  "solana-sdk-ids",
+ "solana-signer",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ members = [
     "sdk/decode-error",
     "sdk/define-syscall",
     "sdk/derivation-path",
+    "sdk/ed25519-instructions",
     "sdk/epoch-rewards",
     "sdk/epoch-schedule",
     "sdk/feature-set",
@@ -438,6 +439,7 @@ solana-decode-error = { path = "sdk/decode-error", version = "=2.2.0" }
 solana-define-syscall = { path = "sdk/define-syscall", version = "=2.2.0" }
 solana-derivation-path = { path = "sdk/derivation-path", version = "=2.2.0" }
 solana-download-utils = { path = "download-utils", version = "=2.2.0" }
+solana-ed25519-instructions = { path = "sdk/ed25519-instructions", version = "=2.2.0" }
 solana-entry = { path = "entry", version = "=2.2.0" }
 solana-program-entrypoint = { path = "sdk/program-entrypoint", version = "=2.2.0" }
 solana-epoch-rewards = { path = "sdk/epoch-rewards", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5460,6 +5460,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-ed25519-instructions"
+version = "2.1.0"
+dependencies = [
+ "bytemuck",
+ "bytemuck_derive",
+ "ed25519-dalek",
+ "solana-feature-set",
+ "solana-instruction",
+ "solana-precompile-error",
+ "solana-pubkey",
+]
+
+[[package]]
 name = "solana-entry"
 version = "2.2.0"
 dependencies = [
@@ -7062,6 +7075,7 @@ dependencies = [
  "solana-commitment-config",
  "solana-decode-error",
  "solana-derivation-path",
+ "solana-ed25519-instructions",
  "solana-feature-set",
  "solana-fee-structure",
  "solana-inflation",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-instructions"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5469,7 +5469,7 @@ dependencies = [
  "solana-feature-set",
  "solana-instruction",
  "solana-precompile-error",
- "solana-pubkey",
+ "solana-sdk-ids",
 ]
 
 [[package]]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -35,6 +35,7 @@ full = [
     "digest",
     "solana-pubkey/rand",
     "dep:solana-cluster-type",
+    "dep:solana-ed25519-instructions",
     "dep:solana-keypair",
     "dep:solana-precompile-error",
     "dep:solana-presigner",
@@ -104,6 +105,7 @@ solana-cluster-type = { workspace = true, features = [
 solana-commitment-config = { workspace = true, optional = true, features = ["serde"] }
 solana-decode-error = { workspace = true }
 solana-derivation-path = { workspace = true }
+solana-ed25519-instructions = { workspace = true, optional = true }
 solana-feature-set = { workspace = true }
 solana-fee-structure = { workspace = true, features = ["serde"] }
 solana-frozen-abi = { workspace = true, optional = true, features = [

--- a/sdk/ed25519-instructions/Cargo.toml
+++ b/sdk/ed25519-instructions/Cargo.toml
@@ -16,7 +16,7 @@ ed25519-dalek = { workspace = true }
 solana-feature-set = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-precompile-error = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-sdk-ids = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }

--- a/sdk/ed25519-instructions/Cargo.toml
+++ b/sdk/ed25519-instructions/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "solana-ed25519-instruction"
+description = "Instructions for the Solana ed25519 native program"
+documentation = "https://docs.rs/solana-ed25519-instruction"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+bytemuck = { workspace = true }
+bytemuck_derive = { workspace = true }
+ed25519-dalek = { workspace = true }
+solana-feature-set = { workspace = true }
+solana-instruction = { workspace = true }
+solana-precompile-error = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/sdk/ed25519-instructions/Cargo.toml
+++ b/sdk/ed25519-instructions/Cargo.toml
@@ -22,8 +22,10 @@ solana-sdk-ids = { workspace = true }
 hex = { workspace = true }
 rand0-7 = { workspace = true }
 solana-hash = { workspace = true }
+solana-keypair = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { path = ".." }
+solana-signer = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/ed25519-instructions/Cargo.toml
+++ b/sdk/ed25519-instructions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "solana-ed25519-instruction"
+name = "solana-ed25519-instructions"
 description = "Instructions for the Solana ed25519 native program"
-documentation = "https://docs.rs/solana-ed25519-instruction"
+documentation = "https://docs.rs/solana-ed25519-instructions"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
@@ -16,6 +16,14 @@ ed25519-dalek = { workspace = true }
 solana-feature-set = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-precompile-error = { workspace = true }
+solana-pubkey = { workspace = true }
+
+[dev-dependencies]
+hex = { workspace = true }
+rand0-7 = { workspace = true }
+solana-hash = { workspace = true }
+solana-logger = { workspace = true }
+solana-sdk = { path = ".." }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/ed25519-instructions/Cargo.toml
+++ b/sdk/ed25519-instructions/Cargo.toml
@@ -14,7 +14,7 @@ bytemuck = { workspace = true }
 bytemuck_derive = { workspace = true }
 ed25519-dalek = { workspace = true }
 solana-feature-set = { workspace = true }
-solana-instruction = { workspace = true }
+solana-instruction = { workspace = true, features = ["std"] }
 solana-precompile-error = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/sdk/ed25519-instructions/src/lib.rs
+++ b/sdk/ed25519-instructions/src/lib.rs
@@ -9,6 +9,7 @@ use {
     solana_feature_set::{ed25519_precompile_verify_strict, FeatureSet},
     solana_instruction::Instruction,
     solana_precompile_error::PrecompileError,
+    solana_pubkey::{pubkey, Pubkey},
 };
 
 pub const PUBKEY_SERIALIZED_SIZE: usize = 32;
@@ -17,6 +18,8 @@ pub const SIGNATURE_OFFSETS_SERIALIZED_SIZE: usize = 14;
 // bytemuck requires structures to be aligned
 pub const SIGNATURE_OFFSETS_START: usize = 2;
 pub const DATA_START: usize = SIGNATURE_OFFSETS_SERIALIZED_SIZE + SIGNATURE_OFFSETS_START;
+// copied from solana_sdk::ed25519_program to avoid solana_sdk dependency
+const ED25519_PROGRAM_ID: Pubkey = pubkey!("Ed25519SigVerify111111111111111111111111111");
 
 #[derive(Default, Debug, Copy, Clone, Zeroable, Pod, Eq, PartialEq)]
 #[repr(C)]
@@ -77,7 +80,7 @@ pub fn new_ed25519_instruction(keypair: &ed25519_dalek::Keypair, message: &[u8])
     instruction_data.extend_from_slice(message);
 
     Instruction {
-        program_id: solana_sdk::ed25519_program::id(),
+        program_id: ED25519_PROGRAM_ID,
         accounts: vec![],
         data: instruction_data,
     }
@@ -188,15 +191,14 @@ fn get_data_slice<'a>(
 pub mod test {
     use {
         super::*,
-        crate::{
-            ed25519_instruction::new_ed25519_instruction,
-            hash::Hash,
-            signature::{Keypair, Signer},
-            transaction::Transaction,
-        },
         hex,
         rand0_7::{thread_rng, Rng},
         solana_feature_set::FeatureSet,
+        solana_hash::Hash,
+        solana_sdk::{
+            signer::{keypair::Keypair, Signer},
+            transaction::Transaction,
+        },
     };
 
     pub fn new_ed25519_instruction_raw(
@@ -247,7 +249,7 @@ pub mod test {
         instruction_data.extend_from_slice(message);
 
         Instruction {
-            program_id: solana_sdk::ed25519_program::id(),
+            program_id: ED25519_PROGRAM_ID,
             accounts: vec![],
             data: instruction_data,
         }
@@ -486,5 +488,10 @@ pub mod test {
 
         let feature_set = FeatureSet::all_enabled();
         assert!(tx.verify_precompiles(&feature_set).is_err()); // verify_strict does NOT pass
+    }
+
+    #[test]
+    fn test_inlined_program_id() {
+        assert_eq!(ED25519_PROGRAM_ID, solana_sdk::ed25519_program::id())
     }
 }

--- a/sdk/ed25519-instructions/src/lib.rs
+++ b/sdk/ed25519-instructions/src/lib.rs
@@ -9,7 +9,6 @@ use {
     solana_feature_set::{ed25519_precompile_verify_strict, FeatureSet},
     solana_instruction::Instruction,
     solana_precompile_error::PrecompileError,
-    solana_pubkey::{pubkey, Pubkey},
 };
 
 pub const PUBKEY_SERIALIZED_SIZE: usize = 32;
@@ -18,8 +17,6 @@ pub const SIGNATURE_OFFSETS_SERIALIZED_SIZE: usize = 14;
 // bytemuck requires structures to be aligned
 pub const SIGNATURE_OFFSETS_START: usize = 2;
 pub const DATA_START: usize = SIGNATURE_OFFSETS_SERIALIZED_SIZE + SIGNATURE_OFFSETS_START;
-// copied from solana_sdk::ed25519_program to avoid solana_sdk dependency
-const ED25519_PROGRAM_ID: Pubkey = pubkey!("Ed25519SigVerify111111111111111111111111111");
 
 #[derive(Default, Debug, Copy, Clone, Zeroable, Pod, Eq, PartialEq)]
 #[repr(C)]
@@ -80,7 +77,7 @@ pub fn new_ed25519_instruction(keypair: &ed25519_dalek::Keypair, message: &[u8])
     instruction_data.extend_from_slice(message);
 
     Instruction {
-        program_id: ED25519_PROGRAM_ID,
+        program_id: solana_sdk_ids::ed25519_program::id(),
         accounts: vec![],
         data: instruction_data,
     }
@@ -488,10 +485,5 @@ pub mod test {
 
         let feature_set = FeatureSet::all_enabled();
         assert!(tx.verify_precompiles(&feature_set).is_err()); // verify_strict does NOT pass
-    }
-
-    #[test]
-    fn test_inlined_program_id() {
-        assert_eq!(ED25519_PROGRAM_ID, solana_sdk::ed25519_program::id())
     }
 }

--- a/sdk/ed25519-instructions/src/lib.rs
+++ b/sdk/ed25519-instructions/src/lib.rs
@@ -245,7 +245,7 @@ pub mod test {
         instruction_data.extend_from_slice(message);
 
         Instruction {
-            program_id: ED25519_PROGRAM_ID,
+            program_id: solana_sdk_ids::ed25519_program::id(),
             accounts: vec![],
             data: instruction_data,
         }

--- a/sdk/ed25519-instructions/src/lib.rs
+++ b/sdk/ed25519-instructions/src/lib.rs
@@ -192,10 +192,9 @@ pub mod test {
         rand0_7::{thread_rng, Rng},
         solana_feature_set::FeatureSet,
         solana_hash::Hash,
-        solana_sdk::{
-            signer::{keypair::Keypair, Signer},
-            transaction::Transaction,
-        },
+        solana_keypair::Keypair,
+        solana_sdk::transaction::Transaction,
+        solana_signer::Signer,
     };
 
     pub fn new_ed25519_instruction_raw(

--- a/sdk/ed25519-instructions/src/lib.rs
+++ b/sdk/ed25519-instructions/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! [np]: https://docs.solanalabs.com/runtime/programs#ed25519-program
 
-#![cfg(feature = "full")]
-
 use {
     bytemuck::bytes_of,
     bytemuck_derive::{Pod, Zeroable},

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -64,7 +64,6 @@ pub use solana_signer::signers;
 pub mod client;
 pub mod compute_budget;
 pub mod deserialize_utils;
-pub mod ed25519_instruction;
 pub mod entrypoint;
 pub mod entrypoint_deprecated;
 pub mod epoch_info;
@@ -120,6 +119,12 @@ pub use solana_bn254 as alt_bn128;
 pub use solana_decode_error as decode_error;
 #[deprecated(since = "2.1.0", note = "Use `solana-derivation-path` crate instead")]
 pub use solana_derivation_path as derivation_path;
+#[cfg(feature = "full")]
+#[deprecated(
+    since = "2.2.0",
+    note = "Use `solana-ed25519-instructions` crate instead"
+)]
+pub use solana_ed25519_instructions as ed25519_instruction;
 #[deprecated(since = "2.1.0", note = "Use `solana-feature-set` crate instead")]
 pub use solana_feature_set as feature_set;
 #[deprecated(since = "2.2.0", note = "Use `solana-fee-structure` crate instead")]


### PR DESCRIPTION
#### Problem
`solana_sdk::ed25519_instruction` blocks ripping out `solana_sdk::precompiles`

#### Summary of Changes
- Move to its own crate and re-export with deprecation notice. Call the new crate `solana-ed25519-instructions` because `solana-ed25519-instruction` is already taken by a community crate
