### PR TITLE
Do cache warmer for vote using quic if enabled

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -421,20 +421,20 @@ fn create_cache_warmer_if_needed(
 ) -> Option<WarmQuicCacheService> {
     let tpu_connection_cache = connection_cache
         .is_some_and(|cache| cache.use_quic())
-        .then_some(connection_cache.unwrap().clone());
+        .then(|| connection_cache.unwrap().clone());
     let vote_connection_cache = vote_connection_cache
         .use_quic()
-        .then_some(vote_connection_cache);
+        .then(|| vote_connection_cache);
 
-    (tpu_connection_cache.is_some() || vote_connection_cache.is_some()).then_some(
+    (tpu_connection_cache.is_some() || vote_connection_cache.is_some()).then(|| {
         WarmQuicCacheService::new(
             tpu_connection_cache,
             vote_connection_cache,
             cluster_info.clone(),
             poh_recorder.clone(),
             exit.clone(),
-        ),
-    )
+        )
+    })
 }
 
 #[cfg(test)]

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -332,21 +332,16 @@ impl Tvu {
             cluster_info.clone(),
             poh_recorder.clone(),
             tower_storage,
-            vote_connection_cache,
+            vote_connection_cache.clone(),
         );
 
-        let warm_quic_cache_service = connection_cache.and_then(|connection_cache| {
-            if connection_cache.use_quic() {
-                Some(WarmQuicCacheService::new(
-                    connection_cache.clone(),
-                    cluster_info.clone(),
-                    poh_recorder.clone(),
-                    exit.clone(),
-                ))
-            } else {
-                None
-            }
-        });
+        let warm_quic_cache_service = create_cache_warmer_if_needed(
+            connection_cache,
+            vote_connection_cache,
+            cluster_info,
+            poh_recorder,
+            &exit,
+        );
 
         let cost_update_service = CostUpdateService::new(blockstore.clone(), cost_update_receiver);
 
@@ -415,6 +410,31 @@ impl Tvu {
         self.duplicate_shred_listener.join()?;
         Ok(())
     }
+}
+
+fn create_cache_warmer_if_needed(
+    connection_cache: Option<&Arc<ConnectionCache>>,
+    vote_connection_cache: Arc<ConnectionCache>,
+    cluster_info: &Arc<ClusterInfo>,
+    poh_recorder: &Arc<RwLock<PohRecorder>>,
+    exit: &Arc<AtomicBool>,
+) -> Option<WarmQuicCacheService> {
+    let tpu_connection_cache = connection_cache
+        .is_some_and(|cache| cache.use_quic())
+        .then_some(connection_cache.unwrap().clone());
+    let vote_connection_cache = vote_connection_cache
+        .use_quic()
+        .then_some(vote_connection_cache);
+
+    (tpu_connection_cache.is_some() || vote_connection_cache.is_some()).then_some(
+        WarmQuicCacheService::new(
+            tpu_connection_cache,
+            vote_connection_cache,
+            cluster_info.clone(),
+            poh_recorder.clone(),
+            exit.clone(),
+        ),
+    )
 }
 
 #[cfg(test)]

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -424,7 +424,7 @@ fn create_cache_warmer_if_needed(
         .then(|| connection_cache.unwrap().clone());
     let vote_connection_cache = vote_connection_cache
         .use_quic()
-        .then(|| vote_connection_cache);
+        .then_some(vote_connection_cache);
 
     (tpu_connection_cache.is_some() || vote_connection_cache.is_some()).then(|| {
         WarmQuicCacheService::new(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -419,12 +419,8 @@ fn create_cache_warmer_if_needed(
     poh_recorder: &Arc<RwLock<PohRecorder>>,
     exit: &Arc<AtomicBool>,
 ) -> Option<WarmQuicCacheService> {
-    let tpu_connection_cache = connection_cache
-        .is_some_and(|cache| cache.use_quic())
-        .then(|| connection_cache.unwrap().clone());
-    let vote_connection_cache = vote_connection_cache
-        .use_quic()
-        .then_some(vote_connection_cache);
+    let tpu_connection_cache = connection_cache.filter(|cache| cache.use_quic()).cloned();
+    let vote_connection_cache = Some(vote_connection_cache).filter(|cache| cache.use_quic());
 
     (tpu_connection_cache.is_some() || vote_connection_cache.is_some()).then(|| {
         WarmQuicCacheService::new(


### PR DESCRIPTION
#### Problem

In order to reduce vote latency when using QUIC, use cache warmer to warm up connections to leaders.  
#### Summary of Changes

Made cache warmer to support both vote and regular tpu.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
