### PR TITLE
remove solana-sdk from solana-notifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7607,7 +7607,7 @@ dependencies = [
  "log",
  "reqwest",
  "serde_json",
- "solana-sdk",
+ "solana-hash",
 ]
 
 [[package]]

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 log = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 serde_json = { workspace = true }
-solana-sdk = { workspace = true }
+solana-hash = { workspace = true }
 
 [lib]
 name = "solana_notifier"

--- a/notifier/src/lib.rs
+++ b/notifier/src/lib.rs
@@ -27,7 +27,7 @@ use log::*;
 use {
     reqwest::{blocking::Client, StatusCode},
     serde_json::json,
-    solana_sdk::hash::Hash,
+    solana_hash::Hash,
     std::{env, str::FromStr, thread::sleep, time::Duration},
 };
 


### PR DESCRIPTION
This crate only needs solana-hash, not solana-sdk