### PR TITLE
program-runtime: double program cache size

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -33,7 +33,7 @@ use {
 };
 
 pub type ProgramRuntimeEnvironment = Arc<BuiltinProgram<InvokeContext<'static>>>;
-pub const MAX_LOADED_ENTRY_COUNT: usize = 256;
+pub const MAX_LOADED_ENTRY_COUNT: usize = 512;
 pub const DELAY_VISIBILITY_SLOT_OFFSET: Slot = 1;
 
 /// Relationship between two fork IDs
@@ -1624,7 +1624,7 @@ mod tests {
         assert_eq!(num_tombstones, num_tombstones_expected);
 
         // Evict entries from the cache
-        let eviction_pct = 2;
+        let eviction_pct = 1;
 
         let num_loaded_expected =
             Percentage::from(eviction_pct).apply_to(crate::loaded_programs::MAX_LOADED_ENTRY_COUNT);
@@ -1707,7 +1707,7 @@ mod tests {
         assert_eq!(num_tombstones, num_tombstones_expected);
 
         // Evict entries from the cache
-        let eviction_pct = 2;
+        let eviction_pct = 1;
 
         let num_loaded_expected =
             Percentage::from(eviction_pct).apply_to(crate::loaded_programs::MAX_LOADED_ENTRY_COUNT);


### PR DESCRIPTION
The cache is currently getting thrashed and programs are getting reloaded pretty much at every single slot. Double the cache size, which makes reloading happen only due to random eviction sometimes picking a popular entry.

The JIT code size with the new cache size is about 800MB.

This change reduces JIT time 15x.

Left is with PR, right is master.

<img width="1964" alt="Screenshot 2024-11-05 at 8 46 59 pm" src="https://github.com/user-attachments/assets/70d81b59-7561-4533-96ac-4fa5de76fe96">
