### PR TITLE
make QUIC tpu QOS parameters configurable

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -11,7 +11,7 @@ use {
         pubkey::Pubkey,
         signature::{read_keypair_file, Keypair},
     },
-    solana_streamer::nonblocking::quic::DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
+    solana_streamer::quic::DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
     solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC},
     std::{
         net::{IpAddr, Ipv4Addr},

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -51,6 +51,13 @@ use {
     tokio::sync::mpsc::Sender as AsyncSender,
 };
 
+// allow multiple connections for NAT and any open/close overlap
+#[deprecated(
+    since = "2.2.0",
+    note = "Use solana_streamer::quic::DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER instead"
+)]
+pub const MAX_QUIC_CONNECTIONS_PER_PEER: usize = 8;
+
 pub struct TpuSockets {
     pub transactions: Vec<UdpSocket>,
     pub transaction_forwards: Vec<UdpSocket>,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -2,6 +2,12 @@
 //! multi-stage transaction processing pipeline in software.
 
 pub use solana_sdk::net::DEFAULT_TPU_COALESCE;
+// allow multiple connections for NAT and any open/close overlap
+#[deprecated(
+    since = "2.2.0",
+    note = "Use solana_streamer::quic::DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER instead"
+)]
+pub use solana_streamer::quic::DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER as MAX_QUIC_CONNECTIONS_PER_PEER;
 use {
     crate::{
         banking_stage::BankingStage,
@@ -50,13 +56,6 @@ use {
     },
     tokio::sync::mpsc::Sender as AsyncSender,
 };
-
-// allow multiple connections for NAT and any open/close overlap
-#[deprecated(
-    since = "2.2.0",
-    note = "Use solana_streamer::quic::DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER instead"
-)]
-pub const MAX_QUIC_CONNECTIONS_PER_PEER: usize = 8;
 
 pub struct TpuSockets {
     pub transactions: Vec<UdpSocket>,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -111,7 +111,7 @@ impl Tpu {
         tpu_enable_udp: bool,
         tpu_quic_server_config: QuicServerParams,
         tpu_fwd_quic_server_config: QuicServerParams,
-        voe_quic_server_config: QuicServerParams,
+        vote_quic_server_config: QuicServerParams,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         block_production_method: BlockProductionMethod,
         enable_block_production_forwarding: bool,
@@ -174,7 +174,7 @@ impl Tpu {
             vote_packet_sender.clone(),
             exit.clone(),
             staked_nodes.clone(),
-            voe_quic_server_config,
+            vote_quic_server_config,
         )
         .unwrap();
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -497,16 +497,19 @@ pub struct ValidatorTpuConfig {
 /// A convenient function to build a ValidatorTpuConfig for testing with good
 /// default.
 pub fn build_validator_tpu_config_for_test(tpu_enable_udp: bool) -> ValidatorTpuConfig {
-    let mut tpu_quic_server_config = QuicServerParams::default();
-    tpu_quic_server_config.max_connections_per_ipaddr_per_min = 32;
+    let tpu_quic_server_config = QuicServerParams {
+        max_connections_per_ipaddr_per_min: 32,
+        ..Default::default()
+    };
 
-    let mut tpu_fwd_quic_server_config = QuicServerParams::default();
-    tpu_fwd_quic_server_config.max_connections_per_ipaddr_per_min = 32;
-    tpu_fwd_quic_server_config.max_unstaked_connections = 0;
+    let tpu_fwd_quic_server_config = QuicServerParams {
+        max_connections_per_ipaddr_per_min: 32,
+        max_unstaked_connections: 0,
+        ..Default::default()
+    };
 
-    let mut vote_quic_server_config = QuicServerParams::default();
-    vote_quic_server_config.max_connections_per_ipaddr_per_min = 32;
-    vote_quic_server_config.max_unstaked_connections = 0;
+    // vote and tpu_fwd share the same characteristics -- disallow non-staked connections:
+    let vote_quic_server_config = tpu_fwd_quic_server_config.clone();
 
     ValidatorTpuConfig {
         use_quic: DEFAULT_TPU_USE_QUIC,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -494,15 +494,19 @@ pub struct ValidatorTpuConfig {
     pub vote_quic_server_config: QuicServerParams,
 }
 
+/// A convenient function to build a ValidatorTpuConfig for testing with good
+/// default.
 pub fn build_validator_tpu_config_for_test(tpu_enable_udp: bool) -> ValidatorTpuConfig {
     let mut tpu_quic_server_config = QuicServerParams::default();
     tpu_quic_server_config.max_connections_per_ipaddr_per_min = 32;
 
     let mut tpu_fwd_quic_server_config = QuicServerParams::default();
     tpu_fwd_quic_server_config.max_connections_per_ipaddr_per_min = 32;
+    tpu_fwd_quic_server_config.max_unstaked_connections = 0;
 
     let mut vote_quic_server_config = QuicServerParams::default();
     vote_quic_server_config.max_connections_per_ipaddr_per_min = 32;
+    vote_quic_server_config.max_unstaked_connections = 0;
 
     ValidatorTpuConfig {
         use_quic: DEFAULT_TPU_USE_QUIC,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -494,31 +494,33 @@ pub struct ValidatorTpuConfig {
     pub vote_quic_server_config: QuicServerParams,
 }
 
-/// A convenient function to build a ValidatorTpuConfig for testing with good
-/// default.
-pub fn build_validator_tpu_config_for_test(tpu_enable_udp: bool) -> ValidatorTpuConfig {
-    let tpu_quic_server_config = QuicServerParams {
-        max_connections_per_ipaddr_per_min: 32,
-        ..Default::default()
-    };
+impl ValidatorTpuConfig {
+    /// A convenient function to build a ValidatorTpuConfig for testing with good
+    /// default.
+    pub fn new_for_tests(tpu_enable_udp: bool) -> Self {
+        let tpu_quic_server_config = QuicServerParams {
+            max_connections_per_ipaddr_per_min: 32,
+            ..Default::default()
+        };
 
-    let tpu_fwd_quic_server_config = QuicServerParams {
-        max_connections_per_ipaddr_per_min: 32,
-        max_unstaked_connections: 0,
-        ..Default::default()
-    };
+        let tpu_fwd_quic_server_config = QuicServerParams {
+            max_connections_per_ipaddr_per_min: 32,
+            max_unstaked_connections: 0,
+            ..Default::default()
+        };
 
-    // vote and tpu_fwd share the same characteristics -- disallow non-staked connections:
-    let vote_quic_server_config = tpu_fwd_quic_server_config.clone();
+        // vote and tpu_fwd share the same characteristics -- disallow non-staked connections:
+        let vote_quic_server_config = tpu_fwd_quic_server_config.clone();
 
-    ValidatorTpuConfig {
-        use_quic: DEFAULT_TPU_USE_QUIC,
-        vote_use_quic: DEFAULT_VOTE_USE_QUIC,
-        tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
-        tpu_enable_udp,
-        tpu_quic_server_config,
-        tpu_fwd_quic_server_config,
-        vote_quic_server_config,
+        ValidatorTpuConfig {
+            use_quic: DEFAULT_TPU_USE_QUIC,
+            vote_use_quic: DEFAULT_VOTE_USE_QUIC,
+            tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            tpu_enable_udp,
+            tpu_quic_server_config,
+            tpu_fwd_quic_server_config,
+            vote_quic_server_config,
+        }
     }
 }
 
@@ -2800,7 +2802,7 @@ mod tests {
             None, // rpc_to_plugin_manager_receiver
             start_progress.clone(),
             SocketAddrSpace::Unspecified,
-            build_validator_tpu_config_for_test(DEFAULT_TPU_ENABLE_UDP),
+            ValidatorTpuConfig::new_for_tests(DEFAULT_TPU_ENABLE_UDP),
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
@@ -3016,7 +3018,7 @@ mod tests {
                     None, // rpc_to_plugin_manager_receiver
                     Arc::new(RwLock::new(ValidatorStartProgress::default())),
                     SocketAddrSpace::Unspecified,
-                    build_validator_tpu_config_for_test(DEFAULT_TPU_ENABLE_UDP),
+                    ValidatorTpuConfig::new_for_tests(DEFAULT_TPU_ENABLE_UDP),
                     Arc::new(RwLock::new(None)),
                 )
                 .expect("assume successful validator start")

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -496,13 +496,13 @@ pub struct ValidatorTpuConfig {
 
 pub fn build_validator_tpu_config_for_test(tpu_enable_udp: bool) -> ValidatorTpuConfig {
     let mut tpu_quic_server_config = QuicServerParams::default();
-    tpu_quic_server_config.max_connections_per_peer = 32; // max connections per IpAddr per minute
+    tpu_quic_server_config.max_connections_per_ipaddr_per_min = 32;
 
     let mut tpu_fwd_quic_server_config = QuicServerParams::default();
-    tpu_fwd_quic_server_config.max_connections_per_peer = 32; // max connections per IpAddr per minute
+    tpu_fwd_quic_server_config.max_connections_per_ipaddr_per_min = 32;
 
     let mut vote_quic_server_config = QuicServerParams::default();
-    vote_quic_server_config.max_connections_per_peer = 32; // max connections per IpAddr per minute
+    vote_quic_server_config.max_connections_per_ipaddr_per_min = 32;
 
     ValidatorTpuConfig {
         use_quic: DEFAULT_TPU_USE_QUIC,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -11,7 +11,9 @@ use {
     solana_client::connection_cache::ConnectionCache,
     solana_core::{
         consensus::tower_storage::FileTowerStorage,
-        validator::{Validator, ValidatorConfig, ValidatorStartProgress, ValidatorTpuConfig},
+        validator::{
+            build_validator_tpu_config_for_test, Validator, ValidatorConfig, ValidatorStartProgress,
+        },
     },
     solana_gossip::{
         cluster_info::Node,
@@ -341,15 +343,9 @@ impl LocalCluster {
             None, // rpc_to_plugin_manager_receiver
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            ValidatorTpuConfig {
-                use_quic: DEFAULT_TPU_USE_QUIC,
-                vote_use_quic: DEFAULT_VOTE_USE_QUIC,
-                tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
-                // We are turning tpu_enable_udp to true in order to prevent concurrent local cluster tests
-                // to use the same QUIC ports due to SO_REUSEPORT.
-                tpu_enable_udp: true,
-                tpu_max_connections_per_ipaddr_per_minute: 32, // max connections per IpAddr per minute
-            },
+            // We are turning tpu_enable_udp to true in order to prevent concurrent local cluster tests
+            // to use the same QUIC ports due to SO_REUSEPORT.
+            build_validator_tpu_config_for_test(true),
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
@@ -553,13 +549,7 @@ impl LocalCluster {
             None, // rpc_to_plugin_manager_receiver
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            ValidatorTpuConfig {
-                use_quic: DEFAULT_TPU_USE_QUIC,
-                vote_use_quic: DEFAULT_VOTE_USE_QUIC,
-                tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
-                tpu_enable_udp: DEFAULT_TPU_ENABLE_UDP,
-                tpu_max_connections_per_ipaddr_per_minute: 32, // max connections per IpAddr per mintute
-            },
+            build_validator_tpu_config_for_test(DEFAULT_TPU_ENABLE_UDP),
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
@@ -1089,13 +1079,7 @@ impl Cluster for LocalCluster {
             None, // rpc_to_plugin_manager_receiver
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            ValidatorTpuConfig {
-                use_quic: DEFAULT_TPU_USE_QUIC,
-                vote_use_quic: DEFAULT_VOTE_USE_QUIC,
-                tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
-                tpu_enable_udp: DEFAULT_TPU_ENABLE_UDP,
-                tpu_max_connections_per_ipaddr_per_minute: 32, // max connections per IpAddr per minute, use higher value because of tests
-            },
+            build_validator_tpu_config_for_test(DEFAULT_TPU_ENABLE_UDP),
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -11,9 +11,7 @@ use {
     solana_client::connection_cache::ConnectionCache,
     solana_core::{
         consensus::tower_storage::FileTowerStorage,
-        validator::{
-            build_validator_tpu_config_for_test, Validator, ValidatorConfig, ValidatorStartProgress,
-        },
+        validator::{Validator, ValidatorConfig, ValidatorStartProgress, ValidatorTpuConfig},
     },
     solana_gossip::{
         cluster_info::Node,
@@ -345,7 +343,7 @@ impl LocalCluster {
             socket_addr_space,
             // We are turning tpu_enable_udp to true in order to prevent concurrent local cluster tests
             // to use the same QUIC ports due to SO_REUSEPORT.
-            build_validator_tpu_config_for_test(true),
+            ValidatorTpuConfig::new_for_tests(true),
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
@@ -549,7 +547,7 @@ impl LocalCluster {
             None, // rpc_to_plugin_manager_receiver
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            build_validator_tpu_config_for_test(DEFAULT_TPU_ENABLE_UDP),
+            ValidatorTpuConfig::new_for_tests(DEFAULT_TPU_ENABLE_UDP),
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
@@ -1079,7 +1077,7 @@ impl Cluster for LocalCluster {
             None, // rpc_to_plugin_manager_receiver
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            build_validator_tpu_config_for_test(DEFAULT_TPU_ENABLE_UDP),
+            ValidatorTpuConfig::new_for_tests(DEFAULT_TPU_ENABLE_UDP),
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -87,13 +87,6 @@ const CONNECTION_CLOSE_REASON_TOO_MANY: &[u8] = b"too_many";
 const CONNECTION_CLOSE_CODE_INVALID_STREAM: u32 = 5;
 const CONNECTION_CLOSE_REASON_INVALID_STREAM: &[u8] = b"invalid_stream";
 
-/// Limit to 250K PPS
-#[deprecated(
-    since = "2.2.0",
-    note = "Use solana_streamer::quic::DEFAULT_MAX_STREAMS_PER_MS"
-)]
-pub const DEFAULT_MAX_STREAMS_PER_MS: u64 = 250;
-
 /// The new connections per minute from a particular IP address.
 /// Heuristically set to the default maximum concurrent connections
 /// per IP address. Might be adjusted later.
@@ -101,7 +94,13 @@ pub const DEFAULT_MAX_STREAMS_PER_MS: u64 = 250;
     since = "2.2.0",
     note = "Use solana_streamer::quic::DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE"
 )]
-pub const DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE: u64 = 8;
+pub use crate::quic::DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE;
+/// Limit to 250K PPS
+#[deprecated(
+    since = "2.2.0",
+    note = "Use solana_streamer::quic::DEFAULT_MAX_STREAMS_PER_MS"
+)]
+pub use crate::quic::DEFAULT_MAX_STREAMS_PER_MS;
 
 /// Total new connection counts per second. Heuristically taken from
 /// the default staked and unstaked connection limits. Might be adjusted

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -87,14 +87,6 @@ const CONNECTION_CLOSE_REASON_TOO_MANY: &[u8] = b"too_many";
 const CONNECTION_CLOSE_CODE_INVALID_STREAM: u32 = 5;
 const CONNECTION_CLOSE_REASON_INVALID_STREAM: &[u8] = b"invalid_stream";
 
-/// Limit to 250K PPS
-pub const DEFAULT_MAX_STREAMS_PER_MS: u64 = 250;
-
-/// The new connections per minute from a particular IP address.
-/// Heuristically set to the default maximum concurrent connections
-/// per IP address. Might be adjusted later.
-pub const DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE: u64 = 8;
-
 /// Total new connection counts per second. Heuristically taken from
 /// the default staked and unstaked connection limits. Might be adjusted
 /// later.

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -87,6 +87,22 @@ const CONNECTION_CLOSE_REASON_TOO_MANY: &[u8] = b"too_many";
 const CONNECTION_CLOSE_CODE_INVALID_STREAM: u32 = 5;
 const CONNECTION_CLOSE_REASON_INVALID_STREAM: &[u8] = b"invalid_stream";
 
+/// Limit to 250K PPS
+#[deprecated(
+    since = "2.2.0",
+    note = "Use solana_streamer::quic::DEFAULT_MAX_STREAMS_PER_MS"
+)]
+pub const DEFAULT_MAX_STREAMS_PER_MS: u64 = 250;
+
+/// The new connections per minute from a particular IP address.
+/// Heuristically set to the default maximum concurrent connections
+/// per IP address. Might be adjusted later.
+#[deprecated(
+    since = "2.2.0",
+    note = "Use solana_streamer::quic::DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE"
+)]
+pub const DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE: u64 = 8;
+
 /// Total new connection counts per second. Heuristically taken from
 /// the default staked and unstaked connection limits. Might be adjusted
 /// later.

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -236,10 +236,8 @@ pub mod test {
     use {
         super::*,
         crate::{
-            nonblocking::{
-                quic::DEFAULT_MAX_STREAMS_PER_MS, stream_throttle::STREAM_LOAD_EMA_INTERVAL_MS,
-            },
-            quic::{StreamerStats, MAX_UNSTAKED_CONNECTIONS},
+            nonblocking::stream_throttle::STREAM_LOAD_EMA_INTERVAL_MS,
+            quic::{StreamerStats, DEFAULT_MAX_STREAMS_PER_MS, DEFAULT_MAX_UNSTAKED_CONNECTIONS},
         },
         std::{
             sync::{atomic::Ordering, Arc},
@@ -251,7 +249,7 @@ pub mod test {
     fn test_max_streams_for_unstaked_connection() {
         let load_ema = Arc::new(StakedStreamLoadEMA::new(
             Arc::new(StreamerStats::default()),
-            MAX_UNSTAKED_CONNECTIONS,
+            DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             DEFAULT_MAX_STREAMS_PER_MS,
         ));
         // 25K packets per ms * 20% / 500 max unstaked connections
@@ -268,7 +266,7 @@ pub mod test {
     fn test_max_streams_for_staked_connection() {
         let load_ema = Arc::new(StakedStreamLoadEMA::new(
             Arc::new(StreamerStats::default()),
-            MAX_UNSTAKED_CONNECTIONS,
+            DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             DEFAULT_MAX_STREAMS_PER_MS,
         ));
 
@@ -448,7 +446,7 @@ pub mod test {
     fn test_update_ema() {
         let stream_load_ema = Arc::new(StakedStreamLoadEMA::new(
             Arc::new(StreamerStats::default()),
-            MAX_UNSTAKED_CONNECTIONS,
+            DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             DEFAULT_MAX_STREAMS_PER_MS,
         ));
         stream_load_ema
@@ -477,7 +475,7 @@ pub mod test {
     fn test_update_ema_missing_interval() {
         let stream_load_ema = Arc::new(StakedStreamLoadEMA::new(
             Arc::new(StreamerStats::default()),
-            MAX_UNSTAKED_CONNECTIONS,
+            DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             DEFAULT_MAX_STREAMS_PER_MS,
         ));
         stream_load_ema
@@ -497,7 +495,7 @@ pub mod test {
     fn test_update_ema_if_needed() {
         let stream_load_ema = Arc::new(StakedStreamLoadEMA::new(
             Arc::new(StreamerStats::default()),
-            MAX_UNSTAKED_CONNECTIONS,
+            DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             DEFAULT_MAX_STREAMS_PER_MS,
         ));
         stream_load_ema

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -2,13 +2,13 @@
 use {
     super::quic::{
         spawn_server_multi, SpawnNonBlockingServerResult, ALPN_TPU_PROTOCOL_ID,
-        DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_STREAMS_PER_MS,
         DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
     },
     crate::{
         quic::{
-            QuicServerParams, StreamerStats, DEFAULT_TPU_COALESCE, MAX_STAKED_CONNECTIONS,
-            MAX_UNSTAKED_CONNECTIONS,
+            QuicServerParams, StreamerStats, DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
+            DEFAULT_MAX_STAKED_CONNECTIONS, DEFAULT_MAX_STREAMS_PER_MS,
+            DEFAULT_MAX_UNSTAKED_CONNECTIONS, DEFAULT_TPU_COALESCE,
         },
         streamer::StakedNodes,
     },
@@ -64,8 +64,8 @@ impl Default for TestServerConfig {
     fn default() -> Self {
         Self {
             max_connections_per_peer: 1,
-            max_staked_connections: MAX_STAKED_CONNECTIONS,
-            max_unstaked_connections: MAX_UNSTAKED_CONNECTIONS,
+            max_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS,
+            max_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
         }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -32,7 +32,20 @@ use {
 // allow multiple connections for NAT and any open/close overlap
 pub const DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER: usize = 8;
 
+#[deprecated(
+    since = "2.2.0",
+    note = "Use solana_streamer::quic::DEFAULT_MAX_STAKED_CONNECTIONS"
+)]
+pub const MAX_STAKED_CONNECTIONS: usize = 2000;
+
 pub const DEFAULT_MAX_STAKED_CONNECTIONS: usize = 2000;
+
+#[deprecated(
+    since = "2.2.0",
+    note = "Use solana_streamer::quic::DEFAULT_MAX_UNSTAKED_CONNECTIONS"
+)]
+pub const MAX_UNSTAKED_CONNECTIONS: usize = 500;
+
 pub const DEFAULT_MAX_UNSTAKED_CONNECTIONS: usize = 500;
 
 /// Limit to 250K PPS

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -1,9 +1,6 @@
 use {
     crate::{
-        nonblocking::quic::{
-            ALPN_TPU_PROTOCOL_ID, DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-            DEFAULT_MAX_STREAMS_PER_MS, DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-        },
+        nonblocking::quic::{ALPN_TPU_PROTOCOL_ID, DEFAULT_WAIT_FOR_CHUNK_TIMEOUT},
         streamer::StakedNodes,
     },
     crossbeam_channel::Sender,
@@ -32,8 +29,19 @@ use {
     tokio::runtime::Runtime,
 };
 
-pub const MAX_STAKED_CONNECTIONS: usize = 2000;
-pub const MAX_UNSTAKED_CONNECTIONS: usize = 500;
+// allow multiple connections for NAT and any open/close overlap
+pub const DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER: usize = 8;
+
+pub const DEFAULT_MAX_STAKED_CONNECTIONS: usize = 2000;
+pub const DEFAULT_MAX_UNSTAKED_CONNECTIONS: usize = 500;
+
+/// Limit to 250K PPS
+pub const DEFAULT_MAX_STREAMS_PER_MS: u64 = 250;
+
+/// The new connections per minute from a particular IP address.
+/// Heuristically set to the default maximum concurrent connections
+/// per IP address. Might be adjusted later.
+pub const DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE: u64 = 8;
 
 // This will be adjusted and parameterized in follow-on PRs.
 pub const DEFAULT_QUIC_ENDPOINTS: usize = 1;
@@ -579,8 +587,8 @@ impl Default for QuicServerParams {
     fn default() -> Self {
         QuicServerParams {
             max_connections_per_peer: 1,
-            max_staked_connections: MAX_STAKED_CONNECTIONS,
-            max_unstaked_connections: MAX_UNSTAKED_CONNECTIONS,
+            max_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS,
+            max_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -13,9 +13,7 @@ use {
     solana_core::{
         admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         consensus::tower_storage::TowerStorage,
-        validator::{
-            build_validator_tpu_config_for_test, Validator, ValidatorConfig, ValidatorStartProgress,
-        },
+        validator::{Validator, ValidatorConfig, ValidatorStartProgress, ValidatorTpuConfig},
     },
     solana_feature_set::FEATURE_NAMES,
     solana_geyser_plugin_manager::{
@@ -1045,7 +1043,7 @@ impl TestValidator {
             rpc_to_plugin_manager_receiver,
             config.start_progress.clone(),
             socket_addr_space,
-            build_validator_tpu_config_for_test(config.tpu_enable_udp),
+            ValidatorTpuConfig::new_for_tests(config.tpu_enable_udp),
             config.admin_rpc_service_post_init.clone(),
         )?);
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -13,7 +13,9 @@ use {
     solana_core::{
         admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         consensus::tower_storage::TowerStorage,
-        validator::{Validator, ValidatorConfig, ValidatorStartProgress, ValidatorTpuConfig},
+        validator::{
+            build_validator_tpu_config_for_test, Validator, ValidatorConfig, ValidatorStartProgress,
+        },
     },
     solana_feature_set::FEATURE_NAMES,
     solana_geyser_plugin_manager::{
@@ -56,10 +58,7 @@ use {
         signature::{read_keypair_file, write_keypair_file, Keypair, Signer},
     },
     solana_streamer::socket::SocketAddrSpace,
-    solana_tpu_client::tpu_client::{
-        DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
-        DEFAULT_VOTE_USE_QUIC,
-    },
+    solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
     std::{
         collections::{HashMap, HashSet},
         ffi::OsStr,
@@ -1046,13 +1045,7 @@ impl TestValidator {
             rpc_to_plugin_manager_receiver,
             config.start_progress.clone(),
             socket_addr_space,
-            ValidatorTpuConfig {
-                use_quic: DEFAULT_TPU_USE_QUIC,
-                vote_use_quic: DEFAULT_VOTE_USE_QUIC,
-                tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
-                tpu_enable_udp: config.tpu_enable_udp,
-                tpu_max_connections_per_ipaddr_per_minute: 32, // max connections per IpAddr per minute for test
-            },
+            build_validator_tpu_config_for_test(config.tpu_enable_udp),
             config.admin_rpc_service_post_init.clone(),
         )?);
 

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -871,7 +871,7 @@ mod tests {
         },
         solana_core::{
             consensus::tower_storage::NullTowerStorage,
-            validator::{build_validator_tpu_config_for_test, Validator, ValidatorConfig},
+            validator::{Validator, ValidatorConfig, ValidatorTpuConfig},
         },
         solana_gossip::cluster_info::{ClusterInfo, Node},
         solana_inline_spl::token,
@@ -1395,7 +1395,7 @@ mod tests {
                 None, // rpc_to_plugin_manager_receiver
                 start_progress.clone(),
                 SocketAddrSpace::Unspecified,
-                build_validator_tpu_config_for_test(DEFAULT_TPU_ENABLE_UDP),
+                ValidatorTpuConfig::new_for_tests(DEFAULT_TPU_ENABLE_UDP),
                 post_init,
             )
             .expect("assume successful validator start");

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -871,7 +871,7 @@ mod tests {
         },
         solana_core::{
             consensus::tower_storage::NullTowerStorage,
-            validator::{Validator, ValidatorConfig, ValidatorTpuConfig},
+            validator::{build_validator_tpu_config_for_test, Validator, ValidatorConfig},
         },
         solana_gossip::cluster_info::{ClusterInfo, Node},
         solana_inline_spl::token,
@@ -893,10 +893,7 @@ mod tests {
             system_program,
         },
         solana_streamer::socket::SocketAddrSpace,
-        solana_tpu_client::tpu_client::{
-            DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP, DEFAULT_TPU_USE_QUIC,
-            DEFAULT_VOTE_USE_QUIC,
-        },
+        solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
         spl_token_2022::{
             solana_program::{program_option::COption, program_pack::Pack},
             state::{Account as TokenAccount, AccountState as TokenAccountState, Mint},
@@ -1398,13 +1395,7 @@ mod tests {
                 None, // rpc_to_plugin_manager_receiver
                 start_progress.clone(),
                 SocketAddrSpace::Unspecified,
-                ValidatorTpuConfig {
-                    use_quic: DEFAULT_TPU_USE_QUIC,
-                    vote_use_quic: DEFAULT_VOTE_USE_QUIC,
-                    tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
-                    tpu_enable_udp: DEFAULT_TPU_ENABLE_UDP,
-                    tpu_max_connections_per_ipaddr_per_minute: 32, // max connections per IpAddr per minute for test
-                },
+                build_validator_tpu_config_for_test(DEFAULT_TPU_ENABLE_UDP),
                 post_init,
             )
             .expect("assume successful validator start");

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -953,6 +953,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Controls the max concurrent connections for TPU-forward from unstaked nodes."),
         )
         .arg(
+            Arg::with_name("max_streams_per_ms")
+                .long("max-streams-per-ms")
+                .takes_value(true)
+                .default_value(&default_args.max_streams_per_ms)
+                .validator(is_parsable::<usize>)
+                .hidden(hidden_unless_forced())
+                .help("Controls the max number of streams per steamer service."),
+        )        
+        .arg(
             Arg::with_name("num_quic_endpoints")
                 .long("num-quic-endpoints")
                 .takes_value(true)

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -953,14 +953,14 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Controls the max concurrent connections for TPU-forward from unstaked nodes."),
         )
         .arg(
-            Arg::with_name("max_streams_per_ms")
-                .long("max-streams-per-ms")
+            Arg::with_name("tpu_max_streams_per_ms")
+                .long("tpu-max-streams-per-ms")
                 .takes_value(true)
-                .default_value(&default_args.max_streams_per_ms)
+                .default_value(&default_args.tpu_max_streams_per_ms)
                 .validator(is_parsable::<usize>)
                 .hidden(hidden_unless_forced())
-                .help("Controls the max number of streams per steamer service."),
-        )        
+                .help("Controls the max number of streams for a TPU service."),
+        )
         .arg(
             Arg::with_name("num_quic_endpoints")
                 .long("num-quic-endpoints")
@@ -2367,7 +2367,7 @@ pub struct DefaultArgs {
     pub max_tpu_unstaked_connections: String,
     pub max_fwd_staked_connections: String,
     pub max_fwd_unstaked_connections: String,
-    pub max_streams_per_ms: String,
+    pub tpu_max_streams_per_ms: String,
 
     pub num_quic_endpoints: String,
     pub vote_use_quic: String,
@@ -2471,7 +2471,7 @@ impl DefaultArgs {
                 .saturating_add(DEFAULT_MAX_UNSTAKED_CONNECTIONS)
                 .to_string(),
             max_fwd_unstaked_connections: 0.to_string(),
-            max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS.to_string(),
+            tpu_max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS.to_string(),
             num_quic_endpoints: DEFAULT_QUIC_ENDPOINTS.to_string(),
             rpc_max_request_body_size: MAX_REQUEST_BODY_SIZE.to_string(),
             exit_min_idle_time: "10".to_string(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -47,17 +47,18 @@ use {
     solana_send_transaction_service::send_transaction_service::{
         self, MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
     },
-    solana_streamer::quic::DEFAULT_QUIC_ENDPOINTS,
+    solana_streamer::quic::{
+        DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER,
+        DEFAULT_MAX_STAKED_CONNECTIONS, DEFAULT_MAX_STREAMS_PER_MS,
+        DEFAULT_MAX_UNSTAKED_CONNECTIONS, DEFAULT_QUIC_ENDPOINTS,
+    },
     solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC},
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     std::{path::PathBuf, str::FromStr},
 };
 
 pub mod thread_args;
-use {
-    solana_streamer::nonblocking::quic::DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-    thread_args::{thread_args, DefaultThreadArgs},
-};
+use thread_args::{thread_args, DefaultThreadArgs};
 
 const EXCLUDE_KEY: &str = "account-index-exclude-key";
 const INCLUDE_KEY: &str = "account-index-include-key";
@@ -905,6 +906,51 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .default_value(&default_args.vote_use_quic)
                 .hidden(hidden_unless_forced())
                 .help("Controls if to use QUIC to send votes."),
+        )
+        .arg(
+            Arg::with_name("tpu_max_connections_per_peer")
+                .long("tpu-max-connections-per-peer")
+                .takes_value(true)
+                .default_value(&default_args.tpu_max_connections_per_peer)
+                .validator(is_parsable::<u32>)
+                .hidden(hidden_unless_forced())
+                .help("Controls the max concurrent connections per IpAddr."),
+        )
+        .arg(
+            Arg::with_name("max_tpu_staked_connections")
+                .long("max-tpu-staked-connections")
+                .takes_value(true)
+                .default_value(&default_args.max_tpu_staked_connections)
+                .validator(is_parsable::<u32>)
+                .hidden(hidden_unless_forced())
+                .help("Controls the max concurrent connections for TPU from staked nodes."),
+        )
+        .arg(
+            Arg::with_name("max_tpu_unstaked_connections")
+                .long("max-tpu-unstaked-connections")
+                .takes_value(true)
+                .default_value(&default_args.max_tpu_unstaked_connections)
+                .validator(is_parsable::<u32>)
+                .hidden(hidden_unless_forced())
+                .help("Controls the max concurrent connections fort TPU from unstaked nodes."),
+        )
+        .arg(
+            Arg::with_name("max_fwd_staked_connections")
+                .long("max-fwd-staked-connections")
+                .takes_value(true)
+                .default_value(&default_args.max_fwd_staked_connections)
+                .validator(is_parsable::<u32>)
+                .hidden(hidden_unless_forced())
+                .help("Controls the max concurrent connections for TPU-forward from staked nodes."),
+        )
+        .arg(
+            Arg::with_name("max_fwd_unstaked_connections")
+                .long("max-fwd-unstaked-connections")
+                .takes_value(true)
+                .default_value(&default_args.max_fwd_unstaked_connections)
+                .validator(is_parsable::<u32>)
+                .hidden(hidden_unless_forced())
+                .help("Controls the max concurrent connections for TPU-forward from unstaked nodes."),
         )
         .arg(
             Arg::with_name("num_quic_endpoints")
@@ -2305,7 +2351,15 @@ pub struct DefaultArgs {
     pub accounts_shrink_optimize_total_space: String,
     pub accounts_shrink_ratio: String,
     pub tpu_connection_pool_size: String,
+
+    pub tpu_max_connections_per_peer: String,
     pub tpu_max_connections_per_ipaddr_per_minute: String,
+    pub max_tpu_staked_connections: String,
+    pub max_tpu_unstaked_connections: String,
+    pub max_fwd_staked_connections: String,
+    pub max_fwd_unstaked_connections: String,
+    pub max_streams_per_ms: String,
+
     pub num_quic_endpoints: String,
     pub vote_use_quic: String,
 
@@ -2401,6 +2455,14 @@ impl DefaultArgs {
             tpu_max_connections_per_ipaddr_per_minute:
                 DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE.to_string(),
             vote_use_quic: DEFAULT_VOTE_USE_QUIC.to_string(),
+            tpu_max_connections_per_peer: DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER.to_string(),
+            max_tpu_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS.to_string(),
+            max_tpu_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS.to_string(),
+            max_fwd_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS
+                .saturating_add(DEFAULT_MAX_UNSTAKED_CONNECTIONS)
+                .to_string(),
+            max_fwd_unstaked_connections: 0.to_string(),
+            max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS.to_string(),
             num_quic_endpoints: DEFAULT_QUIC_ENDPOINTS.to_string(),
             rpc_max_request_body_size: MAX_REQUEST_BODY_SIZE.to_string(),
             exit_min_idle_time: "10".to_string(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -917,37 +917,37 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Controls the max concurrent connections per IpAddr."),
         )
         .arg(
-            Arg::with_name("max_tpu_staked_connections")
-                .long("max-tpu-staked-connections")
+            Arg::with_name("tpu_max_staked_connections")
+                .long("tpu-max-staked-connections")
                 .takes_value(true)
-                .default_value(&default_args.max_tpu_staked_connections)
+                .default_value(&default_args.tpu_max_staked_connections)
                 .validator(is_parsable::<u32>)
                 .hidden(hidden_unless_forced())
                 .help("Controls the max concurrent connections for TPU from staked nodes."),
         )
         .arg(
-            Arg::with_name("max_tpu_unstaked_connections")
-                .long("max-tpu-unstaked-connections")
+            Arg::with_name("tpu_max_unstaked_connections")
+                .long("tpu-max-unstaked-connections")
                 .takes_value(true)
-                .default_value(&default_args.max_tpu_unstaked_connections)
+                .default_value(&default_args.tpu_max_unstaked_connections)
                 .validator(is_parsable::<u32>)
                 .hidden(hidden_unless_forced())
                 .help("Controls the max concurrent connections fort TPU from unstaked nodes."),
         )
         .arg(
-            Arg::with_name("max_fwd_staked_connections")
-                .long("max-fwd-staked-connections")
+            Arg::with_name("tpu_max_fwd_staked_connections")
+                .long("tpu-max-fwd-staked-connections")
                 .takes_value(true)
-                .default_value(&default_args.max_fwd_staked_connections)
+                .default_value(&default_args.tpu_max_fwd_staked_connections)
                 .validator(is_parsable::<u32>)
                 .hidden(hidden_unless_forced())
                 .help("Controls the max concurrent connections for TPU-forward from staked nodes."),
         )
         .arg(
-            Arg::with_name("max_fwd_unstaked_connections")
-                .long("max-fwd-unstaked-connections")
+            Arg::with_name("tpu_max_fwd_unstaked_connections")
+                .long("tpu-max-fwd-unstaked-connections")
                 .takes_value(true)
-                .default_value(&default_args.max_fwd_unstaked_connections)
+                .default_value(&default_args.tpu_max_fwd_unstaked_connections)
                 .validator(is_parsable::<u32>)
                 .hidden(hidden_unless_forced())
                 .help("Controls the max concurrent connections for TPU-forward from unstaked nodes."),
@@ -2363,10 +2363,10 @@ pub struct DefaultArgs {
 
     pub tpu_max_connections_per_peer: String,
     pub tpu_max_connections_per_ipaddr_per_minute: String,
-    pub max_tpu_staked_connections: String,
-    pub max_tpu_unstaked_connections: String,
-    pub max_fwd_staked_connections: String,
-    pub max_fwd_unstaked_connections: String,
+    pub tpu_max_staked_connections: String,
+    pub tpu_max_unstaked_connections: String,
+    pub tpu_max_fwd_staked_connections: String,
+    pub tpu_max_fwd_unstaked_connections: String,
     pub tpu_max_streams_per_ms: String,
 
     pub num_quic_endpoints: String,
@@ -2465,12 +2465,12 @@ impl DefaultArgs {
                 DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE.to_string(),
             vote_use_quic: DEFAULT_VOTE_USE_QUIC.to_string(),
             tpu_max_connections_per_peer: DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER.to_string(),
-            max_tpu_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS.to_string(),
-            max_tpu_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS.to_string(),
-            max_fwd_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS
+            tpu_max_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS.to_string(),
+            tpu_max_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS.to_string(),
+            tpu_max_fwd_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS
                 .saturating_add(DEFAULT_MAX_UNSTAKED_CONNECTIONS)
                 .to_string(),
-            max_fwd_unstaked_connections: 0.to_string(),
+            tpu_max_fwd_unstaked_connections: 0.to_string(),
             tpu_max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS.to_string(),
             num_quic_endpoints: DEFAULT_QUIC_ENDPOINTS.to_string(),
             rpc_max_request_body_size: MAX_REQUEST_BODY_SIZE.to_string(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1987,7 +1987,7 @@ pub fn main() {
 
     let tpu_max_connections_per_ipaddr_per_minute: u64 =
         value_t_or_exit!(matches, "tpu_max_connections_per_ipaddr_per_minute", u64);
-    let max_streams_per_ms = value_t_or_exit!(matches, "max_streams_per_ms", u64);
+    let max_streams_per_ms = value_t_or_exit!(matches, "tpu_max_streams_per_ms", u64);
 
     let node_config = NodeConfig {
         gossip_addr,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1977,13 +1977,14 @@ pub fn main() {
 
     let tpu_max_connections_per_peer =
         value_t_or_exit!(matches, "tpu_max_connections_per_peer", u64);
-    let max_tpu_staked_connections = value_t_or_exit!(matches, "max_tpu_staked_connections", u64);
-    let max_tpu_unstaked_connections =
-        value_t_or_exit!(matches, "max_tpu_unstaked_connections", u64);
+    let tpu_max_staked_connections = value_t_or_exit!(matches, "tpu_max_staked_connections", u64);
+    let tpu_max_unstaked_connections =
+        value_t_or_exit!(matches, "tpu_max_unstaked_connections", u64);
 
-    let max_fwd_staked_connections = value_t_or_exit!(matches, "max_fwd_staked_connections", u64);
-    let max_fwd_unstaked_connections =
-        value_t_or_exit!(matches, "max_fwd_unstaked_connections", u64);
+    let tpu_max_fwd_staked_connections =
+        value_t_or_exit!(matches, "tpu_max_fwd_staked_connections", u64);
+    let tpu_max_fwd_unstaked_connections =
+        value_t_or_exit!(matches, "tpu_max_fwd_unstaked_connections", u64);
 
     let tpu_max_connections_per_ipaddr_per_minute: u64 =
         value_t_or_exit!(matches, "tpu_max_connections_per_ipaddr_per_minute", u64);
@@ -2094,8 +2095,8 @@ pub fn main() {
 
     let tpu_quic_server_config = QuicServerParams {
         max_connections_per_peer: tpu_max_connections_per_peer.try_into().unwrap(),
-        max_staked_connections: max_tpu_staked_connections.try_into().unwrap(),
-        max_unstaked_connections: max_tpu_unstaked_connections.try_into().unwrap(),
+        max_staked_connections: tpu_max_staked_connections.try_into().unwrap(),
+        max_unstaked_connections: tpu_max_unstaked_connections.try_into().unwrap(),
         max_streams_per_ms,
         max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
         coalesce: tpu_coalesce,
@@ -2104,8 +2105,8 @@ pub fn main() {
 
     let tpu_fwd_quic_server_config = QuicServerParams {
         max_connections_per_peer: tpu_max_connections_per_peer.try_into().unwrap(),
-        max_staked_connections: max_fwd_staked_connections.try_into().unwrap(),
-        max_unstaked_connections: max_fwd_unstaked_connections.try_into().unwrap(),
+        max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
+        max_unstaked_connections: tpu_max_fwd_unstaked_connections.try_into().unwrap(),
         max_streams_per_ms,
         max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
         coalesce: tpu_coalesce,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2113,9 +2113,10 @@ pub fn main() {
     };
 
     // Vote shares TPU forward's characteristics, except that we accept 1 connection
-    // per peer.
+    // per peer and no unstaked connections are accepted.
     let mut vote_quic_server_config = tpu_fwd_quic_server_config.clone();
     vote_quic_server_config.max_connections_per_peer = 1;
+    vote_quic_server_config.max_unstaked_connections = 0;
 
     let validator = match Validator::new(
         node,

--- a/vortexor/src/cli.rs
+++ b/vortexor/src/cli.rs
@@ -3,11 +3,9 @@ use {
     solana_clap_utils::input_validators::{is_keypair_or_ask_keyword, is_parsable},
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
     solana_sdk::quic::QUIC_PORT_OFFSET,
-    solana_streamer::{
-        nonblocking::quic::{
-            DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_STREAMS_PER_MS,
-        },
-        quic::{MAX_STAKED_CONNECTIONS, MAX_UNSTAKED_CONNECTIONS},
+    solana_streamer::quic::{
+        DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_STAKED_CONNECTIONS,
+        DEFAULT_MAX_STREAMS_PER_MS, DEFAULT_MAX_UNSTAKED_CONNECTIONS,
     },
 };
 
@@ -33,10 +31,10 @@ impl Default for DefaultArgs {
             bind_address: "0.0.0.0".to_string(),
             dynamic_port_range: format!("{}-{}", VALIDATOR_PORT_RANGE.0, VALIDATOR_PORT_RANGE.1),
             max_connections_per_peer: DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER.to_string(),
-            max_tpu_staked_connections: MAX_STAKED_CONNECTIONS.to_string(),
-            max_tpu_unstaked_connections: MAX_UNSTAKED_CONNECTIONS.to_string(),
-            max_fwd_staked_connections: MAX_STAKED_CONNECTIONS
-                .saturating_add(MAX_UNSTAKED_CONNECTIONS)
+            max_tpu_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS.to_string(),
+            max_tpu_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS.to_string(),
+            max_fwd_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS
+                .saturating_add(DEFAULT_MAX_UNSTAKED_CONNECTIONS)
                 .to_string(),
             max_fwd_unstaked_connections: 0.to_string(),
             max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS.to_string(),

--- a/vortexor/tests/vortexor.rs
+++ b/vortexor/tests/vortexor.rs
@@ -3,11 +3,11 @@ use {
     solana_net_utils::VALIDATOR_PORT_RANGE,
     solana_sdk::{net::DEFAULT_TPU_COALESCE, pubkey::Pubkey, signature::Keypair, signer::Signer},
     solana_streamer::{
-        nonblocking::{
-            quic::{DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_STREAMS_PER_MS},
-            testing_utilities::check_multiple_streams,
+        nonblocking::testing_utilities::check_multiple_streams,
+        quic::{
+            DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_STAKED_CONNECTIONS,
+            DEFAULT_MAX_STREAMS_PER_MS, DEFAULT_MAX_UNSTAKED_CONNECTIONS,
         },
-        quic::{MAX_STAKED_CONNECTIONS, MAX_UNSTAKED_CONNECTIONS},
         streamer::StakedNodes,
     },
     solana_vortexor::{
@@ -54,10 +54,10 @@ async fn test_vortexor() {
         tpu_sender,
         tpu_fwd_sender,
         DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER.try_into().unwrap(),
-        MAX_STAKED_CONNECTIONS.try_into().unwrap(),
-        MAX_UNSTAKED_CONNECTIONS.try_into().unwrap(),
-        MAX_STAKED_CONNECTIONS
-            .saturating_add(MAX_UNSTAKED_CONNECTIONS)
+        DEFAULT_MAX_STAKED_CONNECTIONS.try_into().unwrap(),
+        DEFAULT_MAX_UNSTAKED_CONNECTIONS.try_into().unwrap(),
+        DEFAULT_MAX_STAKED_CONNECTIONS
+            .saturating_add(DEFAULT_MAX_UNSTAKED_CONNECTIONS)
             .try_into()
             .unwrap(), // max_fwd_staked_connections
         0, // max_fwd_unstaked_connections


### PR DESCRIPTION
#### Problem
Making QUIC TPU QOS parameters configurable so that it is easier to tweak performance and do bench marks.

#### Summary of Changes
CLI is enabled to pass the following:

--tpu-max-connections-per-peer
--max-tpu-staked-connections
--max-tpu-unstaked-connections
--max-fwd-staked-connections
--max-fwd-unstaked-connections

They are set to hidden unless forced to be shown.

Elevate QuicServerParams configuration to ValidatorTpuConfig as field to configure 
tpu, tpu forward and vote quic server parameters.

Move the public default parameters to quic from nonblocking::quic to encapsulate better.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
