### PR TITLE
removes fallback on legacy versions in ClusterInfo::get_node_version

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1068,18 +1068,6 @@ impl ClusterInfo {
             .get::<&ContactInfo>(*pubkey)
             .map(ContactInfo::version)
             .cloned()
-            .or_else(|| {
-                gossip_crds
-                    .get::<&Version>(*pubkey)
-                    .map(|entry| entry.version.clone())
-                    .or_else(|| {
-                        gossip_crds
-                            .get::<&crds_data::LegacyVersion>(*pubkey)
-                            .map(|entry| entry.version.clone())
-                            .map(solana_version::LegacyVersion2::from)
-                    })
-                    .map(solana_version::Version::from)
-            })
     }
 
     fn check_socket_addr_space<E>(&self, addr: &Result<SocketAddr, E>) -> bool {

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -99,7 +99,6 @@ pub struct GossipStats {
     pub(crate) filter_crds_values_dropped_values: Counter,
     pub(crate) filter_pull_response: Counter,
     pub(crate) generate_pull_responses: Counter,
-    pub(crate) get_accounts_hash: Counter,
     pub(crate) get_epoch_duration_no_working_bank: Counter,
     pub(crate) get_votes: Counter,
     pub(crate) get_votes_count: Counter,
@@ -206,7 +205,6 @@ pub(crate) fn submit_gossip_stats(
         ("push_vote_read", stats.push_vote_read.clear(), i64),
         ("get_votes", stats.get_votes.clear(), i64),
         ("get_votes_count", stats.get_votes_count.clear(), i64),
-        ("get_accounts_hash", stats.get_accounts_hash.clear(), i64),
         ("all_tvu_peers", stats.all_tvu_peers.clear(), i64),
         ("tvu_peers", stats.tvu_peers.clear(), i64),
         (

--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -374,7 +374,7 @@ impl<'de> Deserialize<'de> for Vote {
 pub(crate) struct LegacyVersion {
     from: Pubkey,
     wallclock: u64,
-    pub(crate) version: solana_version::LegacyVersion1,
+    version: solana_version::LegacyVersion1,
 }
 
 impl Sanitize for LegacyVersion {
@@ -390,7 +390,7 @@ impl Sanitize for LegacyVersion {
 pub(crate) struct Version {
     from: Pubkey,
     wallclock: u64,
-    pub(crate) version: solana_version::LegacyVersion2,
+    version: solana_version::LegacyVersion2,
 }
 
 impl Sanitize for Version {

--- a/gossip/src/crds_entry.rs
+++ b/gossip/src/crds_entry.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         contact_info::ContactInfo,
         crds::VersionedCrdsValue,
-        crds_data::{CrdsData, LegacyVersion, LowestSlot, SnapshotHashes, Version},
+        crds_data::{CrdsData, LowestSlot, SnapshotHashes},
         crds_value::{CrdsValue, CrdsValueLabel},
     },
     indexmap::IndexMap,
@@ -52,9 +52,7 @@ impl_crds_entry!(VersionedCrdsValue, |entry| entry);
 
 // Lookup by Pubkey.
 impl_crds_entry!(ContactInfo, CrdsData::ContactInfo(node), node);
-impl_crds_entry!(LegacyVersion, CrdsData::LegacyVersion(version), version);
 impl_crds_entry!(LowestSlot, CrdsData::LowestSlot(_, slot), slot);
-impl_crds_entry!(Version, CrdsData::Version(version), version);
 impl_crds_entry!(
     SnapshotHashes,
     CrdsData::SnapshotHashes(snapshot_hashes),
@@ -106,10 +104,6 @@ mod tests {
                 }
                 CrdsData::LowestSlot(_, slot) => {
                     assert_eq!(crds.get::<&LowestSlot>(key), Some(slot))
-                }
-                CrdsData::Version(version) => assert_eq!(crds.get::<&Version>(key), Some(version)),
-                CrdsData::LegacyVersion(version) => {
-                    assert_eq!(crds.get::<&LegacyVersion>(key), Some(version))
                 }
                 CrdsData::SnapshotHashes(hash) => {
                     assert_eq!(crds.get::<&SnapshotHashes>(key), Some(hash))

--- a/version/src/legacy.rs
+++ b/version/src/legacy.rs
@@ -27,18 +27,6 @@ pub struct LegacyVersion2 {
     pub feature_set: u32,    // first 4 bytes of the FeatureSet identifier
 }
 
-impl From<LegacyVersion1> for LegacyVersion2 {
-    fn from(legacy_version: LegacyVersion1) -> Self {
-        Self {
-            major: legacy_version.major,
-            minor: legacy_version.minor,
-            patch: legacy_version.patch,
-            commit: legacy_version.commit,
-            feature_set: 0,
-        }
-    }
-}
-
 impl Default for LegacyVersion2 {
     fn default() -> Self {
         let feature_set =
@@ -50,12 +38,6 @@ impl Default for LegacyVersion2 {
             commit: compute_commit(option_env!("CI_COMMIT")),
             feature_set,
         }
-    }
-}
-
-impl fmt::Display for LegacyVersion2 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}.{}.{}", self.major, self.minor, self.patch,)
     }
 }
 

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -53,19 +53,6 @@ fn compute_commit(sha1: Option<&'static str>) -> Option<u32> {
     u32::from_str_radix(sha1?.get(..8)?, /*radix:*/ 16).ok()
 }
 
-impl From<LegacyVersion2> for Version {
-    fn from(version: LegacyVersion2) -> Self {
-        Self {
-            major: version.major,
-            minor: version.minor,
-            patch: version.patch,
-            commit: version.commit.unwrap_or_default(),
-            feature_set: version.feature_set,
-            client: Version::default().client,
-        }
-    }
-}
-
 impl Default for Version {
     fn default() -> Self {
         let feature_set =


### PR DESCRIPTION
#### Problem
New `ContactInfo` is propagated on all clusters and is sufficient to lookup a node's version. `CrdsData` for legacy versions are deprecated and should no longer be used.


#### Summary of Changes
Removed fallback on legacy versions in `ClusterInfo::get_node_version`,