### PR TITLE
move solana_sdk::transaction::Result to solana_transaction_error

### DIFF
--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -144,7 +144,7 @@ pub use solana_transaction_error::{
     since = "2.2.0",
     note = "Use `solana_transaction_error::TransactionResult` instead"
 )]
-pub type Result<T> = solana_transaction_error::TransactionResult<T>;
+pub use solana_transaction_error::TransactionResult as Result;
 pub use {sanitized::*, versioned::*};
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -138,9 +138,13 @@ mod versioned;
 
 #[deprecated(since = "2.1.0", note = "Use solana_transaction_error crate instead")]
 pub use solana_transaction_error::{
-    AddressLoaderError, SanitizeMessageError, TransactionError, TransactionResult as Result,
-    TransportError, TransportResult,
+    AddressLoaderError, SanitizeMessageError, TransactionError, TransportError, TransportResult,
 };
+#[deprecated(
+    since = "2.2.0",
+    note = "Use `solana_transaction_error::TransactionResult` instead"
+)]
+pub type Result<T> = solana_transaction_error::TransactionResult<T>;
 pub use {sanitized::*, versioned::*};
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -137,7 +137,10 @@ mod sanitized;
 mod versioned;
 
 #[deprecated(since = "2.1.0", note = "Use solana_transaction_error crate instead")]
-pub use solana_transaction_error::*;
+pub use solana_transaction_error::{
+    AddressLoaderError, SanitizeMessageError, TransactionError, TransactionResult as Result,
+    TransportError, TransportResult,
+};
 pub use {sanitized::*, versioned::*};
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -146,8 +149,6 @@ pub enum TransactionVerificationMode {
     HashAndVerifyPrecompiles,
     FullVerification,
 }
-
-pub type Result<T> = result::Result<T, TransactionError>;
 
 /// An atomically-committed sequence of instructions.
 ///

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -136,15 +136,15 @@ use {
 mod sanitized;
 mod versioned;
 
-#[deprecated(since = "2.1.0", note = "Use solana_transaction_error crate instead")]
-pub use solana_transaction_error::{
-    AddressLoaderError, SanitizeMessageError, TransactionError, TransportError, TransportResult,
-};
 #[deprecated(
     since = "2.2.0",
     note = "Use `solana_transaction_error::TransactionResult` instead"
 )]
 pub use solana_transaction_error::TransactionResult as Result;
+#[deprecated(since = "2.1.0", note = "Use solana_transaction_error crate instead")]
+pub use solana_transaction_error::{
+    AddressLoaderError, SanitizeMessageError, TransactionError, TransportError, TransportResult,
+};
 pub use {sanitized::*, versioned::*};
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -8,6 +8,8 @@ use {
     core::fmt, solana_instruction::error::InstructionError, solana_sanitize::SanitizeError, std::io,
 };
 
+pub type TransactionResult<T> = Result<T, TransactionError>;
+
 /// Reasons a transaction might be rejected.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -1820,7 +1820,6 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde",
  "typenum",
  "version_check",
 ]
@@ -4483,6 +4482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6615,9 +6623,9 @@ version = "2.2.0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
- "generic-array",
  "rand 0.8.5",
  "serde",
+ "serde-big-array",
  "serde_derive",
  "solana-sanitize",
 ]


### PR DESCRIPTION
#### Problem
`solana_sdk::transaction::Result` imposes a `solana_sdk` dependency on some RPC crates that otherwise don't need the transaction module. This type alias makes more sense next to TransactionError anyway

#### Summary of Changes
- Move it to `solana_transaction_error::TransactionResult` and re-export in `solana_sdk::transaction` with deprecation
- Make all the re-exports from `solana_transaction_error` explicit, otherwise the above gets confusing
