### PR TITLE
Replace unmaintained derivative with derive-where

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,6 +1903,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8855,7 +8866,7 @@ dependencies = [
  "assert_matches",
  "crossbeam-channel",
  "dashmap",
- "derivative",
+ "derive-where",
  "lazy_static",
  "log",
  "qualifier_attr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,7 @@ ctrlc = "3.4.5"
 curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }
 dashmap = "5.5.3"
 derivation-path = { version = "0.2.0", default-features = false }
-derivative = "2.2.0"
+derive-where = "1.2.7"
 dialoguer = "0.10.4"
 digest = "0.10.7"
 dir-diff = "0.3.3"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1371,6 +1371,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7353,7 +7364,7 @@ dependencies = [
  "assert_matches",
  "crossbeam-channel",
  "dashmap",
- "derivative",
+ "derive-where",
  "log",
  "qualifier_attr",
  "scopeguard",

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 assert_matches = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true }
-derivative = { workspace = true }
+derive-where = { workspace = true }
 log = { workspace = true }
 qualifier_attr = { workspace = true }
 scopeguard = { workspace = true }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -14,7 +14,7 @@ use {
     assert_matches::assert_matches,
     crossbeam_channel::{self, never, select_biased, Receiver, RecvError, SendError, Sender},
     dashmap::DashMap,
-    derivative::Derivative,
+    derive_where::derive_where,
     log::*,
     scopeguard::defer,
     solana_ledger::blockstore_processor::{
@@ -569,8 +569,7 @@ mod chained_channel {
 
     // P doesn't need to be `: Clone`, yet rustc derive can't handle it.
     // see https://github.com/rust-lang/rust/issues/26925
-    #[derive(Derivative)]
-    #[derivative(Clone(bound = "C: Clone"))]
+    #[derive_where(Clone)]
     pub(super) struct ChainedChannelReceiver<P, C: Clone> {
         receiver: Receiver<ChainedChannel<P, C>>,
         aux_receiver: Receiver<P>,


### PR DESCRIPTION
#### Problem

the crate `derivative` seems to be unmaintained: https://github.com/mcarton/rust-derivative/issues/117

#### Summary of Changes

Alternatives considered:

- https://crates.io/crates/derive-where (chosen; seems, least popular yet shortest syntax, and patch is small for lexicological proximity.)
- https://crates.io/crates/educe
- ~https://crates.io/crates/derive_more~ (EDIT: turned out not to be usable)
- https://crates.io/crates/impl-tools

fyi, after this pr, the `derivative` is still used by other transitive deps (i.e. included in `Cargo.lock`.). Also, `educe` and `derive_more` are also used by yet other transtive deps.