### PR TITLE
Marks old storages as dirty in clean_accounts()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2532,11 +2532,28 @@ impl AccountsDb {
         is_startup: bool,
         timings: &mut CleanKeyTimings,
         epoch_schedule: &EpochSchedule,
+        old_storages_policy: OldStoragesPolicy,
     ) -> CleaningCandidates {
         let oldest_non_ancient_slot = self.get_oldest_non_ancient_slot(epoch_schedule);
         let mut dirty_store_processing_time = Measure::start("dirty_store_processing");
-        let max_slot_inclusive =
-            max_clean_root_inclusive.unwrap_or_else(|| self.accounts_index.max_root_inclusive());
+        let max_root_inclusive = self.accounts_index.max_root_inclusive();
+        let max_slot_inclusive = max_clean_root_inclusive.unwrap_or(max_root_inclusive);
+
+        if old_storages_policy == OldStoragesPolicy::Clean {
+            let slot_one_epoch_old =
+                max_root_inclusive.saturating_sub(epoch_schedule.slots_per_epoch);
+            // do nothing special for these 100 old storages that will likely get cleaned up shortly
+            let acceptable_straggler_slot_count = 100;
+            let old_slot_cutoff =
+                slot_one_epoch_old.saturating_sub(acceptable_straggler_slot_count);
+            let (old_storages, old_slots) = self.get_snapshot_storages(..old_slot_cutoff);
+            let num_old_storages = old_storages.len();
+            for (old_slot, old_storage) in std::iter::zip(old_slots, old_storages) {
+                self.dirty_stores.entry(old_slot).or_insert(old_storage);
+            }
+            info!("Marked {num_old_storages} old storages as dirty");
+        }
+
         let mut dirty_stores = Vec::with_capacity(self.dirty_stores.len());
         // find the oldest dirty slot
         // we'll add logging if that append vec cannot be marked dead
@@ -2648,7 +2665,16 @@ impl AccountsDb {
 
     /// Call clean_accounts() with the common parameters that tests/benches use.
     pub fn clean_accounts_for_tests(&self) {
-        self.clean_accounts(None, false, &EpochSchedule::default())
+        self.clean_accounts(
+            None,
+            false,
+            &EpochSchedule::default(),
+            if self.ancient_append_vec_offset.is_some() {
+                OldStoragesPolicy::Leave
+            } else {
+                OldStoragesPolicy::Clean
+            },
+        )
     }
 
     /// called with cli argument to verify refcounts are correct on all accounts
@@ -2755,6 +2781,7 @@ impl AccountsDb {
         max_clean_root_inclusive: Option<Slot>,
         is_startup: bool,
         epoch_schedule: &EpochSchedule,
+        old_storages_policy: OldStoragesPolicy,
     ) {
         if self.exhaustively_verify_refcounts {
             self.exhaustively_verify_refcounts(max_clean_root_inclusive);
@@ -2776,6 +2803,7 @@ impl AccountsDb {
             is_startup,
             &mut key_timings,
             epoch_schedule,
+            old_storages_policy,
         );
 
         let num_candidates = Self::count_pubkeys(&candidates);
@@ -4700,7 +4728,15 @@ impl AccountsDb {
         let maybe_clean = || {
             if self.dirty_stores.len() > DIRTY_STORES_CLEANING_THRESHOLD {
                 let latest_full_snapshot_slot = self.latest_full_snapshot_slot();
-                self.clean_accounts(latest_full_snapshot_slot, is_startup, epoch_schedule);
+                self.clean_accounts(
+                    latest_full_snapshot_slot,
+                    is_startup,
+                    epoch_schedule,
+                    // Leave any old storages alone for now.  Once the validator is running
+                    // normal, calls to clean_accounts() will have the correct policy based
+                    // on if ancient storages are enabled or not.
+                    OldStoragesPolicy::Leave,
+                );
             }
         };
 
@@ -6874,40 +6910,6 @@ impl AccountsDb {
         true
     }
 
-    /// storages are sorted by slot and have range info.
-    /// add all stores older than slots_per_epoch to dirty_stores so clean visits these slots
-    fn mark_old_slots_as_dirty(
-        &self,
-        storages: &SortedStorages,
-        slots_per_epoch: Slot,
-        stats: &mut crate::accounts_hash::HashStats,
-    ) {
-        // Nothing to do if ancient append vecs are enabled.
-        // Ancient slots will be visited by the ancient append vec code and dealt with correctly.
-        // we expect these ancient append vecs to be old and keeping accounts
-        // We can expect the normal processes will keep them cleaned.
-        // If we included them here then ALL accounts in ALL ancient append vecs will be visited by clean each time.
-        if self.ancient_append_vec_offset.is_some() {
-            return;
-        }
-
-        let mut mark_time = Measure::start("mark_time");
-        let mut num_dirty_slots: usize = 0;
-        let max = storages.max_slot_inclusive();
-        let acceptable_straggler_slot_count = 100; // do nothing special for these old stores which will likely get cleaned up shortly
-        let sub = slots_per_epoch + acceptable_straggler_slot_count;
-        let in_epoch_range_start = max.saturating_sub(sub);
-        for (slot, storage) in storages.iter_range(&(..in_epoch_range_start)) {
-            if let Some(storage) = storage {
-                self.dirty_stores.insert(slot, storage.clone());
-                num_dirty_slots += 1;
-            }
-        }
-        mark_time.stop();
-        stats.mark_time_us = mark_time.as_us();
-        stats.num_dirty_slots = num_dirty_slots;
-    }
-
     pub fn calculate_accounts_hash_from(
         &self,
         data_source: CalcAccountsHashDataSource,
@@ -7247,8 +7249,6 @@ impl AccountsDb {
         let _guard = self.active_stats.activate(ActiveStatItem::Hash);
         let storages_start_slot = storages.range().start;
         stats.oldest_root = storages_start_slot;
-
-        self.mark_old_slots_as_dirty(storages, config.epoch_schedule.slots_per_epoch, &mut stats);
 
         let slot = storages.max_slot_inclusive();
         let use_bg_thread_pool = config.use_bg_thread_pool;
@@ -9343,6 +9343,20 @@ pub(crate) enum UpdateIndexThreadSelection {
     Inline,
     /// Use a thread-pool if the number of updates exceeds a threshold
     PoolWithThreshold,
+}
+
+/// How should old storages be handled in clean_accounts()?
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum OldStoragesPolicy {
+    /// Clean all old storages, even if they were not explictly marked as dirty.
+    ///
+    /// This is the default behavior when not skipping rewrites.
+    Clean,
+    /// Leave all old storages.
+    ///
+    /// When skipping rewrites, we intentionally will have ancient storages.
+    /// Do not clean them up automatically in clean_accounts().
+    Leave,
 }
 
 // These functions/fields are only usable from a dev context (i.e. tests and benches)


### PR DESCRIPTION
#### Problem

We do not clean up old storages.

More context: when calculating a full accounts hash, we call `mark_old_slots_as_dirty()` as a way to ensure we do not forget or miss cleaning up really old storages (i.e. ones that are older than an epoch old). But, when we enable skipping rewrites, we *don't* want to clean up those old storages, as they'll intentionally be treated as ancient append vecs. So inside `mark_old_slots_as_dirty()` we *conditionally* mark old slots as dirty. This is based on the value of `ancient_append_vec_offset`, which should be None unless ancient append vecs are enabled.

Unfortunately, normal running validators, we end up *never* marking old slots as dirty, because the ancient append vec offset is *always* Some. And thus we don't clean up old storages.


#### Summary of Changes

Mark old storages as dirty in clean_accounts().

We still check if ancient append vecs are enabled, but not with the `ancient_append_vec_offset`. Instead we look at the skipping rewrites feature gate and the cli arg.

By moving this marking into clean_accounts(), we also decouple it from accounts hash calculation, which is not necessary anymore. This also removes behavioral differences based on if snapshots are enabled or not.