### PR TITLE
Update install.sh was 404 on intel ios v1.42 download link

### DIFF
--- a/sdk/sbf/scripts/install.sh
+++ b/sdk/sbf/scripts/install.sh
@@ -3,6 +3,7 @@
 mkdir -p "$(dirname "$0")"/../dependencies
 cd "$(dirname "$0")"/../dependencies
 
+# Determine OS and architecture
 unameOut="$(uname -s)"
 case "${unameOut}" in
   Linux*)
@@ -18,6 +19,7 @@ case "${unameOut}" in
     criterion_suffix=
     machine=linux
 esac
+
 unameOut="$(uname -m)"
 case "${unameOut}" in
   arm64*)
@@ -26,62 +28,79 @@ case "${unameOut}" in
     arch=x86_64
 esac
 
-download() {
-  declare url="$1/$2/$3"
-  declare filename=$3
-  declare wget_args=(
-    "$url" -O "$filename"
-    "--progress=dot:giga"
-    "--retry-connrefused"
-    "--read-timeout=30"
-  )
-  declare curl_args=(
-    -L "$url" -o "$filename"
-  )
-  if hash wget 2>/dev/null; then
-    wget_or_curl="wget ${wget_args[*]}"
-  elif hash curl 2>/dev/null; then
-    wget_or_curl="curl ${curl_args[*]}"
-  else
-    echo "Error: Neither curl nor wget were found" >&2
-    return 1
-  fi
+# Feature flags
+ENABLE_BPF=true  # Change to false to disable BPF installation
 
-  set -x
-  if $wget_or_curl; then
-    tar --strip-components 1 -jxf "$filename" || return 1
-    { set +x; } 2>/dev/null
-    rm -rf "$filename"
-    return 0
-  fi
-  return 1
+download() {
+    declare url="$1"
+    declare filename="$2"
+
+    echo "Downloading from: $url"
+    echo "Saving as: $filename"
+
+    set -x
+    if hash wget 2>/dev/null; then
+        echo "Using wget to download..."
+        wget "$url" -O "$filename" || return 1
+    elif hash curl 2>/dev/null; then
+        echo "Using curl to download..."
+        curl -L "$url" -o "$filename" || return 1
+    else
+        echo "Error: Neither curl nor wget were found" >&2
+        return 1
+    fi
 }
 
+# Get function to handle downloading and extraction
 get() {
   declare version=$1
   declare dirname=$2
-  declare job=$3
+  declare url=$3 
+
+  echo "Entered get() function with parameters:"
+  echo "Version: $version"
+  echo "Dirname: $dirname"
+  echo "URL: $url"
+
   declare cache_root=~/.cache/solana
   declare cache_dirname="$cache_root/$version/$dirname"
   declare cache_partial_dirname="$cache_dirname"_partial
 
+  # Create cache directory if it does not exist
   if [[ -r $cache_dirname ]]; then
+    echo "Cache found. Linking..."
     ln -sf "$cache_dirname" "$dirname" || return 1
     return 0
   fi
 
+  # Clean up any existing partial cache
+  echo "Cleaning up any existing partial cache..."
   rm -rf "$cache_partial_dirname" || return 1
   mkdir -p "$cache_partial_dirname" || return 1
   pushd "$cache_partial_dirname"
 
-  if $job; then
+  # Call download function
+  echo "Calling download function..."
+  download "$url" "platform-tools-osx-x86_64.tar.bz2"
+
+  # Check if the download completed successfully
+  echo "Checking if downloaded file exists..."
+  if [[ ! -f "platform-tools-osx-x86_64.tar.bz2" ]]; then
+    echo "Download failed or file not found!"
     popd
-    mv "$cache_partial_dirname" "$cache_dirname" || return 1
-    ln -sf "$cache_dirname" "$dirname" || return 1
-    return 0
+    return 1
   fi
+
+  echo "Extracting platform-tools-osx-x86_64.tar.bz2"
+  tar --strip-components 1 -jxf "platform-tools-osx-x86_64.tar.bz2" || {
+      echo "Extraction failed!" 
+      popd
+      return 1
+  }
+
   popd
-  return 1
+  mv "$cache_partial_dirname" "$cache_dirname" || return 1
+  ln -sf "$cache_dirname" "$dirname" || return 1
 }
 
 # Install Criterion
@@ -90,49 +109,55 @@ if [[ $machine == "linux" ]]; then
 else
   version=v2.3.2
 fi
+
 if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
-  (
-    set -e
-    rm -rf criterion*
-    job="download \
-           https://github.com/Snaipe/Criterion/releases/download \
-           $version \
-           criterion-$version-$machine$criterion_suffix-x86_64.tar.bz2 \
-           criterion"
-    get $version criterion "$job"
-  )
+  set -e
+  rm -rf criterion*
+  
+  url="https://github.com/Snaipe/Criterion/releases/download/$version/criterion-$version-$machine$criterion_suffix-x86_64.tar.bz2"
+  
+  echo "Attempting to get Criterion from: $url"
+  
+  get $version criterion "$url"
   exitcode=$?
+  
   if [[ $exitcode -ne 0 ]]; then
+    echo "Failed to download Criterion. Exiting with code: $exitcode"
     exit 1
   fi
+
   touch criterion-$version.md
 fi
 
 # Install platform tools
-version=v1.43
+version=v1.41
 if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
-  (
     set -e
     rm -rf platform-tools*
-    job="download \
-           https://github.com/anza-xyz/platform-tools/releases/download \
-           $version \
-           platform-tools-${machine}-${arch}.tar.bz2 \
-           platform-tools"
-    get $version platform-tools "$job"
-  )
-  exitcode=$?
-  if [[ $exitcode -ne 0 ]]; then
-    exit 1
-  fi
-  touch platform-tools-$version.md
-  set -ex
-  ./platform-tools/rust/bin/rustc --version
-  ./platform-tools/rust/bin/rustc --print sysroot
-  set +e
-  rustup toolchain uninstall solana
-  set -e
-  rustup toolchain link solana platform-tools/rust
+    echo "Attempting to download platform tools: https://github.com/anza-xyz/platform-tools/releases/download/v1.41/platform-tools-osx-x86_64.tar.bz2"
+
+    url="https://github.com/anza-xyz/platform-tools/releases/download/v1.41/platform-tools-osx-x86_64.tar.bz2"
+    echo "Attempting to call get() function."
+    
+    get $version platform-tools "$url"
+    
+    exitcode=$?
+    if [[ $exitcode -ne 0 ]]; then
+        echo "Failed to download platform-tools. Exiting with error code: $exitcode"
+        exit 1
+    fi
+
+    # Linking, if successful
+    if [[ -d ~/.cache/solana/v1.41/platform-tools ]]; then
+        ln -sf ~/.cache/solana/v1.41/platform-tools ~/.local/share/solana/install/releases/2.0.16/solana-release/bin/sdk/sbf/dependencies/platform-tools || {
+            echo "Failed to create symbolic link for platform-tools."
+            exit 1
+        }
+    fi
+
+    touch platform-tools-$version.md
 fi
 
+# Final success message
+echo "Script completed successfully."
 exit 0


### PR DESCRIPTION
I changed the version 1.42 or 1.43 that i was giving for v 1.41 in download url for platform-tools when attempting to cargo build-sbf my solana-program... It would fetch v 1.42 for my ios on intel wich was 404 and didn't exist... since i was at it with my good friend cody bant Chatgpt we went through install.sh fixing it up here and therte adding a feature flag for bpf optionnal build when sbf buoilding. then echoed comments during different functiuons explaining what file was doing when: download, extract, create cache folders etc so that people know whats happening and if everything worked out well. Main change download url fix:  https://github.com/anza-xyz/platform-tools/releases/download/v1.42/platform-tools-osx-x86_64.tar.bz2) iis what it would fetch for my ios-x86_64 intel machine wich doesn't exist on versions 1.42 and 1.43 they run aarch: platform-tools-osx-aarch64.tar.bz2 not made for intel. the version was set to 1.42  and the url also... so i corrected it to: https://github.com/anza-xyz/platform-tools/releases/download/v1.41/platform-tools-osx-x86_64.tar.bz2 in order to get intel compatibility but most of all a file not  404... first it wouldn't recognise package and couldn't exctract it also that the second fix tested with curl and tar... hope your happy and it works well i didn't  get to build on the right repo yet i was wondering why my changes didn't take effect on solana when i changed both active release and release (my version) install.sh files. its when i cvommited thast i learned that it was agave not solanas... i would of busted my head a long time trying to figure bout where the download command came from if there wouldn't of been a notice on solana saying its here now thank you now enough and enjoy ill go try and pull. xxx

#### Problem

404 wrong version url for ios-x86_64 on intel build link was 404 and package not recdonised thus not extracted after fixing url
#### Summary of Changes
added echo comments on progress and functions, fixed download url version for ios on intel to 1.41 insted od v1.42 or 1.43 wich doidn't exist for ios on intel... then package extractor couldn't extract once url was set right... thern added a bpf build nopotion bflag whiole sbf builkding option nif necessary..

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
# Feature flags
ENABLE_BPF=true  # Change to false to disable BPF installation
