### PR TITLE
Removes unnecessary casts in datapoints

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -788,53 +788,49 @@ impl GenerateIndexTimings {
             ("total_us", self.index_time, i64),
             ("scan_stores_us", self.scan_time, i64),
             ("insertion_time_us", self.insertion_time_us, i64),
-            ("min_bin_size_in_mem", self.min_bin_size_in_mem as i64, i64),
-            ("max_bin_size_in_mem", self.max_bin_size_in_mem as i64, i64),
+            ("min_bin_size_in_mem", self.min_bin_size_in_mem, i64),
+            ("max_bin_size_in_mem", self.max_bin_size_in_mem, i64),
             (
                 "storage_size_storages_us",
-                self.storage_size_storages_us as i64,
+                self.storage_size_storages_us,
                 i64
             ),
-            ("index_flush_us", self.index_flush_us as i64, i64),
+            ("index_flush_us", self.index_flush_us, i64),
             (
                 "total_rent_paying",
-                self.rent_paying.load(Ordering::Relaxed) as i64,
+                self.rent_paying.load(Ordering::Relaxed),
                 i64
             ),
             (
                 "amount_to_top_off_rent",
-                self.amount_to_top_off_rent.load(Ordering::Relaxed) as i64,
+                self.amount_to_top_off_rent.load(Ordering::Relaxed),
                 i64
             ),
             (
                 "total_items_including_duplicates",
-                self.total_including_duplicates as i64,
+                self.total_including_duplicates,
                 i64
             ),
-            ("total_items_in_mem", self.total_items_in_mem as i64, i64),
+            ("total_items_in_mem", self.total_items_in_mem, i64),
             (
                 "accounts_data_len_dedup_time_us",
-                self.accounts_data_len_dedup_time_us as i64,
+                self.accounts_data_len_dedup_time_us,
                 i64
             ),
             (
                 "total_duplicate_slot_keys",
-                self.total_duplicate_slot_keys as i64,
+                self.total_duplicate_slot_keys,
                 i64
             ),
             (
                 "total_num_unique_duplicate_keys",
-                self.total_num_unique_duplicate_keys as i64,
+                self.total_num_unique_duplicate_keys,
                 i64
             ),
-            (
-                "num_duplicate_accounts",
-                self.num_duplicate_accounts as i64,
-                i64
-            ),
+            ("num_duplicate_accounts", self.num_duplicate_accounts, i64),
             (
                 "populate_duplicate_keys_us",
-                self.populate_duplicate_keys_us as i64,
+                self.populate_duplicate_keys_us,
                 i64
             ),
             ("total_slots", self.total_slots, i64),
@@ -851,14 +847,10 @@ impl GenerateIndexTimings {
             ),
             (
                 "num_zero_lamport_single_refs",
-                self.num_zero_lamport_single_refs as i64,
+                self.num_zero_lamport_single_refs,
                 i64
             ),
-            (
-                "visit_zero_lamports_us",
-                self.visit_zero_lamports_us as i64,
-                i64
-            ),
+            ("visit_zero_lamports_us", self.visit_zero_lamports_us, i64),
             (
                 "all_accounts_are_zero_lamports_slots",
                 self.all_accounts_are_zero_lamports_slots,
@@ -3109,12 +3101,12 @@ impl AccountsDb {
                 key_timings.dirty_store_processing_us,
                 i64
             ),
-            ("accounts_scan", accounts_scan.as_us() as i64, i64),
-            ("clean_old_rooted", clean_old_rooted.as_us() as i64, i64),
-            ("store_counts", store_counts_time.as_us() as i64, i64),
-            ("purge_filter", purge_filter.as_us() as i64, i64),
-            ("calc_deps", calc_deps_time.as_us() as i64, i64),
-            ("reclaims", reclaims_time.as_us() as i64, i64),
+            ("accounts_scan", accounts_scan.as_us(), i64),
+            ("clean_old_rooted", clean_old_rooted.as_us(), i64),
+            ("store_counts", store_counts_time.as_us(), i64),
+            ("purge_filter", purge_filter.as_us(), i64),
+            ("calc_deps", calc_deps_time.as_us(), i64),
+            ("reclaims", reclaims_time.as_us(), i64),
             ("delta_insert_us", key_timings.delta_insert_us, i64),
             ("delta_key_count", key_timings.delta_key_count, i64),
             ("dirty_pubkeys_count", key_timings.dirty_pubkeys_count, i64),
@@ -6240,11 +6232,7 @@ impl AccountsDb {
                 unflushable_unrooted_slot_count,
                 i64
             ),
-            (
-                "flush_roots_elapsed",
-                flush_roots_elapsed.as_us() as i64,
-                i64
-            ),
+            ("flush_roots_elapsed", flush_roots_elapsed.as_us(), i64),
             ("account_bytes_saved", account_bytes_saved, i64),
             ("num_accounts_saved", num_accounts_saved, i64),
             (

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -68,64 +68,64 @@ impl PurgeStats {
                 metric_name,
                 (
                     "safety_checks_elapsed",
-                    self.safety_checks_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.safety_checks_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "remove_cache_elapsed",
-                    self.remove_cache_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.remove_cache_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "remove_storage_entries_elapsed",
                     self.remove_storage_entries_elapsed
-                        .swap(0, Ordering::Relaxed) as i64,
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "drop_storage_entries_elapsed",
-                    self.drop_storage_entries_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.drop_storage_entries_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "num_cached_slots_removed",
-                    self.num_cached_slots_removed.swap(0, Ordering::Relaxed) as i64,
+                    self.num_cached_slots_removed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "num_stored_slots_removed",
-                    self.num_stored_slots_removed.swap(0, Ordering::Relaxed) as i64,
+                    self.num_stored_slots_removed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "total_removed_storage_entries",
                     self.total_removed_storage_entries
-                        .swap(0, Ordering::Relaxed) as i64,
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "total_removed_cached_bytes",
-                    self.total_removed_cached_bytes.swap(0, Ordering::Relaxed) as i64,
+                    self.total_removed_cached_bytes.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "total_removed_stored_bytes",
-                    self.total_removed_stored_bytes.swap(0, Ordering::Relaxed) as i64,
+                    self.total_removed_stored_bytes.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "scan_storages_elapsed",
-                    self.scan_storages_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.scan_storages_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "purge_accounts_index_elapsed",
-                    self.purge_accounts_index_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.purge_accounts_index_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "handle_reclaims_elapsed",
-                    self.handle_reclaims_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.handle_reclaims_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
             );
@@ -211,44 +211,40 @@ impl LatestAccountsIndexRootsStats {
     pub fn report(&self) {
         datapoint_info!(
             "accounts_index_roots_len",
-            (
-                "roots_len",
-                self.roots_len.load(Ordering::Relaxed) as i64,
-                i64
-            ),
+            ("roots_len", self.roots_len.load(Ordering::Relaxed), i64),
             (
                 "uncleaned_roots_len",
-                self.uncleaned_roots_len.load(Ordering::Relaxed) as i64,
+                self.uncleaned_roots_len.load(Ordering::Relaxed),
                 i64
             ),
             (
                 "roots_range_width",
-                self.roots_range.load(Ordering::Relaxed) as i64,
+                self.roots_range.load(Ordering::Relaxed),
                 i64
             ),
             (
                 "unrooted_cleaned_count",
-                self.unrooted_cleaned_count.swap(0, Ordering::Relaxed) as i64,
+                self.unrooted_cleaned_count.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "rooted_cleaned_count",
-                self.rooted_cleaned_count.swap(0, Ordering::Relaxed) as i64,
+                self.rooted_cleaned_count.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "clean_unref_from_storage_us",
-                self.clean_unref_from_storage_us.swap(0, Ordering::Relaxed) as i64,
+                self.clean_unref_from_storage_us.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "clean_dead_slot_us",
-                self.clean_dead_slot_us.swap(0, Ordering::Relaxed) as i64,
+                self.clean_dead_slot_us.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "append_vecs_open",
-                APPEND_VEC_MMAPPED_FILES_OPEN.load(Ordering::Relaxed) as i64,
+                APPEND_VEC_MMAPPED_FILES_OPEN.load(Ordering::Relaxed),
                 i64
             ),
             (
@@ -388,7 +384,7 @@ impl ShrinkStats {
                 ),
                 (
                     "num_slots_shrunk",
-                    self.num_slots_shrunk.swap(0, Ordering::Relaxed) as i64,
+                    self.num_slots_shrunk.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -403,7 +399,7 @@ impl ShrinkStats {
                 ),
                 (
                     "storage_read_elapsed",
-                    self.storage_read_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.storage_read_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -413,78 +409,78 @@ impl ShrinkStats {
                 ),
                 (
                     "index_read_elapsed",
-                    self.index_read_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.index_read_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "create_and_insert_store_elapsed",
                     self.create_and_insert_store_elapsed
-                        .swap(0, Ordering::Relaxed) as i64,
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "store_accounts_elapsed",
-                    self.store_accounts_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.store_accounts_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "update_index_elapsed",
-                    self.update_index_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.update_index_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "handle_reclaims_elapsed",
-                    self.handle_reclaims_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.handle_reclaims_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "remove_old_stores_shrink_us",
-                    self.remove_old_stores_shrink_us.swap(0, Ordering::Relaxed) as i64,
+                    self.remove_old_stores_shrink_us.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "rewrite_elapsed",
-                    self.rewrite_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.rewrite_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "drop_storage_entries_elapsed",
-                    self.drop_storage_entries_elapsed.swap(0, Ordering::Relaxed) as i64,
+                    self.drop_storage_entries_elapsed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "accounts_removed",
-                    self.accounts_removed.swap(0, Ordering::Relaxed) as i64,
+                    self.accounts_removed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "bytes_removed",
-                    self.bytes_removed.swap(0, Ordering::Relaxed) as i64,
+                    self.bytes_removed.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "bytes_written",
-                    self.bytes_written.swap(0, Ordering::Relaxed) as i64,
+                    self.bytes_written.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "skipped_shrink",
-                    self.skipped_shrink.swap(0, Ordering::Relaxed) as i64,
+                    self.skipped_shrink.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "alive_accounts",
-                    self.alive_accounts.swap(0, Ordering::Relaxed) as i64,
+                    self.alive_accounts.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "dead_accounts",
-                    self.dead_accounts.swap(0, Ordering::Relaxed) as i64,
+                    self.dead_accounts.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
                     "accounts_loaded",
-                    self.accounts_loaded.swap(0, Ordering::Relaxed) as i64,
+                    self.accounts_loaded.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -544,7 +540,7 @@ impl ShrinkAncientStats {
                 "num_slots_shrunk",
                 self.shrink_stats
                     .num_slots_shrunk
-                    .swap(0, Ordering::Relaxed) as i64,
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
@@ -565,7 +561,7 @@ impl ShrinkAncientStats {
                 "storage_read_elapsed",
                 self.shrink_stats
                     .storage_read_elapsed
-                    .swap(0, Ordering::Relaxed) as i64,
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
@@ -579,112 +575,108 @@ impl ShrinkAncientStats {
                 "index_read_elapsed",
                 self.shrink_stats
                     .index_read_elapsed
-                    .swap(0, Ordering::Relaxed) as i64,
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "create_and_insert_store_elapsed",
                 self.shrink_stats
                     .create_and_insert_store_elapsed
-                    .swap(0, Ordering::Relaxed) as i64,
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "store_accounts_elapsed",
                 self.shrink_stats
                     .store_accounts_elapsed
-                    .swap(0, Ordering::Relaxed) as i64,
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "update_index_elapsed",
                 self.shrink_stats
                     .update_index_elapsed
-                    .swap(0, Ordering::Relaxed) as i64,
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "handle_reclaims_elapsed",
                 self.shrink_stats
                     .handle_reclaims_elapsed
-                    .swap(0, Ordering::Relaxed) as i64,
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "remove_old_stores_shrink_us",
                 self.shrink_stats
                     .remove_old_stores_shrink_us
-                    .swap(0, Ordering::Relaxed) as i64,
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "rewrite_elapsed",
-                self.shrink_stats.rewrite_elapsed.swap(0, Ordering::Relaxed) as i64,
+                self.shrink_stats.rewrite_elapsed.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "unpackable_slots_count",
                 self.shrink_stats
                     .unpackable_slots_count
-                    .swap(0, Ordering::Relaxed) as i64,
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "newest_alive_packed_count",
                 self.shrink_stats
                     .newest_alive_packed_count
-                    .swap(0, Ordering::Relaxed) as i64,
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "drop_storage_entries_elapsed",
                 self.shrink_stats
                     .drop_storage_entries_elapsed
-                    .swap(0, Ordering::Relaxed) as i64,
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "accounts_removed",
                 self.shrink_stats
                     .accounts_removed
-                    .swap(0, Ordering::Relaxed) as i64,
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "bytes_removed",
-                self.shrink_stats.bytes_removed.swap(0, Ordering::Relaxed) as i64,
+                self.shrink_stats.bytes_removed.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "bytes_written",
-                self.shrink_stats.bytes_written.swap(0, Ordering::Relaxed) as i64,
+                self.shrink_stats.bytes_written.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "alive_accounts",
-                self.shrink_stats.alive_accounts.swap(0, Ordering::Relaxed) as i64,
+                self.shrink_stats.alive_accounts.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "dead_accounts",
-                self.shrink_stats.dead_accounts.swap(0, Ordering::Relaxed) as i64,
+                self.shrink_stats.dead_accounts.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "accounts_loaded",
-                self.shrink_stats.accounts_loaded.swap(0, Ordering::Relaxed) as i64,
+                self.shrink_stats.accounts_loaded.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "ancient_append_vecs_shrunk",
-                self.ancient_append_vecs_shrunk.swap(0, Ordering::Relaxed) as i64,
+                self.ancient_append_vecs_shrunk.swap(0, Ordering::Relaxed),
                 i64
             ),
-            (
-                "random",
-                self.random_shrink.swap(0, Ordering::Relaxed) as i64,
-                i64
-            ),
+            ("random", self.random_shrink.swap(0, Ordering::Relaxed), i64),
             (
                 "slots_eligible_to_shrink",
                 self.slots_eligible_to_shrink.swap(0, Ordering::Relaxed),
@@ -702,37 +694,33 @@ impl ShrinkAncientStats {
             ),
             (
                 "slots_considered",
-                self.slots_considered.swap(0, Ordering::Relaxed) as i64,
+                self.slots_considered.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "ancient_scanned",
-                self.ancient_scanned.swap(0, Ordering::Relaxed) as i64,
+                self.ancient_scanned.swap(0, Ordering::Relaxed),
                 i64
             ),
-            (
-                "total_us",
-                self.total_us.swap(0, Ordering::Relaxed) as i64,
-                i64
-            ),
+            ("total_us", self.total_us.swap(0, Ordering::Relaxed), i64),
             (
                 "bytes_ancient_created",
-                self.bytes_ancient_created.swap(0, Ordering::Relaxed) as i64,
+                self.bytes_ancient_created.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "bytes_from_must_shrink",
-                self.bytes_from_must_shrink.swap(0, Ordering::Relaxed) as i64,
+                self.bytes_from_must_shrink.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "bytes_from_smallest_storages",
-                self.bytes_from_smallest_storages.swap(0, Ordering::Relaxed) as i64,
+                self.bytes_from_smallest_storages.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "bytes_from_newest_storages",
-                self.bytes_from_newest_storages.swap(0, Ordering::Relaxed) as i64,
+                self.bytes_from_newest_storages.swap(0, Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem

The datapoint!() macro no longer needs to have an explicit cast to the desired type. It's already in the macro.


#### Summary of Changes

Remove the explicit casts in accounts-db.