### PR TITLE
update number of return values for `process_transaction_and_record_inner`

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -5653,7 +5653,7 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
 
             let message = Message::new(&[instruction], Some(&mint_pubkey));
             let tx = Transaction::new(&[&mint_keypair], message.clone(), bank.last_blockhash());
-            let (result, _, logs) = process_transaction_and_record_inner(&bank, tx);
+            let (result, _, logs, _) = process_transaction_and_record_inner(&bank, tx);
 
             if direct_mapping {
                 assert!(logs.last().unwrap().ends_with(" failed: InvalidLength"));


### PR DESCRIPTION
#### Problem
ci is failing with:
```
+ cd programs/sbf
--
  | + cargo +nightly-2024-08-08 check --locked --workspace --all-targets --features dummy-for-ci-check,frozen-abi
...
error[E0308]: mismatched types
--
  | --> tests/programs.rs:5656:17
  | \|
  | 5656 \|             let (result, _, logs) = process_transaction_and_record_inner(&bank, tx);
  | \|                 ^^^^^^^^^^^^^^^^^   ----------------------------------------------- this expression has type `(Result<(), solana_sdk::transaction::TransactionError>, Vec<Vec<solana_sdk::inner_instruction::InnerInstruction>>, Vec<String>, u64)`
  | \|                 \|
  | \|                 expected a tuple with 4 elements, found one with 3 elements
  | \|
  | = note: expected tuple `(Result<(), solana_sdk::transaction::TransactionError>, Vec<Vec<solana_sdk::inner_instruction::InnerInstruction>>, Vec<String>, u64)`
  | found tuple `(_, _, _)`
  |  
  | For more information about this error, try `rustc --explain E0308`.
  | error: could not compile `solana-sbf-programs` (test "programs") due to 1 previous error
  | ci/test-checks.sh: Some Cargo.lock might be outdated; sync them (or just be a compilation error?)
  | ci/test-checks.sh: protip: $ ./scripts/cargo-for-all-lock-files.sh [--ignore-exit-code] ... \
  | ci/test-checks.sh:   [tree (for outdated Cargo.lock sync)\|check (for compilation error)\|update -p foo --precise x.y.z (for your Cargo.toml update)] ...
  | 🚨 Error: The command exited with status 101
```

See: https://buildkite.com/anza/agave/builds/15258#0193992e-9a7d-4626-9012-95eee7e86fe4
Looks like this `process_transaction_and_record_inner()` was updated recently but for some reason this test wasn't updated but still got merged. 

#### Summary of Changes
Update sbf test to meet number of return values for `process_transaction_and_record_inner`
