### PR TITLE
sdk: evict hard_forks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7310,6 +7310,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-hard-forks"
+version = "2.2.0"
+dependencies = [
+ "byteorder",
+ "serde",
+ "serde_derive",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+]
+
+[[package]]
 name = "solana-hash"
 version = "2.2.0"
 dependencies = [
@@ -8705,6 +8716,7 @@ dependencies = [
  "solana-fee-structure",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-hard-forks",
  "solana-inflation",
  "solana-instruction",
  "solana-keypair",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ members = [
     "sdk/frozen-abi",
     "sdk/frozen-abi/macro",
     "sdk/gen-headers",
+    "sdk/hard-forks",
     "sdk/hash",
     "sdk/inflation",
     "sdk/instruction",
@@ -491,6 +492,7 @@ solana-genesis-utils = { path = "genesis-utils", version = "=2.2.0" }
 agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=2.2.0" }
 solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.2.0" }
 solana-gossip = { path = "gossip", version = "=2.2.0" }
+solana-hard-forks = { path = "sdk/hard-forks", version = "=2.2.0", default-features = false }
 solana-hash = { path = "sdk/hash", version = "=2.2.0", default-features = false }
 solana-inflation = { path = "sdk/inflation", version = "=2.2.0" }
 solana-inline-spl = { path = "inline-spl", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5834,6 +5834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-hard-forks"
+version = "2.2.0"
+dependencies = [
+ "byteorder 1.5.0",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "solana-hash"
 version = "2.2.0"
 dependencies = [
@@ -7370,6 +7379,7 @@ dependencies = [
  "solana-epoch-rewards-hasher",
  "solana-feature-set",
  "solana-fee-structure",
+ "solana-hard-forks",
  "solana-inflation",
  "solana-instruction",
  "solana-keypair",

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -570,7 +570,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "2bWtYJSWVVvCEnBw6W2PsYZaR7RVs2V7CthFcHArdbUR")
+            frozen_abi(digest = "9NABbrKjv1mmcPAmvtav1tVq4cJ7tTwKpHbYj6RDp3hi")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapper {

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -39,6 +39,7 @@ full = [
     "dep:solana-cluster-type",
     "dep:solana-ed25519-program",
     "dep:solana-compute-budget-interface",
+    "dep:solana-hard-forks",
     "dep:solana-keypair",
     "dep:solana-offchain-message",
     "dep:solana-precompile-error",
@@ -140,6 +141,9 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
+solana-hard-forks = { workspace = true, features = [
+    "serde",
+], optional = true }
 solana-inflation = { workspace = true, features = ["serde"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true, optional = true, features = [

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -39,7 +39,6 @@ full = [
     "dep:solana-cluster-type",
     "dep:solana-ed25519-program",
     "dep:solana-compute-budget-interface",
-    "dep:solana-hard-forks",
     "dep:solana-keypair",
     "dep:solana-offchain-message",
     "dep:solana-precompile-error",
@@ -142,9 +141,7 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-hard-forks = { workspace = true, features = [
-    "serde",
-], optional = true }
+solana-hard-forks = { workspace = true, features = ["serde"] }
 solana-inflation = { workspace = true, features = ["serde"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true, optional = true, features = [

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -39,6 +39,7 @@ full = [
     "dep:solana-cluster-type",
     "dep:solana-ed25519-program",
     "dep:solana-compute-budget-interface",
+    "dep:solana-hard-forks",
     "dep:solana-keypair",
     "dep:solana-offchain-message",
     "dep:solana-precompile-error",
@@ -141,7 +142,9 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-hard-forks = { workspace = true, features = ["serde"] }
+solana-hard-forks = { workspace = true, features = [
+    "serde",
+], optional = true }
 solana-inflation = { workspace = true, features = ["serde"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true, optional = true, features = [

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -75,6 +75,7 @@ frozen-abi = [
     "solana-fee-structure/frozen-abi",
     "solana-account/frozen-abi",
     "solana-cluster-type/frozen-abi",
+    "solana-hard-forks/frozen-abi",
     "solana-inflation/frozen-abi",
     "solana-poh-config/frozen-abi",
     "solana-program/frozen-abi",

--- a/sdk/hard-forks/Cargo.toml
+++ b/sdk/hard-forks/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "solana-hard-forks"
+description = "The list of slot boundaries at which a hard fork should occur."
+documentation = "https://docs.rs/solana-hard-forks"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+byteorder = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = ["dep:serde", "dep:serde_derive"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/sdk/hard-forks/Cargo.toml
+++ b/sdk/hard-forks/Cargo.toml
@@ -13,8 +13,8 @@ edition = { workspace = true }
 byteorder = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
-solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/sdk/hard-forks/src/lib.rs
+++ b/sdk/hard-forks/src/lib.rs
@@ -1,21 +1,22 @@
 //! The list of slot boundaries at which a hard fork should
 //! occur.
 
-#![cfg(feature = "full")]
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
-use {
-    byteorder::{ByteOrder, LittleEndian},
-    solana_sdk::clock::Slot,
-};
+use byteorder::{ByteOrder, LittleEndian};
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Default, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct HardForks {
-    hard_forks: Vec<(Slot, usize)>,
+    hard_forks: Vec<(u64, usize)>,
 }
 impl HardForks {
     // Register a fork to occur at all slots >= `slot` with a parent slot < `slot`
-    pub fn register(&mut self, new_slot: Slot) {
+    pub fn register(&mut self, new_slot: u64) {
         if let Some(i) = self
             .hard_forks
             .iter()
@@ -30,7 +31,7 @@ impl HardForks {
     }
 
     // Returns a sorted-by-slot iterator over the registered hark forks
-    pub fn iter(&self) -> std::slice::Iter<(Slot, usize)> {
+    pub fn iter(&self) -> std::slice::Iter<(u64, usize)> {
         self.hard_forks.iter()
     }
 
@@ -40,7 +41,7 @@ impl HardForks {
     }
 
     // Returns data to include in the bank hash for the given slot if a hard fork is scheduled
-    pub fn get_hash_data(&self, slot: Slot, parent_slot: Slot) -> Option<[u8; 8]> {
+    pub fn get_hash_data(&self, slot: u64, parent_slot: u64) -> Option<[u8; 8]> {
         // The expected number of hard forks in a cluster is small.
         // If this turns out to be false then a more efficient data
         // structure may be needed here to avoid this linear search

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -69,7 +69,7 @@ pub mod exit;
 pub mod feature;
 pub mod genesis_config;
 #[cfg(feature = "full")]
-#[deprecated(since = "2.2.0", note = "Use `solana_hard_forks` crate instead")]
+#[deprecated(since = "2.2.0", note = "Use `solana-hard-forks` crate instead")]
 pub use solana_hard_forks as hard_forks;
 pub mod hash;
 pub mod inner_instruction;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -68,7 +68,9 @@ pub mod example_mocks;
 pub mod exit;
 pub mod feature;
 pub mod genesis_config;
-pub mod hard_forks;
+#[cfg(feature = "full")]
+#[deprecated(since = "2.2.0", note = "Use `solana_hard_forks` crate instead")]
+pub use solana_hard_forks as hard_forks;
 pub mod hash;
 pub mod inner_instruction;
 pub mod log;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -68,6 +68,7 @@ pub mod example_mocks;
 pub mod exit;
 pub mod feature;
 pub mod genesis_config;
+#[cfg(feature = "full")]
 #[deprecated(since = "2.2.0", note = "Use `solana-hard-forks` crate instead")]
 pub use solana_hard_forks as hard_forks;
 pub mod hash;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -68,7 +68,6 @@ pub mod example_mocks;
 pub mod exit;
 pub mod feature;
 pub mod genesis_config;
-#[cfg(feature = "full")]
 #[deprecated(since = "2.2.0", note = "Use `solana-hard-forks` crate instead")]
 pub use solana_hard_forks as hard_forks;
 pub mod hash;

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5654,6 +5654,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-hard-forks"
+version = "2.2.0"
+dependencies = [
+ "byteorder",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "solana-hash"
 version = "2.2.0"
 dependencies = [
@@ -6690,6 +6699,7 @@ dependencies = [
  "solana-epoch-rewards-hasher",
  "solana-feature-set",
  "solana-fee-structure",
+ "solana-hard-forks",
  "solana-inflation",
  "solana-instruction",
  "solana-keypair",


### PR DESCRIPTION
#### Problem
Moving toward evicting `rent_collector` from the SDK, `hard_forks` stands in the way.
https://github.com/anza-xyz/agave/pull/3932

#### Summary of Changes
Extract it into `solana-hard-forks` standalone crate.