### PR TITLE
Correct a typo: mistmatch -> mismatch

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2509,7 +2509,7 @@ pub enum ValidatorError {
     )]
     PohTooSlow { mine: u64, target: u64 },
 
-    #[error("shred version mistmatch: actual {actual}, expected {expected}")]
+    #[error("shred version mismatch: actual {actual}, expected {expected}")]
     ShredVersionMismatch { actual: u16, expected: u16 },
 
     #[error(transparent)]


### PR DESCRIPTION
#### Problem
Currently the code has a typo "mistmatch". It does not impact the functionality of the code but it pollutes the agave client log with this wrong spelling of mismatch. 

#### Summary of Changes
I made this small change from "mistmatch" to "mismatch".

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
