### PR TITLE
Use tpu client next in validator with receiver

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1024,7 +1024,7 @@ impl Validator {
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
 
         // ConnectionCache might be used for JsonRpc and for Forwarding. Since
-        // the later is not migrated yet to the tpu-client-next, create
+        // the latter is not migrated yet to the tpu-client-next, create
         // ConnectionCache regardless of config.use_tpu_client_next for now.
         let connection_cache = if use_quic {
             let connection_cache = ConnectionCache::new_with_client_options(
@@ -1635,10 +1635,9 @@ impl Validator {
         *start_progress.write().unwrap() = ValidatorStartProgress::Running;
         if let Some(client_updater) = client_updater {
             key_notifies.push(client_updater);
-        } else {
-            // add connection_cache because it is still used in Forwarder.
-            key_notifies.push(connection_cache);
         }
+        // add connection_cache because it is still used in Forwarder.
+        key_notifies.push(connection_cache);
 
         *admin_rpc_service_post_init.write().unwrap() = Some(AdminRpcRequestMetadataPostInit {
             bank_forks: bank_forks.clone(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -154,17 +154,12 @@ use {
     tokio::runtime::{self, Runtime as TokioRuntime},
 };
 
-static GLOBAL_RUNTIME: LazyLock<TokioRuntime> = LazyLock::new(|| {
+static STS_CLIENT_RUNTIME: LazyLock<TokioRuntime> = LazyLock::new(|| {
     runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .expect("Failed to create Tokio runtime")
 });
-
-// Function to get a handle to the runtime
-fn get_runtime_handle() -> tokio::runtime::Handle {
-    GLOBAL_RUNTIME.handle().clone()
-}
 
 const MAX_COMPLETED_DATA_SETS_IN_CHANNEL: usize = 100_000;
 const WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT: u64 = 80;
@@ -1116,7 +1111,7 @@ impl Validator {
                     .map_err(|err| ValidatorError::Other(format!("{err}")))?;
 
                 let client = TpuClientNextClient::new(
-                    get_runtime_handle(),
+                    STS_CLIENT_RUNTIME.handle().clone(),
                     my_tpu_address,
                     config.send_transaction_service_config.tpu_peers.clone(),
                     Some(leader_info),

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -73,6 +73,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         replay_transactions_threads: config.replay_transactions_threads,
         tvu_shred_sigverify_threads: config.tvu_shred_sigverify_threads,
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
+        use_tpu_client_next: config.use_tpu_client_next,
     }
 }
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -71,6 +71,7 @@ solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime-transaction = { workspace = true, features = [
     "dev-context-only-utils",
 ] }
+solana-send-transaction-service = { workspace = true, features = ["dev-context-only-utils"] }
 solana-stake-program = { workspace = true }
 spl-pod = { workspace = true }
 symlink = { workspace = true }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 pub mod cache_block_meta_service;
-mod cluster_tpu_info;
+pub mod cluster_tpu_info;
 pub mod filter;
 pub mod max_slots;
 pub mod optimistically_confirmed_bank_tracker;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -379,6 +379,10 @@ impl JsonRpcRequestProcessor {
         let (transaction_sender, transaction_receiver) = unbounded();
 
         let client = Client::create_client(runtime, my_tpu_address, None, 1);
+        assert!(
+            client.protocol() == Protocol::QUIC,
+            "UDP is not supported by this test."
+        );
         SendTransactionService::new(
             &bank_forks,
             transaction_receiver,
@@ -6528,6 +6532,10 @@ pub mod tests {
             Arc::new(PrioritizationFeeCache::default()),
         );
         let client = C::create_client(maybe_runtime, my_tpu_address, None, 1);
+        assert!(
+            client.protocol() == Protocol::QUIC,
+            "UDP is not supported by this test."
+        );
         SendTransactionService::new(&bank_forks, receiver, client, 1000, exit.clone());
 
         let mut bad_transaction = system_transaction::transfer(
@@ -6799,6 +6807,10 @@ pub mod tests {
             Arc::new(PrioritizationFeeCache::default()),
         );
         let client = C::create_client(maybe_runtime, my_tpu_address, None, 1);
+        assert!(
+            client.protocol() == Protocol::QUIC,
+            "UDP is not supported by this test."
+        );
         SendTransactionService::new(&bank_forks, receiver, client, 1000, exit);
 
         assert_eq!(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -115,15 +115,14 @@ use {
 };
 #[cfg(test)]
 use {
-    solana_client::connection_cache::ConnectionCache,
     solana_gossip::contact_info::ContactInfo,
     solana_ledger::get_tmp_ledger_path,
     solana_runtime::commitment::CommitmentSlots,
     solana_send_transaction_service::{
-        send_transaction_service::SendTransactionService, tpu_info::NullTpuInfo,
-        transaction_client::ConnectionCacheClient,
+        send_transaction_service::SendTransactionService, test_utils::ClientWithCreator,
     },
     solana_streamer::socket::SocketAddrSpace,
+    tokio::runtime::Handle,
 };
 
 pub mod account_resolver;
@@ -357,10 +356,10 @@ impl JsonRpcRequestProcessor {
     }
 
     #[cfg(test)]
-    pub fn new_from_bank(
+    pub fn new_from_bank<Client: ClientWithCreator>(
+        runtime: Option<Handle>,
         bank: Bank,
         socket_addr_space: SocketAddrSpace,
-        connection_cache: Arc<ConnectionCache>,
     ) -> Self {
         let genesis_hash = bank.hash();
         let bank_forks = BankForks::new_rw_arc(bank);
@@ -375,19 +374,11 @@ impl JsonRpcRequestProcessor {
             );
             ClusterInfo::new(contact_info, keypair, socket_addr_space)
         });
-        let tpu_address = cluster_info
-            .my_contact_info()
-            .tpu(connection_cache.protocol())
-            .unwrap();
+
+        let my_tpu_address = cluster_info.my_contact_info().tpu(Protocol::QUIC).unwrap();
         let (transaction_sender, transaction_receiver) = unbounded();
 
-        let client = ConnectionCacheClient::<NullTpuInfo>::new(
-            connection_cache.clone(),
-            tpu_address,
-            None,
-            None,
-            1,
-        );
+        let client = Client::create_client(runtime, my_tpu_address, None, 1);
         SendTransactionService::new(
             &bank_forks,
             transaction_receiver,
@@ -4391,7 +4382,8 @@ pub mod tests {
             vote::state::VoteState,
         },
         solana_send_transaction_service::{
-            tpu_info::NullTpuInfo, transaction_client::ConnectionCacheClient,
+            tpu_info::NullTpuInfo,
+            transaction_client::{ConnectionCacheClient, TpuClientNextClient},
         },
         solana_transaction_status::{
             EncodedConfirmedBlock, EncodedTransaction, EncodedTransactionWithStatusMeta,
@@ -4412,6 +4404,7 @@ pub mod tests {
             state::{AccountState as TokenAccountState, Mint},
         },
         std::{borrow::Cow, collections::HashMap, net::Ipv4Addr},
+        tokio::runtime::Handle,
     };
 
     const TEST_MINT_LAMPORTS: u64 = 1_000_000_000;
@@ -4772,16 +4765,14 @@ pub mod tests {
         }
     }
 
-    #[test]
-    fn test_rpc_request_processor_new() {
+    fn rpc_request_processor_new<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
         let bob_pubkey = solana_sdk::pubkey::new_rand();
         let genesis = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let meta = JsonRpcRequestProcessor::new_from_bank(
+        let meta = JsonRpcRequestProcessor::new_from_bank::<C>(
+            maybe_runtime,
             bank,
             SocketAddrSpace::Unspecified,
-            connection_cache,
         );
 
         let bank = meta.bank_forks.read().unwrap().root_bank();
@@ -4796,15 +4787,23 @@ pub mod tests {
     }
 
     #[test]
-    fn test_rpc_get_balance() {
+    fn test_rpc_request_processor_new_connection_cache() {
+        rpc_request_processor_new::<ConnectionCacheClient<NullTpuInfo>>(None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_rpc_request_processor_new_tpu_client_next() {
+        rpc_request_processor_new::<TpuClientNextClient<NullTpuInfo>>(Some(Handle::current()));
+    }
+
+    fn rpc_get_balance<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
         let genesis = create_genesis_config(20);
         let mint_pubkey = genesis.mint_keypair.pubkey();
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let meta = JsonRpcRequestProcessor::new_from_bank(
+        let meta = JsonRpcRequestProcessor::new_from_bank::<C>(
+            maybe_runtime,
             bank,
             SocketAddrSpace::Unspecified,
-            connection_cache,
         );
 
         let mut io = MetaIoHandler::default();
@@ -4828,15 +4827,23 @@ pub mod tests {
     }
 
     #[test]
-    fn test_rpc_get_balance_via_client() {
+    fn test_rpc_get_balance_new_connection_cache() {
+        rpc_get_balance::<ConnectionCacheClient<NullTpuInfo>>(None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_rpc_get_balance_new_tpu_client_next() {
+        rpc_get_balance::<TpuClientNextClient<NullTpuInfo>>(Some(Handle::current()));
+    }
+
+    fn rpc_get_balance_via_client<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
         let genesis = create_genesis_config(20);
         let mint_pubkey = genesis.mint_keypair.pubkey();
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let meta = JsonRpcRequestProcessor::new_from_bank(
+        let meta = JsonRpcRequestProcessor::new_from_bank::<C>(
+            maybe_runtime,
             bank,
             SocketAddrSpace::Unspecified,
-            connection_cache,
         );
 
         let mut io = MetaIoHandler::default();
@@ -4859,6 +4866,16 @@ pub mod tests {
         };
         let (response, _) = futures::executor::block_on(fut);
         assert_eq!(response, 20);
+    }
+
+    #[test]
+    fn test_rpc_get_balance_via_client_connection_cache() {
+        rpc_get_balance_via_client::<ConnectionCacheClient<NullTpuInfo>>(None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_rpc_get_balance_via_client_tpu_client_next() {
+        rpc_get_balance_via_client::<TpuClientNextClient<NullTpuInfo>>(Some(Handle::current()));
     }
 
     #[test]
@@ -4955,16 +4972,14 @@ pub mod tests {
         assert_eq!(result, expected);
     }
 
-    #[test]
-    fn test_rpc_get_tx_count() {
+    fn rpc_get_tx_count<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
         let bob_pubkey = solana_sdk::pubkey::new_rand();
         let genesis = create_genesis_config(10);
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let meta = JsonRpcRequestProcessor::new_from_bank(
+        let meta = JsonRpcRequestProcessor::new_from_bank::<C>(
+            maybe_runtime,
             bank,
             SocketAddrSpace::Unspecified,
-            connection_cache,
         );
 
         let mut io = MetaIoHandler::default();
@@ -4989,6 +5004,17 @@ pub mod tests {
         let result: Response = serde_json::from_str(&res.expect("actual response"))
             .expect("actual response deserialization");
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_rpc_get_tx_count_connection_cache() {
+        rpc_get_tx_count::<ConnectionCacheClient<NullTpuInfo>>(None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+
+    async fn test_rpc_get_tx_count_tpu_client_next() {
+        rpc_get_tx_count::<TpuClientNextClient<NullTpuInfo>>(Some(Handle::current()));
     }
 
     #[test]
@@ -6426,15 +6452,13 @@ pub mod tests {
         assert_eq!(result, expected);
     }
 
-    #[test]
-    fn test_rpc_send_bad_tx() {
+    fn rpc_send_bad_tx<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
         let genesis = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let meta = JsonRpcRequestProcessor::new_from_bank(
+        let meta = JsonRpcRequestProcessor::new_from_bank::<C>(
+            maybe_runtime,
             bank,
             SocketAddrSpace::Unspecified,
-            connection_cache,
         );
 
         let mut io = MetaIoHandler::default();
@@ -6448,7 +6472,16 @@ pub mod tests {
     }
 
     #[test]
-    fn test_rpc_send_transaction_preflight() {
+    fn test_rpc_send_bad_tx_connection_cache() {
+        rpc_send_bad_tx::<ConnectionCacheClient<NullTpuInfo>>(None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_rpc_send_bad_tx_tpu_client_next() {
+        rpc_send_bad_tx::<TpuClientNextClient<NullTpuInfo>>(Some(Handle::current()));
+    }
+
+    fn rpc_send_transaction_preflight<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
         let exit = Arc::new(AtomicBool::new(false));
         let validator_exit = create_validator_exit(exit.clone());
         let ledger_path = get_tmp_ledger_path!();
@@ -6474,11 +6507,7 @@ pub mod tests {
             );
             ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
         });
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let tpu_address = cluster_info
-            .my_contact_info()
-            .tpu(connection_cache.protocol())
-            .unwrap();
+        let my_tpu_address = cluster_info.my_contact_info().tpu(Protocol::QUIC).unwrap();
         let (meta, receiver) = JsonRpcRequestProcessor::new(
             JsonRpcConfig::default(),
             None,
@@ -6498,13 +6527,7 @@ pub mod tests {
             Arc::new(AtomicU64::default()),
             Arc::new(PrioritizationFeeCache::default()),
         );
-        let client = ConnectionCacheClient::<NullTpuInfo>::new(
-            connection_cache.clone(),
-            tpu_address,
-            None,
-            None,
-            1,
-        );
+        let client = C::create_client(maybe_runtime, my_tpu_address, None, 1);
         SendTransactionService::new(&bank_forks, receiver, client, 1000, exit.clone());
 
         let mut bad_transaction = system_transaction::transfer(
@@ -6606,6 +6629,16 @@ pub mod tests {
                 r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"invalid transaction: Transaction failed to sanitize accounts offsets correctly"},"id":1}"#.to_string(),
             )
         );
+    }
+
+    #[test]
+    fn test_rpc_send_transaction_preflight_with_connection_cache() {
+        rpc_send_transaction_preflight::<ConnectionCacheClient<NullTpuInfo>>(None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_rpc_send_transaction_preflight_with_tpu_client_next() {
+        rpc_send_transaction_preflight::<TpuClientNextClient<NullTpuInfo>>(Some(Handle::current()));
     }
 
     #[test]
@@ -6720,8 +6753,7 @@ pub mod tests {
         assert_eq!(result, expected);
     }
 
-    #[test]
-    fn test_rpc_processor_get_block_commitment() {
+    fn rpc_processor_get_block_commitment<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
         let exit = Arc::new(AtomicBool::new(false));
         let validator_exit = create_validator_exit(exit.clone());
         let bank_forks = new_bank_forks().0;
@@ -6744,11 +6776,7 @@ pub mod tests {
         )));
 
         let cluster_info = Arc::new(new_test_cluster_info());
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let tpu_address = cluster_info
-            .my_contact_info()
-            .tpu(connection_cache.protocol())
-            .unwrap();
+        let my_tpu_address = cluster_info.my_contact_info().tpu(Protocol::QUIC).unwrap();
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let (request_processor, receiver) = JsonRpcRequestProcessor::new(
@@ -6770,14 +6798,8 @@ pub mod tests {
             Arc::new(AtomicU64::default()),
             Arc::new(PrioritizationFeeCache::default()),
         );
-        let client = ConnectionCacheClient::<NullTpuInfo>::new(
-            connection_cache.clone(),
-            tpu_address,
-            None,
-            None,
-            1,
-        );
-        SendTransactionService::new(&bank_forks, receiver, client, 1000, exit.clone());
+        let client = C::create_client(maybe_runtime, my_tpu_address, None, 1);
+        SendTransactionService::new(&bank_forks, receiver, client, 1000, exit);
 
         assert_eq!(
             request_processor.get_block_commitment(0),
@@ -6800,6 +6822,18 @@ pub mod tests {
                 total_stake: 42,
             }
         );
+    }
+
+    #[test]
+    fn test_rpc_processor_get_block_commitment_with_connection_cache() {
+        rpc_processor_get_block_commitment::<ConnectionCacheClient<NullTpuInfo>>(None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_rpc_processor_get_block_commitment_with_tpu_client_next() {
+        rpc_processor_get_block_commitment::<TpuClientNextClient<NullTpuInfo>>(Some(
+            Handle::current(),
+        ));
     }
 
     #[test]

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5016,7 +5016,6 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-
     async fn test_rpc_get_tx_count_tpu_client_next() {
         rpc_get_tx_count::<TpuClientNextClient<NullTpuInfo>>(Some(Handle::current()));
     }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -2,7 +2,6 @@
 
 use {
     crate::{
-        cluster_tpu_info::ClusterTpuInfo,
         max_slots::MaxSlots,
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
         rpc::{rpc_accounts::*, rpc_accounts_scan::*, rpc_bank::*, rpc_full::*, rpc_minimal::*, *},
@@ -16,7 +15,6 @@ use {
         RequestMiddlewareAction, ServerBuilder,
     },
     regex::Regex,
-    solana_client::connection_cache::ConnectionCache,
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
         bigtable_upload::ConfirmedBlockUploadConfig,
@@ -25,7 +23,6 @@ use {
     },
     solana_metrics::inc_new_counter_info,
     solana_perf::thread::renice_this_thread,
-    solana_poh::poh_recorder::PohRecorder,
     solana_runtime::{
         bank_forks::BankForks, commitment::BlockCommitmentCache,
         prioritization_fee_cache::PrioritizationFeeCache,
@@ -38,7 +35,7 @@ use {
     },
     solana_send_transaction_service::{
         send_transaction_service::{self, SendTransactionService},
-        transaction_client::ConnectionCacheClient,
+        transaction_client::TransactionClient,
     },
     solana_storage_bigtable::CredentialType,
     std::{
@@ -335,7 +332,7 @@ fn process_rest(bank_forks: &Arc<RwLock<BankForks>>, path: &str) -> Option<Strin
 
 impl JsonRpcService {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new<Client: TransactionClient + Clone + std::marker::Send + 'static>(
         rpc_addr: SocketAddr,
         config: JsonRpcConfig,
         snapshot_config: Option<SnapshotConfig>,
@@ -343,7 +340,6 @@ impl JsonRpcService {
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
         blockstore: Arc<Blockstore>,
         cluster_info: Arc<ClusterInfo>,
-        poh_recorder: Option<Arc<RwLock<PohRecorder>>>,
         genesis_hash: Hash,
         ledger_path: &Path,
         validator_exit: Arc<RwLock<Exit>>,
@@ -354,7 +350,7 @@ impl JsonRpcService {
         send_transaction_service_config: send_transaction_service::Config,
         max_slots: Arc<MaxSlots>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
-        connection_cache: Arc<ConnectionCache>,
+        client: Client,
         max_complete_transaction_status_slot: Arc<AtomicU64>,
         max_complete_rewards_slot: Arc<AtomicU64>,
         prioritization_fee_cache: Arc<PrioritizationFeeCache>,
@@ -375,11 +371,6 @@ impl JsonRpcService {
         let largest_accounts_cache = Arc::new(RwLock::new(LargestAccountsCache::new(
             LARGEST_ACCOUNTS_CACHE_DURATION,
         )));
-
-        let tpu_address = cluster_info
-            .my_contact_info()
-            .tpu(connection_cache.protocol())
-            .map_err(|err| format!("{err}"))?;
 
         // sadly, some parts of our current rpc implemention block the jsonrpc's
         // _socket-listening_ event loop for too long, due to (blocking) long IO or intesive CPU,
@@ -475,15 +466,6 @@ impl JsonRpcService {
             prioritization_fee_cache,
         );
 
-        let leader_info =
-            poh_recorder.map(|recorder| ClusterTpuInfo::new(cluster_info.clone(), recorder));
-        let client = ConnectionCacheClient::new(
-            connection_cache,
-            tpu_address,
-            send_transaction_service_config.tpu_peers.clone(),
-            leader_info,
-            send_transaction_service_config.leader_forward_count,
-        );
         let _send_transaction_service = SendTransactionService::new_with_config(
             &bank_forks,
             receiver,
@@ -591,6 +573,7 @@ mod tests {
     use {
         super::*,
         crate::rpc::{create_validator_exit, tests::new_test_cluster_info},
+        solana_client::connection_cache::Protocol,
         solana_ledger::{
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
             get_tmp_ledger_path_auto_delete,
@@ -601,15 +584,20 @@ mod tests {
             genesis_config::{ClusterType, DEFAULT_GENESIS_ARCHIVE},
             signature::Signer,
         },
+        solana_send_transaction_service::{
+            send_transaction_service::{self},
+            test_utils::ClientWithCreator,
+            tpu_info::NullTpuInfo,
+            transaction_client::{ConnectionCacheClient, TpuClientNextClient},
+        },
         std::{
             io::Write,
             net::{IpAddr, Ipv4Addr},
         },
-        tokio::runtime::Runtime,
+        tokio::runtime::{Handle, Runtime},
     };
 
-    #[test]
-    fn test_rpc_new() {
+    fn rpc_new<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -630,7 +618,20 @@ mod tests {
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
+
+        let send_transaction_service_config = send_transaction_service::Config {
+            retry_rate_ms: 1000,
+            leader_forward_count: 1,
+            ..send_transaction_service::Config::default()
+        };
+
+        let my_tpu_address = cluster_info.my_contact_info().tpu(Protocol::QUIC).unwrap();
+        let client = C::create_client(
+            maybe_runtime,
+            my_tpu_address,
+            send_transaction_service_config.tpu_peers.clone(),
+            send_transaction_service_config.leader_forward_count,
+        );
         let mut rpc_service = JsonRpcService::new(
             rpc_addr,
             JsonRpcConfig::default(),
@@ -639,7 +640,6 @@ mod tests {
             block_commitment_cache,
             blockstore,
             cluster_info,
-            None,
             Hash::default(),
             &PathBuf::from("farf"),
             validator_exit,
@@ -647,14 +647,10 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
             Arc::new(AtomicBool::new(true)),
             optimistically_confirmed_bank,
-            send_transaction_service::Config {
-                retry_rate_ms: 1000,
-                leader_forward_count: 1,
-                ..send_transaction_service::Config::default()
-            },
+            send_transaction_service_config,
             Arc::new(MaxSlots::default()),
             Arc::new(LeaderScheduleCache::default()),
-            connection_cache,
+            client,
             Arc::new(AtomicU64::default()),
             Arc::new(AtomicU64::default()),
             Arc::new(PrioritizationFeeCache::default()),
@@ -673,6 +669,16 @@ mod tests {
         );
         rpc_service.exit();
         rpc_service.join().unwrap();
+    }
+
+    #[test]
+    fn test_rpc_new_with_connection_cache() {
+        rpc_new::<ConnectionCacheClient<NullTpuInfo>>(None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_rpc_new_with_tpu_client_next() {
+        rpc_new::<TpuClientNextClient<NullTpuInfo>>(Some(Handle::current()));
     }
 
     fn create_bank_forks() -> Arc<RwLock<BankForks>> {

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -302,8 +302,9 @@ where
             let Ok(mut lock) = handle.lock() else {
                 return Err("TpuClientNext task panicked.".into());
             };
-            lock.1.cancel();
-            lock.0.take() // Take the `join_handle` out of the critical section
+            let (handle, token) = std::mem::take(&mut *lock);
+            token.cancel();
+            handle
         };
 
         if let Some(join_handle) = join_handle {

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1350,7 +1350,7 @@ mod tests {
     }
 
     impl TestValidatorWithAdminRpc {
-        fn new() -> Self {
+        fn new(use_tpu_client_next: bool) -> Self {
             let leader_keypair = Keypair::new();
             let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
 
@@ -1369,6 +1369,7 @@ mod tests {
                     validator_node.info.rpc().unwrap(),
                     validator_node.info.rpc_pubsub().unwrap(),
                 )),
+                use_tpu_client_next,
                 ..ValidatorConfig::default_for_test()
             };
             let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
@@ -1433,9 +1434,8 @@ mod tests {
     }
 
     // This test checks that `set_identity` call works with working validator and client.
-    #[test]
-    fn test_set_identity_with_validator() {
-        let test_validator = TestValidatorWithAdminRpc::new();
+    fn set_identity_with_validator(use_tpu_client_next: bool) {
+        let test_validator = TestValidatorWithAdminRpc::new(use_tpu_client_next);
         let expected_validator_id = Keypair::new();
         let validator_id_bytes = format!("{:?}", expected_validator_id.to_bytes());
 
@@ -1477,5 +1477,15 @@ mod tests {
             serde_json::from_str(&exit_response.expect("actual response"))
                 .expect("actual response deserialization");
         assert_eq!(actual_parsed_response, expected_parsed_response);
+    }
+
+    #[test]
+    fn test_set_identity_with_validator_connection_cache() {
+        set_identity_with_validator(false);
+    }
+
+    #[test]
+    fn test_set_identity_with_validator_tpu_client_next() {
+        set_identity_with_validator(true);
     }
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1580,6 +1580,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 ),
         )
         .arg(
+            Arg::with_name("use_tpu_client_next")
+                .long("use-tpu-client-next")
+                .takes_value(false)
+                .help(
+                    "Use tpu-client-next crate to send transactions over TPU ports. If not set,\
+                    ConnectionCache is used instead."
+                ),
+        )
+        .arg(
             Arg::with_name("block_verification_method")
                 .long("block-verification-method")
                 .value_name("METHOD")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1604,6 +1604,7 @@ pub fn main() {
         tvu_shred_sigverify_threads: tvu_sigverify_threads,
         delay_leader_block_for_pending_fork: matches
             .is_present("delay_leader_block_for_pending_fork"),
+        use_tpu_client_next: matches.is_present("use_tpu_client_next"),
         wen_restart_proto_path: value_t!(matches, "wen_restart", PathBuf).ok(),
         wen_restart_coordinator: value_t!(matches, "wen_restart_coordinator", Pubkey).ok(),
         ..ValidatorConfig::default()


### PR DESCRIPTION
#### Problem

* add flag to validator to use tpu-client-next,
* add tests on rpc side to work with both ConnectionCache and tpu-client-next
* all the plumbing to select client on the validator side

#### Summary of Changes

