### PR TITLE
blockstore: Remove intermediate Database type

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1329,7 +1329,7 @@ impl Blockstore {
 
         // Write out the accumulated batch.
         let mut start = Measure::start("Write Batch");
-        self.db.write(shred_insertion_tracker.write_batch)?;
+        self.write_batch(shred_insertion_tracker.write_batch)?;
         start.stop();
         metrics.write_batch_elapsed_us += start.as_us();
 
@@ -4089,7 +4089,7 @@ impl Blockstore {
                 .put_in_batch(&mut write_batch, slot, &data)?;
         }
 
-        self.db.write(write_batch)?;
+        self.write_batch(write_batch)?;
         Ok(())
     }
 
@@ -4101,7 +4101,7 @@ impl Blockstore {
             self.roots_cf.put_in_batch(&mut write_batch, *slot, &true)?;
         }
 
-        self.db.write(write_batch)?;
+        self.write_batch(write_batch)?;
         self.max_root
             .fetch_max(max_new_rooted_slot, Ordering::Relaxed);
         Ok(())
@@ -4420,7 +4420,7 @@ impl Blockstore {
                 .put_in_batch(&mut write_batch, meta.slot, &meta)?;
         }
 
-        self.db.write(write_batch)?;
+        self.write_batch(write_batch)?;
         Ok(())
     }
 
@@ -4778,7 +4778,7 @@ impl Blockstore {
     }
 
     pub fn write_batch(&self, write_batch: WriteBatch) -> Result<()> {
-        self.db.write(write_batch)
+        self.db.backend.write(write_batch)
     }
 }
 
@@ -7625,7 +7625,7 @@ pub mod tests {
                 .put(erasure_set.store_key(), working_merkle_root_meta.as_ref())
                 .unwrap();
         }
-        blockstore.db.write(write_batch).unwrap();
+        blockstore.write_batch(write_batch).unwrap();
 
         // Add a shred with different merkle root and index
         let (_, coding_shreds, _) = setup_erasure_shreds(slot, parent_slot, 10);
@@ -7807,7 +7807,7 @@ pub mod tests {
                 .put(erasure_set.store_key(), working_merkle_root_meta.as_ref())
                 .unwrap();
         }
-        blockstore.db.write(write_batch).unwrap();
+        blockstore.write_batch(write_batch).unwrap();
 
         // Add a shred with different merkle root and index
         let (data_shreds, _, _) =
