### PR TITLE
Fix accounts index generation at startup when we don't use disk index

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8566,7 +8566,8 @@ impl AccountsDb {
         // a given pubkey. If there is just a single item, there is no cleaning to
         // be done on that pubkey. Use only those pubkeys with multiple updates.
         if !dirty_pubkeys.is_empty() {
-            self.uncleaned_pubkeys.insert(slot, dirty_pubkeys);
+            let old = self.uncleaned_pubkeys.insert(slot, dirty_pubkeys);
+            assert!(old.is_none());
         }
         SlotIndexGenerationInfo {
             insert_time_us,

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1800,7 +1800,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                     });
 
                 r_account_maps
-                    .update_duplicates_from_in_memory_only_startup(duplicates_from_in_memory);
+                    .startup_update_duplicates_from_in_memory_only(duplicates_from_in_memory);
             }
             insert_time.stop();
             insertion_time.fetch_add(insert_time.as_us(), Ordering::Relaxed);

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1821,23 +1821,17 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         &self,
         f: impl Fn(Vec<(Slot, Pubkey)>) + Sync + Send,
     ) {
-        if self.storage.storage.is_disk_index_enabled() {
-            (0..self.bins())
-                .into_par_iter()
-                .map(|pubkey_bin| {
-                    let r_account_maps = &self.account_maps[pubkey_bin];
+        (0..self.bins())
+            .into_par_iter()
+            .map(|pubkey_bin| {
+                let r_account_maps = &self.account_maps[pubkey_bin];
+                if self.storage.storage.is_disk_index_enabled() {
                     r_account_maps.populate_and_retrieve_duplicate_keys_from_startup()
-                })
-                .for_each(f);
-        } else {
-            (0..self.bins())
-                .into_par_iter()
-                .map(|pubkey_bin| {
-                    let r_account_maps = &self.account_maps[pubkey_bin];
+                } else {
                     r_account_maps.startup_take_duplicates_from_in_memory_only()
-                })
-                .for_each(f);
-        }
+                }
+            })
+            .for_each(f);
     }
 
     /// Updates the given pubkey at the given slot with the new account information.

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1775,7 +1775,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             } else {
                 // not using disk buckets, so just write to in-mem
                 // this is no longer the default case
-                let mut dup_pubkeys = vec![];
+                let mut duplicates_from_in_memory = vec![];
                 items
                     .into_iter()
                     .for_each(|(pubkey, (slot, account_info))| {
@@ -1792,14 +1792,15 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                             InsertNewEntryResults::ExistedNewEntryZeroLamports => {}
                             InsertNewEntryResults::ExistedNewEntryNonZeroLamports(other_slot) => {
                                 if let Some(other_slot) = other_slot {
-                                    dup_pubkeys.push((other_slot, pubkey));
+                                    duplicates_from_in_memory.push((other_slot, pubkey));
                                 }
-                                dup_pubkeys.push((slot, pubkey));
+                                duplicates_from_in_memory.push((slot, pubkey));
                             }
                         }
                     });
 
-                r_account_maps.update_duplicates_from_in_memory_only_startup(dup_pubkeys);
+                r_account_maps
+                    .update_duplicates_from_in_memory_only_startup(duplicates_from_in_memory);
             }
             insert_time.stop();
             insertion_time.fetch_add(insert_time.as_us(), Ordering::Relaxed);

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1834,7 +1834,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                 .into_par_iter()
                 .map(|pubkey_bin| {
                     let r_account_maps = &self.account_maps[pubkey_bin];
-                    r_account_maps.get_duplicates_from_in_memory_only_startup()
+                    r_account_maps.startup_take_duplicates_from_in_memory_only()
                 })
                 .for_each(f);
         }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -156,7 +156,7 @@ struct StartupInfo<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
 
     /// (slot, pubkey) pairs that are duplicates when we are starting from in-memory only index.
     /// And this field is only populated and used when we are building the in-memory only index.
-    duplicate_from_in_memory_only: Mutex<Vec<(Slot, Pubkey)>>,
+    duplicates_from_in_memory_only: Mutex<Vec<(Slot, Pubkey)>>,
 }
 
 #[derive(Default, Debug)]
@@ -737,7 +737,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         let mut duplicates = self
             .startup_info
-            .duplicate_from_in_memory_only
+            .duplicates_from_in_memory_only
             .lock()
             .unwrap();
 
@@ -1175,7 +1175,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     pub fn get_duplicates_from_in_memory_only_startup(&self) -> Vec<(Slot, Pubkey)> {
         let mut duplicates = self
             .startup_info
-            .duplicate_from_in_memory_only
+            .duplicates_from_in_memory_only
             .lock()
             .unwrap();
         std::mem::take(&mut *duplicates)

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -757,6 +757,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 let (slot, account_info) = new_entry.into();
 
                 let slot_list = occupied.get().slot_list.read().unwrap();
+
+                // If there is only one entry in the slot list, it means that
+                // the previous entry inserted was a duplicate, which should be
+                // added to the duplicates list too. Note that we only need to do
+                // this for slot_list.len() == 1. For slot_list.len() > 1, the
+                // items, previously inserted into the slot_list, have already
+                // been added. We don't need to add them again.
                 if slot_list.len() == 1 {
                     other_slot = Some(slot_list[0].0);
                 }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -731,7 +731,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             .fetch_add(m.end_as_us(), Ordering::Relaxed);
     }
 
-    pub fn update_duplicates_from_in_memory_only_startup(&self, items: Vec<(Slot, Pubkey)>) {
+    pub fn startup_update_duplicates_from_in_memory_only(&self, items: Vec<(Slot, Pubkey)>) {
         assert!(self.storage.get_startup());
         assert!(self.bucket.is_none());
 

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -147,7 +147,7 @@ struct StartupInfoDuplicates<T: IndexValue> {
     duplicates_put_on_disk: HashSet<(Slot, Pubkey)>,
 
     /// (slot, pubkey) pairs that are found to be duplicates when we are
-    /// starting from in-memory only index. This filed is used only when disk
+    /// starting from in-memory only index. This field is used only when disk
     /// index is disabled.
     duplicates_from_in_memory_only: Vec<(Slot, Pubkey)>,
 }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1172,7 +1172,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             .collect()
     }
 
-    pub fn get_duplicates_from_in_memory_only_startup(&self) -> Vec<(Slot, Pubkey)> {
+    pub fn startup_take_duplicates_from_in_memory_only(&self) -> Vec<(Slot, Pubkey)> {
         let mut duplicates = self
             .startup_info
             .duplicates_from_in_memory_only


### PR DESCRIPTION
#### Problem

During account's index generation at startup, one of the important steps is to find duplicated `pubkeys` and send them to `clean`.

However, the code path that finds duplicates at index generation, when disk index is disabled, is incorrect. And we are are not finding all the duplicates. This makes clean unable to clean old storages, and results in continue growing of account maps. 

Note this only affects when the validator running with disk index disabled.


#### Summary of Changes

Fix finding duplicated (pubkey, slots) at start up when we disable disk index.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
