### PR TITLE
CHANGELOG: Add entry for breaking change to curve22519-dalek crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Release channels have their own copy of this changelog:
   * SDK:
     * `cargo-build-sbf` and `cargo-build-bpf` have been deprecated for two years and have now been definitely removed.
        Use `cargo-build-sbf` and `cargo-test-sbf` instead.
+    * dependency: `curve25519-dalek` upgraded to new major version 4 (#1693). This causes breakage when mixing v2.0 and v2.1 Solana crates, so be sure to use all of one or the other. Please use only crates compatible with v2.1.
   * Stake:
     * removed the unreleased `redelegate` instruction processor and CLI commands (#2213)
   * Banks-client:


### PR DESCRIPTION
#### Problem

#1693 introduced a breaking change between v2.0 and v2.1 of the Solana crates by bumping a dependency to a new major version, but it isn't reflected in the changelog.

#### Summary of changes

Add a line in the changelog about the breaking change.