### PR TITLE
Address regressions introduced in gce test net setup with image update to latest ubuntu

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -62,7 +62,7 @@ prefix=testnet-dev-${USER//[^A-Za-z0-9]/}
 additionalValidatorCount=2
 clientNodeCount=0
 blockstreamer=false
-validatorBootDiskSizeInGb=500
+validatorBootDiskSizeInGb=100
 clientBootDiskSizeInGb=75
 validatorAdditionalDiskSizeInGb=
 externalNodes=false
@@ -802,6 +802,7 @@ $(
     solana-user-authorized_keys.sh \
     add-testnet-solana-user-authorized_keys.sh \
     install-ag.sh \
+    install-at.sh \
     install-certbot.sh \
     install-earlyoom.sh \
     install-iftop.sh \

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -807,7 +807,7 @@ $(
     install-earlyoom.sh \
     install-iftop.sh \
     install-jq.sh \
-    install-libssl-compatability.sh \
+    install-libssl.sh \
     install-rsync.sh \
     install-perf.sh \
     localtime.sh \

--- a/net/scripts/install-at.sh
+++ b/net/scripts/install-at.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+set -ex
+
+[[ $(uname) = Linux ]] || exit 1
+[[ $USER = root ]] || exit 1
+
+apt-get update
+apt-get --assume-yes install at

--- a/net/scripts/install-libssl-compatability.sh
+++ b/net/scripts/install-libssl-compatability.sh
@@ -8,8 +8,3 @@ set -ex
 apt-get update
 apt-get --assume-yes install libssl-dev
 
-# Install libssl1.1 to be compatible with binaries built in the
-# solanalabs/rust docker image
-#
-# cc: https://github.com/solana-labs/solana/issues/1090
-# apt-get --assume-yes install libssl1.1

--- a/net/scripts/install-libssl-compatability.sh
+++ b/net/scripts/install-libssl-compatability.sh
@@ -12,4 +12,4 @@ apt-get --assume-yes install libssl-dev
 # solanalabs/rust docker image
 #
 # cc: https://github.com/solana-labs/solana/issues/1090
-apt-get --assume-yes install libssl1.1
+# apt-get --assume-yes install libssl1.1

--- a/net/scripts/install-libssl.sh
+++ b/net/scripts/install-libssl.sh
@@ -7,4 +7,3 @@ set -ex
 # Install libssl-dev to be compatible with binaries built on an Ubuntu machine...
 apt-get update
 apt-get --assume-yes install libssl-dev
-


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/3911 introduced regressions that make gce.sh and associated scripts to fail.

#### Summary of Changes

Remove the openssl1.1 install command
Update the gce.sh to pull in the needed packages that are no longer in base image