### PR TITLE
ci: unify solana docker base image

### DIFF
--- a/ci/docker/build.sh
+++ b/ci/docker/build.sh
@@ -16,13 +16,13 @@ fi
 echo "build image: ${CI_DOCKER_IMAGE:?}"
 docker build "${platform[@]}" \
   -f "$here/Dockerfile" \
-  --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
-  --build-arg "RUST_VERSION=${RUST_VERSION}" \
-  --build-arg "RUST_NIGHTLY_VERSION=${RUST_NIGHTLY_VERSION}" \
-  --build-arg "GOLANG_VERSION=${GOLANG_VERSION}" \
-  --build-arg "NODE_MAJOR=${NODE_MAJOR}" \
-  --build-arg "SCCACHE_VERSION=${SCCACHE_VERSION}" \
-  --build-arg "GRCOV_VERSION=${GRCOV_VERSION}" \
+  --build-arg "BASE_IMAGE=${CI_DOCKER_ARG_BASE_IMAGE}" \
+  --build-arg "RUST_VERSION=${CI_DOCKER_ARG_RUST_VERSION}" \
+  --build-arg "RUST_NIGHTLY_VERSION=${CI_DOCKER_ARG_RUST_NIGHTLY_VERSION}" \
+  --build-arg "GOLANG_VERSION=${CI_DOCKER_ARG_GOLANG_VERSION}" \
+  --build-arg "NODE_MAJOR=${CI_DOCKER_ARG_NODE_MAJOR}" \
+  --build-arg "SCCACHE_VERSION=${CI_DOCKER_ARG_SCCACHE_VERSION}" \
+  --build-arg "GRCOV_VERSION=${CI_DOCKER_ARG_GRCOV_VERSION}" \
   -t "$CI_DOCKER_IMAGE" .
 
 docker push "$CI_DOCKER_IMAGE"

--- a/ci/docker/env.sh
+++ b/ci/docker/env.sh
@@ -10,25 +10,25 @@ if [[ -z "${rust_stable}" || -z "${rust_nightly}" ]]; then
   exit 1
 fi
 
-export BASE_IMAGE=ubuntu:22.04
-export RUST_VERSION="${rust_stable}"
-export RUST_NIGHTLY_VERSION="${rust_nightly}"
-export GOLANG_VERSION=1.21.3
-export NODE_MAJOR=18
-export SCCACHE_VERSION=v0.8.1
-export GRCOV_VERSION=v0.8.18
+export CI_DOCKER_ARG_BASE_IMAGE=ubuntu:22.04
+export CI_DOCKER_ARG_RUST_VERSION="${rust_stable}"
+export CI_DOCKER_ARG_RUST_NIGHTLY_VERSION="${rust_nightly}"
+export CI_DOCKER_ARG_GOLANG_VERSION=1.21.3
+export CI_DOCKER_ARG_NODE_MAJOR=18
+export CI_DOCKER_ARG_SCCACHE_VERSION=v0.8.1
+export CI_DOCKER_ARG_GRCOV_VERSION=v0.8.18
 
 hash_vars=(
-  "${BASE_IMAGE}"
-  "${RUST_VERSION}"
-  "${RUST_NIGHTLY_VERSION}"
-  "${GOLANG_VERSION}"
-  "${NODE_MAJOR}"
-  "${SCCACHE_VERSION}"
-  "${GRCOV_VERSION}"
+  "${CI_DOCKER_ARG_BASE_IMAGE}"
+  "${CI_DOCKER_ARG_RUST_VERSION}"
+  "${CI_DOCKER_ARG_RUST_NIGHTLY_VERSION}"
+  "${CI_DOCKER_ARG_GOLANG_VERSION}"
+  "${CI_DOCKER_ARG_NODE_MAJOR}"
+  "${CI_DOCKER_ARG_SCCACHE_VERSION}"
+  "${CI_DOCKER_ARG_GRCOV_VERSION}"
 )
 hash_input=$(IFS="_"; echo "${hash_vars[*]}")
 ci_docker_hash=$(echo -n "${hash_input}" | sha256sum | head -c 8)
 
-SANITIZED_BASE_IMAGE="${BASE_IMAGE//:/-}"
-export CI_DOCKER_IMAGE="anzaxyz/ci:${SANITIZED_BASE_IMAGE}_rust-${RUST_VERSION}_${RUST_NIGHTLY_VERSION}_${ci_docker_hash}"
+CI_DOCKER_SANITIZED_BASE_IMAGE="${CI_DOCKER_ARG_BASE_IMAGE//:/-}"
+export CI_DOCKER_IMAGE="anzaxyz/ci:${CI_DOCKER_SANITIZED_BASE_IMAGE}_rust-${CI_DOCKER_ARG_RUST_VERSION}_${CI_DOCKER_ARG_RUST_NIGHTLY_VERSION}_${ci_docker_hash}"

--- a/sdk/docker-solana/Dockerfile
+++ b/sdk/docker-solana/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:bookworm
+ARG BASE_IMAGE=
+FROM ${BASE_IMAGE}
 
 # RPC JSON
 EXPOSE 8899/tcp

--- a/sdk/docker-solana/build.sh
+++ b/sdk/docker-solana/build.sh
@@ -4,6 +4,7 @@ set -ex
 cd "$(dirname "$0")"/../..
 eval "$(ci/channel-info.sh)"
 source ci/rust-version.sh
+source ci/docker/env.sh
 
 CHANNEL_OR_TAG=
 if [[ -n "$CI_TAG" ]]; then
@@ -29,7 +30,9 @@ cp -f ../../fetch-spl.sh usr/bin/
   ./fetch-spl.sh
 )
 
-docker build -t anzaxyz/agave:"$CHANNEL_OR_TAG" .
+docker build \
+  --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+  -t anzaxyz/agave:"$CHANNEL_OR_TAG" .
 
 maybeEcho=
 if [[ -z $CI ]]; then

--- a/sdk/docker-solana/build.sh
+++ b/sdk/docker-solana/build.sh
@@ -31,7 +31,7 @@ cp -f ../../fetch-spl.sh usr/bin/
 )
 
 docker build \
-  --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+  --build-arg "BASE_IMAGE=${CI_DOCKER_ARG_BASE_IMAGE}" \
   -t anzaxyz/agave:"$CHANNEL_OR_TAG" .
 
 maybeEcho=


### PR DESCRIPTION
#### Problem

we use 2 different docker based images

ci:
https://github.com/anza-xyz/agave/blob/8c3a6bb6898e61b0962d6fe9a892dd29b11da097/ci/docker/env.sh#L13

sdk:
https://github.com/anza-xyz/agave/blob/8c3a6bb6898e61b0962d6fe9a892dd29b11da097/sdk/docker-solana/Dockerfile#L1

this won't be an issue if the sdk and ci were standalone components. however, they are interconnected. the sdk relies on the ci image to build bins. it means the sdk's base image should be compatible with ci's

we are using ubuntu in lots of places. would like to get sdk use it as well.

#### Summary of Changes

migrate sdk's docker base image from `debian` to `ubuntu`
