### PR TITLE
svm: interleave transaction validation and processing

### DIFF
--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -326,7 +326,6 @@ struct LoadedTransactionAccounts {
     pub loaded_accounts_data_size: u32,
 }
 
-#[allow(clippy::too_many_arguments)]
 fn load_transaction_accounts<CB: TransactionProcessingCallback>(
     account_loader: &mut AccountLoader<CB>,
     message: &impl SVMMessage,
@@ -461,7 +460,6 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 fn load_transaction_account<CB: TransactionProcessingCallback>(
     account_loader: &mut AccountLoader<CB>,
     message: &impl SVMMessage,

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -127,7 +127,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
     ) -> Option<LoadedTransactionAccount> {
         let is_writable = usage_pattern == AccountUsagePattern::Writable;
         let is_invisible_read = usage_pattern == AccountUsagePattern::ReadOnlyInvisible;
-        let disable_account_loader_special_case = self
+        let use_program_cache = !self
             .feature_set
             .is_active(&feature_set::disable_account_loader_special_case::id());
 
@@ -140,7 +140,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
                 account: account_override.clone(),
                 rent_collected: 0,
             })
-        } else if let Some(program) = (!disable_account_loader_special_case && is_invisible_read)
+        } else if let Some(program) = (use_program_cache && is_invisible_read)
             .then_some(())
             .and_then(|_| self.program_cache.find(account_key))
         {
@@ -623,7 +623,6 @@ mod tests {
             transaction_context::{TransactionAccount, TransactionContext},
         },
         std::{borrow::Cow, cell::RefCell, collections::HashMap, fs::File, io::Read, sync::Arc},
-        test_case::test_case,
     };
 
     #[derive(Clone, Default)]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -430,7 +430,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 tx,
                 validate_result,
                 &mut error_metrics,
-                &environment.feature_set,
                 environment
                     .rent_collector
                     .unwrap_or(&RentCollector::default()),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -415,7 +415,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         tx,
                         tx_details,
                         &environment.blockhash,
-                        &environment.feature_set,
                         environment.fee_lamports_per_signature,
                         environment
                             .rent_collector
@@ -517,7 +516,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         message: &impl SVMMessage,
         checked_details: CheckedTransactionDetails,
         environment_blockhash: &Hash,
-        feature_set: &FeatureSet,
         fee_lamports_per_signature: u64,
         rent_collector: &dyn SVMRentCollector,
         error_counters: &mut TransactionErrorMetrics,
@@ -546,7 +544,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             account_loader,
             message,
             checked_details,
-            feature_set,
             fee_lamports_per_signature,
             rent_collector,
             error_counters,
@@ -560,7 +557,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         account_loader: &mut AccountLoader<CB>,
         message: &impl SVMMessage,
         checked_details: CheckedTransactionDetails,
-        feature_set: &FeatureSet,
         fee_lamports_per_signature: u64,
         rent_collector: &dyn SVMRentCollector,
         error_counters: &mut TransactionErrorMetrics,
@@ -583,7 +579,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         let fee_payer_loaded_rent_epoch = loaded_fee_payer.account.rent_epoch();
         loaded_fee_payer.rent_collected = collect_rent_from_account(
-            feature_set,
+            &account_loader.feature_set,
             rent_collector,
             fee_payer_address,
             &mut loaded_fee_payer.account,
@@ -601,7 +597,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             lamports_per_signature == 0,
             fee_lamports_per_signature,
             fee_budget_limits.prioritization_fee,
-            feature_set.is_active(&remove_rounding_in_fee_calculation::id()),
+            account_loader
+                .feature_set
+                .is_active(&remove_rounding_in_fee_calculation::id()),
         );
 
         let fee_payer_index = 0;
@@ -2151,7 +2149,6 @@ mod tests {
                     lamports_per_signature,
                 },
                 &Hash::default(),
-                &FeatureSet::default(),
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
@@ -2230,7 +2227,6 @@ mod tests {
                     lamports_per_signature,
                 },
                 &Hash::default(),
-                &FeatureSet::default(),
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
@@ -2282,7 +2278,6 @@ mod tests {
                     lamports_per_signature,
                 },
                 &Hash::default(),
-                &FeatureSet::default(),
                 FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut error_counters,
@@ -2317,7 +2312,6 @@ mod tests {
                     lamports_per_signature,
                 },
                 &Hash::default(),
-                &FeatureSet::default(),
                 FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut error_counters,
@@ -2356,7 +2350,6 @@ mod tests {
                     lamports_per_signature,
                 },
                 &Hash::default(),
-                &FeatureSet::default(),
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
@@ -2393,7 +2386,6 @@ mod tests {
                     lamports_per_signature,
                 },
                 &Hash::default(),
-                &FeatureSet::default(),
                 FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut error_counters,
@@ -2426,7 +2418,6 @@ mod tests {
                     lamports_per_signature,
                 },
                 &Hash::default(),
-                &FeatureSet::default(),
                 FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut error_counters,
