### PR TITLE
[core] check for excessive secp256r1 signature verification in the banking stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6729,6 +6729,7 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-sanitize",
  "solana-sdk",
+ "solana-sdk-ids",
  "solana-send-transaction-service",
  "solana-short-vec",
  "solana-stake-program",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -77,6 +77,7 @@ solana-runtime = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-sanitize = { workspace = true }
 solana-sdk = { workspace = true }
+solana-sdk-ids = { workspace = true }
 solana-send-transaction-service = { workspace = true }
 solana-short-vec = { workspace = true }
 solana-streamer = { workspace = true }

--- a/core/src/banking_stage/packet_filter.rs
+++ b/core/src/banking_stage/packet_filter.rs
@@ -5,6 +5,7 @@ use {
     solana_sdk::{
         ed25519_program, feature_set::FeatureSet, saturating_add_assign, secp256k1_program,
     },
+    solana_sdk_ids::secp256r1_program,
     thiserror::Error,
 };
 
@@ -48,7 +49,10 @@ impl ImmutableDeserializedPacket {
     pub fn check_excessive_precompiles(&self) -> Result<(), PacketFilterFailure> {
         let mut num_precompile_signatures: u64 = 0;
         for (program_id, ix) in self.transaction().get_message().program_instructions_iter() {
-            if secp256k1_program::check_id(program_id) || ed25519_program::check_id(program_id) {
+            if secp256k1_program::check_id(program_id)
+                || ed25519_program::check_id(program_id)
+                || secp256r1_program::check_id(program_id)
+            {
                 let num_signatures = ix.data.first().map_or(0, |byte| u64::from(*byte));
                 saturating_add_assign!(num_precompile_signatures, num_signatures);
             }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5422,6 +5422,7 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-sanitize",
  "solana-sdk",
+ "solana-sdk-ids",
  "solana-send-transaction-service",
  "solana-short-vec",
  "solana-streamer",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5273,6 +5273,7 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-sanitize",
  "solana-sdk",
+ "solana-sdk-ids",
  "solana-send-transaction-service",
  "solana-short-vec",
  "solana-streamer",


### PR DESCRIPTION
#### Problem
The secp256r1 precompile (https://github.com/anza-xyz/agave/pull/3152) was added, but it is not yet incorporated in some of the logic in the monorepo. In particular, we do not check for excessive secp256r1 signature verification in the banking stage.

#### Summary of Changes
Added logic to check for excessive secp256r1 signature verification.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
