### PR TITLE
Space efficient `custom_panic` (take 2)

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7088,6 +7088,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-sbf-rust-efficient-panic"
+version = "2.2.0"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
 name = "solana-sbf-rust-error-handling"
 version = "2.2.0"
 dependencies = [

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -161,6 +161,7 @@ members = [
     "rust/deprecated_loader",
     "rust/divide_by_zero",
     "rust/dup_accounts",
+    "rust/efficient_panic",
     "rust/error_handling",
     "rust/external_spend",
     "rust/finalize",

--- a/programs/sbf/rust/efficient_panic/Cargo.toml
+++ b/programs/sbf/rust/efficient_panic/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "solana-sbf-rust-efficient-panic"
+version = { workspace = true }
+description = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-program = { workspace = true }
+
+[features]
+default = ["efficient-panic"]
+efficient-panic = []
+
+[lib]
+crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/efficient_panic/src/lib.rs
+++ b/programs/sbf/rust/efficient_panic/src/lib.rs
@@ -1,0 +1,34 @@
+// Cargo clippy runs with 1.81, but cargo-build-sbf is on 1.79.
+#![allow(stable_features)]
+#![feature(panic_info_message)]
+
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+solana_program::entrypoint!(process_instruction);
+
+fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    match instruction_data[0] {
+        0 => {
+            // Accessing an invalid index creates a dynamic generated panic message.
+            let a = instruction_data[92341];
+            return Err(ProgramError::Custom(a as u32));
+        }
+        1 => {
+            // Unwrap on a None emit a compiler constant panic message.
+            let a: Option<u64> = None;
+            #[allow(clippy::unnecessary_literal_unwrap)]
+            let b = a.unwrap();
+            return Err(ProgramError::Custom(b as u32));
+        }
+
+        _ => (),
+    }
+    Ok(())
+}

--- a/sdk/define-syscall/src/definitions.rs
+++ b/sdk/define-syscall/src/definitions.rs
@@ -33,6 +33,7 @@ define_syscall!(fn sol_remaining_compute_units() -> u64, SOL_REMAINING_COMPUTE_U
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64, SOL_ALT_BN128_COMPRESSION);
 define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, result: *mut u8, offset: u64, length: u64) -> u64, SOL_GET_SYSVAR);
 define_syscall!(fn sol_get_epoch_stake(vote_address: *const u8) -> u64, SOL_GET_EPOCH_STAKE);
+define_syscall!(fn sol_panic_(filename: *const u8, filename_len: u64, line: u64, column: u64), SOL_PANIC_);
 
 // these are to be deprecated once they are superceded by sol_get_sysvar
 define_syscall!(fn sol_get_clock_sysvar(addr: *mut u8) -> u64, SOL_GET_CLOCK_SYSVAR);

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -11,7 +11,7 @@ pub use solana_define_syscall::definitions::{
     sol_curve_group_op, sol_curve_multiscalar_mul, sol_curve_pairing_map, sol_curve_validate_point,
     sol_get_clock_sysvar, sol_get_epoch_rewards_sysvar, sol_get_epoch_schedule_sysvar,
     sol_get_epoch_stake, sol_get_fees_sysvar, sol_get_last_restart_slot, sol_get_rent_sysvar,
-    sol_get_sysvar, sol_keccak256, sol_remaining_compute_units,
+    sol_get_sysvar, sol_keccak256, sol_panic_, sol_remaining_compute_units,
 };
 #[deprecated(since = "2.1.0", note = "Use `solana_instruction::syscalls` instead")]
 pub use solana_instruction::syscalls::{


### PR DESCRIPTION
#### Problem

Our implementation of `custom_panic` can consume up to 25kb in contracts. This happens because it relies on the `format!` macro and, consequently, on `std::fmt::write`. They include many more functions in the contract and utilize dynamic dispatch, a technique that hinders compiler and link side optimizations for size reduction.

#### Summary of Changes

I implemented a new `custom_panic` that functions independently with only primitive (and unsafe) operations. It needs the stabilization of `fmt::Arguments::as_str`, which is happening in Rust 1.84 (see https://github.com/rust-lang/rust/pull/132511).

#### Size comparison

Take this simple contract as an example:

```rust
entrypoint!(process_instruction);

fn process_instruction(
    _program_id: &Pubkey,
    accounts: &[AccountInfo],
    instruction_data: &[u8],
) -> ProgramResult {
    Ok(())
}
```

The binary size has whooping 17696 bytes (17kb).
The contract with an empty `custom_panic` function has 10336 bytes (10kb), so panic is consuming 7360 bytes.
The contract with my new implementation has 11504 bytes (11kb), so my implementation has 1168 bytes.

#### New error messages

The members of `fmt::Arguments` are all private, so I cannot build custom panic messages during runtime as Rust does (think about the error you get when you access an invalid index from a vector: we can only know the index and the vector length during execution time). These messages will be elided in the new panic implementation (see examples below). Error messages whose content is known at compile time will still be shown normally.

The formatting is also different. It is more efficient to call `sol_log` multiple times than to format a string.

##### Accessing an invalid index from a vector:

OLD:
```
Program log: panicked at src/lib.rs:21:13:\nindex out of bounds: the len is 44 but the index is 85034
```

NEW:
```
Program log: PANICKED AT:
Program log: src/lib.rs
Program log: Line: 21  Column: 13
```
##### Calling unwrap on a None:

OLD:
```
Program log: panicked at src/lib.rs:23:15:\ncalled `Option::unwrap()` on a `None` value
```

NEW:
```
Program log: PANICKED AT:
Program log: src/lib.rs
Program log: Line: 23  Column: 15
Program log: called `Option::unwrap()` on a `None` value
```

### Alternative implementation

For a better log experience (in my opinion), I prefer the implementation in https://github.com/anza-xyz/agave/pull/3951. It is larger, but the messages are more organized.

