### PR TITLE
chore(cargo-build-sbf): allow using it from nix store

### DIFF
--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -33,7 +33,7 @@ struct Config<'a> {
     dump: bool,
     features: Vec<String>,
     force_tools_install: bool,
-    no_install: bool,
+    skip_tools_install: bool,
     generate_child_script_on_failure: bool,
     no_default_features: bool,
     offline: bool,
@@ -62,7 +62,7 @@ impl Default for Config<'_> {
             dump: false,
             features: vec![],
             force_tools_install: false,
-            no_install: false,
+            skip_tools_install: false,
             generate_child_script_on_failure: false,
             no_default_features: false,
             offline: false,
@@ -664,7 +664,7 @@ fn build_solana_package(
         "x86_64"
     };
 
-    if !config.no_install {
+    if !config.skip_tools_install {
         let platform_tools_download_file_name = if cfg!(target_os = "windows") {
             format!("platform-tools-windows-{arch}.tar.bz2")
         } else if cfg!(target_os = "macos") {
@@ -1039,12 +1039,12 @@ fn main() {
             Arg::new("force_tools_install")
                 .long("force-tools-install")
                 .takes_value(false)
-                .conflicts_with("no_install")
+                .conflicts_with("skip_tools_install")
                 .help("Download and install platform-tools even when existing tools are located"),
         )
         .arg(
-            Arg::new("no_install")
-                .long("no-install")
+            Arg::new("skip_tools_install")
+                .long("skip-tools-install")
                 .takes_value(false)
                 .conflicts_with("force_tools_install")
                 .help("Skip downloading and installing platform-tools, assuming they are properly mounted"),
@@ -1172,7 +1172,7 @@ fn main() {
         dump: matches.is_present("dump"),
         features: matches.values_of_t("features").ok().unwrap_or_default(),
         force_tools_install: matches.is_present("force_tools_install"),
-        no_install: matches.is_present("no_install"),
+        skip_tools_install: matches.is_present("skip_tools_install"),
         generate_child_script_on_failure: matches.is_present("generate_child_script_on_failure"),
         no_default_features: matches.is_present("no_default_features"),
         remap_cwd: !matches.is_present("remap_cwd"),

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -33,6 +33,7 @@ struct Config<'a> {
     dump: bool,
     features: Vec<String>,
     force_tools_install: bool,
+    no_install: bool,
     generate_child_script_on_failure: bool,
     no_default_features: bool,
     offline: bool,
@@ -61,6 +62,7 @@ impl Default for Config<'_> {
             dump: false,
             features: vec![],
             force_tools_install: false,
+            no_install: false,
             generate_child_script_on_failure: false,
             no_default_features: false,
             offline: false,
@@ -661,40 +663,43 @@ fn build_solana_package(
     } else {
         "x86_64"
     };
-    let platform_tools_download_file_name = if cfg!(target_os = "windows") {
-        format!("platform-tools-windows-{arch}.tar.bz2")
-    } else if cfg!(target_os = "macos") {
-        format!("platform-tools-osx-{arch}.tar.bz2")
-    } else {
-        format!("platform-tools-linux-{arch}.tar.bz2")
-    };
-    let package = "platform-tools";
-    let target_path = make_platform_tools_path_for_version(package, &platform_tools_version);
-    install_if_missing(
-        config,
-        package,
-        "https://github.com/anza-xyz/platform-tools/releases/download",
-        platform_tools_download_file_name.as_str(),
-        &platform_tools_version,
-        &target_path,
-    )
-    .unwrap_or_else(|err| {
-        // The package version directory doesn't contain a valid
-        // installation, and it should be removed.
-        let target_path_parent = target_path.parent().expect("Invalid package path");
-        if target_path_parent.exists() {
-            fs::remove_dir_all(target_path_parent).unwrap_or_else(|err| {
-                error!(
-                    "Failed to remove {} while recovering from installation failure: {}",
-                    target_path_parent.to_string_lossy(),
-                    err,
-                );
-                exit(1);
-            });
-        }
-        error!("Failed to install platform-tools: {}", err);
-        exit(1);
-    });
+
+    if !config.no_install {
+        let platform_tools_download_file_name = if cfg!(target_os = "windows") {
+            format!("platform-tools-windows-{arch}.tar.bz2")
+        } else if cfg!(target_os = "macos") {
+            format!("platform-tools-osx-{arch}.tar.bz2")
+        } else {
+            format!("platform-tools-linux-{arch}.tar.bz2")
+        };
+        let package = "platform-tools";
+        let target_path = make_platform_tools_path_for_version(package, &platform_tools_version);
+        install_if_missing(
+            config,
+            package,
+            "https://github.com/anza-xyz/platform-tools/releases/download",
+            platform_tools_download_file_name.as_str(),
+            &platform_tools_version,
+            &target_path,
+        )
+        .unwrap_or_else(|err| {
+            // The package version directory doesn't contain a valid
+            // installation, and it should be removed.
+            let target_path_parent = target_path.parent().expect("Invalid package path");
+            if target_path_parent.exists() {
+                fs::remove_dir_all(target_path_parent).unwrap_or_else(|err| {
+                    error!(
+                        "Failed to remove {} while recovering from installation failure: {}",
+                        target_path_parent.to_string_lossy(),
+                        err,
+                    );
+                    exit(1);
+                });
+            }
+            error!("Failed to install platform-tools: {}", err);
+            exit(1);
+        });
+    }
     link_solana_toolchain(config);
 
     let llvm_bin = config
@@ -1034,7 +1039,15 @@ fn main() {
             Arg::new("force_tools_install")
                 .long("force-tools-install")
                 .takes_value(false)
+                .conflicts_with("no_install")
                 .help("Download and install platform-tools even when existing tools are located"),
+        )
+        .arg(
+            Arg::new("no_install")
+                .long("no-install")
+                .takes_value(false)
+                .conflicts_with("force_tools_install")
+                .help("Skip downloading and installing platform-tools, assuming they are properly mounted"),
         )
         .arg(
             Arg::new("generate_child_script_on_failure")
@@ -1159,6 +1172,7 @@ fn main() {
         dump: matches.is_present("dump"),
         features: matches.values_of_t("features").ok().unwrap_or_default(),
         force_tools_install: matches.is_present("force_tools_install"),
+        no_install: matches.is_present("no_install"),
         generate_child_script_on_failure: matches.is_present("generate_child_script_on_failure"),
         no_default_features: matches.is_present("no_default_features"),
         remap_cwd: !matches.is_present("remap_cwd"),


### PR DESCRIPTION
#### Problem

Currently `cargo-build-sbf` assumes very specific file system layout with $HOME env var usage and symbolic link in installation.

For immutable package managers, `nix` in my case (and may be guix, determinstic containers/linuxes same have same issue), platform tools link can be satisfied as link, but not $HOME.

For `nix` users, doing wrapper with replaced $HOME breaks $HOME of CARGO, RUSTC, RUSTUP, RUSTDOC, so really not good option. 

#### Summary of Changes

Added option `no-install` to `cargo-build-sbf` to ignore all checks of existing installation.

Installation in my case is done by `nix`, it is immutable and deterministic solana-cli and platform-tools, and ensures correct tools versions are in place.

#### Notes,

Just want to add that solana(I do not count anchor on top, which another install layer), has installation done by curl install source -> agave install binary -> cargo-build-sbf.  With `nix` I eliminated all adhoc runtime installation and used immutable storage + devshell. But cannot eliminate $HOME until PR merged. After merge, will get verifiable deterministic CI/DEV for solana.

 Prior fix patch https://github.com/arijoon/solana-nix/blob/master/cargo-build-sbf.patch

#### Next

Actually with nix can also disable rustup toolchain side effects, this is next PR, based on patch example.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
