### PR TITLE
Fix - loader-v4

### DIFF
--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -1,13 +1,10 @@
 use {
-    solana_bpf_loader_program::execute,
+    solana_bpf_loader_program::{deploy_program, deploy_program_internal, execute},
     solana_log_collector::{ic_logger_msg, LogCollector},
     solana_measure::measure::Measure,
     solana_program_runtime::{
         invoke_context::InvokeContext,
-        loaded_programs::{
-            LoadProgramMetrics, ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
-            DELAY_VISIBILITY_SLOT_OFFSET,
-        },
+        loaded_programs::{ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType},
     },
     solana_rbpf::{declare_builtin_function, memory_region::MemoryMapping},
     solana_sdk::{
@@ -263,36 +260,15 @@ pub fn process_instruction_deploy(
         .get_data()
         .get(LoaderV4State::program_data_offset()..)
         .ok_or(InstructionError::AccountDataTooSmall)?;
-
-    let deployment_slot = state.slot;
-    let effective_slot = deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET);
-
-    let environments = invoke_context
-        .get_environments_for_slot(effective_slot)
-        .map_err(|err| {
-            // This will never fail since the epoch schedule is already configured.
-            ic_logger_msg!(log_collector, "Failed to get runtime environment {}", err);
-            InstructionError::InvalidArgument
-        })?;
-
-    let mut load_program_metrics = LoadProgramMetrics {
-        program_id: buffer.get_key().to_string(),
-        ..LoadProgramMetrics::default()
-    };
-    let executor = ProgramCacheEntry::new(
+    deploy_program!(
+        invoke_context,
+        program.get_key(),
         &loader_v4::id(),
-        environments.program_runtime_v1.clone(),
-        deployment_slot,
-        effective_slot,
-        programdata,
         buffer.get_data().len(),
-        &mut load_program_metrics,
-    )
-    .map_err(|err| {
-        ic_logger_msg!(log_collector, "{}", err);
-        InstructionError::InvalidAccountData
-    })?;
-    load_program_metrics.submit_datapoint(&mut invoke_context.timings);
+        programdata,
+        current_slot,
+    );
+
     if let Some(mut source_program) = source_program {
         let rent = invoke_context.get_sysvar_cache().get_rent()?;
         let required_lamports = rent.minimum_balance(source_program.get_data().len());
@@ -305,23 +281,6 @@ pub fn process_instruction_deploy(
     let state = get_state_mut(program.get_data_mut()?)?;
     state.slot = current_slot;
     state.status = LoaderV4Status::Deployed;
-
-    if let Some(old_entry) = invoke_context
-        .program_cache_for_tx_batch
-        .find(program.get_key())
-    {
-        executor.tx_usage_counter.store(
-            old_entry.tx_usage_counter.load(Ordering::Relaxed),
-            Ordering::Relaxed,
-        );
-        executor.ix_usage_counter.store(
-            old_entry.ix_usage_counter.load(Ordering::Relaxed),
-            Ordering::Relaxed,
-        );
-    }
-    invoke_context
-        .program_cache_for_tx_batch
-        .store_modified_entry(*program.get_key(), Arc::new(executor));
     Ok(())
 }
 

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -211,14 +211,15 @@ impl Bank {
                 compute_budget,
             );
 
-            solana_bpf_loader_program::direct_deploy_program(
-                &mut dummy_invoke_context,
+            use solana_bpf_loader_program::deploy_program_internal;
+            solana_bpf_loader_program::deploy_program!(
+                dummy_invoke_context,
                 program_id,
                 &bpf_loader_upgradeable::id(),
                 data_len,
                 elf,
                 self.slot,
-            )?
+            );
         }
 
         // Update the program cache by merging with `programs_modified`, which

--- a/sdk/program/src/loader_v4.rs
+++ b/sdk/program/src/loader_v4.rs
@@ -11,7 +11,7 @@ use crate::{
 pub use solana_sdk_ids::loader_v4::{check_id, id, ID};
 
 /// Cooldown before a program can be un-/redeployed again
-pub const DEPLOYMENT_COOLDOWN_IN_SLOTS: u64 = 750;
+pub const DEPLOYMENT_COOLDOWN_IN_SLOTS: u64 = 1;
 
 #[repr(u64)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -191,18 +191,14 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
                     &loader_v4::id(),
                     program_account.data().len(),
                     slot,
-                    environments.program_runtime_v2.clone(),
+                    environments.program_runtime_v1.clone(),
                     reload,
                 )
             })
             .map_err(|_| (slot, ProgramCacheEntryOwner::LoaderV4)),
     }
     .unwrap_or_else(|(slot, owner)| {
-        let env = if let ProgramCacheEntryOwner::LoaderV4 = &owner {
-            environments.program_runtime_v2.clone()
-        } else {
-            environments.program_runtime_v1.clone()
-        };
+        let env = environments.program_runtime_v1.clone();
         ProgramCacheEntry::new_tombstone(
             slot,
             owner,


### PR DESCRIPTION
#### Problem
While writing the integration tests for loader-v4 I noticed several issues.
The rekeying of the associated feature gate will happen separately in #2796.

#### Summary of Changes
- Fix program runtime environment of loader-v4. It was still using the v2 environment in `load_program_with_pubkey()`.

- Removes program account check in loader-v4 execution. Because there should be no need to look at the program account at all during execution as we have the cached program entry.

- Loader-v4 needs to use the same verification logic during deployment as in loader-v3. This prevents programs with certain syscalls from being deployed.