### PR TITLE
dedups shreds by common-header instead of the entire payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9804,6 +9804,7 @@ version = "2.2.0"
 dependencies = [
  "assert_matches",
  "bincode",
+ "bs58",
  "bytes",
  "crossbeam-channel",
  "futures 0.3.31",

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -638,6 +638,11 @@ pub mod layout {
         packet.buffer_mut().get_mut(..size)
     }
 
+    #[inline]
+    pub fn get_common_header_bytes(shred: &[u8]) -> Option<&[u8]> {
+        shred.get(..SIZE_OF_COMMON_SHRED_HEADER)
+    }
+
     pub(crate) fn get_signature(shred: &[u8]) -> Option<Signature> {
         shred
             .get(..SIZE_OF_SIGNATURE)

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -47,6 +47,7 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+bs58 = { workspace = true }
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 test-case = { workspace = true }


### PR DESCRIPTION

#### Problem
Shreds in the retransmit stage:
  * don't have repair nonce (repaired shreds are not retransmitted).
  * are already resigned by this node as the retransmitter.
  * have their leader's signature verified.


Therefore in order to dedup shreds, it suffices to compare:

    (signature, slot, shred-index, shred-type)

Because `ShredCommonHeader` already includes all of the above tuple, the rest of the payload can be skipped.


#### Summary of Changes

The commit dedups shreds by common-header and skips the rest of the payload.