### PR TITLE
Allow AccountInfo to be absent for read-only instruction accounts

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -2581,7 +2581,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(accounts.len(), 1);
-        let caller_account = &accounts[1].1;
+        let caller_account = &accounts[0].1;
         assert_eq!(caller_account.serialized_data, account.data());
         assert_eq!(caller_account.original_data_len, original_data_len);
     }

--- a/programs/sbf/c/src/invoke/invoke.c
+++ b/programs/sbf/c/src/invoke/invoke.c
@@ -344,6 +344,20 @@ extern uint64_t entrypoint(const uint8_t *input) {
       sol_assert(SUCCESS ==
                  sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
     }
+
+    sol_log("Empty accounts slice");
+    {
+	SolAccountMeta arguments[] = {
+	    {accounts[INVOKED_ARGUMENT_INDEX].key, false, false},
+	    {accounts[ARGUMENT_INDEX].key, false, false}};
+	uint8_t data[] = {};
+	const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
+					    arguments, SOL_ARRAY_SIZE(arguments),
+					    data, SOL_ARRAY_SIZE(data)};
+
+	sol_assert(SUCCESS == sol_invoke(&instruction, 0, 0));
+    }
+
     break;
   }
   case TEST_PRIVILEGE_ESCALATION_SIGNER: {
@@ -402,7 +416,8 @@ extern uint64_t entrypoint(const uint8_t *input) {
     sol_log("Empty accounts slice");
 
     SolAccountMeta arguments[] = {
-        {accounts[INVOKED_ARGUMENT_INDEX].key, false, false}};
+        {accounts[INVOKED_ARGUMENT_INDEX].key, false, false},
+        {accounts[ARGUMENT_INDEX].key, true, false}};
     uint8_t data[] = {};
     const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                         arguments, SOL_ARRAY_SIZE(arguments),

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -434,6 +434,19 @@ fn process_instruction<'a>(
                 reordered_accounts.push(account_info);
                 invoke(&instruction, &reordered_accounts)?;
             }
+
+            msg!("Empty accounts slice");
+            {
+                let instruction = create_instruction(
+                    *accounts[INVOKED_PROGRAM_INDEX].key,
+                    &[
+                        (accounts[INVOKED_ARGUMENT_INDEX].key, false, false),
+                        (accounts[ARGUMENT_INDEX].key, false, false),
+                    ],
+                    vec![],
+                );
+                invoke(&instruction, &[])?;
+            }
         }
         TEST_PRIVILEGE_ESCALATION_SIGNER => {
             msg!("Test privilege escalation signer");
@@ -483,7 +496,10 @@ fn process_instruction<'a>(
             msg!("Empty accounts slice");
             let instruction = create_instruction(
                 *accounts[INVOKED_PROGRAM_INDEX].key,
-                &[(accounts[INVOKED_ARGUMENT_INDEX].key, false, false)],
+                &[
+                    (accounts[INVOKED_ARGUMENT_INDEX].key, false, false),
+                    (accounts[ARGUMENT_INDEX].key, true, false),
+                ],
                 vec![],
             );
             invoke(&instruction, &[])?;

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -819,6 +819,7 @@ fn test_program_sbf_invoke_sanity() {
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
+                invoked_program_id.clone(),
             ],
             Languages::Rust => vec![
                 system_program::id(),
@@ -843,6 +844,7 @@ fn test_program_sbf_invoke_sanity() {
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
                 system_program::id(),
+                invoked_program_id.clone(),
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
             ],


### PR DESCRIPTION
#### Problem

With direct mapping, we no longer want to depend on the execute bit in accounts. 
Some programs on mainnet do not pass an `AccountInfo` for programs. So, make this slightly more generic and allow `AccountInfo` to be missing for any read-only instruction account.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
