### PR TITLE
adjust sendmmsg wrapper to use stack allocated libc types

### DIFF
--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -177,6 +177,7 @@ fn sendmmsg_retry(sock: &UdpSocket, hdrs: &mut [mmsghdr]) -> Result<(), SendPkts
     }
 }
 
+#[cfg(target_os = "linux")]
 const MAX_IOV: usize = libc::UIO_MAXIOV as usize;
 
 #[cfg(target_os = "linux")]

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -69,6 +69,8 @@ fn mmsghdr_for_packet(
     const SIZE_OF_SOCKADDR_IN: usize = mem::size_of::<sockaddr_in>();
     const SIZE_OF_SOCKADDR_IN6: usize = mem::size_of::<sockaddr_in6>();
     const SIZE_OF_SOCKADDR_STORAGE: usize = mem::size_of::<sockaddr_storage>();
+    const SOCKADDR_IN_PADDING: usize = SIZE_OF_SOCKADDR_STORAGE - SIZE_OF_SOCKADDR_IN;
+    const SOCKADDR_IN6_PADDING: usize = SIZE_OF_SOCKADDR_STORAGE - SIZE_OF_SOCKADDR_IN6;
 
     iov.write(iovec {
         iov_base: packet.as_ptr() as *mut libc::c_void,
@@ -77,7 +79,7 @@ fn mmsghdr_for_packet(
 
     let msg_namelen = match dest {
         SocketAddr::V4(socket_addr_v4) => {
-            let ptr = addr.as_mut_ptr() as *mut _;
+            let ptr: *mut sockaddr_in = addr.as_mut_ptr() as *mut _;
             unsafe {
                 ptr::write(
                     ptr,
@@ -87,13 +89,13 @@ fn mmsghdr_for_packet(
                 ptr::write_bytes(
                     (ptr as *mut u8).add(SIZE_OF_SOCKADDR_IN),
                     0,
-                    SIZE_OF_SOCKADDR_STORAGE - SIZE_OF_SOCKADDR_IN,
+                    SOCKADDR_IN_PADDING,
                 );
             }
             SIZE_OF_SOCKADDR_IN as socklen_t
         }
         SocketAddr::V6(socket_addr_v6) => {
-            let ptr = addr.as_mut_ptr() as *mut _;
+            let ptr: *mut sockaddr_in6 = addr.as_mut_ptr() as *mut _;
             unsafe {
                 ptr::write(
                     ptr,
@@ -103,7 +105,7 @@ fn mmsghdr_for_packet(
                 ptr::write_bytes(
                     (ptr as *mut u8).add(SIZE_OF_SOCKADDR_IN6),
                     0,
-                    SIZE_OF_SOCKADDR_STORAGE - SIZE_OF_SOCKADDR_IN6,
+                    SOCKADDR_IN6_PADDING,
                 );
             }
             SIZE_OF_SOCKADDR_IN6 as socklen_t


### PR DESCRIPTION
#### Problem
The `sendmmsg` wrapper on linux allocates vectors to initialize headers and their components (`iovec`, `socketaddr_storage`) for each packet. See https://github.com/anza-xyz/agave/issues/3569 for more details.

#### Summary of Changes

This PR stack allocates space in the form of fixed sized arrays for packet headers and their `iovec`, `socketaddr_storage` components. Length is capped at `libc::UIO_MAXIOV` (see https://man7.org/linux/man-pages/man2/sendmmsg.2.html).

This PR also avoids zeroing all uninitialized `sockaddr_storage` slots and just zeroes `mem::size_of::<sockaddr_storage>() - mem::size_of::<sockaddr_in>` (or its IPv6 counterpart) for each initialized slot.

Fixes #3569 

