### PR TITLE
validator: Add CLI args to control rocksdb threadpool sizes

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -470,7 +470,6 @@ pub fn open_blockstore(
             access_type: access_type.clone(),
             recovery_mode: wal_recovery_mode.clone(),
             enforce_ulimit_nofile,
-            column_options: LedgerColumnOptions::default(),
             ..BlockstoreOptions::default()
         },
     ) {

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -471,6 +471,7 @@ pub fn open_blockstore(
             recovery_mode: wal_recovery_mode.clone(),
             enforce_ulimit_nofile,
             column_options: LedgerColumnOptions::default(),
+            ..BlockstoreOptions::default()
         },
     ) {
         Ok(blockstore) => blockstore,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -17,9 +17,7 @@ use {
     solana_ledger::{
         bank_forks_utils::{self, BankForksUtilsError},
         blockstore::{Blockstore, BlockstoreError},
-        blockstore_options::{
-            AccessType, BlockstoreOptions, BlockstoreRecoveryMode, LedgerColumnOptions,
-        },
+        blockstore_options::{AccessType, BlockstoreOptions, BlockstoreRecoveryMode},
         blockstore_processor::{
             self, BlockstoreProcessorError, ProcessOptions, TransactionStatusSender,
         },

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -12,7 +12,7 @@ use {
         blockstore_meta::*,
         blockstore_metrics::BlockstoreRpcApiMetrics,
         blockstore_options::{
-            AccessType, BlockstoreOptions, LedgerColumnOptions, BLOCKSTORE_DIRECTORY_ROCKS_LEVEL,
+            BlockstoreOptions, LedgerColumnOptions, BLOCKSTORE_DIRECTORY_ROCKS_LEVEL,
         },
         blockstore_processor::BlockstoreProcessorError,
         leader_schedule_cache::LeaderScheduleCache,
@@ -90,7 +90,9 @@ pub mod blockstore_purge;
 use static_assertions::const_assert_eq;
 pub use {
     crate::{
-        blockstore_db::BlockstoreError,
+        blockstore_db::{
+            default_num_compaction_threads, default_num_flush_threads, BlockstoreError,
+        },
         blockstore_meta::{OptimisticSlotMetaVersioned, SlotMeta},
         blockstore_metrics::BlockstoreInsertionMetrics,
     },
@@ -4961,10 +4963,9 @@ pub fn create_new_ledger(
     let blockstore = Blockstore::open_with_options(
         ledger_path,
         BlockstoreOptions {
-            access_type: AccessType::Primary,
-            recovery_mode: None,
             enforce_ulimit_nofile: false,
             column_options: column_options.clone(),
+            ..BlockstoreOptions::default()
         },
     )?;
     let ticks_per_slot = genesis_config.ticks_per_slot;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -2010,9 +2010,14 @@ fn get_db_options(blockstore_options: &BlockstoreOptions) -> Options {
         blockstore_options.num_rocksdb_flush_threads.get() as i32
     );
     options.set_env(&env);
-    // The value set in max_background_jobs can grow but not shrink threadpool
-    // sizes. So, set this value to 2 (the default value and 1 low / 1 high) to
-    // avoid rocksdb from messing with the sizes we previously configured.
+    // rocksdb will try to scale threadpool sizes automatically based on the
+    // value set for max_background_jobs. The automatic scaling can increase,
+    // but not decrease the number of threads in each pool. But, we already
+    // set desired threadpool sizes with set_low_priority_background_threads()
+    // and set_high_priority_background_threads(). So, set max_background_jobs
+    // to a small number (2) so that rocksdb will leave the previously
+    // configured threadpool sizes as-is. The value (2) would result in one
+    // low priority and one high priority thread which is the minimum for each.
     options.set_max_background_jobs(2);
 
     // Set max total wal size to 4G.

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -416,7 +416,6 @@ pub(crate) struct Rocks {
 
 impl Rocks {
     pub(crate) fn open(path: PathBuf, options: BlockstoreOptions) -> Result<Rocks> {
-        // let access_type = options.access_type.clone();
         let recovery_mode = options.recovery_mode.clone();
 
         fs::create_dir_all(&path)?;

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -40,12 +40,9 @@ impl Default for BlockstoreOptions {
 impl BlockstoreOptions {
     pub fn default_for_tests() -> Self {
         Self {
-            access_type: AccessType::Primary,
-            recovery_mode: None,
+            // No need to enforce the limit in tests
             enforce_ulimit_nofile: false,
-            column_options: LedgerColumnOptions::default(),
-            num_rocksdb_compaction_threads: default_num_compaction_threads(),
-            num_rocksdb_flush_threads: default_num_flush_threads(),
+            ..BlockstoreOptions::default()
         }
     }
 }

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -1,4 +1,8 @@
-use rocksdb::{DBCompressionType as RocksCompressionType, DBRecoveryMode};
+use {
+    crate::blockstore_db::{default_num_compaction_threads, default_num_flush_threads},
+    rocksdb::{DBCompressionType as RocksCompressionType, DBRecoveryMode},
+    std::num::NonZeroUsize,
+};
 
 /// The subdirectory under ledger directory where the Blockstore lives
 pub const BLOCKSTORE_DIRECTORY_ROCKS_LEVEL: &str = "rocksdb";
@@ -13,6 +17,8 @@ pub struct BlockstoreOptions {
     // desired open file descriptor limit cannot be configured. Default: true.
     pub enforce_ulimit_nofile: bool,
     pub column_options: LedgerColumnOptions,
+    pub num_rocksdb_compaction_threads: NonZeroUsize,
+    pub num_rocksdb_flush_threads: NonZeroUsize,
 }
 
 impl Default for BlockstoreOptions {
@@ -25,6 +31,8 @@ impl Default for BlockstoreOptions {
             recovery_mode: None,
             enforce_ulimit_nofile: true,
             column_options: LedgerColumnOptions::default(),
+            num_rocksdb_compaction_threads: default_num_compaction_threads(),
+            num_rocksdb_flush_threads: default_num_flush_threads(),
         }
     }
 }
@@ -36,6 +44,8 @@ impl BlockstoreOptions {
             recovery_mode: None,
             enforce_ulimit_nofile: false,
             column_options: LedgerColumnOptions::default(),
+            num_rocksdb_compaction_threads: default_num_compaction_threads(),
+            num_rocksdb_flush_threads: default_num_flush_threads(),
         }
     }
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -907,6 +907,8 @@ pub fn main() {
         rayon_global_threads,
         replay_forks_threads,
         replay_transactions_threads,
+        rocksdb_compaction_threads,
+        rocksdb_flush_threads,
         tvu_receive_threads,
         tvu_sigverify_threads,
     } = cli::thread_args::parse_num_threads_args(&matches);
@@ -1055,6 +1057,8 @@ pub fn main() {
         enforce_ulimit_nofile: true,
         // The validator needs primary (read/write)
         access_type: AccessType::Primary,
+        num_rocksdb_compaction_threads: rocksdb_compaction_threads,
+        num_rocksdb_flush_threads: rocksdb_flush_threads,
     };
 
     let accounts_hash_cache_path = matches


### PR DESCRIPTION
#### Problem
See #105 for more context

#### Summary of Changes
- Commit 1: Set the threadpool sizes directly
    - We previously used options.increase_parallelism() which would size the high priority (memtable flush) threadpool differently than what the comments would indicate in the code
- Commit 2: Bubble threadpool size configuration up to validator CLI args

**Threadpool sizes are unchanged from this PR, but will enable fine tuning in subsequent changes**

#### Additional Context for setting threadpool size directly
The below section has some code snippets/links that explain why our current code configures `num_cpus` low priority threads and `num_cpus / 4` high priority threads. Let `N = num_cpus::get()`.
<details>
<summary>Snippets</summary>

We were previously calling `increase_parallelism()` with `N` which ends up [here](https://github.com/facebook/rocksdb/blob/02b4197544f758bdf84d80fe9319238611848c48/options/options.cc#L677-L682):
```c
DBOptions* DBOptions::IncreaseParallelism(int total_threads) {
  max_background_jobs = total_threads;
  env->SetBackgroundThreads(total_threads, Env::LOW);
  env->SetBackgroundThreads(1, Env::HIGH);
  return this;
}
```
This immediately creates `N` low priority threads, and 1 high priority thread. But, note that `max_background_jobs` is also set to `N`. This is important because when the DB is opened, the options are checked for consistency and thread pools are grown if necessary. That happens [here](https://github.com/facebook/rocksdb/blob/02b4197544f758bdf84d80fe9319238611848c48/db/db_impl/db_impl_open.cc#L77-L83):
```c
  auto bg_job_limits = DBImpl::GetBGJobLimits(
      result.max_background_flushes, result.max_background_compactions,
      result.max_background_jobs, true /* parallelize_compactions */);
 ```
 with the implementation [here](https://github.com/facebook/rocksdb/blob/main/db/db_impl/db_impl_compaction_flush.cc#L2941-L2962):
 ```c
 DBImpl::BGJobLimits DBImpl::GetBGJobLimits(int max_background_flushes,
                                           int max_background_compactions,
                                           int max_background_jobs,
                                           bool parallelize_compactions) {
  BGJobLimits res;
  if (max_background_flushes == -1 && max_background_compactions == -1) {
    // for our first stab implementing max_background_jobs, simply allocate a
    // quarter of the threads to flushes.
    res.max_flushes = std::max(1, max_background_jobs / 4);
    res.max_compactions = std::max(1, max_background_jobs - res.max_flushes);
  } else {
    // compatibility code in case users haven't migrated to max_background_jobs,
    // which automatically computes flush/compaction limits
    res.max_flushes = std::max(1, max_background_flushes);
    res.max_compactions = std::max(1, max_background_compactions);
  }
  if (!parallelize_compactions) {
    // throttle background compactions until we deem necessary
    res.max_compactions = 1;
  }
  return res;
}
```
We hit the `if` case and then assuming `N > 4` as it is for validators:
```
res.max_flushes = std::max(1, max_background_jobs / 4) 
                = std::max(1, N / 4) 
                = N / 4
res.max_compactions = std::max(1, max_background_jobs - res.max_flushes) 
                   = std::max(1, N - (N / 4))
                   = std::max(1, 3N / 4)
                   = 3N / 4
```
Then, we go grow these threadpools if necessary [here](https://github.com/facebook/rocksdb/blob/02b4197544f758bdf84d80fe9319238611848c48/db/db_impl/db_impl_open.cc#L77-L83):
```c
  result.env->IncBackgroundThreadsIfNeeded(bg_job_limits.max_compactions,
                                           Env::Priority::LOW);
  result.env->IncBackgroundThreadsIfNeeded(bg_job_limits.max_flushes,
                                           Env::Priority::HIGH);
```
So, the value of `4` that we set here is coerced up on high core count nodes:
https://github.com/anza-xyz/agave/blob/c7131f627f3b249a5756b26d9a2ac6e40bcfa5ea/ledger/src/blockstore_db.rs#L2009

Empirically, if I adjust the value in `options.set_max_background_jobs()` to `256`, I see 192 (`3N/4`) low and 64 (`N/4`) high threads.
</details>

Testing out on a machine with 32 cores / 64 threads, I still see 64 low priority threads / 16 high priority threads with this PR. I also confirmed that setting `--rocksdb-compaction-threads X` and `--rocksdb-flush-threads Y` yields `X` low priority threads and `Y` high priority threads