### PR TITLE
refactor: static meta compute budget details

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -577,7 +577,8 @@ impl Consumer {
             .iter()
             .filter_map(|transaction| {
                 transaction
-                    .compute_budget_limits(&bank.feature_set)
+                    .compute_budget_instruction_details()
+                    .sanitize_and_convert_to_compute_budget_limits()
                     .ok()
                     .map(|limits| limits.compute_unit_price)
             })

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -195,7 +195,8 @@ impl SanitizedTransactionReceiveAndBuffer {
                     .is_ok()
                 })
                 .filter_map(|(packet, tx, deactivation_slot)| {
-                    tx.compute_budget_limits(&working_bank.feature_set)
+                    tx.compute_budget_instruction_details()
+                        .sanitize_and_convert_to_compute_budget_limits()
                         .map(|compute_budget| {
                             (packet, tx, deactivation_slot, compute_budget.into())
                         })

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -189,7 +189,10 @@ impl CostModel {
         // if failed to process compute budget instructions, the transaction
         // will not be executed by `bank`, therefore it should be considered
         // as no execution cost by cost model.
-        match transaction.compute_budget_limits(feature_set) {
+        match transaction
+            .compute_budget_instruction_details()
+            .sanitize_and_convert_to_compute_budget_limits()
+        {
             Ok(compute_budget_limits) => {
                 // if tx contained user-space instructions and a more accurate
                 // estimate available correct it, where

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use solana_runtime_transaction::compute_budget_instruction_details::ComputeBudgetInstructionDetails;
 use {
     crate::block_cost_limits,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -248,13 +250,8 @@ impl solana_runtime_transaction::transaction_meta::StaticMeta for WritableKeysTr
         &DUMMY
     }
 
-    fn compute_budget_limits(
-        &self,
-        _feature_set: &solana_feature_set::FeatureSet,
-    ) -> solana_sdk::transaction::Result<
-        solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
-    > {
-        unimplemented!("WritableKeysTransaction::compute_budget_limits")
+    fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails {
+        unimplemented!("WritableKeysTransaction::compute_budget_instruction_details")
     }
 }
 

--- a/runtime-transaction/src/compute_budget_instruction_details.rs
+++ b/runtime-transaction/src/compute_budget_instruction_details.rs
@@ -16,7 +16,7 @@ use {
 #[cfg_attr(test, derive(Eq, PartialEq))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
 #[derive(Default, Debug)]
-pub(crate) struct ComputeBudgetInstructionDetails {
+pub struct ComputeBudgetInstructionDetails {
     // compute-budget instruction details:
     // the first field in tuple is instruction index, second field is the unsanitized value set by user
     requested_compute_unit_limit: Option<(u8, u32)>,

--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 
-mod compute_budget_instruction_details;
+pub mod compute_budget_instruction_details;
 mod compute_budget_program_id_filter;
 pub mod instructions_processor;
 pub mod runtime_transaction;

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -15,14 +15,11 @@ use {
         transaction_meta::{DynamicMeta, StaticMeta, TransactionMeta},
     },
     core::ops::Deref,
-    solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_sdk::{
-        feature_set::FeatureSet,
         hash::Hash,
         message::{AccountKeys, TransactionSignatureDetails},
         pubkey::Pubkey,
         signature::Signature,
-        transaction::Result,
     },
     solana_svm_transaction::{
         instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
@@ -52,10 +49,8 @@ impl<T> StaticMeta for RuntimeTransaction<T> {
     fn signature_details(&self) -> &TransactionSignatureDetails {
         &self.meta.signature_details
     }
-    fn compute_budget_limits(&self, _feature_set: &FeatureSet) -> Result<ComputeBudgetLimits> {
-        self.meta
-            .compute_budget_instruction_details
-            .sanitize_and_convert_to_compute_budget_limits()
+    fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails {
+        &self.meta.compute_budget_instruction_details
     }
 }
 

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -159,7 +159,6 @@ mod tests {
         },
         solana_sdk::{
             compute_budget::ComputeBudgetInstruction,
-            feature_set::FeatureSet,
             hash::Hash,
             instruction::Instruction,
             message::Message,
@@ -330,7 +329,8 @@ mod tests {
         assert_eq!(0, signature_details.num_ed25519_instruction_signatures());
 
         let compute_budget_limits = runtime_transaction_static
-            .compute_budget_limits(&FeatureSet::default())
+            .compute_budget_instruction_details()
+            .sanitize_and_convert_to_compute_budget_limits()
             .unwrap();
         assert_eq!(compute_unit_limit, compute_budget_limits.compute_unit_limit);
         assert_eq!(compute_unit_price, compute_budget_limits.compute_unit_price);

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -13,11 +13,7 @@
 //!
 use {
     crate::compute_budget_instruction_details::ComputeBudgetInstructionDetails,
-    solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
-    solana_sdk::{
-        feature_set::FeatureSet, hash::Hash, message::TransactionSignatureDetails,
-        transaction::Result,
-    },
+    solana_sdk::{hash::Hash, message::TransactionSignatureDetails},
 };
 
 /// metadata can be extracted statically from sanitized transaction,
@@ -26,7 +22,7 @@ pub trait StaticMeta {
     fn message_hash(&self) -> &Hash;
     fn is_simple_vote_transaction(&self) -> bool;
     fn signature_details(&self) -> &TransactionSignatureDetails;
-    fn compute_budget_limits(&self, feature_set: &FeatureSet) -> Result<ComputeBudgetLimits>;
+    fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails;
 }
 
 /// Statically loaded meta is a supertrait of Dynamically loaded meta, when

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -207,8 +207,9 @@ impl PrioritizationFeeCache {
                     continue;
                 }
 
-                let compute_budget_limits =
-                    sanitized_transaction.compute_budget_limits(&bank.feature_set);
+                let compute_budget_limits = sanitized_transaction
+                    .compute_budget_instruction_details()
+                    .sanitize_and_convert_to_compute_budget_limits();
 
                 let lock_result = validate_account_locks(
                     sanitized_transaction.account_keys(),


### PR DESCRIPTION
#### Problem
`StaticMeta::compute_budget_limits` is the only trait method on `StaticMeta` which is not a simple getter function. In fact, it's actually a fairly expensive trait method given that it has to do extra sanitization and computation for the transaction's default compute limit. This design limits the flexibility of the `sanitize_and_convert_to_compute_budget_limits` method (e.g. it's not possible to change it to accept an iterator of instructions for computing the default compute unit limit).

#### Summary of Changes
- Replaced `StaticMeta::compute_budget_limits` with `StaticMeta::compute_budget_instruction_details` forcing the caller to explicitly sanitize the result if needed.
- Increased visibility of `ComputeBudgetInstructionDetails` to `pub`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
