### PR TITLE
svm: introduce filter_executable_us metric (#3472)

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -278,13 +278,15 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             &mut error_metrics
         ));
 
-        let (mut program_cache_for_tx_batch, program_cache_us) = measure_us!({
-            let mut program_accounts_map = Self::filter_executable_program_accounts(
+        let (mut program_accounts_map, filter_executable_us) =
+            measure_us!(Self::filter_executable_program_accounts(
                 callbacks,
                 sanitized_txs,
                 &validation_results,
-                PROGRAM_OWNERS,
-            );
+                PROGRAM_OWNERS
+            ));
+
+        let (mut program_cache_for_tx_batch, program_cache_us) = measure_us!({
             for builtin_program in self.builtin_program_ids.read().unwrap().iter() {
                 program_accounts_map.insert(*builtin_program, 0);
             }
@@ -384,6 +386,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         execute_timings
             .saturating_add_in_place(ExecuteTimingType::ValidateFeesUs, validate_fees_us);
+        execute_timings
+            .saturating_add_in_place(ExecuteTimingType::FilterExecutableUs, filter_executable_us);
         execute_timings
             .saturating_add_in_place(ExecuteTimingType::ProgramCacheUs, program_cache_us);
         execute_timings.saturating_add_in_place(ExecuteTimingType::LoadUs, load_accounts_us);

--- a/timings/src/lib.rs
+++ b/timings/src/lib.rs
@@ -57,6 +57,7 @@ pub enum ExecuteTimingType {
     UpdateTransactionStatuses,
     ProgramCacheUs,
     CheckBlockLimitsUs,
+    FilterExecutableUs,
 }
 
 pub struct Metrics([u64; ExecuteTimingType::CARDINALITY]);
@@ -105,6 +106,13 @@ eager_macro_rules! { $eager_1
                 *$self
                     .metrics
                     .index(ExecuteTimingType::ValidateFeesUs),
+                i64
+            ),
+            (
+                "filter_executable_us",
+                *$self
+                    .metrics
+                    .index(ExecuteTimingType::FilterExecutableUs),
                 i64
             ),
             (


### PR DESCRIPTION
Split the time taken by filter_executable_accounts() outside of program_cache_us. Filtering takes a considerable amount of time because account_matches_owners is pretty slow.

Manual backport of #3472 because I forgot the label