### PR TITLE
discards packets which are not (fully) populated

### DIFF
--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -90,9 +90,11 @@ impl PacketBatch {
                     // break the payload into smaller messages, and here any errors
                     // should be propagated.
                     error!("Couldn't write to packet {:?}. Data skipped.", e);
+                    packet.meta_mut().set_discard(true);
                 }
             } else {
                 trace!("Dropping packet, as destination is unknown");
+                packet.meta_mut().set_discard(true);
             }
         }
         batch


### PR DESCRIPTION

#### Problem
Not discarding packets which are not (fully) populated is bug prone or might waste resources.

#### Summary of Changes
Discard packets which are not (fully) populated.