### PR TITLE
Store epoch in MaxAge

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -809,7 +809,12 @@ mod tests {
             ..
         } = create_slow_genesis_config(10_000);
         let (bank, bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), 1));
+        // Warp to next epoch for MaxAge tests.
+        let bank = Arc::new(Bank::new_from_parent(
+            bank.clone(),
+            &Pubkey::new_unique(),
+            bank.get_epoch_info().slots_in_epoch,
+        ));
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
@@ -889,7 +894,7 @@ mod tests {
         let bid = TransactionBatchId::new(0);
         let id = TransactionId::new(0);
         let max_age = MaxAge {
-            epoch_invalidation_slot: bank.slot(),
+            sanitized_epoch: bank.epoch(),
             alt_invalidation_slot: bank.slot(),
         };
         let work = ConsumeWork {
@@ -938,7 +943,7 @@ mod tests {
         let bid = TransactionBatchId::new(0);
         let id = TransactionId::new(0);
         let max_age = MaxAge {
-            epoch_invalidation_slot: bank.slot(),
+            sanitized_epoch: bank.epoch(),
             alt_invalidation_slot: bank.slot(),
         };
         let work = ConsumeWork {
@@ -988,7 +993,7 @@ mod tests {
         let id1 = TransactionId::new(1);
         let id2 = TransactionId::new(0);
         let max_age = MaxAge {
-            epoch_invalidation_slot: bank.slot(),
+            sanitized_epoch: bank.epoch(),
             alt_invalidation_slot: bank.slot(),
         };
         consume_sender
@@ -1049,7 +1054,7 @@ mod tests {
         let id1 = TransactionId::new(1);
         let id2 = TransactionId::new(0);
         let max_age = MaxAge {
-            epoch_invalidation_slot: bank.slot(),
+            sanitized_epoch: bank.epoch(),
             alt_invalidation_slot: bank.slot(),
         };
         consume_sender
@@ -1103,6 +1108,7 @@ mod tests {
             .unwrap()
             .set_bank_for_test(bank.clone());
         assert!(bank.slot() > 0);
+        assert!(bank.epoch() > 0);
 
         // No conflicts between transactions. Test 6 cases.
         // 1. Epoch expiration, before slot => still succeeds due to resanitizing
@@ -1187,27 +1193,27 @@ mod tests {
                 transactions: txs,
                 max_ages: vec![
                     MaxAge {
-                        epoch_invalidation_slot: bank.slot() - 1,
+                        sanitized_epoch: bank.epoch() - 1,
                         alt_invalidation_slot: Slot::MAX,
                     },
                     MaxAge {
-                        epoch_invalidation_slot: bank.slot(),
+                        sanitized_epoch: bank.epoch(),
                         alt_invalidation_slot: Slot::MAX,
                     },
                     MaxAge {
-                        epoch_invalidation_slot: bank.slot() + 1,
+                        sanitized_epoch: bank.epoch() + 1,
                         alt_invalidation_slot: Slot::MAX,
                     },
                     MaxAge {
-                        epoch_invalidation_slot: u64::MAX,
+                        sanitized_epoch: bank.epoch(),
                         alt_invalidation_slot: bank.slot() - 1,
                     },
                     MaxAge {
-                        epoch_invalidation_slot: u64::MAX,
+                        sanitized_epoch: bank.epoch(),
                         alt_invalidation_slot: bank.slot(),
                     },
                     MaxAge {
-                        epoch_invalidation_slot: u64::MAX,
+                        sanitized_epoch: bank.epoch(),
                         alt_invalidation_slot: bank.slot() + 1,
                     },
                 ],

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -445,8 +445,8 @@ impl Consumer {
         let pre_results = txs.iter().zip(max_ages).map(|(tx, max_age)| {
             // If the transaction was sanitized before this bank's epoch,
             // additional checks are necessary.
-            if bank.slot() > max_age.epoch_invalidation_slot {
-                // Reserved key set may have cahnged, so we must verify that
+            if bank.epoch() != max_age.sanitized_epoch {
+                // Reserved key set may have changed, so we must verify that
                 // no writable keys are reserved.
                 bank.check_reserved_keys(tx)?;
             }

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -1,6 +1,9 @@
 use {
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
-    solana_sdk::{clock::Slot, transaction::SanitizedTransaction},
+    solana_sdk::{
+        clock::{Epoch, Slot},
+        transaction::SanitizedTransaction,
+    },
     std::fmt::Display,
 };
 
@@ -38,8 +41,15 @@ impl Display for TransactionId {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct MaxAge {
-    pub epoch_invalidation_slot: Slot,
+    pub sanitized_epoch: Epoch,
     pub alt_invalidation_slot: Slot,
+}
+
+impl MaxAge {
+    pub const MAX: Self = Self {
+        sanitized_epoch: Epoch::MAX,
+        alt_invalidation_slot: Slot::MAX,
+    };
 }
 
 /// Message: [Scheduler -> Worker]

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -622,8 +622,8 @@ mod tests {
         crossbeam_channel::{unbounded, Receiver},
         itertools::Itertools,
         solana_sdk::{
-            clock::Slot, compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message,
-            packet::Packet, pubkey::Pubkey, signature::Keypair, signer::Signer, system_instruction,
+            compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message, packet::Packet,
+            pubkey::Pubkey, signature::Keypair, signer::Signer, system_instruction,
             transaction::Transaction,
         },
         std::{borrow::Borrow, sync::Arc},
@@ -709,10 +709,7 @@ mod tests {
             );
             let transaction_ttl = SanitizedTransactionTTL {
                 transaction,
-                max_age: MaxAge {
-                    epoch_invalidation_slot: Slot::MAX,
-                    alt_invalidation_slot: Slot::MAX,
-                },
+                max_age: MaxAge::MAX,
             };
             const TEST_TRANSACTION_COST: u64 = 5000;
             container.insert_new_transaction(

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -210,9 +210,8 @@ mod tests {
     use {
         super::*,
         solana_sdk::{
-            clock::Slot, compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message,
-            packet::Packet, signature::Keypair, signer::Signer, system_instruction,
-            transaction::Transaction,
+            compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message, packet::Packet,
+            signature::Keypair, signer::Signer, system_instruction, transaction::Transaction,
         },
     };
 
@@ -234,10 +233,7 @@ mod tests {
         );
         let transaction_ttl = SanitizedTransactionTTL {
             transaction: RuntimeTransaction::from_transaction_for_tests(tx),
-            max_age: MaxAge {
-                epoch_invalidation_slot: Slot::MAX,
-                alt_invalidation_slot: Slot::MAX,
-            },
+            max_age: MaxAge::MAX,
         };
         const TEST_TRANSACTION_COST: u64 = 5000;
         TransactionState::new(
@@ -328,13 +324,7 @@ mod tests {
             transaction_state,
             TransactionState::Unprocessed { .. }
         ));
-        assert_eq!(
-            transaction_ttl.max_age,
-            MaxAge {
-                epoch_invalidation_slot: Slot::MAX,
-                alt_invalidation_slot: Slot::MAX,
-            }
-        );
+        assert_eq!(transaction_ttl.max_age, MaxAge::MAX);
 
         let _ = transaction_state.transition_to_pending();
         assert!(matches!(
@@ -352,13 +342,7 @@ mod tests {
             transaction_state,
             TransactionState::Unprocessed { .. }
         ));
-        assert_eq!(
-            transaction_ttl.max_age,
-            MaxAge {
-                epoch_invalidation_slot: Slot::MAX,
-                alt_invalidation_slot: Slot::MAX,
-            }
-        );
+        assert_eq!(transaction_ttl.max_age, MaxAge::MAX);
 
         // ensure transaction_ttl is not lost through state transitions
         let transaction_ttl = transaction_state.transition_to_pending();
@@ -373,12 +357,6 @@ mod tests {
             transaction_state,
             TransactionState::Unprocessed { .. }
         ));
-        assert_eq!(
-            transaction_ttl.max_age,
-            MaxAge {
-                epoch_invalidation_slot: Slot::MAX,
-                alt_invalidation_slot: Slot::MAX,
-            }
-        );
+        assert_eq!(transaction_ttl.max_age, MaxAge::MAX);
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -157,8 +157,7 @@ mod tests {
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk::{
             compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message, packet::Packet,
-            signature::Keypair, signer::Signer, slot_history::Slot, system_instruction,
-            transaction::Transaction,
+            signature::Keypair, signer::Signer, system_instruction, transaction::Transaction,
         },
     };
 
@@ -194,10 +193,7 @@ mod tests {
         );
         let transaction_ttl = SanitizedTransactionTTL {
             transaction: tx,
-            max_age: MaxAge {
-                epoch_invalidation_slot: Slot::MAX,
-                alt_invalidation_slot: Slot::MAX,
-            },
+            max_age: MaxAge::MAX,
         };
         const TEST_TRANSACTION_COST: u64 = 5000;
         (transaction_ttl, packet, priority, TEST_TRANSACTION_COST)


### PR DESCRIPTION
#### Problem
- MaxAge stores the last slot in the epoch which is confusing

#### Summary of Changes
- Store `Epoch` instead

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
