### PR TITLE
Renames fn to AccountsDb::get_storages()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2555,7 +2555,7 @@ impl AccountsDb {
             let acceptable_straggler_slot_count = 100;
             let old_slot_cutoff =
                 slot_one_epoch_old.saturating_sub(acceptable_straggler_slot_count);
-            let (old_storages, old_slots) = self.get_snapshot_storages(..old_slot_cutoff);
+            let (old_storages, old_slots) = self.get_storages(..old_slot_cutoff);
             let num_old_storages = old_storages.len();
             self.accounts_index
                 .add_uncleaned_roots(old_slots.iter().copied());
@@ -6936,7 +6936,7 @@ impl AccountsDb {
                 }
 
                 let mut collect_time = Measure::start("collect");
-                let (combined_maps, slots) = self.get_snapshot_storages(..=slot);
+                let (combined_maps, slots) = self.get_storages(..=slot);
                 collect_time.stop();
 
                 let mut sort_time = Measure::start("sort_storages");
@@ -8469,8 +8469,8 @@ impl AccountsDb {
         }
     }
 
-    /// Get storages to use for snapshots, for the requested slots
-    pub fn get_snapshot_storages(
+    /// Returns storages for `requested_slots`
+    pub fn get_storages(
         &self,
         requested_slots: impl RangeBounds<Slot> + Sync,
     ) -> (Vec<Arc<AccountStorageEntry>>, Vec<Slot>) {
@@ -9532,7 +9532,7 @@ impl AccountsDb {
         total_lamports: u64,
         config: VerifyAccountsHashAndLamportsConfig,
     ) -> Result<(), AccountsHashVerificationError> {
-        let snapshot_storages = self.get_snapshot_storages(..);
+        let snapshot_storages = self.get_storages(..);
         let snapshot_storages_and_slots = (
             snapshot_storages.0.as_slice(),
             snapshot_storages.1.as_slice(),

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -670,7 +670,7 @@ pub(crate) fn sample_storages_and_account_in_slot(
     accounts.store_for_tests(slot, &to_store[..]);
     accounts.add_root_and_flush_write_cache(slot);
 
-    let (storages, slots) = accounts.get_snapshot_storages(..=slot);
+    let (storages, slots) = accounts.get_storages(..=slot);
     assert_eq!(storages.len(), slots.len());
     storages
         .iter()
@@ -2623,7 +2623,7 @@ fn test_storage_finder() {
 #[test]
 fn test_get_snapshot_storages_empty() {
     let db = AccountsDb::new_single_for_tests();
-    assert!(db.get_snapshot_storages(..=0).0.is_empty());
+    assert!(db.get_storages(..=0).0.is_empty());
 }
 
 #[test]
@@ -2638,10 +2638,10 @@ fn test_get_snapshot_storages_only_older_than_or_equal_to_snapshot_slot() {
 
     db.store_for_tests(base_slot, &[(&key, &account)]);
     db.add_root_and_flush_write_cache(base_slot);
-    assert!(db.get_snapshot_storages(..=before_slot).0.is_empty());
+    assert!(db.get_storages(..=before_slot).0.is_empty());
 
-    assert_eq!(1, db.get_snapshot_storages(..=base_slot).0.len());
-    assert_eq!(1, db.get_snapshot_storages(..=after_slot).0.len());
+    assert_eq!(1, db.get_storages(..=base_slot).0.len());
+    assert_eq!(1, db.get_storages(..=after_slot).0.len());
 }
 
 #[test]
@@ -2658,13 +2658,13 @@ fn test_get_snapshot_storages_only_non_empty() {
         if pass == 0 {
             db.add_root_and_flush_write_cache(base_slot);
             db.storage.remove(&base_slot, false);
-            assert!(db.get_snapshot_storages(..=after_slot).0.is_empty());
+            assert!(db.get_storages(..=after_slot).0.is_empty());
             continue;
         }
 
         db.store_for_tests(base_slot, &[(&key, &account)]);
         db.add_root_and_flush_write_cache(base_slot);
-        assert_eq!(1, db.get_snapshot_storages(..=after_slot).0.len());
+        assert_eq!(1, db.get_storages(..=after_slot).0.len());
     }
 }
 
@@ -2678,10 +2678,10 @@ fn test_get_snapshot_storages_only_roots() {
     let after_slot = base_slot + 1;
 
     db.store_for_tests(base_slot, &[(&key, &account)]);
-    assert!(db.get_snapshot_storages(..=after_slot).0.is_empty());
+    assert!(db.get_storages(..=after_slot).0.is_empty());
 
     db.add_root_and_flush_write_cache(base_slot);
-    assert_eq!(1, db.get_snapshot_storages(..=after_slot).0.len());
+    assert_eq!(1, db.get_storages(..=after_slot).0.len());
 }
 
 #[test]
@@ -2695,13 +2695,13 @@ fn test_get_snapshot_storages_exclude_empty() {
 
     db.store_for_tests(base_slot, &[(&key, &account)]);
     db.add_root_and_flush_write_cache(base_slot);
-    assert_eq!(1, db.get_snapshot_storages(..=after_slot).0.len());
+    assert_eq!(1, db.get_storages(..=after_slot).0.len());
 
     db.storage
         .get_slot_storage_entry(0)
         .unwrap()
         .remove_accounts(0, true, 1);
-    assert!(db.get_snapshot_storages(..=after_slot).0.is_empty());
+    assert!(db.get_storages(..=after_slot).0.is_empty());
 }
 
 #[test]
@@ -2714,8 +2714,8 @@ fn test_get_snapshot_storages_with_base_slot() {
     let slot = 10;
     db.store_for_tests(slot, &[(&key, &account)]);
     db.add_root_and_flush_write_cache(slot);
-    assert_eq!(0, db.get_snapshot_storages(slot + 1..=slot + 1).0.len());
-    assert_eq!(1, db.get_snapshot_storages(slot..=slot + 1).0.len());
+    assert_eq!(0, db.get_storages(slot + 1..=slot + 1).0.len());
+    assert_eq!(1, db.get_storages(slot..=slot + 1).0.len());
 }
 
 define_accounts_db_test!(
@@ -2812,7 +2812,7 @@ fn do_full_clean_refcount(mut accounts: AccountsDb, store1_first: bool, store_si
     accounts.store_for_tests(current_slot, &[(&pubkey2, &zero_lamport_account)]);
     accounts.store_for_tests(current_slot, &[(&pubkey3, &zero_lamport_account)]);
 
-    let snapshot_stores = accounts.get_snapshot_storages(..=current_slot).0;
+    let snapshot_stores = accounts.get_storages(..=current_slot).0;
     let total_accounts: usize = snapshot_stores.iter().map(|s| s.accounts_count()).sum();
     assert!(!snapshot_stores.is_empty());
     assert!(total_accounts > 0);
@@ -8068,7 +8068,7 @@ define_accounts_db_test!(test_calculate_incremental_accounts_hash, |accounts_db|
             &EpochSchedule::default(),
             OldStoragesPolicy::Leave,
         );
-        let (storages, _) = accounts_db.get_snapshot_storages(..=slot);
+        let (storages, _) = accounts_db.get_storages(..=slot);
         let storages = SortedStorages::new(&storages);
         accounts_db.calculate_accounts_hash(
             &CalcAccountsHashConfig::default(),
@@ -8139,7 +8139,7 @@ define_accounts_db_test!(test_calculate_incremental_accounts_hash, |accounts_db|
             &EpochSchedule::default(),
             OldStoragesPolicy::Leave,
         );
-        let (storages, _) = accounts_db.get_snapshot_storages(full_accounts_hash_slot + 1..=slot);
+        let (storages, _) = accounts_db.get_storages(full_accounts_hash_slot + 1..=slot);
         let storages = SortedStorages::new(&storages);
         accounts_db.calculate_incremental_accounts_hash(
             &CalcAccountsHashConfig::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5769,11 +5769,7 @@ impl Bank {
         // The snapshot storages must be captured *before* starting the background verification.
         // Otherwise, it is possible that a delayed call to `get_snapshot_storages()` will *not*
         // get the correct storages required to calculate and verify the accounts hashes.
-        let snapshot_storages = self
-            .rc
-            .accounts
-            .accounts_db
-            .get_snapshot_storages(RangeFull);
+        let snapshot_storages = self.rc.accounts.accounts_db.get_storages(RangeFull);
         let capitalization = self.capitalization();
         let verify_config = VerifyAccountsHashAndLamportsConfig {
             ancestors: &self.ancestors,
@@ -5955,11 +5951,7 @@ impl Bank {
         // we want to *include* the storage at our slot
         let requested_slots = start_slot..=self.slot();
 
-        self.rc
-            .accounts
-            .accounts_db
-            .get_snapshot_storages(requested_slots)
-            .0
+        self.rc.accounts.accounts_db.get_storages(requested_slots).0
     }
 
     #[must_use]

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -875,11 +875,7 @@ mod tests {
         let expected_accounts_lt_hash = bank.accounts_lt_hash.lock().unwrap().clone();
 
         // go through the storages to find the duplicates
-        let (mut storages, _slots) = bank
-            .rc
-            .accounts
-            .accounts_db
-            .get_snapshot_storages(RangeFull);
+        let (mut storages, _slots) = bank.rc.accounts.accounts_db.get_storages(RangeFull);
         // sort the storages in slot-descending order
         // this makes skipping the latest easier
         storages.sort_unstable_by_key(|storage| cmp::Reverse(storage.slot()));

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -52,7 +52,7 @@ mod tests {
         output_dir: P,
         storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
-        let storage_entries = accounts_db.get_snapshot_storages(RangeFull).0;
+        let storage_entries = accounts_db.get_storages(RangeFull).0;
         let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
@@ -583,7 +583,7 @@ mod tests {
             S: serde::Serializer,
         {
             let bank = Bank::default_for_tests();
-            let snapshot_storages = AccountsDb::example().get_snapshot_storages(0..1).0;
+            let snapshot_storages = AccountsDb::example().get_storages(0..1).0;
             // ensure there is at least one snapshot storage example for ABI digesting
             assert!(!snapshot_storages.is_empty());
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -131,7 +131,7 @@ mod serde_snapshot_tests {
         output_dir: impl AsRef<Path>,
         storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
-        let storage_entries = accounts_db.get_snapshot_storages(RangeFull).0;
+        let storage_entries = accounts_db.get_storages(RangeFull).0;
         let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
@@ -175,7 +175,7 @@ mod serde_snapshot_tests {
         storage_access: StorageAccess,
     ) -> AccountsDb {
         let mut writer = Cursor::new(vec![]);
-        let snapshot_storages = accounts.get_snapshot_storages(..=slot).0;
+        let snapshot_storages = accounts.get_storages(..=slot).0;
         accountsdb_to_stream(
             &mut writer,
             accounts,
@@ -241,7 +241,7 @@ mod serde_snapshot_tests {
             &mut writer,
             &accounts.accounts_db,
             slot,
-            &get_storages_to_serialize(&accounts.accounts_db.get_snapshot_storages(..=slot).0),
+            &get_storages_to_serialize(&accounts.accounts_db.get_storages(..=slot).0),
         )
         .unwrap();
 

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -270,10 +270,7 @@ impl<'a> SnapshotMinimizer<'a> {
         &self,
         minimized_slot_set: DashSet<Slot>,
     ) -> (Vec<Slot>, Vec<Arc<AccountStorageEntry>>) {
-        let snapshot_storages = self
-            .accounts_db()
-            .get_snapshot_storages(..=self.starting_slot)
-            .0;
+        let snapshot_storages = self.accounts_db().get_storages(..=self.starting_slot).0;
 
         let dead_slots = Mutex::new(Vec::new());
         let dead_storages = Mutex::new(Vec::new());
@@ -656,7 +653,7 @@ mod tests {
         };
         minimizer.minimize_accounts_db();
 
-        let snapshot_storages = accounts.get_snapshot_storages(..=current_slot).0;
+        let snapshot_storages = accounts.get_storages(..=current_slot).0;
         assert_eq!(snapshot_storages.len(), 3);
 
         let mut account_count = 0;


### PR DESCRIPTION
#### Problem

As of https://github.com/anza-xyz/agave/pull/3737, we now call `AccountsDb::get_snapshot_storages()` to get storages for reasons other than snapshots. It is really up to the caller to decide what the storages are for. It is now a misnomer for the function to include "snapshot" in its name.


#### Summary of Changes

Remove "snapshot" from the function name.

Note, this PR purposely does not change the name of Bank::get_snapshot_storages().