### PR TITLE
stream crds node updates via geyser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ name = "agave-geyser-plugin-interface"
 version = "2.2.0"
 dependencies = [
  "log",
+ "solana-gossip",
  "solana-sdk",
  "solana-transaction-status",
  "thiserror",
@@ -7021,6 +7022,7 @@ dependencies = [
  "serde_json",
  "solana-accounts-db",
  "solana-entry",
+ "solana-gossip",
  "solana-ledger",
  "solana-measure",
  "solana-metrics",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -665,6 +665,10 @@ impl Validator {
             .as_ref()
             .and_then(|geyser_plugin_service| geyser_plugin_service.get_accounts_update_notifier());
 
+        let gossip_message_notifier = geyser_plugin_service
+            .as_ref()
+            .and_then(|geyser_plugin_service| geyser_plugin_service.get_gossip_message_notifier());
+
         let transaction_notifier = geyser_plugin_service
             .as_ref()
             .and_then(|geyser_plugin_service| geyser_plugin_service.get_transaction_notifier());
@@ -683,10 +687,12 @@ impl Validator {
 
         info!(
             "Geyser plugin: accounts_update_notifier: {}, transaction_notifier: {}, \
-             entry_notifier: {}",
+            entry_notifier: {}, \
+            gossip_message_notifier: {}",
             accounts_update_notifier.is_some(),
             transaction_notifier.is_some(),
-            entry_notifier.is_some()
+            entry_notifier.is_some(),
+            gossip_message_notifier.is_some()
         );
 
         let system_monitor_service = Some(SystemMonitorService::new(
@@ -790,6 +796,7 @@ impl Validator {
         cluster_info.set_contact_debug_interval(config.contact_debug_interval);
         cluster_info.set_entrypoints(cluster_entrypoints);
         cluster_info.restore_contact_info(ledger_path, config.contact_save_interval);
+        cluster_info.set_gossip_message_notifier(gossip_message_notifier);
         let cluster_info = Arc::new(cluster_info);
 
         assert!(is_snapshot_config_valid(

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -11,9 +11,9 @@ edition = { workspace = true }
 
 [dependencies]
 log = { workspace = true }
+solana-gossip = { workspace = true }
 solana-sdk = { workspace = true }
 solana-transaction-status = { workspace = true }
-solana-gossip = { workspace = true }
 thiserror = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 log = { workspace = true }
 solana-sdk = { workspace = true }
 solana-transaction-status = { workspace = true }
+solana-gossip = { workspace = true }
 thiserror = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -352,12 +352,10 @@ impl SlotStatus {
     }
 }
 
-pub const PUBKEY_SIZE: usize = 32;
-
 #[derive(Clone, Debug)]
 #[repr(C)]
 pub struct FfiPubkey {
-    pub pubkey: [u8; PUBKEY_SIZE],
+    pub pubkey: [u8; 32],
 }
 
 pub type Result<T> = std::result::Result<T, GeyserPluginError>;
@@ -463,6 +461,20 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         Ok(())
     }
 
+    /// Called when a ContactInfo is received from a node
+    #[allow(unused_variables)]
+    fn notify_node_update(&self, interface: &FfiContactInfoInterface) -> Result<()> {
+        Ok(())
+    }
+
+    /// Called when a node is removed from the network
+    /// TODO: may need to provide wrapper here? Also maybe ok
+    /// if we marshall to repr(c) for this...
+    #[allow(unused_variables)]
+    fn notify_node_removal(&self, pubkey: &FfiPubkey) -> Result<()> {
+        Ok(())
+    }
+
     /// Check if the plugin is interested in account data
     /// Default is true -- if the plugin is not interested in
     /// account data, please return false.
@@ -482,20 +494,6 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// entry data, return true.
     fn entry_notifications_enabled(&self) -> bool {
         false
-    }
-
-    /// Called when a message is received from a node
-    #[allow(unused_variables)]
-    fn notify_node_update(&self, interface: &FfiContactInfoInterface) -> Result<()> {
-        Ok(())
-    }
-
-    /// Called when a node is removed from the network
-    /// TODO: may need to provide wrapper here? Also maybe ok
-    /// if we marshall to repr(c) for this...
-    #[allow(unused_variables)]
-    fn notify_node_removal(&self, pubkey: &FfiPubkey) -> Result<()> {
-        Ok(())
     }
 
     /// Check if the plugin is interested in gossip m essages

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -349,8 +349,16 @@ impl SlotStatus {
 
 pub const PUBKEY_SIZE: usize = 32;
 
-pub struct FfiNode {
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct FfiPubkey {
     pub pubkey: [u8; PUBKEY_SIZE],
+}
+
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct FfiNode {
+    pub pubkey: FfiPubkey,
     pub wallclock: u64,
     pub shred_version: u16,
     pub version: FfiVersion,
@@ -495,8 +503,15 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         false
     }
 
+    /// Called when a message is received from a node
     #[allow(unused_variables)]
     fn notify_node_update(&self, ffi_node: &FfiNode) -> Result<()> {
+        Ok(())
+    }
+
+    /// Called when a node is removed from the network
+    #[allow(unused_variables)]
+    fn notify_node_removal(&self, pubkey: &FfiPubkey) -> Result<()> {
         Ok(())
     }
 

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -500,6 +500,6 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// Default is true -- if the plugin is not interested in
     /// gossip messages, please return false.
     fn node_update_notifications_enabled(&self) -> bool {
-        true
+        false
     }
 }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -3,6 +3,7 @@
 /// In addition, the dynamic library must export a "C" function _create_plugin which
 /// creates the implementation of the plugin.
 use {
+    solana_gossip::contact_info_ffi::FfiContactInfoInterface,
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
         signature::Signature,
@@ -355,30 +356,6 @@ pub struct FfiPubkey {
     pub pubkey: [u8; PUBKEY_SIZE],
 }
 
-#[derive(Clone, Debug)]
-#[repr(C)]
-pub struct FfiNode {
-    pub pubkey: FfiPubkey,
-    pub wallclock: u64,
-    pub shred_version: u16,
-    pub version: FfiVersion,
-}
-
-#[derive(Clone, Debug)]
-#[repr(C)]
-pub struct FfiVersion {
-    pub major: u16,
-    pub minor: u16,
-    pub patch: u16,
-    pub commit: u32,
-    pub feature_set: u32,
-    pub client: u16,
-}
-
-#[derive(Clone, Debug)]
-#[repr(C)]
-pub struct FfiExtension {}
-
 pub type Result<T> = std::result::Result<T, GeyserPluginError>;
 
 /// Defines a Geyser plugin, to stream data from the runtime.
@@ -505,11 +482,13 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
 
     /// Called when a message is received from a node
     #[allow(unused_variables)]
-    fn notify_node_update(&self, ffi_node: &FfiNode) -> Result<()> {
+    fn notify_node_update(&self, interface: &FfiContactInfoInterface) -> Result<()> {
         Ok(())
     }
 
     /// Called when a node is removed from the network
+    /// TODO: may need to provide wrapper here? Also maybe ok
+    /// if we marshall to repr(c) for this...
     #[allow(unused_variables)]
     fn notify_node_removal(&self, pubkey: &FfiPubkey) -> Result<()> {
         Ok(())

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -304,6 +304,10 @@ pub enum GeyserPluginError {
     /// Error when updating the transaction.
     #[error("Error updating transaction. Error message: ({msg})")]
     TransactionUpdateError { msg: String },
+
+    /// Error when updating the node status.
+    #[error("Error updating node. Error message: ({msg})")]
+    NodeUpdateError { msg: String },
 }
 
 /// The current status of a slot

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -347,6 +347,30 @@ impl SlotStatus {
     }
 }
 
+pub const PUBKEY_SIZE: usize = 32;
+
+pub struct FfiNode {
+    pub pubkey: [u8; PUBKEY_SIZE],
+    pub wallclock: u64,
+    pub shred_version: u16,
+    pub version: FfiVersion,
+}
+
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct FfiVersion {
+    pub major: u16,
+    pub minor: u16,
+    pub patch: u16,
+    pub commit: u32,
+    pub feature_set: u32,
+    pub client: u16,
+}
+
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct FfiExtension {}
+
 pub type Result<T> = std::result::Result<T, GeyserPluginError>;
 
 /// Defines a Geyser plugin, to stream data from the runtime.
@@ -469,5 +493,17 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// entry data, return true.
     fn entry_notifications_enabled(&self) -> bool {
         false
+    }
+
+    #[allow(unused_variables)]
+    fn notify_node_update(&self, ffi_node: &FfiNode) -> Result<()> {
+        Ok(())
+    }
+
+    /// Check if the plugin is interested in gossip m essages
+    /// Default is true -- if the plugin is not interested in
+    /// gossip messages, please return false.
+    fn node_update_notifications_enabled(&self) -> bool {
+        true
     }
 }

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -20,6 +20,7 @@ log = { workspace = true }
 serde_json = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-entry = { workspace = true }
+solana-gossip = { workspace = true }
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -85,6 +85,16 @@ impl GeyserPluginManager {
         false
     }
 
+    /// Check if there is any plugin interested in gossip messages
+    pub fn gossip_messages_notifications_enabled(&self) -> bool {
+        for plugin in &self.plugins {
+            if plugin.node_update_notifications_enabled() {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Check if there is any plugin interested in transaction data
     pub fn transaction_notifications_enabled(&self) -> bool {
         for plugin in &self.plugins {

--- a/geyser-plugin-manager/src/gossip_message_receiver_notifier.rs
+++ b/geyser-plugin-manager/src/gossip_message_receiver_notifier.rs
@@ -4,8 +4,7 @@ use {
     agave_geyser_plugin_interface::geyser_plugin_interface::FfiPubkey,
     log::*,
     solana_gossip::{
-        contact_info::ContactInfo,
-        contact_info_ffi::create_contact_info_interface,
+        contact_info::ContactInfo, contact_info_ffi::create_contact_info_interface,
         gossip_message_notifier_interface::GossipMessageNotifierInterface,
     },
     solana_measure::measure::Measure,
@@ -21,7 +20,7 @@ pub(crate) struct GossipMessageNotifierImpl {
 
 impl GossipMessageNotifierInterface for GossipMessageNotifierImpl {
     fn notify_receive_node_update(&self, contact_info: &ContactInfo) {
-        self.notify_plugins_of_node_update(&contact_info);
+        self.notify_plugins_of_node_update(contact_info);
     }
 
     fn notify_remove_node(&self, pubkey: &Pubkey) {
@@ -55,7 +54,7 @@ impl GossipMessageNotifierImpl {
             match plugin.notify_node_update(&ffi_contact_info_interface) {
                 Err(err) => {
                     error!(
-                        "Failed to insert crds value w/ origin: {}, error: {} to plugin {}",
+                        "Failed to insert ContactInfo w/ origin: {}, error: {} to plugin {}",
                         contact_info.pubkey(),
                         err,
                         plugin.name()
@@ -63,7 +62,7 @@ impl GossipMessageNotifierImpl {
                 }
                 Ok(_) => {
                     trace!(
-                        "Inserted crds value w/ origin: {} to plugin {}",
+                        "Inserted ContactInfo w/ origin: {} to plugin {}",
                         contact_info.pubkey(),
                         plugin.name()
                     )

--- a/geyser-plugin-manager/src/gossip_message_receiver_notifier.rs
+++ b/geyser-plugin-manager/src/gossip_message_receiver_notifier.rs
@@ -1,0 +1,84 @@
+/// Module responsible for notifying plugins of gossip messages
+use {
+    crate::geyser_plugin_manager::GeyserPluginManager,
+    agave_geyser_plugin_interface::geyser_plugin_interface::{FfiNode, FfiVersion},
+    log::*,
+    solana_gossip::{
+        contact_info::ContactInfo,
+        gossip_message_notifier_interface::GossipMessageNotifierInterface,
+    },
+    solana_sdk::pubkey::Pubkey,
+    std::sync::{Arc, RwLock},
+};
+
+#[derive(Debug)]
+pub(crate) struct GossipMessageNotifierImpl {
+    plugin_manager: Arc<RwLock<GeyserPluginManager>>,
+}
+
+impl GossipMessageNotifierInterface for GossipMessageNotifierImpl {
+    fn notify_receive_message(&self, contact_info: &ContactInfo) {
+        let ffi_node = self
+            .ffi_node_from_contact_info(contact_info)
+            .expect("Failed to convert ContactInfo to FfiNode");
+        self.notify_plugins_of_node_update(&ffi_node);
+    }
+}
+
+impl GossipMessageNotifierImpl {
+    pub fn new(plugin_manager: Arc<RwLock<GeyserPluginManager>>) -> Self {
+        Self { plugin_manager }
+    }
+
+    fn ffi_node_from_contact_info(
+        &self,
+        contact_info: &ContactInfo,
+    ) -> Result<FfiNode, std::io::Error> {
+        let pubkey = contact_info.pubkey().to_bytes();
+        let version = contact_info.version();
+        let version = FfiVersion {
+            major: version.major,
+            minor: version.minor,
+            patch: version.patch,
+            commit: version.commit,
+            feature_set: version.feature_set,
+            client: u16::try_from(version.client())
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?,
+        };
+
+        Ok(FfiNode {
+            pubkey,
+            wallclock: contact_info.wallclock(),
+            shred_version: contact_info.shred_version(),
+            version,
+        })
+    }
+
+    fn notify_plugins_of_node_update(&self, ffi_node: &FfiNode) {
+        let plugin_manager = self.plugin_manager.read().unwrap();
+        if plugin_manager.plugins.is_empty() {
+            return;
+        }
+
+        for plugin in plugin_manager.plugins.iter() {
+            // TODO: figure out how to not clone the crds_value
+            match plugin.notify_node_update(ffi_node) {
+                Err(err) => {
+                    error!(
+                        "Failed to insert crds value w/ origin: {}, error: {} to plugin {}",
+                        Pubkey::from(ffi_node.pubkey),
+                        err,
+                        plugin.name()
+                    )
+                }
+                Ok(_) => {
+                    trace!(
+                        "Inserted crds value w/ origin: {} to plugin {}",
+                        Pubkey::from(ffi_node.pubkey),
+                        plugin.name()
+                    )
+                }
+            }
+        }
+    }
+}

--- a/geyser-plugin-manager/src/lib.rs
+++ b/geyser-plugin-manager/src/lib.rs
@@ -4,6 +4,7 @@ pub mod block_metadata_notifier_interface;
 pub mod entry_notifier;
 pub mod geyser_plugin_manager;
 pub mod geyser_plugin_service;
+pub mod gossip_message_receiver_notifier;
 pub mod slot_status_notifier;
 pub mod slot_status_observer;
 pub mod transaction_notifier;

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -34,6 +34,7 @@ use {
         duplicate_shred::DuplicateShred,
         epoch_slots::EpochSlots,
         gossip_error::GossipError,
+        gossip_message_notifier_interface::GossipMessageNotifier,
         legacy_contact_info::LegacyContactInfo,
         ping_pong::{PingCache, Pong},
         protocol::{
@@ -234,6 +235,14 @@ impl ClusterInfo {
         };
         me.refresh_my_gossip_contact_info();
         me
+    }
+
+    pub fn set_gossip_message_notifier(&mut self, notifier: Option<GossipMessageNotifier>) {
+        self.gossip
+            .crds
+            .write()
+            .unwrap()
+            .set_gossip_message_notifier(notifier);
     }
 
     pub fn set_contact_debug_interval(&mut self, new: u64) {

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -208,7 +208,7 @@ impl ContactInfo {
     }
 
     #[inline]
-    pub(crate) fn version(&self) -> &solana_version::Version {
+    pub fn version(&self) -> &solana_version::Version {
         &self.version
     }
 

--- a/gossip/src/contact_info_ffi.rs
+++ b/gossip/src/contact_info_ffi.rs
@@ -1,0 +1,773 @@
+use {
+    crate::contact_info::ContactInfo,
+    solana_client::connection_cache::Protocol,
+    std::net::{IpAddr, SocketAddr},
+};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub enum FfiProtocol {
+    UDP,
+    QUIC,
+}
+
+impl From<FfiProtocol> for Protocol {
+    fn from(ffi_protocol: FfiProtocol) -> Self {
+        match ffi_protocol {
+            FfiProtocol::UDP => Protocol::UDP,
+            FfiProtocol::QUIC => Protocol::QUIC,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct FfiVersion {
+    pub major: u16,
+    pub minor: u16,
+    pub patch: u16,
+    pub commit: u32,
+    pub feature_set: u32,
+    pub client: u16,
+}
+
+impl Default for FfiVersion {
+    fn default() -> Self {
+        FfiVersion {
+            major: 0,
+            minor: 0,
+            patch: 0,
+            commit: 0,
+            feature_set: 0,
+            client: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct FfiIpAddr {
+    is_v4: u8,            // 1 if IPv4, 0 if IPv6
+    addr: [u8; 16],       // IP address bytes
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct FfiSocketAddr {
+    is_v4: u8,            // 1 if IPv4, 0 if IPv6
+    addr: [u8; 16],       // IP address bytes
+    port: u16,         
+}
+
+impl Default for FfiSocketAddr {
+    fn default() -> Self {
+        FfiSocketAddr {
+            is_v4: 0,
+            addr: [0u8; 16],
+            port: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct FfiSocketEntry {
+    key: u8,
+    index: u8,
+    offset: u16,
+}
+
+// Define constants for protocols (same as socket tags)
+pub const PROTOCOL_GOSSIP: u8 = 0;
+pub const PROTOCOL_RPC: u8 = 1;
+pub const PROTOCOL_RPC_PUBSUB: u8 = 2;
+pub const PROTOCOL_SERVE_REPAIR: u8 = 3;
+pub const PROTOCOL_SERVE_REPAIR_QUIC: u8 = 4;
+pub const PROTOCOL_TPU: u8 = 5;
+pub const PROTOCOL_TPU_QUIC: u8 = 6;
+pub const PROTOCOL_TPU_FORWARDS: u8 = 7;
+pub const PROTOCOL_TPU_FORWARDS_QUIC: u8 = 8;
+pub const PROTOCOL_TPU_VOTE: u8 = 9;
+pub const PROTOCOL_TVU: u8 = 10;
+pub const PROTOCOL_TVU_QUIC: u8 = 11;
+
+// Convert Rust IpAddr to and FfiIpAddr
+fn ffi_ip_addr_from_ip_addr(ip_addr: &IpAddr) -> FfiIpAddr {
+    match ip_addr {
+        IpAddr::V4(ipv4) => {
+            let mut addr = [0u8; 16];
+            addr[..4].copy_from_slice(&ipv4.octets());
+            FfiIpAddr { is_v4: 1, addr }
+        }
+        IpAddr::V6(ipv6) => FfiIpAddr {
+            is_v4: 0,
+            addr: ipv6.octets(),
+        },
+    }
+}
+
+fn ffi_socket_addr_from_socket_addr(socket_addr: &SocketAddr) -> FfiSocketAddr {
+    let ip_addr = socket_addr.ip();
+    let ffi_ip_addr = ffi_ip_addr_from_ip_addr(&ip_addr);
+    FfiSocketAddr {
+        is_v4: ffi_ip_addr.is_v4,
+        addr: ffi_ip_addr.addr,
+        port: socket_addr.port(),
+    }
+}
+
+// Define the interface struct
+#[repr(C)]
+pub struct ContactInfoInterface {
+    pub contact_info_ptr: ContactInfoPtr,
+    pub get_pubkey_fn: ContactInfoGetKey,
+    pub get_wallclock_fn: ContactInfoGetWallclockFn,
+    pub get_shred_version_fn: ContactInfoGetShredVersionFn,
+    pub get_version_fn: ContactInfoGetVersionFn,
+
+    // Socket address getter functions
+    pub get_gossip_fn: ContactInfoGetGossipFn,
+    pub get_rpc_fn: ContactInfoGetRpcFn,
+    pub get_rpc_pubsub_fn: ContactInfoGetRpcPubsubpFn,
+    pub get_serve_repair_fn: ContactInfoGetServeRepairFn,
+    pub get_tpu_fn: ContactInfoGetTpuFn,
+    pub get_tpu_forwards_fn: ContactInfoGetTpuForwardsFn,
+    pub get_tpu_vote_fn: ContactInfoGetTpuVoteFn,
+    pub get_tvu_fn: ContactInfoGetTvuFn,
+}
+
+/// The key is a 32-byte array that represents a public key.
+pub type Key = *const u8;
+
+/// An opaque pointer to a ContactInfo. This will be provided to any plugin and
+/// should always be non-null. The plugin should not pass any pointers to any
+/// functions on the [`ContactInfoInterface`] that are not provided.
+pub type ContactInfoPtr = *const core::ffi::c_void;
+
+// Define function pointer types for the interface
+pub type ContactInfoGetKey = unsafe extern "C" fn(
+    contact_info_ptr: ContactInfoPtr,
+) -> *const u8;
+
+pub type ContactInfoGetWallclockFn = unsafe extern "C" fn(
+    contact_info_ptr: ContactInfoPtr,
+) -> u64;
+
+pub type ContactInfoGetShredVersionFn = unsafe extern "C" fn(
+    contact_info_ptr: ContactInfoPtr,
+) -> u16;
+
+pub type ContactInfoGetVersionFn = unsafe extern "C" fn(
+    contact_info_ptr: ContactInfoPtr,
+    ffi_version: *mut FfiVersion,
+) -> bool;
+
+pub type ContactInfoGetGossipFn = unsafe extern "C" fn(
+    contact_info_ptr: ContactInfoPtr,
+    socket: *mut FfiSocketAddr,
+) -> bool;
+
+pub type ContactInfoGetRpcFn = unsafe extern "C" fn(
+    contact_info_ptr: ContactInfoPtr,
+    socket: *mut FfiSocketAddr,
+) -> bool;
+
+pub type ContactInfoGetRpcPubsubpFn = unsafe extern "C" fn(
+    contact_info_ptr: ContactInfoPtr,
+    socket: *mut FfiSocketAddr,
+) -> bool;
+
+pub type ContactInfoGetServeRepairFn = unsafe extern "C" fn(
+    contact_info_ptr: ContactInfoPtr,
+    protocol: FfiProtocol,
+    socket: *mut FfiSocketAddr,
+) -> bool;
+
+pub type ContactInfoGetTpuFn = unsafe extern "C" fn(
+    contact_info_ptr: ContactInfoPtr,
+    protocol: FfiProtocol,
+    socket: *mut FfiSocketAddr,
+) -> bool;
+
+pub type ContactInfoGetTpuForwardsFn = unsafe extern "C" fn(
+    contact_info_ptr: ContactInfoPtr,
+    protocol: FfiProtocol,
+    socket: *mut FfiSocketAddr,
+) -> bool;
+
+pub type ContactInfoGetTpuVoteFn = unsafe extern "C" fn(
+    contact_info_ptr: ContactInfoPtr,
+    socket: *mut FfiSocketAddr,
+) -> bool;
+
+pub type ContactInfoGetTvuFn = unsafe extern "C" fn(
+    contact_info_ptr: ContactInfoPtr,
+    protocol: FfiProtocol,
+    socket: *mut FfiSocketAddr,
+) -> bool;
+
+/// Given a reference to `ContactInfo`, create a `ContactInfoInterface` that 
+/// can be used to interact with the ContactInfo struct in C-compatible code.
+/// This interface is only valid for the lifetime of the ContactInfo 
+/// reference, which cannot be guaranteed by this function interface.
+pub unsafe fn create_contact_info_interface(
+    contact_info: &ContactInfo,
+) -> ContactInfoInterface {
+    extern "C" fn get_pubkey(
+        contact_info_ptr: ContactInfoPtr,
+    ) -> *const u8 {
+        let contact_info = unsafe { &*(contact_info_ptr as *const ContactInfo) };
+        contact_info.pubkey().as_ref().as_ptr() as *const u8
+    }
+
+    extern "C" fn get_wallclock(
+        contact_info_ptr: ContactInfoPtr,
+    ) -> u64 {
+        let contact_info = unsafe { &*(contact_info_ptr as *const ContactInfo) };
+        contact_info.wallclock()
+    }
+
+    extern "C" fn get_shred_version(
+        contact_info_ptr: ContactInfoPtr,
+    ) -> u16 {
+        let contact_info = unsafe { &*(contact_info_ptr as *const ContactInfo) };
+        contact_info.shred_version()
+    }
+
+    // TODO: figure out if we can fix this to not take in a *mut FfiVersion
+    // although this may be the best bet.
+    // Returning a *const FfiVersion is hard because we allocate it on the heap
+    // and we can't guarantee that the caller will free it.
+    extern "C" fn get_version(
+        contact_info_ptr: ContactInfoPtr,
+        ffi_version: *mut FfiVersion,
+    ) -> bool {
+        if contact_info_ptr.is_null() || ffi_version.is_null() {
+            return false;
+        }
+    
+        let contact_info = unsafe { &*(contact_info_ptr as *const ContactInfo) };
+        let version = contact_info.version();
+    
+        unsafe {
+            (*ffi_version).major = version.major;
+            (*ffi_version).minor = version.minor;
+            (*ffi_version).patch = version.patch;
+            (*ffi_version).commit = version.commit;
+            (*ffi_version).feature_set = version.feature_set;
+            (*ffi_version).client = u16::try_from(version.client()).unwrap();
+        }
+        true
+    }
+
+   // Socket address getter functions
+   // replicates gossip(), rpc(), etc in ContactInfo
+    extern "C" fn get_gossip(
+        contact_info_ptr: ContactInfoPtr,
+        socket: *mut FfiSocketAddr,
+    ) -> bool {
+        if contact_info_ptr.is_null() || socket.is_null() {
+            return false;
+        }
+
+        let contact_info = unsafe { &*(contact_info_ptr as *const ContactInfo) };
+        match contact_info.gossip() {
+            Ok(socket_addr) => {
+                let ffi_socket_addr = ffi_socket_addr_from_socket_addr(&socket_addr);
+                unsafe { *socket = ffi_socket_addr };
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    extern "C" fn get_rpc(
+        contact_info_ptr: ContactInfoPtr,
+        socket: *mut FfiSocketAddr,
+    ) -> bool {
+        if contact_info_ptr.is_null() || socket.is_null() {
+            return false;
+        }
+
+        let contact_info = unsafe { &*(contact_info_ptr as *const ContactInfo) };
+        match contact_info.rpc() {
+            Ok(socket_addr) => {
+                let ffi_socket_addr = ffi_socket_addr_from_socket_addr(&socket_addr);
+                unsafe { *socket = ffi_socket_addr };
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    extern "C" fn get_rpc_pubsub(
+        contact_info_ptr: ContactInfoPtr,
+        socket: *mut FfiSocketAddr,
+    ) -> bool {
+        if contact_info_ptr.is_null() || socket.is_null() {
+            return false;
+        }
+
+        let contact_info = unsafe { &*(contact_info_ptr as *const ContactInfo) };
+        match contact_info.rpc_pubsub() {
+            Ok(socket_addr) => {
+                let ffi_socket_addr = ffi_socket_addr_from_socket_addr(&socket_addr);
+                unsafe { *socket = ffi_socket_addr };
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    extern "C" fn get_serve_repair(
+        contact_info_ptr: ContactInfoPtr,
+        protocol: FfiProtocol,
+        socket: *mut FfiSocketAddr,
+    ) -> bool {
+        if contact_info_ptr.is_null() || socket.is_null() {
+            return false;
+        }
+    
+        let contact_info = unsafe { &*(contact_info_ptr as *const ContactInfo) };
+        let protocol = Protocol::from(protocol); // Convert FfiProtocol to Protocol
+    
+        match contact_info.serve_repair(protocol) {
+            Ok(socket_addr) => {
+                let ffi_socket_addr = ffi_socket_addr_from_socket_addr(&socket_addr);
+                unsafe { *socket = ffi_socket_addr };
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    extern "C" fn get_tpu(
+        contact_info_ptr: ContactInfoPtr,
+        protocol: FfiProtocol,
+        socket: *mut FfiSocketAddr,
+    ) -> bool {
+        if contact_info_ptr.is_null() || socket.is_null() {
+            return false;
+        }
+    
+        let contact_info = unsafe { &*(contact_info_ptr as *const ContactInfo) };
+        let protocol = Protocol::from(protocol); // Convert FfiProtocol to Protocol
+    
+        match contact_info.tpu(protocol) {
+            Ok(socket_addr) => {
+                let ffi_socket_addr = ffi_socket_addr_from_socket_addr(&socket_addr);
+                unsafe { *socket = ffi_socket_addr };
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    extern "C" fn get_tpu_forwards(
+        contact_info_ptr: ContactInfoPtr,
+        protocol: FfiProtocol,
+        socket: *mut FfiSocketAddr,
+    ) -> bool {
+        if contact_info_ptr.is_null() || socket.is_null() {
+            return false;
+        }
+    
+        let contact_info = unsafe { &*(contact_info_ptr as *const ContactInfo) };
+        let protocol = Protocol::from(protocol); // Convert FfiProtocol to Protocol
+    
+        match contact_info.tpu_forwards(protocol) {
+            Ok(socket_addr) => {
+                let ffi_socket_addr = ffi_socket_addr_from_socket_addr(&socket_addr);
+                unsafe { *socket = ffi_socket_addr };
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    extern "C" fn get_tpu_vote(
+        contact_info_ptr: ContactInfoPtr,
+        socket: *mut FfiSocketAddr,
+    ) -> bool {
+        if contact_info_ptr.is_null() || socket.is_null() {
+            return false;
+        }
+
+        let contact_info = unsafe { &*(contact_info_ptr as *const ContactInfo) };
+        match contact_info.tpu_vote() {
+            Ok(socket_addr) => {
+                let ffi_socket_addr = ffi_socket_addr_from_socket_addr(&socket_addr);
+                unsafe { *socket = ffi_socket_addr };
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    extern "C" fn get_tvu(
+        contact_info_ptr: ContactInfoPtr,
+        protocol: FfiProtocol,
+        socket: *mut FfiSocketAddr,
+    ) -> bool {
+        if contact_info_ptr.is_null() || socket.is_null() {
+            return false;
+        }
+    
+        let contact_info = unsafe { &*(contact_info_ptr as *const ContactInfo) };
+        let protocol = Protocol::from(protocol); // Convert FfiProtocol to Protocol
+    
+        match contact_info.tvu(protocol) {
+            Ok(socket_addr) => {
+                let ffi_socket_addr = ffi_socket_addr_from_socket_addr(&socket_addr);
+                unsafe { *socket = ffi_socket_addr };
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    ContactInfoInterface {
+        contact_info_ptr: contact_info as *const ContactInfo as *const core::ffi::c_void,
+        get_pubkey_fn: get_pubkey,
+        get_wallclock_fn: get_wallclock,
+        get_shred_version_fn: get_shred_version,
+        get_version_fn: get_version,
+        get_gossip_fn: get_gossip,
+        get_rpc_fn: get_rpc,
+        get_rpc_pubsub_fn: get_rpc_pubsub,
+        get_serve_repair_fn: get_serve_repair,
+        get_tpu_fn: get_tpu,
+        get_tpu_forwards_fn: get_tpu_forwards,
+        get_tpu_vote_fn: get_tpu_vote,
+        get_tvu_fn: get_tvu,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use {
+        solana_sdk::pubkey::Pubkey,
+        std::net::{Ipv4Addr, Ipv6Addr},
+    };
+
+    #[test]
+    fn test_get_pubkey() {
+        let mut rng = rand::thread_rng();
+        let node_pubkey = Pubkey::new_unique();
+        let contact_info = ContactInfo::new_rand(&mut rng, Some(node_pubkey));
+
+        let interface = unsafe { create_contact_info_interface(&contact_info) };
+        let pubkey_ptr = unsafe { (interface.get_pubkey_fn)(interface.contact_info_ptr) };
+        let pubkey_bytes = unsafe { std::slice::from_raw_parts(pubkey_ptr, 32) };
+        assert_eq!(Pubkey::try_from(pubkey_bytes).unwrap(), *contact_info.pubkey());
+    }
+
+    #[test]
+    fn test_get_wallclock() {
+        let contact_info = ContactInfo::new(solana_sdk::pubkey::Pubkey::new_unique(), 123456789, 23);
+        let interface = unsafe { create_contact_info_interface(&contact_info) };
+
+        let wallclock = unsafe { (interface.get_wallclock_fn)(interface.contact_info_ptr) };
+        assert_eq!(wallclock, contact_info.wallclock());
+    }
+
+    #[test]
+    fn test_get_shred_version() {
+        let contact_info = ContactInfo::new(solana_sdk::pubkey::Pubkey::new_unique(), 123456789, 23);
+        let interface = unsafe { create_contact_info_interface(&contact_info) };
+
+        let shred_version = unsafe { (interface.get_shred_version_fn)(interface.contact_info_ptr) };
+        assert_eq!(shred_version, contact_info.shred_version());
+    }
+
+    #[test]
+    fn test_get_version() {
+        let contact_info = ContactInfo::new(solana_sdk::pubkey::Pubkey::new_unique(), 123456789, 23);
+        let interface = unsafe { create_contact_info_interface(&contact_info) };
+
+        let mut ffi_version = FfiVersion::default();
+
+        let success = unsafe {
+            (interface.get_version_fn)(interface.contact_info_ptr, &mut ffi_version as *mut FfiVersion)
+        };
+
+        assert!(success);
+        assert_eq!(ffi_version.major, contact_info.version().major);
+        assert_eq!(ffi_version.minor, contact_info.version().minor);
+        assert_eq!(ffi_version.patch, contact_info.version().patch);
+        assert_eq!(ffi_version.commit, contact_info.version().commit);
+        assert_eq!(ffi_version.feature_set, contact_info.version().feature_set);
+        assert_eq!(ffi_version.client, u16::try_from(contact_info.version().client()).unwrap());
+    }
+
+    #[test]
+    fn test_get_gossip() {
+        let contact_info = ContactInfo::new_localhost(&Pubkey::new_unique(), 123456789);
+        let interface = unsafe { create_contact_info_interface(&contact_info) };
+        let mut ffi_socket = FfiSocketAddr::default();
+
+        let success = unsafe {
+            (interface.get_gossip_fn)(
+                interface.contact_info_ptr,
+                &mut ffi_socket as *mut FfiSocketAddr,
+            )
+        };
+
+        assert!(success);
+
+        let expected_socket_addr = contact_info.gossip().unwrap();
+        let actual_socket_addr = ffi_socket_addr_to_socket_addr(&ffi_socket);
+
+        assert_eq!(expected_socket_addr, actual_socket_addr);
+    }
+
+    #[test]
+    fn test_get_rpc() {
+        let contact_info = ContactInfo::new_localhost(&Pubkey::new_unique(), 123456789);
+        let interface = unsafe { create_contact_info_interface(&contact_info) };
+        let mut ffi_socket = FfiSocketAddr::default();
+
+        let success = unsafe {
+            (interface.get_rpc_fn)(
+                interface.contact_info_ptr,
+                &mut ffi_socket as *mut FfiSocketAddr,
+            )
+        };
+
+        assert!(success);
+
+        let expected_socket_addr = contact_info.rpc().unwrap();
+        let actual_socket_addr = ffi_socket_addr_to_socket_addr(&ffi_socket);
+
+        assert_eq!(expected_socket_addr, actual_socket_addr);
+    }
+
+    #[test]
+    fn test_get_rpc_pubsub() {
+        let contact_info = ContactInfo::new_localhost(&Pubkey::new_unique(), 123456789);
+        let interface = unsafe { create_contact_info_interface(&contact_info) };
+        let mut ffi_socket = FfiSocketAddr::default();
+
+        let success = unsafe {
+            (interface.get_rpc_pubsub_fn)(
+                interface.contact_info_ptr,
+                &mut ffi_socket as *mut FfiSocketAddr,
+            )
+        };
+
+        assert!(success);
+
+        let expected_socket_addr = contact_info.rpc_pubsub().unwrap();
+        let actual_socket_addr = ffi_socket_addr_to_socket_addr(&ffi_socket);
+
+        assert_eq!(expected_socket_addr, actual_socket_addr);
+    }
+
+    #[test]
+    fn test_get_serve_repair() {
+        let contact_info = ContactInfo::new_localhost(&Pubkey::new_unique(), 123456789);
+        let interface = unsafe { create_contact_info_interface(&contact_info) };
+        // test udp
+        let mut ffi_socket = FfiSocketAddr::default();
+
+        let success = unsafe {
+            (interface.get_serve_repair_fn)(
+                interface.contact_info_ptr,
+                FfiProtocol::UDP,
+                &mut ffi_socket as *mut FfiSocketAddr,
+            )
+        };
+
+        assert!(success);
+
+        let expected_socket_addr = contact_info.serve_repair(Protocol::UDP).unwrap();
+        let actual_socket_addr = ffi_socket_addr_to_socket_addr(&ffi_socket);
+
+        assert_eq!(expected_socket_addr, actual_socket_addr);
+
+        // test quic
+        let mut ffi_socket = FfiSocketAddr::default();
+
+        let success = unsafe {
+            (interface.get_serve_repair_fn)(
+                interface.contact_info_ptr,
+                FfiProtocol::QUIC,
+                &mut ffi_socket as *mut FfiSocketAddr,
+            )
+        };
+
+        assert!(success);
+
+        let expected_socket_addr = contact_info.serve_repair(Protocol::QUIC).unwrap();
+        let actual_socket_addr = ffi_socket_addr_to_socket_addr(&ffi_socket);
+
+        assert_eq!(expected_socket_addr, actual_socket_addr);
+
+    }
+
+    #[test]
+    fn test_get_tpu() {
+        let contact_info = ContactInfo::new_localhost(&Pubkey::new_unique(), 123456789);
+        let interface = unsafe { create_contact_info_interface(&contact_info) };
+        // test udp
+        let mut ffi_socket = FfiSocketAddr::default();
+
+        let success = unsafe {
+            (interface.get_tpu_fn)(
+                interface.contact_info_ptr,
+                FfiProtocol::UDP,
+                &mut ffi_socket as *mut FfiSocketAddr,
+            )
+        };
+
+        assert!(success);
+
+        let expected_socket_addr = contact_info.tpu(Protocol::UDP).unwrap();
+        let actual_socket_addr = ffi_socket_addr_to_socket_addr(&ffi_socket);
+
+        assert_eq!(expected_socket_addr, actual_socket_addr);
+
+        // test quic
+        let mut ffi_socket = FfiSocketAddr::default();
+
+        let success = unsafe {
+            (interface.get_tpu_fn)(
+                interface.contact_info_ptr,
+                FfiProtocol::QUIC,
+                &mut ffi_socket as *mut FfiSocketAddr,
+            )
+        };
+
+        assert!(success);
+
+        let expected_socket_addr = contact_info.tpu(Protocol::QUIC).unwrap();
+        let actual_socket_addr = ffi_socket_addr_to_socket_addr(&ffi_socket);
+
+        assert_eq!(expected_socket_addr, actual_socket_addr);
+
+    }
+
+    #[test]
+    fn test_get_tpu_forwards() {
+        let contact_info = ContactInfo::new_localhost(&Pubkey::new_unique(), 123456789);
+        let interface = unsafe { create_contact_info_interface(&contact_info) };
+        // test udp
+        let mut ffi_socket = FfiSocketAddr::default();
+
+        let success = unsafe {
+            (interface.get_tpu_forwards_fn)(
+                interface.contact_info_ptr,
+                FfiProtocol::UDP,
+                &mut ffi_socket as *mut FfiSocketAddr,
+            )
+        };
+
+        assert!(success);
+
+        let expected_socket_addr = contact_info.tpu_forwards(Protocol::UDP).unwrap();
+        let actual_socket_addr = ffi_socket_addr_to_socket_addr(&ffi_socket);
+
+        assert_eq!(expected_socket_addr, actual_socket_addr);
+
+        // test quic
+        let mut ffi_socket = FfiSocketAddr::default();
+
+        let success = unsafe {
+            (interface.get_tpu_forwards_fn)(
+                interface.contact_info_ptr,
+                FfiProtocol::QUIC,
+                &mut ffi_socket as *mut FfiSocketAddr,
+            )
+        };
+
+        assert!(success);
+
+        let expected_socket_addr = contact_info.tpu_forwards(Protocol::QUIC).unwrap();
+        let actual_socket_addr = ffi_socket_addr_to_socket_addr(&ffi_socket);
+
+        assert_eq!(expected_socket_addr, actual_socket_addr);
+
+    }
+
+    #[test]
+    fn test_get_tpu_vote() {
+        let contact_info = ContactInfo::new_localhost(&Pubkey::new_unique(), 123456789);
+        let interface = unsafe { create_contact_info_interface(&contact_info) };
+        let mut ffi_socket = FfiSocketAddr::default();
+
+        let success = unsafe {
+            (interface.get_tpu_vote_fn)(
+                interface.contact_info_ptr,
+                &mut ffi_socket as *mut FfiSocketAddr,
+            )
+        };
+
+        assert!(success);
+
+        let expected_socket_addr = contact_info.tpu_vote().unwrap();
+        let actual_socket_addr = ffi_socket_addr_to_socket_addr(&ffi_socket);
+
+        assert_eq!(expected_socket_addr, actual_socket_addr);
+    }
+
+    #[test]
+    fn test_get_tvu() {
+        let contact_info = ContactInfo::new_localhost(&Pubkey::new_unique(), 123456789);
+        let interface = unsafe { create_contact_info_interface(&contact_info) };
+        // test udp
+        let mut ffi_socket = FfiSocketAddr::default();
+
+        let success = unsafe {
+            (interface.get_tvu_fn)(
+                interface.contact_info_ptr,
+                FfiProtocol::UDP,
+                &mut ffi_socket as *mut FfiSocketAddr,
+            )
+        };
+
+        assert!(success);
+
+        let expected_socket_addr = contact_info.tvu(Protocol::UDP).unwrap();
+        let actual_socket_addr = ffi_socket_addr_to_socket_addr(&ffi_socket);
+
+        assert_eq!(expected_socket_addr, actual_socket_addr);
+
+        // test quic
+        let mut ffi_socket = FfiSocketAddr::default();
+
+        let success = unsafe {
+            (interface.get_tvu_fn)(
+                interface.contact_info_ptr,
+                FfiProtocol::QUIC,
+                &mut ffi_socket as *mut FfiSocketAddr,
+            )
+        };
+
+        assert!(success);
+
+        let expected_socket_addr = contact_info.tvu(Protocol::QUIC).unwrap();
+        let actual_socket_addr = ffi_socket_addr_to_socket_addr(&ffi_socket);
+
+        assert_eq!(expected_socket_addr, actual_socket_addr);
+
+    }
+
+    // Convert FfiSocketAddr to SocketAddr
+    fn ffi_socket_addr_to_socket_addr(ffi_socket: &FfiSocketAddr) -> SocketAddr {
+        let ip_addr = if ffi_socket.is_v4 == 1 {
+            IpAddr::V4(Ipv4Addr::new(
+                ffi_socket.addr[0],
+                ffi_socket.addr[1],
+                ffi_socket.addr[2],
+                ffi_socket.addr[3],
+            ))
+        } else {
+            let mut octets = [0u8; 16];
+            octets.copy_from_slice(&ffi_socket.addr);
+            IpAddr::V6(Ipv6Addr::from(octets))
+        };
+
+        SocketAddr::new(ip_addr, ffi_socket.port)
+    }
+}

--- a/gossip/src/contact_info_ffi.rs
+++ b/gossip/src/contact_info_ffi.rs
@@ -6,7 +6,7 @@ use {
     thiserror::Error,
 };
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Clone, Copy, Debug)]
 pub enum FfiProtocol {
     UDP,

--- a/gossip/src/contact_info_ffi.rs
+++ b/gossip/src/contact_info_ffi.rs
@@ -34,7 +34,7 @@ pub struct FfiVersion {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct FfiIpAddr {
     pub is_v4: u8,      // 1 if IPv4, 0 if IPv6
     pub addr: [u8; 16], // IP address bytes
@@ -43,8 +43,7 @@ pub struct FfiIpAddr {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct FfiSocketAddr {
-    pub is_v4: u8,      // 1 if IPv4, 0 if IPv6
-    pub addr: [u8; 16], // IP address bytes
+    pub ip: FfiIpAddr,
     pub port: u16,
 }
 
@@ -67,24 +66,23 @@ fn ffi_socket_addr_from_socket_addr(socket_addr: &SocketAddr) -> FfiSocketAddr {
     let ip_addr = socket_addr.ip();
     let ffi_ip_addr = ffi_ip_addr_from_ip_addr(&ip_addr);
     FfiSocketAddr {
-        is_v4: ffi_ip_addr.is_v4,
-        addr: ffi_ip_addr.addr,
+        ip: ffi_ip_addr,
         port: socket_addr.port(),
     }
 }
 
 // Convert FfiSocketAddr to SocketAddr
 pub fn ffi_socket_addr_to_socket_addr(ffi_socket: &FfiSocketAddr) -> SocketAddr {
-    let ip_addr = if ffi_socket.is_v4 == 1 {
+    let ip_addr = if ffi_socket.ip.is_v4 == 1 {
         IpAddr::V4(Ipv4Addr::new(
-            ffi_socket.addr[0],
-            ffi_socket.addr[1],
-            ffi_socket.addr[2],
-            ffi_socket.addr[3],
+            ffi_socket.ip.addr[0],
+            ffi_socket.ip.addr[1],
+            ffi_socket.ip.addr[2],
+            ffi_socket.ip.addr[3],
         ))
     } else {
         let mut octets = [0u8; 16];
-        octets.copy_from_slice(&ffi_socket.addr);
+        octets.copy_from_slice(&ffi_socket.ip.addr);
         IpAddr::V6(Ipv6Addr::from(octets))
     };
 

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -254,9 +254,15 @@ impl Crds {
             let versioned_crds_value = self.table.get(label);
             if let Some(value) = versioned_crds_value {
                 if let CrdsData::ContactInfo(contact_info) = &value.value.data() {
-                    gossip_message_notifier.notify_receive_message(contact_info);
+                    gossip_message_notifier.notify_receive_node_update(contact_info);
                 }
             }
+        }
+    }
+
+    fn notify_remove_node(&self, pubkey: &Pubkey) {
+        if let Some(gossip_message_notifier) = &self.gossip_message_notifier {
+            gossip_message_notifier.notify_remove_node(pubkey);
         }
     }
 
@@ -587,6 +593,7 @@ impl Crds {
         match value.value.data() {
             CrdsData::ContactInfo(_) => {
                 self.nodes.swap_remove(&index);
+                self.notify_remove_node(&value.value.pubkey());
             }
             CrdsData::Vote(_, _) => {
                 self.votes.remove(&value.ordinal);

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -33,6 +33,7 @@ use {
         crds_gossip_pull::CrdsTimeouts,
         crds_shards::CrdsShards,
         crds_value::{CrdsValue, CrdsValueLabel},
+        gossip_message_notifier_interface::GossipMessageNotifier,
     },
     assert_matches::debug_assert_matches,
     bincode::serialize,
@@ -88,6 +89,8 @@ pub struct Crds {
     // Mapping from nodes' pubkeys to their respective shred-version.
     shred_versions: HashMap<Pubkey, u16>,
     stats: Mutex<CrdsStats>,
+    /// GeyserPlugin gossip message notifier
+    gossip_message_notifier: Option<GossipMessageNotifier>,
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -189,6 +192,7 @@ impl Default for Crds {
             purged: VecDeque::default(),
             shred_versions: HashMap::default(),
             stats: Mutex::<CrdsStats>::default(),
+            gossip_message_notifier: None,
         }
     }
 }
@@ -241,6 +245,21 @@ impl Crds {
         }
     }
 
+    pub fn set_gossip_message_notifier(&mut self, notifier: Option<GossipMessageNotifier>) {
+        self.gossip_message_notifier = notifier;
+    }
+
+    fn notify_node_update(&self, label: &CrdsValueLabel) {
+        if let Some(gossip_message_notifier) = &self.gossip_message_notifier {
+            let versioned_crds_value = self.table.get(label);
+            if let Some(value) = versioned_crds_value {
+                if let CrdsData::ContactInfo(contact_info) = &value.value.data() {
+                    gossip_message_notifier.notify_receive_message(contact_info);
+                }
+            }
+        }
+    }
+
     pub fn insert(
         &mut self,
         value: CrdsValue,
@@ -248,6 +267,7 @@ impl Crds {
         route: GossipRoute,
     ) -> Result<(), CrdsError> {
         let label = value.label();
+        let gossip_label = label.clone();
         let pubkey = value.pubkey();
         let value = VersionedCrdsValue::new(value, self.cursor, now, route);
         let mut stats = self.stats.lock().unwrap();
@@ -276,6 +296,7 @@ impl Crds {
                 self.records.entry(pubkey).or_default().insert(entry_index);
                 self.cursor.consume(value.ordinal);
                 entry.insert(value);
+                self.notify_node_update(&gossip_label);
                 Ok(())
             }
             Entry::Occupied(mut entry) if overrides(&value.value, entry.get()) => {
@@ -312,6 +333,7 @@ impl Crds {
                 self.cursor.consume(value.ordinal);
                 self.purged.push_back((entry.get().value_hash, now));
                 entry.insert(value);
+                self.notify_node_update(&gossip_label);
                 Ok(())
             }
             Entry::Occupied(mut entry) => {

--- a/gossip/src/gossip_message_notifier_interface.rs
+++ b/gossip/src/gossip_message_notifier_interface.rs
@@ -1,8 +1,11 @@
-use {crate::contact_info::ContactInfo, std::sync::Arc};
+use {crate::contact_info::ContactInfo, solana_sdk::pubkey::Pubkey, std::sync::Arc};
 
 pub trait GossipMessageNotifierInterface: std::fmt::Debug {
     /// Notified when a CrdsValue is upserted
-    fn notify_receive_message(&self, contact_info: &ContactInfo);
+    fn notify_receive_node_update(&self, contact_info: &ContactInfo);
+
+    /// Notified when a node is removed/purged from crds table
+    fn notify_remove_node(&self, pubkey: &Pubkey);
 }
 
 pub type GossipMessageNotifier = Arc<dyn GossipMessageNotifierInterface + Sync + Send>;

--- a/gossip/src/gossip_message_notifier_interface.rs
+++ b/gossip/src/gossip_message_notifier_interface.rs
@@ -1,0 +1,8 @@
+use {crate::contact_info::ContactInfo, std::sync::Arc};
+
+pub trait GossipMessageNotifierInterface: std::fmt::Debug {
+    /// Notified when a CrdsValue is upserted
+    fn notify_receive_message(&self, contact_info: &ContactInfo);
+}
+
+pub type GossipMessageNotifier = Arc<dyn GossipMessageNotifierInterface + Sync + Send>;

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod cluster_info;
 pub mod cluster_info_metrics;
 pub mod contact_info;
+pub mod contact_info_ffi;
 pub mod crds;
 pub mod crds_data;
 pub mod crds_entry;

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -19,6 +19,7 @@ pub mod duplicate_shred_handler;
 pub mod duplicate_shred_listener;
 pub mod epoch_slots;
 pub mod gossip_error;
+pub mod gossip_message_notifier_interface;
 pub mod gossip_service;
 #[macro_use]
 mod legacy_contact_info;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -68,6 +68,7 @@ name = "agave-geyser-plugin-interface"
 version = "2.2.0"
 dependencies = [
  "log",
+ "solana-gossip",
  "solana-sdk",
  "solana-transaction-status",
  "thiserror",
@@ -5586,6 +5587,7 @@ dependencies = [
  "serde_json",
  "solana-accounts-db",
  "solana-entry",
+ "solana-gossip",
  "solana-ledger",
  "solana-measure",
  "solana-metrics",

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -15,7 +15,7 @@ extern crate solana_frozen_abi_macro;
 mod legacy;
 
 #[derive(Debug, Eq, PartialEq)]
-enum ClientId {
+pub enum ClientId {
     SolanaLabs,
     JitoLabs,
     Firedancer,
@@ -44,7 +44,7 @@ impl Version {
         semver::Version::new(self.major as u64, self.minor as u64, self.patch as u64)
     }
 
-    fn client(&self) -> ClientId {
+    pub fn client(&self) -> ClientId {
         ClientId::from(self.client)
     }
 }


### PR DESCRIPTION
Towards removing RPCs from the validator. 

#### Summary of Changes
Stream crds node updates via geyser
Stream node removals from crds via geyser

Expose an FFI interface that wraps ContactInfo
FFI based off of FFI Transaction Interface here: https://github.com/anza-xyz/agave/pull/2125
