### PR TITLE
ci: Exclude `avm` from Anchor downstream project tests

### DIFF
--- a/scripts/build-downstream-anchor-projects.sh
+++ b/scripts/build-downstream-anchor-projects.sh
@@ -69,7 +69,8 @@ anchor() {
   patch_crates_io_solana Cargo.toml "$solana_dir"
   patch_spl_crates . Cargo.toml "$spl_dir"
 
-  $cargo test
+  # Exclude `avm` tests because they don't depend on Solana or SPL
+  $cargo test --workspace --exclude avm
   # serum_dex and mpl-token-metadata are using caret versions of solana and SPL dependencies
   # rather pull and patch those as well, ignore for now
   # (cd spl && $cargo_build_sbf --features dex metadata stake)


### PR DESCRIPTION
### Problem

CI tests for downstream projects include [`avm`](https://github.com/coral-xyz/anchor/tree/ceefae7f0af8ae6a2910779d444a80966f43a072/avm) (Anchor Version Manager), which doesn't depend on any Solana or SPL dependencies.

`avm`'s tests triggered a rate-limit error in [CI](https://github.com/anza-xyz/agave/actions/runs/12532320980/job/34950934034?pr=4214), as mentioned in the [#devops](https://discord.com/channels/428295358100013066/560503042458517505/1322782888789540886) Discord channel.

Although `avm` tests only send 3 API requests in total, it still makes sense to skip those tests because they are completely unrelated to the goal of keeping Agave and Anchor compatible.

### Summary of changes

Exclude `avm` from Anchor downstream project tests in CI.