### PR TITLE
fix: `build-sbf` Home Directory Error on Windows

### DIFF
--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -135,20 +135,22 @@ pub fn is_version_string(arg: &str) -> Result<(), String> {
     Err("a version string may start with 'v' and contains major and minor version numbers separated by a dot, e.g. v1.32 or 1.32".to_string())
 }
 
-fn get_home_dir() -> PathBuf {
+fn home_dir() -> PathBuf {
     PathBuf::from(
         env::var("HOME")
             .or_else(|err| {
                 #[cfg(windows)]
                 {
-                    debug!("Could not read env variable 'HOME': {}", err);
-                    debug!("Falling back to 'USERPROFILE'");
+                    debug!(
+                        "Could not read env variable 'HOME': {}, falling back to 'USERPROFILE'",
+                        err
+                    );
                     env::var("USERPROFILE")
                 }
 
                 #[cfg(not(windows))]
                 {
-                    Err(e)
+                    Err(err)
                 }
             })
             .unwrap_or_else(|err| {
@@ -159,8 +161,7 @@ fn get_home_dir() -> PathBuf {
 }
 
 fn find_installed_platform_tools() -> Vec<String> {
-    let home_dir = get_home_dir();
-    let solana = home_dir.join(".cache").join("solana");
+    let solana = home_dir().join(".cache").join("solana");
     let package = "platform-tools";
     std::fs::read_dir(solana)
         .unwrap()
@@ -262,7 +263,7 @@ fn validate_platform_tools_version(requested_version: &str, builtin_version: &st
 }
 
 fn make_platform_tools_path_for_version(package: &str, version: &str) -> PathBuf {
-    get_home_dir()
+    home_dir()
         .join(".cache")
         .join("solana")
         .join(version)

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -137,24 +137,22 @@ pub fn is_version_string(arg: &str) -> Result<(), String> {
 
 fn home_dir() -> PathBuf {
     PathBuf::from(
-        env::var("HOME")
-            .or_else(|err| {
+        #[cfg_attr(not(windows), allow(clippy::unnecessary_lazy_evaluations))]
+        env::var_os("HOME")
+            .or_else(|| {
                 #[cfg(windows)]
                 {
-                    debug!(
-                        "Could not read env variable 'HOME': {}, falling back to 'USERPROFILE'",
-                        err
-                    );
-                    env::var("USERPROFILE")
+                    debug!("Could not read env variable 'HOME', falling back to 'USERPROFILE'");
+                    env::var_os("USERPROFILE")
                 }
 
                 #[cfg(not(windows))]
                 {
-                    Err(err)
+                    None
                 }
             })
-            .unwrap_or_else(|err| {
-                error!("Can't get home directory path: {}", err);
+            .unwrap_or_else(|| {
+                error!("Can't get home directory path");
                 exit(1);
             }),
     )


### PR DESCRIPTION
#### Problem
The `cargo-build-sbf` command is unable to find the home directory path of the user on Windows and throws an error.
Setting the `HOME` env variable with `set HOME=%USERPROFILE%` fixes the issue but has to be run on each terminal session.

```console
> cargo build-sbf
[2024-11-12T19:54:24.953753800Z ERROR cargo_build_sbf] Can't get home directory path: environment variable not found
```

#### Summary of Changes
Only on Windows, if the `HOME` env variable is not set, automatically fall back to the `USERPROFILE` variable, and if that is not set then throws an error.

- fixes solana-labs/solana#35558
