### PR TITLE
Fix - SVM account_loader tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8449,6 +8449,7 @@ dependencies = [
  "solana-type-overrides",
  "solana-version",
  "solana-vote",
+ "solana_rbpf",
  "spl-token-2022",
  "test-case",
  "thiserror",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -81,6 +81,7 @@ solana-svm = { path = ".", features = ["dev-context-only-utils"] }
 solana-svm-conformance = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
+solana_rbpf = { workspace = true }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 test-case = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1360,52 +1360,6 @@ mod tests {
     }
 
     #[test]
-    fn test_load_transaction_accounts_program_account_not_found_but_loaded() {
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-
-        let message = Message {
-            account_keys: vec![key1.pubkey(), key2.pubkey()],
-            header: MessageHeader::default(),
-            instructions: vec![CompiledInstruction {
-                program_id_index: 1,
-                accounts: vec![0],
-                data: vec![],
-            }],
-            recent_blockhash: Hash::default(),
-        };
-
-        let sanitized_message = new_unchecked_sanitized_message(message);
-        let mut mock_bank = TestCallbacks::default();
-        let mut account_data = AccountSharedData::default();
-        account_data.set_lamports(200);
-        mock_bank.accounts_map.insert(key1.pubkey(), account_data);
-
-        let mut error_metrics = TransactionErrorMetrics::default();
-        let mut loaded_programs = ProgramCacheForTxBatch::default();
-        loaded_programs.replenish(key2.pubkey(), Arc::new(ProgramCacheEntry::default()));
-
-        let sanitized_transaction = SanitizedTransaction::new_for_tests(
-            sanitized_message,
-            vec![Signature::new_unique()],
-            false,
-        );
-        let result = load_transaction_accounts(
-            &mock_bank,
-            sanitized_transaction.message(),
-            LoadedTransactionAccount::default(),
-            &ComputeBudgetLimits::default(),
-            &mut error_metrics,
-            None,
-            &FeatureSet::default(),
-            &RentCollector::default(),
-            &loaded_programs,
-        );
-
-        assert_eq!(result.err(), Some(TransactionError::AccountNotFound));
-    }
-
-    #[test]
     fn test_load_transaction_accounts_program_account_executable_bypass() {
         // currently, the account loader retrieves read-only non-instruction accounts from the program cache
         // it creates a mock AccountSharedData with the executable flag set to true


### PR DESCRIPTION
#### Problem
Some tests in svm/src/account_loader.rs currently do test situations which are impossible to construct in production and do miss cases which are. The issue is a slightly incorrect setup of the program accounts involved. The tests assume that the program cache of the program cache is protocol relevant, which it is not, instead the SVM program loader is.

Otherwise these tests (introduced in #3045) are pretty good, so shout-out to Hana for writing them!

#### Summary of Changes
- Fixes `test_load_transaction_accounts_program_account_executable_bypass`:
Now constructs a loader-v2 tombstone, instead of an impossible program cache entry (a closed built-in) which would not be produced by the SVM program loader. This also changes the expected owner of the loaded program account from the `native_loader` to `bpf_loader` and thus inserts `bpf_loader` in the list of loaded accounts.

- Fixes `test_load_transaction_accounts_data_sizes`:
Now initializes the loader-v3 program with a valid `UpgradeableLoaderState::Program` pointing to a programdata account containing `UpgradeableLoaderState::ProgramData` and an ELF. Before the test simply forced in an impossible program cache entry (a closed built-in) which would not be produced by the SVM program loader. Also, uses the correctly initialized program cache for all tests now. Before it had some with an empty cache, which again can't happen in production because the cache is replenished before the account loader runs. Furthermore, adds two test cases for write lock demotion of loader-v3.

- Removes `test_load_transaction_accounts_program_account_not_found_but_loaded`:
The test constructs a scenario in which the program cache contains an entry even tough the accounts database has no account at the given key. This is not possible because the program cache only has entries for accounts owned by the loaders. A non existent account can not be owned by a loader.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
