### PR TITLE
[geyser] `s/shread/shred/` in `SlotStatus`

### DIFF
--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -339,7 +339,7 @@ impl SlotStatus {
             SlotStatus::Confirmed => "confirmed",
             SlotStatus::Processed => "processed",
             SlotStatus::Rooted => "rooted",
-            SlotStatus::FirstShredReceived => "first_shread_received",
+            SlotStatus::FirstShredReceived => "first_shred_received",
             SlotStatus::Completed => "completed",
             SlotStatus::CreatedBank => "created_bank",
             SlotStatus::Dead(_error) => "dead",


### PR DESCRIPTION
#### Problem

The enum label for ‘first shred received’ is spelled correctly, but the value is not.

#### Summary of Changes

`first_shread_received` => `first_shred_received`