### PR TITLE
Ensures duplicates_lt_hash is Some if accounts lt hash is enabled

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9009,6 +9009,14 @@ impl AccountsDb {
 
         self.accounts_index.log_secondary_indexes();
 
+        // The duplicates lt hash must be Some if should_calculate_duplicates_lt_hash is true.
+        // But, if there were no duplicates, then we'd never set outer_duplicates_lt_hash to Some!
+        // So do one last check here to ensure outer_duplicates_lt_hash is Some if we're supposed
+        // to calculate the duplicates lt hash.
+        if should_calculate_duplicates_lt_hash && outer_duplicates_lt_hash.is_none() {
+            outer_duplicates_lt_hash = Some(Box::new(DuplicatesLtHash::default()));
+        }
+
         IndexGenerationInfo {
             accounts_data_len: accounts_data_len.load(Ordering::Relaxed),
             rent_paying_accounts_by_partition: rent_paying_accounts_by_partition


### PR DESCRIPTION
#### Problem

At startup, if we're using accounts lt hash, then `generate_index()` is tasked with finding the duplicate accounts and tracking them. This value is used later when verifying accounts.

However, if there are no duplicates, the value (since it is an Option), is returned as None. And then `verify_accounts` sees the None and concludes "since this value is None, I should *not* do lattice-based accounts verification, and instead use the original merkle-based accounts verification". 

This is wrong. Even if there are no duplicates, `generate_index()` must always return `Some` when accounts lt hash is enabled.


#### Summary of Changes

Ensure duplicates is always Some when accounts lt hash is enabled.