### PR TITLE
SVM: simplify mock bank

### DIFF
--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -2,9 +2,7 @@
 
 use {
     crate::{
-        mock_bank::{
-            create_executable_environment, deploy_program, register_builtins, MockForkGraph,
-        },
+        mock_bank::{create_custom_loader, deploy_program, register_builtins, MockForkGraph},
         transaction_builder::SanitizedTransactionBuilder,
     },
     assert_matches::assert_matches,
@@ -128,16 +126,16 @@ fn test_program_cache_with_exhaustive_scheduler() {
 // correctly.
 fn svm_concurrent() {
     let mock_bank = Arc::new(MockBankCallback::default());
-    let batch_processor =
-        Arc::new(TransactionBatchProcessor::<MockForkGraph>::new_uninitialized(5, 2));
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
+    let batch_processor = Arc::new(TransactionBatchProcessor::new(
+        5,
+        2,
+        Arc::downgrade(&fork_graph),
+        Some(Arc::new(create_custom_loader())),
+        None, // We are not using program runtime v2.
+    ));
 
-    create_executable_environment(
-        fork_graph.clone(),
-        &mock_bank,
-        &mut batch_processor.program_cache.write().unwrap(),
-    );
-
+    mock_bank.configure_sysvars();
     batch_processor.fill_missing_sysvar_cache_entries(&*mock_bank);
     register_builtins(&mock_bank, &batch_processor);
 

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -211,7 +211,7 @@ pub fn create_executable_environment(
     program_cache: &mut ProgramCache<MockForkGraph>,
 ) {
     program_cache.environments = ProgramRuntimeEnvironments {
-        program_runtime_v1: Arc::new(create_custom_environment()),
+        program_runtime_v1: Arc::new(create_custom_loader()),
         // We are not using program runtime v2
         program_runtime_v2: Arc::new(BuiltinProgram::new_loader(
             Config::default(),
@@ -315,7 +315,7 @@ pub fn register_builtins(
 }
 
 #[allow(unused)]
-fn create_custom_environment<'a>() -> BuiltinProgram<InvokeContext<'a>> {
+pub fn create_custom_loader<'a>() -> BuiltinProgram<InvokeContext<'a>> {
     let compute_budget = ComputeBudget::default();
     let vm_config = Config {
         max_call_depth: compute_budget.max_call_depth,

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -1,3 +1,4 @@
+#![allow(unused)]
 #[allow(deprecated)]
 use solana_sdk::sysvar::recent_blockhashes::{Entry as BlockhashesEntry, RecentBlockhashes};
 use {
@@ -9,9 +10,7 @@ use {
     solana_feature_set::FeatureSet,
     solana_program_runtime::{
         invoke_context::InvokeContext,
-        loaded_programs::{
-            BlockRelation, ForkGraph, ProgramCache, ProgramCacheEntry, ProgramRuntimeEnvironments,
-        },
+        loaded_programs::{BlockRelation, ForkGraph, ProgramCacheEntry},
         solana_rbpf::{
             program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
             vm::Config,
@@ -160,7 +159,6 @@ impl MockBankCallback {
     }
 }
 
-#[allow(unused)]
 fn load_program(name: String) -> Vec<u8> {
     // Loading the program file
     let mut dir = env::current_dir().unwrap();
@@ -176,22 +174,18 @@ fn load_program(name: String) -> Vec<u8> {
     buffer
 }
 
-#[allow(unused)]
 pub fn program_address(program_name: &str) -> Pubkey {
     Pubkey::create_with_seed(&Pubkey::default(), program_name, &Pubkey::default()).unwrap()
 }
 
-#[allow(unused)]
 pub fn program_data_size(program_name: &str) -> usize {
     load_program(program_name.to_string()).len()
 }
 
-#[allow(unused)]
 pub fn deploy_program(name: String, deployment_slot: Slot, mock_bank: &MockBankCallback) -> Pubkey {
     deploy_program_with_upgrade_authority(name, deployment_slot, mock_bank, None)
 }
 
-#[allow(unused)]
 pub fn deploy_program_with_upgrade_authority(
     name: String,
     deployment_slot: Slot,
@@ -247,27 +241,6 @@ pub fn deploy_program_with_upgrade_authority(
     program_account
 }
 
-#[allow(unused)]
-pub fn create_executable_environment(
-    fork_graph: Arc<RwLock<MockForkGraph>>,
-    mock_bank: &MockBankCallback,
-    program_cache: &mut ProgramCache<MockForkGraph>,
-) {
-    program_cache.environments = ProgramRuntimeEnvironments {
-        program_runtime_v1: Arc::new(create_custom_loader()),
-        // We are not using program runtime v2
-        program_runtime_v2: Arc::new(BuiltinProgram::new_loader(
-            Config::default(),
-            FunctionRegistry::default(),
-        )),
-    };
-
-    program_cache.fork_graph = Some(Arc::downgrade(&fork_graph));
-
-    mock_bank.configure_sysvars();
-}
-
-#[allow(unused)]
 pub fn register_builtins(
     mock_bank: &MockBankCallback,
     batch_processor: &TransactionBatchProcessor<MockForkGraph>,
@@ -315,7 +288,6 @@ pub fn register_builtins(
     );
 }
 
-#[allow(unused)]
 pub fn create_custom_loader<'a>() -> BuiltinProgram<InvokeContext<'a>> {
     let compute_budget = ComputeBudget::default();
     let vm_config = Config {


### PR DESCRIPTION
#### Summary of Changes

Now that we have a `new` initializer method on the transaction batch processor, we can stop directly accessing the program cache so much.

---

@LucasSte this was a little less exciting than I expected, but the idea is to use `TransactionBatchProcessor::new` in the mock bank setup, rather than touch the cache directly. Completely up to you if you want this to land, otherwise I'll close.