### PR TITLE
increase ticks per slot for test

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1546,9 +1546,16 @@ fn test_wait_for_max_stake() {
     // make a root and derive the new leader schedule in time.
     let stakers_slot_offset = slots_per_epoch.saturating_mul(MAX_LEADER_SCHEDULE_EPOCH_OFFSET);
     // Reduce this so that we can complete the test faster by advancing through
-    // slots/epochs faster. But don't make it too small because it can make us
-    // susceptible to skipped slots and the cluster getting stuck.
-    let ticks_per_slot = 16;
+    // slots/epochs faster. But don't make it too small because it can cause the
+    // test to fail in two important ways:
+    // 1. Increase likelihood of skipped slots, which can prevent rooting and
+    //    lead to not generating leader schedule in time and cluster getting
+    //    stuck.
+    // 2. Make the cluster advance through too many epochs before all the
+    //    validators spin up, which can lead to not properly observing gossip
+    //    votes, not repairing missing slots, and some subset of nodes getting
+    //    stuck.
+    let ticks_per_slot = 32;
     let num_validators = 4;
     let mut config = ClusterConfig {
         cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,


### PR DESCRIPTION
#### Problem
`fn test_wait_for_max_stake` has been flaky for a while. See #3295 and #3483 for some context.

One of the new problems discovered is that there is a race condition that can lead to 1 or more nodes not participating in voting. The chain of events is supposed to look like this:

1. Pull requests sent
2. Gossip votes observed
3. Insert repair tree
4. Request orphan repairs
5. Replay & freeze blocks
6. Vote (once staked)
7. OC blocks & make roots
8. Generate leader schedule
9. Keep activating stake

However, votes can get filtered out as part of step 2 such that they are never observed and thus we never repair/replay/vote/etc.

The filtering happens for a couple of reasons:
1. At first, we reject the votes because we don't see the vote account key in epoch authorized voters. E.g. the voting validator doesn't show up as staked until epoch 3 but we're seeing votes for epoch 0.
2. Later on, we fail because we don't have epoch stakes for the epoch because root bank never advances (because we're not voting and thus not rooting anything) and we only compute leader schedule 3 epochs ahead

This problem got worse with the changes in #3295 that reduced ticks per slot from 64 (default) to 16. This was an attempt to speed up this long running test, but widens the race condition window.

#### Summary of Changes
Increase ticks per slot from 16 to 32