### PR TITLE
remove unnecessary reqwest features from rpc-client-api

### DIFF
--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = { workspace = true }
 base64 = { workspace = true }
 bs58 = { workspace = true, features = ["std"] }
 jsonrpc-core = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls-tls"] }
 reqwest-middleware = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
#### Problem
solana-rpc-client-api is only using reqwest for the Error struct so it doesn't need all these reqwest features

#### Summary of Changes
Remove the unnecessary reqwest features
