### PR TITLE
builds deduper hashers once per reset cycle

### DIFF
--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -67,7 +67,8 @@ impl<const K: usize, T: ?Sized + Hash> Deduper<K, T> {
     #[allow(clippy::arithmetic_side_effects)]
     pub fn dedup(&self, data: &T) -> bool {
         let mut out = true;
-        for mut hasher in self.hashers.iter().map(AHasher::clone) {
+        for hasher in &self.hashers {
+            let mut hasher = hasher.clone();
             data.hash(&mut hasher);
             let hash: u64 = hasher.finish() % self.num_bits;
             let index = (hash >> 6) as usize;


### PR DESCRIPTION

#### Problem
Deduper does `RandomState::build_hasher` on every item:
https://github.com/anza-xyz/agave/blob/22c89518c/perf/src/deduper.rs#L70

#### Summary of Changes
The commit avoids `RandomState::build_hasher` on each item and instead just clones initialized hahsers which are pretty cheap to clone: https://github.com/tkaitchuck/aHash/blob/7d5c661a7/src/aes_hash.rs#L18-L23