### PR TITLE
extract epoch-rewards-hasher crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6953,6 +6953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-epoch-rewards-hasher"
+version = "2.2.0"
+dependencies = [
+ "siphasher",
+ "solana-hash",
+ "solana-pubkey",
+]
+
+[[package]]
 name = "solana-epoch-schedule"
 version = "2.2.0"
 dependencies = [
@@ -8514,7 +8523,6 @@ dependencies = [
  "serde_with",
  "sha2 0.10.8",
  "sha3",
- "siphasher",
  "solana-account",
  "solana-bn254",
  "solana-cluster-type",
@@ -8524,6 +8532,7 @@ dependencies = [
  "solana-derivation-path",
  "solana-ed25519-program",
  "solana-epoch-info",
+ "solana-epoch-rewards-hasher",
  "solana-feature-set",
  "solana-fee-structure",
  "solana-frozen-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ members = [
     "sdk/ed25519-program",
     "sdk/epoch-info",
     "sdk/epoch-rewards",
+    "sdk/epoch-rewards-hasher",
     "sdk/epoch-schedule",
     "sdk/feature-set",
     "sdk/fee-calculator",
@@ -465,6 +466,7 @@ solana-entry = { path = "entry", version = "=2.2.0" }
 solana-program-entrypoint = { path = "sdk/program-entrypoint", version = "=2.2.0" }
 solana-epoch-info = { path = "sdk/epoch-info", version = "=2.2.0" }
 solana-epoch-rewards = { path = "sdk/epoch-rewards", version = "=2.2.0" }
+solana-epoch-rewards-hasher = { path = "sdk/epoch-rewards-hasher", version = "=2.2.0" }
 solana-epoch-schedule = { path = "sdk/epoch-schedule", version = "=2.2.0" }
 solana-faucet = { path = "faucet", version = "=2.2.0" }
 solana-feature-set = { path = "sdk/feature-set", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5572,6 +5572,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-epoch-rewards-hasher"
+version = "2.2.0"
+dependencies = [
+ "siphasher",
+ "solana-hash",
+ "solana-pubkey",
+]
+
+[[package]]
 name = "solana-epoch-schedule"
 version = "2.2.0"
 dependencies = [
@@ -7216,7 +7225,6 @@ dependencies = [
  "serde_with",
  "sha2 0.10.8",
  "sha3",
- "siphasher",
  "solana-account",
  "solana-bn254",
  "solana-cluster-type",
@@ -7226,6 +7234,7 @@ dependencies = [
  "solana-derivation-path",
  "solana-ed25519-program",
  "solana-epoch-info",
+ "solana-epoch-rewards-hasher",
  "solana-feature-set",
  "solana-fee-structure",
  "solana-inflation",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -112,7 +112,6 @@ serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, features = ["macros"] }
 sha2 = { workspace = true }
 sha3 = { workspace = true, optional = true }
-siphasher = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-bn254 = { workspace = true }
 solana-cluster-type = { workspace = true, features = [
@@ -128,6 +127,7 @@ solana-decode-error = { workspace = true }
 solana-derivation-path = { workspace = true }
 solana-ed25519-program = { workspace = true, optional = true }
 solana-epoch-info = { workspace = true, features = ["serde"] }
+solana-epoch-rewards-hasher = { workspace = true }
 solana-feature-set = { workspace = true }
 solana-fee-structure = { workspace = true, features = ["serde"] }
 solana-frozen-abi = { workspace = true, optional = true, features = [

--- a/sdk/epoch-rewards-hasher/Cargo.toml
+++ b/sdk/epoch-rewards-hasher/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "solana-epoch-rewards-hasher"
+description = "Solana epoch rewards hasher."
+documentation = "https://docs.rs/solana-epoch-rewards-hasher"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+siphasher = { workspace = true }
+solana-hash = { workspace = true }
+solana-pubkey = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/sdk/epoch-rewards-hasher/src/lib.rs
+++ b/sdk/epoch-rewards-hasher/src/lib.rs
@@ -1,8 +1,4 @@
-use {
-    siphasher::sip::SipHasher13,
-    solana_sdk::{hash::Hash, pubkey::Pubkey},
-    std::hash::Hasher,
-};
+use {siphasher::sip::SipHasher13, solana_hash::Hash, solana_pubkey::Pubkey, std::hash::Hasher};
 
 #[derive(Debug, Clone)]
 pub struct EpochRewardsHasher {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -64,7 +64,6 @@ pub use solana_signer::signers;
 pub mod client;
 pub mod entrypoint;
 pub mod entrypoint_deprecated;
-pub mod epoch_rewards_hasher;
 pub mod example_mocks;
 pub mod exit;
 pub mod feature;
@@ -123,6 +122,11 @@ pub use solana_derivation_path as derivation_path;
 pub use solana_ed25519_program as ed25519_instruction;
 #[deprecated(since = "2.2.0", note = "Use `solana-epoch-info` crate instead")]
 pub use solana_epoch_info as epoch_info;
+#[deprecated(
+    since = "2.2.0",
+    note = "Use `solana-epoch-rewards-hasher` crate instead"
+)]
+pub use solana_epoch_rewards_hasher as epoch_rewards_hasher;
 #[deprecated(since = "2.1.0", note = "Use `solana-feature-set` crate instead")]
 pub use solana_feature_set as feature_set;
 #[deprecated(since = "2.2.0", note = "Use `solana-fee-structure` crate instead")]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5413,6 +5413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-epoch-rewards-hasher"
+version = "2.2.0"
+dependencies = [
+ "siphasher",
+ "solana-hash",
+ "solana-pubkey",
+]
+
+[[package]]
 name = "solana-epoch-schedule"
 version = "2.2.0"
 dependencies = [
@@ -6544,7 +6553,6 @@ dependencies = [
  "serde_with",
  "sha2 0.10.8",
  "sha3",
- "siphasher",
  "solana-account",
  "solana-bn254",
  "solana-cluster-type",
@@ -6554,6 +6562,7 @@ dependencies = [
  "solana-derivation-path",
  "solana-ed25519-program",
  "solana-epoch-info",
+ "solana-epoch-rewards-hasher",
  "solana-feature-set",
  "solana-fee-structure",
  "solana-inflation",


### PR DESCRIPTION
#### Problem
`solana_sdk::epoch_rewards_hasher` imposes a `solana_sdk` dep on `solana_runtime`

#### Summary of Changes
Move to its own crate and re-export with deprecation
