### PR TITLE
[streamer] Fix musl build

### DIFF
--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -95,23 +95,22 @@ fn mmsghdr_for_packet(
         }
     };
 
-    let mut msg_hdr: msghdr;
     #[cfg(not(target_env = "musl"))]
-    {
-        msg_hdr = msghdr {
-            msg_name: addr as *mut _ as *mut _,
-            msg_namelen,
-            msg_iov: iov.as_mut_ptr(),
-            msg_iovlen: 1,
-            msg_control: ptr::null::<libc::c_void>() as *mut _,
-            msg_controllen: 0,
-            msg_flags: 0,
-        };
-    }
+    let msg_hdr = msghdr {
+        msg_name: addr as *mut _ as *mut _,
+        msg_namelen,
+        msg_iov: iov.as_mut_ptr(),
+        msg_iovlen: 1,
+        msg_control: ptr::null::<libc::c_void>() as *mut _,
+        msg_controllen: 0,
+        msg_flags: 0,
+    };
 
     #[cfg(target_env = "musl")]
-    {
-        msg_hdr = unsafe { std::mem::zeroed() };
+    let msg_hdr = {
+        // Cannot construct msghdr directly on musl
+        // See https://github.com/rust-lang/libc/issues/2344 for more info
+        let mut msg_hdr: msghdr = unsafe { std::mem::zeroed() };
         msg_hdr.msg_name = addr as *mut _ as *mut _;
         msg_hdr.msg_namelen = msg_namelen;
         msg_hdr.msg_iov = iov.as_mut_ptr();
@@ -119,11 +118,12 @@ fn mmsghdr_for_packet(
         msg_hdr.msg_control = ptr::null::<libc::c_void>() as *mut _;
         msg_hdr.msg_controllen = 0;
         msg_hdr.msg_flags = 0;
-    }
+        msg_hdr
+    };
 
     hdr.write(mmsghdr {
         msg_len: 0,
-        msg_hdr: msg_hdr,
+        msg_hdr,
     });
 }
 


### PR DESCRIPTION
#### Problem

msghdr cannot be directly instantiated on musl due to private padding fields (see rust-lang/libc#2344). The recommended solution is to use `mem::zeroed` to initialize the struct then set the fields as needed.

While we could use the same solution for both glibc and musl, we use a conditional compilation directive to avoid using unsafe code when it's not required.

#### Summary of Changes

* Use `mem::zeroed` to initalize the `msghdr` struct on musl to avoid issues with private padding fields. 

