### PR TITLE
remove solana-sdk from svm-transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9018,11 +9018,12 @@ name = "solana-svm-transaction"
 version = "2.2.0"
 dependencies = [
  "solana-hash",
+ "solana-message",
  "solana-nonce",
- "solana-program",
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-signature",
+ "solana-system-interface",
  "solana-transaction",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9017,7 +9017,14 @@ dependencies = [
 name = "solana-svm-transaction"
 version = "2.2.0"
 dependencies = [
- "solana-sdk",
+ "solana-hash",
+ "solana-nonce",
+ "solana-program",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-transaction",
+ "static_assertions",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7599,7 +7599,12 @@ dependencies = [
 name = "solana-svm-transaction"
 version = "2.2.0"
 dependencies = [
- "solana-sdk",
+ "solana-hash",
+ "solana-program",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-transaction",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7600,7 +7600,7 @@ name = "solana-svm-transaction"
 version = "2.2.0"
 dependencies = [
  "solana-hash",
- "solana-program",
+ "solana-message",
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-signature",

--- a/svm-transaction/Cargo.toml
+++ b/svm-transaction/Cargo.toml
@@ -10,4 +10,13 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-solana-sdk = { workspace = true }
+solana-hash = { workspace = true }
+solana-program = { workspace = true, default-features = false }
+solana-pubkey = { workspace = true }
+solana-sdk-ids = { workspace = true }
+solana-signature = { workspace = true }
+solana-transaction = { workspace = true }
+
+[dev-dependencies]
+solana-nonce = { workspace = true }
+static_assertions = { workspace = true }

--- a/svm-transaction/Cargo.toml
+++ b/svm-transaction/Cargo.toml
@@ -11,12 +11,14 @@ edition = { workspace = true }
 
 [dependencies]
 solana-hash = { workspace = true }
-solana-program = { workspace = true, default-features = false }
+solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
 
 [dev-dependencies]
+solana-message = { workspace = true, features = ["bincode"] }
 solana-nonce = { workspace = true }
+solana-system-interface = { workspace = true }
 static_assertions = { workspace = true }

--- a/svm-transaction/src/instruction.rs
+++ b/svm-transaction/src/instruction.rs
@@ -1,4 +1,4 @@
-use solana_sdk::instruction::CompiledInstruction;
+use solana_program::instruction::CompiledInstruction;
 
 /// A non-owning version of [`CompiledInstruction`] that references
 /// slices of account indexes and data.

--- a/svm-transaction/src/instruction.rs
+++ b/svm-transaction/src/instruction.rs
@@ -1,4 +1,4 @@
-use solana_program::instruction::CompiledInstruction;
+use solana_message::compiled_instruction::CompiledInstruction;
 
 /// A non-owning version of [`CompiledInstruction`] that references
 /// slices of account indexes and data.

--- a/svm-transaction/src/message_address_table_lookup.rs
+++ b/svm-transaction/src/message_address_table_lookup.rs
@@ -1,4 +1,4 @@
-use {solana_program::message::v0, solana_pubkey::Pubkey};
+use {solana_message::v0, solana_pubkey::Pubkey};
 
 /// A non-owning version of [`v0::MessageAddressTableLookup`].
 /// This simply references the data in the original message.

--- a/svm-transaction/src/message_address_table_lookup.rs
+++ b/svm-transaction/src/message_address_table_lookup.rs
@@ -1,4 +1,4 @@
-use solana_sdk::{message::v0, pubkey::Pubkey};
+use {solana_program::message::v0, solana_pubkey::Pubkey};
 
 /// A non-owning version of [`v0::MessageAddressTableLookup`].
 /// This simply references the data in the original message.

--- a/svm-transaction/src/svm_message.rs
+++ b/svm-transaction/src/svm_message.rs
@@ -3,14 +3,21 @@ use {
         instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
     },
     core::fmt::Debug,
-    solana_sdk::{
-        hash::Hash, message::AccountKeys, nonce::NONCED_TX_MARKER_IX_INDEX, pubkey::Pubkey,
-        system_program,
-    },
+    solana_hash::Hash,
+    solana_program::message::AccountKeys,
+    solana_pubkey::Pubkey,
+    solana_sdk_ids::system_program,
 };
 
 mod sanitized_message;
 mod sanitized_transaction;
+// inlined to avoid solana-nonce dep
+#[cfg(test)]
+static_assertions::const_assert_eq!(
+    NONCED_TX_MARKER_IX_INDEX,
+    solana_nonce::NONCED_TX_MARKER_IX_INDEX
+);
+const NONCED_TX_MARKER_IX_INDEX: u8 = 0;
 
 // - Debug to support legacy logging
 pub trait SVMMessage: Debug {

--- a/svm-transaction/src/svm_message.rs
+++ b/svm-transaction/src/svm_message.rs
@@ -4,7 +4,7 @@ use {
     },
     core::fmt::Debug,
     solana_hash::Hash,
-    solana_program::message::AccountKeys,
+    solana_message::AccountKeys,
     solana_pubkey::Pubkey,
     solana_sdk_ids::system_program,
 };

--- a/svm-transaction/src/svm_message/sanitized_message.rs
+++ b/svm-transaction/src/svm_message/sanitized_message.rs
@@ -3,11 +3,9 @@ use {
         instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
         svm_message::SVMMessage,
     },
-    solana_sdk::{
-        hash::Hash,
-        message::{AccountKeys, SanitizedMessage},
-        pubkey::Pubkey,
-    },
+    solana_hash::Hash,
+    solana_program::message::{AccountKeys, SanitizedMessage},
+    solana_pubkey::Pubkey,
 };
 
 // Implement for the "reference" `SanitizedMessage` type.

--- a/svm-transaction/src/svm_message/sanitized_message.rs
+++ b/svm-transaction/src/svm_message/sanitized_message.rs
@@ -4,7 +4,7 @@ use {
         svm_message::SVMMessage,
     },
     solana_hash::Hash,
-    solana_program::message::{AccountKeys, SanitizedMessage},
+    solana_message::{AccountKeys, SanitizedMessage},
     solana_pubkey::Pubkey,
 };
 

--- a/svm-transaction/src/svm_message/sanitized_transaction.rs
+++ b/svm-transaction/src/svm_message/sanitized_transaction.rs
@@ -3,9 +3,10 @@ use {
         instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
         svm_message::SVMMessage,
     },
-    solana_sdk::{
-        hash::Hash, message::AccountKeys, pubkey::Pubkey, transaction::SanitizedTransaction,
-    },
+    solana_hash::Hash,
+    solana_program::message::AccountKeys,
+    solana_pubkey::Pubkey,
+    solana_transaction::sanitized::SanitizedTransaction,
 };
 
 impl SVMMessage for SanitizedTransaction {

--- a/svm-transaction/src/svm_message/sanitized_transaction.rs
+++ b/svm-transaction/src/svm_message/sanitized_transaction.rs
@@ -4,7 +4,7 @@ use {
         svm_message::SVMMessage,
     },
     solana_hash::Hash,
-    solana_program::message::AccountKeys,
+    solana_message::AccountKeys,
     solana_pubkey::Pubkey,
     solana_transaction::sanitized::SanitizedTransaction,
 };

--- a/svm-transaction/src/svm_transaction.rs
+++ b/svm-transaction/src/svm_transaction.rs
@@ -1,4 +1,4 @@
-use {crate::svm_message::SVMMessage, solana_sdk::signature::Signature};
+use {crate::svm_message::SVMMessage, solana_signature::Signature};
 
 mod sanitized_transaction;
 

--- a/svm-transaction/src/svm_transaction/sanitized_transaction.rs
+++ b/svm-transaction/src/svm_transaction/sanitized_transaction.rs
@@ -1,6 +1,6 @@
 use {
-    crate::svm_transaction::SVMTransaction,
-    solana_sdk::{signature::Signature, transaction::SanitizedTransaction},
+    crate::svm_transaction::SVMTransaction, solana_signature::Signature,
+    solana_transaction::sanitized::SanitizedTransaction,
 };
 
 impl SVMTransaction for SanitizedTransaction {

--- a/svm-transaction/src/tests.rs
+++ b/svm-transaction/src/tests.rs
@@ -2,18 +2,16 @@
 use {
     crate::svm_message::SVMMessage,
     solana_hash::Hash,
-    solana_program::{
-        instruction::CompiledInstruction,
-        message::{
-            legacy,
-            v0::{self, LoadedAddresses, MessageAddressTableLookup},
-            MessageHeader, SanitizedMessage, SanitizedVersionedMessage, SimpleAddressLoader,
-            VersionedMessage,
-        },
-        system_instruction::SystemInstruction,
+    solana_message::{
+        compiled_instruction::CompiledInstruction,
+        legacy,
+        v0::{self, LoadedAddresses, MessageAddressTableLookup},
+        MessageHeader, SanitizedMessage, SanitizedVersionedMessage, SimpleAddressLoader,
+        VersionedMessage,
     },
     solana_pubkey::Pubkey,
     solana_sdk_ids::system_program,
+    solana_system_interface::instruction::SystemInstruction,
     std::collections::HashSet,
 };
 

--- a/svm-transaction/src/tests.rs
+++ b/svm-transaction/src/tests.rs
@@ -1,8 +1,8 @@
 #![cfg(test)]
 use {
     crate::svm_message::SVMMessage,
-    solana_sdk::{
-        hash::Hash,
+    solana_hash::Hash,
+    solana_program::{
         instruction::CompiledInstruction,
         message::{
             legacy,
@@ -10,10 +10,10 @@ use {
             MessageHeader, SanitizedMessage, SanitizedVersionedMessage, SimpleAddressLoader,
             VersionedMessage,
         },
-        pubkey::Pubkey,
         system_instruction::SystemInstruction,
-        system_program,
     },
+    solana_pubkey::Pubkey,
+    solana_sdk_ids::system_program,
     std::collections::HashSet,
 };
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6944,7 +6944,12 @@ dependencies = [
 name = "solana-svm-transaction"
 version = "2.2.0"
 dependencies = [
- "solana-sdk",
+ "solana-hash",
+ "solana-program",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-transaction",
 ]
 
 [[package]]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6945,7 +6945,7 @@ name = "solana-svm-transaction"
 version = "2.2.0"
 dependencies = [
  "solana-hash",
- "solana-program",
+ "solana-message",
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-signature",


### PR DESCRIPTION
#### Problem
This crate can compile faster without solana-sdk

#### Summary of Changes
Remove it and replace with constituent crates as appropriate

This branches off #3634 so that needs to be merged first (update: done)