### PR TITLE
CI: Re-enable downstream SPL jobs

### DIFF
--- a/.github/scripts/downstream-project-spl-common.sh
+++ b/.github/scripts/downstream-project-spl-common.sh
@@ -24,13 +24,3 @@ if semverGT "$project_used_solana_version" "$SOLANA_VER"; then
 fi
 
 ./patch.crates-io.sh "$SOLANA_DIR"
-
-# anza migration stopgap. can be removed when agave is fully recommended for public usage.
-sed -i 's/solana-geyser-plugin-interface/agave-geyser-plugin-interface/g' ./Cargo.toml
-
-# should be removed when spl bump their curve25519-dalek
-sed -i "s/^curve25519-dalek =.*/curve25519-dalek = \"4.1.3\"/" token/confidential-transfer/proof-generation/Cargo.toml
-
-# fix curve25519-dalek
-
-sed -i '/\[patch.crates-io\]/a curve25519-dalek = { git = "https://github.com/anza-xyz/curve25519-dalek.git", rev = "b500cdc2a920cd5bff9e2dd974d7b97349d61464" }' ./Cargo.toml

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -38,7 +38,6 @@ env:
 jobs:
   check:
     if: github.repository == 'anza-xyz/agave'
-    if: false # Re-enable once downstream job is fixed
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -92,7 +91,6 @@ jobs:
                 ],
             },
           ]
-    if: false # Re-enable once downstream job is fixed
     steps:
       - uses: actions/checkout@v4
 
@@ -146,7 +144,6 @@ jobs:
           - [name-service/program]
           - [stake-pool/program]
           - [single-pool/program]
-    if: false # Re-enable once downstream job is fixed
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
#### Problem

The downstream SPL jobs were disabled in #3414 because the crates weren't being patched properly.

#### Summary of changes

Since the crates are now being properly patched in https://github.com/solana-labs/solana-program-library/pull/7434, re-enable those jobs! At the same time, remove the patch to bump the curve25519-dalek version.