### PR TITLE
remove solana-program dep from solana-curve25519

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6580,7 +6580,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-program",
+ "solana-define-syscall",
  "thiserror",
 ]
 

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -15,7 +15,7 @@ bytemuck_derive = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
-solana-program = { workspace = true }
+solana-define-syscall = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 curve25519-dalek = { workspace = true, features = ["serde"] }

--- a/curves/curve25519/src/edwards.rs
+++ b/curves/curve25519/src/edwards.rs
@@ -148,7 +148,7 @@ mod target_arch {
     pub fn validate_edwards(point: &PodEdwardsPoint) -> bool {
         let mut validate_result = 0u8;
         let result = unsafe {
-            solana_program::syscalls::sol_curve_validate_point(
+            solana_define_syscall::definitions::sol_curve_validate_point(
                 CURVE25519_EDWARDS,
                 &point.0 as *const u8,
                 &mut validate_result,
@@ -163,7 +163,7 @@ mod target_arch {
     ) -> Option<PodEdwardsPoint> {
         let mut result_point = PodEdwardsPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            solana_define_syscall::definitions::sol_curve_group_op(
                 CURVE25519_EDWARDS,
                 ADD,
                 &left_point.0 as *const u8,
@@ -185,7 +185,7 @@ mod target_arch {
     ) -> Option<PodEdwardsPoint> {
         let mut result_point = PodEdwardsPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            solana_define_syscall::definitions::sol_curve_group_op(
                 CURVE25519_EDWARDS,
                 SUB,
                 &left_point.0 as *const u8,
@@ -207,7 +207,7 @@ mod target_arch {
     ) -> Option<PodEdwardsPoint> {
         let mut result_point = PodEdwardsPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            solana_define_syscall::definitions::sol_curve_group_op(
                 CURVE25519_EDWARDS,
                 MUL,
                 &scalar.0 as *const u8,
@@ -229,7 +229,7 @@ mod target_arch {
     ) -> Option<PodEdwardsPoint> {
         let mut result_point = PodEdwardsPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_multiscalar_mul(
+            solana_define_syscall::definitions::sol_curve_multiscalar_mul(
                 CURVE25519_EDWARDS,
                 scalars.as_ptr() as *const u8,
                 points.as_ptr() as *const u8,

--- a/curves/curve25519/src/ristretto.rs
+++ b/curves/curve25519/src/ristretto.rs
@@ -149,7 +149,7 @@ mod target_arch {
     pub fn validate_ristretto(point: &PodRistrettoPoint) -> bool {
         let mut validate_result = 0u8;
         let result = unsafe {
-            solana_program::syscalls::sol_curve_validate_point(
+            solana_define_syscall::definitions::sol_curve_validate_point(
                 CURVE25519_RISTRETTO,
                 &point.0 as *const u8,
                 &mut validate_result,
@@ -165,7 +165,7 @@ mod target_arch {
     ) -> Option<PodRistrettoPoint> {
         let mut result_point = PodRistrettoPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            solana_define_syscall::definitions::sol_curve_group_op(
                 CURVE25519_RISTRETTO,
                 ADD,
                 &left_point.0 as *const u8,
@@ -187,7 +187,7 @@ mod target_arch {
     ) -> Option<PodRistrettoPoint> {
         let mut result_point = PodRistrettoPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            solana_define_syscall::definitions::sol_curve_group_op(
                 CURVE25519_RISTRETTO,
                 SUB,
                 &left_point.0 as *const u8,
@@ -209,7 +209,7 @@ mod target_arch {
     ) -> Option<PodRistrettoPoint> {
         let mut result_point = PodRistrettoPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            solana_define_syscall::definitions::sol_curve_group_op(
                 CURVE25519_RISTRETTO,
                 MUL,
                 &scalar.0 as *const u8,
@@ -231,7 +231,7 @@ mod target_arch {
     ) -> Option<PodRistrettoPoint> {
         let mut result_point = PodRistrettoPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_multiscalar_mul(
+            solana_define_syscall::definitions::sol_curve_multiscalar_mul(
                 CURVE25519_RISTRETTO,
                 scalars.as_ptr() as *const u8,
                 points.as_ptr() as *const u8,

--- a/define-syscall/src/definitions.rs
+++ b/define-syscall/src/definitions.rs
@@ -1,0 +1,25 @@
+//! This module is only for syscall definitions that bring in no extra dependencies.
+use crate::define_syscall;
+
+define_syscall!(fn sol_keccak256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
+define_syscall!(fn sol_blake3(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
+define_syscall!(fn sol_curve_validate_point(curve_id: u64, point_addr: *const u8, result: *mut u8) -> u64);
+define_syscall!(fn sol_curve_group_op(curve_id: u64, group_op: u64, left_input_addr: *const u8, right_input_addr: *const u8, result_point_addr: *mut u8) -> u64);
+define_syscall!(fn sol_curve_multiscalar_mul(curve_id: u64, scalars_addr: *const u8, points_addr: *const u8, points_len: u64, result_point_addr: *mut u8) -> u64);
+define_syscall!(fn sol_curve_pairing_map(curve_id: u64, point: *const u8, result: *mut u8) -> u64);
+define_syscall!(fn sol_alt_bn128_group_op(group_op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
+define_syscall!(fn sol_big_mod_exp(params: *const u8, result: *mut u8) -> u64);
+define_syscall!(fn sol_remaining_compute_units() -> u64);
+define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
+define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, result: *mut u8, offset: u64, length: u64) -> u64);
+define_syscall!(fn sol_get_epoch_stake(vote_address: *const u8) -> u64);
+
+// these are to be deprecated once they are superceded by sol_get_sysvar
+define_syscall!(fn sol_get_clock_sysvar(addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_epoch_schedule_sysvar(addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_rent_sysvar(addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_last_restart_slot(addr: *mut u8) -> u64);
+define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
+
+// this cannot go through sol_get_sysvar but can be removed once no longer in use
+define_syscall!(fn sol_get_fees_sysvar(addr: *mut u8) -> u64);

--- a/define-syscall/src/lib.rs
+++ b/define-syscall/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod definitions;
+
 #[cfg(target_feature = "static-syscalls")]
 #[macro_export]
 macro_rules! define_syscall {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5267,7 +5267,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-program",
+ "solana-define-syscall",
  "thiserror",
 ]
 

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -2,7 +2,17 @@
 pub use solana_cpi::syscalls::{
     sol_get_return_data, sol_invoke_signed_c, sol_invoke_signed_rust, sol_set_return_data,
 };
-use solana_define_syscall::define_syscall;
+#[deprecated(
+    since = "2.2.0",
+    note = "Use `solana_define_syscall::definitions` instead"
+)]
+pub use solana_define_syscall::definitions::{
+    sol_alt_bn128_compression, sol_alt_bn128_group_op, sol_big_mod_exp, sol_blake3,
+    sol_curve_group_op, sol_curve_multiscalar_mul, sol_curve_pairing_map, sol_curve_validate_point,
+    sol_get_clock_sysvar, sol_get_epoch_rewards_sysvar, sol_get_epoch_schedule_sysvar,
+    sol_get_epoch_stake, sol_get_fees_sysvar, sol_get_last_restart_slot, sol_get_rent_sysvar,
+    sol_get_sysvar, sol_keccak256, sol_remaining_compute_units,
+};
 #[cfg(target_feature = "static-syscalls")]
 pub use solana_define_syscall::sys_hash;
 #[deprecated(since = "2.1.0", note = "Use `solana_instruction::syscalls` instead")]
@@ -27,25 +37,3 @@ pub use solana_pubkey::syscalls::{
 pub use solana_secp256k1_recover::sol_secp256k1_recover;
 #[deprecated(since = "2.1.0", note = "Use solana_sha256_hasher::sol_sha256 instead")]
 pub use solana_sha256_hasher::sol_sha256;
-define_syscall!(fn sol_keccak256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
-define_syscall!(fn sol_blake3(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
-define_syscall!(fn sol_curve_validate_point(curve_id: u64, point_addr: *const u8, result: *mut u8) -> u64);
-define_syscall!(fn sol_curve_group_op(curve_id: u64, group_op: u64, left_input_addr: *const u8, right_input_addr: *const u8, result_point_addr: *mut u8) -> u64);
-define_syscall!(fn sol_curve_multiscalar_mul(curve_id: u64, scalars_addr: *const u8, points_addr: *const u8, points_len: u64, result_point_addr: *mut u8) -> u64);
-define_syscall!(fn sol_curve_pairing_map(curve_id: u64, point: *const u8, result: *mut u8) -> u64);
-define_syscall!(fn sol_alt_bn128_group_op(group_op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
-define_syscall!(fn sol_big_mod_exp(params: *const u8, result: *mut u8) -> u64);
-define_syscall!(fn sol_remaining_compute_units() -> u64);
-define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
-define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, result: *mut u8, offset: u64, length: u64) -> u64);
-define_syscall!(fn sol_get_epoch_stake(vote_address: *const u8) -> u64);
-
-// these are to be deprecated once they are superceded by sol_get_sysvar
-define_syscall!(fn sol_get_clock_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_epoch_schedule_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_rent_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_last_restart_slot(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
-
-// this cannot go through sol_get_sysvar but can be removed once no longer in use
-define_syscall!(fn sol_get_fees_sysvar(addr: *mut u8) -> u64);


### PR DESCRIPTION
#### Problem
solana-curve25519 can compile faster without solana-program

#### Summary of Changes
- Replace the solana-program dep with solana-define-syscall

This branches off #3405 so that needs to be merged first