### PR TITLE
Update validate_acocunt_locks function to use writable locks instead of all loaded accounts

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -566,7 +566,7 @@ impl Accounts {
         // Validate the account locks, then get iterator if successful validation.
         let tx_account_locks_results: Vec<Result<_>> = txs
             .map(|tx| {
-                validate_account_locks(tx.account_keys(), tx_account_lock_limit)
+                validate_account_locks(tx, tx_account_lock_limit)
                     .map(|_| TransactionAccountLocksIterator::new(tx))
             })
             .collect();
@@ -584,7 +584,7 @@ impl Accounts {
         let tx_account_locks_results: Vec<Result<_>> = txs
             .zip(results)
             .map(|(tx, result)| match result {
-                Ok(()) => validate_account_locks(tx.account_keys(), tx_account_lock_limit)
+                Ok(()) => validate_account_locks(tx, tx_account_lock_limit)
                     .map(|_| TransactionAccountLocksIterator::new(tx)),
                 Err(err) => Err(err),
             })

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -539,11 +539,7 @@ impl<T: LikeClusterInfo> SchedulerController<T> {
                 })
                 .inspect(|_| saturating_add_assign!(post_sanitization_count, 1))
                 .filter(|(_packet, tx, _deactivation_slot)| {
-                    validate_account_locks(
-                        tx.message().account_keys(),
-                        transaction_account_lock_limit,
-                    )
-                    .is_ok()
+                    validate_account_locks(tx.message(), transaction_account_lock_limit).is_ok()
                 })
                 .filter_map(|(packet, tx, deactivation_slot)| {
                     process_compute_budget_instructions(SVMMessage::program_instructions_iter(&tx))

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -175,12 +175,7 @@ fn consume_scan_should_process_packet(
         let message = sanitized_transaction.message();
 
         // Check the number of locks and whether there are duplicates
-        if validate_account_locks(
-            message.account_keys(),
-            bank.get_transaction_account_lock_limit(),
-        )
-        .is_err()
-        {
+        if validate_account_locks(message, bank.get_transaction_account_lock_limit()).is_err() {
             payload
                 .message_hash_to_transaction
                 .remove(packet.message_hash());

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3501,8 +3501,7 @@ impl Bank {
         transaction: &'a SanitizedTransaction,
     ) -> TransactionBatch<'_, '_, SanitizedTransaction> {
         let tx_account_lock_limit = self.get_transaction_account_lock_limit();
-        let lock_result =
-            validate_account_locks(transaction.message().account_keys(), tx_account_lock_limit);
+        let lock_result = validate_account_locks(transaction.message(), tx_account_lock_limit);
         let mut batch = TransactionBatch::new(
             vec![lock_result],
             self,

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -209,10 +209,8 @@ impl PrioritizationFeeCache {
                 );
 
                 let message = sanitized_transaction.message();
-                let lock_result = validate_account_locks(
-                    message.account_keys(),
-                    bank.get_transaction_account_lock_limit(),
-                );
+                let lock_result =
+                    validate_account_locks(message, bank.get_transaction_account_lock_limit());
 
                 if compute_budget_limits.is_err() || lock_result.is_err() {
                     continue;


### PR DESCRIPTION
#### Problem
The [current](https://github.com/anza-xyz/agave/blob/ccbe01dd332ab6b75cd2091fb359e4ad8fea0c2c/accounts-db/src/account_locks.rs#L123) TooManyAccountLocks check looks at the [length](https://github.com/anza-xyz/agave/blob/ccbe01dd332ab6b75cd2091fb359e4ad8fea0c2c/sdk/program/src/message/account_keys.rs#L70) of AccountKeys. The length check only checks the amount of accounts loaded, not the number of writable (locked) accounts. This prevents developers from utilizing versioned transactions effectively, as even if the number of writable accounts in the transaction is less than the limit, the transaction does not go through. This is blocking for a few features on our app right now.

#### Summary of Changes
Updated [validate_account_locks](https://github.com/anza-xyz/agave/blob/ccbe01dd332ab6b75cd2091fb359e4ad8fea0c2c/accounts-db/src/account_locks.rs#L118) function to accept a transaction message (instead of account keys) and check if the number of writable locks exceeds the limit. Updated code that calls `validate_account_locks` and unit tests accordingly.

The function was created/updated by @apfitzge 3 months ago, so he might have the best context here. 

Fixes #3395 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
