### PR TITLE
perf: put test_tx.rs behind dev-context-only-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7369,6 +7369,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-logger",
  "solana-metrics",
+ "solana-perf",
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-short-vec",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -125,6 +125,7 @@ sysctl = { workspace = true }
 
 [features]
 dev-context-only-utils = [
+    "solana-perf/dev-context-only-utils",
     "solana-runtime/dev-context-only-utils",
     "solana-streamer/dev-context-only-utils",
 ]

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -28,6 +28,7 @@ solana-sdk = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 solana-logger = { workspace = true }
+solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 
 [lib]
 crate-type = ["lib"]

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -63,6 +63,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 num_cpus = { workspace = true }
 serial_test = { workspace = true }
+solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 test-case = { workspace = true }
 

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -45,9 +45,11 @@ name = "solana_perf"
 assert_matches = { workspace = true }
 rand_chacha = { workspace = true }
 solana-logger = { workspace = true }
+solana-perf = { path = ".", features = ["dev-context-only-utils"] }
 test-case = { workspace = true }
 
 [features]
+dev-context-only-utils = []
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -31,7 +31,7 @@ solana-metrics = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-sdk = { workspace = true }
 solana-short-vec = { workspace = true }
-solana-vote-program = { workspace = true }
+solana-vote-program = { workspace = true, optional = true }
 
 [target."cfg(target_os = \"linux\")".dependencies]
 caps = { workspace = true }
@@ -49,7 +49,7 @@ solana-perf = { path = ".", features = ["dev-context-only-utils"] }
 test-case = { workspace = true }
 
 [features]
-dev-context-only-utils = []
+dev-context-only-utils = ["dep:solana-vote-program"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -8,6 +8,7 @@ pub mod perf_libs;
 pub mod recycler;
 pub mod recycler_cache;
 pub mod sigverify;
+#[cfg(feature = "dev-context-only-utils")]
 pub mod test_tx;
 pub mod thread;
 

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -26,7 +26,7 @@ assert_matches = { workspace = true }
 bincode = { workspace = true }
 rand = { workspace = true }
 solana-logger = { workspace = true }
-solana-perf = { workspace = true }
+solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-poh = { path = ".", features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5766,7 +5766,6 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-short-vec",
- "solana-vote-program",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
This was clearly meant to be behind dev-context-only-utils already. The usage of `solana_sdk::transaction` in test_tx.rs makes it harder to clean up the dependency tree too, which is not such a problem when test_tx.rs is behind dcou.

#### Summary of Changes
Put the test_tx module behind dev-context-only-utils and update dependent crates accordingly
