### PR TITLE
CI: Pin downstream SPL job to v2.0 branch

### DIFF
--- a/.github/scripts/downstream-project-spl-common.sh
+++ b/.github/scripts/downstream-project-spl-common.sh
@@ -8,7 +8,7 @@ source "$here"/../../ci/downstream-projects/common.sh
 
 set -x
 rm -rf spl
-git clone https://github.com/solana-labs/solana-program-library.git spl
+git clone https://github.com/solana-labs/solana-program-library.git spl -b v2.0
 
 # copy toolchain file to use solana's rust version
 cp "$SOLANA_DIR"/rust-toolchain.toml spl/


### PR DESCRIPTION
##### Problem

SPL is about to update to use the v2.1 crates, which will cause the downstream jobs to fail for branch v2.0.

#### Summary of changes

Checkout the `v2.0` branch from the SPL repo for the downstream tests, similar to what we do for the v1.17 and v1.18 branches.