### PR TITLE
[secp256r1] Add bench logic

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
         test:
           - {
               name: "solana-sdk",
-              commands: ["cargo +$rust_nightly bench -p solana-sdk"],
+              commands: ["cargo +$rust_nightly bench -p solana-sdk --features openssl-vendored"],
             }
           - {
               name: "solana-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8461,6 +8461,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
+ "openssl",
  "qualifier_attr",
  "rand 0.7.3",
  "rand 0.8.5",

--- a/ci/bench/part2.sh
+++ b/ci/bench/part2.sh
@@ -8,7 +8,7 @@ source "$here"/common.sh
 
 # Run sdk benches
 _ cargo +"$rust_nightly" bench --manifest-path sdk/Cargo.toml ${V:+--verbose} \
-  -- -Z unstable-options --format=json | tee -a "$BENCH_FILE"
+  --features openssl-vendored -- -Z unstable-options --format=json | tee -a "$BENCH_FILE"
 
 # Run runtime benches
 _ cargo +"$rust_nightly" bench --manifest-path runtime/Cargo.toml ${V:+--verbose} \

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -42,7 +42,7 @@ rm -f "$BENCH_FILE"
 
 # Run sdk benches
 _ $cargoNightly bench --manifest-path sdk/Cargo.toml ${V:+--verbose} \
-  -- -Z unstable-options --format=json | tee -a "$BENCH_FILE"
+  --features openssl-vendored -- -Z unstable-options --format=json | tee -a "$BENCH_FILE"
 
 # Run runtime benches
 _ $cargoNightly bench --manifest-path runtime/Cargo.toml ${V:+--verbose} \

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -189,6 +189,7 @@ anyhow = { workspace = true }
 assert_matches = { workspace = true }
 curve25519-dalek = { workspace = true }
 hex = { workspace = true }
+openssl = { workspace = true }
 solana-logger = { workspace = true }
 solana-program = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { path = ".", features = ["dev-context-only-utils"] }

--- a/sdk/benches/secp256r1_instructions.rs
+++ b/sdk/benches/secp256r1_instructions.rs
@@ -1,0 +1,96 @@
+#![feature(test)]
+
+extern crate test;
+use {
+    openssl::{ec::{EcGroup, EcKey}, nid::Nid},
+    rand0_7::{thread_rng, Rng},
+    solana_feature_set::FeatureSet,
+    solana_sdk::{
+        hash::Hash,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    solana_secp256r1_program::new_secp256r1_instruction,
+    test::Bencher,
+};
+
+// 5k transactions should be enough for benching loop
+const TX_COUNT: u16 = 5120;
+
+// prepare a bunch of unique txs
+fn create_test_transactions(message_length: u16) -> Vec<Transaction> {
+    (0..TX_COUNT)
+        .map(|_| {
+            let mut rng = thread_rng();
+            let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+            let secp_privkey = EcKey::generate(&group).unwrap();
+            let message: Vec<u8> = (0..message_length).map(|_| rng.gen_range(0, 255)).collect();
+            let secp_instruction = new_secp256r1_instruction(&message, secp_privkey).unwrap();
+            let mint_keypair = Keypair::new();
+
+            Transaction::new_signed_with_payer(
+                &[secp_instruction.clone()],
+                Some(&mint_keypair.pubkey()),
+                &[&mint_keypair],
+                Hash::default(),
+            )
+        })
+        .collect()
+}
+
+#[bench]
+fn bench_secp256r1_len_032(b: &mut Bencher) {
+    let feature_set = FeatureSet::all_enabled();
+    let txs = create_test_transactions(32);
+    let mut tx_iter = txs.iter().cycle();
+    b.iter(|| {
+        tx_iter
+            .next()
+            .unwrap()
+            .verify_precompiles(&feature_set)
+            .unwrap();
+    });
+}
+
+#[bench]
+fn bench_secp256r1_len_256(b: &mut Bencher) {
+    let feature_set = FeatureSet::all_enabled();
+    let txs = create_test_transactions(256);
+    let mut tx_iter = txs.iter().cycle();
+    b.iter(|| {
+        tx_iter
+            .next()
+            .unwrap()
+            .verify_precompiles(&feature_set)
+            .unwrap();
+    });
+}
+
+#[bench]
+fn bench_secp256r1_len_32k(b: &mut Bencher) {
+    let feature_set = FeatureSet::all_enabled();
+    let txs = create_test_transactions(32 * 1024);
+    let mut tx_iter = txs.iter().cycle();
+    b.iter(|| {
+        tx_iter
+            .next()
+            .unwrap()
+            .verify_precompiles(&feature_set)
+            .unwrap();
+    });
+}
+
+#[bench]
+fn bench_secp256r1_len_max(b: &mut Bencher) {
+    let required_extra_space = 113_u16; // len for pubkey, sig, and offsets
+    let feature_set = FeatureSet::all_enabled();
+    let txs = create_test_transactions(u16::MAX - required_extra_space);
+    let mut tx_iter = txs.iter().cycle();
+    b.iter(|| {
+        tx_iter
+            .next()
+            .unwrap()
+            .verify_precompiles(&feature_set)
+            .unwrap();
+    });
+}

--- a/sdk/benches/secp256r1_instructions.rs
+++ b/sdk/benches/secp256r1_instructions.rs
@@ -2,7 +2,10 @@
 
 extern crate test;
 use {
-    openssl::{ec::{EcGroup, EcKey}, nid::Nid},
+    openssl::{
+        ec::{EcGroup, EcKey},
+        nid::Nid,
+    },
     rand0_7::{thread_rng, Rng},
     solana_feature_set::FeatureSet,
     solana_sdk::{


### PR DESCRIPTION
#### Problem
The secp256r1 precompile does not have bench code.

#### Summary of Changes
Add bench logic similar to the ones pertaining to ed25519 and secp256k1 precompiles.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
