### PR TITLE
sdk: evict rent collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8596,6 +8596,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-rent-collector"
+version = "2.2.0"
+dependencies = [
+ "assert_matches",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-clock",
+ "solana-epoch-schedule",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-genesis-config",
+ "solana-logger",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+]
+
+[[package]]
 name = "solana-rent-debits"
 version = "2.2.0"
 dependencies = [
@@ -9057,6 +9076,7 @@ dependencies = [
  "solana-program-memory",
  "solana-pubkey",
  "solana-quic-definitions",
+ "solana-rent-collector",
  "solana-rent-debits",
  "solana-reserved-account-keys",
  "solana-reward-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ members = [
     "sdk/pubkey",
     "sdk/quic-definitions",
     "sdk/rent",
+    "sdk/rent-collector",
     "sdk/rent-debits",
     "sdk/reserved-account-keys",
     "sdk/reward-info",
@@ -557,6 +558,7 @@ solana-quic-definitions = { path = "sdk/quic-definitions", version = "=2.2.0" }
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.2.0" }
 solana-remote-wallet = { path = "remote-wallet", version = "=2.2.0", default-features = false }
 solana-rent = { path = "sdk/rent", version = "=2.2.0", default-features = false }
+solana-rent-collector = { path = "sdk/rent-collector", version = "=2.2.0" }
 solana-rent-debits = { path = "sdk/rent-debits", version = "=2.2.0" }
 solana-reserved-account-keys = { path = "sdk/reserved-account-keys", version = "=2.2.0", default-features = false }
 solana-reward-info = { path = "sdk/reward-info", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6806,6 +6806,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-rent-collector"
+version = "2.2.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-clock",
+ "solana-epoch-schedule",
+ "solana-genesis-config",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+]
+
+[[package]]
 name = "solana-rent-debits"
 version = "2.2.0"
 dependencies = [
@@ -7656,6 +7671,7 @@ dependencies = [
  "solana-program-memory",
  "solana-pubkey",
  "solana-quic-definitions",
+ "solana-rent-collector",
  "solana-rent-debits",
  "solana-reserved-account-keys",
  "solana-reward-info",

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -570,7 +570,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "9NABbrKjv1mmcPAmvtav1tVq4cJ7tTwKpHbYj6RDp3hi")
+            frozen_abi(digest = "CiLUqUypBaGKz24XoQbv8EhpyeRD8jwwSFfosYWUrFL4")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapper {

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -45,6 +45,7 @@ full = [
     "dep:solana-precompiles",
     "dep:solana-presigner",
     "dep:solana-quic-definitions",
+    "dep:solana-rent-collector",
     "dep:solana-secp256k1-program",
     "dep:solana-seed-derivable",
     "dep:solana-seed-phrase",
@@ -80,6 +81,7 @@ frozen-abi = [
     "solana-inflation/frozen-abi",
     "solana-poh-config/frozen-abi",
     "solana-program/frozen-abi",
+    "solana-rent-collector/frozen-abi",
     "solana-reward-info/frozen-abi",
     "solana-short-vec/frozen-abi",
     "solana-signature/frozen-abi",
@@ -167,6 +169,9 @@ solana-pubkey = { workspace = true, default-features = false, features = [
     "std",
 ] }
 solana-quic-definitions = { workspace = true, optional = true }
+solana-rent-collector = { workspace = true, features = [
+    "serde"
+], optional = true }
 solana-rent-debits = { workspace = true }
 solana-reserved-account-keys = { workspace = true }
 solana-reward-info = { workspace = true, features = ["serde"] }

--- a/sdk/rent-collector/Cargo.toml
+++ b/sdk/rent-collector/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "solana-rent-collector"
+description = "Calculate and collect rent from accounts."
+documentation = "https://docs.rs/solana-rent-collector"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-account = { workspace = true }
+solana-clock = { workspace = true }
+solana-epoch-schedule = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-genesis-config = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-rent = { workspace = true }
+solana-sdk-ids = { workspace = true }
+
+[dev-dependencies]
+assert_matches = { workspace = true }
+solana-logger = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = [
+  "dep:serde",
+  "dep:serde_derive",
+  "solana-epoch-schedule/serde",
+  "solana-rent/serde",
+]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[lints]
+workspace = true

--- a/sdk/rent-collector/src/lib.rs
+++ b/sdk/rent-collector/src/lib.rs
@@ -1,20 +1,23 @@
-#![cfg(feature = "full")]
+//! Calculate and collect rent from accounts.
 
-//! calculate and collect rent from Accounts
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+
 use {
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
-    solana_sdk::{
-        clock::Epoch,
-        epoch_schedule::EpochSchedule,
-        genesis_config::GenesisConfig,
-        incinerator,
-        pubkey::Pubkey,
-        rent::{Rent, RentDue},
-    },
+    solana_clock::Epoch,
+    solana_epoch_schedule::EpochSchedule,
+    solana_genesis_config::GenesisConfig,
+    solana_pubkey::Pubkey,
+    solana_rent::{Rent, RentDue},
+    solana_sdk_ids::incinerator,
 };
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RentCollector {
     pub epoch: Epoch,
     pub epoch_schedule: EpochSchedule,
@@ -215,7 +218,9 @@ impl std::ops::AddAssign for CollectedInfo {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, assert_matches::assert_matches, solana_account::Account, solana_sdk::sysvar};
+    use {
+        super::*, assert_matches::assert_matches, solana_account::Account, solana_sdk_ids::sysvar,
+    };
 
     fn default_rent_collector_clone_with_epoch(epoch: Epoch) -> RentCollector {
         RentCollector::default().clone_with_epoch(epoch)
@@ -374,7 +379,7 @@ mod tests {
 
         // collect rent on a newly-created account
         let collected = rent_collector
-            .collect_from_created_account(&solana_sdk::pubkey::new_rand(), &mut created_account);
+            .collect_from_created_account(&solana_pubkey::new_rand(), &mut created_account);
         assert!(created_account.lamports() < old_lamports);
         assert_eq!(
             created_account.lamports() + collected.rent_amount,
@@ -385,7 +390,7 @@ mod tests {
 
         // collect rent on a already-existing account
         let collected = rent_collector
-            .collect_from_existing_account(&solana_sdk::pubkey::new_rand(), &mut existing_account);
+            .collect_from_existing_account(&solana_pubkey::new_rand(), &mut existing_account);
         assert!(existing_account.lamports() < old_lamports);
         assert_eq!(
             existing_account.lamports() + collected.rent_amount,
@@ -406,7 +411,7 @@ mod tests {
             let epoch = 3;
             let huge_lamports = 123_456_789_012;
             let tiny_lamports = 789_012;
-            let pubkey = solana_sdk::pubkey::new_rand();
+            let pubkey = solana_pubkey::new_rand();
 
             assert_eq!(account.rent_epoch(), 0);
 
@@ -441,7 +446,7 @@ mod tests {
         account.set_owner(sysvar::id());
         account.set_lamports(tiny_lamports);
 
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
 
         assert_eq!(account.rent_epoch(), 0);
 

--- a/sdk/rent-collector/src/lib.rs
+++ b/sdk/rent-collector/src/lib.rs
@@ -1,5 +1,5 @@
 //! Calculate and collect rent from accounts.
-
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 use {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -79,7 +79,9 @@ pub mod net;
 pub mod precompiles;
 pub mod program_utils;
 pub mod pubkey;
-pub mod rent_collector;
+#[cfg(feature = "full")]
+#[deprecated(since = "2.2.0", note = "Use `solana_rent_collector` crate instead")]
+pub use solana_rent_collector as rent_collector;
 #[deprecated(since = "2.2.0", note = "Use `solana-reward-info` crate instead")]
 pub mod reward_info {
     pub use solana_reward_info::RewardInfo;
@@ -252,10 +254,8 @@ macro_rules! saturating_add_assign {
 
 pub extern crate bs58;
 extern crate log as logger;
-#[cfg_attr(not(target_os = "solana"), macro_use)]
 extern crate serde_derive;
 
-#[cfg_attr(feature = "frozen-abi", macro_use)]
 #[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
 

--- a/sdk/src/program_utils.rs
+++ b/sdk/src/program_utils.rs
@@ -22,7 +22,7 @@ pub mod tests {
 
     #[test]
     fn test_limited_deserialize() {
-        #[derive(Deserialize, Serialize)]
+        #[derive(serde_derive::Deserialize, serde_derive::Serialize)]
         enum Foo {
             Bar(Vec<u8>),
         }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6636,6 +6636,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-rent-collector"
+version = "2.2.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-clock",
+ "solana-epoch-schedule",
+ "solana-genesis-config",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+]
+
+[[package]]
 name = "solana-rent-debits"
 version = "2.2.0"
 dependencies = [
@@ -6985,6 +7000,7 @@ dependencies = [
  "solana-program-memory",
  "solana-pubkey",
  "solana-quic-definitions",
+ "solana-rent-collector",
  "solana-rent-debits",
  "solana-reserved-account-keys",
  "solana-reward-info",


### PR DESCRIPTION
Completes the work for #3932 and finally evicts `RentCollector` from the SDK.