### PR TITLE
v2.1: Disable downstream SPL jobs

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   check:
-    if: github.repository == 'anza-xyz/agave'
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,6 +61,7 @@ jobs:
           cargo check
 
   test:
+    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -123,6 +124,7 @@ jobs:
           done
 
   cargo-test-sbf:
+    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
#### Problem

The downstream jobs are failing on branch v2.1 due to https://github.com/solana-labs/solana-program-library/pull/7465.

#### Summary of changes

Disable them for now.