@@ -2438,7 +2429,6 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_fee_payer_is_nonce() {
-        let feature_set = FeatureSet::default();
         let lamports_per_signature = 5000;
         let rent_collector = RentCollector::default();
         let compute_unit_limit = 2 * solana_compute_budget_program::DEFAULT_COMPUTE_UNITS;
@@ -2499,7 +2489,6 @@ mod tests {
                 &message,
                 tx_details,
                 &environment_blockhash,
-                &feature_set,
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
@@ -2561,7 +2550,6 @@ mod tests {
                     lamports_per_signature,
                 },
                 &Hash::default(),
-                &feature_set,
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
@@ -2622,7 +2610,6 @@ mod tests {
                     lamports_per_signature,
                 },
                 &Hash::default(),
-                &FeatureSet::default(),
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
@@ -2669,7 +2656,6 @@ mod tests {
                 lamports_per_signature: 5000,
             },
             &Hash::default(),
-            &FeatureSet::default(),
             FeeStructure::default().lamports_per_signature,
             &RentCollector::default(),
             &mut TransactionErrorMetrics::default(),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -3,19 +3,19 @@ use qualifier_attr::{field_qualifiers, qualifiers};
 use {
     crate::{
         account_loader::{
-            collect_rent_from_account, load_accounts, validate_fee_payer,
-            CheckedTransactionDetails, LoadedTransaction, LoadedTransactionAccount,
-            TransactionCheckResult, TransactionLoadResult, TransactionValidationResult,
-            ValidatedTransactionDetails,
+            collect_rent_from_account, load_transaction, validate_fee_payer, AccountLoader,
+            AccountUsagePattern, CheckedTransactionDetails, LoadedTransaction,
+            TransactionCheckResult, TransactionLoadResult, ValidatedTransactionDetails,
         },
         account_overrides::AccountOverrides,
         message_processor::MessageProcessor,
+        nonce_info::NonceInfo,
         program_loader::{get_program_modification_slot, load_program_with_pubkey},
         rollback_accounts::RollbackAccounts,
         transaction_account_state_info::TransactionAccountStateInfo,
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
-        transaction_processing_callback::{AccountState, TransactionProcessingCallback},
+        transaction_processing_callback::TransactionProcessingCallback,
         transaction_processing_result::{ProcessedTransaction, TransactionProcessingResult},
     },
     log::debug,
@@ -45,15 +45,17 @@ use {
     solana_runtime_transaction::instructions_processor::process_compute_budget_instructions,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, PROGRAM_OWNERS},
+        account_utils::StateMut,
         clock::{Epoch, Slot},
         fee::{FeeBudgetLimits, FeeStructure},
         hash::Hash,
         inner_instruction::{InnerInstruction, InnerInstructionsList},
         instruction::{CompiledInstruction, TRANSACTION_LEVEL_STACK_HEIGHT},
         native_loader,
+        nonce::state::{DurableNonce, State as NonceState, Versions as NonceVersions},
         pubkey::Pubkey,
         rent_collector::RentCollector,
-        saturating_add_assign,
+        saturating_add_assign, system_program,
         transaction::{self, TransactionError},
         transaction_context::{ExecutionRecord, TransactionContext},
     },
@@ -350,26 +352,14 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         // Initialize metrics.
         let mut error_metrics = TransactionErrorMetrics::default();
         let mut execute_timings = ExecuteTimings::default();
-
-        let (validation_results, validate_fees_us) = measure_us!(self.validate_fees(
-            callbacks,
-            config.account_overrides,
-            sanitized_txs,
-            check_results,
-            &environment.feature_set,
-            environment.fee_lamports_per_signature,
-            environment
-                .rent_collector
-                .unwrap_or(&RentCollector::default()),
-            &mut error_metrics
-        ));
+        let mut processing_results = Vec::with_capacity(sanitized_txs.len());
 
         let native_loader = native_loader::id();
         let (program_accounts_map, filter_executable_us) = measure_us!({
             let mut program_accounts_map = Self::filter_executable_program_accounts(
                 callbacks,
                 sanitized_txs,
-                &validation_results,
+                &check_results,
                 PROGRAM_OWNERS,
             );
             for builtin_program in self.builtin_program_ids.read().unwrap().iter() {
@@ -378,7 +368,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             program_accounts_map
         });
 
-        let (mut program_cache_for_tx_batch, program_cache_us) = measure_us!({
+        let (program_cache_for_tx_batch, program_cache_us) = measure_us!({
             let program_cache_for_tx_batch = self.replenish_program_cache(
                 callbacks,
                 &program_accounts_map,
@@ -399,63 +389,97 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             program_cache_for_tx_batch
         });
 
-        let (loaded_transactions, load_accounts_us) = measure_us!(load_accounts(
-            callbacks,
-            sanitized_txs,
-            validation_results,
-            &mut error_metrics,
+        let mut account_loader = AccountLoader::new(
             config.account_overrides,
-            &environment.feature_set,
-            environment
-                .rent_collector
-                .unwrap_or(&RentCollector::default()),
-            &program_accounts_map,
-            &program_cache_for_tx_batch,
-        ));
+            program_cache_for_tx_batch,
+            program_accounts_map,
+            callbacks,
+            environment.feature_set.clone(),
+        );
 
         let enable_transaction_loading_failure_fees = environment
             .feature_set
             .is_active(&enable_transaction_loading_failure_fees::id());
-        let (processing_results, execution_us): (Vec<TransactionProcessingResult>, u64) =
-            measure_us!(loaded_transactions
-                .into_iter()
-                .zip(sanitized_txs.iter())
-                .map(|(load_result, tx)| match load_result {
-                    TransactionLoadResult::NotLoaded(err) => Err(err),
-                    TransactionLoadResult::FeesOnly(fees_only_tx) => {
-                        if enable_transaction_loading_failure_fees {
-                            Ok(ProcessedTransaction::FeesOnly(Box::new(fees_only_tx)))
-                        } else {
-                            Err(fees_only_tx.load_error)
-                        }
-                    }
-                    TransactionLoadResult::Loaded(loaded_transaction) => {
-                        let executed_tx = self.execute_loaded_transaction(
-                            tx,
-                            loaded_transaction,
-                            &mut execute_timings,
-                            &mut error_metrics,
-                            &mut program_cache_for_tx_batch,
-                            environment,
-                            config,
-                        );
 
-                        // Update batch specific cache of the loaded programs with the modifications
-                        // made by the transaction, if it executed successfully.
-                        if executed_tx.was_successful() {
-                            program_cache_for_tx_batch.merge(&executed_tx.programs_modified_by_tx);
-                        }
+        let (mut validate_fees_us, mut load_us, mut execution_us): (u64, u64, u64) = (0, 0, 0);
 
-                        Ok(ProcessedTransaction::Executed(Box::new(executed_tx)))
+        // Validate, execute, and collect results from each transaction in order.
+        // With SIMD83, transactions must be executed in order, because transactions
+        // in the same batch may modify the same accounts. Transaction order is
+        // preserved within entries written to the ledger.
+        for (tx, check_result) in sanitized_txs.iter().zip(check_results) {
+            let (validate_result, single_validate_fees_us) =
+                measure_us!(check_result.and_then(|tx_details| {
+                    Self::validate_transaction_nonce_and_fee_payer(
+                        &mut account_loader,
+                        tx,
+                        tx_details,
+                        &environment.blockhash,
+                        &environment.feature_set,
+                        environment.fee_lamports_per_signature,
+                        environment
+                            .rent_collector
+                            .unwrap_or(&RentCollector::default()),
+                        &mut error_metrics,
+                    )
+                }));
+            validate_fees_us = validate_fees_us.saturating_add(single_validate_fees_us);
+
+            let (load_result, single_load_us) = measure_us!(load_transaction(
+                &mut account_loader,
+                tx,
+                validate_result,
+                &mut error_metrics,
+                &environment.feature_set,
+                environment
+                    .rent_collector
+                    .unwrap_or(&RentCollector::default()),
+            ));
+            load_us = load_us.saturating_add(single_load_us);
+
+            let (processing_result, single_execution_us) = measure_us!(match load_result {
+                TransactionLoadResult::NotLoaded(err) => Err(err),
+                TransactionLoadResult::FeesOnly(fees_only_tx) => {
+                    if enable_transaction_loading_failure_fees {
+                        Ok(ProcessedTransaction::FeesOnly(Box::new(fees_only_tx)))
+                    } else {
+                        Err(fees_only_tx.load_error)
                     }
-                })
-                .collect());
+                }
+                TransactionLoadResult::Loaded(loaded_transaction) => {
+                    let executed_tx = self.execute_loaded_transaction(
+                        tx,
+                        loaded_transaction,
+                        &mut execute_timings,
+                        &mut error_metrics,
+                        &mut account_loader.program_cache,
+                        environment,
+                        config,
+                    );
+
+                    // Update batch specific cache of the loaded programs with the modifications
+                    // made by the transaction, if it executed successfully.
+                    if executed_tx.was_successful() {
+                        account_loader
+                            .program_cache
+                            .merge(&executed_tx.programs_modified_by_tx);
+                    }
+
+                    Ok(ProcessedTransaction::Executed(Box::new(executed_tx)))
+                }
+            });
+            execution_us = execution_us.saturating_add(single_execution_us);
+
+            processing_results.push(processing_result);
+        }
 
         // Skip eviction when there's no chance this particular tx batch has increased the size of
         // ProgramCache entries. Note that loaded_missing is deliberately defined, so that there's
         // still at least one other batch, which will evict the program cache, even after the
         // occurrences of cooperative loading.
-        if program_cache_for_tx_batch.loaded_missing || program_cache_for_tx_batch.merged_modified {
+        if account_loader.program_cache.loaded_missing
+            || account_loader.program_cache.merged_modified
+        {
             const SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE: u8 = 90;
             self.program_cache
                 .write()
@@ -468,7 +492,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         debug!(
             "load: {}us execute: {}us txs_len={}",
-            load_accounts_us,
+            load_us,
             execution_us,
             sanitized_txs.len(),
         );
@@ -479,7 +503,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .saturating_add_in_place(ExecuteTimingType::FilterExecutableUs, filter_executable_us);
         execute_timings
             .saturating_add_in_place(ExecuteTimingType::ProgramCacheUs, program_cache_us);
-        execute_timings.saturating_add_in_place(ExecuteTimingType::LoadUs, load_accounts_us);
+        execute_timings.saturating_add_in_place(ExecuteTimingType::LoadUs, load_us);
         execute_timings.saturating_add_in_place(ExecuteTimingType::ExecuteUs, execution_us);
 
         LoadAndExecuteSanitizedTransactionsOutput {
@@ -489,45 +513,52 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         }
     }
 
-    fn validate_fees<CB: TransactionProcessingCallback, T: SVMMessage>(
-        &self,
-        callbacks: &CB,
-        account_overrides: Option<&AccountOverrides>,
-        sanitized_txs: &[impl core::borrow::Borrow<T>],
-        check_results: Vec<TransactionCheckResult>,
+    fn validate_transaction_nonce_and_fee_payer<CB: TransactionProcessingCallback>(
+        account_loader: &mut AccountLoader<CB>,
+        message: &impl SVMMessage,
+        checked_details: CheckedTransactionDetails,
+        environment_blockhash: &Hash,
         feature_set: &FeatureSet,
         fee_lamports_per_signature: u64,
         rent_collector: &dyn SVMRentCollector,
         error_counters: &mut TransactionErrorMetrics,
-    ) -> Vec<TransactionValidationResult> {
-        sanitized_txs
-            .iter()
-            .zip(check_results)
-            .map(|(sanitized_tx, check_result)| {
-                check_result.and_then(|checked_details| {
-                    let message = sanitized_tx.borrow();
-                    self.validate_transaction_fee_payer(
-                        callbacks,
-                        account_overrides,
-                        message,
-                        checked_details,
-                        feature_set,
-                        fee_lamports_per_signature,
-                        rent_collector,
-                        error_counters,
-                    )
-                })
-            })
-            .collect()
+    ) -> transaction::Result<ValidatedTransactionDetails> {
+        // If this is a nonce transaction, validate the nonce info.
+        // This must be done for every transaction to support SIMD83 because
+        // it may have changed due to use, authorization, or deallocation.
+        // This function is a successful no-op if given a blockhash transaction.
+        if let CheckedTransactionDetails {
+            nonce: Some(ref nonce_info),
+            lamports_per_signature: _,
+        } = checked_details
+        {
+            let next_durable_nonce = DurableNonce::from_blockhash(environment_blockhash);
+            Self::validate_transaction_nonce(
+                account_loader,
+                message,
+                nonce_info,
+                &next_durable_nonce,
+                error_counters,
+            )?;
+        }
+
+        // Now validate the fee-payer for the transaction unconditionally.
+        Self::validate_transaction_fee_payer(
+            account_loader,
+            message,
+            checked_details,
+            feature_set,
+            fee_lamports_per_signature,
+            rent_collector,
+            error_counters,
+        )
     }
 
     // Loads transaction fee payer, collects rent if necessary, then calculates
     // transaction fees, and deducts them from the fee payer balance. If the
     // account is not found or has insufficient funds, an error is returned.
     fn validate_transaction_fee_payer<CB: TransactionProcessingCallback>(
-        &self,
-        callbacks: &CB,
-        account_overrides: Option<&AccountOverrides>,
+        account_loader: &mut AccountLoader<CB>,
         message: &impl SVMMessage,
         checked_details: CheckedTransactionDetails,
         feature_set: &FeatureSet,
@@ -543,30 +574,20 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         })?;
 
         let fee_payer_address = message.fee_payer();
-        let mut fee_payer_account = if let Some(fee_payer_account) =
-            account_overrides.and_then(|overrides| overrides.get(fee_payer_address).cloned())
-        {
-            fee_payer_account
-        } else if let Some(fee_payer_account) = callbacks.get_account_shared_data(fee_payer_address)
-        {
-            callbacks.inspect_account(
-                fee_payer_address,
-                AccountState::Alive(&fee_payer_account),
-                true, // <-- is_writable
-            );
 
-            fee_payer_account
-        } else {
+        let Some(mut loaded_fee_payer) =
+            account_loader.load_account(fee_payer_address, AccountUsagePattern::Writable)
+        else {
             error_counters.account_not_found += 1;
             return Err(TransactionError::AccountNotFound);
         };
 
-        let fee_payer_loaded_rent_epoch = fee_payer_account.rent_epoch();
-        let fee_payer_rent_debit = collect_rent_from_account(
+        let fee_payer_loaded_rent_epoch = loaded_fee_payer.account.rent_epoch();
+        loaded_fee_payer.rent_collected = collect_rent_from_account(
             feature_set,
             rent_collector,
             fee_payer_address,
-            &mut fee_payer_account,
+            &mut loaded_fee_payer.account,
         )
         .rent_amount;
 
@@ -587,7 +608,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let fee_payer_index = 0;
         validate_fee_payer(
             fee_payer_address,
-            &mut fee_payer_account,
+            &mut loaded_fee_payer.account,
             fee_payer_index,
             error_counters,
             rent_collector,
@@ -599,8 +620,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let rollback_accounts = RollbackAccounts::new(
             nonce,
             *fee_payer_address,
-            fee_payer_account.clone(),
-            fee_payer_rent_debit,
+            loaded_fee_payer.account.clone(),
+            loaded_fee_payer.rent_collected,
             fee_payer_loaded_rent_epoch,
         );
 
@@ -608,12 +629,66 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             fee_details,
             rollback_accounts,
             compute_budget_limits,
-            loaded_fee_payer_account: LoadedTransactionAccount {
-                loaded_size: fee_payer_account.data().len(),
-                account: fee_payer_account,
-                rent_collected: fee_payer_rent_debit,
-            },
+            loaded_fee_payer_account: loaded_fee_payer,
         })
+    }
+
+    fn validate_transaction_nonce<CB: TransactionProcessingCallback>(
+        account_loader: &mut AccountLoader<CB>,
+        message: &impl SVMMessage,
+        nonce_info: &NonceInfo,
+        next_durable_nonce: &DurableNonce,
+        error_counters: &mut TransactionErrorMetrics,
+    ) -> transaction::Result<()> {
+        // When SIMD83 is enabled, if the nonce has been used in this batch already, we must drop
+        // the transaction. This is the same as if it was used in different batches in the same slot.
+        // If the nonce account was closed in the batch, we error as if the blockhash didn't validate.
+        // We must validate the account in case it was reopened, either as a normal system account,
+        // or a fake nonce account. We must also check the signer in case the authority was changed.
+        //
+        // Note these checks are *not* obviated by fee-only transactions.
+        let nonce_is_valid = account_loader
+            .load_account(nonce_info.address(), AccountUsagePattern::Writable)
+            .and_then(|loaded_nonce| {
+                let current_nonce_account = &loaded_nonce.account;
+                system_program::check_id(current_nonce_account.owner()).then_some(())?;
+                StateMut::<NonceVersions>::state(current_nonce_account).ok()
+            })
+            .and_then(
+                |current_nonce_versions| match current_nonce_versions.state() {
+                    NonceState::Initialized(ref current_nonce_data) => {
+                        let nonce_can_be_advanced =
+                            &current_nonce_data.durable_nonce != next_durable_nonce;
+
+                        let nonce_authority_is_valid = message
+                            .account_keys()
+                            .iter()
+                            .enumerate()
+                            .any(|(i, address)| {
+                                address == &current_nonce_data.authority && message.is_signer(i)
+                            });
+
+                        if nonce_authority_is_valid {
+                            Some(nonce_can_be_advanced)
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                },
+            );
+
+        match nonce_is_valid {
+            None => {
+                error_counters.blockhash_not_found += 1;
+                Err(TransactionError::BlockhashNotFound)
+            }
+            Some(false) => {
+                error_counters.account_not_found += 1;
+                Err(TransactionError::AccountNotFound)
+            }
+            Some(true) => Ok(()),
+        }
     }
 
     /// Returns a map from executable program accounts (all accounts owned by any loader)
@@ -621,11 +696,11 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>(
         callbacks: &CB,
         txs: &[impl SVMMessage],
-        validation_results: &[TransactionValidationResult],
+        check_results: &[TransactionCheckResult],
         program_owners: &'a [Pubkey],
     ) -> HashMap<Pubkey, (&'a Pubkey, u64)> {
         let mut result: HashMap<Pubkey, (&'a Pubkey, u64)> = HashMap::new();
-        validation_results.iter().zip(txs).for_each(|etx| {
+        check_results.iter().zip(txs).for_each(|etx| {
             if let (Ok(_), tx) = etx {
                 tx.account_keys()
                     .iter()
@@ -1119,8 +1194,10 @@ mod tests {
     use {
         super::*,
         crate::{
-            account_loader::ValidatedTransactionDetails, nonce_info::NonceInfo,
+            account_loader::{LoadedTransactionAccount, ValidatedTransactionDetails},
+            nonce_info::NonceInfo,
             rollback_accounts::RollbackAccounts,
+            transaction_processing_callback::AccountState,
         },
         solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
         solana_feature_set::FeatureSet,
@@ -1216,6 +1293,18 @@ mod tests {
                 .entry(*address)
                 .or_default()
                 .push((account, is_writable));
+        }
+    }
+
+    impl<'a> From<&'a MockBankCallback> for AccountLoader<'a, MockBankCallback> {
+        fn from(callbacks: &'a MockBankCallback) -> AccountLoader<'a, MockBankCallback> {
+            AccountLoader::new(
+                None,
+                ProgramCacheForTxBatch::default(),
+                HashMap::default(),
+                callbacks,
+                Arc::<FeatureSet>::default(),
+            )
         }
     }
 
@@ -1588,9 +1677,9 @@ mod tests {
             sanitized_transaction_2.clone(),
             sanitized_transaction_1,
         ];
-        let validation_results = vec![
-            Ok(ValidatedTransactionDetails::default()),
-            Ok(ValidatedTransactionDetails::default()),
+        let check_results = vec![
+            Ok(CheckedTransactionDetails::default()),
+            Ok(CheckedTransactionDetails::default()),
             Err(TransactionError::ProgramAccountNotFound),
         ];
         let owners = vec![owner1, owner2];
@@ -1598,7 +1687,7 @@ mod tests {
         let result = TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
             &mock_bank,
             &transactions,
-            &validation_results,
+            &check_results,
             &owners,
         );
 
@@ -1681,8 +1770,8 @@ mod tests {
                 &bank,
                 &[sanitized_tx1, sanitized_tx2],
                 &[
-                    Ok(ValidatedTransactionDetails::default()),
-                    Ok(ValidatedTransactionDetails::default()),
+                    Ok(CheckedTransactionDetails::default()),
+                    Ok(CheckedTransactionDetails::default()),
                 ],
                 owners,
             );
@@ -1773,15 +1862,15 @@ mod tests {
         let sanitized_tx2 = SanitizedTransaction::from_transaction_for_tests(tx2);
 
         let owners = &[program1_pubkey, program2_pubkey];
-        let validation_results = vec![
-            Ok(ValidatedTransactionDetails::default()),
+        let check_results = vec![
+            Ok(CheckedTransactionDetails::default()),
             Err(TransactionError::BlockhashNotFound),
         ];
         let programs =
             TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
                 &bank,
                 &[sanitized_tx1, sanitized_tx2],
-                &validation_results,
+                &check_results,
                 owners,
             );
 
@@ -2051,22 +2140,23 @@ mod tests {
             account_shared_data: Arc::new(RwLock::new(mock_accounts)),
             ..Default::default()
         };
+        let mut account_loader = (&mock_bank).into();
 
         let mut error_counters = TransactionErrorMetrics::default();
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let result = batch_processor.validate_transaction_fee_payer(
-            &mock_bank,
-            None,
-            &message,
-            CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature,
-            },
-            &FeatureSet::default(),
-            FeeStructure::default().lamports_per_signature,
-            &rent_collector,
-            &mut error_counters,
-        );
+        let result =
+            TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
+                &mut account_loader,
+                &message,
+                CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature,
+                },
+                &Hash::default(),
+                &FeatureSet::default(),
+                FeeStructure::default().lamports_per_signature,
+                &rent_collector,
+                &mut error_counters,
+            );
 
         let post_validation_fee_payer_account = {
             let mut account = fee_payer_account.clone();
@@ -2129,22 +2219,23 @@ mod tests {
             account_shared_data: Arc::new(RwLock::new(mock_accounts)),
             ..Default::default()
         };
+        let mut account_loader = (&mock_bank).into();
 
         let mut error_counters = TransactionErrorMetrics::default();
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let result = batch_processor.validate_transaction_fee_payer(
-            &mock_bank,
-            None,
-            &message,
-            CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature,
-            },
-            &FeatureSet::default(),
-            FeeStructure::default().lamports_per_signature,
-            &rent_collector,
-            &mut error_counters,
-        );
+        let result =
+            TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
+                &mut account_loader,
+                &message,
+                CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature,
+                },
+                &Hash::default(),
+                &FeatureSet::default(),
+                FeeStructure::default().lamports_per_signature,
+                &rent_collector,
+                &mut error_counters,
+            );
 
         let post_validation_fee_payer_account = {
             let mut account = fee_payer_account.clone();
@@ -2181,21 +2272,22 @@ mod tests {
             new_unchecked_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique())));
 
         let mock_bank = MockBankCallback::default();
+        let mut account_loader = (&mock_bank).into();
         let mut error_counters = TransactionErrorMetrics::default();
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let result = batch_processor.validate_transaction_fee_payer(
-            &mock_bank,
-            None,
-            &message,
-            CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature,
-            },
-            &FeatureSet::default(),
-            FeeStructure::default().lamports_per_signature,
-            &RentCollector::default(),
-            &mut error_counters,
-        );
+        let result =
+            TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
+                &mut account_loader,
+                &message,
+                CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature,
+                },
+                &Hash::default(),
+                &FeatureSet::default(),
+                FeeStructure::default().lamports_per_signature,
+                &RentCollector::default(),
+                &mut error_counters,
+            );
 
         assert_eq!(error_counters.account_not_found, 1);
         assert_eq!(result, Err(TransactionError::AccountNotFound));
@@ -2214,22 +2306,23 @@ mod tests {
             account_shared_data: Arc::new(RwLock::new(mock_accounts)),
             ..Default::default()
         };
+        let mut account_loader = (&mock_bank).into();
 
         let mut error_counters = TransactionErrorMetrics::default();
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let result = batch_processor.validate_transaction_fee_payer(
-            &mock_bank,
-            None,
-            &message,
-            CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature,
-            },
-            &FeatureSet::default(),
-            FeeStructure::default().lamports_per_signature,
-            &RentCollector::default(),
-            &mut error_counters,
-        );
+        let result =
+            TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
+                &mut account_loader,
+                &message,
+                CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature,
+                },
+                &Hash::default(),
+                &FeatureSet::default(),
+                FeeStructure::default().lamports_per_signature,
+                &RentCollector::default(),
+                &mut error_counters,
+            );
 
         assert_eq!(error_counters.insufficient_funds, 1);
         assert_eq!(result, Err(TransactionError::InsufficientFundsForFee));
@@ -2252,22 +2345,23 @@ mod tests {
             account_shared_data: Arc::new(RwLock::new(mock_accounts)),
             ..Default::default()
         };
+        let mut account_loader = (&mock_bank).into();
 
         let mut error_counters = TransactionErrorMetrics::default();
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let result = batch_processor.validate_transaction_fee_payer(
-            &mock_bank,
-            None,
-            &message,
-            CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature,
-            },
-            &FeatureSet::default(),
-            FeeStructure::default().lamports_per_signature,
-            &rent_collector,
-            &mut error_counters,
-        );
+        let result =
+            TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
+                &mut account_loader,
+                &message,
+                CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature,
+                },
+                &Hash::default(),
+                &FeatureSet::default(),
+                FeeStructure::default().lamports_per_signature,
+                &rent_collector,
+                &mut error_counters,
+            );
 
         assert_eq!(
             result,
@@ -2288,22 +2382,23 @@ mod tests {
             account_shared_data: Arc::new(RwLock::new(mock_accounts)),
             ..Default::default()
         };
+        let mut account_loader = (&mock_bank).into();
 
         let mut error_counters = TransactionErrorMetrics::default();
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let result = batch_processor.validate_transaction_fee_payer(
-            &mock_bank,
-            None,
-            &message,
-            CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature,
-            },
-            &FeatureSet::default(),
-            FeeStructure::default().lamports_per_signature,
-            &RentCollector::default(),
-            &mut error_counters,
-        );
+        let result =
+            TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
+                &mut account_loader,
+                &message,
+                CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature,
+                },
+                &Hash::default(),
+                &FeatureSet::default(),
+                FeeStructure::default().lamports_per_signature,
+                &RentCollector::default(),
+                &mut error_counters,
+            );
 
         assert_eq!(error_counters.invalid_account_for_fee, 1);
         assert_eq!(result, Err(TransactionError::InvalidAccountForFee));
@@ -2321,21 +2416,22 @@ mod tests {
         ));
 
         let mock_bank = MockBankCallback::default();
+        let mut account_loader = (&mock_bank).into();
         let mut error_counters = TransactionErrorMetrics::default();
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let result = batch_processor.validate_transaction_fee_payer(
-            &mock_bank,
-            None,
-            &message,
-            CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature,
-            },
-            &FeatureSet::default(),
-            FeeStructure::default().lamports_per_signature,
-            &RentCollector::default(),
-            &mut error_counters,
-        );
+        let result =
+            TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
+                &mut account_loader,
+                &message,
+                CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature,
+                },
+                &Hash::default(),
+                &FeatureSet::default(),
+                FeeStructure::default().lamports_per_signature,
+                &RentCollector::default(),
+                &mut error_counters,
+            );
 
         assert_eq!(error_counters.invalid_compute_budget, 1);
         assert_eq!(result, Err(TransactionError::DuplicateInstruction(1u8)));
