### PR TITLE
`is_simple_vote_transaction`: Use length check instead of `xor()`

### DIFF
--- a/sdk/src/simple_vote_transaction_checker.rs
+++ b/sdk/src/simple_vote_transaction_checker.rs
@@ -45,7 +45,7 @@ pub fn is_simple_vote_transaction_impl<'a>(
         && is_legacy_message
         && instruction_programs
             .next()
-            .xor(instruction_programs.next())
             .map(|program_id| program_id == &solana_sdk::vote::program::ID)
             .unwrap_or(false)
+        && instruction_programs.next().is_none()
 }


### PR DESCRIPTION
While an `xor()` call works, it is relying on the fact that the iterator is not going to return a `None` followed by a `Some`, and so requires a bit more mental effort from the reader to understand the code.  At first, I actually thought that it was an unsuccessful attempt at checking transactions with both 1 and 2 instructions.

Directly checking the iterator lengths seems as efficient, but also a bit more straightforward.