### PR TITLE
use create_and_canonicalize_directory for snapshots dir

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1670,17 +1670,21 @@ pub fn main() {
         value_t_or_exit!(matches, "maximum_snapshot_download_abort", u64);
 
     let snapshots_dir = if let Some(snapshots) = matches.value_of("snapshots") {
-        &create_and_canonicalize_directory(PathBuf::from(snapshots)).unwrap_or_else(|err| {
-            eprintln!("Unable to access snapshots path '{}': {err}", snapshots);
-            exit(1);
-        })
+        Path::new(snapshots)
     } else {
         &ledger_path
     };
+    let snapshots_dir = create_and_canonicalize_directory(snapshots_dir).unwrap_or_else(|err| {
+        eprintln!(
+            "Failed to create snapshots directory '{}': {err}",
+            snapshots_dir.display(),
+        );
+        exit(1);
+    });
 
     if account_paths
         .iter()
-        .any(|account_path| account_path == snapshots_dir)
+        .any(|account_path| account_path == &snapshots_dir)
     {
         eprintln!(
             "Failed: The --accounts and --snapshots paths must be unique since they \


### PR DESCRIPTION
#### Problem

we don't create "snapshots" dir for users before we canonicalize.

#### Summary of Changes

do something similar with ledger path: https://github.com/anza-xyz/agave/blob/df27fb3a7386f0d2cc64df81c46a09ab79b18ba0/validator/src/main.rs#L997-L1004
