### PR TITLE
remove solana-sdk from cargo-build-sbf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6291,8 +6291,8 @@ dependencies = [
  "semver 1.0.23",
  "serial_test",
  "solana-file-download",
+ "solana-keypair",
  "solana-logger",
- "solana-sdk",
  "tar",
 ]
 

--- a/sdk/cargo-build-sbf/Cargo.toml
+++ b/sdk/cargo-build-sbf/Cargo.toml
@@ -19,15 +19,14 @@ regex = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "rustls-tls"] }
 semver = { workspace = true }
 solana-file-download = { workspace = true }
+solana-keypair = { workspace = true }
 solana-logger = { workspace = true }
-solana-sdk = { workspace = true }
 tar = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 serial_test = { workspace = true }
-solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 
 [features]
 program = []

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -6,7 +6,7 @@ use {
     log::*,
     regex::Regex,
     solana_file_download::download_file,
-    solana_sdk::signature::{write_keypair_file, Keypair},
+    solana_keypair::{write_keypair_file, Keypair},
     std::{
         borrow::Cow,
         collections::{HashMap, HashSet},


### PR DESCRIPTION
#### Problem
cargo-build-sbf doesn't need the whole sdk crate anymore

#### Summary of Changes
remove it