### PR TITLE
Removes index's root check in get_snapshot_storages()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8475,20 +8475,9 @@ impl AccountsDb {
         requested_slots: impl RangeBounds<Slot> + Sync,
     ) -> (Vec<Arc<AccountStorageEntry>>, Vec<Slot>) {
         let start = Instant::now();
-        let max_alive_root_exclusive = self
-            .accounts_index
-            .roots_tracker
-            .read()
-            .unwrap()
-            .alive_roots
-            .max_exclusive();
         let (slots, storages) = self
             .storage
-            .get_if(|slot, storage| {
-                (*slot < max_alive_root_exclusive)
-                    && requested_slots.contains(slot)
-                    && storage.has_accounts()
-            })
+            .get_if(|slot, storage| requested_slots.contains(slot) && storage.has_accounts())
             .into_vec()
             .into_iter()
             .unzip();


### PR DESCRIPTION
#### Problem

`get_snapshot_storages()` needlessly filters the requested slots if they are roots.

1. Maybe the caller actually needs all the slots, regardless if they are rooted yet?
2. All the callers that only operate on roots already enforce this, and only submit roots as their `requested_slots`.


#### Summary of Changes

Remove the accounts index checks in get_snapshot_storages().


#### More Information

There are four places where we call `get_snapshots_storages()`. All of them already only ask for rooted slots.

1. `clean_accounts()`

Since #3737, we now call `get_snapshot_storages()` in `clean_accounts()`. We guarantee that the slots `clean` works on are rooted, so we don't need to do redundant checks in `get_snapshot_storages(); all the storages `clean` asks for will be rooted.

2. snapshots -- normal validator operation

AccountsBackgroundServices periodically takes snapshots. ABS only works on rooted slots. So whenever it calls `get_snapshot_storages()`, it'll only ask for rooted slots. Same as (1).

3. snapshots -- ledger-tool

When creating a snapshot with ledger-tool, by definition the snapshot slot becomes a rooted slot. Therefore the call to `get_snapshot_storages()` is inherently also all roots.

4. snapshots -- startup verification

At startup, we get the storages and perform verification of all the accounts. Since snapshots by definition contain only roots (see (3)), that means calling `get_snapshot_storages()` here can only get roots.


In all the scenarios we already can/do only ask for rooted slots. So we don't need redundant checks inside `get_snapshot_storages()`.