### PR TITLE
v2.1 Add CODEOWNERS to v2.1 to restrict backports

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @anza-xyz/backport-reviewers


### PR DESCRIPTION
backport restrictions are implemented via the CODEOWNERS file, so copying the file from v2.0 to v2.1