### PR TITLE
Refactors cached_frozen_slots()

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -259,20 +259,13 @@ impl AccountsCache {
     }
 
     pub fn cached_frozen_slots(&self) -> Vec<Slot> {
-        let mut slots: Vec<_> = self
-            .cache
+        self.cache
             .iter()
             .filter_map(|item| {
                 let (slot, slot_cache) = item.pair();
-                if slot_cache.is_frozen() {
-                    Some(*slot)
-                } else {
-                    None
-                }
+                slot_cache.is_frozen().then_some(*slot)
             })
-            .collect();
-        slots.sort_unstable();
-        slots
+            .collect()
     }
 
     pub fn contains(&self, slot: Slot) -> bool {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6172,7 +6172,8 @@ impl AccountsDb {
         let mut unflushable_unrooted_slot_count = 0;
         let max_flushed_root = self.accounts_cache.fetch_max_flush_root();
         if self.should_aggressively_flush_cache() {
-            let old_slots = self.accounts_cache.cached_frozen_slots();
+            let mut old_slots = self.accounts_cache.cached_frozen_slots();
+            old_slots.sort_unstable();
             excess_slot_count = old_slots.len();
             let mut flush_stats = FlushStats::default();
             old_slots.into_iter().for_each(|old_slot| {


### PR DESCRIPTION
#### Problem

The accounts write cache `cached_frozen_slots()` can be refactored to use `Bool::then_some()`. And also move the sorting to the caller, as the API doesn't indicate the results will be sorted. This way the caller can decide what is important for their usage.


#### Summary of Changes

Refactor the fn.