### PR TITLE
PrioGraphSchedulerConfig

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -28,6 +28,7 @@ use {
         tracer_packet_stats::TracerPacketStats,
         validator::BlockProductionMethod,
     },
+    consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH,
     crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender},
     histogram::Histogram,
     solana_client::connection_cache::ConnectionCache,
@@ -627,6 +628,7 @@ impl BankingStage {
                 max_cu_per_thread: MAX_BLOCK_UNITS / num_threads as u64,
                 max_transactions_per_scheduling_pass: 100_000,
                 look_ahead_window_size: 2048,
+                target_transactions_per_batch: TARGET_NUM_TRANSACTIONS_PER_BATCH,
             };
             let scheduler =
                 PrioGraphScheduler::new(work_senders, finished_work_receiver, scheduler_config);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -626,6 +626,7 @@ impl BankingStage {
             let scheduler_config = PrioGraphSchedulerConfig {
                 max_cu_per_thread: MAX_BLOCK_UNITS / num_threads as u64,
                 max_transactions_per_scheduling_pass: 100_000,
+                look_ahead_window_size: 2048,
             };
             let scheduler =
                 PrioGraphScheduler::new(work_senders, finished_work_receiver, scheduler_config);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -31,6 +31,7 @@ use {
     crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender},
     histogram::Histogram,
     solana_client::connection_cache::ConnectionCache,
+    solana_cost_model::block_cost_limits::MAX_BLOCK_UNITS,
     solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
     solana_ledger::blockstore_processor::TransactionStatusSender,
     solana_measure::measure_us,
@@ -52,6 +53,7 @@ use {
         time::{Duration, Instant},
     },
     transaction_scheduler::{
+        prio_graph_scheduler::PrioGraphSchedulerConfig,
         receive_and_buffer::SanitizedTransactionReceiveAndBuffer,
         transaction_state_container::TransactionStateContainer,
     },
@@ -621,7 +623,12 @@ impl BankingStage {
                 bank_forks.clone(),
                 forwarder.is_some(),
             );
-            let scheduler = PrioGraphScheduler::new(work_senders, finished_work_receiver);
+            let scheduler_config = PrioGraphSchedulerConfig {
+                max_cu_per_thread: MAX_BLOCK_UNITS / num_threads as u64,
+                max_transactions_per_scheduling_pass: 100_000,
+            };
+            let scheduler =
+                PrioGraphScheduler::new(work_senders, finished_work_receiver, scheduler_config);
             let scheduler_controller = SchedulerController::new(
                 decision_maker.clone(),
                 receive_and_buffer,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -28,11 +28,9 @@ use {
         tracer_packet_stats::TracerPacketStats,
         validator::BlockProductionMethod,
     },
-    consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH,
     crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender},
     histogram::Histogram,
     solana_client::connection_cache::ConnectionCache,
-    solana_cost_model::block_cost_limits::MAX_BLOCK_UNITS,
     solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
     solana_ledger::blockstore_processor::TransactionStatusSender,
     solana_measure::measure_us,
@@ -624,14 +622,11 @@ impl BankingStage {
                 bank_forks.clone(),
                 forwarder.is_some(),
             );
-            let scheduler_config = PrioGraphSchedulerConfig {
-                max_cu_per_thread: MAX_BLOCK_UNITS / num_threads as u64,
-                max_transactions_per_scheduling_pass: 100_000,
-                look_ahead_window_size: 2048,
-                target_transactions_per_batch: TARGET_NUM_TRANSACTIONS_PER_BATCH,
-            };
-            let scheduler =
-                PrioGraphScheduler::new(work_senders, finished_work_receiver, scheduler_config);
+            let scheduler = PrioGraphScheduler::new(
+                work_senders,
+                finished_work_receiver,
+                PrioGraphSchedulerConfig::default(),
+            );
             let scheduler_controller = SchedulerController::new(
                 decision_maker.clone(),
                 receive_and_buffer,

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -6,7 +6,6 @@ use {
         transaction_state::SanitizedTransactionTTL,
     },
     crate::banking_stage::{
-        consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH,
         read_write_account_set::ReadWriteAccountSet,
         scheduler_messages::{
             ConsumeWork, FinishedConsumeWork, MaxAge, TransactionBatchId, TransactionId,
@@ -44,6 +43,7 @@ pub(crate) struct PrioGraphSchedulerConfig {
     pub max_cu_per_thread: u64,
     pub max_transactions_per_scheduling_pass: usize,
     pub look_ahead_window_size: usize,
+    pub target_transactions_per_batch: usize,
 }
 
 pub(crate) struct PrioGraphScheduler<Tx> {
@@ -112,7 +112,7 @@ impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
             });
         }
 
-        let mut batches = Batches::new(num_threads);
+        let mut batches = Batches::new(num_threads, self.config.target_transactions_per_batch);
         // Some transactions may be unschedulable due to multi-thread conflicts.
         // These transactions cannot be scheduled until some conflicting work is completed.
         // However, the scheduler should not allow other transactions that conflict with
@@ -176,8 +176,9 @@ impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
         // Check transactions against filter, remove from container if it fails.
         chunked_pops(container, &mut self.prio_graph, &mut window_budget);
 
-        let mut unblock_this_batch =
-            Vec::with_capacity(self.consume_work_senders.len() * TARGET_NUM_TRANSACTIONS_PER_BATCH);
+        let mut unblock_this_batch = Vec::with_capacity(
+            self.consume_work_senders.len() * self.config.target_transactions_per_batch,
+        );
         let mut num_scheduled: usize = 0;
         let mut num_sent: usize = 0;
         let mut num_unschedulable: usize = 0;
@@ -234,7 +235,8 @@ impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
                         saturating_add_assign!(batches.total_cus[thread_id], cost);
 
                         // If target batch size is reached, send only this batch.
-                        if batches.ids[thread_id].len() >= TARGET_NUM_TRANSACTIONS_PER_BATCH {
+                        if batches.ids[thread_id].len() >= self.config.target_transactions_per_batch
+                        {
                             saturating_add_assign!(
                                 num_sent,
                                 self.send_batch(&mut batches, thread_id)?
@@ -413,7 +415,8 @@ impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
             return Ok(0);
         }
 
-        let (ids, transactions, max_ages, total_cus) = batches.take_batch(thread_index);
+        let (ids, transactions, max_ages, total_cus) =
+            batches.take_batch(thread_index, self.config.target_transactions_per_batch);
 
         let batch_id = self
             .in_flight_tracker
@@ -503,14 +506,14 @@ struct Batches<Tx> {
 }
 
 impl<Tx> Batches<Tx> {
-    fn new(num_threads: usize) -> Self {
+    fn new(num_threads: usize, target_num_transactions_per_batch: usize) -> Self {
         Self {
-            ids: vec![Vec::with_capacity(TARGET_NUM_TRANSACTIONS_PER_BATCH); num_threads],
+            ids: vec![Vec::with_capacity(target_num_transactions_per_batch); num_threads],
 
             transactions: (0..num_threads)
-                .map(|_| Vec::with_capacity(TARGET_NUM_TRANSACTIONS_PER_BATCH))
+                .map(|_| Vec::with_capacity(target_num_transactions_per_batch))
                 .collect(),
-            max_ages: vec![Vec::with_capacity(TARGET_NUM_TRANSACTIONS_PER_BATCH); num_threads],
+            max_ages: vec![Vec::with_capacity(target_num_transactions_per_batch); num_threads],
             total_cus: vec![0; num_threads],
         }
     }
@@ -518,19 +521,20 @@ impl<Tx> Batches<Tx> {
     fn take_batch(
         &mut self,
         thread_id: ThreadId,
+        target_num_transactions_per_batch: usize,
     ) -> (Vec<TransactionId>, Vec<Tx>, Vec<MaxAge>, u64) {
         (
             core::mem::replace(
                 &mut self.ids[thread_id],
-                Vec::with_capacity(TARGET_NUM_TRANSACTIONS_PER_BATCH),
+                Vec::with_capacity(target_num_transactions_per_batch),
             ),
             core::mem::replace(
                 &mut self.transactions[thread_id],
-                Vec::with_capacity(TARGET_NUM_TRANSACTIONS_PER_BATCH),
+                Vec::with_capacity(target_num_transactions_per_batch),
             ),
             core::mem::replace(
                 &mut self.max_ages[thread_id],
-                Vec::with_capacity(TARGET_NUM_TRANSACTIONS_PER_BATCH),
+                Vec::with_capacity(target_num_transactions_per_batch),
             ),
             core::mem::replace(&mut self.total_cus[thread_id], 0),
         )
@@ -647,6 +651,7 @@ mod tests {
             max_cu_per_thread: MAX_BLOCK_UNITS / num_threads as u64,
             max_transactions_per_scheduling_pass: 100_000,
             look_ahead_window_size: 2048,
+            target_transactions_per_batch: TARGET_NUM_TRANSACTIONS_PER_BATCH,
         };
         let scheduler = PrioGraphScheduler::new(
             consume_work_senders,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -451,7 +451,6 @@ mod tests {
         },
         crossbeam_channel::{unbounded, Receiver, Sender},
         itertools::Itertools,
-        solana_cost_model::block_cost_limits::MAX_BLOCK_UNITS,
         solana_gossip::cluster_info::ClusterInfo,
         solana_ledger::{
             blockstore::Blockstore, genesis_utils::GenesisConfigInfo,
@@ -554,18 +553,11 @@ mod tests {
             false,
         );
 
-        let scheduler_config = PrioGraphSchedulerConfig {
-            max_cu_per_thread: MAX_BLOCK_UNITS / num_threads as u64,
-            max_transactions_per_scheduling_pass: 100_000,
-            look_ahead_window_size: 2048,
-            target_transactions_per_batch: TARGET_NUM_TRANSACTIONS_PER_BATCH,
-        };
         let scheduler = PrioGraphScheduler::new(
             consume_work_senders,
             finished_consume_work_receiver,
-            scheduler_config,
+            PrioGraphSchedulerConfig::default(),
         );
-
         let scheduler_controller = SchedulerController::new(
             decision_maker,
             receive_and_buffer,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -557,6 +557,7 @@ mod tests {
         let scheduler_config = PrioGraphSchedulerConfig {
             max_cu_per_thread: MAX_BLOCK_UNITS / num_threads as u64,
             max_transactions_per_scheduling_pass: 100_000,
+            look_ahead_window_size: 2048,
         };
         let scheduler = PrioGraphScheduler::new(
             consume_work_senders,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -441,13 +441,17 @@ mod tests {
                 packet_deserializer::PacketDeserializer,
                 scheduler_messages::{ConsumeWork, FinishedConsumeWork, TransactionBatchId},
                 tests::create_slow_genesis_config,
-                transaction_scheduler::receive_and_buffer::SanitizedTransactionReceiveAndBuffer,
+                transaction_scheduler::{
+                    prio_graph_scheduler::PrioGraphSchedulerConfig,
+                    receive_and_buffer::SanitizedTransactionReceiveAndBuffer,
+                },
             },
             banking_trace::BankingPacketBatch,
             sigverify::SigverifyTracerPacketStats,
         },
         crossbeam_channel::{unbounded, Receiver, Sender},
         itertools::Itertools,
+        solana_cost_model::block_cost_limits::MAX_BLOCK_UNITS,
         solana_gossip::cluster_info::ClusterInfo,
         solana_ledger::{
             blockstore::Blockstore, genesis_utils::GenesisConfigInfo,
@@ -550,11 +554,21 @@ mod tests {
             false,
         );
 
+        let scheduler_config = PrioGraphSchedulerConfig {
+            max_cu_per_thread: MAX_BLOCK_UNITS / num_threads as u64,
+            max_transactions_per_scheduling_pass: 100_000,
+        };
+        let scheduler = PrioGraphScheduler::new(
+            consume_work_senders,
+            finished_consume_work_receiver,
+            scheduler_config,
+        );
+
         let scheduler_controller = SchedulerController::new(
             decision_maker,
             receive_and_buffer,
             bank_forks,
-            PrioGraphScheduler::new(consume_work_senders, finished_consume_work_receiver),
+            scheduler,
             vec![], // no actual workers with metrics to report, this can be empty
             None,
         );

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -558,6 +558,7 @@ mod tests {
             max_cu_per_thread: MAX_BLOCK_UNITS / num_threads as u64,
             max_transactions_per_scheduling_pass: 100_000,
             look_ahead_window_size: 2048,
+            target_transactions_per_batch: TARGET_NUM_TRANSACTIONS_PER_BATCH,
         };
         let scheduler = PrioGraphScheduler::new(
             consume_work_senders,


### PR DESCRIPTION
#### Problem
- Various constants for prio-graph scheduler behavior are used
- They are spread around which makes changing them harder for people who are not as familiar with the code

#### Summary of Changes
- Create a `PrioGraphSchedulerConfig` to wrap these constants
- Pass `config` to `PrioGraphScheduler::new`
- `schedule` uses config instead of constants

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
