### PR TITLE
README: Link to `docs/src/cli/install.md` to build and install for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ $ cd agave
 $ ./cargo build
 ```
 
+> [!NOTE]
+> Note that this builds a debug version that is **not suitable for running a testnet or mainnet validator**. Please read [`docs/src/cli/install.md`](docs/src/cli/install.md#build-from-source) for instructions to build a release version for test and production uses.
+
 # Testing
 
 **Run the test suite:**


### PR DESCRIPTION
#### Problem

When I first built the project to run a testnet validator, I looked at this README by habit with many FOSS projects. `agave-validator` could not even pass the start-time performance self-check. It took me some time to understand it was a debug version that I compiled while I was looking at the other beginner errors like the wrong CPU or the default governor mode.

#### Summary of Changes

This patch links the build section of the README to the dedicated doc that explain how to build and install the project for an actual use on testnet or mainnet.