### PR TITLE
update thiserror version for vortexor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9990,7 +9990,7 @@ dependencies = [
  "solana-streamer",
  "solana-transaction-metrics-tracker",
  "solana-version",
- "thiserror 2.0.6",
+ "thiserror 2.0.8",
  "tokio",
  "x509-parser",
 ]


### PR DESCRIPTION
#### Problem

The thiserror was updated before the last rebase of vortexor PR.

#### Summary of Changes

Update the Cargo.lock for thiserror to 2.0.8.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
