### PR TITLE
Populates cache for accounts lt hash in Bank::new_from_parent()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7416,6 +7416,21 @@ impl AccountsDb {
         Ok(())
     }
 
+    /// Returns all of the accounts' pubkeys for a given slot
+    pub fn get_pubkeys_for_slot(&self, slot: Slot) -> Vec<Pubkey> {
+        let scan_result = self.scan_account_storage(
+            slot,
+            |loaded_account| Some(*loaded_account.pubkey()),
+            |accum: &DashSet<_>, loaded_account, _data| {
+                accum.insert(*loaded_account.pubkey());
+            },
+            ScanAccountStorageData::NoData,
+        );
+        match scan_result {
+            ScanStorageResult::Cached(cached_result) => cached_result,
+            ScanStorageResult::Stored(stored_result) => stored_result.into_iter().collect(),
+        }
+    }
     /// helper to return
     /// 1. pubkey, hash pairs for the slot
     /// 2. us spent scanning

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -59,7 +59,7 @@ use {
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
         verify_precompiles::verify_precompiles,
     },
-    accounts_lt_hash::InitialStateOfAccount,
+    accounts_lt_hash::CacheValue as AccountsLtHashCacheValue,
     ahash::AHashMap,
     byteorder::{ByteOrder, LittleEndian},
     dashmap::{DashMap, DashSet},
@@ -934,7 +934,10 @@ pub struct Bank {
     ///
     /// The accounts lt hash needs both the initial and final state of each
     /// account that was modified in this slot.  Cache the initial state here.
-    cache_for_accounts_lt_hash: RwLock<AHashMap<Pubkey, InitialStateOfAccount>>,
+    ///
+    /// Note: The initial state must be strictly from an ancestor,
+    /// and not an intermediate state within this slot.
+    cache_for_accounts_lt_hash: RwLock<AHashMap<Pubkey, AccountsLtHashCacheValue>>,
 
     /// The unique identifier for the corresponding block for this bank.
     /// None for banks that have not yet completed replay or for leader banks as we cannot populate block_id
@@ -1382,12 +1385,40 @@ impl Bank {
         let (_, fill_sysvar_cache_time_us) = measure_us!(new
             .transaction_processor
             .fill_missing_sysvar_cache_entries(&new));
-        time.stop();
 
+        let (num_accounts_modified_this_slot, populate_cache_for_accounts_lt_hash_us) = new
+            .is_accounts_lt_hash_enabled()
+            .then(|| {
+                measure_us!({
+                    // The cache for accounts lt hash needs to be made aware of accounts modified
+                    // before transaction processing begins.  Otherwise we may calculate the wrong
+                    // accounts lt hash due to having the wrong initial state of the account.  The
+                    // lt hash cache's initial state must always be from an ancestor, and cannot be
+                    // an intermediate state within this Bank's slot.  If the lt hash cache has the
+                    // wrong initial account state, we'll mix out the wrong lt hash value, and thus
+                    // have the wrong overall accounts lt hash, and diverge.
+                    let accounts_modified_this_slot =
+                        new.rc.accounts.accounts_db.get_pubkeys_for_slot(slot);
+                    let num_accounts_modified_this_slot = accounts_modified_this_slot.len();
+                    let cache_for_accounts_lt_hash =
+                        new.cache_for_accounts_lt_hash.get_mut().unwrap();
+                    cache_for_accounts_lt_hash.reserve(num_accounts_modified_this_slot);
+                    for pubkey in accounts_modified_this_slot {
+                        cache_for_accounts_lt_hash
+                            .entry(pubkey)
+                            .or_insert(AccountsLtHashCacheValue::BankNew);
+                    }
+                    num_accounts_modified_this_slot
+                })
+            })
+            .unzip();
+
+        time.stop();
         report_new_bank_metrics(
             slot,
             parent.slot(),
             new.block_height,
+            num_accounts_modified_this_slot,
             NewBankTimings {
                 bank_rc_creation_time_us,
                 total_elapsed_time_us: time.as_us(),
@@ -1407,6 +1438,7 @@ impl Bank {
                 cache_preparation_time_us,
                 update_sysvars_time_us,
                 fill_sysvar_cache_time_us,
+                populate_cache_for_accounts_lt_hash_us,
             },
         );
 

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -46,6 +46,7 @@ pub(crate) struct NewBankTimings {
     pub(crate) cache_preparation_time_us: u64,
     pub(crate) update_sysvars_time_us: u64,
     pub(crate) fill_sysvar_cache_time_us: u64,
+    pub(crate) populate_cache_for_accounts_lt_hash_us: Option<u64>,
 }
 
 pub(crate) fn report_new_epoch_metrics(
@@ -115,6 +116,7 @@ pub(crate) fn report_new_bank_metrics(
     slot: Slot,
     parent_slot: Slot,
     block_height: u64,
+    num_accounts_modified_this_slot: Option<usize>,
     timings: NewBankTimings,
 ) {
     datapoint_info!(
@@ -163,6 +165,16 @@ pub(crate) fn report_new_bank_metrics(
             "fill_sysvar_cache_us",
             timings.fill_sysvar_cache_time_us,
             i64
+        ),
+        (
+            "num_accounts_modified_this_slot",
+            num_accounts_modified_this_slot,
+            Option<i64>
+        ),
+        (
+            "populate_cache_for_accounts_lt_hash_us",
+            timings.populate_cache_for_accounts_lt_hash_us,
+            Option<i64>
         ),
     );
 }


### PR DESCRIPTION
#### Problem

The cache for accounts lt hash can have the wrong *initial* value if the bank updates the account before transaction processing begins.

This happens at the epoch boundary after paying out rewards. A vote account will be credited before transaction processing begins. Then if that same vote account is written in a transaction (e.g. sending a vote tx), the cache for accounts lt hash will see the initial state of this account as *post* rewards payout, which is wrong. The correct initial state must be *pre* rewards payout.


#### Summary of Changes

When creating a new bank from parent, find any account that is updated before transaction processing begins and add its pubkey to the cache for accounts lt hash. This marker is used in `update_accounts_lt_hash()` to know it needs to load this account's initial state -- as if the account was not in the cache at all.

I tested this change by spinning up a local cluster. With my feature-gate code, I would get accounts verification failures at restart. With this change, those failures went away (logging confirmed the previously divergent accounts were now correct). I also put a check in `Bank::freeze()` that recalculated the accounts lt hash with the index and compared it to the value in the bank for every slot and let that run over every slots in the ledger. It was successful.