### PR TITLE
add missing description for solana-lattice-hash

### DIFF
--- a/lattice-hash/Cargo.toml
+++ b/lattice-hash/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "solana-lattice-hash"
+description = "Solana Lattice Hash"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
#### Problem

need the `description` for publishing crate

#### Summary of Changes

add a basic one