### PR TITLE
mark store dirty when all zero store are found

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3862,6 +3862,7 @@ impl AccountsDb {
                 if store.num_zero_lamport_single_ref_accounts() == store.count() {
                     // all accounts in this storage can be dead
                     self.accounts_index.add_uncleaned_roots([slot]);
+                    self.dirty_stores.entry(slot).or_insert(store);
                     self.shrink_stats
                         .num_dead_slots_added_to_clean
                         .fetch_add(1, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem

We track single ref zero accounts in storage. And this enable us to detect when a store are all zero single ref accounts and let clean drop it. 

However, we didn't mark the store dirty when we send it to clean. For clean to work, we need to both add it to uncleaned roots and mark the store dirty.


#### Summary of Changes

Mark the store dirty too when we find all zero single ref accounts.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
