### PR TITLE
tests that Vec<CrdsValue> (de)serialization round trips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7112,6 +7112,7 @@ version = "2.2.0"
 dependencies = [
  "assert_matches",
  "bincode",
+ "bs58",
  "bv",
  "clap 2.33.3",
  "crossbeam-channel",
@@ -7122,7 +7123,9 @@ dependencies = [
  "lru",
  "num-traits",
  "num_cpus",
+ "rand 0.7.3",
  "rand 0.8.5",
+ "rand_chacha 0.2.2",
  "rand_chacha 0.3.1",
  "rayon",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,6 +377,7 @@ quote = "1.0"
 rand = "0.8.5"
 rand0-7 = { package = "rand", version = "0.7" }
 rand_chacha = "0.3.1"
+rand_chacha0-2 = { package = "rand_chacha", version = "0.2.2" }
 rayon = "1.10.0"
 reed-solomon-erasure = "6.0.0"
 regex = "1.11.1"

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -61,7 +61,10 @@ static_assertions = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+bs58 = { workspace = true }
 num_cpus = { workspace = true }
+rand0-7 = { workspace = true }
+rand_chacha0-2 = { workspace = true }
 serial_test = { workspace = true }
 solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/3575 reworks `CrdsValue` (de)serialization.
Need to verify that the serialization does not change and round trips.

#### Summary of Changes
* added a round trip test for `Vec<CrdsValue>` (de)serialization.
* also verifying serialized bytes against a hard-coded hash.