### PR TITLE
Extract offchain-message crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7676,6 +7676,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-offchain-message"
+version = "2.2.0"
+dependencies = [
+ "num_enum",
+ "solana-hash",
+ "solana-keypair",
+ "solana-offchain-message",
+ "solana-packet",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sha256-hasher",
+ "solana-signature",
+ "solana-signer",
+ "static_assertions",
+]
+
+[[package]]
 name = "solana-package-metadata"
 version = "2.2.0"
 dependencies = [
@@ -8536,7 +8553,6 @@ dependencies = [
  "memmap2",
  "num-derive",
  "num-traits",
- "num_enum",
  "openssl",
  "qualifier_attr",
  "rand 0.7.3",
@@ -8568,6 +8584,7 @@ dependencies = [
  "solana-keypair",
  "solana-logger",
  "solana-native-token",
+ "solana-offchain-message",
  "solana-packet",
  "solana-poh-config",
  "solana-precompile-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ members = [
     "sdk/msg",
     "sdk/native-token",
     "sdk/nonce",
+    "sdk/offchain-message",
     "sdk/package-metadata",
     "sdk/package-metadata-macro",
     "sdk/packet",
@@ -507,6 +508,7 @@ solana-net-utils = { path = "net-utils", version = "=2.2.0" }
 solana-nohash-hasher = "0.2.1"
 solana-nonce = { path = "sdk/nonce", version = "=2.2.0" }
 solana-notifier = { path = "notifier", version = "=2.2.0" }
+solana-offchain-message = { path = "sdk/offchain-message", version = "=2.2.0" }
 solana-package-metadata = { path = "sdk/package-metadata", version = "=2.2.0" }
 solana-package-metadata-macro = { path = "sdk/package-metadata-macro", version = "=2.2.0" }
 solana-packet = { path = "sdk/packet", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6053,6 +6053,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-offchain-message"
+version = "2.2.0"
+dependencies = [
+ "num_enum",
+ "solana-hash",
+ "solana-packet",
+ "solana-sanitize",
+ "solana-sha256-hasher",
+ "solana-signature",
+ "solana-signer",
+]
+
+[[package]]
 name = "solana-packet"
 version = "2.2.0"
 dependencies = [
@@ -7232,7 +7245,6 @@ dependencies = [
  "memmap2",
  "num-derive",
  "num-traits",
- "num_enum",
  "qualifier_attr",
  "rand 0.7.3",
  "rand 0.8.5",
@@ -7260,6 +7272,7 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-native-token",
+ "solana-offchain-message",
  "solana-packet",
  "solana-poh-config",
  "solana-precompile-error",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6059,6 +6059,7 @@ dependencies = [
  "num_enum",
  "solana-hash",
  "solana-packet",
+ "solana-pubkey",
  "solana-sanitize",
  "solana-sha256-hasher",
  "solana-signature",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -146,7 +146,7 @@ solana-keypair = { workspace = true, optional = true, features = [
     "seed-derivable",
 ] }
 solana-native-token = { workspace = true }
-solana-offchain-message = { workspace = true, optional = true }
+solana-offchain-message = { workspace = true, optional = true, features = ["verify"] }
 solana-packet = { workspace = true, features = ["bincode", "serde"] }
 solana-poh-config = { workspace = true, features = ["serde"] }
 solana-precompile-error = { workspace = true, optional = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -40,6 +40,7 @@ full = [
     "dep:solana-ed25519-program",
     "dep:solana-compute-budget-interface",
     "dep:solana-keypair",
+    "dep:solana-offchain-message",
     "dep:solana-precompile-error",
     "dep:solana-precompiles",
     "dep:solana-presigner",
@@ -104,7 +105,6 @@ log = { workspace = true }
 memmap2 = { workspace = true, optional = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
-num_enum = { workspace = true }
 qualifier_attr = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 rand0-7 = { workspace = true, optional = true }
@@ -146,6 +146,7 @@ solana-keypair = { workspace = true, optional = true, features = [
     "seed-derivable",
 ] }
 solana-native-token = { workspace = true }
+solana-offchain-message = { workspace = true, optional = true }
 solana-packet = { workspace = true, features = ["bincode", "serde"] }
 solana-poh-config = { workspace = true, features = ["serde"] }
 solana-precompile-error = { workspace = true, optional = true }

--- a/sdk/offchain-message/Cargo.toml
+++ b/sdk/offchain-message/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "solana-offchain-message"
+description = "Solana offchain message signing"
+documentation = "https://docs.rs/solana-offchain-message"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+num_enum = { workspace = true }
+solana-hash = { workspace = true }
+solana-packet = { workspace = true }
+solana-pubkey = { workspace = true, optional = true }
+solana-sanitize = { workspace = true }
+solana-sha256-hasher = { workspace = true }
+solana-signature = { workspace = true }
+solana-signer = { workspace = true }
+
+[dev-dependencies]
+solana-keypair = { workspace = true }
+solana-offchain-message = { path = ".", features = ["dev-context-only-utils"] }
+static_assertions = { workspace = true }
+
+[features]
+dev-context-only-utils = ["verify"]
+verify = ["dep:solana-pubkey", "solana-signature/verify"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/offchain-message/Cargo.toml
+++ b/sdk/offchain-message/Cargo.toml
@@ -30,3 +30,5 @@ verify = ["dep:solana-pubkey", "solana-signature/verify"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]

--- a/sdk/offchain-message/src/lib.rs
+++ b/sdk/offchain-message/src/lib.rs
@@ -1,15 +1,11 @@
 //! Off-chain message container for storing non-transaction messages.
 
-#![cfg(feature = "full")]
-
 use {
-    crate::{
-        hash::Hash,
-        pubkey::Pubkey,
-        signature::{Signature, Signer},
-    },
     num_enum::{IntoPrimitive, TryFromPrimitive},
+    solana_hash::Hash,
     solana_sanitize::SanitizeError,
+    solana_signature::Signature,
+    solana_signer::Signer,
 };
 
 #[cfg(test)]
@@ -46,11 +42,10 @@ pub enum MessageFormat {
 pub mod v0 {
     use {
         super::{is_printable_ascii, is_utf8, MessageFormat, OffchainMessage as Base},
-        crate::{
-            hash::{Hash, Hasher},
-            packet::PACKET_DATA_SIZE,
-        },
+        solana_hash::Hash,
+        solana_packet::PACKET_DATA_SIZE,
         solana_sanitize::SanitizeError,
+        solana_sha256_hasher::Hasher,
     };
 
     /// OffchainMessage Version 0.
@@ -239,15 +234,20 @@ impl OffchainMessage {
         Ok(signer.sign_message(&self.serialize()?))
     }
 
+    #[cfg(feature = "verify")]
     /// Verify that the message signature is valid for the given public key
-    pub fn verify(&self, signer: &Pubkey, signature: &Signature) -> Result<bool, SanitizeError> {
+    pub fn verify(
+        &self,
+        signer: &solana_pubkey::Pubkey,
+        signature: &Signature,
+    ) -> Result<bool, SanitizeError> {
         Ok(signature.verify(signer.as_ref(), &self.serialize()?))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::signature::Keypair, std::str::FromStr};
+    use {super::*, solana_keypair::Keypair, std::str::FromStr};
 
     #[test]
     fn test_offchain_message_ascii() {

--- a/sdk/offchain-message/src/lib.rs
+++ b/sdk/offchain-message/src/lib.rs
@@ -1,5 +1,5 @@
 //! Off-chain message container for storing non-transaction messages.
-
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_hash::Hash,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -131,7 +131,7 @@ pub use solana_fee_structure as fee;
 #[deprecated(since = "2.1.0", note = "Use `solana-inflation` crate instead")]
 pub use solana_inflation as inflation;
 #[cfg(feature = "full")]
-#[deprecated(since = "2.1.0", note = "Use `solana-offchain-message` crate instead")]
+#[deprecated(since = "2.2.0", note = "Use `solana-offchain-message` crate instead")]
 pub use solana_offchain_message as offchain_message;
 #[deprecated(since = "2.1.0", note = "Use `solana-packet` crate instead")]
 pub use solana_packet as packet;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -77,6 +77,7 @@ pub mod native_loader;
 pub mod net;
 pub mod nonce_account;
 pub mod offchain_message;
+pub mod poh_config;
 pub mod precompiles;
 pub mod program_utils;
 pub mod pubkey;
@@ -130,6 +131,9 @@ pub use solana_feature_set as feature_set;
 pub use solana_fee_structure as fee;
 #[deprecated(since = "2.1.0", note = "Use `solana-inflation` crate instead")]
 pub use solana_inflation as inflation;
+#[cfg(feature = "full")]
+#[deprecated(since = "2.1.0", note = "Use `solana-offchain-message` crate instead")]
+pub use solana_offchain_message as offchain_message;
 #[deprecated(since = "2.1.0", note = "Use `solana-packet` crate instead")]
 pub use solana_packet as packet;
 #[deprecated(since = "2.2.0", note = "Use `solana-poh-config` crate instead")]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -76,7 +76,6 @@ pub mod log;
 pub mod native_loader;
 pub mod net;
 pub mod nonce_account;
-pub mod poh_config;
 pub mod precompiles;
 pub mod program_utils;
 pub mod pubkey;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -76,7 +76,6 @@ pub mod log;
 pub mod native_loader;
 pub mod net;
 pub mod nonce_account;
-pub mod offchain_message;
 pub mod poh_config;
 pub mod precompiles;
 pub mod program_utils;

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5873,6 +5873,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-offchain-message"
+version = "2.2.0"
+dependencies = [
+ "num_enum",
+ "solana-hash",
+ "solana-packet",
+ "solana-sanitize",
+ "solana-sha256-hasher",
+ "solana-signature",
+ "solana-signer",
+]
+
+[[package]]
 name = "solana-packet"
 version = "2.2.0"
 dependencies = [
@@ -6561,7 +6574,6 @@ dependencies = [
  "memmap2",
  "num-derive",
  "num-traits",
- "num_enum",
  "rand 0.7.3",
  "rand 0.8.5",
  "serde",
@@ -6588,6 +6600,7 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-native-token",
+ "solana-offchain-message",
  "solana-packet",
  "solana-poh-config",
  "solana-precompile-error",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5879,6 +5879,7 @@ dependencies = [
  "num_enum",
  "solana-hash",
  "solana-packet",
+ "solana-pubkey",
  "solana-sanitize",
  "solana-sha256-hasher",
  "solana-signature",


### PR DESCRIPTION
#### Problem
`solana_sdk::offchain_message` imposes a `solana_sdk` dep on Solana CLI crates

#### Summary of Changes
- Move to its own crate and re-export with deprecation
- Put the `verify` method behind an optional feature like `solana_signature` does

This branches off #3087 so that needs to be merged first (update: done)