### PR TITLE
Add skip preflight to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Release channels have their own copy of this changelog:
 
 <a name="edge-channel"></a>
 ## [2.2.0] - Unreleased
+* Changes
+  * CLI:
+    * Add global `--skip-preflight` option for skipping preflight checks on all transactions sent through RPC. This flag, along with `--use-rpc`, can improve success rate with program deployments using the public RPC nodes.
 
 ## [2.1.0]
 * Breaking:

--- a/cargo-registry/src/client.rs
+++ b/cargo-registry/src/client.rs
@@ -12,6 +12,7 @@ use {
     solana_cli_config::{Config, ConfigInput},
     solana_cli_output::OutputFormat,
     solana_rpc_client::rpc_client::RpcClient,
+    solana_rpc_client_api::config::RpcSendTransactionConfig,
     solana_sdk::{
         commitment_config,
         signature::{read_keypair_file, Keypair},
@@ -30,6 +31,7 @@ impl<'a> RPCCommandConfig<'a> {
             authority: &client.cli_signers[client.authority_signer_index],
             output_format: &OutputFormat::Display,
             use_quic: true,
+            rpc_send_transaction_config: client.rpc_transaction_config,
         })
     }
 }
@@ -42,6 +44,7 @@ pub(crate) struct Client {
     commitment: commitment_config::CommitmentConfig,
     cli_signers: Vec<Keypair>,
     authority_signer_index: SignerIndex,
+    rpc_transaction_config: RpcSendTransactionConfig,
 }
 
 impl Client {
@@ -208,6 +211,8 @@ impl Client {
         let server_url =
             value_t!(matches, "server_url", String).unwrap_or(format!("http://0.0.0.0:{}", port));
 
+        let skip_preflight = matches.is_present("skip_preflight");
+
         Ok(Client {
             rpc_client: Arc::new(RpcClient::new_with_timeouts_and_commitment(
                 json_rpc_url.to_string(),
@@ -221,6 +226,11 @@ impl Client {
             commitment,
             cli_signers: vec![payer_keypair, authority_keypair],
             authority_signer_index: 1,
+            rpc_transaction_config: RpcSendTransactionConfig {
+                skip_preflight,
+                preflight_commitment: Some(commitment.commitment),
+                ..RpcSendTransactionConfig::default()
+            },
         })
     }
 }

--- a/cargo-registry/src/client.rs
+++ b/cargo-registry/src/client.rs
@@ -68,6 +68,13 @@ impl Client {
             .about(about)
             .version(version)
             .arg(
+                Arg::with_name("skip_preflight")
+                    .long("skip-preflight")
+                    .global(true)
+                    .takes_value(false)
+                    .help("Skip the preflight check when sending transactions"),
+            )
+            .arg(
                 Arg::with_name("config_file")
                     .short("C")
                     .long("config")

--- a/cli/src/clap_app.rs
+++ b/cli/src/clap_app.rs
@@ -14,6 +14,13 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
         .about(about)
         .version(version)
         .setting(AppSettings::SubcommandRequiredElseHelp)
+        .arg(
+            Arg::with_name("skip_preflight")
+                .long("skip-preflight")
+                .global(true)
+                .takes_value(false)
+                .help("Skip the preflight check when sending transactions (default: false)"),
+        )
         .arg({
             let arg = Arg::with_name("config_file")
                 .short("C")

--- a/cli/src/clap_app.rs
+++ b/cli/src/clap_app.rs
@@ -19,7 +19,7 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                 .long("skip-preflight")
                 .global(true)
                 .takes_value(false)
-                .help("Skip the preflight check when sending transactions (default: false)"),
+                .help("Skip the preflight check when sending transactions"),
         )
         .arg({
             let arg = Arg::with_name("config_file")

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -990,6 +990,10 @@ fn process_activate(
         FEATURE_NAMES.get(&feature_id).unwrap(),
         feature_id
     );
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&transaction);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+        &transaction,
+        config.commitment,
+        config.send_transaction_config,
+    );
     log_instruction_custom_error::<SystemError>(result, config)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -212,6 +212,8 @@ pub fn parse_args<'a>(
         !DEFAULT_TPU_ENABLE_UDP
     };
 
+    let skip_preflight = matches.is_present("skip_preflight");
+
     let use_tpu_client = matches.is_present("use_tpu_client");
 
     Ok((
@@ -227,6 +229,7 @@ pub fn parse_args<'a>(
             output_format,
             commitment,
             send_transaction_config: RpcSendTransactionConfig {
+                skip_preflight,
                 preflight_commitment: Some(commitment.commitment),
                 ..RpcSendTransactionConfig::default()
             },

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -437,7 +437,11 @@ pub fn process_authorize_nonce_account(
         &tx.message,
         config.commitment,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+        &tx,
+        config.commitment,
+        config.send_transaction_config,
+    );
 
     log_instruction_custom_error::<SystemError>(result, config)
 }
@@ -537,7 +541,11 @@ pub fn process_create_nonce_account(
 
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, latest_blockhash)?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+        &tx,
+        config.commitment,
+        config.send_transaction_config,
+    );
 
     log_instruction_custom_error::<SystemError>(result, config)
 }
@@ -597,7 +605,11 @@ pub fn process_new_nonce(
         &tx.message,
         config.commitment,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+        &tx,
+        config.commitment,
+        config.send_transaction_config,
+    );
 
     log_instruction_custom_error::<SystemError>(result, config)
 }
@@ -667,7 +679,11 @@ pub fn process_withdraw_from_nonce_account(
         &tx.message,
         config.commitment,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+        &tx,
+        config.commitment,
+        config.send_transaction_config,
+    );
 
     log_instruction_custom_error::<SystemError>(result, config)
 }
@@ -697,7 +713,11 @@ pub(crate) fn process_upgrade_nonce_account(
         &tx.message,
         config.commitment,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+        &tx,
+        config.commitment,
+        config.send_transaction_config,
+    );
     log_instruction_custom_error::<SystemError>(result, config)
 }
 

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -35,7 +35,8 @@ use {
     solana_client::{
         connection_cache::ConnectionCache,
         send_and_confirm_transactions_in_parallel::{
-            send_and_confirm_transactions_in_parallel_blocking, SendAndConfirmConfig,
+            send_and_confirm_transactions_in_parallel_blocking_v2,
+            SendAndConfirmConfigV2,
         },
         tpu_client::{TpuClient, TpuClientConfig},
     },
@@ -1575,7 +1576,10 @@ fn process_program_upgrade(
         let signers = &[fee_payer_signer, upgrade_authority_signer];
         tx.try_sign(signers, blockhash)?;
         let final_tx_sig = rpc_client
-            .send_and_confirm_transaction_with_spinner(&tx)
+            .send_and_confirm_transaction_with_spinner_and_config(&tx, 
+                config.commitment, 
+                config.send_transaction_config
+            )
             .map_err(|e| format!("Upgrading program failed: {e}"))?;
         let program_id = CliProgramId {
             program_id: program_id.to_string(),
@@ -2995,15 +2999,15 @@ fn send_deploy_messages(
                         .expect("Should return a valid tpu client")
                     );
 
-                    send_and_confirm_transactions_in_parallel_blocking(
+                    send_and_confirm_transactions_in_parallel_blocking_v2(
                         rpc_client.clone(),
                         tpu_client,
                         &write_messages,
                         &[fee_payer_signer, write_signer],
-                        SendAndConfirmConfig {
+                        SendAndConfirmConfigV2 {
                             resign_txs_count: Some(max_sign_attempts),
                             with_spinner: true,
-                            skip_preflight: config.send_transaction_config.skip_preflight,
+                            rpc_send_transaction_config: config.send_transaction_config,
                         },
                     )
                 },

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -35,8 +35,7 @@ use {
     solana_client::{
         connection_cache::ConnectionCache,
         send_and_confirm_transactions_in_parallel::{
-            send_and_confirm_transactions_in_parallel_blocking_v2,
-            SendAndConfirmConfigV2,
+            send_and_confirm_transactions_in_parallel_blocking_v2, SendAndConfirmConfigV2,
         },
         tpu_client::{TpuClient, TpuClientConfig},
     },
@@ -1576,9 +1575,10 @@ fn process_program_upgrade(
         let signers = &[fee_payer_signer, upgrade_authority_signer];
         tx.try_sign(signers, blockhash)?;
         let final_tx_sig = rpc_client
-            .send_and_confirm_transaction_with_spinner_and_config(&tx, 
-                config.commitment, 
-                config.send_transaction_config
+            .send_and_confirm_transaction_with_spinner_and_config(
+                &tx,
+                config.commitment,
+                config.send_transaction_config,
             )
             .map_err(|e| format!("Upgrading program failed: {e}"))?;
         let program_id = CliProgramId {

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -20,8 +20,7 @@ use {
     solana_client::{
         connection_cache::ConnectionCache,
         send_and_confirm_transactions_in_parallel::{
-            send_and_confirm_transactions_in_parallel_blocking_v2,
-            SendAndConfirmConfigV2,
+            send_and_confirm_transactions_in_parallel_blocking_v2, SendAndConfirmConfigV2,
         },
         tpu_client::{TpuClient, TpuClientConfig},
     },

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -20,7 +20,8 @@ use {
     solana_client::{
         connection_cache::ConnectionCache,
         send_and_confirm_transactions_in_parallel::{
-            send_and_confirm_transactions_in_parallel_blocking, SendAndConfirmConfig,
+            send_and_confirm_transactions_in_parallel_blocking_v2,
+            SendAndConfirmConfigV2,
         },
         tpu_client::{TpuClient, TpuClientConfig},
     },
@@ -1083,15 +1084,15 @@ fn send_messages(
                     .block_on(tpu_client_fut)
                     .expect("Should return a valid tpu client");
 
-                send_and_confirm_transactions_in_parallel_blocking(
+                send_and_confirm_transactions_in_parallel_blocking_v2(
                     rpc_client.clone(),
                     Some(tpu_client),
                     write_messages,
                     &[config.payer, config.authority],
-                    SendAndConfirmConfig {
+                    SendAndConfirmConfigV2 {
                         resign_txs_count: Some(5),
                         with_spinner: true,
-                        skip_preflight: config.rpc_send_transaction_config.skip_preflight,
+                        rpc_send_transaction_config: config.rpc_send_transaction_config,
                     },
                 )
             }

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -567,6 +567,7 @@ pub struct ProgramV4CommandConfig<'a> {
     pub authority: &'a dyn Signer,
     pub output_format: &'a OutputFormat,
     pub use_quic: bool,
+    pub rpc_send_transaction_config: RpcSendTransactionConfig,
 }
 
 impl<'a> ProgramV4CommandConfig<'a> {
@@ -578,6 +579,7 @@ impl<'a> ProgramV4CommandConfig<'a> {
             authority: config.signers[*auth_signer_index],
             output_format: &config.output_format,
             use_quic: config.use_quic,
+            rpc_send_transaction_config: config.send_transaction_config,
         }
     }
 }
@@ -1014,8 +1016,11 @@ fn send_messages(
                 let mut initial_transaction = Transaction::new_unsigned(message.clone());
                 initial_transaction
                     .try_sign(&[config.payer, initial_signer, config.authority], blockhash)?;
-                let result =
-                    rpc_client.send_and_confirm_transaction_with_spinner(&initial_transaction);
+                let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+                    &initial_transaction,
+                    config.commitment,
+                    config.rpc_send_transaction_config,
+                );
                 log_instruction_custom_error_ex::<SystemError, _>(
                     result,
                     config.output_format,
@@ -1031,7 +1036,11 @@ fn send_messages(
 
             let mut initial_transaction = Transaction::new_unsigned(message.clone());
             initial_transaction.try_sign(&[config.payer, config.authority], blockhash)?;
-            let result = rpc_client.send_and_confirm_transaction_with_spinner(&initial_transaction);
+            let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+                &initial_transaction,
+                config.commitment,
+                config.rpc_send_transaction_config,
+            );
             log_instruction_custom_error_ex::<SystemError, _>(
                 result,
                 config.output_format,
@@ -1082,6 +1091,7 @@ fn send_messages(
                     SendAndConfirmConfig {
                         resign_txs_count: Some(5),
                         with_spinner: true,
+                        skip_preflight: config.rpc_send_transaction_config.skip_preflight,
                     },
                 )
             }
@@ -1107,11 +1117,7 @@ fn send_messages(
             .send_and_confirm_transaction_with_spinner_and_config(
                 &final_tx,
                 config.commitment,
-                RpcSendTransactionConfig {
-                    skip_preflight: true,
-                    preflight_commitment: Some(config.commitment.commitment),
-                    ..RpcSendTransactionConfig::default()
-                },
+                config.rpc_send_transaction_config,
             )
             .map_err(|e| format!("Deploying program failed: {e}"))?;
     }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1675,10 +1675,7 @@ pub fn process_stake_authorize(
             config.commitment,
         )?;
         let result = if no_wait {
-            rpc_client.send_transaction_with_config(
-                &tx,
-                config.send_transaction_config,
-            )
+            rpc_client.send_transaction_with_config(&tx, config.send_transaction_config)
         } else {
             rpc_client.send_and_confirm_transaction_with_spinner_and_config(
                 &tx,

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1530,7 +1530,11 @@ pub fn process_create_stake_account(
         )
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<SystemError>(result, config)
     }
 }
@@ -1671,9 +1675,16 @@ pub fn process_stake_authorize(
             config.commitment,
         )?;
         let result = if no_wait {
-            rpc_client.send_transaction(&tx)
+            rpc_client.send_transaction_with_config(
+                &tx,
+                config.send_transaction_config,
+            )
         } else {
-            rpc_client.send_and_confirm_transaction_with_spinner(&tx)
+            rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+                &tx,
+                config.commitment,
+                config.send_transaction_config,
+            )
         };
         log_instruction_custom_error::<StakeError>(result, config)
     }
@@ -1821,7 +1832,11 @@ pub fn process_deactivate_stake_account(
             &tx.message,
             config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<StakeError>(result, config)
     }
 }
@@ -1928,7 +1943,11 @@ pub fn process_withdraw_stake(
             &tx.message,
             config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<StakeError>(result, config)
     }
 }
@@ -2120,7 +2139,11 @@ pub fn process_split_stake(
             &tx.message,
             config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<StakeError>(result, config)
     }
 }
@@ -2337,7 +2360,11 @@ pub fn process_stake_set_lockup(
             &tx.message,
             config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<StakeError>(result, config)
     }
 }
@@ -2820,7 +2847,11 @@ pub fn process_delegate_stake(
             &tx.message,
             config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<StakeError>(result, config)
     }
 }

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -408,7 +408,11 @@ pub fn process_set_validator_info(
     )?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&signers, latest_blockhash)?;
-    let signature_str = rpc_client.send_and_confirm_transaction_with_spinner(&tx)?;
+    let signature_str = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+        &tx,
+        config.commitment,
+        config.send_transaction_config,
+    )?;
 
     println!("Success! Validator info published at: {info_pubkey:?}");
     println!("{signature_str}");

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -932,7 +932,11 @@ pub fn process_create_vote_account(
         )
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<SystemError>(result, config)
     }
 }
@@ -1071,7 +1075,11 @@ pub fn process_vote_authorize(
             &tx.message,
             config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<VoteError>(result, config)
     }
 }
