### PR TITLE
IgnoreReclaims in indexgen

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -737,6 +737,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let entry = map.entry(pubkey);
         m.stop();
         let new_entry_zero_lamports = new_entry.is_zero_lamport();
+        let upsert_reclaim = UpsertReclaim::IgnoreReclaims;
         let (found_in_mem, already_existed) = match entry {
             Entry::Occupied(occupied) => {
                 // in cache, so merge into cache
@@ -746,7 +747,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     (slot, account_info),
                     None, // should be None because we don't expect a different slot # during index generation
                     &mut Vec::default(),
-                    UpsertReclaim::PopulateReclaims, // this should be ignore?
+                    upsert_reclaim,
                 );
                 (
                     true, /* found in mem */
@@ -766,7 +767,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                         // There can be no 'other' slot in the list.
                         None,
                         &mut Vec::default(),
-                        UpsertReclaim::PopulateReclaims,
+                        upsert_reclaim,
                     );
                     vacant.insert(disk_entry);
                     (

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -737,7 +737,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let entry = map.entry(pubkey);
         m.stop();
         let new_entry_zero_lamports = new_entry.is_zero_lamport();
-        let upsert_reclaim = UpsertReclaim::IgnoreReclaims;
         let (found_in_mem, already_existed) = match entry {
             Entry::Occupied(occupied) => {
                 // in cache, so merge into cache
@@ -747,7 +746,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     (slot, account_info),
                     None, // should be None because we don't expect a different slot # during index generation
                     &mut Vec::default(),
-                    upsert_reclaim,
+                    UpsertReclaim::IgnoreReclaims,
                 );
                 (
                     true, /* found in mem */
@@ -767,7 +766,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                         // There can be no 'other' slot in the list.
                         None,
                         &mut Vec::default(),
-                        upsert_reclaim,
+                        UpsertReclaim::IgnoreReclaims,
                     );
                     vacant.insert(disk_entry);
                     (


### PR DESCRIPTION
#### Problem

We don't need to populate `reclaims` at index generation time when we call `upsert`.


#### Summary of Changes

Ignore populating `reclaims` at index generation time.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
