### PR TITLE
Thinlto for validator builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ inherits = "release"
 debug = true
 split-debuginfo = "packed"
 
+[profile.release]
+split-debuginfo = "unpacked"
+lto = "thin"
+
 [workspace]
 members = [
     "account-decoder",


### PR DESCRIPTION
#### Problem
Current builds do not use thinlto and we are leaving performance on the table.

#### Summary of Changes
Enable thinlto, the debug-info can't be packed as it gives build error [duplicate split compilation unit](https://github.com/rust-lang/rust/issues/132677)

## Performance improvements
Results

```
With thinlto and no debuginformation

[2024-11-23T05:30:31.476026905Z INFO  solana_bench_tps::bench]
    Average max TPS: 74236.48, 0 nodes had 0 TPS
[2024-11-23T05:30:31.476031453Z INFO  solana_bench_tps::bench]
    Highest TPS: 74236.48 sampling period 1s max transactions: 4073007 clients: 1 drop rate: 0.78

Without thinlto and no debuginformation

[2024-11-23T06:24:32.517039914Z INFO  solana_bench_tps::bench] 
    Average max TPS: 66351.46, 0 nodes had 0 TPS
[2024-11-23T06:24:32.517061405Z INFO  solana_bench_tps::bench] 
    Highest TPS: 66351.46 sampling period 1s max transactions: 4302710 clients: 1 drop rate: 0.76
[2024-11-23T06:24:32.517083186Z INFO  solana_bench_tps::bench]  Average TPS: 47228.938
```

Measurement technique posted in a [comment below](https://github.com/anza-xyz/agave/pull/3516#issuecomment-2495365755)

Dashboard: https://metrics.solana.com:8889/sources/27/chronograf/data-explorer?query=SELECT%20mean%28%22avail_percent%22%29%20AS%20%22mean_avail_percent%22%2C%20mean%28%22free_percent%22%29%20AS%20%22mean_free_percent%22%2C%20mean%28%22swap_free_percent%22%29%20AS%20%22mean_swap_free_percent%22%20FROM%20%22mainnet-beta%22.%22autogen%22.%22memory-stats%22%20WHERE%20time%20%3E%20%3AdashboardTime%3A%20AND%20time%20%3C%20%3AupperDashboardTime%3A%20AND%20%22host_id%22%3D%27jw13Zme4czmWqdhPAPk5d11dMPbZhiMvHsALKBE4EG3%27%20GROUP%20BY%20time%28%3Ainterval%3A%29%20FILL%28null%29#