### PR TITLE
PrioritizationFeeCache: make update() never sleep on the sender channel

### DIFF
--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -1,6 +1,6 @@
 use {
     crate::{bank::Bank, prioritization_fee::*},
-    crossbeam_channel::{unbounded, Receiver, Sender},
+    crossbeam_channel::{unbounded, Receiver, Sender, TryRecvError},
     log::*,
     solana_accounts_db::account_locks::validate_account_locks,
     solana_measure::measure_us,
@@ -15,7 +15,8 @@ use {
             atomic::{AtomicU64, Ordering},
             Arc, RwLock,
         },
-        thread::{Builder, JoinHandle},
+        thread::{sleep, Builder, JoinHandle},
+        time::Duration,
     },
 };
 
@@ -358,7 +359,18 @@ impl PrioritizationFeeCache {
         // for a slot. The updates are tracked and finalized by bank_id.
         let mut unfinalized = UnfinalizedPrioritizationFees::new();
 
-        for update in receiver.iter() {
+        loop {
+            let update = match receiver.try_recv() {
+                Ok(update) => update,
+                Err(TryRecvError::Empty) => {
+                    sleep(Duration::from_millis(5));
+                    continue;
+                }
+                Err(err @ TryRecvError::Disconnected) => {
+                    info!("PrioritizationFeeCache::service_loop() is stopping because: {err}");
+                    break;
+                }
+            };
             match update {
                 CacheServiceUpdate::TransactionUpdate {
                     slot,


### PR DESCRIPTION
Avoid update() callers having to notify the service_loop() thread by doing an explicit sleep instead of sleeping on channel.recv() when the channel is empty. This avoids the case in which multiple replay/banking threads call update() at the same time and end up... sleeping themselves acquiring the mutex to notify the receiver.

Before and after

<img width="1967" alt="Screenshot 2024-11-28 at 12 26 28 am" src="https://github.com/user-attachments/assets/2d8d8f4b-d55e-4031-bb35-6fb1b35a4ead">


<img width="1961" alt="Screenshot 2024-11-28 at 12 27 04 am" src="https://github.com/user-attachments/assets/14c3627f-71e2-4fe3-b9c8-c63bc0e36817">
