### PR TITLE
[rpc] Fatal `getSignaturesForAddress()` when Bigtable errors

### DIFF
--- a/rpc-client-api/src/custom_error.rs
+++ b/rpc-client-api/src/custom_error.rs
@@ -26,6 +26,7 @@ pub const JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION: i64 = -32015;
 pub const JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED: i64 = -32016;
 pub const JSON_RPC_SERVER_ERROR_EPOCH_REWARDS_PERIOD_ACTIVE: i64 = -32017;
 pub const JSON_RPC_SERVER_ERROR_SLOT_NOT_EPOCH_BOUNDARY: i64 = -32018;
+pub const JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE: i64 = -32019;
 
 #[derive(Error, Debug)]
 pub enum RpcCustomError {
@@ -75,6 +76,8 @@ pub enum RpcCustomError {
     },
     #[error("SlotNotEpochBoundary")]
     SlotNotEpochBoundary { slot: Slot },
+    #[error("LongTermStorageUnreachable")]
+    LongTermStorageUnreachable,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -242,6 +245,11 @@ impl From<RpcCustomError> for Error {
                     "Rewards cannot be found because slot {slot} is not the epoch boundary. This \
                      may be due to gap in the queried node's local ledger or long-term storage"
                 ),
+                data: None,
+            },
+            RpcCustomError::LongTermStorageUnreachable => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE),
+                message: "Failed to query long-term storage; please try again".to_string(),
                 data: None,
             },
         }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1761,8 +1761,8 @@ impl JsonRpcRequestProcessor {
                             bigtable_before = None;
                         }
                         Err(err) => {
-                            warn!("{:?}", err);
-                            return Ok(map_results(results));
+                            warn!("Failed to query Bigtable: {:?}", err);
+                            return Err(RpcCustomError::LongTermStorageUnreachable.into());
                         }
                         Ok(_) => {}
                     }
@@ -1791,8 +1791,10 @@ impl JsonRpcRequestProcessor {
                             }
                         }
                     }
