### PR TITLE
Fixes whitespace in feature-set

### DIFF
--- a/sdk/feature-set/src/lib.rs
+++ b/sdk/feature-set/src/lib.rs
@@ -883,6 +883,7 @@ pub mod disable_account_loader_special_case {
 pub mod enable_secp256r1_precompile {
     solana_pubkey::declare_id!("sr11RdZWgbHTHxSroPALe6zgaT5A1K9LcE4nfsZS4gi");
 }
+
 pub mod accounts_lt_hash {
     solana_pubkey::declare_id!("LtHaSHHsUge7EWTPVrmpuexKz6uVHZXZL6cgJa7W7Zn");
 }


### PR DESCRIPTION
#### Problem

A nit, indeed. There is not a newline preceding the accounts_lt_hash feature set module. I cannot unsee this inconsistency.


#### Summary of Changes

Add a newline.