### PR TITLE
Convert spurious errors to warn

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -1187,8 +1187,8 @@ pub fn fund_keypairs<T: 'static + TpsClient + Send + Sync + ?Sized>(
         );
 
         if funding_key_balance < total + rent {
-            error!(
-                "funder has {}, needed {}",
+            warn!(
+                "Funder has {}, needed {}, requesting airdrop...",
                 Sol(funding_key_balance),
                 Sol(total)
             );

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1821,9 +1821,9 @@ fn post_process_restored_tower(
             let voting_has_been_active =
                 active_vote_account_exists_in_bank(&bank_forks.working_bank(), vote_account);
             if !err.is_file_missing() {
-                datapoint_error!(
+                datapoint_warn!(
                     "tower_error",
-                    ("error", format!("Unable to restore tower: {err}"), String),
+                    ("warn", format!("Unable to restore tower: {err}"), String),
                 );
             }
             if should_require_tower && voting_has_been_active {
@@ -1840,7 +1840,7 @@ fn post_process_restored_tower(
                      start with the vote account..."
                 );
             } else {
-                error!(
+                warn!(
                     "Rebuilding a new tower from the latest vote account due to failed tower \
                      restore: {}",
                     err

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1207,7 +1207,7 @@ impl ClusterInfo {
         let mut gossip_crds = self.gossip.crds.write().unwrap();
         for entry in entries {
             if let Err(err) = gossip_crds.insert(entry, timestamp(), GossipRoute::LocalMessage) {
-                error!("Insert self failed: {err:?}");
+                warn!("Insert self failed: {err:?}");
             }
         }
     }


### PR DESCRIPTION
#### Problem

These show up during bench-tps tests
```
ERROR solana_bench_tps::bench] funder has ◎0.000000000, needed ◎0.001539720
ERROR solana_core::validator] Rebuilding a new tower from the latest vote account due to failed tower restore: IO Error: NullTowerStorage::load() not available
ERROR solana_gossip::cluster_info] Insert self failed: InsertFailed
ERROR solana_metrics::metrics] datapoint: tower_error error="Unable to restore tower: IO Error: NullTowerStorage::load() not available"
```
cargo test --manifest-path bench-tps/Cargo.toml

#### Summary of Changes
Convert to warning