### PR TITLE
use new feature gate for cu depletion

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1471,7 +1471,7 @@ pub fn execute<'a, 'b: 'a>(
             ProgramResult::Err(mut error) => {
                 if invoke_context
                     .get_feature_set()
-                    .is_active(&solana_feature_set::apply_cost_tracker_during_replay::id())
+                    .is_active(&solana_feature_set::deplete_cu_meter_on_vm_failure::id())
                     && !matches!(error, EbpfError::SyscallError(_))
                 {
                     // when an exception is thrown during the execution of a

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4644,13 +4644,13 @@ fn test_deplete_cost_meter_with_access_violation() {
         ..
     } = create_genesis_config(100_123_456_789);
 
-    for apply_cost_tracker in [false, true] {
+    for deplete_cu_meter_on_vm_failure in [false, true] {
         let mut bank = Bank::new_for_tests(&genesis_config);
         let feature_set = Arc::make_mut(&mut bank.feature_set);
         // by default test banks have all features enabled, so we only need to
         // disable when needed
-        if !apply_cost_tracker {
-            feature_set.deactivate(&feature_set::apply_cost_tracker_during_replay::id());
+        if !deplete_cu_meter_on_vm_failure {
+            feature_set.deactivate(&feature_set::deplete_cu_meter_on_vm_failure::id());
         }
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let mut bank_client = BankClient::new_shared(bank.clone());
@@ -4698,7 +4698,7 @@ fn test_deplete_cost_meter_with_access_violation() {
             TransactionError::InstructionError(1, InstructionError::ReadonlyDataModified)
         );
 
-        if apply_cost_tracker {
+        if deplete_cu_meter_on_vm_failure {
             assert_eq!(result.executed_units, u64::from(compute_unit_limit));
         } else {
             assert!(result.executed_units < u64::from(compute_unit_limit));
@@ -4717,13 +4717,13 @@ fn test_program_sbf_deplete_cost_meter_with_divide_by_zero() {
         ..
     } = create_genesis_config(50);
 
-    for apply_cost_tracker in [false, true] {
+    for deplete_cu_meter_on_vm_failure in [false, true] {
         let mut bank = Bank::new_for_tests(&genesis_config);
         let feature_set = Arc::make_mut(&mut bank.feature_set);
         // by default test banks have all features enabled, so we only need to
         // disable when needed
-        if !apply_cost_tracker {
-            feature_set.deactivate(&feature_set::apply_cost_tracker_during_replay::id());
+        if !deplete_cu_meter_on_vm_failure {
+            feature_set.deactivate(&feature_set::deplete_cu_meter_on_vm_failure::id());
         }
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let mut bank_client = BankClient::new_shared(bank.clone());
@@ -4754,7 +4754,7 @@ fn test_program_sbf_deplete_cost_meter_with_divide_by_zero() {
             TransactionError::InstructionError(1, InstructionError::ProgramFailedToComplete)
         );
 
-        if apply_cost_tracker {
+        if deplete_cu_meter_on_vm_failure {
             assert_eq!(result.executed_units, u64::from(compute_unit_limit));
         } else {
             assert!(result.executed_units < u64::from(compute_unit_limit));

--- a/sdk/feature-set/src/lib.rs
+++ b/sdk/feature-set/src/lib.rs
@@ -614,7 +614,7 @@ pub mod delay_visibility_of_program_deployment {
 }
 
 pub mod apply_cost_tracker_during_replay {
-    solana_pubkey::declare_id!("B7H2caeia4ZFcpE3QcgMqbiWiBtWrdBRBSJ1DY6Ktxbq");
+    solana_pubkey::declare_id!("2ry7ygxiYURULZCrypHhveanvP5tzZ4toRwVp89oCNSj");
 }
 pub mod bpf_account_data_direct_mapping {
     solana_pubkey::declare_id!("EenyoWx9UMXYKpR8mW5Jmfmy2fRjzUtM7NduYMY8bx33");

--- a/sdk/feature-set/src/lib.rs
+++ b/sdk/feature-set/src/lib.rs
@@ -892,6 +892,10 @@ pub mod migrate_stake_program_to_core_bpf {
     solana_pubkey::declare_id!("6M4oQ6eXneVhtLoiAr4yRYQY43eVLjrKbiDZDJc892yk");
 }
 
+pub mod deplete_cu_meter_on_vm_failure {
+    solana_pubkey::declare_id!("B7H2caeia4ZFcpE3QcgMqbiWiBtWrdBRBSJ1DY6Ktxbq");
+}
+
 pub mod reserve_minimal_cus_for_builtin_instructions {
     solana_pubkey::declare_id!("C9oAhLxDBm3ssWtJx1yBGzPY55r2rArHmN1pbQn6HogH");
 }
@@ -1114,6 +1118,7 @@ lazy_static! {
         (accounts_lt_hash::id(), "enables lattice-based accounts hash #3333"),
         (enable_secp256r1_precompile::id(), "Enable secp256r1 precompile SIMD-0075"),
         (migrate_stake_program_to_core_bpf::id(), "Migrate Stake program to Core BPF SIMD-0196 #3655"),
+        (deplete_cu_meter_on_vm_failure::id(), "Deplete compute meter for vm errors SIMD-0182 #3993"),
         (reserve_minimal_cus_for_builtin_instructions::id(), "Reserve minimal CUs for builtin instructions SIMD-170 #2562"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]


### PR DESCRIPTION
#### Problem
Firedancer prefers to have a separate feature gate for each SIMD, so rather than reusing and rekeying the existing replay cost tracker feature, we should create a new feature gate for https://github.com/solana-foundation/solana-improvement-documents/pull/182.

#### Summary of Changes
- Revert feature id change for the replay cost tracker feature
- Add new feature gate for cu depletion

Fixes #
Feature Gate Issue: https://github.com/anza-xyz/agave/issues/3993
<!-- Don't forget to add the "feature-gate" label -->
