### PR TITLE
svm: introduce filter_executable_us metric

### DIFF
--- a/timings/src/lib.rs
+++ b/timings/src/lib.rs
@@ -57,6 +57,7 @@ pub enum ExecuteTimingType {
     UpdateTransactionStatuses,
     ProgramCacheUs,
     CheckBlockLimitsUs,
+    FilterExecutableUs,
 }
 
 pub struct Metrics([u64; ExecuteTimingType::CARDINALITY]);
@@ -105,6 +106,13 @@ eager_macro_rules! { $eager_1
                 *$self
                     .metrics
                     .index(ExecuteTimingType::ValidateFeesUs),
+                i64
+            ),
+            (
+                "filter_executable_us",
+                *$self
+                    .metrics
+                    .index(ExecuteTimingType::FilterExecutableUs),
                 i64
             ),
             (


### PR DESCRIPTION
Split the time taken by filter_executable_accounts() outside of program_cache_us. Filtering takes a considerable amount of time because account_matches_owners is pretty slow.