### PR TITLE
remove solana-sdk from solana-remote-wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8285,7 +8285,10 @@ dependencies = [
  "qstring",
  "semver 1.0.23",
  "solana-derivation-path",
- "solana-sdk",
+ "solana-offchain-message",
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
  "thiserror 2.0.6",
  "uriparse",
 ]

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -18,7 +18,7 @@ solana-cluster-type = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-derivation-path = { workspace = true }
 solana-hash = { workspace = true }
-solana-keypair = { workspace = true }
+solana-keypair = { workspace = true, features = ["seed-derivable"] }
 solana-native-token = { workspace = true }
 solana-presigner = { workspace = true }
 solana-program = { workspace = true }

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -27,7 +27,7 @@ solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-native-token = { workspace = true }
 solana-packet = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-system-transaction = { workspace = true }
@@ -36,9 +36,6 @@ solana-version = { workspace = true }
 spl-memo = { workspace = true, features = ["no-entrypoint"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-
-[dev-dependencies]
-solana-pubkey = { workspace = true, features = ["rand"] }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6545,7 +6545,10 @@ dependencies = [
  "qstring",
  "semver",
  "solana-derivation-path",
- "solana-sdk",
+ "solana-offchain-message",
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
  "thiserror 2.0.6",
  "uriparse",
 ]

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -20,7 +20,10 @@ parking_lot = { workspace = true }
 qstring = { workspace = true }
 semver = { workspace = true }
 solana-derivation-path = { workspace = true }
-solana-sdk = { workspace = true }
+solana-offchain-message = { workspace = true }
+solana-pubkey = { workspace = true, features = ["std"] }
+solana-signature = { workspace = true, features = ["std"] }
+solana-signer = { workspace = true }
 thiserror = { workspace = true }
 uriparse = { workspace = true }
 

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -29,6 +29,7 @@ uriparse = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
 
 [features]
 default = ["linux-static-hidraw", "hidapi"]

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -13,7 +13,8 @@ use {
     crate::{ledger_error::LedgerError, locator::Manufacturer},
     log::*,
     num_traits::FromPrimitive,
-    solana_sdk::{pubkey::Pubkey, signature::Signature},
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
     std::{cmp::min, convert::TryFrom},
 };
 
@@ -531,8 +532,8 @@ impl RemoteWallet<hidapi::DeviceInfo> for LedgerWallet {
         message: &[u8],
     ) -> Result<Signature, RemoteWalletError> {
         if message.len()
-            > solana_sdk::offchain_message::v0::OffchainMessage::MAX_LEN_LEDGER
-                + solana_sdk::offchain_message::v0::OffchainMessage::HEADER_LEN
+            > solana_offchain_message::v0::OffchainMessage::MAX_LEN_LEDGER
+                + solana_offchain_message::v0::OffchainMessage::HEADER_LEN
         {
             return Err(RemoteWalletError::InvalidInput(
                 "Off-chain message to sign is too long".to_string(),

--- a/remote-wallet/src/locator.rs
+++ b/remote-wallet/src/locator.rs
@@ -1,5 +1,5 @@
 use {
-    solana_sdk::pubkey::{ParsePubkeyError, Pubkey},
+    solana_pubkey::{ParsePubkeyError, Pubkey},
     std::{
         convert::{Infallible, TryFrom, TryInto},
         str::FromStr,

--- a/remote-wallet/src/remote_keypair.rs
+++ b/remote-wallet/src/remote_keypair.rs
@@ -8,10 +8,9 @@ use {
         },
     },
     solana_derivation_path::DerivationPath,
-    solana_sdk::{
-        pubkey::Pubkey,
-        signature::{Signature, Signer, SignerError},
-    },
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
+    solana_signer::{Signer, SignerError},
 };
 
 pub struct RemoteKeypair {

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -9,10 +9,9 @@ use {
     log::*,
     parking_lot::RwLock,
     solana_derivation_path::{DerivationPath, DerivationPathError},
-    solana_sdk::{
-        pubkey::Pubkey,
-        signature::{Signature, SignerError},
-    },
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
+    solana_signer::SignerError,
     std::{
         rc::Rc,
         time::{Duration, Instant},
@@ -336,7 +335,7 @@ mod tests {
 
     #[test]
     fn test_parse_locator() {
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let locator = Locator {
             manufacturer: Manufacturer::Ledger,
             pubkey: Some(pubkey),
@@ -369,7 +368,7 @@ mod tests {
 
     #[test]
     fn test_remote_wallet_info_matches() {
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let info = RemoteWalletInfo {
             manufacturer: Manufacturer::Ledger,
             model: "Nano S".to_string(),
@@ -391,7 +390,7 @@ mod tests {
         assert!(info.matches(&test_info));
         test_info.host_device_path = "/host/device/path".to_string();
         assert!(info.matches(&test_info));
-        let another_pubkey = solana_sdk::pubkey::new_rand();
+        let another_pubkey = solana_pubkey::new_rand();
         test_info.pubkey = another_pubkey;
         assert!(!info.matches(&test_info));
         test_info.pubkey = pubkey;
@@ -400,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_get_pretty_path() {
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let pubkey_str = pubkey.to_string();
         let remote_wallet_info = RemoteWalletInfo {
             model: "nano-s".to_string(),

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6365,7 +6365,10 @@ dependencies = [
  "qstring",
  "semver",
  "solana-derivation-path",
- "solana-sdk",
+ "solana-offchain-message",
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
  "thiserror 2.0.6",
  "uriparse",
 ]


### PR DESCRIPTION
#### Problem
solana-remote-wallet can compile faster by replacing solana-sdk with its constituent crates

#### Summary of Changes
Do that

This branches off #3443 so that needs to be merged first
