### PR TITLE
rekey feature enable_get_epoch_stake_syscall

### DIFF
--- a/sdk/feature-set/src/lib.rs
+++ b/sdk/feature-set/src/lib.rs
@@ -817,7 +817,7 @@ pub mod migrate_config_program_to_core_bpf {
 }
 
 pub mod enable_get_epoch_stake_syscall {
-    solana_pubkey::declare_id!("7mScTYkJXsbdrcwTQRs7oeCSXoJm4WjzBsRyf8bCU3Np");
+    solana_pubkey::declare_id!("FKe75t4LXxGaQnVHdUKM6DSFifVVraGZ8LyNo7oPwy1Z");
 }
 
 pub mod migrate_address_lookup_table_program_to_core_bpf {


### PR DESCRIPTION
#### Problem
The feature's logic was changed in #3279, which makes any previous versions of Agave incompatible. If the feature was activated, and a node was running an earlier release than the one the patch went into, it would fork off.

#### Summary of Changes
Rekey the feature as a result of the patch fix.