### PR TITLE
replace solana_sdk::pubkey with solana_pubkey in solana-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8681,6 +8681,7 @@ dependencies = [
  "solana-perf",
  "solana-program",
  "solana-program-runtime",
+ "solana-pubkey",
  "solana-rayon-threadlimit",
  "solana-runtime",
  "solana-runtime-transaction",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6833,6 +6833,7 @@ dependencies = [
  "solana-perf",
  "solana-program",
  "solana-program-runtime",
+ "solana-pubkey",
  "solana-rayon-threadlimit",
  "solana-runtime-transaction",
  "solana-sdk",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -71,6 +71,7 @@ solana-metrics = { workspace = true }
 solana-perf = { workspace = true }
 solana-program = { workspace = true }
 solana-program-runtime = { workspace = true }
+solana-pubkey = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-sdk = { workspace = true }

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -19,7 +19,7 @@ use {
 
 fn deposit_many(bank: &Bank, pubkeys: &mut Vec<Pubkey>, num: usize) -> Result<(), LamportsError> {
     for t in 0..num {
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let account =
             AccountSharedData::new((t + 1) as u64, 0, AccountSharedData::default().owner());
         pubkeys.push(pubkey);

--- a/runtime/benches/prioritization_fee_cache.rs
+++ b/runtime/benches/prioritization_fee_cache.rs
@@ -103,7 +103,7 @@ fn bench_process_transactions_multiple_slots(bencher: &mut Bencher) {
     let bank0 = Bank::new_for_benches(&genesis_config);
     let bank_forks = BankForks::new_rw_arc(bank0);
     let bank = bank_forks.read().unwrap().working_bank();
-    let collector = solana_sdk::pubkey::new_rand();
+    let collector = solana_pubkey::new_rand();
     let banks = (1..=NUM_SLOTS)
         .map(|n| Arc::new(Bank::new_from_parent(bank.clone(), &collector, n as u64)))
         .collect::<Vec<_>>();

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -239,7 +239,7 @@ mod tests {
     fn test_collect_accounts_to_store() {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let account0 = AccountSharedData::new(1, 0, &Pubkey::default());
         let account1 = AccountSharedData::new(2, 0, &Pubkey::default());
         let account2 = AccountSharedData::new(3, 0, &Pubkey::default());

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -140,7 +140,7 @@ impl VoteReward {
     pub fn new_random() -> Self {
         let mut rng = rand::thread_rng();
 
-        let validator_pubkey = solana_sdk::pubkey::new_rand();
+        let validator_pubkey = solana_pubkey::new_rand();
         let validator_stake_lamports = rng.gen_range(1..200);
         let validator_voting_keypair = Keypair::new();
 
@@ -207,7 +207,7 @@ fn test_race_register_tick_freeze() {
 
     let (mut genesis_config, _) = create_genesis_config(50);
     genesis_config.ticks_per_slot = 1;
-    let p = solana_sdk::pubkey::new_rand();
+    let p = solana_pubkey::new_rand();
     let hash = hash(p.as_ref());
 
     for _ in 0..1000 {
@@ -287,7 +287,7 @@ fn test_bank_unix_timestamp_from_genesis() {
 
 #[test]
 fn test_bank_new() {
-    let dummy_leader_pubkey = solana_sdk::pubkey::new_rand();
+    let dummy_leader_pubkey = solana_pubkey::new_rand();
     let dummy_leader_stake_lamports = bootstrap_validator_stake_lamports();
     let mint_lamports = 10_000;
     let GenesisConfigInfo {
@@ -418,7 +418,7 @@ fn test_bank_capitalization() {
         accounts: (0..42)
             .map(|_| {
                 (
-                    solana_sdk::pubkey::new_rand(),
+                    solana_pubkey::new_rand(),
                     Account::new(42, 0, &Pubkey::default()),
                 )
             })
@@ -725,7 +725,7 @@ declare_process_instruction!(MockBuiltin, 1, |_invoke_context| {
 #[test]
 fn test_store_account_and_update_capitalization_missing() {
     let bank = create_simple_test_bank(0);
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
 
     let some_lamports = 400;
     let account = AccountSharedData::new(some_lamports, 0, &system_program::id());
@@ -808,7 +808,7 @@ fn test_store_account_and_update_capitalization_unchanged() {
 fn test_rent_distribution() {
     solana_logger::setup();
 
-    let bootstrap_validator_pubkey = solana_sdk::pubkey::new_rand();
+    let bootstrap_validator_pubkey = solana_pubkey::new_rand();
     let bootstrap_validator_stake_lamports = 30;
     let mut genesis_config = create_genesis_config_with_leader(
         10,
@@ -833,7 +833,7 @@ fn test_rent_distribution() {
 
     let rent = Rent::free();
 
-    let validator_1_pubkey = solana_sdk::pubkey::new_rand();
+    let validator_1_pubkey = solana_pubkey::new_rand();
     let validator_1_stake_lamports = 20;
     let validator_1_staking_keypair = Keypair::new();
     let validator_1_voting_keypair = Keypair::new();
@@ -866,7 +866,7 @@ fn test_rent_distribution() {
         Account::from(validator_1_vote_account),
     );
 
-    let validator_2_pubkey = solana_sdk::pubkey::new_rand();
+    let validator_2_pubkey = solana_pubkey::new_rand();
     let validator_2_stake_lamports = 20;
     let validator_2_staking_keypair = Keypair::new();
     let validator_2_voting_keypair = Keypair::new();
@@ -899,7 +899,7 @@ fn test_rent_distribution() {
         Account::from(validator_2_vote_account),
     );
 
-    let validator_3_pubkey = solana_sdk::pubkey::new_rand();
+    let validator_3_pubkey = solana_pubkey::new_rand();
     let validator_3_stake_lamports = 30;
     let validator_3_staking_keypair = Keypair::new();
     let validator_3_voting_keypair = Keypair::new();
@@ -1053,9 +1053,9 @@ fn test_rent_exempt_executable_account() {
     let bank =
         create_child_bank_for_rent_test(root_bank, &genesis_config, bank_forks.as_ref(), None);
 
-    let account_pubkey = solana_sdk::pubkey::new_rand();
+    let account_pubkey = solana_pubkey::new_rand();
     let account_balance = 1;
-    let mut account = AccountSharedData::new(account_balance, 0, &solana_sdk::pubkey::new_rand());
+    let mut account = AccountSharedData::new(account_balance, 0, &solana_pubkey::new_rand());
     account.set_executable(true);
     account.set_owner(bpf_loader_upgradeable::id());
     bank.store_account(&account_pubkey, &account);
@@ -1368,7 +1368,7 @@ fn test_rent_eager_across_epoch_with_half_gap() {
 #[test]
 #[allow(clippy::cognitive_complexity)]
 fn test_rent_eager_across_epoch_without_gap_under_multi_epoch_cycle() {
-    let leader_pubkey = solana_sdk::pubkey::new_rand();
+    let leader_pubkey = solana_pubkey::new_rand();
     let leader_lamports = 3;
     let mut genesis_config =
         create_genesis_config_with_leader(5, &leader_pubkey, leader_lamports).genesis_config;
@@ -1438,7 +1438,7 @@ fn test_rent_eager_across_epoch_without_gap_under_multi_epoch_cycle() {
 
 #[test]
 fn test_rent_eager_across_epoch_with_gap_under_multi_epoch_cycle() {
-    let leader_pubkey = solana_sdk::pubkey::new_rand();
+    let leader_pubkey = solana_pubkey::new_rand();
     let leader_lamports = 3;
     let mut genesis_config =
         create_genesis_config_with_leader(5, &leader_pubkey, leader_lamports).genesis_config;
@@ -1496,7 +1496,7 @@ fn test_rent_eager_across_epoch_with_gap_under_multi_epoch_cycle() {
 
 #[test]
 fn test_rent_eager_with_warmup_epochs_under_multi_epoch_cycle() {
-    let leader_pubkey = solana_sdk::pubkey::new_rand();
+    let leader_pubkey = solana_pubkey::new_rand();
     let leader_lamports = 3;
     let mut genesis_config =
         create_genesis_config_with_leader(5, &leader_pubkey, leader_lamports).genesis_config;
@@ -1553,7 +1553,7 @@ fn test_rent_eager_with_warmup_epochs_under_multi_epoch_cycle() {
 #[test]
 fn test_rent_eager_under_fixed_cycle_for_development() {
     solana_logger::setup();
-    let leader_pubkey = solana_sdk::pubkey::new_rand();
+    let leader_pubkey = solana_pubkey::new_rand();
     let leader_lamports = 3;
     let mut genesis_config =
         create_genesis_config_with_leader(5, &leader_pubkey, leader_lamports).genesis_config;
@@ -1653,9 +1653,9 @@ fn test_rent_eager_collect_rent_in_partition(should_collect_rent: bool) {
         }
     }
 
-    let zero_lamport_pubkey = solana_sdk::pubkey::new_rand();
-    let rent_due_pubkey = solana_sdk::pubkey::new_rand();
-    let rent_exempt_pubkey = solana_sdk::pubkey::new_rand();
+    let zero_lamport_pubkey = solana_pubkey::new_rand();
+    let rent_due_pubkey = solana_pubkey::new_rand();
+    let rent_exempt_pubkey = solana_pubkey::new_rand();
     let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
     assert_eq!(should_collect_rent, bank.should_collect_rent());
@@ -1835,7 +1835,7 @@ fn test_rent_eager_collect_rent_zero_lamport_deterministic() {
 
     let (genesis_config, _mint_keypair) = create_genesis_config(1);
 
-    let zero_lamport_pubkey = solana_sdk::pubkey::new_rand();
+    let zero_lamport_pubkey = solana_pubkey::new_rand();
 
     let genesis_bank1 = Arc::new(Bank::new_for_tests(&genesis_config));
     let genesis_bank2 = Arc::new(Bank::new_for_tests(&genesis_config));
@@ -1911,7 +1911,7 @@ where
         accounts: (0..42)
             .map(|_| {
                 (
-                    solana_sdk::pubkey::new_rand(),
+                    solana_pubkey::new_rand(),
                     Account::new(1_000_000_000, 0, &Pubkey::default()),
                 )
             })
@@ -2040,7 +2040,7 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
         accounts: (0..42)
             .map(|_| {
                 (
-                    solana_sdk::pubkey::new_rand(),
+                    solana_pubkey::new_rand(),
                     Account::new(1_000_000_000, 0, &Pubkey::default()),
                 )
             })
@@ -2067,12 +2067,11 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
         42 * 1_000_000_000 + genesis_sysvar_and_builtin_program_lamports()
     );
 
-    let vote_id = solana_sdk::pubkey::new_rand();
-    let mut vote_account =
-        vote_state::create_account(&vote_id, &solana_sdk::pubkey::new_rand(), 0, 100);
-    let stake_id1 = solana_sdk::pubkey::new_rand();
+    let vote_id = solana_pubkey::new_rand();
+    let mut vote_account = vote_state::create_account(&vote_id, &solana_pubkey::new_rand(), 0, 100);
+    let stake_id1 = solana_pubkey::new_rand();
     let stake_account1 = crate::stakes::tests::create_stake_account(123, &vote_id, &stake_id1);
-    let stake_id2 = solana_sdk::pubkey::new_rand();
+    let stake_id2 = solana_pubkey::new_rand();
     let stake_account2 = crate::stakes::tests::create_stake_account(456, &vote_id, &stake_id2);
 
     // set up accounts
@@ -2165,7 +2164,7 @@ fn test_purge_empty_accounts() {
 
         for _ in 0..10 {
             let blockhash = bank.last_blockhash();
-            let pubkey = solana_sdk::pubkey::new_rand();
+            let pubkey = solana_pubkey::new_rand();
             let tx = system_transaction::transfer(&mint_keypair, &pubkey, 0, blockhash);
             bank.process_transaction(&tx).unwrap();
             bank.freeze();
@@ -2187,7 +2186,7 @@ fn test_purge_empty_accounts() {
         bank0.process_transaction(&tx).unwrap();
 
         let bank1 = new_from_parent_with_fork_next_slot(bank0.clone(), bank_forks.as_ref());
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let blockhash = bank.last_blockhash();
         let tx = system_transaction::transfer(&keypair, &pubkey, amount, blockhash);
         bank1.process_transaction(&tx).unwrap();
@@ -2268,7 +2267,7 @@ fn test_purge_empty_accounts() {
 #[test]
 fn test_two_payments_to_one_party() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
     assert_eq!(bank.last_blockhash(), genesis_config.hash());
@@ -2285,8 +2284,8 @@ fn test_two_payments_to_one_party() {
 #[test]
 fn test_one_source_two_tx_one_batch() {
     let (genesis_config, mint_keypair) = create_genesis_config_no_tx_fee(sol_to_lamports(1.));
-    let key1 = solana_sdk::pubkey::new_rand();
-    let key2 = solana_sdk::pubkey::new_rand();
+    let key1 = solana_pubkey::new_rand();
+    let key2 = solana_pubkey::new_rand();
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
     assert_eq!(bank.last_blockhash(), genesis_config.hash());
@@ -2315,8 +2314,8 @@ fn test_one_source_two_tx_one_batch() {
 fn test_one_tx_two_out_atomic_fail() {
     let amount = sol_to_lamports(1.);
     let (genesis_config, mint_keypair) = create_genesis_config_no_tx_fee_no_rent(amount);
-    let key1 = solana_sdk::pubkey::new_rand();
-    let key2 = solana_sdk::pubkey::new_rand();
+    let key1 = solana_pubkey::new_rand();
+    let key2 = solana_pubkey::new_rand();
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let instructions = system_instruction::transfer_many(
         &mint_keypair.pubkey(),
@@ -2336,8 +2335,8 @@ fn test_one_tx_two_out_atomic_fail() {
 #[test]
 fn test_one_tx_two_out_atomic_pass() {
     let (genesis_config, mint_keypair) = create_genesis_config_no_tx_fee(sol_to_lamports(1.));
-    let key1 = solana_sdk::pubkey::new_rand();
-    let key2 = solana_sdk::pubkey::new_rand();
+    let key1 = solana_pubkey::new_rand();
+    let key2 = solana_pubkey::new_rand();
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
     let instructions = system_instruction::transfer_many(
@@ -2408,7 +2407,7 @@ fn test_insufficient_funds() {
     let mint_amount = sol_to_lamports(1.);
     let (genesis_config, mint_keypair) = create_genesis_config_no_tx_fee(mint_amount);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     let amount = genesis_config.rent.minimum_balance(0);
     bank.transfer(amount, &mint_keypair, &pubkey).unwrap();
     assert_eq!(bank.transaction_count(), 1);
@@ -2436,7 +2435,7 @@ fn test_executed_transaction_count_post_bank_transaction_count_fix() {
     let mint_amount = sol_to_lamports(1.);
     let (genesis_config, mint_keypair) = create_genesis_config(mint_amount);
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     let amount = genesis_config.rent.minimum_balance(0);
     bank.transfer(amount, &mint_keypair, &pubkey).unwrap();
     assert_eq!(
@@ -2480,7 +2479,7 @@ fn test_transfer_to_newb() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     bank.transfer(amount, &mint_keypair, &pubkey).unwrap();
     assert_eq!(bank.get_balance(&pubkey), amount);
 }
@@ -2492,7 +2491,7 @@ fn test_transfer_to_sysvar() {
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
 
-    let normal_pubkey = solana_sdk::pubkey::new_rand();
+    let normal_pubkey = solana_pubkey::new_rand();
     let sysvar_pubkey = sysvar::clock::id();
     assert_eq!(bank.get_balance(&normal_pubkey), 0);
     assert_eq!(bank.get_balance(&sysvar_pubkey), 1_169_280);
@@ -2514,7 +2513,7 @@ fn test_bank_withdraw() {
     let bank = create_simple_test_bank(100);
 
     // Test no account
-    let key = solana_sdk::pubkey::new_rand();
+    let key = solana_pubkey::new_rand();
     assert_eq!(
         bank.withdraw(&key, 10),
         Err(TransactionError::AccountNotFound)
@@ -2575,7 +2574,7 @@ fn test_bank_tx_fee() {
 
     let arbitrary_transfer_amount = 42_000;
     let mint = arbitrary_transfer_amount * 100;
-    let leader = solana_sdk::pubkey::new_rand();
+    let leader = solana_pubkey::new_rand();
     let GenesisConfigInfo {
         mut genesis_config,
         mint_keypair,
@@ -2594,7 +2593,7 @@ fn test_bank_tx_fee() {
 
     let capitalization = bank.capitalization();
 
-    let key = solana_sdk::pubkey::new_rand();
+    let key = solana_pubkey::new_rand();
     let tx = system_transaction::transfer(
         &mint_keypair,
         &key,
@@ -2678,10 +2677,10 @@ fn test_bank_tx_fee() {
 fn test_bank_tx_compute_unit_fee() {
     solana_logger::setup();
 
-    let key = solana_sdk::pubkey::new_rand();
+    let key = solana_pubkey::new_rand();
     let arbitrary_transfer_amount = 42;
     let mint = arbitrary_transfer_amount * 10_000_000;
-    let leader = solana_sdk::pubkey::new_rand();
+    let leader = solana_pubkey::new_rand();
     let GenesisConfigInfo {
         mut genesis_config,
         mint_keypair,
@@ -2788,7 +2787,7 @@ fn test_bank_tx_compute_unit_fee() {
 fn test_bank_blockhash_fee_structure() {
     //solana_logger::setup();
 
-    let leader = solana_sdk::pubkey::new_rand();
+    let leader = solana_pubkey::new_rand();
     let GenesisConfigInfo {
         mut genesis_config,
         mint_keypair,
@@ -2814,7 +2813,7 @@ fn test_bank_blockhash_fee_structure() {
     let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
 
     // Send a transfer using cheap_blockhash
-    let key = solana_sdk::pubkey::new_rand();
+    let key = solana_pubkey::new_rand();
     let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
     let tx = system_transaction::transfer(&mint_keypair, &key, 1, cheap_blockhash);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
@@ -2830,7 +2829,7 @@ fn test_bank_blockhash_fee_structure() {
     );
 
     // Send a transfer using expensive_blockhash
-    let key = solana_sdk::pubkey::new_rand();
+    let key = solana_pubkey::new_rand();
     let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
     let tx = system_transaction::transfer(&mint_keypair, &key, 1, expensive_blockhash);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
@@ -2850,7 +2849,7 @@ fn test_bank_blockhash_fee_structure() {
 fn test_bank_blockhash_compute_unit_fee_structure() {
     //solana_logger::setup();
 
-    let leader = solana_sdk::pubkey::new_rand();
+    let leader = solana_pubkey::new_rand();
     let GenesisConfigInfo {
         mut genesis_config,
         mint_keypair,
@@ -2876,7 +2875,7 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
     let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
 
     // Send a transfer using cheap_blockhash
-    let key = solana_sdk::pubkey::new_rand();
+    let key = solana_pubkey::new_rand();
     let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
     let tx = system_transaction::transfer(&mint_keypair, &key, 1, cheap_blockhash);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
@@ -2892,7 +2891,7 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
     );
 
     // Send a transfer using expensive_blockhash
-    let key = solana_sdk::pubkey::new_rand();
+    let key = solana_pubkey::new_rand();
     let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
     let tx = system_transaction::transfer(&mint_keypair, &key, 1, expensive_blockhash);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
@@ -2910,7 +2909,7 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
 
 #[test]
 fn test_filter_program_errors_and_collect_fee() {
-    let leader = solana_sdk::pubkey::new_rand();
+    let leader = solana_pubkey::new_rand();
     let GenesisConfigInfo { genesis_config, .. } =
         create_genesis_config_with_leader(100_000, &leader, 3);
     let mut bank = Bank::new_for_tests(&genesis_config);
@@ -2949,7 +2948,7 @@ fn test_filter_program_errors_and_collect_fee() {
 
 #[test]
 fn test_filter_program_errors_and_collect_priority_fee() {
-    let leader = solana_sdk::pubkey::new_rand();
+    let leader = solana_pubkey::new_rand();
     let GenesisConfigInfo { genesis_config, .. } =
         create_genesis_config_with_leader(1000000, &leader, 3);
     let mut bank = Bank::new_for_tests(&genesis_config);
@@ -3019,12 +3018,12 @@ fn test_readonly_accounts() {
         genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 0);
+    } = create_genesis_config_with_leader(500, &solana_pubkey::new_rand(), 0);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
-    let vote_pubkey0 = solana_sdk::pubkey::new_rand();
-    let vote_pubkey1 = solana_sdk::pubkey::new_rand();
-    let vote_pubkey2 = solana_sdk::pubkey::new_rand();
+    let vote_pubkey0 = solana_pubkey::new_rand();
+    let vote_pubkey1 = solana_pubkey::new_rand();
+    let vote_pubkey2 = solana_pubkey::new_rand();
     let authorized_voter = Keypair::new();
     let payer0 = Keypair::new();
     let payer1 = Keypair::new();
@@ -3078,7 +3077,7 @@ fn test_readonly_accounts() {
     );
     let tx1 = system_transaction::transfer(
         &authorized_voter,
-        &solana_sdk::pubkey::new_rand(),
+        &solana_pubkey::new_rand(),
         1,
         bank.last_blockhash(),
     );
@@ -3241,7 +3240,7 @@ fn test_readonly_relaxed_locks() {
     let key0 = Keypair::new();
     let key1 = Keypair::new();
     let key2 = Keypair::new();
-    let key3 = solana_sdk::pubkey::new_rand();
+    let key3 = solana_pubkey::new_rand();
 
     let message = Message {
         header: MessageHeader {
@@ -3459,7 +3458,7 @@ fn test_bank_hash_internal_state(is_accounts_lt_hash_enabled: bool) {
     assert_eq!(bank1.hash_internal_state(), initial_state);
 
     let amount = genesis_config.rent.minimum_balance(0);
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     bank0.transfer(amount, &mint_keypair, &pubkey).unwrap();
     bank0.freeze();
     assert_ne!(bank0.hash_internal_state(), initial_state);
@@ -3471,7 +3470,7 @@ fn test_bank_hash_internal_state(is_accounts_lt_hash_enabled: bool) {
     let bank2 = new_from_parent_with_fork_next_slot(bank1, &bank_forks1);
     assert_ne!(bank0.hash_internal_state(), bank2.hash_internal_state());
 
-    let pubkey2 = solana_sdk::pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
     bank2.transfer(amount, &mint_keypair, &pubkey2).unwrap();
     bank2.squash();
     bank2.force_flush_accounts_cache();
@@ -3499,7 +3498,7 @@ fn test_bank_hash_internal_state_verify(is_accounts_lt_hash_enabled: bool) {
         );
 
         let amount = genesis_config.rent.minimum_balance(0);
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         bank0.transfer(amount, &mint_keypair, &pubkey).unwrap();
 
         let bank0_state = bank0.hash_internal_state();
@@ -3507,7 +3506,7 @@ fn test_bank_hash_internal_state_verify(is_accounts_lt_hash_enabled: bool) {
         let bank2 = new_bank_from_parent_with_bank_forks(
             &bank_forks,
             bank0.clone(),
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             2,
         );
         assert_ne!(bank0_state, bank2.hash_internal_state());
@@ -3532,7 +3531,7 @@ fn test_bank_hash_internal_state_verify(is_accounts_lt_hash_enabled: bool) {
         let bank3 = new_bank_from_parent_with_bank_forks(
             &bank_forks,
             bank0.clone(),
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             3,
         );
         assert_eq!(bank0_state, bank0.hash_internal_state());
@@ -3560,7 +3559,7 @@ fn test_bank_hash_internal_state_verify(is_accounts_lt_hash_enabled: bool) {
             continue;
         }
 
-        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
         bank2.transfer(amount, &mint_keypair, &pubkey2).unwrap();
         bank2.freeze(); // <-- keep freeze() *outside* `if pass == 2 {}`
         if pass == 2 {
@@ -3606,7 +3605,7 @@ fn test_verify_hash_unfrozen() {
 #[test]
 fn test_verify_snapshot_bank() {
     solana_logger::setup();
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     bank.transfer(
@@ -3642,7 +3641,7 @@ fn test_bank_hash_internal_state_same_account_different_fork() {
     assert_ne!(bank1.hash_internal_state(), initial_state);
 
     info!("transfer bank1");
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     bank1.transfer(amount, &mint_keypair, &pubkey).unwrap();
     assert_ne!(bank1.hash_internal_state(), initial_state);
 
@@ -3671,8 +3670,8 @@ fn test_hash_internal_state_order() {
     let (bank0, _bank_forks0) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let (bank1, _bank_forks1) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     assert_eq!(bank0.hash_internal_state(), bank1.hash_internal_state());
-    let key0 = solana_sdk::pubkey::new_rand();
-    let key1 = solana_sdk::pubkey::new_rand();
+    let key0 = solana_pubkey::new_rand();
+    let key1 = solana_pubkey::new_rand();
     bank0.transfer(amount, &mint_keypair, &key0).unwrap();
     bank0.transfer(amount * 2, &mint_keypair, &key1).unwrap();
 
@@ -3688,7 +3687,7 @@ fn test_hash_internal_state_error() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
     let amount = genesis_config.rent.minimum_balance(0);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let key0 = solana_sdk::pubkey::new_rand();
+    let key0 = solana_pubkey::new_rand();
     bank.transfer(amount, &mint_keypair, &key0).unwrap();
     let orig = bank.hash_internal_state();
 
@@ -3896,7 +3895,7 @@ fn test_bank_get_account_in_parent_after_squash2() {
 
 #[test]
 fn test_bank_get_account_modified_since_parent_with_fixed_root() {
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
 
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
     let amount = genesis_config.rent.minimum_balance(0);
@@ -4102,7 +4101,7 @@ fn test_bank_update_sysvar_account() {
 
 #[test]
 fn test_bank_epoch_vote_accounts() {
-    let leader_pubkey = solana_sdk::pubkey::new_rand();
+    let leader_pubkey = solana_pubkey::new_rand();
     let leader_lamports = 3;
     let mut genesis_config =
         create_genesis_config_with_leader(5, &leader_pubkey, leader_lamports).genesis_config;
@@ -4205,7 +4204,7 @@ fn test_zero_signatures() {
     let (genesis_config, mint_keypair) = create_genesis_config(500);
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.fee_rate_governor.lamports_per_signature = 2;
-    let key = solana_sdk::pubkey::new_rand();
+    let key = solana_pubkey::new_rand();
 
     let mut transfer_instruction = system_instruction::transfer(&mint_keypair.pubkey(), &key, 0);
     transfer_instruction.accounts[0].is_signer = false;
@@ -4286,14 +4285,14 @@ fn test_bank_inherit_tx_count() {
     let bank1 = new_bank_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
-        &solana_sdk::pubkey::new_rand(),
+        &solana_pubkey::new_rand(),
         1,
     );
     // Bank 2
     let bank2 = new_bank_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
-        &solana_sdk::pubkey::new_rand(),
+        &solana_pubkey::new_rand(),
         2,
     );
 
@@ -4327,7 +4326,7 @@ fn test_bank_inherit_tx_count() {
     let bank6 = new_bank_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank1.clone(),
-        &solana_sdk::pubkey::new_rand(),
+        &solana_pubkey::new_rand(),
         3,
     );
     assert_eq!(bank1.transaction_count(), 1);
@@ -4364,7 +4363,7 @@ fn test_bank_vote_accounts() {
         genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 1);
+    } = create_genesis_config_with_leader(500, &solana_pubkey::new_rand(), 1);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     let vote_accounts = bank.vote_accounts();
@@ -4418,7 +4417,7 @@ fn test_bank_cloned_stake_delegations() {
         ..
     } = create_genesis_config_with_leader(
         123_456_000_000_000,
-        &solana_sdk::pubkey::new_rand(),
+        &solana_pubkey::new_rand(),
         123_000_000_000,
     );
     genesis_config.rent = Rent::default();
@@ -4505,7 +4504,7 @@ fn test_is_delta_with_no_committables() {
     // Should fail with InstructionError, but InstructionErrors are committable,
     // so is_delta should be true
     assert_eq!(
-        bank.transfer(10_001, &mint_keypair, &solana_sdk::pubkey::new_rand()),
+        bank.transfer(10_001, &mint_keypair, &solana_pubkey::new_rand()),
         Err(TransactionError::InstructionError(
             0,
             SystemError::ResultWithNegativeLamports.into(),
@@ -4536,7 +4535,7 @@ fn test_bank_get_program_accounts() {
     );
 
     let bank0 = Arc::new(new_from_parent(parent));
-    let pubkey0 = solana_sdk::pubkey::new_rand();
+    let pubkey0 = solana_pubkey::new_rand();
     let program_id = Pubkey::from([2; 32]);
     let account0 = AccountSharedData::new(1, 0, &program_id);
     bank0.store_account(&pubkey0, &account0);
@@ -4566,11 +4565,11 @@ fn test_bank_get_program_accounts() {
     );
 
     let bank2 = Arc::new(new_from_parent(bank1.clone()));
-    let pubkey1 = solana_sdk::pubkey::new_rand();
+    let pubkey1 = solana_pubkey::new_rand();
     let account1 = AccountSharedData::new(3, 0, &program_id);
     bank2.store_account(&pubkey1, &account1);
     // Accounts with 0 lamports should be filtered out by Accounts::load_by_program()
-    let pubkey2 = solana_sdk::pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
     let account2 = AccountSharedData::new(0, 0, &program_id);
     bank2.store_account(&pubkey2, &account2);
 
@@ -4786,7 +4785,7 @@ fn test_add_duplicate_static_program() {
         genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 0);
+    } = create_genesis_config_with_leader(500, &solana_pubkey::new_rand(), 0);
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     declare_process_instruction!(MockBuiltin, 1, |_invoke_context| {
@@ -5001,7 +5000,7 @@ fn test_banks_leak() {
         const LOTSA: usize = 4_096;
 
         (0..LOTSA).for_each(|_| {
-            let pubkey = solana_sdk::pubkey::new_rand();
+            let pubkey = solana_pubkey::new_rand();
             genesis_config.add_account(
                 pubkey,
                 stake_state::create_lockup_stake_account(
@@ -5702,11 +5701,7 @@ fn test_nonce_fee_calculator_updates() {
     let nonce_tx = Transaction::new_signed_with_payer(
         &[
             system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
-            system_instruction::transfer(
-                &custodian_pubkey,
-                &solana_sdk::pubkey::new_rand(),
-                100_000,
-            ),
+            system_instruction::transfer(&custodian_pubkey, &solana_pubkey::new_rand(), 100_000),
         ],
         Some(&custodian_pubkey),
         &[&custodian_keypair, &nonce_keypair],
@@ -5770,11 +5765,7 @@ fn test_nonce_fee_calculator_updates_tx_wide_cap() {
     let nonce_tx = Transaction::new_signed_with_payer(
         &[
             system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
-            system_instruction::transfer(
-                &custodian_pubkey,
-                &solana_sdk::pubkey::new_rand(),
-                100_000,
-            ),
+            system_instruction::transfer(&custodian_pubkey, &solana_pubkey::new_rand(), 100_000),
         ],
         Some(&custodian_pubkey),
         &[&custodian_keypair, &nonce_keypair],
@@ -5868,8 +5859,8 @@ fn test_collect_balances() {
     let bank0 = Arc::new(new_from_parent(parent));
 
     let keypair = Keypair::new();
-    let pubkey0 = solana_sdk::pubkey::new_rand();
-    let pubkey1 = solana_sdk::pubkey::new_rand();
+    let pubkey0 = solana_pubkey::new_rand();
+    let pubkey1 = solana_pubkey::new_rand();
     let program_id = Pubkey::from([2; 32]);
     let keypair_account = AccountSharedData::new(8, 0, &program_id);
     let account0 = AccountSharedData::new(11, 0, &program_id);
@@ -5919,9 +5910,9 @@ fn test_pre_post_transaction_balances() {
 
     let keypair0 = Keypair::new();
     let keypair1 = Keypair::new();
-    let pubkey0 = solana_sdk::pubkey::new_rand();
-    let pubkey1 = solana_sdk::pubkey::new_rand();
-    let pubkey2 = solana_sdk::pubkey::new_rand();
+    let pubkey0 = solana_pubkey::new_rand();
+    let pubkey1 = solana_pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
     let keypair0_account = AccountSharedData::new(908_000, 0, &Pubkey::default());
     let keypair1_account = AccountSharedData::new(909_000, 0, &Pubkey::default());
     let account0 = AccountSharedData::new(911_000, 0, &Pubkey::default());
@@ -6012,8 +6003,8 @@ fn test_transaction_with_duplicate_accounts_in_instruction() {
         Ok(())
     });
 
-    let from_pubkey = solana_sdk::pubkey::new_rand();
-    let to_pubkey = solana_sdk::pubkey::new_rand();
+    let from_pubkey = solana_pubkey::new_rand();
+    let to_pubkey = solana_pubkey::new_rand();
     let dup_pubkey = from_pubkey;
     let from_account = AccountSharedData::new(sol_to_lamports(100.), 1, &mock_program_id);
     let to_account = AccountSharedData::new(0, 1, &mock_program_id);
@@ -6048,8 +6039,8 @@ fn test_transaction_with_program_ids_passed_to_programs() {
     let (bank, _bank_forks) =
         Bank::new_with_mockup_builtin_for_tests(&genesis_config, mock_program_id, MockBuiltin::vm);
 
-    let from_pubkey = solana_sdk::pubkey::new_rand();
-    let to_pubkey = solana_sdk::pubkey::new_rand();
+    let from_pubkey = solana_pubkey::new_rand();
+    let to_pubkey = solana_pubkey::new_rand();
     let dup_pubkey = from_pubkey;
     let from_account = AccountSharedData::new(100, 1, &mock_program_id);
     let to_account = AccountSharedData::new(0, 1, &mock_program_id);
@@ -6080,8 +6071,8 @@ fn test_account_ids_after_program_ids() {
     let (genesis_config, mint_keypair) = create_genesis_config_no_tx_fee_no_rent(500);
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
-    let from_pubkey = solana_sdk::pubkey::new_rand();
-    let to_pubkey = solana_sdk::pubkey::new_rand();
+    let from_pubkey = solana_pubkey::new_rand();
+    let to_pubkey = solana_pubkey::new_rand();
 
     let account_metas = vec![
         AccountMeta::new(from_pubkey, false),
@@ -6096,7 +6087,7 @@ fn test_account_ids_after_program_ids() {
         bank.last_blockhash(),
     );
 
-    tx.message.account_keys.push(solana_sdk::pubkey::new_rand());
+    tx.message.account_keys.push(solana_pubkey::new_rand());
 
     let slot = bank.slot().saturating_add(1);
     let mut bank = Bank::new_from_parent(bank, &Pubkey::default(), slot);
@@ -6153,8 +6144,8 @@ fn test_duplicate_account_key() {
         MockBuiltin::vm,
     );
 
-    let from_pubkey = solana_sdk::pubkey::new_rand();
-    let to_pubkey = solana_sdk::pubkey::new_rand();
+    let from_pubkey = solana_pubkey::new_rand();
+    let to_pubkey = solana_pubkey::new_rand();
 
     let account_metas = vec![
         AccountMeta::new(from_pubkey, false),
@@ -6184,8 +6175,8 @@ fn test_process_transaction_with_too_many_account_locks() {
         MockBuiltin::vm,
     );
 
-    let from_pubkey = solana_sdk::pubkey::new_rand();
-    let to_pubkey = solana_sdk::pubkey::new_rand();
+    let from_pubkey = solana_pubkey::new_rand();
+    let to_pubkey = solana_pubkey::new_rand();
 
     let account_metas = vec![
         AccountMeta::new(from_pubkey, false),
@@ -6202,7 +6193,7 @@ fn test_process_transaction_with_too_many_account_locks() {
 
     let transaction_account_lock_limit = bank.get_transaction_account_lock_limit();
     while tx.message.account_keys.len() <= transaction_account_lock_limit {
-        tx.message.account_keys.push(solana_sdk::pubkey::new_rand());
+        tx.message.account_keys.push(solana_pubkey::new_rand());
     }
 
     let result = bank.process_transaction(&tx);
@@ -6215,8 +6206,8 @@ fn test_program_id_as_payer() {
     let (genesis_config, mint_keypair) = create_genesis_config(500);
     let mut bank = Bank::new_for_tests(&genesis_config);
 
-    let from_pubkey = solana_sdk::pubkey::new_rand();
-    let to_pubkey = solana_sdk::pubkey::new_rand();
+    let from_pubkey = solana_pubkey::new_rand();
+    let to_pubkey = solana_pubkey::new_rand();
 
     let account_metas = vec![
         AccountMeta::new(from_pubkey, false),
@@ -6258,8 +6249,8 @@ fn test_ref_account_key_after_program_id() {
     let (genesis_config, mint_keypair) = create_genesis_config_no_tx_fee_no_rent(500);
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
-    let from_pubkey = solana_sdk::pubkey::new_rand();
-    let to_pubkey = solana_sdk::pubkey::new_rand();
+    let from_pubkey = solana_pubkey::new_rand();
+    let to_pubkey = solana_pubkey::new_rand();
 
     let account_metas = vec![
         AccountMeta::new(from_pubkey, false),
@@ -6283,7 +6274,7 @@ fn test_ref_account_key_after_program_id() {
         bank.last_blockhash(),
     );
 
-    tx.message.account_keys.push(solana_sdk::pubkey::new_rand());
+    tx.message.account_keys.push(solana_pubkey::new_rand());
     assert_eq!(tx.message.account_keys.len(), 5);
     tx.message.instructions[0].accounts.remove(0);
     tx.message.instructions[0].accounts.push(4);
@@ -6302,7 +6293,7 @@ fn test_fuzz_instructions() {
     let program_keys: Vec<_> = (0..max_programs)
         .enumerate()
         .map(|i| {
-            let key = solana_sdk::pubkey::new_rand();
+            let key = solana_pubkey::new_rand();
             let name = format!("program{i:?}");
             bank.transaction_processor.add_builtin(
                 &bank,
@@ -6318,7 +6309,7 @@ fn test_fuzz_instructions() {
     let keys: Vec<_> = (0..max_keys)
         .enumerate()
         .map(|_| {
-            let key = solana_sdk::pubkey::new_rand();
+            let key = solana_pubkey::new_rand();
             let balance = if thread_rng().gen_ratio(9, 10) {
                 let lamports = if thread_rng().gen_ratio(1, 5) {
                     thread_rng().gen_range(0..10)
@@ -6515,12 +6506,12 @@ fn test_same_program_id_uses_unique_executable_accounts() {
     });
 
     let (genesis_config, mint_keypair) = create_genesis_config(50000);
-    let program1_pubkey = solana_sdk::pubkey::new_rand();
+    let program1_pubkey = solana_pubkey::new_rand();
     let (bank, _bank_forks) =
         Bank::new_with_mockup_builtin_for_tests(&genesis_config, program1_pubkey, MockBuiltin::vm);
 
     // Add a new program owned by the first
-    let program2_pubkey = solana_sdk::pubkey::new_rand();
+    let program2_pubkey = solana_pubkey::new_rand();
     let mut program2_account = AccountSharedData::new(1, 1, &program1_pubkey);
     program2_account.set_executable(true);
     bank.store_account(&program2_pubkey, &program2_account);
@@ -6649,9 +6640,9 @@ fn test_shrink_candidate_slots_cached() {
     solana_logger::setup();
 
     let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000_000);
-    let pubkey0 = solana_sdk::pubkey::new_rand();
-    let pubkey1 = solana_sdk::pubkey::new_rand();
-    let pubkey2 = solana_sdk::pubkey::new_rand();
+    let pubkey0 = solana_pubkey::new_rand();
+    let pubkey1 = solana_pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
 
     // Set root for bank 0, with caching enabled
     let bank0 = Arc::new(Bank::new_with_config_for_tests(
@@ -6720,7 +6711,7 @@ fn test_shrink_candidate_slots_cached() {
 #[test]
 fn test_add_builtin_no_overwrite() {
     let slot = 123;
-    let program_id = solana_sdk::pubkey::new_rand();
+    let program_id = solana_pubkey::new_rand();
 
     let (parent_bank, _bank_forks) = create_simple_test_arc_bank(100_000);
     let mut bank = Arc::new(Bank::new_from_parent(parent_bank, &Pubkey::default(), slot));
@@ -6741,7 +6732,7 @@ fn test_add_builtin_no_overwrite() {
 #[test]
 fn test_add_builtin_loader_no_overwrite() {
     let slot = 123;
-    let loader_id = solana_sdk::pubkey::new_rand();
+    let loader_id = solana_pubkey::new_rand();
 
     let (parent_bank, _bank_forks) = create_simple_test_arc_bank(100_000);
     let mut bank = Arc::new(Bank::new_from_parent(parent_bank, &Pubkey::default(), slot));
@@ -6844,7 +6835,7 @@ fn test_add_builtin_account_inherited_cap_while_replacing() {
     for pass in 0..4 {
         let (genesis_config, mint_keypair) = create_genesis_config(100_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let program_id = solana_sdk::pubkey::new_rand();
+        let program_id = solana_pubkey::new_rand();
 
         bank.add_builtin_account("mock_program", &program_id);
         if pass == 0 {
@@ -6878,7 +6869,7 @@ fn test_add_builtin_account_squatted_while_not_replacing() {
     for pass in 0..3 {
         let (genesis_config, mint_keypair) = create_genesis_config(100_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let program_id = solana_sdk::pubkey::new_rand();
+        let program_id = solana_pubkey::new_rand();
 
         // someone managed to squat at program_id!
         bank.withdraw(&mint_keypair.pubkey(), 10).unwrap();
@@ -6924,7 +6915,7 @@ fn test_add_precompiled_account() {
         activate_all_features(&mut genesis_config);
 
         let slot = 123;
-        let program_id = solana_sdk::pubkey::new_rand();
+        let program_id = solana_pubkey::new_rand();
 
         let bank = Arc::new(Bank::new_from_parent(
             Arc::new(Bank::new_for_tests(&genesis_config)),
@@ -6970,7 +6961,7 @@ fn test_add_precompiled_account_inherited_cap_while_replacing() {
     for pass in 0..4 {
         let (genesis_config, mint_keypair) = create_genesis_config(100_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let program_id = solana_sdk::pubkey::new_rand();
+        let program_id = solana_pubkey::new_rand();
 
         bank.add_precompiled_account(&program_id);
         if pass == 0 {
@@ -7004,7 +6995,7 @@ fn test_add_precompiled_account_squatted_while_not_replacing() {
     for pass in 0..3 {
         let (genesis_config, mint_keypair) = create_genesis_config(100_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let program_id = solana_sdk::pubkey::new_rand();
+        let program_id = solana_pubkey::new_rand();
 
         // someone managed to squat at program_id!
         bank.withdraw(&mint_keypair.pubkey(), 10).unwrap();
@@ -7050,7 +7041,7 @@ fn test_reconfigure_token2_native_mint() {
     solana_logger::setup();
 
     let genesis_config =
-        create_genesis_config_with_leader(5, &solana_sdk::pubkey::new_rand(), 0).genesis_config;
+        create_genesis_config_with_leader(5, &solana_pubkey::new_rand(), 0).genesis_config;
     let bank = Arc::new(Bank::new_for_tests(&genesis_config));
     assert_eq!(bank.get_balance(&token::native_mint::id()), 1000000000);
     let native_mint_account = bank.get_account(&token::native_mint::id()).unwrap();
@@ -7069,8 +7060,8 @@ fn test_bank_load_program() {
     let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 42);
     let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 50);
 
-    let program_key = solana_sdk::pubkey::new_rand();
-    let programdata_key = solana_sdk::pubkey::new_rand();
+    let program_key = solana_pubkey::new_rand();
+    let programdata_key = solana_pubkey::new_rand();
 
     let mut file = File::open("../programs/bpf_loader/test_elfs/out/noop_aligned.so").unwrap();
     let mut elf = Vec::new();
@@ -8145,7 +8136,7 @@ fn test_adjust_sysvar_balance_for_rent() {
 
 #[test]
 fn test_update_clock_timestamp() {
-    let leader_pubkey = solana_sdk::pubkey::new_rand();
+    let leader_pubkey = solana_pubkey::new_rand();
     let GenesisConfigInfo {
         genesis_config,
         voting_keypair,
@@ -8244,7 +8235,7 @@ fn test_timestamp_slow() {
             + (poh_estimate_offset * max_allowable_drift / 100).as_secs()) as i64
     }
 
-    let leader_pubkey = solana_sdk::pubkey::new_rand();
+    let leader_pubkey = solana_pubkey::new_rand();
     let GenesisConfigInfo {
         mut genesis_config,
         voting_keypair,
@@ -8288,7 +8279,7 @@ fn test_timestamp_fast() {
             - (poh_estimate_offset * max_allowable_drift / 100).as_secs()) as i64
     }
 
-    let leader_pubkey = solana_sdk::pubkey::new_rand();
+    let leader_pubkey = solana_pubkey::new_rand();
     let GenesisConfigInfo {
         mut genesis_config,
         voting_keypair,
@@ -8380,7 +8371,7 @@ fn test_store_scan_consistency<F>(
     solana_logger::setup();
     // Set up initial bank
     let mut genesis_config =
-        create_genesis_config_with_leader(10, &solana_sdk::pubkey::new_rand(), 374_999_998_287_840)
+        create_genesis_config_with_leader(10, &solana_pubkey::new_rand(), 374_999_998_287_840)
             .genesis_config;
     genesis_config.rent = Rent::free();
     let bank0 = Arc::new(Bank::new_with_config_for_tests(
@@ -8392,7 +8383,7 @@ fn test_store_scan_consistency<F>(
     // Set up pubkeys to write to
     let total_pubkeys = ITER_BATCH_SIZE * 10;
     let total_pubkeys_to_modify = 10;
-    let all_pubkeys: Vec<Pubkey> = std::iter::repeat_with(solana_sdk::pubkey::new_rand)
+    let all_pubkeys: Vec<Pubkey> = std::iter::repeat_with(solana_pubkey::new_rand)
         .take(total_pubkeys)
         .collect();
     let program_id = system_program::id();
@@ -8560,7 +8551,7 @@ fn test_store_scan_consistency_unrooted() {
                     let slot = current_minor_fork_bank.slot() + 2;
                     current_minor_fork_bank = Arc::new(Bank::new_from_parent(
                         current_minor_fork_bank,
-                        &solana_sdk::pubkey::new_rand(),
+                        &solana_pubkey::new_rand(),
                         slot,
                     ));
                     let account = AccountSharedData::new(lamports, 0, &program_id);
@@ -8585,7 +8576,7 @@ fn test_store_scan_consistency_unrooted() {
                 // *partial* clean of the banks < `next_major_bank`.
                 current_major_fork_bank = Arc::new(Bank::new_from_parent(
                     current_major_fork_bank,
-                    &solana_sdk::pubkey::new_rand(),
+                    &solana_pubkey::new_rand(),
                     current_minor_fork_bank.slot() - 1,
                 ));
                 let lamports = current_major_fork_bank.slot() + starting_lamports + 1;
@@ -8667,7 +8658,7 @@ fn test_store_scan_consistency_root() {
                 let slot = current_bank.slot() + 1;
                 current_bank = Arc::new(Bank::new_from_parent(
                     current_bank,
-                    &solana_sdk::pubkey::new_rand(),
+                    &solana_pubkey::new_rand(),
                     slot,
                 ));
             }
@@ -8709,7 +8700,7 @@ fn setup_banks_on_fork_to_remove(
             let slot = bank_at_fork_tip.slot() + 1;
             bank_at_fork_tip = Arc::new(Bank::new_from_parent(
                 bank_at_fork_tip,
-                &solana_sdk::pubkey::new_rand(),
+                &solana_pubkey::new_rand(),
                 slot,
             ));
             if lamports_this_round == 0 {
@@ -8905,7 +8896,7 @@ fn test_remove_unrooted_scan_interleaved_with_remove_unrooted_slots() {
 fn test_get_inflation_start_slot_devnet_testnet() {
     let GenesisConfigInfo {
         mut genesis_config, ..
-    } = create_genesis_config_with_leader(42, &solana_sdk::pubkey::new_rand(), 42);
+    } = create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
     genesis_config
         .accounts
         .remove(&feature_set::pico_inflation::id())
@@ -8986,7 +8977,7 @@ fn test_get_inflation_start_slot_devnet_testnet() {
 fn test_get_inflation_start_slot_mainnet() {
     let GenesisConfigInfo {
         mut genesis_config, ..
-    } = create_genesis_config_with_leader(42, &solana_sdk::pubkey::new_rand(), 42);
+    } = create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
     genesis_config
         .accounts
         .remove(&feature_set::pico_inflation::id())
@@ -9071,7 +9062,7 @@ fn test_get_inflation_start_slot_mainnet() {
 fn test_get_inflation_num_slots_with_activations() {
     let GenesisConfigInfo {
         mut genesis_config, ..
-    } = create_genesis_config_with_leader(42, &solana_sdk::pubkey::new_rand(), 42);
+    } = create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
     let slots_per_epoch = 32;
     genesis_config.epoch_schedule = EpochSchedule::new(slots_per_epoch);
     genesis_config
@@ -9135,7 +9126,7 @@ fn test_get_inflation_num_slots_with_activations() {
 fn test_get_inflation_num_slots_already_activated() {
     let GenesisConfigInfo {
         mut genesis_config, ..
-    } = create_genesis_config_with_leader(42, &solana_sdk::pubkey::new_rand(), 42);
+    } = create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
     let slots_per_epoch = 32;
     genesis_config.epoch_schedule = EpochSchedule::new(slots_per_epoch);
     let mut bank = Bank::new_for_tests(&genesis_config);
@@ -9575,7 +9566,7 @@ fn test_load_and_execute_commit_transactions_rent_debits() {
 #[test]
 fn test_get_largest_accounts() {
     let GenesisConfigInfo { genesis_config, .. } =
-        create_genesis_config_with_leader(42, &solana_sdk::pubkey::new_rand(), 42);
+        create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
     let bank = Bank::new_for_tests(&genesis_config);
 
     let pubkeys: Vec<_> = (0..5).map(|_| Pubkey::new_unique()).collect();
@@ -9696,7 +9687,7 @@ fn test_transfer_sysvar() {
         &Pubkey::new_unique(),
         bootstrap_validator_stake_lamports(),
     );
-    let program_id = solana_sdk::pubkey::new_rand();
+    let program_id = solana_pubkey::new_rand();
 
     let (bank, _bank_forks) =
         Bank::new_with_mockup_builtin_for_tests(&genesis_config, program_id, MockBuiltin::vm);
@@ -9907,7 +9898,7 @@ fn test_compute_budget_program_noop() {
         &Pubkey::new_unique(),
         bootstrap_validator_stake_lamports(),
     );
-    let program_id = solana_sdk::pubkey::new_rand();
+    let program_id = solana_pubkey::new_rand();
     let (bank, _bank_forks) =
         Bank::new_with_mockup_builtin_for_tests(&genesis_config, program_id, MockBuiltin::vm);
 
@@ -9952,7 +9943,7 @@ fn test_compute_request_instruction() {
         &Pubkey::new_unique(),
         bootstrap_validator_stake_lamports(),
     );
-    let program_id = solana_sdk::pubkey::new_rand();
+    let program_id = solana_pubkey::new_rand();
     let (bank, _bank_forks) =
         Bank::new_with_mockup_builtin_for_tests(&genesis_config, program_id, MockBuiltin::vm);
 
@@ -9998,7 +9989,7 @@ fn test_failed_compute_request_instruction() {
         bootstrap_validator_stake_lamports(),
     );
 
-    let program_id = solana_sdk::pubkey::new_rand();
+    let program_id = solana_pubkey::new_rand();
     let (bank, _bank_forks) =
         Bank::new_with_mockup_builtin_for_tests(&genesis_config, program_id, MockBuiltin::vm);
 
@@ -10063,7 +10054,7 @@ fn test_failed_compute_request_instruction() {
 fn test_verify_and_hash_transaction_sig_len() {
     let GenesisConfigInfo {
         mut genesis_config, ..
-    } = create_genesis_config_with_leader(42, &solana_sdk::pubkey::new_rand(), 42);
+    } = create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
 
     // activate all features
     activate_all_features(&mut genesis_config);
@@ -10120,7 +10111,7 @@ fn test_verify_and_hash_transaction_sig_len() {
 #[test]
 fn test_verify_transactions_packet_data_size() {
     let GenesisConfigInfo { genesis_config, .. } =
-        create_genesis_config_with_leader(42, &solana_sdk::pubkey::new_rand(), 42);
+        create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
     let bank = Bank::new_for_tests(&genesis_config);
 
     let recent_blockhash = Hash::new_unique();
@@ -10466,7 +10457,7 @@ fn test_calculate_fee_secp256k1() {
 #[test]
 fn test_an_empty_instruction_without_program() {
     let (genesis_config, mint_keypair) = create_genesis_config_no_tx_fee_no_rent(1);
-    let destination = solana_sdk::pubkey::new_rand();
+    let destination = solana_pubkey::new_rand();
     let mut ix = system_instruction::transfer(&mint_keypair.pubkey(), &destination, 0);
     ix.program_id = native_loader::id(); // Empty executable account chain
     let message = Message::new(&[ix], Some(&mint_keypair.pubkey()));
@@ -10884,7 +10875,7 @@ fn test_rent_state_changes_sysvars() {
     } = create_genesis_config_with_leader(sol_to_lamports(100.), &Pubkey::new_unique(), 42);
     genesis_config.rent = Rent::default();
 
-    let validator_pubkey = solana_sdk::pubkey::new_rand();
+    let validator_pubkey = solana_pubkey::new_rand();
     let validator_stake_lamports = sol_to_lamports(1.);
     let validator_staking_keypair = Keypair::new();
     let validator_voting_keypair = Keypair::new();
@@ -11349,7 +11340,7 @@ fn test_resize_and_rent() {
         &AccountSharedData::new(1_000_000_000, 0, &mock_program_id),
     );
 
-    let rent_paying_pubkey = solana_sdk::pubkey::new_rand();
+    let rent_paying_pubkey = solana_pubkey::new_rand();
     let mut rent_paying_account = AccountSharedData::new(
         rent_exempt_minimum_small - 1,
         account_data_size_small,
@@ -12587,7 +12578,7 @@ fn test_calc_vote_accounts_to_store_empty() {
 #[test]
 fn test_calc_vote_accounts_to_store_overflow() {
     let vote_account_rewards = DashMap::default();
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     let mut vote_account = AccountSharedData::default();
     vote_account.set_lamports(u64::MAX);
     vote_account_rewards.insert(
@@ -12607,9 +12598,9 @@ fn test_calc_vote_accounts_to_store_overflow() {
 #[test]
 fn test_calc_vote_accounts_to_store_three() {
     let vote_account_rewards = DashMap::default();
-    let pubkey = solana_sdk::pubkey::new_rand();
-    let pubkey2 = solana_sdk::pubkey::new_rand();
-    let pubkey3 = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
+    let pubkey3 = solana_pubkey::new_rand();
     let mut vote_account = AccountSharedData::default();
     vote_account.set_lamports(u64::MAX);
     vote_account_rewards.insert(
@@ -12657,7 +12648,7 @@ fn test_calc_vote_accounts_to_store_three() {
 
 #[test]
 fn test_calc_vote_accounts_to_store_normal() {
-    let pubkey = solana_sdk::pubkey::new_rand();
+    let pubkey = solana_pubkey::new_rand();
     for commission in 0..2 {
         for vote_rewards in 0..2 {
             for vote_needs_store in [false, true] {

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -326,7 +326,7 @@ mod tests {
         let amount = genesis_config.rent.minimum_balance(0);
 
         // Create 2-2 Multisig Transfer instruction.
-        let bob_pubkey = solana_sdk::pubkey::new_rand();
+        let bob_pubkey = solana_pubkey::new_rand();
         let mut transfer_instruction =
             system_instruction::transfer(&john_pubkey, &bob_pubkey, amount);
         transfer_instruction

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -249,13 +249,13 @@ pub(crate) mod tests {
         // Create some vote accounts for each pubkey
         (0..num_nodes)
             .map(|_| {
-                let node_id = solana_sdk::pubkey::new_rand();
+                let node_id = solana_pubkey::new_rand();
                 (
                     node_id,
                     iter::repeat_with(|| {
-                        let authorized_voter = solana_sdk::pubkey::new_rand();
+                        let authorized_voter = solana_pubkey::new_rand();
                         VoteAccountInfo {
-                            vote_account: solana_sdk::pubkey::new_rand(),
+                            vote_account: solana_pubkey::new_rand(),
                             account: create_account_with_authorized(
                                 &node_id,
                                 &authorized_voter,

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -84,8 +84,8 @@ pub fn create_genesis_config(mint_lamports: u64) -> GenesisConfigInfo {
     // accounts-db which in particular will break snapshots test.
     create_genesis_config_with_leader(
         mint_lamports,
-        &solana_sdk::pubkey::new_rand(), // validator_pubkey
-        0,                               // validator_stake_lamports
+        &solana_pubkey::new_rand(), // validator_pubkey
+        0,                          // validator_stake_lamports
     )
 }
 

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -842,7 +842,7 @@ mod tests {
         } = create_genesis_config(10_000);
         let tx0 = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
             &mint_keypair,
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             2,
             genesis_config.hash(),
         ));

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -241,7 +241,7 @@ mod tests {
         let num_genesis_accounts = 10;
         for _ in 0..num_genesis_accounts {
             accounts.insert(
-                solana_sdk::pubkey::new_rand(),
+                solana_pubkey::new_rand(),
                 Account::new(balance, 0, &Pubkey::default()),
             );
         }
@@ -253,7 +253,7 @@ mod tests {
 
         let num_stake_accounts = 3;
         for _ in 0..num_stake_accounts {
-            let pubkey = solana_sdk::pubkey::new_rand();
+            let pubkey = solana_pubkey::new_rand();
             let meta = Meta {
                 authorized: Authorized::auto(&pubkey),
                 lockup: Lockup {

--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -257,7 +257,7 @@ impl PrioritizationFee {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_sdk::pubkey::Pubkey};
+    use {super::*, solana_pubkey::Pubkey};
 
     #[test]
     fn test_update_prioritization_fee() {

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -568,7 +568,7 @@ mod tests {
         let bank0 = Bank::new_for_benches(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank0);
         let bank = bank_forks.read().unwrap().working_bank();
-        let collector = solana_sdk::pubkey::new_rand();
+        let collector = solana_pubkey::new_rand();
 
         let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 1));
         sync_update(
@@ -620,7 +620,7 @@ mod tests {
         let bank0 = Bank::new_for_benches(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank0);
         let bank = bank_forks.read().unwrap().working_bank();
-        let collector = solana_sdk::pubkey::new_rand();
+        let collector = solana_pubkey::new_rand();
         let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 1));
         let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 2));
         let bank3 = Arc::new(Bank::new_from_parent(bank, &collector, 3));
@@ -872,7 +872,7 @@ mod tests {
         let bank0 = Bank::new_for_benches(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank0);
         let bank = bank_forks.read().unwrap().working_bank();
-        let collector = solana_sdk::pubkey::new_rand();
+        let collector = solana_pubkey::new_rand();
         let slot: Slot = 999;
         let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, slot));
         let bank2 = Arc::new(Bank::new_from_parent(bank, &collector, slot + 1));

--- a/runtime/src/root_bank_cache.rs
+++ b/runtime/src/root_bank_cache.rs
@@ -53,7 +53,7 @@ mod tests {
             bank_forks::BankForks,
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
         },
-        solana_sdk::pubkey::Pubkey,
+        solana_pubkey::Pubkey,
     };
 
     #[test]

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -281,7 +281,7 @@ mod serde_snapshot_tests {
         let unrooted_slot = 9;
         let unrooted_bank_id = 9;
         let db = AccountsDb::new_single_for_tests();
-        let key = solana_sdk::pubkey::new_rand();
+        let key = solana_pubkey::new_rand();
         let account0 = AccountSharedData::new(1, 0, &key);
         db.store_for_tests(unrooted_slot, &[(&key, &account0)]);
 
@@ -289,7 +289,7 @@ mod serde_snapshot_tests {
         db.remove_unrooted_slots(&[(unrooted_slot, unrooted_bank_id)]);
 
         // Add a new root
-        let key2 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_pubkey::new_rand();
         let new_root = unrooted_slot + 1;
         db.store_for_tests(new_root, &[(&key2, &account0)]);
         db.add_root_and_flush_write_cache(new_root);
@@ -437,11 +437,11 @@ mod serde_snapshot_tests {
         let owner = *AccountSharedData::default().owner();
 
         let account = AccountSharedData::new(some_lamport, no_data, &owner);
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let zero_lamport_account = AccountSharedData::new(zero_lamport, no_data, &owner);
 
         let account2 = AccountSharedData::new(some_lamport + 1, no_data, &owner);
-        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
 
         let accounts = AccountsDb::new_single_for_tests();
 
@@ -493,9 +493,9 @@ mod serde_snapshot_tests {
         let account3 = AccountSharedData::new(some_lamport + 100_002, no_data, &owner);
         let zero_lamport_account = AccountSharedData::new(zero_lamport, no_data, &owner);
 
-        let pubkey = solana_sdk::pubkey::new_rand();
-        let purged_pubkey1 = solana_sdk::pubkey::new_rand();
-        let purged_pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
+        let purged_pubkey1 = solana_pubkey::new_rand();
+        let purged_pubkey2 = solana_pubkey::new_rand();
 
         let dummy_account = AccountSharedData::new(dummy_lamport, no_data, &owner);
         let dummy_pubkey = Pubkey::default();
@@ -585,10 +585,10 @@ mod serde_snapshot_tests {
         let dummy_account = AccountSharedData::new(99_999_999, no_data, &owner);
         let zero_lamport_account = AccountSharedData::new(zero_lamport, no_data, &owner);
 
-        let pubkey = solana_sdk::pubkey::new_rand();
-        let dummy_pubkey = solana_sdk::pubkey::new_rand();
-        let purged_pubkey1 = solana_sdk::pubkey::new_rand();
-        let purged_pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
+        let dummy_pubkey = solana_pubkey::new_rand();
+        let purged_pubkey1 = solana_pubkey::new_rand();
+        let purged_pubkey2 = solana_pubkey::new_rand();
 
         let mut current_slot = 0;
         let accounts = AccountsDb::new_single_for_tests();
@@ -656,9 +656,9 @@ mod serde_snapshot_tests {
         let dummy_account = AccountSharedData::new(dummy_lamport, no_data, &owner);
         let zero_lamport_account = AccountSharedData::new(zero_lamport, no_data, &owner);
 
-        let pubkey1 = solana_sdk::pubkey::new_rand();
-        let pubkey2 = solana_sdk::pubkey::new_rand();
-        let dummy_pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
+        let dummy_pubkey = solana_pubkey::new_rand();
 
         let mut current_slot = 0;
         let accounts = AccountsDb::new_single_for_tests();
@@ -786,7 +786,7 @@ mod serde_snapshot_tests {
 
             let pubkey_count = 100;
             let pubkeys: Vec<_> = (0..pubkey_count)
-                .map(|_| solana_sdk::pubkey::new_rand())
+                .map(|_| solana_pubkey::new_rand())
                 .collect();
 
             let some_lamport = 223;

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -470,7 +470,7 @@ mod tests {
     fn test_minimization_get_vote_accounts() {
         solana_logger::setup();
 
-        let bootstrap_validator_pubkey = solana_sdk::pubkey::new_rand();
+        let bootstrap_validator_pubkey = solana_pubkey::new_rand();
         let bootstrap_validator_stake_lamports = 30;
         let genesis_config_info = create_genesis_config_with_leader(
             10,
@@ -500,7 +500,7 @@ mod tests {
     fn test_minimization_get_stake_accounts() {
         solana_logger::setup();
 
-        let bootstrap_validator_pubkey = solana_sdk::pubkey::new_rand();
+        let bootstrap_validator_pubkey = solana_pubkey::new_rand();
         let bootstrap_validator_stake_lamports = 30;
         let genesis_config_info = create_genesis_config_with_leader(
             10,
@@ -543,8 +543,8 @@ mod tests {
         let (genesis_config, _) = create_genesis_config(1_000_000);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
-        let pubkey = solana_sdk::pubkey::new_rand();
-        let owner_pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
+        let owner_pubkey = solana_pubkey::new_rand();
         bank.store_account(&pubkey, &AccountSharedData::new(1, 0, &owner_pubkey));
 
         let owner_accounts = DashSet::new();
@@ -568,9 +568,9 @@ mod tests {
         let (genesis_config, _) = create_genesis_config(1_000_000);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
-        let non_program_id = solana_sdk::pubkey::new_rand();
-        let program_id = solana_sdk::pubkey::new_rand();
-        let programdata_address = solana_sdk::pubkey::new_rand();
+        let non_program_id = solana_pubkey::new_rand();
+        let program_id = solana_pubkey::new_rand();
+        let programdata_address = solana_pubkey::new_rand();
 
         let program = UpgradeableLoaderState::Program {
             programdata_address,
@@ -623,7 +623,7 @@ mod tests {
         let minimized_account_set = DashSet::new();
         for _ in 0..num_slots {
             let pubkeys: Vec<_> = (0..num_accounts_per_slot)
-                .map(|_| solana_sdk::pubkey::new_rand())
+                .map(|_| solana_pubkey::new_rand())
                 .collect();
 
             let some_lamport = 223;

--- a/runtime/src/stake_weighted_timestamp.rs
+++ b/runtime/src/stake_weighted_timestamp.rs
@@ -112,11 +112,11 @@ pub mod tests {
         let recent_timestamp: UnixTimestamp = 1_578_909_061;
         let slot = 5;
         let slot_duration = Duration::from_millis(400);
-        let pubkey0 = solana_sdk::pubkey::new_rand();
-        let pubkey1 = solana_sdk::pubkey::new_rand();
-        let pubkey2 = solana_sdk::pubkey::new_rand();
-        let pubkey3 = solana_sdk::pubkey::new_rand();
-        let pubkey4 = solana_sdk::pubkey::new_rand();
+        let pubkey0 = solana_pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
+        let pubkey3 = solana_pubkey::new_rand();
+        let pubkey4 = solana_pubkey::new_rand();
         let max_allowable_drift = MaxAllowableDrift { fast: 25, slow: 25 };
 
         // Test low-staked outlier(s)
@@ -327,9 +327,9 @@ pub mod tests {
         };
         let acceptable_delta = (max_allowable_drift_percentage * poh_offset as u32 / 100) as i64;
         let poh_estimate = epoch_start_timestamp + poh_offset as i64;
-        let pubkey0 = solana_sdk::pubkey::new_rand();
-        let pubkey1 = solana_sdk::pubkey::new_rand();
-        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey0 = solana_pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
 
         let stakes: HashMap<Pubkey, (u64, Account)> = [
             (
@@ -468,9 +468,9 @@ pub mod tests {
             (max_allowable_drift_percentage_50 * poh_offset as u32 / 100) as i64;
         assert!(acceptable_delta_50 > acceptable_delta_25 + 1);
         let poh_estimate = epoch_start_timestamp + poh_offset as i64;
-        let pubkey0 = solana_sdk::pubkey::new_rand();
-        let pubkey1 = solana_sdk::pubkey::new_rand();
-        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey0 = solana_pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
 
         let stakes: HashMap<Pubkey, (u64, Account)> = [
             (
@@ -604,9 +604,9 @@ pub mod tests {
             (max_allowable_drift_percentage_50 * poh_offset as u32 / 100) as i64;
         assert!(acceptable_delta_slow > acceptable_delta_fast + 1);
         let poh_estimate = epoch_start_timestamp + poh_offset as i64;
-        let pubkey0 = solana_sdk::pubkey::new_rand();
-        let pubkey1 = solana_sdk::pubkey::new_rand();
-        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey0 = solana_pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
 
         let stakes: HashMap<Pubkey, (u64, Account)> = [
             (
@@ -742,9 +742,9 @@ pub mod tests {
         };
         let acceptable_delta = (max_allowable_drift_percentage * poh_offset as u32 / 100) as i64;
         let poh_estimate = epoch_start_timestamp + poh_offset as i64;
-        let pubkey0 = solana_sdk::pubkey::new_rand();
-        let pubkey1 = solana_sdk::pubkey::new_rand();
-        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey0 = solana_pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
 
         let stakes: HashMap<Pubkey, (u64, Account)> = [
             (

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -686,10 +686,10 @@ pub(crate) mod tests {
     pub(crate) fn create_staked_node_accounts(
         stake: u64,
     ) -> ((Pubkey, AccountSharedData), (Pubkey, AccountSharedData)) {
-        let vote_pubkey = solana_sdk::pubkey::new_rand();
+        let vote_pubkey = solana_pubkey::new_rand();
         let vote_account =
-            vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1);
-        let stake_pubkey = solana_sdk::pubkey::new_rand();
+            vote_state::create_account(&vote_pubkey, &solana_pubkey::new_rand(), 0, 1);
+        let stake_pubkey = solana_pubkey::new_rand();
         (
             (vote_pubkey, vote_account),
             (
@@ -708,7 +708,7 @@ pub(crate) mod tests {
         stake_state::create_account(
             stake_pubkey,
             vote_pubkey,
-            &vote_state::create_account(vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1),
+            &vote_state::create_account(vote_pubkey, &solana_pubkey::new_rand(), 0, 1),
             &Rent::free(),
             stake,
         )
@@ -718,9 +718,9 @@ pub(crate) mod tests {
         stake: u64,
         epoch: Epoch,
     ) -> ((Pubkey, AccountSharedData), (Pubkey, AccountSharedData)) {
-        let vote_pubkey = solana_sdk::pubkey::new_rand();
+        let vote_pubkey = solana_pubkey::new_rand();
         let vote_account =
-            vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1);
+            vote_state::create_account(&vote_pubkey, &solana_pubkey::new_rand(), 0, 1);
         (
             (vote_pubkey, vote_account),
             create_warming_stake_account(stake, epoch, &vote_pubkey),
@@ -733,13 +733,13 @@ pub(crate) mod tests {
         epoch: Epoch,
         vote_pubkey: &Pubkey,
     ) -> (Pubkey, AccountSharedData) {
-        let stake_pubkey = solana_sdk::pubkey::new_rand();
+        let stake_pubkey = solana_pubkey::new_rand();
         (
             stake_pubkey,
             stake_state::create_account_with_activation_epoch(
                 &stake_pubkey,
                 vote_pubkey,
-                &vote_state::create_account(vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1),
+                &vote_state::create_account(vote_pubkey, &solana_pubkey::new_rand(), 0, 1),
                 &Rent::free(),
                 stake,
                 epoch,
@@ -785,7 +785,7 @@ pub(crate) mod tests {
 
             // activate more
             let mut stake_account =
-                create_stake_account(42, &vote_pubkey, &solana_sdk::pubkey::new_rand());
+                create_stake_account(42, &vote_pubkey, &solana_pubkey::new_rand());
             stakes_cache.check_and_store(&stake_pubkey, &stake_account, None);
             let stake = stake_state::stake_from(&stake_account).unwrap();
             {
@@ -969,7 +969,7 @@ pub(crate) mod tests {
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10);
 
-        let stake_pubkey2 = solana_sdk::pubkey::new_rand();
+        let stake_pubkey2 = solana_pubkey::new_rand();
         let stake_account2 = create_stake_account(10, &vote_pubkey, &stake_pubkey2);
 
         stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -312,16 +312,16 @@ mod tests {
             ..Stakes::default()
         });
         for _ in 0..rng.gen_range(5usize..10) {
-            let vote_pubkey = solana_sdk::pubkey::new_rand();
+            let vote_pubkey = solana_pubkey::new_rand();
             let vote_account = vote_state::create_account(
                 &vote_pubkey,
-                &solana_sdk::pubkey::new_rand(), // node_pubkey
-                rng.gen_range(0..101),           // commission
-                rng.gen_range(0..1_000_000),     // lamports
+                &solana_pubkey::new_rand(),  // node_pubkey
+                rng.gen_range(0..101),       // commission
+                rng.gen_range(0..1_000_000), // lamports
             );
             stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
             for _ in 0..rng.gen_range(10usize..20) {
-                let stake_pubkey = solana_sdk::pubkey::new_rand();
+                let stake_pubkey = solana_pubkey::new_rand();
                 let rent = Rent::with_slots_per_epoch(rng.gen());
                 let stake_account = stake_state::create_account(
                     &stake_pubkey, // authorized

--- a/runtime/src/static_ids.rs
+++ b/runtime/src/static_ids.rs
@@ -1,6 +1,6 @@
 use {
     solana_inline_spl::{associated_token_account, token, token_2022},
-    solana_sdk::pubkey::Pubkey,
+    solana_pubkey::Pubkey,
 };
 
 lazy_static! {

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -193,7 +193,7 @@ mod tests {
     }
 
     fn setup(insert_conflicting_tx: bool) -> (Bank, Vec<RuntimeTransaction<SanitizedTransaction>>) {
-        let dummy_leader_pubkey = solana_sdk::pubkey::new_rand();
+        let dummy_leader_pubkey = solana_pubkey::new_rand();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -201,9 +201,9 @@ mod tests {
         } = create_genesis_config_with_leader(500, &dummy_leader_pubkey, 100);
         let bank = Bank::new_for_tests(&genesis_config);
 
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let keypair2 = Keypair::new();
-        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
 
         let mut txs = vec![RuntimeTransaction::from_transaction_for_tests(
             system_transaction::transfer(&mint_keypair, &pubkey, 1, genesis_config.hash()),

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -51,7 +51,7 @@ fn test_shrink_and_clean() {
         for current_slot in 0..100 {
             while alive_accounts.len() <= 10 {
                 alive_accounts.push((
-                    solana_sdk::pubkey::new_rand(),
+                    solana_pubkey::new_rand(),
                     AccountSharedData::new(thread_rng().gen_range(0..50), 0, &owner),
                 ));
             }
@@ -89,7 +89,7 @@ fn test_bad_bank_hash() {
     let mut accounts_keys: Vec<_> = (0..max_accounts)
         .into_par_iter()
         .map(|_| {
-            let key = solana_sdk::pubkey::new_rand();
+            let key = solana_pubkey::new_rand();
             let lamports = thread_rng().gen_range(0..100);
             let some_data_len = thread_rng().gen_range(0..1000);
             let account = AccountSharedData::new(lamports, some_data_len, &key);

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -141,11 +141,7 @@ fn test_stake_create_and_split_single_signature() {
         genesis_config,
         mint_keypair: staker_keypair,
         ..
-    } = create_genesis_config_with_leader(
-        100_000_000_000,
-        &solana_sdk::pubkey::new_rand(),
-        1_000_000,
-    );
+    } = create_genesis_config_with_leader(100_000_000_000, &solana_pubkey::new_rand(), 1_000_000);
 
     let staker_pubkey = staker_keypair.pubkey();
 
@@ -217,11 +213,7 @@ fn test_stake_create_and_split_to_existing_system_account() {
         genesis_config,
         mint_keypair: staker_keypair,
         ..
-    } = create_genesis_config_with_leader(
-        100_000_000_000,
-        &solana_sdk::pubkey::new_rand(),
-        1_000_000,
-    );
+    } = create_genesis_config_with_leader(100_000_000_000, &solana_pubkey::new_rand(), 1_000_000);
 
     let staker_pubkey = staker_keypair.pubkey();
 
@@ -307,7 +299,7 @@ fn test_stake_account_lifetime() {
         ..
     } = create_genesis_config_with_leader(
         100_000_000_000,
-        &solana_sdk::pubkey::new_rand(),
+        &solana_pubkey::new_rand(),
         2_000_000_000,
     );
     genesis_config.epoch_schedule = EpochSchedule::new(MINIMUM_SLOTS_PER_EPOCH);
@@ -391,7 +383,7 @@ fn test_stake_account_lifetime() {
         &[stake_instruction::withdraw(
             &stake_pubkey,
             &stake_pubkey,
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             1,
             None,
         )],
@@ -516,7 +508,7 @@ fn test_stake_account_lifetime() {
         &[stake_instruction::withdraw(
             &split_stake_pubkey,
             &stake_pubkey,
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             split_starting_delegation + 1,
             None,
         )],
@@ -540,7 +532,7 @@ fn test_stake_account_lifetime() {
         &[stake_instruction::withdraw(
             &split_stake_pubkey,
             &stake_pubkey,
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             split_balance,
             None,
         )],
@@ -557,7 +549,7 @@ fn test_stake_account_lifetime() {
         &[stake_instruction::withdraw(
             &split_stake_pubkey,
             &stake_pubkey,
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             split_unstaked,
             None,
         )],
@@ -582,7 +574,7 @@ fn test_stake_account_lifetime() {
         &[stake_instruction::withdraw(
             &split_stake_pubkey,
             &stake_pubkey,
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             split_remaining_balance,
             None,
         )],
@@ -608,11 +600,7 @@ fn test_create_stake_account_from_seed() {
         genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_leader(
-        100_000_000_000,
-        &solana_sdk::pubkey::new_rand(),
-        1_000_000,
-    );
+    } = create_genesis_config_with_leader(100_000_000_000, &solana_pubkey::new_rand(), 1_000_000);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let mint_pubkey = mint_keypair.pubkey();
     let bank_client = BankClient::new_shared(bank.clone());

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6653,6 +6653,7 @@ dependencies = [
  "solana-perf",
  "solana-program",
  "solana-program-runtime",
+ "solana-pubkey",
  "solana-rayon-threadlimit",
  "solana-runtime-transaction",
  "solana-sdk",


### PR DESCRIPTION
#### Problem
This crate uses solana_sdk in many places. It will take multiple PRs to replace it everywhere

#### Summary of Changes
Find and replace `solana_sdk::pubkey` with `solana_pubkey`
