### PR TITLE
Refactors accounts lt hash startup verification

### DIFF
--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -83,6 +83,7 @@ mod serde_snapshot_tests {
             None,
             (u64::default(), None),
             None,
+            false,
         )
         .map(|(accounts_db, _)| accounts_db)
     }


### PR DESCRIPTION
#### Problem

Startup verification was a bit clumsy due to the separate handling of the accounts lt hash via the cli arg and via the snapshot. These can (should) be unified, and also remove unnecessary memory allocations when the accounts lt hash is *not* in use.


#### Summary of Changes

Refactors accounts lt hash startup verification. Now, if the cli arg is set, or if the snapshot contains an accounts lt hash, then startup accounts verification will use lattice-based verification.