### PR TITLE
Adds --accounts-db-verify-experimental-accumulator-hash

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -511,6 +511,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     storage_access: StorageAccess::Mmap,
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalWithVerify,
     enable_experimental_accumulator_hash: false,
+    verify_experimental_accumulator_hash: false,
     num_clean_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
@@ -536,6 +537,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     storage_access: StorageAccess::Mmap,
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalWithVerify,
     enable_experimental_accumulator_hash: false,
+    verify_experimental_accumulator_hash: false,
     num_clean_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
@@ -663,6 +665,7 @@ pub struct AccountsDbConfig {
     pub storage_access: StorageAccess,
     pub scan_filter_for_shrinking: ScanFilter,
     pub enable_experimental_accumulator_hash: bool,
+    pub verify_experimental_accumulator_hash: bool,
     /// Number of threads for background cleaning operations (`thread_pool_clean')
     pub num_clean_threads: Option<NonZeroUsize>,
     /// Number of threads for foreground operations (`thread_pool`)
@@ -1621,6 +1624,10 @@ pub struct AccountsDb {
     /// (For R&D only; a feature-gate also exists to turn this on and make it a part of consensus.)
     pub is_experimental_accumulator_hash_enabled: AtomicBool,
 
+    /// Flag to indicate if the experimental accounts lattice hash should be verified.
+    /// (For R&D only)
+    pub verify_experimental_accumulator_hash: bool,
+
     /// These are the ancient storages that could be valuable to
     /// shrink, sorted by amount of dead bytes.  The elements
     /// are sorted from the largest dead bytes to the smallest.
@@ -2040,6 +2047,8 @@ impl AccountsDb {
             is_experimental_accumulator_hash_enabled: accounts_db_config
                 .enable_experimental_accumulator_hash
                 .into(),
+            verify_experimental_accumulator_hash: accounts_db_config
+                .verify_experimental_accumulator_hash,
             bank_hash_stats,
             thread_pool,
             thread_pool_clean,

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -131,6 +131,10 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .long("accounts-db-experimental-accumulator-hash")
             .help("Enables the experimental accumulator hash")
             .hidden(hidden_unless_forced()),
+        Arg::with_name("accounts_db_verify_experimental_accumulator_hash")
+            .long("accounts-db-verify-experimental-accumulator-hash")
+            .help("Verifies the experimental accumulator hash")
+            .hidden(hidden_unless_forced()),
         Arg::with_name("accounts_db_hash_threads")
             .long("accounts-db-hash-threads")
             .value_name("NUM_THREADS")
@@ -392,6 +396,8 @@ pub fn get_accounts_db_config(
         scan_filter_for_shrinking,
         enable_experimental_accumulator_hash: arg_matches
             .is_present("accounts_db_experimental_accumulator_hash"),
+        verify_experimental_accumulator_hash: arg_matches
+            .is_present("accounts_db_verify_experimental_accumulator_hash"),
         num_hash_threads,
         ..AccountsDbConfig::default()
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3028,6 +3028,34 @@ impl Bank {
                 // updating the accounts lt hash must happen *outside* of hash_internal_state() so
                 // that rehash() can be called and *not* modify self.accounts_lt_hash.
                 self.update_accounts_lt_hash();
+
+                // For lattice-hash R&D, we have a CLI arg to do extra verfication.  If set, we'll
+                // re-calculate the accounts lt hash every slot and compare it against the value
+                // already stored in the bank.
+                if self
+                    .rc
+                    .accounts
+                    .accounts_db
+                    .verify_experimental_accumulator_hash
+                {
+                    let slot = self.slot();
+                    info!("Verifying the accounts lt hash for slot {slot}...");
+                    let (calculated_accounts_lt_hash, duration) = meas_dur!({
+                        self.rc
+                            .accounts
+                            .accounts_db
+                            .calculate_accounts_lt_hash_at_startup_from_index(&self.ancestors, slot)
+                    });
+                    let actual_accounts_lt_hash = self.accounts_lt_hash.lock().unwrap();
+                    assert_eq!(
+                        calculated_accounts_lt_hash,
+                        *actual_accounts_lt_hash,
+                        "Verifying the accounts lt hash for slot {slot} failed! calculated checksum: {}, actual checksum: {}",
+                        calculated_accounts_lt_hash.0.checksum(),
+                        actual_accounts_lt_hash.0.checksum(),
+                    );
+                    info!("Verifying the accounts lt hash for slot {slot}... Done successfully in {duration:?}");
+                }
             }
             *hash = self.hash_internal_state();
             self.rc.accounts.accounts_db.mark_slot_frozen(self.slot());

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1421,6 +1421,12 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .hidden(hidden_unless_forced()),
         )
         .arg(
+            Arg::with_name("accounts_db_verify_experimental_accumulator_hash")
+                .long("accounts-db-verify-experimental-accumulator-hash")
+                .help("Verifies the experimental accumulator hash")
+                .hidden(hidden_unless_forced()),
+        )
+        .arg(
             Arg::with_name("accounts_index_scan_results_limit_mb")
                 .long("accounts-index-scan-results-limit-mb")
                 .value_name("MEGABYTES")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1364,6 +1364,8 @@ pub fn main() {
         scan_filter_for_shrinking,
         enable_experimental_accumulator_hash: matches
             .is_present("accounts_db_experimental_accumulator_hash"),
+        verify_experimental_accumulator_hash: matches
+            .is_present("accounts_db_verify_experimental_accumulator_hash"),
         num_clean_threads: Some(accounts_db_clean_threads),
         num_foreground_threads: Some(accounts_db_foreground_threads),
         num_hash_threads: Some(accounts_db_hash_threads),


### PR DESCRIPTION
#### Problem

Often while testing/debugging account lattice hash issues, I insert code that verifies the accounts lt hash at every slot. I've done this often enough that I wish it was just built in. Additionally, this will allow firedancer folks to do this same verification as well.


#### Summary of Changes

Add a new hidden cli arg to do extra accounts lattice hash verification. Specifically, recalculate the accounts lt hash during Bank::freeze() and assert it matches the value in the bank.