### PR TITLE
sdk: evict shred version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8770,6 +8770,7 @@ dependencies = [
  "solana-serde",
  "solana-serde-varint",
  "solana-short-vec",
+ "solana-shred-version",
  "solana-signature",
  "solana-signer",
  "solana-system-transaction",
@@ -8954,6 +8955,16 @@ dependencies = [
  "serde_json",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+]
+
+[[package]]
+name = "solana-shred-version"
+version = "2.2.0"
+dependencies = [
+ "byteorder",
+ "solana-hard-forks",
+ "solana-hash",
+ "solana-sha256-hasher",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,7 @@ members = [
     "sdk/serialize-utils",
     "sdk/sha256-hasher",
     "sdk/short-vec",
+    "sdk/shred-version",
     "sdk/signature",
     "sdk/signer",
     "sdk/slot-hashes",
@@ -572,6 +573,7 @@ solana-secp256k1-program = { path = "sdk/secp256k1-program", version = "=2.2.0" 
 solana-secp256k1-recover = { path = "curves/secp256k1-recover", version = "=2.2.0", default-features = false }
 solana-send-transaction-service = { path = "send-transaction-service", version = "=2.2.0" }
 solana-short-vec = { path = "sdk/short-vec", version = "=2.2.0" }
+solana-shred-version = { path = "sdk/shred-version", version = "=2.2.0" }
 solana-stable-layout = { path = "sdk/stable-layout", version = "=2.2.0" }
 solana-stake-program = { path = "programs/stake", version = "=2.2.0" }
 solana-storage-bigtable = { path = "storage-bigtable", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7428,6 +7428,7 @@ dependencies = [
  "solana-serde",
  "solana-serde-varint",
  "solana-short-vec",
+ "solana-shred-version",
  "solana-signature",
  "solana-signer",
  "solana-system-transaction",
@@ -7573,6 +7574,16 @@ name = "solana-short-vec"
 version = "2.2.0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "solana-shred-version"
+version = "2.2.0"
+dependencies = [
+ "byteorder 1.5.0",
+ "solana-hard-forks",
+ "solana-hash",
+ "solana-sha256-hasher",
 ]
 
 [[package]]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -49,6 +49,7 @@ full = [
     "dep:solana-secp256k1-program",
     "dep:solana-seed-derivable",
     "dep:solana-seed-phrase",
+    "dep:solana-shred-version",
     "dep:solana-signer",
     "dep:solana-system-transaction",
     "dep:solana-transaction",
@@ -179,6 +180,7 @@ solana-seed-phrase = { workspace = true, optional = true }
 solana-serde = { workspace = true }
 solana-serde-varint = { workspace = true }
 solana-short-vec = { workspace = true }
+solana-shred-version = { workspace = true, optional = true }
 solana-signature = { workspace = true, features = [
     "rand",
     "serde",

--- a/sdk/shred-version/Cargo.toml
+++ b/sdk/shred-version/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "solana-shred-version"
+description = "Calculation of shred versions."
+documentation = "https://docs.rs/solana-shred-version"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+byteorder = { workspace = true }
+solana-hard-forks = { workspace = true }
+solana-hash = { workspace = true }
+solana-sha256-hasher = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/sdk/shred-version/src/lib.rs
+++ b/sdk/shred-version/src/lib.rs
@@ -2,12 +2,7 @@
 //!
 //! [shred]: https://solana.com/docs/terminology#shred
 
-#![cfg(feature = "full")]
-
-use solana_sdk::{
-    hard_forks::HardForks,
-    hash::{extend_and_hash, Hash},
-};
+use {solana_hard_forks::HardForks, solana_hash::Hash, solana_sha256_hasher::extend_and_hash};
 
 pub fn version_from_hash(hash: &Hash) -> u16 {
     let hash = hash.as_ref();

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -90,7 +90,9 @@ pub mod reward_type {
     pub use solana_reward_info::RewardType;
 }
 pub mod rpc_port;
-pub mod shred_version;
+#[cfg(feature = "full")]
+#[deprecated(since = "2.2.0", note = "Use `solana-shred-version` crate instead")]
+pub use solana_shred_version as shred_version;
 pub mod signature;
 pub mod signer;
 pub mod transaction;

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6747,6 +6747,7 @@ dependencies = [
  "solana-serde",
  "solana-serde-varint",
  "solana-short-vec",
+ "solana-shred-version",
  "solana-signature",
  "solana-signer",
  "solana-system-transaction",
@@ -6892,6 +6893,16 @@ name = "solana-short-vec"
 version = "2.2.0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "solana-shred-version"
+version = "2.2.0"
+dependencies = [
+ "byteorder",
+ "solana-hard-forks",
+ "solana-hash",
+ "solana-sha256-hasher",
 ]
 
 [[package]]


### PR DESCRIPTION
This one could, as an alternative, be rolled into `solana-hard-forks`, but I had the new crate commit locally so I figured I'd put it up for discussion first. Lmk!