### PR TITLE
Update comments of to_vote_instruction failure.

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2611,7 +2611,7 @@ impl ReplayStage {
                 vote_account_pubkey,
                 &authorized_voter_keypair.pubkey(),
             )
-            .expect("Switch threshold failure should not lead to voting");
+            .expect("Switch failure should not lead to voting");
 
         let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&node_keypair.pubkey()));
 


### PR DESCRIPTION
There could be more than switch threshold failures in switch failures now.
