### PR TITLE
Disallow --rocksdb-shred-compaction fifo in the validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Release channels have their own copy of this changelog:
     * removed the unreleased `redelegate` instruction processor and CLI commands (#2213)
   * Banks-client:
     * relax functions to use `&self` instead of `&mut self` (#2591)
+  * `agave-validator`:
+    * Remove the deprecated value of `fifo` for `--rocksdb-shred-compaction` (#WXYZ)
 * Changes
   * SDK:
     * removed the `respan` macro. This was marked as "internal use only" and was no longer used internally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Release channels have their own copy of this changelog:
   * Banks-client:
     * relax functions to use `&self` instead of `&mut self` (#2591)
   * `agave-validator`:
-    * Remove the deprecated value of `fifo` for `--rocksdb-shred-compaction` (#WXYZ)
+    * Remove the deprecated value of `fifo` for `--rocksdb-shred-compaction` (#3451)
 * Changes
   * SDK:
     * removed the `respan` macro. This was marked as "internal use only" and was no longer used internally.

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -666,14 +666,12 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("rocksdb-shred-compaction")
                 .value_name("ROCKSDB_COMPACTION_STYLE")
                 .takes_value(true)
-                .possible_values(&["level", "fifo"])
+                .possible_values(&["level"])
                 .default_value(&default_args.rocksdb_shred_compaction)
                 .help(
                     "Controls how RocksDB compacts shreds. *WARNING*: You will lose your \
                      Blockstore data when you switch between options. Possible values are: \
-                     'level': stores shreds using RocksDB's default (level) compaction. \
-                     'fifo': stores shreds under RocksDB's FIFO compaction. This option is more \
-                     efficient on disk-write-bytes of the Blockstore.",
+                     'level': stores shreds using RocksDB's default (level) compaction.",
                 ),
         )
         .arg(


### PR DESCRIPTION
#### Problem
Fifo compaction in rocksdb (Blockstore) was deprecated in v2.0 (see https://github.com/anza-xyz/agave/pull/1882). Currently, a warning is emitted but use of `fifo` is still permitted.

#### Summary of Changes
This change actually makes `fifo` an invalid option for `--rocksdb-shred-compaction`, leaving `level` as the only valid option.

The actual fifo code that is plumbed down several layers will be removed in a subsequent PR

#### Testing
Started a validator real quick and ensured that things errored out with `--rocksdb-shred-compaction fifo` and that `--rocksdb-shred-compaction level` OR not specifying that flag at all proceeded without issue