### PR TITLE
transaction-error: Fix warning for bpf build, feature gating

### DIFF
--- a/sdk/transaction-error/Cargo.toml
+++ b/sdk/transaction-error/Cargo.toml
@@ -21,7 +21,7 @@ solana-sanitize = { workspace = true }
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-serde = ["dep:serde", "dep:serde_derive"]
+serde = ["dep:serde", "dep:serde_derive", "solana-instruction/serde"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/transaction-error/src/lib.rs
+++ b/sdk/transaction-error/src/lib.rs
@@ -4,9 +4,7 @@
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
-use {
-    core::fmt, solana_instruction::error::InstructionError, solana_sanitize::SanitizeError, std::io,
-};
+use {core::fmt, solana_instruction::error::InstructionError, solana_sanitize::SanitizeError};
 
 pub type TransactionResult<T> = Result<T, TransactionError>;
 
@@ -356,7 +354,7 @@ impl From<SanitizeError> for SanitizeMessageError {
 #[cfg(not(target_os = "solana"))]
 #[derive(Debug)]
 pub enum TransportError {
-    IoError(io::Error),
+    IoError(std::io::Error),
     TransactionError(TransactionError),
     Custom(String),
 }
@@ -386,8 +384,8 @@ impl fmt::Display for TransportError {
 }
 
 #[cfg(not(target_os = "solana"))]
-impl From<io::Error> for TransportError {
-    fn from(e: io::Error) -> Self {
+impl From<std::io::Error> for TransportError {
+    fn from(e: std::io::Error) -> Self {
         TransportError::IoError(e)
     }
 }


### PR DESCRIPTION
#### Problem

There's a warning when building solana-transaction-error in bpf:

```
warning: unused import: `std::io`
 --> sdk/transaction-error/src/lib.rs:8:93
  |
8 | ...or, solana_sanitize::SanitizeError, std::io,
```

This is because the part that uses std::io is gated on `not(target_os = "solana")`.

Also, clippy is failing on this crate individually because the "serde" feature is not enabled on solana-instruction.

#### Summary of changes

Fix those two things.