### PR TITLE
Runs accounts lt hash startup calculation in thread pool

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1732,13 +1732,15 @@ impl Bank {
             // then it will be *required* that the snapshot contains an accounts lt hash.
             let accounts_lt_hash = fields.accounts_lt_hash.unwrap_or_else(|| {
                 let (accounts_lt_hash, duration) = meas_dur!({
-                    bank.rc
-                        .accounts
-                        .accounts_db
-                        .calculate_accounts_lt_hash_at_startup_from_index(
-                            &bank.ancestors,
-                            bank.slot(),
-                        )
+                    thread_pool.install(|| {
+                        bank.rc
+                            .accounts
+                            .accounts_db
+                            .calculate_accounts_lt_hash_at_startup_from_index(
+                                &bank.ancestors,
+                                bank.slot(),
+                            )
+                    })
                 });
                 calculate_accounts_lt_hash_duration = Some(duration);
                 accounts_lt_hash


### PR DESCRIPTION
#### Problem

At startup, if calculating the accounts lt hash, we do not specify a thread pool to run in, so it will end up running in the global thread pool. This may not be ideal, if other tasks are running in the global pool (or get added later).

There is already a thread pool for Bank::new_from_fields(), so we should use that one here.


#### Summary of Changes

At startup, run the accounts lt hash calculation in the Bank::new_from_fields() thread pool.