### PR TITLE
read compute-budget limits directly from RuntimeTransaction static meta

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -29,8 +29,8 @@ use {
     solana_measure::measure_us,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::{
-        instructions_processor::process_compute_budget_instructions,
-        runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
+        runtime_transaction::RuntimeTransaction, transaction_meta::StaticMeta,
+        transaction_with_meta::TransactionWithMeta,
     },
     solana_sdk::{
         self,
@@ -41,7 +41,6 @@ use {
         transaction::SanitizedTransaction,
     },
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
-    solana_svm_transaction::svm_message::SVMMessage,
     std::{
         sync::{Arc, RwLock},
         time::{Duration, Instant},
@@ -552,7 +551,7 @@ impl<T: LikeClusterInfo> SchedulerController<T> {
                     .is_ok()
                 })
                 .filter_map(|(packet, tx, deactivation_slot)| {
-                    process_compute_budget_instructions(SVMMessage::program_instructions_iter(&tx))
+                    tx.compute_budget_limits(&working_bank.feature_set)
                         .map(|compute_budget| {
                             (packet, tx, deactivation_slot, compute_budget.into())
                         })


### PR DESCRIPTION
#### Problem

Sanitized transaction built from `ImmutableDeserializedPacket` is `RuntimeTransaction`, can read ComputeBudgetLimits from from its static meta directly. 

#### Summary of Changes
- read ComputeBudgetLimits directly from RuntimeTransaction's StaticMeta


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
