### PR TITLE
blockstore: Call LedgerColumn methods instead of Database

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -49,7 +49,7 @@ fn analyze_column<
     let mut val_hist = histogram::Histogram::new();
     let mut val_tot: u64 = 0;
     let mut row_hist = histogram::Histogram::new();
-    for (key, val) in db.iter::<C>(blockstore_db::IteratorMode::Start)? {
+    for (key, val) in db.column::<C>().iter(blockstore_db::IteratorMode::Start)? {
         // Key length is fixed, only need to calculate it once
         if key_len == 0 {
             key_len = C::key(key).len() as u64;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3903,7 +3903,7 @@ impl Blockstore {
     }
 
     pub fn is_root(&self, slot: Slot) -> bool {
-        matches!(self.db.get::<cf::Root>(slot), Ok(Some(true)))
+        matches!(self.roots_cf.get(slot), Ok(Some(true)))
     }
 
     /// Returns true if a slot is between the rooted slot bounds of the ledger, but has not itself
@@ -3915,7 +3915,7 @@ impl Blockstore {
             .ok()
             .and_then(|mut iter| iter.next())
             .unwrap_or_default();
-        match self.db.get::<cf::Root>(slot).ok().flatten() {
+        match self.roots_cf.get(slot).ok().flatten() {
             Some(_) => false,
             None => slot < self.max_root() && slot > lowest_root,
         }
@@ -4028,8 +4028,8 @@ impl Blockstore {
 
     pub fn is_dead(&self, slot: Slot) -> bool {
         matches!(
-            self.db
-                .get::<cf::DeadSlots>(slot)
+            self.dead_slots_cf
+                .get(slot)
                 .expect("fetch from DeadSlots column family failed"),
             Some(true)
         )

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -371,8 +371,8 @@ impl Blockstore {
         let db = Arc::new(db);
 
         // Get max root or 0 if it doesn't exist
-        let max_root = db
-            .iter::<cf::Root>(IteratorMode::End)?
+        let max_root = roots_cf
+            .iter(IteratorMode::End)?
             .next()
             .map(|(slot, _)| slot)
             .unwrap_or(0);
@@ -611,8 +611,8 @@ impl Blockstore {
         slot: Slot,
     ) -> Result<impl Iterator<Item = (Slot, SlotMeta)> + '_> {
         let meta_iter = self
-            .db
-            .iter::<cf::SlotMeta>(IteratorMode::From(slot, IteratorDirection::Forward))?;
+            .meta_cf
+            .iter(IteratorMode::From(slot, IteratorDirection::Forward))?;
         Ok(meta_iter.map(|(slot, slot_meta_bytes)| {
             (
                 slot,
@@ -639,7 +639,7 @@ impl Blockstore {
         slot: Slot,
         index: u64,
     ) -> Result<impl Iterator<Item = ((u64, u64), Box<[u8]>)> + '_> {
-        let slot_iterator = self.db.iter::<cf::ShredData>(IteratorMode::From(
+        let slot_iterator = self.data_shred_cf.iter(IteratorMode::From(
             (slot, index),
             IteratorDirection::Forward,
         ))?;
@@ -651,7 +651,7 @@ impl Blockstore {
         slot: Slot,
         index: u64,
     ) -> Result<impl Iterator<Item = ((u64, u64), Box<[u8]>)> + '_> {
-        let slot_iterator = self.db.iter::<cf::ShredCode>(IteratorMode::From(
+        let slot_iterator = self.code_shred_cf.iter(IteratorMode::From(
             (slot, index),
             IteratorDirection::Forward,
         ))?;
@@ -663,9 +663,7 @@ impl Blockstore {
         slot: Slot,
         direction: IteratorDirection,
     ) -> Result<impl Iterator<Item = Slot> + '_> {
-        let slot_iterator = self
-            .db
-            .iter::<cf::Root>(IteratorMode::From(slot, direction))?;
+        let slot_iterator = self.roots_cf.iter(IteratorMode::From(slot, direction))?;
         Ok(slot_iterator.map(move |(rooted_slot, _)| rooted_slot))
     }
 
@@ -683,7 +681,7 @@ impl Blockstore {
     pub fn reversed_optimistic_slots_iterator(
         &self,
     ) -> Result<impl Iterator<Item = (Slot, Hash, UnixTimestamp)> + '_> {
-        let iter = self.db.iter::<cf::OptimisticSlots>(IteratorMode::End)?;
+        let iter = self.optimistic_slots_cf.iter(IteratorMode::End)?;
         Ok(iter.map(|(slot, bytes)| {
             let meta: OptimisticSlotMetaVersioned = deserialize(&bytes).unwrap();
             (slot, meta.hash(), meta.timestamp())
@@ -3479,27 +3477,27 @@ impl Blockstore {
         // or `PerfSampleV2` encoding.  We expect `PerfSampleV1` to be a prefix of the
         // `PerfSampleV2` encoding (see [`perf_sample_v1_is_prefix_of_perf_sample_v2`]), so we try
         // them in order.
-        let samples = self
-            .db
-            .iter::<cf::PerfSamples>(IteratorMode::End)?
-            .take(num)
-            .map(|(slot, data)| {
-                deserialize::<PerfSampleV2>(&data)
-                    .map(|sample| (slot, sample.into()))
-                    .or_else(|err| {
-                        match &*err {
-                            bincode::ErrorKind::Io(io_err)
-                                if matches!(io_err.kind(), ErrorKind::UnexpectedEof) =>
-                            {
-                                // Not enough bytes to deserialize as `PerfSampleV2`.
+        let samples =
+            self.perf_samples_cf
+                .iter(IteratorMode::End)?
+                .take(num)
+                .map(|(slot, data)| {
+                    deserialize::<PerfSampleV2>(&data)
+                        .map(|sample| (slot, sample.into()))
+                        .or_else(|err| {
+                            match &*err {
+                                bincode::ErrorKind::Io(io_err)
+                                    if matches!(io_err.kind(), ErrorKind::UnexpectedEof) =>
+                                {
+                                    // Not enough bytes to deserialize as `PerfSampleV2`.
+                                }
+                                _ => return Err(err),
                             }
-                            _ => return Err(err),
-                        }
 
-                        deserialize::<PerfSampleV1>(&data).map(|sample| (slot, sample.into()))
-                    })
-                    .map_err(Into::into)
-            });
+                            deserialize::<PerfSampleV1>(&data).map(|sample| (slot, sample.into()))
+                        })
+                        .map_err(Into::into)
+                });
 
         samples.collect()
     }
@@ -3513,8 +3511,8 @@ impl Blockstore {
 
     pub fn read_program_costs(&self) -> Result<Vec<(Pubkey, u64)>> {
         Ok(self
-            .db
-            .iter::<cf::ProgramCosts>(IteratorMode::End)?
+            .program_costs_cf
+            .iter(IteratorMode::End)?
             .map(|(pubkey, data)| {
                 let program_cost: ProgramCost = deserialize(&data).unwrap();
                 (pubkey, program_cost.cost)
@@ -4051,8 +4049,8 @@ impl Blockstore {
 
     pub fn get_first_duplicate_proof(&self) -> Option<(Slot, DuplicateSlotProof)> {
         let mut iter = self
-            .db
-            .iter::<cf::DuplicateSlots>(IteratorMode::From(0, IteratorDirection::Forward))
+            .duplicate_slots_cf
+            .iter(IteratorMode::From(0, IteratorDirection::Forward))
             .unwrap();
         iter.next()
             .map(|(slot, proof_bytes)| (slot, deserialize(&proof_bytes).unwrap()))
@@ -4099,22 +4097,22 @@ impl Blockstore {
 
     pub fn orphans_iterator(&self, slot: Slot) -> Result<impl Iterator<Item = u64> + '_> {
         let orphans_iter = self
-            .db
-            .iter::<cf::Orphans>(IteratorMode::From(slot, IteratorDirection::Forward))?;
+            .orphans_cf
+            .iter(IteratorMode::From(slot, IteratorDirection::Forward))?;
         Ok(orphans_iter.map(|(slot, _)| slot))
     }
 
     pub fn dead_slots_iterator(&self, slot: Slot) -> Result<impl Iterator<Item = Slot> + '_> {
         let dead_slots_iterator = self
-            .db
-            .iter::<cf::DeadSlots>(IteratorMode::From(slot, IteratorDirection::Forward))?;
+            .dead_slots_cf
+            .iter(IteratorMode::From(slot, IteratorDirection::Forward))?;
         Ok(dead_slots_iterator.map(|(slot, _)| slot))
     }
 
     pub fn duplicate_slots_iterator(&self, slot: Slot) -> Result<impl Iterator<Item = Slot> + '_> {
         let duplicate_slots_iterator = self
-            .db
-            .iter::<cf::DuplicateSlots>(IteratorMode::From(slot, IteratorDirection::Forward))?;
+            .duplicate_slots_cf
+            .iter(IteratorMode::From(slot, IteratorDirection::Forward))?;
         Ok(duplicate_slots_iterator.map(|(slot, _)| slot))
     }
 
@@ -4168,8 +4166,8 @@ impl Blockstore {
     /// Returns the highest available slot in the blockstore
     pub fn highest_slot(&self) -> Result<Option<Slot>> {
         let highest_slot = self
-            .db
-            .iter::<cf::SlotMeta>(IteratorMode::End)?
+            .meta_cf
+            .iter(IteratorMode::End)?
             .next()
             .map(|(slot, _)| slot);
         Ok(highest_slot)
@@ -5166,85 +5164,85 @@ pub fn make_many_slot_entries(
 // test-only: check that all columns are either empty or start at `min_slot`
 pub fn test_all_empty_or_min(blockstore: &Blockstore, min_slot: Slot) {
     let condition_met = blockstore
-        .db
-        .iter::<cf::SlotMeta>(IteratorMode::Start)
+        .meta_cf
+        .iter(IteratorMode::Start)
         .unwrap()
         .next()
         .map(|(slot, _)| slot >= min_slot)
         .unwrap_or(true)
         & blockstore
-            .db
-            .iter::<cf::Root>(IteratorMode::Start)
+            .roots_cf
+            .iter(IteratorMode::Start)
             .unwrap()
             .next()
             .map(|(slot, _)| slot >= min_slot)
             .unwrap_or(true)
         & blockstore
-            .db
-            .iter::<cf::ShredData>(IteratorMode::Start)
+            .data_shred_cf
+            .iter(IteratorMode::Start)
             .unwrap()
             .next()
             .map(|((slot, _), _)| slot >= min_slot)
             .unwrap_or(true)
         & blockstore
-            .db
-            .iter::<cf::ShredCode>(IteratorMode::Start)
+            .code_shred_cf
+            .iter(IteratorMode::Start)
             .unwrap()
             .next()
             .map(|((slot, _), _)| slot >= min_slot)
             .unwrap_or(true)
         & blockstore
-            .db
-            .iter::<cf::DeadSlots>(IteratorMode::Start)
+            .dead_slots_cf
+            .iter(IteratorMode::Start)
             .unwrap()
             .next()
             .map(|(slot, _)| slot >= min_slot)
             .unwrap_or(true)
         & blockstore
-            .db
-            .iter::<cf::DuplicateSlots>(IteratorMode::Start)
+            .duplicate_slots_cf
+            .iter(IteratorMode::Start)
             .unwrap()
             .next()
             .map(|(slot, _)| slot >= min_slot)
             .unwrap_or(true)
         & blockstore
-            .db
-            .iter::<cf::ErasureMeta>(IteratorMode::Start)
+            .erasure_meta_cf
+            .iter(IteratorMode::Start)
             .unwrap()
             .next()
             .map(|((slot, _), _)| slot >= min_slot)
             .unwrap_or(true)
         & blockstore
-            .db
-            .iter::<cf::Orphans>(IteratorMode::Start)
+            .orphans_cf
+            .iter(IteratorMode::Start)
             .unwrap()
             .next()
             .map(|(slot, _)| slot >= min_slot)
             .unwrap_or(true)
         & blockstore
-            .db
-            .iter::<cf::Index>(IteratorMode::Start)
+            .index_cf
+            .iter(IteratorMode::Start)
             .unwrap()
             .next()
             .map(|(slot, _)| slot >= min_slot)
             .unwrap_or(true)
         & blockstore
-            .db
-            .iter::<cf::TransactionStatus>(IteratorMode::Start)
+            .transaction_status_cf
+            .iter(IteratorMode::Start)
             .unwrap()
             .next()
             .map(|((_, slot), _)| slot >= min_slot || slot == 0)
             .unwrap_or(true)
         & blockstore
-            .db
-            .iter::<cf::AddressSignatures>(IteratorMode::Start)
+            .address_signatures_cf
+            .iter(IteratorMode::Start)
             .unwrap()
             .next()
             .map(|((_, slot, _, _), _)| slot >= min_slot || slot == 0)
             .unwrap_or(true)
         & blockstore
-            .db
-            .iter::<cf::Rewards>(IteratorMode::Start)
+            .rewards_cf
+            .iter(IteratorMode::Start)
             .unwrap()
             .next()
             .map(|(slot, _)| slot >= min_slot)

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -597,8 +597,8 @@ pub mod tests {
         blockstore.run_purge(10, 20, PurgeType::Exact).unwrap();
 
         let status_entries: Vec<_> = blockstore
-            .db
-            .iter::<cf::TransactionStatus>(IteratorMode::Start)
+            .transaction_status_cf
+            .iter(IteratorMode::Start)
             .unwrap()
             .collect();
         assert_eq!(status_entries.len(), 10);
@@ -607,8 +607,8 @@ pub mod tests {
     fn clear_and_repopulate_transaction_statuses_for_test(blockstore: &Blockstore, max_slot: u64) {
         blockstore.run_purge(0, max_slot, PurgeType::Exact).unwrap();
         let mut iter = blockstore
-            .db
-            .iter::<cf::TransactionStatus>(IteratorMode::Start)
+            .transaction_status_cf
+            .iter(IteratorMode::Start)
             .unwrap();
         assert_eq!(iter.next(), None);
 
@@ -758,8 +758,8 @@ pub mod tests {
         blockstore.run_purge(10, 12, PurgeType::Exact).unwrap();
 
         let mut status_entry_iterator = blockstore
-            .db
-            .iter::<cf::TransactionStatus>(IteratorMode::Start)
+            .transaction_status_cf
+            .iter(IteratorMode::Start)
             .unwrap();
         for _ in 0..max_slot + 1 {
             let entry = status_entry_iterator.next().unwrap().0;
@@ -773,8 +773,8 @@ pub mod tests {
         blockstore.run_purge(2, 4, PurgeType::Exact).unwrap();
 
         let mut status_entry_iterator = blockstore
-            .db
-            .iter::<cf::TransactionStatus>(IteratorMode::Start)
+            .transaction_status_cf
+            .iter(IteratorMode::Start)
             .unwrap();
         for _ in 0..7 {
             // 7 entries remaining
@@ -791,8 +791,8 @@ pub mod tests {
             .unwrap();
 
         let mut status_entry_iterator = blockstore
-            .db
-            .iter::<cf::TransactionStatus>(IteratorMode::Start)
+            .transaction_status_cf
+            .iter(IteratorMode::Start)
             .unwrap();
         let entry = status_entry_iterator.next().unwrap().0;
         assert_eq!(entry.1, 9);
@@ -804,8 +804,8 @@ pub mod tests {
         blockstore.run_purge(0, 22, PurgeType::Exact).unwrap();
 
         let mut status_entry_iterator = blockstore
-            .db
-            .iter::<cf::TransactionStatus>(IteratorMode::Start)
+            .transaction_status_cf
+            .iter(IteratorMode::Start)
             .unwrap();
         assert_eq!(status_entry_iterator.next(), None);
     }
@@ -1002,15 +1002,15 @@ pub mod tests {
         clear_and_repopulate_transaction_statuses_for_test(&blockstore, max_slot);
         let first_index = {
             let mut status_entry_iterator = blockstore
-                .db
-                .iter::<cf::TransactionStatus>(IteratorMode::Start)
+                .transaction_status_cf
+                .iter(IteratorMode::Start)
                 .unwrap();
             status_entry_iterator.next().unwrap().0
         };
         let last_index = {
             let mut status_entry_iterator = blockstore
-                .db
-                .iter::<cf::TransactionStatus>(IteratorMode::End)
+                .transaction_status_cf
+                .iter(IteratorMode::End)
                 .unwrap();
             status_entry_iterator.next().unwrap().0
         };
@@ -1023,8 +1023,8 @@ pub mod tests {
         );
 
         let status_entry_iterator = blockstore
-            .db
-            .iter::<cf::TransactionStatus>(IteratorMode::Start)
+            .transaction_status_cf
+            .iter(IteratorMode::Start)
             .unwrap();
         let mut count = 0;
         for ((_signature, slot), _value) in status_entry_iterator {
@@ -1036,15 +1036,15 @@ pub mod tests {
         clear_and_repopulate_transaction_statuses_for_test(&blockstore, max_slot);
         let first_index = {
             let mut status_entry_iterator = blockstore
-                .db
-                .iter::<cf::TransactionStatus>(IteratorMode::Start)
+                .transaction_status_cf
+                .iter(IteratorMode::Start)
                 .unwrap();
             status_entry_iterator.next().unwrap().0
         };
         let last_index = {
             let mut status_entry_iterator = blockstore
-                .db
-                .iter::<cf::TransactionStatus>(IteratorMode::End)
+                .transaction_status_cf
+                .iter(IteratorMode::End)
                 .unwrap();
             status_entry_iterator.next().unwrap().0
         };
@@ -1057,8 +1057,8 @@ pub mod tests {
         );
 
         let status_entry_iterator = blockstore
-            .db
-            .iter::<cf::TransactionStatus>(IteratorMode::Start)
+            .transaction_status_cf
+            .iter(IteratorMode::Start)
             .unwrap();
         let mut count = 0;
         for ((_signature, slot), _value) in status_entry_iterator {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1437,21 +1437,6 @@ impl Database {
         }
     }
 
-    pub fn iter<C>(
-        &self,
-        iterator_mode: IteratorMode<C::Index>,
-    ) -> Result<impl Iterator<Item = (C::Index, Box<[u8]>)> + '_>
-    where
-        C: Column + ColumnName,
-    {
-        let cf = self.cf_handle::<C>();
-        let iter = self.backend.iterator_cf::<C>(cf, iterator_mode);
-        Ok(iter.map(|pair| {
-            let (key, value) = pair.unwrap();
-            (C::index(&key), value)
-        }))
-    }
-
     #[inline]
     pub fn cf_handle<C>(&self) -> &ColumnFamily
     where

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1422,21 +1422,6 @@ impl Database {
         Ok(())
     }
 
-    pub fn get<C>(&self, key: C::Index) -> Result<Option<C::Type>>
-    where
-        C: TypedColumn + ColumnName,
-    {
-        if let Some(pinnable_slice) = self
-            .backend
-            .get_pinned_cf(self.cf_handle::<C>(), &C::key(key))?
-        {
-            let value = deserialize(pinnable_slice.as_ref())?;
-            Ok(Some(value))
-        } else {
-            Ok(None)
-        }
-    }
-
     #[inline]
     pub fn cf_handle<C>(&self) -> &ColumnFamily
     where


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/3603 is looking to introduce a change where the rocksdb keys (byte reference) will be stack-allocated instead of heap-allocated. In order to accomplish this, any method that provides a key (ie just about all of them) need to go through the `LedgerColumn` object since each `LedgerColumn` has a constant key length that is known at compile time.

On the other hand, the `Database` functions that operate on a `Column` take a `Column` as a generic parameter. Since that function is generic over any column, the key must be heap allocated as we can't know what the key length will be until invocation. So, we need to phase out the `Database` calls in order to work towards the stack allocated keys.

This PR pulls breaks several commits out of https://github.com/anza-xyz/agave/pull/3603 to keep reviews smaller

#### Summary of Changes
Use the `LedgerColumn` objects in `Blockstore` to perform `get()` and `iter()` calls instead of getting it from the `Database` object directly