### PR TITLE
remove accounts-db dependency from SVM crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8646,7 +8646,6 @@ dependencies = [
  "serde_json",
  "shuttle",
  "solana-account-decoder",
- "solana-accounts-db",
  "solana-bpf-loader-program",
  "solana-client",
  "solana-compute-budget",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -66,7 +66,6 @@ serde_derive = { workspace = true }
 serde_json = { workspace = true }
 shuttle = { workspace = true }
 solana-account-decoder = { workspace = true }
-solana-accounts-db = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
 solana-client = { workspace = true }
 solana-compute-budget-program = { workspace = true }

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -15,7 +15,6 @@ use {
         parse_token::{get_token_account_mint, is_known_spl_token_id},
         UiAccount, UiAccountEncoding, UiDataSliceConfig, MAX_BASE58_BYTES,
     },
-    solana_accounts_db::blockhash_queue::BlockhashQueue,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_perf::packet::PACKET_DATA_SIZE,
     solana_program_runtime::loaded_programs::ProgramCacheEntry,
@@ -400,7 +399,6 @@ impl JsonRpcRequestProcessor {
         error_counters: &mut TransactionErrorMetrics,
     ) -> Vec<TransactionCheckResult> {
         let last_blockhash = Hash::default();
-        let blockhash_queue = BlockhashQueue::default();
         let next_durable_nonce = DurableNonce::from_blockhash(&last_blockhash);
 
         sanitized_txs
@@ -411,7 +409,6 @@ impl JsonRpcRequestProcessor {
                     tx.borrow(),
                     max_age,
                     &next_durable_nonce,
-                    &blockhash_queue,
                     error_counters,
                 ),
                 Err(e) => Err(e.clone()),
@@ -424,7 +421,6 @@ impl JsonRpcRequestProcessor {
         _tx: &SanitizedTransaction,
         _max_age: usize,
         _next_durable_nonce: &DurableNonce,
-        _hash_queue: &BlockhashQueue,
         _error_counters: &mut TransactionErrorMetrics,
     ) -> TransactionCheckResult {
         /* for now just return defaults */


### PR DESCRIPTION
#### Problem
SVM has dependency on accounts-db crate. This will cause issues in moving SVM to its own repo.

#### Summary of Changes
The dep was caused by usage in rpc-server example code. The code was actually ignoring the object created from this dep. Removed the dep and object instantiation.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
