### PR TITLE
Remove solana-sdk from solana-metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7453,6 +7453,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "serial_test",
+ "solana-clock",
  "solana-cluster-type",
  "solana-sha256-hasher",
  "solana-time-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7453,7 +7453,9 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "serial_test",
- "solana-sdk",
+ "solana-cluster-type",
+ "solana-sha256-hasher",
+ "solana-time-utils",
  "thiserror 1.0.69",
 ]
 

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -15,6 +15,7 @@ gethostname = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+solana-clock = { workspace = true }
 solana-cluster-type = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-time-utils = { workspace = true }

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -15,7 +15,9 @@ gethostname = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
-solana-sdk = { workspace = true }
+solana-cluster-type = { workspace = true }
+solana-sha256-hasher = { workspace = true }
+solana-time-utils = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -1,7 +1,6 @@
 use {
     crate::metrics::submit_counter,
     log::*,
-    solana_sdk::timing,
     std::{
         env,
         sync::atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -174,7 +173,7 @@ impl Counter {
             .compare_and_swap(0, Self::default_metrics_rate(), Ordering::Relaxed);
     }
     pub fn inc(&mut self, level: log::Level, events: usize) {
-        let now = timing::timestamp();
+        let now = solana_time_utils::timestamp();
         let counts = self.counts.fetch_add(events, Ordering::Relaxed);
         let times = self.times.fetch_add(1, Ordering::Relaxed);
         let lograte = self.lograte.load(Ordering::Relaxed);

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -6,7 +6,8 @@ use {
     gethostname::gethostname,
     lazy_static::lazy_static,
     log::*,
-    solana_sdk::{genesis_config::ClusterType, hash::hash},
+    solana_cluster_type::ClusterType,
+    solana_sha256_hasher::hash,
     std::{
         cmp,
         collections::HashMap,

--- a/metrics/src/poh_timing_point.rs
+++ b/metrics/src/poh_timing_point.rs
@@ -3,6 +3,7 @@
 use {
     crossbeam_channel::{Receiver, Sender},
     log::*,
+    solana_clock::Slot,
     std::fmt,
 };
 
@@ -35,9 +36,9 @@ impl fmt::Display for PohTimingPoint {
 #[derive(Clone, Debug)]
 pub struct SlotPohTimingInfo {
     /// current slot
-    pub slot: u64,
+    pub slot: Slot,
     /// root slot
-    pub root_slot: Option<u64>,
+    pub root_slot: Option<Slot>,
     /// timing event
     pub timing_point: PohTimingPoint,
 }
@@ -57,8 +58,8 @@ impl fmt::Display for SlotPohTimingInfo {
 impl SlotPohTimingInfo {
     /// create slot start poh timing point
     pub fn new_slot_start_poh_time_point(
-        slot: u64,
-        root_slot: Option<u64>,
+        slot: Slot,
+        root_slot: Option<Slot>,
         timestamp: u64,
     ) -> SlotPohTimingInfo {
         SlotPohTimingInfo {
@@ -70,8 +71,8 @@ impl SlotPohTimingInfo {
 
     /// create slot end poh timing point
     pub fn new_slot_end_poh_time_point(
-        slot: u64,
-        root_slot: Option<u64>,
+        slot: Slot,
+        root_slot: Option<Slot>,
         timestamp: u64,
     ) -> SlotPohTimingInfo {
         SlotPohTimingInfo {
@@ -83,8 +84,8 @@ impl SlotPohTimingInfo {
 
     /// create slot full poh timing point
     pub fn new_slot_full_poh_time_point(
-        slot: u64,
-        root_slot: Option<u64>,
+        slot: Slot,
+        root_slot: Option<Slot>,
         timestamp: u64,
     ) -> SlotPohTimingInfo {
         SlotPohTimingInfo {

--- a/metrics/src/poh_timing_point.rs
+++ b/metrics/src/poh_timing_point.rs
@@ -3,7 +3,6 @@
 use {
     crossbeam_channel::{Receiver, Sender},
     log::*,
-    solana_sdk::clock::Slot,
     std::fmt,
 };
 
@@ -36,9 +35,9 @@ impl fmt::Display for PohTimingPoint {
 #[derive(Clone, Debug)]
 pub struct SlotPohTimingInfo {
     /// current slot
-    pub slot: Slot,
+    pub slot: u64,
     /// root slot
-    pub root_slot: Option<Slot>,
+    pub root_slot: Option<u64>,
     /// timing event
     pub timing_point: PohTimingPoint,
 }
@@ -58,8 +57,8 @@ impl fmt::Display for SlotPohTimingInfo {
 impl SlotPohTimingInfo {
     /// create slot start poh timing point
     pub fn new_slot_start_poh_time_point(
-        slot: Slot,
-        root_slot: Option<Slot>,
+        slot: u64,
+        root_slot: Option<u64>,
         timestamp: u64,
     ) -> SlotPohTimingInfo {
         SlotPohTimingInfo {
@@ -71,8 +70,8 @@ impl SlotPohTimingInfo {
 
     /// create slot end poh timing point
     pub fn new_slot_end_poh_time_point(
-        slot: Slot,
-        root_slot: Option<Slot>,
+        slot: u64,
+        root_slot: Option<u64>,
         timestamp: u64,
     ) -> SlotPohTimingInfo {
         SlotPohTimingInfo {
@@ -84,8 +83,8 @@ impl SlotPohTimingInfo {
 
     /// create slot full poh timing point
     pub fn new_slot_full_poh_time_point(
-        slot: Slot,
-        root_slot: Option<Slot>,
+        slot: u64,
+        root_slot: Option<u64>,
         timestamp: u64,
     ) -> SlotPohTimingInfo {
         SlotPohTimingInfo {

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -29,13 +29,13 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-hash = { workspace = true }
 solana-metrics = { workspace = true }
-solana-packet = { workspace = true }
+solana-packet = { workspace = true, features = ["bincode"] }
 solana-program = { workspace = true, default-features = false }
 solana-pubkey = { workspace = true, default-features = false }
 solana-rayon-threadlimit = { workspace = true }
 solana-sdk = { workspace = true, optional = true }
 solana-short-vec = { workspace = true }
-solana-signature = { workspace = true }
+solana-signature = { workspace = true, features = ["verify"] }
 solana-time-utils = { workspace = true }
 solana-vote-program = { workspace = true, optional = true }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5888,6 +5888,7 @@ dependencies = [
  "lazy_static",
  "log",
  "reqwest",
+ "solana-clock",
  "solana-cluster-type",
  "solana-sha256-hasher",
  "solana-time-utils",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5888,7 +5888,9 @@ dependencies = [
  "lazy_static",
  "log",
  "reqwest",
- "solana-sdk",
+ "solana-cluster-type",
+ "solana-sha256-hasher",
+ "solana-time-utils",
  "thiserror 1.0.69",
 ]
 


### PR DESCRIPTION
#### Problem
solana-metrics can compile faster without the solana-sdk dependency

#### Summary of Changes
- Replace solana-sdk with its component crates
- Replace `solana_sdk::clock::Slot` with u64 (Slot is just an alias for u64)

This branches off #3372 so that needs to be merged first (update: done)