### PR TITLE
test_hash_transactions

### DIFF
--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -1434,4 +1434,19 @@ mod tests {
             info!("{} {}", time, res);
         }
     }
+
+    #[test]
+    fn test_hash_transactions() {
+        let mut transactions: Vec<_> = [test_tx(), test_tx(), test_tx()]
+            .into_iter()
+            .map(VersionedTransaction::from)
+            .collect();
+
+        // Test different permutations of the transactions have different final hashes.
+        // i.e. that **order** of transactions is included in the hash.
+        let hash1 = hash_transactions(&transactions);
+        transactions.swap(0, 1);
+        let hash2 = hash_transactions(&transactions);
+        assert_ne!(hash1, hash2);
+    }
 }


### PR DESCRIPTION
#### Problem
- No existing test that this function's result depends on order of `transactions`
- The hash must be unique for different transaction orderings for SIMD83 to work i.e. inclusion proof is **not** enough

#### Summary of Changes
- Just add a simple test on transaction order permutations and hash uniqueness

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
