### PR TITLE
ResolvedTransactionView: array writable_cache

### DIFF
--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -32,6 +32,8 @@ pub struct ResolvedTransactionView<D: TransactionData> {
     /// The resolved address lookups.
     resolved_addresses: Option<LoadedAddresses>,
     /// A cache for whether an address is writable.
+    // Sanitized transactions are guaranteed to have a maximum of 256 keys,
+    // because account indexing is done with a u8.
     writable_cache: [bool; 256],
 }
 

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -32,7 +32,7 @@ pub struct ResolvedTransactionView<D: TransactionData> {
     /// The resolved address lookups.
     resolved_addresses: Option<LoadedAddresses>,
     /// A cache for whether an address is writable.
-    writable_cache: Vec<bool>, // TODO: should this be a vec, bitset, or array[256].
+    writable_cache: [bool; 256],
 }
 
 impl<D: TransactionData> Deref for ResolvedTransactionView<D> {
@@ -91,12 +91,12 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
         view: &TransactionView<true, D>,
         resolved_addresses: Option<&LoadedAddresses>,
         reserved_account_keys: &HashSet<Pubkey>,
-    ) -> Vec<bool> {
+    ) -> [bool; 256] {
         // Build account keys so that we can iterate over and check if
         // an address is writable.
         let account_keys = AccountKeys::new(view.static_account_keys(), resolved_addresses);
 
-        let mut is_writable_cache = Vec::with_capacity(account_keys.len());
+        let mut is_writable_cache = [false; 256];
         let num_static_account_keys = usize::from(view.num_static_account_keys());
         let num_writable_lookup_accounts = usize::from(view.total_writable_lookup_accounts());
         let num_signed_accounts = usize::from(view.num_required_signatures());
@@ -120,7 +120,7 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
             };
 
             // If the key is reserved it cannot be writable.
-            is_writable_cache.push(is_requested_write && !reserved_account_keys.contains(key));
+            is_writable_cache[index] = is_requested_write && !reserved_account_keys.contains(key);
         }
 
         // If a program account is locked, it cannot be writable unless the


### PR DESCRIPTION
#### Problem
- ResolvedTransactionView uses `Vec<bool>` for storing the cached `is_writable`
- This allocates for every transaction

#### Summary of Changes
- Remove allocation (in simplest way possible) using statically sized (256) bool array

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
