### PR TITLE
sdk: Extract epoch-rewards crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6676,6 +6676,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-epoch-rewards"
+version = "2.2.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-epoch-rewards",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-hash",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
 name = "solana-epoch-schedule"
 version = "2.2.0"
 dependencies = [
@@ -7434,6 +7448,7 @@ dependencies = [
  "solana-cpi",
  "solana-decode-error",
  "solana-define-syscall",
+ "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
  "solana-frozen-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ members = [
     "sdk/cpi",
     "sdk/decode-error",
     "sdk/derivation-path",
+    "sdk/epoch-rewards",
     "sdk/epoch-schedule",
     "sdk/feature-set",
     "sdk/fee-calculator",
@@ -422,6 +423,7 @@ solana-derivation-path = { path = "sdk/derivation-path", version = "=2.2.0" }
 solana-download-utils = { path = "download-utils", version = "=2.2.0" }
 solana-entry = { path = "entry", version = "=2.2.0" }
 solana-program-entrypoint = { path = "sdk/program-entrypoint", version = "=2.2.0" }
+solana-epoch-rewards = { path = "sdk/epoch-rewards", version = "=2.2.0" }
 solana-epoch-schedule = { path = "sdk/epoch-schedule", version = "=2.2.0" }
 solana-faucet = { path = "faucet", version = "=2.2.0" }
 solana-feature-set = { path = "sdk/feature-set", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5315,6 +5315,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-epoch-rewards"
+version = "2.2.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-hash",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
 name = "solana-epoch-schedule"
 version = "2.2.0"
 dependencies = [
@@ -5802,6 +5813,7 @@ dependencies = [
  "solana-cpi",
  "solana-decode-error",
  "solana-define-syscall",
+ "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
  "solana-hash",

--- a/sdk/epoch-rewards/Cargo.toml
+++ b/sdk/epoch-rewards/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "solana-epoch-rewards"
+description = "Solana epoch rewards sysvar."
+documentation = "https://docs.rs/solana-epoch-rewards"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-hash = { workspace = true, default-features = false }
+solana-sdk-macro = { workspace = true }
+solana-sysvar-id = { workspace = true, optional = true }
+
+[dev-dependencies]
+solana-epoch-rewards = { path = ".", features = ["sysvar"] }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "solana-hash/frozen-abi", "std"]
+serde = ["dep:serde", "dep:serde_derive", "solana-hash/serde"]
+std = []
+sysvar = ["dep:solana-sysvar-id"]
+
+[lints]
+workspace = true

--- a/sdk/epoch-rewards/src/lib.rs
+++ b/sdk/epoch-rewards/src/lib.rs
@@ -2,15 +2,27 @@
 //!
 //! [sv]: https://docs.solanalabs.com/runtime/sysvars#epochrewards
 //!
-//! The sysvar ID is declared in [`sysvar::epoch_rewards`].
+//! The sysvar ID is declared in [`solana_program::sysvar::epoch_rewards`].
 //!
-//! [`sysvar::epoch_rewards`]: crate::sysvar::epoch_rewards
+//! [`solana_program::sysvar::epoch_rewards`]: https://docs.rs/solana-program/latest/solana_program/sysvar/epoch_rewards/index.html
 
-use {crate::hash::Hash, solana_sdk_macro::CloneZeroed};
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+
+#[cfg(feature = "sysvar")]
+pub mod sysvar;
+
+#[cfg(feature = "std")]
+extern crate std;
+#[cfg(feature = "serde")]
+use serde_derive::{Deserialize, Serialize};
+use {solana_hash::Hash, solana_sdk_macro::CloneZeroed};
 
 #[repr(C, align(16))]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, CloneZeroed)]
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, PartialEq, Eq, Default, CloneZeroed)]
 pub struct EpochRewards {
     /// The starting block height of the rewards distribution in the current
     /// epoch

--- a/sdk/epoch-rewards/src/lib.rs
+++ b/sdk/epoch-rewards/src/lib.rs
@@ -2,9 +2,9 @@
 //!
 //! [sv]: https://docs.solanalabs.com/runtime/sysvars#epochrewards
 //!
-//! The sysvar ID is declared in [`solana_program::sysvar::epoch_rewards`].
+//! The sysvar ID is declared in [`sysvar`].
 //!
-//! [`solana_program::sysvar::epoch_rewards`]: https://docs.rs/solana-program/latest/solana_program/sysvar/epoch_rewards/index.html
+//! [`sysvar`]: crate::sysvar
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/sdk/epoch-rewards/src/sysvar.rs
+++ b/sdk/epoch-rewards/src/sysvar.rs
@@ -1,0 +1,3 @@
+use {crate::EpochRewards, solana_sysvar_id::declare_sysvar_id};
+
+declare_sysvar_id!("SysvarEpochRewards1111111111111111111111111", EpochRewards);

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -39,6 +39,7 @@ solana-borsh = { workspace = true, optional = true }
 solana-clock = { workspace = true, features = ["serde", "sysvar"] }
 solana-cpi = { workspace = true }
 solana-decode-error = { workspace = true }
+solana-epoch-rewards = { workspace = true, features = ["serde", "sysvar"] }
 solana-epoch-schedule = { workspace = true, features = ["serde", "sysvar"] }
 solana-fee-calculator = { workspace = true, features = ["serde"] }
 solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
@@ -141,6 +142,7 @@ dev-context-only-utils = ["dep:qualifier_attr"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
+    "solana-epoch-rewards/frozen-abi",
     "solana-epoch-schedule/frozen-abi",
     "solana-fee-calculator/frozen-abi",
     "solana-hash/frozen-abi",

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -478,7 +478,6 @@ pub mod bpf_loader_upgradeable;
 pub mod compute_units;
 pub mod ed25519_program;
 pub mod entrypoint_deprecated;
-pub mod epoch_rewards;
 pub mod epoch_schedule;
 pub mod epoch_stake;
 pub mod feature;
@@ -519,6 +518,8 @@ pub use solana_borsh::v0_10 as borsh0_10;
 #[cfg(feature = "borsh")]
 #[deprecated(since = "2.1.0", note = "Use `solana-borsh` crate instead")]
 pub use solana_borsh::v1 as borsh1;
+#[deprecated(since = "2.1.0", note = "Use `solana-epoch-rewards` crate instead")]
+pub use solana_epoch_rewards as epoch_rewards;
 #[deprecated(since = "2.1.0", note = "Use `solana-fee-calculator` crate instead")]
 pub use solana_fee_calculator as fee_calculator;
 #[deprecated(since = "2.1.0", note = "Use `solana-last-restart-slot` crate instead")]

--- a/sdk/program/src/sysvar/epoch_rewards.rs
+++ b/sdk/program/src/sysvar/epoch_rewards.rs
@@ -159,13 +159,11 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 
-pub use crate::epoch_rewards::EpochRewards;
-use {
-    crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar},
-    solana_sysvar_id::declare_sysvar_id,
+use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
+pub use solana_epoch_rewards::{
+    sysvar::{check_id, id, ID},
+    EpochRewards,
 };
-
-declare_sysvar_id!("SysvarEpochRewards1111111111111111111111111", EpochRewards);
 
 impl Sysvar for EpochRewards {
     impl_sysvar_get!(sol_get_epoch_rewards_sysvar);


### PR DESCRIPTION
#### Problem

Almost all of the sysvars have been properly extracted into separate dependencies, but a few still remain. Epoch rewards is one of those, and thankfully, it's very simple.

#### Summary of changes

Just like the others, move files around. I went a little bolder with this one and made it no-std by default, since it really only requires std for the frozen-abi macro. Let me know how it looks!