### PR TITLE
feature gate metrics usage in program-runtime

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -117,7 +117,7 @@ solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-poh = { workspace = true, features = ["dev-context-only-utils"] }
-solana-program-runtime = { workspace = true }
+solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 solana-stake-program = { workspace = true }
 solana-system-program = { workspace = true }

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -43,7 +43,7 @@ solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-log-collector = { workspace = true }
 solana-logger = { workspace = true }
 solana-measure = { workspace = true }
-solana-program-runtime = { workspace = true }
+solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-rpc = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime-transaction = { workspace = true }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -56,7 +56,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-perf = { workspace = true }
-solana-program-runtime = { workspace = true }
+solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-rayon-threadlimit = { workspace = true }
 solana-runtime = { workspace = true }
 solana-runtime-transaction = { workspace = true }

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -69,6 +69,7 @@ name = "solana_program_runtime"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
+dummy-for-ci-check = ["metrics"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -37,7 +37,7 @@ solana-instruction = { workspace = true }
 solana-last-restart-slot = { workspace = true }
 solana-log-collector = { workspace = true }
 solana-measure = { workspace = true }
-solana-metrics = { workspace = true }
+solana-metrics = { workspace = true, optional = true }
 solana-precompiles = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
@@ -74,6 +74,7 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "solana-compute-budget/frozen-abi",
 ]
+metrics = ["dep:solana-metrics"]
 shuttle-test = [
     "solana-type-overrides/shuttle-test",
     "solana-sbpf/shuttle-test",

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(clippy::arithmetic_side_effects)]
 #![deny(clippy::indexing_slicing)]
 
+#[cfg(feature = "metrics")]
 #[macro_use]
 extern crate solana_metrics;
 

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -23,7 +23,7 @@ solana-log-collector = { workspace = true }
 solana-measure = { workspace = true }
 solana-poseidon = { workspace = true }
 solana-program-memory = { workspace = true }
-solana-program-runtime = { workspace = true }
+solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-sbpf = { workspace = true }
 solana-sdk = { workspace = true }
 solana-timings = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -70,7 +70,7 @@ solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-perf = { workspace = true }
 solana-program = { workspace = true }
-solana-program-runtime = { workspace = true }
+solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-pubkey = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-runtime-transaction = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -41,7 +41,7 @@ solana-message = { workspace = true }
 solana-nonce = { workspace = true }
 solana-precompiles = { workspace = true }
 solana-program = { workspace = true, default-features = false }
-solana-program-runtime = { workspace = true }
+solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-rent-debits = { workspace = true }


### PR DESCRIPTION
#### Problem
solana-program-runtime has an annoying solana-metrics dependency that severely impacts build time and dependency hell. It's particularly annoying for litesvm which depends on solana-program-runtime

#### Summary of Changes
Put solana-metrics behind a feature gate in solana-program-runtime. Activate the metrics feature for crates that should use it

Closes #3390