### PR TITLE
remove solana-sdk from solana-timings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,12 +5330,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "saturating_add_assign"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3c68b8e0f71b18a2544d210b8562170c611b89394b434bcf4a986a3159d69a"
-
-[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9101,7 +9095,6 @@ version = "2.2.0"
 dependencies = [
  "eager",
  "enum-iterator",
- "saturating_add_assign",
  "solana-pubkey",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,6 +5330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "saturating_add_assign"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d3c68b8e0f71b18a2544d210b8562170c611b89394b434bcf4a986a3159d69a"
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9095,7 +9101,8 @@ version = "2.2.0"
 dependencies = [
  "eager",
  "enum-iterator",
- "solana-sdk",
+ "saturating_add_assign",
+ "solana-pubkey",
 ]
 
 [[package]]

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -44,6 +44,7 @@ use {
     solana_svm_transaction::svm_message::SVMMessage,
     solana_timings::ExecuteTimings,
     std::{
+        num::Saturating,
         sync::{atomic::Ordering, Arc},
         time::Instant,
     },
@@ -790,11 +791,11 @@ impl Consumer {
             (0, 0),
             |(units, times), program_timings| {
                 (
-                    (std::num::Saturating(units)
+                    (Saturating(units)
                         + program_timings.accumulated_units
                         + program_timings.total_errored_units)
                         .0,
-                    (std::num::Saturating(times) + program_timings.accumulated_us).0,
+                    (Saturating(times) + program_timings.accumulated_us).0,
                 )
             },
         )
@@ -2521,11 +2522,11 @@ mod tests {
             execute_timings.details.per_program_timings.insert(
                 Pubkey::new_unique(),
                 ProgramTiming {
-                    accumulated_us: n * 100,
-                    accumulated_units: n * 1000,
-                    count: n as u32,
+                    accumulated_us: Saturating(n * 100),
+                    accumulated_units: Saturating(n * 1000),
+                    count: Saturating(n as u32),
                     errored_txs_compute_consumed: vec![],
-                    total_errored_units: 0,
+                    total_errored_units: Saturating(0),
                 },
             );
             expected_us += n * 100;

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -790,10 +790,11 @@ impl Consumer {
             (0, 0),
             |(units, times), program_timings| {
                 (
-                    units
-                        .saturating_add(program_timings.accumulated_units)
-                        .saturating_add(program_timings.total_errored_units),
-                    times.saturating_add(program_timings.accumulated_us),
+                    (std::num::Saturating(units)
+                        + program_timings.accumulated_units
+                        + program_timings.total_errored_units)
+                        .0,
+                    (std::num::Saturating(times) + program_timings.accumulated_us).0,
                 )
             },
         )

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1443,10 +1443,10 @@ impl ReplaySlotStats {
                 (0, 0, 0, 0, 0),
                 |(sum_us, sum_units, sum_count, sum_errored_units, sum_errored_count), a| {
                     (
-                        sum_us + a.1.accumulated_us,
-                        sum_units + a.1.accumulated_units,
-                        sum_count + a.1.count,
-                        sum_errored_units + a.1.total_errored_units,
+                        sum_us + a.1.accumulated_us.0,
+                        sum_units + a.1.accumulated_units.0,
+                        sum_count + a.1.count.0,
+                        sum_errored_units + a.1.total_errored_units.0,
                         sum_errored_count + a.1.errored_txs_compute_consumed.len(),
                     )
                 },
@@ -1457,10 +1457,10 @@ impl ReplaySlotStats {
                 "per_program_timings",
                 ("slot", slot as i64, i64),
                 ("pubkey", pubkey.to_string(), String),
-                ("execute_us", time.accumulated_us, i64),
-                ("accumulated_units", time.accumulated_units, i64),
-                ("errored_units", time.total_errored_units, i64),
-                ("count", time.count, i64),
+                ("execute_us", time.accumulated_us.0, i64),
+                ("accumulated_units", time.accumulated_units.0, i64),
+                ("errored_units", time.total_errored_units.0, i64),
+                ("count", time.count.0, i64),
                 (
                     "errored_count",
                     time.errored_txs_compute_consumed.len(),

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -31,7 +31,6 @@ use {
         native_loader,
         precompiles::Precompile,
         pubkey::Pubkey,
-        saturating_add_assign,
         stable_layout::stable_instruction::StableInstruction,
         sysvar,
         transaction_context::{
@@ -601,13 +600,10 @@ impl<'a> InvokeContext<'a> {
             return Err(InstructionError::BuiltinProgramsMustConsumeComputeUnits);
         }
 
-        saturating_add_assign!(
-            timings
-                .execute_accessories
-                .process_instructions
-                .process_executable_chain_us,
-            process_executable_chain_time.end_as_us()
-        );
+        timings
+            .execute_accessories
+            .process_instructions
+            .process_executable_chain_us += process_executable_chain_time.end_as_us();
         result
     }
 

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -289,13 +289,10 @@ pub struct LoadProgramMetrics {
 
 impl LoadProgramMetrics {
     pub fn submit_datapoint(&self, timings: &mut ExecuteDetailsTimings) {
-        saturating_add_assign!(
-            timings.create_executor_register_syscalls_us,
-            self.register_syscalls_us
-        );
-        saturating_add_assign!(timings.create_executor_load_elf_us, self.load_elf_us);
-        saturating_add_assign!(timings.create_executor_verify_code_us, self.verify_code_us);
-        saturating_add_assign!(timings.create_executor_jit_compile_us, self.jit_compile_us);
+        timings.create_executor_register_syscalls_us += self.register_syscalls_us;
+        timings.create_executor_load_elf_us += self.load_elf_us;
+        timings.create_executor_verify_code_us += self.verify_code_us;
+        timings.create_executor_jit_compile_us += self.jit_compile_us;
         datapoint_trace!(
             "create_executor_trace",
             ("program_id", self.program_id, String),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -43,7 +43,6 @@ use {
         loader_v4, native_loader,
         program_utils::limited_deserialize,
         pubkey::Pubkey,
-        saturating_add_assign,
         system_instruction::{self, MAX_PERMITTED_DATA_LENGTH},
         transaction_context::{IndexOfAccount, InstructionContext, TransactionContext},
     },
@@ -469,10 +468,7 @@ pub fn process_instruction_inner(
         })?;
     drop(program_account);
     get_or_create_executor_time.stop();
-    saturating_add_assign!(
-        invoke_context.timings.get_or_create_executor_us,
-        get_or_create_executor_time.as_us()
-    );
+    invoke_context.timings.get_or_create_executor_us += get_or_create_executor_time.as_us();
 
     executor.ix_usage_counter.fetch_add(1, Ordering::Relaxed);
     match &executor.program {
@@ -1452,7 +1448,7 @@ pub fn execute<'a, 'b: 'a>(
         drop(vm);
         if let Some(execute_time) = invoke_context.execute_time.as_mut() {
             execute_time.stop();
-            saturating_add_assign!(invoke_context.timings.execute_us, execute_time.as_us());
+            invoke_context.timings.execute_us += execute_time.as_us();
         }
 
         ic_logger_msg!(
@@ -1549,12 +1545,9 @@ pub fn execute<'a, 'b: 'a>(
     deserialize_time.stop();
 
     // Update the timings
-    saturating_add_assign!(invoke_context.timings.serialize_us, serialize_time.as_us());
-    saturating_add_assign!(invoke_context.timings.create_vm_us, create_vm_time.as_us());
-    saturating_add_assign!(
-        invoke_context.timings.deserialize_us,
-        deserialize_time.as_us()
-    );
+    invoke_context.timings.serialize_us += serialize_time.as_us();
+    invoke_context.timings.create_vm_us += create_vm_time.as_us();
+    invoke_context.timings.deserialize_us += deserialize_time.as_us();
 
     execute_or_deserialize_result
 }

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -10,7 +10,6 @@ use {
         memory_region::{MemoryRegion, MemoryState},
     },
     solana_sdk::{
-        saturating_add_assign,
         stable_layout::stable_instruction::StableInstruction,
         syscalls::{
             MAX_CPI_ACCOUNT_INFOS, MAX_CPI_INSTRUCTION_ACCOUNTS, MAX_CPI_INSTRUCTION_DATA_LEN,
@@ -1087,7 +1086,7 @@ fn cpi_common<S: SyscallInvokeSigned>(
     )?;
     if let Some(execute_time) = invoke_context.execute_time.as_mut() {
         execute_time.stop();
-        saturating_add_assign!(invoke_context.timings.execute_us, execute_time.as_us());
+        invoke_context.timings.execute_us += execute_time.as_us();
     }
 
     let instruction = S::translate_instruction(instruction_addr, memory_mapping, invoke_context)?;

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -13,7 +13,6 @@ use {
         loader_v4_instruction::LoaderV4Instruction,
         program_utils::limited_deserialize,
         pubkey::Pubkey,
-        saturating_add_assign,
         transaction_context::{BorrowedAccount, InstructionContext},
     },
     solana_type_overrides::sync::{atomic::Ordering, Arc},
@@ -456,10 +455,7 @@ pub fn process_instruction_inner(
                 InstructionError::UnsupportedProgramId
             })?;
         get_or_create_executor_time.stop();
-        saturating_add_assign!(
-            invoke_context.timings.get_or_create_executor_us,
-            get_or_create_executor_time.as_us()
-        );
+        invoke_context.timings.get_or_create_executor_us += get_or_create_executor_time.as_us();
         drop(program);
         loaded_program
             .ix_usage_counter

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4530,12 +4530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "saturating_add_assign"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3c68b8e0f71b18a2544d210b8562170c611b89394b434bcf4a986a3159d69a"
-
-[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7678,7 +7672,6 @@ version = "2.2.0"
 dependencies = [
  "eager",
  "enum-iterator",
- "saturating_add_assign",
  "solana-pubkey",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4530,6 +4530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "saturating_add_assign"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d3c68b8e0f71b18a2544d210b8562170c611b89394b434bcf4a986a3159d69a"
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7672,7 +7678,8 @@ version = "2.2.0"
 dependencies = [
  "eager",
  "enum-iterator",
- "solana-sdk",
+ "saturating_add_assign",
+ "solana-pubkey",
 ]
 
 [[package]]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3668,8 +3668,10 @@ impl Bank {
                 .per_program_timings
                 .iter()
                 .fold(0, |acc: u64, (_, program_timing)| {
-                    acc.saturating_add(program_timing.accumulated_units)
-                        .saturating_add(program_timing.total_errored_units)
+                    (std::num::Saturating(acc)
+                        + program_timing.accumulated_units
+                        + program_timing.total_errored_units)
+                        .0
                 });
 
         debug!("simulate_transaction: {:?}", timings);

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -4402,6 +4402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "saturating_add_assign"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d3c68b8e0f71b18a2544d210b8562170c611b89394b434bcf4a986a3159d69a"
+
+[[package]]
 name = "schannel"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7024,7 +7030,8 @@ version = "2.2.0"
 dependencies = [
  "eager",
  "enum-iterator",
- "solana-sdk",
+ "saturating_add_assign",
+ "solana-pubkey",
 ]
 
 [[package]]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -4402,12 +4402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "saturating_add_assign"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3c68b8e0f71b18a2544d210b8562170c611b89394b434bcf4a986a3159d69a"
-
-[[package]]
 name = "schannel"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7030,7 +7024,6 @@ version = "2.2.0"
 dependencies = [
  "eager",
  "enum-iterator",
- "saturating_add_assign",
  "solana-pubkey",
 ]
 

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -4,7 +4,6 @@ use {
     solana_sdk::{
         account::WritableAccount,
         precompiles::get_precompile,
-        saturating_add_assign,
         sysvar::instructions,
         transaction::TransactionError,
         transaction_context::{IndexOfAccount, InstructionAccount},
@@ -118,13 +117,10 @@ impl MessageProcessor {
                 execute_timings.details.accumulate(&invoke_context.timings);
                 ExecuteDetailsTimings::default()
             };
-            saturating_add_assign!(
-                execute_timings
-                    .execute_accessories
-                    .process_instructions
-                    .total_us,
-                process_instruction_us
-            );
+            execute_timings
+                .execute_accessories
+                .process_instructions
+                .total_us += process_instruction_us;
 
             result
                 .map_err(|err| TransactionError::InstructionError(instruction_index as u8, err))?;

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1010,10 +1010,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         drop(invoke_context);
 
-        saturating_add_assign!(
-            execute_timings.execute_accessories.process_message_us,
-            process_message_time.as_us()
-        );
+        execute_timings.execute_accessories.process_message_us += process_message_time.as_us();
 
         let mut status = process_result
             .and_then(|info| {
@@ -1075,14 +1072,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let status = status.map(|_| ());
 
         loaded_transaction.accounts = accounts;
-        saturating_add_assign!(
-            execute_timings.details.total_account_count,
-            loaded_transaction.accounts.len() as u64
-        );
-        saturating_add_assign!(
-            execute_timings.details.changed_account_count,
-            touched_account_count
-        );
+        execute_timings.details.total_account_count += loaded_transaction.accounts.len() as u64;
+        execute_timings.details.changed_account_count += touched_account_count;
 
         let return_data = if config.recording_config.enable_return_data_recording
             && !return_data.data.is_empty()

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -2470,18 +2470,20 @@ fn svm_metrics_accumulation() {
             result
                 .execute_timings
                 .details
-                .create_executor_jit_compile_us,
+                .create_executor_jit_compile_us
+                .0,
             0
         );
         assert_ne!(
-            result.execute_timings.details.create_executor_load_elf_us,
+            result.execute_timings.details.create_executor_load_elf_us.0,
             0
         );
         assert_ne!(
             result
                 .execute_timings
                 .details
-                .create_executor_verify_code_us,
+                .create_executor_verify_code_us
+                .0,
             0
         );
     }

--- a/timings/Cargo.toml
+++ b/timings/Cargo.toml
@@ -12,7 +12,8 @@ edition = { workspace = true }
 [dependencies]
 eager = { workspace = true }
 enum-iterator = { workspace = true }
-solana-sdk = { workspace = true }
+saturating_add_assign = { workspace = true }
+solana-pubkey = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/timings/Cargo.toml
+++ b/timings/Cargo.toml
@@ -12,7 +12,6 @@ edition = { workspace = true }
 [dependencies]
 eager = { workspace = true }
 enum-iterator = { workspace = true }
-saturating_add_assign = { workspace = true }
 solana-pubkey = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/timings/src/lib.rs
+++ b/timings/src/lib.rs
@@ -461,14 +461,17 @@ mod tests {
             .unwrap();
 
         // Both error and success transactions count towards `accumulated_us`
-        assert_eq!(program_timings.accumulated_us, us.saturating_mul(2));
-        assert_eq!(program_timings.accumulated_units, compute_units_consumed);
-        assert_eq!(program_timings.count, 1,);
+        assert_eq!(program_timings.accumulated_us.0, us.saturating_mul(2));
+        assert_eq!(program_timings.accumulated_units.0, compute_units_consumed);
+        assert_eq!(program_timings.count.0, 1,);
         assert_eq!(
             program_timings.errored_txs_compute_consumed,
             vec![compute_units_consumed]
         );
-        assert_eq!(program_timings.total_errored_units, compute_units_consumed,);
+        assert_eq!(
+            program_timings.total_errored_units.0,
+            compute_units_consumed,
+        );
 
         execute_details_timings
     }

--- a/timings/src/lib.rs
+++ b/timings/src/lib.rs
@@ -3,7 +3,8 @@ extern crate eager;
 use {
     core::fmt,
     enum_iterator::Sequence,
-    solana_sdk::{pubkey::Pubkey, saturating_add_assign},
+    saturating_add_assign::saturating_add_assign,
+    solana_pubkey::Pubkey,
     std::{
         collections::HashMap,
         ops::{Index, IndexMut},

--- a/timings/src/lib.rs
+++ b/timings/src/lib.rs
@@ -97,72 +97,72 @@ eager_macro_rules! { $eager_1
         ($self: expr, $is_unified_scheduler_enabled: expr) => {
             (
                 "validate_transactions_us",
-                *$self
+                $self
                     .metrics
-                    .index(ExecuteTimingType::CheckUs),
+                    .index(ExecuteTimingType::CheckUs).0,
                 i64
             ),
             (
                 "validate_fees_us",
-                *$self
+                $self
                     .metrics
-                    .index(ExecuteTimingType::ValidateFeesUs),
+                    .index(ExecuteTimingType::ValidateFeesUs).0,
                 i64
             ),
             (
                 "filter_executable_us",
-                *$self
+                $self
                     .metrics
-                    .index(ExecuteTimingType::FilterExecutableUs),
+                    .index(ExecuteTimingType::FilterExecutableUs).0,
                 i64
             ),
             (
                 "program_cache_us",
-                *$self
+                $self
                     .metrics
-                    .index(ExecuteTimingType::ProgramCacheUs),
+                    .index(ExecuteTimingType::ProgramCacheUs).0,
                 i64
             ),
             (
                 "load_us",
-                *$self
+                $self
                     .metrics
-                    .index(ExecuteTimingType::LoadUs),
+                    .index(ExecuteTimingType::LoadUs).0,
                 i64
             ),
             (
                 "execute_us",
-                *$self
+                $self
                     .metrics
-                    .index(ExecuteTimingType::ExecuteUs),
+                    .index(ExecuteTimingType::ExecuteUs).0,
                 i64
             ),
             (
                 "collect_logs_us",
-                *$self
+                $self
                     .metrics
-                    .index(ExecuteTimingType::CollectLogsUs),
+                    .index(ExecuteTimingType::CollectLogsUs).0,
                 i64
             ),
             (
                 "store_us",
-                *$self
+                $self
 
                     .metrics
-                    .index(ExecuteTimingType::StoreUs),
+                    .index(ExecuteTimingType::StoreUs).0,
                 i64
             ),
             (
                 "update_stakes_cache_us",
-                *$self
+                $self
 
                     .metrics
-                    .index(ExecuteTimingType::UpdateStakesCacheUs),
+                    .index(ExecuteTimingType::UpdateStakesCacheUs).0,
                 i64
             ),
             (
                 "execute_accessories_update_executors_us",
-                *$self.metrics.index(ExecuteTimingType::UpdateExecutorsUs),
+                $self.metrics.index(ExecuteTimingType::UpdateExecutorsUs).0,
                 i64
             ),
             (
@@ -170,9 +170,9 @@ eager_macro_rules! { $eager_1
                 (if $is_unified_scheduler_enabled {
                     None
                 } else {
-                    Some(*$self
+                    Some($self
                         .metrics
-                        .index(ExecuteTimingType::TotalBatchesLen))
+                        .index(ExecuteTimingType::TotalBatchesLen).0)
                 }),
                 Option<i64>
             ),
@@ -181,96 +181,96 @@ eager_macro_rules! { $eager_1
                 (if $is_unified_scheduler_enabled {
                     None
                 } else {
-                    Some(*$self
+                    Some($self
                         .metrics
-                        .index(ExecuteTimingType::NumExecuteBatches))
+                        .index(ExecuteTimingType::NumExecuteBatches).0)
                 }),
                 Option<i64>
             ),
             (
                 "update_transaction_statuses",
-                *$self
+                $self
                     .metrics
-                    .index(ExecuteTimingType::UpdateTransactionStatuses),
+                    .index(ExecuteTimingType::UpdateTransactionStatuses).0,
                 i64
             ),
             (
                 "check_block_limits_us",
-                *$self.metrics.index(ExecuteTimingType::CheckBlockLimitsUs),
+                $self.metrics.index(ExecuteTimingType::CheckBlockLimitsUs).0,
                 i64
             ),
             (
                 "execute_details_serialize_us",
-                $self.details.serialize_us,
+                $self.details.serialize_us.0,
                 i64
             ),
             (
                 "execute_details_create_vm_us",
-                $self.details.create_vm_us,
+                $self.details.create_vm_us.0,
                 i64
             ),
             (
                 "execute_details_execute_inner_us",
-                $self.details.execute_us,
+                $self.details.execute_us.0,
                 i64
             ),
             (
                 "execute_details_deserialize_us",
-                $self.details.deserialize_us,
+                $self.details.deserialize_us.0,
                 i64
             ),
             (
                 "execute_details_get_or_create_executor_us",
-                $self.details.get_or_create_executor_us,
+                $self.details.get_or_create_executor_us.0,
                 i64
             ),
             (
                 "execute_details_changed_account_count",
-                $self.details.changed_account_count,
+                $self.details.changed_account_count.0,
                 i64
             ),
             (
                 "execute_details_total_account_count",
-                $self.details.total_account_count,
+                $self.details.total_account_count.0,
                 i64
             ),
             (
                 "execute_details_create_executor_register_syscalls_us",
                 $self
                     .details
-                    .create_executor_register_syscalls_us,
+                    .create_executor_register_syscalls_us.0,
                 i64
             ),
             (
                 "execute_details_create_executor_load_elf_us",
-                $self.details.create_executor_load_elf_us,
+                $self.details.create_executor_load_elf_us.0,
                 i64
             ),
             (
                 "execute_details_create_executor_verify_code_us",
-                $self.details.create_executor_verify_code_us,
+                $self.details.create_executor_verify_code_us.0,
                 i64
             ),
             (
                 "execute_details_create_executor_jit_compile_us",
-                $self.details.create_executor_jit_compile_us,
+                $self.details.create_executor_jit_compile_us.0,
                 i64
             ),
             (
                 "execute_accessories_feature_set_clone_us",
                 $self
                     .execute_accessories
-                    .feature_set_clone_us,
+                    .feature_set_clone_us.0,
                 i64
             ),
             (
                 "execute_accessories_get_executors_us",
-                $self.execute_accessories.get_executors_us,
+                $self.execute_accessories.get_executors_us.0,
                 i64
             ),
             (
                 "execute_accessories_process_message_us",
-                $self.execute_accessories.process_message_us,
+                $self.execute_accessories.process_message_us.0,
                 i64
             ),
             (
@@ -278,7 +278,7 @@ eager_macro_rules! { $eager_1
                 $self
                     .execute_accessories
                     .process_instructions
-                    .total_us,
+                    .total_us.0,
                 i64
             ),
             (
@@ -286,7 +286,7 @@ eager_macro_rules! { $eager_1
                 $self
                     .execute_accessories
                     .process_instructions
-                    .verify_caller_us,
+                    .verify_caller_us.0,
                 i64
             ),
             (
@@ -294,7 +294,7 @@ eager_macro_rules! { $eager_1
                 $self
                     .execute_accessories
                     .process_instructions
-                    .process_executable_chain_us,
+                    .process_executable_chain_us.0,
                 i64
             ),
             (
@@ -302,7 +302,7 @@ eager_macro_rules! { $eager_1
                 $self
                     .execute_accessories
                     .process_instructions
-                    .verify_callee_us,
+                    .verify_callee_us.0,
                 i64
             ),
         }

--- a/timings/src/lib.rs
+++ b/timings/src/lib.rs
@@ -61,10 +61,10 @@ pub enum ExecuteTimingType {
     FilterExecutableUs,
 }
 
-pub struct Metrics([u64; ExecuteTimingType::CARDINALITY]);
+pub struct Metrics([Saturating<u64>; ExecuteTimingType::CARDINALITY]);
 
 impl Index<ExecuteTimingType> for Metrics {
-    type Output = u64;
+    type Output = Saturating<u64>;
     fn index(&self, index: ExecuteTimingType) -> &Self::Output {
         self.0.index(index as usize)
     }
@@ -78,7 +78,7 @@ impl IndexMut<ExecuteTimingType> for Metrics {
 
 impl Default for Metrics {
     fn default() -> Self {
-        Metrics([0; ExecuteTimingType::CARDINALITY])
+        Metrics([Saturating(0); ExecuteTimingType::CARDINALITY])
     }
 }
 
@@ -329,7 +329,7 @@ impl ExecuteTimings {
     pub fn saturating_add_in_place(&mut self, timing_type: ExecuteTimingType, value_to_add: u64) {
         let idx = timing_type as usize;
         match self.metrics.0.get_mut(idx) {
-            Some(elem) => *elem = elem.saturating_add(value_to_add),
+            Some(elem) => *elem += value_to_add,
             None => debug_assert!(idx < ExecuteTimingType::CARDINALITY, "Index out of bounds"),
         }
     }
@@ -337,10 +337,10 @@ impl ExecuteTimings {
 
 #[derive(Default, Debug)]
 pub struct ExecuteProcessInstructionTimings {
-    pub total_us: u64,
-    pub verify_caller_us: u64,
-    pub process_executable_chain_us: u64,
-    pub verify_callee_us: u64,
+    pub total_us: Saturating<u64>,
+    pub verify_caller_us: Saturating<u64>,
+    pub process_executable_chain_us: Saturating<u64>,
+    pub verify_callee_us: Saturating<u64>,
 }
 
 impl ExecuteProcessInstructionTimings {
@@ -354,9 +354,9 @@ impl ExecuteProcessInstructionTimings {
 
 #[derive(Default, Debug)]
 pub struct ExecuteAccessoryTimings {
-    pub feature_set_clone_us: u64,
-    pub get_executors_us: u64,
-    pub process_message_us: u64,
+    pub feature_set_clone_us: Saturating<u64>,
+    pub get_executors_us: Saturating<u64>,
+    pub process_message_us: Saturating<u64>,
     pub process_instructions: ExecuteProcessInstructionTimings,
 }
 
@@ -372,17 +372,17 @@ impl ExecuteAccessoryTimings {
 
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct ExecuteDetailsTimings {
-    pub serialize_us: u64,
-    pub create_vm_us: u64,
-    pub execute_us: u64,
-    pub deserialize_us: u64,
-    pub get_or_create_executor_us: u64,
-    pub changed_account_count: u64,
-    pub total_account_count: u64,
-    pub create_executor_register_syscalls_us: u64,
-    pub create_executor_load_elf_us: u64,
-    pub create_executor_verify_code_us: u64,
-    pub create_executor_jit_compile_us: u64,
+    pub serialize_us: Saturating<u64>,
+    pub create_vm_us: Saturating<u64>,
+    pub execute_us: Saturating<u64>,
+    pub deserialize_us: Saturating<u64>,
+    pub get_or_create_executor_us: Saturating<u64>,
+    pub changed_account_count: Saturating<u64>,
+    pub total_account_count: Saturating<u64>,
+    pub create_executor_register_syscalls_us: Saturating<u64>,
+    pub create_executor_load_elf_us: Saturating<u64>,
+    pub create_executor_verify_code_us: Saturating<u64>,
+    pub create_executor_jit_compile_us: Saturating<u64>,
     pub per_program_timings: HashMap<Pubkey, ProgramTiming>,
 }
 

--- a/timings/src/lib.rs
+++ b/timings/src/lib.rs
@@ -497,12 +497,12 @@ mod tests {
         let mut other_execute_details_timings =
             construct_execute_timings_with_program(&program_id, us, compute_units_consumed);
         let account_count = 1;
-        other_execute_details_timings.serialize_us = us;
-        other_execute_details_timings.create_vm_us = us;
-        other_execute_details_timings.execute_us = us;
-        other_execute_details_timings.deserialize_us = us;
-        other_execute_details_timings.changed_account_count = account_count;
-        other_execute_details_timings.total_account_count = account_count;
+        other_execute_details_timings.serialize_us.0 = us;
+        other_execute_details_timings.create_vm_us.0 = us;
+        other_execute_details_timings.execute_us.0 = us;
+        other_execute_details_timings.deserialize_us.0 = us;
+        other_execute_details_timings.changed_account_count.0 = account_count;
+        other_execute_details_timings.total_account_count.0 = account_count;
 
         // Accumulate the other instance into the current instance
         execute_details_timings.accumulate(&other_execute_details_timings);
@@ -516,10 +516,10 @@ mod tests {
         let mut timings = ExecuteTimings::default();
         timings.saturating_add_in_place(ExecuteTimingType::CheckUs, 1);
         let check_us = timings.metrics.index(ExecuteTimingType::CheckUs);
-        assert_eq!(1, *check_us);
+        assert_eq!(1, check_us.0);
 
         timings.saturating_add_in_place(ExecuteTimingType::CheckUs, 2);
         let check_us = timings.metrics.index(ExecuteTimingType::CheckUs);
-        assert_eq!(3, *check_us);
+        assert_eq!(3, check_us.0);
     }
 }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -1806,7 +1806,7 @@ mod tests {
         let (result, timings) = bank.wait_for_completed_scheduler().unwrap();
         assert_matches!(result, Ok(()));
         // ResultWithTimings should be carried over across active=>stale=>active transitions.
-        assert_eq!(timings.metrics[ExecuteTimingType::CheckUs], 246);
+        assert_eq!(timings.metrics[ExecuteTimingType::CheckUs].0, 246);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
This crate can compile faster without `solana-sdk`

#### Summary of Changes
- Use `solana-pubkey` instead of `solana_sdk::pubkey`
- Use the `saturating_add_assign` crate instead of `solana_sdk::saturating_add_assign`. I copied this macro from `solana-sdk` and [published it in a standalone crate](https://docs.rs/saturating_add_assign/latest/saturating_add_assign/). I did this because it seems silly to include this in the normal Agave publishing workflow when this crate will probably never change. For that reason I also pinned the version to "=1.0.0".

That said, I would make no objection to just copy-pasting the macro into solana-timings and other crates