@@ -1155,7 +1163,11 @@ pub fn process_vote_update_validator(
             &tx.message,
             config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<VoteError>(result, config)
     }
 }
@@ -1232,7 +1244,11 @@ pub fn process_vote_update_commission(
             &tx.message,
             config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<VoteError>(result, config)
     }
 }
@@ -1440,7 +1456,11 @@ pub fn process_withdraw_from_vote_account(
             &tx.message,
             config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<VoteError>(result, config)
     }
 }
@@ -1504,7 +1524,11 @@ pub fn process_close_vote_account(
         &tx.message,
         config.commitment,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+        &tx,
+        config.commitment,
+        config.send_transaction_config,
+    );
     log_instruction_custom_error::<VoteError>(result, config)
 }
 

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -986,9 +986,13 @@ pub fn process_transfer(
 
         tx.try_sign(&config.signers, recent_blockhash)?;
         let result = if no_wait {
-            rpc_client.send_transaction(&tx)
+            rpc_client.send_transaction_with_config(&tx, config.send_transaction_config)
         } else {
-            rpc_client.send_and_confirm_transaction_with_spinner(&tx)
+            rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+                &tx,
+                config.commitment,
+                config.send_transaction_config,
+            )
         };
         log_instruction_custom_error::<SystemError>(result, config)
     }

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -11,6 +11,7 @@ use {
         test_utils::wait_n_slots,
     },
     solana_cli_output::{parse_sign_only_reply_string, OutputFormat},
