### PR TITLE
[runtime-transaction] add secp256r1 to precompile signature details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "bincode",
  "criterion",
  "solana-sdk",
+ "solana-secp256r1-program",
  "solana-svm-transaction",
 ]
 
@@ -7550,6 +7551,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sanitize",
  "solana-sdk-ids",
+ "solana-secp256r1-program",
  "solana-sha256-hasher",
  "solana-short-vec",
  "solana-system-interface",
@@ -8462,6 +8464,7 @@ dependencies = [
  "solana-program",
  "solana-pubkey",
  "solana-sdk",
+ "solana-secp256r1-program",
  "solana-svm-transaction",
  "thiserror 2.0.3",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "bincode",
  "criterion",
  "solana-sdk",
- "solana-secp256r1-program",
+ "solana-sdk-ids",
  "solana-svm-transaction",
 ]
 
@@ -7551,7 +7551,6 @@ dependencies = [
  "solana-pubkey",
  "solana-sanitize",
  "solana-sdk-ids",
- "solana-secp256r1-program",
  "solana-sha256-hasher",
  "solana-short-vec",
  "solana-system-interface",
@@ -8464,7 +8463,7 @@ dependencies = [
  "solana-program",
  "solana-pubkey",
  "solana-sdk",
- "solana-secp256r1-program",
+ "solana-sdk-ids",
  "solana-svm-transaction",
  "thiserror 2.0.3",
 ]

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -244,7 +244,7 @@ impl solana_runtime_transaction::transaction_meta::StaticMeta for WritableKeysTr
 
     fn signature_details(&self) -> &solana_sdk::message::TransactionSignatureDetails {
         const DUMMY: solana_sdk::message::TransactionSignatureDetails =
-            solana_sdk::message::TransactionSignatureDetails::new(0, 0, 0);
+            solana_sdk::message::TransactionSignatureDetails::new(0, 0, 0, 0);
         &DUMMY
     }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -78,7 +78,7 @@ name = "agave-transaction-view"
 version = "2.2.0"
 dependencies = [
  "solana-sdk",
- "solana-secp256r1-program",
+ "solana-sdk-ids",
  "solana-svm-transaction",
 ]
 
@@ -5963,7 +5963,6 @@ dependencies = [
  "solana-pubkey",
  "solana-sanitize",
  "solana-sdk-ids",
- "solana-secp256r1-program",
  "solana-short-vec",
  "solana-system-interface",
  "solana-transaction-error",
@@ -6680,7 +6679,7 @@ dependencies = [
  "solana-compute-budget",
  "solana-pubkey",
  "solana-sdk",
- "solana-secp256r1-program",
+ "solana-sdk-ids",
  "solana-svm-transaction",
  "thiserror 2.0.3",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -78,6 +78,7 @@ name = "agave-transaction-view"
 version = "2.2.0"
 dependencies = [
  "solana-sdk",
+ "solana-secp256r1-program",
  "solana-svm-transaction",
 ]
 
@@ -5962,6 +5963,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sanitize",
  "solana-sdk-ids",
+ "solana-secp256r1-program",
  "solana-short-vec",
  "solana-system-interface",
  "solana-transaction-error",
@@ -6678,6 +6680,7 @@ dependencies = [
  "solana-compute-budget",
  "solana-pubkey",
  "solana-sdk",
+ "solana-secp256r1-program",
  "solana-svm-transaction",
  "thiserror 2.0.3",
 ]

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -16,6 +16,7 @@ solana-builtins-default-costs = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk = { workspace = true }
+solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
 solana-svm-transaction = { workspace = true }
 thiserror = { workspace = true }
 

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -16,7 +16,7 @@ solana-builtins-default-costs = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk = { workspace = true }
-solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
+solana-sdk-ids = { workspace = true }
 solana-svm-transaction = { workspace = true }
 thiserror = { workspace = true }
 

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -47,6 +47,7 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
             ),
             precompile_signature_details.num_secp256k1_instruction_signatures,
             precompile_signature_details.num_ed25519_instruction_signatures,
+            precompile_signature_details.num_secp256r1_instruction_signatures,
         );
         let compute_budget_instruction_details = ComputeBudgetInstructionDetails::try_from(
             sanitized_versioned_tx

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -57,6 +57,7 @@ impl<D: TransactionData> RuntimeTransaction<SanitizedTransactionView<D>> {
             u64::from(transaction.num_required_signatures()),
             precompile_signature_details.num_secp256k1_instruction_signatures,
             precompile_signature_details.num_ed25519_instruction_signatures,
+            precompile_signature_details.num_secp256r1_instruction_signatures,
         );
         let compute_budget_instruction_details =
             ComputeBudgetInstructionDetails::try_from(transaction.program_instructions_iter())?;

--- a/runtime-transaction/src/signature_details.rs
+++ b/runtime-transaction/src/signature_details.rs
@@ -94,7 +94,7 @@ impl SignatureDetailsFilter {
             ProgramIdStatus::Secp256k1
         } else if program_id == &solana_sdk::ed25519_program::ID {
             ProgramIdStatus::Ed25519
-        } else if program_id == &solana_secp256r1_program::ID {
+        } else if program_id == &solana_sdk_ids::secp256r1_program::ID {
             ProgramIdStatus::Secp256r1
         } else {
             ProgramIdStatus::NotSignature
@@ -150,7 +150,7 @@ mod tests {
             Pubkey::new_unique(),
             solana_sdk::secp256k1_program::ID,
             solana_sdk::ed25519_program::ID,
-            solana_secp256r1_program::ID,
+            solana_sdk_ids::secp256r1_program::ID,
         ];
         let instructions = [
             make_instruction(&program_ids, 1, &[5]),
@@ -174,7 +174,7 @@ mod tests {
         let program_ids = [
             solana_sdk::secp256k1_program::ID,
             solana_sdk::ed25519_program::ID,
-            solana_secp256r1_program::ID,
+            solana_sdk_ids::secp256r1_program::ID,
         ];
         let instructions = [
             make_instruction(&program_ids, 0, &[]),

--- a/runtime-transaction/src/signature_details.rs
+++ b/runtime-transaction/src/signature_details.rs
@@ -7,6 +7,7 @@ use {
 pub struct PrecompileSignatureDetails {
     pub num_secp256k1_instruction_signatures: u64,
     pub num_ed25519_instruction_signatures: u64,
+    pub num_secp256r1_instruction_signatures: u64,
 }
 
 /// Get transaction signature details.
@@ -20,6 +21,7 @@ pub fn get_precompile_signature_details<'a>(
     // is low enough that the sum of all signatures will not overflow a u64.
     let mut num_secp256k1_instruction_signatures: u64 = 0;
     let mut num_ed25519_instruction_signatures: u64 = 0;
+    let mut num_secp256r1_instruction_signatures: u64 = 0;
     for (program_id, instruction) in instructions {
         let program_id_index = instruction.program_id_index;
         match filter.is_signature(program_id_index, program_id) {
@@ -32,12 +34,17 @@ pub fn get_precompile_signature_details<'a>(
                 num_ed25519_instruction_signatures = num_ed25519_instruction_signatures
                     .wrapping_add(get_num_signatures_in_instruction(&instruction));
             }
+            ProgramIdStatus::Secp256r1 => {
+                num_secp256r1_instruction_signatures = num_secp256r1_instruction_signatures
+                    .wrapping_add(get_num_signatures_in_instruction(&instruction));
+            }
         }
     }
 
     PrecompileSignatureDetails {
         num_secp256k1_instruction_signatures,
         num_ed25519_instruction_signatures,
+        num_secp256r1_instruction_signatures,
     }
 }
 
@@ -51,6 +58,7 @@ enum ProgramIdStatus {
     NotSignature,
     Secp256k1,
     Ed25519,
+    Secp256r1,
 }
 
 struct SignatureDetailsFilter {
@@ -86,6 +94,8 @@ impl SignatureDetailsFilter {
             ProgramIdStatus::Secp256k1
         } else if program_id == &solana_sdk::ed25519_program::ID {
             ProgramIdStatus::Ed25519
+        } else if program_id == &solana_secp256r1_program::ID {
+            ProgramIdStatus::Secp256r1
         } else {
             ProgramIdStatus::NotSignature
         }
@@ -140,19 +150,23 @@ mod tests {
             Pubkey::new_unique(),
             solana_sdk::secp256k1_program::ID,
             solana_sdk::ed25519_program::ID,
+            solana_secp256r1_program::ID,
         ];
         let instructions = [
             make_instruction(&program_ids, 1, &[5]),
             make_instruction(&program_ids, 2, &[3]),
+            make_instruction(&program_ids, 3, &[4]),
             make_instruction(&program_ids, 0, &[]),
             make_instruction(&program_ids, 2, &[2]),
             make_instruction(&program_ids, 1, &[1]),
             make_instruction(&program_ids, 0, &[]),
+            make_instruction(&program_ids, 3, &[3]),
         ];
 
         let signature_details = get_precompile_signature_details(instructions.into_iter());
         assert_eq!(signature_details.num_secp256k1_instruction_signatures, 6);
         assert_eq!(signature_details.num_ed25519_instruction_signatures, 5);
+        assert_eq!(signature_details.num_secp256r1_instruction_signatures, 7);
     }
 
     #[test]
@@ -160,6 +174,7 @@ mod tests {
         let program_ids = [
             solana_sdk::secp256k1_program::ID,
             solana_sdk::ed25519_program::ID,
+            solana_secp256r1_program::ID,
         ];
         let instructions = [
             make_instruction(&program_ids, 0, &[]),
@@ -169,5 +184,6 @@ mod tests {
         let signature_details = get_precompile_signature_details(instructions.into_iter());
         assert_eq!(signature_details.num_secp256k1_instruction_signatures, 0);
         assert_eq!(signature_details.num_ed25519_instruction_signatures, 0);
+        assert_eq!(signature_details.num_secp256r1_instruction_signatures, 0);
     }
 }

--- a/sdk/message/Cargo.toml
+++ b/sdk/message/Cargo.toml
@@ -24,6 +24,7 @@ solana-logger = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
 solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }
+solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
 solana-short-vec = { workspace = true, optional = true }
 solana-system-interface = { workspace = true, optional = true, features = [
     "bincode",

--- a/sdk/message/Cargo.toml
+++ b/sdk/message/Cargo.toml
@@ -24,7 +24,6 @@ solana-logger = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
 solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }
-solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
 solana-short-vec = { workspace = true, optional = true }
 solana-system-interface = { workspace = true, optional = true, features = [
     "bincode",

--- a/sdk/message/src/sanitized.rs
+++ b/sdk/message/src/sanitized.rs
@@ -14,7 +14,7 @@ use {
     solana_instruction::{BorrowedAccountMeta, BorrowedInstruction},
     solana_pubkey::Pubkey,
     solana_sanitize::Sanitize,
-    solana_sdk_ids::{ed25519_program, secp256k1_program},
+    solana_sdk_ids::{ed25519_program, secp256k1_program, secp256r1_program},
     std::{borrow::Cow, collections::HashSet, convert::TryFrom},
 };
 
@@ -411,7 +411,7 @@ impl SanitizedMessage {
                             .num_ed25519_instruction_signatures
                             .saturating_add(u64::from(*num_verifies));
                 }
-            } else if solana_secp256r1_program::check_id(program_id) {
+            } else if secp256r1_program::check_id(program_id) {
                 if let Some(num_verifies) = instruction.data.first() {
                     transaction_signature_details.num_secp256r1_instruction_signatures =
                         transaction_signature_details

--- a/sdk/message/src/sanitized.rs
+++ b/sdk/message/src/sanitized.rs
@@ -411,6 +411,13 @@ impl SanitizedMessage {
                             .num_ed25519_instruction_signatures
                             .saturating_add(u64::from(*num_verifies));
                 }
+            } else if solana_secp256r1_program::check_id(program_id) {
+                if let Some(num_verifies) = instruction.data.first() {
+                    transaction_signature_details.num_secp256r1_instruction_signatures =
+                        transaction_signature_details
+                            .num_secp256r1_instruction_signatures
+                            .saturating_add(u64::from(*num_verifies));
+                }
             }
         }
 
@@ -425,6 +432,7 @@ pub struct TransactionSignatureDetails {
     num_transaction_signatures: u64,
     num_secp256k1_instruction_signatures: u64,
     num_ed25519_instruction_signatures: u64,
+    num_secp256r1_instruction_signatures: u64,
 }
 
 impl TransactionSignatureDetails {
@@ -432,11 +440,13 @@ impl TransactionSignatureDetails {
         num_transaction_signatures: u64,
         num_secp256k1_instruction_signatures: u64,
         num_ed25519_instruction_signatures: u64,
+        num_secp256r1_instruction_signatures: u64,
     ) -> Self {
         Self {
             num_transaction_signatures,
             num_secp256k1_instruction_signatures,
             num_ed25519_instruction_signatures,
+            num_secp256r1_instruction_signatures,
         }
     }
 
@@ -445,6 +455,7 @@ impl TransactionSignatureDetails {
         self.num_transaction_signatures
             .saturating_add(self.num_secp256k1_instruction_signatures)
             .saturating_add(self.num_ed25519_instruction_signatures)
+            .saturating_add(self.num_secp256r1_instruction_signatures)
     }
 
     /// return the number of transaction signatures
@@ -460,6 +471,11 @@ impl TransactionSignatureDetails {
     /// return the number of ed25519 instruction signatures
     pub fn num_ed25519_instruction_signatures(&self) -> u64 {
         self.num_ed25519_instruction_signatures
+    }
+
+    /// return the number of secp256k1 instruction signatures
+    pub fn num_secp256r1_instruction_signatures(&self) -> u64 {
+        self.num_secp256r1_instruction_signatures
     }
 }
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -78,7 +78,7 @@ name = "agave-transaction-view"
 version = "2.2.0"
 dependencies = [
  "solana-sdk",
- "solana-secp256r1-program",
+ "solana-sdk-ids",
  "solana-svm-transaction",
 ]
 
@@ -5783,7 +5783,6 @@ dependencies = [
  "solana-pubkey",
  "solana-sanitize",
  "solana-sdk-ids",
- "solana-secp256r1-program",
  "solana-short-vec",
  "solana-system-interface",
  "solana-transaction-error",
@@ -6500,7 +6499,7 @@ dependencies = [
  "solana-compute-budget",
  "solana-pubkey",
  "solana-sdk",
- "solana-secp256r1-program",
+ "solana-sdk-ids",
  "solana-svm-transaction",
  "thiserror 2.0.3",
 ]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -78,6 +78,7 @@ name = "agave-transaction-view"
 version = "2.2.0"
 dependencies = [
  "solana-sdk",
+ "solana-secp256r1-program",
  "solana-svm-transaction",
 ]
 
@@ -5782,6 +5783,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sanitize",
  "solana-sdk-ids",
+ "solana-secp256r1-program",
  "solana-short-vec",
  "solana-system-interface",
  "solana-transaction-error",
@@ -6498,6 +6500,7 @@ dependencies = [
  "solana-compute-budget",
  "solana-pubkey",
  "solana-sdk",
+ "solana-secp256r1-program",
  "solana-svm-transaction",
  "thiserror 2.0.3",
 ]

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 solana-sdk = { workspace = true }
+solana-secp256r1-program = { workspace = true }
 solana-svm-transaction = { workspace = true }
 
 [dev-dependencies]

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 solana-sdk = { workspace = true }
-solana-secp256r1-program = { workspace = true }
+solana-sdk-ids = { workspace = true }
 solana-svm-transaction = { workspace = true }
 
 [dev-dependencies]

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -17,6 +17,7 @@ use {
         secp256k1_program,
         signature::Signature,
     },
+    solana_sdk_ids::secp256r1_program,
     solana_svm_transaction::{
         instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
         svm_message::SVMMessage, svm_transaction::SVMTransaction,
@@ -177,7 +178,7 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
                     num_ed25519_instruction_signatures =
                         num_ed25519_instruction_signatures.wrapping_add(u64::from(*num_verifies));
                 }
-            } else if solana_secp256r1_program::check_id(program_id) {
+            } else if secp256r1_program::check_id(program_id) {
                 if let Some(num_verifies) = instruction.data.first() {
                     num_secp256r1_instruction_signatures =
                         num_secp256r1_instruction_signatures.wrapping_add(u64::from(*num_verifies));

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -165,6 +165,7 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
         // counting the number of pre-processor operations separately
         let mut num_secp256k1_instruction_signatures: u64 = 0;
         let mut num_ed25519_instruction_signatures: u64 = 0;
+        let mut num_secp256r1_instruction_signatures: u64 = 0;
         for (program_id, instruction) in self.program_instructions_iter() {
             if secp256k1_program::check_id(program_id) {
                 if let Some(num_verifies) = instruction.data.first() {
@@ -176,6 +177,11 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
                     num_ed25519_instruction_signatures =
                         num_ed25519_instruction_signatures.wrapping_add(u64::from(*num_verifies));
                 }
+            } else if solana_secp256r1_program::check_id(program_id) {
+                if let Some(num_verifies) = instruction.data.first() {
+                    num_secp256r1_instruction_signatures =
+                        num_secp256r1_instruction_signatures.wrapping_add(u64::from(*num_verifies));
+                }
             }
         }
 
@@ -183,6 +189,7 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
             u64::from(self.view.num_required_signatures()),
             num_secp256k1_instruction_signatures,
             num_ed25519_instruction_signatures,
+            num_secp256r1_instruction_signatures,
         )
     }
 }


### PR DESCRIPTION
#### Problem
The secp256r1 precompile (https://github.com/anza-xyz/agave/pull/3152) was added, but the logic in some of the crates in the monorepo such as `runtime-transaction` does not yet account for the new precompile.

#### Summary of Changes
Added a secp256r1 signatures field to the main types in the `runtime-transaction`.

The actual costs for the new precompile has to be added to the `cost-model` crate, but I will do it on a follow-up.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
