### PR TITLE
Move remaining syscall definitions out of solana-program

### DIFF
--- a/curves/secp256k1-recover/src/lib.rs
+++ b/curves/secp256k1-recover/src/lib.rs
@@ -87,7 +87,7 @@ impl Secp256k1Pubkey {
 }
 
 #[cfg(target_os = "solana")]
-solana_define_syscall::define_syscall!(fn sol_secp256k1_recover(hash: *const u8, recovery_id: u64, signature: *const u8, result: *mut u8) -> u64);
+pub use solana_define_syscall::definitions::sol_secp256k1_recover;
 
 /// Recover the public key from a [secp256k1] ECDSA signature and
 /// cryptographically-hashed message.

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -170,7 +170,7 @@ impl PoseidonHash {
 }
 
 #[cfg(target_os = "solana")]
-solana_define_syscall::define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
+pub use solana_define_syscall::definitions::sol_poseidon;
 
 /// Return a Poseidon hash for the given data with the given elliptic curve and
 /// endianness.

--- a/sdk/cpi/src/syscalls.rs
+++ b/sdk/cpi/src/syscalls.rs
@@ -1,7 +1,7 @@
 /// Syscall definitions used by `solana_cpi`.
+pub use solana_define_syscall::definitions::{
+    sol_invoke_signed_c, sol_invoke_signed_rust, sol_set_return_data,
+};
 use {solana_define_syscall::define_syscall, solana_pubkey::Pubkey};
 
-define_syscall!(fn sol_invoke_signed_c(instruction_addr: *const u8, account_infos_addr: *const u8, account_infos_len: u64, signers_seeds_addr: *const u8, signers_seeds_len: u64) -> u64);
-define_syscall!(fn sol_invoke_signed_rust(instruction_addr: *const u8, account_infos_addr: *const u8, account_infos_len: u64, signers_seeds_addr: *const u8, signers_seeds_len: u64) -> u64);
-define_syscall!(fn sol_set_return_data(data: *const u8, length: u64));
 define_syscall!(fn sol_get_return_data(data: *mut u8, length: u64, program_id: *mut Pubkey) -> u64);

--- a/sdk/define-syscall/src/definitions.rs
+++ b/sdk/define-syscall/src/definitions.rs
@@ -1,6 +1,24 @@
 //! This module is only for syscall definitions that bring in no extra dependencies.
 use crate::define_syscall;
 
