### PR TITLE
tls-utils: Make publishable, remove sdk dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9174,7 +9174,6 @@ dependencies = [
  "rustls 0.23.19",
  "solana-keypair",
  "solana-pubkey",
- "solana-sdk",
  "solana-signer",
  "x509-parser",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7739,7 +7739,6 @@ dependencies = [
  "rustls 0.23.19",
  "solana-keypair",
  "solana-pubkey",
- "solana-sdk",
  "solana-signer",
  "x509-parser",
 ]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7084,7 +7084,6 @@ dependencies = [
  "rustls 0.23.19",
  "solana-keypair",
  "solana-pubkey",
- "solana-sdk",
  "solana-signer",
  "x509-parser",
 ]

--- a/tls-utils/Cargo.toml
+++ b/tls-utils/Cargo.toml
@@ -2,7 +2,6 @@
 name = "solana-tls-utils"
 description = "Solana TLS utilities"
 documentation = "https://docs.rs/solana-tls-utils"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
@@ -14,7 +13,6 @@ edition = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-sdk = { workspace = true }
 solana-signer = { workspace = true }
 x509-parser = { workspace = true }
 

--- a/tls-utils/src/quic_client_certificate.rs
+++ b/tls-utils/src/quic_client_certificate.rs
@@ -1,7 +1,7 @@
 use {
     crate::new_dummy_x509_certificate,
     rustls::pki_types::{CertificateDer, PrivateKeyDer},
-    solana_sdk::signature::Keypair,
+    solana_keypair::Keypair,
 };
 
 pub struct QuicClientCertificate {


### PR DESCRIPTION
#### Problem

The new tls-utils crate is a great extraction of re-used logic, but it wasn't marked publishable, even though it will need to be published due to transitive dependencies from client crates.

Also, it has an unnecessary dependency on solana-sdk.

#### Summary of changes

Remove the solana-sdk dependency and use solana-keypair directly. And make the crate publishable.

The crate ownership has been passed to `anza-team`, so once it's accepted, we should be able to merge this.