### PR TITLE
Bank::new_from_fields() always gets the accounts lt hash from the snapshot

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6677,8 +6677,6 @@ impl AccountsDb {
         ancestors: &Ancestors,
         startup_slot: Slot,
     ) -> AccountsLtHash {
-        debug_assert!(self.is_experimental_accumulator_hash_enabled());
-
         // This impl iterates over all the index bins in parallel, and computes the lt hash
         // sequentially per bin.  Then afterwards reduces to a single lt hash.
         // This implementation is quite fast.  Runtime is about 150 seconds on mnb as of 10/2/2024.
@@ -6744,8 +6742,6 @@ impl AccountsDb {
         storages: &[Arc<AccountStorageEntry>],
         duplicates_lt_hash: &DuplicatesLtHash,
     ) -> AccountsLtHash {
-        debug_assert!(self.is_experimental_accumulator_hash_enabled());
-
         let mut lt_hash = storages
             .par_iter()
             .fold(LtHash::identity, |mut accum, storage| {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1730,11 +1730,13 @@ impl Bank {
         bank.rebuild_skipped_rewrites();
 
         let mut calculate_accounts_lt_hash_duration = None;
-        if bank.is_accounts_lt_hash_enabled() {
+        if let Some(accounts_lt_hash) = fields.accounts_lt_hash {
+            *bank.accounts_lt_hash.get_mut().unwrap() = accounts_lt_hash;
+        } else {
             // Use the accounts lt hash from the snapshot, if present, otherwise calculate it.
             // When there is a feature gate for the accounts lt hash, if the feature is enabled
             // then it will be *required* that the snapshot contains an accounts lt hash.
-            let accounts_lt_hash = fields.accounts_lt_hash.unwrap_or_else(|| {
+            if bank.is_accounts_lt_hash_enabled() {
                 info!("Calculating the accounts lt hash...");
                 let (ancestors, slot) = if bank.is_frozen() {
                     // Loading from a snapshot necessarily means this slot was rooted, and thus
@@ -1762,11 +1764,10 @@ impl Bank {
                             .calculate_accounts_lt_hash_at_startup_from_index(&ancestors, slot)
                     })
                 });
-                info!("Calculating the accounts lt hash... Done in {duration:?}");
                 calculate_accounts_lt_hash_duration = Some(duration);
-                accounts_lt_hash
-            });
-            *bank.accounts_lt_hash.get_mut().unwrap() = accounts_lt_hash;
+                *bank.accounts_lt_hash.get_mut().unwrap() = accounts_lt_hash;
+                info!("Calculating the accounts lt hash... Done in {duration:?}");
+            }
         }
 
         // Sanity assertions between bank snapshot and genesis config


### PR DESCRIPTION
#### Problem

While prototype testing feature activation of the accounts lt hash I found an issue when restarting from a snapshot.

If the snapshot was created with the accounts lt hash CLI arg ON, but loaded with the cli arg OFF, then the accounts verification at startup would fail.

This is because we copy the accounts lt hash from the snapshot based on the CLI arg, but verify the accounts based on the snapshot value. This is a mismatch in logic; both need to be the same.


#### Summary of Changes

In Bank::new_from_fields(), copy the accounts lt hash from the snapshot always (if present). This now matches the behavior used to verify the accounts at startup.
