### PR TITLE
retryable_indexes allocated and dropped by scheduler

### DIFF
--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -41,11 +41,9 @@ pub struct ConsumeWork<Tx> {
     pub ids: Vec<TransactionId>,
     pub transactions: Vec<Tx>,
     pub max_ages: Vec<MaxAge>,
-}
 
-/// Message: [Worker -> Scheduler]
-/// Processed transactions.
-pub struct FinishedConsumeWork<Tx> {
-    pub work: ConsumeWork<Tx>,
+    // Only set by consume worker after processing.
+    // This is pre-allocated by the scheduler, and is dropped
+    // by the scheduler upon completion.
     pub retryable_indexes: Vec<usize>,
 }


### PR DESCRIPTION
#### Problem
- Communication pattern between the scheduler and worker thread allocations is a bit off.
- Currently, the scheduler sends a `ConsumeWork` and the workers respond with `FinishedConsumeWork` which holds an additional `Vec<usize>` representing the retryable transactions
- This leads to the worker threads consistently allocating vectors that are then dropped by the scheduler thread

#### Summary of Changes
- Pre-allocate retryable_indexes on work message which is then populated by the workers and returned for inspection/deallocation by the scheduler thread

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
