### PR TITLE
update quinn-proto to 0.11.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,7 +368,7 @@ protobuf-src = "1.1.0"
 qstring = "0.7.2"
 qualifier_attr = { version = "0.2.2", default-features = false }
 quinn = "0.11.6"
-quinn-proto = "0.11.7"
+quinn-proto = "0.11.9"
 quote = "1.0"
 rand = "0.8.5"
 rand0-7 = { package = "rand", version = "0.7" }


### PR DESCRIPTION
#### Problem

Updated Quinn-proto to 0.11.9 to take advantage of some new enhancements

#### Summary of Changes

Updated cargo.toml to use Quinn-proto 0.11.9

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
