### PR TITLE
Marks old storages as dirty and uncleaned in clean_accounts()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -75,7 +75,8 @@ use {
         accounts::{AccountAddressFilter, Accounts, PubkeyAccountSlot},
         accounts_db::{
             AccountStorageEntry, AccountsDb, AccountsDbConfig, CalcAccountsHashDataSource,
-            DuplicatesLtHash, PubkeyHashAccount, VerifyAccountsHashAndLamportsConfig,
+            DuplicatesLtHash, OldStoragesPolicy, PubkeyHashAccount,
+            VerifyAccountsHashAndLamportsConfig,
         },
         accounts_hash::{
             AccountHash, AccountsHash, AccountsLtHash, CalcAccountsHashConfig, HashStats,
@@ -6279,7 +6280,7 @@ impl Bank {
             let should_clean = force_clean || (!skip_shrink && self.slot() > 0);
             if should_clean {
                 info!("Cleaning...");
-                // We cannot clean past the last full snapshot's slot because we are about to
+                // We cannot clean past the latest full snapshot's slot because we are about to
                 // perform an accounts hash calculation *up to that slot*.  If we cleaned *past*
                 // that slot, then accounts could be removed from older storages, which would
                 // change the accounts hash.
@@ -6287,6 +6288,7 @@ impl Bank {
                     Some(latest_full_snapshot_slot),
                     true,
                     self.epoch_schedule(),
+                    self.clean_accounts_old_storages_policy(),
                 );
                 info!("Cleaning... Done.");
             } else {
@@ -6594,6 +6596,7 @@ impl Bank {
             Some(highest_slot_to_clean),
             false,
             self.epoch_schedule(),
+            self.clean_accounts_old_storages_policy(),
         );
     }
 
@@ -6609,20 +6612,34 @@ impl Bank {
     }
 
     pub(crate) fn shrink_ancient_slots(&self) {
+        // Invoke ancient slot shrinking only when the validator is
+        // explicitly configured to do so. This condition may be
+        // removed when the skip rewrites feature is enabled.
+        if self.are_ancient_storages_enabled() {
+            self.rc
+                .accounts
+                .accounts_db
+                .shrink_ancient_slots(self.epoch_schedule())
+        }
+    }
+
+    /// Returns if ancient storages are enabled or not
+    pub fn are_ancient_storages_enabled(&self) -> bool {
         let can_skip_rewrites = self.bank_hash_skips_rent_rewrites();
         let test_skip_rewrites_but_include_in_bank_hash = self
             .rc
             .accounts
             .accounts_db
             .test_skip_rewrites_but_include_in_bank_hash;
-        // Invoke ancient slot shrinking only when the validator is
-        // explicitly configured to do so. This condition may be
-        // removed when the skip rewrites feature is enabled.
-        if can_skip_rewrites || test_skip_rewrites_but_include_in_bank_hash {
-            self.rc
-                .accounts
-                .accounts_db
-                .shrink_ancient_slots(self.epoch_schedule())
+        can_skip_rewrites || test_skip_rewrites_but_include_in_bank_hash
+    }
+
+    /// Returns how clean_accounts() should handle old storages
+    fn clean_accounts_old_storages_policy(&self) -> OldStoragesPolicy {
+        if self.are_ancient_storages_enabled() {
+            OldStoragesPolicy::Leave
+        } else {
+            OldStoragesPolicy::Clean
         }
     }
 


### PR DESCRIPTION
#### Problem

Copied from #3702 

We do not clean up old storages.

More context: when calculating a full accounts hash, we call `mark_old_slots_as_dirty()` as a way to ensure we do not forget or miss cleaning up really old storages (i.e. ones that are older than an epoch old). But, when we enable skipping rewrites, we *don't* want to clean up those old storages, as they'll intentionally be treated as ancient append vecs. So inside `mark_old_slots_as_dirty()` we *conditionally* mark old slots as dirty. This is based on the value of `ancient_append_vec_offset`, which should be None unless ancient append vecs are enabled.

Unfortunately, normal running validators, we end up *never* marking old slots as dirty, because the ancient append vec offset is *always* Some. And thus we don't clean up old storages.


#### Summary of Changes

Mark old storages as dirty, and add to the uncleaned roots list in clean_accounts().

We still check if ancient append vecs are enabled, but not with the `ancient_append_vec_offset`. Instead we look at the skipping rewrites feature gate and the cli arg.

By moving this marking into clean_accounts(), we also decouple it from accounts hash calculation, which is not necessary anymore. This also removes behavioral differences based on if snapshots are enabled or not.