### PR TITLE
fix: Fix file extension inconsistency between code and comments

### DIFF
--- a/docs/convert-ascii-to-svg.sh
+++ b/docs/convert-ascii-to-svg.sh
@@ -22,6 +22,6 @@ while read -r bob_file; do
 done < <(find art/*.bob)
 
 while read -r msc_file; do
-  out_file=$(basename "${msc_file%.*}".png)
-  mscgen -T png -o "$output_dir/$out_file" -i "$msc_file"
+  out_file=$(basename "${msc_file%.*}".svg)
+  mscgen -T svg -o "$output_dir/$out_file" -i "$msc_file"
 done < <(find art/*.msc)


### PR DESCRIPTION
#### Problem

I noticed an inconsistency between the code and the comment regarding the file extensions used for `.msc` files. The code was using `.png` as the file extension, while the comment specified that all files should be converted to `.svg`. I've corrected this discrepancy by ensuring that the files now correctly use the `.svg` extension, in line with the comment. 

#### Summary of Changes

Everything should be consistent now. Let me know if you need any further changes!
