### PR TITLE
sdk: Extract curve syscalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6579,7 +6579,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-program",
+ "solana-define-syscall",
  "thiserror",
 ]
 
@@ -7465,6 +7465,7 @@ dependencies = [
  "solana-borsh",
  "solana-clock",
  "solana-cpi",
+ "solana-curve25519",
  "solana-decode-error",
  "solana-define-syscall",
  "solana-epoch-schedule",

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -15,7 +15,7 @@ bytemuck_derive = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
-solana-program = { workspace = true }
+solana-define-syscall = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 curve25519-dalek = { workspace = true, features = ["serde"] }

--- a/curves/curve25519/src/edwards.rs
+++ b/curves/curve25519/src/edwards.rs
@@ -148,7 +148,7 @@ mod target_arch {
     pub fn validate_edwards(point: &PodEdwardsPoint) -> bool {
         let mut validate_result = 0u8;
         let result = unsafe {
-            solana_program::syscalls::sol_curve_validate_point(
+            crate::syscalls::sol_curve_validate_point(
                 CURVE25519_EDWARDS,
                 &point.0 as *const u8,
                 &mut validate_result,
@@ -163,7 +163,7 @@ mod target_arch {
     ) -> Option<PodEdwardsPoint> {
         let mut result_point = PodEdwardsPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            crate::syscalls::sol_curve_group_op(
                 CURVE25519_EDWARDS,
                 ADD,
                 &left_point.0 as *const u8,
@@ -185,7 +185,7 @@ mod target_arch {
     ) -> Option<PodEdwardsPoint> {
         let mut result_point = PodEdwardsPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            crate::syscalls::sol_curve_group_op(
                 CURVE25519_EDWARDS,
                 SUB,
                 &left_point.0 as *const u8,
@@ -207,7 +207,7 @@ mod target_arch {
     ) -> Option<PodEdwardsPoint> {
         let mut result_point = PodEdwardsPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            crate::syscalls::sol_curve_group_op(
                 CURVE25519_EDWARDS,
                 MUL,
                 &scalar.0 as *const u8,
@@ -229,7 +229,7 @@ mod target_arch {
     ) -> Option<PodEdwardsPoint> {
         let mut result_point = PodEdwardsPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_multiscalar_mul(
+            crate::syscalls::sol_curve_multiscalar_mul(
                 CURVE25519_EDWARDS,
                 scalars.as_ptr() as *const u8,
                 points.as_ptr() as *const u8,

--- a/curves/curve25519/src/lib.rs
+++ b/curves/curve25519/src/lib.rs
@@ -6,3 +6,5 @@ pub mod edwards;
 pub mod errors;
 pub mod ristretto;
 pub mod scalar;
+#[cfg(target_os = "solana")]
+pub mod syscalls;

--- a/curves/curve25519/src/ristretto.rs
+++ b/curves/curve25519/src/ristretto.rs
@@ -149,7 +149,7 @@ mod target_arch {
     pub fn validate_ristretto(point: &PodRistrettoPoint) -> bool {
         let mut validate_result = 0u8;
         let result = unsafe {
-            solana_program::syscalls::sol_curve_validate_point(
+            crate::syscalls::sol_curve_validate_point(
                 CURVE25519_RISTRETTO,
                 &point.0 as *const u8,
                 &mut validate_result,
@@ -165,7 +165,7 @@ mod target_arch {
     ) -> Option<PodRistrettoPoint> {
         let mut result_point = PodRistrettoPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            crate::syscalls::sol_curve_group_op(
                 CURVE25519_RISTRETTO,
                 ADD,
                 &left_point.0 as *const u8,
@@ -187,7 +187,7 @@ mod target_arch {
     ) -> Option<PodRistrettoPoint> {
         let mut result_point = PodRistrettoPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            crate::syscalls::sol_curve_group_op(
                 CURVE25519_RISTRETTO,
                 SUB,
                 &left_point.0 as *const u8,
@@ -209,7 +209,7 @@ mod target_arch {
     ) -> Option<PodRistrettoPoint> {
         let mut result_point = PodRistrettoPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            crate::syscalls::sol_curve_group_op(
                 CURVE25519_RISTRETTO,
                 MUL,
                 &scalar.0 as *const u8,
@@ -231,7 +231,7 @@ mod target_arch {
     ) -> Option<PodRistrettoPoint> {
         let mut result_point = PodRistrettoPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_multiscalar_mul(
+            crate::syscalls::sol_curve_multiscalar_mul(
                 CURVE25519_RISTRETTO,
                 scalars.as_ptr() as *const u8,
                 points.as_ptr() as *const u8,

--- a/curves/curve25519/src/syscalls.rs
+++ b/curves/curve25519/src/syscalls.rs
@@ -1,0 +1,6 @@
+use solana_define_syscall::define_syscall;
+
+define_syscall!(fn sol_curve_validate_point(curve_id: u64, point_addr: *const u8, result: *mut u8) -> u64);
+define_syscall!(fn sol_curve_group_op(curve_id: u64, group_op: u64, left_input_addr: *const u8, right_input_addr: *const u8, result_point_addr: *mut u8) -> u64);
+define_syscall!(fn sol_curve_multiscalar_mul(curve_id: u64, scalars_addr: *const u8, points_addr: *const u8, points_len: u64, result_point_addr: *mut u8) -> u64);
+define_syscall!(fn sol_curve_pairing_map(curve_id: u64, point: *const u8, result: *mut u8) -> u64);

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5266,7 +5266,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-program",
+ "solana-define-syscall",
  "thiserror",
 ]
 
@@ -5830,6 +5830,7 @@ dependencies = [
  "solana-borsh",
  "solana-clock",
  "solana-cpi",
+ "solana-curve25519",
  "solana-decode-error",
  "solana-define-syscall",
  "solana-epoch-schedule",

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -38,6 +38,7 @@ solana-bincode = { workspace = true }
 solana-borsh = { workspace = true, optional = true }
 solana-clock = { workspace = true, features = ["serde", "sysvar"] }
 solana-cpi = { workspace = true }
+solana-curve25519 = { workspace = true }
 solana-decode-error = { workspace = true }
 solana-epoch-schedule = { workspace = true, features = ["serde", "sysvar"] }
 solana-fee-calculator = { workspace = true, features = ["serde"] }

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -2,6 +2,10 @@
 pub use solana_cpi::syscalls::{
     sol_get_return_data, sol_invoke_signed_c, sol_invoke_signed_rust, sol_set_return_data,
 };
+#[deprecated(since = "2.2.0", note = "Use `solana_curve25519::syscalls` instead")]
+pub use solana_curve25519::syscalls::{
+    sol_curve_group_op, sol_curve_multiscalar_mul, sol_curve_pairing_map, sol_curve_validate_point,
+};
 use solana_define_syscall::define_syscall;
 #[cfg(target_feature = "static-syscalls")]
 pub use solana_define_syscall::sys_hash;
@@ -29,10 +33,6 @@ pub use solana_secp256k1_recover::sol_secp256k1_recover;
 pub use solana_sha256_hasher::sol_sha256;
 define_syscall!(fn sol_keccak256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_blake3(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
-define_syscall!(fn sol_curve_validate_point(curve_id: u64, point_addr: *const u8, result: *mut u8) -> u64);
-define_syscall!(fn sol_curve_group_op(curve_id: u64, group_op: u64, left_input_addr: *const u8, right_input_addr: *const u8, result_point_addr: *mut u8) -> u64);
-define_syscall!(fn sol_curve_multiscalar_mul(curve_id: u64, scalars_addr: *const u8, points_addr: *const u8, points_len: u64, result_point_addr: *mut u8) -> u64);
-define_syscall!(fn sol_curve_pairing_map(curve_id: u64, point: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_alt_bn128_group_op(group_op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
 define_syscall!(fn sol_big_mod_exp(params: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_remaining_compute_units() -> u64);


### PR DESCRIPTION
#### Problem

There is now a `curve25519` crate but its syscalls are still being defined by `solana-program`.

#### Summary of Changes

Extract the definition of curve syscalls out of `solana-program` and place them into a `syscalls` module under the `curve25519` crate, re-exporting them to maintain backwards compatibility. As a side-effect, `curve25519` does not depend on `solana-program` (the dependency is inverted).

Definitions moved:
* `sol_curve_validate_point`
* `sol_curve_group_op`
* `sol_curve_multiscalar_mul`
* `sol_curve_pairing_map`