### PR TITLE
Benchmarks for upgradeable loader instructions

### DIFF
--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -72,6 +72,10 @@ name = "solana_bpf_loader_program"
 name = "serialization"
 harness = false
 
+[[bench]]
+name = "bpf_loader_upgradeable"
+harness = false
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 

--- a/programs/bpf_loader/benches/bpf_loader_upgradeable.rs
+++ b/programs/bpf_loader/benches/bpf_loader_upgradeable.rs
@@ -1,0 +1,219 @@
+use {
+    criterion::{criterion_group, criterion_main, Criterion},
+    solana_account::{state_traits::StateMut, AccountSharedData},
+    solana_bpf_loader_program::Entrypoint,
+    solana_instruction::AccountMeta,
+    solana_program::{
+        bpf_loader_upgradeable::{self, UpgradeableLoaderState},
+        loader_upgradeable_instruction::UpgradeableLoaderInstruction,
+    },
+    solana_program_runtime::invoke_context::mock_process_instruction,
+    solana_pubkey::Pubkey,
+};
+
+#[derive(Default)]
+struct TestSetup {
+    loader_address: Pubkey,
+    authority_address: Pubkey,
+    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+
+    instruction_accounts: Vec<AccountMeta>,
+    instruction_data: Vec<u8>,
+}
+
+const ACCOUNT_BALANCE: u64 = u64::MAX / 4;
+const PROGRAM_BUFFER_SIZE: usize = 1024;
+
+impl TestSetup {
+    fn new() -> Self {
+        let loader_address = bpf_loader_upgradeable::id();
+        let buffer_address = Pubkey::new_unique();
+        let authority_address = Pubkey::new_unique();
+
+        let instruction_accounts = vec![AccountMeta {
+            pubkey: buffer_address,
+            is_signer: false,
+            is_writable: true,
+        }];
+        let transaction_accounts = vec![
+            (
+                buffer_address,
+                AccountSharedData::new(
+                    ACCOUNT_BALANCE,
+                    UpgradeableLoaderState::size_of_buffer(PROGRAM_BUFFER_SIZE),
+                    &loader_address,
+                ),
+            ),
+            (
+                authority_address,
+                AccountSharedData::new(ACCOUNT_BALANCE, 0, &loader_address),
+            ),
+        ];
+
+        Self {
+            loader_address,
+            authority_address,
+            transaction_accounts,
+            instruction_accounts,
+            ..TestSetup::default()
+        }
+    }
+
+    fn prep_initialize_buffer(&mut self) {
+        self.instruction_accounts.push(AccountMeta {
+            pubkey: self.authority_address,
+            is_signer: false,
+            is_writable: false,
+        });
+        self.instruction_data =
+            bincode::serialize(&UpgradeableLoaderInstruction::InitializeBuffer).unwrap();
+    }
+
+    fn prep_write(&mut self) {
+        self.instruction_accounts.push(AccountMeta {
+            pubkey: self.authority_address,
+            is_signer: true,
+            is_writable: false,
+        });
+
+        self.transaction_accounts[0]
+            .1
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(self.authority_address),
+            })
+            .unwrap();
+
+        self.instruction_data = bincode::serialize(&UpgradeableLoaderInstruction::Write {
+            offset: 0,
+            bytes: vec![64; PROGRAM_BUFFER_SIZE],
+        })
+        .unwrap();
+    }
+
+    fn prep_set_authority(&mut self, checked: bool) {
+        let new_authority_address = Pubkey::new_unique();
+        self.instruction_accounts.push(AccountMeta {
+            pubkey: self.authority_address,
+            is_signer: true,
+            is_writable: false,
+        });
+        self.instruction_accounts.push(AccountMeta {
+            pubkey: new_authority_address,
+            is_signer: checked,
+            is_writable: false,
+        });
+
+        self.transaction_accounts[0]
+            .1
+            .set_state(&UpgradeableLoaderState::ProgramData {
+                slot: 0,
+                upgrade_authority_address: Some(self.authority_address),
+            })
+            .unwrap();
+        self.transaction_accounts.push((
+            new_authority_address,
+            AccountSharedData::new(ACCOUNT_BALANCE, 0, &self.loader_address),
+        ));
+        let instruction = if checked {
+            UpgradeableLoaderInstruction::SetAuthorityChecked
+        } else {
+            UpgradeableLoaderInstruction::SetAuthority
+        };
+        self.instruction_data = bincode::serialize(&instruction).unwrap();
+    }
+
+    fn prep_close(&mut self) {
+        self.instruction_accounts.push(AccountMeta {
+            pubkey: self.authority_address,
+            is_signer: false,
+            is_writable: true,
+        });
+        self.instruction_accounts.push(AccountMeta {
+            pubkey: self.authority_address,
+            is_signer: true,
+            is_writable: false,
+        });
+
+        // lets use the same account for recipient and authority
+        self.transaction_accounts
+            .push(self.transaction_accounts[1].clone());
+        self.instruction_data = bincode::serialize(&UpgradeableLoaderInstruction::Close).unwrap();
+    }
+
+    fn run(&self) {
+        mock_process_instruction(
+            &self.loader_address,
+            Vec::new(),
+            &self.instruction_data,
+            self.transaction_accounts.clone(),
+            self.instruction_accounts.clone(),
+            Ok(()),
+            Entrypoint::vm,
+            |_invoke_context| {},
+            |_invoke_context| {},
+        );
+    }
+}
+
+fn bench_initialize_buffer(c: &mut Criterion) {
+    let mut test_setup = TestSetup::new();
+    test_setup.prep_initialize_buffer();
+
+    c.bench_function("initialize_buffer", |bencher| {
+        bencher.iter(|| test_setup.run())
+    });
+}
+
+fn bench_write(c: &mut Criterion) {
+    let mut test_setup = TestSetup::new();
+    test_setup.prep_write();
+
+    c.bench_function("write", |bencher| {
+        bencher.iter(|| {
+            test_setup.run();
+        })
+    });
+}
+
+fn bench_set_authority(c: &mut Criterion) {
+    let mut test_setup = TestSetup::new();
+    test_setup.prep_set_authority(false);
+
+    c.bench_function("set_authority", |bencher| {
+        bencher.iter(|| {
+            test_setup.run();
+        })
+    });
+}
+
+fn bench_close(c: &mut Criterion) {
+    let mut test_setup = TestSetup::new();
+    test_setup.prep_close();
+
+    c.bench_function("close", |bencher| {
+        bencher.iter(|| {
+            test_setup.run();
+        })
+    });
+}
+
+fn bench_set_authority_checked(c: &mut Criterion) {
+    let mut test_setup = TestSetup::new();
+    test_setup.prep_set_authority(true);
+
+    c.bench_function("set_authority_checked", |bencher| {
+        bencher.iter(|| {
+            test_setup.run();
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_initialize_buffer,
+    bench_write,
+    bench_set_authority,
+    bench_close,
+    bench_set_authority_checked
+);
+criterion_main!(benches);


### PR DESCRIPTION
#### Problem

Part of https://github.com/anza-xyz/agave/issues/3364, to benchmark each `loader` instructions to determine their static CU consumption.

This PR lacks 1 instruction:
* `DeployWithMaxDataLen` because whatever I tried it never returns `Ok`. I tried to create a test for this https://github.com/anza-xyz/agave/pull/3759 -- also no success.


#### Summary of Changes

add benches for each instruction, aiming to run through their happy-path.

#### Bmk run results

Machine: 48x AMD EPYC 7502P 32-Core Processor

```shell
Benchmarking initialize_buffer: Collecting 100 samples in estimated 5.0298 s (550k itera
initialize_buffer       time:   [9.1225 µs 9.1239 µs 9.1253 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high severe

write                   time:   [9.5727 µs 9.5749 µs 9.5771 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

Benchmarking upgradeable_upgrade: Collecting 100 samples in estimated 5.2428 s (101k ite
upgradeable_upgrade     time:   [47.692 µs 47.863 µs 48.079 µs]

Benchmarking set_authority: Collecting 100 samples in estimated 5.0219 s (475k iteration
set_authority           time:   [10.582 µs 10.584 µs 10.586 µs]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

close                   time:   [10.217 µs 10.220 µs 10.224 µs]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

Benchmarking extend_program/64: Collecting 100 samples in estimated 5.1122 s (101k itera
extend_program/64       time:   [45.792 µs 45.961 µs 46.186 µs]
                        thrpt:  [1.3215 MiB/s 1.3280 MiB/s 1.3329 MiB/s]
Benchmarking extend_program/256: Collecting 100 samples in estimated 5.1309 s (101k iter
extend_program/256      time:   [50.421 µs 50.439 µs 50.458 µs]
                        thrpt:  [4.8385 MiB/s 4.8403 MiB/s 4.8420 MiB/s]
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
Benchmarking extend_program/1024: Collecting 100 samples in estimated 5.0467 s (101k ite
extend_program/1024     time:   [46.170 µs 46.180 µs 46.192 µs]
                        thrpt:  [21.142 MiB/s 21.147 MiB/s 21.152 MiB/s]
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe
Benchmarking extend_program/4096: Collecting 100 samples in estimated 5.2005 s (101k ite
extend_program/4096     time:   [50.488 µs 50.525 µs 50.574 µs]
                        thrpt:  [77.238 MiB/s 77.313 MiB/s 77.369 MiB/s]

Benchmarking set_authority_checked: Collecting 100 samples in estimated 5.0435 s (480k i
set_authority_checked   time:   [10.530 µs 10.531 µs 10.533 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```

