### PR TITLE
Update syn for derive-where in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,7 +1911,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1378,7 +1378,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem

ci is broken... T_T

in short, i needed to rebase #3402 onto #3417 and #3459:

```
$ git log --oneline --graph HEAD ryoqun/derive-where Cargo.lock
* e311043c98d (HEAD, ryoqun/derive-where-fixup) Update syn for derive-where in Cargo.lock
* a3f6c7db909 (origin-anza/master) Replace unmaintained derivative with derive-where (#3402)
* 144925eda5e (kevinheavey/master, brooksprumo8/master) Extract client code in send_transaction_service into a new structure (#3423)
* c3bc1bf012c extract reward-info crate (#2971)
* 9b56f30a606 TransactionBatch - hold RuntimeTransaction (#3041)
* b83222fa213 remove solana-sdk from solana-perf (#3457)
* cbf7d9fface build(deps): bump thiserror from 1.0.65 to 1.0.67 (#3456)
* e3baa7ee947 build(deps): bump tar from 0.4.42 to 0.4.43 (#3458)
* 823d29b2062 build(deps): bump syn from 2.0.86 to 2.0.87 (#3459)    !!!!!!!
* 09374b71078 perf: put test_tx.rs behind dev-context-only-utils (#3438)
* 59bf0f075fa streamer: put testing_utilities.rs behind dev-context-only-utils (#3442)
* a0241d5c8f0 build(deps): bump anyhow from 1.0.91 to 1.0.92 (#3419)
* 33120115a0a build(deps): bump syn from 2.0.85 to 2.0.86 (#3417)    !!!!!!!
* d9c24ed5837 remove solana-program from zk-token-sdk (#3410)
* 3b175b7747b remove solana-program from zk-sdk (#3409)
| * 2b15a91dde5 (ryoqun/derive-where, anza-pull/3402/head) Replace unmaintained derivative with derive-where
|/  
* ccbe01dd332 sdk: Extract epoch-rewards crate (#3338)

```

#### Summary of Changes


Fixes ci