### PR TITLE
FeatureSet: ahash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6987,6 +6987,7 @@ dependencies = [
 name = "solana-feature-set"
 version = "2.2.0"
 dependencies = [
+ "ahash 0.8.11",
  "lazy_static",
  "solana-epoch-schedule",
  "solana-frozen-abi",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5603,6 +5603,7 @@ dependencies = [
 name = "solana-feature-set"
 version = "2.2.0"
 dependencies = [
+ "ahash 0.8.11",
  "lazy_static",
  "solana-epoch-schedule",
  "solana-hash",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -60,7 +60,7 @@ use {
         verify_precompiles::verify_precompiles,
     },
     accounts_lt_hash::{CacheValue as AccountsLtHashCacheValue, Stats as AccountsLtHashStats},
-    ahash::AHashMap,
+    ahash::{AHashMap, AHashSet},
     byteorder::{ByteOrder, LittleEndian},
     dashmap::{DashMap, DashSet},
     log::*,
@@ -6841,10 +6841,10 @@ impl Bank {
 
     /// Compute the active feature set based on the current bank state,
     /// and return it together with the set of newly activated features.
-    fn compute_active_feature_set(&self, include_pending: bool) -> (FeatureSet, HashSet<Pubkey>) {
+    fn compute_active_feature_set(&self, include_pending: bool) -> (FeatureSet, AHashSet<Pubkey>) {
         let mut active = self.feature_set.active.clone();
-        let mut inactive = HashSet::new();
-        let mut pending = HashSet::new();
+        let mut inactive = AHashSet::new();
+        let mut pending = AHashSet::new();
         let slot = self.slot();
 
         for feature_id in &self.feature_set.inactive {
@@ -6878,7 +6878,7 @@ impl Bank {
     fn apply_builtin_program_feature_transitions(
         &mut self,
         only_apply_transitions_for_new_features: bool,
-        new_feature_activations: &HashSet<Pubkey>,
+        new_feature_activations: &AHashSet<Pubkey>,
     ) {
         for builtin in BUILTINS.iter() {
             // The `builtin_is_bpf` flag is used to handle the case where a

--- a/runtime/src/bank/builtin_programs.rs
+++ b/runtime/src/bank/builtin_programs.rs
@@ -37,7 +37,7 @@ mod tests {
         let only_apply_transitions_for_new_features = true;
         bank.apply_builtin_program_feature_transitions(
             only_apply_transitions_for_new_features,
-            &HashSet::new(),
+            &AHashSet::new(),
         );
     }
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -47,13 +47,13 @@ full = [
     "dep:solana-seed-derivable",
     "dep:solana-seed-phrase",
     "dep:solana-signer",
-    "dep:solana-transaction-error"
+    "dep:solana-transaction-error",
 ]
 borsh = [
     "dep:borsh",
     "solana-compute-budget-interface/borsh",
     "solana-program/borsh",
-    "solana-secp256k1-recover/borsh"
+    "solana-secp256k1-recover/borsh",
 ]
 dev-context-only-utils = [
     "qualifier_attr",
@@ -74,7 +74,7 @@ frozen-abi = [
     "solana-reward-info/frozen-abi",
     "solana-short-vec/frozen-abi",
     "solana-signature/frozen-abi",
-    "solana-transaction-error/frozen-abi"
+    "solana-transaction-error/frozen-abi",
 ]
 # Enables the "vendored" feature of openssl inside of secp256r1-program
 openssl-vendored = ["solana-precompiles/openssl-vendored"]
@@ -115,7 +115,9 @@ solana-bn254 = { workspace = true }
 solana-cluster-type = { workspace = true, features = [
     "serde",
 ], optional = true }
-solana-commitment-config = { workspace = true, optional = true, features = ["serde"] }
+solana-commitment-config = { workspace = true, optional = true, features = [
+    "serde",
+] }
 solana-compute-budget-interface = { workspace = true, optional = true, features = [
     "serde",
 ] }
@@ -133,7 +135,9 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-inflation = { workspace = true, features = ["serde"] }
 solana-instruction = { workspace = true }
-solana-keypair = { workspace = true, optional = true, features = ["seed-derivable"] }
+solana-keypair = { workspace = true, optional = true, features = [
+    "seed-derivable",
+] }
 solana-native-token = { workspace = true }
 solana-packet = { workspace = true, features = ["bincode", "serde"] }
 solana-precompile-error = { workspace = true, optional = true }
@@ -141,7 +145,9 @@ solana-precompiles = { workspace = true, optional = true }
 solana-presigner = { workspace = true, optional = true }
 solana-program = { workspace = true }
 solana-program-memory = { workspace = true }
-solana-pubkey = { workspace = true, default-features = false, features = ["std"] }
+solana-pubkey = { workspace = true, default-features = false, features = [
+    "std",
+] }
 solana-quic-definitions = { workspace = true, optional = true }
 solana-rent-debits = { workspace = true }
 solana-reserved-account-keys = { workspace = true }
@@ -149,7 +155,9 @@ solana-reward-info = { workspace = true, features = ["serde"] }
 solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sdk-macro = { workspace = true }
-solana-secp256k1-program = { workspace = true, optional = true, features = ["bincode"] }
+solana-secp256k1-program = { workspace = true, optional = true, features = [
+    "bincode",
+] }
 solana-secp256k1-recover = { workspace = true }
 solana-secp256r1-program = { workspace = true, default-features = false }
 solana-seed-derivable = { workspace = true, optional = true }
@@ -165,10 +173,10 @@ solana-signature = { workspace = true, features = [
 ], optional = true }
 solana-signer = { workspace = true, optional = true }
 solana-time-utils = { workspace = true }
-solana-transaction-context = { workspace = true, features = [
-    "bincode",
-] }
-solana-transaction-error = { workspace = true, features = ["serde"], optional = true }
+solana-transaction-context = { workspace = true, features = ["bincode"] }
+solana-transaction-error = { workspace = true, features = [
+    "serde",
+], optional = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/sdk/feature-set/Cargo.toml
+++ b/sdk/feature-set/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 lazy_static = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
@@ -23,10 +24,7 @@ solana-pubkey = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 
 [features]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/feature-set/src/lib.rs
+++ b/sdk/feature-set/src/lib.rs
@@ -20,12 +20,12 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 use {
+    ahash::{AHashMap, AHashSet},
     lazy_static::lazy_static,
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_sha256_hasher::Hasher,
-    std::collections::{HashMap, HashSet},
 };
 
 pub mod deprecate_rewards_sysvar {
@@ -894,7 +894,7 @@ pub mod migrate_stake_program_to_core_bpf {
 
 lazy_static! {
     /// Map of feature identifiers to user-visible description
-    pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
+    pub static ref FEATURE_NAMES: AHashMap<Pubkey, &'static str> = [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
         (deprecate_rewards_sysvar::id(), "deprecate unused rewards sysvar"),
         (pico_inflation::id(), "pico inflation"),
@@ -1136,7 +1136,7 @@ pub struct FullInflationFeaturePair {
 
 lazy_static! {
     /// Set of feature pairs that once enabled will trigger full inflation
-    pub static ref FULL_INFLATION_FEATURE_PAIRS: HashSet<FullInflationFeaturePair> = [
+    pub static ref FULL_INFLATION_FEATURE_PAIRS: AHashSet<FullInflationFeaturePair> = [
         FullInflationFeaturePair {
             vote_id: full_inflation::mainnet::certusone::vote::id(),
             enable_id: full_inflation::mainnet::certusone::enable::id(),
@@ -1151,14 +1151,14 @@ lazy_static! {
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FeatureSet {
-    pub active: HashMap<Pubkey, u64>,
-    pub inactive: HashSet<Pubkey>,
+    pub active: AHashMap<Pubkey, u64>,
+    pub inactive: AHashSet<Pubkey>,
 }
 impl Default for FeatureSet {
     fn default() -> Self {
         // All features disabled
         Self {
-            active: HashMap::new(),
+            active: AHashMap::new(),
             inactive: FEATURE_NAMES.keys().cloned().collect(),
         }
     }
@@ -1173,7 +1173,7 @@ impl FeatureSet {
     }
 
     /// List of enabled features that trigger full inflation
-    pub fn full_inflation_features_enabled(&self) -> HashSet<Pubkey> {
+    pub fn full_inflation_features_enabled(&self) -> AHashSet<Pubkey> {
         let mut hash_set = FULL_INFLATION_FEATURE_PAIRS
             .iter()
             .filter_map(|pair| {
@@ -1183,7 +1183,7 @@ impl FeatureSet {
                     None
                 }
             })
-            .collect::<HashSet<_>>();
+            .collect::<AHashSet<_>>();
 
         if self.is_active(&full_inflation::devnet_and_testnet::id()) {
             hash_set.insert(full_inflation::devnet_and_testnet::id());
@@ -1195,7 +1195,7 @@ impl FeatureSet {
     pub fn all_enabled() -> Self {
         Self {
             active: FEATURE_NAMES.keys().cloned().map(|key| (key, 0)).collect(),
-            inactive: HashSet::new(),
+            inactive: AHashSet::new(),
         }
     }
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5444,6 +5444,7 @@ dependencies = [
 name = "solana-feature-set"
 version = "2.2.0"
 dependencies = [
+ "ahash 0.8.11",
  "lazy_static",
  "solana-epoch-schedule",
  "solana-hash",


### PR DESCRIPTION
#### Problem
- `is_active` is popping up over and over in profiles
- SIP hash is slow and we shouldn't use it here

#### Summary of Changes
- use ahash for `FeatureSet` and related maps/sets

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
