### PR TITLE
revert signing prune messages with prefix

### DIFF
--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -241,7 +241,8 @@ impl Signable for PruneData {
     }
 
     fn signable_data(&self) -> Cow<[u8]> {
-        self.signable_data_with_prefix()
+        // Continue to return signable data without a prefix until cluster has upgraded
+        self.signable_data_without_prefix()
     }
 
     fn get_signature(&self) -> Signature {


### PR DESCRIPTION
#### Problem
Signed pruned messages with the prune prefix are not getting handled properly by the receiver. As a result, prunes are getting ignored and push message duplicates increase

#### Summary of Changes
revert the PR that signs prune messages with the prune message prefix. PR: https://github.com/anza-xyz/agave/pull/3713
