### PR TITLE
Vote use quic.client.test2

### DIFF
--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -16,6 +16,7 @@ pub(crate) fn upcoming_leader_tpu_vote_sockets(
     cluster_info: &ClusterInfo,
     poh_recorder: &RwLock<PohRecorder>,
     fanout_slots: u64,
+    protocol: Protocol,
 ) -> Vec<SocketAddr> {
     let upcoming_leaders = {
         let poh_recorder = poh_recorder.read().unwrap();
@@ -29,7 +30,7 @@ pub(crate) fn upcoming_leader_tpu_vote_sockets(
         .dedup()
         .filter_map(|leader_pubkey| {
             cluster_info
-                .lookup_contact_info(&leader_pubkey, |node| node.tpu_vote(Protocol::UDP))?
+                .lookup_contact_info(&leader_pubkey, |node| node.tpu_vote(protocol))?
                 .ok()
         })
         // dedup again since leaders could potentially share the same tpu vote socket

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -4,6 +4,7 @@ use {
         next_leader::upcoming_leader_tpu_vote_sockets,
     },
     crossbeam_channel::Receiver,
+    solana_client::connection_cache::ConnectionCache,
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure::Measure,
     solana_poh::poh_recorder::PohRecorder,
@@ -48,6 +49,7 @@ impl VotingService {
         cluster_info: Arc<ClusterInfo>,
         poh_recorder: Arc<RwLock<PohRecorder>>,
         tower_storage: Arc<dyn TowerStorage>,
+        connection_cache: Arc<ConnectionCache>,
     ) -> Self {
         let thread_hdl = Builder::new()
             .name("solVoteService".to_string())
@@ -58,6 +60,7 @@ impl VotingService {
                         &poh_recorder,
                         tower_storage.as_ref(),
                         vote_op,
+                        connection_cache.clone(),
                     );
                 }
             })
@@ -70,6 +73,7 @@ impl VotingService {
         poh_recorder: &RwLock<PohRecorder>,
         tower_storage: &dyn TowerStorage,
         vote_op: VoteOp,
+        connection_cache: Arc<ConnectionCache>,
     ) {
         if let VoteOp::PushVote { saved_tower, .. } = &vote_op {
             let mut measure = Measure::start("tower storage save");
@@ -89,15 +93,20 @@ impl VotingService {
             cluster_info,
             poh_recorder,
             UPCOMING_LEADER_FANOUT_SLOTS,
+            connection_cache.protocol(),
         );
 
         if !upcoming_leader_sockets.is_empty() {
             for tpu_vote_socket in upcoming_leader_sockets {
-                let _ = cluster_info.send_transaction(vote_op.tx(), Some(tpu_vote_socket));
+                let _ = cluster_info.send_transaction(
+                    vote_op.tx(),
+                    Some(tpu_vote_socket),
+                    &connection_cache,
+                );
             }
         } else {
             // Send to our own tpu vote socket if we cannot find a leader to send to
-            let _ = cluster_info.send_transaction(vote_op.tx(), None);
+            let _ = cluster_info.send_transaction(vote_op.tx(), None, &connection_cache);
         }
 
         match vote_op {

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -51,7 +51,6 @@ use {
     itertools::Itertools,
     rand::{seq::SliceRandom, thread_rng, CryptoRng, Rng},
     rayon::{prelude::*, ThreadPool, ThreadPoolBuilder},
-    serde::ser::Serialize,
     solana_client::connection_cache::ConnectionCache,
     solana_connection_cache::client_connection::ClientConnection,
     solana_feature_set::FeatureSet,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -50,7 +50,7 @@ use {
     solana_streamer::{socket::SocketAddrSpace, streamer::StakedNodes},
     solana_tpu_client::tpu_client::{
         TpuClient, TpuClientConfig, DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP,
-        DEFAULT_TPU_USE_QUIC,
+        DEFAULT_TPU_USE_QUIC, DEFAULT_VOTE_USE_QUIC,
     },
     solana_vote_program::{
         vote_instruction,
@@ -96,6 +96,7 @@ pub struct ClusterConfig {
     pub additional_accounts: Vec<(Pubkey, AccountSharedData)>,
     pub tpu_use_quic: bool,
     pub tpu_connection_pool_size: usize,
+    pub vote_use_quic: bool,
 }
 
 impl ClusterConfig {
@@ -135,6 +136,7 @@ impl Default for ClusterConfig {
             additional_accounts: vec![],
             tpu_use_quic: DEFAULT_TPU_USE_QUIC,
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            vote_use_quic: DEFAULT_VOTE_USE_QUIC,
         }
     }
 }
@@ -339,6 +341,7 @@ impl LocalCluster {
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_VOTE_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             // We are turning tpu_enable_udp to true in order to prevent concurrent local cluster tests
             // to use the same QUIC ports due to SO_REUSEPORT.
@@ -546,6 +549,7 @@ impl LocalCluster {
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_VOTE_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
             32, // max connections per IpAddr per mintute
@@ -1079,6 +1083,7 @@ impl Cluster for LocalCluster {
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_VOTE_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
             32, // max connections per IpAddr per minute, use higher value because of tests

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -55,6 +55,7 @@ use {
     solana_streamer::socket::SocketAddrSpace,
     solana_tpu_client::tpu_client::{
         DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
+        DEFAULT_VOTE_USE_QUIC,
     },
     std::{
         collections::{HashMap, HashSet},
@@ -1045,6 +1046,7 @@ impl TestValidator {
             config.start_progress.clone(),
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_VOTE_USE_QUIC,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             config.tpu_enable_udp,
             32, // max connections per IpAddr per minute for test

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -30,6 +30,7 @@ use {
 
 pub const DEFAULT_TPU_ENABLE_UDP: bool = false;
 pub const DEFAULT_TPU_USE_QUIC: bool = true;
+pub const DEFAULT_VOTE_USE_QUIC: bool = true;
 
 /// The default connection count is set to 1 -- it should
 /// be sufficient for most use cases. Validators can use

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -48,7 +48,7 @@ use {
         self, MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
     },
     solana_streamer::quic::DEFAULT_QUIC_ENDPOINTS,
-    solana_tpu_client::tpu_client::DEFAULT_TPU_CONNECTION_POOL_SIZE,
+    solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC},
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     std::{path::PathBuf, str::FromStr},
 };
@@ -911,6 +911,13 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .validator(is_parsable::<u32>)
                 .hidden(hidden_unless_forced())
                 .help("Controls the rate of the clients connections per IpAddr per minute."),
+        )
+        .arg(
+            Arg::with_name("vote_use_quic")
+                .long("vote-use-quic")
+                .takes_value(true)
+                .default_value(&default_args.vote_use_quic)
+                .help("Use QUIC to send votes."),
         )
         .arg(
             Arg::with_name("num_quic_endpoints")
@@ -2282,6 +2289,7 @@ pub struct DefaultArgs {
     pub tpu_connection_pool_size: String,
     pub tpu_max_connections_per_ipaddr_per_minute: String,
     pub num_quic_endpoints: String,
+    pub vote_use_quic: String,
 
     // Exit subcommand
     pub exit_min_idle_time: String,
@@ -2373,6 +2381,7 @@ impl DefaultArgs {
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE.to_string(),
             tpu_max_connections_per_ipaddr_per_minute:
                 DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE.to_string(),
+            vote_use_quic: DEFAULT_VOTE_USE_QUIC.to_string(),
             num_quic_endpoints: DEFAULT_QUIC_ENDPOINTS.to_string(),
             rpc_max_request_body_size: MAX_REQUEST_BODY_SIZE.to_string(),
             exit_min_idle_time: "10".to_string(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1124,6 +1124,8 @@ pub fn main() {
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
     let tpu_use_quic = !matches.is_present("tpu_disable_quic");
+    let vote_use_quic = value_t_or_exit!(matches, "vote_use_quic", bool);
+
     let tpu_enable_udp = if matches.is_present("tpu_enable_udp") {
         true
     } else {
@@ -2068,6 +2070,7 @@ pub fn main() {
         start_progress,
         socket_addr_space,
         tpu_use_quic,
+        vote_use_quic,
         tpu_connection_pool_size,
         tpu_enable_udp,
         tpu_max_connections_per_ipaddr_per_minute,


### PR DESCRIPTION
#### Problem

Test voting TPU using QUIC by default. For test only -- do not review.
This turns DEFAULT_VOTE_USE_QUIC to true to send TPU vote via QUIC only.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
