### PR TITLE
sdk: Feature gate BorrowedInstruction properly

### DIFF
--- a/sdk/instruction/src/lib.rs
+++ b/sdk/instruction/src/lib.rs
@@ -17,8 +17,9 @@
 
 #[cfg(feature = "std")]
 extern crate std;
+use solana_pubkey::Pubkey;
 #[cfg(feature = "std")]
-use {solana_pubkey::Pubkey, std::vec::Vec};
+use std::vec::Vec;
 pub mod account_meta;
 #[cfg(feature = "std")]
 pub use account_meta::AccountMeta;
@@ -311,6 +312,7 @@ pub struct BorrowedAccountMeta<'a> {
 ///
 /// This struct is used by the runtime when constructing the instructions sysvar. It is not
 /// useful to Solana programs.
+#[cfg(feature = "std")]
 pub struct BorrowedInstruction<'a> {
     pub program_id: &'a Pubkey,
     pub accounts: Vec<BorrowedAccountMeta<'a>>,


### PR DESCRIPTION
#### Problem

`solana-instruction` doesn't currently build without the `std` feature, because the feature gates usage of `Pubkey` and `Vec`.

#### Summary of changes

Always bring in `Pubkey` for usage in `BorrowedAccountMeta`, gate `BorrowedInstruction` on the `std` feature.