### PR TITLE
Add CLI arg to control size of rayon global thread pool

### DIFF
--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -69,6 +69,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         wen_restart_coordinator: config.wen_restart_coordinator,
         unified_scheduler_handler_threads: config.unified_scheduler_handler_threads,
         ip_echo_server_threads: config.ip_echo_server_threads,
+        rayon_global_threads: config.rayon_global_threads,
         replay_forks_threads: config.replay_forks_threads,
         replay_transactions_threads: config.replay_transactions_threads,
         tvu_shred_sigverify_threads: config.tvu_shred_sigverify_threads,

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -15,6 +15,7 @@ pub struct DefaultThreadArgs {
     pub accounts_db_hash_threads: String,
     pub accounts_index_flush_threads: String,
     pub ip_echo_server_threads: String,
+    pub rayon_global_threads: String,
     pub replay_forks_threads: String,
     pub replay_transactions_threads: String,
     pub tvu_receive_threads: String,
@@ -31,6 +32,7 @@ impl Default for DefaultThreadArgs {
             accounts_index_flush_threads: AccountsIndexFlushThreadsArg::bounded_default()
                 .to_string(),
             ip_echo_server_threads: IpEchoServerThreadsArg::bounded_default().to_string(),
+            rayon_global_threads: RayonGlobalThreadsArg::bounded_default().to_string(),
             replay_forks_threads: ReplayForksThreadsArg::bounded_default().to_string(),
             replay_transactions_threads: ReplayTransactionsThreadsArg::bounded_default()
                 .to_string(),
@@ -47,6 +49,7 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
         new_thread_arg::<AccountsDbHashThreadsArg>(&defaults.accounts_db_hash_threads),
         new_thread_arg::<AccountsIndexFlushThreadsArg>(&defaults.accounts_index_flush_threads),
         new_thread_arg::<IpEchoServerThreadsArg>(&defaults.ip_echo_server_threads),
+        new_thread_arg::<RayonGlobalThreadsArg>(&defaults.rayon_global_threads),
         new_thread_arg::<ReplayForksThreadsArg>(&defaults.replay_forks_threads),
         new_thread_arg::<ReplayTransactionsThreadsArg>(&defaults.replay_transactions_threads),
         new_thread_arg::<TvuReceiveThreadsArg>(&defaults.tvu_receive_threads),
@@ -71,6 +74,7 @@ pub struct NumThreadConfig {
     pub accounts_db_hash_threads: NonZeroUsize,
     pub accounts_index_flush_threads: NonZeroUsize,
     pub ip_echo_server_threads: NonZeroUsize,
+    pub rayon_global_threads: NonZeroUsize,
     pub replay_forks_threads: NonZeroUsize,
     pub replay_transactions_threads: NonZeroUsize,
     pub tvu_receive_threads: NonZeroUsize,
@@ -104,6 +108,7 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
             IpEchoServerThreadsArg::NAME,
             NonZeroUsize
         ),
+        rayon_global_threads: value_t_or_exit!(matches, RayonGlobalThreadsArg::NAME, NonZeroUsize),
         replay_forks_threads: if matches.is_present("replay_slots_concurrently") {
             NonZeroUsize::new(4).expect("4 is non-zero")
         } else {
@@ -210,6 +215,17 @@ impl ThreadArg for IpEchoServerThreadsArg {
     }
     fn min() -> usize {
         solana_net_utils::MINIMUM_IP_ECHO_SERVER_THREADS.get()
+    }
+}
+
+struct RayonGlobalThreadsArg;
+impl ThreadArg for RayonGlobalThreadsArg {
+    const NAME: &'static str = "rayon_global_threads";
+    const LONG_NAME: &'static str = "rayon-global-threads";
+    const HELP: &'static str = "Number of threads to use for the global rayon thread pool";
+
+    fn default() -> usize {
+        get_max_thread_count()
     }
 }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -915,6 +915,7 @@ pub fn main() {
         accounts_db_hash_threads,
         accounts_index_flush_threads,
         ip_echo_server_threads,
+        rayon_global_threads,
         replay_forks_threads,
         replay_transactions_threads,
         tvu_receive_threads,
@@ -1542,6 +1543,7 @@ pub fn main() {
             UseSnapshotArchivesAtStartup
         ),
         ip_echo_server_threads,
+        rayon_global_threads,
         replay_forks_threads,
         replay_transactions_threads,
         tvu_shred_sigverify_threads: tvu_sigverify_threads,


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/issues/105

#### Summary of Changes
The arg is hidden for now, and default behavior of one thread in the pool per system thread remains

To test, I:
- Made note of number of threads before this machine (64 for my box)
- Restarted a node with this commit (without flag set) and observed the pool is same size
- Restart a node with the commit + flag set and observed custom size is respected