### PR TITLE
The `getTokenAccountsByOwner` bench now actually fetches accounts

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -395,7 +395,7 @@ fn run_rpc_bench_loop(
             RpcBench::TokenAccountsByOwner => {
                 let mut rpc_time = Measure::start("rpc-get-token-accounts-by-owner");
                 let filter = TokenAccountsFilter::Mint(*mint.as_ref().unwrap());
-                match client.get_token_accounts_by_owner(program_id, filter) {
+                match client.get_token_accounts_by_owner(base_keypair_pubkey, filter) {
                     Ok(_accounts) => {
                         rpc_time.stop();
                         stats.success += 1;


### PR DESCRIPTION
#### Problem

This benchmark ‘works’ but it doesn't actually fetch any accounts.

#### Summary of Changes

Change the owner to the actual owner of the token accounts, so that the call actually returns accounts. Verified this by a carefully placed `println!("{:?}", _accounts)`.