### PR TITLE
Runs accounts delta hash calculation in thread pool

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7516,8 +7516,9 @@ impl AccountsDb {
             hashes.retain(|k| k.0 != ignore);
         }
 
-        let accounts_delta_hash =
-            AccountsDeltaHash(AccountsHasher::accumulate_account_hashes(hashes));
+        let accounts_delta_hash = self
+            .thread_pool
+            .install(|| AccountsDeltaHash(AccountsHasher::accumulate_account_hashes(hashes)));
         accumulate.stop();
         let mut uncleaned_time = Measure::start("uncleaned_index");
         self.uncleaned_pubkeys.insert(slot, dirty_keys);


### PR DESCRIPTION
#### Problem

In Bank::freeze() we calculate the accounts delta hash for the slot. This is in the critical path, so we do the delta hash calc in parallel. Since an explicit thread pool is not specified, the delta hash calc ends up running in the global thread pool. This may not be ideal, if other tasks are running in the global pool (or get added later).

There is already a thread pool for foreground tasks, so we should use that one here.

h/t to @steviez for bringing this up


#### Summary of Changes

Run the accounts delta hash calc in the accounts-db foreground thread pool.


#### Results

Here's metrics from `mce3` and `mce4` before and after picking up this change:
(Note, mce3 restarted twice, which is why it has two spikes. mce4 only restarted once, hence one spike.)

![Screenshot 2024-10-31 at 9 28 15 AM](https://github.com/user-attachments/assets/e44daece-e34b-4eca-aa54-98cae62358f0)

Comparing pre and post, we see the accounts delta hash time got faster for both machines by quite a noticeable amount! ~1 ms for mce3 and ~0.5 ms for mce4.