### PR TITLE
Enable `std` for log in Geyser interface docblock

### DIFF
--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -10,7 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-log = { workspace = true }
+log = { workspace = true, features = ["std"] }
 solana-sdk = { workspace = true }
 solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
#### Problem

```
cd geyser-plugin-interface
cargo test
```

…fails with…

```
---- geyser-plugin-interface/src/geyser_plugin_interface.rs - geyser_plugin_interface::GeyserPlugin::setup_logger (line 361) stdout ----
error[E0277]: the trait bound `SetLoggerError: std::error::Error` is not satisfied
  --> geyser-plugin-interface/src/geyser_plugin_interface.rs:372:49
   |
14 |            return Err(GeyserPluginError::Custom(Box::new(err)));
   |                                                 ^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `SetLoggerError`
   |
   = note: required for the cast from `Box<SetLoggerError>` to `Box<(dyn std::error::Error + Send + Sync + 'static)>`
```

#### Summary of Changes

This enables the `std` feature for log, allowing the code in this docblock to typecheck.