### PR TITLE
remove solana-program from solana-bincode dev deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6158,7 +6158,7 @@ dependencies = [
  "bincode",
  "serde",
  "solana-instruction",
- "solana-program",
+ "solana-system-interface",
 ]
 
 [[package]]

--- a/sdk/bincode/Cargo.toml
+++ b/sdk/bincode/Cargo.toml
@@ -17,7 +17,7 @@ solana-instruction = { workspace = true, default-features = false, features = [
 ] }
 
 [dev-dependencies]
-solana-program = { path = "../program" }
+solana-system-interface = { workspace = true, features = ["bincode"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/bincode/src/lib.rs
+++ b/sdk/bincode/src/lib.rs
@@ -20,7 +20,7 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use {super::*, solana_program::system_instruction::SystemInstruction};
+    use {super::*, solana_system_interface::instruction::SystemInstruction};
 
     #[test]
     fn test_limited_deserialize_advance_nonce_account() {


### PR DESCRIPTION
#### Problem
This only needs solana-system-interface, not all of solana-program

#### Summary of Changes
Replace solana-program with solana-system-interface
