### PR TITLE
signs prune messages after dropping the lock on gossip CRDS table

### DIFF
--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -98,6 +98,7 @@ pub struct GossipStats {
     pub(crate) filter_crds_values_dropped_requests: Counter,
     pub(crate) filter_crds_values_dropped_values: Counter,
     pub(crate) filter_pull_response: Counter,
+    pub(crate) generate_prune_messages: Counter,
     pub(crate) generate_pull_responses: Counter,
     pub(crate) get_epoch_duration_no_working_bank: Counter,
     pub(crate) get_votes: Counter,
@@ -471,6 +472,11 @@ pub(crate) fn submit_gossip_stats(
         (
             "get_epoch_duration_no_working_bank",
             stats.get_epoch_duration_no_working_bank.clear(),
+            i64
+        ),
+        (
+            "generate_prune_messages",
+            stats.generate_prune_messages.clear(),
             i64
         ),
     );


### PR DESCRIPTION

#### Problem
Signing prune messages while holding a lock on gossip CRDS table can exacerbate lock contentions:
https://github.com/anza-xyz/agave/blob/c2880bbb3/gossip/src/cluster_info.rs#L2061-L2083


#### Summary of Changes
The commit signs prune messages after dropping the lock on gossip CRDS table