### PR TITLE
fix secp256r1-program id location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8035,7 +8035,6 @@ dependencies = [
  "solana-program",
  "solana-pubkey",
  "solana-sdk-ids",
- "solana-secp256r1-program",
 ]
 
 [[package]]
@@ -8458,8 +8457,8 @@ dependencies = [
  "solana-instruction",
  "solana-logger",
  "solana-precompile-error",
- "solana-pubkey",
  "solana-sdk",
+ "solana-sdk-ids",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6357,7 +6357,6 @@ dependencies = [
  "solana-feature-set",
  "solana-pubkey",
  "solana-sdk-ids",
- "solana-secp256r1-program",
 ]
 
 [[package]]
@@ -7183,7 +7182,7 @@ dependencies = [
  "solana-feature-set",
  "solana-instruction",
  "solana-precompile-error",
- "solana-pubkey",
+ "solana-sdk-ids",
 ]
 
 [[package]]

--- a/sdk/reserved-account-keys/Cargo.toml
+++ b/sdk/reserved-account-keys/Cargo.toml
@@ -20,7 +20,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-pubkey = { workspace = true, default-features = false }
 solana-sdk-ids = { workspace = true }
-solana-secp256r1-program = { workspace = true }
 
 [dev-dependencies]
 solana-program = { path = "../program" }

--- a/sdk/reserved-account-keys/src/lib.rs
+++ b/sdk/reserved-account-keys/src/lib.rs
@@ -10,10 +10,9 @@ use {
     solana_sdk_ids::{
         address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
         compute_budget, config, ed25519_program, feature, loader_v4, native_loader,
-        secp256k1_program, stake, system_program, sysvar, vote, zk_elgamal_proof_program,
-        zk_token_proof_program,
+        secp256k1_program, secp256r1_program, stake, system_program, sysvar, vote,
+        zk_elgamal_proof_program, zk_token_proof_program,
     },
-    solana_secp256r1_program as secp256r1_program,
     std::collections::{HashMap, HashSet},
 };
 

--- a/sdk/sdk-ids/src/lib.rs
+++ b/sdk/sdk-ids/src/lib.rs
@@ -44,6 +44,10 @@ pub mod secp256k1_program {
     solana_pubkey::declare_id!("KeccakSecp256k11111111111111111111111111111");
 }
 
+pub mod secp256r1_program {
+    solana_pubkey::declare_id!("Secp256r1SigVerify1111111111111111111111111");
+}
+
 pub mod stake {
     pub mod config {
         solana_pubkey::declare_deprecated_id!("StakeConfig11111111111111111111111111111111");

--- a/sdk/secp256r1-program/Cargo.toml
+++ b/sdk/secp256r1-program/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 bytemuck = { workspace = true, features = ["derive"] }
 solana-feature-set = { workspace = true }
 solana-precompile-error = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-sdk-ids = { workspace = true }
 
 [target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "solana")))'.dependencies]
 solana-instruction = { workspace = true, features = ["std"] }

--- a/sdk/secp256r1-program/src/lib.rs
+++ b/sdk/secp256r1-program/src/lib.rs
@@ -9,9 +9,8 @@
 //! This property can be problematic for developers who assume each signature is unique. Without enforcing
 //! low-S values, the same message and key can produce two different valid signatures, potentially breaking
 //! replay protection schemes that rely on signature uniqueness.
-solana_pubkey::declare_id!("Secp256r1SigVerify1111111111111111111111111");
-
 use bytemuck::{Pod, Zeroable};
+pub use solana_sdk_ids::secp256r1_program::{check_id, id, ID};
 
 #[derive(Default, Debug, Copy, Clone, Zeroable, Pod, Eq, PartialEq)]
 #[repr(C)]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6178,7 +6178,6 @@ dependencies = [
  "solana-feature-set",
  "solana-pubkey",
  "solana-sdk-ids",
- "solana-secp256r1-program",
 ]
 
 [[package]]
@@ -6519,7 +6518,7 @@ dependencies = [
  "solana-feature-set",
  "solana-instruction",
  "solana-precompile-error",
- "solana-pubkey",
+ "solana-sdk-ids",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
This program ID is used in such a way that it blows up the dependency tree of solana-reserved-account-keys

#### Summary of Changes
Move it to solana-sdk-ids
