### PR TITLE
CI: Disable downstream jobs temporarily

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -38,6 +38,7 @@ env:
 jobs:
   check:
     if: github.repository == 'anza-xyz/agave'
+    if: false # Re-enable once downstream job is fixed
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -91,6 +92,7 @@ jobs:
                 ],
             },
           ]
+    if: false # Re-enable once downstream job is fixed
     steps:
       - uses: actions/checkout@v4
 
@@ -144,7 +146,7 @@ jobs:
           - [name-service/program]
           - [stake-pool/program]
           - [single-pool/program]
-
+    if: false # Re-enable once downstream job is fixed
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
#### Problem

Downstream jobs are failing, most likely because the patching script isn't up to date.

#### Summary of Changes

To quickly unblock CI, just disable the downstream jobs. We'll fixup the patch scripts later

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
