### PR TITLE
CostModel::estimate_cost

### DIFF
--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -1,12 +1,8 @@
 #[cfg(feature = "dev-context-only-utils")]
 use solana_compute_budget_instruction::compute_budget_instruction_details::ComputeBudgetInstructionDetails;
 use {
-    crate::block_cost_limits,
-    solana_runtime_transaction::{
-        transaction_meta::StaticMeta, transaction_with_meta::TransactionWithMeta,
-    },
-    solana_sdk::pubkey::Pubkey,
-    solana_svm_transaction::svm_message::SVMMessage,
+    crate::block_cost_limits, solana_runtime_transaction::transaction_meta::StaticMeta,
+    solana_sdk::pubkey::Pubkey, solana_svm_transaction::svm_message::SVMMessage,
 };
 
 /// TransactionCost is used to represent resources required to process
@@ -264,7 +260,9 @@ impl solana_runtime_transaction::transaction_meta::StaticMeta for WritableKeysTr
 }
 
 #[cfg(feature = "dev-context-only-utils")]
-impl TransactionWithMeta for WritableKeysTransaction {
+impl solana_runtime_transaction::transaction_with_meta::TransactionWithMeta
+    for WritableKeysTransaction
+{
     #[allow(refining_impl_trait)]
     fn as_sanitized_transaction(
         &self,

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -2,8 +2,11 @@
 use solana_compute_budget_instruction::compute_budget_instruction_details::ComputeBudgetInstructionDetails;
 use {
     crate::block_cost_limits,
-    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
+    solana_runtime_transaction::{
+        transaction_meta::StaticMeta, transaction_with_meta::TransactionWithMeta,
+    },
     solana_sdk::pubkey::Pubkey,
+    solana_svm_transaction::svm_message::SVMMessage,
 };
 
 /// TransactionCost is used to represent resources required to process
@@ -17,12 +20,12 @@ use {
 const SIMPLE_VOTE_USAGE_COST: u64 = 3428;
 
 #[derive(Debug)]
-pub enum TransactionCost<'a, Tx: TransactionWithMeta> {
+pub enum TransactionCost<'a, Tx> {
     SimpleVote { transaction: &'a Tx },
     Transaction(UsageCostDetails<'a, Tx>),
 }
 
-impl<'a, Tx: TransactionWithMeta> TransactionCost<'a, Tx> {
+impl<'a, Tx> TransactionCost<'a, Tx> {
     pub fn sum(&self) -> u64 {
         #![allow(clippy::assertions_on_constants)]
         match self {
@@ -90,7 +93,9 @@ impl<'a, Tx: TransactionWithMeta> TransactionCost<'a, Tx> {
             Self::Transaction(usage_cost) => usage_cost.write_lock_cost,
         }
     }
+}
 
+impl<Tx: SVMMessage> TransactionCost<'_, Tx> {
     pub fn writable_accounts(&self) -> impl Iterator<Item = &Pubkey> {
         let transaction = match self {
             Self::SimpleVote { transaction } => transaction,
@@ -102,7 +107,9 @@ impl<'a, Tx: TransactionWithMeta> TransactionCost<'a, Tx> {
             .enumerate()
             .filter_map(|(index, key)| transaction.is_writable(index).then_some(key))
     }
+}
 
+impl<Tx: StaticMeta> TransactionCost<'_, Tx> {
     pub fn num_transaction_signatures(&self) -> u64 {
         match self {
             Self::SimpleVote { .. } => 1,
@@ -136,7 +143,7 @@ impl<'a, Tx: TransactionWithMeta> TransactionCost<'a, Tx> {
 
 // costs are stored in number of 'compute unit's
 #[derive(Debug)]
-pub struct UsageCostDetails<'a, Tx: TransactionWithMeta> {
+pub struct UsageCostDetails<'a, Tx> {
     pub transaction: &'a Tx,
     pub signature_cost: u64,
     pub write_lock_cost: u64,
@@ -146,7 +153,7 @@ pub struct UsageCostDetails<'a, Tx: TransactionWithMeta> {
     pub allocated_accounts_data_size: u64,
 }
 
-impl<'a, Tx: TransactionWithMeta> UsageCostDetails<'a, Tx> {
+impl<'a, Tx> UsageCostDetails<'a, Tx> {
     pub fn sum(&self) -> u64 {
         self.signature_cost
             .saturating_add(self.write_lock_cost)


### PR DESCRIPTION
#### Problem
- Current interface for CostModel does not provide a way to get cost without first resolving ATLs
- Resolving ATLs is expensive due to looking in accounts-table
- We ideally want to perform prioritization and see if we want to keep a transaction in our working set before resolving ATLs

#### Summary of Changes
- Refactoring of private `CostModel` functions to take instruction iterator or static meta
- Add `CostModel::estimate_cost`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
