### PR TITLE
TransactionView: ReceiveAndBuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6840,6 +6840,7 @@ name = "solana-core"
 version = "2.2.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
+ "agave-transaction-view",
  "ahash 0.8.11",
  "anyhow",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,7 @@ version = "2.2.0"
 dependencies = [
  "agave-transaction-view",
  "bincode",
+ "bytes",
  "criterion",
  "solana-hash",
  "solana-instruction",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,6 @@ version = "2.2.0"
 dependencies = [
  "agave-transaction-view",
  "bincode",
- "bytes",
  "criterion",
  "solana-hash",
  "solana-instruction",

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -11,7 +11,7 @@ use {
     solana_core::{
         banking_stage::{update_bank_forks_and_poh_recorder_for_new_tpu_bank, BankingStage},
         banking_trace::{BankingTracer, Channels, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
-        validator::BlockProductionMethod,
+        validator::{BlockProductionMethod, TransactionStructure},
     },
     solana_gossip::cluster_info::{ClusterInfo, Node},
     solana_ledger::{
@@ -291,6 +291,14 @@ fn main() {
                 .help(BlockProductionMethod::cli_message()),
         )
         .arg(
+            Arg::with_name("transaction_struct")
+                .long("transaction-structure")
+                .value_name("STRUCT")
+                .takes_value(true)
+                .possible_values(TransactionStructure::cli_names())
+                .help(TransactionStructure::cli_message()),
+        )
+        .arg(
             Arg::new("num_banking_threads")
                 .long("num-banking-threads")
                 .takes_value(true)
@@ -319,6 +327,9 @@ fn main() {
 
     let block_production_method = matches
         .value_of_t::<BlockProductionMethod>("block_production_method")
+        .unwrap_or_default();
+    let transaction_struct = matches
+        .value_of_t::<TransactionStructure>("transaction_struct")
         .unwrap_or_default();
     let num_banking_threads = matches
         .value_of_t::<u32>("num_banking_threads")
@@ -470,6 +481,7 @@ fn main() {
     };
     let banking_stage = BankingStage::new_num_threads(
         block_production_method,
+        transaction_struct,
         &cluster_info,
         &poh_recorder,
         non_vote_receiver,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ codecov = { repository = "solana-labs/solana", branch = "master", service = "git
 
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
+agave-transaction-view = { workspace = true }
 ahash = { workspace = true }
 anyhow = { workspace = true }
 arrayvec = { workspace = true }

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -8,7 +8,7 @@ use {
             BankingTracer, ChannelLabel, Channels, TimedTracedEvent, TracedEvent, TracedSender,
             TracerThread, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT, BASENAME,
         },
-        validator::BlockProductionMethod,
+        validator::{BlockProductionMethod, TransactionStructure},
     },
     agave_banking_stage_ingress_types::BankingPacketBatch,
     assert_matches::assert_matches,
@@ -679,6 +679,7 @@ impl BankingSimulator {
         bank_forks: Arc<RwLock<BankForks>>,
         blockstore: Arc<Blockstore>,
         block_production_method: BlockProductionMethod,
+        transaction_struct: TransactionStructure,
     ) -> (SenderLoop, SimulatorLoop, SimulatorThreads) {
         let parent_slot = self.parent_slot().unwrap();
         let mut packet_batches_by_time = self.banking_trace_events.packet_batches_by_time;
@@ -810,6 +811,7 @@ impl BankingSimulator {
         let prioritization_fee_cache = &Arc::new(PrioritizationFeeCache::new(0u64));
         let banking_stage = BankingStage::new_num_threads(
             block_production_method.clone(),
+            transaction_struct.clone(),
             &cluster_info,
             &poh_recorder,
             non_vote_receiver,
@@ -896,12 +898,14 @@ impl BankingSimulator {
         bank_forks: Arc<RwLock<BankForks>>,
         blockstore: Arc<Blockstore>,
         block_production_method: BlockProductionMethod,
+        transaction_struct: TransactionStructure,
     ) -> Result<(), SimulateError> {
         let (sender_loop, simulator_loop, simulator_threads) = self.prepare_simulation(
             genesis_config,
             bank_forks,
             blockstore,
             block_production_method,
+            transaction_struct,
         );
 
         sender_loop.log_starting();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -25,7 +25,7 @@ use {
                 scheduler_controller::SchedulerController, scheduler_error::SchedulerError,
             },
         },
-        validator::BlockProductionMethod,
+        validator::{BlockProductionMethod, TransactionStructure},
     },
     agave_banking_stage_ingress_types::BankingPacketReceiver,
     crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender},
@@ -53,7 +53,9 @@ use {
     },
     transaction_scheduler::{
         prio_graph_scheduler::PrioGraphSchedulerConfig,
-        receive_and_buffer::SanitizedTransactionReceiveAndBuffer,
+        receive_and_buffer::{
+            ReceiveAndBuffer, SanitizedTransactionReceiveAndBuffer, TransactionViewReceiveAndBuffer,
+        },
         transaction_state_container::TransactionStateContainer,
     },
 };
@@ -401,6 +403,7 @@ impl BankingStage {
     ) -> Self {
         match block_production_method {
             BlockProductionMethod::CentralScheduler => Self::new_central_scheduler(
+                TransactionStructure::Sdk,
                 cluster_info,
                 poh_recorder,
                 non_vote_receiver,
@@ -420,6 +423,7 @@ impl BankingStage {
 
     #[allow(clippy::too_many_arguments)]
     pub fn new_central_scheduler(
+        transaction_struct: TransactionStructure,
         cluster_info: &impl LikeClusterInfo,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         non_vote_receiver: BankingPacketReceiver,
@@ -482,6 +486,77 @@ impl BankingStage {
             ));
         }
 
+        let transaction_struct = if enable_forwarding {
+            warn!(
+                "Forwarding only supported for `Sdk` transaction struct. Overriding to use `Sdk`."
+            );
+            TransactionStructure::Sdk
+        } else {
+            transaction_struct
+        };
+
+        match transaction_struct {
+            TransactionStructure::Sdk => {
+                let receive_and_buffer = SanitizedTransactionReceiveAndBuffer::new(
+                    PacketDeserializer::new(non_vote_receiver),
+                    bank_forks.clone(),
+                    enable_forwarding,
+                );
+                Self::spawn_scheduler_and_workers(
+                    &mut bank_thread_hdls,
+                    receive_and_buffer,
+                    decision_maker,
+                    committer,
+                    cluster_info,
+                    poh_recorder,
+                    num_threads,
+                    log_messages_bytes_limit,
+                    connection_cache,
+                    bank_forks,
+                    enable_forwarding,
+                    data_budget,
+                );
+            }
+            TransactionStructure::View => {
+                let receive_and_buffer = TransactionViewReceiveAndBuffer {
+                    receiver: non_vote_receiver,
+                    bank_forks: bank_forks.clone(),
+                };
+                Self::spawn_scheduler_and_workers(
+                    &mut bank_thread_hdls,
+                    receive_and_buffer,
+                    decision_maker,
+                    committer,
+                    cluster_info,
+                    poh_recorder,
+                    num_threads,
+                    log_messages_bytes_limit,
+                    connection_cache,
+                    bank_forks,
+                    enable_forwarding,
+                    data_budget,
+                );
+            }
+        }
+
+        Self { bank_thread_hdls }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_scheduler_and_workers<R: ReceiveAndBuffer + Send + Sync + 'static>(
+        bank_thread_hdls: &mut Vec<JoinHandle<()>>,
+        receive_and_buffer: R,
+        decision_maker: DecisionMaker,
+        committer: Committer,
+        cluster_info: &impl LikeClusterInfo,
+        poh_recorder: &Arc<RwLock<PohRecorder>>,
+        num_threads: u32,
+        log_messages_bytes_limit: Option<usize>,
+        connection_cache: Arc<ConnectionCache>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        enable_forwarding: bool,
+        data_budget: Arc<DataBudget>,
+    ) {
         // Create channels for communication between scheduler and workers
         let num_workers = (num_threads).saturating_sub(NUM_VOTE_PROCESSING_THREADS);
         let (work_senders, work_receivers): (Vec<Sender<_>>, Vec<Receiver<_>>) =
@@ -527,39 +602,34 @@ impl BankingStage {
         });
 
         // Spawn the central scheduler thread
-        bank_thread_hdls.push({
-            let packet_deserializer = PacketDeserializer::new(non_vote_receiver);
-            let receive_and_buffer = SanitizedTransactionReceiveAndBuffer::new(
-                packet_deserializer,
-                bank_forks.clone(),
-                forwarder.is_some(),
-            );
-            let scheduler = PrioGraphScheduler::new(
-                work_senders,
-                finished_work_receiver,
-                PrioGraphSchedulerConfig::default(),
-            );
-            let scheduler_controller = SchedulerController::new(
-                decision_maker.clone(),
-                receive_and_buffer,
-                bank_forks,
-                scheduler,
-                worker_metrics,
-                forwarder,
-            );
+        bank_thread_hdls.push(
             Builder::new()
                 .name("solBnkTxSched".to_string())
-                .spawn(move || match scheduler_controller.run() {
-                    Ok(_) => {}
-                    Err(SchedulerError::DisconnectedRecvChannel(_)) => {}
-                    Err(SchedulerError::DisconnectedSendChannel(_)) => {
-                        warn!("Unexpected worker disconnect from scheduler")
+                .spawn(move || {
+                    let scheduler = PrioGraphScheduler::new(
+                        work_senders,
+                        finished_work_receiver,
+                        PrioGraphSchedulerConfig::default(),
+                    );
+                    let scheduler_controller = SchedulerController::new(
+                        decision_maker.clone(),
+                        receive_and_buffer,
+                        bank_forks,
+                        scheduler,
+                        worker_metrics,
+                        forwarder,
+                    );
+
+                    match scheduler_controller.run() {
+                        Ok(_) => {}
+                        Err(SchedulerError::DisconnectedRecvChannel(_)) => {}
+                        Err(SchedulerError::DisconnectedSendChannel(_)) => {
+                            warn!("Unexpected worker disconnect from scheduler")
+                        }
                     }
                 })
-                .unwrap()
-        });
-
-        Self { bank_thread_hdls }
+                .unwrap(),
+        );
     }
 
     fn spawn_thread_local_multi_iterator_thread<T: LikeClusterInfo>(

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -489,14 +489,15 @@ impl BankingStage {
             ));
         }
 
-        let transaction_struct = if enable_forwarding {
-            warn!(
+        let transaction_struct =
+            if enable_forwarding && !matches!(transaction_struct, TransactionStructure::Sdk) {
+                warn!(
                 "Forwarding only supported for `Sdk` transaction struct. Overriding to use `Sdk`."
             );
-            TransactionStructure::Sdk
-        } else {
-            transaction_struct
-        };
+                TransactionStructure::Sdk
+            } else {
+                transaction_struct
+            };
 
         match transaction_struct {
             TransactionStructure::Sdk => {

--- a/core/src/banking_stage/packet_filter.rs
+++ b/core/src/banking_stage/packet_filter.rs
@@ -9,6 +9,8 @@ use {
     thiserror::Error,
 };
 
+pub const MAX_ALLOWED_PRECOMPILE_SIGNATURES: u64 = 8;
+
 lazy_static! {
     // To calculate the static_builtin_cost_sum conservatively, an all-enabled dummy feature_set
     // is used. It lowers required minimal compute_unit_limit, aligns with future versions.
@@ -58,7 +60,6 @@ impl ImmutableDeserializedPacket {
             }
         }
 
-        const MAX_ALLOWED_PRECOMPILE_SIGNATURES: u64 = 8;
         if num_precompile_signatures <= MAX_ALLOWED_PRECOMPILE_SIGNATURES {
             Ok(())
         } else {

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -378,11 +378,6 @@ impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
                             continue;
                         }
                     }
-                    // Transaction must be dropped before removing, since we
-                    // currently have ownership of the transaction, and
-                    // therefore may have a reference to the backing-memory
-                    // that the container expects to be free.
-                    drop(transaction);
                     container.remove_by_id(id);
                 }
 

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -721,7 +721,7 @@ mod tests {
             const TEST_TRANSACTION_COST: u64 = 5000;
             container.insert_new_transaction(
                 transaction_ttl,
-                packet,
+                Some(packet),
                 compute_unit_price,
                 TEST_TRANSACTION_COST,
             );

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -726,7 +726,7 @@ mod tests {
             const TEST_TRANSACTION_COST: u64 = 5000;
             container.insert_new_transaction(
                 transaction_ttl,
-                Some(packet),
+                packet,
                 compute_unit_price,
                 TEST_TRANSACTION_COST,
             );

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -378,6 +378,11 @@ impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
                             continue;
                         }
                     }
+                    // Transaction must be dropped before removing, since we
+                    // currently have ownership of the transaction, and
+                    // therefore may have a reference to the backing-memory
+                    // that the container expects to be free.
+                    drop(transaction);
                     container.remove_by_id(id);
                 }
 

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -1,18 +1,30 @@
 use {
     super::{
         scheduler_metrics::{SchedulerCountMetrics, SchedulerTimingMetrics},
-        transaction_state_container::StateContainer,
+        transaction_state::TransactionState,
+        transaction_state_container::{
+            StateContainer, SuccessfulInsert, TransactionViewStateContainer,
+        },
     },
-    crate::banking_stage::{
-        decision_maker::BufferedPacketsDecision,
-        immutable_deserialized_packet::ImmutableDeserializedPacket,
-        packet_deserializer::PacketDeserializer, scheduler_messages::MaxAge,
-        transaction_scheduler::transaction_state::SanitizedTransactionTTL,
-        TransactionStateContainer,
+    crate::{
+        banking_stage::{
+            decision_maker::BufferedPacketsDecision,
+            immutable_deserialized_packet::ImmutableDeserializedPacket,
+            packet_deserializer::PacketDeserializer,
+            packet_filter::MAX_ALLOWED_PRECOMPILE_SIGNATURES, scheduler_messages::MaxAge,
+            transaction_scheduler::transaction_state::SanitizedTransactionTTL,
+            TransactionStateContainer,
+        },
+        banking_trace::{BankingPacketBatch, BankingPacketReceiver},
+    },
+    agave_transaction_view::{
+        resolved_transaction_view::ResolvedTransactionView,
+        transaction_version::TransactionVersion, transaction_view::SanitizedTransactionView,
     },
     arrayvec::ArrayVec,
+    bytes::Bytes,
     core::time::Duration,
-    crossbeam_channel::RecvTimeoutError,
+    crossbeam_channel::{RecvTimeoutError, TryRecvError},
     solana_accounts_db::account_locks::validate_account_locks,
     solana_cost_model::cost_model::CostModel,
     solana_measure::measure_us,
@@ -26,10 +38,14 @@ use {
         clock::{Epoch, Slot, MAX_PROCESSING_AGE},
         fee::FeeBudgetLimits,
         saturating_add_assign,
-        transaction::SanitizedTransaction,
+        transaction::{MessageHash, SanitizedTransaction},
     },
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
-    std::sync::{Arc, RwLock},
+    solana_svm_transaction::svm_message::SVMMessage,
+    std::{
+        sync::{Arc, RwLock},
+        time::Instant,
+    },
 };
 
 pub(crate) trait ReceiveAndBuffer {
@@ -278,6 +294,231 @@ impl SanitizedTransactionReceiveAndBuffer {
     }
 }
 
+pub(crate) struct TransactionViewRecieveAndBuffer {
+    pub receiver: BankingPacketReceiver,
+    pub bank_forks: Arc<RwLock<BankForks>>,
+}
+
+impl ReceiveAndBuffer for TransactionViewRecieveAndBuffer {
+    type Transaction = RuntimeTransaction<ResolvedTransactionView<Bytes>>;
+    type Container = TransactionViewStateContainer;
+
+    fn receive_and_buffer_packets(
+        &mut self,
+        container: &mut Self::Container,
+        timing_metrics: &mut SchedulerTimingMetrics,
+        count_metrics: &mut SchedulerCountMetrics,
+        decision: &BufferedPacketsDecision,
+    ) -> bool {
+        // Receive packet batches.
+        const TIMEOUT: Duration = Duration::from_millis(10);
+        let start = Instant::now();
+
+        // If not leader, do a blocking-receive initially. This lets the thread
+        // sleep when there is not work to do.
+        // TODO: Is it better to manually sleep instead, avoiding the locking
+        //       overhead for wakers? But then risk not waking up when message
+        //       received - as long as sleep is somewhat short, this should be
+        //       fine.
+        if matches!(
+            decision,
+            BufferedPacketsDecision::Forward
+                | BufferedPacketsDecision::ForwardAndHold
+                | BufferedPacketsDecision::Hold
+        ) {
+            match self.receiver.recv_timeout(TIMEOUT) {
+                Ok(packet_batch_message) => {
+                    self.handle_packet_batch_message(
+                        container,
+                        timing_metrics,
+                        count_metrics,
+                        decision,
+                        packet_batch_message,
+                    );
+                }
+                Err(RecvTimeoutError::Timeout) => return true,
+                Err(RecvTimeoutError::Disconnected) => return false,
+            }
+        }
+
+        while start.elapsed() < TIMEOUT {
+            match self.receiver.try_recv() {
+                Ok(packet_batch_message) => {
+                    self.handle_packet_batch_message(
+                        container,
+                        timing_metrics,
+                        count_metrics,
+                        decision,
+                        packet_batch_message,
+                    );
+                }
+                Err(TryRecvError::Empty) => return true,
+                Err(TryRecvError::Disconnected) => return false,
+            }
+        }
+
+        true
+    }
+}
+
+impl TransactionViewRecieveAndBuffer {
+    fn handle_packet_batch_message(
+        &mut self,
+        container: &mut TransactionViewStateContainer,
+        timing_metrics: &mut SchedulerTimingMetrics,
+        count_metrics: &mut SchedulerCountMetrics,
+        decision: &BufferedPacketsDecision,
+        packet_batch_message: BankingPacketBatch,
+    ) {
+        // Do not support forwarding - only add support for this if we really need it.
+        if matches!(decision, BufferedPacketsDecision::Forward) {
+            return;
+        }
+
+        let start = Instant::now();
+        // Sanitize packets, generate IDs, and insert into the container.
+        let (root_bank, working_bank) = {
+            let bank_forks = self.bank_forks.read().unwrap();
+            let root_bank = bank_forks.root_bank();
+            let working_bank = bank_forks.working_bank();
+            (root_bank, working_bank)
+        };
+        let alt_resolved_slot = root_bank.slot();
+        let sanitized_epoch = root_bank.epoch();
+        let transaction_account_lock_limit = working_bank.get_transaction_account_lock_limit();
+
+        let mut num_received = 0usize;
+        let mut num_buffered = 0usize;
+        let mut num_dropped_on_capacity = 0usize;
+        let mut num_dropped_on_receive = 0usize;
+        for packet_batch in packet_batch_message.0.iter() {
+            for packet in packet_batch.iter() {
+                let Some(packet_data) = packet.data(..) else {
+                    continue;
+                };
+
+                num_received += 1;
+
+                // Reserve free-space to copy packet into, run sanitization checks, and insert.
+                if container.try_insert_with(|mut bytes| {
+                    // Copy packet data into the buffer, and freeze.
+                    bytes.extend_from_slice(packet_data);
+                    let bytes = bytes.freeze();
+
+                    match Self::try_handle_packet(
+                        bytes.clone(),
+                        &root_bank,
+                        &working_bank,
+                        alt_resolved_slot,
+                        sanitized_epoch,
+                        transaction_account_lock_limit,
+                    ) {
+                        Ok(state) => {
+                            num_buffered += 1;
+                            Ok(SuccessfulInsert { state, bytes })
+                        }
+                        Err(()) => {
+                            num_dropped_on_receive += 1;
+                            Err(bytes.try_into_mut().expect("no leaks"))
+                        }
+                    }
+                }) {
+                    num_dropped_on_capacity += 1;
+                };
+            }
+        }
+
+        let buffer_time_us = start.elapsed().as_micros() as u64;
+        timing_metrics.update(|timing_metrics| {
+            saturating_add_assign!(timing_metrics.buffer_time_us, buffer_time_us);
+        });
+        count_metrics.update(|count_metrics| {
+            saturating_add_assign!(count_metrics.num_received, num_received);
+            saturating_add_assign!(count_metrics.num_buffered, num_buffered);
+            saturating_add_assign!(
+                count_metrics.num_dropped_on_capacity,
+                num_dropped_on_capacity
+            );
+            saturating_add_assign!(count_metrics.num_dropped_on_receive, num_dropped_on_receive);
+        });
+    }
+
+    fn try_handle_packet(
+        bytes: Bytes,
+        root_bank: &Bank,
+        working_bank: &Bank,
+        alt_resolved_slot: Slot,
+        sanitized_epoch: Epoch,
+        transaction_account_lock_limit: usize,
+    ) -> Result<TransactionState<RuntimeTransaction<ResolvedTransactionView<Bytes>>>, ()> {
+        // Parsing and basic sanitization checks
+        let Ok(view) = SanitizedTransactionView::try_new_sanitized(bytes.clone()) else {
+            return Err(());
+        };
+
+        let Ok(view) = RuntimeTransaction::<SanitizedTransactionView<_>>::try_from(
+            view,
+            MessageHash::Compute,
+            None,
+        ) else {
+            return Err(());
+        };
+
+        // Check excessive pre-compiles.
+        let signature_detials = view.signature_details();
+        let num_precompiles = signature_detials.num_ed25519_instruction_signatures()
+            + signature_detials.num_secp256k1_instruction_signatures();
+        if num_precompiles > MAX_ALLOWED_PRECOMPILE_SIGNATURES {
+            return Err(());
+        }
+
+        // Load addresses for transaction.
+        let load_addresses_result = match view.version() {
+            TransactionVersion::Legacy => Ok((None, u64::MAX)),
+            TransactionVersion::V0 => root_bank
+                .load_addresses_from_ref(view.address_table_lookup_iter())
+                .map(|(loaded_addresses, deactivation_slot)| {
+                    (Some(loaded_addresses), deactivation_slot)
+                }),
+        };
+        let Ok((loaded_addresses, deactivation_slot)) = load_addresses_result else {
+            return Err(());
+        };
+
+        let Ok(view) = RuntimeTransaction::<ResolvedTransactionView<_>>::try_from(
+            view,
+            loaded_addresses,
+            root_bank.get_reserved_account_keys(),
+        ) else {
+            return Err(());
+        };
+
+        if validate_account_locks(view.account_keys(), transaction_account_lock_limit).is_err() {
+            return Err(());
+        }
+
+        let Ok(compute_budget_limits) = view.compute_budget_limits(&working_bank.feature_set)
+        else {
+            return Err(());
+        };
+
+        let max_age = calculate_max_age(sanitized_epoch, deactivation_slot, alt_resolved_slot);
+        let fee_budget_limits = FeeBudgetLimits::from(compute_budget_limits);
+        let (priority, cost) =
+            calculate_priority_and_cost(&view, &fee_budget_limits, &working_bank);
+
+        Ok(TransactionState::new(
+            SanitizedTransactionTTL {
+                transaction: view,
+                max_age,
+            },
+            None,
+            priority,
+            cost,
+        ))
+    }
+}
+
 /// Calculate priority and cost for a transaction:
 ///
 /// Cost is calculated through the `CostModel`,
@@ -297,7 +538,7 @@ impl SanitizedTransactionReceiveAndBuffer {
 /// Any difference in the prioritization is negligible for
 /// the current transaction costs.
 fn calculate_priority_and_cost(
-    transaction: &RuntimeTransaction<SanitizedTransaction>,
+    transaction: &impl TransactionWithMeta,
     fee_budget_limits: &FeeBudgetLimits,
     bank: &Bank,
 ) -> (u64, u64) {

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -242,7 +242,7 @@ impl SanitizedTransactionReceiveAndBuffer {
                     max_age,
                 };
 
-                if container.insert_new_transaction(transaction_ttl, packet, priority, cost) {
+                if container.insert_new_transaction(transaction_ttl, Some(packet), priority, cost) {
                     saturating_add_assign!(num_dropped_on_capacity, 1);
                 }
                 saturating_add_assign!(num_buffered, 1);

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -480,9 +480,9 @@ impl TransactionViewReceiveAndBuffer {
         };
 
         // Check excessive pre-compiles.
-        let signature_detials = view.signature_details();
-        let num_precompiles = signature_detials.num_ed25519_instruction_signatures()
-            + signature_detials.num_secp256k1_instruction_signatures();
+        let signature_details = view.signature_details();
+        let num_precompiles = signature_details.num_ed25519_instruction_signatures()
+            + signature_details.num_secp256k1_instruction_signatures();
         if num_precompiles > MAX_ALLOWED_PRECOMPILE_SIGNATURES {
             return Err(());
         }

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -321,18 +321,19 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
         let start = Instant::now();
         let mut received_message = false;
 
-        // If not leader, do a blocking-receive initially. This lets the thread
-        // sleep when there is not work to do.
-        // TODO: Is it better to manually sleep instead, avoiding the locking
-        //       overhead for wakers? But then risk not waking up when message
-        //       received - as long as sleep is somewhat short, this should be
-        //       fine.
-        if matches!(
-            decision,
-            BufferedPacketsDecision::Forward
-                | BufferedPacketsDecision::ForwardAndHold
-                | BufferedPacketsDecision::Hold
-        ) {
+        // If not leader/unknown, do a blocking-receive initially. This lets
+        // the thread sleep until a message is received, or until the timeout.
+        // Additionally, only sleep if the container is empty.
+        if container.is_empty()
+            && matches!(
+                decision,
+                BufferedPacketsDecision::Forward | BufferedPacketsDecision::ForwardAndHold
+            )
+        {
+            // TODO: Is it better to manually sleep instead, avoiding the locking
+            //       overhead for wakers? But then risk not waking up when message
+            //       received - as long as sleep is somewhat short, this should be
+            //       fine.
             match self.receiver.recv_timeout(TIMEOUT) {
                 Ok(packet_batch_message) => {
                     received_message = true;

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -3,7 +3,7 @@ use {
         scheduler_metrics::{SchedulerCountMetrics, SchedulerTimingMetrics},
         transaction_state::TransactionState,
         transaction_state_container::{
-            StateContainer, SuccessfulInsert, TransactionViewStateContainer,
+            SharedBytes, StateContainer, SuccessfulInsert, TransactionViewStateContainer,
         },
     },
     crate::banking_stage::{
@@ -20,7 +20,6 @@ use {
         transaction_version::TransactionVersion, transaction_view::SanitizedTransactionView,
     },
     arrayvec::ArrayVec,
-    bytes::Bytes,
     core::time::Duration,
     crossbeam_channel::{RecvTimeoutError, TryRecvError},
     solana_accounts_db::account_locks::validate_account_locks,
@@ -299,7 +298,7 @@ pub(crate) struct TransactionViewReceiveAndBuffer {
 }
 
 impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
-    type Transaction = RuntimeTransaction<ResolvedTransactionView<Bytes>>;
+    type Transaction = RuntimeTransaction<ResolvedTransactionView<SharedBytes>>;
     type Container = TransactionViewStateContainer;
 
     fn receive_and_buffer_packets(
@@ -414,13 +413,10 @@ impl TransactionViewReceiveAndBuffer {
                 num_received += 1;
 
                 // Reserve free-space to copy packet into, run sanitization checks, and insert.
-                if container.try_insert_with(|mut bytes| {
-                    // Copy packet data into the buffer, and freeze.
-                    bytes.extend_from_slice(packet_data);
-                    let bytes = bytes.freeze();
-
-                    match Self::try_handle_packet(
-                        bytes.clone(),
+                if container.try_insert_with_data(
+                    packet_data,
+                    |bytes| match Self::try_handle_packet(
+                        bytes,
                         root_bank,
                         working_bank,
                         alt_resolved_slot,
@@ -429,14 +425,14 @@ impl TransactionViewReceiveAndBuffer {
                     ) {
                         Ok(state) => {
                             num_buffered += 1;
-                            Ok(SuccessfulInsert { state, bytes })
+                            Ok(SuccessfulInsert { state })
                         }
                         Err(()) => {
                             num_dropped_on_receive += 1;
-                            Err(bytes.try_into_mut().expect("no leaks"))
+                            Err(())
                         }
-                    }
-                }) {
+                    },
+                ) {
                     num_dropped_on_capacity += 1;
                 };
             }
@@ -458,15 +454,16 @@ impl TransactionViewReceiveAndBuffer {
     }
 
     fn try_handle_packet(
-        bytes: Bytes,
+        bytes: SharedBytes,
         root_bank: &Bank,
         working_bank: &Bank,
         alt_resolved_slot: Slot,
         sanitized_epoch: Epoch,
         transaction_account_lock_limit: usize,
-    ) -> Result<TransactionState<RuntimeTransaction<ResolvedTransactionView<Bytes>>>, ()> {
+    ) -> Result<TransactionState<RuntimeTransaction<ResolvedTransactionView<SharedBytes>>>, ()>
+    {
         // Parsing and basic sanitization checks
-        let Ok(view) = SanitizedTransactionView::try_new_sanitized(bytes.clone()) else {
+        let Ok(view) = SanitizedTransactionView::try_new_sanitized(bytes) else {
             return Err(());
         };
 

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -479,6 +479,11 @@ impl TransactionViewReceiveAndBuffer {
             return Err(());
         };
 
+        // Discard non-vote packets if in vote-only mode.
+        if root_bank.vote_only_bank() && !view.is_simple_vote_transaction() {
+            return Err(());
+        }
+
         // Check excessive pre-compiles.
         let signature_details = view.signature_details();
         let num_precompiles = signature_details.num_ed25519_instruction_signatures()

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -2,7 +2,9 @@ use {
     super::{
         scheduler_metrics::{SchedulerCountMetrics, SchedulerTimingMetrics},
         transaction_state::TransactionState,
-        transaction_state_container::{SharedBytes, StateContainer, TransactionViewStateContainer},
+        transaction_state_container::{
+            SharedBytes, StateContainer, TransactionViewState, TransactionViewStateContainer,
+        },
     },
     crate::banking_stage::{
         decision_maker::BufferedPacketsDecision,
@@ -458,8 +460,7 @@ impl TransactionViewReceiveAndBuffer {
         alt_resolved_slot: Slot,
         sanitized_epoch: Epoch,
         transaction_account_lock_limit: usize,
-    ) -> Result<TransactionState<RuntimeTransaction<ResolvedTransactionView<SharedBytes>>>, ()>
-    {
+    ) -> Result<TransactionViewState, ()> {
         // Parsing and basic sanitization checks
         let Ok(view) = SanitizedTransactionView::try_new_sanitized(bytes) else {
             return Err(());

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -420,8 +420,8 @@ impl TransactionViewReceiveAndBuffer {
 
                     match Self::try_handle_packet(
                         bytes.clone(),
-                        &root_bank,
-                        &working_bank,
+                        root_bank,
+                        working_bank,
                         alt_resolved_slot,
                         sanitized_epoch,
                         transaction_account_lock_limit,

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -2,9 +2,7 @@ use {
     super::{
         scheduler_metrics::{SchedulerCountMetrics, SchedulerTimingMetrics},
         transaction_state::TransactionState,
-        transaction_state_container::{
-            SharedBytes, StateContainer, SuccessfulInsert, TransactionViewStateContainer,
-        },
+        transaction_state_container::{SharedBytes, StateContainer, TransactionViewStateContainer},
     },
     crate::banking_stage::{
         decision_maker::BufferedPacketsDecision,
@@ -425,7 +423,7 @@ impl TransactionViewReceiveAndBuffer {
                     ) {
                         Ok(state) => {
                             num_buffered += 1;
-                            Ok(SuccessfulInsert { state })
+                            Ok(state)
                         }
                         Err(()) => {
                             num_dropped_on_receive += 1;

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -50,7 +50,8 @@ pub(crate) trait ReceiveAndBuffer {
     type Transaction: TransactionWithMeta + Send + Sync;
     type Container: StateContainer<Self::Transaction> + Send + Sync;
 
-    /// Returns whether the packet receiver is still connected.
+    /// Returns false only if no packets were received
+    /// AND the receiver is disconnected.
     fn receive_and_buffer_packets(
         &mut self,
         container: &mut Self::Container,
@@ -311,6 +312,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
         // Receive packet batches.
         const TIMEOUT: Duration = Duration::from_millis(10);
         let start = Instant::now();
+        let mut received_message = false;
 
         // If not leader, do a blocking-receive initially. This lets the thread
         // sleep when there is not work to do.
@@ -326,6 +328,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
         ) {
             match self.receiver.recv_timeout(TIMEOUT) {
                 Ok(packet_batch_message) => {
+                    received_message = true;
                     self.handle_packet_batch_message(
                         container,
                         timing_metrics,
@@ -335,13 +338,16 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
                     );
                 }
                 Err(RecvTimeoutError::Timeout) => return true,
-                Err(RecvTimeoutError::Disconnected) => return false,
+                Err(RecvTimeoutError::Disconnected) => {
+                    return received_message;
+                }
             }
         }
 
         while start.elapsed() < TIMEOUT {
             match self.receiver.try_recv() {
                 Ok(packet_batch_message) => {
+                    received_message = true;
                     self.handle_packet_batch_message(
                         container,
                         timing_metrics,
@@ -351,7 +357,9 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
                     );
                 }
                 Err(TryRecvError::Empty) => return true,
-                Err(TryRecvError::Disconnected) => return false,
+                Err(TryRecvError::Disconnected) => {
+                    return received_message;
+                }
             }
         }
 

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -309,6 +309,13 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
         count_metrics: &mut SchedulerCountMetrics,
         decision: &BufferedPacketsDecision,
     ) -> bool {
+        let (root_bank, working_bank) = {
+            let bank_forks = self.bank_forks.read().unwrap();
+            let root_bank = bank_forks.root_bank();
+            let working_bank = bank_forks.working_bank();
+            (root_bank, working_bank)
+        };
+
         // Receive packet batches.
         const TIMEOUT: Duration = Duration::from_millis(10);
         let start = Instant::now();
@@ -334,6 +341,8 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
                         timing_metrics,
                         count_metrics,
                         decision,
+                        &root_bank,
+                        &working_bank,
                         packet_batch_message,
                     );
                 }
@@ -353,6 +362,8 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
                         timing_metrics,
                         count_metrics,
                         decision,
+                        &root_bank,
+                        &working_bank,
                         packet_batch_message,
                     );
                 }
@@ -374,6 +385,8 @@ impl TransactionViewReceiveAndBuffer {
         timing_metrics: &mut SchedulerTimingMetrics,
         count_metrics: &mut SchedulerCountMetrics,
         decision: &BufferedPacketsDecision,
+        root_bank: &Bank,
+        working_bank: &Bank,
         packet_batch_message: BankingPacketBatch,
     ) {
         // Do not support forwarding - only add support for this if we really need it.
@@ -383,12 +396,6 @@ impl TransactionViewReceiveAndBuffer {
 
         let start = Instant::now();
         // Sanitize packets, generate IDs, and insert into the container.
-        let (root_bank, working_bank) = {
-            let bank_forks = self.bank_forks.read().unwrap();
-            let root_bank = bank_forks.root_bank();
-            let working_bank = bank_forks.working_bank();
-            (root_bank, working_bank)
-        };
         let alt_resolved_slot = root_bank.slot();
         let sanitized_epoch = root_bank.epoch();
         let transaction_account_lock_limit = working_bank.get_transaction_account_lock_limit();

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -256,7 +256,7 @@ impl SanitizedTransactionReceiveAndBuffer {
                     max_age,
                 };
 
-                if container.insert_new_transaction(transaction_ttl, Some(packet), priority, cost) {
+                if container.insert_new_transaction(transaction_ttl, packet, priority, cost) {
                     saturating_add_assign!(num_dropped_on_capacity, 1);
                 }
                 saturating_add_assign!(num_buffered, 1);

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -49,15 +49,15 @@ pub(crate) trait ReceiveAndBuffer {
     type Transaction: TransactionWithMeta + Send + Sync;
     type Container: StateContainer<Self::Transaction> + Send + Sync;
 
-    /// Returns false only if no packets were received
-    /// AND the receiver is disconnected.
+    /// Return Err if the receiver is disconnected AND no packets were
+    /// received. Otherwise return Ok(num_received).
     fn receive_and_buffer_packets(
         &mut self,
         container: &mut Self::Container,
         timing_metrics: &mut SchedulerTimingMetrics,
         count_metrics: &mut SchedulerCountMetrics,
         decision: &BufferedPacketsDecision,
-    ) -> bool;
+    ) -> Result<usize, ()>;
 }
 
 pub(crate) struct SanitizedTransactionReceiveAndBuffer {
@@ -79,7 +79,7 @@ impl ReceiveAndBuffer for SanitizedTransactionReceiveAndBuffer {
         timing_metrics: &mut SchedulerTimingMetrics,
         count_metrics: &mut SchedulerCountMetrics,
         decision: &BufferedPacketsDecision,
-    ) -> bool {
+    ) -> Result<usize, ()> {
         let remaining_queue_capacity = container.remaining_capacity();
 
         const MAX_PACKET_RECEIVE_TIME: Duration = Duration::from_millis(10);
@@ -109,7 +109,7 @@ impl ReceiveAndBuffer for SanitizedTransactionReceiveAndBuffer {
             saturating_add_assign!(timing_metrics.receive_time_us, receive_time_us);
         });
 
-        match received_packet_results {
+        let num_received = match received_packet_results {
             Ok(receive_packet_results) => {
                 let num_received_packets = receive_packet_results.deserialized_packets.len();
 
@@ -135,12 +135,13 @@ impl ReceiveAndBuffer for SanitizedTransactionReceiveAndBuffer {
                         );
                     });
                 }
+                num_received_packets
             }
-            Err(RecvTimeoutError::Timeout) => {}
-            Err(RecvTimeoutError::Disconnected) => return false,
-        }
+            Err(RecvTimeoutError::Timeout) => 0,
+            Err(RecvTimeoutError::Disconnected) => return Err(()),
+        };
 
-        true
+        Ok(num_received)
     }
 }
 
@@ -307,7 +308,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
         timing_metrics: &mut SchedulerTimingMetrics,
         count_metrics: &mut SchedulerCountMetrics,
         decision: &BufferedPacketsDecision,
-    ) -> bool {
+    ) -> Result<usize, ()> {
         let (root_bank, working_bank) = {
             let bank_forks = self.bank_forks.read().unwrap();
             let root_bank = bank_forks.root_bank();
@@ -318,6 +319,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
         // Receive packet batches.
         const TIMEOUT: Duration = Duration::from_millis(10);
         let start = Instant::now();
+        let mut num_received = 0;
         let mut received_message = false;
 
         // If not leader/unknown, do a blocking-receive initially. This lets
@@ -336,7 +338,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
             match self.receiver.recv_timeout(TIMEOUT) {
                 Ok(packet_batch_message) => {
                     received_message = true;
-                    self.handle_packet_batch_message(
+                    num_received += self.handle_packet_batch_message(
                         container,
                         timing_metrics,
                         count_metrics,
@@ -346,9 +348,9 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
                         packet_batch_message,
                     );
                 }
-                Err(RecvTimeoutError::Timeout) => return true,
+                Err(RecvTimeoutError::Timeout) => return Ok(num_received),
                 Err(RecvTimeoutError::Disconnected) => {
-                    return received_message;
+                    return received_message.then_some(num_received).ok_or(());
                 }
             }
         }
@@ -357,7 +359,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
             match self.receiver.try_recv() {
                 Ok(packet_batch_message) => {
                     received_message = true;
-                    self.handle_packet_batch_message(
+                    num_received += self.handle_packet_batch_message(
                         container,
                         timing_metrics,
                         count_metrics,
@@ -367,18 +369,19 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
                         packet_batch_message,
                     );
                 }
-                Err(TryRecvError::Empty) => return true,
+                Err(TryRecvError::Empty) => return Ok(num_received),
                 Err(TryRecvError::Disconnected) => {
-                    return received_message;
+                    return received_message.then_some(num_received).ok_or(());
                 }
             }
         }
 
-        true
+        Ok(num_received)
     }
 }
 
 impl TransactionViewReceiveAndBuffer {
+    /// Return number of received packets.
     fn handle_packet_batch_message(
         &mut self,
         container: &mut TransactionViewStateContainer,
@@ -388,10 +391,10 @@ impl TransactionViewReceiveAndBuffer {
         root_bank: &Bank,
         working_bank: &Bank,
         packet_batch_message: BankingPacketBatch,
-    ) {
+    ) -> usize {
         // Do not support forwarding - only add support for this if we really need it.
         if matches!(decision, BufferedPacketsDecision::Forward) {
-            return;
+            return 0;
         }
 
         let start = Instant::now();
@@ -451,6 +454,8 @@ impl TransactionViewReceiveAndBuffer {
             );
             saturating_add_assign!(count_metrics.num_dropped_on_receive, num_dropped_on_receive);
         });
+
+        num_received
     }
 
     fn try_handle_packet(

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -482,7 +482,8 @@ impl TransactionViewReceiveAndBuffer {
         // Check excessive pre-compiles.
         let signature_details = view.signature_details();
         let num_precompiles = signature_details.num_ed25519_instruction_signatures()
-            + signature_details.num_secp256k1_instruction_signatures();
+            + signature_details.num_secp256k1_instruction_signatures()
+            + signature_details.num_secp256r1_instruction_signatures();
         if num_precompiles > MAX_ALLOWED_PRECOMPILE_SIGNATURES {
             return Err(());
         }

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -282,13 +282,13 @@ impl<C: LikeClusterInfo, R: ReceiveAndBuffer> SchedulerController<C, R> {
                 ids_to_add_back.push(*id); // add back to the queue at end
                 let state = self.container.get_mut_transaction_state(id.id).unwrap();
                 let sanitized_transaction = &state.transaction_ttl().transaction;
-                let immutable_packet = state.packet().clone();
+                let immutable_packet = state.packet().expect("forwarding requires packet");
 
                 // If not already forwarded and can be forwarded, add to forwardable packets.
                 if state.should_forward()
                     && forwarder.try_add_packet(
                         sanitized_transaction,
-                        immutable_packet,
+                        immutable_packet.clone(),
                         feature_set,
                     )
                 {

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -444,8 +444,9 @@ mod tests {
                 prio_graph_scheduler::PrioGraphSchedulerConfig,
                 receive_and_buffer::SanitizedTransactionReceiveAndBuffer,
             },
+            TransactionViewReceiveAndBuffer,
         },
-        agave_banking_stage_ingress_types::BankingPacketBatch,
+        agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
         crossbeam_channel::{unbounded, Receiver, Sender},
         itertools::Itertools,
         solana_gossip::cluster_info::ClusterInfo,
@@ -456,21 +457,15 @@ mod tests {
         solana_perf::packet::{to_packet_batches, PacketBatch, NUM_PACKETS},
         solana_poh::poh_recorder::{PohRecorder, Record, WorkingBankEntry},
         solana_runtime::bank::Bank,
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::transaction_meta::StaticMeta,
         solana_sdk::{
-            compute_budget::ComputeBudgetInstruction,
-            fee_calculator::FeeRateGovernor,
-            hash::Hash,
-            message::Message,
-            poh_config::PohConfig,
-            pubkey::Pubkey,
-            signature::Keypair,
-            signer::Signer,
-            system_instruction, system_transaction,
-            transaction::{SanitizedTransaction, Transaction},
+            compute_budget::ComputeBudgetInstruction, fee_calculator::FeeRateGovernor, hash::Hash,
+            message::Message, poh_config::PohConfig, pubkey::Pubkey, signature::Keypair,
+            signer::Signer, system_instruction, system_transaction, transaction::Transaction,
         },
         std::sync::{atomic::AtomicBool, Arc, RwLock},
         tempfile::TempDir,
+        test_case::test_case,
     };
 
     fn create_channels<T>(num: usize) -> (Vec<Sender<T>>, Vec<Receiver<T>>) {
@@ -479,7 +474,7 @@ mod tests {
 
     // Helper struct to create tests that hold channels, files, etc.
     // such that our tests can be more easily set up and run.
-    struct TestFrame {
+    struct TestFrame<Tx> {
         bank: Arc<Bank>,
         mint_keypair: Keypair,
         _ledger_path: TempDir,
@@ -488,18 +483,38 @@ mod tests {
         poh_recorder: Arc<RwLock<PohRecorder>>,
         banking_packet_sender: Sender<Arc<Vec<PacketBatch>>>,
 
-        consume_work_receivers:
-            Vec<Receiver<ConsumeWork<RuntimeTransaction<SanitizedTransaction>>>>,
-        finished_consume_work_sender:
-            Sender<FinishedConsumeWork<RuntimeTransaction<SanitizedTransaction>>>,
+        consume_work_receivers: Vec<Receiver<ConsumeWork<Tx>>>,
+        finished_consume_work_sender: Sender<FinishedConsumeWork<Tx>>,
+    }
+
+    fn test_create_sanitized_transaction_receive_and_buffer(
+        receiver: BankingPacketReceiver,
+        bank_forks: Arc<RwLock<BankForks>>,
+    ) -> SanitizedTransactionReceiveAndBuffer {
+        SanitizedTransactionReceiveAndBuffer::new(
+            PacketDeserializer::new(receiver),
+            bank_forks,
+            false,
+        )
+    }
+
+    fn test_create_transaction_view_receive_and_buffer(
+        receiver: BankingPacketReceiver,
+        bank_forks: Arc<RwLock<BankForks>>,
+    ) -> TransactionViewReceiveAndBuffer {
+        TransactionViewReceiveAndBuffer {
+            receiver,
+            bank_forks,
+        }
     }
 
     #[allow(clippy::type_complexity)]
-    fn create_test_frame(
+    fn create_test_frame<R: ReceiveAndBuffer>(
         num_threads: usize,
+        create_receive_and_buffer: impl FnOnce(BankingPacketReceiver, Arc<RwLock<BankForks>>) -> R,
     ) -> (
-        TestFrame,
-        SchedulerController<Arc<ClusterInfo>, SanitizedTransactionReceiveAndBuffer>,
+        TestFrame<R::Transaction>,
+        SchedulerController<Arc<ClusterInfo>, R>,
     ) {
         let GenesisConfigInfo {
             mut genesis_config,
@@ -527,7 +542,8 @@ mod tests {
         let decision_maker = DecisionMaker::new(Pubkey::new_unique(), poh_recorder.clone());
 
         let (banking_packet_sender, banking_packet_receiver) = unbounded();
-        let packet_deserializer = PacketDeserializer::new(banking_packet_receiver);
+        let receive_and_buffer =
+            create_receive_and_buffer(banking_packet_receiver, bank_forks.clone());
 
         let (consume_work_senders, consume_work_receivers) = create_channels(num_threads);
         let (finished_consume_work_sender, finished_consume_work_receiver) = unbounded();
@@ -543,12 +559,6 @@ mod tests {
             consume_work_receivers,
             finished_consume_work_sender,
         };
-
-        let receive_and_buffer = SanitizedTransactionReceiveAndBuffer::new(
-            packet_deserializer,
-            bank_forks.clone(),
-            false,
-        );
 
         let scheduler = PrioGraphScheduler::new(
             consume_work_senders,
@@ -605,10 +615,7 @@ mod tests {
     // In the tests, the decision will not become stale, so it is more convenient
     // to receive first and then schedule.
     fn test_receive_then_schedule(
-        scheduler_controller: &mut SchedulerController<
-            Arc<ClusterInfo>,
-            SanitizedTransactionReceiveAndBuffer,
-        >,
+        scheduler_controller: &mut SchedulerController<Arc<ClusterInfo>, impl ReceiveAndBuffer>,
     ) {
         let decision = scheduler_controller
             .decision_maker
@@ -619,10 +626,13 @@ mod tests {
         assert!(scheduler_controller.process_transactions(&decision).is_ok());
     }
 
-    #[test]
+    #[test_case(test_create_sanitized_transaction_receive_and_buffer; "Sdk")]
+    #[test_case(test_create_transaction_view_receive_and_buffer; "View")]
     #[should_panic(expected = "batch id 0 is not being tracked")]
-    fn test_unexpected_batch_id() {
-        let (test_frame, scheduler_controller) = create_test_frame(1);
+    fn test_unexpected_batch_id<R: ReceiveAndBuffer>(
+        create_receive_and_buffer: impl FnOnce(BankingPacketReceiver, Arc<RwLock<BankForks>>) -> R,
+    ) {
+        let (test_frame, scheduler_controller) = create_test_frame(1, create_receive_and_buffer);
         let TestFrame {
             finished_consume_work_sender,
             ..
@@ -643,9 +653,13 @@ mod tests {
         scheduler_controller.run().unwrap();
     }
 
-    #[test]
-    fn test_schedule_consume_single_threaded_no_conflicts() {
-        let (test_frame, mut scheduler_controller) = create_test_frame(1);
+    #[test_case(test_create_sanitized_transaction_receive_and_buffer; "Sdk")]
+    #[test_case(test_create_transaction_view_receive_and_buffer; "View")]
+    fn test_schedule_consume_single_threaded_no_conflicts<R: ReceiveAndBuffer>(
+        create_receive_and_buffer: impl FnOnce(BankingPacketReceiver, Arc<RwLock<BankForks>>) -> R,
+    ) {
+        let (test_frame, mut scheduler_controller) =
+            create_test_frame(1, create_receive_and_buffer);
         let TestFrame {
             bank,
             mint_keypair,
@@ -699,9 +713,13 @@ mod tests {
         assert_eq!(message_hashes, vec![&tx2_hash, &tx1_hash]);
     }
 
-    #[test]
-    fn test_schedule_consume_single_threaded_conflict() {
-        let (test_frame, mut scheduler_controller) = create_test_frame(1);
+    #[test_case(test_create_sanitized_transaction_receive_and_buffer; "Sdk")]
+    #[test_case(test_create_transaction_view_receive_and_buffer; "View")]
+    fn test_schedule_consume_single_threaded_conflict<R: ReceiveAndBuffer>(
+        create_receive_and_buffer: impl FnOnce(BankingPacketReceiver, Arc<RwLock<BankForks>>) -> R,
+    ) {
+        let (test_frame, mut scheduler_controller) =
+            create_test_frame(1, create_receive_and_buffer);
         let TestFrame {
             bank,
             mint_keypair,
@@ -758,9 +776,13 @@ mod tests {
         assert_eq!(message_hashes, vec![&tx2_hash, &tx1_hash]);
     }
 
-    #[test]
-    fn test_schedule_consume_single_threaded_multi_batch() {
-        let (test_frame, mut scheduler_controller) = create_test_frame(1);
+    #[test_case(test_create_sanitized_transaction_receive_and_buffer; "Sdk")]
+    #[test_case(test_create_transaction_view_receive_and_buffer; "View")]
+    fn test_schedule_consume_single_threaded_multi_batch<R: ReceiveAndBuffer>(
+        create_receive_and_buffer: impl FnOnce(BankingPacketReceiver, Arc<RwLock<BankForks>>) -> R,
+    ) {
+        let (test_frame, mut scheduler_controller) =
+            create_test_frame(1, create_receive_and_buffer);
         let TestFrame {
             bank,
             mint_keypair,
@@ -822,9 +844,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_schedule_consume_simple_thread_selection() {
-        let (test_frame, mut scheduler_controller) = create_test_frame(2);
+    #[test_case(test_create_sanitized_transaction_receive_and_buffer; "Sdk")]
+    #[test_case(test_create_transaction_view_receive_and_buffer; "View")]
+    fn test_schedule_consume_simple_thread_selection<R: ReceiveAndBuffer>(
+        create_receive_and_buffer: impl FnOnce(BankingPacketReceiver, Arc<RwLock<BankForks>>) -> R,
+    ) {
+        let (test_frame, mut scheduler_controller) =
+            create_test_frame(2, create_receive_and_buffer);
         let TestFrame {
             bank,
             mint_keypair,
@@ -889,9 +915,13 @@ mod tests {
         assert_eq!(t1_actual, t1_expected);
     }
 
-    #[test]
-    fn test_schedule_consume_retryable() {
-        let (test_frame, mut scheduler_controller) = create_test_frame(1);
+    #[test_case(test_create_sanitized_transaction_receive_and_buffer; "Sdk")]
+    #[test_case(test_create_transaction_view_receive_and_buffer; "View")]
+    fn test_schedule_consume_retryable<R: ReceiveAndBuffer>(
+        create_receive_and_buffer: impl FnOnce(BankingPacketReceiver, Arc<RwLock<BankForks>>) -> R,
+    ) {
+        let (test_frame, mut scheduler_controller) =
+            create_test_frame(1, create_receive_and_buffer);
         let TestFrame {
             bank,
             mint_keypair,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -107,7 +107,7 @@ impl<C: LikeClusterInfo, R: ReceiveAndBuffer> SchedulerController<C, R> {
 
             self.process_transactions(&decision)?;
             self.receive_completed()?;
-            if !self.receive_and_buffer_packets(&decision) {
+            if self.receive_and_buffer_packets(&decision).is_err() {
                 break;
             }
             // Report metrics only if there is data.
@@ -421,7 +421,10 @@ impl<C: LikeClusterInfo, R: ReceiveAndBuffer> SchedulerController<C, R> {
     }
 
     /// Returns whether the packet receiver is still connected.
-    fn receive_and_buffer_packets(&mut self, decision: &BufferedPacketsDecision) -> bool {
+    fn receive_and_buffer_packets(
+        &mut self,
+        decision: &BufferedPacketsDecision,
+    ) -> Result<usize, ()> {
         self.receive_and_buffer.receive_and_buffer_packets(
             &mut self.container,
             &mut self.timing_metrics,
@@ -622,7 +625,16 @@ mod tests {
             .make_consume_or_forward_decision();
         assert!(matches!(decision, BufferedPacketsDecision::Consume(_)));
         assert!(scheduler_controller.receive_completed().is_ok());
-        assert!(scheduler_controller.receive_and_buffer_packets(&decision));
+
+        // Time is not a reliable way for deterministic testing.
+        // Loop here until no more packets are received, this avoids parallel
+        // tests from inconsistently timing out and not receiving
+        // from the channel.
+        while scheduler_controller
+            .receive_and_buffer_packets(&decision)
+            .map(|n| n > 0)
+            .unwrap_or_default()
+        {}
         assert!(scheduler_controller.process_transactions(&decision).is_ok());
     }
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -59,10 +59,10 @@ impl<Tx> TransactionState<Tx> {
         priority: u64,
         cost: u64,
     ) -> Self {
-        let should_forward = !packet
+        let should_forward = packet
             .as_ref()
             .map(|packet| {
-                packet.original_packet().meta().forwarded()
+                !packet.original_packet().meta().forwarded()
                     && packet.original_packet().meta().is_from_staked_node()
             })
             .unwrap_or_default();

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -35,14 +35,14 @@ pub(crate) enum TransactionState<Tx> {
     /// The transaction is available for scheduling.
     Unprocessed {
         transaction_ttl: SanitizedTransactionTTL<Tx>,
-        packet: Arc<ImmutableDeserializedPacket>,
+        packet: Option<Arc<ImmutableDeserializedPacket>>,
         priority: u64,
         cost: u64,
         should_forward: bool,
     },
     /// The transaction is currently scheduled or being processed.
     Pending {
-        packet: Arc<ImmutableDeserializedPacket>,
+        packet: Option<Arc<ImmutableDeserializedPacket>>,
         priority: u64,
         cost: u64,
         should_forward: bool,
@@ -55,12 +55,17 @@ impl<Tx> TransactionState<Tx> {
     /// Creates a new `TransactionState` in the `Unprocessed` state.
     pub(crate) fn new(
         transaction_ttl: SanitizedTransactionTTL<Tx>,
-        packet: Arc<ImmutableDeserializedPacket>,
+        packet: Option<Arc<ImmutableDeserializedPacket>>,
         priority: u64,
         cost: u64,
     ) -> Self {
-        let should_forward = !packet.original_packet().meta().forwarded()
-            && packet.original_packet().meta().is_from_staked_node();
+        let should_forward = !packet
+            .as_ref()
+            .map(|packet| {
+                packet.original_packet().meta().forwarded()
+                    && packet.original_packet().meta().is_from_staked_node()
+            })
+            .unwrap_or_default();
         Self::Unprocessed {
             transaction_ttl,
             packet,
@@ -116,10 +121,10 @@ impl<Tx> TransactionState<Tx> {
     }
 
     /// Return the packet of the transaction.
-    pub(crate) fn packet(&self) -> &Arc<ImmutableDeserializedPacket> {
+    pub(crate) fn packet(&self) -> Option<&Arc<ImmutableDeserializedPacket>> {
         match self {
-            Self::Unprocessed { packet, .. } => packet,
-            Self::Pending { packet, .. } => packet,
+            Self::Unprocessed { packet, .. } => packet.as_ref(),
+            Self::Pending { packet, .. } => packet.as_ref(),
             Self::Transitioning => unreachable!(),
         }
     }
@@ -244,7 +249,7 @@ mod tests {
         const TEST_TRANSACTION_COST: u64 = 5000;
         TransactionState::new(
             transaction_ttl,
-            packet,
+            Some(packet),
             compute_unit_price,
             TEST_TRANSACTION_COST,
         )

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -2,6 +2,7 @@ use {
     crate::banking_stage::{
         immutable_deserialized_packet::ImmutableDeserializedPacket, scheduler_messages::MaxAge,
     },
+    solana_sdk::packet::{self},
     std::sync::Arc,
 };
 
@@ -61,10 +62,7 @@ impl<Tx> TransactionState<Tx> {
     ) -> Self {
         let should_forward = packet
             .as_ref()
-            .map(|packet| {
-                !packet.original_packet().meta().forwarded()
-                    && packet.original_packet().meta().is_from_staked_node()
-            })
+            .map(|packet| initialize_should_forward(packet.original_packet().meta()))
             .unwrap_or_default();
         Self::Unprocessed {
             transaction_ttl,
@@ -211,10 +209,15 @@ impl<Tx> TransactionState<Tx> {
     }
 }
 
+fn initialize_should_forward(meta: &packet::Meta) -> bool {
+    !meta.forwarded() && meta.is_from_staked_node()
+}
+
 #[cfg(test)]
 mod tests {
     use {
         super::*,
+        packet::PacketFlags,
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk::{
             compute_budget::ComputeBudgetInstruction,
@@ -369,5 +372,24 @@ mod tests {
             TransactionState::Unprocessed { .. }
         ));
         assert_eq!(transaction_ttl.max_age, MaxAge::MAX);
+    }
+
+    #[test]
+    fn test_initialize_should_forward() {
+        let meta = packet::Meta::default();
+        assert!(!initialize_should_forward(&meta));
+
+        let mut meta = packet::Meta::default();
+        meta.flags.set(PacketFlags::FORWARDED, true);
+        assert!(!initialize_should_forward(&meta));
+
+        let mut meta = packet::Meta::default();
+        meta.set_from_staked_node(true);
+        assert!(initialize_should_forward(&meta));
+
+        let mut meta = packet::Meta::default();
+        meta.flags.set(PacketFlags::FORWARDED, true);
+        meta.set_from_staked_node(true);
+        assert!(!initialize_should_forward(&meta));
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -62,7 +62,7 @@ impl<Tx> TransactionState<Tx> {
     ) -> Self {
         let should_forward = packet
             .as_ref()
-            .map(|packet| initialize_should_forward(packet.original_packet().meta()))
+            .map(|packet| should_forward_from_meta(packet.original_packet().meta()))
             .unwrap_or_default();
         Self::Unprocessed {
             transaction_ttl,
@@ -209,7 +209,7 @@ impl<Tx> TransactionState<Tx> {
     }
 }
 
-fn initialize_should_forward(meta: &packet::Meta) -> bool {
+fn should_forward_from_meta(meta: &packet::Meta) -> bool {
     !meta.forwarded() && meta.is_from_staked_node()
 }
 
@@ -377,19 +377,19 @@ mod tests {
     #[test]
     fn test_initialize_should_forward() {
         let meta = packet::Meta::default();
-        assert!(!initialize_should_forward(&meta));
+        assert!(!should_forward_from_meta(&meta));
 
         let mut meta = packet::Meta::default();
         meta.flags.set(PacketFlags::FORWARDED, true);
-        assert!(!initialize_should_forward(&meta));
+        assert!(!should_forward_from_meta(&meta));
 
         let mut meta = packet::Meta::default();
         meta.set_from_staked_node(true);
-        assert!(initialize_should_forward(&meta));
+        assert!(should_forward_from_meta(&meta));
 
         let mut meta = packet::Meta::default();
         meta.flags.set(PacketFlags::FORWARDED, true);
         meta.set_from_staked_node(true);
-        assert!(!initialize_should_forward(&meta));
+        assert!(!should_forward_from_meta(&meta));
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -211,16 +211,17 @@ pub struct TransactionViewStateContainer {
     bytes_buffer: Box<[SharedBytes]>,
 }
 
-pub(crate) struct SuccessfulInsert {
-    pub state: TransactionState<RuntimeTransaction<ResolvedTransactionView<SharedBytes>>>,
-}
-
 impl TransactionViewStateContainer {
     /// Returns true if packet was dropped due to capacity limits.
     pub(crate) fn try_insert_with_data(
         &mut self,
         data: &[u8],
-        f: impl FnOnce(SharedBytes) -> Result<SuccessfulInsert, ()>,
+        f: impl FnOnce(
+            SharedBytes,
+        ) -> Result<
+            TransactionState<RuntimeTransaction<ResolvedTransactionView<SharedBytes>>>,
+            (),
+        >,
     ) -> bool {
         // Get remaining capacity before inserting.
         let remaining_capacity = self.remaining_capacity();
@@ -251,7 +252,7 @@ impl TransactionViewStateContainer {
 
         // Attempt to insert the transaction.
         match f(Arc::clone(bytes_entry)) {
-            Ok(SuccessfulInsert { state }) => {
+            Ok(state) => {
                 let priority_id = TransactionPriorityId::new(state.priority(), transaction_id);
                 vacant_entry.insert(state);
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -233,6 +233,14 @@ impl TransactionViewStateContainer {
         let bytes_entry = &mut self.bytes_buffer[transaction_id];
         // Assert the entry is unique, then copy the packet data.
         {
+            // The strong count must be 1 here. These are only cloned into the
+            // inner container below, wrapped by a `ResolveTransactionView`,
+            // which does not expose the backing memory (the `Arc`), or
+            // implement `Clone`.
+            // This could only fail if there is a bug in the container that the
+            // entry in the slab was not cleared. However, since we share
+            // indexing between the slab and our `bytes_buffer`, we know that
+            // `vacant_entry` is not occupied.
             assert_eq!(Arc::strong_count(bytes_entry), 1, "entry must be unique");
             let bytes = Arc::make_mut(bytes_entry);
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -158,7 +158,7 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
     pub(crate) fn insert_new_transaction(
         &mut self,
         transaction_ttl: SanitizedTransactionTTL<Tx>,
-        packet: Option<Arc<ImmutableDeserializedPacket>>,
+        packet: Arc<ImmutableDeserializedPacket>,
         priority: u64,
         cost: u64,
     ) -> bool {
@@ -170,7 +170,7 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
             let transaction_id = entry.key();
             entry.insert(TransactionState::new(
                 transaction_ttl,
-                packet,
+                Some(packet),
                 priority,
                 cost,
             ));
@@ -377,7 +377,7 @@ mod tests {
     ) {
         for priority in 0..num as u64 {
             let (transaction_ttl, packet, priority, cost) = test_transaction(priority);
-            container.insert_new_transaction(transaction_ttl, Some(packet), priority, cost);
+            container.insert_new_transaction(transaction_ttl, packet, priority, cost);
         }
     }
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -70,7 +70,7 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
     fn insert_new_transaction(
         &mut self,
         transaction_ttl: SanitizedTransactionTTL<Tx>,
-        packet: Arc<ImmutableDeserializedPacket>,
+        packet: Option<Arc<ImmutableDeserializedPacket>>,
         priority: u64,
         cost: u64,
     ) -> bool;
@@ -135,7 +135,7 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
     fn insert_new_transaction(
         &mut self,
         transaction_ttl: SanitizedTransactionTTL<Tx>,
-        packet: Arc<ImmutableDeserializedPacket>,
+        packet: Option<Arc<ImmutableDeserializedPacket>>,
         priority: u64,
         cost: u64,
     ) -> bool {
@@ -264,7 +264,7 @@ mod tests {
     ) {
         for priority in 0..num as u64 {
             let (transaction_ttl, packet, priority, cost) = test_transaction(priority);
-            container.insert_new_transaction(transaction_ttl, packet, priority, cost);
+            container.insert_new_transaction(transaction_ttl, Some(packet), priority, cost);
         }
     }
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -118,6 +118,7 @@ impl Tpu {
         tpu_max_connections_per_ipaddr_per_minute: u64,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         block_production_method: BlockProductionMethod,
+        transaction_struct: TransactionStructure,
         enable_block_production_forwarding: bool,
         _generator_config: Option<GeneratorConfig>, /* vestigial code for replay invalidator */
     ) -> (Self, Vec<Arc<dyn NotifyKeyUpdate + Sync + Send>>) {
@@ -269,7 +270,7 @@ impl Tpu {
 
         let banking_stage = BankingStage::new(
             block_production_method,
-            TransactionStructure::Sdk, // TODO: add cli
+            transaction_struct,
             cluster_info,
             poh_recorder,
             non_vote_receiver,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -15,7 +15,7 @@ use {
         sigverify_stage::SigVerifyStage,
         staked_nodes_updater_service::StakedNodesUpdaterService,
         tpu_entry_notifier::TpuEntryNotifier,
-        validator::{BlockProductionMethod, GeneratorConfig},
+        validator::{BlockProductionMethod, GeneratorConfig, TransactionStructure},
     },
     bytes::Bytes,
     crossbeam_channel::{unbounded, Receiver},
@@ -269,6 +269,7 @@ impl Tpu {
 
         let banking_stage = BankingStage::new(
             block_production_method,
+            TransactionStructure::Sdk, // TODO: add cli
             cluster_info,
             poh_recorder,
             non_vote_receiver,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -298,6 +298,7 @@ pub struct ValidatorConfig {
     pub banking_trace_dir_byte_limit: banking_trace::DirByteLimit,
     pub block_verification_method: BlockVerificationMethod,
     pub block_production_method: BlockProductionMethod,
+    pub transaction_struct: TransactionStructure,
     pub enable_block_production_forwarding: bool,
     pub generator_config: Option<GeneratorConfig>,
     pub use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup,
@@ -370,6 +371,7 @@ impl Default for ValidatorConfig {
             banking_trace_dir_byte_limit: 0,
             block_verification_method: BlockVerificationMethod::default(),
             block_production_method: BlockProductionMethod::default(),
+            transaction_struct: TransactionStructure::default(),
             enable_block_production_forwarding: false,
             generator_config: None,
             use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup::default(),
@@ -894,8 +896,8 @@ impl Validator {
             config.accounts_db_test_hash_calculation,
         );
         info!(
-            "Using: block-verification-method: {}, block-production-method: {}",
-            config.block_verification_method, config.block_production_method
+            "Using: block-verification-method: {}, block-production-method: {}, transaction-structure: {}",
+            config.block_verification_method, config.block_production_method, config.transaction_struct
         );
 
         let (replay_vote_sender, replay_vote_receiver) = unbounded();
@@ -1549,6 +1551,7 @@ impl Validator {
             tpu_max_connections_per_ipaddr_per_minute,
             &prioritization_fee_cache,
             config.block_production_method.clone(),
+            config.transaction_struct.clone(),
             config.enable_block_production_forwarding,
             config.generator_config.clone(),
         );

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -207,6 +207,31 @@ impl BlockProductionMethod {
     }
 }
 
+#[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
+#[strum(serialize_all = "kebab-case")]
+pub enum TransactionStructure {
+    #[default]
+    Sdk,
+    View,
+}
+
+impl TransactionStructure {
+    pub const fn cli_names() -> &'static [&'static str] {
+        Self::VARIANTS
+    }
+
+    pub fn cli_message() -> &'static str {
+        lazy_static! {
+            static ref MESSAGE: String = format!(
+                "Switch internal transaction structure/representation [default: {}]",
+                TransactionStructure::default()
+            );
+        };
+
+        &MESSAGE
+    }
+}
+
 /// Configuration for the block generator invalidator for replay.
 #[derive(Clone, Debug)]
 pub struct GeneratorConfig {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -33,7 +33,7 @@ use {
     solana_core::{
         banking_simulation::{BankingSimulator, BankingTraceEvents},
         system_monitor_service::{SystemMonitorService, SystemMonitorStatsReportConfig},
-        validator::{BlockProductionMethod, BlockVerificationMethod},
+        validator::{BlockProductionMethod, BlockVerificationMethod, TransactionStructure},
     },
     solana_cost_model::{cost_model::CostModel, cost_tracker::CostTracker},
     solana_feature_set::{self as feature_set, FeatureSet},
@@ -2492,14 +2492,18 @@ fn main() {
                         BlockProductionMethod
                     )
                     .unwrap_or_default();
+                    let transaction_struct =
+                        value_t!(arg_matches, "transaction_struct", TransactionStructure)
+                            .unwrap_or_default();
 
-                    info!("Using: block-production-method: {block_production_method}");
+                    info!("Using: block-production-method: {block_production_method} transaction-structure: {transaction_struct}");
 
                     match simulator.start(
                         genesis_config,
                         bank_forks,
                         blockstore,
                         block_production_method,
+                        transaction_struct,
                     ) {
                         Ok(()) => println!("Ok"),
                         Err(error) => {

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -61,6 +61,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         banking_trace_dir_byte_limit: config.banking_trace_dir_byte_limit,
         block_verification_method: config.block_verification_method.clone(),
         block_production_method: config.block_production_method.clone(),
+        transaction_struct: config.transaction_struct.clone(),
         enable_block_production_forwarding: config.enable_block_production_forwarding,
         generator_config: config.generator_config.clone(),
         use_snapshot_archives_at_startup: config.use_snapshot_archives_at_startup,

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -112,6 +112,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --block-production-method ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 == --transaction-structure ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 == --wen-restart ]]; then
       args+=("$1" "$2")
       shift 2

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -182,6 +182,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --block-production-method ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 == --transaction-structure ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 == --wen-restart ]]; then
       args+=("$1" "$2")
       shift 2

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -87,7 +87,6 @@ dependencies = [
 name = "agave-transaction-view"
 version = "2.2.0"
 dependencies = [
- "bytes",
  "solana-hash",
  "solana-message",
  "solana-packet",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5487,6 +5487,7 @@ name = "solana-core"
 version = "2.2.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
+ "agave-transaction-view",
  "ahash 0.8.11",
  "anyhow",
  "arrayvec",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
 name = "agave-transaction-view"
 version = "2.2.0"
 dependencies = [
+ "bytes",
  "solana-hash",
  "solana-message",
  "solana-packet",

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -3,6 +3,7 @@ use {
     crate::bank::CollectorFeeDetails,
     log::{debug, warn},
     solana_feature_set::{remove_rounding_in_fee_calculation, reward_full_priority_fee},
+    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_sdk::{
         account::{ReadableAccount, WritableAccount},
         fee::FeeBudgetLimits,
@@ -10,7 +11,6 @@ use {
         reward_info::RewardInfo,
         reward_type::RewardType,
         system_program,
-        transaction::SanitizedTransaction,
     },
     solana_svm_rent_collector::svm_rent_collector::SVMRentCollector,
     solana_vote::vote_account::VoteAccountsHashMap,
@@ -73,7 +73,7 @@ impl Bank {
 
     pub fn calculate_reward_for_transaction(
         &self,
-        transaction: &SanitizedTransaction,
+        transaction: &impl TransactionWithMeta,
         fee_budget_limits: &FeeBudgetLimits,
     ) -> u64 {
         let fee_details = solana_fee::calculate_fee_details(

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5338,6 +5338,7 @@ name = "solana-core"
 version = "2.2.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
+ "agave-transaction-view",
  "ahash 0.8.11",
  "anyhow",
  "arrayvec",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -87,7 +87,6 @@ dependencies = [
 name = "agave-transaction-view"
 version = "2.2.0"
 dependencies = [
- "bytes",
  "solana-hash",
  "solana-message",
  "solana-packet",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
 name = "agave-transaction-view"
 version = "2.2.0"
 dependencies = [
+ "bytes",
  "solana-hash",
  "solana-message",
  "solana-packet",

--- a/svm/examples/Cargo.toml
+++ b/svm/examples/Cargo.toml
@@ -1,9 +1,5 @@
 [workspace]
-members = [
-    "json-rpc/client",
-    "json-rpc/server",
-    "paytube",
-]
+members = ["json-rpc/client", "json-rpc/server", "paytube"]
 
 resolver = "2"
 

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -10,7 +10,6 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-bytes = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
 solana-packet = { workspace = true }

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bytes = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
 solana-packet = { workspace = true }

--- a/transaction-view/src/transaction_data.rs
+++ b/transaction-view/src/transaction_data.rs
@@ -17,3 +17,10 @@ impl TransactionData for bytes::Bytes {
         self.as_ref()
     }
 }
+
+impl TransactionData for std::sync::Arc<Vec<u8>> {
+    #[inline]
+    fn data(&self) -> &[u8] {
+        self.as_ref()
+    }
+}

--- a/transaction-view/src/transaction_data.rs
+++ b/transaction-view/src/transaction_data.rs
@@ -11,13 +11,6 @@ impl TransactionData for &[u8] {
     }
 }
 
-impl TransactionData for bytes::Bytes {
-    #[inline]
-    fn data(&self) -> &[u8] {
-        self.as_ref()
-    }
-}
-
 impl TransactionData for std::sync::Arc<Vec<u8>> {
     #[inline]
     fn data(&self) -> &[u8] {

--- a/transaction-view/src/transaction_data.rs
+++ b/transaction-view/src/transaction_data.rs
@@ -10,3 +10,10 @@ impl TransactionData for &[u8] {
         self
     }
 }
+
+impl TransactionData for bytes::Bytes {
+    #[inline]
+    fn data(&self) -> &[u8] {
+        self.as_ref()
+    }
+}

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -21,7 +21,7 @@ use {
     },
     solana_core::{
         banking_trace::{DirByteLimit, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
-        validator::{BlockProductionMethod, BlockVerificationMethod},
+        validator::{BlockProductionMethod, BlockVerificationMethod, TransactionStructure},
     },
     solana_faucet::faucet::{self, FAUCET_PORT},
     solana_ledger::use_snapshot_archives_at_startup,
@@ -1598,6 +1598,14 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .possible_values(BlockProductionMethod::cli_names())
                 .help(BlockProductionMethod::cli_message()),
+        )
+        .arg(
+            Arg::with_name("transaction_struct")
+                .long("transaction-structure")
+                .value_name("STRUCT")
+                .takes_value(true)
+                .possible_values(TransactionStructure::cli_names())
+                .help(TransactionStructure::cli_message()),
         )
         .arg(
             Arg::with_name("unified_scheduler_handler_threads")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -35,8 +35,9 @@ use {
         system_monitor_service::SystemMonitorService,
         tpu::DEFAULT_TPU_COALESCE,
         validator::{
-            is_snapshot_config_valid, BlockProductionMethod, BlockVerificationMethod, Validator,
-            ValidatorConfig, ValidatorError, ValidatorStartProgress, ValidatorTpuConfig,
+            is_snapshot_config_valid, BlockProductionMethod, BlockVerificationMethod,
+            TransactionStructure, Validator, ValidatorConfig, ValidatorError,
+            ValidatorStartProgress, ValidatorTpuConfig,
         },
     },
     solana_gossip::{
@@ -1846,6 +1847,12 @@ pub fn main() {
         matches, // comment to align formatting...
         "block_production_method",
         BlockProductionMethod
+    )
+    .unwrap_or_default();
+    validator_config.transaction_struct = value_t!(
+        matches, // comment to align formatting...
+        "transaction_struct",
+        TransactionStructure
     )
     .unwrap_or_default();
     validator_config.enable_block_production_forwarding = staked_nodes_overrides_path.is_some();


### PR DESCRIPTION
#### Problem
- Need to ingest new tx type into banking stage

#### Summary of Changes
- Implement a new `TransactionViewReceiveAndBuffer` to allow banking stage to ingest `TransactionView`-based transactions
- Add argument to BankingStage::new to switch between transaction representations
- Hook up CLI for validator and relevant benchmarks
- Run all BankingStage and SchedulerController tests using both options

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
