### PR TITLE
The accounts cluster benchmark can once again create token accounts to test `getTokenAccountsByOwner`

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -19,12 +19,14 @@ use {
         hash::Hash,
         instruction::{AccountMeta, Instruction},
         message::Message,
+        program_pack::Pack,
         pubkey::Pubkey,
         signature::{read_keypair_file, Keypair, Signer},
         system_instruction, system_program,
         transaction::Transaction,
     },
     solana_streamer::socket::SocketAddrSpace,
+    spl_token::state::Account,
     std::{
         cmp::min,
         process::exit,
@@ -139,7 +141,11 @@ fn make_create_message(
     maybe_space: Option<u64>,
     mint: Option<Pubkey>,
 ) -> Message {
-    let space = maybe_space.unwrap_or_else(|| thread_rng().gen_range(0..1000));
+    let space = if mint.is_some() {
+        Account::get_packed_len() as u64
+    } else {
+        maybe_space.unwrap_or_else(|| thread_rng().gen_range(0..1000))
+    };
 
     let instructions: Vec<_> = (0..num_instructions)
         .flat_map(|_| {
@@ -850,6 +856,7 @@ fn main() {
                 .long("space")
                 .takes_value(true)
                 .value_name("BYTES")
+                .conflicts_with("mint")
                 .help("Size of accounts to create"),
         )
         .arg(


### PR DESCRIPTION
#### Problem

This code chooses a random amount of space to allocate to an account:

https://github.com/anza-xyz/agave/blob/master/accounts-cluster-bench/src/main.rs#L142

That's fine when you're testing system accounts, but when it comes to initializing an associated token account:

https://github.com/anza-xyz/agave/blob/master/accounts-cluster-bench/src/main.rs#L165-L170

The account needs to have enough space allocated to it.

#### Summary of Changes

* `--mint` and `--space` are now incompatible arguments
* allocate enough space for a token account when `--mint` is supplied

```shell
 $ cargo run -- --identity ~/.config/solana/id.json --rpc-bench token-accounts-by-owner  --iterations 0 --url l --mint 7z5aMSb5zfJThETMRgFFd3XNKKVcZGNtWQDS3qfgbQ2t  --space 1234
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.57s
     Running `/home/sol/src/agave/target/debug/solana-accounts-cluster-bench --identity /home/sol/.config/solana/id.json --rpc-bench token-accounts-by-owner --iterations 0 --url l --mint 7z5aMSb5zfJThETMRgFFd3XNKKVcZGNtWQDS3qfgbQ2t --space 1234`
error: The argument '--mint <MINT_ADDRESS>' cannot be used with '--space <BYTES>'

USAGE:
    solana-accounts-cluster-bench --config <FILEPATH> --identity <FILE>... --iterations <NUM_ITERATIONS> --url <URL_OR_MONIKER> --mint <MINT_ADDRESS> --rpc-bench <RPC_BENCH_TYPE(S)>... --space <BYTES>

For more information try --help
```

```shell
 $ cargo run -- --identity ~/.config/solana/id.json --rpc-bench token-accounts-by-owner  --iterations 0 --url l --mint 7z5aMSb5zfJThETMRgFFd3XNKKVcZGNtWQDS3qfgbQ2t
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.58s
     Running `/home/sol/src/agave/target/debug/solana-accounts-cluster-bench --identity /home/sol/.config/solana/id.json --rpc-bench token-accounts-by-owner --iterations 0 --url l --mint 7z5aMSb5zfJThETMRgFFd3XNKKVcZGNtWQDS3qfgbQ2t`
[2024-12-06T00:33:23.865797039Z INFO  solana_accounts_cluster_bench] Targeting http://localhost:8899
[2024-12-06T00:33:23.869231442Z INFO  solana_accounts_cluster_bench] Starting balance(s): [720134087520]
[2024-12-06T00:33:23.870244266Z INFO  solana_accounts_cluster_bench] creating 4 new
[2024-12-06T00:33:23.874149513Z INFO  solana_accounts_cluster_bench] txs: 4
[2024-12-06T00:33:23.899370357Z INFO  solana_accounts_cluster_bench] ids: 4
[2024-12-06T00:33:24.902503766Z INFO  solana_accounts_cluster_bench] creating 4 new
[2024-12-06T00:33:24.903443051Z INFO  solana_accounts_cluster_bench] txs: 4
[2024-12-06T00:33:24.928191567Z INFO  solana_accounts_cluster_bench] ids: 4
[2024-12-06T00:33:25.429089322Z INFO  solana_accounts_cluster_bench] creating 4 new
[2024-12-06T00:33:25.429916263Z INFO  solana_accounts_cluster_bench] txs: 4
[2024-12-06T00:33:25.455834161Z INFO  solana_accounts_cluster_bench] ids: 4
[2024-12-06T00:33:25.957388604Z INFO  solana_accounts_cluster_bench] creating 4 new
[2024-12-06T00:33:25.958193442Z INFO  solana_accounts_cluster_bench] txs: 4
[2024-12-06T00:33:25.983392285Z INFO  solana_accounts_cluster_bench] ids: 4
[2024-12-06T00:33:26.484415569Z INFO  solana_accounts_cluster_bench] creating 1 new
[2024-12-06T00:33:26.484971515Z INFO  solana_accounts_cluster_bench] txs: 1
[2024-12-06T00:33:26.491616928Z INFO  solana_accounts_cluster_bench] ids: 1
[2024-12-06T00:33:26.992576592Z INFO  solana_accounts_cluster_bench] creating 4 new
[2024-12-06T00:33:26.993359178Z INFO  solana_accounts_cluster_bench] txs: 4
[2024-12-06T00:33:27.018587907Z INFO  solana_accounts_cluster_bench] ids: 4
[2024-12-06T00:33:27.018607835Z INFO  solana_accounts_cluster_bench] total_accounts_created: 21 total_accounts_closed: 0 tx_sent_count: 21 loop_count: 7 balance(s): [719969009040]
[2024-12-06T00:33:27.519874153Z INFO  solana_accounts_cluster_bench] creating 4 new
[2024-12-06T00:33:27.520750788Z INFO  solana_accounts_cluster_bench] txs: 4
[2024-12-06T00:33:27.544640944Z INFO  solana_accounts_cluster_bench] ids: 4
[2024-12-06T00:33:27.934502591Z INFO  solana_accounts_cluster_bench] t(0) rpc(TokenAccountsByOwner) iters: 34 success: 35 errors: 0
[2024-12-06T00:33:27.934563046Z INFO  solana_accounts_cluster_bench]  t(0) rpc(TokenAccountsByOwner average success_time: 116138 us
```