### PR TITLE
Quelch too-many-arguments warning on `make_rpc_bench_threads`

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -746,6 +746,7 @@ fn run_rpc_bench_loop(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn make_rpc_bench_threads(
     rpc_benches: Vec<RpcBench>,
     mint: &Option<Pubkey>,


### PR DESCRIPTION
I had a ton of PRs in a stack, none of which pushed this method over the limit itself, but the rebased version of #3960 (on top of one of the others) did.