### PR TITLE
Revert "remove test-only bool arg from calculate_fee (#3211)"

### DIFF
--- a/cli/tests/address_lookup_table.rs
+++ b/cli/tests/address_lookup_table.rs
@@ -23,11 +23,8 @@ fn test_cli_create_extend_and_freeze_address_lookup_table() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
@@ -141,11 +138,8 @@ fn test_cli_create_and_deactivate_address_lookup_table() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -81,11 +81,8 @@ fn test_cli_program_deploy_non_upgradeable() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -289,11 +286,8 @@ fn test_cli_program_deploy_no_authority() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -684,11 +678,8 @@ fn test_cli_program_deploy_with_authority() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -1088,11 +1079,8 @@ fn test_cli_program_upgrade_auto_extend() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -1244,11 +1232,8 @@ fn test_cli_program_close_program() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -1366,11 +1351,8 @@ fn test_cli_program_extend_program() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -1539,11 +1521,8 @@ fn test_cli_program_write_buffer() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -2029,11 +2008,8 @@ fn test_cli_program_set_buffer_authority() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -2204,11 +2180,8 @@ fn test_cli_program_mismatch_buffer_authority() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -2333,11 +2306,8 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -2529,11 +2499,8 @@ fn test_cli_program_show() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -2729,11 +2696,8 @@ fn test_cli_program_dump() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -17,11 +17,8 @@ fn test_cli_request_airdrop() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let mut bob_config = CliConfig::recent_for_tests();
     bob_config.json_rpc_url = test_validator.rpc_url();

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -205,11 +205,8 @@ fn test_seed_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -304,11 +301,8 @@ fn test_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -399,11 +393,8 @@ fn test_offline_stake_delegation_and_deactivation(compute_unit_price: Option<u64
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -562,11 +553,8 @@ fn test_nonced_stake_delegation_and_deactivation(compute_unit_price: Option<u64>
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -694,11 +682,8 @@ fn test_stake_authorize(compute_unit_price: Option<u64>) {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -1656,11 +1641,8 @@ fn test_offline_nonced_create_stake_account_and_withdraw(compute_unit_price: Opt
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -1691,10 +1673,10 @@ fn test_offline_nonced_create_stake_account_and_withdraw(compute_unit_price: Opt
         &rpc_client,
         &config_offline,
         &offline_pubkey,
-        200_000_000_000,
+        100_000_000_000,
     )
     .unwrap();
-    check_balance!(200_000_000_000, &rpc_client, &offline_pubkey);
+    check_balance!(100_000_000_000, &rpc_client, &offline_pubkey);
 
     // Create nonce account
     let minimum_nonce_balance = rpc_client
@@ -1902,11 +1884,8 @@ fn test_stake_checked_instructions() {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -2140,7 +2119,7 @@ fn test_stake_checked_instructions() {
 #[test]
 fn test_stake_minimum_delegation() {
     let test_validator =
-        TestValidator::with_no_base_fees(Pubkey::new_unique(), None, SocketAddrSpace::Unspecified);
+        TestValidator::with_no_fees(Pubkey::new_unique(), None, SocketAddrSpace::Unspecified);
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
 

--- a/cli/tests/validator_info.rs
+++ b/cli/tests/validator_info.rs
@@ -23,11 +23,8 @@ fn test_publish(compute_unit_price: Option<u64>) {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -26,11 +26,8 @@ fn test_vote_authorize_and_withdraw(compute_unit_price: Option<u64>) {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -40,14 +37,8 @@ fn test_vote_authorize_and_withdraw(compute_unit_price: Option<u64>) {
     config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&default_signer];
 
-    let priority_fee = 200_000 * compute_unit_price.unwrap_or(0);
-    request_and_confirm_airdrop(
-        &rpc_client,
-        &config,
-        &config.signers[0].pubkey(),
-        100_000 + priority_fee,
-    )
-    .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &config, &config.signers[0].pubkey(), 100_000)
+        .unwrap();
 
     // Create vote account
     let vote_account_keypair = Keypair::new();
@@ -240,11 +231,8 @@ fn test_offline_vote_authorize_and_withdraw(compute_unit_price: Option<u64>) {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
-    let test_validator = TestValidator::with_no_base_fees(
-        mint_pubkey,
-        Some(faucet_addr),
-        SocketAddrSpace::Unspecified,
-    );
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
 
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
@@ -262,32 +250,23 @@ fn test_offline_vote_authorize_and_withdraw(compute_unit_price: Option<u64>) {
     // Verify that we cannot reach the cluster
     process_command(&config_offline).unwrap_err();
 
-    let airdrop_amount = 100_000_000;
     request_and_confirm_airdrop(
         &rpc_client,
         &config_payer,
         &config_payer.signers[0].pubkey(),
-        airdrop_amount,
+        100_000,
     )
     .unwrap();
-    check_balance!(
-        airdrop_amount,
-        &rpc_client,
-        &config_payer.signers[0].pubkey()
-    );
+    check_balance!(100_000, &rpc_client, &config_payer.signers[0].pubkey());
 
     request_and_confirm_airdrop(
         &rpc_client,
         &config_offline,
         &config_offline.signers[0].pubkey(),
-        airdrop_amount,
+        100_000,
     )
     .unwrap();
-    check_balance!(
-        airdrop_amount,
-        &rpc_client,
-        &config_offline.signers[0].pubkey()
-    );
+    check_balance!(100_000, &rpc_client, &config_offline.signers[0].pubkey());
 
     // Create vote account with specific withdrawer
     let vote_account_keypair = Keypair::new();

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -64,7 +64,7 @@ fn test_rpc_client() {
 
     let alice = Keypair::new();
     let test_validator =
-        TestValidator::with_no_base_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
+        TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
 
     let bob_pubkey = solana_sdk::pubkey::new_rand();
 

--- a/client-test/tests/send_and_confirm_transactions_in_parallel.rs
+++ b/client-test/tests/send_and_confirm_transactions_in_parallel.rs
@@ -36,7 +36,7 @@ fn test_send_and_confirm_transactions_in_parallel_without_tpu_client() {
 
     let alice = Keypair::new();
     let test_validator =
-        TestValidator::with_no_base_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
+        TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
 
     let bob_pubkey = solana_sdk::pubkey::new_rand();
     let alice_pubkey = alice.pubkey();
@@ -86,7 +86,7 @@ fn test_send_and_confirm_transactions_in_parallel_with_tpu_client() {
 
     let alice = Keypair::new();
     let test_validator =
-        TestValidator::with_no_base_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
+        TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
 
     let bob_pubkey = solana_sdk::pubkey::new_rand();
     let alice_pubkey = alice.pubkey();

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -761,6 +761,7 @@ impl Consumer {
         )?);
         let fee = solana_fee::calculate_fee(
             message,
+            bank.get_lamports_per_signature() == 0,
             bank.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             bank.feature_set

--- a/fee/src/lib.rs
+++ b/fee/src/lib.rs
@@ -1,14 +1,16 @@
 use {solana_sdk::fee::FeeDetails, solana_svm_transaction::svm_message::SVMMessage};
 
-/// Calculate fee for `SVMMessage`
+/// Calculate fee for `SanitizedMessage`
 pub fn calculate_fee(
     message: &impl SVMMessage,
+    zero_fees_for_test: bool,
     lamports_per_signature: u64,
     prioritization_fee: u64,
     remove_rounding_in_fee_calculation: bool,
 ) -> u64 {
     calculate_fee_details(
         message,
+        zero_fees_for_test,
         lamports_per_signature,
         prioritization_fee,
         remove_rounding_in_fee_calculation,
@@ -18,10 +20,14 @@ pub fn calculate_fee(
 
 pub fn calculate_fee_details(
     message: &impl SVMMessage,
+    zero_fees_for_test: bool,
     lamports_per_signature: u64,
     prioritization_fee: u64,
     remove_rounding_in_fee_calculation: bool,
 ) -> FeeDetails {
+    if zero_fees_for_test {
+        return FeeDetails::default();
+    }
     let signature_fee = message
         .num_total_signatures()
         .saturating_mul(lamports_per_signature);

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3854,7 +3854,7 @@ fn test_program_fees() {
     let mut bank = Bank::new_for_tests(&genesis_config);
     let fee_structure =
         FeeStructure::new(0.000005, 0.0, vec![(200, 0.0000005), (1400000, 0.000005)]);
-    bank.set_fee_structure(fee_structure.clone());
+    bank.set_fee_structure(&fee_structure);
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
     let mut bank_client = BankClient::new_shared(bank);
     let authority_keypair = Keypair::new();
@@ -3886,6 +3886,7 @@ fn test_program_fees() {
     );
     let expected_normal_fee = solana_fee::calculate_fee(
         &sanitized_message,
+        congestion_multiplier == 0,
         fee_structure.lamports_per_signature,
         fee_budget_limits.prioritization_fee,
         true,
@@ -3917,6 +3918,7 @@ fn test_program_fees() {
     );
     let expected_prioritized_fee = solana_fee::calculate_fee(
         &sanitized_message,
+        congestion_multiplier == 0,
         fee_structure.lamports_per_signature,
         fee_budget_limits.prioritization_fee,
         true,

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -69,7 +69,7 @@ fn test_rpc_send_tx() {
 
     let alice = Keypair::new();
     let test_validator =
-        TestValidator::with_no_base_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
+        TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
     let rpc_url = test_validator.rpc_url();
 
     let bob_pubkey = solana_sdk::pubkey::new_rand();
@@ -141,8 +141,7 @@ fn test_simulation_replaced_blockhash() -> ClientResult<()> {
     solana_logger::setup();
 
     let alice = Keypair::new();
-    let validator =
-        TestValidator::with_no_base_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
+    let validator = TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
     let rpc_client = RpcClient::new(validator.rpc_url());
 
     let bob = Keypair::new();
@@ -188,7 +187,7 @@ fn test_rpc_invalid_requests() {
 
     let alice = Keypair::new();
     let test_validator =
-        TestValidator::with_no_base_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
+        TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
     let rpc_url = test_validator.rpc_url();
 
     let bob_pubkey = solana_sdk::pubkey::new_rand();
@@ -220,7 +219,7 @@ fn test_rpc_slot_updates() {
     solana_logger::setup();
 
     let test_validator =
-        TestValidator::with_no_base_fees(Pubkey::new_unique(), None, SocketAddrSpace::Unspecified);
+        TestValidator::with_no_fees(Pubkey::new_unique(), None, SocketAddrSpace::Unspecified);
 
     // Track when slot updates are ready
     let (update_sender, update_receiver) = unbounded::<SlotUpdate>();
@@ -498,7 +497,7 @@ fn run_tpu_send_transaction(tpu_use_quic: bool) {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let test_validator =
-        TestValidator::with_no_base_fees(mint_pubkey, None, SocketAddrSpace::Unspecified);
+        TestValidator::with_no_fees(mint_pubkey, None, SocketAddrSpace::Unspecified);
     let rpc_client = Arc::new(RpcClient::new_with_commitment(
         test_validator.rpc_url(),
         CommitmentConfig::processed(),
@@ -560,8 +559,7 @@ fn deserialize_rpc_error() -> ClientResult<()> {
     solana_logger::setup();
 
     let alice = Keypair::new();
-    let validator =
-        TestValidator::with_no_base_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
+    let validator = TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
     let rpc_client = RpcClient::new(validator.rpc_url());
 
     let bob = Keypair::new();

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -78,6 +78,7 @@ impl Bank {
     ) -> u64 {
         let fee_details = solana_fee::calculate_fee_details(
             transaction,
+            self.get_lamports_per_signature() == 0,
             self.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             self.feature_set

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2693,6 +2693,10 @@ fn test_bank_tx_compute_unit_fee() {
 
     let expected_fee_paid = calculate_test_fee(
         &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
+        genesis_config
+            .fee_rate_governor
+            .create_fee_calculator()
+            .lamports_per_signature,
         bank.fee_structure(),
     );
 
@@ -2777,6 +2781,130 @@ fn test_bank_tx_compute_unit_fee() {
                 commission: None,
             }
         )]
+    );
+}
+
+#[test]
+fn test_bank_blockhash_fee_structure() {
+    //solana_logger::setup();
+
+    let leader = solana_sdk::pubkey::new_rand();
+    let GenesisConfigInfo {
+        mut genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config_with_leader(1_000_000, &leader, 3);
+    genesis_config
+        .fee_rate_governor
+        .target_lamports_per_signature = 5000;
+    genesis_config.fee_rate_governor.target_signatures_per_slot = 0;
+
+    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    goto_end_of_slot(bank.clone());
+    let cheap_blockhash = bank.last_blockhash();
+    let cheap_lamports_per_signature = bank.get_lamports_per_signature();
+    assert_eq!(cheap_lamports_per_signature, 0);
+
+    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
+    goto_end_of_slot(bank.clone());
+    let expensive_blockhash = bank.last_blockhash();
+    let expensive_lamports_per_signature = bank.get_lamports_per_signature();
+    assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
+
+    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
+
+    // Send a transfer using cheap_blockhash
+    let key = solana_sdk::pubkey::new_rand();
+    let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
+    let tx = system_transaction::transfer(&mint_keypair, &key, 1, cheap_blockhash);
+    assert_eq!(bank.process_transaction(&tx), Ok(()));
+    assert_eq!(bank.get_balance(&key), 1);
+    let cheap_fee = calculate_test_fee(
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
+        cheap_lamports_per_signature,
+        bank.fee_structure(),
+    );
+    assert_eq!(
+        bank.get_balance(&mint_keypair.pubkey()),
+        initial_mint_balance - 1 - cheap_fee
+    );
+
+    // Send a transfer using expensive_blockhash
+    let key = solana_sdk::pubkey::new_rand();
+    let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
+    let tx = system_transaction::transfer(&mint_keypair, &key, 1, expensive_blockhash);
+    assert_eq!(bank.process_transaction(&tx), Ok(()));
+    assert_eq!(bank.get_balance(&key), 1);
+    let expensive_fee = calculate_test_fee(
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
+        expensive_lamports_per_signature,
+        bank.fee_structure(),
+    );
+    assert_eq!(
+        bank.get_balance(&mint_keypair.pubkey()),
+        initial_mint_balance - 1 - expensive_fee
+    );
+}
+
+#[test]
+fn test_bank_blockhash_compute_unit_fee_structure() {
+    //solana_logger::setup();
+
+    let leader = solana_sdk::pubkey::new_rand();
+    let GenesisConfigInfo {
+        mut genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config_with_leader(1_000_000_000, &leader, 3);
+    genesis_config
+        .fee_rate_governor
+        .target_lamports_per_signature = 1000;
+    genesis_config.fee_rate_governor.target_signatures_per_slot = 1;
+
+    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    goto_end_of_slot(bank.clone());
+    let cheap_blockhash = bank.last_blockhash();
+    let cheap_lamports_per_signature = bank.get_lamports_per_signature();
+    assert_eq!(cheap_lamports_per_signature, 0);
+
+    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
+    goto_end_of_slot(bank.clone());
+    let expensive_blockhash = bank.last_blockhash();
+    let expensive_lamports_per_signature = bank.get_lamports_per_signature();
+    assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
+
+    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
+
+    // Send a transfer using cheap_blockhash
+    let key = solana_sdk::pubkey::new_rand();
+    let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
+    let tx = system_transaction::transfer(&mint_keypair, &key, 1, cheap_blockhash);
+    assert_eq!(bank.process_transaction(&tx), Ok(()));
+    assert_eq!(bank.get_balance(&key), 1);
+    let cheap_fee = calculate_test_fee(
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
+        cheap_lamports_per_signature,
+        bank.fee_structure(),
+    );
+    assert_eq!(
+        bank.get_balance(&mint_keypair.pubkey()),
+        initial_mint_balance - 1 - cheap_fee
+    );
+
+    // Send a transfer using expensive_blockhash
+    let key = solana_sdk::pubkey::new_rand();
+    let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
+    let tx = system_transaction::transfer(&mint_keypair, &key, 1, expensive_blockhash);
+    assert_eq!(bank.process_transaction(&tx), Ok(()));
+    assert_eq!(bank.get_balance(&key), 1);
+    let expensive_fee = calculate_test_fee(
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
+        expensive_lamports_per_signature,
+        bank.fee_structure(),
+    );
+    assert_eq!(
+        bank.get_balance(&mint_keypair.pubkey()),
+        initial_mint_balance - 1 - expensive_fee
     );
 }
 
@@ -10066,13 +10194,18 @@ fn test_call_precomiled_program() {
     bank.process_transaction(&tx).unwrap();
 }
 
-fn calculate_test_fee(message: &impl SVMMessage, fee_structure: &FeeStructure) -> u64 {
+fn calculate_test_fee(
+    message: &impl SVMMessage,
+    lamports_per_signature: u64,
+    fee_structure: &FeeStructure,
+) -> u64 {
     let fee_budget_limits = FeeBudgetLimits::from(
         process_compute_budget_instructions(message.program_instructions_iter())
             .unwrap_or_default(),
     );
     solana_fee::calculate_fee(
         message,
+        lamports_per_signature == 0,
         fee_structure.lamports_per_signature,
         fee_budget_limits.prioritization_fee,
         true,
@@ -10086,6 +10219,7 @@ fn test_calculate_fee() {
     assert_eq!(
         calculate_test_fee(
             &message,
+            0,
             &FeeStructure {
                 lamports_per_signature: 0,
                 ..FeeStructure::default()
@@ -10098,6 +10232,7 @@ fn test_calculate_fee() {
     assert_eq!(
         calculate_test_fee(
             &message,
+            1,
             &FeeStructure {
                 lamports_per_signature: 1,
                 ..FeeStructure::default()
@@ -10115,6 +10250,7 @@ fn test_calculate_fee() {
     assert_eq!(
         calculate_test_fee(
             &message,
+            2,
             &FeeStructure {
                 lamports_per_signature: 2,
                 ..FeeStructure::default()
@@ -10137,7 +10273,7 @@ fn test_calculate_fee_compute_units() {
 
     let message = new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique())));
     assert_eq!(
-        calculate_test_fee(&message, &fee_structure,),
+        calculate_test_fee(&message, 1, &fee_structure,),
         max_fee + lamports_per_signature
     );
 
@@ -10147,7 +10283,7 @@ fn test_calculate_fee_compute_units() {
     let ix1 = system_instruction::transfer(&Pubkey::new_unique(), &Pubkey::new_unique(), 1);
     let message = new_sanitized_message(Message::new(&[ix0, ix1], Some(&Pubkey::new_unique())));
     assert_eq!(
-        calculate_test_fee(&message, &fee_structure,),
+        calculate_test_fee(&message, 1, &fee_structure,),
         max_fee + 3 * lamports_per_signature
     );
 
@@ -10179,7 +10315,7 @@ fn test_calculate_fee_compute_units() {
             ],
             Some(&Pubkey::new_unique()),
         ));
-        let fee = calculate_test_fee(&message, &fee_structure);
+        let fee = calculate_test_fee(&message, 1, &fee_structure);
         assert_eq!(
             fee,
             lamports_per_signature + prioritization_fee_details.get_fee()
@@ -10210,7 +10346,11 @@ fn test_calculate_prioritization_fee() {
         Some(&Pubkey::new_unique()),
     ));
 
-    let fee = calculate_test_fee(&message, &fee_structure);
+    let fee = calculate_test_fee(
+        &message,
+        fee_structure.lamports_per_signature,
+        &fee_structure,
+    );
     assert_eq!(
         fee,
         fee_structure.lamports_per_signature + prioritization_fee
@@ -10246,7 +10386,7 @@ fn test_calculate_fee_secp256k1() {
         ],
         Some(&key0),
     ));
-    assert_eq!(calculate_test_fee(&message, &fee_structure,), 2);
+    assert_eq!(calculate_test_fee(&message, 1, &fee_structure,), 2);
 
     secp_instruction1.data = vec![0];
     secp_instruction2.data = vec![10];
@@ -10254,7 +10394,7 @@ fn test_calculate_fee_secp256k1() {
         &[ix0, secp_instruction1, secp_instruction2],
         Some(&key0),
     ));
-    assert_eq!(calculate_test_fee(&message, &fee_structure,), 11);
+    assert_eq!(calculate_test_fee(&message, 1, &fee_structure,), 11);
 }
 
 #[test]
@@ -11793,6 +11933,10 @@ fn test_feature_hashes_per_tick() {
 
 #[test]
 fn test_calculate_fee_with_congestion_multiplier() {
+    let lamports_scale: u64 = 5;
+    let base_lamports_per_signature: u64 = 5_000;
+    let cheap_lamports_per_signature: u64 = base_lamports_per_signature / lamports_scale;
+    let expensive_lamports_per_signature: u64 = base_lamports_per_signature * lamports_scale;
     let signature_count: u64 = 2;
     let signature_fee: u64 = 10;
     let fee_structure = FeeStructure {
@@ -11810,14 +11954,14 @@ fn test_calculate_fee_with_congestion_multiplier() {
     // assert when lamports_per_signature is less than BASE_LAMPORTS, turnning on/off
     // congestion_multiplier has no effect on fee.
     assert_eq!(
-        calculate_test_fee(&message, &fee_structure),
+        calculate_test_fee(&message, cheap_lamports_per_signature, &fee_structure),
         signature_fee * signature_count
     );
 
     // assert when lamports_per_signature is more than BASE_LAMPORTS, turnning on/off
     // congestion_multiplier will change calculated fee.
     assert_eq!(
-        calculate_test_fee(&message, &fee_structure,),
+        calculate_test_fee(&message, expensive_lamports_per_signature, &fee_structure,),
         signature_fee * signature_count
     );
 }
@@ -11826,6 +11970,7 @@ fn test_calculate_fee_with_congestion_multiplier() {
 fn test_calculate_fee_with_request_heap_frame_flag() {
     let key0 = Pubkey::new_unique();
     let key1 = Pubkey::new_unique();
+    let lamports_per_signature: u64 = 5_000;
     let signature_fee: u64 = 10;
     let request_cu: u64 = 1;
     let lamports_per_cu: u64 = 5;
@@ -11846,7 +11991,7 @@ fn test_calculate_fee_with_request_heap_frame_flag() {
     // assert when request_heap_frame is presented in tx, prioritization fee will be counted
     // into transaction fee
     assert_eq!(
-        calculate_test_fee(&message, &fee_structure),
+        calculate_test_fee(&message, lamports_per_signature, &fee_structure),
         signature_fee + request_cu * lamports_per_cu
     );
 }

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -82,17 +82,6 @@ impl FeeDetails {
 pub const ACCOUNT_DATA_COST_PAGE_SIZE: u64 = 32_u64.saturating_mul(1024);
 
 impl FeeStructure {
-    pub fn zero_fees() -> Self {
-        Self {
-            lamports_per_signature: 0,
-            lamports_per_write_lock: 0,
-            compute_fee_bins: vec![FeeBin {
-                limit: u64::MAX,
-                fee: 0,
-            }],
-        }
-    }
-
     pub fn new(
         sol_per_signature: f64,
         sol_per_write_lock: f64,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -479,12 +479,13 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         let CheckedTransactionDetails {
             nonce,
-            lamports_per_signature: _,
+            lamports_per_signature,
         } = checked_details;
 
         let fee_budget_limits = FeeBudgetLimits::from(compute_budget_limits);
         let fee_details = solana_fee::calculate_fee_details(
             message,
+            lamports_per_signature == 0,
             fee_structure.lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             feature_set.is_active(&remove_rounding_in_fee_calculation::id()),

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -702,7 +702,7 @@ impl TestValidator {
     /// Faucet optional.
     ///
     /// This function panics on initialization failure.
-    pub fn with_no_base_fees(
+    pub fn with_no_fees(
         mint_address: Pubkey,
         faucet_addr: Option<SocketAddr>,
         socket_addr_space: SocketAddrSpace,

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -1350,7 +1350,7 @@ mod tests {
 
     fn simple_test_validator_no_fees(pubkey: Pubkey) -> TestValidator {
         let test_validator =
-            TestValidator::with_no_base_fees(pubkey, None, SocketAddrSpace::Unspecified);
+            TestValidator::with_no_fees(pubkey, None, SocketAddrSpace::Unspecified);
         test_validator.set_startup_verification_complete_for_tests();
         test_validator
     }

--- a/tokens/tests/commands.rs
+++ b/tokens/tests/commands.rs
@@ -12,7 +12,7 @@ fn test_process_distribute_with_rpc_client() {
 
     let mint_keypair = Keypair::new();
     let test_validator =
-        TestValidator::with_no_base_fees(mint_keypair.pubkey(), None, SocketAddrSpace::Unspecified);
+        TestValidator::with_no_fees(mint_keypair.pubkey(), None, SocketAddrSpace::Unspecified);
 
     let client = RpcClient::new(test_validator.rpc_url());
     test_process_distribute_tokens_with_client(&client, mint_keypair, None);


### PR DESCRIPTION
This reverts commit aad0381e10e3c4a6507d9aa2e57588e6dc6fc995.

#### Problem
- Testnet has a 0 `target_lamports_per_signature` in its genesis config which was triggering this case intended to be for only local-cluster/tests.

#### Summary of Changes
- Revert the commit

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