+                    Err(StorageError::SignatureNotFound) => {}
                     Err(err) => {
-                        warn!("{:?}", err);
+                        warn!("Failed to query Bigtable: {:?}", err);
+                        return Err(RpcCustomError::LongTermStorageUnreachable.into());
                     }
                 }
             }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1689,118 +1689,116 @@ impl JsonRpcRequestProcessor {
         let commitment = config.commitment.unwrap_or_default();
         check_is_at_least_confirmed(commitment)?;
 
-        if self.config.enable_rpc_transaction_history {
-            let highest_super_majority_root = self
-                .block_commitment_cache
-                .read()
-                .unwrap()
-                .highest_super_majority_root();
-            let highest_slot = if commitment.is_confirmed() {
-                let confirmed_bank = self.get_bank_with_config(config)?;
-                confirmed_bank.slot()
-            } else {
-                let min_context_slot = config.min_context_slot.unwrap_or_default();
-                if highest_super_majority_root < min_context_slot {
-                    return Err(RpcCustomError::MinContextSlotNotReached {
-                        context_slot: highest_super_majority_root,
-                    }
-                    .into());
+        if !self.config.enable_rpc_transaction_history {
+            return Err(RpcCustomError::TransactionHistoryNotAvailable.into());
+        }
+
+        let highest_super_majority_root = self
+            .block_commitment_cache
+            .read()
+            .unwrap()
+            .highest_super_majority_root();
+        let highest_slot = if commitment.is_confirmed() {
+            let confirmed_bank = self.get_bank_with_config(config)?;
+            confirmed_bank.slot()
+        } else {
+            let min_context_slot = config.min_context_slot.unwrap_or_default();
+            if highest_super_majority_root < min_context_slot {
+                return Err(RpcCustomError::MinContextSlotNotReached {
+                    context_slot: highest_super_majority_root,
                 }
-                highest_super_majority_root
-            };
+                .into());
+            }
+            highest_super_majority_root
+        };
 
-            let SignatureInfosForAddress {
-                infos: mut results,
-                found_before,
-            } = self
-                .blockstore
-                .get_confirmed_signatures_for_address2(address, highest_slot, before, until, limit)
-                .map_err(|err| Error::invalid_params(format!("{err}")))?;
+        let SignatureInfosForAddress {
+            infos: mut results,
+            found_before,
+        } = self
+            .blockstore
+            .get_confirmed_signatures_for_address2(address, highest_slot, before, until, limit)
+            .map_err(|err| Error::invalid_params(format!("{err}")))?;
 
-            let map_results = |results: Vec<ConfirmedTransactionStatusWithSignature>| {
-                results
-                    .into_iter()
-                    .map(|x| {
-                        let mut item: RpcConfirmedTransactionStatusWithSignature = x.into();
-                        if item.slot <= highest_super_majority_root {
-                            item.confirmation_status =
-                                Some(TransactionConfirmationStatus::Finalized);
-                        } else {
-                            item.confirmation_status =
-                                Some(TransactionConfirmationStatus::Confirmed);
-                            if item.block_time.is_none() {
-                                let r_bank_forks = self.bank_forks.read().unwrap();
-                                item.block_time = r_bank_forks
-                                    .get(item.slot)
-                                    .map(|bank| bank.clock().unix_timestamp);
-                            }
-                        }
-                        item
-                    })
-                    .collect()
-            };
-
-            if results.len() < limit {
-                if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
-                    let mut bigtable_before = before;
-                    if !results.is_empty() {
-                        limit -= results.len();
-                        bigtable_before = results.last().map(|x| x.signature);
-                    }
-
-                    // If the oldest address-signature found in Blockstore has not yet been
-                    // uploaded to long-term storage, modify the storage query to return all latest
-                    // signatures to prevent erroring on RowNotFound. This can race with upload.
-                    if found_before && bigtable_before.is_some() {
-                        match bigtable_ledger_storage
-                            .get_signature_status(&bigtable_before.unwrap())
-                            .await
-                        {
-                            Err(StorageError::SignatureNotFound) => {
-                                bigtable_before = None;
-                            }
-                            Err(err) => {
-                                warn!("{:?}", err);
-                                return Ok(map_results(results));
-                            }
-                            Ok(_) => {}
+        let map_results = |results: Vec<ConfirmedTransactionStatusWithSignature>| {
+            results
+                .into_iter()
+                .map(|x| {
+                    let mut item: RpcConfirmedTransactionStatusWithSignature = x.into();
+                    if item.slot <= highest_super_majority_root {
+                        item.confirmation_status = Some(TransactionConfirmationStatus::Finalized);
+                    } else {
+                        item.confirmation_status = Some(TransactionConfirmationStatus::Confirmed);
+                        if item.block_time.is_none() {
+                            let r_bank_forks = self.bank_forks.read().unwrap();
+                            item.block_time = r_bank_forks
+                                .get(item.slot)
+                                .map(|bank| bank.clock().unix_timestamp);
                         }
                     }
+                    item
+                })
+                .collect()
+        };
 
-                    let bigtable_results = bigtable_ledger_storage
-                        .get_confirmed_signatures_for_address(
-                            &address,
-                            bigtable_before.as_ref(),
-                            until.as_ref(),
-                            limit,
-                        )
-                        .await;
-                    match bigtable_results {
-                        Ok(bigtable_results) => {
-                            let results_set: HashSet<_> =
-                                results.iter().map(|result| result.signature).collect();
-                            for (bigtable_result, _) in bigtable_results {
-                                // In the upload race condition, latest address-signatures in
-                                // long-term storage may include original `before` signature...
-                                if before != Some(bigtable_result.signature)
-                                    // ...or earlier Blockstore signatures
-                                    && !results_set.contains(&bigtable_result.signature)
-                                {
-                                    results.push(bigtable_result);
-                                }
-                            }
+        if results.len() < limit {
+            if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
+                let mut bigtable_before = before;
+                if !results.is_empty() {
+                    limit -= results.len();
+                    bigtable_before = results.last().map(|x| x.signature);
+                }
+
+                // If the oldest address-signature found in Blockstore has not yet been
+                // uploaded to long-term storage, modify the storage query to return all latest
+                // signatures to prevent erroring on RowNotFound. This can race with upload.
+                if found_before && bigtable_before.is_some() {
+                    match bigtable_ledger_storage
+                        .get_signature_status(&bigtable_before.unwrap())
+                        .await
+                    {
+                        Err(StorageError::SignatureNotFound) => {
+                            bigtable_before = None;
                         }
                         Err(err) => {
                             warn!("{:?}", err);
+                            return Ok(map_results(results));
                         }
+                        Ok(_) => {}
+                    }
+                }
+
+                let bigtable_results = bigtable_ledger_storage
+                    .get_confirmed_signatures_for_address(
+                        &address,
+                        bigtable_before.as_ref(),
+                        until.as_ref(),
+                        limit,
+                    )
+                    .await;
+                match bigtable_results {
+                    Ok(bigtable_results) => {
+                        let results_set: HashSet<_> =
+                            results.iter().map(|result| result.signature).collect();
+                        for (bigtable_result, _) in bigtable_results {
+                            // In the upload race condition, latest address-signatures in
+                            // long-term storage may include original `before` signature...
+                            if before != Some(bigtable_result.signature)
+                                    // ...or earlier Blockstore signatures
+                                    && !results_set.contains(&bigtable_result.signature)
+                            {
+                                results.push(bigtable_result);
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        warn!("{:?}", err);
                     }
                 }
             }
-
-            Ok(map_results(results))
-        } else {
-            Err(RpcCustomError::TransactionHistoryNotAvailable.into())
         }
+
+        Ok(map_results(results))
     }
 
     pub async fn get_first_available_block(&self) -> Slot {

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -796,7 +796,11 @@ impl LedgerStorage {
             Some(before_signature) => {
                 let TransactionInfo { slot, index, .. } = bigtable
                     .get_bincode_cell("tx", before_signature.to_string())
-                    .await?;
+                    .await
+                    .map_err(|err| match err {
+                        bigtable::Error::RowNotFound => Error::SignatureNotFound,
+                        _ => err.into(),
+                    })?;
 
                 (slot, index)
             }
@@ -808,7 +812,11 @@ impl LedgerStorage {
             Some(until_signature) => {
                 let TransactionInfo { slot, index, .. } = bigtable
                     .get_bincode_cell("tx", until_signature.to_string())
-                    .await?;
+                    .await
+                    .map_err(|err| match err {
+                        bigtable::Error::RowNotFound => Error::SignatureNotFound,
+                        _ => err.into(),
+                    })?;
 
                 (slot, index)
             }


### PR DESCRIPTION
### Problem

Consider a request to `getSignaturesForAddress()`. Imagine that there are no signatures in blockstore, but there _are_ signatures in long-term storage (ie. Bigtable).

Currently, if we fail to _reach_ Bigtable – because of a timeout or a connection failure – we return whatever signatures we have. This means that people who query the RPC can't distinguish between the following cases:

* No signatures were found because there are none, or
* No signatures were found because Bigtable was temporarily unavailable

### Summary of Changes

1. When doing a range query in `get_confirmed_signatures_for_address` and the `before`/`until` can't be found, throw a `SignatureNotFound` error instead of `RowNotFound`.
2. Now that we can match on actual connection errors – separate from `SignatureNotFound` errors – return a JSON-RPC error in the event that long-term storage errors out.

### Test Plan

#### With the Bigtable emulator

```shell
> gcloud beta emulators bigtable start
> ./init-bigtable.sh
```

```shell
> tail -f validator.log | grep [Bb]ig[Tt]able
[2024-11-19T23:06:05.994676924Z INFO  solana_rpc::rpc_service] rpc configuration: JsonRpcConfig { enable_rpc_transaction_history: true, enable_extended_tx_metadata_storage: true, faucet_addr: Some(0.0.0.0:9900), health_check_slot_distance: 0, skip_preflight_health_check: false, rpc_bigtable_config: Some(RpcBigtableConfig { enable_bigtable_ledger_upload: false, bigtable_instance_name: "solana-ledger", bigtable_app_profile_id: "default", timeout: None, max_message_size: 67108864 }), max_multiple_accounts: None, account_indexes: AccountSecondaryIndexes { keys: None, indexes: {} }, rpc_threads: 0, rpc_niceness_adj: 0, full_api: true, rpc_scan_and_fix_roots: false, max_request_body_size: None, disable_health_check: true }
[2024-11-19T23:06:05.995145895Z INFO  solana_storage_bigtable::bigtable] Connecting to bigtable emulator at localhost:8086
[2024-11-19T23:06:05.995411312Z INFO  solana_rpc::rpc_service] BigTable ledger storage initialized
```

##### Fetching a signature for an address that does not exist locally

Observe that the RPC goes out to Bigtable and fetches successfully (finds nothing)

```shell
curl localhost:8899 -d '{
  "id": "1",
  "jsonrpc": "2.0",
  "method": "getSignaturesForAddress",
  "params": [
    "BzszvNFvokG4v4qb1ipYSDGtKuhen8PMtYjevfZeAkKZ"
  ]
}' --header 'Content-Type: application/json'
{"jsonrpc":"2.0","result":[],"id":"1"}
```

##### Fetching a signature for an address _and_ before signature that don't exist locally

Observe that Bigtable can't find the before signature, but doesn't fatal the request

```shell
curl localhost:8899 -d '{
  "id": "1",
  "jsonrpc": "2.0",
  "method": "getSignaturesForAddress",
  "params": [
    "BzszvNFvokG4v4qb1ipYSDGtKuhen8PMtYjevfZeAkKZ",
    {"before":"31AUDAUXgD4B5DqqtFZZe8udgHUfbJX9dQbiXQGmNiRqeKRkzRTYitrRbJDtpt4DMd4P3G8haaXMJ8TU6wwQmf3h"}
  ]
}' --header 'Content-Type: application/json'
{"jsonrpc":"2.0","result":[],"id":"1"}
```

##### Fetching a signature for an address that is completely available locally

Observe Bigtable is never contacted.

```shell
curl localhost:8899 -d '{
  "id": "1",
  "jsonrpc": "2.0",
  "method": "getSignaturesForAddress",
  "params": [
    "jZ2L6sHvF862QMKYxD7ho7JQAX5m1rT9VzVKvzSSbin",
    {"limit": 1}
  ]
}' --header 'Content-Type: application/json'
{"jsonrpc":"2.0","result":[{"blockTime":1732058393,"confirmationStatus":"finalized","err":null,"memo":null,"signature":"3mZUQjhaGA7ytwb3g9PnjYL4d1ErsWf7nheMCqnSuwW6x2hF8tx4DuuvG1u7j6qVCC2J9JqpRHbJ7z57ayhJZyW2","slot":9284}],"id":"1"}
```

##### Fetching a signature for an address that does exist but with a bad `before` signature

Observe that Bigtable can't find the before signature, but doesn't fatal the request

```shell
curl localhost:8899 -d '{
  "id": "1",
  "jsonrpc": "2.0",
  "method": "getSignaturesForAddress",
  "params": [
    "jZ2L6sHvF862QMKYxD7ho7JQAX5m1rT9VzVKvzSSbin",
    {"before":"419mQJ2ZpM1uJ2VJyHckWNzmEpRKkyuirvRQH9NfgKvzQJxTcTa5v8U7tXJ4VkqEH8GsTtG7iqSsQBJe8VxxC2XQ","limit": 1}
  ]
}' --header 'Content-Type: application/json'
{"jsonrpc":"2.0","result":[],"id":"1"}
```

##### Fetching a signature before the last signature, forcing the RPC to go to Bigtable where there is no data

Observe that the RPC goes out to Bigtable and fetches successfully (finds nothing)

```shell
curl localhost:8899 -d '{
  "id": "1",
  "jsonrpc": "2.0",
  "method": "getSignaturesForAddress",
  "params": [
    "jZ2L6sHvF862QMKYxD7ho7JQAX5m1rT9VzVKvzSSbin",
    {
      "before":"45z1V6qdGUXRHid4YDzSSqV13pegyP2naBaA3aG4ZoS4xMdKjC3eBvhwTkbXrqEXJT38grfRJ11wCTn5Qop67AEv",
      "limit": 1
    }
  ]
}' --header 'Content-Type: application/json'
{"jsonrpc":"2.0","result":[],"id":"1"}
```

#### With the Bigtable emulator shut down, simulating a connection failure

##### Fetching a signature for an address that does not exist locally

```shell
curl localhost:8899 -d '{
  "id": "1",
  "jsonrpc": "2.0",
  "method": "getSignaturesForAddress",
  "params": [
    "BzszvNFvokG4v4qb1ipYSDGtKuhen8PMtYjevfZeAkKZ"
  ]
}' --header 'Content-Type: application/json'
{"jsonrpc":"2.0","error":{"code":-32019,"message":"Failed to query long-term storage; please try again"},"id":"1"}
```

##### Fetching a signature for an address _and_ before signature that don't exist locally

Observe that Bigtable experiences a connection error.

```shell
curl localhost:8899 -d '{
  "id": "1",
  "jsonrpc": "2.0",
  "method": "getSignaturesForAddress",
  "params": [
    "BzszvNFvokG4v4qb1ipYSDGtKuhen8PMtYjevfZeAkKZ",
    {"before":"31AUDAUXgD4B5DqqtFZZe8udgHUfbJX9dQbiXQGmNiRqeKRkzRTYitrRbJDtpt4DMd4P3G8haaXMJ8TU6wwQmf3h"}
  ]
}' --header 'Content-Type: application/json'
{"jsonrpc":"2.0","error":{"code":-32019,"message":"Failed to query long-term storage; please try again"},"id":"1"}
```

##### Fetching a signature for an address that is completely available locally

Observe Bigtable is never contacted.

```shell
curl localhost:8899 -d '{
  "id": "1",
  "jsonrpc": "2.0",
  "method": "getSignaturesForAddress",
  "params": [
    "jZ2L6sHvF862QMKYxD7ho7JQAX5m1rT9VzVKvzSSbin",
    {"limit": 1}
  ]
}' --header 'Content-Type: application/json'
{"jsonrpc":"2.0","result":{"jsonrpc":"2.0","result":[{"blockTime":1732058393,"confirmationStatus":"finalized","err":null,"memo":null,"signature":"3mZUQjhaGA7ytwb3g9PnjYL4d1ErsWf7nheMCqnSuwW6x2hF8tx4DuuvG1u7j6qVCC2J9JqpRHbJ7z57ayhJZyW2","slot":9284}],"id":"1"}
```

##### Fetching a signature for an address that does exist but with a bad `before` signature

Observe that Bigtable experiences a connection error.

```shell
curl localhost:8899 -d '{
  "id": "1",
  "jsonrpc": "2.0",
  "method": "getSignaturesForAddress",
  "params": [
    "jZ2L6sHvF862QMKYxD7ho7JQAX5m1rT9VzVKvzSSbin",
    {"before":"419mQJ2ZpM1uJ2VJyHckWNzmEpRKkyuirvRQH9NfgKvzQJxTcTa5v8U7tXJ4VkqEH8GsTtG7iqSsQBJe8VxxC2XQ","limit": 1}
  ]
}' --header 'Content-Type: application/json'
{"jsonrpc":"2.0","error":{"code":-32019,"message":"Failed to query long-term storage; please try again"},"id":"1"}
```

##### Fetching a signature before the last signature, forcing the RPC to go to Bigtable where there is no data

Observe that Bigtable experiences a connection error.

```shell
curl localhost:8899 -d '{
  "id": "1",
  "jsonrpc": "2.0",
  "method": "getSignaturesForAddress",
  "params": [
    "jZ2L6sHvF862QMKYxD7ho7JQAX5m1rT9VzVKvzSSbin",
    {
      "before":"45z1V6qdGUXRHid4YDzSSqV13pegyP2naBaA3aG4ZoS4xMdKjC3eBvhwTkbXrqEXJT38grfRJ11wCTn5Qop67AEv",
      "limit": 1
    }
  ]
}' --header 'Content-Type: application/json'
{"jsonrpc":"2.0","error":{"code":-32019,"message":"Failed to query long-term storage; please try again"},"id":"1"}
```

Fixes #3696