### PR TITLE
streamer: put testing_utilities.rs behind dev-context-only-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8381,6 +8381,7 @@ dependencies = [
  "solana-metrics",
  "solana-perf",
  "solana-sdk",
+ "solana-streamer",
  "solana-transaction-metrics-tracker",
  "thiserror",
  "tokio",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -124,7 +124,10 @@ test-case = { workspace = true }
 sysctl = { workspace = true }
 
 [features]
-dev-context-only-utils = ["solana-runtime/dev-context-only-utils"]
+dev-context-only-utils = [
+    "solana-runtime/dev-context-only-utils",
+    "solana-streamer/dev-context-only-utils",
+]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -14,7 +14,7 @@ async-channel = { workspace = true }
 bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true }
-futures  = { workspace = true }
+futures = { workspace = true }
 futures-util = { workspace = true }
 governor = { workspace = true }
 histogram = { workspace = true }
@@ -44,6 +44,7 @@ x509-parser = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 solana-logger = { workspace = true }
+solana-streamer = { path = ".", features = ["dev-context-only-utils"] }
 
 [features]
 dev-context-only-utils = []

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -45,6 +45,9 @@ x509-parser = { workspace = true }
 assert_matches = { workspace = true }
 solana-logger = { workspace = true }
 
+[features]
+dev-context-only-utils = []
+
 [lib]
 crate-type = ["lib"]
 name = "solana_streamer"

--- a/streamer/src/nonblocking/mod.rs
+++ b/streamer/src/nonblocking/mod.rs
@@ -3,4 +3,5 @@ pub mod quic;
 pub mod recvmmsg;
 pub mod sendmmsg;
 mod stream_throttle;
+#[cfg(feature = "dev-context-only-utils")]
 pub mod testing_utilities;

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -29,6 +29,7 @@ tokio-util = { workspace = true }
 crossbeam-channel = { workspace = true }
 futures = { workspace = true }
 solana-cli-config = { workspace = true }
+solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
#### Problem
As its name suggests, this module should be behind dev-context-only utils. This will also make it easier to remove the solana-sdk dependency

#### Summary of Changes
- Put testing_utils.rs behind dcou
- Update dependent crates accordingly
