### PR TITLE
svm: skip appending loaders to loaded accounts

### DIFF
--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -110,7 +110,7 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
     transaction_ref: Option<&'a SanitizedTransaction>,
     transaction_accounts: &'a [TransactionAccount],
 ) {
-    for (i, (address, account)) in transaction_accounts.iter().enumerate() {
+    for (i, (address, account)) in (0..transaction.account_keys().len()).zip(transaction_accounts) {
         if !transaction.is_writable(i) {
             continue;
         }

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -110,7 +110,7 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
     transaction_ref: Option<&'a SanitizedTransaction>,
     transaction_accounts: &'a [TransactionAccount],
 ) {
-    for (i, (address, account)) in (0..transaction.account_keys().len()).zip(transaction_accounts) {
+    for (i, (address, account)) in transaction_accounts.iter().enumerate() {
         if !transaction.is_writable(i) {
             continue;
         }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -248,7 +248,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
         message: &impl SVMMessage,
         transaction_accounts: &[TransactionAccount],
     ) {
-        for (i, (address, account)) in transaction_accounts.iter().enumerate() {
+        for (i, (address, account)) in (0..message.account_keys().len()).zip(transaction_accounts) {
             if !message.is_writable(i) {
                 continue;
             }


### PR DESCRIPTION
#### Problem
after transaction account loading, all bpf loaders required for instruction program ids are loaded, validated, counted against transaction size, and appended to the accounts list. validating and counting them is necessary according to current consensus rules, but adding them to accounts is not. all bpf loaders are resident in the batch-local program cache by design, otherwise cpi would not work

#### Summary of Changes
stop appending them to the accounts list. we also take the opportunity to do some minor housekeeping:
* the previous flow was quite obscure: after account loading, it would record the last index of the accounts list, then skip loading the loader if it was found _past_ this index, otherwise validate and append it. this was very easy to misread as loading each loader every time it was used, instead of loading each loader at most once. we use a hashset of validated loader ids now to make this clearer
* dont accumulate a list of found account booleans, just load the program account again. `load_account()` is idempotent in its return value, and the second call for an existing account comes from the intermediate account cache, instead of accounts-db
* get program ids from the message iterator directly instead of extracting them from the accumulated accounts list
* load the loader with `load_account()`, instead of bypassing normal account loading and going directly to accounts-db

overall this pr is a minor cleanup with no effect on runtime behavior. what this code actually does will change several times in the future as feature gates are activated, but eventually when [simd186](https://github.com/solana-foundation/solana-improvement-documents/pull/186) is implemented we expect to be able to delete it entirely