### PR TITLE
ed25519_verify_cpu: remove allocation in hot path

### DIFF
--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -515,18 +515,11 @@ pub fn shrink_batches(batches: &mut Vec<PacketBatch>) {
 pub fn ed25519_verify_cpu(batches: &mut [PacketBatch], reject_non_vote: bool, packet_count: usize) {
     debug!("CPU ECDSA for {}", packet_count);
     PAR_THREAD_POOL.install(|| {
-        batches
-            .par_iter_mut()
-            .flatten()
-            .collect::<Vec<&mut Packet>>()
-            .par_chunks_mut(VERIFY_PACKET_CHUNK_SIZE)
-            .for_each(|packets| {
-                for packet in packets.iter_mut() {
-                    if !packet.meta().discard() && !verify_packet(packet, reject_non_vote) {
-                        packet.meta_mut().set_discard(true);
-                    }
-                }
-            });
+        batches.par_iter_mut().flatten().for_each(|packet| {
+            if !packet.meta().discard() && !verify_packet(packet, reject_non_vote) {
+                packet.meta_mut().set_discard(true);
+            }
+        });
     });
 }
 


### PR DESCRIPTION
The old code was a remnant from a time when we tried to "balance" the amount of work across threads by re-batching and therefore allocating.

This is a hot path. Allocations are bad. Let work stealing work its magic.

before
```
running 8 tests
test bench_sigverify_high_packets_large_batch   ... bench:  16,990,766.60 ns/iter (+/- 3,061,142.38)
test bench_sigverify_high_packets_small_batch   ... bench:  17,250,462.50 ns/iter (+/- 2,758,672.55)
test bench_sigverify_low_packets_large_batch    ... bench:   9,067,963.60 ns/iter (+/- 136,488.70)
test bench_sigverify_low_packets_small_batch    ... bench:   9,054,538.40 ns/iter (+/- 125,983.52)
test bench_sigverify_medium_packets_large_batch ... bench:  17,483,717.50 ns/iter (+/- 6,094,133.22)
test bench_sigverify_medium_packets_small_batch ... bench:  18,705,141.90 ns/iter (+/- 5,872,418.63)
test bench_sigverify_simple                     ... bench:  20,167,362.70 ns/iter (+/- 2,705,726.58)
test bench_sigverify_uneven                     ... bench:   7,192,356.90 ns/iter (+/- 815,398.52)
```

after
```
running 8 tests
test bench_sigverify_high_packets_large_batch   ... bench:  10,494,283.30 ns/iter (+/- 852,231.77)
test bench_sigverify_high_packets_small_batch   ... bench:  10,249,499.70 ns/iter (+/- 226,444.85)
test bench_sigverify_low_packets_large_batch    ... bench:     465,018.57 ns/iter (+/- 21,994.14)
test bench_sigverify_low_packets_small_batch    ... bench:     461,375.30 ns/iter (+/- 24,855.80)
test bench_sigverify_medium_packets_large_batch ... bench:   2,650,445.62 ns/iter (+/- 177,836.54)
test bench_sigverify_medium_packets_small_batch ... bench:   2,779,869.52 ns/iter (+/- 145,892.43)
test bench_sigverify_simple                     ... bench:     768,623.86 ns/iter (+/- 56,839.41)
test bench_sigverify_uneven                     ... bench:   1,325,557.05 ns/iter (+/- 92,470.47)
```