### PR TITLE
Faster status cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10259,6 +10259,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "blake3",
+ "boxcar",
  "bv",
  "bytemuck",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,7 @@ blake3 = "1.8.3"
 blst = "0.3.16"
 blstrs = "0.7.1"
 borsh = { version = "1.6.0", features = ["derive", "unstable__schema"] }
+boxcar = "0.2.7"
 bs58 = { version = "0.5.1", default-features = false }
 bv = "0.11.1"
 byte-unit = "4.0.19"
@@ -258,7 +259,7 @@ crossbeam-channel = "0.5.15"
 csv = "1.4.0"
 ctrlc = "3.5.2"
 curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }
-dashmap = "5.5.3"
+dashmap = { version = "5.5.3", features = ["serde"] }
 derivation-path = { version = "0.2.0", default-features = false }
 derive-where = "1.6.0"
 derive_more = { version = "2.1.1", features = ["full"] }

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -314,11 +314,7 @@ fn test_slots_to_snapshot() {
             .unwrap()
             .root_bank()
             .status_cache
-            .read()
-            .unwrap()
             .roots()
-            .iter()
-            .cloned()
             .sorted();
         assert!(slots_to_snapshot.into_iter().eq(expected_slots_to_snapshot));
     }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1319,6 +1319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
 name = "brotli"
 version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8397,6 +8403,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "blake3",
+ "boxcar",
  "bv",
  "bytemuck",
  "crossbeam-channel",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -66,6 +66,7 @@ assert_matches = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
 blake3 = { workspace = true }
