### PR TITLE
instruction: Derive everything for wasm build

### DIFF
--- a/sdk/instruction/src/lib.rs
+++ b/sdk/instruction/src/lib.rs
@@ -105,6 +105,11 @@ pub struct Instruction {
 /// is fixed. This must not diverge from the regular non-wasm Instruction struct.
 #[cfg(all(feature = "std", target_arch = "wasm32"))]
 #[wasm_bindgen::prelude::wasm_bindgen]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Instruction {
     #[wasm_bindgen(skip)]
     pub program_id: Pubkey,


### PR DESCRIPTION
#### Problem

As noticed in
https://github.com/solana-labs/solana-program-library/pull/7489, the wasm build for `Instruction` doesn't contain `Clone`. This is because we missed the derivations for the wasm version of `Instruction` in https://github.com/anza-xyz/agave/pull/1658.

#### Summary of changes

Looking back through that PR, I noticed that we only missed those additional derives on `Instruction`, so just fix those in `Instruction`.

Since this is fixing a small regression for wasm builds, I think we should backport the change to v2.1.