### PR TITLE
sdk: Add wasm target for docs

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -198,7 +198,9 @@ static_assertions = { workspace = true }
 tiny-bip39 = { workspace = true }
 
 [package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/sdk/hash/Cargo.toml
+++ b/sdk/hash/Cargo.toml
@@ -10,7 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 

--- a/sdk/instruction/Cargo.toml
+++ b/sdk/instruction/Cargo.toml
@@ -48,7 +48,7 @@ serde = [
 std = []
 
 [package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 

--- a/sdk/keypair/Cargo.toml
+++ b/sdk/keypair/Cargo.toml
@@ -33,6 +33,6 @@ tiny-bip39 = { workspace = true }
 seed-derivable = ["dep:solana-derivation-path", "dep:solana-seed-derivable", "dep:ed25519-dalek-bip32"]
 
 [package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]

--- a/sdk/message/Cargo.toml
+++ b/sdk/message/Cargo.toml
@@ -71,7 +71,7 @@ serde = [
 ]
 
 [package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -129,7 +129,9 @@ static_assertions = { workspace = true }
 test-case = { workspace = true }
 
 [package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -465,6 +465,7 @@
 
 #![allow(incomplete_features)]
 #![cfg_attr(feature = "frozen-abi", feature(specialization))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 // Allows macro expansion of `use ::solana_program::*` to work within this crate
 extern crate self as solana_program;

--- a/sdk/pubkey/Cargo.toml
+++ b/sdk/pubkey/Cargo.toml
@@ -77,7 +77,7 @@ sha2 = ["dep:solana-sha256-hasher", "solana-sha256-hasher/sha2"]
 std = []
 
 [package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -31,6 +31,7 @@
 
 #![allow(incomplete_features)]
 #![cfg_attr(feature = "frozen-abi", feature(specialization))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 // Allows macro expansion of `use ::solana_sdk::*` to work within this crate
 extern crate self as solana_sdk;


### PR DESCRIPTION
#### Problem

As pointed out in [this PR comment](https://github.com/anza-xyz/agave/pull/3634#discussion_r1867791497) it's good to specify that docs build for wasm32 where needed.

Also, solana-sdk and solana-program don't configure docs builds with all features enabled.

#### Summary of changes

In most places, add "wasm32-unknown-unknown" as a build target. For sdk and program, also configure the features to be enabled.