### PR TITLE
extract nonce-account crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7763,6 +7763,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-nonce-account"
+version = "2.2.0"
+dependencies = [
+ "solana-account",
+ "solana-fee-calculator",
+ "solana-hash",
+ "solana-nonce",
+ "solana-pubkey",
+ "solana-sdk-ids",
+]
+
+[[package]]
 name = "solana-notifier"
 version = "2.2.0"
 dependencies = [
@@ -8710,6 +8722,7 @@ dependencies = [
  "solana-keypair",
  "solana-logger",
  "solana-native-token",
+ "solana-nonce-account",
  "solana-offchain-message",
  "solana-packet",
  "solana-poh-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ members = [
     "sdk/msg",
     "sdk/native-token",
     "sdk/nonce",
+    "sdk/nonce-account",
     "sdk/offchain-message",
     "sdk/package-metadata",
     "sdk/package-metadata-macro",
@@ -513,6 +514,7 @@ solana-native-token = { path = "sdk/native-token", version = "=2.2.0" }
 solana-net-utils = { path = "net-utils", version = "=2.2.0" }
 solana-nohash-hasher = "0.2.1"
 solana-nonce = { path = "sdk/nonce", version = "=2.2.0" }
+solana-nonce-account = { path = "sdk/nonce-account", version = "=2.2.0" }
 solana-notifier = { path = "notifier", version = "=2.2.0" }
 solana-offchain-message = { path = "sdk/offchain-message", version = "=2.2.0" }
 solana-package-metadata = { path = "sdk/package-metadata", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6129,6 +6129,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-nonce-account"
+version = "2.2.0"
+dependencies = [
+ "solana-account",
+ "solana-hash",
+ "solana-nonce",
+ "solana-sdk-ids",
+]
+
+[[package]]
 name = "solana-offchain-message"
 version = "2.2.0"
 dependencies = [
@@ -7374,6 +7384,7 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-native-token",
+ "solana-nonce-account",
  "solana-offchain-message",
  "solana-packet",
  "solana-poh-config",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -146,6 +146,7 @@ solana-keypair = { workspace = true, optional = true, features = [
     "seed-derivable",
 ] }
 solana-native-token = { workspace = true }
+solana-nonce-account = { workspace = true }
 solana-offchain-message = { workspace = true, optional = true, features = ["verify"] }
 solana-packet = { workspace = true, features = ["bincode", "serde"] }
 solana-poh-config = { workspace = true, features = ["serde"] }

--- a/sdk/nonce-account/Cargo.toml
+++ b/sdk/nonce-account/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "solana-nonce-account"
+description = "Solana nonce account utils."
+documentation = "https://docs.rs/solana-nonce-account"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+solana-account = { workspace = true, features = ["bincode"] }
+solana-hash = { workspace = true }
+solana-nonce = { workspace = true, features = ["serde"] }
+solana-sdk-ids = { workspace = true }
+
+[dev-dependencies]
+solana-fee-calculator = { workspace = true }
+solana-pubkey = { workspace = true }

--- a/sdk/nonce-account/src/lib.rs
+++ b/sdk/nonce-account/src/lib.rs
@@ -1,15 +1,13 @@
 //! Functions related to nonce accounts.
 
 use {
-    crate::{
-        account_utils::StateMut,
-        hash::Hash,
-        nonce::{
-            state::{Data, Versions},
-            State,
-        },
+    solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount},
+    solana_hash::Hash,
+    solana_nonce::{
+        state::{Data, State},
+        versions::Versions,
     },
-    solana_account::{AccountSharedData, ReadableAccount},
+    solana_sdk_ids::system_program,
     std::cell::RefCell,
 };
 
@@ -19,7 +17,7 @@ pub fn create_account(lamports: u64) -> RefCell<AccountSharedData> {
             lamports,
             &Versions::new(State::Uninitialized),
             State::size(),
-            &crate::system_program::id(),
+            &system_program::id(),
         )
         .expect("nonce_account"),
     )
@@ -31,7 +29,7 @@ pub fn verify_nonce_account(
     account: &AccountSharedData,
     recent_blockhash: &Hash, // Transaction.message.recent_blockhash
 ) -> Option<Data> {
-    (account.owner() == &crate::system_program::id())
+    (account.owner() == &system_program::id())
         .then(|| {
             StateMut::<Versions>::state(account)
                 .ok()?
@@ -52,18 +50,15 @@ pub fn lamports_per_signature_of(account: &AccountSharedData) -> Option<u64> {
 mod tests {
     use {
         super::*,
-        crate::{
-            fee_calculator::FeeCalculator,
-            nonce::state::{Data, DurableNonce},
-            pubkey::Pubkey,
-            system_program,
-        },
+        solana_fee_calculator::FeeCalculator,
+        solana_nonce::state::{Data, DurableNonce},
+        solana_pubkey::Pubkey,
     };
 
     #[test]
     fn test_verify_bad_account_owner_fails() {
         let program_id = Pubkey::new_unique();
-        assert_ne!(program_id, crate::system_program::id());
+        assert_ne!(program_id, system_program::id());
         let account = AccountSharedData::new_data_with_space(
             42,
             &Versions::new(State::Uninitialized),

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -74,7 +74,6 @@ pub mod inner_instruction;
 pub mod log;
 pub mod native_loader;
 pub mod net;
-pub mod nonce_account;
 pub mod precompiles;
 pub mod program_utils;
 pub mod pubkey;
@@ -133,6 +132,8 @@ pub use solana_feature_set as feature_set;
 pub use solana_fee_structure as fee;
 #[deprecated(since = "2.1.0", note = "Use `solana-inflation` crate instead")]
 pub use solana_inflation as inflation;
+#[deprecated(since = "2.2.0", note = "Use `solana-nonce-account` crate instead")]
+pub use solana_nonce_account as nonce_account;
 #[cfg(feature = "full")]
 #[deprecated(since = "2.2.0", note = "Use `solana-offchain-message` crate instead")]
 pub use solana_offchain_message as offchain_message;

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5949,6 +5949,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-nonce-account"
+version = "2.2.0"
+dependencies = [
+ "solana-account",
+ "solana-hash",
+ "solana-nonce",
+ "solana-sdk-ids",
+]
+
+[[package]]
 name = "solana-offchain-message"
 version = "2.2.0"
 dependencies = [
@@ -6694,6 +6704,7 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-native-token",
+ "solana-nonce-account",
  "solana-offchain-message",
  "solana-packet",
  "solana-poh-config",


### PR DESCRIPTION
#### Problem
`solana_sdk::nonce_account` imposes a `solana_sdk` dep in various places

#### Summary of Changes
Move to its own crate and re-export with deprecation
