### PR TITLE
sysvar: Remove bincode feature for `get_sysvar`

### DIFF
--- a/sdk/sysvar/src/lib.rs
+++ b/sdk/sysvar/src/lib.rs
@@ -213,7 +213,6 @@ macro_rules! impl_sysvar_get {
     };
 }
 
-#[cfg(feature = "bincode")]
 /// Handler for retrieving a slice of sysvar data from the `sol_get_sysvar`
 /// syscall.
 fn get_sysvar(

--- a/sdk/sysvar/src/slot_hashes.rs
+++ b/sdk/sysvar/src/slot_hashes.rs
@@ -99,7 +99,6 @@ pub struct PodSlotHashes {
 
 #[cfg(feature = "bytemuck")]
 impl PodSlotHashes {
-    #[cfg(feature = "bincode")]
     /// Fetch all of the raw sysvar data using the `sol_get_sysvar` syscall.
     pub fn fetch() -> Result<Self, solana_program_error::ProgramError> {
         // Allocate an uninitialized buffer for the raw sysvar data.
@@ -207,7 +206,7 @@ impl SlotHashesSysvar {
     }
 }
 
-#[cfg(all(feature = "bincode", feature = "bytemuck"))]
+#[cfg(feature = "bytemuck")]
 fn get_pod_slot_hashes() -> Result<Vec<PodSlotHash>, solana_program_error::ProgramError> {
     let mut pod_hashes = vec![PodSlotHash::default(); solana_slot_hashes::MAX_ENTRIES];
     {


### PR DESCRIPTION
#### Problem

The `get_sysvar` function requires the `bincode` feature, but only because one of the sysvars deserializers uses it.

#### Summary of changes

Rewrite the deserializer by hand, and remove the `bincode` feature gating.