### PR TITLE
remove solana-sdk from zk-token-proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10022,9 +10022,10 @@ dependencies = [
  "num-derive",
  "num-traits",
  "solana-feature-set",
+ "solana-instruction",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk",
+ "solana-sdk-ids",
  "solana-zk-token-sdk",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8367,9 +8367,10 @@ dependencies = [
  "num-derive",
  "num-traits",
  "solana-feature-set",
+ "solana-instruction",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk",
+ "solana-sdk-ids",
  "solana-zk-token-sdk",
 ]
 

--- a/programs/zk-token-proof/Cargo.toml
+++ b/programs/zk-token-proof/Cargo.toml
@@ -13,9 +13,10 @@ bytemuck = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 solana-feature-set = { workspace = true }
+solana-instruction = { workspace = true }
 solana-log-collector = { workspace = true }
 solana-program-runtime = { workspace = true }
-solana-sdk = { workspace = true }
+solana-sdk-ids = { workspace = true }
 solana-zk-token-sdk = { workspace = true }
 
 [dev-dependencies]

--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -3,12 +3,10 @@
 use {
     bytemuck::Pod,
     solana_feature_set as feature_set,
+    solana_instruction::{error::InstructionError, TRANSACTION_LEVEL_STACK_HEIGHT},
     solana_log_collector::ic_msg,
     solana_program_runtime::{declare_process_instruction, invoke_context::InvokeContext},
-    solana_sdk::{
-        instruction::{InstructionError, TRANSACTION_LEVEL_STACK_HEIGHT},
-        system_program,
-    },
+    solana_sdk_ids::system_program,
     solana_zk_token_sdk::{
         zk_token_proof_instruction::*,
         zk_token_proof_program::id,

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7703,9 +7703,10 @@ dependencies = [
  "num-derive",
  "num-traits",
  "solana-feature-set",
+ "solana-instruction",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk",
+ "solana-sdk-ids",
  "solana-zk-token-sdk",
 ]
 


### PR DESCRIPTION
#### Problem
This no longer needs all of solana-sdk

#### Summary of Changes
Replace with the relevant constituent crates
