### PR TITLE
Fixes svm's Cargo.lock

### DIFF
--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6934,9 +6934,10 @@ dependencies = [
  "lazy_static",
  "log",
  "rand 0.8.5",
+ "solana-packet",
  "solana-perf",
- "solana-sdk",
  "solana-short-vec",
+ "solana-signature",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem

Build is broken due to `svm/examples/Cargo.lock`'s packages. Likely due to PR #3663 and PR #3439 merging and destructively interfering.


#### Summary of Changes

Fix.