### PR TITLE
Recorder

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9048,8 +9048,8 @@ impl AccountsDb {
                     all_zero_slots_to_clean.len()
                 );
                 for (slot, storage) in all_zero_slots_to_clean {
-                    self.dirty_stores.insert(slot, storage);
                     self.accounts_index.add_uncleaned_roots([slot]);
+                    self.dirty_stores.insert(slot, storage);
                 }
             }
 


### PR DESCRIPTION
#### Problem

In clean thread, we load read dirty_store first before filter on uncleaned roots. 
Therefore, to make sure that the dirty_store is not filtered out by uncleaned roots, we should always add to uncleaned roots first before adding to dirty stores to avoid the race condition. 

In pracitce, this is very unlikey to happen, because race window is so large that before we hit uncleaned root filter in clean threads, the adding to uncleaned roots should have certainly already finished. 

But from a logical data race perspective, the correct order should be add to uncleaned roots first. 


#### Summary of Changes

reorder to add uncleaned roots first before adding to dirty_store.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
