### PR TITLE
Add CODEOWNERS for SVM-related directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# The SVM team is in the process of migrating these subdirectories to a new 
+# repo and would like to avoid introducing dependencies in the meantime.
+/transaction-view/ @anza-xyz/svm
+/programs/bpf_loader/ @anza-xyz/svm
+/builtins-default-costs/ @anza-xyz/svm
+/compute-budget/ @anza-xyz/svm
+/programs/compute-budget/ @anza-xyz/svm
+/fee/ @anza-xyz/svm
+/programs/loader-v4/ @anza-xyz/svm
+/log-collector/ @anza-xyz/svm
+/program-runtime/ @anza-xyz/svm
+/runtime-transaction/ @anza-xyz/svm
+/svm/ @anza-xyz/svm
+/svm-conformance/ @anza-xyz/svm
+/svm-rent-collector/ @anza-xyz/svm
+/svm-transaction/ @anza-xyz/svm
+/programs/system/ @anza-xyz/svm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# The SVM team is in the process of migrating these subdirectories to a new 
+# The SVM team is in the process of migrating these subdirectories to a new
 # repo and would like to avoid introducing dependencies in the meantime.
 /transaction-view/ @anza-xyz/svm
 /programs/bpf_loader/ @anza-xyz/svm


### PR DESCRIPTION
#### Problem
The SVM-releated crates are going to move to their own repo soon. The team has sorted out the dependencies and would like to keep things organized until the crates are moved.

#### Summary of Changes
Add CODEOWNERS for the relevant directories. We will also need to enable: `Require review from Code Owners` for the master branch.

#### The Plan
* PR passes CI and is approved
* I turn on `Require review from Code Owners` and make sure that this PR can still be merged. This directory has no owners and I want to make sure that the rule still allows merging without owner approval for files without owners
* Merge this PR.