### PR TITLE
adjust pubkey bins for tests

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -514,7 +514,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     num_clean_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
-    hash_calculation_pubkey_bins: None,
+    hash_calculation_pubkey_bins: Some(4),
 };
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),


### PR DESCRIPTION
#### Problem

The default pubkey bins for hash calculation in account's db config is 64K. 

For tests on CI, this number is way too much for the small number of accounts created in tests. Most of the bins will be empty. 

So we should make the bin number smaller and speed up those tests.


#### Summary of Changes

Choose a small number (i.e. 4) for pubkey bin in test account's db config.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
