### PR TITLE
Reduce CacheBlockMetaService channel recv() rate

### DIFF
--- a/core/src/cache_block_meta_service.rs
+++ b/core/src/cache_block_meta_service.rs
@@ -1,6 +1,6 @@
 pub use solana_ledger::blockstore_processor::CacheBlockMetaSender;
 use {
-    crossbeam_channel::{Receiver, RecvTimeoutError},
+    crossbeam_channel::{Receiver, TryRecvError},
     solana_ledger::blockstore::Blockstore,
     solana_measure::measure::Measure,
     solana_runtime::bank::Bank,
@@ -9,7 +9,7 @@ use {
             atomic::{AtomicBool, Ordering},
             Arc,
         },
-        thread::{self, Builder, JoinHandle},
+        thread::{self, sleep, Builder, JoinHandle},
         time::Duration,
     },
 };
@@ -19,6 +19,10 @@ pub type CacheBlockMetaReceiver = Receiver<Arc<Bank>>;
 pub struct CacheBlockMetaService {
     thread_hdl: JoinHandle<()>,
 }
+
+// ReplayStage sends a new item to this service for every frozen Bank. Banks
+// are frozen every 400ms at steady state so checking every 100ms is sufficient
+const TRY_RECV_INTERVAL: Duration = Duration::from_millis(100);
 
 const CACHE_BLOCK_TIME_WARNING_MS: u64 = 150;
 
@@ -34,23 +38,27 @@ impl CacheBlockMetaService {
                 if exit.load(Ordering::Relaxed) {
                     break;
                 }
-                let recv_result = cache_block_meta_receiver.recv_timeout(Duration::from_secs(1));
-                match recv_result {
-                    Err(RecvTimeoutError::Disconnected) => {
+
+                let bank = match cache_block_meta_receiver.try_recv() {
+                    Ok(bank) => bank,
+                    Err(TryRecvError::Empty) => {
+                        sleep(TRY_RECV_INTERVAL);
+                        continue;
+                    }
+                    Err(err @ TryRecvError::Disconnected) => {
+                        info!("CacheBlockMetaService is stopping because {err}");
                         break;
                     }
-                    Ok(bank) => {
-                        let mut cache_block_meta_timer = Measure::start("cache_block_meta_timer");
-                        Self::cache_block_meta(&bank, &blockstore);
-                        cache_block_meta_timer.stop();
-                        if cache_block_meta_timer.as_ms() > CACHE_BLOCK_TIME_WARNING_MS {
-                            warn!(
-                                "cache_block_meta operation took: {}ms",
-                                cache_block_meta_timer.as_ms()
-                            );
-                        }
-                    }
-                    _ => {}
+                };
+
+                let mut cache_block_meta_timer = Measure::start("cache_block_meta_timer");
+                Self::cache_block_meta(&bank, &blockstore);
+                cache_block_meta_timer.stop();
+                if cache_block_meta_timer.as_ms() > CACHE_BLOCK_TIME_WARNING_MS {
+                    warn!(
+                        "cache_block_meta operation took: {}ms",
+                        cache_block_meta_timer.as_ms()
+                    );
                 }
             })
             .unwrap();


### PR DESCRIPTION
#### Problem
The service currently reads from the channel with recv_timeout(1s); however, a new item will only come across the channel every time a Bank is frozen (~400ms). Moreso, it isn't critical for this service to perform its' work the exact moment a new Bank is made available.

#### Summary of Changes
So, switch the service to read with try_recv() and sleep 100ms if the channel is empty

Notes:
- Similar to https://github.com/anza-xyz/agave/pull/3979
- This file could use some cleanup (and a move to `solana-rpc`); however, I held off on that incase we decide to BP this. The send side of this channel is in ReplayStage so the reduced contention could potentially make a noticeable difference for RPC nodes
    - Will perform the cleanup in a subsequent PR
