### PR TITLE
TPU Vote using quic -- client side implementation

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -450,15 +450,16 @@ fn main() {
     };
     let cluster_info = Arc::new(cluster_info);
     let tpu_disable_quic = matches.is_present("tpu_disable_quic");
-    let connection_cache = match tpu_disable_quic {
-        false => ConnectionCache::new_quic(
-            "connection_cache_banking_bench_quic",
-            DEFAULT_TPU_CONNECTION_POOL_SIZE,
-        ),
-        true => ConnectionCache::with_udp(
+    let connection_cache = if tpu_disable_quic {
+        ConnectionCache::with_udp(
             "connection_cache_banking_bench_udp",
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
-        ),
+        )
+    } else {
+        ConnectionCache::new_quic(
+            "connection_cache_banking_bench_quic",
+            DEFAULT_TPU_CONNECTION_POOL_SIZE,
+        )
     };
     let banking_stage = BankingStage::new_num_threads(
         block_production_method,

--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -16,6 +16,7 @@ pub(crate) fn upcoming_leader_tpu_vote_sockets(
     cluster_info: &ClusterInfo,
     poh_recorder: &RwLock<PohRecorder>,
     fanout_slots: u64,
+    protocol: Protocol,
 ) -> Vec<SocketAddr> {
     let upcoming_leaders = {
         let poh_recorder = poh_recorder.read().unwrap();
@@ -29,7 +30,7 @@ pub(crate) fn upcoming_leader_tpu_vote_sockets(
         .dedup()
         .filter_map(|leader_pubkey| {
             cluster_info
-                .lookup_contact_info(&leader_pubkey, |node| node.tpu_vote(Protocol::UDP))?
+                .lookup_contact_info(&leader_pubkey, |node| node.tpu_vote(protocol))?
                 .ok()
         })
         // dedup again since leaders could potentially share the same tpu vote socket

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4275,7 +4275,7 @@ pub(crate) mod tests {
             transaction::TransactionError,
         },
         solana_streamer::socket::SocketAddrSpace,
-        solana_tpu_client::tpu_client::DEFAULT_VOTE_USE_QUIC,
+        solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC},
         solana_transaction_status::VersionedTransactionWithStatusMeta,
         solana_vote_program::{
             vote_state::{self, TowerSync, VoteStateVersions},
@@ -7561,9 +7561,16 @@ pub(crate) mod tests {
             .recv_timeout(Duration::from_secs(1))
             .unwrap();
 
-        let connection_cache = match DEFAULT_VOTE_USE_QUIC {
-            true => ConnectionCache::new_quic("connection_cache_vote_quic", 1),
-            false => ConnectionCache::with_udp("connection_cache_vote_udp", 1),
+        let connection_cache = if DEFAULT_VOTE_USE_QUIC {
+            ConnectionCache::new_quic(
+                "connection_cache_vote_quic",
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            )
+        } else {
+            ConnectionCache::with_udp(
+                "connection_cache_vote_udp",
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            )
         };
 
         crate::voting_service::VotingService::handle_vote(
@@ -7643,9 +7650,16 @@ pub(crate) mod tests {
             .recv_timeout(Duration::from_secs(1))
             .unwrap();
 
-        let connection_cache = match DEFAULT_VOTE_USE_QUIC {
-            true => ConnectionCache::new_quic("connection_cache_vote_quic", 1),
-            false => ConnectionCache::with_udp("connection_cache_vote_udp", 1),
+        let connection_cache = if DEFAULT_VOTE_USE_QUIC {
+            ConnectionCache::new_quic(
+                "connection_cache_vote_quic",
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            )
+        } else {
+            ConnectionCache::with_udp(
+                "connection_cache_vote_udp",
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            )
         };
 
         crate::voting_service::VotingService::handle_vote(
@@ -7733,9 +7747,16 @@ pub(crate) mod tests {
         let vote_info = voting_receiver
             .recv_timeout(Duration::from_secs(1))
             .unwrap();
-        let connection_cache = match DEFAULT_VOTE_USE_QUIC {
-            true => ConnectionCache::new_quic("connection_cache_vote_quic", 1),
-            false => ConnectionCache::with_udp("connection_cache_vote_udp", 1),
+        let connection_cache = if DEFAULT_VOTE_USE_QUIC {
+            ConnectionCache::new_quic(
+                "connection_cache_vote_quic",
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            )
+        } else {
+            ConnectionCache::with_udp(
+                "connection_cache_vote_udp",
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            )
         };
 
         crate::voting_service::VotingService::handle_vote(
@@ -7854,9 +7875,16 @@ pub(crate) mod tests {
         let vote_info = voting_receiver
             .recv_timeout(Duration::from_secs(1))
             .unwrap();
-        let connection_cache = match DEFAULT_VOTE_USE_QUIC {
-            true => ConnectionCache::new_quic("connection_cache_vote_quic", 1),
-            false => ConnectionCache::with_udp("connection_cache_vote_udp", 1),
+        let connection_cache = if DEFAULT_VOTE_USE_QUIC {
+            ConnectionCache::new_quic(
+                "connection_cache_vote_quic",
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            )
+        } else {
+            ConnectionCache::with_udp(
+                "connection_cache_vote_udp",
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            )
         };
 
         crate::voting_service::VotingService::handle_vote(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -437,7 +437,7 @@ pub mod tests {
         solana_runtime::bank::Bank,
         solana_sdk::signature::{Keypair, Signer},
         solana_streamer::socket::SocketAddrSpace,
-        solana_tpu_client::tpu_client::DEFAULT_VOTE_USE_QUIC,
+        solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC},
         std::sync::atomic::{AtomicU64, Ordering},
     };
 
@@ -496,9 +496,16 @@ pub mod tests {
         } else {
             None
         };
-        let connection_cache = match DEFAULT_VOTE_USE_QUIC {
-            true => ConnectionCache::new_quic("connection_cache_vote_quic", 1),
-            false => ConnectionCache::with_udp("connection_cache_vote_udp", 1),
+        let connection_cache = if DEFAULT_VOTE_USE_QUIC {
+            ConnectionCache::new_quic(
+                "connection_cache_vote_quic",
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            )
+        } else {
+            ConnectionCache::with_udp(
+                "connection_cache_vote_udp",
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            )
         };
 
         let tvu = Tvu::new(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1026,7 +1026,7 @@ impl Validator {
                         node.info
                             .tpu_vote(Protocol::QUIC)
                             .map_err(|err| {
-                                ValidatorError::Other(format!("Invalid TPU address: {err:?}"))
+                                ValidatorError::Other(format!("Invalid TPU Vote address: {err:?}"))
                             })?
                             .ip(),
                     )),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -529,6 +529,7 @@ impl Validator {
         start_progress: Arc<RwLock<ValidatorStartProgress>>,
         socket_addr_space: SocketAddrSpace,
         use_quic: bool,
+        vote_use_quic: bool,
         tpu_connection_pool_size: usize,
         tpu_enable_udp: bool,
         tpu_max_connections_per_ipaddr_per_minute: u64,
@@ -1014,6 +1015,28 @@ impl Validator {
             )),
         };
 
+        let vote_connection_cache = match vote_use_quic {
+            true => {
+                let vote_connection_cache = ConnectionCache::new_with_client_options(
+                    "connection_cache_vote_quic",
+                    1,
+                    None,
+                    Some((
+                        &identity_keypair,
+                        node.info
+                            .tpu_vote(Protocol::QUIC)
+                            .map_err(|err| {
+                                ValidatorError::Other(format!("Invalid TPU address: {err:?}"))
+                            })?
+                            .ip(),
+                    )),
+                    Some((&staked_nodes, &identity_keypair.pubkey())),
+                );
+                Arc::new(vote_connection_cache)
+            }
+            false => Arc::new(ConnectionCache::with_udp("connection_cache_vote_udp", 1)),
+        };
+
         let rpc_override_health_check =
             Arc::new(AtomicBool::new(config.rpc_config.disable_health_check));
         let (
@@ -1427,6 +1450,7 @@ impl Validator {
             cluster_slots.clone(),
             wen_restart_repair_slots.clone(),
             slot_status_notifier,
+            vote_connection_cache,
         )
         .map_err(ValidatorError::Other)?;
 
@@ -2710,6 +2734,7 @@ mod tests {
         solana_sdk::{genesis_config::create_genesis_config, poh_config::PohConfig},
         solana_tpu_client::tpu_client::{
             DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
+            DEFAULT_VOTE_USE_QUIC,
         },
         std::{fs::remove_dir_all, thread, time::Duration},
     };
@@ -2749,6 +2774,7 @@ mod tests {
             start_progress.clone(),
             SocketAddrSpace::Unspecified,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_VOTE_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
             32, // max connections per IpAddr per minute for test
@@ -2968,6 +2994,7 @@ mod tests {
                     Arc::new(RwLock::new(ValidatorStartProgress::default())),
                     SocketAddrSpace::Unspecified,
                     DEFAULT_TPU_USE_QUIC,
+                    DEFAULT_VOTE_USE_QUIC,
                     DEFAULT_TPU_CONNECTION_POOL_SIZE,
                     DEFAULT_TPU_ENABLE_UDP,
                     32, // max connections per IpAddr per minute for test

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -476,6 +476,20 @@ struct TransactionHistoryServices {
     cache_block_meta_service: Option<CacheBlockMetaService>,
 }
 
+/// A struct easing passing Validator TPU Configurations
+pub struct ValidatorTpuConfig {
+    /// Controls if to use QUIC for sending regular TPU transaction
+    pub use_quic: bool,
+    /// Controls if to use QUIC for sending TPU votes
+    pub vote_use_quic: bool,
+    /// Controls the connection cache pool size
+    pub tpu_connection_pool_size: usize,
+    /// Controls if to enable UDP for TPU tansactions.
+    pub tpu_enable_udp: bool,
+    /// Controls the new maximum connections per IpAddr per minute
+    pub tpu_max_connections_per_ipaddr_per_minute: u64,
+}
+
 pub struct Validator {
     validator_exit: Arc<RwLock<Exit>>,
     json_rpc_service: Option<JsonRpcService>,
@@ -528,13 +542,17 @@ impl Validator {
         rpc_to_plugin_manager_receiver: Option<Receiver<GeyserPluginManagerRequest>>,
         start_progress: Arc<RwLock<ValidatorStartProgress>>,
         socket_addr_space: SocketAddrSpace,
-        use_quic: bool,
-        vote_use_quic: bool,
-        tpu_connection_pool_size: usize,
-        tpu_enable_udp: bool,
-        tpu_max_connections_per_ipaddr_per_minute: u64,
+        tpu_config: ValidatorTpuConfig,
         admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
     ) -> Result<Self> {
+        let ValidatorTpuConfig {
+            use_quic,
+            vote_use_quic,
+            tpu_connection_pool_size,
+            tpu_enable_udp,
+            tpu_max_connections_per_ipaddr_per_minute,
+        } = tpu_config;
+
         let start_time = Instant::now();
 
         // Initialize the global rayon pool first to ensure the value in config
@@ -990,51 +1008,52 @@ impl Validator {
 
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
 
-        let connection_cache = match use_quic {
-            true => {
-                let connection_cache = ConnectionCache::new_with_client_options(
-                    "connection_cache_tpu_quic",
-                    tpu_connection_pool_size,
-                    None,
-                    Some((
-                        &identity_keypair,
-                        node.info
-                            .tpu(Protocol::UDP)
-                            .map_err(|err| {
-                                ValidatorError::Other(format!("Invalid TPU address: {err:?}"))
-                            })?
-                            .ip(),
-                    )),
-                    Some((&staked_nodes, &identity_keypair.pubkey())),
-                );
-                Arc::new(connection_cache)
-            }
-            false => Arc::new(ConnectionCache::with_udp(
+        let connection_cache = if use_quic {
+            let connection_cache = ConnectionCache::new_with_client_options(
+                "connection_cache_tpu_quic",
+                tpu_connection_pool_size,
+                None,
+                Some((
+                    &identity_keypair,
+                    node.info
+                        .tpu(Protocol::UDP)
+                        .map_err(|err| {
+                            ValidatorError::Other(format!("Invalid TPU address: {err:?}"))
+                        })?
+                        .ip(),
+                )),
+                Some((&staked_nodes, &identity_keypair.pubkey())),
+            );
+            Arc::new(connection_cache)
+        } else {
+            Arc::new(ConnectionCache::with_udp(
                 "connection_cache_tpu_udp",
                 tpu_connection_pool_size,
-            )),
+            ))
         };
 
-        let vote_connection_cache = match vote_use_quic {
-            true => {
-                let vote_connection_cache = ConnectionCache::new_with_client_options(
-                    "connection_cache_vote_quic",
-                    1,
-                    None,
-                    Some((
-                        &identity_keypair,
-                        node.info
-                            .tpu_vote(Protocol::QUIC)
-                            .map_err(|err| {
-                                ValidatorError::Other(format!("Invalid TPU Vote address: {err:?}"))
-                            })?
-                            .ip(),
-                    )),
-                    Some((&staked_nodes, &identity_keypair.pubkey())),
-                );
-                Arc::new(vote_connection_cache)
-            }
-            false => Arc::new(ConnectionCache::with_udp("connection_cache_vote_udp", 1)),
+        let vote_connection_cache = if vote_use_quic {
+            let vote_connection_cache = ConnectionCache::new_with_client_options(
+                "connection_cache_vote_quic",
+                tpu_connection_pool_size,
+                None, // client_endpoint
+                Some((
+                    &identity_keypair,
+                    node.info
+                        .tpu_vote(Protocol::QUIC)
+                        .map_err(|err| {
+                            ValidatorError::Other(format!("Invalid TPU Vote address: {err:?}"))
+                        })?
+                        .ip(),
+                )),
+                Some((&staked_nodes, &identity_keypair.pubkey())),
+            );
+            Arc::new(vote_connection_cache)
+        } else {
+            Arc::new(ConnectionCache::with_udp(
+                "connection_cache_vote_udp",
+                tpu_connection_pool_size,
+            ))
         };
 
         let rpc_override_health_check =
@@ -2773,11 +2792,13 @@ mod tests {
             None, // rpc_to_plugin_manager_receiver
             start_progress.clone(),
             SocketAddrSpace::Unspecified,
-            DEFAULT_TPU_USE_QUIC,
-            DEFAULT_VOTE_USE_QUIC,
-            DEFAULT_TPU_CONNECTION_POOL_SIZE,
-            DEFAULT_TPU_ENABLE_UDP,
-            32, // max connections per IpAddr per minute for test
+            ValidatorTpuConfig {
+                use_quic: DEFAULT_TPU_USE_QUIC,
+                vote_use_quic: DEFAULT_VOTE_USE_QUIC,
+                tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+                tpu_enable_udp: DEFAULT_TPU_ENABLE_UDP,
+                tpu_max_connections_per_ipaddr_per_minute: 32, // max connections per IpAddr per minute for test
+            },
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
@@ -2993,11 +3014,13 @@ mod tests {
                     None, // rpc_to_plugin_manager_receiver
                     Arc::new(RwLock::new(ValidatorStartProgress::default())),
                     SocketAddrSpace::Unspecified,
-                    DEFAULT_TPU_USE_QUIC,
-                    DEFAULT_VOTE_USE_QUIC,
-                    DEFAULT_TPU_CONNECTION_POOL_SIZE,
-                    DEFAULT_TPU_ENABLE_UDP,
-                    32, // max connections per IpAddr per minute for test
+                    ValidatorTpuConfig {
+                        use_quic: DEFAULT_TPU_USE_QUIC,
+                        vote_use_quic: DEFAULT_VOTE_USE_QUIC,
+                        tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+                        tpu_enable_udp: DEFAULT_TPU_ENABLE_UDP,
+                        tpu_max_connections_per_ipaddr_per_minute: 32, // max connections per IpAddr per minute for test
+                    },
                     Arc::new(RwLock::new(None)),
                 )
                 .expect("assume successful validator start")

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -4,6 +4,7 @@ use {
         next_leader::upcoming_leader_tpu_vote_sockets,
     },
     crossbeam_channel::Receiver,
+    solana_client::connection_cache::ConnectionCache,
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure::Measure,
     solana_poh::poh_recorder::PohRecorder,
@@ -48,6 +49,7 @@ impl VotingService {
         cluster_info: Arc<ClusterInfo>,
         poh_recorder: Arc<RwLock<PohRecorder>>,
         tower_storage: Arc<dyn TowerStorage>,
+        connection_cache: Arc<ConnectionCache>,
     ) -> Self {
         let thread_hdl = Builder::new()
             .name("solVoteService".to_string())
@@ -58,6 +60,7 @@ impl VotingService {
                         &poh_recorder,
                         tower_storage.as_ref(),
                         vote_op,
+                        connection_cache.clone(),
                     );
                 }
             })
@@ -70,6 +73,7 @@ impl VotingService {
         poh_recorder: &RwLock<PohRecorder>,
         tower_storage: &dyn TowerStorage,
         vote_op: VoteOp,
+        connection_cache: Arc<ConnectionCache>,
     ) {
         if let VoteOp::PushVote { saved_tower, .. } = &vote_op {
             let mut measure = Measure::start("tower storage save");
@@ -89,15 +93,20 @@ impl VotingService {
             cluster_info,
             poh_recorder,
             UPCOMING_LEADER_FANOUT_SLOTS,
+            connection_cache.protocol(),
         );
 
         if !upcoming_leader_sockets.is_empty() {
             for tpu_vote_socket in upcoming_leader_sockets {
-                let _ = cluster_info.send_transaction(vote_op.tx(), Some(tpu_vote_socket));
+                let _ = cluster_info.send_transaction(
+                    vote_op.tx(),
+                    Some(tpu_vote_socket),
+                    &connection_cache,
+                );
             }
         } else {
             // Send to our own tpu vote socket if we cannot find a leader to send to
-            let _ = cluster_info.send_transaction(vote_op.tx(), None);
+            let _ = cluster_info.send_transaction(vote_op.tx(), None, &connection_cache);
         }
 
         match vote_op {

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -259,14 +259,13 @@ fn create_sender_thread(
     tpu_use_quic: bool,
 ) -> thread::JoinHandle<()> {
     // ConnectionCache is used instead of client because it gives ~6% higher pps
-    let connection_cache = match tpu_use_quic {
-        true => ConnectionCache::new_quic(
+    let connection_cache = if tpu_use_quic {
+        ConnectionCache::new_quic(
             "connection_cache_dos_quic",
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
-        ),
-        false => {
-            ConnectionCache::with_udp("connection_cache_dos_udp", DEFAULT_TPU_CONNECTION_POOL_SIZE)
-        }
+        )
+    } else {
+        ConnectionCache::with_udp("connection_cache_dos_udp", DEFAULT_TPU_CONNECTION_POOL_SIZE)
     };
     let connection = connection_cache.get_connection(target);
 

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -51,6 +51,9 @@ use {
     itertools::Itertools,
     rand::{seq::SliceRandom, thread_rng, CryptoRng, Rng},
     rayon::{prelude::*, ThreadPool, ThreadPoolBuilder},
+    serde::ser::Serialize,
+    solana_client::connection_cache::ConnectionCache,
+    solana_connection_cache::client_connection::ClientConnection,
     solana_feature_set::FeatureSet,
     solana_ledger::shred::Shred,
     solana_measure::measure::Measure,
@@ -154,7 +157,6 @@ pub struct ClusterInfo {
     my_contact_info: RwLock<ContactInfo>,
     ping_cache: Mutex<PingCache>,
     stats: GossipStats,
-    socket: UdpSocket,
     local_message_pending_push_queue: Mutex<Vec<CrdsValue>>,
     contact_debug_interval: u64, // milliseconds, 0 = disabled
     contact_save_interval: u64,  // milliseconds, 0 = disabled
@@ -929,13 +931,21 @@ impl ClusterInfo {
         &self,
         transaction: &Transaction,
         tpu: Option<SocketAddr>,
+        connection_cache: &Arc<ConnectionCache>,
     ) -> Result<(), GossipError> {
         let tpu = tpu
             .map(Ok)
-            .unwrap_or_else(|| self.my_contact_info().tpu(contact_info::Protocol::UDP))?;
+            .unwrap_or_else(|| self.my_contact_info().tpu(connection_cache.protocol()))?;
         let buf = serialize(transaction)?;
-        self.socket.send_to(&buf, tpu)?;
-        Ok(())
+        let client = connection_cache.get_connection(&tpu);
+        let result = client.send_data_async(buf);
+        match result {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                debug!("Ran into exception sending vote: {err:?}");
+                Err(GossipError::SendError)
+            }
+        }
     }
 
     /// Returns votes inserted since the given cursor.

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -51,7 +51,6 @@ use {
     itertools::Itertools,
     rand::{seq::SliceRandom, thread_rng, CryptoRng, Rng},
     rayon::{prelude::*, ThreadPool, ThreadPoolBuilder},
-    serde::ser::Serialize,
     solana_client::connection_cache::ConnectionCache,
     solana_connection_cache::client_connection::ClientConnection,
     solana_feature_set::FeatureSet,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -941,7 +941,7 @@ impl ClusterInfo {
         match result {
             Ok(_) => Ok(()),
             Err(err) => {
-                debug!("Ran into exception sending vote: {err:?}");
+                trace!("Ran into an error when sending vote: {err:?} to {tpu:?}");
                 Err(GossipError::SendError)
             }
         }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -11,7 +11,7 @@ use {
     solana_client::connection_cache::ConnectionCache,
     solana_core::{
         consensus::tower_storage::FileTowerStorage,
-        validator::{Validator, ValidatorConfig, ValidatorStartProgress},
+        validator::{Validator, ValidatorConfig, ValidatorStartProgress, ValidatorTpuConfig},
     },
     solana_gossip::{
         cluster_info::Node,
@@ -341,13 +341,15 @@ impl LocalCluster {
             None, // rpc_to_plugin_manager_receiver
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            DEFAULT_TPU_USE_QUIC,
-            DEFAULT_VOTE_USE_QUIC,
-            DEFAULT_TPU_CONNECTION_POOL_SIZE,
-            // We are turning tpu_enable_udp to true in order to prevent concurrent local cluster tests
-            // to use the same QUIC ports due to SO_REUSEPORT.
-            true,
-            32, // max connections per IpAddr per minute
+            ValidatorTpuConfig {
+                use_quic: DEFAULT_TPU_USE_QUIC,
+                vote_use_quic: DEFAULT_VOTE_USE_QUIC,
+                tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+                // We are turning tpu_enable_udp to true in order to prevent concurrent local cluster tests
+                // to use the same QUIC ports due to SO_REUSEPORT.
+                tpu_enable_udp: true,
+                tpu_max_connections_per_ipaddr_per_minute: 32, // max connections per IpAddr per minute
+            },
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
@@ -549,11 +551,13 @@ impl LocalCluster {
             None, // rpc_to_plugin_manager_receiver
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            DEFAULT_TPU_USE_QUIC,
-            DEFAULT_VOTE_USE_QUIC,
-            DEFAULT_TPU_CONNECTION_POOL_SIZE,
-            DEFAULT_TPU_ENABLE_UDP,
-            32, // max connections per IpAddr per mintute
+            ValidatorTpuConfig {
+                use_quic: DEFAULT_TPU_USE_QUIC,
+                vote_use_quic: DEFAULT_VOTE_USE_QUIC,
+                tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+                tpu_enable_udp: DEFAULT_TPU_ENABLE_UDP,
+                tpu_max_connections_per_ipaddr_per_minute: 32, // max connections per IpAddr per mintute
+            },
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
@@ -1083,11 +1087,13 @@ impl Cluster for LocalCluster {
             None, // rpc_to_plugin_manager_receiver
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            DEFAULT_TPU_USE_QUIC,
-            DEFAULT_VOTE_USE_QUIC,
-            DEFAULT_TPU_CONNECTION_POOL_SIZE,
-            DEFAULT_TPU_ENABLE_UDP,
-            32, // max connections per IpAddr per minute, use higher value because of tests
+            ValidatorTpuConfig {
+                use_quic: DEFAULT_TPU_USE_QUIC,
+                vote_use_quic: DEFAULT_VOTE_USE_QUIC,
+                tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+                tpu_enable_udp: DEFAULT_TPU_ENABLE_UDP,
+                tpu_max_connections_per_ipaddr_per_minute: 32, // max connections per IpAddr per minute, use higher value because of tests
+            },
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -51,7 +51,7 @@ use {
     solana_streamer::{socket::SocketAddrSpace, streamer::StakedNodes},
     solana_tpu_client::tpu_client::{
         TpuClient, TpuClientConfig, DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP,
-        DEFAULT_TPU_USE_QUIC,
+        DEFAULT_TPU_USE_QUIC, DEFAULT_VOTE_USE_QUIC,
     },
     solana_vote_program::{
         vote_instruction,
@@ -97,6 +97,7 @@ pub struct ClusterConfig {
     pub additional_accounts: Vec<(Pubkey, AccountSharedData)>,
     pub tpu_use_quic: bool,
     pub tpu_connection_pool_size: usize,
+    pub vote_use_quic: bool,
 }
 
 impl ClusterConfig {
@@ -136,6 +137,7 @@ impl Default for ClusterConfig {
             additional_accounts: vec![],
             tpu_use_quic: DEFAULT_TPU_USE_QUIC,
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            vote_use_quic: DEFAULT_VOTE_USE_QUIC,
         }
     }
 }
@@ -340,6 +342,7 @@ impl LocalCluster {
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_VOTE_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             // We are turning tpu_enable_udp to true in order to prevent concurrent local cluster tests
             // to use the same QUIC ports due to SO_REUSEPORT.
@@ -547,6 +550,7 @@ impl LocalCluster {
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_VOTE_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
             32, // max connections per IpAddr per mintute
@@ -1080,6 +1084,7 @@ impl Cluster for LocalCluster {
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_VOTE_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
             32, // max connections per IpAddr per minute, use higher value because of tests

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -502,13 +502,10 @@ fn run_tpu_send_transaction(tpu_use_quic: bool) {
         test_validator.rpc_url(),
         CommitmentConfig::processed(),
     ));
-    let connection_cache = match tpu_use_quic {
-        true => {
-            ConnectionCache::new_quic("connection_cache_test", DEFAULT_TPU_CONNECTION_POOL_SIZE)
-        }
-        false => {
-            ConnectionCache::with_udp("connection_cache_test", DEFAULT_TPU_CONNECTION_POOL_SIZE)
-        }
+    let connection_cache = if tpu_use_quic {
+        ConnectionCache::new_quic("connection_cache_test", DEFAULT_TPU_CONNECTION_POOL_SIZE)
+    } else {
+        ConnectionCache::with_udp("connection_cache_test", DEFAULT_TPU_CONNECTION_POOL_SIZE)
     };
     let recent_blockhash = rpc_client.get_latest_blockhash().unwrap();
     let tx =

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -58,6 +58,7 @@ use {
     solana_streamer::socket::SocketAddrSpace,
     solana_tpu_client::tpu_client::{
         DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
+        DEFAULT_VOTE_USE_QUIC,
     },
     std::{
         collections::{HashMap, HashSet},
@@ -1046,6 +1047,7 @@ impl TestValidator {
             config.start_progress.clone(),
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_VOTE_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             config.tpu_enable_udp,
             32, // max connections per IpAddr per minute for test

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -13,7 +13,7 @@ use {
     solana_core::{
         admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         consensus::tower_storage::TowerStorage,
-        validator::{Validator, ValidatorConfig, ValidatorStartProgress},
+        validator::{Validator, ValidatorConfig, ValidatorStartProgress, ValidatorTpuConfig},
     },
     solana_feature_set::FEATURE_NAMES,
     solana_geyser_plugin_manager::{
@@ -1046,11 +1046,13 @@ impl TestValidator {
             rpc_to_plugin_manager_receiver,
             config.start_progress.clone(),
             socket_addr_space,
-            DEFAULT_TPU_USE_QUIC,
-            DEFAULT_VOTE_USE_QUIC,
-            DEFAULT_TPU_CONNECTION_POOL_SIZE,
-            config.tpu_enable_udp,
-            32, // max connections per IpAddr per minute for test
+            ValidatorTpuConfig {
+                use_quic: DEFAULT_TPU_USE_QUIC,
+                vote_use_quic: DEFAULT_VOTE_USE_QUIC,
+                tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+                tpu_enable_udp: config.tpu_enable_udp,
+                tpu_max_connections_per_ipaddr_per_minute: 32, // max connections per IpAddr per minute for test
+            },
             config.admin_rpc_service_post_init.clone(),
         )?);
 

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -31,7 +31,7 @@ use {
 
 pub const DEFAULT_TPU_ENABLE_UDP: bool = false;
 pub const DEFAULT_TPU_USE_QUIC: bool = true;
-pub const DEFAULT_VOTE_USE_QUIC: bool = true;
+pub const DEFAULT_VOTE_USE_QUIC: bool = false;
 
 /// The default connection count is set to 1 -- it should
 /// be sufficient for most use cases. Validators can use

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -31,6 +31,7 @@ use {
 
 pub const DEFAULT_TPU_ENABLE_UDP: bool = false;
 pub const DEFAULT_TPU_USE_QUIC: bool = true;
+pub const DEFAULT_VOTE_USE_QUIC: bool = true;
 
 /// The default connection count is set to 1 -- it should
 /// be sufficient for most use cases. Validators can use

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -871,7 +871,7 @@ mod tests {
         },
         solana_core::{
             consensus::tower_storage::NullTowerStorage,
-            validator::{Validator, ValidatorConfig},
+            validator::{Validator, ValidatorConfig, ValidatorTpuConfig},
         },
         solana_gossip::cluster_info::{ClusterInfo, Node},
         solana_inline_spl::token,
@@ -895,6 +895,7 @@ mod tests {
         solana_streamer::socket::SocketAddrSpace,
         solana_tpu_client::tpu_client::{
             DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
+            DEFAULT_VOTE_USE_QUIC,
         },
         spl_token_2022::{
             solana_program::{program_option::COption, program_pack::Pack},
@@ -1397,10 +1398,13 @@ mod tests {
                 None, // rpc_to_plugin_manager_receiver
                 start_progress.clone(),
                 SocketAddrSpace::Unspecified,
-                DEFAULT_TPU_USE_QUIC,
-                DEFAULT_TPU_CONNECTION_POOL_SIZE,
-                DEFAULT_TPU_ENABLE_UDP,
-                32, // max connections per IpAddr per minute for test
+                ValidatorTpuConfig {
+                    use_quic: DEFAULT_TPU_USE_QUIC,
+                    vote_use_quic: DEFAULT_VOTE_USE_QUIC,
+                    tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+                    tpu_enable_udp: DEFAULT_TPU_ENABLE_UDP,
+                    tpu_max_connections_per_ipaddr_per_minute: 32, // max connections per IpAddr per minute for test
+                },
                 post_init,
             )
             .expect("assume successful validator start");

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -903,6 +903,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("vote-use-quic")
                 .takes_value(true)
                 .default_value(&default_args.vote_use_quic)
+                .hidden(hidden_unless_forced())
                 .help("Controls if to use QUIC to send votes."),
         )
         .arg(

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -48,7 +48,7 @@ use {
         self, MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
     },
     solana_streamer::quic::DEFAULT_QUIC_ENDPOINTS,
-    solana_tpu_client::tpu_client::DEFAULT_TPU_CONNECTION_POOL_SIZE,
+    solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC},
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     std::{path::PathBuf, str::FromStr},
 };
@@ -897,6 +897,13 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .validator(is_parsable::<u32>)
                 .hidden(hidden_unless_forced())
                 .help("Controls the rate of the clients connections per IpAddr per minute."),
+        )
+        .arg(
+            Arg::with_name("vote_use_quic")
+                .long("vote-use-quic")
+                .takes_value(true)
+                .default_value(&default_args.vote_use_quic)
+                .help("Use QUIC to send votes."),
         )
         .arg(
             Arg::with_name("num_quic_endpoints")
@@ -2294,6 +2301,7 @@ pub struct DefaultArgs {
     pub tpu_connection_pool_size: String,
     pub tpu_max_connections_per_ipaddr_per_minute: String,
     pub num_quic_endpoints: String,
+    pub vote_use_quic: String,
 
     // Exit subcommand
     pub exit_min_idle_time: String,
@@ -2385,6 +2393,7 @@ impl DefaultArgs {
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE.to_string(),
             tpu_max_connections_per_ipaddr_per_minute:
                 DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE.to_string(),
+            vote_use_quic: DEFAULT_VOTE_USE_QUIC.to_string(),
             num_quic_endpoints: DEFAULT_QUIC_ENDPOINTS.to_string(),
             rpc_max_request_body_size: MAX_REQUEST_BODY_SIZE.to_string(),
             exit_min_idle_time: "10".to_string(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -903,7 +903,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("vote-use-quic")
                 .takes_value(true)
                 .default_value(&default_args.vote_use_quic)
-                .help("Use QUIC to send votes."),
+                .help("Controls if to use QUIC to send votes."),
         )
         .arg(
             Arg::with_name("num_quic_endpoints")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1124,6 +1124,8 @@ pub fn main() {
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
     let tpu_use_quic = !matches.is_present("tpu_disable_quic");
+    let vote_use_quic = value_t_or_exit!(matches, "vote_use_quic", bool);
+
     let tpu_enable_udp = if matches.is_present("tpu_enable_udp") {
         true
     } else {
@@ -2078,6 +2080,7 @@ pub fn main() {
         start_progress,
         socket_addr_space,
         tpu_use_quic,
+        vote_use_quic,
         tpu_connection_pool_size,
         tpu_enable_udp,
         tpu_max_connections_per_ipaddr_per_minute,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -34,7 +34,7 @@ use {
         tpu::DEFAULT_TPU_COALESCE,
         validator::{
             is_snapshot_config_valid, BlockProductionMethod, BlockVerificationMethod, Validator,
-            ValidatorConfig, ValidatorError, ValidatorStartProgress,
+            ValidatorConfig, ValidatorError, ValidatorStartProgress, ValidatorTpuConfig,
         },
     },
     solana_gossip::{
@@ -2079,11 +2079,13 @@ pub fn main() {
         rpc_to_plugin_manager_receiver,
         start_progress,
         socket_addr_space,
-        tpu_use_quic,
-        vote_use_quic,
-        tpu_connection_pool_size,
-        tpu_enable_udp,
-        tpu_max_connections_per_ipaddr_per_minute,
+        ValidatorTpuConfig {
+            use_quic: tpu_use_quic,
+            vote_use_quic,
+            tpu_connection_pool_size,
+            tpu_enable_udp,
+            tpu_max_connections_per_ipaddr_per_minute,
+        },
         admin_service_post_init,
     ) {
         Ok(validator) => validator,


### PR DESCRIPTION
#### Problem
TPU vote using QUIC.

#### Summary of Changes

Use Connection cache to encapsulate sending TPU vote via either QUIC or UDP.

Introduced a validator flag to control if to send TPU vote via QUIC -- the default is false -- meaning using UDP. The default should have no impacts on TPU vote sending

Tests:

Tests have been done to turn DEFAULT_VOTE_USE_QUIC to true -- meaning sending TPU votes via QUIC only.
This is done in test PR: https://github.com/anza-xyz/agave/pull/3571. Showing CI results are okay.

Further I disabled votes in gossips -- to ensure only sending votes via TPU vote using QUIC. The GCE cluster launched with this configuration is still functioning as expected. Metrics in  connection_cache_vote_quic and quic_streamer_tpu_vote shows votes streams sent and received on the client and server side respectively.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
