### PR TITLE
refactor: stake withdraw logic

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -884,15 +884,7 @@ pub fn withdraw(
         // Don't allow withdrawing the reserved rent balance or active stake
         let lamports_and_reserve = checked_add(lamports, reserve)?;
         if lamports_and_reserve > stake_account.get_lamports() {
-            // if the stake is active, we mustn't allow the account to go away
-            if is_staked {
-                return Err(InstructionError::InsufficientFunds);
-            }
-
-            // fail if not a full withdrawal
-            if lamports != stake_account.get_lamports() {
-                return Err(InstructionError::InsufficientFunds);
-            }
+            return Err(InstructionError::InsufficientFunds);
         }
     }
 

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -872,22 +872,28 @@ pub fn withdraw(
         return Err(StakeError::LockupInForce.into());
     }
 
-    let lamports_and_reserve = checked_add(lamports, reserve)?;
-    if lamports_and_reserve > stake_account.get_lamports() {
+    if lamports == stake_account.get_lamports() {
         // if the stake is active, we mustn't allow the account to go away
         if is_staked {
             return Err(InstructionError::InsufficientFunds);
         }
 
-        // fail if not a full withdrawal
-        if lamports != stake_account.get_lamports() {
-            return Err(InstructionError::InsufficientFunds);
-        }
-    }
-
-    // Deinitialize state upon zero balance
-    if lamports == stake_account.get_lamports() {
+        // Deinitialize state upon zero balance
         stake_account.set_state(&StakeStateV2::Uninitialized)?;
+    } else {
+        // Don't allow withdrawing the reserved rent balance or active stake
+        let lamports_and_reserve = checked_add(lamports, reserve)?;
+        if lamports_and_reserve > stake_account.get_lamports() {
+            // if the stake is active, we mustn't allow the account to go away
+            if is_staked {
+                return Err(InstructionError::InsufficientFunds);
+            }
+
+            // fail if not a full withdrawal
+            if lamports != stake_account.get_lamports() {
+                return Err(InstructionError::InsufficientFunds);
+            }
+        }
     }
 
     stake_account.checked_sub_lamports(lamports)?;

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -873,18 +873,16 @@ pub fn withdraw(
     }
 
     let lamports_and_reserve = checked_add(lamports, reserve)?;
-    // if the stake is active, we mustn't allow the account to go away
-    if is_staked // line coverage for branch coverage
-            && lamports_and_reserve > stake_account.get_lamports()
-    {
-        return Err(InstructionError::InsufficientFunds);
-    }
+    if lamports_and_reserve > stake_account.get_lamports() {
+        // if the stake is active, we mustn't allow the account to go away
+        if is_staked {
+            return Err(InstructionError::InsufficientFunds);
+        }
 
-    if lamports != stake_account.get_lamports() // not a full withdrawal
-            && lamports_and_reserve > stake_account.get_lamports()
-    {
-        assert!(!is_staked);
-        return Err(InstructionError::InsufficientFunds);
+        // fail if not a full withdrawal
+        if lamports != stake_account.get_lamports() {
+            return Err(InstructionError::InsufficientFunds);
+        }
     }
 
     // Deinitialize state upon zero balance


### PR DESCRIPTION
#### Problem
The stake withdraw logic is hard to follow

#### Summary of Changes
No functional changes or error variants should change as a result of this change.

- https://github.com/anza-xyz/agave/commit/eccb68d1c2b7373037fbac2ae4286e6109949bc5 straightforward logical refactor
- https://github.com/anza-xyz/agave/commit/cebea2f892bb0985d76966c590684fdef4912f87 pull out full withdrawal special case and check it first. Note that if `lamports == stake_account.get_lamports()`, then it's impossible for `checked_add(lamports, reserve)?` to fail
- https://github.com/anza-xyz/agave/commit/84a5994c3f638eca6f224f48ea6f20b32222889c straightforward logical refactor

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
