### PR TITLE
remove solana-sdk from zk-token-proof-tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10034,9 +10034,17 @@ version = "2.2.0"
 dependencies = [
  "bytemuck",
  "curve25519-dalek 4.1.3",
+ "solana-account",
  "solana-compute-budget",
+ "solana-compute-budget-interface",
+ "solana-instruction",
+ "solana-keypair",
  "solana-program-test",
- "solana-sdk",
+ "solana-pubkey",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-transaction",
+ "solana-transaction-error",
  "solana-zk-token-sdk",
 ]
 

--- a/programs/zk-token-proof-tests/Cargo.toml
+++ b/programs/zk-token-proof-tests/Cargo.toml
@@ -10,7 +10,15 @@ edition = { workspace = true }
 [dev-dependencies]
 bytemuck = { workspace = true }
 curve25519-dalek = { workspace = true }
+solana-account = { workspace = true }
 solana-compute-budget = { workspace = true }
+solana-compute-budget-interface = { workspace = true }
+solana-instruction = { workspace = true }
+solana-keypair = { workspace = true }
 solana-program-test = { workspace = true }
-solana-sdk = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-signer = { workspace = true }
+solana-system-interface = { workspace = true }
+solana-transaction = { workspace = true }
+solana-transaction-error = { workspace = true }
 solana-zk-token-sdk = { workspace = true }

--- a/programs/zk-token-proof-tests/tests/process_transaction.rs
+++ b/programs/zk-token-proof-tests/tests/process_transaction.rs
@@ -1,16 +1,15 @@
 use {
     bytemuck::{bytes_of, Pod},
     curve25519_dalek::scalar::Scalar,
+    solana_account::Account,
+    solana_instruction::error::InstructionError,
+    solana_keypair::Keypair,
     solana_program_test::*,
-    solana_sdk::{
-        account::Account,
-        instruction::InstructionError,
-        pubkey::Pubkey,
-        signature::Signer,
-        signer::keypair::Keypair,
-        system_instruction,
-        transaction::{Transaction, TransactionError},
-    },
+    solana_pubkey::Pubkey,
+    solana_signer::Signer,
+    solana_system_interface::instruction as system_instruction,
+    solana_transaction::Transaction,
+    solana_transaction_error::TransactionError,
     solana_zk_token_sdk::{
         encryption::{
             elgamal::{ElGamalKeypair, ElGamalSecretKey},
@@ -1713,10 +1712,10 @@ trait WithMaxComputeUnitLimit {
     fn with_max_compute_unit_limit(self) -> Self;
 }
 
-impl WithMaxComputeUnitLimit for Vec<solana_sdk::instruction::Instruction> {
+impl WithMaxComputeUnitLimit for Vec<solana_instruction::Instruction> {
     fn with_max_compute_unit_limit(mut self) -> Self {
         self.push(
-            solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(
+            solana_compute_budget_interface::ComputeBudgetInstruction::set_compute_unit_limit(
                 solana_compute_budget::compute_budget_limits::MAX_COMPUTE_UNIT_LIMIT,
             ),
         );


### PR DESCRIPTION
#### Problem
This no longer needs all of solana-sdk

#### Summary of Changes
Replace with the relevant constituent crates
