### PR TITLE
fix audit

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -29,6 +29,17 @@ cargo_audit_ignores=(
   # Solution:  Upgrade to >=2
   --ignore RUSTSEC-2022-0093
 
+  # Crate:     idna
+  # Version:   0.1.5
+  # Title:     `idna` accepts Punycode labels that do not produce any non-ASCII when decoded
+  # Date:      2024-12-09
+  # ID:        RUSTSEC-2024-0421
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2024-0421
+  # Solution:  Upgrade to >=1.0.0
+  # need to solve this depentant tree:
+  # jsonrpc-core-client v18.0.0 -> jsonrpc-client-transports v18.0.0 -> url v1.7.2 -> idna v0.1.5
+  --ignore RUSTSEC-2024-0421
+
   # === programs/sbf ===
   #
   # Crate:     curve25519-dalek


### PR DESCRIPTION
#### Problem

the audit failed. we need to upgrade idna to >= 1.0.0. however, the dep chain looks like:
```
jsonrpc-core-client v18.0.0 -> jsonrpc-client-transports v18.0.0 -> url v1.7.2 -> idna v0.1.5
```

and jsonrpc-core-client has not released any new version in the past 3y ...

#### Summary of Changes

ignore it as a stopgap