### PR TITLE
skip preflight for rpc client

### DIFF
--- a/tps-client/src/rpc_client.rs
+++ b/tps-client/src/rpc_client.rs
@@ -1,5 +1,6 @@
 use {
     crate::{TpsClient, TpsClientError, TpsClientResult},
+    solana_client::rpc_config::RpcSendTransactionConfig,
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::config::RpcBlockConfig,
     solana_sdk::{
@@ -18,7 +19,15 @@ use {
 
 impl TpsClient for RpcClient {
     fn send_transaction(&self, transaction: Transaction) -> TpsClientResult<Signature> {
-        RpcClient::send_transaction(self, &transaction).map_err(|err| err.into())
+        RpcClient::send_transaction_with_config(
+            self,
+            &transaction,
+            RpcSendTransactionConfig {
+                skip_preflight: true,
+                ..Default::default()
+            },
+        )
+        .map_err(|err| err.into())
     }
 
     fn send_batch(&self, transactions: Vec<Transaction>) -> TpsClientResult<()> {


### PR DESCRIPTION
#### Problem

By default implementation of `TpsClient` trait for `RpcClient` structure has `skip_preflight: false`. Validator spends ~200us for these checks (compared to ~7us for the rest of rpc call), which is limiting tps for bench-tps when used with `--use-rpc-cient` by the factor of 2. Although preflight checks are useful for debugging transaction failures, since bench-tps is for creating max load, it makes more sense to skip these checks.  

#### Summary of Changes

