### PR TITLE
bench-streamer: Fix argument parsing

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -84,7 +84,7 @@ fn main() -> Result<()> {
         num_sockets = max(num_sockets, n.to_string().parse().expect("integer"));
     }
 
-    let num_producers: u64 = matches.value_of_t("num_producers").unwrap_or(4);
+    let num_producers: u64 = matches.value_of_t("num-producers").unwrap_or(4);
 
     let port = 0;
     let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);


### PR DESCRIPTION
#### Problem
The value to parse is declared as num-producers but the code is currently parsing num_producers. So, this value cannot actually be changed as is