### PR TITLE
remove solana-sdk from compute-budget-bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6690,8 +6690,11 @@ dependencies = [
  "criterion",
  "solana-compute-budget",
  "solana-compute-budget-instruction",
+ "solana-compute-budget-interface",
  "solana-compute-budget-program",
- "solana-sdk",
+ "solana-feature-set",
+ "solana-message",
+ "solana-sdk-ids",
  "solana-svm-transaction",
 ]
 

--- a/programs/compute-budget-bench/Cargo.toml
+++ b/programs/compute-budget-bench/Cargo.toml
@@ -12,8 +12,11 @@ edition = { workspace = true }
 criterion = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-instruction = { workspace = true }
+solana-compute-budget-interface = { workspace = true }
 solana-compute-budget-program = { workspace = true }
-solana-sdk = { workspace = true }
+solana-feature-set = { workspace = true }
+solana-message = { workspace = true }
+solana-sdk-ids = { workspace = true }
 solana-svm-transaction = { workspace = true }
 
 [[bench]]

--- a/programs/compute-budget-bench/benches/compute_budget.rs
+++ b/programs/compute-budget-bench/benches/compute_budget.rs
@@ -2,10 +2,9 @@ use {
     criterion::{black_box, criterion_group, criterion_main, Criterion},
     solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
-    solana_sdk::{
-        compute_budget::ComputeBudgetInstruction, feature_set::FeatureSet,
-        instruction::CompiledInstruction,
-    },
+    solana_compute_budget_interface::ComputeBudgetInstruction,
+    solana_feature_set::FeatureSet,
+    solana_message::compiled_instruction::CompiledInstruction,
     solana_svm_transaction::instruction::SVMInstruction,
     std::num::NonZero,
 };
@@ -15,7 +14,7 @@ const SIXTY_FOUR_MB: u32 = 64 * 1024 * 1024;
 
 fn bench_request_heap_frame(c: &mut Criterion) {
     let instruction = [(
-        solana_sdk::compute_budget::id(),
+        solana_sdk_ids::compute_budget::id(),
         CompiledInstruction::new_from_raw_parts(
             0,
             ComputeBudgetInstruction::request_heap_frame(ONE_PAGE).data,
@@ -48,7 +47,7 @@ fn bench_request_heap_frame(c: &mut Criterion) {
 
 fn bench_set_compute_unit_limit(c: &mut Criterion) {
     let instruction = [(
-        solana_sdk::compute_budget::id(),
+        solana_sdk_ids::compute_budget::id(),
         CompiledInstruction::new_from_raw_parts(
             0,
             ComputeBudgetInstruction::set_compute_unit_limit(1024).data,
@@ -81,7 +80,7 @@ fn bench_set_compute_unit_limit(c: &mut Criterion) {
 
 fn bench_set_compute_unit_price(c: &mut Criterion) {
     let instruction = [(
-        solana_sdk::compute_budget::id(),
+        solana_sdk_ids::compute_budget::id(),
         CompiledInstruction::new_from_raw_parts(
             0,
             ComputeBudgetInstruction::set_compute_unit_price(1).data,
@@ -114,7 +113,7 @@ fn bench_set_compute_unit_price(c: &mut Criterion) {
 
 fn bench_set_loaded_accounts_data_size_limit(c: &mut Criterion) {
     let instruction = [(
-        solana_sdk::compute_budget::id(),
+        solana_sdk_ids::compute_budget::id(),
         CompiledInstruction::new_from_raw_parts(
             0,
             ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(1).data,


### PR DESCRIPTION
#### Problem
This no longer needs all of solana-sdk

#### Summary of Changes
Replace with the relevant constituent crates