+define_syscall!(fn sol_secp256k1_recover(hash: *const u8, recovery_id: u64, signature: *const u8, result: *mut u8) -> u64);
+define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
+define_syscall!(fn sol_invoke_signed_c(instruction_addr: *const u8, account_infos_addr: *const u8, account_infos_len: u64, signers_seeds_addr: *const u8, signers_seeds_len: u64) -> u64);
+define_syscall!(fn sol_invoke_signed_rust(instruction_addr: *const u8, account_infos_addr: *const u8, account_infos_len: u64, signers_seeds_addr: *const u8, signers_seeds_len: u64) -> u64);
+define_syscall!(fn sol_set_return_data(data: *const u8, length: u64));
+define_syscall!(fn sol_get_stack_height() -> u64);
+define_syscall!(fn sol_log_(message: *const u8, len: u64));
+define_syscall!(fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64));
+define_syscall!(fn sol_log_compute_units_());
+define_syscall!(fn sol_log_data(data: *const u8, data_len: u64));
+define_syscall!(fn sol_memcpy_(dst: *mut u8, src: *const u8, n: u64));
+define_syscall!(fn sol_memmove_(dst: *mut u8, src: *const u8, n: u64));
+define_syscall!(fn sol_memcmp_(s1: *const u8, s2: *const u8, n: u64, result: *mut i32));
+define_syscall!(fn sol_memset_(s: *mut u8, c: u8, n: u64));
+define_syscall!(fn sol_log_pubkey(pubkey_addr: *const u8));
+define_syscall!(fn sol_create_program_address(seeds_addr: *const u8, seeds_len: u64, program_id_addr: *const u8, address_bytes_addr: *const u8) -> u64);
+define_syscall!(fn sol_try_find_program_address(seeds_addr: *const u8, seeds_len: u64, program_id_addr: *const u8, address_bytes_addr: *const u8, bump_seed_addr: *const u8) -> u64);
+define_syscall!(fn sol_sha256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_keccak256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_blake3(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_curve_validate_point(curve_id: u64, point_addr: *const u8, result: *mut u8) -> u64);

--- a/sdk/define-syscall/src/definitions.rs
+++ b/sdk/define-syscall/src/definitions.rs
@@ -1,0 +1,25 @@
+//! This module is only for syscall definitions that bring in no extra dependencies.
+use crate::define_syscall;
+
+define_syscall!(fn sol_keccak256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
+define_syscall!(fn sol_blake3(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
+define_syscall!(fn sol_curve_validate_point(curve_id: u64, point_addr: *const u8, result: *mut u8) -> u64);
+define_syscall!(fn sol_curve_group_op(curve_id: u64, group_op: u64, left_input_addr: *const u8, right_input_addr: *const u8, result_point_addr: *mut u8) -> u64);
+define_syscall!(fn sol_curve_multiscalar_mul(curve_id: u64, scalars_addr: *const u8, points_addr: *const u8, points_len: u64, result_point_addr: *mut u8) -> u64);
+define_syscall!(fn sol_curve_pairing_map(curve_id: u64, point: *const u8, result: *mut u8) -> u64);
+define_syscall!(fn sol_alt_bn128_group_op(group_op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
+define_syscall!(fn sol_big_mod_exp(params: *const u8, result: *mut u8) -> u64);
+define_syscall!(fn sol_remaining_compute_units() -> u64);
+define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
+define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, result: *mut u8, offset: u64, length: u64) -> u64);
+define_syscall!(fn sol_get_epoch_stake(vote_address: *const u8) -> u64);
+
+// these are to be deprecated once they are superceded by sol_get_sysvar
+define_syscall!(fn sol_get_clock_sysvar(addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_epoch_schedule_sysvar(addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_rent_sysvar(addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_last_restart_slot(addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
+
+// this cannot go through sol_get_sysvar but can be removed once no longer in use
+define_syscall!(fn sol_get_fees_sysvar(addr: *mut u8) -> u64);

--- a/sdk/define-syscall/src/lib.rs
+++ b/sdk/define-syscall/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod definitions;
+
 #[cfg(target_feature = "static-syscalls")]
 #[macro_export]
 macro_rules! define_syscall {

--- a/sdk/instruction/src/syscalls.rs
+++ b/sdk/instruction/src/syscalls.rs
@@ -1,3 +1,4 @@
+pub use solana_define_syscall::definitions::sol_get_stack_height;
 use {
     crate::{AccountMeta, ProcessedSiblingInstruction},
     solana_define_syscall::define_syscall,
@@ -5,4 +6,3 @@ use {
 };
 
 define_syscall!(fn sol_get_processed_sibling_instruction(index: u64, meta: *mut ProcessedSiblingInstruction, program_id: *mut Pubkey, data: *mut u8, accounts: *mut AccountMeta) -> u64);
-define_syscall!(fn sol_get_stack_height() -> u64);

--- a/sdk/msg/src/syscalls.rs
+++ b/sdk/msg/src/syscalls.rs
@@ -1,7 +1,4 @@
 /// Syscall definitions used by `solana_msg`.
-use solana_define_syscall::define_syscall;
-
-define_syscall!(fn sol_log_(message: *const u8, len: u64));
-define_syscall!(fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64));
-define_syscall!(fn sol_log_compute_units_());
-define_syscall!(fn sol_log_data(data: *const u8, data_len: u64));
+pub use solana_define_syscall::definitions::{
+    sol_log_, sol_log_64_, sol_log_compute_units_, sol_log_data,
+};

--- a/sdk/program-memory/src/lib.rs
+++ b/sdk/program-memory/src/lib.rs
@@ -5,11 +5,9 @@
 
 #[cfg(target_os = "solana")]
 pub mod syscalls {
-    use solana_define_syscall::define_syscall;
-    define_syscall!(fn sol_memcpy_(dst: *mut u8, src: *const u8, n: u64));
-    define_syscall!(fn sol_memmove_(dst: *mut u8, src: *const u8, n: u64));
-    define_syscall!(fn sol_memcmp_(s1: *const u8, s2: *const u8, n: u64, result: *mut i32));
-    define_syscall!(fn sol_memset_(s: *mut u8, c: u8, n: u64));
+    pub use solana_define_syscall::definitions::{
+        sol_memcmp_, sol_memcpy_, sol_memmove_, sol_memset_,
+    };
 }
 
 /// Check that two regions do not overlap.

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -2,7 +2,17 @@
 pub use solana_cpi::syscalls::{
     sol_get_return_data, sol_invoke_signed_c, sol_invoke_signed_rust, sol_set_return_data,
 };
-use solana_define_syscall::define_syscall;
+#[deprecated(
+    since = "2.2.0",
+    note = "Use `solana_define_syscall::definitions` instead"
+)]
+pub use solana_define_syscall::definitions::{
+    sol_alt_bn128_compression, sol_alt_bn128_group_op, sol_big_mod_exp, sol_blake3,
+    sol_curve_group_op, sol_curve_multiscalar_mul, sol_curve_pairing_map, sol_curve_validate_point,
+    sol_get_clock_sysvar, sol_get_epoch_rewards_sysvar, sol_get_epoch_schedule_sysvar,
+    sol_get_epoch_stake, sol_get_fees_sysvar, sol_get_last_restart_slot, sol_get_rent_sysvar,
+    sol_get_sysvar, sol_keccak256, sol_remaining_compute_units,
+};
 #[cfg(target_feature = "static-syscalls")]
 pub use solana_define_syscall::sys_hash;
 #[deprecated(since = "2.1.0", note = "Use `solana_instruction::syscalls` instead")]
@@ -27,25 +37,3 @@ pub use solana_pubkey::syscalls::{
 pub use solana_secp256k1_recover::sol_secp256k1_recover;
 #[deprecated(since = "2.1.0", note = "Use solana_sha256_hasher::sol_sha256 instead")]
 pub use solana_sha256_hasher::sol_sha256;
-define_syscall!(fn sol_keccak256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
-define_syscall!(fn sol_blake3(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
-define_syscall!(fn sol_curve_validate_point(curve_id: u64, point_addr: *const u8, result: *mut u8) -> u64);
-define_syscall!(fn sol_curve_group_op(curve_id: u64, group_op: u64, left_input_addr: *const u8, right_input_addr: *const u8, result_point_addr: *mut u8) -> u64);
-define_syscall!(fn sol_curve_multiscalar_mul(curve_id: u64, scalars_addr: *const u8, points_addr: *const u8, points_len: u64, result_point_addr: *mut u8) -> u64);
-define_syscall!(fn sol_curve_pairing_map(curve_id: u64, point: *const u8, result: *mut u8) -> u64);
-define_syscall!(fn sol_alt_bn128_group_op(group_op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
-define_syscall!(fn sol_big_mod_exp(params: *const u8, result: *mut u8) -> u64);
-define_syscall!(fn sol_remaining_compute_units() -> u64);
-define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
-define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, result: *mut u8, offset: u64, length: u64) -> u64);
-define_syscall!(fn sol_get_epoch_stake(vote_address: *const u8) -> u64);
-
-// these are to be deprecated once they are superceded by sol_get_sysvar
-define_syscall!(fn sol_get_clock_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_epoch_schedule_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_rent_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_last_restart_slot(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
-
-// this cannot go through sol_get_sysvar but can be removed once no longer in use
-define_syscall!(fn sol_get_fees_sysvar(addr: *mut u8) -> u64);

--- a/sdk/pubkey/src/syscalls.rs
+++ b/sdk/pubkey/src/syscalls.rs
@@ -1,6 +1,4 @@
 /// Syscall definitions used by `solana_pubkey`.
-use solana_define_syscall::define_syscall;
-
-define_syscall!(fn sol_log_pubkey(pubkey_addr: *const u8));
-define_syscall!(fn sol_create_program_address(seeds_addr: *const u8, seeds_len: u64, program_id_addr: *const u8, address_bytes_addr: *const u8) -> u64);
-define_syscall!(fn sol_try_find_program_address(seeds_addr: *const u8, seeds_len: u64, program_id_addr: *const u8, address_bytes_addr: *const u8, bump_seed_addr: *const u8) -> u64);
+pub use solana_define_syscall::definitions::{
+    sol_create_program_address, sol_log_pubkey, sol_try_find_program_address,
+};

--- a/sdk/sha256-hasher/src/lib.rs
+++ b/sdk/sha256-hasher/src/lib.rs
@@ -28,7 +28,7 @@ impl Hasher {
 }
 
 #[cfg(target_os = "solana")]
-define_syscall!(fn sol_sha256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
+pub use solana_define_syscall::definitions::sol_sha256;
 
 /// Return a Sha256 hash for the given data.
 pub fn hashv(vals: &[&[u8]]) -> Hash {

--- a/sdk/sha256-hasher/src/lib.rs
+++ b/sdk/sha256-hasher/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #[cfg(any(feature = "sha2", not(target_os = "solana")))]
 use sha2::{Digest, Sha256};
-#[cfg(target_os = "solana")]
-use solana_define_syscall::define_syscall;
 use solana_hash::Hash;
 
 #[cfg(any(feature = "sha2", not(target_os = "solana")))]


### PR DESCRIPTION
#### Problem
There are still some syscall definitions that are imposing a `solana_program` dep on other crates.

#### Summary of Changes
- Move remaining syscall definitions out of `solana_program::syscalls::definitions` and into `solana_define_syscall::definitions`. This causes no measurable increase in build time for `solana_define_syscall`
- Re-export the syscalls with deprecation notice
- Add a doc note saying that the new `definitions` module is only for syscall definitions that bring in no extra deps
