### PR TITLE
remove solana-sdk from solana-bucket-map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6245,9 +6245,10 @@ dependencies = [
  "num_enum",
  "rand 0.8.5",
  "rayon",
+ "solana-clock",
  "solana-logger",
  "solana-measure",
- "solana-sdk",
+ "solana-pubkey",
  "tempfile",
 ]
 

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -19,14 +19,16 @@ memmap2 = { workspace = true }
 modular-bitfield = { workspace = true }
 num_enum = { workspace = true }
 rand = { workspace = true }
+solana-clock = { workspace = true }
 solana-measure = { workspace = true }
-solana-sdk = { workspace = true }
+solana-pubkey = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]
 fs_extra = { workspace = true }
 rayon = { workspace = true }
 solana-logger = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
 
 [lib]
 crate-type = ["lib"]

--- a/bucket_map/benches/bucket_map.rs
+++ b/bucket_map/benches/bucket_map.rs
@@ -22,7 +22,7 @@ extern crate test;
 use {
     rayon::prelude::*,
     solana_bucket_map::bucket_map::{BucketMap, BucketMapConfig},
-    solana_sdk::pubkey::Pubkey,
+    solana_pubkey::Pubkey,
     std::{collections::hash_map::HashMap, sync::RwLock},
     test::Bencher,
 };

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -16,7 +16,7 @@ use {
     },
     rand::{thread_rng, Rng},
     solana_measure::measure::Measure,
-    solana_sdk::pubkey::Pubkey,
+    solana_pubkey::Pubkey,
     std::{
         collections::hash_map::DefaultHasher,
         fs,

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -3,7 +3,7 @@ use {
         bucket::Bucket, bucket_item::BucketItem, bucket_map::BucketMapError,
         bucket_stats::BucketMapStats, restart::RestartableBucket, MaxSearch, RefCount,
     },
-    solana_sdk::pubkey::Pubkey,
+    solana_pubkey::Pubkey,
     std::{
         ops::RangeBounds,
         path::PathBuf,

--- a/bucket_map/src/bucket_item.rs
+++ b/bucket_map/src/bucket_item.rs
@@ -1,4 +1,4 @@
-use {crate::RefCount, solana_sdk::pubkey::Pubkey};
+use {crate::RefCount, solana_pubkey::Pubkey};
 
 #[derive(Debug, Default, Clone)]
 pub struct BucketItem<T> {

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         bucket_api::BucketApi, bucket_stats::BucketMapStats, restart::Restart, MaxSearch, RefCount,
     },
-    solana_sdk::pubkey::Pubkey,
+    solana_pubkey::Pubkey,
     std::{
         convert::TryInto,
         fmt::Debug,
@@ -491,7 +491,7 @@ mod tests {
 
                     let additions = (0..to_add)
                         .map(|_| {
-                            let k = solana_sdk::pubkey::new_rand();
+                            let k = solana_pubkey::new_rand();
                             let mut v = gen_rand_value();
                             if use_batch_insert {
                                 // refcount has to be 1 to use batch insert

--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -8,7 +8,8 @@ use {
     bv::BitVec,
     modular_bitfield::prelude::*,
     num_enum::FromPrimitive,
-    solana_sdk::{clock::Slot, pubkey::Pubkey},
+    solana_clock::Slot,
+    solana_pubkey::Pubkey,
     std::{fmt::Debug, marker::PhantomData},
 };
 

--- a/bucket_map/tests/bucket_map.rs
+++ b/bucket_map/tests/bucket_map.rs
@@ -2,7 +2,7 @@ use {
     rayon::prelude::*,
     solana_bucket_map::bucket_map::{BucketMap, BucketMapConfig},
     solana_measure::measure::Measure,
-    solana_sdk::pubkey::Pubkey,
+    solana_pubkey::Pubkey,
     std::path::PathBuf,
 };
 #[test]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5137,8 +5137,9 @@ dependencies = [
  "modular-bitfield",
  "num_enum",
  "rand 0.8.5",
+ "solana-clock",
  "solana-measure",
- "solana-sdk",
+ "solana-pubkey",
  "tempfile",
 ]
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -4989,8 +4989,9 @@ dependencies = [
  "modular-bitfield",
  "num_enum",
  "rand 0.8.5",
+ "solana-clock",
  "solana-measure",
- "solana-sdk",
+ "solana-pubkey",
  "tempfile",
 ]
 
@@ -6770,6 +6771,7 @@ dependencies = [
 name = "solana-svm"
 version = "2.2.0"
 dependencies = [
+ "ahash 0.8.11",
  "itertools 0.12.1",
  "log",
  "percentage",


### PR DESCRIPTION
This can compile faster by replacing solana-sdk with its constituent crates