### PR TITLE
remove solana-sdk from transaction-status-client-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9431,8 +9431,13 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-sdk",
+ "solana-commitment-config",
+ "solana-program",
+ "solana-reward-info",
  "solana-signature",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-transaction-error",
  "thiserror 2.0.4",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9432,7 +9432,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-commitment-config",
- "solana-program",
+ "solana-message",
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7889,8 +7889,13 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-sdk",
+ "solana-commitment-config",
+ "solana-program",
+ "solana-reward-info",
  "solana-signature",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-transaction-error",
  "thiserror 2.0.4",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7890,7 +7890,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-commitment-config",
- "solana-program",
+ "solana-message",
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = { workspace = true }
 solana-account = { workspace = true }
 solana-account-decoder-client-types = { workspace = true }
 solana-clock = { workspace = true }
-solana-commitment-config = { workspace = true }
+solana-commitment-config = { workspace = true, features = ["serde"] }
 solana-fee-calculator = { workspace = true }
 solana-inflation = { workspace = true }
 solana-inline-spl = { workspace = true }

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 const_format = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -24,7 +24,7 @@ solana-account = { workspace = true }
 solana-account-decoder-client-types = { workspace = true }
 solana-clock = { workspace = true }
 solana-commitment-config = { workspace = true, features = ["serde"] }
-solana-fee-calculator = { workspace = true }
+solana-fee-calculator = { workspace = true, features = ["serde"] }
 solana-inflation = { workspace = true }
 solana-inline-spl = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7234,8 +7234,13 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-sdk",
+ "solana-commitment-config",
+ "solana-program",
+ "solana-reward-info",
  "solana-signature",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-transaction-error",
  "thiserror 2.0.4",
 ]
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7235,7 +7235,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-commitment-config",
- "solana-program",
+ "solana-message",
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",

--- a/transaction-status-client-types/Cargo.toml
+++ b/transaction-status-client-types/Cargo.toml
@@ -18,7 +18,7 @@ serde_derive = { workspace = true }
 serde_json = { workspace = true }
 solana-account-decoder-client-types = { workspace = true }
 solana-commitment-config = { workspace = true }
-solana-program = { workspace = true, default-features = false }
+solana-message = { workspace = true }
 solana-reward-info = { workspace = true, features = ["serde"] }
 solana-signature = { workspace = true, default-features = false }
 solana-transaction = { workspace = true, features = ["serde"] }

--- a/transaction-status-client-types/Cargo.toml
+++ b/transaction-status-client-types/Cargo.toml
@@ -17,8 +17,13 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 solana-account-decoder-client-types = { workspace = true }
-solana-sdk = { workspace = true }
+solana-commitment-config = { workspace = true }
+solana-program = { workspace = true, default-features = false }
+solana-reward-info = { workspace = true, features = ["serde"] }
 solana-signature = { workspace = true, default-features = false }
+solana-transaction = { workspace = true, features = ["serde"] }
+solana-transaction-context = { workspace = true }
+solana-transaction-error = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -6,20 +6,19 @@ use {
     serde_derive::{Deserialize, Serialize},
     serde_json::Value,
     solana_account_decoder_client_types::token::UiTokenAmount,
-    solana_sdk::{
-        commitment_config::CommitmentConfig,
+    solana_commitment_config::CommitmentConfig,
+    solana_program::{
         instruction::CompiledInstruction,
         message::{
             v0::{LoadedAddresses, MessageAddressTableLookup},
             MessageHeader,
         },
-        reward_type::RewardType,
-        transaction::{
-            Result as TransactionResult, TransactionError, TransactionVersion, VersionedTransaction,
-        },
-        transaction_context::TransactionReturnData,
     },
+    solana_reward_info::RewardType,
     solana_signature::Signature,
+    solana_transaction::versioned::{TransactionVersion, VersionedTransaction},
+    solana_transaction_context::TransactionReturnData,
+    solana_transaction_error::{TransactionError, TransactionResult},
     thiserror::Error,
 };
 pub mod option_serializer;

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -7,12 +7,10 @@ use {
     serde_json::Value,
     solana_account_decoder_client_types::token::UiTokenAmount,
     solana_commitment_config::CommitmentConfig,
-    solana_program::{
-        instruction::CompiledInstruction,
-        message::{
-            v0::{LoadedAddresses, MessageAddressTableLookup},
-            MessageHeader,
-        },
+    solana_message::{
+        compiled_instruction::CompiledInstruction,
+        v0::{LoadedAddresses, MessageAddressTableLookup},
+        MessageHeader,
     },
     solana_reward_info::RewardType,
     solana_signature::Signature,


### PR DESCRIPTION
#### Problem
This crate can compile faster without solana-sdk

#### Summary of Changes
Replace solana-sdk with its constituent crates as appropriate

This branches off #3634 so that needs to be merged first (update: done)