### PR TITLE
gossip: Add `save_contact_info_time` metric

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -308,6 +308,7 @@ impl ClusterInfo {
     }
 
     pub fn save_contact_info(&self) {
+        let _st = ScopedTimer::from(&self.stats.save_contact_info_time);
         let nodes = {
             let entrypoint_gossip_addrs = self
                 .entrypoints

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -171,6 +171,7 @@ pub struct GossipStats {
     pub(crate) push_vote_read: Counter,
     pub(crate) repair_peers: Counter,
     pub(crate) require_stake_for_gossip_unknown_stakes: Counter,
+    pub(crate) save_contact_info_time: Counter,
     pub(crate) skip_pull_response_shred_version: Counter,
     pub(crate) skip_pull_shred_version: Counter,
     pub(crate) skip_push_message_shred_version: Counter,
@@ -316,6 +317,11 @@ pub(crate) fn submit_gossip_stats(
         (
             "push_response_count",
             stats.push_response_count.clear(),
+            i64
+        ),
+        (
+            "save_contact_info_time",
+            stats.save_contact_info_time.clear(),
             i64
         ),
     );


### PR DESCRIPTION
Add `save_contact_info_time` metric which measures the time spent by the `solGossip` thread on fetching and saving contact info.