### PR TITLE
Startup only sets latest_full_snapshot_slot if generating snapshots

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1614,6 +1614,7 @@ pub struct AccountsDb {
     pub epoch_accounts_hash_manager: EpochAccountsHashManager,
 
     /// The latest full snapshot slot dictates how to handle zero lamport accounts
+    /// Note, this is None if we're told to *not* take snapshots
     latest_full_snapshot_slot: SeqLock<Option<Slot>>,
 
     /// Flag to indicate if the experimental accounts lattice hash is enabled.

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -335,10 +335,20 @@ fn bank_forks_from_snapshot(
     // We must inform accounts-db of the latest full snapshot slot, which is used by the background
     // processes to handle zero lamport accounts.  Since we've now successfully loaded the bank
     // from snapshots, this is a good time to do that update.
-    bank.rc
-        .accounts
-        .accounts_db
-        .set_latest_full_snapshot_slot(full_snapshot_archive_info.slot());
+    // Note, this must only be set if we should generate snapshots.
+    if snapshot_config.should_generate_snapshots() {
+        bank.rc
+            .accounts
+            .accounts_db
+            .set_latest_full_snapshot_slot(full_snapshot_archive_info.slot());
+    } else {
+        assert!(bank
+            .rc
+            .accounts
+            .accounts_db
+            .latest_full_snapshot_slot()
+            .is_none());
+    }
 
     let full_snapshot_hash = FullSnapshotHash((
         full_snapshot_archive_info.slot(),


### PR DESCRIPTION
#### Problem

AccountsDb uses the latest full snapshot slot to gate how much, and what, to clean/etc. The latest full snapshot slot is updated every time a new full snapshot is taken.

If snapshots are *disabled*, then the latest full snapshot slot is never updated, and we cannot purge zero lamport accounts past the latest full snapshot slot.

The accounts-db code is aware of this though. If `latest_full_snapshot_slot` is None, we can clean everything. Yay!

The problem is that we *always* set the latest full snapshot slot at startup to Some, thus we never clean zero lamport accounts past the startup full snapshot slot!


#### Summary of Changes

If we're not generating snapshots, the latest full snapshot slot should be None.