### PR TITLE
remove solana-sdk from transaction-metrics-tracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8728,9 +8728,11 @@ dependencies = [
  "lazy_static",
  "log",
  "rand 0.8.5",
+ "solana-packet",
  "solana-perf",
  "solana-sdk",
  "solana-short-vec",
+ "solana-signature",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7231,9 +7231,10 @@ dependencies = [
  "lazy_static",
  "log",
  "rand 0.8.5",
+ "solana-packet",
  "solana-perf",
- "solana-sdk",
  "solana-short-vec",
+ "solana-signature",
 ]
 
 [[package]]

--- a/transaction-metrics-tracker/Cargo.toml
+++ b/transaction-metrics-tracker/Cargo.toml
@@ -16,9 +16,13 @@ bincode = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
+solana-packet = { workspace = true }
 solana-perf = { workspace = true }
-solana-sdk = { workspace = true }
 solana-short-vec = { workspace = true }
+solana-signature = { workspace = true }
+
+[dev-dependencies]
+solana-sdk = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-metrics-tracker/src/lib.rs
+++ b/transaction-metrics-tracker/src/lib.rs
@@ -1,10 +1,7 @@
 use {
-    lazy_static::lazy_static,
-    log::*,
-    rand::Rng,
-    solana_perf::sigverify::PacketError,
-    solana_sdk::{packet::Packet, signature::SIGNATURE_BYTES},
-    solana_short_vec::decode_shortu16_len,
+    lazy_static::lazy_static, log::*, rand::Rng, solana_packet::Packet,
+    solana_perf::sigverify::PacketError, solana_short_vec::decode_shortu16_len,
+    solana_signature::SIGNATURE_BYTES,
 };
 
 // The mask is 12 bits long (1<<12 = 4096), it means the probability of matching


### PR DESCRIPTION
#### Problem
transaction-metrics-tracker can compile faster without solana-sdk

#### Summary of Changes
Remove solana-sdk and replace with the crates that were pulled out of it