@@ -11968,7 +11968,7 @@ pub mod tests {
             .merkle_root_meta_cf
             .delete_range_in_batch(&mut write_batch, slot, slot)
             .unwrap();
-        blockstore.db.write(write_batch).unwrap();
+        blockstore.write_batch(write_batch).unwrap();
         assert!(blockstore
             .merkle_root_meta(coding_shred_previous.erasure_set())
             .unwrap()
@@ -12034,7 +12034,7 @@ pub mod tests {
             .merkle_root_meta_cf
             .delete_range_in_batch(&mut write_batch, slot, slot)
             .unwrap();
-        blockstore.db.write(write_batch).unwrap();
+        blockstore.write_batch(write_batch).unwrap();
         assert!(blockstore
             .merkle_root_meta(next_coding_shreds[0].erasure_set())
             .unwrap()

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2603,10 +2603,7 @@ impl Blockstore {
         end_index: u64,
         max_missing: usize,
     ) -> Vec<u64> {
-        let Ok(mut db_iterator) = self
-            .db
-            .backend
-            .raw_iterator_cf(self.db.cf_handle::<cf::ShredData>())
+        let Ok(mut db_iterator) = self.db.backend.raw_iterator_cf(self.data_shred_cf.handle())
         else {
             return vec![];
         };

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2603,22 +2603,23 @@ impl Blockstore {
         end_index: u64,
         max_missing: usize,
     ) -> Vec<u64> {
-        if let Ok(mut db_iterator) = self
+        let Ok(mut db_iterator) = self
             .db
+            .backend
             .raw_iterator_cf(self.db.cf_handle::<cf::ShredData>())
-        {
-            Self::find_missing_indexes::<cf::ShredData>(
-                &mut db_iterator,
-                slot,
-                first_timestamp,
-                defer_threshold_ticks,
-                start_index,
-                end_index,
-                max_missing,
-            )
-        } else {
-            vec![]
-        }
+        else {
+            return vec![];
+        };
+
+        Self::find_missing_indexes::<cf::ShredData>(
+            &mut db_iterator,
+            slot,
+            first_timestamp,
+            defer_threshold_ticks,
+            start_index,
+            end_index,
+            max_missing,
+        )
     }
 
     fn get_block_time(&self, slot: Slot) -> Result<Option<UnixTimestamp>> {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -672,7 +672,7 @@ impl Blockstore {
     }
 
     pub fn live_files_metadata(&self) -> Result<Vec<LiveFile>> {
-        self.db.live_files_metadata()
+        self.db.backend.live_files_metadata()
     }
 
     pub fn slot_data_iterator(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -669,6 +669,16 @@ impl Blockstore {
         self.db.live_files_metadata()
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn iterator_cf(
+        &self,
+        cf_name: &str,
+    ) -> Result<impl Iterator<Item = (Box<[u8]>, Box<[u8]>)> + '_> {
+        let cf = self.db.cf_handle(cf_name);
+        let iterator = self.db.iterator_cf_raw_key(cf, IteratorMode::Start);
+        Ok(iterator.map(|pair| pair.unwrap()))
+    }
+
     pub fn slot_data_iterator(
         &self,
         slot: Slot,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2924,7 +2924,7 @@ impl Blockstore {
         if highest_primary_index_slot.is_some_and(|slot| slot != 0) {
             self.set_highest_primary_index_slot(highest_primary_index_slot);
         } else {
-            self.db.set_clean_slot_0(true);
+            self.db.backend.set_clean_slot_0(true);
         }
         Ok(())
     }
@@ -2934,7 +2934,7 @@ impl Blockstore {
         if let Some(highest_primary_index_slot) = *w_highest_primary_index_slot {
             if oldest_slot > highest_primary_index_slot {
                 *w_highest_primary_index_slot = None;
-                self.db.set_clean_slot_0(true);
+                self.db.backend.set_clean_slot_0(true);
             }
         }
         Ok(())

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -387,27 +387,27 @@ impl Blockstore {
         info!("Opening blockstore at {:?}", blockstore_path);
         let db = Database::open(blockstore_path, options)?;
 
-        let address_signatures_cf = db.column();
-        let bank_hash_cf = db.column();
-        let block_height_cf = db.column();
-        let blocktime_cf = db.column();
-        let code_shred_cf = db.column();
-        let data_shred_cf = db.column();
-        let dead_slots_cf = db.column();
-        let duplicate_slots_cf = db.column();
-        let erasure_meta_cf = db.column();
-        let index_cf = db.column();
-        let merkle_root_meta_cf = db.column();
-        let meta_cf = db.column();
-        let optimistic_slots_cf = db.column();
-        let orphans_cf = db.column();
-        let perf_samples_cf = db.column();
-        let program_costs_cf = db.column();
-        let rewards_cf = db.column();
-        let roots_cf = db.column();
-        let transaction_memos_cf = db.column();
-        let transaction_status_cf = db.column();
-        let transaction_status_index_cf = db.column();
+        let address_signatures_cf = Rocks::column(db.backend.clone());
+        let bank_hash_cf = Rocks::column(db.backend.clone());
+        let block_height_cf = Rocks::column(db.backend.clone());
+        let blocktime_cf = Rocks::column(db.backend.clone());
+        let code_shred_cf = Rocks::column(db.backend.clone());
+        let data_shred_cf = Rocks::column(db.backend.clone());
+        let dead_slots_cf = Rocks::column(db.backend.clone());
+        let duplicate_slots_cf = Rocks::column(db.backend.clone());
+        let erasure_meta_cf = Rocks::column(db.backend.clone());
+        let index_cf = Rocks::column(db.backend.clone());
+        let merkle_root_meta_cf = Rocks::column(db.backend.clone());
+        let meta_cf = Rocks::column(db.backend.clone());
+        let optimistic_slots_cf = Rocks::column(db.backend.clone());
+        let orphans_cf = Rocks::column(db.backend.clone());
+        let perf_samples_cf = Rocks::column(db.backend.clone());
+        let program_costs_cf = Rocks::column(db.backend.clone());
+        let rewards_cf = Rocks::column(db.backend.clone());
+        let roots_cf = Rocks::column(db.backend.clone());
+        let transaction_memos_cf = Rocks::column(db.backend.clone());
+        let transaction_status_cf = Rocks::column(db.backend.clone());
+        let transaction_status_index_cf = Rocks::column(db.backend.clone());
 
         let db = Arc::new(db);
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7,7 +7,7 @@ use {
         ancestor_iterator::AncestorIterator,
         blockstore_db::{
             columns as cf, Column, ColumnIndexDeprecation, Database, IteratorDirection,
-            IteratorMode, LedgerColumn, Result, WriteBatch,
+            IteratorMode, LedgerColumn, Result, Rocks, WriteBatch,
         },
         blockstore_meta::*,
         blockstore_metrics::BlockstoreRpcApiMetrics,
@@ -534,7 +534,7 @@ impl Blockstore {
     pub fn destroy(ledger_path: &Path) -> Result<()> {
         // Database::destroy() fails if the root directory doesn't exist
         fs::create_dir_all(ledger_path)?;
-        Database::destroy(&Path::new(ledger_path).join(BLOCKSTORE_DIRECTORY_ROCKS_LEVEL))
+        Rocks::destroy(&Path::new(ledger_path).join(BLOCKSTORE_DIRECTORY_ROCKS_LEVEL))
     }
 
     /// Returns the SlotMeta of the specified slot.

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4298,7 +4298,7 @@ impl Blockstore {
 
     /// Returns whether the blockstore has primary (read and write) access
     pub fn is_primary_access(&self) -> bool {
-        self.db.is_primary_access()
+        self.db.backend.is_primary_access()
     }
 
     /// Scan for any ancestors of the supplied `start_root` that are not

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -385,7 +385,7 @@ impl Blockstore {
         // Open the database
         let mut measure = Measure::start("blockstore open");
         info!("Opening blockstore at {:?}", blockstore_path);
-        let db = Database::open(&blockstore_path, options)?;
+        let db = Database::open(blockstore_path, options)?;
 
         let address_signatures_cf = db.column();
         let bank_hash_cf = db.column();
@@ -4275,7 +4275,7 @@ impl Blockstore {
     }
 
     pub fn storage_size(&self) -> Result<u64> {
-        self.db.storage_size()
+        self.db.backend.storage_size()
     }
 
     /// Returns the total physical storage size contributed by all data shreds.

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -182,7 +182,7 @@ impl Blockstore {
         self.meta_cf
             .put_in_batch(&mut write_batch, slot, &slot_meta)?;
 
-        self.db.write(write_batch).inspect_err(|e| {
+        self.write_batch(write_batch).inspect_err(|e| {
             error!(
                 "Error: {:?} while submitting write batch for slot {:?}",
                 e, slot
@@ -214,7 +214,7 @@ impl Blockstore {
         delete_range_timer.stop();
 
         let mut write_timer = Measure::start("write_batch");
-        self.db.write(write_batch).inspect_err(|e| {
+        self.write_batch(write_batch).inspect_err(|e| {
             error!(
                 "Error: {:?} while submitting write batch for purge from_slot {} to_slot {}",
                 e, from_slot, to_slot

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -73,7 +73,7 @@ impl Blockstore {
         // convert here from inclusive purged range end to inclusive alive range start to align
         // with Slot::default() for initial compaction filter behavior consistency
         let to_slot = to_slot.checked_add(1).unwrap();
-        self.db.set_oldest_slot(to_slot);
+        self.db.backend.set_oldest_slot(to_slot);
 
         if let Err(err) = self.maybe_cleanup_highest_primary_index_slot(to_slot) {
             warn!("Could not clean up TransactionStatusIndex: {err:?}");
@@ -827,7 +827,7 @@ pub mod tests {
 
     fn purge_compaction_filter(blockstore: &Blockstore, oldest_slot: Slot) {
         let (first_index, last_index) = get_index_bounds(blockstore);
-        blockstore.db.set_oldest_slot(oldest_slot);
+        blockstore.db.backend.set_oldest_slot(oldest_slot);
         blockstore
             .db
             .compact_range_cf::<cf::TransactionStatus>(&first_index, &last_index);
@@ -1009,7 +1009,7 @@ pub mod tests {
         };
 
         let oldest_slot = 3;
-        blockstore.db.set_oldest_slot(oldest_slot);
+        blockstore.db.backend.set_oldest_slot(oldest_slot);
         blockstore.db.compact_range_cf::<cf::TransactionStatus>(
             &cf::TransactionStatus::key(first_index),
             &cf::TransactionStatus::key(last_index),
@@ -1043,7 +1043,7 @@ pub mod tests {
         };
 
         let oldest_slot = 12;
-        blockstore.db.set_oldest_slot(oldest_slot);
+        blockstore.db.backend.set_oldest_slot(oldest_slot);
         blockstore.db.compact_range_cf::<cf::TransactionStatus>(
             &cf::TransactionStatus::key(first_index),
             &cf::TransactionStatus::key(last_index),
@@ -1117,7 +1117,7 @@ pub mod tests {
         };
 
         // Purge at slot 0 should not affect any memos
-        blockstore.db.set_oldest_slot(0);
+        blockstore.db.backend.set_oldest_slot(0);
         blockstore
             .db
             .compact_range_cf::<cf::TransactionMemos>(&first_index, &last_index);
@@ -1132,7 +1132,7 @@ pub mod tests {
         assert_eq!(count, 4);
 
         // Purge at oldest_slot without clean_slot_0 only purges the current memo at slot 4
-        blockstore.db.set_oldest_slot(oldest_slot);
+        blockstore.db.backend.set_oldest_slot(oldest_slot);
         blockstore
             .db
             .compact_range_cf::<cf::TransactionMemos>(&first_index, &last_index);

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -154,7 +154,7 @@ impl Blockstore {
         let Some(mut slot_meta) = self.meta(slot)? else {
             return Err(BlockstoreError::SlotUnavailable);
         };
-        let mut write_batch = self.db.batch()?;
+        let mut write_batch = self.get_write_batch()?;
 
         let columns_purged = self.purge_range(&mut write_batch, slot, slot, PurgeType::Exact)?;
 
@@ -207,7 +207,7 @@ impl Blockstore {
         purge_type: PurgeType,
         purge_stats: &mut PurgeStats,
     ) -> Result<bool> {
-        let mut write_batch = self.db.batch()?;
+        let mut write_batch = self.get_write_batch()?;
 
         let mut delete_range_timer = Measure::start("delete_range");
         let columns_purged = self.purge_range(&mut write_batch, from_slot, to_slot, purge_type)?;
@@ -980,7 +980,7 @@ pub mod tests {
         );
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
-        let mut write_batch = blockstore.db.batch().unwrap();
+        let mut write_batch = blockstore.get_write_batch().unwrap();
         blockstore
             .purge_special_columns_exact(&mut write_batch, slot, slot + 1)
             .unwrap();

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -829,8 +829,8 @@ pub mod tests {
         let (first_index, last_index) = get_index_bounds(blockstore);
         blockstore.db.backend.set_oldest_slot(oldest_slot);
         blockstore
-            .db
-            .compact_range_cf::<cf::TransactionStatus>(&first_index, &last_index);
+            .transaction_status_cf
+            .compact_range_raw_key(&first_index, &last_index);
     }
 
     #[test_case(purge_exact; "exact")]
@@ -1010,7 +1010,7 @@ pub mod tests {
 
         let oldest_slot = 3;
         blockstore.db.backend.set_oldest_slot(oldest_slot);
-        blockstore.db.compact_range_cf::<cf::TransactionStatus>(
+        blockstore.transaction_status_cf.compact_range_raw_key(
             &cf::TransactionStatus::key(first_index),
             &cf::TransactionStatus::key(last_index),
         );
@@ -1044,7 +1044,7 @@ pub mod tests {
 
         let oldest_slot = 12;
         blockstore.db.backend.set_oldest_slot(oldest_slot);
-        blockstore.db.compact_range_cf::<cf::TransactionStatus>(
+        blockstore.transaction_status_cf.compact_range_raw_key(
             &cf::TransactionStatus::key(first_index),
             &cf::TransactionStatus::key(last_index),
         );
@@ -1119,8 +1119,8 @@ pub mod tests {
         // Purge at slot 0 should not affect any memos
         blockstore.db.backend.set_oldest_slot(0);
         blockstore
-            .db
-            .compact_range_cf::<cf::TransactionMemos>(&first_index, &last_index);
+            .transaction_memos_cf
+            .compact_range_raw_key(&first_index, &last_index);
         let memos_iterator = blockstore
             .transaction_memos_cf
             .iterator_cf_raw_key(IteratorMode::Start);
@@ -1134,8 +1134,8 @@ pub mod tests {
         // Purge at oldest_slot without clean_slot_0 only purges the current memo at slot 4
         blockstore.db.backend.set_oldest_slot(oldest_slot);
         blockstore
-            .db
-            .compact_range_cf::<cf::TransactionMemos>(&first_index, &last_index);
+            .transaction_memos_cf
+            .compact_range_raw_key(&first_index, &last_index);
         let memos_iterator = blockstore
             .transaction_memos_cf
             .iterator_cf_raw_key(IteratorMode::Start);
@@ -1151,8 +1151,8 @@ pub mod tests {
         // Purge at oldest_slot with clean_slot_0 purges deprecated memos
         blockstore.db.backend.set_clean_slot_0(true);
         blockstore
-            .db
-            .compact_range_cf::<cf::TransactionMemos>(&first_index, &last_index);
+            .transaction_memos_cf
+            .compact_range_raw_key(&first_index, &last_index);
         let memos_iterator = blockstore
             .transaction_memos_cf
             .iterator_cf_raw_key(IteratorMode::Start);

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -73,7 +73,7 @@ impl Blockstore {
         // convert here from inclusive purged range end to inclusive alive range start to align
         // with Slot::default() for initial compaction filter behavior consistency
         let to_slot = to_slot.checked_add(1).unwrap();
-        self.db.backend.set_oldest_slot(to_slot);
+        self.db.set_oldest_slot(to_slot);
 
         if let Err(err) = self.maybe_cleanup_highest_primary_index_slot(to_slot) {
             warn!("Could not clean up TransactionStatusIndex: {err:?}");
@@ -827,7 +827,7 @@ pub mod tests {
 
     fn purge_compaction_filter(blockstore: &Blockstore, oldest_slot: Slot) {
         let (first_index, last_index) = get_index_bounds(blockstore);
-        blockstore.db.backend.set_oldest_slot(oldest_slot);
+        blockstore.db.set_oldest_slot(oldest_slot);
         blockstore
             .transaction_status_cf
             .compact_range_raw_key(&first_index, &last_index);
@@ -1009,7 +1009,7 @@ pub mod tests {
         };
 
         let oldest_slot = 3;
-        blockstore.db.backend.set_oldest_slot(oldest_slot);
+        blockstore.db.set_oldest_slot(oldest_slot);
         blockstore.transaction_status_cf.compact_range_raw_key(
             &cf::TransactionStatus::key(first_index),
             &cf::TransactionStatus::key(last_index),
@@ -1043,7 +1043,7 @@ pub mod tests {
         };
 
         let oldest_slot = 12;
-        blockstore.db.backend.set_oldest_slot(oldest_slot);
+        blockstore.db.set_oldest_slot(oldest_slot);
         blockstore.transaction_status_cf.compact_range_raw_key(
             &cf::TransactionStatus::key(first_index),
             &cf::TransactionStatus::key(last_index),
@@ -1085,7 +1085,7 @@ pub mod tests {
             .put_deprecated(random_signature(), &"another memo".to_string())
             .unwrap();
         // Set clean_slot_0 to false, since we have deprecated memos
-        blockstore.db.backend.set_clean_slot_0(false);
+        blockstore.db.set_clean_slot_0(false);
 
         // Insert some current TransactionMemos
         blockstore
@@ -1117,7 +1117,7 @@ pub mod tests {
         };
 
         // Purge at slot 0 should not affect any memos
-        blockstore.db.backend.set_oldest_slot(0);
+        blockstore.db.set_oldest_slot(0);
         blockstore
             .transaction_memos_cf
             .compact_range_raw_key(&first_index, &last_index);
@@ -1132,7 +1132,7 @@ pub mod tests {
         assert_eq!(count, 4);
 
         // Purge at oldest_slot without clean_slot_0 only purges the current memo at slot 4
-        blockstore.db.backend.set_oldest_slot(oldest_slot);
+        blockstore.db.set_oldest_slot(oldest_slot);
         blockstore
             .transaction_memos_cf
             .compact_range_raw_key(&first_index, &last_index);
@@ -1149,7 +1149,7 @@ pub mod tests {
         assert_eq!(count, 3);
 
         // Purge at oldest_slot with clean_slot_0 purges deprecated memos
-        blockstore.db.backend.set_clean_slot_0(true);
+        blockstore.db.set_clean_slot_0(true);
         blockstore
             .transaction_memos_cf
             .compact_range_raw_key(&first_index, &last_index);

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -1085,7 +1085,7 @@ pub mod tests {
             .put_deprecated(random_signature(), &"another memo".to_string())
             .unwrap();
         // Set clean_slot_0 to false, since we have deprecated memos
-        blockstore.db.set_clean_slot_0(false);
+        blockstore.db.backend.set_clean_slot_0(false);
 
         // Insert some current TransactionMemos
         blockstore
@@ -1149,7 +1149,7 @@ pub mod tests {
         assert_eq!(count, 3);
 
         // Purge at oldest_slot with clean_slot_0 purges deprecated memos
-        blockstore.db.set_clean_slot_0(true);
+        blockstore.db.backend.set_clean_slot_0(true);
         blockstore
             .db
             .compact_range_cf::<cf::TransactionMemos>(&first_index, &last_index);

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -742,7 +742,7 @@ impl Rocks {
         }
     }
 
-    fn is_primary_access(&self) -> bool {
+    pub(crate) fn is_primary_access(&self) -> bool {
         self.access_type == AccessType::Primary
             || self.access_type == AccessType::PrimaryForMaintenance
     }
@@ -1463,10 +1463,6 @@ impl Database {
 
     pub fn storage_size(&self) -> Result<u64> {
         Ok(fs_extra::dir::get_size(&self.path)?)
-    }
-
-    pub fn is_primary_access(&self) -> bool {
-        self.backend.is_primary_access()
     }
 
     pub fn set_oldest_slot(&self, oldest_slot: Slot) {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -717,15 +717,17 @@ impl Rocks {
     }
 
     pub(crate) fn batch(&self) -> Result<WriteBatch> {
-        Ok(WriteBatch { write_batch: RWriteBatch::default() })
+        Ok(WriteBatch {
+            write_batch: RWriteBatch::default(),
+        })
     }
 
-    fn write(&self, batch: RWriteBatch) -> Result<()> {
+    pub(crate) fn write(&self, batch: WriteBatch) -> Result<()> {
         let op_start_instant = maybe_enable_rocksdb_perf(
             self.column_options.rocks_perf_sample_interval,
             &self.write_batch_perf_status,
         );
-        let result = self.db.write(batch);
+        let result = self.db.write(batch.write_batch);
         if let Some(op_start_instant) = op_start_instant {
             report_rocksdb_write_perf(
                 PERF_METRIC_OP_NAME_WRITE_BATCH, // We use write_batch as cf_name for write batch.
@@ -1457,10 +1459,6 @@ impl Database {
             read_perf_status: PerfSamplingStatus::default(),
             write_perf_status: PerfSamplingStatus::default(),
         }
-    }
-
-    pub fn write(&self, batch: WriteBatch) -> Result<()> {
-        self.backend.write(batch.write_batch)
     }
 
     pub fn storage_size(&self) -> Result<u64> {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -403,7 +403,7 @@ impl OldestSlot {
 }
 
 #[derive(Debug)]
-struct Rocks {
+pub(crate) struct Rocks {
     db: rocksdb::DB,
     access_type: AccessType,
     oldest_slot: OldestSlot,
@@ -1326,7 +1326,7 @@ impl TypedColumn for columns::MerkleRootMeta {
 
 #[derive(Debug)]
 pub struct Database {
-    backend: Arc<Rocks>,
+    pub(crate) backend: Arc<Rocks>,
     path: Arc<Path>,
     column_options: Arc<LedgerColumnOptions>,
 }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -770,6 +770,10 @@ impl Rocks {
     pub(crate) fn set_oldest_slot(&self, oldest_slot: Slot) {
         self.oldest_slot.set(oldest_slot);
     }
+
+    pub(crate) fn set_clean_slot_0(&self, clean_slot_0: bool) {
+        self.oldest_slot.set_clean_slot_0(clean_slot_0);
+    }
 }
 
 pub trait Column {
@@ -1467,10 +1471,6 @@ impl Database {
 
     pub fn storage_size(&self) -> Result<u64> {
         Ok(fs_extra::dir::get_size(&self.path)?)
-    }
-
-    pub(crate) fn set_clean_slot_0(&self, clean_slot_0: bool) {
-        self.backend.oldest_slot.set_clean_slot_0(clean_slot_0);
     }
 
     pub fn live_files_metadata(&self) -> Result<Vec<LiveFile>> {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1453,11 +1453,6 @@ impl Database {
         let backend = Arc::new(Rocks::open(path, options)?);
         Ok(Database { backend })
     }
-
-    pub fn compact_range_cf<C: Column + ColumnName>(&self, from: &[u8], to: &[u8]) {
-        let cf = self.backend.cf_handle(C::NAME);
-        self.backend.db.compact_range_cf(cf, Some(from), Some(to));
-    }
 }
 
 impl<C> LedgerColumn<C>
@@ -1531,6 +1526,12 @@ where
         let to = Some(C::key(C::as_index(to)));
         self.backend.db.compact_range_cf(cf, from, to);
         Ok(true)
+    }
+
+    #[cfg(test)]
+    pub fn compact_range_raw_key(&self, from: &[u8], to: &[u8]) {
+        let cf = self.handle();
+        self.backend.db.compact_range_cf(cf, Some(from), Some(to));
     }
 
     #[inline]

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -621,7 +621,7 @@ impl Rocks {
         }
     }
 
-    fn destroy(path: &Path) -> Result<()> {
+    pub(crate) fn destroy(path: &Path) -> Result<()> {
         DB::destroy(&Options::default(), path)?;
 
         Ok(())
@@ -1440,12 +1440,6 @@ impl Database {
             path: Arc::from(path),
             column_options,
         })
-    }
-
-    pub fn destroy(path: &Path) -> Result<()> {
-        Rocks::destroy(path)?;
-
-        Ok(())
     }
 
     #[inline]

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1454,16 +1454,8 @@ impl Database {
         Ok(Database { backend })
     }
 
-    #[inline]
-    pub fn cf_handle<C>(&self) -> &ColumnFamily
-    where
-        C: Column + ColumnName,
-    {
-        self.backend.cf_handle(C::NAME)
-    }
-
     pub fn compact_range_cf<C: Column + ColumnName>(&self, from: &[u8], to: &[u8]) {
-        let cf = self.cf_handle::<C>();
+        let cf = self.backend.cf_handle(C::NAME);
         self.backend.db.compact_range_cf(cf, Some(from), Some(to));
     }
 }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -712,8 +712,8 @@ impl Rocks {
         self.db.iterator_cf(cf, iterator_mode)
     }
 
-    fn raw_iterator_cf(&self, cf: &ColumnFamily) -> DBRawIterator {
-        self.db.raw_iterator_cf(cf)
+    pub(crate) fn raw_iterator_cf(&self, cf: &ColumnFamily) -> Result<DBRawIterator> {
+        Ok(self.db.raw_iterator_cf(cf))
     }
 
     fn batch(&self) -> RWriteBatch {
@@ -1459,11 +1459,6 @@ impl Database {
         }
     }
 
-    #[inline]
-    pub fn raw_iterator_cf(&self, cf: &ColumnFamily) -> Result<DBRawIterator> {
-        Ok(self.backend.raw_iterator_cf(cf))
-    }
-
     pub fn batch(&self) -> Result<WriteBatch> {
         let write_batch = self.backend.batch();
         Ok(WriteBatch { write_batch })
@@ -1579,7 +1574,7 @@ where
 
     #[cfg(test)]
     pub fn is_empty(&self) -> Result<bool> {
-        let mut iter = self.backend.raw_iterator_cf(self.handle());
+        let mut iter = self.backend.raw_iterator_cf(self.handle())?;
         iter.seek_to_first();
         Ok(!iter.valid())
     }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -716,8 +716,8 @@ impl Rocks {
         Ok(self.db.raw_iterator_cf(cf))
     }
 
-    fn batch(&self) -> RWriteBatch {
-        RWriteBatch::default()
+    pub(crate) fn batch(&self) -> Result<WriteBatch> {
+        Ok(WriteBatch { write_batch: RWriteBatch::default() })
     }
 
     fn write(&self, batch: RWriteBatch) -> Result<()> {
@@ -1457,11 +1457,6 @@ impl Database {
             read_perf_status: PerfSamplingStatus::default(),
             write_perf_status: PerfSamplingStatus::default(),
         }
-    }
-
-    pub fn batch(&self) -> Result<WriteBatch> {
-        let write_batch = self.backend.batch();
-        Ok(WriteBatch { write_batch })
     }
 
     pub fn write(&self, batch: WriteBatch) -> Result<()> {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -760,7 +760,7 @@ impl Rocks {
         }
     }
 
-    fn live_files_metadata(&self) -> Result<Vec<LiveFile>> {
+    pub(crate) fn live_files_metadata(&self) -> Result<Vec<LiveFile>> {
         match self.db.live_files() {
             Ok(live_files) => Ok(live_files),
             Err(e) => Err(BlockstoreError::RocksDb(e)),
@@ -1471,10 +1471,6 @@ impl Database {
 
     pub fn storage_size(&self) -> Result<u64> {
         Ok(fs_extra::dir::get_size(&self.path)?)
-    }
-
-    pub fn live_files_metadata(&self) -> Result<Vec<LiveFile>> {
-        self.backend.live_files_metadata()
     }
 
     pub fn compact_range_cf<C: Column + ColumnName>(&self, from: &[u8], to: &[u8]) {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -766,6 +766,10 @@ impl Rocks {
             Err(e) => Err(BlockstoreError::RocksDb(e)),
         }
     }
+
+    pub(crate) fn set_oldest_slot(&self, oldest_slot: Slot) {
+        self.oldest_slot.set(oldest_slot);
+    }
 }
 
 pub trait Column {
@@ -1463,10 +1467,6 @@ impl Database {
 
     pub fn storage_size(&self) -> Result<u64> {
         Ok(fs_extra::dir::get_size(&self.path)?)
-    }
-
-    pub fn set_oldest_slot(&self, oldest_slot: Slot) {
-        self.backend.oldest_slot.set(oldest_slot);
     }
 
     pub(crate) fn set_clean_slot_0(&self, clean_slot_0: bool) {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -643,7 +643,7 @@ impl Rocks {
         Ok(())
     }
 
-    fn cf_handle(&self, cf: &str) -> &ColumnFamily {
+    pub(crate) fn cf_handle(&self, cf: &str) -> &ColumnFamily {
         self.db
             .cf_handle(cf)
             .expect("should never get an unknown column")
@@ -711,7 +711,7 @@ impl Rocks {
         self.db.iterator_cf(cf, iterator_mode)
     }
 
-    fn iterator_cf_raw_key(
+    pub(crate) fn iterator_cf_raw_key(
         &self,
         cf: &ColumnFamily,
         iterator_mode: IteratorMode<Vec<u8>>,


### PR DESCRIPTION
#### Problem
The public facing type `Blockstore` currently contains a `Database`, which contains a `Rocks`. `Database` is mostly a pass-through to `Rocks`, so it just adds an extra layer that gives no benefit.

#### Summary of Changes
Remove the pass-through `Database` type.

The commits should make it easy to follow/review; I basically made `Blockstore` use `Rocks` methods (instead of `Database` methods) one-by-one, until there were no callers of the `Database` methods left. Then, just rip out the now unused type + an update to ledger-tool