### PR TITLE
Add a VmSlice class for slices stored within the interpreter's virtual memory

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -265,6 +265,16 @@ impl<T> VmSlice<T> {
         self.len
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Adjust the length of the vector. This is unchecked, and it assumes that the pointer
+    /// points to valid memory of the correct length after vm-translation.
+    pub fn resize(&mut self, len: u64) {
+        self.len = len;
+    }
+
     /// Returns a slice using a mapped physical address
     pub fn translate(
         &self,
@@ -776,6 +786,7 @@ fn translate_slice_of_slices_inner<'a, T>(
     Ok(unsafe { from_raw_parts_mut(host_addr as *mut VmSlice<T>, len as usize) })
 }
 
+#[allow(dead_code)]
 fn translate_slice_of_slices_mut<'a, T>(
     memory_mapping: &MemoryMapping,
     vm_addr: u64,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -10,7 +10,6 @@ pub use self::{
         SyscallGetSysvar,
     },
 };
-
 #[allow(deprecated)]
 use {
     solana_account_info::AccountInfo,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -258,6 +258,9 @@ impl<T> VmSlice<T> {
         }
     }
 
+    pub fn ptr(&self) -> u64 {
+        self.ptr
+    }
     pub fn len(&self) -> u64 {
         self.len
     }
@@ -1976,7 +1979,7 @@ declare_builtin_function!(
             poseidon::HASH_BYTES as u64,
             invoke_context.get_check_aligned(),
         )?;
-        let inputs = translate_slice::<&[u8]>(
+        let inputs = translate_slice_of_slices::<u8>(
             memory_mapping,
             vals_addr,
             vals_len,
@@ -1984,14 +1987,7 @@ declare_builtin_function!(
         )?;
         let inputs = inputs
             .iter()
-            .map(|input| {
-                translate_slice::<u8>(
-                    memory_mapping,
-                    input.as_ptr() as *const _ as u64,
-                    input.len() as u64,
-                    invoke_context.get_check_aligned(),
-                )
-            })
+            .map(|input| input.translate(memory_mapping, invoke_context.get_check_aligned()))
             .collect::<Result<Vec<_>, Error>>()?;
 
         let simplify_alt_bn128_syscall_error_codes = invoke_context
@@ -2192,22 +2188,18 @@ declare_builtin_function!(
         )?;
         let mut hasher = H::create_hasher();
         if vals_len > 0 {
-            let vals = translate_slice::<&[u8]>(
+            let vals = translate_slice_of_slices::<u8>(
                 memory_mapping,
                 vals_addr,
                 vals_len,
                 invoke_context.get_check_aligned(),
             )?;
+
             for val in vals.iter() {
-                let bytes = translate_slice::<u8>(
-                    memory_mapping,
-                    val.as_ptr() as u64,
-                    val.len() as u64,
-                    invoke_context.get_check_aligned(),
-                )?;
+                let bytes = val.translate(memory_mapping, invoke_context.get_check_aligned())?;
                 let cost = compute_budget.mem_op_base_cost.max(
                     hash_byte_cost.saturating_mul(
-                        (val.len() as u64)
+                        val.len()
                             .checked_div(2)
                             .expect("div by non-zero literal"),
                     ),

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -10,6 +10,7 @@ pub use self::{
         SyscallGetSysvar,
     },
 };
+
 #[allow(deprecated)]
 use {
     solana_account_info::AccountInfo,
@@ -64,6 +65,7 @@ use {
     solana_type_overrides::sync::Arc,
     std::{
         alloc::Layout,
+        marker::PhantomData,
         mem::{align_of, size_of},
         slice::from_raw_parts_mut,
         str::{from_utf8, Utf8Error},
@@ -235,40 +237,26 @@ pub struct VmSlice<'a, T> {
     memory_mapping: &'a MemoryMapping<'a>,
     ptr: u64,
     len: u64,
+    resource_type: PhantomData<T>,
 }
 
 impl<'a, T> VmSlice<'a, T> {
-    pub fn new<'a, T>(memory_mapping: &'a MemoryMapping, ptr: u64, len: u64) -> Self {
-        VmSlice { memory_mapping, ptr, len }
+    pub fn new(memory_mapping: &'a MemoryMapping, ptr: u64, len: u64) -> Self {
+        VmSlice {
+            memory_mapping,
+            ptr,
+            len,
+            resource_type: PhantomData,
+        }
     }
 
     // Returns a slice using a mapped physical address
-    pub fn translate<'a, T>(
-        &self
-    ) -> Result<&'a [T], Error> {
-        translate_slice(self.memory_mapping, self.ptr, self.len, false)
+    pub fn translate(&self) -> Result<&'a [T], Error> {
+        translate_slice::<T>(self.memory_mapping, self.ptr, self.len, false)
     }
 
-    pub fn translate_mut<'a, T>(
-        &mut self,
-    ) -> Result<&'a mut [T], Error> {
-        translate_slice_mut(self.memory_mapping, self.ptr, self.len, false)
-    }
-}
-
-impl<'a, T> Iterator for VmSlice<'a, T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.len > 0 {
-            let res = translate_type(self.memory_mapping, self.ptr, false).ok();
-            self.ptr.saturating_add(size_of::<T>());
-            self.len.saturating_sub(1);
-            res
-        }
-        else {
-            None
-        }
+    pub fn translate_mut(&mut self) -> Result<&'a mut [T], Error> {
+        translate_slice_mut::<T>(self.memory_mapping, self.ptr, self.len, false)
     }
 }
 

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -258,7 +258,7 @@ impl<'a, T> VmSlice<'a, T> {
         }
     }
 
