### PR TITLE
Revert "rolls back chained Merkle shreds for testnet downgrade (#3194)"

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -508,7 +508,7 @@ fn should_chain_merkle_shreds(_slot: Slot, cluster_type: ClusterType) -> bool {
         ClusterType::Development => true,
         ClusterType::Devnet => false,
         ClusterType::MainnetBeta => false,
-        ClusterType::Testnet => false,
+        ClusterType::Testnet => true,
     }
 }
 


### PR DESCRIPTION

#### Problem
Revert chained Merkle shreds rollback: https://github.com/anza-xyz/agave/pull/3194

#### Summary of Changes
This reverts commit 69916f1077bd96e2c4aa17383ddf9abd7ec1fc77.

