### PR TITLE
Ensure that hashing across account data and resize area works

### DIFF
--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -440,7 +440,7 @@ where
     Ok(T::default())
 }
 
-pub struct MemoryChunkIterator<'a> {
+struct MemoryChunkIterator<'a> {
     memory_mapping: &'a MemoryMapping<'a>,
     accounts: &'a [SerializedAccountMetadata],
     access_type: AccessType,
@@ -454,7 +454,7 @@ pub struct MemoryChunkIterator<'a> {
 }
 
 impl<'a> MemoryChunkIterator<'a> {
-    pub fn new(
+    fn new(
         memory_mapping: &'a MemoryMapping,
         accounts: &'a [SerializedAccountMetadata],
         access_type: AccessType,

--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -410,7 +410,7 @@ where
     Ok(T::default())
 }
 
-struct MemoryChunkIterator<'a> {
+pub struct MemoryChunkIterator<'a> {
     memory_mapping: &'a MemoryMapping<'a>,
     accounts: &'a [SerializedAccountMetadata],
     access_type: AccessType,
@@ -424,7 +424,7 @@ struct MemoryChunkIterator<'a> {
 }
 
 impl<'a> MemoryChunkIterator<'a> {
-    fn new(
+    pub fn new(
         memory_mapping: &'a MemoryMapping,
         accounts: &'a [SerializedAccountMetadata],
         access_type: AccessType,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -3,10 +3,7 @@ pub use self::{
     logging::{
         SyscallLog, SyscallLogBpfComputeUnits, SyscallLogData, SyscallLogPubkey, SyscallLogU64,
     },
-    mem_ops::{
-        iter_memory_chunks, MemoryChunkIterator, SyscallMemcmp, SyscallMemcpy, SyscallMemmove,
-        SyscallMemset,
-    },
+    mem_ops::{iter_memory_chunks, SyscallMemcmp, SyscallMemcpy, SyscallMemmove, SyscallMemset},
     sysvar::{
         SyscallGetClockSysvar, SyscallGetEpochRewardsSysvar, SyscallGetEpochScheduleSysvar,
         SyscallGetFeesSysvar, SyscallGetLastRestartSlotSysvar, SyscallGetRentSysvar,

--- a/programs/sbf/rust/account_mem/src/lib.rs
+++ b/programs/sbf/rust/account_mem/src/lib.rs
@@ -2,6 +2,7 @@
 
 use solana_program::{
     account_info::AccountInfo,
+    blake3,
     entrypoint::ProgramResult,
     program_error::ProgramError,
     program_memory::{sol_memcmp, sol_memcpy, sol_memmove, sol_memset},
@@ -109,6 +110,30 @@ pub fn process_instruction(
             unsafe { sol_memmove(too_early(3).as_mut_ptr(), buf.as_ptr(), 10) };
         }
 
+        20 => {
+            use solana_program::hash::{hashv, Hasher};
+
+            let mut hasher = Hasher::default();
+            hasher.hashv(&[data]);
+
+            assert_eq!(hashv(&[data]), hasher.result());
+        }
+
+        21 => {
+            use solana_program::keccak::{hashv, Hasher};
+
+            let mut hasher = Hasher::default();
+            hasher.hashv(&[data]);
+
+            assert_eq!(hashv(&[data]), hasher.result());
+        }
+
+        22 => {
+            use solana_program::blake3::hashv;
+
+            let hash = blake3::hash(data);
+            assert_eq!(hashv(&[data]).0, hash.to_bytes());
+        }
         _ => {}
     }
 

--- a/programs/sbf/rust/account_mem/src/lib.rs
+++ b/programs/sbf/rust/account_mem/src/lib.rs
@@ -124,7 +124,8 @@ pub fn process_instruction(
             use solana_program::keccak::{hashv, Hasher};
 
             let mut hasher = Hasher::default();
-            let data = unsafe { std::slice::from_raw_parts_mut(data_ptr, data_len + 11) };
+            let data =
+                unsafe { std::slice::from_raw_parts_mut(data_ptr, data_len.wrapping_add(11)) };
 
             hasher.hashv(&[data]);
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -5684,7 +5684,7 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
                 Some(&mint_pubkey),
             );
             let tx = Transaction::new(&[&mint_keypair], message.clone(), bank.last_blockhash());
-            let (result, _, _logs) = process_transaction_and_record_inner(&bank, tx);
+            let (result, _, _logs, _) = process_transaction_and_record_inner(&bank, tx);
 
             assert!(result.is_ok());
         }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -5662,5 +5662,25 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
                 assert!(!logs.last().unwrap().ends_with(" failed: InvalidLength"));
             }
         }
+
+        // now test the hashing functions
+
+        for instr in 20..=22 {
+            println!("Testing direct_mapping:{direct_mapping} instruction:{instr}");
+            let instruction =
+                Instruction::new_with_bytes(program_id, &[instr], account_metas.clone());
+
+            let message = Message::new(
+                &[
+                    instruction,
+                    ComputeBudgetInstruction::set_compute_unit_limit(1_000_000_000),
+                ],
+                Some(&mint_pubkey),
+            );
+            let tx = Transaction::new(&[&mint_keypair], message.clone(), bank.last_blockhash());
+            let (result, _, _logs) = process_transaction_and_record_inner(&bank, tx);
+
+            assert!(result.is_ok());
+        }
     }
 }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -5646,12 +5646,18 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
         let account = AccountSharedData::new(42, 1024, &program_id);
         bank.store_account(&account_keypair.pubkey(), &account);
 
-        for instr in 0..=13 {
+        for instr in 0..=16 {
             println!("Testing direct_mapping:{direct_mapping} instruction:{instr}");
             let instruction =
                 Instruction::new_with_bytes(program_id, &[instr], account_metas.clone());
 
-            let message = Message::new(&[instruction], Some(&mint_pubkey));
+            let message = Message::new(
+                &[
+                    instruction,
+                    ComputeBudgetInstruction::set_compute_unit_limit(1_000_000_000),
+                ],
+                Some(&mint_pubkey),
+            );
             let tx = Transaction::new(&[&mint_keypair], message.clone(), bank.last_blockhash());
             let (result, _, logs, _) = process_transaction_and_record_inner(&bank, tx);
 

--- a/sdk/feature-set/src/lib.rs
+++ b/sdk/feature-set/src/lib.rs
@@ -617,7 +617,7 @@ pub mod apply_cost_tracker_during_replay {
     solana_pubkey::declare_id!("B7H2caeia4ZFcpE3QcgMqbiWiBtWrdBRBSJ1DY6Ktxbq");
 }
 pub mod bpf_account_data_direct_mapping {
-    solana_pubkey::declare_id!("EenyoWx9UMXYKpR8mW5Jmfmy2fRjzUtM7NduYMY8bx33");
+    solana_pubkey::declare_id!("GJVDwRkUPNdk9QaK4VsU4g1N41QNxhy1hevjf8kz45Mq");
 }
 
 pub mod add_set_tx_loaded_accounts_data_size_instruction {


### PR DESCRIPTION
#### Problem

The account data consists of two areas: the orignal account data and the resize area, for when the account size is increased. Hashing across these two regions does not work, since they are distinct regions.

This change is required for direct mapping.

See [stricter VM verfication SIMD](https://github.com/Lichtso/solana-improvement-documents/blob/stricter-vm-verification-constraints/proposals/0185-stricter-vm-verification.md)

