### PR TITLE
Space efficient `custom_panic`

### DIFF
--- a/sdk/define-syscall/src/definitions.rs
+++ b/sdk/define-syscall/src/definitions.rs
@@ -31,6 +31,7 @@ define_syscall!(fn sol_remaining_compute_units() -> u64);
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
 define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, result: *mut u8, offset: u64, length: u64) -> u64);
 define_syscall!(fn sol_get_epoch_stake(vote_address: *const u8) -> u64);
+define_syscall!(fn sol_panic_(filename: *const u8, filename_len: u64, line: u64, column: u64));
 
 // these are to be deprecated once they are superceded by sol_get_sysvar
 define_syscall!(fn sol_get_clock_sysvar(addr: *mut u8) -> u64);

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -11,7 +11,7 @@ pub use solana_define_syscall::definitions::{
     sol_curve_group_op, sol_curve_multiscalar_mul, sol_curve_pairing_map, sol_curve_validate_point,
     sol_get_clock_sysvar, sol_get_epoch_rewards_sysvar, sol_get_epoch_schedule_sysvar,
     sol_get_epoch_stake, sol_get_fees_sysvar, sol_get_last_restart_slot, sol_get_rent_sysvar,
-    sol_get_sysvar, sol_keccak256, sol_remaining_compute_units,
+    sol_get_sysvar, sol_keccak256, sol_panic_, sol_remaining_compute_units,
 };
 #[cfg(target_feature = "static-syscalls")]
 pub use solana_define_syscall::sys_hash;


### PR DESCRIPTION
#### Problem

Our implementation of `custom_panic` can consume up to 25kb in contracts. This happens because it relies on the `format!` macro and, consequently, on `std::fmt::write`. They include many more functions in the contract and utilize dynamic dispatch, a technique that hinders compiler and link side optimizations for size reduction.

#### Summary of Changes

I implemented a new `custom_panic` that functions independently with only primitive (and unsafe) operations. It needs the stabilization of `fmt::Arguments::as_str`, which is happening in Rust 1.84 (see https://github.com/rust-lang/rust/pull/132511).

#### Size comparison

Take this simple contract as an example:

```rust
entrypoint!(process_instruction);

fn process_instruction(
    _program_id: &Pubkey,
    accounts: &[AccountInfo],
    instruction_data: &[u8],
) -> ProgramResult {
    Ok(())
}
```

The binary size has whooping 17696 bytes (17kb).
The contract with an empty `custom_panic` function has 10336 bytes (10kb), so panic is consuming 7360 bytes.
The contract with my new implementation has 11696 bytes (11kb), so my implementation has 1360 bytes.

#### New error messages

The members of `fmt::Arguments` are all private, so I cannot build custom panic messages during runtime as Rust does (think about the error you get when you access an invalid index from a vector: we can only know the index and the vector length during execution time). These messages will be elided in the new panic implementation (see examples below). Error messages whose content is known at compile time will still be shown normally.

The formatting is also different. It is more efficient to call `sol_log` multiple times than to format a string.

##### Accessing an invalid index from a vector:

OLD:
```
Program log: panicked at src/lib.rs:21:13:\nindex out of bounds: the len is 44 but the index is 85034
```

NEW:
```
Program log: Panicked at: src/lib.rs:21:13
```
##### Calling unwrap on a None:

OLD:
```
Program log: panicked at src/lib.rs:23:15:\ncalled `Option::unwrap()` on a `None` value
```

NEW:
```
Program log: Panicked at: src/lib.rs:23:15
Program log: called `Option::unwrap()` on a `None` value
```

### Alternative implementation

Instead of pre-allocating a vector, I can use a fixed length buffer and save even more bytes. In this case, however, I split the error in three log messages. I not sure if the experience is good in this case, and I'm looking for feedback. Please, check it at https://github.com/anza-xyz/agave/pull/3952. It has 1168 bytes.
