### PR TITLE
Fix builtin default cost dependents on migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6763,6 +6763,7 @@ dependencies = [
  "rand 0.8.5",
  "solana-builtins-default-costs",
  "solana-compute-budget",
+ "solana-compute-budget-program",
  "solana-cost-model",
  "solana-feature-set",
  "solana-frozen-abi",

--- a/builtins-default-costs/benches/builtin_instruction_costs.rs
+++ b/builtins-default-costs/benches/builtin_instruction_costs.rs
@@ -17,7 +17,6 @@ struct BenchSetup {
 }
 
 const NUM_TRANSACTIONS_PER_ITER: usize = 1024;
-const DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT: u32 = 200_000;
 
 fn setup(all_features_enabled: bool) -> BenchSetup {
     let pubkeys: [Pubkey; 12] = [
@@ -50,14 +49,7 @@ fn setup(all_features_enabled: bool) -> BenchSetup {
 fn do_hash_find(setup: &BenchSetup) {
     for _t in 0..NUM_TRANSACTIONS_PER_ITER {
         let idx = rand::thread_rng().gen_range(0..setup.pubkeys.len());
-        let ix_execution_cost = if let Some(builtin_cost) =
-            get_builtin_instruction_cost(&setup.pubkeys[idx], &setup.feature_set)
-        {
-            builtin_cost
-        } else {
-            u64::from(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT)
-        };
-        assert!(ix_execution_cost != DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64);
+        get_builtin_instruction_cost(&setup.pubkeys[idx], &setup.feature_set);
     }
 }
 

--- a/builtins-default-costs/benches/builtin_instruction_costs.rs
+++ b/builtins-default-costs/benches/builtin_instruction_costs.rs
@@ -53,7 +53,7 @@ fn do_hash_find(setup: &BenchSetup) {
         let ix_execution_cost = if let Some(builtin_cost) =
             get_builtin_instruction_cost(&setup.pubkeys[idx], &setup.feature_set)
         {
-            *builtin_cost
+            builtin_cost
         } else {
             u64::from(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT)
         };

--- a/builtins-default-costs/benches/builtin_instruction_costs.rs
+++ b/builtins-default-costs/benches/builtin_instruction_costs.rs
@@ -2,22 +2,24 @@
 extern crate test;
 use {
     rand::Rng,
-    solana_builtins_default_costs::BUILTIN_INSTRUCTION_COSTS,
+    solana_builtins_default_costs::get_builtin_instruction_cost,
     solana_sdk::{
         address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
-        compute_budget, ed25519_program, loader_v4, pubkey::Pubkey, secp256k1_program,
+        compute_budget, ed25519_program, feature_set::FeatureSet, loader_v4, pubkey::Pubkey,
+        secp256k1_program,
     },
     test::Bencher,
 };
 
 struct BenchSetup {
     pubkeys: [Pubkey; 12],
+    feature_set: FeatureSet,
 }
 
 const NUM_TRANSACTIONS_PER_ITER: usize = 1024;
 const DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT: u32 = 200_000;
 
-fn setup() -> BenchSetup {
+fn setup(all_features_enabled: bool) -> BenchSetup {
     let pubkeys: [Pubkey; 12] = [
         solana_stake_program::id(),
         solana_config_program::id(),
@@ -33,23 +35,46 @@ fn setup() -> BenchSetup {
         ed25519_program::id(),
     ];
 
-    BenchSetup { pubkeys }
+    let feature_set = if all_features_enabled {
+        FeatureSet::all_enabled()
+    } else {
+        FeatureSet::default()
+    };
+
+    BenchSetup {
+        pubkeys,
+        feature_set,
+    }
+}
+
+fn do_hash_find(setup: &BenchSetup) {
+    for _t in 0..NUM_TRANSACTIONS_PER_ITER {
+        let idx = rand::thread_rng().gen_range(0..setup.pubkeys.len());
+        let ix_execution_cost = if let Some(builtin_cost) =
+            get_builtin_instruction_cost(&setup.pubkeys[idx], &setup.feature_set)
+        {
+            *builtin_cost
+        } else {
+            u64::from(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT)
+        };
+        assert!(ix_execution_cost != DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64);
+    }
 }
 
 #[bench]
-fn bench_hash_find(bencher: &mut Bencher) {
-    let BenchSetup { pubkeys } = setup();
+fn bench_hash_find_builtins_not_migrated(bencher: &mut Bencher) {
+    let bench_setup = setup(false);
 
     bencher.iter(|| {
-        for _t in 0..NUM_TRANSACTIONS_PER_ITER {
-            let idx = rand::thread_rng().gen_range(0..pubkeys.len());
-            let ix_execution_cost =
-                if let Some(builtin_cost) = BUILTIN_INSTRUCTION_COSTS.get(&pubkeys[idx]) {
-                    *builtin_cost
-                } else {
-                    u64::from(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT)
-                };
-            assert!(ix_execution_cost != DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64);
-        }
+        do_hash_find(&bench_setup);
+    });
+}
+
+#[bench]
+fn bench_hash_find_builtins_migrated(bencher: &mut Bencher) {
+    let bench_setup = setup(true);
+
+    bencher.iter(|| {
+        do_hash_find(&bench_setup);
     });
 }

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -5,37 +5,125 @@ use {
     lazy_static::lazy_static,
     solana_sdk::{
         address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
-        compute_budget, ed25519_program, feature_set::FeatureSet, loader_v4, pubkey::Pubkey,
+        compute_budget, ed25519_program,
+        feature_set::{self, FeatureSet},
+        loader_v4,
+        pubkey::Pubkey,
         secp256k1_program,
     },
 };
 
+/// DEVELOPER: when a builtin is migrated to sbpf, please add its corresponding
+/// migration feature ID to BUILTIN_INSTRUCTION_COSTS, so the builtin's default
+/// cost can be determined properly based on feature status.
+/// When migration completed, eg the feature gate is enabled everywhere, please
+/// remove that builtin entry from BUILTIN_INSTRUCTION_COSTS.
+#[derive(Clone)]
+struct BuiltinCost {
+    native_cost: u64,
+    sbpf_migration_feature: Option<Pubkey>,
+}
+
 // Number of compute units for each built-in programs
 lazy_static! {
-    /// Number of compute units for each built-in programs
-    ///
-    /// DEVELOPER WARNING: This map CANNOT be modified without causing a
-    /// consensus failure because this map is used to calculate the compute
-    /// limit for transactions that don't specify a compute limit themselves as
-    /// of https://github.com/anza-xyz/agave/issues/2212.  It's also used to
-    /// calculate the cost of a transaction which is used in replay to enforce
-    /// block cost limits as of
-    /// https://github.com/solana-labs/solana/issues/29595.
-    static ref BUILTIN_INSTRUCTION_COSTS: AHashMap<Pubkey, u64> = [
-        (solana_stake_program::id(), solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS),
-        (solana_config_program::id(), solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS),
-        (solana_vote_program::id(), solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS),
-        (solana_system_program::id(), solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS),
-        (compute_budget::id(), solana_compute_budget_program::DEFAULT_COMPUTE_UNITS),
-        (address_lookup_table::program::id(), solana_address_lookup_table_program::processor::DEFAULT_COMPUTE_UNITS),
-        (bpf_loader_upgradeable::id(), solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS),
-        (bpf_loader_deprecated::id(), solana_bpf_loader_program::DEPRECATED_LOADER_COMPUTE_UNITS),
-        (bpf_loader::id(), solana_bpf_loader_program::DEFAULT_LOADER_COMPUTE_UNITS),
-        (loader_v4::id(), solana_loader_v4_program::DEFAULT_COMPUTE_UNITS),
-        // Note: These are precompile, run directly in bank during sanitizing;
-        (secp256k1_program::id(), 0),
-        (ed25519_program::id(), 0),
-        // DO NOT ADD MORE ENTRIES TO THIS MAP
+/// Number of compute units for each built-in programs
+///
+/// DEVELOPER WARNING: This map CANNOT be modified without causing a
+/// consensus failure because this map is used to calculate the compute
+/// limit for transactions that don't specify a compute limit themselves as
+/// of https://github.com/anza-xyz/agave/issues/2212.  It's also used to
+/// calculate the cost of a transaction which is used in replay to enforce
+/// block cost limits as of
+/// https://github.com/solana-labs/solana/issues/29595.
+    static ref BUILTIN_INSTRUCTION_COSTS: AHashMap<Pubkey, BuiltinCost> = [
+    (
+        solana_stake_program::id(),
+        BuiltinCost {
+            native_cost: solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS,
+            sbpf_migration_feature: Some(feature_set::migrate_stake_program_to_core_bpf::id()),
+        },
+    ),
+    (
+        solana_config_program::id(),
+        BuiltinCost {
+            native_cost: solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS,
+            sbpf_migration_feature: Some(feature_set::migrate_config_program_to_core_bpf::id()),
+        },
+    ),
+    (
+        solana_vote_program::id(),
+        BuiltinCost {
+            native_cost: solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS,
+            sbpf_migration_feature: None,
+        },
+    ),
+    (
+        solana_system_program::id(),
+        BuiltinCost {
+            native_cost: solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS,
+            sbpf_migration_feature: None,
+        },
+    ),
+    (
+        compute_budget::id(),
+        BuiltinCost {
+            native_cost: solana_compute_budget_program::DEFAULT_COMPUTE_UNITS,
+            sbpf_migration_feature: None,
+        },
+    ),
+    (
+        address_lookup_table::program::id(),
+        BuiltinCost {
+            native_cost: solana_address_lookup_table_program::processor::DEFAULT_COMPUTE_UNITS,
+            sbpf_migration_feature: Some(
+                feature_set::migrate_address_lookup_table_program_to_core_bpf::id(),
+            ),
+        },
+    ),
+    (
+        bpf_loader_upgradeable::id(),
+        BuiltinCost {
+            native_cost: solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS,
+            sbpf_migration_feature: None,
+        },
+    ),
+    (
+        bpf_loader_deprecated::id(),
+        BuiltinCost {
+            native_cost: solana_bpf_loader_program::DEPRECATED_LOADER_COMPUTE_UNITS,
+            sbpf_migration_feature: None,
+        },
+    ),
+    (
+        bpf_loader::id(),
+        BuiltinCost {
+            native_cost: solana_bpf_loader_program::DEFAULT_LOADER_COMPUTE_UNITS,
+            sbpf_migration_feature: None,
+        },
+    ),
+    (
+        loader_v4::id(),
+        BuiltinCost {
+            native_cost: solana_loader_v4_program::DEFAULT_COMPUTE_UNITS,
+            sbpf_migration_feature: None,
+        },
+    ),
+    // Note: These are precompile, run directly in bank during sanitizing;
+    (
+        secp256k1_program::id(),
+        BuiltinCost {
+            native_cost: 0,
+            sbpf_migration_feature: None,
+        },
+    ),
+    (
+        ed25519_program::id(),
+        BuiltinCost {
+            native_cost: 0,
+            sbpf_migration_feature: None,
+        },
+    ),
+    // DO NOT ADD MORE ENTRIES TO THIS MAP
     ]
     .iter()
     .cloned()
@@ -58,7 +146,19 @@ lazy_static! {
 
 pub fn get_builtin_instruction_cost<'a>(
     program_id: &'a Pubkey,
-    _feature_set: &'a FeatureSet,
+    feature_set: &'a FeatureSet,
 ) -> Option<&'a u64> {
-    BUILTIN_INSTRUCTION_COSTS.get(program_id)
+    BUILTIN_INSTRUCTION_COSTS
+        .get(program_id)
+        .map(|builtin_cost| {
+            builtin_cost
+                .sbpf_migration_feature
+                .map_or(&builtin_cost.native_cost, |feature_id| {
+                    if feature_set.is_active(&feature_id) {
+                        &0
+                    } else {
+                        &builtin_cost.native_cost
+                    }
+                })
+        })
 }

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -162,3 +162,38 @@ pub fn get_builtin_instruction_cost<'a>(
                 })
         })
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_get_builtin_instruction_cost() {
+        // use native cost if no migration planned
+        assert_eq!(
+            Some(&solana_compute_budget_program::DEFAULT_COMPUTE_UNITS),
+            get_builtin_instruction_cost(&compute_budget::id(), &FeatureSet::all_enabled())
+        );
+
+        // use native cost if migration is planned but not activated
+        assert_eq!(
+            Some(&solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS),
+            get_builtin_instruction_cost(&solana_stake_program::id(), &FeatureSet::default())
+        );
+
+        // zero cost if migration is planned and activated
+        assert_eq!(
+            Some(&0),
+            get_builtin_instruction_cost(&solana_stake_program::id(), &FeatureSet::all_enabled())
+        );
+
+        // None if not builtin
+        assert!(
+            get_builtin_instruction_cost(&Pubkey::new_unique(), &FeatureSet::default()).is_none()
+        );
+        assert!(
+            get_builtin_instruction_cost(&Pubkey::new_unique(), &FeatureSet::all_enabled())
+                .is_none()
+        );
+    }
+}

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -154,8 +154,10 @@ pub fn get_builtin_instruction_cost<'a>(
             // Returns true if builtin program id has no sbpf_migration_feature or feature is not activated;
             // otherwise returns false because it's not considered as builtin
             |builtin_cost| -> bool {
-                builtin_cost.sbpf_migration_feature.is_none()
-                    || !feature_set.is_active(&builtin_cost.sbpf_migration_feature.unwrap())
+                builtin_cost
+                    .sbpf_migration_feature
+                    .map(|feature_id| !feature_set.is_active(&feature_id))
+                    .unwrap_or(true)
             },
         )
         .map(|builtin_cost| builtin_cost.native_cost)

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -24,17 +24,16 @@ struct BuiltinCost {
     core_bpf_migration_feature: Option<Pubkey>,
 }
 
-// Number of compute units for each built-in programs
 lazy_static! {
-/// Number of compute units for each built-in programs
-///
-/// DEVELOPER WARNING: This map CANNOT be modified without causing a
-/// consensus failure because this map is used to calculate the compute
-/// limit for transactions that don't specify a compute limit themselves as
-/// of https://github.com/anza-xyz/agave/issues/2212.  It's also used to
-/// calculate the cost of a transaction which is used in replay to enforce
-/// block cost limits as of
-/// https://github.com/solana-labs/solana/issues/29595.
+    /// Number of compute units for each built-in programs
+    ///
+    /// DEVELOPER WARNING: This map CANNOT be modified without causing a
+    /// consensus failure because this map is used to calculate the compute
+    /// limit for transactions that don't specify a compute limit themselves as
+    /// of https://github.com/anza-xyz/agave/issues/2212.  It's also used to
+    /// calculate the cost of a transaction which is used in replay to enforce
+    /// block cost limits as of
+    /// https://github.com/solana-labs/solana/issues/29595.
     static ref BUILTIN_INSTRUCTION_COSTS: AHashMap<Pubkey, BuiltinCost> = [
     (
         solana_stake_program::id(),

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -21,7 +21,7 @@ use {
 #[derive(Clone)]
 struct BuiltinCost {
     native_cost: u64,
-    sbpf_migration_feature: Option<Pubkey>,
+    core_bpf_migration_feature: Option<Pubkey>,
 }
 
 // Number of compute units for each built-in programs
@@ -40,42 +40,42 @@ lazy_static! {
         solana_stake_program::id(),
         BuiltinCost {
             native_cost: solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS,
-            sbpf_migration_feature: Some(feature_set::migrate_stake_program_to_core_bpf::id()),
+            core_bpf_migration_feature: Some(feature_set::migrate_stake_program_to_core_bpf::id()),
         },
     ),
     (
         solana_config_program::id(),
         BuiltinCost {
             native_cost: solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS,
-            sbpf_migration_feature: Some(feature_set::migrate_config_program_to_core_bpf::id()),
+            core_bpf_migration_feature: Some(feature_set::migrate_config_program_to_core_bpf::id()),
         },
     ),
     (
         solana_vote_program::id(),
         BuiltinCost {
             native_cost: solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS,
-            sbpf_migration_feature: None,
+            core_bpf_migration_feature: None,
         },
     ),
     (
         solana_system_program::id(),
         BuiltinCost {
             native_cost: solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS,
-            sbpf_migration_feature: None,
+            core_bpf_migration_feature: None,
         },
     ),
     (
         compute_budget::id(),
         BuiltinCost {
             native_cost: solana_compute_budget_program::DEFAULT_COMPUTE_UNITS,
-            sbpf_migration_feature: None,
+            core_bpf_migration_feature: None,
         },
     ),
     (
         address_lookup_table::program::id(),
         BuiltinCost {
             native_cost: solana_address_lookup_table_program::processor::DEFAULT_COMPUTE_UNITS,
-            sbpf_migration_feature: Some(
+            core_bpf_migration_feature: Some(
                 feature_set::migrate_address_lookup_table_program_to_core_bpf::id(),
             ),
         },
@@ -84,28 +84,28 @@ lazy_static! {
         bpf_loader_upgradeable::id(),
         BuiltinCost {
             native_cost: solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS,
-            sbpf_migration_feature: None,
+            core_bpf_migration_feature: None,
         },
     ),
     (
         bpf_loader_deprecated::id(),
         BuiltinCost {
             native_cost: solana_bpf_loader_program::DEPRECATED_LOADER_COMPUTE_UNITS,
-            sbpf_migration_feature: None,
+            core_bpf_migration_feature: None,
         },
     ),
     (
         bpf_loader::id(),
         BuiltinCost {
             native_cost: solana_bpf_loader_program::DEFAULT_LOADER_COMPUTE_UNITS,
-            sbpf_migration_feature: None,
+            core_bpf_migration_feature: None,
         },
     ),
     (
         loader_v4::id(),
         BuiltinCost {
             native_cost: solana_loader_v4_program::DEFAULT_COMPUTE_UNITS,
-            sbpf_migration_feature: None,
+            core_bpf_migration_feature: None,
         },
     ),
     // Note: These are precompile, run directly in bank during sanitizing;
@@ -113,14 +113,14 @@ lazy_static! {
         secp256k1_program::id(),
         BuiltinCost {
             native_cost: 0,
-            sbpf_migration_feature: None,
+            core_bpf_migration_feature: None,
         },
     ),
     (
         ed25519_program::id(),
         BuiltinCost {
             native_cost: 0,
-            sbpf_migration_feature: None,
+            core_bpf_migration_feature: None,
         },
     ),
     // DO NOT ADD MORE ENTRIES TO THIS MAP
@@ -151,11 +151,11 @@ pub fn get_builtin_instruction_cost<'a>(
     BUILTIN_INSTRUCTION_COSTS
         .get(program_id)
         .filter(
-            // Returns true if builtin program id has no sbpf_migration_feature or feature is not activated;
+            // Returns true if builtin program id has no core_bpf_migration_feature or feature is not activated;
             // otherwise returns false because it's not considered as builtin
             |builtin_cost| -> bool {
                 builtin_cost
-                    .sbpf_migration_feature
+                    .core_bpf_migration_feature
                     .map(|feature_id| !feature_set.is_active(&feature_id))
                     .unwrap_or(true)
             },

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -5,7 +5,8 @@ use {
     lazy_static::lazy_static,
     solana_sdk::{
         address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
-        compute_budget, ed25519_program, loader_v4, pubkey::Pubkey, secp256k1_program,
+        compute_budget, ed25519_program, feature_set::FeatureSet, loader_v4, pubkey::Pubkey,
+        secp256k1_program,
     },
 };
 
@@ -20,7 +21,7 @@ lazy_static! {
     /// calculate the cost of a transaction which is used in replay to enforce
     /// block cost limits as of
     /// https://github.com/solana-labs/solana/issues/29595.
-    pub static ref BUILTIN_INSTRUCTION_COSTS: AHashMap<Pubkey, u64> = [
+    static ref BUILTIN_INSTRUCTION_COSTS: AHashMap<Pubkey, u64> = [
         (solana_stake_program::id(), solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS),
         (solana_config_program::id(), solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS),
         (solana_vote_program::id(), solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS),
@@ -53,4 +54,11 @@ lazy_static! {
             .for_each(|key| temp_table[key.as_ref()[0] as usize] = true);
         temp_table
     };
+}
+
+pub fn get_builtin_instruction_cost<'a>(
+    program_id: &'a Pubkey,
+    _feature_set: &'a FeatureSet,
+) -> Option<&'a u64> {
+    BUILTIN_INSTRUCTION_COSTS.get(program_id)
 }

--- a/core/src/banking_stage/packet_filter.rs
+++ b/core/src/banking_stage/packet_filter.rs
@@ -1,11 +1,18 @@
 use {
     super::immutable_deserialized_packet::ImmutableDeserializedPacket,
+    lazy_static::lazy_static,
     solana_builtins_default_costs::get_builtin_instruction_cost,
     solana_sdk::{
         ed25519_program, feature_set::FeatureSet, saturating_add_assign, secp256k1_program,
     },
     thiserror::Error,
 };
+
+lazy_static! {
+    // To calculate the static_builtin_cost_sum conservatively, an all-enabled dummy feature_set
+    // is used. It lowers required minimal compute_unit_limit, aligns with future versions.
+    static ref FEATURE_SET: FeatureSet = FeatureSet::all_enabled();
+}
 
 #[derive(Debug, Error, PartialEq)]
 pub enum PacketFilterFailure {
@@ -22,13 +29,9 @@ impl ImmutableDeserializedPacket {
     /// which are statically known to exceed the compute budget, and will
     /// result in no useful state-change.
     pub fn check_insufficent_compute_unit_limit(&self) -> Result<(), PacketFilterFailure> {
-        // To calculate the static_builtin_cost_sum conservatively, an all-enabled dummy feature_set
-        // is used. It lowers required minimal compute_unit_limit, aligns with future versions.
-        let feature_set = FeatureSet::all_enabled();
-
         let mut static_builtin_cost_sum: u64 = 0;
         for (program_id, _) in self.transaction().get_message().program_instructions_iter() {
-            if let Some(ix_cost) = get_builtin_instruction_cost(program_id, &feature_set) {
+            if let Some(ix_cost) = get_builtin_instruction_cost(program_id, &FEATURE_SET) {
                 saturating_add_assign!(static_builtin_cost_sum, ix_cost);
             }
         }

--- a/core/src/banking_stage/packet_filter.rs
+++ b/core/src/banking_stage/packet_filter.rs
@@ -29,7 +29,7 @@ impl ImmutableDeserializedPacket {
         let mut static_builtin_cost_sum: u64 = 0;
         for (program_id, _) in self.transaction().get_message().program_instructions_iter() {
             if let Some(ix_cost) = get_builtin_instruction_cost(program_id, &feature_set) {
-                saturating_add_assign!(static_builtin_cost_sum, *ix_cost);
+                saturating_add_assign!(static_builtin_cost_sum, ix_cost);
             }
         }
 

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -36,6 +36,7 @@ name = "solana_cost_model"
 itertools = { workspace = true }
 rand = "0.8.5"
 # See order-crates-for-publishing.py for using this unusual `path = "."`
+solana-compute-budget-program = { workspace = true }
 solana-cost-model = { path = ".", features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-runtime-transaction = { workspace = true, features = [

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -7,7 +7,7 @@
 
 use {
     crate::{block_cost_limits::*, transaction_cost::*},
-    solana_builtins_default_costs::BUILTIN_INSTRUCTION_COSTS,
+    solana_builtins_default_costs::get_builtin_instruction_cost,
     solana_compute_budget::compute_budget_limits::{
         DEFAULT_HEAP_COST, DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT, MAX_COMPUTE_UNIT_LIMIT,
     },
@@ -163,7 +163,7 @@ impl CostModel {
 
         for (program_id, instruction) in transaction.program_instructions_iter() {
             let ix_execution_cost =
-                if let Some(builtin_cost) = BUILTIN_INSTRUCTION_COSTS.get(program_id) {
+                if let Some(builtin_cost) = get_builtin_instruction_cost(program_id, feature_set) {
                     *builtin_cost
                 } else {
                     has_user_space_instructions = true;
@@ -518,14 +518,13 @@ mod tests {
         );
 
         // expected cost for one system transfer instructions
-        let expected_execution_cost = BUILTIN_INSTRUCTION_COSTS
-            .get(&system_program::id())
-            .unwrap();
+        let expected_execution_cost =
+            solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS;
 
         let (program_execution_cost, _loaded_accounts_data_size_cost, data_bytes_cost) =
             CostModel::get_transaction_cost(&simple_transaction, &FeatureSet::all_enabled());
 
-        assert_eq!(*expected_execution_cost, program_execution_cost);
+        assert_eq!(expected_execution_cost, program_execution_cost);
         assert_eq!(3, data_bytes_cost);
     }
 
@@ -672,9 +671,7 @@ mod tests {
         debug!("many transfer transaction {:?}", tx);
 
         // expected cost for two system transfer instructions
-        let program_cost = BUILTIN_INSTRUCTION_COSTS
-            .get(&system_program::id())
-            .unwrap();
+        let program_cost = solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS;
         let expected_cost = program_cost * 2;
 
         let (program_execution_cost, _loaded_accounts_data_size_cost, data_bytes_cost) =
@@ -757,9 +754,8 @@ mod tests {
         ));
 
         let expected_account_cost = WRITE_LOCK_UNITS * 2;
-        let expected_execution_cost = BUILTIN_INSTRUCTION_COSTS
-            .get(&system_program::id())
-            .unwrap();
+        let expected_execution_cost =
+            solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS;
         const DEFAULT_PAGE_COST: u64 = 8;
         let expected_loaded_accounts_data_size_cost =
             solana_compute_budget::compute_budget_limits::MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get()
@@ -769,7 +765,7 @@ mod tests {
 
         let tx_cost = CostModel::calculate_cost(&tx, &FeatureSet::all_enabled());
         assert_eq!(expected_account_cost, tx_cost.write_lock_cost());
-        assert_eq!(*expected_execution_cost, tx_cost.programs_execution_cost());
+        assert_eq!(expected_execution_cost, tx_cost.programs_execution_cost());
         assert_eq!(2, tx_cost.writable_accounts().count());
         assert_eq!(
             expected_loaded_accounts_data_size_cost,
@@ -795,12 +791,8 @@ mod tests {
 
         let feature_set = FeatureSet::all_enabled();
         let expected_account_cost = WRITE_LOCK_UNITS * 2;
-        let expected_execution_cost = BUILTIN_INSTRUCTION_COSTS
-            .get(&system_program::id())
-            .unwrap()
-            + BUILTIN_INSTRUCTION_COSTS
-                .get(&compute_budget::id())
-                .unwrap();
+        let expected_execution_cost = solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS
+            + solana_compute_budget_program::DEFAULT_COMPUTE_UNITS;
         let expected_loaded_accounts_data_size_cost = (data_limit as u64) / (32 * 1024) * 8;
 
         let tx_cost = CostModel::calculate_cost(&tx, &feature_set);
@@ -828,9 +820,7 @@ mod tests {
                 start_hash,
             ));
         // transaction has one builtin instruction, and one bpf instruction, no ComputeBudget::compute_unit_limit
-        let expected_builtin_cost = *BUILTIN_INSTRUCTION_COSTS
-            .get(&solana_system_program::id())
-            .unwrap();
+        let expected_builtin_cost = solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS;
         let expected_bpf_cost = DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT;
 
         let (program_execution_cost, _loaded_accounts_data_size_cost, _data_bytes_cost) =
@@ -857,12 +847,8 @@ mod tests {
                 start_hash,
             ));
         // transaction has one builtin instruction, and one ComputeBudget::compute_unit_limit
-        let expected_cost = *BUILTIN_INSTRUCTION_COSTS
-            .get(&solana_system_program::id())
-            .unwrap()
-            + BUILTIN_INSTRUCTION_COSTS
-                .get(&compute_budget::id())
-                .unwrap();
+        let expected_cost = solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS
+            + solana_compute_budget_program::DEFAULT_COMPUTE_UNITS;
 
         let (program_execution_cost, _loaded_accounts_data_size_cost, _data_bytes_cost) =
             CostModel::get_transaction_cost(&transaction, &FeatureSet::all_enabled());

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -164,7 +164,7 @@ impl CostModel {
         for (program_id, instruction) in transaction.program_instructions_iter() {
             let ix_execution_cost =
                 if let Some(builtin_cost) = get_builtin_instruction_cost(program_id, feature_set) {
-                    *builtin_cost
+                    builtin_cost
                 } else {
                     has_user_space_instructions = true;
                     u64::from(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT)

--- a/runtime/src/bank/builtins/mod.rs
+++ b/runtime/src/bank/builtins/mod.rs
@@ -31,6 +31,11 @@ macro_rules! testable_prototype {
     };
 }
 
+/// DEVELOPER: when a builtin is migrated to sbpf, please add its corresponding
+/// migration feature ID to solana-builtin-default-costs::BUILTIN_INSTRUCTION_COSTS,
+/// so the builtin's default cost can be determined properly based on feature status.
+/// When migration completed, and the feature gate is enabled everywhere, please
+/// remove that builtin entry from solana-builtin-default-costs::BUILTIN_INSTRUCTION_COSTS.
 pub static BUILTINS: &[BuiltinPrototype] = &[
     testable_prototype!(BuiltinPrototype {
         core_bpf_migration_config: None,


### PR DESCRIPTION
#### Problem

Some of builtin programs are being migrated to sbpf, while the rest is being planned for too. Once a builtin program is migrated in a cluster, it's "default cost" defined in BUILTIN_INSTRUCTION_COSTS should be changed to `0`.

#### Summary of Changes
- add public function to fetch correct default cost for builtin program, based on migration feature status
- add BuiltinCost struct to track migration feature ID
- add developer notes to remind to add migration feature ID whenever it becomes available.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
