### PR TITLE
add bank hash to frozen slot update

### DIFF
--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -202,6 +202,7 @@ pub enum SlotUpdate {
         slot: Slot,
         timestamp: u64,
         stats: SlotTransactionStats,
+        hash: String,
     },
     Dead {
         slot: Slot,

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -333,6 +333,7 @@ impl OptimisticallyConfirmedBankTracker {
                             num_failed_transactions: bank.transaction_error_count(),
                             max_transactions_per_entry: bank.transactions_per_entry_max(),
                         },
+                        hash: bank.hash().to_string(),
                     });
 
                     Self::notify_slot_status(

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -333,7 +333,7 @@ impl OptimisticallyConfirmedBankTracker {
                             num_failed_transactions: bank.transaction_error_count(),
                             max_transactions_per_entry: bank.transactions_per_entry_max(),
                         },
-                        hash: bank.hash().to_string(),
+                        hash: bank.last_blockhash().to_string(),
                     });
 
                     Self::notify_slot_status(


### PR DESCRIPTION
#### Problem

There is no easy way to get bank hashes as fast as possible

#### Summary of Changes

Added bank hash for frozen slot update


