### PR TITLE
Add tpu-client-next to `SendTransactionService`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8149,6 +8149,7 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 name = "solana-send-transaction-service"
 version = "2.2.0"
 dependencies = [
+ "async-trait",
  "crossbeam-channel",
  "itertools 0.12.1",
  "log",
@@ -8159,7 +8160,9 @@ dependencies = [
  "solana-metrics",
  "solana-runtime",
  "solana-sdk",
- "solana-tpu-client",
+ "solana-tpu-client-next",
+ "tokio",
+ "tokio-util 0.7.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8150,6 +8150,7 @@ name = "solana-send-transaction-service"
 version = "2.2.0"
 dependencies = [
  "crossbeam-channel",
+ "itertools 0.12.1",
  "log",
  "solana-client",
  "solana-connection-cache",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8158,6 +8158,7 @@ dependencies = [
  "solana-logger",
  "solana-measure",
  "solana-metrics",
+ "solana-quic-client",
  "solana-runtime",
  "solana-sdk",
  "solana-tpu-client-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -521,6 +521,7 @@ solana-test-validator = { path = "test-validator", version = "=2.2.0" }
 solana-thin-client = { path = "thin-client", version = "=2.2.0" }
 solana-transaction-error = { path = "sdk/transaction-error", version = "=2.2.0" }
 solana-tpu-client = { path = "tpu-client", version = "=2.2.0", default-features = false }
+solana-tpu-client-next = { path = "tpu-client-next", version = "=2.2.0" }
 solana-transaction-status = { path = "transaction-status", version = "=2.2.0" }
 solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=2.2.0" }
 solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=2.2.0" }

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -28,6 +28,7 @@ use {
     solana_send_transaction_service::{
         send_transaction_service::{SendTransactionService, TransactionInfo},
         tpu_info::NullTpuInfo,
+        transaction_client::ConnectionCacheClient,
     },
     std::{
         io,
@@ -453,16 +454,15 @@ pub async fn start_tcp_server(
         .map(move |chan| {
             let (sender, receiver) = unbounded();
 
-            SendTransactionService::new::<NullTpuInfo>(
-                tpu_addr,
-                &bank_forks,
-                None,
-                receiver,
+            let client = ConnectionCacheClient::<NullTpuInfo>::new(
                 connection_cache.clone(),
-                5_000,
+                tpu_addr,
+                None,
+                None,
                 0,
-                exit.clone(),
             );
+
+            SendTransactionService::new(&bank_forks, receiver, client, 5_000, exit.clone());
 
             let server = BanksServer::new(
                 bank_forks.clone(),

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -458,7 +458,7 @@ pub async fn start_tcp_server(
                 &bank_forks,
                 None,
                 receiver,
-                &connection_cache,
+                connection_cache.clone(),
                 5_000,
                 0,
                 exit.clone(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -289,6 +289,7 @@ pub struct ValidatorConfig {
     pub replay_transactions_threads: NonZeroUsize,
     pub tvu_shred_sigverify_threads: NonZeroUsize,
     pub delay_leader_block_for_pending_fork: bool,
+    pub use_tpu_client_next: bool,
 }
 
 impl Default for ValidatorConfig {
@@ -362,6 +363,7 @@ impl Default for ValidatorConfig {
             replay_transactions_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             tvu_shred_sigverify_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             delay_leader_block_for_pending_fork: false,
+            use_tpu_client_next: false,
         }
     }
 }

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -74,6 +74,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         replay_transactions_threads: config.replay_transactions_threads,
         tvu_shred_sigverify_threads: config.tvu_shred_sigverify_threads,
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
+        use_tpu_client_next: config.use_tpu_client_next,
     }
 }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6889,6 +6889,7 @@ name = "solana-send-transaction-service"
 version = "2.2.0"
 dependencies = [
  "crossbeam-channel",
+ "itertools 0.12.1",
  "log",
  "solana-client",
  "solana-connection-cache",

--- a/quic-client/src/quic_client.rs
+++ b/quic-client/src/quic_client.rs
@@ -68,7 +68,7 @@ impl AsyncTaskSemaphore {
 lazy_static! {
     static ref ASYNC_TASK_SEMAPHORE: AsyncTaskSemaphore =
         AsyncTaskSemaphore::new(MAX_OUTSTANDING_TASK);
-    static ref RUNTIME: Runtime = tokio::runtime::Builder::new_multi_thread()
+    pub static ref RUNTIME: Runtime = tokio::runtime::Builder::new_multi_thread()
         .thread_name("solQuicClientRt")
         .enable_all()
         .build()

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::arithmetic_side_effects)]
-mod cluster_tpu_info;
+pub mod cluster_tpu_info;
 pub mod filter;
 pub mod max_slots;
 pub mod optimistically_confirmed_bank_tracker;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -348,7 +348,6 @@ impl JsonRpcRequestProcessor {
         )
     }
 
-    // TODO(klykov): Why don't than declare it for tests?
     // Useful for unit testing
     pub fn new_from_bank<Client: ClientWithCreator>(
         bank: Bank,
@@ -4367,7 +4366,6 @@ pub mod tests {
             vote::state::VoteState,
         },
         solana_send_transaction_service::{
-            create_client_for_tests::CreateClient,
             tpu_info::NullTpuInfo,
             transaction_client::{ConnectionCacheClient, TpuClientNextClient},
         },
@@ -6421,10 +6419,7 @@ pub mod tests {
     fn rpc_send_bad_tx<C: ClientWithCreator>() {
         let genesis = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let meta = JsonRpcRequestProcessor::new_from_bank::<ConnectionCacheClient<NullTpuInfo>>(
-            bank,
-            SocketAddrSpace::Unspecified,
-        );
+        let meta = JsonRpcRequestProcessor::new_from_bank::<C>(bank, SocketAddrSpace::Unspecified);
 
         let mut io = MetaIoHandler::default();
         io.extend_with(rpc_full::FullImpl.to_delegate());

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -377,7 +377,7 @@ impl JsonRpcRequestProcessor {
             &bank_forks,
             None,
             receiver,
-            &connection_cache,
+            connection_cache,
             1000,
             1,
             exit.clone(),

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -36,7 +36,10 @@ use {
         exit::Exit, genesis_config::DEFAULT_GENESIS_DOWNLOAD_PATH, hash::Hash,
         native_token::lamports_to_sol,
     },
-    solana_send_transaction_service::send_transaction_service::{self, SendTransactionService},
+    solana_send_transaction_service::{
+        send_transaction_service::{self, SendTransactionService},
+        transaction_client::ConnectionCacheClient,
+    },
     solana_storage_bigtable::CredentialType,
     std::{
         net::SocketAddr,
@@ -474,15 +477,20 @@ impl JsonRpcService {
 
         let leader_info =
             poh_recorder.map(|recorder| ClusterTpuInfo::new(cluster_info.clone(), recorder));
-        let _send_transaction_service = Arc::new(SendTransactionService::new_with_config(
-            tpu_address,
-            &bank_forks,
-            leader_info,
-            receiver,
+        let client = ConnectionCacheClient::new(
             connection_cache,
+            tpu_address,
+            send_transaction_service_config.tpu_peers.clone(), //TODO(klykov): check if we can avoid cloning
+            leader_info,
+            send_transaction_service_config.leader_forward_count,
+        );
+        let _send_transaction_service = SendTransactionService::new_with_config(
+            &bank_forks,
+            receiver,
+            client,
             send_transaction_service_config,
             exit,
-        ));
+        );
 
         #[cfg(test)]
         let test_request_processor = request_processor.clone();

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -479,7 +479,7 @@ impl JsonRpcService {
             &bank_forks,
             leader_info,
             receiver,
-            &connection_cache,
+            connection_cache,
             send_transaction_service_config,
             exit,
         ));

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 crossbeam-channel = { workspace = true }
+itertools = { workspace = true }
 log = { workspace = true }
 solana-client = { workspace = true }
 solana-connection-cache = { workspace = true }

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -10,6 +10,9 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+# TODO(klykov): remove this dependency when trait for leader updater
+# will be changed
+async-trait = { workspace = true }
 crossbeam-channel = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
@@ -19,7 +22,9 @@ solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
-solana-tpu-client = { workspace = true }
+solana-tpu-client-next = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }
 
 [dev-dependencies]
 solana-logger = { workspace = true }

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -29,6 +29,7 @@ tokio-util = { workspace = true }
 [dev-dependencies]
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-quic-client = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -20,6 +20,7 @@ solana-client = { workspace = true }
 solana-connection-cache = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
+solana-quic-client = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 solana-tpu-client-next = { workspace = true }
@@ -29,7 +30,6 @@ tokio-util = { workspace = true }
 [dev-dependencies]
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-quic-client = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/send-transaction-service/src/create_client_for_tests.rs
+++ b/send-transaction-service/src/create_client_for_tests.rs
@@ -52,6 +52,7 @@ impl CreateClient for TpuClientNextClient {
             tpu_peers,
             None,
             leader_forward_count,
+            None,
         )
     }
 }

--- a/send-transaction-service/src/create_client_for_tests.rs
+++ b/send-transaction-service/src/create_client_for_tests.rs
@@ -1,0 +1,67 @@
+//! This module contains functionality required to create tests parametrized
+//! with the client type.
+
+use {
+    crate::{
+        tpu_info::NullTpuInfo,
+        transaction_client::TransactionClient,
+        transaction_client::{
+            spawn_tpu_client_send_txs, Cancelable, ConnectionCacheClient, TpuClientNextClient,
+        },
+    },
+    solana_client::connection_cache::ConnectionCache,
+    solana_quic_client::quic_client::RUNTIME,
+    std::{net::SocketAddr, sync::Arc},
+};
+
+pub trait CreateClient: TransactionClient {
+    fn create_client(
+        my_tpu_address: SocketAddr,
+        tpu_peers: Option<Vec<SocketAddr>>,
+        leader_forward_count: u64,
+    ) -> Self;
+}
+
+impl CreateClient for ConnectionCacheClient<NullTpuInfo> {
+    fn create_client(
+        my_tpu_address: SocketAddr,
+        tpu_peers: Option<Vec<SocketAddr>>,
+        leader_forward_count: u64,
+    ) -> Self {
+        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
+        ConnectionCacheClient::new(
+            connection_cache,
+            my_tpu_address,
+            tpu_peers,
+            None,
+            leader_forward_count,
+        )
+    }
+}
+
+impl CreateClient for TpuClientNextClient {
+    fn create_client(
+        my_tpu_address: SocketAddr,
+        tpu_peers: Option<Vec<SocketAddr>>,
+        leader_forward_count: u64,
+    ) -> Self {
+        let runtime = &*RUNTIME;
+        spawn_tpu_client_send_txs::<NullTpuInfo>(
+            runtime,
+            my_tpu_address,
+            tpu_peers,
+            None,
+            leader_forward_count,
+        )
+    }
+}
+
+// Define type alias to simplify definition of test functions.
+pub trait ClientWithCreator:
+    CreateClient + TransactionClient + Cancelable + Send + Clone + 'static
+{
+}
+impl<T> ClientWithCreator for T where
+    T: CreateClient + TransactionClient + Cancelable + Send + Clone + 'static
+{
+}

--- a/send-transaction-service/src/lib.rs
+++ b/send-transaction-service/src/lib.rs
@@ -4,5 +4,8 @@ pub mod send_transaction_service_stats;
 pub mod tpu_info;
 pub mod transaction_client;
 
+//TODO(klykov): shall it be under #[cfg(feature = "dev-context-only-utils")]?
+pub mod create_client_for_tests;
+
 #[macro_use]
 extern crate solana_metrics;

--- a/send-transaction-service/src/lib.rs
+++ b/send-transaction-service/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::arithmetic_side_effects)]
 pub mod send_transaction_service;
+pub mod send_transaction_service_stats;
 pub mod tpu_info;
+pub mod transaction_client;
 
 #[macro_use]
 extern crate solana_metrics;

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -931,7 +931,11 @@ mod test {
             ),
         );
         let stats = SendTransactionServiceStats::default();
-        let client = C::create_client(config.tpu_peers, leader_forward_count);
+        let client = C::create_client(
+            "127.0.0.1:0".parse().unwrap(),
+            config.tpu_peers,
+            leader_forward_count,
+        );
         let result = SendTransactionService::process_transactions(
             &working_bank,
             &root_bank,

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -4,17 +4,15 @@ use {
             SendTransactionServiceStats, SendTransactionServiceStatsReport,
         },
         tpu_info::TpuInfo,
-        transaction_client::CurrentLeaderInfo,
+        transaction_client::{ConnectionCacheClient, TransactionClient},
     },
     crossbeam_channel::{Receiver, RecvTimeoutError},
+    itertools::Itertools,
     log::*,
-    solana_client::connection_cache::{ConnectionCache, Protocol},
-    solana_connection_cache::client_connection::ClientConnection as TpuConnection,
-    solana_measure::measure::Measure,
+    solana_client::connection_cache::ConnectionCache,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_sdk::{
-        clock::Slot, hash::Hash, nonce_account, pubkey::Pubkey, saturating_add_assign,
-        signature::Signature, transport::TransportError,
+        hash::Hash, nonce_account, pubkey::Pubkey, saturating_add_assign, signature::Signature,
     },
     std::{
         collections::{
@@ -147,7 +145,7 @@ impl SendTransactionService {
         bank_forks: &Arc<RwLock<BankForks>>,
         leader_info: Option<T>,
         receiver: Receiver<TransactionInfo>,
-        connection_cache: &Arc<ConnectionCache>,
+        connection_cache: Arc<ConnectionCache>,
         retry_rate_ms: u64,
         leader_forward_count: u64,
         exit: Arc<AtomicBool>,
@@ -173,7 +171,7 @@ impl SendTransactionService {
         bank_forks: &Arc<RwLock<BankForks>>,
         leader_info: Option<T>,
         receiver: Receiver<TransactionInfo>,
-        connection_cache: &Arc<ConnectionCache>,
+        connection_cache: Arc<ConnectionCache>,
         config: Config,
         exit: Arc<AtomicBool>,
     ) -> Self {
@@ -181,26 +179,33 @@ impl SendTransactionService {
 
         let retry_transactions = Arc::new(Mutex::new(HashMap::new()));
 
-        let leader_info_provider = Arc::new(Mutex::new(CurrentLeaderInfo::new(leader_info)));
+        let client = ConnectionCacheClient::new(
+            connection_cache,
+            tpu_address,
+            config.tpu_peers,
+            leader_info,
+            config.leader_forward_count,
+        );
 
         let receive_txn_thread = Self::receive_txn_thread(
-            tpu_address,
             receiver,
-            leader_info_provider.clone(),
-            connection_cache.clone(),
-            config.clone(),
+            client.clone(),
             retry_transactions.clone(),
             stats_report.clone(),
+            config.batch_send_rate_ms,
+            config.batch_size,
+            config.retry_pool_max_size,
             exit.clone(),
         );
 
         let retry_thread = Self::retry_thread(
-            tpu_address,
             bank_forks.clone(),
-            leader_info_provider,
-            connection_cache.clone(),
-            config,
+            client,
             retry_transactions,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             stats_report,
             exit.clone(),
         );
@@ -213,26 +218,23 @@ impl SendTransactionService {
 
     /// Thread responsible for receiving transactions from RPC clients.
     fn receive_txn_thread<T: TpuInfo + std::marker::Send + 'static>(
-        tpu_address: SocketAddr,
         receiver: Receiver<TransactionInfo>,
-        leader_info_provider: Arc<Mutex<CurrentLeaderInfo<T>>>,
-        connection_cache: Arc<ConnectionCache>,
-        config: Config,
+        client: ConnectionCacheClient<T>,
         retry_transactions: Arc<Mutex<HashMap<Signature, TransactionInfo>>>,
         stats_report: Arc<SendTransactionServiceStatsReport>,
+        batch_send_rate_ms: u64,
+        batch_size: usize,
+        retry_pool_max_size: usize,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
         let mut last_batch_sent = Instant::now();
         let mut transactions = HashMap::new();
 
-        info!(
-            "Starting send-transaction-service::receive_txn_thread with config {:?}",
-            config
-        );
+        info!("Starting send-transaction-service::receive_txn_thread with config.",);
         Builder::new()
             .name("solStxReceive".to_string())
             .spawn(move || loop {
-                let recv_timeout_ms = config.batch_send_rate_ms;
+                let recv_timeout_ms = batch_send_rate_ms;
                 let stats = &stats_report.stats;
                 let recv_result = receiver.recv_timeout(Duration::from_millis(recv_timeout_ms));
                 if exit.load(Ordering::Relaxed) {
@@ -268,20 +270,17 @@ impl SendTransactionService {
                 }
 
                 if (!transactions.is_empty()
-                    && last_batch_sent.elapsed().as_millis() as u64 >= config.batch_send_rate_ms)
-                    || transactions.len() >= config.batch_size
+                    && last_batch_sent.elapsed().as_millis() as u64 >= batch_send_rate_ms)
+                    || transactions.len() >= batch_size
                 {
                     stats
                         .sent_transactions
                         .fetch_add(transactions.len() as u64, Ordering::Relaxed);
-                    Self::send_transactions_in_batch(
-                        &tpu_address,
-                        &transactions,
-                        leader_info_provider.lock().unwrap().get_leader_info(),
-                        &connection_cache,
-                        &config,
-                        stats,
-                    );
+                    let wire_transactions = transactions
+                        .values()
+                        .map(|transaction_info| transaction_info.wire_transaction.clone())
+                        .collect::<Vec<Vec<u8>>>();
+                    client.send_transactions_in_batch(wire_transactions, stats);
                     let last_sent_time = Instant::now();
                     {
                         // take a lock of retry_transactions and move the batch to the retry set.
@@ -292,7 +291,7 @@ impl SendTransactionService {
                             let retry_len = retry_transactions.len();
                             let entry = retry_transactions.entry(signature);
                             if let Entry::Vacant(_) = entry {
-                                if retry_len >= config.retry_pool_max_size {
+                                if retry_len >= retry_pool_max_size {
                                     break;
                                 } else {
                                     transaction_info.last_sent_time = Some(last_sent_time);
@@ -319,23 +318,21 @@ impl SendTransactionService {
 
     /// Thread responsible for retrying transactions
     fn retry_thread<T: TpuInfo + std::marker::Send + 'static>(
-        tpu_address: SocketAddr,
         bank_forks: Arc<RwLock<BankForks>>,
-        leader_info_provider: Arc<Mutex<CurrentLeaderInfo<T>>>,
-        connection_cache: Arc<ConnectionCache>,
-        config: Config,
+        client: ConnectionCacheClient<T>,
         retry_transactions: Arc<Mutex<HashMap<Signature, TransactionInfo>>>,
+        retry_rate_ms: u64,
+        service_max_retries: usize,
+        default_max_retries: Option<usize>,
+        batch_size: usize,
         stats_report: Arc<SendTransactionServiceStatsReport>,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
-        info!(
-            "Starting send-transaction-service::retry_thread with config {:?}",
-            config
-        );
+        info!("Starting send-transaction-service::retry_thread with config.");
         Builder::new()
             .name("solStxRetry".to_string())
             .spawn(move || loop {
-                let retry_interval_ms = config.retry_rate_ms;
+                let retry_interval_ms = retry_rate_ms;
                 let stats = &stats_report.stats;
                 sleep(Duration::from_millis(
                     MAX_RETRY_SLEEP_MS.min(retry_interval_ms),
@@ -356,11 +353,12 @@ impl SendTransactionService {
                     let _result = Self::process_transactions(
                         &working_bank,
                         &root_bank,
-                        &tpu_address,
                         &mut transactions,
-                        &leader_info_provider,
-                        &connection_cache,
-                        &config,
+                        &client,
+                        retry_rate_ms,
+                        service_max_retries,
+                        default_max_retries,
+                        batch_size,
                         stats,
                     );
                     stats_report.report();
@@ -369,60 +367,22 @@ impl SendTransactionService {
             .unwrap()
     }
 
-    /// Process transactions in batch.
-    fn send_transactions_in_batch<T: TpuInfo>(
-        tpu_address: &SocketAddr,
-        transactions: &HashMap<Signature, TransactionInfo>,
-        leader_info: Option<&T>,
-        connection_cache: &Arc<ConnectionCache>,
-        config: &Config,
-        stats: &SendTransactionServiceStats,
-    ) {
-        // Processing the transactions in batch
-        let mut addresses = config
-            .tpu_peers
-            .as_ref()
-            .map(|addrs| addrs.iter().map(|a| (a, 0)).collect::<Vec<_>>())
-            .unwrap_or_default();
-        let leader_addresses = Self::get_tpu_addresses_with_slots(
-            tpu_address,
-            leader_info,
-            config,
-            connection_cache.protocol(),
-        );
-        addresses.extend(leader_addresses);
-
-        let wire_transactions = transactions
-            .iter()
-            .map(|(_, transaction_info)| {
-                debug!(
-                    "Sending transacation {} to (address, slot): {:?}",
-                    transaction_info.signature, addresses,
-                );
-                transaction_info.wire_transaction.as_ref()
-            })
-            .collect::<Vec<&[u8]>>();
-
-        for (address, _) in &addresses {
-            Self::send_transactions(address, &wire_transactions, connection_cache, stats);
-        }
-    }
-
     /// Retry transactions sent before.
     fn process_transactions<T: TpuInfo + std::marker::Send + 'static>(
         working_bank: &Bank,
         root_bank: &Bank,
-        tpu_address: &SocketAddr,
         transactions: &mut HashMap<Signature, TransactionInfo>,
-        leader_info_provider: &Arc<Mutex<CurrentLeaderInfo<T>>>,
-        connection_cache: &Arc<ConnectionCache>,
-        config: &Config,
+        client: &ConnectionCacheClient<T>,
+        retry_rate_ms: u64,
+        service_max_retries: usize,
+        default_max_retries: Option<usize>,
+        batch_size: usize,
         stats: &SendTransactionServiceStats,
     ) -> ProcessTransactionsResult {
         let mut result = ProcessTransactionsResult::default();
 
         let mut batched_transactions = HashSet::new();
-        let retry_rate = Duration::from_millis(config.retry_rate_ms);
+        let retry_rate = Duration::from_millis(retry_rate_ms);
 
         transactions.retain(|signature, transaction_info| {
             if transaction_info.durable_nonce_info.is_some() {
@@ -460,8 +420,8 @@ impl SendTransactionService {
 
             let max_retries = transaction_info
                 .max_retries
-                .or(config.default_max_retries)
-                .map(|max_retries| max_retries.min(config.service_max_retries));
+                .or(default_max_retries)
+                .map(|max_retries| max_retries.min(service_max_retries));
 
             if let Some(max_retries) = max_retries {
                 if transaction_info.retries >= max_retries {
@@ -516,112 +476,15 @@ impl SendTransactionService {
             let wire_transactions = transactions
                 .iter()
                 .filter(|(signature, _)| batched_transactions.contains(signature))
-                .map(|(_, transaction_info)| transaction_info.wire_transaction.as_ref())
-                .collect::<Vec<&[u8]>>();
+                .map(|(_, transaction_info)| transaction_info.wire_transaction.clone());
 
-            let iter = wire_transactions.chunks(config.batch_size);
-            for chunk in iter {
-                let mut addresses = config
-                    .tpu_peers
-                    .as_ref()
-                    .map(|addrs| addrs.iter().collect::<Vec<_>>())
-                    .unwrap_or_default();
-                let mut leader_info_provider = leader_info_provider.lock().unwrap();
-                let leader_info = leader_info_provider.get_leader_info();
-                let leader_addresses = Self::get_tpu_addresses(
-                    tpu_address,
-                    leader_info,
-                    config,
-                    connection_cache.protocol(),
-                );
-                addresses.extend(leader_addresses);
-
-                for address in &addresses {
-                    Self::send_transactions(address, chunk, connection_cache, stats);
-                }
+            let iter = wire_transactions.chunks(batch_size);
+            for chunk in &iter {
+                let chunk = chunk.collect();
+                client.send_transactions_in_batch(chunk, stats);
             }
         }
         result
-    }
-
-    fn send_transaction(
-        tpu_address: &SocketAddr,
-        wire_transaction: &[u8],
-        connection_cache: &Arc<ConnectionCache>,
-    ) -> Result<(), TransportError> {
-        let conn = connection_cache.get_connection(tpu_address);
-        conn.send_data_async(wire_transaction.to_vec())
-    }
-
-    fn send_transactions_with_metrics(
-        tpu_address: &SocketAddr,
-        wire_transactions: &[&[u8]],
-        connection_cache: &Arc<ConnectionCache>,
-    ) -> Result<(), TransportError> {
-        let wire_transactions = wire_transactions.iter().map(|t| t.to_vec()).collect();
-        let conn = connection_cache.get_connection(tpu_address);
-        conn.send_data_batch_async(wire_transactions)
-    }
-
-    fn send_transactions(
-        tpu_address: &SocketAddr,
-        wire_transactions: &[&[u8]],
-        connection_cache: &Arc<ConnectionCache>,
-        stats: &SendTransactionServiceStats,
-    ) {
-        let mut measure = Measure::start("send-us");
-        let result = if wire_transactions.len() == 1 {
-            Self::send_transaction(tpu_address, wire_transactions[0], connection_cache)
-        } else {
-            Self::send_transactions_with_metrics(tpu_address, wire_transactions, connection_cache)
-        };
-
-        if let Err(err) = result {
-            warn!(
-                "Failed to send transaction transaction to {}: {:?}",
-                tpu_address, err
-            );
-            stats.send_failure_count.fetch_add(1, Ordering::Relaxed);
-        }
-
-        measure.stop();
-        stats.send_us.fetch_add(measure.as_us(), Ordering::Relaxed);
-        stats.send_attempt_count.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn get_tpu_addresses<'a, T: TpuInfo>(
-        tpu_address: &'a SocketAddr,
-        leader_info: Option<&'a T>,
-        config: &'a Config,
-        protocol: Protocol,
-    ) -> Vec<&'a SocketAddr> {
-        let addresses = leader_info
-            .as_ref()
-            .map(|leader_info| leader_info.get_leader_tpus(config.leader_forward_count, protocol));
-        addresses
-            .map(|address_list| {
-                if address_list.is_empty() {
-                    vec![tpu_address]
-                } else {
-                    address_list
-                }
-            })
-            .unwrap_or_else(|| vec![tpu_address])
-    }
-
-    fn get_tpu_addresses_with_slots<'a, T: TpuInfo>(
-        tpu_address: &'a SocketAddr,
-        leader_info: Option<&'a T>,
-        config: &'a Config,
-        protocol: Protocol,
-    ) -> Vec<(&'a SocketAddr, Slot)> {
-        leader_info
-            .as_ref()
-            .map(|leader_info| {
-                leader_info.get_leader_tpus_with_slots(config.leader_forward_count, protocol)
-            })
-            .filter(|addresses| !addresses.is_empty())
-            .unwrap_or_else(|| vec![(tpu_address, 0)])
     }
 
     pub fn join(self) -> thread::Result<()> {
@@ -661,7 +524,7 @@ mod test {
             &bank_forks,
             None,
             receiver,
-            &connection_cache,
+            connection_cache,
             1000,
             1,
             Arc::new(AtomicBool::new(false)),
@@ -695,7 +558,7 @@ mod test {
             &bank_forks,
             None,
             receiver,
-            &connection_cache,
+            connection_cache,
             1000,
             1,
             exit.clone(),
@@ -713,6 +576,22 @@ mod test {
         }
     }
 
+    fn create_client(
+        tpu_peers: Option<Vec<SocketAddr>>,
+        leader_forward_count: u64,
+    ) -> ConnectionCacheClient<NullTpuInfo> {
+        let tpu_address = "127.0.0.1:0".parse().unwrap();
+        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
+
+        ConnectionCacheClient::new(
+            connection_cache,
+            tpu_address,
+            tpu_peers,
+            None,
+            leader_forward_count,
+        )
+    }
+
     #[test]
     fn process_transactions() {
         solana_logger::setup();
@@ -720,7 +599,6 @@ mod test {
         let (mut genesis_config, mint_keypair) = create_genesis_config(4);
         genesis_config.fee_rate_governor = solana_sdk::fee_calculator::FeeRateGovernor::new(0, 0);
         let (_, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-        let tpu_address = "127.0.0.1:0".parse().unwrap();
         let config = Config {
             leader_forward_count: 1,
             ..Config::default()
@@ -767,7 +645,6 @@ mod test {
         let mut transactions = HashMap::new();
 
         info!("Expired transactions are dropped...");
-        let leader_info_provider = Arc::new(Mutex::new(CurrentLeaderInfo::new(None)));
         let stats = SendTransactionServiceStats::default();
         transactions.insert(
             Signature::default(),
@@ -780,15 +657,17 @@ mod test {
                 Some(Instant::now()),
             ),
         );
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
+
+        let client = create_client(config.tpu_peers, config.leader_forward_count);
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert!(transactions.is_empty());
@@ -815,11 +694,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert!(transactions.is_empty());
@@ -846,11 +726,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert!(transactions.is_empty());
@@ -877,11 +758,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert_eq!(transactions.len(), 1);
@@ -910,11 +792,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert_eq!(transactions.len(), 1);
@@ -953,11 +836,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert_eq!(transactions.len(), 1);
@@ -972,11 +856,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert!(transactions.is_empty());
@@ -996,7 +881,6 @@ mod test {
         let (mut genesis_config, mint_keypair) = create_genesis_config(4);
         genesis_config.fee_rate_governor = solana_sdk::fee_calculator::FeeRateGovernor::new(0, 0);
         let (_, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-        let tpu_address = "127.0.0.1:0".parse().unwrap();
         let config = Config {
             leader_forward_count: 1,
             ..Config::default()
@@ -1064,17 +948,17 @@ mod test {
                 Some(Instant::now()),
             ),
         );
-        let leader_info_provider = Arc::new(Mutex::new(CurrentLeaderInfo::new(None)));
         let stats = SendTransactionServiceStats::default();
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
+        let client = create_client(config.tpu_peers, config.leader_forward_count);
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert!(transactions.is_empty());
@@ -1100,11 +984,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert!(transactions.is_empty());
@@ -1132,11 +1017,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert!(transactions.is_empty());
@@ -1162,11 +1048,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert!(transactions.is_empty());
@@ -1193,11 +1080,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert!(transactions.is_empty());
@@ -1224,11 +1112,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert_eq!(transactions.len(), 1);
@@ -1257,11 +1146,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert_eq!(transactions.len(), 1);
@@ -1287,11 +1177,12 @@ mod test {
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
-            &tpu_address,
             &mut transactions,
-            &leader_info_provider,
-            &connection_cache,
-            &config,
+            &client,
+            config.retry_rate_ms,
+            config.service_max_retries,
+            config.default_max_retries,
+            config.batch_size,
             &stats,
         );
         assert_eq!(transactions.len(), 0);

--- a/send-transaction-service/src/send_transaction_service_stats.rs
+++ b/send-transaction-service/src/send_transaction_service_stats.rs
@@ -1,0 +1,148 @@
+use {
+    solana_sdk::timing::AtomicInterval,
+    std::sync::atomic::{AtomicU64, Ordering},
+};
+
+/// Report the send transaction metrics for every 5 seconds.
+const SEND_TRANSACTION_METRICS_REPORT_RATE_MS: u64 = 5000;
+
+/// Metrics of the send-transaction-service.
+#[derive(Default)]
+pub struct SendTransactionServiceStats {
+    /// Count of the received transactions
+    pub received_transactions: AtomicU64,
+
+    /// Count of the received duplicate transactions
+    pub received_duplicate_transactions: AtomicU64,
+
+    /// Count of transactions sent in batch
+    pub sent_transactions: AtomicU64,
+
+    /// Count of transactions not being added to retry queue
+    /// due to queue size limit
+    pub retry_queue_overflow: AtomicU64,
+
+    /// retry queue size
+    pub retry_queue_size: AtomicU64,
+
+    /// The count of calls of sending transactions which can be in batch or single.
+    pub send_attempt_count: AtomicU64,
+
+    /// Time spent on transactions in micro seconds
+    pub send_us: AtomicU64,
+
+    /// Send failure count
+    pub send_failure_count: AtomicU64,
+
+    /// Count of nonced transactions
+    pub nonced_transactions: AtomicU64,
+
+    /// Count of rooted transactions
+    pub rooted_transactions: AtomicU64,
+
+    /// Count of expired transactions
+    pub expired_transactions: AtomicU64,
+
+    /// Count of transactions exceeding max retries
+    pub transactions_exceeding_max_retries: AtomicU64,
+
+    /// Count of retries of transactions
+    pub retries: AtomicU64,
+
+    /// Count of transactions failed
+    pub failed_transactions: AtomicU64,
+}
+
+#[derive(Default)]
+pub(crate) struct SendTransactionServiceStatsReport {
+    pub stats: SendTransactionServiceStats,
+    last_report: AtomicInterval,
+}
+
+impl SendTransactionServiceStatsReport {
+    /// report metrics of the send transaction service
+    pub fn report(&self) {
+        if self
+            .last_report
+            .should_update(SEND_TRANSACTION_METRICS_REPORT_RATE_MS)
+        {
+            datapoint_info!(
+                "send_transaction_service",
+                (
+                    "recv-tx",
+                    self.stats.received_transactions.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "recv-duplicate",
+                    self.stats
+                        .received_duplicate_transactions
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "sent-tx",
+                    self.stats.sent_transactions.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "retry-queue-overflow",
+                    self.stats.retry_queue_overflow.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "retry-queue-size",
+                    self.stats.retry_queue_size.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "send-us",
+                    self.stats.send_us.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "send-attempt-count",
+                    self.stats.send_attempt_count.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "send-failure-count",
+                    self.stats.send_failure_count.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "nonced-tx",
+                    self.stats.nonced_transactions.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "rooted-tx",
+                    self.stats.rooted_transactions.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "expired-tx",
+                    self.stats.expired_transactions.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "max-retries-exceeded-tx",
+                    self.stats
+                        .transactions_exceeding_max_retries
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "retries",
+                    self.stats.retries.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "failed-tx",
+                    self.stats.failed_transactions.swap(0, Ordering::Relaxed),
+                    i64
+                )
+            );
+        }
+    }
+}

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -27,11 +27,27 @@ pub struct ConnectionCacheClient<T: TpuInfo + std::marker::Send + 'static> {
     leader_forward_count: u64,
 }
 
+// Manual implementation of Clone without requiring T to be Clone
+impl<T> Clone for ConnectionCacheClient<T>
+where
+    T: TpuInfo + std::marker::Send + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            connection_cache: Arc::clone(&self.connection_cache),
+            tpu_address: self.tpu_address,
+            tpu_peers: self.tpu_peers.clone(),
+            leader_info_provider: Arc::clone(&self.leader_info_provider),
+            leader_forward_count: self.leader_forward_count,
+        }
+    }
+}
+
 impl<T> ConnectionCacheClient<T>
 where
     T: TpuInfo + std::marker::Send + 'static,
 {
-    fn new(
+    pub fn new(
         connection_cache: Arc<ConnectionCache>,
         tpu_address: SocketAddr,
         tpu_peers: Option<Vec<SocketAddr>>,

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -32,6 +32,8 @@ pub trait TransactionClient {
         wire_transactions: Vec<Vec<u8>>,
         stats: &SendTransactionServiceStats,
     );
+
+    fn protocol(&self) -> Protocol;
 }
 
 pub trait Cancelable {
@@ -144,6 +146,10 @@ where
             self.send_transactions(address, wire_transactions.clone(), stats);
         }
     }
+
+    fn protocol(&self) -> Protocol {
+        self.connection_cache.protocol()
+    }
 }
 
 impl<T> Cancelable for ConnectionCacheClient<T>
@@ -213,6 +219,10 @@ impl TransactionClient for TpuClientNextClient {
                 stats.send_failure_count.fetch_add(1, Ordering::Relaxed);
             }
         }
+    }
+
+    fn protocol(&self) -> Protocol {
+        Protocol::QUIC
     }
 }
 

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -1,14 +1,25 @@
 use {
     crate::{send_transaction_service_stats::SendTransactionServiceStats, tpu_info::TpuInfo},
+    async_trait::async_trait,
     log::warn,
-    solana_client::connection_cache::ConnectionCache,
+    solana_client::connection_cache::{ConnectionCache, Protocol},
     solana_connection_cache::client_connection::ClientConnection as TpuConnection,
     solana_measure::measure::Measure,
+    solana_tpu_client_next::{
+        connection_workers_scheduler::ConnectionWorkersSchedulerConfig,
+        leader_updater::LeaderUpdater, transaction_batch::TransactionBatch,
+        ConnectionWorkersScheduler,
+    },
     std::{
-        net::SocketAddr,
-        sync::{atomic::Ordering, Arc, Mutex},
+        net::{Ipv4Addr, SocketAddr},
+        sync::{atomic::Ordering, Arc, Mutex, RwLock},
         time::{Duration, Instant},
     },
+    tokio::{
+        runtime::Runtime,
+        sync::mpsc::{self, Sender},
+    },
+    tokio_util::sync::CancellationToken,
 };
 
 pub trait TransactionClient {
@@ -125,6 +136,101 @@ where
             self.send_transactions(address, wire_transactions.clone(), stats);
         }
     }
+}
+
+pub struct SendTransactionServiceLeaderUpdater<T: TpuInfo + std::marker::Send + 'static> {
+    leader_info_provider: CurrentLeaderInfo<T>,
+    my_tpu_address: SocketAddr,
+    tpu_peers: Option<Vec<SocketAddr>>,
+}
+
+//TODO(klykov): it is should not be async trait because we don't need here it to be stoppable
+#[async_trait]
+impl<T> LeaderUpdater for SendTransactionServiceLeaderUpdater<T>
+where
+    T: TpuInfo + std::marker::Send + 'static,
+{
+    //TODO(klykov): So each call will lead to shit tons of allocations, I think
+    //we should recalculate only once a slot or something?
+    fn next_leaders(&mut self, lookahead_slots: u64) -> Vec<SocketAddr> {
+        // it is &mut because it is not a service! so it needs to update the state
+        // so i had to change the interface
+        let discovered_peers = self
+            .leader_info_provider
+            .get_leader_info()
+            .map(|leader_info| leader_info.get_leader_tpus(lookahead_slots / 4, Protocol::QUIC))
+            .filter(|addresses| !addresses.is_empty())
+            .unwrap_or_else(|| vec![&self.my_tpu_address]);
+        let mut all_peers = self.tpu_peers.clone().unwrap_or_default();
+        all_peers.extend(discovered_peers.into_iter().cloned());
+        all_peers
+    }
+    async fn stop(&mut self) {}
+}
+
+struct TpuClientNextClient {
+    sender: Sender<TransactionBatch>,
+}
+
+impl TransactionClient for TpuClientNextClient {
+    fn send_transactions_in_batch(
+        &self,
+        wire_transactions: Vec<Vec<u8>>,
+        stats: &SendTransactionServiceStats,
+    ) {
+        let res = self
+            .sender
+            .try_send(TransactionBatch::new(wire_transactions));
+        match res {
+            Ok(_) => {
+                stats.send_attempt_count.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(_) => {
+                warn!("Failed to send transaction transaction, transaction chanel is full.");
+                stats.send_failure_count.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+pub(crate) fn spawn_tpu_client_send_txs<T>(
+    runtime: Runtime,
+    my_tpu_address: SocketAddr,
+    tpu_peers: Option<Vec<SocketAddr>>,
+    leader_info: Option<T>,
+    leader_forward_count: u64,
+) -> Sender<TransactionBatch>
+where
+    T: TpuInfo + std::marker::Send + 'static,
+{
+    let leader_info_provider = CurrentLeaderInfo::new(leader_info);
+
+    let (transaction_sender, transaction_receiver) = mpsc::channel(16); // random number of now
+    let validator_identity = None;
+    runtime.spawn(async move {
+        let cancel = CancellationToken::new();
+        let leader_updater = SendTransactionServiceLeaderUpdater {
+            leader_info_provider,
+            my_tpu_address,
+            tpu_peers,
+        };
+        let config = ConnectionWorkersSchedulerConfig {
+            bind: SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 0),
+            stake_identity: validator_identity, //TODO In CC, do we send with identity?
+            num_connections: 1,
+            skip_check_transaction_age: true,
+            worker_channel_size: 2,
+            max_reconnect_attempts: 4,
+            lookahead_slots: leader_forward_count,
+        };
+        let _scheduler = tokio::spawn(ConnectionWorkersScheduler::run(
+            config,
+            Box::new(leader_updater),
+            transaction_receiver,
+            cancel.clone(),
+        ));
+    });
+    transaction_sender
 }
 
 /// The leader info refresh rate.

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -12,7 +12,7 @@ use {
     },
     std::{
         net::{Ipv4Addr, SocketAddr},
-        sync::{atomic::Ordering, Arc, Mutex, RwLock},
+        sync::{atomic::Ordering, Arc, Mutex},
         time::{Duration, Instant},
     },
     tokio::{

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -1,0 +1,161 @@
+use {
+    crate::{send_transaction_service_stats::SendTransactionServiceStats, tpu_info::TpuInfo},
+    log::warn,
+    solana_client::connection_cache::ConnectionCache,
+    solana_connection_cache::client_connection::ClientConnection as TpuConnection,
+    solana_measure::measure::Measure,
+    std::{
+        net::SocketAddr,
+        sync::{atomic::Ordering, Arc, Mutex},
+        time::{Duration, Instant},
+    },
+};
+
+pub trait TransactionClient {
+    fn send_transactions_in_batch(
+        &self,
+        wire_transactions: Vec<Vec<u8>>,
+        stats: &SendTransactionServiceStats,
+    );
+}
+
+pub struct ConnectionCacheClient<T: TpuInfo + std::marker::Send + 'static> {
+    connection_cache: Arc<ConnectionCache>,
+    tpu_address: SocketAddr,
+    tpu_peers: Option<Vec<SocketAddr>>,
+    leader_info_provider: Arc<Mutex<CurrentLeaderInfo<T>>>,
+    leader_forward_count: u64,
+}
+
+impl<T> ConnectionCacheClient<T>
+where
+    T: TpuInfo + std::marker::Send + 'static,
+{
+    fn new(
+        connection_cache: Arc<ConnectionCache>,
+        tpu_address: SocketAddr,
+        tpu_peers: Option<Vec<SocketAddr>>,
+        leader_info: Option<T>,
+        leader_forward_count: u64,
+    ) -> Self {
+        let leader_info_provider = Arc::new(Mutex::new(CurrentLeaderInfo::new(leader_info)));
+        Self {
+            connection_cache,
+            tpu_address,
+            tpu_peers,
+            leader_info_provider,
+            leader_forward_count,
+        }
+    }
+
+    fn get_tpu_addresses_with_slots<'a>(
+        &'a self,
+        leader_info: Option<&'a T>,
+    ) -> Vec<&'a SocketAddr> {
+        leader_info
+            .map(|leader_info| {
+                leader_info
+                    .get_leader_tpus(self.leader_forward_count, self.connection_cache.protocol())
+            })
+            .filter(|addresses| !addresses.is_empty())
+            .unwrap_or_else(|| vec![&self.tpu_address])
+    }
+
+    fn send_transactions(
+        &self,
+        peer: &SocketAddr,
+        wire_transactions: Vec<Vec<u8>>,
+        stats: &SendTransactionServiceStats,
+    ) {
+        let mut measure = Measure::start("send-us");
+        let conn = self.connection_cache.get_connection(peer);
+        let result = conn.send_data_batch_async(wire_transactions);
+
+        if let Err(err) = result {
+            warn!(
+                "Failed to send transaction transaction to {}: {:?}",
+                self.tpu_address, err
+            );
+            stats.send_failure_count.fetch_add(1, Ordering::Relaxed);
+        }
+
+        measure.stop();
+        stats.send_us.fetch_add(measure.as_us(), Ordering::Relaxed);
+        stats.send_attempt_count.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl<T> TransactionClient for ConnectionCacheClient<T>
+where
+    T: TpuInfo + std::marker::Send + 'static,
+{
+    fn send_transactions_in_batch(
+        &self,
+        wire_transactions: Vec<Vec<u8>>,
+        stats: &SendTransactionServiceStats,
+    ) {
+        // Processing the transactions in batch
+        let mut addresses = self
+            .tpu_peers
+            .as_ref()
+            .map(|addrs| addrs.iter().collect::<Vec<_>>())
+            .unwrap_or_default();
+        let mut leader_info_provider = self.leader_info_provider.lock().unwrap();
+        let leader_info = leader_info_provider.get_leader_info();
+        let leader_addresses = self.get_tpu_addresses_with_slots(leader_info);
+        addresses.extend(leader_addresses);
+
+        for address in &addresses {
+            self.send_transactions(address, wire_transactions.clone(), stats);
+        }
+    }
+}
+
+/// The leader info refresh rate.
+pub const LEADER_INFO_REFRESH_RATE_MS: u64 = 1000;
+
+/// A struct responsible for holding up-to-date leader information
+/// used for sending transactions.
+pub(crate) struct CurrentLeaderInfo<T>
+where
+    T: TpuInfo + std::marker::Send + 'static,
+{
+    /// The last time the leader info was refreshed
+    last_leader_refresh: Option<Instant>,
+
+    /// The leader info
+    leader_info: Option<T>,
+
+    /// How often to refresh the leader info
+    refresh_rate: Duration,
+}
+
+impl<T> CurrentLeaderInfo<T>
+where
+    T: TpuInfo + std::marker::Send + 'static,
+{
+    /// Get the leader info, refresh if expired
+    pub fn get_leader_info(&mut self) -> Option<&T> {
+        if let Some(leader_info) = self.leader_info.as_mut() {
+            let now = Instant::now();
+            let need_refresh = self
+                .last_leader_refresh
+                .map(|last| now.duration_since(last) >= self.refresh_rate)
+                .unwrap_or(true);
+
+            if need_refresh {
+                leader_info.refresh_recent_peers();
+                self.last_leader_refresh = Some(now);
+            }
+        }
+        self.leader_info.as_ref()
+    }
+
+    pub fn new(leader_info: Option<T>) -> Self {
+        Self {
+            last_leader_refresh: None,
+            leader_info,
+            refresh_rate: Duration::from_millis(LEADER_INFO_REFRESH_RATE_MS),
+        }
+    }
+}

--- a/tpu-client-next/src/leader_updater.rs
+++ b/tpu-client-next/src/leader_updater.rs
@@ -35,7 +35,7 @@ pub trait LeaderUpdater: Send {
     /// If the current leader estimation is incorrect and transactions are sent to
     /// only one estimated leader, there is a risk of losing all the transactions,
     /// depending on the forwarding policy.
-    fn next_leaders(&self, lookahead_slots: u64) -> Vec<SocketAddr>;
+    fn next_leaders(&mut self, lookahead_slots: u64) -> Vec<SocketAddr>;
 
     /// Stop [`LeaderUpdater`] and releases all associated resources.
     async fn stop(&mut self);
@@ -98,7 +98,7 @@ struct LeaderUpdaterService {
 
 #[async_trait]
 impl LeaderUpdater for LeaderUpdaterService {
-    fn next_leaders(&self, lookahead_slots: u64) -> Vec<SocketAddr> {
+    fn next_leaders(&mut self, lookahead_slots: u64) -> Vec<SocketAddr> {
         self.leader_tpu_service.leader_tpu_sockets(lookahead_slots)
     }
 
@@ -116,7 +116,7 @@ struct PinnedLeaderUpdater {
 
 #[async_trait]
 impl LeaderUpdater for PinnedLeaderUpdater {
-    fn next_leaders(&self, _lookahead_slots: u64) -> Vec<SocketAddr> {
+    fn next_leaders(&mut self, _lookahead_slots: u64) -> Vec<SocketAddr> {
         self.address.clone()
     }
 

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1557,6 +1557,16 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 ),
         )
         .arg(
+            Arg::with_name("use_tpu_client_next")
+                .hidden(hidden_unless_forced())
+                .long("use-tpu-client-next")
+                .takes_value(false)
+                .help(
+                    "Use tpu-client-next crate to send transactions over TPU ports. If not set,\
+                    ConnectionCache is used instead."
+                ),
+        )
+        .arg(
             Arg::with_name("block_verification_method")
                 .long("block-verification-method")
                 .value_name("METHOD")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1549,6 +1549,7 @@ pub fn main() {
         tvu_shred_sigverify_threads: tvu_sigverify_threads,
         delay_leader_block_for_pending_fork: matches
             .is_present("delay_leader_block_for_pending_fork"),
+        use_tpu_client_next: matches.is_present("use_tpu_client_next"),
         wen_restart_proto_path: value_t!(matches, "wen_restart", PathBuf).ok(),
         wen_restart_coordinator: value_t!(matches, "wen_restart_coordinator", Pubkey).ok(),
         ..ValidatorConfig::default()


### PR DESCRIPTION
#### Problem

This PR is based on https://github.com/anza-xyz/agave/pull/3423

It adds a new client type to the SendTransactionService and instruments tests to use both.

#### Summary of Changes

