### PR TITLE
extract inner-instruction crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7231,6 +7231,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-inner-instruction"
+version = "2.2.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-program",
+]
+
+[[package]]
 name = "solana-instruction"
 version = "2.2.0"
 dependencies = [
@@ -8523,6 +8532,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-inflation",
+ "solana-inner-instruction",
  "solana-instruction",
  "solana-keypair",
  "solana-logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7236,7 +7236,7 @@ version = "2.2.0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-program",
+ "solana-message",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ members = [
     "sdk/gen-headers",
     "sdk/hash",
     "sdk/inflation",
+    "sdk/inner-instruction",
     "sdk/instruction",
     "sdk/keccak-hasher",
     "sdk/keypair",
@@ -477,6 +478,7 @@ solana-gossip = { path = "gossip", version = "=2.2.0" }
 solana-hash = { path = "sdk/hash", version = "=2.2.0", default-features = false }
 solana-inflation = { path = "sdk/inflation", version = "=2.2.0" }
 solana-inline-spl = { path = "inline-spl", version = "=2.2.0" }
+solana-inner-instruction = { path = "sdk/inner-instruction", version = "=2.2.0" }
 solana-instruction = { path = "sdk/instruction", version = "=2.2.0", default-features = false }
 solana-keccak-hasher = { path = "sdk/keccak-hasher", version = "=2.2.0" }
 solana-keypair = { path = "sdk/keypair", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5768,6 +5768,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-inner-instruction"
+version = "2.2.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-program",
+]
+
+[[package]]
 name = "solana-instruction"
 version = "2.2.0"
 dependencies = [
@@ -7217,6 +7226,7 @@ dependencies = [
  "solana-feature-set",
  "solana-fee-structure",
  "solana-inflation",
+ "solana-inner-instruction",
  "solana-instruction",
  "solana-keypair",
  "solana-native-token",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5773,7 +5773,7 @@ version = "2.2.0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-program",
+ "solana-message",
 ]
 
 [[package]]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -134,6 +134,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-inflation = { workspace = true, features = ["serde"] }
+solana-inner-instruction = { workspace = true, features = ["serde"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true, optional = true, features = [
     "seed-derivable",

--- a/sdk/inner-instruction/Cargo.toml
+++ b/sdk/inner-instruction/Cargo.toml
@@ -10,9 +10,9 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-solana-program = { workspace = true, default-features = false }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
+solana-program = { workspace = true, default-features = false }
 
 [features]
 serde = ["dep:serde", "dep:serde_derive"]

--- a/sdk/inner-instruction/Cargo.toml
+++ b/sdk/inner-instruction/Cargo.toml
@@ -12,10 +12,10 @@ edition = { workspace = true }
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-program = { workspace = true, default-features = false }
+solana-message = { workspace = true }
 
 [features]
-serde = ["dep:serde", "dep:serde_derive"]
+serde = ["dep:serde", "dep:serde_derive", "solana-message/serde"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/inner-instruction/Cargo.toml
+++ b/sdk/inner-instruction/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "solana-inner-instruction"
+description = "Solana inner instruction types."
+documentation = "https://docs.rs/solana-inner-instruction"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-program = { workspace = true, default-features = false }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+
+[features]
+serde = ["dep:serde", "dep:serde_derive"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]

--- a/sdk/inner-instruction/src/lib.rs
+++ b/sdk/inner-instruction/src/lib.rs
@@ -1,10 +1,12 @@
-use {
-    crate::instruction::CompiledInstruction,
-    serde::{Deserialize, Serialize},
-};
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+use solana_program::instruction::CompiledInstruction;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize),
+    serde(rename_all = "camelCase")
+)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InnerInstruction {
     pub instruction: CompiledInstruction,
     /// Invocation stack height of this instruction. Instruction stack height

--- a/sdk/inner-instruction/src/lib.rs
+++ b/sdk/inner-instruction/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-use solana_program::instruction::CompiledInstruction;
+use solana_message::compiled_instruction::CompiledInstruction;
 
 #[cfg_attr(
     feature = "serde",

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -71,7 +71,6 @@ pub mod feature;
 pub mod genesis_config;
 pub mod hard_forks;
 pub mod hash;
-pub mod inner_instruction;
 pub mod log;
 pub mod native_loader;
 pub mod net;
@@ -130,6 +129,8 @@ pub use solana_feature_set as feature_set;
 pub use solana_fee_structure as fee;
 #[deprecated(since = "2.1.0", note = "Use `solana-inflation` crate instead")]
 pub use solana_inflation as inflation;
+#[deprecated(since = "2.2.0", note = "Use `solana-inner-instruction` crate instead")]
+pub use solana_inner_instruction as inner_instruction;
 #[deprecated(since = "2.1.0", note = "Use `solana-packet` crate instead")]
 pub use solana_packet as packet;
 #[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5588,6 +5588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-inner-instruction"
+version = "2.2.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-message",
+]
+
+[[package]]
 name = "solana-instruction"
 version = "2.2.0"
 dependencies = [
@@ -6552,6 +6561,7 @@ dependencies = [
  "solana-feature-set",
  "solana-fee-structure",
  "solana-inflation",
+ "solana-inner-instruction",
  "solana-instruction",
  "solana-keypair",
  "solana-native-token",


### PR DESCRIPTION
#### Problem
`solana_sdk::inner_instruction` imposes a `solana_sdk` dep on `solana_svm`, `solana_transaction_status` and `solana_banks_interface`

#### Summary of Changes
- Move to its own crate and re-export with deprecation notice
- Make serde optional in the new crate