### PR TITLE
remove solana-sdk from solana-compute-budget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6384,8 +6384,9 @@ dependencies = [
 name = "solana-compute-budget"
 version = "2.2.0"
 dependencies = [
+ "solana-fee-structure",
  "solana-frozen-abi",
- "solana-sdk",
+ "solana-program-entrypoint",
 ]
 
 [[package]]

--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -10,17 +10,14 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+solana-fee-structure = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-fee-structure = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 
 [features]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "solana-fee-structure/frozen-abi",
-]
+frozen-abi = ["dep:solana-frozen-abi", "solana-fee-structure/frozen-abi"]
 
 [lints]
 workspace = true

--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -13,12 +13,13 @@ edition = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-sdk = { workspace = true }
+solana-fee-structure = { workspace = true }
+solana-program-entrypoint = { workspace = true }
 
 [features]
 frozen-abi = [
     "dep:solana-frozen-abi",
-    "solana-sdk/frozen-abi",
+    "solana-fee-structure/frozen-abi",
 ]
 
 [lints]

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -177,7 +177,7 @@ impl ComputeBudget {
             curve25519_ristretto_multiply_cost: 2_208,
             curve25519_ristretto_msm_base_cost: 2303,
             curve25519_ristretto_msm_incremental_cost: 788,
-            heap_size: u32::try_from(solana_sdk::entrypoint::HEAP_LENGTH).unwrap(),
+            heap_size: u32::try_from(solana_program_entrypoint::HEAP_LENGTH).unwrap(),
             heap_cost: DEFAULT_HEAP_COST,
             mem_op_base_cost: 10,
             alt_bn128_addition_cost: 334,

--- a/compute-budget/src/compute_budget_limits.rs
+++ b/compute-budget/src/compute_budget_limits.rs
@@ -1,6 +1,7 @@
 use {
     crate::prioritization_fee::{PrioritizationFeeDetails, PrioritizationFeeType},
-    solana_sdk::{entrypoint::HEAP_LENGTH, fee::FeeBudgetLimits},
+    solana_fee_structure::FeeBudgetLimits,
+    solana_program_entrypoint::HEAP_LENGTH,
     std::num::NonZeroU32,
 };
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5102,7 +5102,8 @@ dependencies = [
 name = "solana-compute-budget"
 version = "2.2.0"
 dependencies = [
- "solana-sdk",
+ "solana-fee-structure",
+ "solana-program-entrypoint",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
solana-compute-budget imposes a solana-sdk on solana-program-runtime (and therefore solana-svm)

#### Summary of Changes
Replace solana-sdk with its constituent crates

This branches off #3311 so that needs to be merged first
