### PR TITLE
remove solana-sdk from solana-net-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7615,7 +7615,7 @@ dependencies = [
  "serde_derive",
  "socket2 0.5.8",
  "solana-logger",
- "solana-sdk",
+ "solana-serde",
  "solana-version",
  "tokio",
  "url 2.5.4",

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -20,7 +20,7 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 socket2 = { workspace = true }
 solana-logger = { workspace = true, optional = true }
-solana-sdk = { workspace = true }
+solana-serde = { workspace = true }
 solana-version = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -2,7 +2,7 @@ use {
     crate::{bind_to_unspecified, HEADER_LENGTH, IP_ECHO_SERVER_RESPONSE_LENGTH},
     log::*,
     serde_derive::{Deserialize, Serialize},
-    solana_sdk::deserialize_utils::default_on_eof,
+    solana_serde::default_on_eof,
     std::{
         io,
         net::{IpAddr, SocketAddr},

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6007,7 +6007,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "socket2 0.5.8",
- "solana-sdk",
+ "solana-serde",
  "tokio",
  "url 2.5.4",
 ]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5827,7 +5827,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "socket2",
- "solana-sdk",
+ "solana-serde",
  "tokio",
  "url 2.5.4",
 ]


### PR DESCRIPTION
#### Problem
This crate only needs solana-serde, not all of solana-sdk

#### Summary of Changes
Replace solana-sdk with solana-serde
