### PR TITLE
Freezes bank in tests

### DIFF
--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -892,6 +892,11 @@ mod tests {
         )
         .unwrap();
 
+        // Correctly calculating the accounts lt hash in Bank::new_from_fields() depends on the
+        // bank being frozen.  This is so we don't call `update_accounts_lt_hash()` twice on the
+        // same bank!
+        assert!(roundtrip_bank.is_frozen());
+
         // Wait for the startup verification to complete.  If we don't panic, then we're good!
         roundtrip_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
         assert_eq!(roundtrip_bank, *bank);

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -325,7 +325,7 @@ mod tests {
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         bank0.squash();
         let mut bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
-
+        bank.freeze();
         add_root_and_flush_write_cache(&bank0);
         bank.rc
             .accounts
@@ -470,6 +470,7 @@ mod tests {
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         bank0.squash();
         let mut bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
+        bank.freeze();
         add_root_and_flush_write_cache(&bank0);
         bank.rc
             .accounts


### PR DESCRIPTION
#### Problem

As part of the work to add featurization code for accounts lt hash, we must enforce the invariant that a bank loaded from a snapshot is frozen. This means, in `Bank::new_from_fields()`, the bank hash cannot be Hash::default().

There are a few tests that violate this assertion though.


#### Summary of Changes

* Update the tests to call Bank::freeze()
* Assert the loaded bank is frozen, in the existing test_verify_accounts_lt_hash_at_startup() test