### PR TITLE
rolls out chained Merkle shreds to ~5% of mainnet slots

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -503,11 +503,12 @@ impl BroadcastRun for StandardBroadcastRun {
     }
 }
 
-fn should_chain_merkle_shreds(_slot: Slot, cluster_type: ClusterType) -> bool {
+fn should_chain_merkle_shreds(slot: Slot, cluster_type: ClusterType) -> bool {
     match cluster_type {
         ClusterType::Development => true,
         ClusterType::Devnet => true,
-        ClusterType::MainnetBeta => false,
+        // Roll out chained Merkle shreds to ~5% of mainnet slots.
+        ClusterType::MainnetBeta => slot % 19 == 1,
         ClusterType::Testnet => true,
     }
 }


### PR DESCRIPTION
#### Problem
Rolling out chained Merkle shreds to testnet.

#### Summary of Changes
The commit rolls out chained Merkle shreds to ~5% of mainnet slots.