### PR TITLE
Avoid processing compute-budget instructions by accessing static meta

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -576,11 +576,10 @@ impl Consumer {
             .sanitized_transactions()
             .iter()
             .filter_map(|transaction| {
-                process_compute_budget_instructions(SVMMessage::program_instructions_iter(
-                    transaction,
-                ))
-                .ok()
-                .map(|limits| limits.compute_unit_price)
+                transaction
+                    .compute_budget_limits(&bank.feature_set)
+                    .ok()
+                    .map(|limits| limits.compute_unit_price)
             })
             .minmax();
         let (min_prioritization_fees, max_prioritization_fees) =


### PR DESCRIPTION
#### Problem

Looks like can save another call to `process_compute_budget_instructions()`

#### Summary of Changes
- access runtime-transaction static-meta 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
