### PR TITLE
remove solana-sdk from transaction-metrics-tracker dev deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9500,11 +9500,14 @@ dependencies = [
  "lazy_static",
  "log",
  "rand 0.8.5",
+ "solana-hash",
+ "solana-keypair",
  "solana-packet",
  "solana-perf",
- "solana-sdk",
+ "solana-pubkey",
  "solana-short-vec",
  "solana-signature",
+ "solana-system-transaction",
 ]
 
 [[package]]

--- a/transaction-metrics-tracker/Cargo.toml
+++ b/transaction-metrics-tracker/Cargo.toml
@@ -22,7 +22,10 @@ solana-short-vec = { workspace = true }
 solana-signature = { workspace = true }
 
 [dev-dependencies]
-solana-sdk = { workspace = true }
+solana-hash = { workspace = true }
+solana-keypair = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
+solana-system-transaction = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-metrics-tracker/src/lib.rs
+++ b/transaction-metrics-tracker/src/lib.rs
@@ -54,10 +54,7 @@ pub fn get_signature_from_packet(packet: &Packet) -> Result<&[u8; SIGNATURE_BYTE
 #[cfg(test)]
 mod tests {
     use {
-        super::*,
-        solana_hash::Hash,
-        solana_keypair::Keypair,
-        solana_signature::Signature,
+        super::*, solana_hash::Hash, solana_keypair::Keypair, solana_signature::Signature,
         solana_system_transaction as system_transaction,
     };
 

--- a/transaction-metrics-tracker/src/lib.rs
+++ b/transaction-metrics-tracker/src/lib.rs
@@ -55,11 +55,10 @@ pub fn get_signature_from_packet(packet: &Packet) -> Result<&[u8; SIGNATURE_BYTE
 mod tests {
     use {
         super::*,
-        solana_sdk::{
-            hash::Hash,
-            signature::{Keypair, Signature},
-            system_transaction,
-        },
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_signature::Signature,
+        solana_system_transaction as system_transaction,
     };
 
     #[test]
@@ -72,7 +71,7 @@ mod tests {
         // Use a valid transaction, it should succeed
         let tx = system_transaction::transfer(
             &Keypair::new(),
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             1,
             Hash::new_unique(),
         );
@@ -116,7 +115,7 @@ mod tests {
         // Use a valid transaction which is not matched
         let tx = system_transaction::transfer(
             &Keypair::new(),
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             1,
             Hash::new_unique(),
         );
@@ -127,7 +126,7 @@ mod tests {
         // Now simulate a txn matching the signature mask
         let mut tx = system_transaction::transfer(
             &Keypair::new(),
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             1,
             Hash::new_unique(),
         );


### PR DESCRIPTION
#### Problem
This no longer needs all of solana-sdk

#### Summary of Changes
Replace with constituent crates
