### PR TITLE
remove frozen-abi from runtime-transaction

### DIFF
--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 
 mod builtin_programs_filter;


### PR DESCRIPTION
#### Problem

Nothing left in `RuntimeTransaction` crate need to be ABI stable

#### Summary of Changes
- remove frozen-abi from it

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
