### PR TITLE
Adds buffers and cached bytes to memory-stats datapoint

### DIFF
--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -679,6 +679,8 @@ impl SystemMonitorService {
                 "memory-stats",
                 ("total", info.total * KB, i64),
                 ("swap_total", info.swap_total * KB, i64),
+                ("buffers_bytes", info.buffers * KB, i64),
+                ("cached_bytes", info.cached * KB, i64),
                 (
                     "free_percent",
                     Self::calc_percent(info.free, info.total),


### PR DESCRIPTION
#### Problem

The memory-stats datapoint only includes percentages for the buffers and cached sizes, not the number of bytes. This makes it cumbersome to track the pagecache/mmap sizes in metrics.


#### Summary of Changes

Add buffers and cached bytes to the memory-stats datapoint.