### PR TITLE
CI: Re-enable downstream SPL job

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -61,6 +61,7 @@ jobs:
           cargo check
 
   test:
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -123,6 +124,7 @@ jobs:
           done
 
   cargo-test-sbf:
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -37,8 +37,7 @@ env:
 
 jobs:
   check:
-    # if: github.repository == 'anza-xyz/agave'
-    if: false
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +61,6 @@ jobs:
           cargo check
 
   test:
-    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -125,7 +123,6 @@ jobs:
           done
 
   cargo-test-sbf:
-    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
#### Problem

The downstream SPL job was disabled in #3498 because the moved crates weren't correctly picked up in the SPL's patch script. The SPL patch script was fixed in
https://github.com/solana-labs/solana-program-library/pull/7465, but the jobs are still disabled.

#### Summary of changes

Re-enable the SPL downstream jobs.

Side note: should all of the jobs have the `if: github.repository == 'anza-xyz/agave'` part?