### PR TITLE
Accounting migrating builtin programs default Compute Unit Limit with feature status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6312,6 +6312,7 @@ dependencies = [
  "solana-stake-program",
  "solana-system-program",
  "solana-vote-program",
+ "static_assertions",
 ]
 
 [[package]]

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -45,6 +45,7 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "solana-vote-program/frozen-abi",
 ]
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -35,6 +35,7 @@ name = "solana_builtins_default_costs"
 
 [dev-dependencies]
 rand = "0.8.5"
+static_assertions = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -161,9 +161,32 @@ pub fn get_builtin_instruction_cost<'a>(
         .map(|builtin_cost| builtin_cost.native_cost)
 }
 
-#[inline]
-pub fn is_builtin_program(program_id: &Pubkey) -> bool {
-    BUILTIN_INSTRUCTION_COSTS.contains_key(program_id)
+lazy_static! {
+    /// A static list of builtin programs' migration feature IDs.
+    pub static ref MIGRATION_FEATURES_ID: Vec<Pubkey> = {
+        BUILTIN_INSTRUCTION_COSTS
+            .values()
+            .filter_map(|builtin_cost| builtin_cost.core_bpf_migration_feature)
+            .collect()
+    };
+}
+
+/// Given a program pubkey, returns:
+/// - None, if it is not in BUILTIN_INSTRUCTION_COSTS dictionary;
+/// - Some<None>, is builtin, but no associated migration feature ID;
+/// - Some<usize>, is builtin, and its associated migration feature ID
+///   index in MIGRATION_FEATURES_ID.
+pub fn get_builtin_migration_feature_index(program_id: &Pubkey) -> Option<Option<usize>> {
+    BUILTIN_INSTRUCTION_COSTS
+        .get(program_id)
+        .map(|builtin_cost| {
+            builtin_cost.core_bpf_migration_feature.map(|id| {
+                MIGRATION_FEATURES_ID
+                    .iter()
+                    .position(|&x| x == id)
+                    .expect("must be known migration feature ID")
+            })
+        })
 }
 
 #[cfg(test)]
@@ -198,6 +221,31 @@ mod test {
         assert!(
             get_builtin_instruction_cost(&Pubkey::new_unique(), &FeatureSet::all_enabled())
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn test_get_builtin_migration_feature_index() {
+        assert!(get_builtin_migration_feature_index(&Pubkey::new_unique()).is_none());
+        assert_eq!(
+            get_builtin_migration_feature_index(&compute_budget::id()),
+            Some(None)
+        );
+        let feature_index = get_builtin_migration_feature_index(&solana_stake_program::id());
+        assert_eq!(
+            MIGRATION_FEATURES_ID[feature_index.unwrap().unwrap()],
+            feature_set::migrate_stake_program_to_core_bpf::id()
+        );
+        let feature_index = get_builtin_migration_feature_index(&solana_config_program::id());
+        assert_eq!(
+            MIGRATION_FEATURES_ID[feature_index.unwrap().unwrap()],
+            feature_set::migrate_config_program_to_core_bpf::id()
+        );
+        let feature_index =
+            get_builtin_migration_feature_index(&address_lookup_table::program::id());
+        assert_eq!(
+            MIGRATION_FEATURES_ID[feature_index.unwrap().unwrap()],
+            feature_set::migrate_address_lookup_table_program_to_core_bpf::id()
         );
     }
 }

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![feature(const_option)]
 #![allow(clippy::arithmetic_side_effects)]
 use {
     ahash::AHashMap,
@@ -14,13 +13,19 @@ use {
 };
 
 #[derive(Clone)]
-struct CoreBpfMigrationFeature {
-    feature_id: Pubkey,
+pub struct MigratingBuiltinCost {
+    native_cost: u64,
+    core_bpf_migration_feature: Pubkey,
     // encoding positional information explicitly for migration feature item,
     // its value must be correctly corresponding to this object's position
     // in MIGRATING_BUILTINS_COSTS, otherwise a const validation
     // `validate_position(MIGRATING_BUILTINS_COSTS)` will fail at compile time.
     position: usize,
+}
+
+#[derive(Clone)]
+pub struct NotMigratingBuiltinCost {
+    native_cost: u64,
 }
 
 /// DEVELOPER: when a builtin is migrated to sbpf, please add its corresponding
@@ -30,30 +35,46 @@ struct CoreBpfMigrationFeature {
 /// When migration completed, eg the feature gate is enabled everywhere, please
 /// remove that builtin entry from MIGRATING_BUILTINS_COSTS.
 #[derive(Clone)]
-pub struct BuiltinCost {
-    native_cost: u64,
-    core_bpf_migration_feature: Option<CoreBpfMigrationFeature>,
+pub enum BuiltinCost {
+    Migrating(MigratingBuiltinCost),
+    NotMigrating(NotMigratingBuiltinCost),
 }
 
-/// const function validates `position` correctness at compile time.
-#[allow(dead_code)]
-const fn validate_position(migrating_builtins: &[(Pubkey, BuiltinCost)]) {
-    let mut index = 0;
-    while index < migrating_builtins.len() {
-        assert!(
-            migrating_builtins[index]
-                .1
-                .core_bpf_migration_feature
-                .as_ref()
-                .unwrap()
-                .position
-                == index,
-            "migration feture must exist and at correct position"
-        );
-        index += 1;
+impl BuiltinCost {
+    pub fn native_cost(&self) -> u64 {
+        match self {
+            BuiltinCost::Migrating(MigratingBuiltinCost { native_cost, .. }) => *native_cost,
+            BuiltinCost::NotMigrating(NotMigratingBuiltinCost { native_cost }) => *native_cost,
+        }
+    }
+
+    pub fn core_bpf_migration_feature(&self) -> Option<&Pubkey> {
+        match self {
+            BuiltinCost::Migrating(MigratingBuiltinCost {
+                core_bpf_migration_feature,
+                ..
+            }) => Some(core_bpf_migration_feature),
+            BuiltinCost::NotMigrating(_) => None,
+        }
+    }
+
+    pub fn position(&self) -> Option<usize> {
+        match self {
+            BuiltinCost::Migrating(MigratingBuiltinCost { position, .. }) => Some(*position),
+            BuiltinCost::NotMigrating(_) => None,
+        }
+    }
+
+    fn has_migrated(&self, feature_set: &FeatureSet) -> bool {
+        match self {
+            BuiltinCost::Migrating(MigratingBuiltinCost {
+                core_bpf_migration_feature,
+                ..
+            }) => feature_set.is_active(core_bpf_migration_feature),
+            BuiltinCost::NotMigrating(_) => false,
+        }
     }
 }
-const _: () = validate_position(MIGRATING_BUILTINS_COSTS);
 
 lazy_static! {
     /// Number of compute units for each built-in programs
@@ -91,100 +112,82 @@ static_assertions::const_assert_eq!(
 pub const MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
     (
         stake::id(),
-        BuiltinCost {
+        BuiltinCost::Migrating(MigratingBuiltinCost {
             native_cost: solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS,
-            core_bpf_migration_feature: Some(CoreBpfMigrationFeature {
-                feature_id: feature_set::migrate_stake_program_to_core_bpf::id(),
-                position: 0,
-            }),
-        },
+            core_bpf_migration_feature: feature_set::migrate_stake_program_to_core_bpf::id(),
+            position: 0,
+        }),
     ),
     (
         config::id(),
-        BuiltinCost {
+        BuiltinCost::Migrating(MigratingBuiltinCost {
             native_cost: solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS,
-            core_bpf_migration_feature: Some(CoreBpfMigrationFeature {
-                feature_id: feature_set::migrate_config_program_to_core_bpf::id(),
-                position: 1,
-            }),
-        },
+            core_bpf_migration_feature: feature_set::migrate_config_program_to_core_bpf::id(),
+            position: 1,
+        }),
     ),
     (
         address_lookup_table::id(),
-        BuiltinCost {
+        BuiltinCost::Migrating(MigratingBuiltinCost {
             native_cost: solana_address_lookup_table_program::processor::DEFAULT_COMPUTE_UNITS,
-            core_bpf_migration_feature: Some(CoreBpfMigrationFeature {
-                feature_id: feature_set::migrate_address_lookup_table_program_to_core_bpf::id(),
-                position: 2,
-            }),
-        },
+            core_bpf_migration_feature:
+                feature_set::migrate_address_lookup_table_program_to_core_bpf::id(),
+            position: 2,
+        }),
     ),
 ];
 
 pub const NON_MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
     (
         vote::id(),
-        BuiltinCost {
+        BuiltinCost::NotMigrating(NotMigratingBuiltinCost {
             native_cost: solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS,
-            core_bpf_migration_feature: None,
-        },
+        }),
     ),
     (
         system_program::id(),
-        BuiltinCost {
+        BuiltinCost::NotMigrating(NotMigratingBuiltinCost {
             native_cost: solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS,
-            core_bpf_migration_feature: None,
-        },
+        }),
     ),
     (
         compute_budget::id(),
-        BuiltinCost {
+        BuiltinCost::NotMigrating(NotMigratingBuiltinCost {
             native_cost: solana_compute_budget_program::DEFAULT_COMPUTE_UNITS,
-            core_bpf_migration_feature: None,
-        },
+        }),
     ),
     (
         bpf_loader_upgradeable::id(),
-        BuiltinCost {
+        BuiltinCost::NotMigrating(NotMigratingBuiltinCost {
             native_cost: solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS,
-            core_bpf_migration_feature: None,
-        },
+        }),
     ),
     (
         bpf_loader_deprecated::id(),
-        BuiltinCost {
+        BuiltinCost::NotMigrating(NotMigratingBuiltinCost {
             native_cost: solana_bpf_loader_program::DEPRECATED_LOADER_COMPUTE_UNITS,
-            core_bpf_migration_feature: None,
-        },
+        }),
     ),
     (
         bpf_loader::id(),
-        BuiltinCost {
+        BuiltinCost::NotMigrating(NotMigratingBuiltinCost {
             native_cost: solana_bpf_loader_program::DEFAULT_LOADER_COMPUTE_UNITS,
-            core_bpf_migration_feature: None,
-        },
+        }),
     ),
     (
         loader_v4::id(),
-        BuiltinCost {
+        BuiltinCost::NotMigrating(NotMigratingBuiltinCost {
             native_cost: solana_loader_v4_program::DEFAULT_COMPUTE_UNITS,
-            core_bpf_migration_feature: None,
-        },
+        }),
     ),
     // Note: These are precompile, run directly in bank during sanitizing;
     (
         secp256k1_program::id(),
-        BuiltinCost {
-            native_cost: 0,
-            core_bpf_migration_feature: None,
-        },
+        BuiltinCost::NotMigrating(NotMigratingBuiltinCost { native_cost: 0 }),
     ),
     (
         ed25519_program::id(),
-        BuiltinCost {
-            native_cost: 0,
-            core_bpf_migration_feature: None,
-        },
+        BuiltinCost::NotMigrating(NotMigratingBuiltinCost { native_cost: 0 }),
     ),
 ];
 
@@ -208,18 +211,8 @@ pub fn get_builtin_instruction_cost<'a>(
 ) -> Option<u64> {
     BUILTIN_INSTRUCTION_COSTS
         .get(program_id)
-        .filter(
-            // Returns true if builtin program id has no core_bpf_migration_feature or feature is not activated;
-            // otherwise returns false because it's not considered as builtin
-            |builtin_cost| -> bool {
-                builtin_cost
-                    .core_bpf_migration_feature
-                    .as_ref()
-                    .map(|migration_feature| !feature_set.is_active(&migration_feature.feature_id))
-                    .unwrap_or(true)
-            },
-        )
-        .map(|builtin_cost| builtin_cost.native_cost)
+        .filter(|builtin_cost| !builtin_cost.has_migrated(feature_set))
+        .map(|builtin_cost| builtin_cost.native_cost())
 }
 
 pub enum BuiltinMigrationFeatureIndex {
@@ -228,50 +221,53 @@ pub enum BuiltinMigrationFeatureIndex {
     BuiltinWithMigrationFeature(usize),
 }
 
-/// Given a program pubkey, returns:
-/// - None, if it is not in BUILTIN_INSTRUCTION_COSTS dictionary;
-/// - Some<None>, is builtin, but no associated migration feature ID;
-/// - Some<usize>, is builtin, and its associated migration feature ID
-///   index in MIGRATION_FEATURES_ID.
 pub fn get_builtin_migration_feature_index(program_id: &Pubkey) -> BuiltinMigrationFeatureIndex {
     BUILTIN_INSTRUCTION_COSTS.get(program_id).map_or(
         BuiltinMigrationFeatureIndex::NotBuiltin,
         |builtin_cost| {
-            builtin_cost.core_bpf_migration_feature.as_ref().map_or(
+            builtin_cost.position().map_or(
                 BuiltinMigrationFeatureIndex::BuiltinNoMigrationFeature,
-                |migration_feature| {
-                    BuiltinMigrationFeatureIndex::BuiltinWithMigrationFeature(
-                        migration_feature.position,
-                    )
-                },
+                BuiltinMigrationFeatureIndex::BuiltinWithMigrationFeature,
             )
         },
     )
 }
 
+/// const function validates `position` correctness at compile time.
+#[allow(dead_code)]
+const fn validate_position(migrating_builtins: &[(Pubkey, BuiltinCost)]) {
+    let mut index = 0;
+    while index < migrating_builtins.len() {
+        match migrating_builtins[index].1 {
+            BuiltinCost::Migrating(MigratingBuiltinCost { position, .. }) => assert!(
+                position == index,
+                "migration feture must exist and at correct position"
+            ),
+            BuiltinCost::NotMigrating(_) => {
+                panic!("migration feture must exist and at correct position")
+            }
+        }
+        index += 1;
+    }
+}
+const _: () = validate_position(MIGRATING_BUILTINS_COSTS);
+
 /// Helper function to return ref of migration feature Pubkey at position `index`
 /// from MIGRATING_BUILTINS_COSTS
 pub fn get_migration_feature_id(index: usize) -> &'static Pubkey {
-    &MIGRATING_BUILTINS_COSTS
+    MIGRATING_BUILTINS_COSTS
         .get(index)
         .expect("valid index of MIGRATING_BUILTINS_COSTS")
         .1
-        .core_bpf_migration_feature
-        .as_ref()
+        .core_bpf_migration_feature()
         .expect("migrating builtin")
-        .feature_id
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 pub fn get_migration_feature_position(feature_id: &Pubkey) -> usize {
     MIGRATING_BUILTINS_COSTS
         .iter()
-        .position(|(_, c)| {
-            c.core_bpf_migration_feature
-                .as_ref()
-                .map(|f| f.feature_id)
-                .unwrap()
-                == *feature_id
-        })
+        .position(|(_, c)| c.core_bpf_migration_feature().expect("migrating builtin") == feature_id)
         .unwrap()
 }
 
@@ -286,13 +282,11 @@ mod test {
             .iter()
             .enumerate()
             .all(|(index, (_, c))| {
-                let migration_feature = &c.core_bpf_migration_feature;
-                migration_feature.is_some()
-                    && migration_feature.as_ref().map(|f| f.position) == Some(index)
+                c.core_bpf_migration_feature().is_some() && c.position() == Some(index)
             }));
         assert!(NON_MIGRATING_BUILTINS_COSTS
             .iter()
-            .all(|(_, c)| c.core_bpf_migration_feature.is_none()));
+            .all(|(_, c)| c.core_bpf_migration_feature().is_none()));
     }
 
     #[test]

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![feature(const_option)]
 #![allow(clippy::arithmetic_side_effects)]
 use {
     ahash::AHashMap,
@@ -12,6 +13,16 @@ use {
     },
 };
 
+#[derive(Clone)]
+struct CoreBpfMigrationFeature {
+    feature_id: Pubkey,
+    // encoding positional information explicitly for migration feature item,
+    // its value must be correctly corresponding to this object's position
+    // in MIGRATING_BUILTINS_COSTS, otherwise a const validation
+    // `validate_position(MIGRATING_BUILTINS_COSTS)` will fail at compile time.
+    position: usize,
+}
+
 /// DEVELOPER: when a builtin is migrated to sbpf, please add its corresponding
 /// migration feature ID to BUILTIN_INSTRUCTION_COSTS, and move it from
 /// NON_MIGRATING_BUILTINS_COSTS to MIGRATING_BUILTINS_COSTS, so the builtin's
@@ -21,40 +32,91 @@ use {
 #[derive(Clone)]
 pub struct BuiltinCost {
     native_cost: u64,
-    core_bpf_migration_feature: Option<Pubkey>,
+    core_bpf_migration_feature: Option<CoreBpfMigrationFeature>,
 }
 
-/// Number of compute units for each built-in programs
+/// const function validates `position` correctness at compile time.
+#[allow(dead_code)]
+const fn validate_position(migrating_builtins: &[(Pubkey, BuiltinCost)]) {
+    let mut index = 0;
+    while index < migrating_builtins.len() {
+        assert!(
+            migrating_builtins[index]
+                .1
+                .core_bpf_migration_feature
+                .as_ref()
+                .unwrap()
+                .position
+                == index,
+            "migration feture must exist and at correct position"
+        );
+        index += 1;
+    }
+}
+const _: () = validate_position(MIGRATING_BUILTINS_COSTS);
+
+lazy_static! {
+    /// Number of compute units for each built-in programs
+    ///
+    /// DEVELOPER WARNING: This map CANNOT be modified without causing a
+    /// consensus failure because this map is used to calculate the compute
+    /// limit for transactions that don't specify a compute limit themselves as
+    /// of https://github.com/anza-xyz/agave/issues/2212.  It's also used to
+    /// calculate the cost of a transaction which is used in replay to enforce
+    /// block cost limits as of
+    /// https://github.com/solana-labs/solana/issues/29595.
+    static ref BUILTIN_INSTRUCTION_COSTS: AHashMap<Pubkey, BuiltinCost> =
+        MIGRATING_BUILTINS_COSTS
+          .iter()
+          .chain(NON_MIGRATING_BUILTINS_COSTS.iter())
+          .cloned()
+          .collect();
+    // DO NOT ADD MORE ENTRIES TO THIS MAP
+}
+
+/// DEVELOPER WARNING: please do not add new entry into MIGRATING_BUILTINS_COSTS or
+/// NON_MIGRATING_BUILTINS_COSTS, do so will modify BUILTIN_INSTRUCTION_COSTS therefore
+/// cause consensus failure. However, when a builtin started being migrated to core bpf,
+/// it MUST be moved from NON_MIGRATING_BUILTINS_COSTS to MIGRATING_BUILTINS_COSTS, then
+/// correctly furnishing `core_bpf_migration_feature`.
 ///
-/// DEVELOPER WARNING: This map CANNOT be modified without causing a
-/// consensus failure because this map is used to calculate the compute
-/// limit for transactions that don't specify a compute limit themselves as
-/// of https://github.com/anza-xyz/agave/issues/2212.  It's also used to
-/// calculate the cost of a transaction which is used in replay to enforce
-/// block cost limits as of
-/// https://github.com/solana-labs/solana/issues/29595.
+#[allow(dead_code)]
+const TOTAL_COUNT_BUILTS: usize = 12;
+#[cfg(test)]
+static_assertions::const_assert_eq!(
+    MIGRATING_BUILTINS_COSTS.len() + NON_MIGRATING_BUILTINS_COSTS.len(),
+    TOTAL_COUNT_BUILTS
+);
+
 pub const MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
     (
         stake::id(),
         BuiltinCost {
             native_cost: solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS,
-            core_bpf_migration_feature: Some(feature_set::migrate_stake_program_to_core_bpf::id()),
+            core_bpf_migration_feature: Some(CoreBpfMigrationFeature {
+                feature_id: feature_set::migrate_stake_program_to_core_bpf::id(),
+                position: 0,
+            }),
         },
     ),
     (
         config::id(),
         BuiltinCost {
             native_cost: solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS,
-            core_bpf_migration_feature: Some(feature_set::migrate_config_program_to_core_bpf::id()),
+            core_bpf_migration_feature: Some(CoreBpfMigrationFeature {
+                feature_id: feature_set::migrate_config_program_to_core_bpf::id(),
+                position: 1,
+            }),
         },
     ),
     (
         address_lookup_table::id(),
         BuiltinCost {
             native_cost: solana_address_lookup_table_program::processor::DEFAULT_COMPUTE_UNITS,
-            core_bpf_migration_feature: Some(
-                feature_set::migrate_address_lookup_table_program_to_core_bpf::id(),
-            ),
+            core_bpf_migration_feature: Some(CoreBpfMigrationFeature {
+                feature_id: feature_set::migrate_address_lookup_table_program_to_core_bpf::id(),
+                position: 2,
+            }),
         },
     ),
 ];
@@ -127,16 +189,6 @@ pub const NON_MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
 ];
 
 lazy_static! {
-    static ref BUILTIN_INSTRUCTION_COSTS: AHashMap<Pubkey, BuiltinCost> =
-        MIGRATING_BUILTINS_COSTS
-          .iter()
-          .chain(NON_MIGRATING_BUILTINS_COSTS.iter())
-          .cloned()
-          .collect();
-    // DO NOT ADD MORE ENTRIES TO THIS MAP
-}
-
-lazy_static! {
     /// A table of 256 booleans indicates whether the first `u8` of a Pubkey exists in
     /// BUILTIN_INSTRUCTION_COSTS. If the value is true, the Pubkey might be a builtin key;
     /// if false, it cannot be a builtin key. This table allows for quick filtering of
@@ -162,21 +214,18 @@ pub fn get_builtin_instruction_cost<'a>(
             |builtin_cost| -> bool {
                 builtin_cost
                     .core_bpf_migration_feature
-                    .map(|feature_id| !feature_set.is_active(&feature_id))
+                    .as_ref()
+                    .map(|migration_feature| !feature_set.is_active(&migration_feature.feature_id))
                     .unwrap_or(true)
             },
         )
         .map(|builtin_cost| builtin_cost.native_cost)
 }
 
-lazy_static! {
-    /// A static list of builtin programs' migration feature IDs.
-    pub static ref MIGRATION_FEATURES_ID: Vec<Pubkey> = {
-        BUILTIN_INSTRUCTION_COSTS
-            .values()
-            .filter_map(|builtin_cost| builtin_cost.core_bpf_migration_feature)
-            .collect()
-    };
+pub enum BuiltinMigrationFeatureIndex {
+    NotBuiltin,
+    BuiltinNoMigrationFeature,
+    BuiltinWithMigrationFeature(usize),
 }
 
 /// Given a program pubkey, returns:
@@ -184,22 +233,67 @@ lazy_static! {
 /// - Some<None>, is builtin, but no associated migration feature ID;
 /// - Some<usize>, is builtin, and its associated migration feature ID
 ///   index in MIGRATION_FEATURES_ID.
-pub fn get_builtin_migration_feature_index(program_id: &Pubkey) -> Option<Option<usize>> {
-    BUILTIN_INSTRUCTION_COSTS
-        .get(program_id)
-        .map(|builtin_cost| {
-            builtin_cost.core_bpf_migration_feature.map(|id| {
-                MIGRATION_FEATURES_ID
-                    .iter()
-                    .position(|&x| x == id)
-                    .expect("must be known migration feature ID")
-            })
+pub fn get_builtin_migration_feature_index(program_id: &Pubkey) -> BuiltinMigrationFeatureIndex {
+    BUILTIN_INSTRUCTION_COSTS.get(program_id).map_or(
+        BuiltinMigrationFeatureIndex::NotBuiltin,
+        |builtin_cost| {
+            builtin_cost.core_bpf_migration_feature.as_ref().map_or(
+                BuiltinMigrationFeatureIndex::BuiltinNoMigrationFeature,
+                |migration_feature| {
+                    BuiltinMigrationFeatureIndex::BuiltinWithMigrationFeature(
+                        migration_feature.position,
+                    )
+                },
+            )
+        },
+    )
+}
+
+/// Helper function to return ref of migration feature Pubkey at position `index`
+/// from MIGRATING_BUILTINS_COSTS
+pub fn get_migration_feature_id(index: usize) -> &'static Pubkey {
+    &MIGRATING_BUILTINS_COSTS
+        .get(index)
+        .expect("valid index of MIGRATING_BUILTINS_COSTS")
+        .1
+        .core_bpf_migration_feature
+        .as_ref()
+        .expect("migrating builtin")
+        .feature_id
+}
+
+pub fn get_migration_feature_position(feature_id: &Pubkey) -> usize {
+    MIGRATING_BUILTINS_COSTS
+        .iter()
+        .position(|(_, c)| {
+            c.core_bpf_migration_feature
+                .as_ref()
+                .map(|f| f.feature_id)
+                .unwrap()
+                == *feature_id
         })
+        .unwrap()
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_const_builtin_cost_arrays() {
+        // sanity check to make sure built-ins are declared in the correct array
+        assert!(MIGRATING_BUILTINS_COSTS
+            .iter()
+            .enumerate()
+            .all(|(index, (_, c))| {
+                let migration_feature = &c.core_bpf_migration_feature;
+                migration_feature.is_some()
+                    && migration_feature.as_ref().map(|f| f.position) == Some(index)
+            }));
+        assert!(NON_MIGRATING_BUILTINS_COSTS
+            .iter()
+            .all(|(_, c)| c.core_bpf_migration_feature.is_none()));
+    }
 
     #[test]
     fn test_get_builtin_instruction_cost() {
@@ -212,15 +306,11 @@ mod test {
         // use native cost if migration is planned but not activated
         assert_eq!(
             Some(solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS),
-            get_builtin_instruction_cost(&solana_stake_program::id(), &FeatureSet::default())
+            get_builtin_instruction_cost(&stake::id(), &FeatureSet::default())
         );
 
         // None if migration is planned and activated, in which case, it's no longer builtin
-        assert!(get_builtin_instruction_cost(
-            &solana_stake_program::id(),
-            &FeatureSet::all_enabled()
-        )
-        .is_none());
+        assert!(get_builtin_instruction_cost(&stake::id(), &FeatureSet::all_enabled()).is_none());
 
         // None if not builtin
         assert!(
@@ -234,26 +324,61 @@ mod test {
 
     #[test]
     fn test_get_builtin_migration_feature_index() {
-        assert!(get_builtin_migration_feature_index(&Pubkey::new_unique()).is_none());
-        assert_eq!(
+        assert!(matches!(
+            get_builtin_migration_feature_index(&Pubkey::new_unique()),
+            BuiltinMigrationFeatureIndex::NotBuiltin
+        ));
+        assert!(matches!(
             get_builtin_migration_feature_index(&compute_budget::id()),
-            Some(None)
-        );
-        let feature_index = get_builtin_migration_feature_index(&solana_stake_program::id());
+            BuiltinMigrationFeatureIndex::BuiltinNoMigrationFeature,
+        ));
+        let feature_index = get_builtin_migration_feature_index(&stake::id());
+        assert!(matches!(
+            feature_index,
+            BuiltinMigrationFeatureIndex::BuiltinWithMigrationFeature(_)
+        ));
+        let BuiltinMigrationFeatureIndex::BuiltinWithMigrationFeature(feature_index) =
+            feature_index
+        else {
+            panic!("expect migrating builtin")
+        };
         assert_eq!(
-            MIGRATION_FEATURES_ID[feature_index.unwrap().unwrap()],
-            feature_set::migrate_stake_program_to_core_bpf::id()
+            get_migration_feature_id(feature_index),
+            &feature_set::migrate_stake_program_to_core_bpf::id()
         );
-        let feature_index = get_builtin_migration_feature_index(&solana_config_program::id());
+        let feature_index = get_builtin_migration_feature_index(&config::id());
+        assert!(matches!(
+            feature_index,
+            BuiltinMigrationFeatureIndex::BuiltinWithMigrationFeature(_)
+        ));
+        let BuiltinMigrationFeatureIndex::BuiltinWithMigrationFeature(feature_index) =
+            feature_index
+        else {
+            panic!("expect migrating builtin")
+        };
         assert_eq!(
-            MIGRATION_FEATURES_ID[feature_index.unwrap().unwrap()],
-            feature_set::migrate_config_program_to_core_bpf::id()
+            get_migration_feature_id(feature_index),
+            &feature_set::migrate_config_program_to_core_bpf::id()
         );
-        let feature_index =
-            get_builtin_migration_feature_index(&address_lookup_table::program::id());
+        let feature_index = get_builtin_migration_feature_index(&address_lookup_table::id());
+        assert!(matches!(
+            feature_index,
+            BuiltinMigrationFeatureIndex::BuiltinWithMigrationFeature(_)
+        ));
+        let BuiltinMigrationFeatureIndex::BuiltinWithMigrationFeature(feature_index) =
+            feature_index
+        else {
+            panic!("expect migrating builtin")
+        };
         assert_eq!(
-            MIGRATION_FEATURES_ID[feature_index.unwrap().unwrap()],
-            feature_set::migrate_address_lookup_table_program_to_core_bpf::id()
+            get_migration_feature_id(feature_index),
+            &feature_set::migrate_address_lookup_table_program_to_core_bpf::id()
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "valid index of MIGRATING_BUILTINS_COSTS")]
+    fn test_get_migration_feature_id_invalid_index() {
+        let _ = get_migration_feature_id(MIGRATING_BUILTINS_COSTS.len() + 1);
     }
 }

--- a/compute-budget-instruction/Cargo.toml
+++ b/compute-budget-instruction/Cargo.toml
@@ -26,6 +26,7 @@ name = "solana_compute_budget_instruction"
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
+solana-builtins-default-costs =  { workspace = true, features = ["dev-context-only-utils"] }
 solana-program = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/compute-budget-instruction/src/builtin_programs_filter.rs
+++ b/compute-budget-instruction/src/builtin_programs_filter.rs
@@ -1,5 +1,7 @@
 use {
-    solana_builtins_default_costs::{get_builtin_migration_feature_index, MAYBE_BUILTIN_KEY},
+    solana_builtins_default_costs::{
+        get_builtin_migration_feature_index, BuiltinMigrationFeatureIndex, MAYBE_BUILTIN_KEY,
+    },
     solana_sdk::{packet::PACKET_DATA_SIZE, pubkey::Pubkey},
 };
 
@@ -46,21 +48,24 @@ impl BuiltinProgramsFilter {
             return ProgramKind::NotBuiltin;
         }
 
-        get_builtin_migration_feature_index(program_id).map_or(
-            ProgramKind::NotBuiltin,
-            |some_builtin| match some_builtin {
-                Some(core_bpf_migration_feature_index) => ProgramKind::MigratingBuiltin {
-                    core_bpf_migration_feature_index,
-                },
-                None => ProgramKind::Builtin,
+        match get_builtin_migration_feature_index(program_id) {
+            BuiltinMigrationFeatureIndex::NotBuiltin => ProgramKind::NotBuiltin,
+            BuiltinMigrationFeatureIndex::BuiltinNoMigrationFeature => ProgramKind::Builtin,
+            BuiltinMigrationFeatureIndex::BuiltinWithMigrationFeature(
+                core_bpf_migration_feature_index,
+            ) => ProgramKind::MigratingBuiltin {
+                core_bpf_migration_feature_index,
             },
-        )
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use {super::*, solana_builtins_default_costs::MIGRATION_FEATURES_ID, solana_sdk::feature_set};
+    use {
+        super::*, solana_builtins_default_costs::get_migration_feature_position,
+        solana_sdk::feature_set,
+    };
 
     const DUMMY_PROGRAM_ID: &str = "dummmy1111111111111111111111111111111111111";
 
@@ -122,10 +127,9 @@ mod test {
             assert_eq!(
                 test_store.get_program_kind(index, &migrating_builtin_pubkey),
                 ProgramKind::MigratingBuiltin {
-                    core_bpf_migration_feature_index: MIGRATION_FEATURES_ID
-                        .iter()
-                        .position(|&x| x == migration_feature_id)
-                        .unwrap(),
+                    core_bpf_migration_feature_index: get_migration_feature_position(
+                        &migration_feature_id
+                    ),
                 }
             );
         }

--- a/compute-budget-instruction/src/builtin_programs_filter.rs
+++ b/compute-budget-instruction/src/builtin_programs_filter.rs
@@ -12,7 +12,7 @@ pub(crate) enum ProgramKind {
     Builtin,
     // Builtin program maybe in process of being migrated to core bpf,
     // if core_bpf_migration_feature is activated, then the migration has
-    // completed and it should not longer be considered as builtin
+    // completed and it should no longer be considered as builtin
     MigratingBuiltin {
         core_bpf_migration_feature_index: usize,
     },

--- a/compute-budget-instruction/src/compute_budget_instruction_details.rs
+++ b/compute-budget-instruction/src/compute_budget_instruction_details.rs
@@ -25,13 +25,13 @@ struct MigrationBuiltinFeatureCounter {
     // The vector of counters, matching the size of the static vector MIGRATION_FEATURE_IDS,
     // each counter representing the number of times its corresponding feature ID is
     // referenced in this transaction.
-    migrating_builtin: Vec<u16>,
+    migrating_builtin: [u16; solana_builtins_default_costs::MIGRATING_BUILTINS_COSTS.len()],
 }
 
 impl Default for MigrationBuiltinFeatureCounter {
     fn default() -> Self {
         Self {
-            migrating_builtin: vec![0; MIGRATION_FEATURES_ID.len()],
+            migrating_builtin: [0; solana_builtins_default_costs::MIGRATING_BUILTINS_COSTS.len()],
         }
     }
 }

--- a/compute-budget-instruction/src/compute_budget_instruction_details.rs
+++ b/compute-budget-instruction/src/compute_budget_instruction_details.rs
@@ -3,6 +3,7 @@ use {
         builtin_programs_filter::{BuiltinProgramsFilter, ProgramKind},
         compute_budget_program_id_filter::ComputeBudgetProgramIdFilter,
     },
+    solana_builtins_default_costs::MIGRATION_FEATURES_ID,
     solana_compute_budget::compute_budget_limits::*,
     solana_sdk::{
         borsh1::try_from_slice_unchecked,
@@ -19,6 +20,24 @@ use {
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
+#[derive(Debug)]
+struct MigrationBuiltinFeatureCounter {
+    // The vector of counters, matching the size of the static vector MIGRATION_FEATURE_IDS,
+    // each counter representing the number of times its corresponding feature ID is
+    // referenced in this transaction.
+    migrating_builtin: Vec<u16>,
+}
+
+impl Default for MigrationBuiltinFeatureCounter {
+    fn default() -> Self {
+        Self {
+            migrating_builtin: vec![0; MIGRATION_FEATURES_ID.len()],
+        }
+    }
+}
+
+#[cfg_attr(test, derive(Eq, PartialEq))]
+#[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
 #[derive(Default, Debug)]
 pub struct ComputeBudgetInstructionDetails {
     // compute-budget instruction details:
@@ -31,6 +50,7 @@ pub struct ComputeBudgetInstructionDetails {
     // Additional builtin program counters
     num_builtin_instructions: u16,
     num_non_builtin_instructions: u16,
+    migrating_builtin_feature_counters: MigrationBuiltinFeatureCounter,
 }
 
 impl ComputeBudgetInstructionDetails {
@@ -68,6 +88,20 @@ impl ComputeBudgetInstructionDetails {
                     ProgramKind::NotBuiltin => {
                         saturating_add_assign!(
                             compute_budget_instruction_details.num_non_builtin_instructions,
+                            1
+                        );
+                    }
+                    ProgramKind::MigratingBuiltin {
+                        core_bpf_migration_feature_index,
+                    } => {
+                        saturating_add_assign!(
+                            *compute_budget_instruction_details
+                                .migrating_builtin_feature_counters
+                                .migrating_builtin
+                                .get_mut(core_bpf_migration_feature_index)
+                                .expect(
+                                    "migrating feature index within range of MIGRATION_FEATURE_IDS"
+                                ),
                             1
                         );
                     }
@@ -175,10 +209,26 @@ impl ComputeBudgetInstructionDetails {
 
     fn calculate_default_compute_unit_limit(&self, feature_set: &FeatureSet) -> u32 {
         if feature_set.is_active(&feature_set::reserve_minimal_cus_for_builtin_instructions::id()) {
+            // evaluate if any builtin has migrated with feature_set
+            let (num_migrated, num_not_migrated) = self
+                .migrating_builtin_feature_counters
+                .migrating_builtin
+                .iter()
+                .enumerate()
+                .fold((0, 0), |(migrated, not_migrated), (index, count)| {
+                    if feature_set.is_active(&MIGRATION_FEATURES_ID[index]) {
+                        (migrated + count, not_migrated)
+                    } else {
+                        (migrated, not_migrated + count)
+                    }
+                });
+
             u32::from(self.num_builtin_instructions)
+                .saturating_add(u32::from(num_not_migrated))
                 .saturating_mul(MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT)
                 .saturating_add(
                     u32::from(self.num_non_builtin_instructions)
+                        .saturating_add(u32::from(num_migrated))
                         .saturating_mul(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT),
                 )
         } else {
@@ -520,5 +570,90 @@ mod test {
                 })
             );
         }
+    }
+
+    #[test]
+    fn test_builtin_program_migration() {
+        let tx = build_sanitized_transaction(&[
+            Instruction::new_with_bincode(Pubkey::new_unique(), &(), vec![]),
+            solana_sdk::stake::instruction::delegate_stake(
+                &Pubkey::new_unique(),
+                &Pubkey::new_unique(),
+                &Pubkey::new_unique(),
+            ),
+        ]);
+        let feature_id_index = MIGRATION_FEATURES_ID
+            .iter()
+            .position(|id| *id == feature_set::migrate_stake_program_to_core_bpf::id())
+            .unwrap();
+        let mut expected_details = ComputeBudgetInstructionDetails {
+            num_non_compute_budget_instructions: 2,
+            num_non_builtin_instructions: 1,
+            ..ComputeBudgetInstructionDetails::default()
+        };
+        expected_details
+            .migrating_builtin_feature_counters
+            .migrating_builtin[feature_id_index] = 1;
+        let expected_details = Ok(expected_details);
+        let details =
+            ComputeBudgetInstructionDetails::try_from(SVMMessage::program_instructions_iter(&tx));
+        assert_eq!(details, expected_details);
+        let details = details.unwrap();
+
+        // reserve_minimal_cus_for_builtin_instructions: false;
+        // migrate_stake_program_to_core_bpf: false;
+        // expect: 1 bpf ix, 1 non-compute-budget builtin, cu-limit = 2 * 200K
+        let mut feature_set = FeatureSet::default();
+        let cu_limits = details.sanitize_and_convert_to_compute_budget_limits(&feature_set);
+        assert_eq!(
+            cu_limits,
+            Ok(ComputeBudgetLimits {
+                compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT * 2,
+                ..ComputeBudgetLimits::default()
+            })
+        );
+
+        // reserve_minimal_cus_for_builtin_instructions: true;
+        // migrate_stake_program_to_core_bpf: false;
+        // expect: 1 bpf ix, 1 non-compute-budget builtin, cu-limit = 200K + 3K
+        feature_set.activate(
+            &feature_set::reserve_minimal_cus_for_builtin_instructions::id(),
+            0,
+        );
+        let cu_limits = details.sanitize_and_convert_to_compute_budget_limits(&feature_set);
+        assert_eq!(
+            cu_limits,
+            Ok(ComputeBudgetLimits {
+                compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                    + MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
+                ..ComputeBudgetLimits::default()
+            })
+        );
+
+        // reserve_minimal_cus_for_builtin_instructions: true;
+        // migrate_stake_program_to_core_bpf: true;
+        // expect: 2 bpf ix, cu-limit = 2 * 200K
+        feature_set.activate(&feature_set::migrate_stake_program_to_core_bpf::id(), 0);
+        let cu_limits = details.sanitize_and_convert_to_compute_budget_limits(&feature_set);
+        assert_eq!(
+            cu_limits,
+            Ok(ComputeBudgetLimits {
+                compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT * 2,
+                ..ComputeBudgetLimits::default()
+            })
+        );
+
+        // reserve_minimal_cus_for_builtin_instructions: false;
+        // migrate_stake_program_to_core_bpf: false;
+        // expect: 1 bpf ix, 1 non-compute-budget builtin, cu-limit = 2 * 200K
+        feature_set.deactivate(&feature_set::reserve_minimal_cus_for_builtin_instructions::id());
+        let cu_limits = details.sanitize_and_convert_to_compute_budget_limits(&feature_set);
+        assert_eq!(
+            cu_limits,
+            Ok(ComputeBudgetLimits {
+                compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT * 2,
+                ..ComputeBudgetLimits::default()
+            })
+        );
     }
 }


### PR DESCRIPTION
#### Problem

When a builtin program migrated into sbpf, it should no longer be considered as 'builtin', therefore its default Compute Budget Limit should change from 3K to 200K CU, per #3799. It is currently not supported by Compute Budget Instruction processing.

#### Summary of Changes
- Add fixed-length (currently `3` entries) vector `MigrationBuiltinFeatureCounter` to transaction static meta;
- Counts migrating builtin features gates during `try_from()`
- Check `feature_set` to resolve if builtin has migrated during `calculate_default_compute_unit_limit()` if Compute Unit Limit was not requested.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