+boxcar = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/runtime/benches/status_cache.rs
+++ b/runtime/benches/status_cache.rs
@@ -14,7 +14,7 @@ use {
 
 #[bench]
 fn bench_status_cache_serialize(bencher: &mut Bencher) {
-    let mut status_cache = BankStatusCache::default();
+    let status_cache = BankStatusCache::default();
     status_cache.add_root(0);
     status_cache.clear();
     for hash_index in 0..100 {
@@ -29,7 +29,7 @@ fn bench_status_cache_serialize(bencher: &mut Bencher) {
             status_cache.insert(&blockhash, sig, 0, Ok(()));
         }
     }
-    assert!(status_cache.roots().contains(&0));
+    assert!(status_cache.roots().collect::<Vec<_>>().contains(&0));
     bencher.iter(|| {
         let _ = serialize(&status_cache.root_slot_deltas()).unwrap();
     });
@@ -43,7 +43,7 @@ fn bench_status_cache_serialize_max(bencher: &mut Bencher) {
     let mut status_cache = BankStatusCache::default();
     fill_status_cache(&mut status_cache, max_cache_entries, 100_000);
 
-    assert!(status_cache.roots().contains(&0));
+    assert!(status_cache.roots().collect::<Vec<_>>().contains(&0));
     bencher.iter(|| {
         let _ = serialize(&status_cache.root_slot_deltas()).unwrap();
     });
@@ -51,7 +51,7 @@ fn bench_status_cache_serialize_max(bencher: &mut Bencher) {
 
 #[bench]
 fn bench_status_cache_root_slot_deltas(bencher: &mut Bencher) {
-    let mut status_cache = BankStatusCache::default();
+    let status_cache = BankStatusCache::default();
 
     // fill the status cache
     let slots: Vec<_> = (42..).take(MAX_CACHE_ENTRIES).collect();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -746,7 +746,7 @@ pub struct Bank {
     pub rc: BankRc,
 
     /// A cache of signature statuses
-    pub status_cache: Arc<RwLock<BankStatusCache>>,
+    pub status_cache: Arc<BankStatusCache>,
 
     /// FIFO queue of `recent_blockhash` items
     blockhash_queue: RwLock<BlockhashQueue>,
@@ -1086,7 +1086,7 @@ impl Bank {
     fn default_with_accounts(accounts: Accounts) -> Self {
         let mut bank = Self {
             rc: BankRc::new(accounts),
-            status_cache: Arc::<RwLock<BankStatusCache>>::default(),
+            status_cache: Arc::<BankStatusCache>::default(),
             blockhash_queue: RwLock::<BlockhashQueue>::default(),
             ancestors: Ancestors::default(),
             hash: RwLock::<Hash>::default(),
@@ -1874,7 +1874,7 @@ impl Bank {
         let stakes_accounts_load_duration = now.elapsed();
         let mut bank = Self {
             rc: bank_rc,
-            status_cache: Arc::<RwLock<BankStatusCache>>::default(),
+            status_cache: Arc::<BankStatusCache>::default(),
             blockhash_queue: RwLock::new(fields.blockhash_queue),
             ancestors,
             hash: RwLock::new(fields.hash),
@@ -2075,7 +2075,7 @@ impl Bank {
     }
 
     pub fn status_cache_ancestors(&self) -> Vec<u64> {
-        let mut roots = self.status_cache.read().unwrap().roots().clone();
+        let mut roots = self.status_cache.roots().collect::<HashSet<_>>();
         let min = roots.iter().min().cloned().unwrap_or(0);
         for ancestor in self.ancestors.keys() {
             if ancestor >= min {
@@ -2649,7 +2649,7 @@ impl Bank {
         let mut squash_cache_time = Measure::start("squash_cache_time");
         roots
             .iter()
-            .for_each(|slot| self.status_cache.write().unwrap().add_root(*slot));
+            .for_each(|slot| self.status_cache.add_root(*slot));
         squash_cache_time.stop();
 
         SquashTiming {
@@ -2901,11 +2901,11 @@ impl Bank {
     /// Forget all signatures. Useful for benchmarking.
     #[cfg(feature = "dev-context-only-utils")]
     pub fn clear_signatures(&self) {
-        self.status_cache.write().unwrap().clear();
+        self.status_cache.clear();
     }
 
     pub fn clear_slot_signatures(&self, slot: Slot) {
-        self.status_cache.write().unwrap().clear_slot_entries(slot);
+        self.status_cache.clear_slot_entries(slot);
     }
 
     fn update_transaction_statuses(
@@ -2913,13 +2913,12 @@ impl Bank {
         sanitized_txs: &[impl TransactionWithMeta],
         processing_results: &[TransactionProcessingResult],
     ) {
-        let mut status_cache = self.status_cache.write().unwrap();
         assert_eq!(sanitized_txs.len(), processing_results.len());
         for (tx, processing_result) in sanitized_txs.iter().zip(processing_results) {
             if let Ok(processed_tx) = &processing_result {
                 // Add the message hash to the status cache to ensure that this message
                 // won't be processed again with a different signature.
-                status_cache.insert(
+                self.status_cache.insert(
                     tx.recent_blockhash(),
                     tx.message_hash(),
                     self.slot(),
@@ -2928,7 +2927,7 @@ impl Bank {
                 // Add the transaction signature to the status cache so that transaction status
                 // can be queried by transaction signature over RPC. In the future, this should
                 // only be added for API nodes because voting validators don't need to do this.
-                status_cache.insert(
+                self.status_cache.insert(
                     tx.recent_blockhash(),
                     tx.signature(),
                     self.slot(),
@@ -4634,8 +4633,7 @@ impl Bank {
         signature: &Signature,
         blockhash: &Hash,
     ) -> Option<Result<()>> {
-        let rcache = self.status_cache.read().unwrap();
-        rcache
+        self.status_cache
             .get_status(signature, blockhash, &self.ancestors)
             .map(|v| v.1)
     }
@@ -4645,15 +4643,14 @@ impl Bank {
         message_hash: &Hash,
         transaction_blockhash: &Hash,
     ) -> Option<(Slot, bool)> {
-        let rcache = self.status_cache.read().unwrap();
-        rcache
+        self.status_cache
             .get_status(message_hash, transaction_blockhash, &self.ancestors)
             .map(|(slot, status)| (slot, status.is_ok()))
     }
 
     pub fn get_signature_status_slot(&self, signature: &Signature) -> Option<(Slot, Result<()>)> {
-        let rcache = self.status_cache.read().unwrap();
-        rcache.get_status_any_blockhash(signature, &self.ancestors)
+        self.status_cache
+            .get_status_any_blockhash(signature, &self.ancestors)
     }
 
     pub fn get_signature_status(&self, signature: &Signature) -> Option<Result<()>> {

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -239,13 +239,12 @@ impl Bank {
         } else {
             None
         };
-        let rcache = self.status_cache.read().unwrap();
 
         for (sanitized_tx_ref, lock_result) in sanitized_txs.iter().zip(lock_results) {
             let sanitized_tx = sanitized_tx_ref.borrow();
 
             let (result, processed_slot) = if lock_result.is_ok() {
-                if let Some(slot) = self.get_processed_slot(sanitized_tx, &rcache) {
+                if let Some(slot) = self.get_processed_slot(sanitized_tx, &self.status_cache) {
                     error_counters.already_processed += 1;
                     (Err(TransactionError::AlreadyProcessed), Some(slot))
                 } else {

--- a/runtime/src/read_optimized_dashmap.rs
+++ b/runtime/src/read_optimized_dashmap.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 #[cfg(feature = "shuttle-test")]
 use shuttle::sync::Arc;
 #[cfg(not(feature = "shuttle-test"))]
@@ -89,6 +87,8 @@ where
 
     /// Retains only the elements specified by the predicate or that are being
     /// accessed by other threads.
+    // FIXME: use this?
+    #[cfg(test)]
     pub fn retain_if_accessed_or(&self, mut f: impl FnMut(&K, &mut ROValue<V>) -> bool) {
         self.inner.retain(|k, v| v.shared() || f(k, v))
     }

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -226,7 +226,7 @@ pub fn bank_from_snapshot_archives(
 
     verify_slot_deltas(slot_deltas.as_slice(), &bank)?;
 
-    bank.status_cache.write().unwrap().append(&slot_deltas);
+    bank.status_cache.append(&slot_deltas);
 
     let snapshot_archive_info = incremental_snapshot_archive_info.map_or_else(
         || full_snapshot_archive_info.snapshot_archive_info(),
@@ -407,7 +407,7 @@ pub fn bank_from_snapshot_dir(
 
     verify_slot_deltas(slot_deltas.as_slice(), &bank)?;
 
-    bank.status_cache.write().unwrap().append(&slot_deltas);
+    bank.status_cache.append(&slot_deltas);
 
     if !bank.verify_snapshot_bank(
         true,
@@ -674,7 +674,7 @@ pub fn bank_to_full_snapshot_archive(
         SnapshotKind::Archive(snapshot_archive_kind),
         bank,
         bank.get_snapshot_storages(None),
-        bank.status_cache.read().unwrap().root_slot_deltas(),
+        bank.status_cache.root_slot_deltas(),
     );
 
     let snapshot_config = SnapshotConfig {
@@ -745,7 +745,7 @@ pub fn bank_to_incremental_snapshot_archive(
         SnapshotKind::Archive(snapshot_archive_kind),
         bank,
         bank.get_snapshot_storages(Some(full_snapshot_slot)),
-        bank.status_cache.read().unwrap().root_slot_deltas(),
+        bank.status_cache.root_slot_deltas(),
     );
 
     // Note: Since the snapshot_storages above are *only* the incremental storages,

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -126,7 +126,7 @@ impl SnapshotController {
             let mut snapshot_time = Measure::start("squash::snapshot_time");
             // Save off the status cache because these may get pruned if another
             // `set_root()` is called before the snapshots package can be generated
-            let status_cache_slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
+            let status_cache_slot_deltas = bank.status_cache.root_slot_deltas();
             if let Err(e) = self.abs_request_sender.send(SnapshotRequest {
                 snapshot_root_bank: Arc::clone(bank),
                 status_cache_slot_deltas,


### PR DESCRIPTION
This PR removes the global RwLock around the status cache, and introduces more granular RwLocks per-blockhash and per-slot. Additionally, it changes the internal hash tables from std HashMap to Dashmap, so that operations at the blockhash and slot level can be done only holding read locks. 

This is not the final design of A Performant Status Cache - which, I think, can make check and update go straight to 0 -  but it's a good incremental improvement. 

Results are pretty good: check_transactions is ~6x faster, and update_transaction_statuses is ~2.5x faster.

<img width="1963" alt="Screenshot 2024-11-26 at 10 57 34 pm" src="https://github.com/user-attachments/assets/a31c35cc-b5fb-4e34-99d7-89e0f4d7e9bf">

<img width="1936" alt="Screenshot 2024-11-26 at 10 59 04 pm" src="https://github.com/user-attachments/assets/6e31c6da-7d78-4823-a158-db3490f0802d">

