### PR TITLE
Skip redundant cost limit update in banking-bench

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -554,11 +554,6 @@ fn main() {
             bank = bank_forks.read().unwrap().working_bank();
             insert_time.stop();
 
-            // set cost tracker limits to MAX so it will not filter out TXs
-            bank.write_cost_tracker()
-                .unwrap()
-                .set_limits(u64::MAX, u64::MAX, u64::MAX);
-
             assert!(poh_recorder.read().unwrap().bank().is_none());
             poh_recorder
                 .write()


### PR DESCRIPTION
#### Problem

as cost limit inheriting was sneaked in #2733 _by me_, banking-bench is currently needlessly setting the bank cost limits to max repeatedly inside the loop.

the bench is doing it already before the loop and it's enough by now.

#### Summary of Changes

Remove the redundant setting in banking-stage.

extracted from #3946, see the pr for the general overview.