### PR TITLE
replace solana_sdk::pubkey with solana_pubkey in solana-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6814,6 +6814,7 @@ dependencies = [
  "solana-perf",
  "solana-poh",
  "solana-program-runtime",
+ "solana-pubkey",
  "solana-quic-client",
  "solana-rayon-threadlimit",
  "solana-rpc",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -70,6 +70,7 @@ solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-perf = { workspace = true }
 solana-poh = { workspace = true }
+solana-pubkey = { workspace = true }
 solana-quic-client = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-rpc = { workspace = true }

--- a/core/benches/forwarder.rs
+++ b/core/benches/forwarder.rs
@@ -81,7 +81,7 @@ fn setup(num_packets: usize, contentious_transaction: bool) -> BenchSetup {
             let mut transaction =
                 system_transaction::transfer(&keypair, &Keypair::new().pubkey(), min_balance, hash);
             if !contentious_transaction {
-                transaction.message.account_keys[0] = solana_sdk::pubkey::Pubkey::new_unique();
+                transaction.message.account_keys[0] = solana_pubkey::Pubkey::new_unique();
             }
             let mut packet = Packet::from_data(None, transaction).unwrap();
             packet.meta_mut().set_from_staked_node(true);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1055,16 +1055,16 @@ mod tests {
             bank.process_transaction(&fund_tx).unwrap();
 
             // good tx
-            let to = solana_sdk::pubkey::new_rand();
+            let to = solana_pubkey::new_rand();
             let tx = system_transaction::transfer(&mint_keypair, &to, 1, start_hash);
 
             // good tx, but no verify
-            let to2 = solana_sdk::pubkey::new_rand();
+            let to2 = solana_pubkey::new_rand();
             let tx_no_ver = system_transaction::transfer(&keypair, &to2, 2, start_hash);
 
             // bad tx, AccountNotFound
             let keypair = Keypair::new();
-            let to3 = solana_sdk::pubkey::new_rand();
+            let to3 = solana_pubkey::new_rand();
             let tx_anf = system_transaction::transfer(&keypair, &to3, 1, start_hash);
 
             // send 'em over
@@ -1286,9 +1286,9 @@ mod tests {
                 .write()
                 .unwrap()
                 .set_bank_for_test(bank.clone());
-            let pubkey = solana_sdk::pubkey::new_rand();
+            let pubkey = solana_pubkey::new_rand();
             let keypair2 = Keypair::new();
-            let pubkey2 = solana_sdk::pubkey::new_rand();
+            let pubkey2 = solana_pubkey::new_rand();
 
             let txs = vec![
                 system_transaction::transfer(&mint_keypair, &pubkey, 1, genesis_config.hash())
@@ -1320,7 +1320,7 @@ mod tests {
     }
 
     pub(crate) fn create_slow_genesis_config(lamports: u64) -> GenesisConfigInfo {
-        create_slow_genesis_config_with_leader(lamports, &solana_sdk::pubkey::new_rand())
+        create_slow_genesis_config_with_leader(lamports, &solana_pubkey::new_rand())
     }
 
     pub(crate) fn create_slow_genesis_config_with_leader(

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1038,9 +1038,9 @@ mod tests {
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         // Set up unparallelizable conflicting transactions
-        let pubkey0 = solana_sdk::pubkey::new_rand();
-        let pubkey1 = solana_sdk::pubkey::new_rand();
-        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey0 = solana_pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
+        let pubkey2 = solana_pubkey::new_rand();
         let transactions = vec![
             system_transaction::transfer(mint_keypair, &pubkey0, 1, genesis_config.hash()),
             system_transaction::transfer(mint_keypair, &pubkey1, 1, genesis_config.hash()),
@@ -1080,7 +1080,7 @@ mod tests {
             ..
         } = create_slow_genesis_config(10_000);
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
 
         let transactions = sanitize_transactions(vec![system_transaction::transfer(
             &mint_keypair,
@@ -1373,7 +1373,7 @@ mod tests {
             ..
         } = create_slow_genesis_config(10_000);
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
 
         let transactions = {
             let mut tx =
@@ -1460,7 +1460,7 @@ mod tests {
         let mut bank = Bank::new_for_tests(&genesis_config);
         bank.ns_per_slot = u128::MAX;
         let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         {
@@ -1616,8 +1616,8 @@ mod tests {
             ..
         } = create_slow_genesis_config(10_000);
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let pubkey = solana_sdk::pubkey::new_rand();
-        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
 
         let transactions = sanitize_transactions(vec![
             system_transaction::transfer(&mint_keypair, &pubkey, 1, genesis_config.hash()),
@@ -1823,7 +1823,7 @@ mod tests {
         } = create_slow_genesis_config(10_000);
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
 
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
 
         let transactions = sanitize_transactions(vec![system_transaction::transfer(
             &mint_keypair,
@@ -1905,8 +1905,8 @@ mod tests {
         genesis_config.rent.lamports_per_byte_year = 50;
         genesis_config.rent.exemption_threshold = 2.0;
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let pubkey = solana_sdk::pubkey::new_rand();
-        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
+        let pubkey1 = solana_pubkey::new_rand();
         let keypair1 = Keypair::new();
 
         let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);

--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -217,8 +217,8 @@ mod tests {
 
     #[test]
     fn test_should_process_or_forward_packets() {
-        let my_pubkey = solana_sdk::pubkey::new_rand();
-        let my_pubkey1 = solana_sdk::pubkey::new_rand();
+        let my_pubkey = solana_pubkey::new_rand();
+        let my_pubkey1 = solana_pubkey::new_rand();
         let bank = Arc::new(Bank::default_for_tests());
         let bank_start = Some(BankStart {
             working_bank: bank,

--- a/core/src/banking_stage/forward_packet_batches_by_accounts.rs
+++ b/core/src/banking_stage/forward_packet_batches_by_accounts.rs
@@ -188,7 +188,7 @@ mod tests {
         DeserializedPacket,
         u32,
     ) {
-        let from_account = solana_sdk::pubkey::new_rand();
+        let from_account = solana_pubkey::new_rand();
 
         let transaction = Transaction::new_unsigned(Message::new(
             &[
@@ -214,8 +214,8 @@ mod tests {
     fn test_try_add_packet_to_multiple_batches() {
         // setup two transactions, one has high priority that writes to hot account, the
         // other write to non-contentious account with no priority
-        let hot_account = solana_sdk::pubkey::new_rand();
-        let other_account = solana_sdk::pubkey::new_rand();
+        let hot_account = solana_pubkey::new_rand();
+        let other_account = solana_pubkey::new_rand();
         let (tx_high_priority, packet_high_priority, limit_ratio) =
             build_test_transaction_and_packet(10, &hot_account);
         let (tx_low_priority, packet_low_priority, _) =
@@ -292,7 +292,7 @@ mod tests {
     #[test]
     fn test_try_add_packet_to_single_batch() {
         let (tx, packet, limit_ratio) =
-            build_test_transaction_and_packet(10, &solana_sdk::pubkey::new_rand());
+            build_test_transaction_and_packet(10, &solana_pubkey::new_rand());
         let number_of_batches = 1;
         let mut forward_packet_batches_by_accounts =
             ForwardPacketBatchesByAccounts::new(limit_ratio, number_of_batches);
@@ -332,7 +332,7 @@ mod tests {
         {
             // build a small packet to a non-contentious account with high priority
             let (tx2, packet2, _) =
-                build_test_transaction_and_packet(100, &solana_sdk::pubkey::new_rand());
+                build_test_transaction_and_packet(100, &solana_pubkey::new_rand());
 
             assert!(forward_packet_batches_by_accounts.try_add_packet(
                 &tx2,

--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -437,7 +437,7 @@ mod tests {
         // Create `PacketBatch` with 1 unprocessed packet
         let tx = system_transaction::transfer(
             &Keypair::new(),
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             rent_min_balance,
             blockhash,
         );
@@ -504,7 +504,7 @@ mod tests {
         } = setup();
 
         let keypair = Keypair::new();
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
 
         // forwarded packets will not be forwarded again
         let forwarded_packet = {

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -218,7 +218,7 @@ mod tests {
     fn simple_deserialized_packet() {
         let tx = system_transaction::transfer(
             &Keypair::new(),
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             1,
             Hash::new_unique(),
         );

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -1090,8 +1090,8 @@ impl LeaderSlotMetricsTracker {
 mod tests {
     use {
         super::*,
+        solana_pubkey::Pubkey,
         solana_runtime::{bank::Bank, genesis_utils::create_genesis_config},
-        solana_sdk::pubkey::Pubkey,
         std::{mem, sync::Arc},
     };
 

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -728,7 +728,7 @@ mod tests {
         let transaction = solana_sdk::transaction::Transaction::new_unsigned(solana_sdk::message::Message::new(
             &[
                 solana_sdk::compute_budget::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(loaded_accounts_data_size),
-                solana_sdk::system_instruction::transfer(&keypair.pubkey(), &solana_sdk::pubkey::Pubkey::new_unique(), 1),
+                solana_sdk::system_instruction::transfer(&keypair.pubkey(), &solana_pubkey::Pubkey::new_unique(), 1),
             ],
             Some(&keypair.pubkey()),
         ));
@@ -852,7 +852,7 @@ mod tests {
         let transaction = solana_sdk::transaction::Transaction::new_unsigned(solana_sdk::message::Message::new(
             &[
                 solana_sdk::compute_budget::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(loaded_accounts_data_size),
-                solana_sdk::system_instruction::transfer(&keypair.pubkey(), &solana_sdk::pubkey::Pubkey::new_unique(), 1),
+                solana_sdk::system_instruction::transfer(&keypair.pubkey(), &solana_pubkey::Pubkey::new_unique(), 1),
             ],
             Some(&keypair.pubkey()),
         ));

--- a/core/src/banking_stage/read_write_account_set.rs
+++ b/core/src/banking_stage/read_write_account_set.rs
@@ -1,6 +1,4 @@
-use {
-    ahash::AHashSet, solana_sdk::pubkey::Pubkey, solana_svm_transaction::svm_message::SVMMessage,
-};
+use {ahash::AHashSet, solana_pubkey::Pubkey, solana_svm_transaction::svm_message::SVMMessage};
 
 /// Wrapper struct to accumulate locks for a batch of transactions.
 #[derive(Debug, Default)]

--- a/core/src/banking_stage/transaction_scheduler/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/transaction_scheduler/thread_aware_account_locks.rs
@@ -1,6 +1,6 @@
 use {
     ahash::AHashMap,
-    solana_sdk::pubkey::Pubkey,
+    solana_pubkey::Pubkey,
     std::{
         collections::hash_map::Entry,
         fmt::{Debug, Display},

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -228,11 +228,7 @@ mod tests {
     ) -> TransactionState<RuntimeTransaction<SanitizedTransaction>> {
         let from_keypair = Keypair::new();
         let ixs = vec![
-            system_instruction::transfer(
-                &from_keypair.pubkey(),
-                &solana_sdk::pubkey::new_rand(),
-                1,
-            ),
+            system_instruction::transfer(&from_keypair.pubkey(), &solana_pubkey::new_rand(), 1),
             ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price),
         ];
         let message = Message::new(&ixs, Some(&from_keypair.pubkey()));

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -235,11 +235,7 @@ mod tests {
     ) {
         let from_keypair = Keypair::new();
         let ixs = vec![
-            system_instruction::transfer(
-                &from_keypair.pubkey(),
-                &solana_sdk::pubkey::new_rand(),
-                1,
-            ),
+            system_instruction::transfer(&from_keypair.pubkey(), &solana_pubkey::new_rand(), 1),
             ComputeBudgetInstruction::set_compute_unit_price(priority),
         ];
         let message = Message::new(&ixs, Some(&from_keypair.pubkey()));

--- a/core/src/banking_stage/unprocessed_packet_batches.rs
+++ b/core/src/banking_stage/unprocessed_packet_batches.rs
@@ -311,7 +311,7 @@ mod tests {
     fn simple_deserialized_packet() -> DeserializedPacket {
         let tx = system_transaction::transfer(
             &Keypair::new(),
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
             1,
             Hash::new_unique(),
         );
@@ -323,12 +323,12 @@ mod tests {
         compute_unit_price: u64,
         compute_unit_limit: u64,
     ) -> DeserializedPacket {
-        let from_account = solana_sdk::pubkey::new_rand();
+        let from_account = solana_pubkey::new_rand();
         let tx = Transaction::new_unsigned(Message::new(
             &[
                 ComputeBudgetInstruction::set_compute_unit_limit(compute_unit_limit as u32),
                 ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price),
-                system_instruction::transfer(&from_account, &solana_sdk::pubkey::new_rand(), 1),
+                system_instruction::transfer(&from_account, &solana_pubkey::new_rand(), 1),
             ],
             Some(&from_account),
         ));

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -1186,7 +1186,7 @@ mod tests {
     fn test_unprocessed_transaction_storage_insert() -> Result<(), Box<dyn Error>> {
         let keypair = Keypair::new();
         let vote_keypair = Keypair::new();
-        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
 
         let small_transfer = Packet::from_data(
             None,

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -789,7 +789,7 @@ mod tests {
         } = setup();
 
         // Check outdated slots are purged with new root
-        let new_voter = solana_sdk::pubkey::new_rand();
+        let new_voter = solana_pubkey::new_rand();
         // Make separate copy so the original doesn't count toward
         // the ref count, which would prevent cleanup
         let new_voter_ = new_voter;

--- a/core/src/cluster_slots_service/cluster_slots.rs
+++ b/core/src/cluster_slots_service/cluster_slots.rs
@@ -279,8 +279,8 @@ mod tests {
     fn test_best_peer_2() {
         let cs = ClusterSlots::default();
         let mut map = HashMap::new();
-        let k1 = solana_sdk::pubkey::new_rand();
-        let k2 = solana_sdk::pubkey::new_rand();
+        let k1 = solana_pubkey::new_rand();
+        let k2 = solana_pubkey::new_rand();
         map.insert(k1, u64::MAX / 2);
         map.insert(k2, 0);
         cs.cluster_slots
@@ -296,8 +296,8 @@ mod tests {
     fn test_best_peer_3() {
         let cs = ClusterSlots::default();
         let mut map = HashMap::new();
-        let k1 = solana_sdk::pubkey::new_rand();
-        let k2 = solana_sdk::pubkey::new_rand();
+        let k1 = solana_pubkey::new_rand();
+        let k2 = solana_pubkey::new_rand();
         map.insert(k2, 0);
         cs.cluster_slots
             .write()
@@ -324,7 +324,7 @@ mod tests {
         let cs = ClusterSlots::default();
         let contact_infos: Vec<_> = std::iter::repeat_with(|| {
             ContactInfo::new(
-                solana_sdk::pubkey::new_rand(),
+                solana_pubkey::new_rand(),
                 0, // wallclock
                 0, // shred_version
             )

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -410,22 +410,20 @@ mod tests {
 
         let rooted_stake_amount = 40;
 
-        let sk1 = solana_sdk::pubkey::new_rand();
-        let pk1 = solana_sdk::pubkey::new_rand();
+        let sk1 = solana_pubkey::new_rand();
+        let pk1 = solana_pubkey::new_rand();
         let mut vote_account1 =
-            vote_state::create_account(&pk1, &solana_sdk::pubkey::new_rand(), 0, 100);
+            vote_state::create_account(&pk1, &solana_pubkey::new_rand(), 0, 100);
         let stake_account1 =
             stake_state::create_account(&sk1, &pk1, &vote_account1, &genesis_config.rent, 100);
-        let sk2 = solana_sdk::pubkey::new_rand();
-        let pk2 = solana_sdk::pubkey::new_rand();
-        let mut vote_account2 =
-            vote_state::create_account(&pk2, &solana_sdk::pubkey::new_rand(), 0, 50);
+        let sk2 = solana_pubkey::new_rand();
+        let pk2 = solana_pubkey::new_rand();
+        let mut vote_account2 = vote_state::create_account(&pk2, &solana_pubkey::new_rand(), 0, 50);
         let stake_account2 =
             stake_state::create_account(&sk2, &pk2, &vote_account2, &genesis_config.rent, 50);
-        let sk3 = solana_sdk::pubkey::new_rand();
-        let pk3 = solana_sdk::pubkey::new_rand();
-        let mut vote_account3 =
-            vote_state::create_account(&pk3, &solana_sdk::pubkey::new_rand(), 0, 1);
+        let sk3 = solana_pubkey::new_rand();
+        let pk3 = solana_pubkey::new_rand();
+        let mut vote_account3 = vote_state::create_account(&pk3, &solana_pubkey::new_rand(), 0, 1);
         let stake_account3 = stake_state::create_account(
             &sk3,
             &pk3,
@@ -433,10 +431,9 @@ mod tests {
             &genesis_config.rent,
             rooted_stake_amount,
         );
-        let sk4 = solana_sdk::pubkey::new_rand();
-        let pk4 = solana_sdk::pubkey::new_rand();
-        let mut vote_account4 =
-            vote_state::create_account(&pk4, &solana_sdk::pubkey::new_rand(), 0, 1);
+        let sk4 = solana_pubkey::new_rand();
+        let pk4 = solana_pubkey::new_rand();
+        let mut vote_account4 = vote_state::create_account(&pk4, &solana_pubkey::new_rand(), 0, 1);
         let stake_account4 = stake_state::create_account(
             &sk4,
             &pk4,
@@ -495,7 +492,7 @@ mod tests {
             pk1
         } else {
             // Use some random pubkey as dummy to suppress the override.
-            solana_sdk::pubkey::new_rand()
+            solana_pubkey::new_rand()
         };
 
         let (commitment, rooted_stake) = AggregateCommitmentService::aggregate_commitment(

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1830,7 +1830,7 @@ pub mod test {
                 )
                 .expect("serialize state");
                 (
-                    solana_sdk::pubkey::new_rand(),
+                    solana_pubkey::new_rand(),
                     (*lamports, VoteAccount::try_from(account).unwrap()),
                 )
             })

--- a/core/src/consensus/progress_map.rs
+++ b/core/src/consensus/progress_map.rs
@@ -425,7 +425,7 @@ mod test {
     #[test]
     fn test_add_vote_pubkey() {
         let mut stats = PropagatedStats::default();
-        let mut vote_pubkey = solana_sdk::pubkey::new_rand();
+        let mut vote_pubkey = solana_pubkey::new_rand();
 
         // Add a vote pubkey, the number of references in all_pubkeys
         // should be 2
@@ -439,7 +439,7 @@ mod test {
         assert_eq!(stats.propagated_validators_stake, 1);
 
         // Adding another pubkey should succeed
-        vote_pubkey = solana_sdk::pubkey::new_rand();
+        vote_pubkey = solana_pubkey::new_rand();
         stats.add_vote_pubkey(vote_pubkey, 2);
         assert!(stats.propagated_validators.contains(&vote_pubkey));
         assert_eq!(stats.propagated_validators_stake, 3);
@@ -449,7 +449,7 @@ mod test {
     fn test_add_node_pubkey_internal() {
         let num_vote_accounts = 10;
         let staked_vote_accounts = 5;
-        let vote_account_pubkeys: Vec<_> = std::iter::repeat_with(solana_sdk::pubkey::new_rand)
+        let vote_account_pubkeys: Vec<_> = std::iter::repeat_with(solana_pubkey::new_rand)
             .take(num_vote_accounts)
             .collect();
         let epoch_vote_accounts: HashMap<_, _> = vote_account_pubkeys
@@ -459,7 +459,7 @@ mod test {
             .collect();
 
         let mut stats = PropagatedStats::default();
-        let mut node_pubkey = solana_sdk::pubkey::new_rand();
+        let mut node_pubkey = solana_pubkey::new_rand();
 
         // Add a vote pubkey, the number of references in all_pubkeys
         // should be 2
@@ -480,7 +480,7 @@ mod test {
 
         // Adding another pubkey with same vote accounts should succeed, but stake
         // shouldn't increase
-        node_pubkey = solana_sdk::pubkey::new_rand();
+        node_pubkey = solana_pubkey::new_rand();
         stats.add_node_pubkey_internal(&node_pubkey, &vote_account_pubkeys, &epoch_vote_accounts);
         assert!(stats.propagated_node_ids.contains(&node_pubkey));
         assert_eq!(
@@ -490,8 +490,8 @@ mod test {
 
         // Adding another pubkey with different vote accounts should succeed
         // and increase stake
-        node_pubkey = solana_sdk::pubkey::new_rand();
-        let vote_account_pubkeys: Vec<_> = std::iter::repeat_with(solana_sdk::pubkey::new_rand)
+        node_pubkey = solana_pubkey::new_rand();
+        let vote_account_pubkeys: Vec<_> = std::iter::repeat_with(solana_pubkey::new_rand)
             .take(num_vote_accounts)
             .collect();
         let epoch_vote_accounts: HashMap<_, _> = vote_account_pubkeys

--- a/core/src/consensus/vote_stake_tracker.rs
+++ b/core/src/consensus/vote_stake_tracker.rs
@@ -1,4 +1,4 @@
-use {solana_sdk::pubkey::Pubkey, std::collections::HashSet};
+use {solana_pubkey::Pubkey, std::collections::HashSet};
 
 #[derive(Default)]
 pub struct VoteStakeTracker {
@@ -55,7 +55,7 @@ mod test {
         let total_epoch_stake = 10;
         let mut vote_stake_tracker = VoteStakeTracker::default();
         for i in 0..10 {
-            let pubkey = solana_sdk::pubkey::new_rand();
+            let pubkey = solana_pubkey::new_rand();
             let (is_confirmed_thresholds, is_new) = vote_stake_tracker.add_vote_pubkey(
                 pubkey,
                 1,

--- a/core/src/gen_keys.rs
+++ b/core/src/gen_keys.rs
@@ -47,7 +47,7 @@ impl GenKeys {
 
 #[cfg(test)]
 mod tests {
-    pub use solana_sdk::pubkey::Pubkey;
+    pub use solana_pubkey::Pubkey;
     use {super::*, solana_sdk::signature::Signer, std::collections::HashSet};
 
     #[test]

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -148,8 +148,8 @@ impl OptimisticConfirmationVerifier {
 mod test {
     use {
         super::*, crate::vote_simulator::VoteSimulator,
-        solana_ledger::get_tmp_ledger_path_auto_delete, solana_runtime::bank::Bank,
-        solana_sdk::pubkey::Pubkey, std::collections::HashMap, trees::tr,
+        solana_ledger::get_tmp_ledger_path_auto_delete, solana_pubkey::Pubkey,
+        solana_runtime::bank::Bank, std::collections::HashMap, trees::tr,
     };
 
     #[test]

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1590,7 +1590,7 @@ mod tests {
             Arc::new(RwLock::new(HashSet::default())),
         );
         let keypair = cluster_info.keypair().clone();
-        let repair_peer_id = solana_sdk::pubkey::new_rand();
+        let repair_peer_id = solana_pubkey::new_rand();
         let repair_request = ShredRepairType::Orphan(123);
 
         let rsp = serve_repair
@@ -1626,7 +1626,7 @@ mod tests {
         let slot: Slot = 50;
         let nonce = 70;
         let cluster_info = Arc::new(new_test_cluster_info());
-        let repair_peer_id = solana_sdk::pubkey::new_rand();
+        let repair_peer_id = solana_pubkey::new_rand();
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let keypair = cluster_info.keypair().clone();
 
@@ -1676,7 +1676,7 @@ mod tests {
             Arc::new(RwLock::new(HashSet::default())),
         );
         let keypair = cluster_info.keypair().clone();
-        let repair_peer_id = solana_sdk::pubkey::new_rand();
+        let repair_peer_id = solana_pubkey::new_rand();
 
         let slot = 50;
         let shred_index = 60;
@@ -2015,7 +2015,7 @@ mod tests {
 
         let serve_repair_addr = socketaddr!(Ipv4Addr::LOCALHOST, 1243);
         let mut nxt = ContactInfo::new(
-            solana_sdk::pubkey::new_rand(),
+            solana_pubkey::new_rand(),
             timestamp(), // wallclock
             0u16,        // shred_version
         );
@@ -2050,7 +2050,7 @@ mod tests {
 
         let serve_repair_addr2 = socketaddr!([127, 0, 0, 2], 1243);
         let mut nxt = ContactInfo::new(
-            solana_sdk::pubkey::new_rand(),
+            solana_pubkey::new_rand(),
             timestamp(), // wallclock
             0u16,        // shred_version
         );
@@ -2320,10 +2320,8 @@ mod tests {
         let me = cluster_info.my_contact_info();
         let (repair_request_quic_sender, _) = tokio::sync::mpsc::channel(/*buffer:*/ 128);
         // Insert two peers on the network
-        let contact_info2 =
-            ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
-        let contact_info3 =
-            ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
+        let contact_info2 = ContactInfo::new_localhost(&solana_pubkey::new_rand(), timestamp());
+        let contact_info3 = ContactInfo::new_localhost(&solana_pubkey::new_rand(), timestamp());
         cluster_info.insert_info(contact_info2.clone());
         cluster_info.insert_info(contact_info3.clone());
         let identity_keypair = cluster_info.keypair().clone();
@@ -2337,7 +2335,7 @@ mod tests {
         // 1) repair validator set doesn't exist in gossip
         // 2) repair validator set only includes our own id
         // then no repairs should be generated
-        for pubkey in &[solana_sdk::pubkey::new_rand(), *me.pubkey()] {
+        for pubkey in &[solana_pubkey::new_rand(), *me.pubkey()] {
             let known_validators = Some(vec![*pubkey].into_iter().collect());
             assert!(serve_repair.repair_peers(&known_validators, 1).is_empty());
             assert_matches!(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5065,7 +5065,7 @@ pub(crate) mod tests {
             (*pubkey, vote_state)
         }
 
-        let leader_pubkey = solana_sdk::pubkey::new_rand();
+        let leader_pubkey = solana_pubkey::new_rand();
         let leader_lamports = 3;
         let genesis_config_info =
             create_genesis_config_with_leader(50, &leader_pubkey, leader_lamports);
@@ -5121,7 +5121,7 @@ pub(crate) mod tests {
             let _res = bank.transfer(
                 10,
                 &genesis_config_info.mint_keypair,
-                &solana_sdk::pubkey::new_rand(),
+                &solana_pubkey::new_rand(),
             );
             for _ in 0..genesis_config.ticks_per_slot {
                 bank.register_default_tick_for_test();

--- a/core/src/staked_nodes_updater_service.rs
+++ b/core/src/staked_nodes_updater_service.rs
@@ -1,6 +1,6 @@
 use {
+    solana_pubkey::Pubkey,
     solana_runtime::bank_forks::BankForks,
-    solana_sdk::pubkey::Pubkey,
     solana_streamer::streamer::StakedNodes,
     std::{
         collections::HashMap,

--- a/core/src/warm_quic_cache_service.rs
+++ b/core/src/warm_quic_cache_service.rs
@@ -10,7 +10,7 @@ use {
         contact_info::{ContactInfo, Error},
     },
     solana_poh::poh_recorder::PohRecorder,
-    solana_sdk::pubkey::Pubkey,
+    solana_pubkey::Pubkey,
     std::{
         net::SocketAddr,
         sync::{

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -87,9 +87,9 @@ impl SnapshotTestConfig {
         // bank stakes which results in mismatch when banks are loaded from
         // snapshots.
         let mut genesis_config_info = create_genesis_config_with_leader(
-            10_000,                          // mint_lamports
-            &solana_sdk::pubkey::new_rand(), // validator_pubkey
-            1,                               // validator_stake_lamports
+            10_000,                     // mint_lamports
+            &solana_pubkey::new_rand(), // validator_pubkey
+            1,                          // validator_stake_lamports
         );
         genesis_config_info.genesis_config.cluster_type = cluster_type;
         let bank0 = Bank::new_with_paths_for_tests(
@@ -483,11 +483,11 @@ fn test_bank_forks_incremental_snapshot(
             let bank_scheduler = bank_forks.write().unwrap().insert(bank);
             let bank = bank_scheduler.clone_without_scheduler();
 
-            let key = solana_sdk::pubkey::new_rand();
+            let key = solana_pubkey::new_rand();
             let tx = system_transaction::transfer(mint_keypair, &key, 1, bank.last_blockhash());
             assert_eq!(bank.process_transaction(&tx), Ok(()));
 
-            let key = solana_sdk::pubkey::new_rand();
+            let key = solana_pubkey::new_rand();
             let tx = system_transaction::transfer(mint_keypair, &key, 0, bank.last_blockhash());
             assert_eq!(bank.process_transaction(&tx), Ok(()));
 
@@ -760,11 +760,11 @@ fn test_snapshots_with_background_services(
                 .insert(bank)
                 .clone_without_scheduler();
 
-            let key = solana_sdk::pubkey::new_rand();
+            let key = solana_pubkey::new_rand();
             let tx = system_transaction::transfer(mint_keypair, &key, 1, bank.last_blockhash());
             assert_eq!(bank.process_transaction(&tx), Ok(()));
 
-            let key = solana_sdk::pubkey::new_rand();
+            let key = solana_pubkey::new_rand();
             let tx = system_transaction::transfer(mint_keypair, &key, 0, bank.last_blockhash());
             assert_eq!(bank.process_transaction(&tx), Ok(()));
 

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -96,7 +96,7 @@ fn test_scheduler_waited_by_drop_bank_service() {
 
     let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
         &mint_keypair,
-        &solana_sdk::pubkey::new_rand(),
+        &solana_pubkey::new_rand(),
         2,
         genesis_config.hash(),
     ));

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5477,6 +5477,7 @@ dependencies = [
  "solana-net-utils",
  "solana-perf",
  "solana-poh",
+ "solana-pubkey",
  "solana-quic-client",
  "solana-rayon-threadlimit",
  "solana-rpc",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5328,6 +5328,7 @@ dependencies = [
  "solana-net-utils",
  "solana-perf",
  "solana-poh",
+ "solana-pubkey",
  "solana-quic-client",
  "solana-rayon-threadlimit",
  "solana-rpc",


### PR DESCRIPTION
#### Problem
This crate uses solana_sdk in many places. It will take multiple PRs to replace it everywhere

#### Summary of Changes
Find and replace `solana_sdk::pubkey` with `solana_pubkey`
