### PR TITLE
Eliminate some obviously useless threading

### DIFF
--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -490,10 +490,10 @@ pub fn ed25519_verify_cpu(batches: &mut [PacketBatch], reject_non_vote: bool, pa
 pub fn ed25519_verify_disabled(batches: &mut [PacketBatch]) {
     let packet_count = count_packets_in_batches(batches);
     debug!("disabled ECDSA for {}", packet_count);
-    batches.iter_mut().for_each(|batch| {
-        batch
-            .iter_mut()
-            .for_each(|p| p.meta_mut().set_discard(false))
+    PAR_THREAD_POOL.install(|| {
+        batches.par_iter_mut().flatten().for_each(|packet| {
+            packet.meta_mut().set_discard(false);
+        });
     });
 }
 

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -490,9 +490,9 @@ pub fn ed25519_verify_cpu(batches: &mut [PacketBatch], reject_non_vote: bool, pa
 pub fn ed25519_verify_disabled(batches: &mut [PacketBatch]) {
     let packet_count = count_packets_in_batches(batches);
     debug!("disabled ECDSA for {}", packet_count);
-    batches.into_par_iter().for_each(|batch| {
+    batches.iter_mut().for_each(|batch| {
         batch
-            .par_iter_mut()
+            .iter_mut()
             .for_each(|p| p.meta_mut().set_discard(false))
     });
 }


### PR DESCRIPTION
#### Problem
pub fn ed25519_verify_disabled(batches: &mut [PacketBatch]) in perf/src/sigverify.rs
does pretty much no work (sets a boolean flag for each Packet in PacketBatch) and yet it creates doubly nested parallel iterators to achieve this results. It further does this on rayon's global thread pool so it is impossible to do accounting on this activity.

#### Summary of Changes
Changed the function to set the flags in single flattened iterator using appropriate pool, this also matches the behavior of ed25519_verify for consistency.