### PR TITLE
blockstore: Refactor Rocks iterator methods

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -675,7 +675,7 @@ impl Blockstore {
         cf_name: &str,
     ) -> Result<impl Iterator<Item = (Box<[u8]>, Box<[u8]>)> + '_> {
         let cf = self.db.cf_handle(cf_name);
-        let iterator = self.db.iterator_cf_raw_key(cf, IteratorMode::Start);
+        let iterator = self.db.iterator_cf(cf, rocksdb::IteratorMode::Start);
         Ok(iterator.map(|pair| pair.unwrap()))
     }
 

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -866,22 +866,22 @@ pub mod tests {
             .put(1, &index1)
             .unwrap();
 
-        let statuses: Vec<_> = blockstore
+        let num_statuses = blockstore
             .transaction_status_cf
-            .iterator_cf_raw_key(IteratorMode::Start)
-            .collect();
-        assert_eq!(statuses.len(), 15);
+            .iter(IteratorMode::Start)
+            .unwrap()
+            .count();
+        assert_eq!(num_statuses, 15);
 
         // Delete some of primary-index 0
         let oldest_slot = 3;
         purge(&blockstore, oldest_slot);
         let status_entry_iterator = blockstore
             .transaction_status_cf
-            .iterator_cf_raw_key(IteratorMode::Start);
+            .iter(IteratorMode::Start)
+            .unwrap();
         let mut count = 0;
-        for entry in status_entry_iterator {
-            let (key, _value) = entry.unwrap();
-            let (_signature, slot) = <cf::TransactionStatus as Column>::index(&key);
+        for ((_signature, slot), _value) in status_entry_iterator {
             assert!(slot >= oldest_slot);
             count += 1;
         }
@@ -892,11 +892,10 @@ pub mod tests {
         purge(&blockstore, oldest_slot);
         let status_entry_iterator = blockstore
             .transaction_status_cf
-            .iterator_cf_raw_key(IteratorMode::Start);
+            .iter(IteratorMode::Start)
+            .unwrap();
         let mut count = 0;
-        for entry in status_entry_iterator {
-            let (key, _value) = entry.unwrap();
-            let (_signature, slot) = <cf::TransactionStatus as Column>::index(&key);
+        for ((_signature, slot), _value) in status_entry_iterator {
             assert!(slot >= oldest_slot);
             count += 1;
         }
@@ -907,11 +906,10 @@ pub mod tests {
         purge(&blockstore, oldest_slot);
         let status_entry_iterator = blockstore
             .transaction_status_cf
-            .iterator_cf_raw_key(IteratorMode::Start);
+            .iter(IteratorMode::Start)
+            .unwrap();
         let mut count = 0;
-        for entry in status_entry_iterator {
-            let (key, _value) = entry.unwrap();
-            let (_signature, slot) = <cf::TransactionStatus as Column>::index(&key);
+        for ((_signature, slot), _value) in status_entry_iterator {
             assert!(slot >= oldest_slot);
             count += 1;
         }
@@ -922,11 +920,10 @@ pub mod tests {
         purge(&blockstore, oldest_slot);
         let status_entry_iterator = blockstore
             .transaction_status_cf
-            .iterator_cf_raw_key(IteratorMode::Start);
+            .iter(IteratorMode::Start)
+            .unwrap();
         let mut count = 0;
-        for entry in status_entry_iterator {
-            let (key, _value) = entry.unwrap();
-            let (_signature, slot) = <cf::TransactionStatus as Column>::index(&key);
+        for ((_signature, slot), _value) in status_entry_iterator {
             assert!(slot >= oldest_slot);
             count += 1;
         }
@@ -937,11 +934,10 @@ pub mod tests {
         purge(&blockstore, oldest_slot);
         let status_entry_iterator = blockstore
             .transaction_status_cf
-            .iterator_cf_raw_key(IteratorMode::Start);
+            .iter(IteratorMode::Start)
+            .unwrap();
         let mut count = 0;
-        for entry in status_entry_iterator {
-            let (key, _value) = entry.unwrap();
-            let (_signature, slot) = <cf::TransactionStatus as Column>::index(&key);
+        for ((_signature, slot), _value) in status_entry_iterator {
             assert!(slot >= oldest_slot);
             count += 1;
         }
@@ -952,7 +948,8 @@ pub mod tests {
         purge(&blockstore, oldest_slot);
         let mut status_entry_iterator = blockstore
             .transaction_status_cf
-            .iterator_cf_raw_key(IteratorMode::Start);
+            .iter(IteratorMode::Start)
+            .unwrap();
         assert!(status_entry_iterator.next().is_none());
     }
 

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -1118,15 +1118,12 @@ pub mod tests {
         blockstore
             .transaction_memos_cf
             .compact_range_raw_key(&first_index, &last_index);
-        let memos_iterator = blockstore
+        let num_memos = blockstore
             .transaction_memos_cf
-            .iterator_cf_raw_key(IteratorMode::Start);
-        let mut count = 0;
-        for item in memos_iterator {
-            let _item = item.unwrap();
-            count += 1;
-        }
-        assert_eq!(count, 4);
+            .iter(IteratorMode::Start)
+            .unwrap()
+            .count();
+        assert_eq!(num_memos, 4);
 
         // Purge at oldest_slot without clean_slot_0 only purges the current memo at slot 4
         blockstore.db.set_oldest_slot(oldest_slot);
@@ -1135,11 +1132,10 @@ pub mod tests {
             .compact_range_raw_key(&first_index, &last_index);
         let memos_iterator = blockstore
             .transaction_memos_cf
-            .iterator_cf_raw_key(IteratorMode::Start);
+            .iter(IteratorMode::Start)
+            .unwrap();
         let mut count = 0;
-        for item in memos_iterator {
-            let (key, _value) = item.unwrap();
-            let slot = <cf::TransactionMemos as Column>::index(&key).1;
+        for ((_signature, slot), _value) in memos_iterator {
             assert!(slot == 0 || slot >= oldest_slot);
             count += 1;
         }
@@ -1152,11 +1148,10 @@ pub mod tests {
             .compact_range_raw_key(&first_index, &last_index);
         let memos_iterator = blockstore
             .transaction_memos_cf
-            .iterator_cf_raw_key(IteratorMode::Start);
+            .iter(IteratorMode::Start)
+            .unwrap();
         let mut count = 0;
-        for item in memos_iterator {
-            let (key, _value) = item.unwrap();
-            let slot = <cf::TransactionMemos as Column>::index(&key).1;
+        for ((_signature, slot), _value) in memos_iterator {
             assert!(slot >= oldest_slot);
             count += 1;
         }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -695,7 +695,11 @@ impl Rocks {
         Ok(())
     }
 
-    fn iterator_cf(&self, cf: &ColumnFamily, iterator_mode: RocksIteratorMode) -> DBIterator {
+    pub(crate) fn iterator_cf(
+        &self,
+        cf: &ColumnFamily,
+        iterator_mode: RocksIteratorMode,
+    ) -> DBIterator {
         self.db.iterator_cf(cf, iterator_mode)
     }
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -2197,20 +2197,14 @@ pub mod tests {
     {
         pub(crate) fn iterator_cf_raw_key(
             &self,
-            iterator_mode: IteratorMode<Vec<u8>>,
-        ) -> DBIterator {
-            let cf = self.handle();
-            let start_key;
-            let iterator_mode = match iterator_mode {
-                IteratorMode::Start => RocksIteratorMode::Start,
-                IteratorMode::End => RocksIteratorMode::End,
-                IteratorMode::From(start_from, direction) => {
-                    start_key = start_from.clone();
-                    RocksIteratorMode::From(&start_key, direction)
-                }
-            };
-
-            self.backend.iterator_cf(cf, iterator_mode)
+            iterator_mode: IteratorMode<C::Index>,
+        ) -> impl Iterator<Item = (Box<[u8]>, Box<[u8]>)> + '_ {
+            // The conversion of key back into Box<[u8]> incurs an extra
+            // allocation. However, this is test code and the goal is to
+            // maximize code reuse over efficiency
+            self.iter(iterator_mode)
+                .unwrap()
+                .map(|(key, value)| (Box::from(C::key(key)), value))
         }
     }
 }


### PR DESCRIPTION
#### Problem
There will be an upcoming PR for https://github.com/anza-xyz/agave/issues/3850, this breaks out some cleanup and refactoring that will enable that PR to come in with a smaller diff. No functional changes in this PR.

#### Summary of Changes
- Perform `C::index` conversion in `LedgerColumn` instead of `Rocks`
    - Actually a bit of a precursor for https://github.com/anza-xyz/agave/pull/3603
- Single source the iterator path
- Cleanup tests in `blockstore_purge.rs`
