### PR TITLE
blockstore: don't write shreds to the WAL

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1241,7 +1241,7 @@ impl Blockstore {
         metrics.commit_working_sets_elapsed_us += start.as_us();
 
         let mut start = Measure::start("Write Batch");
-        self.db.write(write_batch)?;
+        self.db.write_no_wal(write_batch)?;
         start.stop();
         metrics.write_batch_elapsed_us += start.as_us();
 


### PR DESCRIPTION
We don't need the WAL to recover shreds in the case of crashes - shred recovery can be done via chain protocol duh.

This makes inserting shreds into rocks about 4x faster since it stops flushing the WAL to disk.

![image](https://github.com/user-attachments/assets/e6e3a164-f132-4203-bb7a-1bdf156c3303)
