### PR TITLE
sdk: Add deprecation warning to `solana_program::nonce`

### DIFF
--- a/sdk/program/src/nonce.rs
+++ b/sdk/program/src/nonce.rs
@@ -1,5 +1,7 @@
+#[deprecated(since = "2.1.0", note = "Use `solana-nonce` crate instead")]
 pub use solana_nonce::{state::State, NONCED_TX_MARKER_IX_INDEX};
 pub mod state {
+    #[deprecated(since = "2.1.0", note = "Use `solana-nonce` crate instead")]
     pub use solana_nonce::{
         state::{Data, DurableNonce, State},
         versions::{AuthorizeNonceError, Versions},


### PR DESCRIPTION
#### Problem

As pointed out at
https://github.com/anza-xyz/agave/pull/3370#issuecomment-2447743597, the solana-nonce crate re-export in solana-program does not have a deprecated warning.

#### Summary of changes

Add the warning.

Note: for usage of solana-nonce in a BPF implementation of the system program, this will be backported after #3370 lands.