### PR TITLE
move program::wasm::instructions to instruction crate

### DIFF
--- a/sdk/instruction/src/lib.rs
+++ b/sdk/instruction/src/lib.rs
@@ -26,6 +26,8 @@ pub use account_meta::AccountMeta;
 pub mod error;
 #[cfg(target_os = "solana")]
 pub mod syscalls;
+#[cfg(feature = "std")]
+pub mod wasm;
 
 /// A directive for a single invocation of a Solana program.
 ///

--- a/sdk/instruction/src/lib.rs
+++ b/sdk/instruction/src/lib.rs
@@ -26,7 +26,7 @@ pub use account_meta::AccountMeta;
 pub mod error;
 #[cfg(target_os = "solana")]
 pub mod syscalls;
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", target_arch = "wasm32"))]
 pub mod wasm;
 
 /// A directive for a single invocation of a Solana program.

--- a/sdk/instruction/src/wasm.rs
+++ b/sdk/instruction/src/wasm.rs
@@ -1,12 +1,13 @@
-//! The `Instructions` struct is a workaround for the lack of Vec<T> support in wasm-bindgen
+//! The `Instructions` struct is a legacy workaround
+//! from when wasm-bindgen lacked Vec<T> support
 //! (ref: https://github.com/rustwasm/wasm-bindgen/issues/111)
 #![cfg(target_arch = "wasm32")]
-use {crate::instruction::Instruction, wasm_bindgen::prelude::*};
+use {crate::Instruction, wasm_bindgen::prelude::*};
 
 #[wasm_bindgen]
 #[derive(Default)]
 pub struct Instructions {
-    instructions: Vec<Instruction>,
+    instructions: std::vec::Vec<Instruction>,
 }
 
 #[wasm_bindgen]
@@ -21,7 +22,7 @@ impl Instructions {
     }
 }
 
-impl From<Instructions> for Vec<Instruction> {
+impl From<Instructions> for std::vec::Vec<Instruction> {
     fn from(instructions: Instructions) -> Self {
         instructions.instructions
     }

--- a/sdk/instruction/src/wasm.rs
+++ b/sdk/instruction/src/wasm.rs
@@ -1,7 +1,6 @@
 //! The `Instructions` struct is a legacy workaround
 //! from when wasm-bindgen lacked Vec<T> support
 //! (ref: https://github.com/rustwasm/wasm-bindgen/issues/111)
-#![cfg(target_arch = "wasm32")]
 use {crate::Instruction, wasm_bindgen::prelude::*};
 
 #[wasm_bindgen]

--- a/sdk/program/src/wasm/mod.rs
+++ b/sdk/program/src/wasm/mod.rs
@@ -1,9 +1,8 @@
 //! solana-program Javascript interface
 #![cfg(target_arch = "wasm32")]
-use wasm_bindgen::prelude::*;
-
 #[deprecated(since = "2.2.0", note = "Use solana_instruction::wasm instead.")]
 pub use solana_instruction::wasm as instructions;
+use wasm_bindgen::prelude::*;
 // This module is intentionally left empty. The wasm system instruction impl can be
 // found in the `solana-system-interface` crate.
 pub mod system_instruction {}

--- a/sdk/program/src/wasm/mod.rs
+++ b/sdk/program/src/wasm/mod.rs
@@ -2,7 +2,8 @@
 #![cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
-pub mod instructions;
+#[deprecated(since = "2.2.0", note = "Use solana_instruction::wasm instead.")]
+pub use solana_instruction::wasm as instructions;
 // This module is intentionally left empty. The wasm system instruction impl can be
 // found in the `solana-system-interface` crate.
 pub mod system_instruction {}


### PR DESCRIPTION
#### Problem
`solana_program::wasm::instructions` imposes a `solana-program` dep on `solana-transaction` (which is getting pulled out in #3634. The contents of instructions.rs are a legacy solution because wasm_bindgen now supports Vec<T>, but until we make a breaking change, `solana-transaction` requires instructions.rs

#### Summary of Changes
- Move to the solana-instruction crate and re-export with deprecation