### PR TITLE
computes precise limit for the size of the bloom filter in gossip pull requests

### DIFF
--- a/gossip/benches/crds_gossip_pull.rs
+++ b/gossip/benches/crds_gossip_pull.rs
@@ -6,7 +6,6 @@ use {
     rand::{thread_rng, Rng},
     rayon::ThreadPoolBuilder,
     solana_gossip::{
-        cluster_info::MAX_BLOOM_SIZE,
         crds::{Crds, GossipRoute},
         crds_gossip_pull::{CrdsFilter, CrdsGossipPull},
         crds_value::CrdsValue,
@@ -51,7 +50,11 @@ fn bench_build_crds_filters(bencher: &mut Bencher) {
     assert_eq!(num_inserts, 90_000);
     let crds = RwLock::new(crds);
     bencher.iter(|| {
-        let filters = crds_gossip_pull.build_crds_filters(&thread_pool, &crds, MAX_BLOOM_SIZE);
+        let filters = crds_gossip_pull.build_crds_filters(
+            &thread_pool,
+            &crds,
+            992, // max_bloom_filter_bytes
+        );
         assert_eq!(filters.len(), 16);
     });
 }

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -5,7 +5,6 @@ use {
     rayon::{prelude::*, ThreadPool, ThreadPoolBuilder},
     serial_test::serial,
     solana_gossip::{
-        cluster_info,
         cluster_info_metrics::GossipStats,
         contact_info::ContactInfo,
         crds::GossipRoute,
@@ -530,7 +529,7 @@ fn network_run_pull(
                             now,
                             None,
                             &HashMap::new(),
-                            cluster_info::MAX_BLOOM_SIZE,
+                            992, // max_bloom_filter_bytes
                             from.ping_cache.deref(),
                             &mut pings,
                             &SocketAddrSpace::Unspecified,


### PR DESCRIPTION

#### Problem
Because gossip pull requests
     
    Protocol::PullRequest(CrdsFilter, /*caller:*/ CrdsValue)

have to fit inside a packet, we can only use limited number of bytes for the bloom filter.

Current master code is using a hard-coded constant for this limit:
https://github.com/anza-xyz/agave/blob/b7028a1dc/gossip/src/cluster_info.rs#L105-L106

which, depending on the serialized size of the accompanying `CrdsValue`, might either under-utilize bytes in the packet or overflow `PACKET_DATA_SIZE`.



#### Summary of Changes
The commit instead computes a precise limit for the size of the bloom filter based on the serialized size of the pull request components.

