### PR TITLE
add wait loop for epoch accounts hash test

### DIFF
--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -342,14 +342,19 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
         if bank.slot() == epoch_accounts_hash_utils::calculation_stop(&bank) {
             // Sometimes AHV does not get scheduled to run, which causes the test to fail
             // spuriously.  Sleep a bit here to ensure AHV gets a chance to run.
-            std::thread::sleep(Duration::from_secs(1));
-            let actual_epoch_accounts_hash = bank.epoch_accounts_hash();
-            debug!(
-                "slot {},   actual epoch accounts hash: {:?}",
-                bank.slot(),
-                actual_epoch_accounts_hash,
-            );
-            assert_eq!(expected_epoch_accounts_hash, actual_epoch_accounts_hash);
+            for _i in 0..10 {
+                let actual_epoch_accounts_hash = bank.epoch_accounts_hash();
+                if actual_epoch_accounts_hash == expected_epoch_accounts_hash {
+                    break;
+                }
+                std::thread::sleep(Duration::from_secs(1));
+                debug!(
+                    "slot {},   actual epoch accounts hash: {:?}",
+                    bank.slot(),
+                    actual_epoch_accounts_hash,
+                );
+            }
+            assert_eq!(expected_epoch_accounts_hash, bank.epoch_accounts_hash());
         }
 
         // Give the background services a chance to run


### PR DESCRIPTION
#### Problem

epoch accounts hash test fails spuriously on CI if we don't wait enough for the EAH to be calculated.

https://buildkite.com/anza/agave/builds/13832#019327d4-2d30-4383-85eb-d8a1b3b57805

```
failures:
    test_epoch_accounts_hash_basic::without_snapshots
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 24.35s
--- STDERR:              solana-core::epoch_accounts_hash test_epoch_accounts_hash_basic::without_snapshots ---
thread 'test_epoch_accounts_hash_basic::without_snapshots' panicked at core/tests/epoch_accounts_hash.rs:352:13:
assertion `left == right` failed
  left: Some(EpochAccountsHash(HwggTB33Gp8fziXTD3ArzXu1wh1GAnRxvdGeEK3TAgwF))
 right: None
stack backtrace:
   0: rust_begin_unwind
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/panicking.rs:74:14
   2: core::panicking::assert_failed_inner
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/panicking.rs:410:17
   3: core::panicking::assert_failed
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/panicking.rs:365:5
   4: epoch_accounts_hash::test_epoch_accounts_hash_basic
             at ./tests/epoch_accounts_hash.rs:352:13
   5: epoch_accounts_hash::test_epoch_accounts_hash_basic::without_snapshots
             at ./tests/epoch_accounts_hash.rs:258:1
   6: epoch_accounts_hash::test_epoch_accounts_hash_basic::without_snapshots::{{closure}}
             at ./tests/epoch_accounts_hash.rs:258:80
   7: core::ops::function::FnOnce::call_once
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/ops/function.rs:250:5
   8: core::ops::function::FnOnce::call_once
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

We can increate the wait time to make the test more robust. 

#### Summary of Changes

Add a wait loop of max 10 iteration for epoch accounts hash test


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
