### PR TITLE
blockstore: Use Vec::from() instead of slice::to_vec()

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2350,7 +2350,7 @@ impl Blockstore {
         self.slot_data_iterator(slot, start_index)
             .expect("blockstore couldn't fetch iterator")
             .map(|(_, bytes)| {
-                Shred::new_from_serialized_shred(bytes.to_vec()).map_err(|err| {
+                Shred::new_from_serialized_shred(Vec::from(bytes)).map_err(|err| {
                     BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
                         format!("Could not reconstruct shred from shred payload: {err:?}"),
                     )))
@@ -2410,7 +2410,7 @@ impl Blockstore {
     ) -> std::result::Result<Vec<Shred>, shred::Error> {
         self.slot_coding_iterator(slot, start_index)
             .expect("blockstore couldn't fetch iterator")
-            .map(|code| Shred::new_from_serialized_shred(code.1.to_vec()))
+            .map(|(_, bytes)| Shred::new_from_serialized_shred(Vec::from(bytes)))
             .collect()
     }
 


### PR DESCRIPTION
#### Problem
Vec::from() on a Box<[T]> takes over the heap allocation whereas slice::to_vec() copies the contents into a new Vec. We don't need the old Box<[u8]> so transferring ownership is sufficient here

#### Summary of Changes
Use `Vec::from()` instead of `to_vec()`. Playing with it on godbolt, we save a `movzx` when optimization cranked up. So, not something that will move the needle on TPS or anything, but I view this more as a correctness thing too.

https://godbolt.org/z/Wbs6v6vEs