### PR TITLE
blockstore: Make WriteBatch operations go through LedgerColumn

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2950,7 +2950,7 @@ impl Blockstore {
         keys_with_writable: impl Iterator<Item = (&'a Pubkey, bool)>,
         status: TransactionStatusMeta,
         transaction_index: usize,
-        db_write_batch: &mut WriteBatch<'_>,
+        db_write_batch: &mut WriteBatch,
     ) -> Result<()> {
         self.write_transaction_status_helper(
             slot,
@@ -3000,7 +3000,7 @@ impl Blockstore {
         signature: &Signature,
         slot: Slot,
         memos: String,
-        db_write_batch: &mut WriteBatch<'_>,
+        db_write_batch: &mut WriteBatch,
     ) -> Result<()> {
         self.transaction_memos_cf
             .put_in_batch(db_write_batch, (*signature, slot), &memos)
@@ -4687,7 +4687,7 @@ impl Blockstore {
         res
     }
 
-    pub fn get_write_batch(&self) -> std::result::Result<WriteBatch<'_>, BlockstoreError> {
+    pub fn get_write_batch(&self) -> std::result::Result<WriteBatch, BlockstoreError> {
         self.db.batch()
     }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1209,7 +1209,8 @@ impl Blockstore {
                 continue;
             }
             let (slot, fec_set_index) = erasure_set.store_key();
-            write_batch.put::<cf::ErasureMeta>(
+            self.erasure_meta_cf.put_in_batch(
+                &mut write_batch,
                 (slot, u64::from(fec_set_index)),
                 working_erasure_meta.as_ref(),
             )?;
@@ -1220,7 +1221,8 @@ impl Blockstore {
                 // No need to rewrite the column
                 continue;
             }
-            write_batch.put::<cf::MerkleRootMeta>(
+            self.merkle_root_meta_cf.put_in_batch(
+                &mut write_batch,
                 erasure_set.store_key(),
                 working_merkle_root_meta.as_ref(),
             )?;
@@ -1228,7 +1230,11 @@ impl Blockstore {
 
         for (&slot, index_working_set_entry) in index_working_set.iter() {
             if index_working_set_entry.did_insert_occur {
-                write_batch.put::<cf::Index>(slot, &index_working_set_entry.index)?;
+                self.index_cf.put_in_batch(
+                    &mut write_batch,
+                    slot,
+                    &index_working_set_entry.index,
+                )?;
             }
         }
         start.stop();
@@ -1655,7 +1661,9 @@ impl Blockstore {
                      {} is not full, marking slot dead",
                     shred_index, slot_meta.received, slot
                 );
-                write_batch.put::<cf::DeadSlots>(slot, &true).unwrap();
+                self.dead_slots_cf
+                    .put_in_batch(write_batch, slot, &true)
+                    .unwrap();
             }
 
             if !self.should_insert_data_shred(
@@ -1728,7 +1736,8 @@ impl Blockstore {
 
         // Commit step: commit all changes to the mutable structures at once, or none at all.
         // We don't want only a subset of these changes going through.
-        write_batch.put_bytes::<cf::ShredCode>((slot, shred_index), shred.payload())?;
+        self.code_shred_cf
+            .put_bytes_in_batch(write_batch, (slot, shred_index), shred.payload())?;
         index_meta.coding_mut().insert(shred_index);
 
         Ok(())
@@ -2191,7 +2200,11 @@ impl Blockstore {
 
         // Commit step: commit all changes to the mutable structures at once, or none at all.
         // We don't want only a subset of these changes going through.
-        write_batch.put_bytes::<cf::ShredData>((slot, index), shred.bytes_to_store())?;
+        self.data_shred_cf.put_bytes_in_batch(
+            write_batch,
+            (slot, index),
+            shred.bytes_to_store(),
+        )?;
         data_index.insert(index);
         let newly_completed_data_sets = update_slot_meta(
             last_in_slot,
@@ -2946,7 +2959,8 @@ impl Blockstore {
             status,
             transaction_index,
             |address, slot, tx_index, signature, writeable| {
-                db_write_batch.put::<cf::AddressSignatures>(
+                self.address_signatures_cf.put_in_batch(
+                    db_write_batch,
                     (*address, slot, tx_index, signature),
                     &AddressSignatureMeta { writeable },
                 )
@@ -2988,7 +3002,8 @@ impl Blockstore {
         memos: String,
         db_write_batch: &mut WriteBatch<'_>,
     ) -> Result<()> {
-        db_write_batch.put::<cf::TransactionMemos>((*signature, slot), &memos)
+        self.transaction_memos_cf
+            .put_in_batch(db_write_batch, (*signature, slot), &memos)
     }
 
     /// Acquires the `lowest_cleanup_slot` lock and returns a tuple of the held lock
@@ -3986,7 +4001,8 @@ impl Blockstore {
                 frozen_hash,
                 is_duplicate_confirmed: true,
             });
-            write_batch.put::<cf::BankHash>(slot, &data)?;
+            self.bank_hash_cf
+                .put_in_batch(&mut write_batch, slot, &data)?;
         }
 
         self.db.write(write_batch)?;
@@ -3998,7 +4014,7 @@ impl Blockstore {
         let mut max_new_rooted_slot = 0;
         for slot in rooted_slots {
             max_new_rooted_slot = std::cmp::max(max_new_rooted_slot, *slot);
-            write_batch.put::<cf::Root>(*slot, &true)?;
+            self.roots_cf.put_in_batch(&mut write_batch, *slot, &true)?;
         }
 
         self.db.write(write_batch)?;
@@ -4303,7 +4319,8 @@ impl Blockstore {
         // slot match the flags of slots that become connected the typical way.
         root_meta.set_parent_connected();
         root_meta.set_connected();
-        write_batch.put::<cf::SlotMeta>(root_meta.slot, &root_meta)?;
+        self.meta_cf
+            .put_in_batch(&mut write_batch, root_meta.slot, &root_meta)?;
 
         let mut next_slots = VecDeque::from(root_meta.next_slots);
         while !next_slots.is_empty() {
@@ -4315,7 +4332,8 @@ impl Blockstore {
             if meta.set_parent_connected() {
                 next_slots.extend(meta.next_slots.iter());
             }
-            write_batch.put::<cf::SlotMeta>(meta.slot, &meta)?;
+            self.meta_cf
+                .put_in_batch(&mut write_batch, meta.slot, &meta)?;
         }
 
         self.db.write(write_batch)?;
@@ -4357,7 +4375,7 @@ impl Blockstore {
         // Write all the newly changed slots in new_chained_slots to the write_batch
         for (slot, meta) in new_chained_slots.iter() {
             let meta: &SlotMeta = &RefCell::borrow(meta);
-            write_batch.put::<cf::SlotMeta>(*slot, meta)?;
+            self.meta_cf.put_in_batch(write_batch, *slot, meta)?;
         }
         Ok(())
     }
@@ -4433,7 +4451,8 @@ impl Blockstore {
                     // If the parent of `slot` is a newly inserted orphan, insert it into the orphans
                     // column family
                     if RefCell::borrow(&*prev_slot_meta).is_orphan() {
-                        write_batch.put::<cf::Orphans>(prev_slot, &true)?;
+                        self.orphans_cf
+                            .put_in_batch(write_batch, prev_slot, &true)?;
                     }
                 }
             }
@@ -4542,7 +4561,7 @@ impl Blockstore {
             // Check if the working copy of the metadata has changed
             if Some(meta) != meta_backup.as_ref() {
                 should_signal = should_signal || slot_has_updates(meta, meta_backup);
-                write_batch.put::<cf::SlotMeta>(*slot, meta)?;
+                self.meta_cf.put_in_batch(write_batch, *slot, meta)?;
             }
         }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4529,8 +4529,6 @@ impl Blockstore {
     /// Arguments:
     /// - `slot_meta_working_set`: a map that maintains slot-id to its `SlotMeta`
     ///   mapping.
-    /// - `completed_slot_senders`: the units which are responsible for sending
-    ///   signals for completed slots.
     /// - `write_batch`: the write batch which includes all the updates of the
     ///   the current write and ensures their atomicity.
     ///

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4459,7 +4459,7 @@ impl Blockstore {
 
             // At this point this slot has received a parent, so it's no longer an orphan
             if was_orphan_slot {
-                write_batch.delete::<cf::Orphans>(slot)?;
+                self.orphans_cf.delete_in_batch(write_batch, slot)?;
             }
         }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7539,11 +7539,9 @@ pub mod tests {
         );
 
         for (erasure_set, working_merkle_root_meta) in merkle_root_metas {
-            write_batch
-                .put::<cf::MerkleRootMeta>(
-                    erasure_set.store_key(),
-                    working_merkle_root_meta.as_ref(),
-                )
+            blockstore
+                .merkle_root_meta_cf
+                .put(erasure_set.store_key(), working_merkle_root_meta.as_ref())
                 .unwrap();
         }
         blockstore.db.write(write_batch).unwrap();
@@ -7738,11 +7736,9 @@ pub mod tests {
         );
 
         for (erasure_set, working_merkle_root_meta) in merkle_root_metas {
-            write_batch
-                .put::<cf::MerkleRootMeta>(
-                    erasure_set.store_key(),
-                    working_merkle_root_meta.as_ref(),
-                )
+            blockstore
+                .merkle_root_meta_cf
+                .put(erasure_set.store_key(), working_merkle_root_meta.as_ref())
                 .unwrap();
         }
         blockstore.db.write(write_batch).unwrap();
@@ -11930,8 +11926,8 @@ pub mod tests {
             .unwrap();
         let mut write_batch = blockstore.db.batch().unwrap();
         blockstore
-            .db
-            .delete_range_cf::<cf::MerkleRootMeta>(&mut write_batch, slot, slot)
+            .merkle_root_meta_cf
+            .delete_range_in_batch(&mut write_batch, slot, slot)
             .unwrap();
         blockstore.db.write(write_batch).unwrap();
         assert!(blockstore
@@ -11996,8 +11992,8 @@ pub mod tests {
         // an older version.
         let mut write_batch = blockstore.db.batch().unwrap();
         blockstore
-            .db
-            .delete_range_cf::<cf::MerkleRootMeta>(&mut write_batch, slot, slot)
+            .merkle_root_meta_cf
+            .delete_range_in_batch(&mut write_batch, slot, slot)
             .unwrap();
         blockstore.db.write(write_batch).unwrap();
         assert!(blockstore

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -255,68 +255,68 @@ impl Blockstore {
         purge_type: PurgeType,
     ) -> Result<bool> {
         let columns_purged = self
-            .db
-            .delete_range_cf::<cf::SlotMeta>(write_batch, from_slot, to_slot)
+            .meta_cf
+            .delete_range_in_batch(write_batch, from_slot, to_slot)
             .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::BankHash>(write_batch, from_slot, to_slot)
+                .bank_hash_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::Root>(write_batch, from_slot, to_slot)
+                .roots_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::ShredData>(write_batch, from_slot, to_slot)
+                .data_shred_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::ShredCode>(write_batch, from_slot, to_slot)
+                .code_shred_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::DeadSlots>(write_batch, from_slot, to_slot)
+                .dead_slots_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::DuplicateSlots>(write_batch, from_slot, to_slot)
+                .duplicate_slots_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::ErasureMeta>(write_batch, from_slot, to_slot)
+                .erasure_meta_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::Orphans>(write_batch, from_slot, to_slot)
+                .orphans_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::Index>(write_batch, from_slot, to_slot)
+                .index_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::Rewards>(write_batch, from_slot, to_slot)
+                .rewards_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::Blocktime>(write_batch, from_slot, to_slot)
+                .blocktime_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::PerfSamples>(write_batch, from_slot, to_slot)
+                .perf_samples_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::BlockHeight>(write_batch, from_slot, to_slot)
+                .block_height_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::OptimisticSlots>(write_batch, from_slot, to_slot)
+                .optimistic_slots_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .db
-                .delete_range_cf::<cf::MerkleRootMeta>(write_batch, from_slot, to_slot)
+                .merkle_root_meta_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok();
 
         match purge_type {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1414,12 +1414,7 @@ impl WriteBatch {
         Ok(())
     }
 
-    fn delete_range_cf(
-        &mut self,
-        cf: &ColumnFamily,
-        from: &[u8],
-        to: &[u8],
-    ) -> Result<()> {
+    fn delete_range_cf(&mut self, cf: &ColumnFamily, from: &[u8], to: &[u8]) -> Result<()> {
         self.write_batch.delete_range_cf(cf, from, to);
         Ok(())
     }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1403,6 +1403,28 @@ pub struct WriteBatch {
     write_batch: RWriteBatch,
 }
 
+impl WriteBatch {
+    fn put_cf(&mut self, cf: &ColumnFamily, key: &[u8], value: &[u8]) -> Result<()> {
+        self.write_batch.put_cf(cf, key, value);
+        Ok(())
+    }
+
+    fn delete_cf(&mut self, cf: &ColumnFamily, key: &[u8]) -> Result<()> {
+        self.write_batch.delete_cf(cf, key);
+        Ok(())
+    }
+
+    fn delete_range_cf(
+        &mut self,
+        cf: &ColumnFamily,
+        from: &[u8],
+        to: &[u8],
+    ) -> Result<()> {
+        self.write_batch.delete_range_cf(cf, from, to);
+        Ok(())
+    }
+}
+
 impl Database {
     pub fn open(path: &Path, options: BlockstoreOptions) -> Result<Self> {
         let column_options = Arc::new(options.column_options.clone());
@@ -1877,28 +1899,6 @@ where
     ) -> Result<()> {
         let key = C::deprecated_key(key);
         batch.delete_cf(self.handle(), &key)
-    }
-}
-
-impl WriteBatch {
-    fn put_cf(&mut self, cf: &ColumnFamily, key: &[u8], value: &[u8]) -> Result<()> {
-        self.write_batch.put_cf(cf, key, value);
-        Ok(())
-    }
-
-    fn delete_cf(&mut self, cf: &ColumnFamily, key: &[u8]) -> Result<()> {
-        self.write_batch.delete_cf(cf, key);
-        Ok(())
-    }
-
-    fn delete_range_cf(
-        &mut self,
-        cf: &ColumnFamily,
-        from: &[u8],
-        to: &[u8],
-    ) -> Result<()> {
-        self.write_batch.delete_range_cf(cf, from, to);
-        Ok(())
     }
 }
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1881,27 +1881,21 @@ where
 }
 
 impl WriteBatch {
+    fn put_cf(&mut self, cf: &ColumnFamily, key: &[u8], value: &[u8]) -> Result<()> {
+        self.write_batch.put_cf(cf, key, value);
+        Ok(())
+    }
+
     fn delete_cf(&mut self, cf: &ColumnFamily, key: &[u8]) -> Result<()> {
         self.write_batch.delete_cf(cf, key);
         Ok(())
     }
 
-    pub fn put_cf(&mut self, cf: &ColumnFamily, key: &[u8], value: &[u8]) -> Result<()> {
-        self.write_batch.put_cf(cf, key, value);
-        Ok(())
-    }
-
-    /// Adds a \[`from`, `to`) range deletion entry to the batch.
-    ///
-    /// Note that the \[`from`, `to`) deletion range of WriteBatch::delete_range_cf
-    /// is different from \[`from`, `to`\] of Database::delete_range_cf as we makes
-    /// the semantics of Database::delete_range_cf matches the blockstore purge
-    /// logic.
     fn delete_range_cf(
         &mut self,
         cf: &ColumnFamily,
         from: &[u8],
-        to: &[u8], // exclusive
+        to: &[u8],
     ) -> Result<()> {
         self.write_batch.delete_range_cf(cf, from, to);
         Ok(())

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1638,6 +1638,11 @@ where
         result
     }
 
+    pub fn delete_in_batch(&self, batch: &mut WriteBatch, key: C::Index) -> Result<()> {
+        let key = C::key(key);
+        batch.delete_cf(self.handle(), &key)
+    }
+
     /// Adds a \[`from`, `to`\] range that deletes all entries between the `from` slot
     /// and `to` slot inclusively.  If `from` slot and `to` slot are the same, then all
     /// entries in that slot will be removed.
@@ -1870,15 +1875,20 @@ where
                 .map(|index| (index, value))
         }))
     }
+
+    pub(crate) fn delete_deprecated_in_batch(
+        &self,
+        batch: &mut WriteBatch,
+        key: C::DeprecatedIndex,
+    ) -> Result<()> {
+        let key = C::deprecated_key(key);
+        batch.delete_cf(self.handle(), &key)
+    }
 }
 
 impl<'a> WriteBatch<'a> {
-    pub fn delete<C: Column + ColumnName>(&mut self, key: C::Index) -> Result<()> {
-        self.delete_raw::<C>(&C::key(key))
-    }
-
-    pub(crate) fn delete_raw<C: Column + ColumnName>(&mut self, key: &[u8]) -> Result<()> {
-        self.write_batch.delete_cf(self.get_cf::<C>(), key);
+    fn delete_cf(&mut self, cf: &ColumnFamily, key: &[u8]) -> Result<()> {
+        self.write_batch.delete_cf(cf, key);
         Ok(())
     }
 


### PR DESCRIPTION
#### Problem
- rocksdb keys are currently allocated as `Vec`'s; these allocations occur very frequently
- https://github.com/anza-xyz/agave/pull/3603 looks to make rocksdb key allocation happen on the stack to avoid the frequent heap allocation
- rocksdb keys can be stack allocated if we perform that logic within `LedgerColumn` since each column has a fixed-and-known-at-compile-time key length
- So, we need to shift logic that creates the rocksdb byte array keys into `LedgerColumn`

#### Summary of Changes
Shift the logic of converting keys from the `Index` type to bytes from `WriteBatch` to `LedgerColumn`, and add methods to `LedgerColumn` to add puts and deletes into a `WriteBatch`

This is similar to https://github.com/anza-xyz/agave/pull/3650, with the goal of making https://github.com/anza-xyz/agave/pull/3603 (which will contain the more interesting changes) a smaller diff