-    // Returns a slice using a mapped physical address
+    /// Returns a slice using a mapped physical address
     pub fn translate(&self) -> Result<&'a [T], Error> {
         translate_slice::<T>(self.memory_mapping, self.ptr, self.len, false)
     }

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -240,6 +240,14 @@ pub struct VmSlice<'a, T> {
     resource_type: PhantomData<T>,
 }
 
+// The VmSlice class is used for cases when you need a slice that is stored in the BPF
+// interpreter's virtual address space. Because this source code can be compiled with
+// addresses of different bit depths, we cannot assume that the 64-bit BPF interpreter's
+// pointer sizes can be mapped to physical pointer sizes. In particular, if you need a
+// slice-of-slices in the virtual space, the inner slices will be different sizes in a
+// 32-bit app build than in the 64-bit virtual space. Therefore instead of a slice-of-slices,
+// you should implement a slice-of-VmSlices, which can then use VmSlice::translate() to
+// map to the physical address.
 impl<'a, T> VmSlice<'a, T> {
     pub fn new(memory_mapping: &'a MemoryMapping, ptr: u64, len: u64) -> Self {
         VmSlice {

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -231,6 +231,47 @@ impl HasherImpl for Keccak256Hasher {
     }
 }
 
+pub struct VmSlice<'a, T> {
+    memory_mapping: &'a MemoryMapping<'a>,
+    ptr: u64,
+    len: u64,
+}
+
+impl<'a, T> VmSlice<'a, T> {
+    pub fn new<'a, T>(memory_mapping: &'a MemoryMapping, ptr: u64, len: u64) -> Self {
+        VmSlice { memory_mapping, ptr, len }
+    }
+
+    // Returns a slice using a mapped physical address
+    pub fn translate<'a, T>(
+        &self
+    ) -> Result<&'a [T], Error> {
+        translate_slice(self.memory_mapping, self.ptr, self.len, false)
+    }
+
+    pub fn translate_mut<'a, T>(
+        &mut self,
+    ) -> Result<&'a mut [T], Error> {
+        translate_slice_mut(self.memory_mapping, self.ptr, self.len, false)
+    }
+}
+
+impl<'a, T> Iterator for VmSlice<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.len > 0 {
+            let res = translate_type(self.memory_mapping, self.ptr, false).ok();
+            self.ptr.saturating_add(size_of::<T>());
+            self.len.saturating_sub(1);
+            res
+        }
+        else {
+            None
+        }
+    }
+}
+
 fn consume_compute_meter(invoke_context: &InvokeContext, amount: u64) -> Result<(), Error> {
     invoke_context.consume_checked(amount)?;
     Ok(())

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -242,6 +242,8 @@ impl HasherImpl for Keccak256Hasher {
 // map to the physical address.
 // This class must consist only of 16 bytes: a u64 ptr and a u64 len, to match the 64-bit
 // implementation of a slice in Rust. The PhantomData entry takes up 0 bytes.
+
+#[repr(C)]
 pub struct VmSlice<T> {
     ptr: u64,
     len: u64,


### PR DESCRIPTION
#### Problem
When doing a 32-bit build of Agave, pointers are of course 32 bits. When a slice pointer to the interpreter's 64-bit address space is itself stored in the virtual address space, its pointer is 32 bits, when 64 bits are needed. This class uses a u64 to represent the address instead, which can then be correctly translated from virtual to physical space.

#### Summary of Changes
Added VmSlice class
Added translate_slice_of_slices(), which returns a slice of VmSlices rather than physically addressed Rust slices.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
