### PR TITLE
remove solana-program from solana-account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5807,12 +5807,15 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "solana-account",
+ "solana-account-info",
+ "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-instruction",
  "solana-logger",
- "solana-program",
  "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-sysvar",
 ]
 
 [[package]]

--- a/account-decoder-client-types/Cargo.toml
+++ b/account-decoder-client-types/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 base64 = { workspace = true }
-bs58 = { workspace = true }
+bs58 = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4890,8 +4890,12 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
+ "solana-account-info",
+ "solana-clock",
  "solana-instruction",
- "solana-program",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-sysvar",
 ]
 
 [[package]]

--- a/sdk/account/Cargo.toml
+++ b/sdk/account/Cargo.toml
@@ -23,13 +23,18 @@ solana-instruction = { workspace = true }
 solana-logger = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
-solana-sysvar = { workspace = true }
+solana-sysvar = { workspace = true, features = ["bincode"], optional = true }
 
 [dev-dependencies]
 solana-account = { path = ".", features = ["dev-context-only-utils"] }
 
 [features]
-bincode = ["dep:bincode", "solana-instruction/serde", "serde"]
+bincode = [
+    "dep:bincode",
+    "dep:solana-sysvar",
+    "solana-instruction/serde",
+    "serde",
+]
 dev-context-only-utils = ["bincode", "dep:qualifier_attr"]
 frozen-abi = [
     "dep:solana-frozen-abi",

--- a/sdk/account/Cargo.toml
+++ b/sdk/account/Cargo.toml
@@ -15,26 +15,34 @@ qualifier_attr = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
+solana-account-info = { workspace = true }
+solana-clock = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
-solana-instruction = { workspace = true, optional = true }
+solana-instruction = { workspace = true }
 solana-logger = { workspace = true, optional = true }
-solana-program = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-sdk-ids = { workspace = true }
+solana-sysvar = { workspace = true }
 
 [dev-dependencies]
 solana-account = { path = ".", features = ["dev-context-only-utils"] }
-solana-pubkey = { workspace = true }
 
 [features]
-bincode = ["dep:bincode", "dep:solana-instruction", "serde"]
+bincode = ["dep:bincode", "solana-instruction/serde", "serde"]
 dev-context-only-utils = ["bincode", "dep:qualifier_attr"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "dep:solana-logger",
-    "solana-program/frozen-abi",
+    "solana-pubkey/frozen-abi",
 ]
-serde = ["dep:serde", "dep:serde_bytes", "dep:serde_derive"]
+serde = [
+    "dep:serde",
+    "dep:serde_bytes",
+    "dep:serde_derive",
+    "solana-pubkey/serde",
+]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/account/src/lib.rs
+++ b/sdk/account/src/lib.rs
@@ -9,17 +9,13 @@ use serde::ser::{Serialize, Serializer};
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{frozen_abi, AbiExample};
 #[cfg(feature = "bincode")]
-use solana_program::sysvar::Sysvar;
+use solana_sysvar::Sysvar;
 use {
-    solana_program::{
-        account_info::AccountInfo,
-        bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
-        clock::{Epoch, INITIAL_RENT_EPOCH},
-        debug_account_data::*,
-        lamports::LamportsError,
-        loader_v4,
-        pubkey::Pubkey,
-    },
+    solana_account_info::{debug_account_data::*, AccountInfo},
+    solana_clock::{Epoch, INITIAL_RENT_EPOCH},
+    solana_instruction::error::LamportsError,
+    solana_pubkey::Pubkey,
+    solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4},
     std::{
         cell::{Ref, RefCell},
         fmt,
@@ -67,7 +63,8 @@ mod account_serialize {
     use {
         crate::ReadableAccount,
         serde::{ser::Serializer, Serialize},
-        solana_program::{clock::Epoch, pubkey::Pubkey},
+        solana_clock::Epoch,
+        solana_pubkey::Pubkey,
     };
     #[repr(C)]
     #[cfg_attr(
@@ -722,7 +719,7 @@ pub fn create_account_with_fields<S: Sysvar>(
     (lamports, rent_epoch): InheritableAccountFields,
 ) -> Account {
     let data_len = S::size_of().max(bincode::serialized_size(sysvar).unwrap() as usize);
-    let mut account = Account::new(lamports, data_len, &solana_program::sysvar::id());
+    let mut account = Account::new(lamports, data_len, &solana_sdk_ids::sysvar::id());
     to_account::<S, Account>(sysvar, &mut account).unwrap();
     account.rent_epoch = rent_epoch;
     account
@@ -764,7 +761,7 @@ pub fn to_account<S: Sysvar, T: WritableAccount>(sysvar: &S, account: &mut T) ->
 
 /// Return the information required to construct an `AccountInfo`.  Used by the
 /// `AccountInfo` conversion implementations.
-impl solana_program::account_info::Account for Account {
+impl solana_account_info::Account for Account {
     fn get(&mut self) -> (&mut u64, &mut [u8], &Pubkey, bool, Epoch) {
         (
             &mut self.lamports,

--- a/sdk/pubkey/Cargo.toml
+++ b/sdk/pubkey/Cargo.toml
@@ -68,7 +68,8 @@ default = ["std"]
 dev-context-only-utils = ["dep:arbitrary", "rand"]
 frozen-abi = [
     "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro"
+    "dep:solana-frozen-abi-macro",
+    "std",
 ]
 rand = ["dep:rand", "std"]
 serde = ["dep:serde", "dep:serde_derive"]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -4742,8 +4742,12 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
+ "solana-account-info",
+ "solana-clock",
  "solana-instruction",
- "solana-program",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-sysvar",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
solana-account can compile faster by replacing solana-program with the required smaller crates

#### Summary of Changes
- Replace solana-program
- Make the "frozen-abi" feature of solana-pubkey activate the "std" feature of solana-pubkey. Only noticed in this PR that this should be how it works

This branches off #3680 so that needs to be merged first (update: done)