### PR TITLE
Extract system-transaction crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9062,7 +9062,7 @@ version = "2.2.0"
 dependencies = [
  "solana-hash",
  "solana-keypair",
- "solana-program",
+ "solana-message",
  "solana-pubkey",
  "solana-signer",
  "solana-system-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8558,6 +8558,7 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-signer",
+ "solana-system-transaction",
  "solana-sysvar",
  "solana-time-utils",
  "solana-transaction",
@@ -9053,6 +9054,19 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk",
  "solana-type-overrides",
+]
+
+[[package]]
+name = "solana-system-transaction"
+version = "2.2.0"
+dependencies = [
+ "solana-hash",
+ "solana-keypair",
+ "solana-program",
+ "solana-pubkey",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-transaction",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ members = [
     "sdk/slot-hashes",
     "sdk/slot-history",
     "sdk/stable-layout",
+    "sdk/system-transaction",
     "sdk/sysvar",
     "sdk/sysvar-id",
     "sdk/time-utils",
@@ -570,6 +571,7 @@ solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.2.0" }
 solana-svm-transaction = { path = "svm-transaction", version = "=2.2.0" }
 solana-system-interface = "1.0"
 solana-system-program = { path = "programs/system", version = "=2.2.0" }
+solana-system-transaction = { path = "sdk/system-transaction", version = "=2.2.0" }
 solana-sysvar = { path = "sdk/sysvar", version = "=2.2.0" }
 solana-sysvar-id = { path = "sdk/sysvar-id", version = "=2.2.0" }
 solana-test-validator = { path = "test-validator", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7256,6 +7256,7 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-signer",
+ "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
  "solana-transaction-context",
@@ -7630,6 +7631,19 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk",
  "solana-type-overrides",
+]
+
+[[package]]
+name = "solana-system-transaction"
+version = "2.2.0"
+dependencies = [
+ "solana-hash",
+ "solana-keypair",
+ "solana-program",
+ "solana-pubkey",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-transaction",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7639,7 +7639,7 @@ version = "2.2.0"
 dependencies = [
  "solana-hash",
  "solana-keypair",
- "solana-program",
+ "solana-message",
  "solana-pubkey",
  "solana-signer",
  "solana-system-interface",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -175,6 +175,7 @@ solana-signature = { workspace = true, features = [
     "verify",
 ], optional = true }
 solana-signer = { workspace = true, optional = true }
+solana-system-transaction = { workspace = true }
 solana-time-utils = { workspace = true }
 solana-transaction = { workspace = true, features = [
     "blake3",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -47,6 +47,7 @@ full = [
     "dep:solana-seed-derivable",
     "dep:solana-seed-phrase",
     "dep:solana-signer",
+    "dep:solana-system-transaction",
     "dep:solana-transaction",
     "dep:solana-transaction-error",
 ]
@@ -175,7 +176,7 @@ solana-signature = { workspace = true, features = [
     "verify",
 ], optional = true }
 solana-signer = { workspace = true, optional = true }
-solana-system-transaction = { workspace = true }
+solana-system-transaction = { workspace = true, optional = true }
 solana-time-utils = { workspace = true }
 solana-transaction = { workspace = true, features = [
     "blake3",

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -95,7 +95,6 @@ pub mod rpc_port;
 pub mod shred_version;
 pub mod signature;
 pub mod signer;
-pub mod system_transaction;
 pub mod transaction;
 pub mod transport;
 pub mod wasm;
@@ -201,6 +200,12 @@ pub use solana_serde as deserialize_utils;
 pub use solana_serde_varint as serde_varint;
 #[deprecated(since = "2.1.0", note = "Use `solana-short-vec` crate instead")]
 pub use solana_short_vec as short_vec;
+#[cfg(feature = "full")]
+#[deprecated(
+    since = "2.2.0",
+    note = "Use `solana-system-transaction` crate instead"
+)]
+pub use solana_system_transaction as system_transaction;
 #[deprecated(since = "2.2.0", note = "Use `solana-time-utils` crate instead")]
 pub use solana_time_utils as timing;
 #[cfg(feature = "full")]

--- a/sdk/system-transaction/Cargo.toml
+++ b/sdk/system-transaction/Cargo.toml
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
-solana-program = { workspace = true }
+solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }
-solana-transaction = { workspace = true }
+solana-transaction = { workspace = true, features = ["bincode"] }

--- a/sdk/system-transaction/Cargo.toml
+++ b/sdk/system-transaction/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "solana-system-transaction"
+description = "Functionality for creating system transactions."
+documentation = "https://docs.rs/solana-system-transaction"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+solana-hash = { workspace = true }
+solana-keypair = { workspace = true }
+solana-program = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-signer = { workspace = true }
+solana-system-interface = { workspace = true, features = ["bincode"] }
+solana-transaction = { workspace = true }

--- a/sdk/system-transaction/src/lib.rs
+++ b/sdk/system-transaction/src/lib.rs
@@ -1,7 +1,7 @@
 //! The `system_transaction` module provides functionality for creating system transactions.
 
 use {
-    solana_hash::Hash, solana_keypair::Keypair, solana_program::message::Message,
+    solana_hash::Hash, solana_keypair::Keypair, solana_message::Message,
     solana_pubkey::Pubkey, solana_signer::Signer,
     solana_system_interface::instruction as system_instruction, solana_transaction::Transaction,
 };

--- a/sdk/system-transaction/src/lib.rs
+++ b/sdk/system-transaction/src/lib.rs
@@ -1,13 +1,9 @@
 //! The `system_transaction` module provides functionality for creating system transactions.
-#![cfg(feature = "full")]
 
-use crate::{
-    hash::Hash,
-    message::Message,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    system_instruction,
-    transaction::Transaction,
+use {
+    solana_hash::Hash, solana_keypair::Keypair, solana_program::message::Message,
+    solana_pubkey::Pubkey, solana_signer::Signer,
+    solana_system_interface::instruction as system_instruction, solana_transaction::Transaction,
 };
 
 /// Create and sign new SystemInstruction::CreateAccount transaction

--- a/sdk/system-transaction/src/lib.rs
+++ b/sdk/system-transaction/src/lib.rs
@@ -1,9 +1,9 @@
 //! The `system_transaction` module provides functionality for creating system transactions.
 
 use {
-    solana_hash::Hash, solana_keypair::Keypair, solana_message::Message,
-    solana_pubkey::Pubkey, solana_signer::Signer,
-    solana_system_interface::instruction as system_instruction, solana_transaction::Transaction,
+    solana_hash::Hash, solana_keypair::Keypair, solana_message::Message, solana_pubkey::Pubkey,
+    solana_signer::Signer, solana_system_interface::instruction as system_instruction,
+    solana_transaction::Transaction,
 };
 
 /// Create and sign new SystemInstruction::CreateAccount transaction

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6584,6 +6584,7 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-signer",
+ "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
  "solana-transaction-context",
@@ -6975,6 +6976,19 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk",
  "solana-type-overrides",
+]
+
+[[package]]
+name = "solana-system-transaction"
+version = "2.2.0"
+dependencies = [
+ "solana-hash",
+ "solana-keypair",
+ "solana-program",
+ "solana-pubkey",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-transaction",
 ]
 
 [[package]]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6984,7 +6984,7 @@ version = "2.2.0"
 dependencies = [
  "solana-hash",
  "solana-keypair",
- "solana-program",
+ "solana-message",
  "solana-pubkey",
  "solana-signer",
  "solana-system-interface",


### PR DESCRIPTION
#### Problem
`solana_sdk::system_transaction` imposes a solana-sdk dep in various places

#### Summary of Changes
Move to its own crate and re-export with deprecation

This branches off #3634 so that needs to be merged first