### PR TITLE
Uses Acquire/Release semantics for SlotCache::is_frozen

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -104,11 +104,11 @@ impl SlotCacheInner {
     }
 
     pub fn mark_slot_frozen(&self) {
-        self.is_frozen.store(true, Ordering::SeqCst);
+        self.is_frozen.store(true, Ordering::Release);
     }
 
     pub fn is_frozen(&self) -> bool {
-        self.is_frozen.load(Ordering::SeqCst)
+        self.is_frozen.load(Ordering::Acquire)
     }
 
     pub fn total_bytes(&self) -> u64 {


### PR DESCRIPTION
#### Problem

SlotCache::is_frozen is an atomic that currently uses *Sequential Consistency* semantics for loading and storing, even though `is_frozen` never interacts with another atomic. Thus there is no implicit or explicit relationship requiring sequential consistency.

After auditing the uses of `is_frozen`, we load in one place, and store in one place:

##### Load

Loading `is_frozen` is only used when flushing the accounts write cache in `AccountsDb::flush_accounts_cache()`.  This is when we get a Vec of the old/frozen slots, which is then used for determining which ones to flush.

##### Store

Storing `is_frozen` only happens during `Bank::freeze()`, and is already protected by a write lock on `Bank::hash`. So `SlotCache::is_frozen` already inherits the visibility ordering from the RwLock.


Overall, the SlotCache's `is_frozen` is an optimization so that we don't have to look somewhere else if the slot is frozen or not. Since we don't use this field to influence other *atomic* variables, there's no need for it to use Sequential Consistency.

The accounts write cache was added in https://github.com/solana-labs/solana/pull/13140/, and the PR has a discussion about `is_frozen`.


#### Summary of Changes

Switch ordering to use Acquire-Release semantics. 