### PR TITLE
remove solana-program from solana-bn254 and solana-curve25519

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6181,7 +6181,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-program",
+ "solana-define-syscall",
  "thiserror",
 ]
 
@@ -6730,7 +6730,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-program",
+ "solana-define-syscall",
  "thiserror",
 ]
 

--- a/curves/bn254/Cargo.toml
+++ b/curves/bn254/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 bytemuck = { workspace = true, features = ["derive"] }
-solana-program = { workspace = true }
+solana-define-syscall = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]

--- a/curves/bn254/src/compression.rs
+++ b/curves/bn254/src/compression.rs
@@ -194,7 +194,7 @@ mod target_arch {
         super::*,
         alt_bn128_compression_size::{G1, G1_COMPRESSED, G2, G2_COMPRESSED},
         prelude::*,
-        solana_program::syscalls,
+        solana_define_syscall::definitions as syscalls,
     };
 
     pub fn alt_bn128_g1_compress(

--- a/curves/bn254/src/lib.rs
+++ b/curves/bn254/src/lib.rs
@@ -305,7 +305,7 @@ mod target_arch {
 
 #[cfg(target_os = "solana")]
 mod target_arch {
-    use {super::*, solana_program::syscalls};
+    use {super::*, solana_define_syscall::definitions as syscalls};
 
     pub fn alt_bn128_addition(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> {
         if input.len() > ALT_BN128_ADDITION_INPUT_LEN {

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -15,7 +15,7 @@ bytemuck_derive = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
-solana-program = { workspace = true }
+solana-define-syscall = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 curve25519-dalek = { workspace = true, features = ["serde"] }

--- a/curves/curve25519/src/edwards.rs
+++ b/curves/curve25519/src/edwards.rs
@@ -148,7 +148,7 @@ mod target_arch {
     pub fn validate_edwards(point: &PodEdwardsPoint) -> bool {
         let mut validate_result = 0u8;
         let result = unsafe {
-            solana_program::syscalls::sol_curve_validate_point(
+            solana_define_syscall::definitions::sol_curve_validate_point(
                 CURVE25519_EDWARDS,
                 &point.0 as *const u8,
                 &mut validate_result,
@@ -163,7 +163,7 @@ mod target_arch {
     ) -> Option<PodEdwardsPoint> {
         let mut result_point = PodEdwardsPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            solana_define_syscall::definitions::sol_curve_group_op(
                 CURVE25519_EDWARDS,
                 ADD,
                 &left_point.0 as *const u8,
@@ -185,7 +185,7 @@ mod target_arch {
     ) -> Option<PodEdwardsPoint> {
         let mut result_point = PodEdwardsPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            solana_define_syscall::definitions::sol_curve_group_op(
                 CURVE25519_EDWARDS,
                 SUB,
                 &left_point.0 as *const u8,
@@ -207,7 +207,7 @@ mod target_arch {
     ) -> Option<PodEdwardsPoint> {
         let mut result_point = PodEdwardsPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            solana_define_syscall::definitions::sol_curve_group_op(
                 CURVE25519_EDWARDS,
                 MUL,
                 &scalar.0 as *const u8,
@@ -229,7 +229,7 @@ mod target_arch {
     ) -> Option<PodEdwardsPoint> {
         let mut result_point = PodEdwardsPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_multiscalar_mul(
+            solana_define_syscall::definitions::sol_curve_multiscalar_mul(
                 CURVE25519_EDWARDS,
                 scalars.as_ptr() as *const u8,
                 points.as_ptr() as *const u8,

--- a/curves/curve25519/src/ristretto.rs
+++ b/curves/curve25519/src/ristretto.rs
@@ -149,7 +149,7 @@ mod target_arch {
     pub fn validate_ristretto(point: &PodRistrettoPoint) -> bool {
         let mut validate_result = 0u8;
         let result = unsafe {
-            solana_program::syscalls::sol_curve_validate_point(
+            solana_define_syscall::definitions::sol_curve_validate_point(
                 CURVE25519_RISTRETTO,
                 &point.0 as *const u8,
                 &mut validate_result,
@@ -165,7 +165,7 @@ mod target_arch {
     ) -> Option<PodRistrettoPoint> {
         let mut result_point = PodRistrettoPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            solana_define_syscall::definitions::sol_curve_group_op(
                 CURVE25519_RISTRETTO,
                 ADD,
                 &left_point.0 as *const u8,
@@ -187,7 +187,7 @@ mod target_arch {
     ) -> Option<PodRistrettoPoint> {
         let mut result_point = PodRistrettoPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            solana_define_syscall::definitions::sol_curve_group_op(
                 CURVE25519_RISTRETTO,
                 SUB,
                 &left_point.0 as *const u8,
@@ -209,7 +209,7 @@ mod target_arch {
     ) -> Option<PodRistrettoPoint> {
         let mut result_point = PodRistrettoPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_group_op(
+            solana_define_syscall::definitions::sol_curve_group_op(
                 CURVE25519_RISTRETTO,
                 MUL,
                 &scalar.0 as *const u8,
@@ -231,7 +231,7 @@ mod target_arch {
     ) -> Option<PodRistrettoPoint> {
         let mut result_point = PodRistrettoPoint::zeroed();
         let result = unsafe {
-            solana_program::syscalls::sol_curve_multiscalar_mul(
+            solana_define_syscall::definitions::sol_curve_multiscalar_mul(
                 CURVE25519_RISTRETTO,
                 scalars.as_ptr() as *const u8,
                 points.as_ptr() as *const u8,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5069,7 +5069,7 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "bytemuck",
- "solana-program",
+ "solana-define-syscall",
  "thiserror",
 ]
 
@@ -5416,7 +5416,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-program",
+ "solana-define-syscall",
  "thiserror",
 ]
 


### PR DESCRIPTION
#### Problem
These two crates don't need solana-program anymore

#### Summary of Changes
Remove it and replace with solana-define-syscall

This branches off #3405 so that needs to be merged first (update: done)