### PR TITLE
Update svm codeowners to avoid Cargo.lock reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,5 @@
 /svm-rent-collector/ @anza-xyz/svm
 /svm-transaction/ @anza-xyz/svm
 /svm/ @anza-xyz/svm
+/svm/examples/Cargo.lock
 /transaction-view/ @anza-xyz/svm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,17 @@
 # The SVM team is in the process of migrating these subdirectories to a new
 # repo and would like to avoid introducing dependencies in the meantime.
-/transaction-view/ @anza-xyz/svm
-/programs/bpf_loader/ @anza-xyz/svm
 /builtins-default-costs/ @anza-xyz/svm
 /compute-budget/ @anza-xyz/svm
-/programs/compute-budget/ @anza-xyz/svm
 /fee/ @anza-xyz/svm
-/programs/loader-v4/ @anza-xyz/svm
 /log-collector/ @anza-xyz/svm
 /program-runtime/ @anza-xyz/svm
+/programs/bpf_loader/ @anza-xyz/svm
+/programs/compute-budget/ @anza-xyz/svm
+/programs/loader-v4/ @anza-xyz/svm
+/programs/system/ @anza-xyz/svm
 /runtime-transaction/ @anza-xyz/svm
-/svm/ @anza-xyz/svm
 /svm-conformance/ @anza-xyz/svm
 /svm-rent-collector/ @anza-xyz/svm
 /svm-transaction/ @anza-xyz/svm
-/programs/system/ @anza-xyz/svm
+/svm/ @anza-xyz/svm
+/transaction-view/ @anza-xyz/svm


### PR DESCRIPTION
#### Problem
The SVM team doesn't need to review changes that only touch Cargo.lock files

#### Summary of Changes
First commit just sorts the existing CODEOWNERS file. Sorting can change behavior, but in this case there are no overlapping rules so it is a no-op.

Second commit adds `/svm/examples/Cargo.lock` with no owner. Rules are evaluated from top to bottom and the last matching rule takes precedence, so the new record removes the `@anza-xyz/svm` ownership for that one file.


