### PR TITLE
Marks local-cluster tests with #[serial]

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -102,6 +102,7 @@ use {
 };
 
 #[test]
+#[serial]
 fn test_local_cluster_start_and_exit() {
     solana_logger::setup();
     let num_nodes = 1;
@@ -115,6 +116,7 @@ fn test_local_cluster_start_and_exit() {
 }
 
 #[test]
+#[serial]
 fn test_local_cluster_start_and_exit_with_config() {
     solana_logger::setup();
     const NUM_NODES: usize = 1;
@@ -1535,6 +1537,7 @@ fn test_fake_shreds_broadcast_leader() {
 }
 
 #[test]
+#[serial]
 fn test_wait_for_max_stake() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     let validator_config = ValidatorConfig::default_for_test();
@@ -1584,6 +1587,7 @@ fn test_wait_for_max_stake() {
 }
 
 #[test]
+#[serial]
 // Test that when a leader is leader for banks B_i..B_{i+n}, and B_i is not
 // votable, then B_{i+1} still chains to B_i
 fn test_no_voting() {
@@ -2083,6 +2087,7 @@ fn restart_whole_cluster_after_hard_fork(
 }
 
 #[test]
+#[serial]
 fn test_hard_fork_invalidates_tower() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
 
@@ -4429,6 +4434,7 @@ fn test_leader_failure_4() {
 // slot_hash expiry to 64 slots.
 
 #[test]
+#[serial]
 fn test_slot_hash_expiry() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     solana_sdk::slot_hashes::set_entries_for_tests_only(64);


### PR DESCRIPTION
#### Problem

local-cluster tests timeout a lot; one is test_wait_for_max_stake(). All the local-cluster tests are marked with `#[serial]` to ensure they don't interfere with each other, but test_wait_for_max_stake() is *not*. We also see test failures in test_boot_from_local_state, which are due to timeouts too. Since `#[serial]` is opt-in, if we do not add the annotation, the test can run concurrently with other tests.


#### Summary of Changes

Mark all the local-cluster tests with #[serial].