### PR TITLE
remove solana-sdk from watchtower

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,12 +324,14 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-cli-output",
+ "solana-hash",
  "solana-logger",
  "solana-metrics",
+ "solana-native-token",
  "solana-notifier",
+ "solana-pubkey",
  "solana-rpc-client",
  "solana-rpc-client-api",
- "solana-sdk",
  "solana-version",
 ]
 

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -16,12 +16,14 @@ log = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-cli-output = { workspace = true }
+solana-hash = { workspace = true }
 solana-logger = { workspace = true }
 solana-metrics = { workspace = true }
+solana-native-token = { workspace = true }
 solana-notifier = { workspace = true }
+solana-pubkey = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
-solana-sdk = { workspace = true }
 solana-version = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -10,15 +10,13 @@ use {
         input_validators::{is_parsable, is_pubkey_or_keypair, is_url, is_valid_percentage},
     },
     solana_cli_output::display::format_labeled_address,
+    solana_hash::Hash,
     solana_metrics::{datapoint_error, datapoint_info},
+    solana_native_token::{sol_to_lamports, Sol},
     solana_notifier::{NotificationType, Notifier},
+    solana_pubkey::Pubkey,
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::{client_error, response::RpcVoteAccountStatus},
-    solana_sdk::{
-        hash::Hash,
-        native_token::{sol_to_lamports, Sol},
-        pubkey::Pubkey,
-    },
     std::{
         collections::HashMap,
         error,


### PR DESCRIPTION
#### Problem
This no longer needs all of solana-sdk

#### Summary of Changes
Replace with the relevant constituent crates
