### PR TITLE
[zk-sdk] Expose ElGamal decryption and proof program to wasm target

### DIFF
--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -17,7 +17,7 @@ merlin = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["bytemuck"] }
 solana-sdk-ids = { workspace = true }
 thiserror = { workspace = true }
 

--- a/zk-sdk/src/encryption/discrete_log.rs
+++ b/zk-sdk/src/encryption/discrete_log.rs
@@ -146,6 +146,7 @@ impl DiscreteLog {
     /// Solves the discrete log problem under the assumption that the solution
     /// is a positive 32-bit number.
     pub fn decode_u32(self) -> Option<u64> {
+        #[allow(unused_variables)]
         if let Some(num_threads) = self.num_threads {
             #[cfg(not(target_arch = "wasm32"))]
             {

--- a/zk-sdk/src/encryption/mod.rs
+++ b/zk-sdk/src/encryption/mod.rs
@@ -17,7 +17,7 @@ use crate::{RISTRETTO_POINT_LEN, SCALAR_LEN};
 pub(crate) mod macros;
 #[cfg(not(target_os = "solana"))]
 pub mod auth_encryption;
-#[cfg(all(not(target_os = "solana"), not(target_arch = "wasm32")))]
+#[cfg(not(target_os = "solana"))]
 pub mod discrete_log;
 #[cfg(not(target_os = "solana"))]
 pub mod elgamal;

--- a/zk-sdk/src/lib.rs
+++ b/zk-sdk/src/lib.rs
@@ -25,7 +25,6 @@ pub mod pod;
 mod range_proof;
 mod sigma_proofs;
 mod transcript;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod zk_elgamal_proof_program;
 
 /// Byte length of a compressed Ristretto point or scalar in Curve255519


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/2996, which exposes `ElGamalPubkey` and `ElGamalKeypair` explicitly removes the ElGamal decryption and proof program from wasm build target in order to minimize the wasm binary as much as possible. However, after the agave 2.1 upgrade, the spl token22 program cannot build for wasm target (https://github.com/solana-labs/solana-program-library/issues/7478).

#### Summary of Changes
Include the ElGamal decryption and proof program modules to wasm target. This does increase the wasm binary almost doubles the size of the wasm binary, but the binary size can be optimized in subsequent PRs. This PR should be backported 2.1. Any subsequent PRs related to zk-sdk wasm do not have to be backported since the wasm built library will be published in npm.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
