### PR TITLE
removes CrdsValue.{signature,data} from public interface

### DIFF
--- a/gossip/src/crds_entry.rs
+++ b/gossip/src/crds_entry.rs
@@ -37,7 +37,7 @@ macro_rules! impl_crds_entry (
             type Key = Pubkey;
             fn get_entry(table:&'a CrdsTable, key: Self::Key) -> Option<Self> {
                 let key = CrdsValueLabel::$name(key);
-                match &table.get(&key)?.value.data {
+                match table.get(&key)?.value.data() {
                     $pat => Some($expr),
                     _ => None,
                 }
@@ -47,7 +47,7 @@ macro_rules! impl_crds_entry (
 );
 
 // Lookup by CrdsValueLabel.
-impl_crds_entry!(CrdsData, |entry| Some(&entry?.value.data));
+impl_crds_entry!(CrdsData, |entry| Some(entry?.value.data()));
 impl_crds_entry!(CrdsValue, |entry| Some(&entry?.value));
 impl_crds_entry!(VersionedCrdsValue, |entry| entry);
 
@@ -98,10 +98,10 @@ mod tests {
         for entry in entries.values() {
             let key = entry.label();
             assert_eq!(crds.get::<&CrdsValue>(&key), Some(entry));
-            assert_eq!(crds.get::<&CrdsData>(&key), Some(&entry.data));
+            assert_eq!(crds.get::<&CrdsData>(&key), Some(entry.data()));
             assert_eq!(crds.get::<&VersionedCrdsValue>(&key).unwrap().value, *entry);
             let key = entry.pubkey();
-            match &entry.data {
+            match entry.data() {
                 CrdsData::ContactInfo(node) => {
                     assert_eq!(crds.get::<&ContactInfo>(key), Some(node))
                 }

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -101,7 +101,7 @@ impl CrdsGossip {
         let mut crds = self.crds.write().unwrap();
         if crds
             .get_records(&pubkey)
-            .any(|value| match &value.value.data {
+            .any(|value| match value.value.data() {
                 CrdsData::DuplicateShred(_, value) => value.slot == shred_slot,
                 _ => false,
             })
@@ -121,7 +121,7 @@ impl CrdsGossip {
         let mut num_dup_shreds = 0;
         let offset = crds
             .get_records(&pubkey)
-            .filter_map(|value| match &value.value.data {
+            .filter_map(|value| match value.value.data() {
                 CrdsData::DuplicateShred(ix, value) => {
                     num_dup_shreds += 1;
                     Some((value.wallclock, *ix))

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -44,8 +44,8 @@ pub const MAX_EPOCH_SLOTS: EpochSlotsIndex = 255;
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct CrdsValue {
-    pub signature: Signature,
-    pub data: CrdsData,
+    signature: Signature,
+    data: CrdsData,
 }
 
 impl Sanitize for CrdsValue {
@@ -603,6 +603,16 @@ impl CrdsValue {
                 Self::new_signed(data, keypair)
             }
         }
+    }
+
+    #[inline]
+    pub(crate) fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    #[inline]
+    pub(crate) fn data(&self) -> &CrdsData {
+        &self.data
     }
 
     /// Totally unsecure unverifiable wallclock of the node that generated this message


### PR DESCRIPTION
#### Problem
Working towards making changes to `CrdsValue` serialization/deserialization, which requires not exposing inner fields to public interface.

#### Summary of Changes
Removed `CrdsValue.{signature,data}` from public interface