### PR TITLE
Remove solana-sdk from solana-udp-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9061,8 +9061,10 @@ dependencies = [
  "async-trait",
  "solana-connection-cache",
  "solana-net-utils",
- "solana-sdk",
+ "solana-packet",
+ "solana-signer",
  "solana-streamer",
+ "solana-transaction-error",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9060,9 +9060,9 @@ version = "2.2.0"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
+ "solana-keypair",
  "solana-net-utils",
  "solana-packet",
- "solana-signer",
  "solana-streamer",
  "solana-transaction-error",
  "thiserror",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7547,8 +7547,8 @@ version = "2.2.0"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
+ "solana-keypair",
  "solana-net-utils",
- "solana-signer",
  "solana-streamer",
  "solana-transaction-error",
  "thiserror",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7548,8 +7548,9 @@ dependencies = [
  "async-trait",
  "solana-connection-cache",
  "solana-net-utils",
- "solana-sdk",
+ "solana-signer",
  "solana-streamer",
+ "solana-transaction-error",
  "thiserror",
  "tokio",
 ]

--- a/udp-client/Cargo.toml
+++ b/udp-client/Cargo.toml
@@ -13,7 +13,11 @@ edition = { workspace = true }
 async-trait = { workspace = true }
 solana-connection-cache = { workspace = true }
 solana-net-utils = { workspace = true }
-solana-sdk = { workspace = true }
+solana-signer = { workspace = true, features = ["keypair"] }
 solana-streamer = { workspace = true }
+solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+
+[dev-dependencies]
+solana-packet = { workspace = true }

--- a/udp-client/Cargo.toml
+++ b/udp-client/Cargo.toml
@@ -12,8 +12,8 @@ edition = { workspace = true }
 [dependencies]
 async-trait = { workspace = true }
 solana-connection-cache = { workspace = true }
+solana-keypair = { workspace = true }
 solana-net-utils = { workspace = true }
-solana-signer = { workspace = true, features = ["keypair"] }
 solana-streamer = { workspace = true }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -15,7 +15,7 @@ use {
         },
         connection_cache_stats::ConnectionCacheStats,
     },
-    solana_sdk::signature::Keypair,
+    solana_signer::keypair::Keypair,
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
         sync::Arc,

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -15,7 +15,7 @@ use {
         },
         connection_cache_stats::ConnectionCacheStats,
     },
-    solana_signer::keypair::Keypair,
+    solana_keypair::Keypair,
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
         sync::Arc,

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -4,9 +4,8 @@
 use {
     async_trait::async_trait, core::iter::repeat,
     solana_connection_cache::nonblocking::client_connection::ClientConnection,
-    solana_transaction_error::TransportResult,
-    solana_streamer::nonblocking::sendmmsg::batch_send, std::net::SocketAddr,
-    tokio::net::UdpSocket,
+    solana_streamer::nonblocking::sendmmsg::batch_send, solana_transaction_error::TransportResult,
+    std::net::SocketAddr, tokio::net::UdpSocket,
 };
 
 pub struct UdpClientConnection {

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -4,7 +4,7 @@
 use {
     async_trait::async_trait, core::iter::repeat,
     solana_connection_cache::nonblocking::client_connection::ClientConnection,
-    solana_sdk::transport::Result as TransportResult,
+    solana_transaction_error::TransportResult,
     solana_streamer::nonblocking::sendmmsg::batch_send, std::net::SocketAddr,
     tokio::net::UdpSocket,
 };
@@ -47,7 +47,7 @@ impl ClientConnection for UdpClientConnection {
 mod tests {
     use {
         super::*,
-        solana_sdk::packet::{Packet, PACKET_DATA_SIZE},
+        solana_packet::{Packet, PACKET_DATA_SIZE},
         solana_streamer::nonblocking::recvmmsg::recv_mmsg,
         std::net::{IpAddr, Ipv4Addr},
         tokio::net::UdpSocket,

--- a/udp-client/src/udp_client.rs
+++ b/udp-client/src/udp_client.rs
@@ -4,8 +4,8 @@
 use {
     core::iter::repeat,
     solana_connection_cache::client_connection::ClientConnection,
-    solana_transaction_error::TransportResult,
     solana_streamer::sendmmsg::batch_send,
+    solana_transaction_error::TransportResult,
     std::{
         net::{SocketAddr, UdpSocket},
         sync::Arc,

--- a/udp-client/src/udp_client.rs
+++ b/udp-client/src/udp_client.rs
@@ -4,7 +4,7 @@
 use {
     core::iter::repeat,
     solana_connection_cache::client_connection::ClientConnection,
-    solana_sdk::transport::Result as TransportResult,
+    solana_transaction_error::TransportResult,
     solana_streamer::sendmmsg::batch_send,
     std::{
         net::{SocketAddr, UdpSocket},


### PR DESCRIPTION
#### Problem
solana-udp-client can compile faster without solana-sdk

#### Summary of Changes
replace it with crates that were ripped out of solana-sdk

This branches off #3087 so that needs to be merged first