### PR TITLE
remove ntapi patch

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -201,6 +201,7 @@ check_dcou() {
     # shellcheck source=scripts/spl-token-cli-version.sh
     source "$SOLANA_ROOT"/scripts/spl-token-cli-version.sh
 
+    # shellcheck disable=SC2086
     "$cargo" $maybeRustVersion install --locked spl-token-cli --root "$installDir" $maybeSplTokenCliVersionArg
   fi
 )

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -204,7 +204,7 @@ check_dcou() {
     # the patch-related configs are needed for rust 1.69+ on Windows; see Cargo.toml
     # shellcheck disable=SC2086 # Don't want to double quote $rust_version
     "$cargo" $maybeRustVersion \
-      --config 'patch.crates-io.ntapi.git="https://github.com/solana-labs/ntapi"' \
+      --config 'patch.crates-io.ntapi.git="https://github.com/anza-xyz/ntapi"' \
       --config 'patch.crates-io.ntapi.rev="97ede981a1777883ff86d142b75024b023f04fad"' \
       install --locked spl-token-cli --root "$installDir" $maybeSplTokenCliVersionArg
   fi

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -201,12 +201,7 @@ check_dcou() {
     # shellcheck source=scripts/spl-token-cli-version.sh
     source "$SOLANA_ROOT"/scripts/spl-token-cli-version.sh
 
-    # the patch-related configs are needed for rust 1.69+ on Windows; see Cargo.toml
-    # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-    "$cargo" $maybeRustVersion \
-      --config 'patch.crates-io.ntapi.git="https://github.com/anza-xyz/ntapi"' \
-      --config 'patch.crates-io.ntapi.rev="97ede981a1777883ff86d142b75024b023f04fad"' \
-      install --locked spl-token-cli --root "$installDir" $maybeSplTokenCliVersionArg
+    "$cargo" $maybeRustVersion install --locked spl-token-cli --root "$installDir" $maybeSplTokenCliVersionArg
   fi
 )
 


### PR DESCRIPTION
#### Problem

~we should use anza-xyz/ntapi as the vendor. just forked it and the commit, [https://github.com/anza-xyz/ntapi/commits/97ede981a1777883ff86d142b75024b023f04fad](https://github.com/anza-xyz/ntapi/commits/97ede981a1777883ff86d142b75024b023f04fad), is reachable~

remove outdated patch

