### PR TITLE
remove vote-program dep from rpc-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8229,7 +8229,6 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status-client-types",
  "solana-version",
- "solana-vote-program",
  "tokio",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6516,7 +6516,6 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status-client-types",
  "solana-version",
- "solana-vote-program",
  "tokio",
 ]
 

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -27,7 +27,6 @@ solana-rpc-client-api = { workspace = true }
 solana-sdk = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
 solana-version = { workspace = true }
-solana-vote-program = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -45,12 +45,12 @@ use {
         pubkey::Pubkey,
         signature::Signature,
         transaction,
+        vote::state::MAX_LOCKOUT_HISTORY,
     },
     solana_transaction_status_client_types::{
         EncodedConfirmedBlock, EncodedConfirmedTransactionWithStatusMeta, TransactionStatus,
         UiConfirmedBlock, UiTransactionEncoding,
     },
-    solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY,
     std::{
         net::SocketAddr,
         str::FromStr,

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6336,7 +6336,6 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status-client-types",
  "solana-version",
- "solana-vote-program",
  "tokio",
 ]
 


### PR DESCRIPTION
#### Problem
solana-rpc-client is depending on solana-vote-program just for a const that it re-exports from solana_program

#### Summary of Changes
Don't do that
