### PR TITLE
update tests to include set_tpu_vote_quic

### DIFF
--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -2028,6 +2028,7 @@ mod tests {
         nxt.set_tpu((Ipv4Addr::LOCALHOST, 1238)).unwrap();
         nxt.set_tpu_forwards((Ipv4Addr::LOCALHOST, 1239)).unwrap();
         nxt.set_tpu_vote((Ipv4Addr::LOCALHOST, 1240)).unwrap();
+        nxt.set_tpu_vote_quic((Ipv4Addr::LOCALHOST, 1243)).unwrap();
         nxt.set_rpc((Ipv4Addr::LOCALHOST, 1241)).unwrap();
         nxt.set_rpc_pubsub((Ipv4Addr::LOCALHOST, 1242)).unwrap();
         nxt.set_serve_repair(serve_repair_addr).unwrap();
@@ -2063,6 +2064,7 @@ mod tests {
         nxt.set_tpu((Ipv4Addr::LOCALHOST, 1238)).unwrap();
         nxt.set_tpu_forwards((Ipv4Addr::LOCALHOST, 1239)).unwrap();
         nxt.set_tpu_vote((Ipv4Addr::LOCALHOST, 1240)).unwrap();
+        nxt.set_tpu_vote_quic((Ipv4Addr::LOCALHOST, 1243)).unwrap();
         nxt.set_rpc((Ipv4Addr::LOCALHOST, 1241)).unwrap();
         nxt.set_rpc_pubsub((Ipv4Addr::LOCALHOST, 1242)).unwrap();
         nxt.set_serve_repair(serve_repair_addr2).unwrap();

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -404,6 +404,7 @@ impl ContactInfo {
         node.set_tpu((Ipv4Addr::LOCALHOST, 8003)).unwrap(); // quic: 8009
         node.set_tpu_forwards((Ipv4Addr::LOCALHOST, 8004)).unwrap(); // quic: 8010
         node.set_tpu_vote((Ipv4Addr::LOCALHOST, 8005)).unwrap();
+        node.set_tpu_vote_quic((Ipv4Addr::LOCALHOST, 8009)).unwrap();
         node.set_rpc((Ipv4Addr::LOCALHOST, DEFAULT_RPC_PORT))
             .unwrap();
         node.set_rpc_pubsub((Ipv4Addr::LOCALHOST, DEFAULT_RPC_PUBSUB_PORT))
@@ -429,6 +430,7 @@ impl ContactInfo {
         node.set_tpu((addr, port)).unwrap(); // quic: port + 6
         node.set_tpu_forwards((addr, port + 5)).unwrap(); // quic: port + 11
         node.set_tpu_vote((addr, port + 7)).unwrap();
+        node.set_tpu_vote_quic((addr, port + 9)).unwrap();
         node.set_rpc((addr, DEFAULT_RPC_PORT)).unwrap();
         node.set_rpc_pubsub((addr, DEFAULT_RPC_PUBSUB_PORT))
             .unwrap();


### PR DESCRIPTION
#### Problem
`set_tpu_vote_quic()` was added but tests were not updated 

#### Summary of Changes
add `set_tpu_vote_quic()` in tests.
`set_tpu_vote_quic` is not used to set sockets for any external/production code  
