### PR TITLE
Revert "Thinlto for validator builds. (#3516)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,6 @@ inherits = "release"
 debug = true
 split-debuginfo = "packed"
 
-[profile.release]
-split-debuginfo = "unpacked"
-lto = "thin"
-
 [workspace]
 members = [
     "account-decoder",


### PR DESCRIPTION
The edge canaries have been failing with:
```
error: duplicate split compilation unit (0xc869f7a189ad6264)

error: could not compile `solana-keygen` (bin "solana-keygen") due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: duplicate split compilation unit (0xba0ecc60f32480d7)

error: could not compile `solana-faucet` (bin "solana-faucet") due to 1 previous error
error: could not compile `solana-cargo-build-sbf` (bin "cargo-build-sbf") due to 1 previous error
```
I believe this is from #3516 (and reverting it the build succeeds). If there's an easier solution than reverting I'm happy to close this, but I'm OOO this won't so don't have time to debug it.
