### PR TITLE
Add Http headers for RPC and PubSub Clients

### DIFF
--- a/rpc-client/src/http_sender.rs
+++ b/rpc-client/src/http_sender.rs
@@ -60,6 +60,33 @@ impl HttpSender {
 
     /// Create an HTTP RPC sender.
     ///
+    /// The URL is an HTTP URL, usually for port 8899.
+    /// The sender has a default timeout of 30 seconds.
+    pub fn new_with_headers<U: ToString>(url: U, headers: header::HeaderMap) -> Self {
+        Self::new_with_timeout_and_headers(url, Duration::from_secs(30), headers)
+    }
+
+    /// Create an HTTP RPC sender.
+    ///
+    /// The URL is an HTTP URL, usually for port 8899.
+    pub fn new_with_timeout_and_headers<U: ToString>(
+        url: U,
+        timeout: Duration,
+        headers: header::HeaderMap,
+    ) -> Self {
+        Self::new_with_client(
+            url,
+            reqwest::Client::builder()
+                .default_headers(headers)
+                .timeout(timeout)
+                .pool_idle_timeout(timeout)
+                .build()
+                .expect("build rpc client"),
+        )
+    }
+
+    /// Create an HTTP RPC sender.
+    ///
     /// Most flexible way to create a sender. Pass a created `reqwest::Client`.
     pub fn new_with_client<U: ToString>(url: U, client: reqwest::Client) -> Self {
         Self {

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -22,6 +22,7 @@ use {
     base64::{prelude::BASE64_STANDARD, Engine},
     bincode::serialize,
     log::*,
+    reqwest::header,
     serde_json::{json, Value},
     solana_account::Account,
     solana_account_decoder_client_types::{
@@ -310,6 +311,188 @@ impl RpcClient {
     ) -> Self {
         Self::new_sender(
             HttpSender::new_with_timeout(url, timeout),
+            RpcClientConfig {
+                commitment_config,
+                confirm_transaction_initial_timeout: Some(confirm_transaction_initial_timeout),
+            },
+        )
+    }
+
+    /// Create an HTTP `RpcClient` with desired HTTP headers.
+    ///
+    /// The URL is an HTTP URL, usually for port 8899, as in
+    /// "http://localhost:8899".
+    ///
+    /// The client has a default timeout of 30 seconds, and a default [commitment
+    /// level][cl] of [`Finalized`](CommitmentLevel::Finalized).
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use reqwest::header;
+    /// # use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+    /// let url = "http://localhost:8899".to_string();
+    /// let mut headers = HeaderMap::new();
+    /// headers.append(header::AUTHORIZATION, header::HeaderValue::from_str("Bearer <token>").unwrap());
+    /// let client = RpcClient::new_with_headers(url, headers);
+    /// ```
+    pub fn new_with_headers(url: String, headers: header::HeaderMap) -> Self {
+        Self::new_with_commitment_and_headers(url, CommitmentConfig::default(), headers)
+    }
+
+    /// Create an HTTP `RpcClient` with specified [commitment level][cl] and desired HTTP headers.
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// The URL is an HTTP URL, usually for port 8899, as in
+    /// "http://localhost:8899".
+    ///
+    /// The client has a default timeout of 30 seconds, and a user-specified
+    /// [`CommitmentLevel`] via [`CommitmentConfig`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use reqwest::header;
+    /// # use solana_sdk::commitment_config::CommitmentConfig;
+    /// # use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+    /// let url = "http://localhost:8899".to_string();
+    /// let commitment_config = CommitmentConfig::processed();
+    /// let mut headers = HeaderMap::new();
+    /// headers.append(header::AUTHORIZATION, header::HeaderValue::from_str("Bearer <token>").unwrap());
+    /// let client = RpcClient::new_with_commitment_and_headers(url, commitment_config, headers);
+    /// ```
+    pub fn new_with_commitment_and_headers(
+        url: String,
+        commitment_config: CommitmentConfig,
+        headers: header::HeaderMap,
+    ) -> Self {
+        Self::new_sender(
+            HttpSender::new_with_headers(url, headers),
+            RpcClientConfig::with_commitment(commitment_config),
+        )
+    }
+
+    /// Create an HTTP `RpcClient` with specified timeout and desired HTTP headers.
+    ///
+    /// The URL is an HTTP URL, usually for port 8899, as in
+    /// "http://localhost:8899".
+    ///
+    /// The client has and a default [commitment level][cl] of
+    /// [`Finalized`](CommitmentLevel::Finalized).
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use reqwest::header;
+    /// # use std::time::Duration;
+    /// # use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+    /// let url = "http://localhost::8899".to_string();
+    /// let timeout = Duration::from_secs(1);
+    /// let mut headers = HeaderMap::new();
+    /// headers.append(header::AUTHORIZATION, header::HeaderValue::from_str("Bearer <token>").unwrap());
+    /// let client = RpcClient::new_with_timeout_and_headers(url, timeout, headers);
+    /// ```
+    pub fn new_with_timeout_and_headers(
+        url: String,
+        timeout: Duration,
+        headers: header::HeaderMap,
+    ) -> Self {
+        Self::new_sender(
+            HttpSender::new_with_timeout_and_headers(url, timeout, headers),
+            RpcClientConfig::with_commitment(CommitmentConfig::default()),
+        )
+    }
+
+    /// Create an HTTP `RpcClient` with specified timeout, [commitment level][cl]
+    /// and decired HTTP headers.
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// The URL is an HTTP URL, usually for port 8899, as in
+    /// "http://localhost:8899".
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use reqwest::header;
+    /// # use std::time::Duration;
+    /// # use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+    /// # use solana_sdk::commitment_config::CommitmentConfig;
+    /// let url = "http://localhost::8899".to_string();
+    /// let timeout = Duration::from_secs(1);
+    /// let commitment_config = CommitmentConfig::processed();
+    /// let mut headers = HeaderMap::new();
+    /// headers.append(header::AUTHORIZATION, header::HeaderValue::from_str("Bearer <token>").unwrap());
+    /// let client = RpcClient::new_with_timeout_and_commitment_and_headers(
+    ///     url,
+    ///     timeout,
+    ///     commitment_config,
+    ///     headers,
+    /// );
+    /// ```
+    pub fn new_with_timeout_and_commitment_and_headers(
+        url: String,
+        timeout: Duration,
+        commitment_config: CommitmentConfig,
+        headers: header::HeaderMap,
+    ) -> Self {
+        Self::new_sender(
+            HttpSender::new_with_timeout_and_headers(url, timeout, headers),
+            RpcClientConfig::with_commitment(commitment_config),
+        )
+    }
+
+    /// Create an HTTP `RpcClient` with specified timeout, [commitment level][cl]
+    /// and decired HTTP headers.
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// The URL is an HTTP URL, usually for port 8899, as in
+    /// "http://localhost:8899".
+    ///
+    /// The `confirm_transaction_initial_timeout` argument specifies the amount of
+    /// time to allow for the server to initially process a transaction, when
+    /// confirming a transaction via one of the `_with_spinner` methods, like
+    /// [`RpcClient::send_and_confirm_transaction_with_spinner`]. In
+    /// other words, setting `confirm_transaction_initial_timeout` to > 0 allows
+    /// `RpcClient` to wait for confirmation of a transaction that the server
+    /// has not "seen" yet.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use reqwest::header;
+    /// # use std::time::Duration;
+    /// # use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+    /// # use solana_sdk::commitment_config::CommitmentConfig;
+    /// let url = "http://localhost::8899".to_string();
+    /// let timeout = Duration::from_secs(1);
+    /// let commitment_config = CommitmentConfig::processed();
+    /// let confirm_transaction_initial_timeout = Duration::from_secs(10);
+    /// let mut headers = HeaderMap::new();
+    /// headers.append(header::AUTHORIZATION, header::HeaderValue::from_str("Bearer <token>").unwrap());
+    /// let client = RpcClient::new_with_timeouts_and_commitment_and_headers(
+    ///     url,
+    ///     timeout,
+    ///     commitment_config,
+    ///     confirm_transaction_initial_timeout,
+    ///     headers,
+    /// );
+    /// ```
+    pub fn new_with_timeouts_and_commitment_and_headers(
+        url: String,
+        timeout: Duration,
+        commitment_config: CommitmentConfig,
+        confirm_transaction_initial_timeout: Duration,
+        headers: header::HeaderMap,
+    ) -> Self {
+        Self::new_sender(
+            HttpSender::new_with_timeout_and_headers(url, timeout, headers),
             RpcClientConfig {
                 commitment_config,
                 confirm_transaction_initial_timeout: Some(confirm_transaction_initial_timeout),


### PR DESCRIPTION
#### Problem
Some RPC and WSS servers need specific HTTP headers. It is possible to solve the problem for RPC client but I could not find a way for WebSocket besides doing my own connections and requests. So here is the solution for those problems.

#### Summary of Changes
Added `reqwest::header` parameters for some methods.
Created new methods for `rpc-client` and added new parameters for `pubsub-client`.

Fixes https://github.com/anza-xyz/agave/issues/3917