### PR TITLE
bump solana docker image's based image to bookworm

### DIFF
--- a/sdk/docker-solana/Dockerfile
+++ b/sdk/docker-solana/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 # RPC JSON
 EXPOSE 8899/tcp


### PR DESCRIPTION
#### Problem

I bumped our build image to ubuntu 22.04 (https://github.com/anza-xyz/agave/pull/3774) but forgot to upgrade sdk's base image to the corresponding one

context: https://discord.com/channels/428295358100013066/670512312339398668/1314633956058202154
```
$> docker run --rm -ti anzaxyz/agave:v2.1.4 agave-validator -h

solana-faucet: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by solana-faucet)
solana-faucet: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by solana-faucet)
solana-faucet: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by solana-faucet)
...
```

#### Summary of Changes

bump solana docker image's based image to bookworm

---

Note:

we build bins in the build image (https://github.com/anza-xyz/agave/blob/master/ci/docker/Dockerfile) then copy to the sdk image (https://github.com/anza-xyz/agave/blob/master/sdk/docker-solana/Dockerfile)

