### PR TITLE
rpc: Reduce RewardsRecorderService channel recv() rate

### DIFF
--- a/rpc/src/rewards_recorder_service.rs
+++ b/rpc/src/rewards_recorder_service.rs
@@ -24,7 +24,7 @@ pub struct RewardsRecorderService {
 }
 
 // ReplayStage sends a new item to this service for every frozen Bank. Banks
-// are frozen every 400ms at steady state, check slightly more often than that
+// are frozen every 400ms at steady state so checking every 100ms is sufficient
 const TRY_RECV_INTERVAL: Duration = Duration::from_millis(100);
 
 impl RewardsRecorderService {


### PR DESCRIPTION
#### Problem
RewardsRecorderService currently does recv_timeout(1s) on the channel. A
new item will only come across the channel every time a Bank is frozen,
or every 400ms.

#### Summary of Changes
Adjust the service to use try_recv() instead every 100ms. Also, handle the error instead of using `.expect()` to allow a more graceful shutdown for other services