### PR TITLE
Uses Acquire/Release semantics for test_accounts_locks_multithreaded()

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1107,7 +1107,7 @@ mod tests {
                 .lock_accounts(txs.iter(), MAX_TX_ACCOUNT_LOCKS);
             for result in results.iter() {
                 if result.is_ok() {
-                    counter_clone.clone().fetch_add(1, Ordering::SeqCst);
+                    counter_clone.clone().fetch_add(1, Ordering::Release);
                 }
             }
             accounts_clone.unlock_accounts(txs.iter().zip(&results));
@@ -1122,9 +1122,9 @@ mod tests {
                 .clone()
                 .lock_accounts(txs.iter(), MAX_TX_ACCOUNT_LOCKS);
             if results[0].is_ok() {
-                let counter_value = counter_clone.clone().load(Ordering::SeqCst);
+                let counter_value = counter_clone.clone().load(Ordering::Acquire);
                 thread::sleep(time::Duration::from_millis(50));
-                assert_eq!(counter_value, counter_clone.clone().load(Ordering::SeqCst));
+                assert_eq!(counter_value, counter_clone.clone().load(Ordering::Acquire));
             }
             accounts_arc.unlock_accounts(txs.iter().zip(&results));
             thread::sleep(time::Duration::from_millis(50));


### PR DESCRIPTION
#### Problem

Similar to https://github.com/anza-xyz/agave/pull/4222, but for a test.

`test_accounts_locks_multithreaded()` uses *Sequential Consistency* semantics even though the `counter` atomic never interacts with another atomic. Thus, sequential consistency is not required for correctness. Additionally, I argue that using sequential consistency when not required *is a bug*, as it implies a relationship that is otherwise not explicit. Since there is no relationship with another atomic, the code is both (1) less performant, and (2) communicates wrong information to the reader.

Here's the PR where the test was added: https://github.com/solana-labs/solana/pull/4691. I wanted to see if the test originally had another atomic variable, which may've necessitated sequential consistency. Looks like "no".


#### Summary of Changes

Switch ordering to use Acquire-Release semantics.


I ran this test in a loop on my macbook for 6 hours without any failures as well.