### PR TITLE
blockstore: Move rocksdb keys from heap to stack

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -234,27 +234,28 @@ pub struct Blockstore {
     ledger_path: PathBuf,
     db: Arc<Rocks>,
     // Column families
-    address_signatures_cf: LedgerColumn<cf::AddressSignatures>,
-    bank_hash_cf: LedgerColumn<cf::BankHash>,
-    block_height_cf: LedgerColumn<cf::BlockHeight>,
-    blocktime_cf: LedgerColumn<cf::Blocktime>,
-    code_shred_cf: LedgerColumn<cf::ShredCode>,
-    data_shred_cf: LedgerColumn<cf::ShredData>,
-    dead_slots_cf: LedgerColumn<cf::DeadSlots>,
-    duplicate_slots_cf: LedgerColumn<cf::DuplicateSlots>,
-    erasure_meta_cf: LedgerColumn<cf::ErasureMeta>,
-    index_cf: LedgerColumn<cf::Index>,
-    merkle_root_meta_cf: LedgerColumn<cf::MerkleRootMeta>,
-    meta_cf: LedgerColumn<cf::SlotMeta>,
-    optimistic_slots_cf: LedgerColumn<cf::OptimisticSlots>,
-    orphans_cf: LedgerColumn<cf::Orphans>,
-    perf_samples_cf: LedgerColumn<cf::PerfSamples>,
-    program_costs_cf: LedgerColumn<cf::ProgramCosts>,
-    rewards_cf: LedgerColumn<cf::Rewards>,
-    roots_cf: LedgerColumn<cf::Root>,
-    transaction_memos_cf: LedgerColumn<cf::TransactionMemos>,
-    transaction_status_cf: LedgerColumn<cf::TransactionStatus>,
-    transaction_status_index_cf: LedgerColumn<cf::TransactionStatusIndex>,
+    address_signatures_cf: LedgerColumn<cf::AddressSignatures, { cf::AddressSignatures::KEY_LEN }>,
+    bank_hash_cf: LedgerColumn<cf::BankHash, { cf::BankHash::KEY_LEN }>,
+    block_height_cf: LedgerColumn<cf::BlockHeight, { cf::BlockHeight::KEY_LEN }>,
+    blocktime_cf: LedgerColumn<cf::Blocktime, { cf::Blocktime::KEY_LEN }>,
+    code_shred_cf: LedgerColumn<cf::ShredCode, { cf::ShredCode::KEY_LEN }>,
+    data_shred_cf: LedgerColumn<cf::ShredData, { cf::ShredData::KEY_LEN }>,
+    dead_slots_cf: LedgerColumn<cf::DeadSlots, { cf::DeadSlots::KEY_LEN }>,
+    duplicate_slots_cf: LedgerColumn<cf::DuplicateSlots, { cf::DuplicateSlots::KEY_LEN }>,
+    erasure_meta_cf: LedgerColumn<cf::ErasureMeta, { cf::ErasureMeta::KEY_LEN }>,
+    index_cf: LedgerColumn<cf::Index, { cf::Index::KEY_LEN }>,
+    merkle_root_meta_cf: LedgerColumn<cf::MerkleRootMeta, { cf::MerkleRootMeta::KEY_LEN }>,
+    meta_cf: LedgerColumn<cf::SlotMeta, { cf::SlotMeta::KEY_LEN }>,
+    optimistic_slots_cf: LedgerColumn<cf::OptimisticSlots, { cf::OptimisticSlots::KEY_LEN }>,
+    orphans_cf: LedgerColumn<cf::Orphans, { cf::Orphans::KEY_LEN }>,
+    perf_samples_cf: LedgerColumn<cf::PerfSamples, { cf::PerfSamples::KEY_LEN }>,
+    program_costs_cf: LedgerColumn<cf::ProgramCosts, { cf::ProgramCosts::KEY_LEN }>,
+    rewards_cf: LedgerColumn<cf::Rewards, { cf::Rewards::KEY_LEN }>,
+    roots_cf: LedgerColumn<cf::Root, { cf::Root::KEY_LEN }>,
+    transaction_memos_cf: LedgerColumn<cf::TransactionMemos, { cf::TransactionMemos::KEY_LEN }>,
+    transaction_status_cf: LedgerColumn<cf::TransactionStatus, { cf::TransactionStatus::KEY_LEN }>,
+    transaction_status_index_cf:
+        LedgerColumn<cf::TransactionStatusIndex, { cf::TransactionStatusIndex::KEY_LEN }>,
 
     highest_primary_index_slot: RwLock<Option<Slot>>,
     max_root: AtomicU64,
@@ -763,7 +764,7 @@ impl Blockstore {
         slot: Slot,
         erasure_meta: &'a ErasureMeta,
         prev_inserted_shreds: &'a HashMap<ShredId, Shred>,
-        data_cf: &'a LedgerColumn<cf::ShredData>,
+        data_cf: &'a LedgerColumn<cf::ShredData, { cf::ShredData::KEY_LEN }>,
     ) -> impl Iterator<Item = Shred> + 'a {
         erasure_meta.data_shreds_indices().filter_map(move |i| {
             let key = ShredId::new(slot, u32::try_from(i).unwrap(), ShredType::Data);
@@ -792,7 +793,7 @@ impl Blockstore {
         slot: Slot,
         erasure_meta: &'a ErasureMeta,
         prev_inserted_shreds: &'a HashMap<ShredId, Shred>,
-        code_cf: &'a LedgerColumn<cf::ShredCode>,
+        code_cf: &'a LedgerColumn<cf::ShredCode, { cf::ShredCode::KEY_LEN }>,
     ) -> impl Iterator<Item = Shred> + 'a {
         erasure_meta.coding_shreds_indices().filter_map(move |i| {
             let key = ShredId::new(slot, u32::try_from(i).unwrap(), ShredType::Code);
@@ -821,8 +822,8 @@ impl Blockstore {
         erasure_meta: &ErasureMeta,
         prev_inserted_shreds: &HashMap<ShredId, Shred>,
         recovered_shreds: &mut Vec<Shred>,
-        data_cf: &LedgerColumn<cf::ShredData>,
-        code_cf: &LedgerColumn<cf::ShredCode>,
+        data_cf: &LedgerColumn<cf::ShredData, { cf::ShredData::KEY_LEN }>,
+        code_cf: &LedgerColumn<cf::ShredCode, { cf::ShredCode::KEY_LEN }>,
         reed_solomon_cache: &ReedSolomonCache,
     ) {
         // Find shreds for this erasure set and try recovery

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1422,12 +1422,12 @@ impl<C> LedgerColumn<C>
 where
     C: Column + ColumnName,
 {
-    pub fn get_bytes(&self, key: C::Index) -> Result<Option<Vec<u8>>> {
+    pub fn get_bytes(&self, index: C::Index) -> Result<Option<Vec<u8>>> {
         let is_perf_enabled = maybe_enable_rocksdb_perf(
             self.column_options.rocks_perf_sample_interval,
             &self.read_perf_status,
         );
-        let result = self.backend.get_cf(self.handle(), &C::key(key));
+        let result = self.backend.get_cf(self.handle(), &C::key(index));
         if let Some(op_start_instant) = is_perf_enabled {
             report_rocksdb_read_perf(
                 C::NAME,
@@ -1519,12 +1519,12 @@ where
         Ok(!iter.valid())
     }
 
-    pub fn put_bytes(&self, key: C::Index, value: &[u8]) -> Result<()> {
+    pub fn put_bytes(&self, index: C::Index, value: &[u8]) -> Result<()> {
         let is_perf_enabled = maybe_enable_rocksdb_perf(
             self.column_options.rocks_perf_sample_interval,
             &self.write_perf_status,
         );
-        let result = self.backend.put_cf(self.handle(), &C::key(key), value);
+        let result = self.backend.put_cf(self.handle(), &C::key(index), value);
         if let Some(op_start_instant) = is_perf_enabled {
             report_rocksdb_write_perf(
                 C::NAME,
@@ -1539,10 +1539,10 @@ where
     pub fn put_bytes_in_batch(
         &self,
         batch: &mut WriteBatch,
-        key: C::Index,
+        index: C::Index,
         value: &[u8],
     ) -> Result<()> {
-        let key = C::key(key);
+        let key = C::key(index);
         batch.put_cf(self.handle(), &key, value)
     }
 
@@ -1555,12 +1555,12 @@ where
         self.backend.get_int_property_cf(self.handle(), name)
     }
 
-    pub fn delete(&self, key: C::Index) -> Result<()> {
+    pub fn delete(&self, index: C::Index) -> Result<()> {
         let is_perf_enabled = maybe_enable_rocksdb_perf(
             self.column_options.rocks_perf_sample_interval,
             &self.write_perf_status,
         );
-        let result = self.backend.delete_cf(self.handle(), &C::key(key));
+        let result = self.backend.delete_cf(self.handle(), &C::key(index));
         if let Some(op_start_instant) = is_perf_enabled {
             report_rocksdb_write_perf(
                 C::NAME,
@@ -1572,8 +1572,8 @@ where
         result
     }
 
-    pub fn delete_in_batch(&self, batch: &mut WriteBatch, key: C::Index) -> Result<()> {
-        let key = C::key(key);
+    pub fn delete_in_batch(&self, batch: &mut WriteBatch, index: C::Index) -> Result<()> {
+        let key = C::key(index);
         batch.delete_cf(self.handle(), &key)
     }
 
@@ -1640,8 +1640,8 @@ where
         }
     }
 
-    pub fn get(&self, key: C::Index) -> Result<Option<C::Type>> {
-        self.get_raw(&C::key(key))
+    pub fn get(&self, index: C::Index) -> Result<Option<C::Type>> {
+        self.get_raw(&C::key(index))
     }
 
     pub fn get_raw(&self, key: &[u8]) -> Result<Option<C::Type>> {
@@ -1666,7 +1666,7 @@ where
         result
     }
 
-    pub fn put(&self, key: C::Index, value: &C::Type) -> Result<()> {
+    pub fn put(&self, index: C::Index, value: &C::Type) -> Result<()> {
         let is_perf_enabled = maybe_enable_rocksdb_perf(
             self.column_options.rocks_perf_sample_interval,
             &self.write_perf_status,
@@ -1675,7 +1675,7 @@ where
 
         let result = self
             .backend
-            .put_cf(self.handle(), &C::key(key), &serialized_value);
+            .put_cf(self.handle(), &C::key(index), &serialized_value);
 
         if let Some(op_start_instant) = is_perf_enabled {
             report_rocksdb_write_perf(
@@ -1691,10 +1691,10 @@ where
     pub fn put_in_batch(
         &self,
         batch: &mut WriteBatch,
-        key: C::Index,
+        index: C::Index,
         value: &C::Type,
     ) -> Result<()> {
-        let key = C::key(key);
+        let key = C::key(index);
         let serialized_value = serialize(value)?;
         batch.put_cf(self.handle(), &key, &serialized_value)
     }
@@ -1706,9 +1706,9 @@ where
 {
     pub fn get_protobuf_or_bincode<T: DeserializeOwned + Into<C::Type>>(
         &self,
-        key: C::Index,
+        index: C::Index,
     ) -> Result<Option<C::Type>> {
-        self.get_raw_protobuf_or_bincode::<T>(&C::key(key))
+        self.get_raw_protobuf_or_bincode::<T>(&C::key(index))
     }
 
     pub(crate) fn get_raw_protobuf_or_bincode<T: DeserializeOwned + Into<C::Type>>(
@@ -1740,12 +1740,12 @@ where
         }
     }
 
-    pub fn get_protobuf(&self, key: C::Index) -> Result<Option<C::Type>> {
+    pub fn get_protobuf(&self, index: C::Index) -> Result<Option<C::Type>> {
         let is_perf_enabled = maybe_enable_rocksdb_perf(
             self.column_options.rocks_perf_sample_interval,
             &self.read_perf_status,
         );
-        let result = self.backend.get_pinned_cf(self.handle(), &C::key(key));
+        let result = self.backend.get_pinned_cf(self.handle(), &C::key(index));
         if let Some(op_start_instant) = is_perf_enabled {
             report_rocksdb_read_perf(
                 C::NAME,
@@ -1762,7 +1762,7 @@ where
         }
     }
 
-    pub fn put_protobuf(&self, key: C::Index, value: &C::Type) -> Result<()> {
+    pub fn put_protobuf(&self, index: C::Index, value: &C::Type) -> Result<()> {
         let mut buf = Vec::with_capacity(value.encoded_len());
         value.encode(&mut buf)?;
 
@@ -1770,7 +1770,7 @@ where
             self.column_options.rocks_perf_sample_interval,
             &self.write_perf_status,
         );
-        let result = self.backend.put_cf(self.handle(), &C::key(key), &buf);
+        let result = self.backend.put_cf(self.handle(), &C::key(index), &buf);
         if let Some(op_start_instant) = is_perf_enabled {
             report_rocksdb_write_perf(
                 C::NAME,
@@ -1837,9 +1837,9 @@ where
     pub(crate) fn delete_deprecated_in_batch(
         &self,
         batch: &mut WriteBatch,
-        key: C::DeprecatedIndex,
+        index: C::DeprecatedIndex,
     ) -> Result<()> {
-        let key = C::deprecated_key(key);
+        let key = C::deprecated_key(index);
         batch.delete_cf(self.handle(), &key)
     }
 }
@@ -2174,13 +2174,13 @@ pub mod tests {
     {
         pub fn put_deprecated_protobuf(
             &self,
-            key: C::DeprecatedIndex,
+            index: C::DeprecatedIndex,
             value: &C::Type,
         ) -> Result<()> {
             let mut buf = Vec::with_capacity(value.encoded_len());
             value.encode(&mut buf)?;
             self.backend
-                .put_cf(self.handle(), &C::deprecated_key(key), &buf)
+                .put_cf(self.handle(), &C::deprecated_key(index), &buf)
         }
     }
 
@@ -2188,10 +2188,10 @@ pub mod tests {
     where
         C: ColumnIndexDeprecation + TypedColumn + ColumnName,
     {
-        pub fn put_deprecated(&self, key: C::DeprecatedIndex, value: &C::Type) -> Result<()> {
+        pub fn put_deprecated(&self, index: C::DeprecatedIndex, value: &C::Type) -> Result<()> {
             let serialized_value = serialize(value)?;
             self.backend
-                .put_cf(self.handle(), &C::deprecated_key(key), &serialized_value)
+                .put_cf(self.handle(), &C::deprecated_key(index), &serialized_value)
         }
     }
 


### PR DESCRIPTION
#### Problem
The Blockstore stores different data types in different columns. More so, the index type might vary column to column. For example, we access a `SlotMeta` by slot but a data shred by `(Slot, /*shred_index:*/ u64)`.

Under the hood, rocksdb just wants a `&[u8]` for the key. So, we have a function for turning the index (`Slot` from our `SlotaMeta` example) into a `Vec<u8>`:
https://github.com/anza-xyz/agave/blob/7629a152d1c7748ebc3c3a11bf62445eae4c0e02/ledger/src/blockstore_db.rs#L772

Returning a `Vec<u8>` here obviously results in a heap allocation. The `key()` function is used in just about all operations with the Blockstore. A simple counter in `C::key()` (for all columns) shows about ~20k calls per second against MNB at steady state (Dec 13, 2024). This number is higher during catchup, and will be higher for RPC nodes that are accessing the Blockstore for queries.
<details>
<summary>Count key() calls patch</summary>
  
```rust
diff --git a/ledger/src/blockstore.rs b/ledger/src/blockstore.rs
index 3669b9fc05..2e878fdc06 100644
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -831,6 +831,8 @@ impl Blockstore {
     ///
     /// [`BlockstoreRocksDbColumnFamilyMetrics`]: crate::blockstore_metrics::BlockstoreRocksDbColumnFamilyMetrics
     pub fn submit_rocksdb_cf_metrics_for_all_cfs(&self) {
+        let key_count = crate::blockstore_db::KEY_COUNT.swap(0, Ordering::Relaxed);
+        info!("steviez key() count over 10s: {key_count}");
         self.meta_cf.submit_rocksdb_cf_metrics();
         self.dead_slots_cf.submit_rocksdb_cf_metrics();
         self.duplicate_slots_cf.submit_rocksdb_cf_metrics();
diff --git a/ledger/src/blockstore_db.rs b/ledger/src/blockstore_db.rs
index 3b469a6a38..d4dca30bce 100644
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -45,6 +45,8 @@ use {
     thiserror::Error,
 };
 
+pub static KEY_COUNT: AtomicU64 = AtomicU64::new(0);
+
 const BLOCKSTORE_METRICS_ERROR: i64 = -1;
 
 const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
@@ -816,6 +818,7 @@ impl<T: SlotColumn> Column for T {
 
     /// Converts a u64 Index to its RocksDB key.
     fn key(slot: u64) -> Vec<u8> {
+        KEY_COUNT.fetch_add(1, Ordering::Relaxed);
         let mut key = vec![0; 8];
         BigEndian::write_u64(&mut key[..], slot);
         key
@@ -870,6 +873,7 @@ impl Column for columns::TransactionStatus {
     type Index = (Signature, Slot);
 
     fn key((signature, slot): Self::Index) -> Vec<u8> {
+        KEY_COUNT.fetch_add(1, Ordering::Relaxed);
         let mut key = vec![0; Self::CURRENT_INDEX_LEN];
         key[0..64].copy_from_slice(&signature.as_ref()[0..64]);
         BigEndian::write_u64(&mut key[64..72], slot);
@@ -939,6 +943,7 @@ impl Column for columns::AddressSignatures {
     type Index = (Pubkey, Slot, u32, Signature);
 
     fn key((pubkey, slot, transaction_index, signature): Self::Index) -> Vec<u8> {
+        KEY_COUNT.fetch_add(1, Ordering::Relaxed);
         let mut key = vec![0; Self::CURRENT_INDEX_LEN];
         key[0..32].copy_from_slice(&pubkey.as_ref()[0..32]);
         BigEndian::write_u64(&mut key[32..40], slot);
@@ -1011,6 +1016,7 @@ impl Column for columns::TransactionMemos {
     type Index = (Signature, Slot);
 
     fn key((signature, slot): Self::Index) -> Vec<u8> {
+        KEY_COUNT.fetch_add(1, Ordering::Relaxed);
         let mut key = vec![0; Self::CURRENT_INDEX_LEN];
         key[0..64].copy_from_slice(&signature.as_ref()[0..64]);
         BigEndian::write_u64(&mut key[64..72], slot);
@@ -1066,6 +1072,7 @@ impl Column for columns::TransactionStatusIndex {
     type Index = u64;
 
     fn key(index: u64) -> Vec<u8> {
+        KEY_COUNT.fetch_add(1, Ordering::Relaxed);
         let mut key = vec![0; 8];
         BigEndian::write_u64(&mut key[..], index);
         key
@@ -1126,6 +1133,7 @@ impl Column for columns::ProgramCosts {
     type Index = Pubkey;
 
     fn key(pubkey: Pubkey) -> Vec<u8> {
+        KEY_COUNT.fetch_add(1, Ordering::Relaxed);
         let mut key = vec![0; 32]; // size_of Pubkey
         key[0..32].copy_from_slice(&pubkey.as_ref()[0..32]);
         key
@@ -1148,6 +1156,7 @@ impl Column for columns::ShredCode {
     type Index = (Slot, u64);
 
     fn key(index: (Slot, u64)) -> Vec<u8> {
+        KEY_COUNT.fetch_add(1, Ordering::Relaxed);
         columns::ShredData::key(index)
     }
 
@@ -1171,6 +1180,7 @@ impl Column for columns::ShredData {
     type Index = (Slot, u64);
 
     fn key((slot, index): (Slot, u64)) -> Vec<u8> {
+        KEY_COUNT.fetch_add(1, Ordering::Relaxed);
         let mut key = vec![0; 16];
         BigEndian::write_u64(&mut key[..8], slot);
         BigEndian::write_u64(&mut key[8..16], index);
@@ -1262,6 +1272,7 @@ impl Column for columns::ErasureMeta {
     }
 
     fn key((slot, set_index): (Slot, u64)) -> Vec<u8> {
+        KEY_COUNT.fetch_add(1, Ordering::Relaxed);
         let mut key = vec![0; 16];
         BigEndian::write_u64(&mut key[..8], slot);
         BigEndian::write_u64(&mut key[8..], set_index);
@@ -1302,6 +1313,7 @@ impl Column for columns::MerkleRootMeta {
     }
 
     fn key((slot, fec_set_index): Self::Index) -> Vec<u8> {
+        KEY_COUNT.fetch_add(1, Ordering::Relaxed);
         let mut key = vec![0; 12];
         BigEndian::write_u64(&mut key[..8], slot);
         BigEndian::write_u32(&mut key[8..], fec_set_index);
```
</details>

#### Summary of Changes
- Outside of this PR, several PR's have been merged to shift all of the `C::Index ==> [u8]` conversion into `LedgerColumn` from several types in `blockstore_db.rs`
- Add a `KEY_LEN` field to `Column` trait, and parameterize `LedgerColumn` over this value (`K`)
    - The key size is fixed and known at compile time so we take advantage of that
    - We must introduce the new parameter `K` and can't use `C::KEY_LEN` unfortunately, see [this comment](https://github.com/anza-xyz/agave/pull/3603#discussion_r1884210482)
- Replace instances of `C::key()` with a helper function that will host the key on the stack

#### Performance
This item hasn't come up in flamegraphs nor have I heard it from others, but in any case, ~20k is a non-trivial number of allocations per second. So, while this doesn't have an immediate measurable metric, this is the kind of change that "unclogs" the system a bit

#### Future Work
This PR hasn't addressed every single caller of `C::key()`. There are several items left that
- Calls to `multi_get()`
    - The number of keys can be variable so I plan on introducing a thin type where I place the key consecutively in one `Vec`
- A single instance of converting bytes to a key from use of a `DBRawIterator`
    - This function is used in a touchy function, so I decided to do this change standalone
- The `deprecated_key()` calls in `DeprecatedColumn` trait
    - I believe we can remove `DeprecatedColumn` altogether. If that is incorrect, I'll optimize those calls too

Aside from that, we could also consider using `MaybeUninit` so that don't need zero'd memory in `key_from_index()`