### PR TITLE
Reduce usage of solana-sdk in accounts-db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5980,6 +5980,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-nohash-hasher",
+ "solana-pubkey",
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-stake-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5971,6 +5971,7 @@ dependencies = [
  "smallvec",
  "solana-accounts-db",
  "solana-bucket-map",
+ "solana-clock",
  "solana-compute-budget",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5974,6 +5974,7 @@ dependencies = [
  "solana-compute-budget",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-hash",
  "solana-inline-spl",
  "solana-lattice-hash",
  "solana-logger",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -48,6 +48,7 @@ solana-lattice-hash = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-nohash-hasher = { workspace = true }
+solana-pubkey = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-sdk = { workspace = true }
 solana-stake-program = { workspace = true, optional = true }
@@ -87,6 +88,7 @@ dev-context-only-utils = [
     "dep:qualifier_attr",
     "dep:solana-stake-program",
     "dep:solana-vote-program",
+    "solana-pubkey/rand",
 ]
 frozen-abi = [
     "dep:solana-frozen-abi",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -37,6 +37,7 @@ serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
 smallvec = { workspace = true, features = ["const_generics"] }
 solana-bucket-map = { workspace = true }
+solana-clock = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -43,6 +43,7 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
+solana-hash = { workspace = true }
 solana-inline-spl = { workspace = true }
 solana-lattice-hash = { workspace = true }
 solana-measure = { workspace = true }

--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -111,7 +111,7 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
     let mut old_pubkey = Pubkey::default();
     let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
     for i in 0..1000 {
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let account = AccountSharedData::new(i + 1, 0, AccountSharedData::default().owner());
         accounts.store_slow_uncached(i, &pubkey, &account);
         accounts.store_slow_uncached(i, &old_pubkey, &zero_account);
@@ -136,7 +136,7 @@ where
     let num_keys = 1000;
     let slot = 0;
 
-    let pubkeys: Vec<_> = std::iter::repeat_with(solana_sdk::pubkey::new_rand)
+    let pubkeys: Vec<_> = std::iter::repeat_with(solana_pubkey::new_rand)
         .take(num_keys)
         .collect();
     let accounts_data: Vec<_> = std::iter::repeat(
@@ -169,7 +169,7 @@ where
 
     let num_new_keys = 1000;
     bencher.iter(|| {
-        let new_pubkeys: Vec<_> = std::iter::repeat_with(solana_sdk::pubkey::new_rand)
+        let new_pubkeys: Vec<_> = std::iter::repeat_with(solana_pubkey::new_rand)
             .take(num_new_keys)
             .collect();
         let new_storable_accounts: Vec<_> = new_pubkeys.iter().zip(accounts_data.iter()).collect();

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -3,7 +3,7 @@
 use {
     crate::accounts_db::{AccountStorageEntry, AccountsFileId},
     dashmap::DashMap,
-    solana_sdk::clock::Slot,
+    solana_clock::Slot,
     std::sync::Arc,
 };
 

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -866,13 +866,13 @@ mod tests {
         let accounts = Accounts::new(Arc::new(accounts_db));
 
         // Load accounts owned by various programs into AccountsDb
-        let pubkey0 = solana_sdk::pubkey::new_rand();
+        let pubkey0 = solana_pubkey::new_rand();
         let account0 = AccountSharedData::new(1, 0, &Pubkey::from([2; 32]));
         accounts.store_slow_uncached(0, &pubkey0, &account0);
-        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
         let account1 = AccountSharedData::new(1, 0, &Pubkey::from([2; 32]));
         accounts.store_slow_uncached(0, &pubkey1, &account1);
-        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
         let account2 = AccountSharedData::new(1, 0, &Pubkey::from([3; 32]));
         accounts.store_slow_uncached(0, &pubkey2, &account2);
 
@@ -1292,7 +1292,7 @@ mod tests {
         let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
         info!("storing..");
         for i in 0..2_000 {
-            let pubkey = solana_sdk::pubkey::new_rand();
+            let pubkey = solana_pubkey::new_rand();
             let account = AccountSharedData::new(i + 1, 0, AccountSharedData::default().owner());
             accounts.store_for_tests(i, &pubkey, &account);
             accounts.store_for_tests(i, &old_pubkey, &zero_account);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9344,7 +9344,7 @@ impl AccountsDb {
     ) {
         let ancestors = vec![(slot, 0)].into_iter().collect();
         for t in 0..num {
-            let pubkey = solana_sdk::pubkey::new_rand();
+            let pubkey = solana_pubkey::new_rand();
             let account =
                 AccountSharedData::new((t + 1) as u64, space, AccountSharedData::default().owner());
             pubkeys.push(pubkey);
@@ -9352,7 +9352,7 @@ impl AccountsDb {
             self.store_for_tests(slot, &[(&pubkey, &account)]);
         }
         for t in 0..num_vote {
-            let pubkey = solana_sdk::pubkey::new_rand();
+            let pubkey = solana_pubkey::new_rand();
             let account =
                 AccountSharedData::new((num + t + 1) as u64, space, &solana_vote_program::id());
             pubkeys.push(pubkey);
@@ -9491,7 +9491,7 @@ pub mod test_utils {
         }
 
         for t in 0..num {
-            let pubkey = solana_sdk::pubkey::new_rand();
+            let pubkey = solana_pubkey::new_rand();
             let account = AccountSharedData::new(
                 (t + 1) as u64,
                 data_size,

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -234,7 +234,7 @@ pub mod tests {
     fn test_notify_account_restore_from_snapshot_once_per_slot() {
         let mut accounts = AccountsDb::new_single_for_tests();
         // Account with key1 is updated twice in the store -- should only get notified once.
-        let key1 = solana_sdk::pubkey::new_rand();
+        let key1 = solana_pubkey::new_rand();
         let mut account1_lamports: u64 = 1;
         let account1 =
             AccountSharedData::new(account1_lamports, 1, AccountSharedData::default().owner());
@@ -246,7 +246,7 @@ pub mod tests {
         accounts.store_uncached(slot0, &[(&key1, &account1)]);
         let notifier = GeyserTestPlugin::default();
 
-        let key2 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_pubkey::new_rand();
         let account2_lamports: u64 = 100;
         let account2 =
             AccountSharedData::new(account2_lamports, 1, AccountSharedData::default().owner());
@@ -284,14 +284,14 @@ pub mod tests {
         // Account with key1 is updated twice in two different slots -- should only get notified once.
         // Account with key2 is updated slot0, should get notified once
         // Account with key3 is updated in slot1, should get notified once
-        let key1 = solana_sdk::pubkey::new_rand();
+        let key1 = solana_pubkey::new_rand();
         let mut account1_lamports: u64 = 1;
         let account1 =
             AccountSharedData::new(account1_lamports, 1, AccountSharedData::default().owner());
         let slot0 = 0;
         accounts.store_uncached(slot0, &[(&key1, &account1)]);
 
-        let key2 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_pubkey::new_rand();
         let account2_lamports: u64 = 200;
         let account2 =
             AccountSharedData::new(account2_lamports, 1, AccountSharedData::default().owner());
@@ -303,7 +303,7 @@ pub mod tests {
         accounts.store_uncached(slot1, &[(&key1, &account1)]);
         let notifier = GeyserTestPlugin::default();
 
-        let key3 = solana_sdk::pubkey::new_rand();
+        let key3 = solana_pubkey::new_rand();
         let account3_lamports: u64 = 300;
         let account3 =
             AccountSharedData::new(account3_lamports, 1, AccountSharedData::default().owner());
@@ -353,14 +353,14 @@ pub mod tests {
         // Account with key1 is updated twice in two different slots -- should only get notified twice.
         // Account with key2 is updated slot0, should get notified once
         // Account with key3 is updated in slot1, should get notified once
-        let key1 = solana_sdk::pubkey::new_rand();
+        let key1 = solana_pubkey::new_rand();
         let account1_lamports1: u64 = 1;
         let account1 =
             AccountSharedData::new(account1_lamports1, 1, AccountSharedData::default().owner());
         let slot0 = 0;
         accounts.store_cached((slot0, &[(&key1, &account1)][..]), None);
 
-        let key2 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_pubkey::new_rand();
         let account2_lamports: u64 = 200;
         let account2 =
             AccountSharedData::new(account2_lamports, 1, AccountSharedData::default().owner());
@@ -371,7 +371,7 @@ pub mod tests {
         let account1 = AccountSharedData::new(account1_lamports2, 1, account1.owner());
         accounts.store_cached((slot1, &[(&key1, &account1)][..]), None);
 
-        let key3 = solana_sdk::pubkey::new_rand();
+        let key3 = solana_pubkey::new_rand();
         let account3_lamports: u64 = 300;
         let account3 =
             AccountSharedData::new(account3_lamports, 1, AccountSharedData::default().owner());

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -530,7 +530,7 @@ mod tests {
         data.accounts = av;
 
         let storage = Arc::new(data);
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let acc = AccountSharedData::new(1, 48, AccountSharedData::default().owner());
         let mark_alive = false;
         append_single_account_with_default_hash(&storage, &pubkey, &acc, mark_alive, None);
@@ -583,8 +583,8 @@ mod tests {
         let tf = crate::append_vec::test_utils::get_append_vec_path(
             "test_accountsdb_scan_account_storage_no_bank",
         );
-        let pubkey1 = solana_sdk::pubkey::new_rand();
-        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
         let mark_alive = false;
         let storage = sample_storage_with_entries(&tf, slot_expected, &pubkey1, mark_alive);
         let lamports = storage
@@ -631,7 +631,7 @@ mod tests {
                 accounts_file_provider,
             );
             let storage = Arc::new(data);
-            let pubkey = solana_sdk::pubkey::new_rand();
+            let pubkey = solana_pubkey::new_rand();
             let acc = AccountSharedData::new(1, 48, AccountSharedData::default().owner());
             let mark_alive = false;
             append_single_account_with_default_hash(&storage, &pubkey, &acc, mark_alive, None);

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -5467,8 +5467,8 @@ define_accounts_db_test!(
     test_calculate_storage_count_and_alive_bytes_2_accounts,
     |accounts| {
         let keys = [
-            solana_sdk::pubkey::Pubkey::from([0; 32]),
-            solana_sdk::pubkey::Pubkey::from([255; 32]),
+            solana_pubkey::Pubkey::from([0; 32]),
+            solana_pubkey::Pubkey::from([255; 32]),
         ];
         accounts.accounts_index.set_startup(Startup::Startup);
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -452,10 +452,10 @@ fn test_get_keys_to_unref_ancient() {
     let owner = Pubkey::default();
     let data = Vec::new();
 
-    let pubkey = solana_sdk::pubkey::new_rand();
-    let pubkey2 = solana_sdk::pubkey::new_rand();
-    let pubkey3 = solana_sdk::pubkey::new_rand();
-    let pubkey4 = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
+    let pubkey3 = solana_pubkey::new_rand();
+    let pubkey4 = solana_pubkey::new_rand();
 
     let meta = StoredMeta {
         write_version_obsolete: 5,
@@ -1021,7 +1021,7 @@ define_accounts_db_test!(test_accountsdb_count_stores, |db| {
     db.add_root_and_flush_write_cache(0);
     db.check_storage(0, 2, 2);
 
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     let account = AccountSharedData::new(1, DEFAULT_FILE_SIZE as usize / 3, &pubkey);
     db.store_for_tests(1, &[(&pubkey, &account)]);
     db.store_for_tests(1, &[(&pubkeys[0], &account)]);
@@ -1181,7 +1181,7 @@ fn test_account_grow_many() {
     };
     let mut keys = vec![];
     for i in 0..9 {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let account = AccountSharedData::new(i + 1, size as usize / 4, &key);
         accounts.store_for_tests(0, &[(&key, &account)]);
         keys.push(key);
@@ -1217,7 +1217,7 @@ fn test_account_grow() {
         let accounts = AccountsDb::new_single_for_tests();
 
         let status = [AccountStorageStatus::Available, AccountStorageStatus::Full];
-        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
         let account1 = AccountSharedData::new(1, DEFAULT_FILE_SIZE as usize / 2, &pubkey1);
         accounts.store_for_tests(0, &[(&pubkey1, &account1)]);
         if pass == 0 {
@@ -1228,7 +1228,7 @@ fn test_account_grow() {
             continue;
         }
 
-        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
         let account2 = AccountSharedData::new(1, DEFAULT_FILE_SIZE as usize / 2, &pubkey2);
         accounts.store_for_tests(0, &[(&pubkey2, &account2)]);
 
@@ -1295,7 +1295,7 @@ fn test_lazy_gc_slot() {
     //A slot is purged when a non root bank is cleaned up.  If a slot is behind root but it is
     //not root, it means we are retaining dead banks.
     let accounts = AccountsDb::new_single_for_tests();
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     let account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
     //store an account
     accounts.store_for_tests(0, &[(&pubkey, &account)]);
@@ -1343,8 +1343,8 @@ fn test_clean_zero_lamport_and_dead_slot() {
     solana_logger::setup();
 
     let accounts = AccountsDb::new_single_for_tests();
-    let pubkey1 = solana_sdk::pubkey::new_rand();
-    let pubkey2 = solana_sdk::pubkey::new_rand();
+    let pubkey1 = solana_pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
     let account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
@@ -1644,8 +1644,8 @@ fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
     solana_logger::setup();
 
     let accounts = AccountsDb::new_single_for_tests();
-    let pubkey1 = solana_sdk::pubkey::new_rand();
-    let pubkey2 = solana_sdk::pubkey::new_rand();
+    let pubkey1 = solana_pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
     // Store 2 accounts in slot 0, then update account 1 in two more slots
@@ -1691,7 +1691,7 @@ fn test_clean_zero_lamport_and_old_roots() {
     solana_logger::setup();
 
     let accounts = AccountsDb::new_single_for_tests();
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     let account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
@@ -1732,7 +1732,7 @@ fn test_clean_old_with_normal_account() {
     solana_logger::setup();
 
     let accounts = AccountsDb::new_single_for_tests();
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     let account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
     //store an account
     accounts.store_for_tests(0, &[(&pubkey, &account)]);
@@ -1760,8 +1760,8 @@ fn test_clean_old_with_zero_lamport_account() {
     solana_logger::setup();
 
     let accounts = AccountsDb::new_single_for_tests();
-    let pubkey1 = solana_sdk::pubkey::new_rand();
-    let pubkey2 = solana_sdk::pubkey::new_rand();
+    let pubkey1 = solana_pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
     let normal_account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
     let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
     //store an account
@@ -1797,8 +1797,8 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
         account_indexes: spl_token_mint_index_enabled(),
         ..AccountsDb::new_single_for_tests()
     };
-    let pubkey1 = solana_sdk::pubkey::new_rand();
-    let pubkey2 = solana_sdk::pubkey::new_rand();
+    let pubkey1 = solana_pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
 
     // Set up account to be added to secondary index
     let mint_key = Pubkey::new_unique();
@@ -1932,7 +1932,7 @@ fn test_clean_max_slot_zero_lamport_account() {
     solana_logger::setup();
 
     let accounts = AccountsDb::new_single_for_tests();
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     let account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
     let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
@@ -1990,10 +1990,10 @@ fn test_accounts_db_purge_keep_live() {
     let owner = *AccountSharedData::default().owner();
 
     let account = AccountSharedData::new(some_lamport, no_data, &owner);
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
 
     let account2 = AccountSharedData::new(some_lamport, no_data, &owner);
-    let pubkey2 = solana_sdk::pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
 
     let zero_lamport_account = AccountSharedData::new(zero_lamport, no_data, &owner);
 
@@ -2072,7 +2072,7 @@ fn test_accounts_db_purge1() {
     let owner = *AccountSharedData::default().owner();
 
     let account = AccountSharedData::new(some_lamport, no_data, &owner);
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
 
     let zero_lamport_account = AccountSharedData::new(zero_lamport, no_data, &owner);
 
@@ -2139,7 +2139,7 @@ fn test_store_account_stress() {
             std::thread::Builder::new()
                 .name("account-writers".to_string())
                 .spawn(move || {
-                    let pubkey = solana_sdk::pubkey::new_rand();
+                    let pubkey = solana_pubkey::new_rand();
                     let mut account = AccountSharedData::new(1, 0, &pubkey);
                     let mut i = 0;
                     loop {
@@ -2171,12 +2171,12 @@ fn test_accountsdb_scan_accounts() {
     solana_logger::setup();
     let db = AccountsDb::new_single_for_tests();
     let key = Pubkey::default();
-    let key0 = solana_sdk::pubkey::new_rand();
+    let key0 = solana_pubkey::new_rand();
     let account0 = AccountSharedData::new(1, 0, &key);
 
     db.store_for_tests(0, &[(&key0, &account0)]);
 
-    let key1 = solana_sdk::pubkey::new_rand();
+    let key1 = solana_pubkey::new_rand();
     let account1 = AccountSharedData::new(2, 0, &key);
     db.store_for_tests(1, &[(&key1, &account1)]);
 
@@ -2211,12 +2211,12 @@ fn test_cleanup_key_not_removed() {
     let db = AccountsDb::new_single_for_tests();
 
     let key = Pubkey::default();
-    let key0 = solana_sdk::pubkey::new_rand();
+    let key0 = solana_pubkey::new_rand();
     let account0 = AccountSharedData::new(1, 0, &key);
 
     db.store_for_tests(0, &[(&key0, &account0)]);
 
-    let key1 = solana_sdk::pubkey::new_rand();
+    let key1 = solana_pubkey::new_rand();
     let account1 = AccountSharedData::new(2, 0, &key);
     db.store_for_tests(1, &[(&key1, &account1)]);
 
@@ -2378,7 +2378,7 @@ fn test_verify_accounts_hash() {
     solana_logger::setup();
     let db = AccountsDb::new_single_for_tests();
 
-    let key = solana_sdk::pubkey::new_rand();
+    let key = solana_pubkey::new_rand();
     let some_data_len = 0;
     let some_slot: Slot = 0;
     let account = AccountSharedData::new(1, some_data_len, &key);
@@ -2428,7 +2428,7 @@ fn test_verify_bank_capitalization() {
         solana_logger::setup();
         let db = AccountsDb::new_single_for_tests();
 
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let some_data_len = 0;
         let some_slot: Slot = 0;
         let account = AccountSharedData::new(1, some_data_len, &key);
@@ -2453,7 +2453,7 @@ fn test_verify_bank_capitalization() {
             continue;
         }
 
-        let native_account_pubkey = solana_sdk::pubkey::new_rand();
+        let native_account_pubkey = solana_pubkey::new_rand();
         db.store_for_tests(
             some_slot,
             &[(
@@ -2546,10 +2546,10 @@ fn test_storage_finder() {
         file_size: 16 * 1024,
         ..AccountsDb::new_single_for_tests()
     };
-    let key = solana_sdk::pubkey::new_rand();
+    let key = solana_pubkey::new_rand();
     let lamports = 100;
     let data_len = 8190;
-    let account = AccountSharedData::new(lamports, data_len, &solana_sdk::pubkey::new_rand());
+    let account = AccountSharedData::new(lamports, data_len, &solana_pubkey::new_rand());
     // pre-populate with a smaller empty store
     db.create_and_insert_store(1, 8192, "test_storage_finder");
     db.store_for_tests(1, &[(&key, &account)]);
@@ -2657,7 +2657,7 @@ define_accounts_db_test!(
     test_storage_remove_account_double_remove,
     panic = "double remove of account in slot: 0/store: 0!!",
     |accounts| {
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
         accounts.store_for_tests(0, &[(&pubkey, &account)]);
         accounts.add_root_and_flush_write_cache(0);
@@ -2820,7 +2820,7 @@ fn test_shrink_candidate_slots() {
 
     let pubkey_count = 30000;
     let pubkeys: Vec<_> = (0..pubkey_count)
-        .map(|_| solana_sdk::pubkey::new_rand())
+        .map(|_| solana_pubkey::new_rand())
         .collect();
 
     let some_lamport = 223;
@@ -3313,7 +3313,7 @@ fn test_store_overhead() {
     solana_logger::setup();
     let accounts = AccountsDb::new_single_for_tests();
     let account = AccountSharedData::default();
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     accounts.store_for_tests(0, &[(&pubkey, &account)]);
     accounts.add_root_and_flush_write_cache(0);
     let store = accounts.storage.get_slot_storage_entry(0).unwrap();
@@ -3329,10 +3329,10 @@ fn test_store_clean_after_shrink() {
     let epoch_schedule = EpochSchedule::default();
 
     let account = AccountSharedData::new(1, 16 * 4096, &Pubkey::default());
-    let pubkey1 = solana_sdk::pubkey::new_rand();
+    let pubkey1 = solana_pubkey::new_rand();
     accounts.store_cached((0, &[(&pubkey1, &account)][..]), None);
 
-    let pubkey2 = solana_sdk::pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
     accounts.store_cached((0, &[(&pubkey2, &account)][..]), None);
 
     let zero_account = AccountSharedData::new(0, 1, &Pubkey::default());
@@ -3514,9 +3514,9 @@ fn test_flush_accounts_cache() {
     let unrooted_slot = 4;
     let root5 = 5;
     let root6 = 6;
-    let unrooted_key = solana_sdk::pubkey::new_rand();
-    let key5 = solana_sdk::pubkey::new_rand();
-    let key6 = solana_sdk::pubkey::new_rand();
+    let unrooted_key = solana_pubkey::new_rand();
+    let key5 = solana_pubkey::new_rand();
+    let key6 = solana_pubkey::new_rand();
     db.store_cached((unrooted_slot, &[(&unrooted_key, &account0)][..]), None);
     db.store_cached((root5, &[(&key5, &account0)][..]), None);
     db.store_cached((root6, &[(&key6, &account0)][..]), None);
@@ -5422,7 +5422,7 @@ fn test_is_candidate_for_shrink() {
 
 define_accounts_db_test!(test_calculate_storage_count_and_alive_bytes, |accounts| {
     accounts.accounts_index.set_startup(Startup::Startup);
-    let shared_key = solana_sdk::pubkey::new_rand();
+    let shared_key = solana_pubkey::new_rand();
     let account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
     let slot0 = 0;
 
@@ -5514,7 +5514,7 @@ define_accounts_db_test!(
 
 define_accounts_db_test!(test_set_storage_count_and_alive_bytes, |accounts| {
     // make sure we have storage 0
-    let shared_key = solana_sdk::pubkey::new_rand();
+    let shared_key = solana_pubkey::new_rand();
     let account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
     let slot0 = 0;
     accounts.store_for_tests(slot0, &[(&shared_key, &account)]);
@@ -5556,9 +5556,9 @@ define_accounts_db_test!(test_set_storage_count_and_alive_bytes, |accounts| {
 
 define_accounts_db_test!(test_purge_alive_unrooted_slots_after_clean, |accounts| {
     // Key shared between rooted and nonrooted slot
-    let shared_key = solana_sdk::pubkey::new_rand();
+    let shared_key = solana_pubkey::new_rand();
     // Key to keep the storage entry for the unrooted slot alive
-    let unrooted_key = solana_sdk::pubkey::new_rand();
+    let unrooted_key = solana_pubkey::new_rand();
     let slot0 = 0;
     let slot1 = 1;
 
@@ -5615,8 +5615,8 @@ fn assert_no_storages_at_slot(db: &AccountsDb, slot: Slot) {
 define_accounts_db_test!(
     test_clean_accounts_with_latest_full_snapshot_slot,
     |accounts_db| {
-        let pubkey = solana_sdk::pubkey::new_rand();
-        let owner = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
+        let owner = solana_pubkey::new_rand();
         let space = 0;
 
         let slot1: Slot = 1;
@@ -5681,7 +5681,7 @@ fn test_filter_zero_lamport_clean_for_incremental_snapshots() {
 
     let do_test = |test_params: TestParameters| {
         let account_info = AccountInfo::new(StorageLocation::AppendVec(42, 128), 0);
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let mut key_set = HashSet::default();
         key_set.insert(pubkey);
         let store_count = 0;
@@ -6492,7 +6492,7 @@ fn test_hash_storage_info() {
         let mut hasher = DefaultHasher::new();
         let slot: Slot = 0;
         let tf = crate::append_vec::test_utils::get_append_vec_path("test_hash_storage_info");
-        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
         let mark_alive = false;
         let storage = sample_storage_with_entries(&tf, slot, &pubkey1, mark_alive);
 
@@ -6508,7 +6508,7 @@ fn test_hash_storage_info() {
                                  // can't assert hash here - it is a function of mod date
         assert!(load);
         let mut hasher = DefaultHasher::new();
-        append_sample_data_to_storage(&storage, &solana_sdk::pubkey::new_rand(), false, None);
+        append_sample_data_to_storage(&storage, &solana_pubkey::new_rand(), false, None);
         let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);
         let hash3 = hasher.finish();
         assert_ne!(hash2, hash3); // moddate and written size changed
@@ -6801,7 +6801,7 @@ fn test_shrink_collect_simple() {
     let max_appended_accounts = 2;
     let max_num_accounts = *account_counts.iter().max().unwrap();
     let pubkeys = (0..(max_num_accounts + max_appended_accounts))
-        .map(|_| solana_sdk::pubkey::new_rand())
+        .map(|_| solana_pubkey::new_rand())
         .collect::<Vec<_>>();
     // write accounts, maybe remove from index
     // check shrink_collect results
@@ -7569,7 +7569,7 @@ pub(crate) fn create_storages_and_update_index_with_customized_account_size_per_
         .unwrap_or(999);
     for (i, account_data_size) in account_data_sizes.iter().enumerate().take(num_slots) {
         let id = starting_id + (i as AccountsFileId);
-        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
         let storage = sample_storage_with_entries_id_fill_percentage(
             tf,
             starting_slot + (i as Slot),
@@ -7616,7 +7616,7 @@ pub(crate) fn create_storages_and_update_index(
         .unwrap_or(999);
     for i in 0..num_slots {
         let id = starting_id + (i as AccountsFileId);
-        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
         let storage = sample_storage_with_entries_id(
             tf,
             starting_slot + (i as Slot),
@@ -7770,7 +7770,7 @@ fn test_should_move_to_ancient_accounts_file() {
     let tf = crate::append_vec::test_utils::get_append_vec_path(
         "test_should_move_to_ancient_append_vec",
     );
-    let pubkey1 = solana_sdk::pubkey::new_rand();
+    let pubkey1 = solana_pubkey::new_rand();
     let storage = sample_storage_with_entries(&tf, slot5, &pubkey1, false);
     let mut current_ancient = CurrentAncientAccountsFile::default();
 

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -2166,7 +2166,7 @@ pub mod tests {
 
     #[test]
     fn test_get_empty() {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let ancestors = Ancestors::default();
         let key = &key;
@@ -2283,7 +2283,7 @@ pub mod tests {
 
     #[test]
     fn test_insert_no_ancestors() {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let mut gc = Vec::new();
         index.upsert(
@@ -2330,7 +2330,7 @@ pub mod tests {
 
     #[test]
     fn test_insert_duplicates() {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let pubkey = &key;
         let slot = 0;
         let mut ancestors = Ancestors::default();
@@ -2354,7 +2354,7 @@ pub mod tests {
 
     #[test]
     fn test_insert_new_with_lock_no_ancestors() {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let pubkey = &key;
         let slot = 0;
 
@@ -2494,8 +2494,8 @@ pub mod tests {
     #[test]
     fn test_batch_insert() {
         let slot0 = 0;
-        let key0 = solana_sdk::pubkey::new_rand();
-        let key1 = solana_sdk::pubkey::new_rand();
+        let key0 = solana_pubkey::new_rand();
+        let key1 = solana_pubkey::new_rand();
 
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let account_infos = [true, false];
@@ -2533,7 +2533,7 @@ pub mod tests {
 
         let slot0 = 0;
         let slot1 = 1;
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
 
         let mut config = ACCOUNTS_INDEX_CONFIG_FOR_TESTING;
         config.index_limit_mb = if use_disk {
@@ -2655,7 +2655,7 @@ pub mod tests {
 
     #[test]
     fn test_insert_with_lock_no_ancestors() {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let slot = 0;
         let account_info = true;
@@ -2701,7 +2701,7 @@ pub mod tests {
 
     #[test]
     fn test_insert_wrong_ancestors() {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let mut gc = Vec::new();
         index.upsert(
@@ -2732,7 +2732,7 @@ pub mod tests {
     fn test_insert_ignore_reclaims() {
         {
             // non-cached
-            let key = solana_sdk::pubkey::new_rand();
+            let key = solana_pubkey::new_rand();
             let index = AccountsIndex::<u64, u64>::default_for_tests();
             let mut reclaims = Vec::new();
             let slot = 0;
@@ -2778,7 +2778,7 @@ pub mod tests {
         }
         {
             // cached
-            let key = solana_sdk::pubkey::new_rand();
+            let key = solana_pubkey::new_rand();
             let index = AccountsIndex::<AccountInfoTest, AccountInfoTest>::default_for_tests();
             let mut reclaims = Vec::new();
             let slot = 0;
@@ -2826,7 +2826,7 @@ pub mod tests {
 
     #[test]
     fn test_insert_with_ancestors() {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let mut gc = Vec::new();
         index.upsert(
@@ -2877,7 +2877,7 @@ pub mod tests {
         let root_slot = 0;
 
         let mut pubkeys: Vec<Pubkey> = std::iter::repeat_with(|| {
-            let new_pubkey = solana_sdk::pubkey::new_rand();
+            let new_pubkey = solana_pubkey::new_rand();
             index.upsert(
                 root_slot,
                 root_slot,
@@ -3041,7 +3041,7 @@ pub mod tests {
         index.upsert(
             0,
             0,
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             true,
@@ -3061,7 +3061,7 @@ pub mod tests {
 
     #[test]
     fn test_insert_with_root() {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let mut gc = Vec::new();
         index.upsert(
@@ -3108,7 +3108,7 @@ pub mod tests {
 
     #[test]
     fn test_update_last_wins() {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let ancestors = vec![(0, 0)].into_iter().collect();
         let mut gc = Vec::new();
@@ -3165,7 +3165,7 @@ pub mod tests {
     #[test]
     fn test_update_new_slot() {
         solana_logger::setup();
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let ancestors = vec![(0, 0)].into_iter().collect();
         let mut gc = Vec::new();
@@ -3220,7 +3220,7 @@ pub mod tests {
 
     #[test]
     fn test_update_gc_purged_slot() {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let mut gc = Vec::new();
         index.upsert(
@@ -3312,7 +3312,7 @@ pub mod tests {
 
     #[test]
     fn test_purge() {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<u64, u64>::default_for_tests();
         let mut gc = Vec::new();
         assert_eq!(0, account_maps_stats_len(&index));
@@ -4010,7 +4010,7 @@ pub mod tests {
     #[test]
     fn test_unref() {
         let value = true;
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let slot1 = 1;
 
@@ -4042,8 +4042,8 @@ pub mod tests {
     fn test_clean_rooted_entries_return() {
         solana_logger::setup();
         let value = true;
-        let key = solana_sdk::pubkey::new_rand();
-        let key_unknown = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
+        let key_unknown = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let slot1 = 1;
 
@@ -4140,7 +4140,7 @@ pub mod tests {
 
     #[test]
     fn test_handle_dead_keys_return() {
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
 
         assert_eq!(

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -2111,8 +2111,8 @@ mod tests {
 
     #[test]
     fn test_remove_if_slot_list_empty_entry() {
-        let key = solana_sdk::pubkey::new_rand();
-        let unknown_key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
+        let unknown_key = solana_pubkey::new_rand();
 
         let test = new_for_test::<u64>();
 

--- a/accounts-db/src/accounts_partition.rs
+++ b/accounts-db/src/accounts_partition.rs
@@ -556,7 +556,7 @@ pub(crate) mod tests {
     fn map_to_test_bad_range() -> std::collections::BTreeMap<Pubkey, i8> {
         let mut map = std::collections::BTreeMap::new();
         // when empty, std::collections::BTreeMap doesn't sanitize given range...
-        map.insert(solana_sdk::pubkey::new_rand(), 1);
+        map.insert(solana_pubkey::new_rand(), 1);
         map
     }
 

--- a/accounts-db/src/ancestors.rs
+++ b/accounts-db/src/ancestors.rs
@@ -1,7 +1,7 @@
 use {
     crate::rolling_bit_field::RollingBitField,
     core::fmt::{Debug, Formatter},
-    solana_sdk::clock::Slot,
+    solana_clock::Slot,
     std::collections::HashMap,
 };
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1420,7 +1420,7 @@ pub mod tests {
                     .map(|storage| {
                         (0..(total_accounts_per_storage - 1))
                             .map(|_| {
-                                let pk = solana_sdk::pubkey::new_rand();
+                                let pk = solana_pubkey::new_rand();
                                 let mut account = account_template.clone();
                                 account.set_lamports(lamports);
                                 lamports += 1;
@@ -1527,7 +1527,7 @@ pub mod tests {
                     .map(|storage| {
                         (0..(total_accounts_per_storage - 1))
                             .map(|_| {
-                                let pk = solana_sdk::pubkey::new_rand();
+                                let pk = solana_pubkey::new_rand();
                                 let mut account = account_template.clone();
                                 account.set_data((0..data_size).map(|x| (x % 256) as u8).collect());
                                 data_size += 1;
@@ -1873,7 +1873,7 @@ pub mod tests {
 
                                 if add_dead_account {
                                     storages.iter().for_each(|storage| {
-                                        let pk = solana_sdk::pubkey::new_rand();
+                                        let pk = solana_pubkey::new_rand();
                                         let alive = false;
                                         append_single_account_with_default_hash(
                                             storage,
@@ -2044,7 +2044,7 @@ pub mod tests {
                 .iter()
                 .map(|store| db.get_unique_accounts_from_storage(store))
                 .collect::<Vec<_>>();
-            let pk_with_1_ref = solana_sdk::pubkey::new_rand();
+            let pk_with_1_ref = solana_pubkey::new_rand();
             let slot1 = slots.start;
             let account_with_2_refs = original_results
                 .first()
@@ -2238,7 +2238,7 @@ pub mod tests {
                 .map(|store| db.get_unique_accounts_from_storage(store))
                 .collect::<Vec<_>>();
             let storage = storages.first().unwrap().clone();
-            let pk_with_1_ref = solana_sdk::pubkey::new_rand();
+            let pk_with_1_ref = solana_pubkey::new_rand();
             let slot1 = slots.start;
             let account_with_2_refs = original_results
                 .first()
@@ -3902,7 +3902,7 @@ pub mod tests {
         let empty_account = AccountSharedData::default();
         for count in 0..3 {
             let pubkeys_to_unref = (0..count)
-                .map(|_| solana_sdk::pubkey::new_rand())
+                .map(|_| solana_pubkey::new_rand())
                 .collect::<Vec<_>>();
             // how many of `many_ref_accounts` should be found in the index with ref_count=1
             let mut expected_ref_counts_before_unref = HashMap::<Pubkey, u64>::default();

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -18,8 +18,8 @@ use {
     },
     rand::{thread_rng, Rng},
     rayon::prelude::{IntoParallelRefIterator, ParallelIterator},
+    solana_clock::Slot,
     solana_measure::measure_us,
-    solana_sdk::clock::Slot,
     std::{
         collections::{HashMap, VecDeque},
         num::{NonZeroU64, Saturating},

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1579,7 +1579,7 @@ pub mod tests {
             let mut av = AppendVec::new(path, true, 256);
             av.set_no_remove_on_drop();
 
-            let pubkey = solana_sdk::pubkey::new_rand();
+            let pubkey = solana_pubkey::new_rand();
             let owner = Pubkey::default();
             let data_len = 3_u64;
             let mut account = AccountSharedData::new(0, data_len as usize, &owner);
@@ -1915,7 +1915,7 @@ pub mod tests {
         check_fn: impl Fn(&AppendVec, &[Pubkey], &[usize], &[AccountSharedData]),
     ) {
         const NUM_ACCOUNTS: usize = 37;
-        let pubkeys: Vec<_> = std::iter::repeat_with(solana_sdk::pubkey::new_rand)
+        let pubkeys: Vec<_> = std::iter::repeat_with(solana_pubkey::new_rand)
             .take(NUM_ACCOUNTS)
             .collect();
 
@@ -2008,12 +2008,12 @@ pub mod tests {
             let fake_stored_meta = StoredMeta {
                 write_version_obsolete: 0,
                 data_len: 100,
-                pubkey: solana_sdk::pubkey::new_rand(),
+                pubkey: solana_pubkey::new_rand(),
             };
             let fake_account_meta = AccountMeta {
                 lamports: 100,
                 rent_epoch: 10,
-                owner: solana_sdk::pubkey::new_rand(),
+                owner: solana_pubkey::new_rand(),
                 executable: false,
             };
 
@@ -2107,12 +2107,12 @@ pub mod tests {
             let fake_stored_meta = StoredMeta {
                 write_version_obsolete: 0,
                 data_len: 100,
-                pubkey: solana_sdk::pubkey::new_rand(),
+                pubkey: solana_pubkey::new_rand(),
             };
             let fake_account_meta = AccountMeta {
                 lamports: 100,
                 rent_epoch: 10,
-                owner: solana_sdk::pubkey::new_rand(),
+                owner: solana_pubkey::new_rand(),
                 executable: false,
             };
 

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -569,7 +569,7 @@ mod tests {
                                 let mut pk;
                                 loop {
                                     // expensive, but small numbers and for tests, so ok
-                                    pk = solana_sdk::pubkey::new_rand();
+                                    pk = solana_pubkey::new_rand();
                                     if binner.bin_from_pubkey(&pk) == bin {
                                         break;
                                     }

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -576,7 +576,7 @@ mod tests {
                                 }
 
                                 CalculateHashIntermediate {
-                                    hash: AccountHash(solana_sdk::hash::Hash::new_unique()),
+                                    hash: AccountHash(solana_hash::Hash::new_unique()),
                                     lamports: ct as u64,
                                     pubkey: pk,
                                 }

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -5,8 +5,8 @@ use {
     crate::{accounts_hash::CalculateHashIntermediate, cache_hash_data_stats::CacheHashDataStats},
     bytemuck_derive::{Pod, Zeroable},
     memmap2::MmapMut,
+    solana_clock::Slot,
     solana_measure::{measure::Measure, measure_us},
-    solana_sdk::clock::Slot,
     std::{
         collections::HashSet,
         fs::{self, remove_file, File, OpenOptions},

--- a/accounts-db/src/epoch_accounts_hash.rs
+++ b/accounts-db/src/epoch_accounts_hash.rs
@@ -7,7 +7,7 @@
 //!
 //! This results in all nodes effectively voting on the accounts state (at least) once per epoch.
 
-use {crate::accounts_hash::AccountsHash, solana_sdk::hash::Hash};
+use {crate::accounts_hash::AccountsHash, solana_hash::Hash};
 
 mod manager;
 pub use manager::Manager as EpochAccountsHashManager;

--- a/accounts-db/src/epoch_accounts_hash/manager.rs
+++ b/accounts-db/src/epoch_accounts_hash/manager.rs
@@ -1,6 +1,6 @@
 use {
     super::EpochAccountsHash,
-    solana_sdk::clock::Slot,
+    solana_clock::Slot,
     std::sync::{Condvar, Mutex},
 };
 

--- a/accounts-db/src/epoch_accounts_hash/manager.rs
+++ b/accounts-db/src/epoch_accounts_hash/manager.rs
@@ -103,7 +103,7 @@ enum State {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_sdk::hash::Hash, std::time::Duration};
+    use {super::*, solana_hash::Hash, std::time::Duration};
 
     #[test]
     fn test_new_valid() {

--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -1,4 +1,4 @@
-use solana_sdk::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(Debug)]
 pub struct PubkeyBinCalculator24 {

--- a/accounts-db/src/rolling_bit_field.rs
+++ b/accounts-db/src/rolling_bit_field.rs
@@ -4,8 +4,8 @@
 
 mod iterators;
 use {
-    bv::BitVec, iterators::RollingBitFieldOnesIter, solana_nohash_hasher::IntSet,
-    solana_sdk::clock::Slot,
+    bv::BitVec, iterators::RollingBitFieldOnesIter, solana_clock::Slot,
+    solana_nohash_hasher::IntSet,
 };
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]

--- a/accounts-db/src/sorted_storages.rs
+++ b/accounts-db/src/sorted_storages.rs
@@ -1,8 +1,8 @@
 use {
     crate::accounts_db::AccountStorageEntry,
     log::*,
+    solana_clock::Slot,
     solana_measure::measure::Measure,
-    solana_sdk::clock::Slot,
     std::{
         collections::HashMap,
         ops::{Bound, Range, RangeBounds},

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -63,7 +63,7 @@ impl StakeReward {
 
         let rent = Rent::free();
 
-        let validator_pubkey = solana_sdk::pubkey::new_rand();
+        let validator_pubkey = solana_pubkey::new_rand();
         let validator_stake_lamports = 20;
         let validator_staking_keypair = Keypair::new();
         let validator_voting_keypair = Keypair::new();

--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -315,7 +315,7 @@ mod tests {
             append_vec::test_utils::get_append_vec_path, tiered_storage::file::TieredWritableFile,
         },
         memoffset::offset_of,
-        solana_sdk::hash::Hash,
+        solana_hash::Hash,
     };
 
     #[test]

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -5,7 +5,7 @@ use {
     },
     bytemuck::{Pod, Zeroable},
     memmap2::Mmap,
-    solana_sdk::pubkey::Pubkey,
+    solana_pubkey::Pubkey,
 };
 
 /// The in-memory struct for the writing index block.

--- a/accounts-db/src/tiered_storage/meta.rs
+++ b/accounts-db/src/tiered_storage/meta.rs
@@ -264,7 +264,7 @@ pub mod tests {
 
     #[test]
     fn test_pubkey_range_update_single() {
-        let address = solana_sdk::pubkey::new_rand();
+        let address = solana_pubkey::new_rand();
         let mut address_range = AccountAddressRange::default();
 
         address_range.update(&address);
@@ -285,7 +285,7 @@ pub mod tests {
 
         // Generate random addresses and track expected min and max indices
         for i in 0..NUM_PUBKEYS {
-            let address = solana_sdk::pubkey::new_rand();
+            let address = solana_pubkey::new_rand();
             addresses.push(address);
 
             // Update expected min and max indices

--- a/accounts-db/src/tiered_storage/owners.rs
+++ b/accounts-db/src/tiered_storage/owners.rs
@@ -5,7 +5,7 @@ use {
     },
     indexmap::set::IndexSet,
     memmap2::Mmap,
-    solana_sdk::pubkey::Pubkey,
+    solana_pubkey::Pubkey,
 };
 
 /// The offset to an owner entry in the owners block.

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4986,6 +4986,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "solana-bucket-map",
+ "solana-hash",
  "solana-inline-spl",
  "solana-lattice-hash",
  "solana-measure",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4991,6 +4991,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-nohash-hasher",
+ "solana-pubkey",
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-svm-transaction",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4986,6 +4986,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "solana-bucket-map",
+ "solana-clock",
  "solana-hash",
  "solana-inline-spl",
  "solana-lattice-hash",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -4842,6 +4842,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-nohash-hasher",
+ "solana-pubkey",
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-svm-transaction",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -4837,6 +4837,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "solana-bucket-map",
+ "solana-hash",
  "solana-inline-spl",
  "solana-lattice-hash",
  "solana-measure",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -4837,6 +4837,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "solana-bucket-map",
+ "solana-clock",
  "solana-hash",
  "solana-inline-spl",
  "solana-lattice-hash",


### PR DESCRIPTION
#### Problem
Most of the solana-sdk usage in accounts-db can be replaced.

#### Summary of Changes
Replace some of it. There's a lot to replace and this PR is big enough already
