### PR TITLE
sdk: Extract instructions-sysvar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7366,6 +7366,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-instructions-sysvar"
+version = "2.2.0"
+dependencies = [
+ "bitflags 2.6.0",
+ "qualifier_attr",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-serialize-utils",
+ "solana-sysvar-id",
+]
+
+[[package]]
 name = "solana-keccak-hasher"
 version = "2.2.0"
 dependencies = [
@@ -8004,6 +8020,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-hash",
  "solana-instruction",
+ "solana-instructions-sysvar",
  "solana-keccak-hasher",
  "solana-last-restart-slot",
  "solana-logger",
@@ -8707,6 +8724,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-inflation",
  "solana-instruction",
+ "solana-instructions-sysvar",
  "solana-keypair",
  "solana-logger",
  "solana-native-token",
@@ -8738,7 +8756,6 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-system-transaction",
- "solana-sysvar",
  "solana-time-utils",
  "solana-transaction",
  "solana-transaction-context",
@@ -9263,11 +9280,9 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bincode",
- "bitflags 2.6.0",
  "bytemuck",
  "bytemuck_derive",
  "lazy_static",
- "qualifier_attr",
  "serde",
  "serde_derive",
  "serial_test",
@@ -9281,6 +9296,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-hash",
  "solana-instruction",
+ "solana-instructions-sysvar",
  "solana-last-restart-slot",
  "solana-msg",
  "solana-program",
@@ -9293,7 +9309,6 @@ dependencies = [
  "solana-sdk",
  "solana-sdk-ids",
  "solana-sdk-macro",
- "solana-serialize-utils",
  "solana-sha256-hasher",
  "solana-slot-hashes",
  "solana-slot-history",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8800,6 +8800,7 @@ dependencies = [
  "solana-feature-set",
  "solana-hash",
  "solana-instruction",
+ "solana-instructions-sysvar",
  "solana-keccak-hasher",
  "solana-keypair",
  "solana-logger",
@@ -8810,7 +8811,6 @@ dependencies = [
  "solana-sdk-ids",
  "solana-secp256k1-program",
  "solana-signer",
- "solana-sysvar",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ members = [
     "sdk/hash",
     "sdk/inflation",
     "sdk/instruction",
+    "sdk/instructions-sysvar",
     "sdk/keccak-hasher",
     "sdk/keypair",
     "sdk/logger",
@@ -495,6 +496,7 @@ solana-hash = { path = "sdk/hash", version = "=2.2.0", default-features = false 
 solana-inflation = { path = "sdk/inflation", version = "=2.2.0" }
 solana-inline-spl = { path = "inline-spl", version = "=2.2.0" }
 solana-instruction = { path = "sdk/instruction", version = "=2.2.0", default-features = false }
+solana-instructions-sysvar = { path = "sdk/instructions-sysvar", version = "=2.2.0" }
 solana-keccak-hasher = { path = "sdk/keccak-hasher", version = "=2.2.0" }
 solana-keypair = { path = "sdk/keypair", version = "=2.2.0" }
 solana-last-restart-slot = { path = "sdk/last-restart-slot", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5882,6 +5882,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-instructions-sysvar"
+version = "2.2.0"
+dependencies = [
+ "bitflags 2.6.0",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-serialize-utils",
+ "solana-sysvar-id",
+]
+
+[[package]]
 name = "solana-keccak-hasher"
 version = "2.2.0"
 dependencies = [
@@ -6287,6 +6302,7 @@ dependencies = [
  "solana-fee-calculator",
  "solana-hash",
  "solana-instruction",
+ "solana-instructions-sysvar",
  "solana-keccak-hasher",
  "solana-last-restart-slot",
  "solana-message",
@@ -7801,7 +7817,6 @@ version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "bitflags 2.6.0",
  "bytemuck",
  "bytemuck_derive",
  "lazy_static",
@@ -7815,6 +7830,7 @@ dependencies = [
  "solana-fee-calculator",
  "solana-hash",
  "solana-instruction",
+ "solana-instructions-sysvar",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
  "solana-program-error",
@@ -7824,7 +7840,6 @@ dependencies = [
  "solana-sanitize",
  "solana-sdk-ids",
  "solana-sdk-macro",
- "solana-serialize-utils",
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-sysvar-id",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -206,10 +206,10 @@ assert_matches = { workspace = true }
 curve25519-dalek = { workspace = true }
 hex = { workspace = true }
 openssl = { workspace = true }
+solana-instructions-sysvar = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-program = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { path = ".", features = ["dev-context-only-utils"] }
-solana-sysvar = { workspace = true, features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 tiny-bip39 = { workspace = true }
 

--- a/sdk/benches/serialize_instructions.rs
+++ b/sdk/benches/serialize_instructions.rs
@@ -3,13 +3,13 @@
 extern crate test;
 use {
     bincode::{deserialize, serialize},
+    solana_instructions_sysvar::{self as instructions, construct_instructions_data},
     solana_sdk::{
         instruction::{AccountMeta, Instruction},
         message::{Message, SanitizedMessage},
         pubkey::{self, Pubkey},
         reserved_account_keys::ReservedAccountKeys,
     },
-    solana_sysvar::instructions::{self, construct_instructions_data},
     test::Bencher,
 };
 

--- a/sdk/instructions-sysvar/Cargo.toml
+++ b/sdk/instructions-sysvar/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "solana-instructions-sysvar"
+description = "Type for instruction introspection during execution of Solana programs."
+documentation = "https://docs.rs/solana-instructions-sysvar"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+qualifier_attr = { workspace = true, optional = true }
+solana-account-info = { workspace = true }
+solana-instruction = { workspace = true, default-features = false }
+solana-program-error = { workspace = true }
+solana-pubkey = { workspace = true, default-features = false }
+solana-sanitize = { workspace = true }
+solana-sdk-ids = { workspace = true }
+solana-serialize-utils = { workspace = true }
+solana-sysvar-id = { workspace = true }
+
+[target.'cfg(not(target_os = "solana"))'.dependencies]
+bitflags = { workspace = true }
+
+[features]
+dev-context-only-utils = ["dep:qualifier_attr"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[lints]
+workspace = true

--- a/sdk/instructions-sysvar/src/lib.rs
+++ b/sdk/instructions-sysvar/src/lib.rs
@@ -27,16 +27,16 @@
 //!
 //! [`secp256k1_instruction`]: https://docs.rs/solana-sdk/latest/solana_sdk/secp256k1_instruction/index.html
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
-#[deprecated(since = "2.2.0", note = "Use solana-instruction crate instead")]
-pub use solana_instruction::{BorrowedAccountMeta, BorrowedInstruction};
 pub use solana_sdk_ids::sysvar::instructions::{check_id, id, ID};
 #[cfg(not(target_os = "solana"))]
 use {
     bitflags::bitflags,
+    solana_instruction::BorrowedInstruction,
     solana_serialize_utils::{append_slice, append_u16, append_u8},
 };
 use {
@@ -284,11 +284,6 @@ mod tests {
         solana_pubkey::Pubkey,
         solana_sanitize::SanitizeError,
         solana_sdk_ids::sysvar::instructions::id,
-        solana_sysvar::instructions::{
-            construct_instructions_data, deserialize_instruction, get_instruction_relative,
-            load_current_index_checked, load_instruction_at_checked, serialize_instructions,
-            store_current_index,
-        },
     };
 
     #[test]

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -49,6 +49,7 @@ solana-instruction = { workspace = true, default-features = false, features = [
     "serde",
     "std",
 ] }
+solana-instructions-sysvar = { workspace = true }
 solana-keccak-hasher = { workspace = true, features = ["sha3"] }
 solana-last-restart-slot = { workspace = true, features = ["serde", "sysvar"] }
 solana-message = { workspace = true, features = ["bincode", "blake3"] }

--- a/sdk/program/src/sysvar.rs
+++ b/sdk/program/src/sysvar.rs
@@ -5,8 +5,29 @@ pub use solana_sysvar_id::{declare_deprecated_sysvar_id, declare_sysvar_id, Sysv
 pub use {
     solana_sdk_ids::sysvar::{check_id, id, ID},
     solana_sysvar::{
-        clock, epoch_rewards, epoch_schedule, fees, instructions, is_sysvar_id, last_restart_slot,
+        clock, epoch_rewards, epoch_schedule, fees, is_sysvar_id, last_restart_slot,
         recent_blockhashes, rent, rewards, slot_hashes, slot_history, stake_history, Sysvar,
         ALL_IDS,
     },
 };
+
+pub mod instructions {
+    #[deprecated(since = "2.2.0", note = "Use solana-instruction crate instead")]
+    pub use solana_instruction::{BorrowedAccountMeta, BorrowedInstruction};
+    #[cfg(not(target_os = "solana"))]
+    #[deprecated(since = "2.2.0", note = "Use solana-instructions-sysvar crate instead")]
+    pub use solana_instructions_sysvar::construct_instructions_data;
+    #[cfg(all(not(target_os = "solana"), feature = "dev-context-only-utils"))]
+    #[deprecated(since = "2.2.0", note = "Use solana-instructions-sysvar crate instead")]
+    pub use solana_instructions_sysvar::serialize_instructions;
+    #[cfg(feature = "dev-context-only-utils")]
+    #[deprecated(since = "2.2.0", note = "Use solana-instructions-sysvar crate instead")]
+    pub use solana_instructions_sysvar::{deserialize_instruction, load_instruction_at};
+    #[deprecated(since = "2.2.0", note = "Use solana-instructions-sysvar crate instead")]
+    pub use solana_instructions_sysvar::{
+        get_instruction_relative, load_current_index_checked, load_instruction_at_checked,
+        store_current_index, Instructions,
+    };
+    #[deprecated(since = "2.2.0", note = "Use solana-sdk-ids crate instead")]
+    pub use solana_sdk_ids::sysvar::instructions::{check_id, id, ID};
+}

--- a/sdk/secp256k1-program/Cargo.toml
+++ b/sdk/secp256k1-program/Cargo.toml
@@ -35,7 +35,7 @@ solana-program-error = { workspace = true }
 solana-sdk = { path = ".." }
 solana-secp256k1-program = { path = ".", features = ["dev-context-only-utils"] }
 solana-signer = { workspace = true }
-solana-sysvar = { workspace = true }
+solana-instructions-sysvar = { workspace = true }
 
 [features]
 bincode = [

--- a/sdk/secp256k1-program/Cargo.toml
+++ b/sdk/secp256k1-program/Cargo.toml
@@ -27,6 +27,7 @@ hex = { workspace = true }
 rand0-7 = { workspace = true }
 solana-account-info = { workspace = true }
 solana-hash = { workspace = true }
+solana-instructions-sysvar = { workspace = true }
 solana-keccak-hasher = { workspace = true }
 solana-keypair = { workspace = true }
 solana-logger = { workspace = true }
@@ -35,7 +36,6 @@ solana-program-error = { workspace = true }
 solana-sdk = { path = ".." }
 solana-secp256k1-program = { path = ".", features = ["dev-context-only-utils"] }
 solana-signer = { workspace = true }
-solana-instructions-sysvar = { workspace = true }
 
 [features]
 bincode = [

--- a/sdk/secp256k1-program/src/lib.rs
+++ b/sdk/secp256k1-program/src/lib.rs
@@ -326,7 +326,7 @@
 //! use solana_msg::msg;
 //! use solana_program_error::{ProgramError, ProgramResult};
 //! use solana_sdk_ids::secp256k1_program;
-//! use solana_sysvar::instructions;
+//! use solana_instructions_sysvar::load_instruction_at_checked;
 //!
 //! /// An Ethereum address corresponding to a secp256k1 secret key that is
 //! /// authorized to sign our messages.
@@ -354,7 +354,7 @@
 //!     // Load the secp256k1 instruction.
 //!     // `new_secp256k1_instruction` generates an instruction that must be at index 0.
 //!     let secp256k1_instr =
-//!         instructions::load_instruction_at_checked(0, instructions_sysvar_account)?;
+//!         solana_instructions_sysvar::load_instruction_at_checked(0, instructions_sysvar_account)?;
 //!
 //!     // Verify it is a secp256k1 instruction.
 //!     // This is security-critical - what if the transaction uses an imposter secp256k1 program?
@@ -533,7 +533,7 @@
 //! use solana_program_error::{ProgramError, ProgramResult};
 //! use solana_msg::msg;
 //! use solana_sdk_ids::secp256k1_program;
-//! use solana_sysvar::instructions;
+//! use solana_instructions_sysvar::{get_instruction_relative, load_instruction_at_checked};
 //!
 //! /// A struct to hold the values specified in the `SecpSignatureOffsets` struct.
 //! struct SecpSignature {
@@ -553,15 +553,15 @@
 //! ) -> Result<Vec<SecpSignature>, ProgramError> {
 //!     let mut sigs = vec![];
 //!     for offsets in secp256k1_defs::iter_signature_offsets(secp256k1_instr_data)? {
-//!         let signature_instr = instructions::load_instruction_at_checked(
+//!         let signature_instr = load_instruction_at_checked(
 //!             offsets.signature_instruction_index as usize,
 //!             instructions_sysvar_account,
 //!         )?;
-//!         let eth_address_instr = instructions::load_instruction_at_checked(
+//!         let eth_address_instr = load_instruction_at_checked(
 //!             offsets.eth_address_instruction_index as usize,
 //!             instructions_sysvar_account,
 //!         )?;
-//!         let message_instr = instructions::load_instruction_at_checked(
+//!         let message_instr = load_instruction_at_checked(
 //!             offsets.message_instruction_index as usize,
 //!             instructions_sysvar_account,
 //!         )?;
@@ -603,7 +603,7 @@
 //!     ));
 //!
 //!     let secp256k1_instr =
-//!         instructions::get_instruction_relative(-1, instructions_sysvar_account)?;
+//!         solana_instructions_sysvar::get_instruction_relative(-1, instructions_sysvar_account)?;
 //!
 //!     assert!(secp256k1_program::check_id(&secp256k1_instr.program_id));
 //!
@@ -635,7 +635,6 @@
 //! };
 //! use solana_signer::Signer;
 //! use solana_keypair::Keypair;
-//! use solana_sysvar::instructions;
 //! use solana_sdk::transaction::Transaction;
 //!
 //! /// A struct to hold the values specified in the `SecpSignatureOffsets` struct.

--- a/sdk/sysvar/Cargo.toml
+++ b/sdk/sysvar/Cargo.toml
@@ -14,7 +14,6 @@ bincode = { workspace = true, optional = true }
 bytemuck = { workspace = true, optional = true }
 bytemuck_derive = { workspace = true, optional = true }
 lazy_static = { workspace = true }
-qualifier_attr = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-account-info = { workspace = true }
@@ -26,6 +25,7 @@ solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-hash = { workspace = true, features = ["bytemuck"] }
 solana-instruction = { workspace = true }
+solana-instructions-sysvar = { workspace = true }
 solana-last-restart-slot = { workspace = true, features = ["sysvar"] }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
@@ -34,14 +34,12 @@ solana-rent = { workspace = true, features = ["sysvar"] }
 solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sdk-macro = { workspace = true }
-solana-serialize-utils = { workspace = true }
 solana-slot-hashes = { workspace = true, features = ["sysvar"] }
 solana-slot-history = { workspace = true, features = ["sysvar"] }
 solana-sysvar-id = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 base64 = { workspace = true }
-bitflags = { workspace = true }
 solana-program-memory = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
@@ -60,7 +58,7 @@ test-case = { workspace = true }
 [features]
 bincode = ["dep:bincode", "serde"]
 bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
-dev-context-only-utils = ["dep:qualifier_attr", "bincode", "bytemuck"]
+dev-context-only-utils = ["bincode", "bytemuck", "solana-instructions-sysvar/dev-context-only-utils"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = [
     "dep:serde",

--- a/sdk/sysvar/src/lib.rs
+++ b/sdk/sysvar/src/lib.rs
@@ -101,7 +101,6 @@ pub mod clock;
 pub mod epoch_rewards;
 pub mod epoch_schedule;
 pub mod fees;
-pub mod instructions;
 pub mod last_restart_slot;
 pub mod program_stubs;
 pub mod recent_blockhashes;
@@ -131,7 +130,7 @@ mod sysvar_ids {
             slot_hashes::id(),
             slot_history::id(),
             stake_history::id(),
-            instructions::id(),
+            solana_sdk_ids::sysvar::instructions::id(),
         ];
     }
 }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5702,6 +5702,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-instructions-sysvar"
+version = "2.2.0"
+dependencies = [
+ "bitflags 2.6.0",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-serialize-utils",
+ "solana-sysvar-id",
+]
+
+[[package]]
 name = "solana-keccak-hasher"
 version = "2.2.0"
 dependencies = [
@@ -6107,6 +6122,7 @@ dependencies = [
  "solana-fee-calculator",
  "solana-hash",
  "solana-instruction",
+ "solana-instructions-sysvar",
  "solana-keccak-hasher",
  "solana-last-restart-slot",
  "solana-message",
@@ -7138,7 +7154,6 @@ version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "bitflags 2.6.0",
  "bytemuck",
  "bytemuck_derive",
  "lazy_static",
@@ -7152,6 +7167,7 @@ dependencies = [
  "solana-fee-calculator",
  "solana-hash",
  "solana-instruction",
+ "solana-instructions-sysvar",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
  "solana-program-error",
@@ -7161,7 +7177,6 @@ dependencies = [
  "solana-sanitize",
  "solana-sdk-ids",
  "solana-sdk-macro",
- "solana-serialize-utils",
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-sysvar-id",


### PR DESCRIPTION
#### Problem

The instructions sysvar currently lives in the `solana-sysvar` crate, but it doesn't require any of the types from the sysvar crate, making it a great candidate for extraction.

#### Summary of changes

Since `solana-sysvar` hasn't been officially published yet, we can make a breaking change to it, and totally extract the instructions sysvar from it, then re-export the functionality from `solana-program` directly.