### PR TITLE
Reduce the usage of global rayon thread pool in accountsdb

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1532,9 +1532,9 @@ pub struct AccountsDb {
 
     /// Foreground thread pool used for par_iter
     pub thread_pool: ThreadPool,
-    /// Background operations
+    /// Thread pool for AccountsBackgroundServices
     pub thread_pool_clean: ThreadPool,
-    /// Background hashing thread pool
+    /// Thread pool for AccountsHashVerifier
     pub thread_pool_hash: ThreadPool,
 
     accounts_delta_hashes: Mutex<HashMap<Slot, AccountsDeltaHash>>,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -689,6 +689,7 @@ impl Validator {
         for cluster_entrypoint in &cluster_entrypoints {
             info!("entrypoint: {:?}", cluster_entrypoint);
         }
+
         if solana_perf::perf_libs::api().is_some() {
             info!("Initializing sigverify, this could take a while...");
         } else {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -619,12 +619,12 @@ impl Validator {
 
         let start_time = Instant::now();
 
-        // Initialize the global rayon pool first to ensure the value in config
-        // is honored. Otherwise, some code accessing the global pool could
-        // cause it to get initialized with Rayon's default (not ours)
+        // Initialize the global rayon pool with one thread to ensure people do not use
+        // it accidentally. Otherwise, some code accessing the global pool could
+        // cause it to get initialized with Rayon's default of all cores which is always wrong for agave
         if rayon::ThreadPoolBuilder::new()
             .thread_name(|i| format!("solRayonGlob{i:02}"))
-            .num_threads(config.rayon_global_threads.get())
+            .num_threads(1)
             .build_global()
             .is_err()
         {
@@ -689,7 +689,6 @@ impl Validator {
         for cluster_entrypoint in &cluster_entrypoints {
             info!("entrypoint: {:?}", cluster_entrypoint);
         }
-
         if solana_perf::perf_libs::api().is_some() {
             info!("Initializing sigverify, this could take a while...");
         } else {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -619,12 +619,12 @@ impl Validator {
 
         let start_time = Instant::now();
 
-        // Initialize the global rayon pool with one thread to ensure people do not use
-        // it accidentally. Otherwise, some code accessing the global pool could
-        // cause it to get initialized with Rayon's default of all cores which is always wrong for agave
+        // Initialize the global rayon pool first to ensure the value in config
+        // is honored. Otherwise, some code accessing the global pool could
+        // cause it to get initialized with Rayon's default (not ours)
         if rayon::ThreadPoolBuilder::new()
             .thread_name(|i| format!("solRayonGlob{i:02}"))
-            .num_threads(1)
+            .num_threads(config.rayon_global_threads.get())
             .build_global()
             .is_err()
         {


### PR DESCRIPTION
#### Problem
 * Global thread pool in rayon is difficult to manage during agave runtime as it can accidentally use a lot of cores
#### Summary of Changes
* Use one of accountsdB existing thread pools (solAccounts) instead of global pool where appropriate

