### PR TITLE
uses serde_bytes for (de)serializing Vec<u8>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
+ "serde_bytes",
  "serde_derive",
  "serde_json",
  "signal-hook",

--- a/core/src/consensus/tower_storage.rs
+++ b/core/src/consensus/tower_storage.rs
@@ -79,11 +79,12 @@ impl From<SavedTower1_7_14> for SavedTowerVersions {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "2XiuhmDfRzWGdwZdMbpH5NcjGnTRi9zY1XTNHSknddA7")
+    frozen_abi(digest = "GqJW8vVvSkSZwTJE6x6MFFhi7kcU6mqst8PF7493h2hk")
 )]
 #[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SavedTower {
     signature: Signature,
+    #[serde(with = "serde_bytes")]
     data: Vec<u8>,
     #[serde(skip)]
     node_pubkey: Pubkey,

--- a/gossip/src/deprecated.rs
+++ b/gossip/src/deprecated.rs
@@ -19,5 +19,6 @@ impl Default for CompressionType {
 pub(crate) struct EpochIncompleteSlots {
     first: Slot,
     compression: CompressionType,
+    #[serde(with = "serde_bytes")]
     compressed_list: Vec<u8>,
 }

--- a/gossip/src/epoch_slots.rs
+++ b/gossip/src/epoch_slots.rs
@@ -45,6 +45,7 @@ impl Sanitize for Uncompressed {
 pub struct Flate2 {
     pub first_slot: Slot,
     pub num: usize,
+    #[serde(with = "serde_bytes")]
     pub compressed: Vec<u8>,
 }
 

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -24,6 +24,7 @@ num_cpus = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
+serde_bytes = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 solana-account-decoder = { workspace = true }

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -361,6 +361,7 @@ pub struct CliDuplicateShred {
     merkle_root: Option<Hash>,
     chained_merkle_root: Option<Hash>,
     last_in_slot: bool,
+    #[serde(with = "serde_bytes")]
     payload: Vec<u8>,
 }
 

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -60,6 +60,7 @@ struct Account {
 struct Input {
     program_id: String,
     accounts: Vec<Account>,
+    #[serde(with = "serde_bytes")]
     instruction_data: Vec<u8>,
 }
 fn load_accounts(path: &Path) -> Result<Input> {


### PR DESCRIPTION

#### Problem
By default `Vec<u8>` is treated just as any `Vec<T>` and is inefficiently (de)serialized byte by byte.
`serde_bytes` instead uses `Serializer::serialize_bytes` and `Deserializer::deserialize_bytes` which do so more efficiently.
https://docs.rs/serde/latest/serde/trait.Serializer.html#tymethod.serialize_bytes
https://docs.rs/serde/latest/serde/trait.Deserializer.html#tymethod.deserialize_bytes


#### Summary of Changes
The commit uses `serde_bytes` for (de)serializing `Vec<u8>`.