### PR TITLE
Disable solana-metrics dependency for wasm target

### DIFF
--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -37,7 +37,6 @@ solana-instruction = { workspace = true }
 solana-last-restart-slot = { workspace = true }
 solana-log-collector = { workspace = true }
 solana-measure = { workspace = true }
-solana-metrics = { workspace = true }
 solana-precompiles = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
@@ -51,6 +50,9 @@ solana-timings = { workspace = true }
 solana-transaction-context = { workspace = true }
 solana-type-overrides = { workspace = true }
 thiserror = { workspace = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+solana-metrics = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(clippy::arithmetic_side_effects)]
 #![deny(clippy::indexing_slicing)]
 
+#[cfg(not(target_family = "wasm"))]
 #[macro_use]
 extern crate solana_metrics;
 

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -291,6 +291,8 @@ impl LoadProgramMetrics {
         timings.create_executor_load_elf_us += self.load_elf_us;
         timings.create_executor_verify_code_us += self.verify_code_us;
         timings.create_executor_jit_compile_us += self.jit_compile_us;
+
+        #[cfg(not(target_family = "wasm"))]
         datapoint_trace!(
             "create_executor_trace",
             ("program_id", self.program_id, String),


### PR DESCRIPTION
#### Problem

I'm trying to use solana-account-decoder crate in wasm32 target. However, `gethostname` crate gets pulled in due to dependency on solana-metrics in solana-program-runtime 

```
gethostname v0.2.3
└── solana-metrics v2.1.7
    └── solana-program-runtime v2.1.7
        └── solana-config-program v2.1.7
            └── solana-account-decoder v2.1.7
```

#### Summary of Changes

Use build cfg to remove solana-metrics from program-runtime 



@ifiokjr FYI 