### PR TITLE
remove unused dependencies from solana-program-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8088,7 +8088,6 @@ dependencies = [
  "bincode",
  "enum-iterator",
  "itertools 0.12.1",
- "libc",
  "log",
  "num-derive",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8106,7 +8106,6 @@ dependencies = [
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-log-collector",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-precompiles",

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -55,7 +55,6 @@ thiserror = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 solana-instruction = { workspace = true, features = ["bincode"] }
-solana-logger = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-transaction-context = { workspace = true, features = [
     "dev-context-only-utils",

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -14,7 +14,6 @@ base64 = { workspace = true }
 bincode = { workspace = true }
 enum-iterator = { workspace = true }
 itertools = { workspace = true }
-libc = { workspace = true }
 log = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6369,7 +6369,6 @@ dependencies = [
  "bincode",
  "enum-iterator",
  "itertools 0.12.1",
- "libc",
  "log",
  "num-derive",
  "num-traits",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6189,7 +6189,6 @@ dependencies = [
  "bincode",
  "enum-iterator",
  "itertools 0.12.1",
- "libc",
  "log",
  "num-derive",
  "num-traits",


### PR DESCRIPTION
#### Problem

`libc` is not used in `solana-program-runtime` any more.

#### Summary of Changes

This PR removes `libc` from the dependencies of `solana-program-runtime`.