### PR TITLE
Introduce API to safely initialize Packets

### DIFF
--- a/ci/test-miri.sh
+++ b/ci/test-miri.sh
@@ -6,8 +6,8 @@ source ci/_
 source ci/rust-version.sh nightly
 
 # miri is very slow; so only run very few of selective tests!
+_ cargo "+${rust_nightly}" miri test -p solana-packet -- test_packet_buffer_writer
 _ cargo "+${rust_nightly}" miri test -p solana-program -- hash:: account_info::
-
 _ cargo "+${rust_nightly}" miri test -p solana-unified-scheduler-logic
 
 # run intentionally-#[ignored] ub triggering tests for each to make sure they fail

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -557,7 +557,7 @@ fn start_verify_transactions_gpu(
                     uninitialized_packets
                         .zip(transaction_iter)
                         .all(|(uninit_packet, tx)| {
-                            Packet::init_packet(uninit_packet, &tx, None).is_ok()
+                            Packet::init_packet_from_data(uninit_packet, &tx, None).is_ok()
                         });
 
                 if all_packets_initialized {

--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -14,6 +14,7 @@ use {
     rayon::prelude::*,
     serde::{Deserialize, Serialize},
     std::{
+        mem::MaybeUninit,
         ops::{Index, IndexMut},
         os::raw::c_int,
         slice::{Iter, IterMut, SliceIndex},
@@ -127,6 +128,10 @@ impl<T: Clone + Default + Sized> PinnedVec<T> {
 
     pub fn iter_mut(&mut self) -> IterMut<'_, T> {
         self.x.iter_mut()
+    }
+
+    pub fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        self.x.spare_capacity_mut()
     }
 
     pub fn capacity(&self) -> usize {

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -7,6 +7,7 @@ use {
     serde::{de::DeserializeOwned, Deserialize, Serialize},
     std::{
         io::Read,
+        mem::MaybeUninit,
         net::SocketAddr,
         ops::{Index, IndexMut},
         slice::{Iter, IterMut, SliceIndex},
@@ -150,6 +151,10 @@ impl PacketBatch {
 
     pub fn iter_mut(&mut self) -> IterMut<'_, Packet> {
         self.packets.iter_mut()
+    }
+
+    pub fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<Packet>] {
+        self.packets.spare_capacity_mut()
     }
 
     /// See Vector::set_len() for more details

--- a/sdk/packet/src/lib.rs
+++ b/sdk/packet/src/lib.rs
@@ -363,6 +363,11 @@ impl Meta {
     }
 
     #[inline]
+    pub fn set_flags(&mut self, flags: PacketFlags) {
+        self.flags = flags;
+    }
+
+    #[inline]
     pub fn discard(&self) -> bool {
         self.flags.contains(PacketFlags::DISCARD)
     }

--- a/sdk/packet/src/lib.rs
+++ b/sdk/packet/src/lib.rs
@@ -192,9 +192,10 @@ impl Packet {
 
     #[cfg(feature = "bincode")]
     pub fn from_data<T: serde::Serialize>(dest: Option<&SocketAddr>, data: T) -> Result<Self> {
-        let mut packet = Self::default();
-        Self::populate_packet(&mut packet, dest, &data)?;
-        Ok(packet)
+        let mut packet = mem::MaybeUninit::uninit();
+        Self::init_packet(&mut packet, &data, dest)?;
+        // SAFETY: init_packet_from_data() just initialized the packet
+        unsafe { Ok(packet.assume_init()) }
     }
 
     #[cfg(feature = "bincode")]

--- a/sdk/packet/src/lib.rs
+++ b/sdk/packet/src/lib.rs
@@ -332,7 +332,7 @@ impl io::Write for PacketWriter {
         // so this write will not push us past the end of the buffer. Likewise,
         // we can update self.spare_capacity without fear of overflow
         unsafe {
-            ptr::copy(buf.as_ptr(), self.position, buf.len());
+            ptr::copy_nonoverlapping(buf.as_ptr(), self.position, buf.len());
             // Update position and spare_capacity for the next call to write()
             self.position = self.position.add(buf.len());
             self.spare_capacity = self.spare_capacity.saturating_sub(buf.len());


### PR DESCRIPTION
#### Problem
We currently abuse uninitialized data with the `Packet` type that leaves us open to UB in several places. A common pattern is:
- Initialize a `PacketBatch` (mostly a `Vec<Packet>`) with capacity `N`
- Call `set_len(N)` on that `PacketBatch`
- Access individual `Packet`'s as if they are properly initialized
https://github.com/anza-xyz/agave/blob/f621667cd1d159142a57922ee4e9fb49ec0182ff/entry/src/entry.rs#L546-L569

As that comment suggests, we did this to avoid writing data / 0's that we will immediately overwrite. However, the manner in which we're doing it is not safe.

#### Summary of Changes
- Introduce `PacketWriter` to help fill the buffer of a `MaybeUninit<Packet>` through pointers instead of references
- Add several methods to `Packet` to initialize from some serializable data or a regular byte stream
- Update abusers in `entry.rs` and `ShredFetchStage`

#### Subsequent PR's
Some other work that I have in mind that I'd like to defer to subsequent PR's for the sake of keeping each individual PR as small as possible.

<details>
<summary>Remaining packet_batch.set_len()</summary>

There is still one more location where we do `set_len()` and access the item:
https://github.com/anza-xyz/agave/blob/f621667cd1d159142a57922ee4e9fb49ec0182ff/streamer/src/nonblocking/quic.rs#L960-L972

This one is slightly different as the writes could come out of order, so I was thinking of refactoring that in a different PR
</details>

<details>
<summary>clippy::uninit_assumed_init()</summary>

Another instance where me may immediately access uninitialized data is here:
https://github.com/anza-xyz/agave/blob/f621667cd1d159142a57922ee4e9fb49ec0182ff/sdk/packet/src/lib.rs#L210-L219

I would like to address this separately as well, as I think the proper solution is to deprecate `Packet::default()`. However, `Packet` lives in sdk so we have to be a little more careful with that one
</details>