@@ -2368,9 +2464,11 @@ mod tests {
         {
             let fee_payer_account = AccountSharedData::new_data(
                 min_balance + transaction_fee + priority_fee,
-                &nonce::state::Versions::new(nonce::State::Initialized(
-                    nonce::state::Data::default(),
-                )),
+                &nonce::state::Versions::new(nonce::State::Initialized(nonce::state::Data::new(
+                    *fee_payer_address,
+                    DurableNonce::default(),
+                    lamports_per_signature,
+                ))),
                 &system_program::id(),
             )
             .unwrap();
@@ -2381,23 +2479,27 @@ mod tests {
                 account_shared_data: Arc::new(RwLock::new(mock_accounts)),
                 ..Default::default()
             };
+            let mut account_loader = (&mock_bank).into();
 
             let mut error_counters = TransactionErrorMetrics::default();
-            let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
-            let nonce = Some(NonceInfo::new(
-                *fee_payer_address,
-                fee_payer_account.clone(),
-            ));
+            let environment_blockhash = Hash::new_unique();
+            let next_durable_nonce = DurableNonce::from_blockhash(&environment_blockhash);
+            let mut future_nonce = NonceInfo::new(*fee_payer_address, fee_payer_account.clone());
+            future_nonce
+                .try_advance_nonce(next_durable_nonce, lamports_per_signature)
+                .unwrap();
 
-            let result = batch_processor.validate_transaction_fee_payer(
-                &mock_bank,
-                None,
+            let tx_details = CheckedTransactionDetails {
+                nonce: Some(future_nonce.clone()),
+                lamports_per_signature,
+            };
+
+            let result = TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
+                &mut account_loader,
                 &message,
-                CheckedTransactionDetails {
-                    nonce: nonce.clone(),
-                    lamports_per_signature,
-                },
+                tx_details,
+                &environment_blockhash,
                 &feature_set,
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
@@ -2415,7 +2517,7 @@ mod tests {
                 result,
                 Ok(ValidatedTransactionDetails {
                     rollback_accounts: RollbackAccounts::new(
-                        nonce,
+                        Some(future_nonce),
                         *fee_payer_address,
                         post_validation_fee_payer_account.clone(),
                         0, // fee_payer_rent_debit
@@ -2449,17 +2551,17 @@ mod tests {
                 account_shared_data: Arc::new(RwLock::new(mock_accounts)),
                 ..Default::default()
             };
+            let mut account_loader = (&mock_bank).into();
 
             let mut error_counters = TransactionErrorMetrics::default();
-            let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-            let result = batch_processor.validate_transaction_fee_payer(
-                &mock_bank,
-                None,
+            let result = TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
+                &mut account_loader,
                 &message,
                 CheckedTransactionDetails {
                     nonce: None,
                     lamports_per_signature,
                 },
+                &Hash::default(),
                 &feature_set,
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
@@ -2502,23 +2604,30 @@ mod tests {
             account_shared_data: Arc::new(RwLock::new(mock_accounts)),
             ..Default::default()
         };
+        let mut account_loader = AccountLoader::new(
+            Some(&account_overrides),
+            ProgramCacheForTxBatch::default(),
+            HashMap::default(),
+            &mock_bank,
+            Arc::<FeatureSet>::default(),
+        );
 
         let mut error_counters = TransactionErrorMetrics::default();
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
-        let result = batch_processor.validate_transaction_fee_payer(
-            &mock_bank,
-            Some(&account_overrides),
-            &message,
-            CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature,
-            },
-            &FeatureSet::default(),
-            FeeStructure::default().lamports_per_signature,
-            &rent_collector,
-            &mut error_counters,
-        );
+        let result =
+            TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
+                &mut account_loader,
+                &message,
+                CheckedTransactionDetails {
+                    nonce: None,
+                    lamports_per_signature,
+                },
+                &Hash::default(),
+                &FeatureSet::default(),
+                FeeStructure::default().lamports_per_signature,
+                &rent_collector,
+                &mut error_counters,
+            );
         assert!(
             result.is_ok(),
             "test_account_override_used: {:?}",
@@ -2543,6 +2652,7 @@ mod tests {
             .write()
             .unwrap()
             .insert(fee_payer_address, fee_payer_account.clone());
+        let mut account_loader = (&mock_bank).into();
 
         let message = new_unchecked_sanitized_message(Message::new_with_blockhash(
             &[
@@ -2552,22 +2662,20 @@ mod tests {
             Some(&fee_payer_address),
             &Hash::new_unique(),
         ));
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        batch_processor
-            .validate_transaction_fee_payer(
-                &mock_bank,
-                None,
-                &message,
-                CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature: 5000,
-                },
-                &FeatureSet::default(),
-                FeeStructure::default().lamports_per_signature,
-                &RentCollector::default(),
-                &mut TransactionErrorMetrics::default(),
-            )
-            .unwrap();
+        TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
+            &mut account_loader,
+            &message,
+            CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: 5000,
+            },
+            &Hash::default(),
+            &FeatureSet::default(),
+            FeeStructure::default().lamports_per_signature,
+            &RentCollector::default(),
+            &mut TransactionErrorMetrics::default(),
+        )
+        .unwrap();
 
         // ensure the fee payer is an inspected account
         let actual_inspected_accounts: Vec<_> = mock_bank


### PR DESCRIPTION
#### Problem
[simd83](https://github.com/solana-foundation/solana-improvement-documents/pull/83) intends to relax entry-level constraints, namely that a transaction which takes a write lock on an account cannot be batched with any other transaction which takes a read or write lock on it

before the locking code can be changed, however, svm must be able to support such batches. presently, if one transaction were to write to an account, and a subsequent transaction read from or wrote to that account, svm would not pass the updated account state to the second transaction; it gets them from accounts-db, which is not updated until after all transaction execution finishes

previously, in #3146, we attempted to implement a jit account loader with intermediate account cache to pass updated accounts forward to future transaction in the batch. however, due to existing patterns in how the program cache is used, this has proven quite difficult to get right, and the volume of code changes required is quite large

#### Summary of Changes

this pr extracts all code from #3146 which does not modify behavior. we would like to commit it standalone for ease of review, and focus specifically on the cache behaviors in a following pr

the existing transaction processing loop in master validates all transaction fee-payers together, loads all transaction accounts together, and then executes each transaction in serial. the new transaction processing loop validates one fee-payer, loads accounts for one transaction, and then executes that transaction before proceeding to the next. this prepares us for an svm where accounts can change in between transactions

we also validate nonce accounts before each transaction, because these accounts can also change in the future svm. a future pr may choose to eliminate most nonce validation code from the `check_transactions`, but that is out of scope here

futhermore, we create a new type, `AccountLoader`, which encapsulates the batch-local program cache, account overrides, and the accounts-db callback. it provides the method `load_account`, which is opaque to its caller, returning a `LoadedTransactionAccount` according to the exact same rules as the current `load_transaction_account`

this pr changes nothing about account loading, but introducing `AccountLoader` prepares us to add the internal account cache in support of simd83