### PR TITLE
Unhides `--accounts-db-access-storages-method`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Release channels have their own copy of this changelog:
 * Changes
   * CLI:
     * Add global `--skip-preflight` option for skipping preflight checks on all transactions sent through RPC. This flag, along with `--use-rpc`, can improve success rate with program deployments using the public RPC nodes.
+  * Unhide `--accounts-db-access-storages-method` for agave-validator and agave-ledger-tool
 
 ## [2.1.0]
 * Breaking:

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -126,8 +126,7 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .value_name("METHOD")
             .takes_value(true)
             .possible_values(&["mmap", "file"])
-            .help("Access account storage using this method")
-            .hidden(hidden_unless_forced()),
+            .help("Access account storages using this method"),
         Arg::with_name("accounts_db_experimental_accumulator_hash")
             .long("accounts-db-experimental-accumulator-hash")
             .help("Enables the experimental accumulator hash")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1358,8 +1358,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("METHOD")
                 .takes_value(true)
                 .possible_values(&["mmap", "file"])
-                .help("Access account storage using this method")
-                .hidden(hidden_unless_forced()),
+                .help("Access account storages using this method")
         )
         .arg(
             Arg::with_name("accounts_db_ancient_append_vecs")


### PR DESCRIPTION
#### Problem

Specifying the storage access method for accounts-db requires setting a hidden CLI arg. Most operators are unfamiliar with how to do this, and it also communicates "do not use these CLI args". We want to enable operators to opt in
to using file io for accessing storages, and a hidden cli arg doesn't make that easy.


#### Summary of Changes

Unhide the cli arg.