### PR TITLE
Snapshots use lattice-based accounts hash

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -512,6 +512,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalWithVerify,
     enable_experimental_accumulator_hash: false,
     verify_experimental_accumulator_hash: false,
+    snapshots_use_experimental_accumulator_hash: false,
     num_clean_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
@@ -538,6 +539,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalWithVerify,
     enable_experimental_accumulator_hash: false,
     verify_experimental_accumulator_hash: false,
+    snapshots_use_experimental_accumulator_hash: false,
     num_clean_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
@@ -666,6 +668,7 @@ pub struct AccountsDbConfig {
     pub scan_filter_for_shrinking: ScanFilter,
     pub enable_experimental_accumulator_hash: bool,
     pub verify_experimental_accumulator_hash: bool,
+    pub snapshots_use_experimental_accumulator_hash: bool,
     /// Number of threads for background cleaning operations (`thread_pool_clean')
     pub num_clean_threads: Option<NonZeroUsize>,
     /// Number of threads for foreground operations (`thread_pool`)
@@ -1627,6 +1630,10 @@ pub struct AccountsDb {
     /// (For R&D only)
     pub verify_experimental_accumulator_hash: bool,
 
+    /// Flag to indicate if the experimental accounts lattice hash is used for snapshots.
+    /// (For R&D only; a feature-gate also exists to turn this on.)
+    pub snapshots_use_experimental_accumulator_hash: AtomicBool,
+
     /// These are the ancient storages that could be valuable to
     /// shrink, sorted by amount of dead bytes.  The elements
     /// are sorted from the largest dead bytes to the smallest.
@@ -2046,6 +2053,9 @@ impl AccountsDb {
                 .into(),
             verify_experimental_accumulator_hash: accounts_db_config
                 .verify_experimental_accumulator_hash,
+            snapshots_use_experimental_accumulator_hash: accounts_db_config
+                .snapshots_use_experimental_accumulator_hash
+                .into(),
             thread_pool,
             thread_pool_clean,
             thread_pool_hash,
@@ -2133,6 +2143,18 @@ impl AccountsDb {
     /// Sets if the experimental accounts lattice hash is enabled
     pub fn set_is_experimental_accumulator_hash_enabled(&self, is_enabled: bool) {
         self.is_experimental_accumulator_hash_enabled
+            .store(is_enabled, Ordering::Release);
+    }
+
+    /// Returns if snapshots use the experimental accounts lattice hash
+    pub fn snapshots_use_experimental_accumulator_hash(&self) -> bool {
+        self.snapshots_use_experimental_accumulator_hash
+            .load(Ordering::Acquire)
+    }
+
+    /// Sets if snapshots use the experimental accounts lattice hash
+    pub fn set_snapshots_use_experimental_accumulator_hash(&self, is_enabled: bool) {
+        self.snapshots_use_experimental_accumulator_hash
             .store(is_enabled, Ordering::Release);
     }
 

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1280,6 +1280,15 @@ pub const ZERO_LAMPORT_ACCOUNT_LT_HASH: AccountLtHash = AccountLtHash(LtHash::id
 pub struct AccountsLtHash(pub LtHash);
 
 /// Hash of accounts
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum MerkleOrLatticeAccountsHash {
+    /// Merkle-based hash of accounts
+    Merkle(AccountsHashKind),
+    /// Lattice-based hash of accounts
+    Lattice,
+}
+
+/// Hash of accounts
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum AccountsHashKind {
     Full(AccountsHash),

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -628,17 +628,24 @@ enum VerifyAccountsKind {
     Merkle,
     Lattice,
 }
+#[derive(Debug, Eq, PartialEq)]
+enum VerifySnapshotHashKind {
+    Merkle,
+    Lattice,
+}
 
 /// Spin up the background services fully then test taking & verifying snapshots
 #[test_matrix(
     V1_2_0,
     [Development, Devnet, Testnet, MainnetBeta],
-    [VerifyAccountsKind::Merkle, VerifyAccountsKind::Lattice]
+    [VerifyAccountsKind::Merkle, VerifyAccountsKind::Lattice],
+    [VerifySnapshotHashKind::Merkle, VerifySnapshotHashKind::Lattice]
 )]
 fn test_snapshots_with_background_services(
     snapshot_version: SnapshotVersion,
     cluster_type: ClusterType,
     verify_accounts_kind: VerifyAccountsKind,
+    verify_snapshot_hash_kind: VerifySnapshotHashKind,
 ) {
     solana_logger::setup();
 
@@ -825,6 +832,8 @@ fn test_snapshots_with_background_services(
     let (_tmp_dir, temporary_accounts_dir) = create_tmp_accounts_dir_for_tests();
     let accounts_db_config = AccountsDbConfig {
         enable_experimental_accumulator_hash: verify_accounts_kind == VerifyAccountsKind::Lattice,
+        snapshots_use_experimental_accumulator_hash: verify_snapshot_hash_kind
+            == VerifySnapshotHashKind::Lattice,
         ..ACCOUNTS_DB_CONFIG_FOR_TESTING
     };
     let (deserialized_bank, ..) = snapshot_bank_utils::bank_from_latest_snapshot_archives(

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -135,6 +135,10 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .long("accounts-db-verify-experimental-accumulator-hash")
             .help("Verifies the experimental accumulator hash")
             .hidden(hidden_unless_forced()),
+        Arg::with_name("accounts_db_snapshots_use_experimental_accumulator_hash")
+            .long("accounts-db-snapshots-use-experimental-accumulator-hash")
+            .help("Snapshots use the experimental accumulator hash")
+            .hidden(hidden_unless_forced()),
         Arg::with_name("accounts_db_hash_threads")
             .long("accounts-db-hash-threads")
             .value_name("NUM_THREADS")
@@ -398,6 +402,8 @@ pub fn get_accounts_db_config(
             .is_present("accounts_db_experimental_accumulator_hash"),
         verify_experimental_accumulator_hash: arg_matches
             .is_present("accounts_db_verify_experimental_accumulator_hash"),
+        snapshots_use_experimental_accumulator_hash: arg_matches
+            .is_present("accounts_db_snapshots_use_experimental_accumulator_hash"),
         num_hash_threads,
         ..AccountsDbConfig::default()
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -79,7 +79,7 @@ use {
         },
         accounts_hash::{
             AccountHash, AccountsHash, AccountsLtHash, CalcAccountsHashConfig, HashStats,
-            IncrementalAccountsHash,
+            IncrementalAccountsHash, MerkleOrLatticeAccountsHash,
         },
         accounts_index::{IndexKey, ScanConfig, ScanResult},
         accounts_partition::{self, Partition, PartitionIndex},
@@ -6223,20 +6223,52 @@ impl Bank {
     ///
     /// # Panics
     ///
-    /// Panics if there is both-or-neither of an `AccountsHash` and an `IncrementalAccountsHash`
-    /// for this bank's slot.  There may only be one or the other.
+    /// If the snapshots lt hash feature is not enabled, panics if there is both-or-neither of an
+    /// `AccountsHash` and an `IncrementalAccountsHash` for this bank's slot.  There may only be
+    /// one or the other.
     pub fn get_snapshot_hash(&self) -> SnapshotHash {
+        if self.is_snapshots_lt_hash_enabled() {
+            self.get_lattice_snapshot_hash()
+        } else {
+            self.get_merkle_snapshot_hash()
+        }
+    }
+
+    /// Returns the merkle-based `SnapshotHash` for this bank's slot
+    ///
+    /// This fn is used at startup to verify the bank was rebuilt correctly.
+    ///
+    /// # Panics
+    ///
+    /// If the snapshots lt hash feature is not enabled, panics if there is both-or-neither of an
+    /// `AccountsHash` and an `IncrementalAccountsHash` for this bank's slot.  There may only be
+    /// one or the other.
+    pub fn get_merkle_snapshot_hash(&self) -> SnapshotHash {
         let accounts_hash = self.get_accounts_hash();
         let incremental_accounts_hash = self.get_incremental_accounts_hash();
-
-        let accounts_hash = match (accounts_hash, incremental_accounts_hash) {
+        let accounts_hash_kind = match (accounts_hash, incremental_accounts_hash) {
             (Some(_), Some(_)) => panic!("Both full and incremental accounts hashes are present for slot {}; it is ambiguous which one to use for the snapshot hash!", self.slot()),
             (Some(accounts_hash), None) => accounts_hash.into(),
             (None, Some(incremental_accounts_hash)) => incremental_accounts_hash.into(),
             (None, None) => panic!("accounts hash is required to get snapshot hash"),
         };
         let epoch_accounts_hash = self.get_epoch_accounts_hash_to_serialize();
-        SnapshotHash::new(&accounts_hash, epoch_accounts_hash.as_ref())
+        SnapshotHash::new(
+            &MerkleOrLatticeAccountsHash::Merkle(accounts_hash_kind),
+            epoch_accounts_hash.as_ref(),
+            None,
+        )
+    }
+
+    /// Returns the lattice-based `SnapshotHash` for this bank's slot
+    ///
+    /// This fn is used at startup to verify the bank was rebuilt correctly.
+    pub fn get_lattice_snapshot_hash(&self) -> SnapshotHash {
+        SnapshotHash::new(
+            &MerkleOrLatticeAccountsHash::Lattice,
+            self.get_epoch_accounts_hash_to_serialize().as_ref(),
+            Some(self.accounts_lt_hash.lock().unwrap().0.checksum()),
+        )
     }
 
     pub fn load_account_into_read_cache(&self, key: &Pubkey) {

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -29,6 +29,19 @@ impl Bank {
                 .is_active(&feature_set::accounts_lt_hash::id())
     }
 
+    /// Returns if snapshots use the accounts lt hash
+    pub fn is_snapshots_lt_hash_enabled(&self) -> bool {
+        self.is_accounts_lt_hash_enabled()
+            && (self
+                .rc
+                .accounts
+                .accounts_db
+                .snapshots_use_experimental_accumulator_hash()
+                || self
+                    .feature_set
+                    .is_active(&feature_set::snapshots_lt_hash::id()))
+    }
+
     /// Updates the accounts lt hash
     ///
     /// When freezing a bank, we compute and update the accounts lt hash.
@@ -1159,6 +1172,95 @@ mod tests {
         let (_accounts_tempdir, accounts_dir) = snapshot_utils::create_tmp_accounts_dir_for_tests();
         let accounts_db_config = AccountsDbConfig {
             enable_experimental_accumulator_hash: match verify_cli {
+                Cli::Off => false,
+                Cli::On => true,
+            },
+            ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+        };
+        let (roundtrip_bank, _) = snapshot_bank_utils::bank_from_snapshot_archives(
+            &[accounts_dir],
+            &bank_snapshots_dir,
+            &snapshot,
+            None,
+            &genesis_config,
+            &RuntimeConfig::default(),
+            None,
+            None,
+            None,
+            false,
+            false,
+            false,
+            false,
+            Some(accounts_db_config),
+            None,
+            Arc::default(),
+        )
+        .unwrap();
+
+        // Wait for the startup verification to complete.  If we don't panic, then we're good!
+        roundtrip_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
+        assert_eq!(roundtrip_bank, *bank);
+    }
+
+    /// Ensure that the snapshot hash is correct when snapshots_lt_hash is enabled
+    #[test_matrix(
+        [Features::None, Features::All],
+        [Cli::Off, Cli::On],
+        [Cli::Off, Cli::On]
+    )]
+    fn test_snapshots_lt_hash(features: Features, cli: Cli, verify_cli: Cli) {
+        let (genesis_config, mint_keypair) = genesis_config_with(features);
+        let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        bank.rc
+            .accounts
+            .accounts_db
+            .set_is_experimental_accumulator_hash_enabled(features == Features::None);
+        // ensure the accounts lt hash is enabled, otherwise the snapshot lt hash is disabled
+        assert!(bank.is_accounts_lt_hash_enabled());
+
+        bank.rc
+            .accounts
+            .accounts_db
+            .set_snapshots_use_experimental_accumulator_hash(match cli {
+                Cli::Off => false,
+                Cli::On => true,
+            });
+
+        let amount = cmp::max(
+            bank.get_minimum_balance_for_rent_exemption(0),
+            LAMPORTS_PER_SOL,
+        );
+
+        // create some banks with some modified accounts so that there are stored accounts
+        // (note: the number of banks is arbitrary)
+        for _ in 0..3 {
+            let slot = bank.slot() + 1;
+            bank =
+                new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
+            bank.register_unique_recent_blockhash_for_test();
+            bank.transfer(amount, &mint_keypair, &pubkey::new_rand())
+                .unwrap();
+            bank.fill_bank_with_ticks_for_tests();
+            bank.squash();
+            bank.force_flush_accounts_cache();
+        }
+
+        let snapshot_config = SnapshotConfig::default();
+        let bank_snapshots_dir = TempDir::new().unwrap();
+        let snapshot_archives_dir = TempDir::new().unwrap();
+        let snapshot = snapshot_bank_utils::bank_to_full_snapshot_archive(
+            &bank_snapshots_dir,
+            &bank,
+            Some(snapshot_config.snapshot_version),
+            &snapshot_archives_dir,
+            &snapshot_archives_dir,
+            snapshot_config.archive_format,
+        )
+        .unwrap();
+        let (_accounts_tempdir, accounts_dir) = snapshot_utils::create_tmp_accounts_dir_for_tests();
+        let accounts_db_config = AccountsDbConfig {
+            enable_experimental_accumulator_hash: features == Features::None,
+            snapshots_use_experimental_accumulator_hash: match verify_cli {
                 Cli::Off => false,
                 Cli::On => true,
             },

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -339,8 +339,11 @@ pub enum SnapshotError {
     #[error("no snapshot archives to load from '{0}'")]
     NoSnapshotArchives(PathBuf),
 
-    #[error("snapshot has mismatch: deserialized bank: {0:?}, snapshot archive info: {1:?}")]
-    MismatchedSlotHash((Slot, SnapshotHash), (Slot, SnapshotHash)),
+    #[error("snapshot slot mismatch: deserialized bank: {0}, snapshot archive: {1}")]
+    MismatchedSlot(Slot, Slot),
+
+    #[error("snapshot hash mismatch: deserialized bank: {0:?}, snapshot archive: {1:?}")]
+    MismatchedHash(SnapshotHash, SnapshotHash),
 
     #[error("snapshot slot deltas are invalid: {0}")]
     VerifySlotDeltas(#[from] VerifySlotDeltasError),

--- a/sdk/feature-set/src/lib.rs
+++ b/sdk/feature-set/src/lib.rs
@@ -888,6 +888,10 @@ pub mod accounts_lt_hash {
     solana_pubkey::declare_id!("LtHaSHHsUge7EWTPVrmpuexKz6uVHZXZL6cgJa7W7Zn");
 }
 
+pub mod snapshots_lt_hash {
+    solana_pubkey::declare_id!("LTsNAP8h1voEVVToMNBNqoiNQex4aqfUrbFhRH3mSQ2");
+}
+
 pub mod migrate_stake_program_to_core_bpf {
     solana_pubkey::declare_id!("6M4oQ6eXneVhtLoiAr4yRYQY43eVLjrKbiDZDJc892yk");
 }
@@ -1120,6 +1124,7 @@ lazy_static! {
         (lift_cpi_caller_restriction::id(), "Lift the restriction in CPI that the caller must have the callee as an instruction account #2202"),
         (disable_account_loader_special_case::id(), "Disable account loader special case #3513"),
         (accounts_lt_hash::id(), "enables lattice-based accounts hash #3333"),
+        (snapshots_lt_hash::id(), "snapshots use lattice-based accounts hash #3598"),
         (enable_secp256r1_precompile::id(), "Enable secp256r1 precompile SIMD-0075"),
         (migrate_stake_program_to_core_bpf::id(), "Migrate Stake program to Core BPF SIMD-0196 #3655"),
         (deplete_cu_meter_on_vm_failure::id(), "Deplete compute meter for vm errors SIMD-0182 #3993"),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1435,6 +1435,12 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .hidden(hidden_unless_forced()),
         )
         .arg(
+            Arg::with_name("accounts_db_snapshots_use_experimental_accumulator_hash")
+                .long("accounts-db-snapshots-use-experimental-accumulator-hash")
+                .help("Snapshots use the experimental accumulator hash")
+                .hidden(hidden_unless_forced()),
+        )
+        .arg(
             Arg::with_name("accounts_index_scan_results_limit_mb")
                 .long("accounts-index-scan-results-limit-mb")
                 .value_name("MEGABYTES")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1371,6 +1371,8 @@ pub fn main() {
             .is_present("accounts_db_experimental_accumulator_hash"),
         verify_experimental_accumulator_hash: matches
             .is_present("accounts_db_verify_experimental_accumulator_hash"),
+        snapshots_use_experimental_accumulator_hash: matches
+            .is_present("accounts_db_snapshots_use_experimental_accumulator_hash"),
         num_clean_threads: Some(accounts_db_clean_threads),
         num_foreground_threads: Some(accounts_db_foreground_threads),
         num_hash_threads: Some(accounts_db_hash_threads),


### PR DESCRIPTION
#### Problem

With the accounts lattice hash, we no longer need to do an expensive merkle-based accounts hash calculation for snapshots. Instead, we can use the accounts lattice hash directly.

See https://github.com/anza-xyz/agave/issues/3598 for more information.


#### Summary of Changes

If the snapshots lt hash is enabled (either feature gate or cli arg), then do not do a merkle-based accounts hash calculation for snapshots; use the accounts lt hash directly.

Feature Gate Issue: #3598
