### PR TITLE
test-validator: Fix upgradeable programs at genesis

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -808,7 +808,7 @@ impl TestValidator {
                     lamports: Rent::default().minimum_balance(program_data.len()).max(1),
                     data: program_data,
                     owner: upgradeable_program.loader,
-                    executable: true,
+                    executable: false,
                     rent_epoch: 0,
                 }),
             );


### PR DESCRIPTION
#### Problem

As noted in https://solana.stackexchange.com/questions/17478/solana-localnet-error-while-upgrading-a-program-loaded-at-genesis-using-solan, an upgradeable program loaded at genesis is not actually upgradeable, failing with `instruction changed executable accounts data`. This is because the program-data account is incorrectly set as "executable", which it isn't really.

#### Summary of changes

Don't set the program-data account as executable. This is the only place in the repo where we were doing this incorrectly.

Since this is a small change that fixes a bug only the test validator, I think this is a good candidate for a backport.