### PR TITLE
move incinerator ID to sdk-ids

### DIFF
--- a/sdk/program/src/incinerator.rs
+++ b/sdk/program/src/incinerator.rs
@@ -1,6 +1,2 @@
-//! A designated address for burning lamports.
-//!
-//! Lamports credited to this address will be removed from the total supply
-//! (burned) at the end of the current block.
-
-crate::declare_id!("1nc1nerator11111111111111111111111111111111");
+#[deprecated(since = "2.2.0", note = "Use `solana_sdk_ids::incinerator` instead")]
+pub use solana_sdk_ids::incinerator::{check_id, id, ID};

--- a/sdk/sdk-ids/src/lib.rs
+++ b/sdk/sdk-ids/src/lib.rs
@@ -32,6 +32,14 @@ pub mod feature {
     solana_pubkey::declare_id!("Feature111111111111111111111111111111111111");
 }
 
+/// A designated address for burning lamports.
+///
+/// Lamports credited to this address will be removed from the total supply
+/// (burned) at the end of the current block.
+pub mod incinerator {
+    solana_pubkey::declare_id!("1nc1nerator11111111111111111111111111111111");
+}
+
 pub mod loader_v4 {
     solana_pubkey::declare_id!("LoaderV411111111111111111111111111111111111");
 }


### PR DESCRIPTION
#### Problem
This program ID was missed in #3141 and creates a solana-program dep in various places

#### Summary of Changes
Move it to solana-sdk-ids and re-export with deprecation
