### PR TITLE
Thinlto for validator builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 inherits = "release"
 debug = true
 split-debuginfo = "packed"
+lto = false # Preserve the 'thin local LTO' for this build.
+
+[profile.release]
+split-debuginfo = "unpacked"
+lto = "thin"
 
 [workspace]
 members = [


### PR DESCRIPTION
## Problem

release-with-debug builds started failing because they derive from release builds.

```
scripts/cargo-install-all.sh --release-with-debug ~/temp/build
```

## Fix
Disable ThinLTO in release-with-debug only keep the [Thin local LTO](https://doc.rust-lang.org/cargo/reference/profiles.html#lto). Re-landing #3516 with fix.


