### PR TITLE
Simplify check for data Rc in account info data and improve tesing

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -186,12 +186,7 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
             let ref_to_len_in_vm = if direct_mapping {
                 let vm_addr = (account_info.data.as_ptr() as *const u64 as u64)
                     .saturating_add(size_of::<u64>() as u64);
-                // In the same vein as the other check_account_info_pointer() checks, we don't lock
-                // this pointer to a specific address but we don't want it to be inside accounts, or
-                // callees might be able to write to the pointed memory.
-                if vm_addr >= ebpf::MM_INPUT_START {
-                    return Err(SyscallError::InvalidPointer.into());
-                }
+
                 VmValue::VmAddress {
                     vm_addr,
                     memory_mapping,

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -2,6 +2,7 @@ SBF_SDK_PATH := ../../sdk/sbf
 SRC_DIR := c/src
 OUT_DIR := target/sbf-solana-solana/release
 
+
 test: rust all
 	SBF_OUT_DIR=$(OUT_DIR) cargo test --features="sbf_rust,sbf_c" $(TEST_ARGS)
 

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -1523,22 +1523,24 @@ fn process_instruction<'a>(
             .unwrap();
         }
         TEST_ACCOUNT_INFO_LAMPORTS_RC => {
-            msg!("TEST_ACCOUNT_INFO_LAMPORTS_RC_IN_ACCOUNT");
+            msg!("TEST_ACCOUNT_INFO_LAMPORTS_RC");
 
-            let mut account0 = accounts[0].clone();
-            let account1 = accounts[1].clone();
+            let account0 = accounts[0].clone();
+            let mut account1 = accounts[1].clone();
             let account2 = accounts[2].clone();
 
-            account0.lamports = unsafe {
-                let dst = account1.data.borrow_mut().as_mut_ptr();
-                // 32 = size_of::<RcBox>()
+            account1.lamports = unsafe {
+                let dst = account0.data.borrow_mut().as_mut_ptr();
+                // 32 = size_of::<Rc<RefCell<&mut u64>()
                 std::ptr::copy(
-                    std::mem::transmute::<Rc<RefCell<&mut u64>>, *const u8>(account0.lamports),
+                    std::mem::transmute::<Rc<RefCell<&mut u64>>, *const u8>(account1.lamports),
                     dst,
                     32,
                 );
                 std::mem::transmute::<*mut u8, Rc<RefCell<&mut u64>>>(dst)
             };
+
+            account0.realloc(account1.data_len() + 102, false)?;
 
             let mut instruction_data = vec![TEST_WRITE_ACCOUNT, 1];
             instruction_data.extend_from_slice(&1u64.to_le_bytes());
@@ -1549,8 +1551,8 @@ fn process_instruction<'a>(
                     *program_id,
                     &[
                         (program_id, false, false),
-                        (accounts[1].key, true, false),
-                        (accounts[0].key, false, false),
+                        (accounts[0].key, true, false),
+                        (accounts[1].key, false, false),
                     ],
                     instruction_data.to_vec(),
                 ),
@@ -1559,19 +1561,19 @@ fn process_instruction<'a>(
             .unwrap();
         }
         TEST_ACCOUNT_INFO_DATA_RC => {
-            msg!("TEST_ACCOUNT_INFO_DATA_RC_IN_ACCOUNT");
+            msg!("TEST_ACCOUNT_INFO_DATA_RC");
 
-            let mut account0 = accounts[0].clone();
-            let account1 = accounts[1].clone();
+            let account0 = accounts[0].clone();
+            let mut account1 = accounts[1].clone();
             let account2 = accounts[2].clone();
 
-            account0.data = unsafe {
-                let dst = account1.data.borrow_mut().as_mut_ptr();
-                // 32 = size_of::<RcBox>()
+            account1.data = unsafe {
+                let dst = account0.data.borrow_mut().as_mut_ptr();
+                // 40 = size_of::<Rc<RefCell<&[u8]>()
                 std::ptr::copy(
-                    std::mem::transmute::<Rc<RefCell<&mut [u8]>>, *const u8>(account0.data),
+                    std::mem::transmute::<Rc<RefCell<&mut [u8]>>, *const u8>(account1.data),
                     dst,
-                    32,
+                    40,
                 );
                 std::mem::transmute::<*mut u8, Rc<RefCell<&mut [u8]>>>(dst)
             };
@@ -1585,8 +1587,8 @@ fn process_instruction<'a>(
                     *program_id,
                     &[
                         (program_id, false, false),
-                        (accounts[1].key, true, false),
-                        (accounts[0].key, false, false),
+                        (accounts[0].key, true, false),
+                        (accounts[1].key, false, false),
                     ],
                     instruction_data.to_vec(),
                 ),

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -5197,8 +5197,8 @@ fn test_account_info_rc_in_account() {
         let mint_pubkey = mint_keypair.pubkey();
 
         let account_metas = vec![
-            AccountMeta::new(mint_pubkey, true),
             AccountMeta::new(account_keypair.pubkey(), false),
+            AccountMeta::new(mint_pubkey, true),
             AccountMeta::new_readonly(invoke_program_id, false),
         ];
 


### PR DESCRIPTION
sol_invoke_signed_rust() takes an slice of AccountInfo. The account data field is defined as a Rc<RefCell<&mut [u8]>. This means that the AccountInfo struct holds a single pointer for the data field, which points to a struct containing:

 - Rc fields for strong and weak reference count
 - borrow count field for the RefCell
 - a pointer and length for the &[u8] slice

account_info.data.as_ptr() gives as the pointer to the data field of the Rc<RefCell<>> struct, not the data pointer itself; it's the data of the RefCell.

The check for the offset of the length field is therefore redundant and therefore removed.

Also improve the test which show UB without the checks we added in https://github.com/anza-xyz/agave/pull/3471

