### PR TITLE
update socket config and create builder pattern

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -3,7 +3,7 @@
 use {
     clap::{crate_description, crate_name, Arg, Command},
     crossbeam_channel::unbounded,
-    solana_net_utils::bind_to_unspecified,
+    solana_net_utils::{bind_to_unspecified, SocketConfig},
     solana_streamer::{
         packet::{Packet, PacketBatch, PacketBatchRecycler, PACKET_DATA_SIZE},
         streamer::{receiver, PacketBatchReceiver, StreamerReceiveStats},
@@ -95,9 +95,10 @@ fn main() -> Result<()> {
     let mut read_channels = Vec::new();
     let mut read_threads = Vec::new();
     let recycler = PacketBatchRecycler::default();
-    let (_port, read_sockets) = solana_net_utils::multi_bind_in_range(
+    let (_port, read_sockets) = solana_net_utils::multi_bind_in_range_with_config(
         ip_addr,
         (port, port + num_sockets as u16),
+        SocketConfig::default().reuseport(true),
         num_sockets,
     )
     .unwrap();

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -98,7 +98,7 @@ fn main() -> Result<()> {
     let (_port, read_sockets) = solana_net_utils::multi_bind_in_range_with_config(
         ip_addr,
         (port, port + num_sockets as u16),
-        SocketConfig::default().reuseport(true),
+        SocketConfig::default_rw().reuseport(true),
         num_sockets,
     )
     .unwrap();

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -98,7 +98,7 @@ fn main() -> Result<()> {
     let (_port, read_sockets) = solana_net_utils::multi_bind_in_range_with_config(
         ip_addr,
         (port, port + num_sockets as u16),
-        SocketConfig::default_rw().reuseport(true),
+        SocketConfig::default().reuseport(true),
         num_sockets,
     )
     .unwrap();

--- a/connection-cache/Cargo.toml
+++ b/connection-cache/Cargo.toml
@@ -22,6 +22,7 @@ rayon = { workspace = true }
 solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
+solana-net-utils = { workspace = true }
 solana-time-utils = { workspace = true }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -514,6 +514,7 @@ mod tests {
         async_trait::async_trait,
         rand::{Rng, SeedableRng},
         rand_chacha::ChaChaRng,
+        solana_net_utils::SocketConfig,
         solana_transaction_error::TransportResult,
         std::{
             net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
@@ -571,8 +572,11 @@ mod tests {
         fn default() -> Self {
             Self {
                 udp_socket: Arc::new(
-                    solana_net_utils::bind_with_any_port(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
-                        .expect("Unable to bind to UDP socket"),
+                    solana_net_utils::bind_with_any_port_with_config(
+                        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                        SocketConfig::default(),
+                    )
+                    .expect("Unable to bind to UDP socket"),
                 ),
             }
         }
@@ -582,8 +586,11 @@ mod tests {
         fn new() -> Result<Self, ClientError> {
             Ok(Self {
                 udp_socket: Arc::new(
-                    solana_net_utils::bind_with_any_port(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
-                        .map_err(Into::<ClientError>::into)?,
+                    solana_net_utils::bind_with_any_port_with_config(
+                        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                        SocketConfig::default(),
+                    )
+                    .map_err(Into::<ClientError>::into)?,
                 ),
             })
         }

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -574,7 +574,7 @@ mod tests {
                 udp_socket: Arc::new(
                     solana_net_utils::bind_with_any_port_with_config(
                         IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                        SocketConfig::default(),
+                        SocketConfig::default_rw(),
                     )
                     .expect("Unable to bind to UDP socket"),
                 ),
@@ -588,7 +588,7 @@ mod tests {
                 udp_socket: Arc::new(
                     solana_net_utils::bind_with_any_port_with_config(
                         IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                        SocketConfig::default(),
+                        SocketConfig::default_rw(),
                     )
                     .map_err(Into::<ClientError>::into)?,
                 ),

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -574,7 +574,7 @@ mod tests {
                 udp_socket: Arc::new(
                     solana_net_utils::bind_with_any_port_with_config(
                         IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                        SocketConfig::default_rw(),
+                        SocketConfig::default(),
                     )
                     .expect("Unable to bind to UDP socket"),
                 ),
@@ -588,7 +588,7 @@ mod tests {
                 udp_socket: Arc::new(
                     solana_net_utils::bind_with_any_port_with_config(
                         IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                        SocketConfig::default_rw(),
+                        SocketConfig::default(),
                     )
                     .map_err(Into::<ClientError>::into)?,
                 ),

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -54,10 +54,10 @@ use {
     solana_ledger::shred::Shred,
     solana_measure::measure::Measure,
     solana_net_utils::{
-        bind_common, bind_common_in_range, bind_in_range, bind_in_range_with_config,
-        bind_more_with_config, bind_to_localhost, bind_to_unspecified,
+        bind_common_in_range_with_config, bind_common_with_config, bind_in_range,
+        bind_in_range_with_config, bind_more_with_config, bind_to_localhost, bind_to_unspecified,
         bind_two_in_range_with_offset_and_config, find_available_port_in_range,
-        multi_bind_in_range, PortRange, SocketConfig, VALIDATOR_PORT_RANGE,
+        multi_bind_in_range_with_config, PortRange, SocketConfig, VALIDATOR_PORT_RANGE,
     },
     solana_perf::{
         data_budget::DataBudget,
@@ -2612,8 +2612,8 @@ impl Node {
         let localhost_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let port_range = (1024, 65535);
 
-        let udp_config = SocketConfig { reuseport: false };
-        let quic_config = SocketConfig { reuseport: true };
+        let udp_config = SocketConfig::default();
+        let quic_config = SocketConfig::default().reuseport(true);
         let ((_tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_in_range_with_offset_and_config(
                 localhost_ip_addr,
@@ -2626,7 +2626,8 @@ impl Node {
         let tpu_quic =
             bind_more_with_config(tpu_quic, num_quic_endpoints, quic_config.clone()).unwrap();
         let (gossip_port, (gossip, ip_echo)) =
-            bind_common_in_range(localhost_ip_addr, port_range).unwrap();
+            bind_common_in_range_with_config(localhost_ip_addr, port_range, udp_config.clone())
+                .unwrap();
         let gossip_addr = SocketAddr::new(localhost_ip_addr, gossip_port);
         let tvu = bind_to_localhost().unwrap();
         let tvu_quic = bind_to_localhost().unwrap();
@@ -2730,20 +2731,18 @@ impl Node {
         port_range: PortRange,
         bind_ip_addr: IpAddr,
     ) -> (u16, (UdpSocket, TcpListener)) {
+        let config = SocketConfig::default();
         if gossip_addr.port() != 0 {
             (
                 gossip_addr.port(),
-                bind_common(bind_ip_addr, gossip_addr.port()).unwrap_or_else(|e| {
-                    panic!("gossip_addr bind_to port {}: {}", gossip_addr.port(), e)
-                }),
+                bind_common_with_config(bind_ip_addr, gossip_addr.port(), config).unwrap_or_else(
+                    |e| panic!("gossip_addr bind_to port {}: {}", gossip_addr.port(), e),
+                ),
             )
         } else {
-            bind_common_in_range(bind_ip_addr, port_range).expect("Failed to bind")
+            bind_common_in_range_with_config(bind_ip_addr, port_range, config)
+                .expect("Failed to bind")
         }
-    }
-    fn bind(bind_ip_addr: IpAddr, port_range: PortRange) -> (u16, UdpSocket) {
-        let config = SocketConfig { reuseport: false };
-        Self::bind_with_config(bind_ip_addr, port_range, config)
     }
 
     fn bind_with_config(
@@ -2762,49 +2761,74 @@ impl Node {
     ) -> Self {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(gossip_addr, port_range, bind_ip_addr);
-        let (tvu_port, tvu) = Self::bind(bind_ip_addr, port_range);
-        let (tvu_quic_port, tvu_quic) = Self::bind(bind_ip_addr, port_range);
-        let udp_config = SocketConfig { reuseport: false };
-        let quic_config = SocketConfig { reuseport: true };
+
+        let read_write_socket_config = SocketConfig::default();
+        let (tvu_port, tvu) =
+            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+        let (tvu_quic_port, tvu_quic) =
+            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+        let tpu_udp_config = SocketConfig::default();
+        let tpu_quic_config = SocketConfig::default().reuseport(true);
         let ((tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_in_range_with_offset_and_config(
                 bind_ip_addr,
                 port_range,
                 QUIC_PORT_OFFSET,
-                udp_config.clone(),
-                quic_config.clone(),
+                tpu_udp_config.clone(),
+                tpu_quic_config.clone(),
             )
             .unwrap();
         let tpu_quic: Vec<UdpSocket> =
-            bind_more_with_config(tpu_quic, DEFAULT_QUIC_ENDPOINTS, quic_config.clone()).unwrap();
+            bind_more_with_config(tpu_quic, DEFAULT_QUIC_ENDPOINTS, tpu_quic_config.clone())
+                .unwrap();
+
+        let tpu_forwards_udp_config = SocketConfig::default();
+        let tpu_forwards_quic_config = SocketConfig::default().reuseport(true);
         let ((tpu_forwards_port, tpu_forwards), (_tpu_forwards_quic_port, tpu_forwards_quic)) =
             bind_two_in_range_with_offset_and_config(
                 bind_ip_addr,
                 port_range,
                 QUIC_PORT_OFFSET,
-                udp_config,
-                quic_config.clone(),
+                tpu_forwards_udp_config,
+                tpu_forwards_quic_config.clone(),
             )
             .unwrap();
         let tpu_forwards_quic = bind_more_with_config(
             tpu_forwards_quic,
             DEFAULT_QUIC_ENDPOINTS,
-            quic_config.clone(),
+            tpu_forwards_quic_config.clone(),
         )
         .unwrap();
-        let (tpu_vote_port, tpu_vote) = Self::bind(bind_ip_addr, port_range);
-        let (tpu_vote_quic_port, tpu_vote_quic) = Self::bind(bind_ip_addr, port_range);
-        let tpu_vote_quic: Vec<UdpSocket> =
-            bind_more_with_config(tpu_vote_quic, DEFAULT_QUIC_ENDPOINTS, quic_config).unwrap();
 
-        let (_, retransmit_socket) = Self::bind(bind_ip_addr, port_range);
-        let (_, repair) = Self::bind(bind_ip_addr, port_range);
-        let (_, repair_quic) = Self::bind(bind_ip_addr, port_range);
-        let (serve_repair_port, serve_repair) = Self::bind(bind_ip_addr, port_range);
-        let (serve_repair_quic_port, serve_repair_quic) = Self::bind(bind_ip_addr, port_range);
-        let (_, broadcast) = Self::bind(bind_ip_addr, port_range);
-        let (_, ancestor_hashes_requests) = Self::bind(bind_ip_addr, port_range);
-        let (_, ancestor_hashes_requests_quic) = Self::bind(bind_ip_addr, port_range);
+        let tpu_vote_udp_config = SocketConfig::default();
+        let tpu_vote_quic_config = SocketConfig::default().reuseport(true);
+        let (tpu_vote_port, tpu_vote) =
+            Self::bind_with_config(bind_ip_addr, port_range, tpu_vote_udp_config.clone());
+        // using udp port for quic really because we need to reusport set to false, since Self::bind() defaults to false
+        let (tpu_vote_quic_port, tpu_vote_quic) =
+            Self::bind_with_config(bind_ip_addr, port_range, tpu_vote_udp_config);
+        let tpu_vote_quic: Vec<UdpSocket> =
+            bind_more_with_config(tpu_vote_quic, DEFAULT_QUIC_ENDPOINTS, tpu_vote_quic_config)
+                .unwrap();
+
+        let write_only_socket_config = SocketConfig::default();
+
+        let (_, retransmit_socket) =
+            Self::bind_with_config(bind_ip_addr, port_range, write_only_socket_config.clone());
+        let (_, repair) =
+            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+        let (_, repair_quic) =
+            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+        let (serve_repair_port, serve_repair) =
+            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+        let (serve_repair_quic_port, serve_repair_quic) =
+            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+        let (_, broadcast) =
+            Self::bind_with_config(bind_ip_addr, port_range, write_only_socket_config);
+        let (_, ancestor_hashes_requests) =
+            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+        let (_, ancestor_hashes_requests_quic) =
+            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
 
         let rpc_port = find_available_port_in_range(bind_ip_addr, port_range).unwrap();
         let rpc_pubsub_port = find_available_port_in_range(bind_ip_addr, port_range).unwrap();
@@ -2880,24 +2904,40 @@ impl Node {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(&gossip_addr, port_range, bind_ip_addr);
 
-        let (tvu_port, tvu_sockets) =
-            multi_bind_in_range(bind_ip_addr, port_range, num_tvu_sockets.get())
-                .expect("tvu multi_bind");
-        let (tvu_quic_port, tvu_quic) = Self::bind(bind_ip_addr, port_range);
-        let (tpu_port, tpu_sockets) =
-            multi_bind_in_range(bind_ip_addr, port_range, 32).expect("tpu multi_bind");
+        let tvu_config = SocketConfig::default().reuseport(true);
+        let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
+            bind_ip_addr,
+            port_range,
+            tvu_config.clone(),
+            num_tvu_sockets.get(),
+        )
+        .expect("tvu multi_bind");
 
-        let quic_config = SocketConfig { reuseport: true };
+        let tvu_config = SocketConfig::default().reuseport(false);
+        let (tvu_quic_port, tvu_quic) =
+            Self::bind_with_config(bind_ip_addr, port_range, tvu_config);
+
+        let tpu_config = SocketConfig::default().reuseport(true);
+        let (tpu_port, tpu_sockets) =
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, tpu_config.clone(), 32)
+                .expect("tpu multi_bind");
+
         let (_tpu_port_quic, tpu_quic) = Self::bind_with_config(
             bind_ip_addr,
             (tpu_port + QUIC_PORT_OFFSET, tpu_port + QUIC_PORT_OFFSET + 1),
-            quic_config.clone(),
+            tpu_config.clone(),
         );
         let tpu_quic =
-            bind_more_with_config(tpu_quic, num_quic_endpoints.get(), quic_config.clone()).unwrap();
+            bind_more_with_config(tpu_quic, num_quic_endpoints.get(), tpu_config.clone()).unwrap();
 
-        let (tpu_forwards_port, tpu_forwards_sockets) =
-            multi_bind_in_range(bind_ip_addr, port_range, 8).expect("tpu_forwards multi_bind");
+        let tpu_forwards_config = SocketConfig::default().reuseport(true);
+        let (tpu_forwards_port, tpu_forwards_sockets) = multi_bind_in_range_with_config(
+            bind_ip_addr,
+            port_range,
+            tpu_forwards_config.clone(),
+            8,
+        )
+        .expect("tpu_forwards multi_bind");
 
         let (_tpu_forwards_port_quic, tpu_forwards_quic) = Self::bind_with_config(
             bind_ip_addr,
@@ -2905,37 +2945,58 @@ impl Node {
                 tpu_forwards_port + QUIC_PORT_OFFSET,
                 tpu_forwards_port + QUIC_PORT_OFFSET + 1,
             ),
-            quic_config.clone(),
+            tpu_forwards_config.clone(),
         );
         let tpu_forwards_quic = bind_more_with_config(
             tpu_forwards_quic,
             num_quic_endpoints.get(),
-            quic_config.clone(),
+            tpu_forwards_config.clone(),
         )
         .unwrap();
 
+        let tpu_vote_config = SocketConfig::default().reuseport(true);
         let (tpu_vote_port, tpu_vote_sockets) =
-            multi_bind_in_range(bind_ip_addr, port_range, 1).expect("tpu_vote multi_bind");
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, tpu_vote_config.clone(), 1)
+                .expect("tpu_vote multi_bind");
 
-        let (tpu_vote_quic_port, tpu_vote_quic) = Self::bind(bind_ip_addr, port_range);
+        let tpu_vote_config = SocketConfig::default();
+        let (tpu_vote_quic_port, tpu_vote_quic) =
+            Self::bind_with_config(bind_ip_addr, port_range, tpu_vote_config.clone());
 
-        let tpu_vote_quic =
-            bind_more_with_config(tpu_vote_quic, num_quic_endpoints.get(), quic_config.clone())
-                .unwrap();
+        let tpu_vote_config = SocketConfig::default().reuseport(true);
+        let tpu_vote_quic = bind_more_with_config(
+            tpu_vote_quic,
+            num_quic_endpoints.get(),
+            tpu_vote_config.clone(),
+        )
+        .unwrap();
 
+        let retransmit_config = SocketConfig::default().reuseport(true);
         let (_, retransmit_sockets) =
-            multi_bind_in_range(bind_ip_addr, port_range, 8).expect("retransmit multi_bind");
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, retransmit_config, 8)
+                .expect("retransmit multi_bind");
 
-        let (_, repair) = Self::bind(bind_ip_addr, port_range);
-        let (_, repair_quic) = Self::bind(bind_ip_addr, port_range);
-        let (serve_repair_port, serve_repair) = Self::bind(bind_ip_addr, port_range);
-        let (serve_repair_quic_port, serve_repair_quic) = Self::bind(bind_ip_addr, port_range);
+        let repair_config = SocketConfig::default();
+        let (_, repair) = Self::bind_with_config(bind_ip_addr, port_range, repair_config.clone());
+        let (_, repair_quic) =
+            Self::bind_with_config(bind_ip_addr, port_range, repair_config.clone());
 
+        let serve_repair_config = SocketConfig::default();
+        let (serve_repair_port, serve_repair) =
+            Self::bind_with_config(bind_ip_addr, port_range, serve_repair_config.clone());
+        let (serve_repair_quic_port, serve_repair_quic) =
+            Self::bind_with_config(bind_ip_addr, port_range, serve_repair_config);
+
+        let broadcast_config = SocketConfig::default().reuseport(true);
         let (_, broadcast) =
-            multi_bind_in_range(bind_ip_addr, port_range, 4).expect("broadcast multi_bind");
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, broadcast_config, 4)
+                .expect("broadcast multi_bind");
 
-        let (_, ancestor_hashes_requests) = Self::bind(bind_ip_addr, port_range);
-        let (_, ancestor_hashes_requests_quic) = Self::bind(bind_ip_addr, port_range);
+        let ancestor_hashes_config = SocketConfig::default();
+        let (_, ancestor_hashes_requests) =
+            Self::bind_with_config(bind_ip_addr, port_range, ancestor_hashes_config.clone());
+        let (_, ancestor_hashes_requests_quic) =
+            Self::bind_with_config(bind_ip_addr, port_range, ancestor_hashes_config);
 
         let mut info = ContactInfo::new(
             *pubkey,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2762,73 +2762,70 @@ impl Node {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(gossip_addr, port_range, bind_ip_addr);
 
-        let read_write_socket_config = SocketConfig::default();
+        let socket_config = SocketConfig::default();
+        let socket_config_reuseport = SocketConfig::default().reuseport(true);
         let (tvu_port, tvu) =
-            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
         let (tvu_quic_port, tvu_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
-        let tpu_udp_config = SocketConfig::default();
-        let tpu_quic_config = SocketConfig::default().reuseport(true);
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
         let ((tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_in_range_with_offset_and_config(
                 bind_ip_addr,
                 port_range,
                 QUIC_PORT_OFFSET,
-                tpu_udp_config.clone(),
-                tpu_quic_config.clone(),
+                socket_config.clone(),
+                socket_config_reuseport.clone(),
             )
             .unwrap();
-        let tpu_quic: Vec<UdpSocket> =
-            bind_more_with_config(tpu_quic, DEFAULT_QUIC_ENDPOINTS, tpu_quic_config.clone())
-                .unwrap();
+        let tpu_quic: Vec<UdpSocket> = bind_more_with_config(
+            tpu_quic,
+            DEFAULT_QUIC_ENDPOINTS,
+            socket_config_reuseport.clone(),
+        )
+        .unwrap();
 
-        let tpu_forwards_udp_config = SocketConfig::default();
-        let tpu_forwards_quic_config = SocketConfig::default().reuseport(true);
         let ((tpu_forwards_port, tpu_forwards), (_tpu_forwards_quic_port, tpu_forwards_quic)) =
             bind_two_in_range_with_offset_and_config(
                 bind_ip_addr,
                 port_range,
                 QUIC_PORT_OFFSET,
-                tpu_forwards_udp_config,
-                tpu_forwards_quic_config.clone(),
+                socket_config.clone(),
+                socket_config_reuseport.clone(),
             )
             .unwrap();
         let tpu_forwards_quic = bind_more_with_config(
             tpu_forwards_quic,
             DEFAULT_QUIC_ENDPOINTS,
-            tpu_forwards_quic_config.clone(),
+            socket_config_reuseport.clone(),
         )
         .unwrap();
 
-        let tpu_vote_udp_config = SocketConfig::default();
-        let tpu_vote_quic_config = SocketConfig::default().reuseport(true);
         let (tpu_vote_port, tpu_vote) =
-            Self::bind_with_config(bind_ip_addr, port_range, tpu_vote_udp_config.clone());
-        // using udp port for quic really because we need to reusport set to false, since Self::bind() defaults to false
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
         let (tpu_vote_quic_port, tpu_vote_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, tpu_vote_udp_config);
-        let tpu_vote_quic: Vec<UdpSocket> =
-            bind_more_with_config(tpu_vote_quic, DEFAULT_QUIC_ENDPOINTS, tpu_vote_quic_config)
-                .unwrap();
-
-        let write_only_socket_config = SocketConfig::default();
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+        let tpu_vote_quic: Vec<UdpSocket> = bind_more_with_config(
+            tpu_vote_quic,
+            DEFAULT_QUIC_ENDPOINTS,
+            socket_config_reuseport,
+        )
+        .unwrap();
 
         let (_, retransmit_socket) =
-            Self::bind_with_config(bind_ip_addr, port_range, write_only_socket_config.clone());
-        let (_, repair) =
-            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+        let (_, repair) = Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
         let (_, repair_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
         let (serve_repair_port, serve_repair) =
-            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
         let (serve_repair_quic_port, serve_repair_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
         let (_, broadcast) =
-            Self::bind_with_config(bind_ip_addr, port_range, write_only_socket_config);
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
         let (_, ancestor_hashes_requests) =
-            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
         let (_, ancestor_hashes_requests_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
 
         let rpc_port = find_available_port_in_range(bind_ip_addr, port_range).unwrap();
         let rpc_pubsub_port = find_available_port_in_range(bind_ip_addr, port_range).unwrap();
@@ -2904,37 +2901,44 @@ impl Node {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(&gossip_addr, port_range, bind_ip_addr);
 
-        let tvu_config = SocketConfig::default().reuseport(true);
+        let socket_config = SocketConfig::default();
+        let socket_config_reuseport = SocketConfig::default().reuseport(true);
+
         let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
-            tvu_config.clone(),
+            socket_config_reuseport.clone(),
             num_tvu_sockets.get(),
         )
         .expect("tvu multi_bind");
 
-        let tvu_config = SocketConfig::default().reuseport(false);
         let (tvu_quic_port, tvu_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, tvu_config);
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
 
-        let tpu_config = SocketConfig::default().reuseport(true);
-        let (tpu_port, tpu_sockets) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, tpu_config.clone(), 32)
-                .expect("tpu multi_bind");
+        let (tpu_port, tpu_sockets) = multi_bind_in_range_with_config(
+            bind_ip_addr,
+            port_range,
+            socket_config_reuseport.clone(),
+            32,
+        )
+        .expect("tpu multi_bind");
 
         let (_tpu_port_quic, tpu_quic) = Self::bind_with_config(
             bind_ip_addr,
             (tpu_port + QUIC_PORT_OFFSET, tpu_port + QUIC_PORT_OFFSET + 1),
-            tpu_config.clone(),
+            socket_config_reuseport.clone(),
         );
-        let tpu_quic =
-            bind_more_with_config(tpu_quic, num_quic_endpoints.get(), tpu_config.clone()).unwrap();
+        let tpu_quic = bind_more_with_config(
+            tpu_quic,
+            num_quic_endpoints.get(),
+            socket_config_reuseport.clone(),
+        )
+        .unwrap();
 
-        let tpu_forwards_config = SocketConfig::default().reuseport(true);
         let (tpu_forwards_port, tpu_forwards_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
-            tpu_forwards_config.clone(),
+            socket_config_reuseport.clone(),
             8,
         )
         .expect("tpu_forwards multi_bind");
@@ -2945,58 +2949,62 @@ impl Node {
                 tpu_forwards_port + QUIC_PORT_OFFSET,
                 tpu_forwards_port + QUIC_PORT_OFFSET + 1,
             ),
-            tpu_forwards_config.clone(),
+            socket_config_reuseport.clone(),
         );
         let tpu_forwards_quic = bind_more_with_config(
             tpu_forwards_quic,
             num_quic_endpoints.get(),
-            tpu_forwards_config.clone(),
+            socket_config_reuseport.clone(),
         )
         .unwrap();
 
-        let tpu_vote_config = SocketConfig::default().reuseport(true);
-        let (tpu_vote_port, tpu_vote_sockets) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, tpu_vote_config.clone(), 1)
-                .expect("tpu_vote multi_bind");
+        let (tpu_vote_port, tpu_vote_sockets) = multi_bind_in_range_with_config(
+            bind_ip_addr,
+            port_range,
+            socket_config_reuseport.clone(),
+            1,
+        )
+        .expect("tpu_vote multi_bind");
 
-        let tpu_vote_config = SocketConfig::default();
         let (tpu_vote_quic_port, tpu_vote_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, tpu_vote_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
 
-        let tpu_vote_config = SocketConfig::default().reuseport(true);
         let tpu_vote_quic = bind_more_with_config(
             tpu_vote_quic,
             num_quic_endpoints.get(),
-            tpu_vote_config.clone(),
+            socket_config_reuseport.clone(),
         )
         .unwrap();
 
-        let retransmit_config = SocketConfig::default().reuseport(true);
-        let (_, retransmit_sockets) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, retransmit_config, 8)
-                .expect("retransmit multi_bind");
+        let (_, retransmit_sockets) = multi_bind_in_range_with_config(
+            bind_ip_addr,
+            port_range,
+            socket_config_reuseport.clone(),
+            8,
+        )
+        .expect("retransmit multi_bind");
 
-        let repair_config = SocketConfig::default();
-        let (_, repair) = Self::bind_with_config(bind_ip_addr, port_range, repair_config.clone());
+        let (_, repair) = Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
         let (_, repair_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, repair_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
 
-        let serve_repair_config = SocketConfig::default();
         let (serve_repair_port, serve_repair) =
-            Self::bind_with_config(bind_ip_addr, port_range, serve_repair_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
         let (serve_repair_quic_port, serve_repair_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, serve_repair_config);
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
 
-        let broadcast_config = SocketConfig::default().reuseport(true);
-        let (_, broadcast) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, broadcast_config, 4)
-                .expect("broadcast multi_bind");
+        let (_, broadcast) = multi_bind_in_range_with_config(
+            bind_ip_addr,
+            port_range,
+            socket_config_reuseport.clone(),
+            4,
+        )
+        .expect("broadcast multi_bind");
 
-        let ancestor_hashes_config = SocketConfig::default();
         let (_, ancestor_hashes_requests) =
-            Self::bind_with_config(bind_ip_addr, port_range, ancestor_hashes_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
         let (_, ancestor_hashes_requests_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, ancestor_hashes_config);
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
 
         let mut info = ContactInfo::new(
             *pubkey,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2619,15 +2619,13 @@ impl Node {
                 localhost_ip_addr,
                 port_range,
                 QUIC_PORT_OFFSET,
-                udp_config.clone(),
-                quic_config.clone(),
+                udp_config,
+                quic_config,
             )
             .unwrap();
-        let tpu_quic =
-            bind_more_with_config(tpu_quic, num_quic_endpoints, quic_config.clone()).unwrap();
+        let tpu_quic = bind_more_with_config(tpu_quic, num_quic_endpoints, quic_config).unwrap();
         let (gossip_port, (gossip, ip_echo)) =
-            bind_common_in_range_with_config(localhost_ip_addr, port_range, udp_config.clone())
-                .unwrap();
+            bind_common_in_range_with_config(localhost_ip_addr, port_range, udp_config).unwrap();
         let gossip_addr = SocketAddr::new(localhost_ip_addr, gossip_port);
         let tvu = bind_to_localhost().unwrap();
         let tvu_quic = bind_to_localhost().unwrap();
@@ -2636,13 +2634,12 @@ impl Node {
                 localhost_ip_addr,
                 port_range,
                 QUIC_PORT_OFFSET,
-                udp_config.clone(),
-                quic_config.clone(),
+                udp_config,
+                quic_config,
             )
             .unwrap();
         let tpu_forwards_quic =
-            bind_more_with_config(tpu_forwards_quic, num_quic_endpoints, quic_config.clone())
-                .unwrap();
+            bind_more_with_config(tpu_forwards_quic, num_quic_endpoints, quic_config).unwrap();
         let tpu_vote = bind_to_localhost().unwrap();
         let tpu_vote_quic = bind_to_localhost().unwrap();
         let tpu_vote_quic =
@@ -2764,46 +2761,42 @@ impl Node {
 
         let socket_config = SocketConfig::default();
         let socket_config_reuseport = SocketConfig::default().reuseport(true);
-        let (tvu_port, tvu) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+        let (tvu_port, tvu) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (tvu_quic_port, tvu_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let ((tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_in_range_with_offset_and_config(
                 bind_ip_addr,
                 port_range,
                 QUIC_PORT_OFFSET,
-                socket_config.clone(),
-                socket_config_reuseport.clone(),
+                socket_config,
+                socket_config_reuseport,
             )
             .unwrap();
-        let tpu_quic: Vec<UdpSocket> = bind_more_with_config(
-            tpu_quic,
-            DEFAULT_QUIC_ENDPOINTS,
-            socket_config_reuseport.clone(),
-        )
-        .unwrap();
+        let tpu_quic: Vec<UdpSocket> =
+            bind_more_with_config(tpu_quic, DEFAULT_QUIC_ENDPOINTS, socket_config_reuseport)
+                .unwrap();
 
         let ((tpu_forwards_port, tpu_forwards), (_tpu_forwards_quic_port, tpu_forwards_quic)) =
             bind_two_in_range_with_offset_and_config(
                 bind_ip_addr,
                 port_range,
                 QUIC_PORT_OFFSET,
-                socket_config.clone(),
-                socket_config_reuseport.clone(),
+                socket_config,
+                socket_config_reuseport,
             )
             .unwrap();
         let tpu_forwards_quic = bind_more_with_config(
             tpu_forwards_quic,
             DEFAULT_QUIC_ENDPOINTS,
-            socket_config_reuseport.clone(),
+            socket_config_reuseport,
         )
         .unwrap();
 
         let (tpu_vote_port, tpu_vote) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (tpu_vote_quic_port, tpu_vote_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let tpu_vote_quic: Vec<UdpSocket> = bind_more_with_config(
             tpu_vote_quic,
             DEFAULT_QUIC_ENDPOINTS,
@@ -2812,20 +2805,18 @@ impl Node {
         .unwrap();
 
         let (_, retransmit_socket) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
-        let (_, repair) = Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
-        let (_, repair_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
+        let (_, repair) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
+        let (_, repair_quic) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (serve_repair_port, serve_repair) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (serve_repair_quic_port, serve_repair_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
-        let (_, broadcast) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
+        let (_, broadcast) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (_, ancestor_hashes_requests) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (_, ancestor_hashes_requests_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
         let rpc_port = find_available_port_in_range(bind_ip_addr, port_range).unwrap();
         let rpc_pubsub_port = find_available_port_in_range(bind_ip_addr, port_range).unwrap();
@@ -2907,41 +2898,30 @@ impl Node {
         let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
-            socket_config_reuseport.clone(),
+            socket_config_reuseport,
             num_tvu_sockets.get(),
         )
         .expect("tvu multi_bind");
 
         let (tvu_quic_port, tvu_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
-        let (tpu_port, tpu_sockets) = multi_bind_in_range_with_config(
-            bind_ip_addr,
-            port_range,
-            socket_config_reuseport.clone(),
-            32,
-        )
-        .expect("tpu multi_bind");
+        let (tpu_port, tpu_sockets) =
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 32)
+                .expect("tpu multi_bind");
 
         let (_tpu_port_quic, tpu_quic) = Self::bind_with_config(
             bind_ip_addr,
             (tpu_port + QUIC_PORT_OFFSET, tpu_port + QUIC_PORT_OFFSET + 1),
-            socket_config_reuseport.clone(),
+            socket_config_reuseport,
         );
-        let tpu_quic = bind_more_with_config(
-            tpu_quic,
-            num_quic_endpoints.get(),
-            socket_config_reuseport.clone(),
-        )
-        .unwrap();
+        let tpu_quic =
+            bind_more_with_config(tpu_quic, num_quic_endpoints.get(), socket_config_reuseport)
+                .unwrap();
 
-        let (tpu_forwards_port, tpu_forwards_sockets) = multi_bind_in_range_with_config(
-            bind_ip_addr,
-            port_range,
-            socket_config_reuseport.clone(),
-            8,
-        )
-        .expect("tpu_forwards multi_bind");
+        let (tpu_forwards_port, tpu_forwards_sockets) =
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 8)
+                .expect("tpu_forwards multi_bind");
 
         let (_tpu_forwards_port_quic, tpu_forwards_quic) = Self::bind_with_config(
             bind_ip_addr,
@@ -2949,62 +2929,49 @@ impl Node {
                 tpu_forwards_port + QUIC_PORT_OFFSET,
                 tpu_forwards_port + QUIC_PORT_OFFSET + 1,
             ),
-            socket_config_reuseport.clone(),
+            socket_config_reuseport,
         );
         let tpu_forwards_quic = bind_more_with_config(
             tpu_forwards_quic,
             num_quic_endpoints.get(),
-            socket_config_reuseport.clone(),
+            socket_config_reuseport,
         )
         .unwrap();
 
-        let (tpu_vote_port, tpu_vote_sockets) = multi_bind_in_range_with_config(
-            bind_ip_addr,
-            port_range,
-            socket_config_reuseport.clone(),
-            1,
-        )
-        .expect("tpu_vote multi_bind");
+        let (tpu_vote_port, tpu_vote_sockets) =
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 1)
+                .expect("tpu_vote multi_bind");
 
         let (tpu_vote_quic_port, tpu_vote_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
         let tpu_vote_quic = bind_more_with_config(
             tpu_vote_quic,
             num_quic_endpoints.get(),
-            socket_config_reuseport.clone(),
+            socket_config_reuseport,
         )
         .unwrap();
 
-        let (_, retransmit_sockets) = multi_bind_in_range_with_config(
-            bind_ip_addr,
-            port_range,
-            socket_config_reuseport.clone(),
-            8,
-        )
-        .expect("retransmit multi_bind");
+        let (_, retransmit_sockets) =
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 8)
+                .expect("retransmit multi_bind");
 
-        let (_, repair) = Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
-        let (_, repair_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+        let (_, repair) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
+        let (_, repair_quic) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
         let (serve_repair_port, serve_repair) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (serve_repair_quic_port, serve_repair_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
-        let (_, broadcast) = multi_bind_in_range_with_config(
-            bind_ip_addr,
-            port_range,
-            socket_config_reuseport.clone(),
-            4,
-        )
-        .expect("broadcast multi_bind");
+        let (_, broadcast) =
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 4)
+                .expect("broadcast multi_bind");
 
         let (_, ancestor_hashes_requests) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (_, ancestor_hashes_requests_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config.clone());
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
         let mut info = ContactInfo::new(
             *pubkey,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2612,8 +2612,8 @@ impl Node {
         let localhost_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let port_range = (1024, 65535);
 
-        let udp_config = SocketConfig::default_rw();
-        let quic_config = SocketConfig::default_rw().reuseport(true);
+        let udp_config = SocketConfig::default();
+        let quic_config = SocketConfig::default().reuseport(true);
         let ((_tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_in_range_with_offset_and_config(
                 localhost_ip_addr,
@@ -2731,7 +2731,7 @@ impl Node {
         port_range: PortRange,
         bind_ip_addr: IpAddr,
     ) -> (u16, (UdpSocket, TcpListener)) {
-        let config = SocketConfig::default_rw();
+        let config = SocketConfig::default();
         if gossip_addr.port() != 0 {
             (
                 gossip_addr.port(),
@@ -2762,13 +2762,13 @@ impl Node {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(gossip_addr, port_range, bind_ip_addr);
 
-        let read_write_socket_config = SocketConfig::default_rw();
+        let read_write_socket_config = SocketConfig::default();
         let (tvu_port, tvu) =
             Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
         let (tvu_quic_port, tvu_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
-        let tpu_udp_config = SocketConfig::default_rw();
-        let tpu_quic_config = SocketConfig::default_rw().reuseport(true);
+        let tpu_udp_config = SocketConfig::default();
+        let tpu_quic_config = SocketConfig::default().reuseport(true);
         let ((tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_in_range_with_offset_and_config(
                 bind_ip_addr,
@@ -2782,8 +2782,8 @@ impl Node {
             bind_more_with_config(tpu_quic, DEFAULT_QUIC_ENDPOINTS, tpu_quic_config.clone())
                 .unwrap();
 
-        let tpu_forwards_udp_config = SocketConfig::default_rw();
-        let tpu_forwards_quic_config = SocketConfig::default_rw().reuseport(true);
+        let tpu_forwards_udp_config = SocketConfig::default();
+        let tpu_forwards_quic_config = SocketConfig::default().reuseport(true);
         let ((tpu_forwards_port, tpu_forwards), (_tpu_forwards_quic_port, tpu_forwards_quic)) =
             bind_two_in_range_with_offset_and_config(
                 bind_ip_addr,
@@ -2800,8 +2800,8 @@ impl Node {
         )
         .unwrap();
 
-        let tpu_vote_udp_config = SocketConfig::default_rw();
-        let tpu_vote_quic_config = SocketConfig::default_rw().reuseport(true);
+        let tpu_vote_udp_config = SocketConfig::default();
+        let tpu_vote_quic_config = SocketConfig::default().reuseport(true);
         let (tpu_vote_port, tpu_vote) =
             Self::bind_with_config(bind_ip_addr, port_range, tpu_vote_udp_config.clone());
         // using udp port for quic really because we need to reusport set to false, since Self::bind() defaults to false
@@ -2811,7 +2811,7 @@ impl Node {
             bind_more_with_config(tpu_vote_quic, DEFAULT_QUIC_ENDPOINTS, tpu_vote_quic_config)
                 .unwrap();
 
-        let write_only_socket_config = SocketConfig::default_rw();
+        let write_only_socket_config = SocketConfig::default();
 
         let (_, retransmit_socket) =
             Self::bind_with_config(bind_ip_addr, port_range, write_only_socket_config.clone());
@@ -2904,7 +2904,7 @@ impl Node {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(&gossip_addr, port_range, bind_ip_addr);
 
-        let tvu_config = SocketConfig::default_rw().reuseport(true);
+        let tvu_config = SocketConfig::default().reuseport(true);
         let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
@@ -2913,11 +2913,11 @@ impl Node {
         )
         .expect("tvu multi_bind");
 
-        let tvu_config = SocketConfig::default_rw().reuseport(false);
+        let tvu_config = SocketConfig::default().reuseport(false);
         let (tvu_quic_port, tvu_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, tvu_config);
 
-        let tpu_config = SocketConfig::default_rw().reuseport(true);
+        let tpu_config = SocketConfig::default().reuseport(true);
         let (tpu_port, tpu_sockets) =
             multi_bind_in_range_with_config(bind_ip_addr, port_range, tpu_config.clone(), 32)
                 .expect("tpu multi_bind");
@@ -2930,7 +2930,7 @@ impl Node {
         let tpu_quic =
             bind_more_with_config(tpu_quic, num_quic_endpoints.get(), tpu_config.clone()).unwrap();
 
-        let tpu_forwards_config = SocketConfig::default_rw().reuseport(true);
+        let tpu_forwards_config = SocketConfig::default().reuseport(true);
         let (tpu_forwards_port, tpu_forwards_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
@@ -2954,16 +2954,16 @@ impl Node {
         )
         .unwrap();
 
-        let tpu_vote_config = SocketConfig::default_rw().reuseport(true);
+        let tpu_vote_config = SocketConfig::default().reuseport(true);
         let (tpu_vote_port, tpu_vote_sockets) =
             multi_bind_in_range_with_config(bind_ip_addr, port_range, tpu_vote_config.clone(), 1)
                 .expect("tpu_vote multi_bind");
 
-        let tpu_vote_config = SocketConfig::default_rw();
+        let tpu_vote_config = SocketConfig::default();
         let (tpu_vote_quic_port, tpu_vote_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, tpu_vote_config.clone());
 
-        let tpu_vote_config = SocketConfig::default_rw().reuseport(true);
+        let tpu_vote_config = SocketConfig::default().reuseport(true);
         let tpu_vote_quic = bind_more_with_config(
             tpu_vote_quic,
             num_quic_endpoints.get(),
@@ -2971,28 +2971,28 @@ impl Node {
         )
         .unwrap();
 
-        let retransmit_config = SocketConfig::default_rw().reuseport(true);
+        let retransmit_config = SocketConfig::default().reuseport(true);
         let (_, retransmit_sockets) =
             multi_bind_in_range_with_config(bind_ip_addr, port_range, retransmit_config, 8)
                 .expect("retransmit multi_bind");
 
-        let repair_config = SocketConfig::default_rw();
+        let repair_config = SocketConfig::default();
         let (_, repair) = Self::bind_with_config(bind_ip_addr, port_range, repair_config.clone());
         let (_, repair_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, repair_config.clone());
 
-        let serve_repair_config = SocketConfig::default_rw();
+        let serve_repair_config = SocketConfig::default();
         let (serve_repair_port, serve_repair) =
             Self::bind_with_config(bind_ip_addr, port_range, serve_repair_config.clone());
         let (serve_repair_quic_port, serve_repair_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, serve_repair_config);
 
-        let broadcast_config = SocketConfig::default_rw().reuseport(true);
+        let broadcast_config = SocketConfig::default().reuseport(true);
         let (_, broadcast) =
             multi_bind_in_range_with_config(bind_ip_addr, port_range, broadcast_config, 4)
                 .expect("broadcast multi_bind");
 
-        let ancestor_hashes_config = SocketConfig::default_rw();
+        let ancestor_hashes_config = SocketConfig::default();
         let (_, ancestor_hashes_requests) =
             Self::bind_with_config(bind_ip_addr, port_range, ancestor_hashes_config.clone());
         let (_, ancestor_hashes_requests_quic) =

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2612,8 +2612,8 @@ impl Node {
         let localhost_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let port_range = (1024, 65535);
 
-        let udp_config = SocketConfig::default();
-        let quic_config = SocketConfig::default().reuseport(true);
+        let udp_config = SocketConfig::default_rw();
+        let quic_config = SocketConfig::default_rw().reuseport(true);
         let ((_tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_in_range_with_offset_and_config(
                 localhost_ip_addr,
@@ -2731,7 +2731,7 @@ impl Node {
         port_range: PortRange,
         bind_ip_addr: IpAddr,
     ) -> (u16, (UdpSocket, TcpListener)) {
-        let config = SocketConfig::default();
+        let config = SocketConfig::default_rw();
         if gossip_addr.port() != 0 {
             (
                 gossip_addr.port(),
@@ -2762,13 +2762,13 @@ impl Node {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(gossip_addr, port_range, bind_ip_addr);
 
-        let read_write_socket_config = SocketConfig::default();
+        let read_write_socket_config = SocketConfig::default_rw();
         let (tvu_port, tvu) =
             Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
         let (tvu_quic_port, tvu_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, read_write_socket_config.clone());
-        let tpu_udp_config = SocketConfig::default();
-        let tpu_quic_config = SocketConfig::default().reuseport(true);
+        let tpu_udp_config = SocketConfig::default_rw();
+        let tpu_quic_config = SocketConfig::default_rw().reuseport(true);
         let ((tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_in_range_with_offset_and_config(
                 bind_ip_addr,
@@ -2782,8 +2782,8 @@ impl Node {
             bind_more_with_config(tpu_quic, DEFAULT_QUIC_ENDPOINTS, tpu_quic_config.clone())
                 .unwrap();
 
-        let tpu_forwards_udp_config = SocketConfig::default();
-        let tpu_forwards_quic_config = SocketConfig::default().reuseport(true);
+        let tpu_forwards_udp_config = SocketConfig::default_rw();
+        let tpu_forwards_quic_config = SocketConfig::default_rw().reuseport(true);
         let ((tpu_forwards_port, tpu_forwards), (_tpu_forwards_quic_port, tpu_forwards_quic)) =
             bind_two_in_range_with_offset_and_config(
                 bind_ip_addr,
@@ -2800,8 +2800,8 @@ impl Node {
         )
         .unwrap();
 
-        let tpu_vote_udp_config = SocketConfig::default();
-        let tpu_vote_quic_config = SocketConfig::default().reuseport(true);
+        let tpu_vote_udp_config = SocketConfig::default_rw();
+        let tpu_vote_quic_config = SocketConfig::default_rw().reuseport(true);
         let (tpu_vote_port, tpu_vote) =
             Self::bind_with_config(bind_ip_addr, port_range, tpu_vote_udp_config.clone());
         // using udp port for quic really because we need to reusport set to false, since Self::bind() defaults to false
@@ -2811,7 +2811,7 @@ impl Node {
             bind_more_with_config(tpu_vote_quic, DEFAULT_QUIC_ENDPOINTS, tpu_vote_quic_config)
                 .unwrap();
 
-        let write_only_socket_config = SocketConfig::default();
+        let write_only_socket_config = SocketConfig::default_rw();
 
         let (_, retransmit_socket) =
             Self::bind_with_config(bind_ip_addr, port_range, write_only_socket_config.clone());
@@ -2904,7 +2904,7 @@ impl Node {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(&gossip_addr, port_range, bind_ip_addr);
 
-        let tvu_config = SocketConfig::default().reuseport(true);
+        let tvu_config = SocketConfig::default_rw().reuseport(true);
         let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
@@ -2913,11 +2913,11 @@ impl Node {
         )
         .expect("tvu multi_bind");
 
-        let tvu_config = SocketConfig::default().reuseport(false);
+        let tvu_config = SocketConfig::default_rw().reuseport(false);
         let (tvu_quic_port, tvu_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, tvu_config);
 
-        let tpu_config = SocketConfig::default().reuseport(true);
+        let tpu_config = SocketConfig::default_rw().reuseport(true);
         let (tpu_port, tpu_sockets) =
             multi_bind_in_range_with_config(bind_ip_addr, port_range, tpu_config.clone(), 32)
                 .expect("tpu multi_bind");
@@ -2930,7 +2930,7 @@ impl Node {
         let tpu_quic =
             bind_more_with_config(tpu_quic, num_quic_endpoints.get(), tpu_config.clone()).unwrap();
 
-        let tpu_forwards_config = SocketConfig::default().reuseport(true);
+        let tpu_forwards_config = SocketConfig::default_rw().reuseport(true);
         let (tpu_forwards_port, tpu_forwards_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
@@ -2954,16 +2954,16 @@ impl Node {
         )
         .unwrap();
 
-        let tpu_vote_config = SocketConfig::default().reuseport(true);
+        let tpu_vote_config = SocketConfig::default_rw().reuseport(true);
         let (tpu_vote_port, tpu_vote_sockets) =
             multi_bind_in_range_with_config(bind_ip_addr, port_range, tpu_vote_config.clone(), 1)
                 .expect("tpu_vote multi_bind");
 
-        let tpu_vote_config = SocketConfig::default();
+        let tpu_vote_config = SocketConfig::default_rw();
         let (tpu_vote_quic_port, tpu_vote_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, tpu_vote_config.clone());
 
-        let tpu_vote_config = SocketConfig::default().reuseport(true);
+        let tpu_vote_config = SocketConfig::default_rw().reuseport(true);
         let tpu_vote_quic = bind_more_with_config(
             tpu_vote_quic,
             num_quic_endpoints.get(),
@@ -2971,28 +2971,28 @@ impl Node {
         )
         .unwrap();
 
-        let retransmit_config = SocketConfig::default().reuseport(true);
+        let retransmit_config = SocketConfig::default_rw().reuseport(true);
         let (_, retransmit_sockets) =
             multi_bind_in_range_with_config(bind_ip_addr, port_range, retransmit_config, 8)
                 .expect("retransmit multi_bind");
 
-        let repair_config = SocketConfig::default();
+        let repair_config = SocketConfig::default_rw();
         let (_, repair) = Self::bind_with_config(bind_ip_addr, port_range, repair_config.clone());
         let (_, repair_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, repair_config.clone());
 
-        let serve_repair_config = SocketConfig::default();
+        let serve_repair_config = SocketConfig::default_rw();
         let (serve_repair_port, serve_repair) =
             Self::bind_with_config(bind_ip_addr, port_range, serve_repair_config.clone());
         let (serve_repair_quic_port, serve_repair_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, serve_repair_config);
 
-        let broadcast_config = SocketConfig::default().reuseport(true);
+        let broadcast_config = SocketConfig::default_rw().reuseport(true);
         let (_, broadcast) =
             multi_bind_in_range_with_config(bind_ip_addr, port_range, broadcast_config, 4)
                 .expect("broadcast multi_bind");
 
-        let ancestor_hashes_config = SocketConfig::default();
+        let ancestor_hashes_config = SocketConfig::default_rw();
         let (_, ancestor_hashes_requests) =
             Self::bind_with_config(bind_ip_addr, port_range, ancestor_hashes_config.clone());
         let (_, ancestor_hashes_requests_quic) =

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -36,11 +36,6 @@ pub type PortRange = (u16, u16);
 pub const VALIDATOR_PORT_RANGE: PortRange = (8000, 10_000);
 pub const MINIMUM_VALIDATOR_PORT_RANGE_WIDTH: u16 = 17; // VALIDATOR_PORT_RANGE must be at least this wide
 
-#[cfg(not(any(windows, target_os = "ios")))]
-const DEFAULT_RECV_BUFFER_SIZE: usize = 64 * 1024 * 1024; // 64MB - Doubled to 128MB by the kernel
-#[cfg(not(any(windows, target_os = "ios")))]
-const DEFAULT_SEND_BUFFER_SIZE: usize = 64 * 1024 * 1024; // 64MB - Doubled to 128MB by the kernel
-
 #[derive(Clone, Debug)]
 pub enum SocketUsage {
     ReadOnly,
@@ -398,48 +393,49 @@ pub fn is_host_port(string: String) -> Result<(), String> {
     parse_host_port(&string).map(|_| ())
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(any(windows, target_os = "ios"), derive(Default))]
+#[derive(Clone, Debug, Default)]
 pub struct SocketConfig {
     reuseport: bool,
     #[cfg(not(any(windows, target_os = "ios")))]
-    recv_buffer_size: usize,
+    recv_buffer_size: Option<usize>,
     #[cfg(not(any(windows, target_os = "ios")))]
-    send_buffer_size: usize,
+    send_buffer_size: Option<usize>,
 }
 
 impl SocketConfig {
-    pub fn default_rw() -> Self {
-        Self {
-            reuseport: false,
-            #[cfg(not(any(windows, target_os = "ios")))]
-            recv_buffer_size: DEFAULT_RECV_BUFFER_SIZE,
-            #[cfg(not(any(windows, target_os = "ios")))]
-            send_buffer_size: DEFAULT_SEND_BUFFER_SIZE,
-        }
-    }
-
     pub fn reuseport(mut self, reuseport: bool) -> Self {
         self.reuseport = reuseport;
         self
     }
 
+    /// Sets the receive buffer size for the socket.
+    ///
+    /// **Note:** On Linux the kernel will double the value you specify.
+    /// For example, if you specify `16MB`, the kernel will configure the
+    /// socket to use `32MB`.
+    /// See: https://man7.org/linux/man-pages/man7/socket.7.html: SO_RCVBUF
     // allow here to supress unused warnings from windows/ios builds
     #[allow(unused_mut, unused_variables)]
     pub fn recv_buffer_size(mut self, size: usize) -> Self {
         #[cfg(not(any(windows, target_os = "ios")))]
         {
-            self.recv_buffer_size = size;
+            self.recv_buffer_size = Some(size);
         }
         self
     }
 
+    /// Sets the send buffer size for the socket.
+    ///
+    /// **Note:** On Linux the kernel will double the value you specify.
+    /// For example, if you specify `16MB`, the kernel will configure the
+    /// socket to use `32MB`.
+    /// See: https://man7.org/linux/man-pages/man7/socket.7.html: SO_SNDBUF
     // allow here to supress unused warnings from windows/ios builds
     #[allow(unused_mut, unused_variables)]
     pub fn send_buffer_size(mut self, size: usize) -> Self {
         #[cfg(not(any(windows, target_os = "ios")))]
         {
-            self.send_buffer_size = size;
+            self.send_buffer_size = Some(size);
         }
         self
     }
@@ -463,8 +459,13 @@ fn udp_socket_with_config(config: SocketConfig) -> io::Result<Socket> {
     let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
 
     // Set buffer sizes
-    sock.set_recv_buffer_size(recv_buffer_size)?;
-    sock.set_send_buffer_size(send_buffer_size)?;
+    if let Some(recv_buffer_size) = recv_buffer_size {
+        sock.set_recv_buffer_size(recv_buffer_size)?;
+    }
+
+    if let Some(send_buffer_size) = send_buffer_size {
+        sock.set_send_buffer_size(send_buffer_size)?;
+    }
 
     if reuseport {
         setsockopt(&sock, ReusePort, &true).ok();
@@ -500,11 +501,11 @@ pub fn bind_common_in_range(
     ip_addr: IpAddr,
     range: PortRange,
 ) -> io::Result<(u16, (UdpSocket, TcpListener))> {
-    bind_common_in_range_with_config(ip_addr, range, SocketConfig::default_rw())
+    bind_common_in_range_with_config(ip_addr, range, SocketConfig::default())
 }
 
 pub fn bind_in_range(ip_addr: IpAddr, range: PortRange) -> io::Result<(u16, UdpSocket)> {
-    let config = SocketConfig::default_rw();
+    let config = SocketConfig::default();
     bind_in_range_with_config(ip_addr, range, config)
 }
 
@@ -547,7 +548,7 @@ pub fn bind_with_any_port_with_config(
 
 #[deprecated(since = "2.2.0", note = "use `bind_with_any_port_with_config` instead")]
 pub fn bind_with_any_port(ip_addr: IpAddr) -> io::Result<UdpSocket> {
-    bind_with_any_port_with_config(ip_addr, SocketConfig::default_rw())
+    bind_with_any_port_with_config(ip_addr, SocketConfig::default())
 }
 
 // binds many sockets to the same port in a range with config
@@ -615,12 +616,12 @@ pub fn multi_bind_in_range(
     range: PortRange,
     mut num: usize,
 ) -> io::Result<(u16, Vec<UdpSocket>)> {
-    let config = SocketConfig::default_rw().reuseport(true);
+    let config = SocketConfig::default().reuseport(true);
     multi_bind_in_range_with_config(ip_addr, range, config, num)
 }
 
 pub fn bind_to(ip_addr: IpAddr, port: u16, reuseport: bool) -> io::Result<UdpSocket> {
-    let config = SocketConfig::default_rw().reuseport(reuseport);
+    let config = SocketConfig::default().reuseport(reuseport);
     bind_to_with_config(ip_addr, port, config)
 }
 
@@ -630,7 +631,7 @@ pub async fn bind_to_async(
     port: u16,
     reuseport: bool,
 ) -> io::Result<TokioUdpSocket> {
-    let config = SocketConfig::default_rw().reuseport(reuseport);
+    let config = SocketConfig::default().reuseport(reuseport);
     let socket = bind_to_with_config_non_blocking(ip_addr, port, config)?;
     TokioUdpSocket::from_std(socket)
 }
@@ -699,7 +700,7 @@ pub fn bind_to_with_config_non_blocking(
 
 // binds both a UdpSocket and a TcpListener
 pub fn bind_common(ip_addr: IpAddr, port: u16) -> io::Result<(UdpSocket, TcpListener)> {
-    let config = SocketConfig::default_rw();
+    let config = SocketConfig::default();
     bind_common_with_config(ip_addr, port, config)
 }
 
@@ -722,8 +723,8 @@ pub fn bind_two_in_range_with_offset(
     range: PortRange,
     offset: u16,
 ) -> io::Result<((u16, UdpSocket), (u16, UdpSocket))> {
-    let sock1_config = SocketConfig::default_rw();
-    let sock2_config = SocketConfig::default_rw();
+    let sock1_config = SocketConfig::default();
+    let sock2_config = SocketConfig::default();
     bind_two_in_range_with_offset_and_config(ip_addr, range, offset, sock1_config, sock2_config)
 }
 
@@ -901,7 +902,7 @@ mod tests {
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
         assert_eq!(bind_in_range(ip_addr, (2000, 2001)).unwrap().0, 2000);
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let config = SocketConfig::default_rw().reuseport(true);
+        let config = SocketConfig::default().reuseport(true);
         let x = bind_to_with_config(ip_addr, 2002, config.clone()).unwrap();
         let y = bind_to_with_config(ip_addr, 2002, config.clone()).unwrap();
         assert_eq!(
@@ -921,7 +922,7 @@ mod tests {
     #[test]
     fn test_bind_with_any_port() {
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let config = SocketConfig::default_rw();
+        let config = SocketConfig::default();
         let x = bind_with_any_port_with_config(ip_addr, config.clone()).unwrap();
         let y = bind_with_any_port_with_config(ip_addr, config.clone()).unwrap();
         assert_ne!(
@@ -954,7 +955,7 @@ mod tests {
     #[test]
     fn test_bind_common_in_range() {
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let config = SocketConfig::default_rw();
+        let config = SocketConfig::default();
         let (port, _sockets) =
             bind_common_in_range_with_config(ip_addr, (3100, 3150), config.clone()).unwrap();
         assert!((3100..3150).contains(&port));
@@ -966,7 +967,7 @@ mod tests {
     fn test_get_public_ip_addr_none() {
         solana_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let config = SocketConfig::default_rw();
+        let config = SocketConfig::default();
         let (_server_port, (server_udp_socket, server_tcp_listener)) =
             bind_common_in_range_with_config(ip_addr, (3200, 3250), config).unwrap();
 
@@ -989,7 +990,7 @@ mod tests {
     fn test_get_public_ip_addr_reachable() {
         solana_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let config = SocketConfig::default_rw();
+        let config = SocketConfig::default();
         let (_server_port, (server_udp_socket, server_tcp_listener)) =
             bind_common_in_range_with_config(ip_addr, (3200, 3250), config.clone()).unwrap();
         let (client_port, (client_udp_socket, client_tcp_listener)) =
@@ -1018,7 +1019,7 @@ mod tests {
     fn test_get_public_ip_addr_tcp_unreachable() {
         solana_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let config = SocketConfig::default_rw();
+        let config = SocketConfig::default();
         let (_server_port, (server_udp_socket, _server_tcp_listener)) =
             bind_common_in_range_with_config(ip_addr, (3200, 3250), config.clone()).unwrap();
 
@@ -1042,7 +1043,7 @@ mod tests {
     fn test_get_public_ip_addr_udp_unreachable() {
         solana_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let config = SocketConfig::default_rw();
+        let config = SocketConfig::default();
         let (_server_port, (server_udp_socket, _server_tcp_listener)) =
             bind_common_in_range_with_config(ip_addr, (3200, 3250), config.clone()).unwrap();
 
@@ -1084,7 +1085,7 @@ mod tests {
     #[test]
     fn test_multi_bind_in_range_with_config_reuseport_disabled() {
         let ip_addr: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let config = SocketConfig::default_rw(); //reuseport is false by default
+        let config = SocketConfig::default(); //reuseport is false by default
 
         let result = multi_bind_in_range_with_config(ip_addr, (2010, 2110), config, 2);
 

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -36,13 +36,6 @@ pub type PortRange = (u16, u16);
 pub const VALIDATOR_PORT_RANGE: PortRange = (8000, 10_000);
 pub const MINIMUM_VALIDATOR_PORT_RANGE_WIDTH: u16 = 17; // VALIDATOR_PORT_RANGE must be at least this wide
 
-#[derive(Clone, Debug)]
-pub enum SocketUsage {
-    ReadOnly,
-    WriteOnly,
-    ReadWrite,
-}
-
 pub(crate) const HEADER_LENGTH: usize = 4;
 pub(crate) const IP_ECHO_SERVER_RESPONSE_LENGTH: usize = HEADER_LENGTH + 23;
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5423,6 +5423,7 @@ dependencies = [
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
+ "solana-net-utils",
  "solana-time-utils",
  "solana-transaction-error",
  "thiserror 2.0.6",

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -75,7 +75,7 @@ impl QuicLazyInitializedEndpoint {
         let mut endpoint = if let Some(endpoint) = &self.client_endpoint {
             endpoint.clone()
         } else {
-            let config = SocketConfig::default();
+            let config = SocketConfig::default_rw();
             let client_socket = solana_net_utils::bind_in_range_with_config(
                 IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                 VALIDATOR_PORT_RANGE,

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -75,7 +75,7 @@ impl QuicLazyInitializedEndpoint {
         let mut endpoint = if let Some(endpoint) = &self.client_endpoint {
             endpoint.clone()
         } else {
-            let config = SocketConfig::default_rw();
+            let config = SocketConfig::default();
             let client_socket = solana_net_utils::bind_in_range_with_config(
                 IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                 VALIDATOR_PORT_RANGE,

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -17,7 +17,7 @@ use {
     },
     solana_keypair::Keypair,
     solana_measure::measure::Measure,
-    solana_net_utils::VALIDATOR_PORT_RANGE,
+    solana_net_utils::{SocketConfig, VALIDATOR_PORT_RANGE},
     solana_quic_definitions::{
         QUIC_CONNECTION_HANDSHAKE_TIMEOUT, QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT,
     },
@@ -75,9 +75,11 @@ impl QuicLazyInitializedEndpoint {
         let mut endpoint = if let Some(endpoint) = &self.client_endpoint {
             endpoint.clone()
         } else {
-            let client_socket = solana_net_utils::bind_in_range(
+            let config = SocketConfig::default();
+            let client_socket = solana_net_utils::bind_in_range_with_config(
                 IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                 VALIDATOR_PORT_RANGE,
+                config,
             )
             .expect("QuicLazyInitializedEndpoint::create_endpoint bind_in_range")
             .1;

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5274,6 +5274,7 @@ dependencies = [
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
+ "solana-net-utils",
  "solana-time-utils",
  "solana-transaction-error",
  "thiserror 2.0.6",

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -16,6 +16,7 @@ use {
         connection_cache_stats::ConnectionCacheStats,
     },
     solana_keypair::Keypair,
+    solana_net_utils::SocketConfig,
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
         sync::Arc,
@@ -62,8 +63,11 @@ pub struct UdpConfig {
 
 impl NewConnectionConfig for UdpConfig {
     fn new() -> Result<Self, ClientError> {
-        let socket = solana_net_utils::bind_with_any_port(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
-            .map_err(Into::<ClientError>::into)?;
+        let socket = solana_net_utils::bind_with_any_port_with_config(
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            SocketConfig::default(),
+        )
+        .map_err(Into::<ClientError>::into)?;
         Ok(Self {
             udp_socket: Arc::new(socket),
         })

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -65,7 +65,7 @@ impl NewConnectionConfig for UdpConfig {
     fn new() -> Result<Self, ClientError> {
         let socket = solana_net_utils::bind_with_any_port_with_config(
             IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            SocketConfig::default_rw(),
+            SocketConfig::default(),
         )
         .map_err(Into::<ClientError>::into)?;
         Ok(Self {

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -65,7 +65,7 @@ impl NewConnectionConfig for UdpConfig {
     fn new() -> Result<Self, ClientError> {
         let socket = solana_net_utils::bind_with_any_port_with_config(
             IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            SocketConfig::default(),
+            SocketConfig::default_rw(),
         )
         .map_err(Into::<ClientError>::into)?;
         Ok(Self {

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -46,7 +46,7 @@ impl ClientConnection for UdpClientConnection {
 mod tests {
     use {
         super::*,
-        solana_net_utils::bind_to_async,
+        solana_net_utils::{bind_to_async, SocketConfig},
         solana_packet::{Packet, PACKET_DATA_SIZE},
         solana_streamer::nonblocking::recvmmsg::recv_mmsg,
         std::net::{IpAddr, Ipv4Addr},
@@ -73,8 +73,11 @@ mod tests {
     async fn test_send_from_addr() {
         let addr_str = "0.0.0.0:50100";
         let addr = addr_str.parse().unwrap();
-        let socket =
-            solana_net_utils::bind_with_any_port(IpAddr::V4(Ipv4Addr::UNSPECIFIED)).unwrap();
+        let socket = solana_net_utils::bind_with_any_port_with_config(
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            SocketConfig::default(),
+        )
+        .unwrap();
         let connection = UdpClientConnection::new_from_addr(socket, addr);
         let reader = bind_to_async(
             addr.ip(),

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -75,7 +75,7 @@ mod tests {
         let addr = addr_str.parse().unwrap();
         let socket = solana_net_utils::bind_with_any_port_with_config(
             IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            SocketConfig::default(),
+            SocketConfig::default_rw(),
         )
         .unwrap();
         let connection = UdpClientConnection::new_from_addr(socket, addr);

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -75,7 +75,7 @@ mod tests {
         let addr = addr_str.parse().unwrap();
         let socket = solana_net_utils::bind_with_any_port_with_config(
             IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            SocketConfig::default_rw(),
+            SocketConfig::default(),
         )
         .unwrap();
         let connection = UdpClientConnection::new_from_addr(socket, addr);


### PR DESCRIPTION
#### Problem
We allocate large send and receive buffers for all sockets. However, not all sockets read and write equally from/to their buffers. In fact, 6 sockets are primarily Read and 2 are primarily Write. Meaning we are allocating memory that is never used. 

#### Summary of Changes
preparation for reducing socket buffer sizes. This PR leaves socket buffer sizes as is.
1) Update `SocketConfig` to use builder pattern
2) Deprecate unused `net-utils` methods that use default `SocketConfig`

Services/Sockets
Read/Write
1) Gossip
2) RPC - TCP
3) Ip_echo - TCP
4) Tvu
5) tvu_quic
6) Repair
7) Repair_quic
8) Serve_repair
9) Serve_repair_quic
10) Ancestor_hashes_requests_quic
11) Ancestor_hashes_requests

Primarily Read
1) Tpu
2) Tpu_forwards
3) Tpu_vote
4) Tpu_quic
5) Tpu_forwards_quic
6) Tpu_vote_quic

Primarily Write
1) Retransmitter
2) Broadcast

Follow Up PR:
1) get rid of target gating
2) Reduce size of unused side of socket
3) Make better sizing decisions for the sockets that don't need a full 128MB buffer