+    solana_client::rpc_config::RpcSendTransactionConfig,
     solana_faucet::faucet::run_local_faucet,
     solana_feature_set::enable_alt_bn128_syscall,
     solana_rpc::rpc::JsonRpcConfig,
@@ -373,9 +374,11 @@ fn test_cli_program_deploy_no_authority() {
     );
 }
 
-#[test_case(true; "Feature enabled")]
-#[test_case(false; "Feature disabled")]
-fn test_cli_program_deploy_feature(enable_feature: bool) {
+#[test_case(true, true; "Feature enabled, skip preflight")]
+#[test_case(true, false; "Feature enabled, don't skip preflight")]
+#[test_case(false, true; "Feature disabled, skip preflight")]
+#[test_case(false, false; "Feature disabled, don't skip preflight")]
+fn test_cli_program_deploy_feature(enable_feature: bool, skip_preflight: bool) {
     solana_logger::setup();
 
     let mut program_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -432,6 +435,7 @@ fn test_cli_program_deploy_feature(enable_feature: bool) {
         lamports: 100 * minimum_balance_for_programdata + minimum_balance_for_program,
     };
     config.signers = vec![&keypair];
+    config.send_transaction_config.skip_preflight = skip_preflight;
     process_command(&config).unwrap();
 
     config.signers = vec![&keypair, &upgrade_authority];
@@ -459,10 +463,10 @@ fn test_cli_program_deploy_feature(enable_feature: bool) {
         assert!(res.is_ok());
     } else {
         expect_command_failure(
-            &config,
-            "Program contains a syscall from a deactivated feature",
-            "ELF error: ELF error: Unresolved symbol (sol_alt_bn128_group_op) at instruction #49 (ELF file offset 0x188)"
-        );
+                &config,
+                "Program contains a syscall from a deactivated feature",
+                "ELF error: ELF error: Unresolved symbol (sol_alt_bn128_group_op) at instruction #49 (ELF file offset 0x188)"
+            );
 
         // If we bypass the verification, there should be no error
         config.command = CliCommand::Program(ProgramCliCommand::Deploy {
@@ -485,11 +489,19 @@ fn test_cli_program_deploy_feature(enable_feature: bool) {
 
         // When we skip verification, we fail at a later stage
         let response = process_command(&config);
-        assert!(response
-            .err()
-            .unwrap()
-            .to_string()
-            .contains("Deploying program failed: RPC response error -32002:"));
+        if skip_preflight {
+            assert!(response
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("Deploying program failed"));
+        } else {
+            assert!(response
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("Deploying program failed: RPC response error -32002:"));
+        }
     }
 }
 
@@ -1060,8 +1072,9 @@ fn test_cli_program_deploy_with_authority() {
     assert_eq!("none", authority_pubkey_str);
 }
 
-#[test]
-fn test_cli_program_upgrade_auto_extend() {
+#[test_case(true; "Skip preflight")]
+#[test_case(false; "Dont skip preflight")]
+fn test_cli_program_upgrade_auto_extend(skip_preflight: bool) {
     solana_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -1136,6 +1149,7 @@ fn test_cli_program_upgrade_auto_extend() {
         skip_feature_verification: true,
     });
     config.output_format = OutputFormat::JsonCompact;
+    config.send_transaction_config.skip_preflight = skip_preflight;
     process_command(&config).unwrap();
 
     // Attempt to upgrade the program with a larger program, but with the
@@ -1158,18 +1172,26 @@ fn test_cli_program_upgrade_auto_extend() {
         use_rpc: false,
         skip_feature_verification: true,
     });
-    expect_command_failure(
-        &config,
-        "Can not upgrade a program when ELF does not fit into the allocated data account",
-        "Deploying program failed: \
-         RPC response error -32002: \
-         Transaction simulation failed: \
-         Error processing Instruction 0: \
-         account data too small for instruction; 3 log messages:\n  \
-         Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [1]\n  \
-         ProgramData account not large enough\n  \
-         Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n",
-    );
+    if skip_preflight {
+        expect_command_failure(
+            &config,
+            "Cannot upgrade a program when ELF does not fit into the allocated data account",
+            "Deploying program failed: Error processing Instruction 0: account data too small for instruction",
+        );
+    } else {
+        expect_command_failure(
+            &config,
+            "Can not upgrade a program when ELF does not fit into the allocated data account",
+            "Deploying program failed: \
+            RPC response error -32002: \
+            Transaction simulation failed: \
+            Error processing Instruction 0: \
+            account data too small for instruction; 3 log messages:\n  \
+            Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [1]\n  \
+            ProgramData account not large enough\n  \
+            Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n",
+        );
+    }
 
     // Attempt to upgrade the program with a larger program, this time without
     // the --no-auto-extend flag. This should automatically extend the program data.
@@ -1332,8 +1354,9 @@ fn test_cli_program_close_program() {
     assert_eq!(programdata_lamports, recipient_account.lamports);
 }
 
-#[test]
-fn test_cli_program_extend_program() {
+#[test_case(true; "Skip Preflight")]
+#[test_case(false; "Dont skip Preflight")]
+fn test_cli_program_extend_program_skip_preflight(skip_preflight: bool) {
     solana_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -1378,6 +1401,11 @@ fn test_cli_program_extend_program() {
     config.command = CliCommand::Airdrop {
         pubkey: None,
         lamports: 100 * minimum_balance_for_programdata + minimum_balance_for_program,
+    };
+    config.send_transaction_config = RpcSendTransactionConfig {
+        skip_preflight: skip_preflight,
+        preflight_commitment: Some(CommitmentConfig::processed().commitment),
+        ..RpcSendTransactionConfig::default()
     };
     process_command(&config).unwrap();
 
@@ -1452,7 +1480,14 @@ fn test_cli_program_extend_program() {
         use_rpc: false,
         skip_feature_verification: true,
     });
-    expect_command_failure(
+    if skip_preflight {
+        expect_command_failure(
+            &config,
+            "Program upgrade must fail, as the buffer is 1 byte too short",
+            "Deploying program failed: Error processing Instruction 0: account data too small for instruction",
+        );
+    } else {
+        expect_command_failure(
         &config,
         "Program upgrade must fail, as the buffer is 1 byte too short",
         "Deploying program failed: \
@@ -1464,6 +1499,7 @@ fn test_cli_program_extend_program() {
          ProgramData account not large enough\n  \
          Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n",
     );
+    }
 
     // Wait one slot to avoid "Program was deployed in this block already" error
     wait_n_slots(&rpc_client, 1);

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -558,9 +558,8 @@ fn test_transfer_all(compute_unit_price: Option<u64>) {
     check_balance!(500_000 - fee, &rpc_client, &recipient_pubkey);
 }
 
-#[test_case(true; "Skip Preflight")]
-#[test_case(false; "Don`t skip Preflight")]
-fn test_transfer_unfunded_recipient(skip_preflight: bool) {
+#[test]
+fn test_transfer_unfunded_recipient() {
     solana_logger::setup();
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -580,7 +579,7 @@ fn test_transfer_unfunded_recipient(skip_preflight: bool) {
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&default_signer];
-    config.send_transaction_config.skip_preflight = skip_preflight;
+    config.send_transaction_config.skip_preflight = false;
 
     let sender_pubkey = config.signers[0].pubkey();
     let recipient_pubkey = Pubkey::from([1u8; 32]);

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -26,8 +26,9 @@ use {
     test_case::test_case,
 };
 
-#[test]
-fn test_transfer() {
+#[test_case(true; "Skip Preflight")]
+#[test_case(false; "Don`t skip Preflight")]
+fn test_transfer(skip_preflight: bool) {
     solana_logger::setup();
     let fee_one_sig = FeeStructure::default().get_max_fee(1, 0);
     let fee_two_sig = FeeStructure::default().get_max_fee(2, 0);
@@ -50,6 +51,7 @@ fn test_transfer() {
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&default_signer];
+    config.send_transaction_config.skip_preflight = skip_preflight;
 
     let sender_pubkey = config.signers[0].pubkey();
     let recipient_pubkey = Pubkey::from([1u8; 32]);
@@ -556,8 +558,9 @@ fn test_transfer_all(compute_unit_price: Option<u64>) {
     check_balance!(500_000 - fee, &rpc_client, &recipient_pubkey);
 }
 
-#[test]
-fn test_transfer_unfunded_recipient() {
+#[test_case(true; "Skip Preflight")]
+#[test_case(false; "Don`t skip Preflight")]
+fn test_transfer_unfunded_recipient(skip_preflight: bool) {
     solana_logger::setup();
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -577,6 +580,7 @@ fn test_transfer_unfunded_recipient() {
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&default_signer];
+    config.send_transaction_config.skip_preflight = skip_preflight;
 
     let sender_pubkey = config.signers[0].pubkey();
     let recipient_pubkey = Pubkey::from([1u8; 32]);

--- a/client-test/tests/send_and_confirm_transactions_in_parallel.rs
+++ b/client-test/tests/send_and_confirm_transactions_in_parallel.rs
@@ -1,8 +1,9 @@
 use {
     solana_client::{
         nonblocking::tpu_client::TpuClient,
+        rpc_config::RpcSendTransactionConfig,
         send_and_confirm_transactions_in_parallel::{
-            send_and_confirm_transactions_in_parallel_blocking, SendAndConfirmConfig,
+            send_and_confirm_transactions_in_parallel_blocking_v2, SendAndConfirmConfigV2,
         },
     },
     solana_rpc_client::rpc_client::RpcClient,
@@ -51,15 +52,21 @@ fn test_send_and_confirm_transactions_in_parallel_without_tpu_client() {
     let original_alice_balance = rpc_client.get_balance(&alice.pubkey()).unwrap();
     let (messages, sum) = create_messages(alice_pubkey, bob_pubkey);
 
-    let txs_errors = send_and_confirm_transactions_in_parallel_blocking(
+    let txs_errors = send_and_confirm_transactions_in_parallel_blocking_v2(
         rpc_client.clone(),
         None,
         &messages,
         &[&alice],
-        SendAndConfirmConfig {
+        SendAndConfirmConfigV2 {
             with_spinner: false,
             resign_txs_count: Some(5),
-            skip_preflight: false,
+            rpc_send_transaction_config: RpcSendTransactionConfig {
+                skip_preflight: false,
+                preflight_commitment: Some(CommitmentConfig::confirmed().commitment),
+                encoding: None,
+                max_retries: None,
+                min_context_slot: None,
+            },
         },
     );
     assert!(txs_errors.is_ok());
@@ -110,15 +117,21 @@ fn test_send_and_confirm_transactions_in_parallel_with_tpu_client() {
     );
     let tpu_client = rpc_client.runtime().block_on(tpu_client_fut).unwrap();
 
-    let txs_errors = send_and_confirm_transactions_in_parallel_blocking(
+    let txs_errors = send_and_confirm_transactions_in_parallel_blocking_v2(
         rpc_client.clone(),
         Some(tpu_client),
         &messages,
         &[&alice],
-        SendAndConfirmConfig {
+        SendAndConfirmConfigV2 {
             with_spinner: false,
             resign_txs_count: Some(5),
-            skip_preflight: false,
+            rpc_send_transaction_config: RpcSendTransactionConfig {
+                skip_preflight: false,
+                preflight_commitment: Some(CommitmentConfig::confirmed().commitment),
+                encoding: None,
+                max_retries: None,
+                min_context_slot: None,
+            },
         },
     );
     assert!(txs_errors.is_ok());

--- a/client-test/tests/send_and_confirm_transactions_in_parallel.rs
+++ b/client-test/tests/send_and_confirm_transactions_in_parallel.rs
@@ -59,6 +59,7 @@ fn test_send_and_confirm_transactions_in_parallel_without_tpu_client() {
         SendAndConfirmConfig {
             with_spinner: false,
             resign_txs_count: Some(5),
+            skip_preflight: false,
         },
     );
     assert!(txs_errors.is_ok());
@@ -117,6 +118,7 @@ fn test_send_and_confirm_transactions_in_parallel_with_tpu_client() {
         SendAndConfirmConfig {
             with_spinner: false,
             resign_txs_count: Some(5),
+            skip_preflight: false,
         },
     );
     assert!(txs_errors.is_ok());

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -56,7 +56,6 @@ struct BlockHashData {
 }
 
 // Deprecated struct to maintain backward compatibility
-#[allow(deprecated)]
 #[deprecated(
     since = "2.2.0",
     note = "Use SendAndConfirmConfigV2 with send_and_confirm_transactions_in_parallel_v2"

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -56,7 +56,11 @@ struct BlockHashData {
 }
 
 // Deprecated struct to maintain backward compatibility
-#[deprecated(note = "Use SendAndConfirmConfigV2 with send_and_confirm_transactions_in_parallel_v2")]
+#[allow(deprecated)]
+#[deprecated(
+    since = "2.2.0",
+    note = "Use SendAndConfirmConfigV2 with send_and_confirm_transactions_in_parallel_v2"
+)]
 #[derive(Clone, Debug, Copy)]
 pub struct SendAndConfirmConfig {
     pub with_spinner: bool,
@@ -71,7 +75,11 @@ pub struct SendAndConfirmConfigV2 {
     pub rpc_send_transaction_config: RpcSendTransactionConfig,
 }
 
-#[deprecated(note = "Use send_and_confirm_transactions_in_parallel_v2")]
+#[allow(deprecated)]
+#[deprecated(
+    since = "2.2.0",
+    note = "Use send_and_confirm_transactions_in_parallel_v2"
+)]
 pub async fn send_and_confirm_transactions_in_parallel<T: Signers + ?Sized>(
     rpc_client: Arc<RpcClient>,
     tpu_client: Option<QuicTpuClient>,
@@ -83,7 +91,6 @@ pub async fn send_and_confirm_transactions_in_parallel<T: Signers + ?Sized>(
         with_spinner: config.with_spinner,
         resign_txs_count: config.resign_txs_count,
         rpc_send_transaction_config: RpcSendTransactionConfig {
-            skip_preflight: false,
             ..RpcSendTransactionConfig::default()
         },
     };
@@ -93,7 +100,11 @@ pub async fn send_and_confirm_transactions_in_parallel<T: Signers + ?Sized>(
     .await
 }
 
-#[deprecated(note = "Use send_and_confirm_transactions_in_parallel_blocking_v2")]
+#[allow(deprecated)]
+#[deprecated(
+    since = "2.2.0",
+    note = "Use send_and_confirm_transactions_in_parallel_blocking_v2"
+)]
 pub fn send_and_confirm_transactions_in_parallel_blocking<T: Signers + ?Sized>(
     rpc_client: Arc<BlockingRpcClient>,
     tpu_client: Option<QuicTpuClient>,
@@ -105,7 +116,6 @@ pub fn send_and_confirm_transactions_in_parallel_blocking<T: Signers + ?Sized>(
         with_spinner: config.with_spinner,
         resign_txs_count: config.resign_txs_count,
         rpc_send_transaction_config: RpcSendTransactionConfig {
-            skip_preflight: false,
             ..RpcSendTransactionConfig::default()
         },
     };

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -17,7 +17,6 @@ use {
     solana_sdk::{
         hash::Hash,
         message::Message,
-        msg,
         signature::{Signature, SignerError},
         signers::Signers,
         transaction::{Transaction, TransactionError},
@@ -210,13 +209,13 @@ async fn send_transaction_with_rpc_fallback(
     } else {
         true
     };
-    //println!("skipPreflight: {}", skip_preflight);
     if send_over_rpc {
         if let Err(e) = rpc_client
             .send_transaction_with_config(
                 &transaction,
                 RpcSendTransactionConfig {
                     skip_preflight,
+                    preflight_commitment: Some(rpc_client.commitment().commitment),
                     ..RpcSendTransactionConfig::default()
                 },
             )

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -868,6 +868,7 @@ impl RpcClient {
         };
         let config = RpcSendTransactionConfig {
             encoding: Some(encoding),
+            skip_preflight: config.skip_preflight,
             preflight_commitment: Some(preflight_commitment.commitment),
             ..config
         };

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -868,7 +868,6 @@ impl RpcClient {
         };
         let config = RpcSendTransactionConfig {
             encoding: Some(encoding),
-            skip_preflight: config.skip_preflight,
             preflight_commitment: Some(preflight_commitment.commitment),
             ..config
         };


### PR DESCRIPTION
#### Problem
CLI was missing the option to set skip-preflight option. 
This is especially useful because some RPC providers are not using swqos when preflight is enabled. 
This is speeding up program deployments by a lot using these RPC providers.  

#### Summary of Changes
I added skip-preflight as global flag and changed all the places where transactions are sent to use that flag. 
Some test had the skip preflight flag set to true, but it was not actually used. So these tests that were parsing the responses are adjusted to handle both cases. 


#### Refactoring? 
In an additional step if would maybe be nice to remove CommitmentConfig from the CliConfig and move it into the RpcSendTransactionConfig. But that looked like a bit of a bigger refactoring so I didnt include it. 
Another option would also be moving RpcSendTransactionConfig directly into RpcClient to enable it everywhere. But that is an even bigger refactoring. 

