### PR TITLE
Make unified-scheduler use transaction_status_sender in ledger-tool

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -283,6 +283,44 @@ pub fn load_and_process_ledger(
     };
 
     let exit = Arc::new(AtomicBool::new(false));
+
+    let enable_rpc_transaction_history = arg_matches.is_present("enable_rpc_transaction_history");
+
+    let (transaction_status_sender, transaction_status_service) = if geyser_plugin_active
+        || enable_rpc_transaction_history
+    {
+        // Need Primary (R/W) access to insert transaction data;
+        // obtain Primary access if we do not already have it
+        let tss_blockstore = if enable_rpc_transaction_history && !blockstore.is_primary_access() {
+            Arc::new(open_blockstore(
+                blockstore.ledger_path(),
+                arg_matches,
+                AccessType::PrimaryForMaintenance,
+            ))
+        } else {
+            blockstore.clone()
+        };
+
+        let (transaction_status_sender, transaction_status_receiver) = unbounded();
+        let transaction_status_service = TransactionStatusService::new(
+            transaction_status_receiver,
+            Arc::default(),
+            enable_rpc_transaction_history,
+            transaction_notifier,
+            tss_blockstore,
+            arg_matches.is_present("enable_extended_tx_metadata_storage"),
+            exit.clone(),
+        );
+        (
+            Some(TransactionStatusSender {
+                sender: transaction_status_sender,
+            }),
+            Some(transaction_status_service),
+        )
+    } else {
+        (transaction_status_sender, None)
+    };
+
     let (bank_forks, leader_schedule_cache, starting_snapshot_hashes, ..) =
         bank_forks_utils::load_bank_forks(
             genesis_config,
@@ -319,7 +357,6 @@ pub fn load_and_process_ledger(
             }
         }
         BlockVerificationMethod::UnifiedScheduler => {
-            let no_transaction_status_sender = None;
             let no_replay_vote_sender = None;
             let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
             bank_forks
@@ -328,7 +365,7 @@ pub fn load_and_process_ledger(
                 .install_scheduler_pool(DefaultSchedulerPool::new_dyn(
                     unified_scheduler_handler_threads,
                     process_options.runtime_config.log_messages_bytes_limit,
-                    no_transaction_status_sender,
+                    transaction_status_sender.clone(),
                     no_replay_vote_sender,
                     ignored_prioritization_fee_cache,
                 ));
@@ -367,43 +404,6 @@ pub fn load_and_process_ledger(
         abs_request_handler,
         process_options.accounts_db_test_hash_calculation,
     );
-
-    let enable_rpc_transaction_history = arg_matches.is_present("enable_rpc_transaction_history");
-
-    let (transaction_status_sender, transaction_status_service) = if geyser_plugin_active
-        || enable_rpc_transaction_history
-    {
-        // Need Primary (R/W) access to insert transaction data;
-        // obtain Primary access if we do not already have it
-        let tss_blockstore = if enable_rpc_transaction_history && !blockstore.is_primary_access() {
-            Arc::new(open_blockstore(
-                blockstore.ledger_path(),
-                arg_matches,
-                AccessType::PrimaryForMaintenance,
-            ))
-        } else {
-            blockstore.clone()
-        };
-
-        let (transaction_status_sender, transaction_status_receiver) = unbounded();
-        let transaction_status_service = TransactionStatusService::new(
-            transaction_status_receiver,
-            Arc::default(),
-            enable_rpc_transaction_history,
-            transaction_notifier,
-            tss_blockstore,
-            arg_matches.is_present("enable_extended_tx_metadata_storage"),
-            exit.clone(),
-        );
-        (
-            Some(TransactionStatusSender {
-                sender: transaction_status_sender,
-            }),
-            Some(transaction_status_service),
-        )
-    } else {
-        (transaction_status_sender, None)
-    };
 
     let result = blockstore_processor::process_blockstore_from_root(
         blockstore.as_ref(),


### PR DESCRIPTION
#### Problem

Some functionalities (`--enable-rpc-transaction-history` and `--record-slots-config=tx`) of `agave-ledger-tool verify` is broken if `unified-scheduler` is active as `block-verification-method`.

Notably, I'd propose to bp this pr to both v2.0 and v2.1, because `agave-ledger-tool`'s `--enable-rpc-transaction-history` and `--enable-extended-tx-metadata-storage` are kind of important functionalities for ops.

as for v2.0, `unified-scheduler` won't be active unless explicitly enabled via CLI flags. On the other hand, it will be active by default for v2.1. So, bp to v2.1 is kind of a must. bp to v2.0 is desired for consistency.

#### Summary of Changes

Fit it by plumbing properly the `transaction_status_sender`....
