### PR TITLE
Fix hanging bench_sigverify_stage_with_same_tx

### DIFF
--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -175,18 +175,20 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
             packet_s.send(batch).unwrap();
         }
         let mut received = 0;
-        trace!("sent: {}", sent_len);
+        let expected = if use_same_tx { 1 } else { sent_len };
+        trace!("sent: {}, expected: {}", sent_len, expected);
         loop {
             if let Ok(verifieds) = verified_r.recv_timeout(Duration::from_millis(10)) {
                 received += verifieds.iter().map(|batch| batch.len()).sum::<usize>();
                 test::black_box(verifieds);
-                if received >= sent_len {
+                if received >= expected {
                     break;
                 }
             }
         }
         trace!("received: {}", received);
     });
+    // This will wait for all packets to make it through sigverify.
     stage.join().unwrap();
 }
 


### PR DESCRIPTION
#### Problem
- Bench is running indefinitely after #4043
- The number of verified packets will never be >1 when we have the same packet

#### Summary of Changes
- Fix exit condition for `use_same_packet` variant of bench

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
