### PR TITLE
Refactor - program v4 CLI

### DIFF
--- a/cargo-registry/src/client.rs
+++ b/cargo-registry/src/client.rs
@@ -28,10 +28,10 @@ pub(crate) struct Client {
 }
 
 impl Client {
-    pub fn get_cli_config<'a>(&'a self) -> CliConfig<'a> {
+    pub fn get_cli_config(&'_ self) -> CliConfig<'_> {
         CliConfig {
             websocket_url: self.websocket_url.clone(),
-            commitment: self.commitment.clone(),
+            commitment: self.commitment,
             signers: vec![&self.cli_signers[0], &self.cli_signers[1]],
             send_transaction_config: self.send_transaction_config,
             ..CliConfig::default()

--- a/cargo-registry/src/client.rs
+++ b/cargo-registry/src/client.rs
@@ -5,12 +5,8 @@ use {
         input_validators::is_url_or_moniker,
         keypair::{DefaultSigner, SignerIndex},
     },
-    solana_cli::{
-        cli::{DEFAULT_CONFIRM_TX_TIMEOUT_SECONDS, DEFAULT_RPC_TIMEOUT_SECONDS},
-        program_v4::ProgramV4CommandConfig,
-    },
+    solana_cli::cli::{CliConfig, DEFAULT_CONFIRM_TX_TIMEOUT_SECONDS, DEFAULT_RPC_TIMEOUT_SECONDS},
     solana_cli_config::{Config, ConfigInput},
-    solana_cli_output::OutputFormat,
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::config::RpcSendTransactionConfig,
     solana_sdk::{
@@ -20,22 +16,6 @@ use {
     std::{error, sync::Arc, time::Duration},
 };
 
-pub(crate) struct RPCCommandConfig<'a>(pub ProgramV4CommandConfig<'a>);
-
-impl<'a> RPCCommandConfig<'a> {
-    pub fn new(client: &'a Client) -> Self {
-        Self(ProgramV4CommandConfig {
-            websocket_url: &client.websocket_url,
-            commitment: client.commitment,
-            payer: &client.cli_signers[0],
-            authority: &client.cli_signers[client.authority_signer_index],
-            output_format: &OutputFormat::Display,
-            use_quic: true,
-            rpc_send_transaction_config: client.rpc_transaction_config,
-        })
-    }
-}
-
 pub(crate) struct Client {
     pub rpc_client: Arc<RpcClient>,
     pub port: u16,
@@ -43,11 +23,21 @@ pub(crate) struct Client {
     websocket_url: String,
     commitment: commitment_config::CommitmentConfig,
     cli_signers: Vec<Keypair>,
-    authority_signer_index: SignerIndex,
-    rpc_transaction_config: RpcSendTransactionConfig,
+    pub authority_signer_index: SignerIndex,
+    send_transaction_config: RpcSendTransactionConfig,
 }
 
 impl Client {
+    pub fn get_cli_config<'a>(&'a self) -> CliConfig<'a> {
+        CliConfig {
+            websocket_url: self.websocket_url.clone(),
+            commitment: self.commitment.clone(),
+            signers: vec![&self.cli_signers[0], &self.cli_signers[1]],
+            send_transaction_config: self.send_transaction_config,
+            ..CliConfig::default()
+        }
+    }
+
     fn get_keypair(
         matches: &ArgMatches<'_>,
         config_path: &str,
@@ -233,7 +223,7 @@ impl Client {
             commitment,
             cli_signers: vec![payer_keypair, authority_keypair],
             authority_signer_index: 1,
-            rpc_transaction_config: RpcSendTransactionConfig {
+            send_transaction_config: RpcSendTransactionConfig {
                 skip_preflight,
                 preflight_commitment: Some(commitment.commitment),
                 ..RpcSendTransactionConfig::default()

--- a/cargo-registry/src/crate_handler.rs
+++ b/cargo-registry/src/crate_handler.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        client::{Client, RPCCommandConfig},
+        client::Client,
         sparse_index::{IndexEntry, RegistryIndex},
     },
     flate2::{
@@ -12,7 +12,7 @@ use {
     serde_derive::{Deserialize, Serialize},
     serde_json::from_slice,
     sha2::{Digest, Sha256},
-    solana_cli::program_v4::{process_deploy_program, process_dump, read_and_verify_elf},
+    solana_cli::program_v4::{process_deploy_program, process_dump},
     solana_sdk::{
         pubkey::Pubkey,
         signature::{Keypair, Signer},
@@ -110,8 +110,11 @@ impl Program {
             return Err("Signer doesn't match program ID".into());
         }
 
-        let mut program_data = read_and_verify_elf(self.path.as_ref(), &client.rpc_client)
-            .map_err(|e| format!("failed to read the program: {}", e))?;
+        let mut file = fs::File::open(&self.path)
+            .map_err(|err| format!("Unable to open program file: {err}"))?;
+        let mut program_data = Vec::new();
+        file.read_to_end(&mut program_data)
+            .map_err(|err| format!("Unable to read program file: {err}"))?;
 
         if APPEND_CRATE_TO_ELF {
             let program_id_str = Program::program_id_to_crate_name(self.id);
@@ -121,15 +124,16 @@ impl Program {
             program_data.extend_from_slice(&crate_tar_gz.0);
             program_data.extend_from_slice(&crate_len);
         }
-        let command_config = RPCCommandConfig::new(client.as_ref());
 
         process_deploy_program(
             client.rpc_client.clone(),
-            &command_config.0,
-            &program_data,
-            program_data.len() as u32,
+            &client.get_cli_config(),
+            &client.authority_signer_index,
             &signer.pubkey(),
+            &program_data,
+            None..None,
             Some(signer),
+            false,
         )
         .map_err(|e| {
             error!("Failed to deploy the program: {}", e);
@@ -141,11 +145,10 @@ impl Program {
 
     fn dump(&mut self, client: Arc<Client>) -> Result<(), Error> {
         info!("Fetching program {:?}", self.id);
-        let command_config = RPCCommandConfig::new(client.as_ref());
 
         process_dump(
             client.rpc_client.clone(),
-            command_config.0.commitment,
+            &client.get_cli_config(),
             Some(self.id),
             &self.path,
         )

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -498,7 +498,7 @@ pub fn process_program_v4_subcommand(
                 .map_err(|err| format!("Unable to read program file: {err}"))?;
             process_deploy_program(
                 rpc_client,
-                &config,
+                config,
                 authority_signer_index,
                 &program_address
                     .unwrap_or_else(|| config.signers[program_signer_index.unwrap()].pubkey()),
@@ -513,14 +513,14 @@ pub fn process_program_v4_subcommand(
         ProgramV4CliCommand::Undeploy {
             program_address,
             authority_signer_index,
-        } => process_undeploy_program(rpc_client, &config, authority_signer_index, program_address),
+        } => process_undeploy_program(rpc_client, config, authority_signer_index, program_address),
         ProgramV4CliCommand::TransferAuthority {
             program_address,
             authority_signer_index,
             new_authority_signer_index,
         } => process_transfer_authority_of_program(
             rpc_client,
-            &config,
+            config,
             authority_signer_index,
             program_address,
             config.signers[*new_authority_signer_index],
@@ -531,7 +531,7 @@ pub fn process_program_v4_subcommand(
             next_version_signer_index,
         } => process_finalize_program(
             rpc_client,
-            &config,
+            config,
             authority_signer_index,
             program_address,
             config.signers[*next_version_signer_index],
@@ -540,11 +540,11 @@ pub fn process_program_v4_subcommand(
             account_pubkey,
             authority,
             all,
-        } => process_show(rpc_client, &config, *account_pubkey, *authority, *all),
+        } => process_show(rpc_client, config, *account_pubkey, *authority, *all),
         ProgramV4CliCommand::Dump {
             account_pubkey,
             output_location,
-        } => process_dump(rpc_client, &config, *account_pubkey, output_location),
+        } => process_dump(rpc_client, config, *account_pubkey, output_location),
     }
 }
 
@@ -624,7 +624,7 @@ pub fn process_deploy_program(
         program_data.len(),
     );
     let executable =
-        Executable::<InvokeContext>::from_elf(&program_data, Arc::new(program_runtime_environment))
+        Executable::<InvokeContext>::from_elf(program_data, Arc::new(program_runtime_environment))
             .map_err(|err| format!("ELF error: {err}"))?;
     executable
         .verify::<RequisiteVerifier>()
@@ -643,7 +643,7 @@ pub fn process_deploy_program(
     }
 
     let lamports_required = rpc_client.get_minimum_balance_for_rent_exemption(
-        LoaderV4State::program_data_offset().saturating_add(program_data.len() as usize),
+        LoaderV4State::program_data_offset().saturating_add(program_data.len()),
     )?;
     let (buffer_address, buffer_account) = if let Some(buffer_signer) = buffer_signer {
         // Deploy new program or redeploy with a buffer account


### PR DESCRIPTION
#### Problem
The program v4 CLI is missing some features which the program v3 CLI has.

#### Summary of Changes
New features:
- Adds `--use-rpc` option for deployment.
- Combines `deploy` and `redeploy` commands into one.
- Adds optional upload range parameters `--start-offset` and `--end-offset`.
- Enables partial deployments (so one can restart a failed deployment attempt).

General cleanup:
- Removes `ProgramV4CommandConfig` wrapper. This allows us to have access to all the config fields, not just a subset of them.
- Moves `program_location` parameter inside `process_deploy_program()`.
- Combines the underlying `ProgramV4CliCommand` as well.
- Inlines `build_create_buffer_message()`, `build_retract_and_truncate_messages()` and `build_retract_and_deploy_messages()`.
- Fixes cargo registry.