### PR TITLE
Add cli options to set the ancient storage tuning parameters

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -617,7 +617,7 @@ pub struct AccountsAddRootTiming {
 /// |  older  |<- abs(offset) ->|<- slots in an epoch ->| max root
 /// | ancient |                 modern                  |
 ///
-/// Note that another constant ANCIENT_STORAGES_MAX sets a
+/// Note that another constant DEFAULT_MAX_ANCIENT_STORAGES sets a
 /// threshold for combining ancient storages so that their overall
 /// number is under a certain limit, whereas this constant establishes
 /// the distance from the max root slot beyond which storages holding

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -500,8 +500,8 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     read_cache_limit_bytes: None,
     write_cache_limit_bytes: None,
     ancient_append_vec_offset: None,
-    ancient_ideal_storage_size: None,
-    ancient_storages_max: None,
+    ancient_storage_ideal_size: None,
+    max_ancient_storages: None,
     skip_initial_hash_calc: false,
     exhaustively_verify_refcounts: false,
     create_ancient_storage: CreateAncientStorage::Pack,
@@ -524,8 +524,8 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     read_cache_limit_bytes: None,
     write_cache_limit_bytes: None,
     ancient_append_vec_offset: None,
-    ancient_ideal_storage_size: None,
-    ancient_storages_max: None,
+    ancient_storage_ideal_size: None,
+    max_ancient_storages: None,
     skip_initial_hash_calc: false,
     exhaustively_verify_refcounts: false,
     create_ancient_storage: CreateAncientStorage::Pack,
@@ -627,10 +627,10 @@ const ANCIENT_APPEND_VEC_DEFAULT_OFFSET: Option<i64> = Some(100_000);
 /// The smallest size of ideal ancient storage.
 /// The setting can be overridden on the command line
 /// with --accounts-db-ancient-ideal-storage-size option.
-const ANCIENT_IDEAL_STORAGE_SIZE: u64 = 100_000;
+const DEFAULT_ANCIENT_STORAGE_IDEAL_SIZE: u64 = 100_000;
 /// Default value for the number of ancient storages the ancient slot
 /// combining should converge to.
-pub const ANCIENT_STORAGES_MAX: usize = 100_000;
+pub const DEFAULT_MAX_ANCIENT_STORAGES: usize = 100_000;
 
 #[derive(Debug, Default, Clone)]
 pub struct AccountsDbConfig {
@@ -648,8 +648,8 @@ pub struct AccountsDbConfig {
     /// if None, ancient append vecs are set to ANCIENT_APPEND_VEC_DEFAULT_OFFSET
     /// Some(offset) means include slots up to (max_slot - (slots_per_epoch - 'offset'))
     pub ancient_append_vec_offset: Option<i64>,
-    pub ancient_ideal_storage_size: Option<u64>,
-    pub ancient_storages_max: Option<usize>,
+    pub ancient_storage_ideal_size: Option<u64>,
+    pub max_ancient_storages: Option<usize>,
     pub test_skip_rewrites_but_include_in_bank_hash: bool,
     pub skip_initial_hash_calc: bool,
     pub exhaustively_verify_refcounts: bool,
@@ -1419,8 +1419,8 @@ pub struct AccountsDb {
     /// Some(offset) iff we want to squash old append vecs together into 'ancient append vecs'
     /// Some(offset) means for slots up to (max_slot - (slots_per_epoch - 'offset')), put them in ancient append vecs
     pub ancient_append_vec_offset: Option<i64>,
-    pub ancient_ideal_storage_size: u64,
-    pub ancient_storages_max: usize,
+    pub ancient_storage_ideal_size: u64,
+    pub max_ancient_storages: usize,
     /// true iff we want to skip the initial hash calculation on startup
     pub skip_initial_hash_calc: bool,
 
@@ -1955,12 +1955,12 @@ impl AccountsDb {
             ancient_append_vec_offset: accounts_db_config
                 .ancient_append_vec_offset
                 .or(ANCIENT_APPEND_VEC_DEFAULT_OFFSET),
-            ancient_ideal_storage_size: accounts_db_config
-                .ancient_ideal_storage_size
-                .unwrap_or(ANCIENT_IDEAL_STORAGE_SIZE),
-            ancient_storages_max: accounts_db_config
-                .ancient_storages_max
-                .unwrap_or(ANCIENT_STORAGES_MAX),
+            ancient_storage_ideal_size: accounts_db_config
+                .ancient_storage_ideal_size
+                .unwrap_or(DEFAULT_ANCIENT_STORAGE_IDEAL_SIZE),
+            max_ancient_storages: accounts_db_config
+                .max_ancient_storages
+                .unwrap_or(DEFAULT_MAX_ANCIENT_STORAGES),
             account_indexes: accounts_db_config.account_indexes.unwrap_or_default(),
             shrink_ratio: accounts_db_config.shrink_ratio,
             accounts_update_notifier,
@@ -15964,7 +15964,7 @@ pub mod tests {
         assert!(db
             .get_sorted_potential_ancient_slots(oldest_non_ancient_slot)
             .is_empty());
-        let root1 = ANCIENT_STORAGES_MAX as u64 + ancient_append_vec_offset as u64 + 1;
+        let root1 = DEFAULT_MAX_ANCIENT_STORAGES as u64 + ancient_append_vec_offset as u64 + 1;
         db.add_root(root1);
         let root2 = root1 + 1;
         db.add_root(root2);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -627,10 +627,10 @@ const ANCIENT_APPEND_VEC_DEFAULT_OFFSET: Option<i64> = Some(100_000);
 /// The smallest size of ideal ancient storage.
 /// The setting can be overridden on the command line
 /// with --accounts-db-ancient-ideal-storage-size option.
-const ANCIENT_IDEAL_STORAGE_SIZE: Option<u64> = Some(100_000);
+const ANCIENT_IDEAL_STORAGE_SIZE: u64 = 100_000;
 /// Default value for the number of ancient storages the ancient slot
 /// combining should converge to.
-pub const ANCIENT_STORAGES_MAX: Option<usize> = Some(100_000);
+pub const ANCIENT_STORAGES_MAX: usize = 100_000;
 
 #[derive(Debug, Default, Clone)]
 pub struct AccountsDbConfig {
@@ -1419,8 +1419,8 @@ pub struct AccountsDb {
     /// Some(offset) iff we want to squash old append vecs together into 'ancient append vecs'
     /// Some(offset) means for slots up to (max_slot - (slots_per_epoch - 'offset')), put them in ancient append vecs
     pub ancient_append_vec_offset: Option<i64>,
-    pub ancient_ideal_storage_size: Option<u64>,
-    pub ancient_storages_max: Option<usize>,
+    pub ancient_ideal_storage_size: u64,
+    pub ancient_storages_max: usize,
     /// true iff we want to skip the initial hash calculation on startup
     pub skip_initial_hash_calc: bool,
 
@@ -1957,10 +1957,10 @@ impl AccountsDb {
                 .or(ANCIENT_APPEND_VEC_DEFAULT_OFFSET),
             ancient_ideal_storage_size: accounts_db_config
                 .ancient_ideal_storage_size
-                .or(ANCIENT_IDEAL_STORAGE_SIZE),
+                .unwrap_or(ANCIENT_IDEAL_STORAGE_SIZE),
             ancient_storages_max: accounts_db_config
                 .ancient_storages_max
-                .or(ANCIENT_STORAGES_MAX),
+                .unwrap_or(ANCIENT_STORAGES_MAX),
             account_indexes: accounts_db_config.account_indexes.unwrap_or_default(),
             shrink_ratio: accounts_db_config.shrink_ratio,
             accounts_update_notifier,
@@ -15964,7 +15964,7 @@ pub mod tests {
         assert!(db
             .get_sorted_potential_ancient_slots(oldest_non_ancient_slot)
             .is_empty());
-        let root1 = ANCIENT_STORAGES_MAX.unwrap() as u64 + ancient_append_vec_offset as u64 + 1;
+        let root1 = ANCIENT_STORAGES_MAX as u64 + ancient_append_vec_offset as u64 + 1;
         db.add_root(root1);
         let root2 = root1 + 1;
         db.add_root(root2);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -504,6 +504,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     read_cache_limit_bytes: None,
     write_cache_limit_bytes: None,
     ancient_append_vec_offset: None,
+    ancient_ideal_storage_size: None,
     skip_initial_hash_calc: false,
     exhaustively_verify_refcounts: false,
     create_ancient_storage: CreateAncientStorage::Pack,
@@ -526,6 +527,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     read_cache_limit_bytes: None,
     write_cache_limit_bytes: None,
     ancient_append_vec_offset: None,
+    ancient_ideal_storage_size: None,
     skip_initial_hash_calc: false,
     exhaustively_verify_refcounts: false,
     create_ancient_storage: CreateAncientStorage::Pack,
@@ -624,6 +626,10 @@ pub struct AccountsAddRootTiming {
 /// the account data for the slots are considered ancient by the
 /// shrinking algorithm.
 const ANCIENT_APPEND_VEC_DEFAULT_OFFSET: Option<i64> = Some(100_000);
+/// The smallest size of ideal ancient storage.
+/// The setting can be overridden on the command line
+/// with --accounts-db-ancient-ideal-storage-size option.
+const ANCIENT_IDEAL_STORAGE_SIZE: Option<u64> = Some(5_000_000);
 
 #[derive(Debug, Default, Clone)]
 pub struct AccountsDbConfig {
@@ -641,6 +647,7 @@ pub struct AccountsDbConfig {
     /// if None, ancient append vecs are set to ANCIENT_APPEND_VEC_DEFAULT_OFFSET
     /// Some(offset) means include slots up to (max_slot - (slots_per_epoch - 'offset'))
     pub ancient_append_vec_offset: Option<i64>,
+    pub ancient_ideal_storage_size: Option<u64>,
     pub test_skip_rewrites_but_include_in_bank_hash: bool,
     pub skip_initial_hash_calc: bool,
     pub exhaustively_verify_refcounts: bool,
@@ -1410,7 +1417,7 @@ pub struct AccountsDb {
     /// Some(offset) iff we want to squash old append vecs together into 'ancient append vecs'
     /// Some(offset) means for slots up to (max_slot - (slots_per_epoch - 'offset')), put them in ancient append vecs
     pub ancient_append_vec_offset: Option<i64>,
-
+    pub ancient_ideal_storage_size: Option<u64>,
     /// true iff we want to skip the initial hash calculation on startup
     pub skip_initial_hash_calc: bool,
 
@@ -1945,6 +1952,9 @@ impl AccountsDb {
             ancient_append_vec_offset: accounts_db_config
                 .ancient_append_vec_offset
                 .or(ANCIENT_APPEND_VEC_DEFAULT_OFFSET),
+            ancient_ideal_storage_size: accounts_db_config
+                .ancient_ideal_storage_size
+                .or(ANCIENT_IDEAL_STORAGE_SIZE),
             account_indexes: accounts_db_config.account_indexes.unwrap_or_default(),
             shrink_ratio: accounts_db_config.shrink_ratio,
             accounts_update_notifier,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -342,7 +342,7 @@ impl AccountsDb {
     ) {
         let tuning = PackedAncientStorageTuning {
             // Slots old enough to be ancient.
-            max_ancient_slots: self.ancient_storages_max.unwrap(),
+            max_ancient_slots: self.ancient_storages_max,
             // Don't re-pack anything just to shrink.
             // shrink_candidate_slots will handle these old storages.
             percent_of_alive_shrunk_data: 0,
@@ -525,7 +525,7 @@ impl AccountsDb {
         // divided by half of max ancient slots
         tuning.ideal_storage_size = NonZeroU64::new(
             (ancient_slot_infos.total_alive_bytes.0 * 2 / tuning.max_ancient_slots.max(1) as u64)
-                .max(self.ancient_ideal_storage_size.unwrap()),
+                .max(self.ancient_ideal_storage_size),
         )
         .unwrap();
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -11,7 +11,6 @@ use {
             stats::{ShrinkAncientStats, ShrinkStatsSub},
             AccountFromStorage, AccountStorageEntry, AccountsDb, AliveAccounts,
             GetUniqueAccountsResult, ShrinkCollect, ShrinkCollectAliveSeparatedByRefs,
-            MAX_ANCIENT_SLOTS_DEFAULT,
         },
         accounts_file::AccountsFile,
         active_stats::ActiveStatItem,
@@ -342,9 +341,8 @@ impl AccountsDb {
         can_randomly_shrink: bool,
     ) {
         let tuning = PackedAncientStorageTuning {
-            // Slots old enough to be ancient.  Setting this parameter
-            // to 100k makes ancient storages to be approx 5M.
-            max_ancient_slots: MAX_ANCIENT_SLOTS_DEFAULT,
+            // Slots old enough to be ancient.
+            max_ancient_slots: self.ancient_storages_max.unwrap(),
             // Don't re-pack anything just to shrink.
             // shrink_candidate_slots will handle these old storages.
             percent_of_alive_shrunk_data: 0,
@@ -4005,7 +4003,7 @@ pub mod tests {
         let infos = db.collect_sort_filter_ancient_slots(slot_vec.clone(), &mut tuning);
         let ideal_storage_size = tuning.ideal_storage_size.get();
         let max_resulting_storages = tuning.max_resulting_storages.get();
-        let expected_all_infos_len = max_resulting_storages * ideal_storage_size / data_size - 1;
+        let expected_all_infos_len = max_resulting_storages * ideal_storage_size / data_size;
         assert_eq!(infos.all_infos.len(), expected_all_infos_len as usize);
     }
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -31,8 +31,6 @@ use {
 /// this many # of highest slot values should be treated as desirable to pack.
 /// This gives us high slots to move packed accounts into.
 const HIGH_SLOT_OFFSET: u64 = 100;
-/// The smallest size of ideal ancient storage.
-const MINIMAL_IDEAL_STORAGE_SIZE: u64 = 5_000_000;
 
 /// ancient packing algorithm tuning per pass
 #[derive(Debug)]
@@ -529,7 +527,7 @@ impl AccountsDb {
         // divided by half of max ancient slots
         tuning.ideal_storage_size = NonZeroU64::new(
             (ancient_slot_infos.total_alive_bytes.0 * 2 / tuning.max_ancient_slots.max(1) as u64)
-                .max(MINIMAL_IDEAL_STORAGE_SIZE),
+                .max(self.ancient_ideal_storage_size.unwrap()),
         )
         .unwrap();
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -342,7 +342,7 @@ impl AccountsDb {
     ) {
         let tuning = PackedAncientStorageTuning {
             // Slots old enough to be ancient.
-            max_ancient_slots: self.ancient_storages_max,
+            max_ancient_slots: self.max_ancient_storages,
             // Don't re-pack anything just to shrink.
             // shrink_candidate_slots will handle these old storages.
             percent_of_alive_shrunk_data: 0,
@@ -525,7 +525,7 @@ impl AccountsDb {
         // divided by half of max ancient slots
         tuning.ideal_storage_size = NonZeroU64::new(
             (ancient_slot_infos.total_alive_bytes.0 * 2 / tuning.max_ancient_slots.max(1) as u64)
-                .max(self.ancient_ideal_storage_size),
+                .max(self.ancient_storage_ideal_size),
         )
         .unwrap();
 

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -139,6 +139,20 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .validator(|s| is_within_range(s, 1..=num_cpus::get()))
             .help("Number of threads to use for background accounts hashing")
             .hidden(hidden_unless_forced()),
+        Arg::with_name("accounts_db_ancient_storage_ideal_size")
+            .long("accounts-db-ancient-storage-ideal-size")
+            .value_name("BYTES")
+            .validator(is_parsable::<u64>)
+            .takes_value(true)
+            .help("The smallest size of ideal ancient storage.")
+            .hidden(hidden_unless_forced()),
+        Arg::with_name("accounts_db_max_ancient_storages")
+            .long("accounts-db-max-ancient-storages")
+            .value_name("USIZE")
+            .validator(is_parsable::<usize>)
+            .takes_value(true)
+            .help("The number of ancient storages the ancient slot combining should converge to.")
+            .hidden(hidden_unless_forced()),
     ]
     .into_boxed_slice()
 }
@@ -349,6 +363,13 @@ pub fn get_accounts_db_config(
         accounts_hash_cache_path: Some(accounts_hash_cache_path),
         ancient_append_vec_offset: value_t!(arg_matches, "accounts_db_ancient_append_vecs", i64)
             .ok(),
+        ancient_storage_ideal_size: value_t!(
+            arg_matches,
+            "accounts_db_ancient_storage_ideal_size",
+            u64
+        )
+        .ok(),
+        max_ancient_storages: value_t!(arg_matches, "accounts_db_max_ancient_storages", usize).ok(),
         exhaustively_verify_refcounts: arg_matches.is_present("accounts_db_verify_refcounts"),
         skip_initial_hash_calc: arg_matches.is_present("accounts_db_skip_initial_hash_calculation"),
         test_partitioned_epoch_rewards,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1385,6 +1385,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .hidden(hidden_unless_forced()),
         )
         .arg(
+            Arg::with_name("accounts_db_ancient_storages_max")
+                .long("accounts-db-ancient-storages-max")
+                .value_name("USIZE")
+                .validator(is_parsable::<usize>)
+                .takes_value(true)
+                .help("The number of ancient storages the ancient slot combining should converge to.")
+                .hidden(hidden_unless_forced()),
+        )
+        .arg(
             Arg::with_name("accounts_db_cache_limit_mb")
                 .long("accounts-db-cache-limit-mb")
                 .value_name("MEGABYTES")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1376,8 +1376,8 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .hidden(hidden_unless_forced()),
         )
         .arg(
-            Arg::with_name("accounts_db_ancient_ideal_storage_size")
-                .long("accounts-db-ancient-ideal-storage-size")
+            Arg::with_name("accounts_db_ancient_storage_ideal_size")
+                .long("accounts-db-ancient-storage-ideal-size")
                 .value_name("BYTES")
                 .validator(is_parsable::<u64>)
                 .takes_value(true)
@@ -1385,8 +1385,8 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .hidden(hidden_unless_forced()),
         )
         .arg(
-            Arg::with_name("accounts_db_ancient_storages_max")
-                .long("accounts-db-ancient-storages-max")
+            Arg::with_name("accounts_db_max_ancient_storages")
+                .long("accounts-db-max-ancient-storages")
                 .value_name("USIZE")
                 .validator(is_parsable::<usize>)
                 .takes_value(true)

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1376,6 +1376,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .hidden(hidden_unless_forced()),
         )
         .arg(
+            Arg::with_name("accounts_db_ancient_ideal_storage_size")
+                .long("accounts-db-ancient-ideal-storage-size")
+                .value_name("BYTES")
+                .validator(is_parsable::<u64>)
+                .takes_value(true)
+                .help("The smallest size of ideal ancient storage.")
+                .hidden(hidden_unless_forced()),
+        )
+        .arg(
             Arg::with_name("accounts_db_cache_limit_mb")
                 .long("accounts-db-cache-limit-mb")
                 .value_name("MEGABYTES")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1315,6 +1315,12 @@ pub fn main() {
             u64
         )
         .ok(),
+        ancient_storages_max: value_t!(
+            matches,
+            "accounts_db_ancient_storages_max",
+            usize
+        )
+        .ok(),
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
         create_ancient_storage,
         test_partitioned_epoch_rewards,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1309,13 +1309,13 @@ pub fn main() {
             .ok()
             .map(|mb| mb * MB as u64),
         ancient_append_vec_offset: value_t!(matches, "accounts_db_ancient_append_vecs", i64).ok(),
-        ancient_ideal_storage_size: value_t!(
+        ancient_storage_ideal_size: value_t!(
             matches,
-            "accounts_db_ancient_ideal_storage_size",
+            "accounts_db_ancient_storage_ideal_size",
             u64
         )
         .ok(),
-        ancient_storages_max: value_t!(matches, "accounts_db_ancient_storages_max", usize).ok(),
+        max_ancient_storages: value_t!(matches, "accounts_db_max_ancient_storages", usize).ok(),
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
         create_ancient_storage,
         test_partitioned_epoch_rewards,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1309,6 +1309,12 @@ pub fn main() {
             .ok()
             .map(|mb| mb * MB as u64),
         ancient_append_vec_offset: value_t!(matches, "accounts_db_ancient_append_vecs", i64).ok(),
+        ancient_ideal_storage_size: value_t!(
+            matches,
+            "accounts_db_ancient_ideal_storage_size",
+            u64
+        )
+        .ok(),
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
         create_ancient_storage,
         test_partitioned_epoch_rewards,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1315,12 +1315,7 @@ pub fn main() {
             u64
         )
         .ok(),
-        ancient_storages_max: value_t!(
-            matches,
-            "accounts_db_ancient_storages_max",
-            usize
-        )
-        .ok(),
+        ancient_storages_max: value_t!(matches, "accounts_db_ancient_storages_max", usize).ok(),
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
         create_ancient_storage,
         test_partitioned_epoch_rewards,


### PR DESCRIPTION
#### Problem

Ideal ancient storage size and the maximum number of ancient storage files are hard coded as compile time constants. This disables experimentation with various sizes.

#### Summary of Changes

Add hidden validator command line options to specify the aforementioned parameters to enable experimentation.
