### PR TITLE
Extract client-traits crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6546,6 +6546,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-client-traits"
+version = "2.2.0"
+dependencies = [
+ "solana-account",
+ "solana-commitment-config",
+ "solana-epoch-info",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-program",
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
+ "solana-transaction",
+ "solana-transaction-error",
+]
+
+[[package]]
 name = "solana-clock"
 version = "2.2.0"
 dependencies = [
@@ -8520,6 +8538,7 @@ dependencies = [
  "siphasher",
  "solana-account",
  "solana-bn254",
+ "solana-client-traits",
  "solana-cluster-type",
  "solana-commitment-config",
  "solana-compute-budget-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6555,10 +6555,11 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
- "solana-program",
+ "solana-message",
  "solana-pubkey",
  "solana-signature",
  "solana-signer",
+ "solana-system-interface",
  "solana-transaction",
  "solana-transaction-error",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ members = [
     "sdk/borsh",
     "sdk/cargo-build-sbf",
     "sdk/cargo-test-sbf",
+    "sdk/client-traits",
     "sdk/clock",
     "sdk/cluster-type",
     "sdk/commitment-config",
@@ -444,6 +445,7 @@ solana-cli = { path = "cli", version = "=2.2.0" }
 solana-cli-config = { path = "cli-config", version = "=2.2.0" }
 solana-cli-output = { path = "cli-output", version = "=2.2.0" }
 solana-client = { path = "client", version = "=2.2.0" }
+solana-client-traits = { path = "sdk/client-traits", version = "=2.2.0" }
 solana-clock = { path = "sdk/clock", version = "=2.2.0" }
 solana-cluster-type = { path = "sdk/cluster-type", version = "=2.2.0" }
 solana-commitment-config = { path = "sdk/commitment-config", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5281,10 +5281,11 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
- "solana-program",
+ "solana-message",
  "solana-pubkey",
  "solana-signature",
  "solana-signer",
+ "solana-system-interface",
  "solana-transaction",
  "solana-transaction-error",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5272,6 +5272,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-client-traits"
+version = "2.2.0"
+dependencies = [
+ "solana-account",
+ "solana-commitment-config",
+ "solana-epoch-info",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-program",
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
+ "solana-transaction",
+ "solana-transaction-error",
+]
+
+[[package]]
 name = "solana-clock"
 version = "2.2.0"
 dependencies = [
@@ -7219,6 +7237,7 @@ dependencies = [
  "siphasher",
  "solana-account",
  "solana-bn254",
+ "solana-client-traits",
  "solana-cluster-type",
  "solana-commitment-config",
  "solana-compute-budget-interface",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -35,6 +35,7 @@ full = [
     "solana-commitment-config",
     "digest",
     "solana-pubkey/rand",
+    "dep:solana-client-traits",
     "dep:solana-cluster-type",
     "dep:solana-ed25519-program",
     "dep:solana-compute-budget-interface",
@@ -115,6 +116,7 @@ sha3 = { workspace = true, optional = true }
 siphasher = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-bn254 = { workspace = true }
+solana-client-traits = { workspace = true, optional = true }
 solana-cluster-type = { workspace = true, features = [
     "serde",
 ], optional = true }

--- a/sdk/client-traits/Cargo.toml
+++ b/sdk/client-traits/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "solana-client-traits"
+description = "Traits for Solana clients"
+documentation = "https://docs.rs/solana-client-traits"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-account = { workspace = true }
+solana-commitment-config = { workspace = true }
+solana-epoch-info = { workspace = true }
+solana-hash = { workspace = true }
+solana-instruction = { workspace = true }
+solana-keypair = { workspace = true }
+solana-program = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-signature = { workspace = true }
+solana-signer = { workspace = true }
+solana-transaction = { workspace = true }
+solana-transaction-error = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/client-traits/Cargo.toml
+++ b/sdk/client-traits/Cargo.toml
@@ -16,10 +16,11 @@ solana-epoch-info = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-program = { workspace = true }
+solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
+solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true, features = ["bincode"] }
 solana-transaction-error = { workspace = true }
 

--- a/sdk/client-traits/Cargo.toml
+++ b/sdk/client-traits/Cargo.toml
@@ -20,7 +20,7 @@ solana-program = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
-solana-transaction = { workspace = true }
+solana-transaction = { workspace = true, features = ["bincode"] }
 solana-transaction-error = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/sdk/client-traits/src/lib.rs
+++ b/sdk/client-traits/src/lib.rs
@@ -14,10 +14,11 @@ use {
     solana_hash::Hash,
     solana_instruction::Instruction,
     solana_keypair::Keypair,
-    solana_program::{message::Message, system_instruction::transfer},
+    solana_message::Message,
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_signer::{signers::Signers, Signer},
+    solana_system_interface::instruction::transfer,
     solana_transaction::{versioned::VersionedTransaction, Transaction},
     solana_transaction_error::{TransactionResult, TransportResult as Result},
 };

--- a/sdk/client-traits/src/lib.rs
+++ b/sdk/client-traits/src/lib.rs
@@ -7,25 +7,19 @@
 //! Asynchronous implementations are expected to create transactions, sign them, and send
 //! them but without waiting to see if the server accepted it.
 
-#![cfg(feature = "full")]
-
 use {
-    crate::{
-        clock::Slot,
-        commitment_config::CommitmentConfig,
-        epoch_info::EpochInfo,
-        hash::Hash,
-        instruction::Instruction,
-        message::Message,
-        pubkey::Pubkey,
-        signature::{Keypair, Signature},
-        signer::Signer,
-        signers::Signers,
-        system_instruction,
-        transaction::{self, Transaction, VersionedTransaction},
-        transport::Result,
-    },
     solana_account::Account,
+    solana_commitment_config::CommitmentConfig,
+    solana_epoch_info::EpochInfo,
+    solana_hash::Hash,
+    solana_instruction::Instruction,
+    solana_keypair::Keypair,
+    solana_program::{message::Message, system_instruction::transfer},
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
+    solana_signer::{signers::Signers, Signer},
+    solana_transaction::{versioned::VersionedTransaction, Transaction},
+    solana_transaction_error::{TransactionResult, TransportResult as Result},
 };
 
 pub trait Client: SyncClient + AsyncClient {
@@ -84,20 +78,17 @@ pub trait SyncClient {
     fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> Result<u64>;
 
     /// Get signature status.
-    fn get_signature_status(
-        &self,
-        signature: &Signature,
-    ) -> Result<Option<transaction::Result<()>>>;
+    fn get_signature_status(&self, signature: &Signature) -> Result<Option<TransactionResult<()>>>;
 
     /// Get signature status. Uses explicit commitment configuration.
     fn get_signature_status_with_commitment(
         &self,
         signature: &Signature,
         commitment_config: CommitmentConfig,
-    ) -> Result<Option<transaction::Result<()>>>;
+    ) -> Result<Option<TransactionResult<()>>>;
 
     /// Get last known slot
-    fn get_slot(&self) -> Result<Slot>;
+    fn get_slot(&self) -> Result<u64>;
 
     /// Get last known slot. Uses explicit commitment configuration.
     fn get_slot_with_commitment(&self, commitment_config: CommitmentConfig) -> Result<u64>;
@@ -200,8 +191,7 @@ pub trait AsyncClient {
         pubkey: &Pubkey,
         recent_blockhash: Hash,
     ) -> Result<Signature> {
-        let transfer_instruction =
-            system_instruction::transfer(&keypair.pubkey(), pubkey, lamports);
+        let transfer_instruction = transfer(&keypair.pubkey(), pubkey, lamports);
         self.async_send_instruction(keypair, transfer_instruction, recent_blockhash)
     }
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -62,7 +62,6 @@ pub use solana_program::{borsh, borsh0_10, borsh1};
 #[cfg(feature = "full")]
 #[deprecated(since = "2.2.0", note = "Use `solana-signer` crate instead")]
 pub use solana_signer::signers;
-pub mod client;
 pub mod entrypoint;
 pub mod entrypoint_deprecated;
 pub mod epoch_rewards_hasher;
@@ -109,6 +108,9 @@ pub use solana_account as account;
 pub use solana_account::state_traits as account_utils;
 #[deprecated(since = "2.1.0", note = "Use `solana-bn254` crate instead")]
 pub use solana_bn254 as alt_bn128;
+#[cfg(feature = "full")]
+#[deprecated(since = "2.2.0", note = "Use `solana-client-traits` crate instead")]
+pub use solana_client_traits as client;
 #[deprecated(
     since = "2.2.0",
     note = "Use `solana-compute-budget-interface` crate instead"

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5123,6 +5123,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-client-traits"
+version = "2.2.0"
+dependencies = [
+ "solana-account",
+ "solana-commitment-config",
+ "solana-epoch-info",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-program",
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
+ "solana-transaction",
+ "solana-transaction-error",
+]
+
+[[package]]
 name = "solana-clock"
 version = "2.2.0"
 dependencies = [
@@ -6547,6 +6565,7 @@ dependencies = [
  "siphasher",
  "solana-account",
  "solana-bn254",
+ "solana-client-traits",
  "solana-cluster-type",
  "solana-commitment-config",
  "solana-compute-budget-interface",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5132,10 +5132,11 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
- "solana-program",
+ "solana-message",
  "solana-pubkey",
  "solana-signature",
  "solana-signer",
+ "solana-system-interface",
  "solana-transaction",
  "solana-transaction-error",
 ]


### PR DESCRIPTION
#### Problem
`solana_sdk::client` imposes a `solana_sdk` dep on `solana_rpc_client`

#### Summary of Changes
Move to its own crate and re-export with deprecation

This branches off #3634 so that needs to be merged first (update: done)