### PR TITLE
excludes deprecated values from pull responses

### DIFF
--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -401,9 +401,9 @@ impl Crds {
         cursor: &'a mut Cursor,
     ) -> impl Iterator<Item = &'a VersionedCrdsValue> {
         let range = (Bound::Included(cursor.ordinal()), Bound::Unbounded);
-        self.entries.range(range).map(move |(ordinal, index)| {
-            cursor.consume(*ordinal);
-            self.table.index(*index)
+        self.entries.range(range).map(move |(&ordinal, &index)| {
+            cursor.consume(ordinal);
+            self.table.index(index)
         })
     }
 
@@ -463,6 +463,7 @@ impl Crds {
 
     /// Returns all crds values which the first 'mask_bits'
     /// of their hash value is equal to 'mask'.
+    /// Excludes deprecated values.
     pub(crate) fn filter_bitmask(
         &self,
         mask: u64,
@@ -471,6 +472,7 @@ impl Crds {
         self.shards
             .find(mask, mask_bits)
             .map(move |i| self.table.index(i))
+            .filter(|VersionedCrdsValue { value, .. }| !value.data().is_deprecated())
     }
 
     /// Update the timestamp's of all the labels that are associated with Pubkey

--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -176,6 +176,28 @@ impl CrdsData {
             CrdsData::RestartHeaviestFork(fork) => fork.from,
         }
     }
+
+    #[inline]
+    #[must_use]
+    pub(crate) fn is_deprecated(&self) -> bool {
+        match self {
+            Self::LegacyContactInfo(_) => true,
+            Self::Vote(..) => false,
+            Self::LowestSlot(0, _) => false,
+            Self::LowestSlot(1.., _) => true,
+            Self::LegacySnapshotHashes(_) => true,
+            Self::AccountsHashes(_) => true,
+            Self::EpochSlots(..) => false,
+            Self::LegacyVersion(_) => true,
+            Self::Version(_) => true,
+            Self::NodeInstance(_) => true,
+            Self::DuplicateShred(..) => false,
+            Self::SnapshotHashes(_) => false,
+            Self::ContactInfo(_) => false,
+            Self::RestartLastVotedForkSlots(_) => false,
+            Self::RestartHeaviestFork(_) => false,
+        }
+    }
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -1820,7 +1820,6 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde",
  "typenum",
  "version_check",
 ]
@@ -4483,6 +4482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6615,9 +6623,9 @@ version = "2.2.0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
- "generic-array",
  "rand 0.8.5",
  "serde",
+ "serde-big-array",
  "serde_derive",
  "solana-sanitize",
 ]


### PR DESCRIPTION
#### Problem
Shouldn't waste bandwidth on propagating deperecated values.

#### Summary of Changes
The commit excludes deprecated values from pull responses.