### PR TITLE
move metrics usage out of program-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6067,6 +6067,7 @@ dependencies = [
  "solana-poseidon",
  "solana-program-memory",
  "solana-program-runtime",
+ "solana-program-runtime-metrics",
  "solana-sdk",
  "solana-timings",
  "solana-type-overrides",
@@ -7100,6 +7101,7 @@ dependencies = [
  "solana-log-collector",
  "solana-measure",
  "solana-program-runtime",
+ "solana-program-runtime-metrics",
  "solana-sdk",
  "solana-type-overrides",
  "solana_rbpf",
@@ -7569,7 +7571,6 @@ dependencies = [
  "solana-log-collector",
  "solana-logger",
  "solana-measure",
- "solana-metrics",
  "solana-sdk",
  "solana-timings",
  "solana-type-overrides",
@@ -7577,6 +7578,21 @@ dependencies = [
  "solana_rbpf",
  "test-case",
  "thiserror",
+]
+
+[[package]]
+name = "solana-program-runtime-metrics"
+version = "2.2.0"
+dependencies = [
+ "log",
+ "solana-measure",
+ "solana-metrics",
+ "solana-program-runtime",
+ "solana-pubkey",
+ "solana-sdk",
+ "solana-timings",
+ "solana-type-overrides",
+ "solana_rbpf",
 ]
 
 [[package]]
@@ -8418,6 +8434,7 @@ dependencies = [
  "solana-perf",
  "solana-program",
  "solana-program-runtime",
+ "solana-program-runtime-metrics",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-runtime-transaction",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "solana-logger",
  "solana-measure",
  "solana-program-runtime",
+ "solana-program-runtime-metrics",
  "solana-rpc",
  "solana-runtime",
  "solana-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ members = [
     "poh-bench",
     "poseidon",
     "program-runtime",
+    "program-runtime-metrics",
     "program-test",
     "programs/address-lookup-table",
     "programs/address-lookup-table-tests",
@@ -474,6 +475,7 @@ solana-program-memory = { path = "sdk/program-memory", version = "=2.2.0" }
 solana-program-option = { path = "sdk/program-option", version = "=2.2.0" }
 solana-program-pack = { path = "sdk/program-pack", version = "=2.2.0" }
 solana-program-runtime = { path = "program-runtime", version = "=2.2.0" }
+solana-program-runtime-metrics = { path = "program-runtime-metrics", version = "=2.2.0" }
 solana-program-test = { path = "program-test", version = "=2.2.0" }
 solana-pubkey = { path = "sdk/pubkey", version = "=2.2.0", default-features = false }
 solana-pubsub-client = { path = "pubsub-client", version = "=2.2.0" }

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -43,6 +43,7 @@ solana-log-collector = { workspace = true }
 solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-program-runtime = { workspace = true }
+solana-program-runtime-metrics = { workspace = true }
 solana-rpc = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true }

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -12,11 +12,10 @@ use {
     solana_ledger::blockstore_options::AccessType,
     solana_program_runtime::{
         invoke_context::InvokeContext,
-        loaded_programs::{
-            LoadProgramMetrics, ProgramCacheEntryType, DELAY_VISIBILITY_SLOT_OFFSET,
-        },
+        loaded_programs::{ProgramCacheEntryType, DELAY_VISIBILITY_SLOT_OFFSET},
         with_mock_invoke_context,
     },
+    solana_program_runtime_metrics::LoadProgramMetrics,
     solana_rbpf::{
         assembler::assemble, elf::Executable, static_analysis::Analysis,
         verifier::RequisiteVerifier,

--- a/program-runtime-metrics/Cargo.toml
+++ b/program-runtime-metrics/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "solana-program-runtime-metrics"
+description = "Metrics utilities for solana-program-runtime"
+documentation = "https://docs.rs/solana-program-runtime-metrics"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+log = { workspace = true }
+solana-measure = { workspace = true }
+solana-metrics = { workspace = true }
+solana-program-runtime = { workspace = true }
+solana-pubkey = { workspace = true }
+solana_rbpf = { workspace = true }
+solana-sdk = { workspace = true }
+solana-timings = { workspace = true }
+solana-type-overrides = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/program-runtime-metrics/Cargo.toml
+++ b/program-runtime-metrics/Cargo.toml
@@ -15,10 +15,10 @@ solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }
-solana_rbpf = { workspace = true }
 solana-sdk = { workspace = true }
 solana-timings = { workspace = true }
 solana-type-overrides = { workspace = true }
+solana_rbpf = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/program-runtime-metrics/src/lib.rs
+++ b/program-runtime-metrics/src/lib.rs
@@ -1,0 +1,143 @@
+use {
+    solana_measure::measure::Measure,
+    solana_program_runtime::{
+        invoke_context::InvokeContext,
+        loaded_programs::{
+            ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
+            ProgramRuntimeEnvironment,
+        },
+    },
+    solana_pubkey::Pubkey,
+    solana_rbpf::{elf::Executable, program::BuiltinProgram, verifier::RequisiteVerifier},
+    solana_sdk::saturating_add_assign,
+    solana_timings::ExecuteDetailsTimings,
+    solana_type_overrides::sync::{atomic::AtomicU64, Arc},
+};
+
+/// Time measurements for loading a single [ProgramCacheEntry].
+#[derive(Debug, Default)]
+pub struct LoadProgramMetrics {
+    /// Program address, but as text
+    pub program_id: String,
+    /// Microseconds it took to `create_program_runtime_environment`
+    pub register_syscalls_us: u64,
+    /// Microseconds it took to `Executable::<InvokeContext>::load`
+    pub load_elf_us: u64,
+    /// Microseconds it took to `executable.verify::<RequisiteVerifier>`
+    pub verify_code_us: u64,
+    /// Microseconds it took to `executable.jit_compile`
+    pub jit_compile_us: u64,
+}
+
+impl LoadProgramMetrics {
+    pub fn submit_datapoint(&self, timings: &mut ExecuteDetailsTimings) {
+        saturating_add_assign!(
+            timings.create_executor_register_syscalls_us,
+            self.register_syscalls_us
+        );
+        saturating_add_assign!(timings.create_executor_load_elf_us, self.load_elf_us);
+        saturating_add_assign!(timings.create_executor_verify_code_us, self.verify_code_us);
+        saturating_add_assign!(timings.create_executor_jit_compile_us, self.jit_compile_us);
+        solana_metrics::datapoint_trace!(
+            "create_executor_trace",
+            ("program_id", self.program_id, String),
+            ("register_syscalls_us", self.register_syscalls_us, i64),
+            ("load_elf_us", self.load_elf_us, i64),
+            ("verify_code_us", self.verify_code_us, i64),
+            ("jit_compile_us", self.jit_compile_us, i64),
+        );
+    }
+}
+
+/// Creates a new user program
+pub fn new_program_cache_entry(
+    loader_key: &Pubkey,
+    program_runtime_environment: ProgramRuntimeEnvironment,
+    deployment_slot: u64,
+    effective_slot: u64,
+    elf_bytes: &[u8],
+    account_size: usize,
+    metrics: &mut LoadProgramMetrics,
+) -> Result<ProgramCacheEntry, Box<dyn std::error::Error>> {
+    new_internal(
+        loader_key,
+        program_runtime_environment,
+        deployment_slot,
+        effective_slot,
+        elf_bytes,
+        account_size,
+        metrics,
+        false, /* reloading */
+    )
+}
+
+/// Reloads a user program, *without* running the verifier.
+///
+/// # Safety
+///
+/// This method is unsafe since it assumes that the program has already been verified. Should
+/// only be called when the program was previously verified and loaded in the cache, but was
+/// unloaded due to inactivity. It should also be checked that the `program_runtime_environment`
+/// hasn't changed since it was unloaded.
+pub unsafe fn reload_program_cache_entry(
+    loader_key: &Pubkey,
+    program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
+    deployment_slot: u64,
+    effective_slot: u64,
+    elf_bytes: &[u8],
+    account_size: usize,
+    metrics: &mut LoadProgramMetrics,
+) -> Result<ProgramCacheEntry, Box<dyn std::error::Error>> {
+    new_internal(
+        loader_key,
+        program_runtime_environment,
+        deployment_slot,
+        effective_slot,
+        elf_bytes,
+        account_size,
+        metrics,
+        true, /* reloading */
+    )
+}
+
+fn new_internal(
+    loader_key: &Pubkey,
+    program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
+    deployment_slot: u64,
+    effective_slot: u64,
+    elf_bytes: &[u8],
+    account_size: usize,
+    metrics: &mut LoadProgramMetrics,
+    reloading: bool,
+) -> Result<ProgramCacheEntry, Box<dyn std::error::Error>> {
+    let load_elf_time = Measure::start("load_elf_time");
+    // The following unused_mut exception is needed for architectures that do not
+    // support JIT compilation.
+    #[allow(unused_mut)]
+    let mut executable = Executable::load(elf_bytes, program_runtime_environment.clone())?;
+    metrics.load_elf_us = load_elf_time.end_as_us();
+
+    if !reloading {
+        let verify_code_time = Measure::start("verify_code_time");
+        executable.verify::<RequisiteVerifier>()?;
+        metrics.verify_code_us = verify_code_time.end_as_us();
+    }
+
+    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
+    {
+        let jit_compile_time = Measure::start("jit_compile_time");
+        executable.jit_compile()?;
+        metrics.jit_compile_us = jit_compile_time.end_as_us();
+    }
+
+    Ok(ProgramCacheEntry {
+        deployment_slot,
+        account_owner: ProgramCacheEntryOwner::try_from(loader_key).unwrap(),
+        account_size,
+        effective_slot,
+        tx_usage_counter: AtomicU64::new(0),
+        program: ProgramCacheEntryType::Loaded(executable),
+        ix_usage_counter: AtomicU64::new(0),
+        latest_access_slot: AtomicU64::new(0),
+    })
+}

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -31,7 +31,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-log-collector = { workspace = true }
 solana-measure = { workspace = true }
-solana-metrics = { workspace = true }
 solana-sdk = { workspace = true }
 solana-timings = { workspace = true }
 solana-type-overrides = { workspace = true }

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -2,9 +2,6 @@
 #![deny(clippy::arithmetic_side_effects)]
 #![deny(clippy::indexing_slicing)]
 
-#[macro_use]
-extern crate solana_metrics;
-
 pub use solana_rbpf;
 pub mod invoke_context;
 pub mod loaded_programs;

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -2,11 +2,9 @@ use {
     crate::invoke_context::{BuiltinFunctionWithContext, InvokeContext},
     log::{debug, error, log_enabled, trace},
     percentage::PercentageInteger,
-    solana_measure::measure::Measure,
     solana_rbpf::{
         elf::Executable,
         program::{BuiltinProgram, FunctionRegistry},
-        verifier::RequisiteVerifier,
         vm::Config,
     },
     solana_sdk::{
@@ -16,7 +14,6 @@ use {
         pubkey::Pubkey,
         saturating_add_assign,
     },
-    solana_timings::ExecuteDetailsTimings,
     solana_type_overrides::{
         rand::{thread_rng, Rng},
         sync::{
@@ -272,41 +269,6 @@ impl ProgramCacheStats {
     }
 }
 
-/// Time measurements for loading a single [ProgramCacheEntry].
-#[derive(Debug, Default)]
-pub struct LoadProgramMetrics {
-    /// Program address, but as text
-    pub program_id: String,
-    /// Microseconds it took to `create_program_runtime_environment`
-    pub register_syscalls_us: u64,
-    /// Microseconds it took to `Executable::<InvokeContext>::load`
-    pub load_elf_us: u64,
-    /// Microseconds it took to `executable.verify::<RequisiteVerifier>`
-    pub verify_code_us: u64,
-    /// Microseconds it took to `executable.jit_compile`
-    pub jit_compile_us: u64,
-}
-
-impl LoadProgramMetrics {
-    pub fn submit_datapoint(&self, timings: &mut ExecuteDetailsTimings) {
-        saturating_add_assign!(
-            timings.create_executor_register_syscalls_us,
-            self.register_syscalls_us
-        );
-        saturating_add_assign!(timings.create_executor_load_elf_us, self.load_elf_us);
-        saturating_add_assign!(timings.create_executor_verify_code_us, self.verify_code_us);
-        saturating_add_assign!(timings.create_executor_jit_compile_us, self.jit_compile_us);
-        datapoint_trace!(
-            "create_executor_trace",
-            ("program_id", self.program_id, String),
-            ("register_syscalls_us", self.register_syscalls_us, i64),
-            ("load_elf_us", self.load_elf_us, i64),
-            ("verify_code_us", self.verify_code_us, i64),
-            ("jit_compile_us", self.jit_compile_us, i64),
-        );
-    }
-}
-
 impl PartialEq for ProgramCacheEntry {
     fn eq(&self, other: &Self) -> bool {
         self.effective_slot == other.effective_slot
@@ -316,99 +278,6 @@ impl PartialEq for ProgramCacheEntry {
 }
 
 impl ProgramCacheEntry {
-    /// Creates a new user program
-    pub fn new(
-        loader_key: &Pubkey,
-        program_runtime_environment: ProgramRuntimeEnvironment,
-        deployment_slot: Slot,
-        effective_slot: Slot,
-        elf_bytes: &[u8],
-        account_size: usize,
-        metrics: &mut LoadProgramMetrics,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        Self::new_internal(
-            loader_key,
-            program_runtime_environment,
-            deployment_slot,
-            effective_slot,
-            elf_bytes,
-            account_size,
-            metrics,
-            false, /* reloading */
-        )
-    }
-
-    /// Reloads a user program, *without* running the verifier.
-    ///
-    /// # Safety
-    ///
-    /// This method is unsafe since it assumes that the program has already been verified. Should
-    /// only be called when the program was previously verified and loaded in the cache, but was
-    /// unloaded due to inactivity. It should also be checked that the `program_runtime_environment`
-    /// hasn't changed since it was unloaded.
-    pub unsafe fn reload(
-        loader_key: &Pubkey,
-        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
-        deployment_slot: Slot,
-        effective_slot: Slot,
-        elf_bytes: &[u8],
-        account_size: usize,
-        metrics: &mut LoadProgramMetrics,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        Self::new_internal(
-            loader_key,
-            program_runtime_environment,
-            deployment_slot,
-            effective_slot,
-            elf_bytes,
-            account_size,
-            metrics,
-            true, /* reloading */
-        )
-    }
-
-    fn new_internal(
-        loader_key: &Pubkey,
-        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
-        deployment_slot: Slot,
-        effective_slot: Slot,
-        elf_bytes: &[u8],
-        account_size: usize,
-        metrics: &mut LoadProgramMetrics,
-        reloading: bool,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        let load_elf_time = Measure::start("load_elf_time");
-        // The following unused_mut exception is needed for architectures that do not
-        // support JIT compilation.
-        #[allow(unused_mut)]
-        let mut executable = Executable::load(elf_bytes, program_runtime_environment.clone())?;
-        metrics.load_elf_us = load_elf_time.end_as_us();
-
-        if !reloading {
-            let verify_code_time = Measure::start("verify_code_time");
-            executable.verify::<RequisiteVerifier>()?;
-            metrics.verify_code_us = verify_code_time.end_as_us();
-        }
-
-        #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
-        {
-            let jit_compile_time = Measure::start("jit_compile_time");
-            executable.jit_compile()?;
-            metrics.jit_compile_us = jit_compile_time.end_as_us();
-        }
-
-        Ok(Self {
-            deployment_slot,
-            account_owner: ProgramCacheEntryOwner::try_from(loader_key).unwrap(),
-            account_size,
-            effective_slot,
-            tx_usage_counter: AtomicU64::new(0),
-            program: ProgramCacheEntryType::Loaded(executable),
-            ix_usage_counter: AtomicU64::new(0),
-            latest_access_slot: AtomicU64::new(0),
-        })
-    }
-
     pub fn to_unloaded(&self) -> Option<Self> {
         match &self.program {
             ProgramCacheEntryType::Loaded(_) => {}

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -24,6 +24,7 @@ solana-measure = { workspace = true }
 solana-poseidon = { workspace = true }
 solana-program-memory = { workspace = true }
 solana-program-runtime = { workspace = true }
+solana-program-runtime-metrics = { workspace = true }
 solana-sdk = { workspace = true }
 solana-timings = { workspace = true }
 solana-type-overrides = { workspace = true }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -14,12 +14,15 @@ use {
     solana_program_runtime::{
         invoke_context::{BpfAllocator, InvokeContext, SerializedAccountMetadata, SyscallContext},
         loaded_programs::{
-            LoadProgramMetrics, ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
+            ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
             DELAY_VISIBILITY_SLOT_OFFSET,
         },
         mem_pool::VmMemoryPool,
         stable_log,
         sysvar_cache::get_sysvar_with_account_check,
+    },
+    solana_program_runtime_metrics::{
+        new_program_cache_entry, reload_program_cache_entry, LoadProgramMetrics,
     },
     solana_rbpf::{
         declare_builtin_function,
@@ -74,7 +77,7 @@ pub fn load_program_from_bytes(
     let loaded_program = if reloading {
         // Safety: this is safe because the program is being reloaded in the cache.
         unsafe {
-            ProgramCacheEntry::reload(
+            reload_program_cache_entry(
                 loader_key,
                 program_runtime_environment,
                 deployment_slot,
@@ -85,7 +88,7 @@ pub fn load_program_from_bytes(
             )
         }
     } else {
-        ProgramCacheEntry::new(
+        new_program_cache_entry(
             loader_key,
             program_runtime_environment,
             deployment_slot,

--- a/programs/loader-v4/Cargo.toml
+++ b/programs/loader-v4/Cargo.toml
@@ -15,6 +15,7 @@ solana-compute-budget = { workspace = true }
 solana-log-collector = { workspace = true }
 solana-measure = { workspace = true }
 solana-program-runtime = { workspace = true }
+solana-program-runtime-metrics = { workspace = true }
 solana-sdk = { workspace = true }
 solana-type-overrides = { workspace = true }
 solana_rbpf = { workspace = true }

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -5,10 +5,11 @@ use {
     solana_program_runtime::{
         invoke_context::InvokeContext,
         loaded_programs::{
-            LoadProgramMetrics, ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
+            ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
             DELAY_VISIBILITY_SLOT_OFFSET,
         },
     },
+    solana_program_runtime_metrics::{new_program_cache_entry, LoadProgramMetrics},
     solana_rbpf::{declare_builtin_function, memory_region::MemoryMapping},
     solana_sdk::{
         instruction::InstructionError,
@@ -278,7 +279,7 @@ pub fn process_instruction_deploy(
         program_id: buffer.get_key().to_string(),
         ..LoadProgramMetrics::default()
     };
-    let executor = ProgramCacheEntry::new(
+    let executor = new_program_cache_entry(
         &loader_v4::id(),
         environments.program_runtime_v1.clone(),
         deployment_slot,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4953,6 +4953,7 @@ dependencies = [
  "solana-poseidon",
  "solana-program-memory",
  "solana-program-runtime",
+ "solana-program-runtime-metrics",
  "solana-sdk",
  "solana-timings",
  "solana-type-overrides",
@@ -5627,6 +5628,7 @@ dependencies = [
  "solana-log-collector",
  "solana-measure",
  "solana-program-runtime",
+ "solana-program-runtime-metrics",
  "solana-sdk",
  "solana-type-overrides",
  "solana_rbpf",
@@ -5925,13 +5927,27 @@ dependencies = [
  "solana-feature-set",
  "solana-log-collector",
  "solana-measure",
- "solana-metrics",
  "solana-sdk",
  "solana-timings",
  "solana-type-overrides",
  "solana-vote",
  "solana_rbpf",
  "thiserror",
+]
+
+[[package]]
+name = "solana-program-runtime-metrics"
+version = "2.2.0"
+dependencies = [
+ "log",
+ "solana-measure",
+ "solana-metrics",
+ "solana-program-runtime",
+ "solana-pubkey",
+ "solana-sdk",
+ "solana-timings",
+ "solana-type-overrides",
+ "solana_rbpf",
 ]
 
 [[package]]
@@ -7075,6 +7091,7 @@ dependencies = [
  "solana-log-collector",
  "solana-measure",
  "solana-program-runtime",
+ "solana-program-runtime-metrics",
  "solana-runtime-transaction",
  "solana-sdk",
  "solana-svm-rent-collector",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -30,6 +30,7 @@ solana-loader-v4-program = { workspace = true }
 solana-log-collector = { workspace = true }
 solana-measure = { workspace = true }
 solana-program-runtime = { workspace = true }
+solana-program-runtime-metrics = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-sdk = { workspace = true }
 solana-svm-rent-collector = { workspace = true }

--- a/svm/examples/json-rpc/server/src/svm_bridge.rs
+++ b/svm/examples/json-rpc/server/src/svm_bridge.rs
@@ -8,15 +8,13 @@ use {
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_program_runtime::{
         invoke_context::InvokeContext,
-        loaded_programs::{
-            BlockRelation, ForkGraph, LoadProgramMetrics, ProgramCacheEntry,
-            ProgramRuntimeEnvironments,
-        },
+        loaded_programs::{BlockRelation, ForkGraph, ProgramRuntimeEnvironments},
         solana_rbpf::{
             program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
             vm::Config,
         },
     },
+    solana_program_runtime_metrics::{new_program_cache_entry, LoadProgramMetrics},
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::{Clock, Slot, UnixTimestamp},
@@ -233,7 +231,7 @@ pub fn create_executable_environment(
                 program_cache.assign_program(
                     *key,
                     Arc::new(
-                        ProgramCacheEntry::new(
+                        new_program_cache_entry(
                             &solana_sdk::bpf_loader_upgradeable::id(),
                             program_runtime_environment,
                             0,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -1,8 +1,11 @@
 use {
     crate::transaction_processing_callback::TransactionProcessingCallback,
     solana_program_runtime::loaded_programs::{
-        LoadProgramMetrics, ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
+        ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
         ProgramRuntimeEnvironment, ProgramRuntimeEnvironments, DELAY_VISIBILITY_SLOT_OFFSET,
+    },
+    solana_program_runtime_metrics::{
+        new_program_cache_entry, reload_program_cache_entry, LoadProgramMetrics,
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
@@ -40,7 +43,7 @@ pub(crate) fn load_program_from_bytes(
     if reloading {
         // Safety: this is safe because the program is being reloaded in the cache.
         unsafe {
-            ProgramCacheEntry::reload(
+            reload_program_cache_entry(
                 loader_key,
                 program_runtime_environment.clone(),
                 deployment_slot,
@@ -51,7 +54,7 @@ pub(crate) fn load_program_from_bytes(
             )
         }
     } else {
-        ProgramCacheEntry::new(
+        new_program_cache_entry(
             loader_key,
             program_runtime_environment.clone(),
             deployment_slot,


### PR DESCRIPTION
#### Problem
solana-program-runtime has an annoying solana-metrics dependency that severely impacts build time and dependency hell. It's particularly annoying for litesvm which depends on solana-program-runtime

#### Summary of Changes
- Make a new solana-program-runtime-metrics crate
- Move LoadProgramMetrics into the new crate
- Move ProgramCacheEntry::new and ProgramCacheEntry::reload into the new crate as free functions
- Update all affected usage of program-runtime in this repo to use the new crate where necessary

None of these API changes affect crates that are covered by the backwards compatibility policy. I don't think deprecation is the way to go here as it would require waiting a long time to actually remove the dependencies