### PR TITLE
accounts-cluster-bench: Fix clippy / CI

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -746,6 +746,7 @@ fn run_rpc_bench_loop(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn make_rpc_bench_threads(
     rpc_benches: Vec<RpcBench>,
     mint: &Option<Pubkey>,


### PR DESCRIPTION
#### Problem

The clippy CI job is currently failing due to too many arguments in a function introduced in #3987:
https://buildkite.com/anza/agave/builds/15544#0193ace5-f9fa-475e-91a2-81dd45120c13

#### Summary of changes

Add the annotation to appease clippy.